### PR TITLE
Debugging cp_dbcsr_diag.F

### DIFF
--- a/src/cp_dbcsr_diag.F
+++ b/src/cp_dbcsr_diag.F
@@ -149,6 +149,8 @@ CONTAINS
                                ncol_global=n, para_env=para_env)
       CALL cp_fm_create(fm_matrix, fm_struct, name="fm_matrix")
 
+      CALL copy_dbcsr_to_fm(matrix, fm_matrix)
+
       IF (PRESENT(eigenvectors)) THEN
          CALL cp_fm_create(fm_eigenvectors, fm_struct, name="fm_eigenvectors")
          CALL cp_fm_syevx(fm_matrix, fm_eigenvectors, eigenvalues, neig, work_syevx)


### PR DESCRIPTION
There is an error in cp_dbcsr_diag.F that is solved with this pull request. The function shall calculate the eigenvalues and eigenvectors of a dbcsr matrix using an fm_matrix intermediate. Unfortunately, it has been forgotten to actually copy the dbcsr matrix in the fm_matrix resulting in eigenvalues being all zero.