### PR TITLE
S-ALMO valgrind bug fix

### DIFF
--- a/src/almo_scf.F
+++ b/src/almo_scf.F
@@ -510,7 +510,7 @@ CONTAINS
                                                             nspins, unit_nr
       INTEGER, DIMENSION(2)                              :: nelectron_spin
       LOGICAL                                            :: aspc_guess, has_unit_metric
-      REAL(KIND=dp)                                      :: alpha, cs_pos, energy
+      REAL(KIND=dp)                                      :: alpha, cs_pos, kTS_sum, energy
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -715,6 +715,12 @@ CONTAINS
          END IF
       ENDIF
 
+      IF (almo_scf_env%smear) THEN
+         kTS_sum = SUM(almo_scf_env%kTS)
+      ELSE
+         kTS_sum = 0.0_dp
+      ENDIF
+
       CALL almo_dm_to_almo_ks(qs_env, &
                               almo_scf_env%matrix_p, &
                               almo_scf_env%matrix_ks, &
@@ -722,7 +728,7 @@ CONTAINS
                               almo_scf_env%eps_filter, &
                               almo_scf_env%mat_distr_aos, &
                               smear=almo_scf_env%smear, &
-                              kTS=almo_scf_env%kTS)
+                              kTS_sum=kTS_sum)
 
       IF (unit_nr > 0) THEN
          IF (almo_scf_env%almo_scf_guess .EQ. molecular_guess) THEN

--- a/src/almo_scf.F
+++ b/src/almo_scf.F
@@ -510,7 +510,7 @@ CONTAINS
                                                             nspins, unit_nr
       INTEGER, DIMENSION(2)                              :: nelectron_spin
       LOGICAL                                            :: aspc_guess, has_unit_metric
-      REAL(KIND=dp)                                      :: alpha, cs_pos, kTS_sum, energy
+      REAL(KIND=dp)                                      :: alpha, cs_pos, energy, kTS_sum
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env

--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -442,9 +442,8 @@ CONTAINS
 
       INTEGER                                            :: handle, iscf, ispin, nspin, unit_nr
       LOGICAL                                            :: converged, prepare_to_exit, should_stop
-      REAL(KIND=dp)                                      :: denergy_tot, density_rec, energy_diff, &
-                                                            energy_new, energy_old, error_norm, &
-                                                            error_norm_0, kTS_sum, spin_factor, t1, t2
+      REAL(KIND=dp) :: denergy_tot, density_rec, energy_diff, energy_new, energy_old, error_norm, &
+         error_norm_0, kTS_sum, spin_factor, t1, t2
       REAL(KIND=dp), DIMENSION(2)                        :: denergy_spin
       TYPE(almo_scf_diis_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: almo_diis

--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -126,7 +126,7 @@ CONTAINS
       LOGICAL                                            :: converged, prepare_to_exit, should_stop, &
                                                             use_diis, use_prev_as_guess
       REAL(KIND=dp) :: density_rec, energy_diff, energy_new, energy_old, error_norm, &
-         error_norm_ispin, prev_error_norm, t1, t2, true_mixing_fraction
+         error_norm_ispin, kTS_sum, prev_error_norm, t1, t2, true_mixing_fraction
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: local_mu
       TYPE(almo_scf_diis_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: almo_diis
@@ -357,6 +357,12 @@ CONTAINS
                END IF
             ENDIF
 
+            IF (almo_scf_env%smear) THEN
+               kTS_sum = SUM(almo_scf_env%kTS)
+            ELSE
+               kTS_sum = 0.0_dp
+            ENDIF
+
             ! compute the new KS matrix and new energy
             CALL almo_dm_to_almo_ks(qs_env, &
                                     almo_scf_env%matrix_p, &
@@ -365,7 +371,7 @@ CONTAINS
                                     almo_scf_env%eps_filter, &
                                     almo_scf_env%mat_distr_aos, &
                                     smear=almo_scf_env%smear, &
-                                    kTS=almo_scf_env%kTS)
+                                    kTS_sum=kTS_sum)
 
          ENDIF ! prepare_to_exit
 
@@ -438,7 +444,7 @@ CONTAINS
       LOGICAL                                            :: converged, prepare_to_exit, should_stop
       REAL(KIND=dp)                                      :: denergy_tot, density_rec, energy_diff, &
                                                             energy_new, energy_old, error_norm, &
-                                                            error_norm_0, spin_factor, t1, t2
+                                                            error_norm_0, kTS_sum, spin_factor, t1, t2
       REAL(KIND=dp), DIMENSION(2)                        :: denergy_spin
       TYPE(almo_scf_diis_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: almo_diis
@@ -754,6 +760,13 @@ CONTAINS
 
             ! compute the new KS matrix and new energy
             IF (.NOT. almo_scf_env%perturbative_delocalization) THEN
+
+               IF (almo_scf_env%smear) THEN
+                  kTS_sum = SUM(almo_scf_env%kTS)
+               ELSE
+                  kTS_sum = 0.0_dp
+               ENDIF
+
                CALL almo_dm_to_almo_ks(qs_env, &
                                        almo_scf_env%matrix_p, &
                                        almo_scf_env%matrix_ks, &
@@ -761,7 +774,7 @@ CONTAINS
                                        almo_scf_env%eps_filter, &
                                        almo_scf_env%mat_distr_aos, &
                                        smear=almo_scf_env%smear, &
-                                       kTS=almo_scf_env%kTS)
+                                       kTS_sum=kTS_sum)
             ENDIF
 
          ENDIF ! prepare_to_exit

--- a/src/almo_scf_qs.F
+++ b/src/almo_scf_qs.F
@@ -771,28 +771,28 @@ CONTAINS
 !> \param eps_filter ...
 !> \param mat_distr_aos ...
 !> \param smear ...
-!> \param kTS ...
+!> \param kTS_sum ...
 !> \par History
 !>       2011.05 created [Rustam Z Khaliullin]
 !>       2018.09 smearing support [Ruben Staub]
 !> \author Rustam Z Khaliullin
 ! **************************************************************************************************
    SUBROUTINE almo_dm_to_almo_ks(qs_env, matrix_p, matrix_ks, energy_total, eps_filter, &
-                                 mat_distr_aos, smear, kTS)
+                                 mat_distr_aos, smear, kTS_sum)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_type), DIMENSION(:)                     :: matrix_p, matrix_ks
       REAL(KIND=dp)                                      :: energy_total, eps_filter
       INTEGER, INTENT(IN)                                :: mat_distr_aos
       LOGICAL, INTENT(IN), OPTIONAL                      :: smear
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: kTS
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: kTS_sum
 
       CHARACTER(len=*), PARAMETER :: routineN = 'almo_dm_to_almo_ks', &
          routineP = moduleN//':'//routineN
 
       INTEGER                                            :: handle, ispin, nspins
       LOGICAL                                            :: smearing
-      REAL(KIND=dp)                                      :: kTS_sum
+      REAL(KIND=dp)                                      :: entropic_term
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_qs_ks
 
       CALL timeset(routineN, handle)
@@ -803,16 +803,16 @@ CONTAINS
          smearing = .FALSE.
       ENDIF
 
-      IF (PRESENT(kTS) .AND. smearing) THEN
-         kTS_sum = SUM(kTS)
+      IF (PRESENT(kTS_sum)) THEN
+         entropic_term = kTS_sum
       ELSE
-         kTS_sum = 0.0_dp
+         entropic_term = 0.0_dp
       ENDIF
 
       ! update KS matrix in the QS env
       CALL almo_dm_to_qs_ks(qs_env, matrix_p, energy_total, mat_distr_aos, &
                             smear=smearing, &
-                            kTS_sum=kTS_sum)
+                            kTS_sum=entropic_term)
 
       nspins = SIZE(matrix_ks)
 


### PR DESCRIPTION
Fermi-Dirac smearing within the ALMO formalism, allowing an ALMO description of metals.
(contains also a quick fix for molecular guess with the diagonalisation algorithm, within ALMO)
(should be compatible with old compilers and valgrind, with an even more robust fix proposed by @oschuett)