### PR TITLE
Allow to use MKL's FFTW3 interface when using GNU Fortran

### DIFF
--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -99,7 +99,7 @@ SUBROUTINE fftw3_do_init(wisdom_file)
 !$    BIND (c) :: /fftw3_mkl/
 !DEC$ ENDIF
 !DEC$ ENDIF
-#else defined (__MKL) && defined (__FFTW3)
+#elif defined (__MKL) && defined (__FFTW3)
 ! Preprocessing is enabled by default, and below header is not language specific
 #include <mkl_version.h>
 #endif

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -99,6 +99,9 @@ SUBROUTINE fftw3_do_init(wisdom_file)
 !$    BIND (c) :: /fftw3_mkl/
 !DEC$ ENDIF
 !DEC$ ENDIF
+#else defined (__MKL) && defined (__FFTW3)
+! Preprocessing is enabled by default, and below header is not language specific
+# include <mkl_version.h>
 #endif
 
     ! Read FFTW wisdom (if available)
@@ -122,9 +125,11 @@ SUBROUTINE fftw3_do_init(wisdom_file)
 ! If we are not using the Intel compiler, there is no way to tell which
 ! MKL version is in use, so fail safe...
 !$     mkl_is_safe = .FALSE.
+#if defined (__MKL) && defined (__FFTW3) && defined(INTEL_MKL_VERSION) && (110100 < INTEL_MKL_VERSION)
+!$     mkl_is_safe = .TRUE.
+#elif defined (__INTEL_COMPILER) && defined (__MKL) && defined (__FFTW3)
 ! If we have an Intel compiler (__INTEL_COMPILER is defined) then check the
 ! MKL version and make the appropriate action
-#if defined (__INTEL_COMPILER) && defined (__MKL) && defined (__FFTW3)
 !DEC$ IF DEFINED (INTEL_MKL_VERSION)
 !DEC$ IF INTEL_MKL_VERSION .EQ. 110100
 !$     mkl_dft_number_of_user_threads=omp_get_max_threads() 

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -101,7 +101,7 @@ SUBROUTINE fftw3_do_init(wisdom_file)
 !DEC$ ENDIF
 #else defined (__MKL) && defined (__FFTW3)
 ! Preprocessing is enabled by default, and below header is not language specific
-# include <mkl_version.h>
+#include <mkl_version.h>
 #endif
 
     ! Read FFTW wisdom (if available)

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -4,6 +4,8 @@ Data file MM_POTENTIAL copied to tests/QMMM/QS
 Data file POTENTIAL copied to tests/QMMM/QS
 Flag FD_DEBUG not mentioned in INSTALL.md
 Flag FD_DEBUG not mentioned in cp2k_flags()
+Flag INTEL_MKL_VERSION not mentioned in INSTALL.md
+Flag INTEL_MKL_VERSION not mentioned in cp2k_flags()
 Flag LIBMICSMM_USE_LIBXSMM not mentioned in INSTALL.md
 Flag LIBMICSMM_USE_LIBXSMM not mentioned in cp2k_flags()
 Flag LIBMICSMM_USE_MKLSMM not mentioned in INSTALL.md

--- a/tools/toolchain/scripts/install_mkl.sh
+++ b/tools/toolchain/scripts/install_mkl.sh
@@ -96,7 +96,7 @@ if [ "$with_mkl" != "__DONTUSE__" ] ; then
         enable_mkl_scalapack="__FALSE__"
     fi
     MKL_LIBS="${MKL_LIBS} -Wl,--end-group -lpthread -lm -ldl"
-    MKL_CFLAGS="${MKL_CFLAGS} -I${MKLROOT}/include"
+    MKL_CFLAGS="${MKL_CFLAGS} -I${MKLROOT}/include -I${MKLROOT}/include/fftw"
 
     # write setup files
     cat <<EOF > "${BUILDDIR}/setup_mkl"


### PR DESCRIPTION
Allow to use MKL's FFTW3 interface when using GNU Fortran (or any compiler without DEC-extensions). Please note, the previous version-check (for sufficient MKL) relies on DEC-extensions (which are supported by IFORT). As a side-note, checking for MKL 11.x may outdated ("obsolescent"). In any case, this change enables FFTW3 served by Intel MKL (no need to build FFTW anymore if MKL is used).