### PR TITLE
do_regtest: remove SVN refs, remove self-update functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ all: dirs makedep
 
 # foreground testing, compilation happens in do_regtest
 test: dirs
-	cd $(TSTDIR); $(TOOLSRC)/regtesting/do_regtest -nosvn -nogit -quick -arch $(ARCH) -version $(ONEVERSION) -cp2kdir ../../../  $(TESTOPTS)
+	cd $(TSTDIR); $(TOOLSRC)/regtesting/do_regtest -quick -arch $(ARCH) -version $(ONEVERSION) -cp2kdir ../../../  $(TESTOPTS)
 
 # background testing, compilation happens here
 testbg: dirs makedep all
@@ -188,7 +188,7 @@ $(LIBDIR)/libcp2k$(ARCHIVE_EXT) : $(ALL_NONEXE_OBJECTS)
 
 testbg:
 	@echo "testing: $(ONEVERSION) : full log in $(TSTDIR)/regtest.log "
-	@$(TOOLSRC)/regtesting/do_regtest -nobuild -nosvn -arch $(ARCH) -version $(ONEVERSION) -cp2kdir ../../../  $(TESTOPTS) >& $(TSTDIR)/regtest.log
+	@$(TOOLSRC)/regtesting/do_regtest -nobuild $(ARCH) -version $(ONEVERSION) -cp2kdir ../../../  $(TESTOPTS) >& $(TSTDIR)/regtest.log
 	@cat `grep 'regtesting location error_summary file:' $(TSTDIR)/regtest.log | awk '{print $$NF}'`
 	@cat `grep 'regtesting location summary file:' $(TSTDIR)/regtest.log | awk '{print $$NF}'`
 	@grep "Number of FAILED  tests 0" $(TSTDIR)/regtest.log >& /dev/null
@@ -408,15 +408,10 @@ vpath %.cxx   $(ALL_SRC_DIRS)
 vpath %.cc    $(ALL_SRC_DIRS)
 
 #
-# Add additional dependency of cp2k_info.F to SVN-entry or git-HEAD.
+# Add additional dependency of cp2k_info.F to git-HEAD.
 # Ensuring that cp2k prints the correct source code revision number in its banner.
 #
-SVN_ENTRY    := $(wildcard $(SRCDIR)/.svn/entries*)
-ifneq ($(strip $(SVN_ENTRY)),)
-cp2k_info.o: $(SVN_ENTRY)
-endif
-
-GIT_HEAD     := $(wildcard $(CP2KHOME)/../.git/HEAD*)
+GIT_HEAD := $(wildcard $(CP2KHOME)/../.git/HEAD*)
 ifneq ($(strip $(GIT_HEAD)),)
 cp2k_info.o: $(GIT_HEAD)
 endif

--- a/tools/regtesting/do_regtest
+++ b/tools/regtesting/do_regtest
@@ -23,7 +23,6 @@ ndirstorestrict=0
 restrict_dirs[1]=""
 default_err_tolerance="1.0E-14"
 mpiexec="mpiexec --bind-to none"
-svnrec=
 
 # parse options
 while [ $# -ge 1 ]; do
@@ -94,9 +93,6 @@ while [ $# -ge 1 ]; do
  # Perform no git pull
  -nogit)
   nogit="nogit";;
- # Perform no svn update
- -nosvn)
-  nosvn="nosvn";;
  # do not reset reference outputs
  -noreset)
   noreset="noreset";;
@@ -106,13 +102,6 @@ while [ $# -ge 1 ]; do
  # specify the full string "-D 2005-02-01" to get a check-out of a specific date
  -farming)
   farming="yes";;
- -svndate)
-  svndate=$2
-  datum_short=${svndate}
-  shift;;
- -svnrev)
-  svnrev=$2
-  shift;;
  # do not check if code has changed
  -noemptycheck)
   emptycheck="NO";;
@@ -137,12 +126,7 @@ while [ $# -ge 1 ]; do
   echo ""
   echo "Git:"
   echo "  -nogit                    do not run git pull. Default: off."
-  echo ""
-  echo "Svn:"
-  echo "  -svndate DATE             checkout svn revision of given DATE. Default: use trunk."
-  echo "  -svnrev REV               checkout svn revision of given REV. Default: use trunk."
-  echo "  -nosvn                    do not run svn update. Default: off."
-  echo "  -noemptycheck             run tests even when no changes in svn were made. Default: on."
+  echo "  -noemptycheck             run tests even when no changes in Git were made. Default: on."
   echo ""
   echo "Build:"
   echo "  -version VERSION          VERSION passed to make. Default: sopt."
@@ -160,7 +144,7 @@ while [ $# -ge 1 ]; do
   echo ""
   echo "Testing:"
   echo "  -noreset                  do not reset the reference outputs. Default: off."
-  echo "  -skiptest                 do not run test, only svn update and build. Default: off."
+  echo "  -skiptest                 do not run test, only Git update and build. Default: off."
   echo "  -skipunittest             do not run unit tests. Default: off."
   echo "  -skipdir TESTDIR          do not run tests in TESTDIR. This switch can repeated."
   echo "  -restrictdir TESTDIR      run only tests in TESTDIR. This switch can repeated."
@@ -168,14 +152,14 @@ while [ $# -ge 1 ]; do
   echo ""
   echo "Exit codes:"
   echo "    0   clean exit with testing"
-  echo "    1   problem with svn update"
+  echo "    1   problem with Git update"
   echo "    3   problem with realclean"
   echo "    4   build errors"
   echo "    5   problem with retest option - no TEST directory with latest test results found"
   echo "    6   problem with retest option - no error summary exists in the last TEST directory"
   echo "    7   reference directory is locked"
   echo "    8   ctrl-C (SIGINT) and various other signals trapped"
-  echo "  100   no svn changes since last run - clean exit without testing"
+  echo "  100   no Git changes since last run - clean exit without testing"
   echo ""
   echo "For more information visit: <http://cp2k.org/dev:regtesting>"
   exit 0;;
@@ -203,7 +187,6 @@ emptycheck=${emptycheck:-"NO"}
 leakcheck=${leakcheck:-"NO"}
 doretest=${doretest:-"no"}
 nogit=${nogit:-"git"}
-nosvn=${nosvn:-"svn"}
 nobuild=${nobuild:-"build"}
 cp2k_run_postfix=${cp2k_run_postfix:-""}
 make=${make:-make}
@@ -213,7 +196,7 @@ noreset=${noreset:-"reset"}
 skiptest=${skiptest:-"noskiptest"}
 do_unit_test=${do_unit_test:-"yes"}
 farming=${farming:-"no"}
-svndate=${svndate:-"$datum_full"}
+date="${datum_full}"
 #
 # guessing the number of tasks / threads / ranks
 #
@@ -288,7 +271,6 @@ changelog_tests_new=${changelog_tests}.new
 changelog_tests_old=${changelog_tests}.old
 mkdir -p ${dir_out}
 mkdir -p ${dir_last}
-svn_out=${dir_out}/svn.out
 git_out=${dir_out}/git.out
 make_out=${dir_out}/make.out
 error_description_file=${dir_out}/error_summary
@@ -722,11 +704,6 @@ echo " regtesting location last dir: $dir_last"
 # Start testing
 echo "*************************** testing started ******************************"
 echo " started on " `date`
-if [ -z "$svnver" ]; then
-    echo " checking version ${svndate} "
-else
-    echo " checking version ${svnrev} "
-fi
 echo " configuration: ${dir_triplet}-${cp2k_version} "
 file_info
 #
@@ -747,7 +724,6 @@ echo "emptycheck       = ${emptycheck}"
 echo "leakcheck        = ${leakcheck}"
 echo "doretest         = ${doretest}"
 echo "nogit            = ${nogit}"
-echo "nosvn            = ${nosvn}"
 echo "nobuild          = ${nobuild}"
 echo "quick            = ${quick}"
 echo "noreset          = ${noreset}"
@@ -755,11 +731,7 @@ echo "skiptest         = ${skiptest}"
 echo "do_unit_test     = ${do_unit_test}"
 echo "farming          = ${farming}"
 echo "maxbuildtasks    = ${maxbuildtasks}"
-if [ -z "$svnver" ]; then
-    echo "svndate          = ${svndate}"
-else
-    echo "svnrev          = ${svnrev}"
-fi
+
 t=1
 while [ $t -le ${ndirstoskip} ]; do
  echo "skip_dirs        = ${skip_dirs[t]}"
@@ -770,95 +742,51 @@ while [ $t -le ${ndirstorestrict} ]; do
  echo "restrict_dirs    = ${restrict_dirs[t]}"
  let t=t+1
 done
-# Check for svn and perform update if requested
-echo "--------------------------- SVN ------------------------------------------"
-if svn info ${repo_dir} &>/dev/null; then
-   if [[ ${nosvn} != "nosvn" ]]; then
-      cd ${repo_dir}
-      # If ChangeLog does not exist for the first time, it is created
-      if [[ ! -s ${changelog} ]]; then
-         echo "Creating ChangeLog file for the first time. This may take a while ..."
-         ${repo_dir}/tools/svn2cl/svn2cl.sh -i -o ${changelog}
+
+echo "--------------------------- GIT ------------------------------------------"
+if git -C ${repo_dir} rev-parse &>/dev/null; then
+   if [[ ${nogit} != "nogit" ]]; then
+      sha1_old=$(git -C ${repo_dir} log -1 --pretty='%H')
+      git -C ${repo_dir} log --pretty="CommitSHA: %H%nCommitTime: %ci%nCommitAuthor: %an%nCommitAuthorEmail: %ae%nCommitSubject: %s%n#" >${changelog_old}
+      git -C ${repo_dir} pull &>${git_out}
+      if (( $? )); then
+         echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
+         cat ${git_out} >>${error_description_file}
+         echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
+         echo "ERROR: git -C ${repo_dir} pull failed ... bailing out" >>${error_description_file}
+         cat "${error_description_file}"
+         end_test 1 ${lockfile}
       fi
-      for d in src data tests tools; do
-         echo "Updating $d ..."
-         if [ -z "$svnver" ]; then
-            svn update -r {${svndate}} $d &>${svn_out}
-         else
-            svn update -r ${svnrev} $d &>${svn_out}
-         fi
-         if (( $? )); then
-            echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
-            cat ${svn_out} >>${error_description_file}
-            echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
-            echo "ERROR: svn update $d failed ... bailing out" >>${error_description_file}
-            cat "${error_description_file}"
-            end_test 1 ${lockfile}
-         fi
-         cat ${svn_out}
-      done
-      #  cp2k_lines=`wc *.F | tail -1 |  ${awk} '{print $1}'`
-      #  echo "cp2k is now ${cp2k_lines} lines .F"
+      sha1_new=$(git -C ${repo_dir} log -1 --pretty='%H')
+      git -C ${repo_dir} log --pretty="CommitSHA: %H%nCommitTime: %ci%nCommitAuthor: %an%nCommitAuthorEmail: %ae%nCommitSubject: %s%n#" >${changelog}
+      cat ${git_out}
       echo "--------------------------- ChangeLog diff -------------------------------"
-      # Using svn2cl.pl to generate GNU like ChangeLog
-      ${repo_dir}/tools/svn2cl/svn2cl.sh --limit 100 -i -o ${changelog_new} >>${error_description_file} 2>&1
-      line1="$(head -n 1 ${changelog})"
-      nline=$(grep -n "${line1}" ${changelog_new} | head -n 1 | cut -f 1 -d:)
-      mv ${changelog} ${changelog_old}
-      head -n $((nline - 1)) ${changelog_new} >${changelog}
-      cat ${changelog_old} >>${changelog}
-      diff ${changelog} ${changelog_old} >${changelog_diff}
+      line1="$(head -n 1 ${changelog_old})"
+      nline=$(grep -n "${line1}" ${changelog} | head -n 1 | cut -f 1 -d:)
+      head -n $(( nline - 1 )) ${changelog} >${changelog_diff}
       cat ${changelog_diff}
-      rm ${changelog_new} ${changelog_old}
+      rm ${changelog_old}
    else
-      echo "No svn update has been performed due to user request"
+      echo "No git pull has been performed due to user request"
    fi
 else
-   echo "No svn repository found in ${repo_dir}"
-   echo "--------------------------- GIT ------------------------------------------"
-   if git -C ${repo_dir} rev-parse &>/dev/null; then
-      if [[ ${nogit} != "nogit" ]]; then
-         sha1_old=$(git -C ${repo_dir} log -1 --pretty='%H')
-         git -C ${repo_dir} log --pretty="CommitSHA: %H%nCommitTime: %ci%nCommitAuthor: %an%nCommitAuthorEmail: %ae%nCommitSubject: %s%n#" >${changelog_old}
-         git -C ${repo_dir} pull &>${git_out}
-         if (( $? )); then
-            echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
-            cat ${git_out} >>${error_description_file}
-            echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
-            echo "ERROR: git -C ${repo_dir} pull failed ... bailing out" >>${error_description_file}
-            cat "${error_description_file}"
-            end_test 1 ${lockfile}
+   if [[ ${nogit} != "nogit" ]]; then
+      if git --version &>/dev/null; then
+         git_version=$(git --version | awk '{print $3}' | cut -d. -f1)
+         if (( git_version < 2 )); then
+            echo "$(git --version) is too old"
+            echo "No update of the git repository ${repo_dir} was performed"
+         else
+            echo "No git repository found in ${repo_dir}"
          fi
-         sha1_new=$(git -C ${repo_dir} log -1 --pretty='%H')
-         git -C ${repo_dir} log --pretty="CommitSHA: %H%nCommitTime: %ci%nCommitAuthor: %an%nCommitAuthorEmail: %ae%nCommitSubject: %s%n#" >${changelog}
-         cat ${git_out}
-         echo "--------------------------- ChangeLog diff -------------------------------"
-         line1="$(head -n 1 ${changelog_old})"
-         nline=$(grep -n "${line1}" ${changelog} | head -n 1 | cut -f 1 -d:)
-         head -n $(( nline - 1 )) ${changelog} >${changelog_diff}
-         cat ${changelog_diff}
-         rm ${changelog_old}
       else
-         echo "No git pull has been performed due to user request"
+         echo "git is not installed"
       fi
    else
-      if [[ ${nogit} != "nogit" ]]; then
-         if git --version &>/dev/null; then
-            git_version=$(git --version | awk '{print $3}' | cut -d. -f1)
-            if (( git_version < 2 )); then
-               echo "$(git --version) is too old"
-               echo "No update of the git repository ${repo_dir} was performed"
-            else
-               echo "No git repository found in ${repo_dir}"
-            fi
-         else
-            echo "git is not installed"
-         fi
-      else
-         echo "No git pull has been performed due to user request"
-      fi
+      echo "No git pull has been performed due to user request"
    fi
 fi
+
 
 echo "--------------------------- Preparations ---------------------------------"
 
@@ -933,7 +861,7 @@ if [[ ${skiptest} != "skiptest" ]]; then
    
    ###################################################################################
    #
-   # parse the TEST_TYPES file to do different kinds of test (done after svn update)
+   # parse the TEST_TYPES file to do different kinds of test (done after Git update)
    #
    # tests grep for the last line in the file where a string matches (test_grep)
    # and compares a numeric field at a given column (test_col)

--- a/tools/regtesting/do_regtest
+++ b/tools/regtesting/do_regtest
@@ -726,6 +726,36 @@ while [ $t -le ${ndirstorestrict} ]; do
  let t=t+1
 done
 
+echo "--------------------------- GIT ------------------------------------------"
+
+git_sha="<N/A>"
+
+if [[ -d "${dir_base}/${cp2k_dir}/.git" ]] ; then
+   head_ref=$(<"${dir_base}/${cp2k_dir}/.git/HEAD")
+
+   if [[ ${head_ref} =~ ^ref:\ (.*) ]] ; then
+      ref_file="${dir_base}/${cp2k_dir}/.git/${BASH_REMATCH[1]}"
+
+      if [[ -f "${ref_file}" ]] ; then
+         git_sha=$(<"${ref_file}")
+      fi
+   else
+      # this is a detached HEAD, no further deref needed
+      git_sha="${head_ref}"
+   fi
+fi
+
+echo "CommitSHA: ${git_sha}"
+
+# add some more information about that last commit if `git` is available
+if [[ "${git_sha}" != "<N/A>" ]] && command -v git >/dev/null 2>&1 ; then
+   GIT_WORK_TREE="${dir_base}/${cp2k_dir}" GIT_DIR="${dir_base}/${cp2k_dir}/.git" \
+      git \
+         log -n 1 \
+         --format="CommitTime: %ci%nCommitAuthor: %an%nCommitAuthorEmail: %ae%nCommitSubject: %s%n" \
+         "${git_sha}"
+fi
+
 echo "--------------------------- Preparations ---------------------------------"
 
 # make realclean

--- a/tools/regtesting/do_regtest
+++ b/tools/regtesting/do_regtest
@@ -151,6 +151,13 @@ while [ $# -ge 1 ]; do
   echo ""
   echo "For more information visit: <http://cp2k.org/dev:regtesting>"
   exit 0;;
+ -svndate|-svnrev)
+  shift;&
+ -nogit|-nosvn|-noemptycheck)
+  echo "WARNING: The following flags have been removed and will now be ignored:"
+  echo "         -nogit, -nosvn, -noemptycheck, -svndate, -svnrev"
+  echo "         This warning will soon be converted into an error, please remove them from your script invocation."
+  ;;
  # stop on invalid flag
  -*)
   echo "ERROR: Invalid command line flag $1 found"

--- a/tools/regtesting/do_regtest
+++ b/tools/regtesting/do_regtest
@@ -90,9 +90,6 @@ while [ $# -ge 1 ]; do
  # enable partial testing of only those directories that contain failed tests
  -retest)
   doretest="yes";;
- # Perform no git pull
- -nogit)
-  nogit="nogit";;
  # do not reset reference outputs
  -noreset)
   noreset="noreset";;
@@ -103,9 +100,6 @@ while [ $# -ge 1 ]; do
  -farming)
   farming="yes";;
  # do not check if code has changed
- -noemptycheck)
-  emptycheck="NO";;
- # do not build cp2k, turns on automatically quick option, so that do_regtest does not do realclean
  -nobuild)
   quick="quick"; nobuild="nobuild";;
  # do not test, actually.
@@ -124,10 +118,6 @@ while [ $# -ge 1 ]; do
   echo "  -dirout PATH              root path of output folder (default: current working directory)."
   echo "  -mpiexec EXE              name of the executable to run mpi-ranks. Default: mpiexec."
   echo ""
-  echo "Git:"
-  echo "  -nogit                    do not run git pull. Default: off."
-  echo "  -noemptycheck             run tests even when no changes in Git were made. Default: on."
-  echo ""
   echo "Build:"
   echo "  -version VERSION          VERSION passed to make. Default: sopt."
   echo "  -arch ARCH                ARCH passed to make. Default: Linux-x86-64-gfortran."
@@ -144,7 +134,7 @@ while [ $# -ge 1 ]; do
   echo ""
   echo "Testing:"
   echo "  -noreset                  do not reset the reference outputs. Default: off."
-  echo "  -skiptest                 do not run test, only Git update and build. Default: off."
+  echo "  -skiptest                 do not run test, only build. Default: off."
   echo "  -skipunittest             do not run unit tests. Default: off."
   echo "  -skipdir TESTDIR          do not run tests in TESTDIR. This switch can repeated."
   echo "  -restrictdir TESTDIR      run only tests in TESTDIR. This switch can repeated."
@@ -152,14 +142,12 @@ while [ $# -ge 1 ]; do
   echo ""
   echo "Exit codes:"
   echo "    0   clean exit with testing"
-  echo "    1   problem with Git update"
   echo "    3   problem with realclean"
   echo "    4   build errors"
   echo "    5   problem with retest option - no TEST directory with latest test results found"
   echo "    6   problem with retest option - no error summary exists in the last TEST directory"
   echo "    7   reference directory is locked"
   echo "    8   ctrl-C (SIGINT) and various other signals trapped"
-  echo "  100   no Git changes since last run - clean exit without testing"
   echo ""
   echo "For more information visit: <http://cp2k.org/dev:regtesting>"
   exit 0;;
@@ -183,10 +171,8 @@ done
 cp2k_version=${cp2k_version:-sopt}
 dir_out=${dir_out:-${dir_base}}
 dir_triplet=${dir_triplet:-Linux-x86-64-gfortran}
-emptycheck=${emptycheck:-"NO"}
 leakcheck=${leakcheck:-"NO"}
 doretest=${doretest:-"no"}
-nogit=${nogit:-"git"}
 nobuild=${nobuild:-"build"}
 cp2k_run_postfix=${cp2k_run_postfix:-""}
 make=${make:-make}
@@ -271,7 +257,6 @@ changelog_tests_new=${changelog_tests}.new
 changelog_tests_old=${changelog_tests}.old
 mkdir -p ${dir_out}
 mkdir -p ${dir_last}
-git_out=${dir_out}/git.out
 make_out=${dir_out}/make.out
 error_description_file=${dir_out}/error_summary
 >${error_description_file}
@@ -720,10 +705,8 @@ echo "cp2k_postfix     = ${cp2k_postfix}"
 echo "cp2k_version     = ${cp2k_version}"
 echo "dir_triplet      = ${dir_triplet}"
 echo "job_max_time     = ${job_max_time}"
-echo "emptycheck       = ${emptycheck}"
 echo "leakcheck        = ${leakcheck}"
 echo "doretest         = ${doretest}"
-echo "nogit            = ${nogit}"
 echo "nobuild          = ${nobuild}"
 echo "quick            = ${quick}"
 echo "noreset          = ${noreset}"
@@ -743,68 +726,7 @@ while [ $t -le ${ndirstorestrict} ]; do
  let t=t+1
 done
 
-echo "--------------------------- GIT ------------------------------------------"
-if git -C ${repo_dir} rev-parse &>/dev/null; then
-   if [[ ${nogit} != "nogit" ]]; then
-      sha1_old=$(git -C ${repo_dir} log -1 --pretty='%H')
-      git -C ${repo_dir} log --pretty="CommitSHA: %H%nCommitTime: %ci%nCommitAuthor: %an%nCommitAuthorEmail: %ae%nCommitSubject: %s%n#" >${changelog_old}
-      git -C ${repo_dir} pull &>${git_out}
-      if (( $? )); then
-         echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
-         cat ${git_out} >>${error_description_file}
-         echo "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" >>${error_description_file}
-         echo "ERROR: git -C ${repo_dir} pull failed ... bailing out" >>${error_description_file}
-         cat "${error_description_file}"
-         end_test 1 ${lockfile}
-      fi
-      sha1_new=$(git -C ${repo_dir} log -1 --pretty='%H')
-      git -C ${repo_dir} log --pretty="CommitSHA: %H%nCommitTime: %ci%nCommitAuthor: %an%nCommitAuthorEmail: %ae%nCommitSubject: %s%n#" >${changelog}
-      cat ${git_out}
-      echo "--------------------------- ChangeLog diff -------------------------------"
-      line1="$(head -n 1 ${changelog_old})"
-      nline=$(grep -n "${line1}" ${changelog} | head -n 1 | cut -f 1 -d:)
-      head -n $(( nline - 1 )) ${changelog} >${changelog_diff}
-      cat ${changelog_diff}
-      rm ${changelog_old}
-   else
-      echo "No git pull has been performed due to user request"
-   fi
-else
-   if [[ ${nogit} != "nogit" ]]; then
-      if git --version &>/dev/null; then
-         git_version=$(git --version | awk '{print $3}' | cut -d. -f1)
-         if (( git_version < 2 )); then
-            echo "$(git --version) is too old"
-            echo "No update of the git repository ${repo_dir} was performed"
-         else
-            echo "No git repository found in ${repo_dir}"
-         fi
-      else
-         echo "git is not installed"
-      fi
-   else
-      echo "No git pull has been performed due to user request"
-   fi
-fi
-
-
 echo "--------------------------- Preparations ---------------------------------"
-
-# Check if there is any update or difference that thus requires a rerun
-# one day, this requires improvement for speed.
-if [[ ${emptycheck} == "YES" ]]; then
-   isempty=`nl ${changelog_diff} | awk '{print $1}'`
-
-   if [[ ${isempty} == "1" ]]; then
-      echo "No changes since last run -- clean exit without testing"
-
-      # cleanup of empty directories
-      rm -rf ${dir_out}
-      end_test 100 ${lockfile}
-   else
-      echo "Code has changed since last run -- continue regtest"
-   fi
-fi
 
 # make realclean
 if [[ ${quick} != "quick" ]]; then
@@ -861,7 +783,7 @@ if [[ ${skiptest} != "skiptest" ]]; then
    
    ###################################################################################
    #
-   # parse the TEST_TYPES file to do different kinds of test (done after Git update)
+   # parse the TEST_TYPES file to do different kinds of test
    #
    # tests grep for the last line in the file where a string matches (test_grep)
    # and compares a numeric field at a given column (test_col)

--- a/tools/regtesting/do_regtest
+++ b/tools/regtesting/do_regtest
@@ -899,7 +899,7 @@ fi
 # from here failures are likely to be bugs in cp2k
 if [[ ${nobuild} != "nobuild" ]]; then
    echo "--------------------------- ARCH-file ------------------------------------"
-   cat ${dir_base}/${cp2k_dir}/arch/${ARCH}.${cp2k_version}
+   cat "${arch_dir:-${dir_base}/${cp2k_dir}/arch}/${ARCH}.${cp2k_version}"
    echo "-------------------------- Build-Tools -----------------------------------"
    cd ${dir_base}/${cp2k_dir}
    ${make} toolversions ${ARCH_SPEC} VERSION=${cp2k_version}


### PR DESCRIPTION
forgot one line where the `do_regtest` directly references the arch file