### PR TITLE
Include new Intel regtests on Swan

### DIFF
--- a/exts/README.md
+++ b/exts/README.md
@@ -1,2 +1,3 @@
-This directory is read-only in SVN and it is automatically updated. Please refer to the external repositories for any changes:
+This directory provides access to external libraries via GIT submodules. 
+Please refer to the external repositories for any changes:
 DBCSR: https://github.com/cp2k/dbcsr

--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -322,8 +322,30 @@ host:        Cray, Swan
 report_type: regtest
 report_url:  http://www.cp2k.org/static/regtest/trunk/swan-skl28/CRAY-XC40-intel.psmp_17.0.4.196.out
 
+[intel1704-mkl-psmp]
+sortkey:     715
+name:        Linux-x86-64-intel.psmp, v17.0.4.196
+host:        Cray, Swan
+report_type: regtest
+report_url:  http://www.cp2k.org/static/regtest/trunk/swan-skl28/CRAY-XC40-intel-mkl.psmp_17.0.4.196.out
+
+[intel1803-ssmp]
+sortkey:     720
+name:        Linux-x86-64-intel.ssmp, v18.0.3.222
+host:        Cray, Swan
+report_type: regtest
+report_url:  http://www.cp2k.org/static/regtest/trunk/swan-skl28/CRAY-XC40-intel-mkl.ssmp_18.0.3.222.out
+
+[intel1803-popt]
+sortkey:     721
+name:        Linux-x86-64-intel.popt, v18.0.3.222
+host:        Cray, Swan
+report_type: regtest
+report_url:  http://www.cp2k.org/static/regtest/trunk/swan-skl28/CRAY-XC40-intel-mkl.popt_18.0.3.222.out
+
+
 [intel1803-psmp]
-sortkey:     712
+sortkey:     722
 name:        Linux-x86-64-intel.psmp, v18.0.3.222
 host:        Cray, Swan
 report_type: regtest


### PR DESCRIPTION
Extended the regtests to include Intel 18.0.3 for popt and ssmp