### PR TITLE
Fix toolchain scripts

### DIFF
--- a/tools/toolchain/scripts/install_openblas.sh
+++ b/tools/toolchain/scripts/install_openblas.sh
@@ -64,7 +64,7 @@ case "$with_openblas" in
                  install > install.serial.log 2>&1
             if [ $ENABLE_OMP = "__TRUE__" ] ; then
                make clean > clean.log 2>&1
-               make -j $nprocs \
+               make -j $NPROCS \
                     USE_THREAD=1 \
                     USE_OPENMP=1 \
                     LIBNAMESUFFIX=omp \
@@ -72,7 +72,7 @@ case "$with_openblas" in
                     FC=$(basename $FC) \
                     PREFIX="${pkg_install_dir}" \
                     > make.omp.log 2>&1
-               make -j $nprocs \
+               make -j $NPROCS \
                     USE_THREAD=1 \
                     USE_OPENMP=1 \
                     LIBNAMESUFFIX=omp \

--- a/tools/toolchain/scripts/install_openmpi.sh
+++ b/tools/toolchain/scripts/install_openmpi.sh
@@ -45,7 +45,7 @@ case "$with_openmpi" in
                [ $glibc_major_ver -eq 2 -a $glibc_minor_ver -lt 12 ] ; then
                 CFLAGS="${CFLAGS} -fgnu89-inline"
             fi
-            ./configure --prefix=${pkg_install_dir} --libdir="${pkg_install_dir}/lib" CFLAGS="${CFLAGS}" > configure.log 2>&1
+            ./configure --enable-mpi-cxx --prefix=${pkg_install_dir} --libdir="${pkg_install_dir}/lib" CFLAGS="${CFLAGS}" > configure.log 2>&1
             make -j $NPROCS > make.log 2>&1
             make -j $NPROCS install > install.log 2>&1
             cd ..


### PR DESCRIPTION
* replace $nprocs with $NPROCS in install_openblas.sh;
* enable C++ MPI binding in install_openmpi.sh.

C++ binding is only needed to compile CP2K with PLUMED. However linking flags "-lmpi_cxx -lstdc++" appear in generated local arch files even if we do not use PLUMED at all.