### PR TITLE
Bugs related to SIRIUS interface

### DIFF
--- a/src/sirius_interface.F
+++ b/src/sirius_interface.F
@@ -82,7 +82,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_sirius_init', routineP = moduleN//':'//routineN
 
-      CALL sirius_initialize(bool(.TRUE.))
+      CALL sirius_initialize(bool(.FALSE.))
 
    END SUBROUTINE cp_sirius_init
 #else

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -266,6 +266,7 @@ CONTAINS
          CALL cp_sirius_finalize()
          CALL pw_cuda_finalize()
          CALL farming_run(input_declaration, root_section, para_env)
+         CALL cp_sirius_init()
          CALL dbcsr_init_lib()
          CALL pw_cuda_init()
       CASE (do_opt_basis)

--- a/tests/TEST_TYPES
+++ b/tests/TEST_TYPES
@@ -1,4 +1,4 @@
-84
+85
 Total energy:!3
 POTENTIAL ENERGY!4
 Total energy \[eV\]:!4

--- a/tests/sirius/regtest-1/TEST_FILES
+++ b/tests/sirius/regtest-1/TEST_FILES
@@ -10,5 +10,5 @@
 #   with the standard move types, check i
 # fully test non colinear magnetism with spin orbit coupling
 Au.inp                                      85    1.0E-5           -147.171051899887289
-Fe.inp                                      85    1.0E-5            -253.181250028399461
+Fe.inp                                      85    1.0E-5            -253.18124883
 #EOF

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -299,11 +299,11 @@ with_openblas=__INSTALL__
 with_reflapack=__INSTALL__
 
 # sirius is not activated by default.
-with_sirius="__DONTUSE__"
-with_gsl="__DONTUSE__"
-with_spglib="__DONTUSE__"
-with_hdf5="__DONTUSE__"
-with_json_fortran="__DONTUSE__"
+with_sirius="__INSTALL__"
+with_gsl="__INSTALL__"
+with_spglib="__INSTALL__"
+with_hdf5="__INSTALL__"
+with_json_fortran="__INSTALL__"
 
 # for MPI, we try to detect system MPI variant
 with_openmpi=__SYSTEM__
@@ -631,6 +631,10 @@ if [ $MPI_MODE = no ] ; then
         echo "Not using MPI, so PEXSI is disabled."
         with_pexsi="__DONTUSE__"
     fi
+    if [ "$with_sirius" != "__DONTUSE__" ] ; then
+        echo "Not using MPI, so sirius is disabled"
+        with_sirius="__DONTUSE__"
+    fi
 else
     # if gcc is installed, then mpi needs to be installed too
     if [ "$with_gcc" = "__INSTALL__" ] ; then
@@ -718,7 +722,7 @@ if [ "$with_sirius" = "__INSTALL__" ] ; then
         exit 1
     fi
     if [ "$with_json_fortran" = "__DONTUSE__"  ] ; then
-        report_error "For SIRIUS intergration tro cp2k to work you need a working json-fortran library use --with-json option to specify if you wish to install it or specify its location."
+        report_error "For SIRIUS to work you need a working json-fortran library use --with-json option to specify if you wish to install it or specify its location."
     exit 1
     fi
 fi


### PR DESCRIPTION
this pull request fixes a few bugs encountered during the farming and mpi tests. This pull request fixes the following items
- Fix a double initialization of mpi
- Fix a crash of cp2k when the farming tests are done. The crash was due to the fact that sirius was not reinitialized after going out the farming tests
- Activate Sirius by default. 
