### PR TITLE
Allow CPASSERT to be elided if NDEBUG is defined. Introduced CP_VERSIONx.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ GNU make should be on your system (gmake or make on linux) and used for the buil
 Python 2.x is needed to run the dependency generator. On most system Python is already installed. For more information visit: https://www.python.org/
 
 ### 2c. Fortran and C Compiler (required, build system)
-A Fortran 2003 compiler and matching C compiler should be installed on your system. We have good experience with gcc/gfortran (gcc >=4.6 works, later version recommended). Be aware that some compilers have bugs that might cause them to fail (internal compiler errors, segfaults) or, worse, yield a mis-compiled CP2K. Report bugs to compiler vendors; they (and we) have an interest in fixing them. Always run a `make -j test` (See point 5.) after compilation to identifiy these problems.
+A Fortran 2003 compiler and matching C compiler should be installed on your system. We have good experience with gcc/gfortran (gcc >=4.6 works, later version recommended). Be aware that some compilers have bugs that might cause them to fail (internal compiler errors, segfaults) or, worse, yield a mis-compiled CP2K. Report bugs to compiler vendors; they (and we) have an interest in fixing them. Always run a `make -j test` (See point 5.) after compilation to identify these problems.
 
 ### 2d. BLAS and LAPACK (required, base functionality)
 BLAS and LAPACK should be installed.  Using vendor-provided libraries can make a very significant difference (up to 100%, e.g., ACML, MKL, ESSL), not all optimized libraries are bug free. Use the latest versions available, use the interfaces matching your compiler, and download all patches!
@@ -69,14 +69,13 @@ Hartree-Fock exchange (optional, use `-D__LIBINT`) requires the libint package t
   * :warning: Do **NOT** use libinit-1.1.3, which was buggy.
 
 ### 2h. libsmm (optional, improved performance for matrix multiplication)
-  * A library for small matrix multiplies can be built from the included source (see tools/build_libsmm/README).  Usually only the double precision real and perhaps complex is needed.  Link to the generated libraries. For a couple of architectures prebuild libsmm are available at https://www.cp2k.org/static/downloads/libsmm/.
+  * A library for small matrix multiplies can be built from the included source (see tools/build_libsmm/README).  Usually only the double precision real and perhaps complex is needed.  Link to the generated libraries. For a couple of architectures prebuilt libsmm are available at https://www.cp2k.org/static/downloads/libsmm/.
   * Add `-D__HAS_smm_dnn` to the defines to make the code use the double precision real library.  Similarly use `-D__HAS_smm_snn` for single precision real and `-D__HAS_smm_znn` / `-D__HAS_smm_cnn` for double / single precision complex.
   * Add `-D__HAS_smm_vec` to enable the new vectorized interfaces of libsmm.
 
 ### 2i. libxsmm (optional, improved performance for matrix multiplication)
-  * A library for small matrix multiplications which is provided by Intel: https://github.com/hfp/libxsmm/
+  * A library for matrix operations and deep learning primitives: https://github.com/hfp/libxsmm/
   * Add `-D__LIBXSMM` to enable it (with suitable include and library paths)
-  * Tested with the released version 1.1.
 
 ### 2j. CUDA (optional, improved performance on GPU systems)
   * `-D__ACC` needed to enable accelerator support.
@@ -160,6 +159,8 @@ SIRIUS is a domain specific library for electronic structure calculations.
 
 ### 3a. ARCH files
 The location of compiler and libraries needs to be specified. Examples for a number of common architectures examples can be found in [arch folder](./arch/). The names of these files match `architecture.version` e.g., [Linux-x86-64-gfortran.sopt](./arch/Linux-x86-64-gfortran.sopt). Alternatively https://dashboard.cp2k.org/ provides sample arch files as part of the testing reports (click on the status field, search for 'ARCH-file').
+  * With -DNDEBUG assertions may be stripped ("compiled out").
+  * Regular release builds may carry assertions for safety.
 
 Conventionally, there are six versions:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,6 +160,7 @@ SIRIUS is a domain specific library for electronic structure calculations.
 ### 3a. ARCH files
 The location of compiler and libraries needs to be specified. Examples for a number of common architectures examples can be found in [arch folder](./arch/). The names of these files match `architecture.version` e.g., [Linux-x86-64-gfortran.sopt](./arch/Linux-x86-64-gfortran.sopt). Alternatively https://dashboard.cp2k.org/ provides sample arch files as part of the testing reports (click on the status field, search for 'ARCH-file').
   * With -DNDEBUG assertions may be stripped ("compiled out").
+  * NDEBUG is the ANSI-conforming symbol name (not __NDEBUG).
   * Regular release builds may carry assertions for safety.
 
 Conventionally, there are six versions:

--- a/src/base/base_uses.f90
+++ b/src/base/base_uses.f90
@@ -19,7 +19,13 @@
 #define __LOCATION__ cp__l(__SHORT_FILE__,__LINE__)
 #define CPWARN(msg) CALL cp__w(__SHORT_FILE__,__LINE__,msg)
 #define CPABORT(msg) CALL cp__b(__SHORT_FILE__,__LINE__,msg)
-#define CPASSERT(cond) IF(.NOT.(cond))CALL cp__a(__SHORT_FILE__,__LINE__)
+
+! CPASSERT can be elided if NDEBUG is defined.
+#if defined(NDEBUG)
+# define CPASSERT(cond)
+#else
+# define CPASSERT(cond) IF(.NOT.(cond))CALL cp__a(__SHORT_FILE__,__LINE__)
+#endif
 
 ! The MARK_USED macro can be used to mark an argument/variable as used.
 ! It is intended to make it possible to switch on -Werror=unused-dummy-argument,
@@ -27,3 +33,8 @@
 ! This code should be valid for any Fortran variable, is always standard conforming,
 ! and will be optimized away completely by the compiler
 #define MARK_USED(foo) IF(.FALSE.)THEN; DO ; IF(SIZE(SHAPE(foo))==-1) EXIT ;  END DO ; ENDIF
+
+! Calculate version number from 3-components.
+#define CP_VERSION3(MAJOR, MINOR, UPDATE) ((MAJOR) * 10000 + (MINOR) * 100 + (UPDATE))
+! Calculate version number from 4-components.
+#define CP_VERSION4(MAJOR, MINOR, UPDATE, PATCH) ((MAJOR) * 100000000 + (MINOR) * 1000000 + (UPDATE) * 10000 + (PATCH))

--- a/src/base/base_uses.f90
+++ b/src/base/base_uses.f90
@@ -35,6 +35,4 @@
 #define MARK_USED(foo) IF(.FALSE.)THEN; DO ; IF(SIZE(SHAPE(foo))==-1) EXIT ;  END DO ; ENDIF
 
 ! Calculate version number from 3-components.
-#define CP_VERSION3(MAJOR, MINOR, UPDATE) ((MAJOR) * 10000 + (MINOR) * 100 + (UPDATE))
-! Calculate version number from 4-components.
-#define CP_VERSION4(MAJOR, MINOR, UPDATE, PATCH) ((MAJOR) * 100000000 + (MINOR) * 1000000 + (UPDATE) * 10000 + (PATCH))
+#define CPVERSION(MAJOR, MINOR, UPDATE) ((MAJOR) * 10000 + (MINOR) * 100 + (UPDATE))

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -94,8 +94,10 @@ CONTAINS
       tmp_str = ""
       flags = TRIM(flags)//TRIM(tmp_str)
 
+#if defined(__NDEBUG)
+      flags = TRIM(flags)//" ndebug"
+#endif
 !$    flags = TRIM(flags)//" omp"
-
 #if defined(__LIBINT)
       flags = TRIM(flags)//" libint"
 #endif

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -94,7 +94,7 @@ CONTAINS
       tmp_str = ""
       flags = TRIM(flags)//TRIM(tmp_str)
 
-#if defined(__NDEBUG)
+#if defined(NDEBUG)
       flags = TRIM(flags)//" ndebug"
 #endif
 !$    flags = TRIM(flags)//" omp"

--- a/tools/toolchain/scripts/install_spglib.sh
+++ b/tools/toolchain/scripts/install_spglib.sh
@@ -16,6 +16,11 @@ cd "${BUILDDIR}"
 case "$with_spglib" in
     __INSTALL__)
         echo "==================== Installing spglib ===================="
+        echo "                                                           "
+        echo " note that this package depends on cmake to be activated.  "
+        echo "                                                           "
+        echo "==========================================================="
+
         pkg_install_dir="${INSTALLDIR}/spglib-${spglib_ver}"
         install_lock_file="$pkg_install_dir/install_successful"
         if [ -f "${install_lock_file}" ] ; then
@@ -81,11 +86,11 @@ export CP_LDFLAGS="\${CP_LDFLAGS} ${SPGLIB_LDFLAGS}"
 ###################################################################
 #
 # NB : spglib is only used and compiled when sirius is activated.
-# So right now I only include the library when I detect MPI and OMP
+#      Right now the library is only included if MPI is detected.
 #
 ###################################################################
 
-export CP_LIBS="IF_MPI(IF_OMP(${SPGLIB_LIBS}|)|) \${CP_LIBS}"
+export CP_LIBS="IF_MPI(${SPGLIB_LIBS}|) \${CP_LIBS}"
 EOF
         cat "${BUILDDIR}/setup_spglib" >> $SETUPFILE
 fi

--- a/tools/toolchain/scripts/install_spglib.sh
+++ b/tools/toolchain/scripts/install_spglib.sh
@@ -90,7 +90,7 @@ export CP_LDFLAGS="\${CP_LDFLAGS} ${SPGLIB_LDFLAGS}"
 #
 ###################################################################
 
-export CP_LIBS="IF_MPI(${SPGLIB_LIBS}|) \${CP_LIBS}"
+export CP_LIBS="${SPGLIB_LIBS} \${CP_LIBS}"
 EOF
         cat "${BUILDDIR}/setup_spglib" >> $SETUPFILE
 fi


### PR DESCRIPTION
Allow CPASSERT to be elided if NDEBUG is defined. Introduced CP_VERSION3 and CP_VERSION4 to consistently calculate a single (version-)number such that it can be compared using the preprocessor e.g., #if CP_VERSION3(1, 2, 3) <= CP_VERSION3(MYLIB_MAJOR, MYLIB_MINOR, MYLIB_UPDATE).

This change may allow to setup a test with NDEBUG defined aka "release build" (not meant to spawn a discussion of whether or not an actual production-build should contain assertions). Anyhow, a test with NDEBUG can unveil potential side-effects or misuses of CPASSERT. The current status (to my knowledge) is that regression tests fail to a large portion if CPASSERT is elided.

**Note**: `make pretty` appears to fail parsing this change.