### PR TITLE
[WIP] Conventions: Remove INTENT(OUT) dummy args

### DIFF
--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -4293,7 +4293,7 @@ CONTAINS
    SUBROUTINE opt_k_apply_preconditioner_blk(almo_scf_env, step, grad, ispin)
 
       TYPE(almo_scf_env_type), INTENT(INOUT)             :: almo_scf_env
-      TYPE(dbcsr_type), INTENT(OUT)                      :: step
+      TYPE(dbcsr_type)                                   :: step
       TYPE(dbcsr_type), INTENT(IN)                       :: grad
       INTEGER, INTENT(IN)                                :: ispin
 

--- a/src/aobasis/ai_angmom.F
+++ b/src/aobasis/ai_angmom.F
@@ -53,7 +53,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: la_min, lb_max, npgfb
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: zetb, rpgfb
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rac, rbc
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: angab
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: angab
 
       INTEGER                                            :: ax, ay, az, bx, by, bz, i, ipgf, j, &
                                                             jpgf, la, la_start, lb, na, nb

--- a/src/aobasis/ai_coulomb.F
+++ b/src/aobasis/ai_coulomb.F
@@ -810,7 +810,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rac
       REAL(KIND=dp), INTENT(IN)                          :: rac2, rbc2
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: vabc
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: int_abc
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: int_abc
       REAL(KIND=dp), DIMENSION(:, :, :, :)               :: v
       REAL(KIND=dp), DIMENSION(0:)                       :: f
       INTEGER, INTENT(IN), OPTIONAL                      :: maxder

--- a/src/aobasis/ai_derivatives.F
+++ b/src/aobasis/ai_derivatives.F
@@ -84,7 +84,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: lb_min
       REAL(KIND=dp), INTENT(IN)                          :: dab
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ab
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: dabdx, dabdy, dabdz
+      REAL(KIND=dp), DIMENSION(:, :)                     :: dabdx, dabdy, dabdz
 
       INTEGER                                            :: ax, ay, az, bx, by, bz, coa, coamx, &
                                                             coamy, coamz, coapx, coapy, coapz, &
@@ -233,7 +233,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: lb_min
       REAL(KIND=dp), INTENT(IN)                          :: dab
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ab
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: adbdx, adbdy, adbdz
+      REAL(KIND=dp), DIMENSION(:, :)                     :: adbdx, adbdy, adbdz
 
       INTEGER                                            :: ax, ay, az, bx, by, bz, coa, cob, cobmx, &
                                                             cobmy, cobmz, cobpx, cobpy, cobpz, &
@@ -365,7 +365,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: zeta
       INTEGER, INTENT(IN)                                :: lb_max, npgfb
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ab
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: dabdx, dabdy, dabdz
+      REAL(KIND=dp), DIMENSION(:, :)                     :: dabdx, dabdy, dabdz
 
       INTEGER                                            :: ax, ay, az, bx, by, bz, coa, coamx, &
                                                             coamy, coamz, coapx, coapy, coapz, &

--- a/src/aobasis/ai_moments.F
+++ b/src/aobasis/ai_moments.F
@@ -1337,7 +1337,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: zetb, rpgfb
       INTEGER, INTENT(IN)                                :: lb_min
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rab
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: difab
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: difab
 
       INTEGER                                            :: lda_min, ldb_min, lds, lmax
       REAL(KIND=dp)                                      :: dab, rab2
@@ -1402,7 +1402,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: zetb, rpgfb
       INTEGER, INTENT(IN)                                :: lb_min, order
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rac, rbc
-      REAL(KIND=dp), DIMENSION(:, :, :, :), INTENT(OUT)  :: difmab
+      REAL(KIND=dp), DIMENSION(:, :, :, :)               :: difmab
       REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
          POINTER                                         :: mab_ext
 

--- a/src/aobasis/ai_onecenter.F
+++ b/src/aobasis/ai_onecenter.F
@@ -61,7 +61,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_overlap(smat, l, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: smat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: smat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa, pb
 
@@ -100,7 +100,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_kinetic(kmat, l, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: kmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: kmat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa, pb
 
@@ -137,7 +137,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_nuclear(umat, l, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: umat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: umat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa, pb
 
@@ -174,7 +174,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_kinnuc(umat, l, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: umat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: umat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa, pb
 
@@ -235,7 +235,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_erf(upmat, l, a, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: upmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: upmat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), INTENT(IN)                          :: a
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa, pb
@@ -343,7 +343,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_proj_ol(spmat, l, p, k, rc)
 
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: spmat
+      REAL(KIND=dp), DIMENSION(:)                        :: spmat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: p
       INTEGER, INTENT(IN)                                :: k
@@ -381,7 +381,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_gpot(vpmat, k, rc, l, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: vpmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: vpmat
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), INTENT(IN)                          :: rc
       INTEGER, INTENT(IN)                                :: l
@@ -424,7 +424,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_conf(gmat, rc, k, l, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: gmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: gmat
       REAL(KIND=dp), INTENT(IN)                          :: rc
       INTEGER, INTENT(IN)                                :: k, l
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa, pb
@@ -464,7 +464,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_coulomb(eri, nu, pa, lab, pc, lcd)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: eri
+      REAL(KIND=dp), DIMENSION(:, :)                     :: eri
       INTEGER, INTENT(IN)                                :: nu
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa
       INTEGER, INTENT(IN)                                :: lab
@@ -535,7 +535,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_exchange(eri, nu, pa, lac, pb, lbd)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: eri
+      REAL(KIND=dp), DIMENSION(:, :)                     :: eri
       INTEGER, INTENT(IN)                                :: nu
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa
       INTEGER, INTENT(IN)                                :: lac
@@ -621,7 +621,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sg_erfc(umat, l, a, pa, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: umat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: umat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), INTENT(IN)                          :: a
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa, pb
@@ -701,7 +701,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sto_overlap(smat, na, pa, nb, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: smat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: smat
       INTEGER, DIMENSION(:), INTENT(IN)                  :: na
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa
       INTEGER, DIMENSION(:), INTENT(IN)                  :: nb
@@ -746,7 +746,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sto_kinetic(kmat, l, na, pa, nb, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: kmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: kmat
       INTEGER, INTENT(IN)                                :: l
       INTEGER, DIMENSION(:), INTENT(IN)                  :: na
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa
@@ -794,7 +794,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sto_nuclear(umat, na, pa, nb, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: umat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: umat
       INTEGER, DIMENSION(:), INTENT(IN)                  :: na
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: pa
       INTEGER, DIMENSION(:), INTENT(IN)                  :: nb
@@ -839,7 +839,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sto_conf(gmat, rc, k, na, pa, nb, pb)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: gmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: gmat
       REAL(KIND=dp), INTENT(IN)                          :: rc
       INTEGER, INTENT(IN)                                :: k
       INTEGER, DIMENSION(:), INTENT(IN)                  :: na
@@ -913,7 +913,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_overlap(smat, ra, rb, wr)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: smat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: smat
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra, rb
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wr
 
@@ -952,7 +952,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_kinetic(kmat, l, ra, dra, rb, drb, r, wr)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: kmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: kmat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra, dra, rb, drb
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r, wr
@@ -990,7 +990,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_nuclear(umat, ra, rb, r, wr)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: umat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: umat
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra, rb
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r, wr
 
@@ -1029,7 +1029,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_kinnuc(umat, l, ra, dra, rb, drb, r, wr)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: umat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: umat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra, dra, rb, drb
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r, wr
@@ -1068,7 +1068,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_erf(upmat, a, ra, rb, r, wr)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: upmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: upmat
       REAL(KIND=dp), INTENT(IN)                          :: a
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra, rb
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r, wr
@@ -1115,7 +1115,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_proj_ol(spmat, l, ra, k, rc, r, wr)
 
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: spmat
+      REAL(KIND=dp), DIMENSION(:)                        :: spmat
       INTEGER, INTENT(IN)                                :: l
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra
       INTEGER, INTENT(IN)                                :: k
@@ -1165,7 +1165,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_gpot(vpmat, k, rc, ra, rb, r, wr)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: vpmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: vpmat
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), INTENT(IN)                          :: rc
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra, rb
@@ -1213,7 +1213,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE num_conf(gmat, rc, k, ra, rb, r, wr)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: gmat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: gmat
       REAL(KIND=dp), INTENT(IN)                          :: rc
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ra, rb

--- a/src/aobasis/ai_oneelectron.F
+++ b/src/aobasis/ai_oneelectron.F
@@ -99,7 +99,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT)   :: s
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
          OPTIONAL                                        :: pab
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: force_a, force_b
+      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: force_a, force_b
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT), &
          OPTIONAL                                        :: fs
 

--- a/src/aobasis/ai_overlap.F
+++ b/src/aobasis/ai_overlap.F
@@ -84,7 +84,7 @@ CONTAINS
          OPTIONAL                                        :: sdab
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
          OPTIONAL                                        :: pab
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: force_a
+      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: force_a
 
       CHARACTER(len=*), PARAMETER :: routineN = 'overlap', routineP = moduleN//':'//routineN
 

--- a/src/aobasis/ai_overlap_ppl.F
+++ b/src/aobasis/ai_overlap_ppl.F
@@ -109,7 +109,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT)   :: s
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
          OPTIONAL                                        :: pab
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: force_a, force_b
+      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: force_a, force_b
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT), &
          OPTIONAL                                        :: fs
 

--- a/src/aobasis/ao_util.F
+++ b/src/aobasis/ao_util.F
@@ -475,7 +475,7 @@ CONTAINS
    SUBROUTINE transform_c2s(CPC_co, CPC_so, maxl, lm1, lm2)
 
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: CPC_co
-      REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: CPC_so
+      REAL(dp), DIMENSION(:, :)                          :: CPC_so
       INTEGER                                            :: maxl, lm1, lm2
 
       CHARACTER(len=*), PARAMETER :: routineN = 'transform_c2s', routineP = moduleN//':'//routineN
@@ -572,7 +572,7 @@ CONTAINS
    SUBROUTINE transform_c2s_new(CPC_co, CPC_so, maxl)
 
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: CPC_co
-      REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: CPC_so
+      REAL(dp), DIMENSION(:, :)                          :: CPC_so
       INTEGER                                            :: maxl
 
       CHARACTER(len=*), PARAMETER :: routineN = 'transform_c2s_new', &
@@ -610,7 +610,7 @@ CONTAINS
    SUBROUTINE transform_s2c(matso, matco, maxl, lm1, lm2)
 
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: matso
-      REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: matco
+      REAL(dp), DIMENSION(:, :)                          :: matco
       INTEGER, INTENT(IN)                                :: maxl, lm1, lm2
 
       CHARACTER(len=*), PARAMETER :: routineN = 'transform_s2c', routineP = moduleN//':'//routineN

--- a/src/aobasis/basis_set_types.F
+++ b/src/aobasis/basis_set_types.F
@@ -671,11 +671,10 @@ CONTAINS
       ! - Creation (10.01.2002,MK)
 
       TYPE(gto_basis_set_type), POINTER                  :: gto_basis_set
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name, aliases
-      INTEGER, INTENT(OUT), OPTIONAL                     :: norm_type
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: kind_radius
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ncgf, nset, nsgf
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name, aliases
+      INTEGER, OPTIONAL                                  :: norm_type
+      REAL(KIND=dp), OPTIONAL                            :: kind_radius
+      INTEGER, OPTIONAL                                  :: ncgf, nset, nsgf
       CHARACTER(LEN=12), DIMENSION(:), OPTIONAL, POINTER :: cgf_symbol
       CHARACTER(LEN=6), DIMENSION(:), OPTIONAL, POINTER  :: sgf_symbol
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: norm_cgf, set_radius
@@ -686,11 +685,11 @@ CONTAINS
                                                             last_sgf, n
       REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
          POINTER                                         :: gcc
-      INTEGER, INTENT(OUT), OPTIONAL                     :: maxco, maxl, maxpgf, maxsgf_set, &
+      INTEGER, OPTIONAL                                  :: maxco, maxl, maxpgf, maxsgf_set, &
                                                             maxshell, maxso, nco_sum, npgf_sum, &
                                                             nshell_sum
       INTEGER, INTENT(IN), OPTIONAL                      :: maxder
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: short_kind_radius
+      REAL(KIND=dp), OPTIONAL                            :: short_kind_radius
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_gto_basis_set', &
          routineP = moduleN//':'//routineN
@@ -2130,13 +2129,12 @@ CONTAINS
    SUBROUTINE get_sto_basis_set(sto_basis_set, name, nshell, symbol, nq, lq, zet, maxlq, numsto)
 
       TYPE(sto_basis_set_type), POINTER                  :: sto_basis_set
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nshell
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
+      INTEGER, OPTIONAL                                  :: nshell
       CHARACTER(LEN=6), DIMENSION(:), OPTIONAL, POINTER  :: symbol
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: nq, lq
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: zet
-      INTEGER, INTENT(OUT), OPTIONAL                     :: maxlq, numsto
+      INTEGER, OPTIONAL                                  :: maxlq, numsto
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_sto_basis_set', &
          routineP = moduleN//':'//routineN

--- a/src/aobasis/soft_basis_set.F
+++ b/src/aobasis/soft_basis_set.F
@@ -57,7 +57,7 @@ CONTAINS
 
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis, soft_basis
       REAL(dp), INTENT(IN)                               :: eps_fit, rc
-      LOGICAL, INTENT(OUT)                               :: paw_atom
+      LOGICAL                                            :: paw_atom
       LOGICAL, INTENT(IN)                                :: paw_type_forced, gpw_type_forced
 
       CHARACTER(len=*), PARAMETER :: routineN = 'create_soft_basis', &

--- a/src/aobasis/sto_ng.F
+++ b/src/aobasis/sto_ng.F
@@ -52,7 +52,7 @@ CONTAINS
 
       REAL(KIND=dp), INTENT(IN)                          :: zeta
       INTEGER, INTENT(IN)                                :: n, nq, lq
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: alpha, coef
+      REAL(KIND=dp), DIMENSION(:)                        :: alpha, coef
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_sto_ng', routineP = moduleN//':'//routineN
 

--- a/src/arnoldi/arnoldi_api.F
+++ b/src/arnoldi/arnoldi_api.F
@@ -254,8 +254,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE arnoldi_extremal(matrix_a, max_ev, min_ev, converged, threshold, max_iter)
       TYPE(dbcsr_type), INTENT(INOUT), TARGET            :: matrix_a
-      REAL(KIND=dp), INTENT(OUT)                         :: max_ev, min_ev
-      LOGICAL, INTENT(OUT)                               :: converged
+      REAL(KIND=dp)                                      :: max_ev, min_ev
+      LOGICAL                                            :: converged
       REAL(KIND=dp), INTENT(IN)                          :: threshold
       INTEGER, INTENT(IN)                                :: max_iter
 
@@ -306,7 +306,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(IN), TARGET               :: matrix_a
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: vec_x
       TYPE(dbcsr_type), INTENT(IN), OPTIONAL, TARGET     :: matrix_p
-      LOGICAL, INTENT(OUT)                               :: converged
+      LOGICAL                                            :: converged
       REAL(KIND=dp), INTENT(IN)                          :: threshold
       INTEGER, INTENT(IN)                                :: max_iter
 

--- a/src/atom_admm_methods.F
+++ b/src/atom_admm_methods.F
@@ -439,7 +439,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE lowdin_matrix(wfn, lamat, ovlp)
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: wfn
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: lamat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: lamat
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ovlp
 
       INTEGER                                            :: i, j, k, n

--- a/src/atom_electronic_structure.F
+++ b/src/atom_electronic_structure.F
@@ -59,7 +59,7 @@ CONTAINS
       TYPE(atom_type), POINTER                           :: atom
       INTEGER, INTENT(IN)                                :: iw
       LOGICAL, INTENT(IN), OPTIONAL                      :: noguess
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: converged
+      LOGICAL, OPTIONAL                                  :: converged
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_atom', routineP = moduleN//':'//routineN
 
@@ -117,7 +117,7 @@ CONTAINS
       TYPE(atom_type), POINTER                           :: atom
       INTEGER, INTENT(IN)                                :: iw
       LOGICAL, INTENT(IN), OPTIONAL                      :: noguess
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: converged
+      LOGICAL, OPTIONAL                                  :: converged
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_atom_restricted', &
          routineP = moduleN//':'//routineN
@@ -444,7 +444,7 @@ CONTAINS
       TYPE(atom_type), POINTER                           :: atom
       INTEGER, INTENT(IN)                                :: iw
       LOGICAL, INTENT(IN), OPTIONAL                      :: noguess
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: converged
+      LOGICAL, OPTIONAL                                  :: converged
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_atom_unrestricted', &
          routineP = moduleN//':'//routineN

--- a/src/atom_fit.F
+++ b/src/atom_fit.F
@@ -1159,7 +1159,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: n
       REAL(dp), INTENT(IN)                               :: aval, cval
       REAL(dp), DIMENSION(:), INTENT(INOUT)              :: co
-      REAL(dp), INTENT(OUT)                              :: aerr
+      REAL(dp)                                           :: aerr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'density_fit', routineP = moduleN//':'//routineN
 
@@ -1233,7 +1233,7 @@ CONTAINS
       TYPE(atom_p_type), DIMENSION(:, :), POINTER        :: atom_info
       TYPE(atom_basis_type), POINTER                     :: basis
       LOGICAL, INTENT(IN)                                :: pptype
-      REAL(dp), INTENT(OUT)                              :: afun
+      REAL(dp)                                           :: afun
       INTEGER, INTENT(IN)                                :: iw
       LOGICAL, INTENT(IN)                                :: penalty
 
@@ -1335,7 +1335,7 @@ CONTAINS
       TYPE(atom_p_type), DIMENSION(:, :), POINTER        :: atom_info
       TYPE(wfn_init), DIMENSION(:, :), POINTER           :: wfn_guess
       TYPE(atom_potential_type), POINTER                 :: ppot
-      REAL(dp), INTENT(OUT)                              :: afun
+      REAL(dp)                                           :: afun
       REAL(dp), INTENT(IN)                               :: wtot
       REAL(dp), DIMENSION(:, :, 0:, :, :), INTENT(INOUT) :: pval
       REAL(dp), DIMENSION(:, :, :, :, :), INTENT(INOUT)  :: dener
@@ -1549,8 +1549,8 @@ CONTAINS
 !> \param gthpot ...
 ! **************************************************************************************************
    SUBROUTINE get_pseudo_param(pvec, nval, gthpot)
-      REAL(KIND=dp), DIMENSION(:), INTENT(out)           :: pvec
-      INTEGER, INTENT(out)                               :: nval
+      REAL(KIND=dp), DIMENSION(:)                        :: pvec
+      INTEGER                                            :: nval
       TYPE(atom_gthpot_type), INTENT(in)                 :: gthpot
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_pseudo_param', &
@@ -1852,7 +1852,7 @@ CONTAINS
       TYPE(opgrid_type), POINTER                         :: kgpot
       INTEGER, INTENT(IN)                                :: ng, np
       REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: cval
-      REAL(dp), INTENT(OUT)                              :: aerr
+      REAL(dp)                                           :: aerr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'kgpot_fit', routineP = moduleN//':'//routineN
 

--- a/src/atom_grb.F
+++ b/src/atom_grb.F
@@ -822,7 +822,7 @@ CONTAINS
    SUBROUTINE grb_fit(atom, basis, afun, iw)
       TYPE(atom_type), POINTER                           :: atom
       TYPE(atom_basis_type), POINTER                     :: basis
-      REAL(dp), INTENT(OUT)                              :: afun
+      REAL(dp)                                           :: afun
       INTEGER, INTENT(IN)                                :: iw
 
       CHARACTER(len=*), PARAMETER :: routineN = 'grb_fit', routineP = moduleN//':'//routineN
@@ -1184,8 +1184,8 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: lval
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: am
       INTEGER, INTENT(IN)                                :: nbas
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: ener
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: orb
+      REAL(KIND=dp), DIMENSION(:)                        :: ener
+      REAL(KIND=dp), DIMENSION(:, :)                     :: orb
 
       CHARACTER(len=*), PARAMETER :: routineN = 'hydrogenic', routineP = moduleN//':'//routineN
 

--- a/src/atom_operators.F
+++ b/src/atom_operators.F
@@ -1039,7 +1039,7 @@ CONTAINS
 !> \param basis_b ...
 ! **************************************************************************************************
    SUBROUTINE atom_basis_projection_overlap(ovlap, basis_a, basis_b)
-      REAL(KIND=dp), DIMENSION(:, :, 0:), INTENT(OUT)    :: ovlap
+      REAL(KIND=dp), DIMENSION(:, :, 0:)                 :: ovlap
       TYPE(atom_basis_type), INTENT(IN)                  :: basis_a, basis_b
 
       INTEGER                                            :: i, j, l, ma, mb, na, nb

--- a/src/atom_sgp.F
+++ b/src/atom_sgp.F
@@ -944,7 +944,7 @@ CONTAINS
 !> \param z ...
 ! **************************************************************************************************
    SUBROUTINE erffit(ac, vlocal, r, z)
-      REAL(KIND=dp), INTENT(OUT)                         :: ac
+      REAL(KIND=dp)                                      :: ac
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vlocal, r
       REAL(KIND=dp), INTENT(IN)                          :: z
 

--- a/src/atom_types.F
+++ b/src/atom_types.F
@@ -1261,8 +1261,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE Clementi_geobas(zval, cval, aval, ngto, ival)
       INTEGER, INTENT(IN)                                :: zval
-      REAL(dp), INTENT(OUT)                              :: cval, aval
-      INTEGER, DIMENSION(0:lmat), INTENT(OUT)            :: ngto, ival
+      REAL(dp)                                           :: cval, aval
+      INTEGER, DIMENSION(0:lmat)                         :: ngto, ival
 
       CHARACTER(len=*), PARAMETER :: routineN = 'Clementi_geobas', &
          routineP = moduleN//':'//routineN

--- a/src/atom_utils.F
+++ b/src/atom_utils.F
@@ -97,7 +97,7 @@ CONTAINS
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), POINTER                           :: ostring
       REAL(Kind=dp), DIMENSION(0:lmat, 10)               :: occupation, wfnocc
-      INTEGER, INTENT(OUT), OPTIONAL                     :: multiplicity
+      INTEGER, OPTIONAL                                  :: multiplicity
 
       CHARACTER(len=*), PARAMETER :: routineN = 'atom_set_occupation', &
          routineP = moduleN//':'//routineN
@@ -349,7 +349,7 @@ CONTAINS
 !> \param rr ...
 ! **************************************************************************************************
    SUBROUTINE atom_density(density, pmat, basis, maxl, typ, rr)
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: density
+      REAL(KIND=dp), DIMENSION(:)                        :: density
       REAL(KIND=dp), DIMENSION(:, :, 0:), INTENT(IN)     :: pmat
       TYPE(atom_basis_type), INTENT(IN)                  :: basis
       INTEGER, INTENT(IN)                                :: maxl
@@ -507,7 +507,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE atom_read_external_density(density, atom, iw)
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: density
+      REAL(KIND=dp), DIMENSION(:)                        :: density
       TYPE(atom_type), INTENT(INOUT)                     :: atom
       INTEGER, INTENT(IN)                                :: iw
 
@@ -602,7 +602,7 @@ CONTAINS
 !> \author D. Varsano [daniele.varsano@nano.cnr.it]
 ! **************************************************************************************************
    SUBROUTINE atom_read_external_vxc(vxc, atom, iw)
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: vxc
+      REAL(KIND=dp), DIMENSION(:)                        :: vxc
       TYPE(atom_type), INTENT(INOUT)                     :: atom
       INTEGER, INTENT(IN)                                :: iw
 
@@ -651,7 +651,7 @@ CONTAINS
 !> \param basis ...
 ! **************************************************************************************************
    SUBROUTINE atom_orbital_charge(charge, wfn, rcov, l, basis)
-      REAL(KIND=dp), INTENT(OUT)                         :: charge
+      REAL(KIND=dp)                                      :: charge
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wfn
       REAL(KIND=dp), INTENT(IN)                          :: rcov
       INTEGER, INTENT(IN)                                :: l
@@ -843,7 +843,7 @@ CONTAINS
 !> \param basis ...
 ! **************************************************************************************************
    SUBROUTINE atom_orbital_max(rmax, wfn, rcov, l, basis)
-      REAL(KIND=dp), INTENT(OUT)                         :: rmax
+      REAL(KIND=dp)                                      :: rmax
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wfn
       REAL(KIND=dp), INTENT(IN)                          :: rcov
       INTEGER, INTENT(IN)                                :: l
@@ -884,7 +884,7 @@ CONTAINS
 !> \param basis ...
 ! **************************************************************************************************
    SUBROUTINE atom_orbital_nodes(node, wfn, rcov, l, basis)
-      INTEGER, INTENT(OUT)                               :: node
+      INTEGER                                            :: node
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wfn
       REAL(KIND=dp), INTENT(IN)                          :: rcov
       INTEGER, INTENT(IN)                                :: l
@@ -921,7 +921,7 @@ CONTAINS
 !> \param basis ...
 ! **************************************************************************************************
    SUBROUTINE atom_wfnr0(value, wfn, basis)
-      REAL(KIND=dp), INTENT(OUT)                         :: value
+      REAL(KIND=dp)                                      :: value
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wfn
       TYPE(atom_basis_type), INTENT(IN)                  :: basis
 
@@ -1833,8 +1833,8 @@ CONTAINS
 !> \param nbs ...
 ! **************************************************************************************************
    SUBROUTINE err_matrix(emat, demax, kmat, pmat, umat, upmat, nval, nbs)
-      REAL(KIND=dp), DIMENSION(:, :, 0:), INTENT(OUT)    :: emat
-      REAL(KIND=dp), INTENT(OUT)                         :: demax
+      REAL(KIND=dp), DIMENSION(:, :, 0:)                 :: emat
+      REAL(KIND=dp)                                      :: demax
       REAL(KIND=dp), DIMENSION(:, :, 0:), INTENT(IN)     :: kmat, pmat, umat, upmat
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nval, nbs
 
@@ -1872,7 +1872,7 @@ CONTAINS
 !> \param grid ...
 ! **************************************************************************************************
    SUBROUTINE slater_density(density1, density2, zcore, state, grid)
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: density1, density2
+      REAL(KIND=dp), DIMENSION(:)                        :: density1, density2
       INTEGER, INTENT(IN)                                :: zcore
       TYPE(atom_state), INTENT(IN)                       :: state
       TYPE(grid_atom_type), INTENT(IN)                   :: grid
@@ -1935,7 +1935,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE wigner_slater_functional(rho, vxc)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: rho
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: vxc
+      REAL(KIND=dp), DIMENSION(:)                        :: vxc
 
       CHARACTER(len=*), PARAMETER :: routineN = 'wigner_slater_functional', &
          routineP = moduleN//':'//routineN
@@ -1990,7 +1990,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_rho0(atom, rho0)
       TYPE(atom_type), INTENT(IN)                        :: atom
-      REAL(KIND=dp), INTENT(OUT)                         :: rho0
+      REAL(KIND=dp)                                      :: rho0
 
       INTEGER                                            :: m0, m1, m2, method, nr
       LOGICAL                                            :: nlcc, spinpol
@@ -2249,7 +2249,7 @@ CONTAINS
    SUBROUTINE atom_basis_condnum(basis, rad, cnum)
       TYPE(atom_basis_type)                              :: basis
       REAL(KIND=dp), INTENT(IN)                          :: rad
-      REAL(KIND=dp), INTENT(OUT)                         :: cnum
+      REAL(KIND=dp)                                      :: cnum
 
       CHARACTER(len=*), PARAMETER :: routineN = 'atom_basis_condnum', &
          routineP = moduleN//':'//routineN

--- a/src/atom_xc.F
+++ b/src/atom_xc.F
@@ -653,7 +653,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: pmat
       INTEGER, INTENT(IN)                                :: maxl
       TYPE(section_vals_type), POINTER                   :: xc_section
-      REAL(KIND=dp), INTENT(OUT)                         :: fexc
+      REAL(KIND=dp)                                      :: fexc
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT)   :: xcmat
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'atom_vxc_lda', routineP = moduleN//':'//routineN
@@ -806,7 +806,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: pmata, pmatb
       INTEGER, INTENT(IN)                                :: maxl
       TYPE(section_vals_type), POINTER                   :: xc_section
-      REAL(KIND=dp), INTENT(OUT)                         :: fexc
+      REAL(KIND=dp)                                      :: fexc
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT)   :: xcmata, xcmatb
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'atom_vxc_lsd', routineP = moduleN//':'//routineN
@@ -989,7 +989,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: pmat1
       INTEGER, INTENT(IN)                                :: maxl
       CHARACTER(LEN=*), INTENT(IN)                       :: functional
-      REAL(KIND=dp), INTENT(OUT)                         :: dfexc
+      REAL(KIND=dp)                                      :: dfexc
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: linxpar
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'atom_dpot_lda', routineP = moduleN//':'//routineN

--- a/src/auto_basis.F
+++ b/src/auto_basis.F
@@ -565,8 +565,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_basis_keyfigures(basis_set, lmax, zmin, zmax, zeff)
       TYPE(gto_basis_set_type), POINTER                  :: basis_set
-      INTEGER, INTENT(OUT)                               :: lmax
-      REAL(KIND=dp), DIMENSION(0:9), INTENT(OUT)         :: zmin, zmax, zeff
+      INTEGER                                            :: lmax
+      REAL(KIND=dp), DIMENSION(0:9)                      :: zmin, zmax, zeff
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_basis_keyfigures', &
          routineP = moduleN//':'//routineN
@@ -643,7 +643,7 @@ CONTAINS
    SUBROUTINE get_basis_products(lmax, zmin, zmax, zeff, pmin, pmax, peff)
       INTEGER, INTENT(IN)                                :: lmax
       REAL(KIND=dp), DIMENSION(0:9), INTENT(IN)          :: zmin, zmax, zeff
-      REAL(KIND=dp), DIMENSION(0:18), INTENT(OUT)        :: pmin, pmax, peff
+      REAL(KIND=dp), DIMENSION(0:18)                     :: pmin, pmax, peff
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_basis_products', &
          routineP = moduleN//':'//routineN
@@ -684,7 +684,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: nfit
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: afit
       REAL(KIND=dp), INTENT(IN)                          :: amet
-      REAL(KIND=dp), INTENT(OUT)                         :: eval
+      REAL(KIND=dp)                                      :: eval
 
       CHARACTER(len=*), PARAMETER :: routineN = 'overlap_maximum', &
          routineP = moduleN//':'//routineN
@@ -786,7 +786,7 @@ CONTAINS
    SUBROUTINE get_basis_functions(basis_set, lin, np, nf, zval, gcval)
       TYPE(gto_basis_set_type), POINTER                  :: basis_set
       INTEGER, INTENT(IN)                                :: lin
-      INTEGER, INTENT(OUT)                               :: np, nf
+      INTEGER                                            :: np, nf
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zval
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: gcval
 

--- a/src/base/machine.F
+++ b/src/base/machine.F
@@ -208,7 +208,7 @@ END FUNCTION read_energy
 !>      10.2009 created [Joost VandeVondele]
 ! **************************************************************************************************
 SUBROUTINE m_datum(cal_date)
-      CHARACTER(len=*), INTENT(OUT)                      :: cal_date
+      CHARACTER(len=*)                                   :: cal_date
 
       CHARACTER(len=10)                                  :: time
       CHARACTER(len=8)                                   :: date

--- a/src/base/machine_posix.f90
+++ b/src/base/machine_posix.f90
@@ -100,7 +100,7 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE m_memory(mem)
 
-      INTEGER(KIND=int_8), OPTIONAL, INTENT(OUT)         :: mem
+      INTEGER(KIND=int_8), OPTIONAL         :: mem
       INTEGER(KIND=int_8)                      :: mem_local
 
       !
@@ -293,7 +293,7 @@ CONTAINS
 !> \param hname ...
 ! **************************************************************************************************
   SUBROUTINE m_hostnm(hname)
-    CHARACTER(len=*), INTENT(OUT)            :: hname
+    CHARACTER(len=*)            :: hname
 #if defined(__MINGW)
     ! While there is a gethostname in the Windows (POSIX) API, it requires that winsocks is
     ! initialised prior to using it via WSAStartup(..), respectively cleaned up at the end via WSACleanup().
@@ -328,7 +328,7 @@ CONTAINS
 !> \param curdir ...
 ! **************************************************************************************************
   SUBROUTINE m_getcwd(curdir)
-    CHARACTER(len=*), INTENT(OUT)            :: curdir
+    CHARACTER(len=*)            :: curdir
     TYPE(C_PTR)                              :: stat
     INTEGER                                  :: i
     CHARACTER(len=default_path_length), TARGET  :: tmp
@@ -360,7 +360,7 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE m_chdir(dir,ierror)
     CHARACTER(len=*), INTENT(IN)             :: dir
-    INTEGER, INTENT(OUT)                     :: ierror
+    INTEGER                     :: ierror
 
     INTERFACE
       FUNCTION chdir(path) BIND(C,name="chdir") RESULT(errno)
@@ -380,7 +380,7 @@ CONTAINS
 !> \param user ...
 ! **************************************************************************************************
   SUBROUTINE m_getlog(user)
-    CHARACTER(len=*), INTENT(OUT) :: user
+    CHARACTER(len=*) :: user
     INTEGER                       :: status
 
     ! on a posix system LOGNAME should be defined
@@ -404,7 +404,7 @@ CONTAINS
 !> \param pid ...
 ! **************************************************************************************************
   SUBROUTINE m_getpid(pid)
-   INTEGER, INTENT(OUT)                     :: pid
+   INTEGER                     :: pid
 
    INTERFACE
      FUNCTION getpid() BIND(C,name="getpid") RESULT(pid)
@@ -425,7 +425,7 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE m_getarg(i,arg)
     INTEGER, INTENT(IN)                      :: i
-    CHARACTER(len=*), INTENT(OUT)            :: arg
+    CHARACTER(len=*)            :: arg
     CHARACTER(len=1024)                      :: tmp
     INTEGER                                  :: istat
 

--- a/src/beta_gamma_psi.F
+++ b/src/beta_gamma_psi.F
@@ -598,7 +598,7 @@ SUBROUTINE bgrat (a, b, x, y, w, eps, ierr)
       REAL(dp), INTENT(IN)                               :: a, b, x, y
       REAL(dp), INTENT(INOUT)                            :: w
       REAL(dp), INTENT(IN)                               :: eps
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       REAL(dp), PARAMETER                                :: half = 0.5e0_dp, one = 1.e0_dp, &
                                                             quarter = 0.25e0_dp, zero = 0.e0_dp
@@ -693,7 +693,7 @@ SUBROUTINE grat1 (a, x, r, p, q, eps)
 !        THE INPUT ARGUMENT R HAS THE VALUE E**(-X)*X**A/GAMMA(A)
 !-----------------------------------------------------------------------
       REAL(dp), INTENT(IN)                               :: a, x, r
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: p, q
+      REAL(dp), OPTIONAL                                 :: p, q
       REAL(dp), INTENT(IN)                               :: eps
 
       REAL(dp), PARAMETER                                :: half = 0.5e0_dp, one = 1.e0_dp, &
@@ -1382,8 +1382,8 @@ SUBROUTINE bratio (a, b, x, y, w, w1, ierr)
 !     REVISED ... APRIL 1993
 !-----------------------------------------------------------------------
       REAL(dp), INTENT(IN)                               :: a, b, x, y
-      REAL(dp), INTENT(OUT)                              :: w, w1
-      INTEGER, INTENT(OUT)                               :: ierr
+      REAL(dp)                                           :: w, w1
+      INTEGER                                            :: ierr
 
       INTEGER                                            :: ierr1, ind, n
       REAL(dp)                                           :: a0, b0, eps, lambda, t, x0, y0, z

--- a/src/bsse.F
+++ b/src/bsse.F
@@ -160,11 +160,11 @@ CONTAINS
    SUBROUTINE eval_bsse_energy(conf, Em, force_env, n_frags, root_section, &
                                globenv, should_stop)
       INTEGER, DIMENSION(:), INTENT(IN)                  :: conf
-      REAL(KIND=dp), INTENT(OUT)                         :: Em
+      REAL(KIND=dp)                                      :: Em
       TYPE(force_env_type), POINTER                      :: force_env
       TYPE(section_vals_type), POINTER                   :: n_frags, root_section
       TYPE(global_environment_type), POINTER             :: globenv
-      LOGICAL, INTENT(OUT)                               :: should_stop
+      LOGICAL                                            :: should_stop
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_bsse_energy', &
          routineP = moduleN//':'//routineN
@@ -231,7 +231,7 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: conf, conf_loc
       TYPE(section_vals_type), POINTER                   :: n_frags, root_section
       TYPE(global_environment_type), POINTER             :: globenv
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                                      :: energy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_bsse_energy_low', &
          routineP = moduleN//':'//routineN
@@ -417,7 +417,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE conf_info_setup(present_charge, present_multpl, conf, conf_loc, &
                               bsse_section, dft_section)
-      INTEGER, INTENT(OUT)                               :: present_charge, present_multpl
+      INTEGER                                            :: present_charge, present_multpl
       INTEGER, DIMENSION(:), INTENT(IN)                  :: conf, conf_loc
       TYPE(section_vals_type), POINTER                   :: bsse_section, dft_section
 

--- a/src/cell_methods.F
+++ b/src/cell_methods.F
@@ -70,7 +70,7 @@ CONTAINS
    RECURSIVE SUBROUTINE read_cell(cell, cell_ref, use_ref_cell, cell_section, &
                                   check_for_ref, para_env)
       TYPE(cell_type), POINTER                           :: cell, cell_ref
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: use_ref_cell
+      LOGICAL, OPTIONAL                                  :: use_ref_cell
       TYPE(section_vals_type), OPTIONAL, POINTER         :: cell_section
       LOGICAL, INTENT(IN), OPTIONAL                      :: check_for_ref
       TYPE(cp_para_env_type), POINTER                    :: para_env

--- a/src/colvar_methods.F
+++ b/src/colvar_methods.F
@@ -1398,7 +1398,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(colvar_type), POINTER                         :: colvar
       INTEGER, INTENT(IN)                                :: colvar_id
-      INTEGER, INTENT(OUT)                               :: n_oxygens, n_hydrogens
+      INTEGER                                            :: n_oxygens, n_hydrogens
       INTEGER, DIMENSION(:), POINTER                     :: i_oxygens, i_hydrogens
 
       CHARACTER(len=*), PARAMETER :: routineN = 'read_hydronium_colvars', &
@@ -1476,7 +1476,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(colvar_type), POINTER                         :: colvar
       INTEGER, INTENT(IN)                                :: colvar_id
-      INTEGER, INTENT(OUT)                               :: n_oxygens_water, n_oxygens_acid, &
+      INTEGER                                            :: n_oxygens_water, n_oxygens_acid, &
                                                             n_hydrogens
       INTEGER, DIMENSION(:), POINTER                     :: i_oxygens_water, i_oxygens_acid, &
                                                             i_hydrogens
@@ -1898,7 +1898,7 @@ CONTAINS
    SUBROUTINE get_coordinates(colvar, i, ri, my_particles)
       TYPE(colvar_type), POINTER                         :: colvar
       INTEGER, INTENT(IN)                                :: i
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: ri
+      REAL(KIND=dp), DIMENSION(3)                        :: ri
       TYPE(particle_type), DIMENSION(:), POINTER         :: my_particles
 
       IF (colvar%use_points) THEN
@@ -1920,7 +1920,7 @@ CONTAINS
    SUBROUTINE get_mass(colvar, i, mi, my_particles)
       TYPE(colvar_type), POINTER                         :: colvar
       INTEGER, INTENT(IN)                                :: i
-      REAL(KIND=dp), INTENT(OUT)                         :: mi
+      REAL(KIND=dp)                                      :: mi
       TYPE(particle_type), DIMENSION(:), POINTER         :: my_particles
 
       IF (colvar%use_points) THEN
@@ -5877,7 +5877,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: nr_frames
       REAL(dp), DIMENSION(:, :), POINTER                 :: r_ref
-      INTEGER, INTENT(OUT)                               :: n_atoms
+      INTEGER                                            :: n_atoms
 
       CHARACTER(len=*), PARAMETER :: routineN = 'read_frames', routineP = moduleN//':'//routineN
 

--- a/src/colvar_utils.F
+++ b/src/colvar_utils.F
@@ -193,7 +193,7 @@ CONTAINS
 
       TYPE(force_env_type), POINTER                      :: force_env
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: coords
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: cvalues
+      REAL(KIND=dp), DIMENSION(:)                        :: cvalues
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: Bmatrix
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: MassI
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: Amatrix
@@ -520,7 +520,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT), &
          OPTIONAL                                        :: forces, coords
       INTEGER, INTENT(IN)                                :: nsize_xyz, nsize_int
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: cvalues, Mmatrix
+      REAL(KIND=dp), DIMENSION(:)                        :: cvalues, Mmatrix
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_clv_force', routineP = moduleN//':'//routineN
 

--- a/src/common/cp_array_sort.F
+++ b/src/common/cp_array_sort.F
@@ -49,7 +49,7 @@ USE kinds, ONLY: ${uselist(usekinds)}$
 subroutine cp_1d_${nametype1}$_sort(arr, n, indices)
    integer, intent(in)                  :: n
    ${type1}$, dimension(1:n), intent(inout) :: arr
-   integer, dimension(1:n), intent(out)   :: indices
+   integer, dimension(1:n)                  :: indices
 
    integer :: i
    ${type1}$, pointer                   :: tmp_arr(:)

--- a/src/common/cp_min_heap.F
+++ b/src/common/cp_min_heap.F
@@ -114,7 +114,7 @@ CONTAINS
 !> \param n ...
 ! **************************************************************************************************
    SUBROUTINE cp_heap_new(heap, n)
-      TYPE(cp_heap_type), INTENT(OUT)                    :: heap
+      TYPE(cp_heap_type)                                 :: heap
       INTEGER, INTENT(IN)                                :: n
 
       heap%n = n
@@ -170,9 +170,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_heap_get_first(heap, key, value, found)
       TYPE(cp_heap_type), INTENT(INOUT)                  :: heap
-      INTEGER(KIND=keyt), INTENT(OUT)                    :: key
-      INTEGER(KIND=valt), INTENT(OUT)                    :: value
-      LOGICAL, INTENT(OUT)                               :: found
+      INTEGER(KIND=keyt)                                 :: key
+      INTEGER(KIND=valt)                                 :: value
+      LOGICAL                                            :: found
 
       IF (heap%n .LT. 1) THEN
          found = .FALSE.
@@ -193,9 +193,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_heap_pop(heap, key, value, found)
       TYPE(cp_heap_type), INTENT(INOUT)                  :: heap
-      INTEGER(KIND=keyt), INTENT(OUT)                    :: key
-      INTEGER(KIND=valt), INTENT(OUT)                    :: value
-      LOGICAL, INTENT(OUT)                               :: found
+      INTEGER(KIND=keyt)                                 :: key
+      INTEGER(KIND=valt)                                 :: value
+      LOGICAL                                            :: found
 
 !
 
@@ -354,7 +354,7 @@ CONTAINS
    SUBROUTINE bubble_up(heap, first, new_pos)
       TYPE(cp_heap_type), INTENT(INOUT)                  :: heap
       INTEGER, INTENT(IN)                                :: first
-      INTEGER, INTENT(OUT)                               :: new_pos
+      INTEGER                                            :: new_pos
 
       INTEGER                                            :: e, parent
       INTEGER(kind=valt)                                 :: my_value, parent_value

--- a/src/common/cuda_profiling.F
+++ b/src/common/cuda_profiling.F
@@ -121,7 +121,7 @@ CONTAINS
 !> \param total ...
 ! **************************************************************************************************
    SUBROUTINE cuda_mem_info(free, total)
-      INTEGER(KIND=int_8), INTENT(OUT)         :: free, total
+      INTEGER(KIND=int_8)         :: free, total
 #if defined( __CUDA_PROFILING )
       INTEGER(KIND=C_INT)                      :: istat
       INTEGER(KIND=C_SIZE_T)                   :: free_c, total_c

--- a/src/common/eigenvalueproblems.F
+++ b/src/common/eigenvalueproblems.F
@@ -55,7 +55,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: matrix(:, :)
       INTEGER, INTENT(IN)                                :: mysize
       CHARACTER(LEN=*), INTENT(IN)                       :: storageform
-      REAL(KIND=dp), INTENT(OUT)                         :: eigenvalues(:), eigenvectors(:, :)
+      REAL(KIND=dp)                                      :: eigenvalues(:), eigenvectors(:, :)
 
       CHARACTER(len=*), PARAMETER :: routineN = 'diagonalise_ssyev', &
          routineP = moduleN//':'//routineN
@@ -104,8 +104,8 @@ CONTAINS
       COMPLEX(KIND=dp), INTENT(INOUT)                    :: matrix(:)
       INTEGER, INTENT(IN)                                :: mysize
       CHARACTER(LEN=*), INTENT(IN)                       :: storageform
-      REAL(KIND=dp), INTENT(OUT)                         :: eigenvalues(:)
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: eigenvectors(:, :)
+      REAL(KIND=dp)                                      :: eigenvalues(:)
+      COMPLEX(KIND=dp)                                   :: eigenvectors(:, :)
 
       CHARACTER(len=*), PARAMETER :: routineN = 'diagonalise_chpev', &
          routineP = moduleN//':'//routineN
@@ -148,9 +148,9 @@ CONTAINS
    SUBROUTINE cp2k_sgesvd(matrix, svalues, mrow, ncol, uvec, vtvec)
 
       REAL(KIND=dp), INTENT(IN)                          :: matrix(:, :)
-      REAL(KIND=dp), INTENT(OUT)                         :: svalues(:)
+      REAL(KIND=dp)                                      :: svalues(:)
       INTEGER, INTENT(IN)                                :: mrow, ncol
-      REAL(KIND=dp), INTENT(OUT)                         :: uvec(:, :), vtvec(:, :)
+      REAL(KIND=dp)                                      :: uvec(:, :), vtvec(:, :)
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp2k_sgesvd', routineP = moduleN//':'//routineN
       CHARACTER, PARAMETER                               :: jobu = "A", jobvt = "A"
@@ -183,9 +183,9 @@ CONTAINS
    SUBROUTINE cp2k_cgesvd(matrix, svalues, mrow, ncol, uvec, vtvec)
 
       COMPLEX(KIND=dp), INTENT(IN)                       :: matrix(:, :)
-      REAL(KIND=dp), INTENT(OUT)                         :: svalues(:)
+      REAL(KIND=dp)                                      :: svalues(:)
       INTEGER, INTENT(IN)                                :: mrow, ncol
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: uvec(:, :), vtvec(:, :)
+      COMPLEX(KIND=dp)                                   :: uvec(:, :), vtvec(:, :)
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp2k_cgesvd', routineP = moduleN//':'//routineN
       CHARACTER, PARAMETER                               :: jobu = "A", jobvt = "A"

--- a/src/common/fparser.F
+++ b/src/common/fparser.F
@@ -483,7 +483,7 @@ CONTAINS
       !----- -------- --------- --------- --------- --------- --------- --------- -------
       CHARACTER(LEN=*), INTENT(in)                       :: str
       CHARACTER(LEN=*), DIMENSION(:), INTENT(in)         :: Var
-      INTEGER, INTENT(out), OPTIONAL                     :: ibegin, inext
+      INTEGER, OPTIONAL                                  :: ibegin, inext
       INTEGER(is)                                        :: n
 
       INTEGER                                            :: ib, in, j, lstr
@@ -873,8 +873,8 @@ CONTAINS
       ! Get real number from string - Format: [blanks][+|-][nnn][.nnn][e|E|d|D[+|-]nnn]
       !----- -------- --------- --------- --------- --------- --------- --------- -------
       CHARACTER(LEN=*), INTENT(in)                       :: str
-      INTEGER, INTENT(out), OPTIONAL                     :: ibegin, inext
-      LOGICAL, INTENT(out), OPTIONAL                     :: error
+      INTEGER, OPTIONAL                                  :: ibegin, inext
+      LOGICAL, OPTIONAL                                  :: error
       REAL(rn)                                           :: res
 
       INTEGER                                            :: ib, in, istat
@@ -963,7 +963,7 @@ CONTAINS
       ! Transform upper case letters in str1 into lower case letters, result is str2
       !----- -------- --------- --------- --------- --------- --------- --------- -------
       CHARACTER(LEN=*), INTENT(in)                       :: str1
-      CHARACTER(LEN=*), INTENT(out)                      :: str2
+      CHARACTER(LEN=*)                                   :: str2
 
       CHARACTER(LEN=*), PARAMETER :: lc = 'abcdefghijklmnopqrstuvwxyz', &
          uc = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -994,8 +994,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: id_fun, ipar
       REAL(KIND=rn), DIMENSION(:), INTENT(INOUT)         :: vals
       REAL(KIND=rn), INTENT(IN)                          :: h
-      REAL(KIND=rn), INTENT(OUT)                         :: err
-      REAL(KIND=rn)                                      :: derivative
+      REAL(KIND=rn)                                      :: err, derivative
 
       CHARACTER(len=*), PARAMETER :: routineN = 'evalfd', routineP = moduleN//':'//routineN
       INTEGER, PARAMETER                                 :: ntab = 10

--- a/src/common/gamma.F
+++ b/src/common/gamma.F
@@ -158,7 +158,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: nmax
       REAL(KIND=dp), INTENT(IN)                          :: t
-      REAL(KIND=dp), DIMENSION(0:nmax), INTENT(OUT)      :: f
+      REAL(KIND=dp), DIMENSION(0:nmax)                   :: f
 
       INTEGER                                            :: itab, k, n
       REAL(KIND=dp)                                      :: expt, g, tdelta, tmp, ttab
@@ -285,8 +285,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: nmax
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: t
-      REAL(KIND=dp), DIMENSION(SIZE(t, 1), 0:nmax), &
-         INTENT(OUT)                                     :: f
+      REAL(KIND=dp), DIMENSION(SIZE(t, 1), 0:nmax)       :: f
 
       INTEGER                                            :: i, itab, k, n
       REAL(KIND=dp)                                      :: expt, g, tdelta, tmp, ttab

--- a/src/common/mathlib.F
+++ b/src/common/mathlib.F
@@ -253,7 +253,7 @@ CONTAINS
    SUBROUTINE build_rotmat(phi, a, rotmat)
       REAL(KIND=dp), INTENT(IN)                          :: phi
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: a
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: rotmat
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: rotmat
 
       REAL(KIND=dp)                                      :: cosp, cost, length_of_a, sinp
       REAL(KIND=dp), DIMENSION(3)                        :: d
@@ -339,7 +339,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE diamat_all(a, eigval, dac)
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: a
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigval
+      REAL(KIND=dp), DIMENSION(:)                        :: eigval
       LOGICAL, INTENT(IN), OPTIONAL                      :: dac
 
       CHARACTER(len=*), PARAMETER :: routineN = 'diamat_all', routineP = moduleN//':'//routineN
@@ -510,7 +510,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE invmat(a, info)
       REAL(KIND=dp), INTENT(INOUT)                       :: a(:, :)
-      INTEGER, INTENT(OUT)                               :: info
+      INTEGER                                            :: info
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'invmat', routineP = moduleN//':'//routineN
 
@@ -613,8 +613,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE invert_matrix_d(a, a_inverse, eval_error, option, improve)
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: a
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: a_inverse
-      REAL(KIND=dp), INTENT(OUT)                         :: eval_error
+      REAL(KIND=dp), DIMENSION(:, :)                     :: a_inverse
+      REAL(KIND=dp)                                      :: eval_error
       CHARACTER(LEN=1), INTENT(IN), OPTIONAL             :: option
       LOGICAL, INTENT(IN), OPTIONAL                      :: improve
 
@@ -778,8 +778,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE invert_matrix_z(a, a_inverse, eval_error, option)
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: a
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: a_inverse
-      REAL(KIND=dp), INTENT(OUT)                         :: eval_error
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: a_inverse
+      REAL(KIND=dp)                                      :: eval_error
       CHARACTER(LEN=1), INTENT(IN), OPTIONAL             :: option
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'invert_matrix_z', &
@@ -926,7 +926,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(:, :)                     :: a, a_pinverse
       REAL(KIND=dp), INTENT(IN)                          :: rskip
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: determinant
+      REAL(KIND=dp), OPTIONAL                            :: determinant
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT), &
          OPTIONAL, POINTER                               :: sval
 
@@ -1403,7 +1403,7 @@ CONTAINS
 !> \param vec ...
 ! **************************************************************************************************
    SUBROUTINE matvec_3x3(res, mat, vec)
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: res
+      REAL(KIND=dp), DIMENSION(3)                        :: res
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: mat
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: vec
 
@@ -1534,8 +1534,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE jacobi(a, d, v)
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: a
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: d
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: v
+      REAL(KIND=dp), DIMENSION(:)                        :: d
+      REAL(KIND=dp), DIMENSION(:, :)                     :: v
 
       INTEGER                                            :: n
 
@@ -1564,8 +1564,8 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: n
       REAL(KIND=dp), DIMENSION(n, n), INTENT(INOUT)      :: a
-      REAL(KIND=dp), DIMENSION(n), INTENT(OUT)           :: d
-      REAL(KIND=dp), DIMENSION(n, n), INTENT(OUT)        :: v
+      REAL(KIND=dp), DIMENSION(n)                        :: d
+      REAL(KIND=dp), DIMENSION(n, n)                     :: v
 
       INTEGER                                            :: i, ip, iq
       REAL(KIND=dp)                                      :: a_max, c, d_min, g, h, s, t, tau, theta, &

--- a/src/common/parallel_rng_types.F
+++ b/src/common/parallel_rng_types.F
@@ -607,7 +607,7 @@ CONTAINS
       ! Dump a RNG stream as a record given as an internal file (string).
 
       TYPE(rng_stream_type), POINTER                     :: rng_stream
-      CHARACTER(LEN=rng_record_length), INTENT(OUT)      :: rng_record
+      CHARACTER(LEN=rng_record_length)                   :: rng_record
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dump_rng_stream', &
          routineP = moduleN//':'//routineN
@@ -656,13 +656,12 @@ CONTAINS
       ! Get the components of a RNG stream.
 
       TYPE(rng_stream_type), POINTER                     :: rng_stream
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: name
-      INTEGER, INTENT(OUT), OPTIONAL                     :: distribution_type
-      REAL(KIND=dp), DIMENSION(3, 2), INTENT(OUT), &
-         OPTIONAL                                        :: bg, cg, ig
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: antithetic, extended_precision
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: buffer
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: buffer_filled
+      CHARACTER(LEN=*), OPTIONAL                         :: name
+      INTEGER, OPTIONAL                                  :: distribution_type
+      REAL(KIND=dp), DIMENSION(3, 2), OPTIONAL           :: bg, cg, ig
+      LOGICAL, OPTIONAL                                  :: antithetic, extended_precision
+      REAL(KIND=dp), OPTIONAL                            :: buffer
+      LOGICAL, OPTIONAL                                  :: buffer_filled
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_rng_stream', routineP = moduleN//':'//routineN
 
@@ -811,7 +810,7 @@ CONTAINS
       ! Returns c = MODULO(a*b,m).
 
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: a, b
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: c
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: c
       REAL(KIND=dp), INTENT(IN)                          :: m
 
       INTEGER                                            :: i
@@ -836,7 +835,7 @@ CONTAINS
       ! Compute matrix b = MODULO(a**n,m)
 
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: a
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: b
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: b
       REAL(KIND=dp), INTENT(IN)                          :: m
       INTEGER, INTENT(IN)                                :: n
 
@@ -889,7 +888,7 @@ CONTAINS
       ! Compute matrix b = MODULO(a**(2**e),m)
 
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: a
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: b
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: b
       REAL(KIND=dp), INTENT(IN)                          :: m
       INTEGER, INTENT(IN)                                :: e
 
@@ -923,7 +922,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: a
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: v
+      REAL(KIND=dp), DIMENSION(3)                        :: v
       REAL(KIND=dp), INTENT(IN)                          :: m
 
       INTEGER                                            :: i, j

--- a/src/common/periodic_table.F
+++ b/src/common/periodic_table.F
@@ -70,10 +70,10 @@ CONTAINS
                               vdw_radius, found)
 
       CHARACTER(LEN=2), INTENT(IN)                       :: symbol
-      INTEGER, INTENT(OUT), OPTIONAL                     :: number
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: amass
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ielement
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: covalent_radius, vdw_radius
+      INTEGER, OPTIONAL                                  :: number
+      REAL(KIND=dp), OPTIONAL                            :: amass
+      INTEGER, OPTIONAL                                  :: ielement
+      REAL(KIND=dp), OPTIONAL                            :: covalent_radius, vdw_radius
       LOGICAL, OPTIONAL                                  :: found
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_ptable_info', &

--- a/src/common/reference_manager.F
+++ b/src/common/reference_manager.F
@@ -127,7 +127,7 @@ CONTAINS
 !>      - DOI: provide the DOI without a link. The link will be automatically created as needed.
 ! **************************************************************************************************
   SUBROUTINE add_reference(key,ISI_record,DOI)
-      INTEGER, INTENT(OUT)                               :: key
+      INTEGER                                            :: key
       CHARACTER(LEN=*), DIMENSION(:)                     :: ISI_record
       CHARACTER(LEN=*)                                   :: DOI
 

--- a/src/common/spherical_harmonics.F
+++ b/src/common/spherical_harmonics.F
@@ -73,7 +73,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE clebsch_gordon_complex(l1, m1, l2, m2, clm)
       INTEGER, INTENT(IN)                                :: l1, m1, l2, m2
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: clm
+      REAL(KIND=dp), DIMENSION(:)                        :: clm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'clebsch_gordon_complex', &
          routineP = moduleN//':'//routineN
@@ -109,7 +109,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE clebsch_gordon_real(l1, m1, l2, m2, rlm)
       INTEGER, INTENT(IN)                                :: l1, m1, l2, m2
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: rlm
+      REAL(KIND=dp), DIMENSION(:, :)                     :: rlm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'clebsch_gordon_real', &
          routineP = moduleN//':'//routineN
@@ -420,7 +420,7 @@ CONTAINS
 ! Input: r == (x,y,z) : normalised    x^2 + y^2 + z^2 = 1
 !
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: r
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: y
+      REAL(KIND=dp), DIMENSION(:)                        :: y
       INTEGER, INTENT(IN)                                :: l, m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rvy_lm', routineP = moduleN//':'//routineN
@@ -553,7 +553,7 @@ CONTAINS
 ! Input: r == (x,y,z) : normalised    x^2 + y^2 + z^2 = 1
 !
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r
-      REAL(KIND=dp), INTENT(OUT)                         :: y
+      REAL(KIND=dp)                                      :: y
       INTEGER, INTENT(IN)                                :: l, m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rry_lm', routineP = moduleN//':'//routineN
@@ -682,7 +682,7 @@ CONTAINS
 ! Input: r == (x,y,z) : normalised    x^2 + y^2 + z^2 = 1
 !
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: r
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(OUT)        :: y
+      COMPLEX(KIND=dp), DIMENSION(:)                     :: y
       INTEGER, INTENT(IN)                                :: l, m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cvy_lm', routineP = moduleN//':'//routineN
@@ -864,7 +864,7 @@ CONTAINS
 ! Input: r == (x,y,z) : normalised    x^2 + y^2 + z^2 = 1
 !
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: y
+      COMPLEX(KIND=dp)                                   :: y
       INTEGER, INTENT(IN)                                :: l, m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'ccy_lm', routineP = moduleN//':'//routineN
@@ -1026,7 +1026,7 @@ CONTAINS
 !
 
       REAL(KIND=dp), DIMENSION(2), INTENT(IN)            :: c
-      REAL(KIND=dp), DIMENSION(2), INTENT(OUT)           :: dy
+      REAL(KIND=dp), DIMENSION(2)                        :: dy
       INTEGER, INTENT(IN)                                :: l, m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dry_lm', routineP = moduleN//':'//routineN
@@ -1181,7 +1181,7 @@ CONTAINS
 !
 
       REAL(KIND=dp), DIMENSION(2), INTENT(IN)            :: c
-      COMPLEX(KIND=dp), DIMENSION(2), INTENT(OUT)        :: dy
+      COMPLEX(KIND=dp), DIMENSION(2)                     :: dy
       INTEGER, INTENT(IN)                                :: l, m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dcy_lm', routineP = moduleN//':'//routineN

--- a/src/common/splines.F
+++ b/src/common/splines.F
@@ -79,7 +79,7 @@ CONTAINS
    SUBROUTINE spline3ders(x, y, xnew, ynew, dynew, d2ynew)
       ! Just like 'spline', but also calculate 1st and 2nd derivatives
       REAL(dp), INTENT(in)                               :: x(:), y(:), xnew(:)
-      REAL(dp), INTENT(out), OPTIONAL                    :: ynew(:), dynew(:), d2ynew(:)
+      REAL(dp), OPTIONAL                                 :: ynew(:), dynew(:), d2ynew(:)
 
       INTEGER                                            :: i, ip
       REAL(dp)                                           :: c(0:4, SIZE(x)-1)
@@ -109,12 +109,12 @@ CONTAINS
       REAL(dp), INTENT(in)                               :: xi(:), yi(:)
       INTEGER, INTENT(in)                                :: bctype(2)
       REAL(dp), INTENT(in)                               :: bcval(2)
-      REAL(dp), INTENT(out)                              :: c(0:, :)
+      REAL(dp)                                           :: c(0:, :)
 
       INTEGER                                            :: i, i2, info, ipiv(4), j, n
-      REAL(dp) :: Ae(4, 4), be(4), bemat(4, 1), c1, c2, c3, c4, ce(4), d2p1, d2pn, x0, xe(4), &
-         ye(4), hi(SIZE(c, 2)), cs(2*SIZE(c, 2)), bs(2*SIZE(c, 2)), bmat(2*SIZE(c, 2), 1), &
-         As(5, 2*SIZE(c, 2))
+      REAL(dp) :: Ae(4, 4), be(4), bemat(4, 1), bs(2*SIZE(c, 2)), bmat(2*SIZE(c, 2), 1), &
+         As(5, 2*SIZE(c, 2)), c1, c2, c3, c4, ce(4), cs(2*SIZE(c, 2)), d2p1, d2pn, hi(SIZE(c, 2)), &
+         x0, xe(4), ye(4)
       INTEGER                                            :: ipiv2(2*SIZE(c, 2))
 
       ! x values of data
@@ -260,7 +260,7 @@ CONTAINS
       ! Returns value and 1st derivative of spline defined by knots xi and parameters c
       ! returned by spline3pars
       REAL(dp), INTENT(in)                               :: x, xi(:), c(0:, :)
-      REAL(dp), INTENT(out)                              :: val, der
+      REAL(dp)                                           :: val, der
 
       INTEGER                                            :: i1, n
 

--- a/src/common/string_utilities.F
+++ b/src/common/string_utilities.F
@@ -1585,7 +1585,7 @@ CONTAINS
    SUBROUTINE ascii_to_string(nascii, string)
 
       INTEGER, DIMENSION(:), INTENT(IN)                  :: nascii
-      CHARACTER(LEN=*), INTENT(OUT)                      :: string
+      CHARACTER(LEN=*)                                   :: string
 
       INTEGER                                            :: i
 
@@ -1661,7 +1661,7 @@ CONTAINS
    SUBROUTINE integer_to_string(inumber, string)
 
       INTEGER, INTENT(IN)                                :: inumber
-      CHARACTER(LEN=*), INTENT(OUT)                      :: string
+      CHARACTER(LEN=*)                                   :: string
 
       WRITE (UNIT=string, FMT='(I0)') inumber
    END SUBROUTINE integer_to_string
@@ -1677,7 +1677,7 @@ CONTAINS
    SUBROUTINE string_to_ascii(string, nascii)
 
       CHARACTER(LEN=*), INTENT(IN)                       :: string
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: nascii
+      INTEGER, DIMENSION(:)                              :: nascii
 
       INTEGER                                            :: i
 
@@ -1899,7 +1899,7 @@ CONTAINS
    SUBROUTINE xstring(string, ia, ib)
 
       CHARACTER(LEN=*), INTENT(IN)                       :: string
-      INTEGER, INTENT(OUT)                               :: ia, ib
+      INTEGER                                            :: ia, ib
 
       ia = 1
       ib = LEN_TRIM(string)

--- a/src/common/structure_factors.F
+++ b/src/common/structure_factors.F
@@ -93,7 +93,7 @@ CONTAINS
 
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: bds
       INTEGER, INTENT(IN)                                :: nparts
-      TYPE(structure_factor_type), INTENT(OUT)           :: exp_igr
+      TYPE(structure_factor_type)                        :: exp_igr
       LOGICAL, INTENT(IN), OPTIONAL                      :: allocate_centre, allocate_shell_e, &
                                                             allocate_shell_centre
       INTEGER, INTENT(IN), OPTIONAL                      :: nshell
@@ -155,9 +155,9 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(:), INTENT(in)            :: delta
       INTEGER, DIMENSION(3), INTENT(IN)                  :: lb
-      COMPLEX(KIND=dp), DIMENSION(lb(1):), INTENT(out)   :: ex
-      COMPLEX(KIND=dp), DIMENSION(lb(2):), INTENT(out)   :: ey
-      COMPLEX(KIND=dp), DIMENSION(lb(3):), INTENT(out)   :: ez
+      COMPLEX(KIND=dp), DIMENSION(lb(1):)                :: ex
+      COMPLEX(KIND=dp), DIMENSION(lb(2):)                :: ey
+      COMPLEX(KIND=dp), DIMENSION(lb(3):)                :: ez
 
       COMPLEX(KIND=dp)                                   :: fm, fp
       INTEGER                                            :: j, l0, l1, m0, m1, n0, n1

--- a/src/common/util.F
+++ b/src/common/util.F
@@ -91,7 +91,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE sort_unique1(arr, unique)
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: arr
-      LOGICAL, INTENT(OUT)                               :: unique
+      LOGICAL                                            :: unique
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'sort_unique1', routineP = moduleN//':'//routineN
 
@@ -121,7 +121,7 @@ CONTAINS
    SUBROUTINE sort_cv(arr, n, index)
       INTEGER, INTENT(IN)                                :: n
       CHARACTER(LEN=*), INTENT(INOUT)                    :: arr(1:n)
-      INTEGER, INTENT(OUT)                               :: INDEX(1:n)
+      INTEGER                                            :: INDEX(1:n)
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'sort_cv', routineP = moduleN//':'//routineN
 

--- a/src/common/xml_parser.F
+++ b/src/common/xml_parser.F
@@ -264,7 +264,7 @@ CONTAINS
 !> \param mustread ...
 ! **************************************************************************************************
    SUBROUTINE xml_open(info, fname, mustread)
-      TYPE(XML_PARSE), INTENT(out)                       :: info
+      TYPE(XML_PARSE)                                    :: info
       CHARACTER(len=*), INTENT(in)                       :: fname
       LOGICAL, INTENT(in)                                :: mustread
 
@@ -369,12 +369,12 @@ CONTAINS
    SUBROUTINE xml_get(info, tag, endtag, attribs, no_attribs, &
                       DATA, no_data)
       TYPE(XML_PARSE), INTENT(inout)                     :: info
-      CHARACTER(len=*), INTENT(out)                      :: tag
-      LOGICAL, INTENT(out)                               :: endtag
-      CHARACTER(len=*), DIMENSION(:, :), INTENT(out)     :: attribs
-      INTEGER, INTENT(out)                               :: no_attribs
-      CHARACTER(len=*), DIMENSION(:), INTENT(out)        :: DATA
-      INTEGER, INTENT(out)                               :: no_data
+      CHARACTER(len=*)                                   :: tag
+      LOGICAL                                            :: endtag
+      CHARACTER(len=*), DIMENSION(:, :)                  :: attribs
+      INTEGER                                            :: no_attribs
+      CHARACTER(len=*), DIMENSION(:)                     :: DATA
+      INTEGER                                            :: no_data
 
       CHARACTER(len=XML_BUFFER_LENGTH)                   :: nextline
       INTEGER                                            :: idxat, idxdat, ierr, kend, keq, kfirst, &

--- a/src/commutator_rkinetic.F
+++ b/src/commutator_rkinetic.F
@@ -292,7 +292,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: lb_min
       REAL(KIND=dp), INTENT(IN)                          :: dab
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: ab
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: comabr
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: comabr
 
       INTEGER                                            :: ax, ay, az, bx, by, bz, coa, coap, &
                                                             coapx, coapy, coapz, cob, cobp, cobpx, &

--- a/src/constraint.F
+++ b/src/constraint.F
@@ -349,7 +349,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(INOUT)                       :: pos(:, :), vel(:, :)
       REAL(KIND=dp), INTENT(IN)                          :: dt
       TYPE(simpar_type), INTENT(IN)                      :: simpar
-      REAL(KIND=dp), INTENT(OUT)                         :: roll_tol
+      REAL(KIND=dp)                                      :: roll_tol
       INTEGER, INTENT(INOUT)                             :: iroll
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vector_r, vector_v
       INTEGER, INTENT(IN)                                :: group
@@ -496,7 +496,7 @@ CONTAINS
       TYPE(simpar_type), INTENT(IN)                      :: simpar
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vector
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: veps
-      REAL(KIND=dp), INTENT(OUT)                         :: roll_tol
+      REAL(KIND=dp)                                      :: roll_tol
       INTEGER, INTENT(INOUT)                             :: iroll
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &

--- a/src/constraint_util.F
+++ b/src/constraint_util.F
@@ -481,7 +481,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE check_tol(roll_tol, iroll, char, matrix, veps)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: roll_tol
+      REAL(KIND=dp)                                      :: roll_tol
       INTEGER, INTENT(INOUT)                             :: iroll
       CHARACTER(LEN=*), INTENT(IN)                       :: char
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
@@ -537,8 +537,7 @@ CONTAINS
    SUBROUTINE get_roll_matrix(char, r_shake, v_shake, vector_r, vector_v, u)
 
       CHARACTER(len=*), INTENT(IN)                       :: char
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT), &
-         OPTIONAL                                        :: r_shake, v_shake
+      REAL(KIND=dp), DIMENSION(:, :), OPTIONAL           :: r_shake, v_shake
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: vector_r, vector_v
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
          OPTIONAL                                        :: u

--- a/src/core_ae.F
+++ b/src/core_ae.F
@@ -425,7 +425,7 @@ CONTAINS
    SUBROUTINE verfc_force(habd, pab, fa, fb, nder, la_max, la_min, npgfa, zeta, lb_max, lb_min, npgfb, zetb, rab)
 
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: habd, pab
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: fa, fb
+      REAL(KIND=dp), DIMENSION(3)                        :: fa, fb
       INTEGER, INTENT(IN)                                :: nder, la_max, la_min, npgfa
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: zeta
       INTEGER, INTENT(IN)                                :: lb_max, lb_min, npgfb

--- a/src/cp_dbcsr_diag.F
+++ b/src/cp_dbcsr_diag.F
@@ -67,7 +67,7 @@ CONTAINS
       ! needs more workspace in the worst case, but much better distributed
 
       TYPE(dbcsr_type)                                   :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
 
@@ -124,7 +124,7 @@ CONTAINS
 
       TYPE(dbcsr_type), POINTER                          :: matrix
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
       INTEGER, INTENT(IN), OPTIONAL                      :: neig
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: work_syevx
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -179,7 +179,7 @@ CONTAINS
 
       TYPE(dbcsr_type)                                   :: matrix
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
 

--- a/src/cp_dbcsr_operations.F
+++ b/src/cp_dbcsr_operations.F
@@ -418,7 +418,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_dbcsr_dist2d_to_dist(dist2d, dist)
       TYPE(distribution_2d_type), INTENT(IN), TARGET     :: dist2d
-      TYPE(dbcsr_distribution_type), INTENT(OUT)          :: dist
+      TYPE(dbcsr_distribution_type)          :: dist
 
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid, col_dist_data, row_dist_data
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
@@ -988,7 +988,7 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE create_bl_distribution (block_distribution,&
        block_size, nelements, nbins)
-      INTEGER, DIMENSION(:), INTENT(OUT), POINTER        :: block_distribution, block_size
+      INTEGER, DIMENSION(:), POINTER        :: block_distribution, block_size
       INTEGER, INTENT(IN)                                :: nelements, nbins
 
       CHARACTER(len=*), PARAMETER :: routineN = 'create_bl_distribution', &
@@ -1088,10 +1088,10 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE dbcsr_create_dist_r_unrot(dist_right, dist_left, ncolumns,&
        right_col_blk_sizes)
-      TYPE(dbcsr_distribution_type), INTENT(OUT)          :: dist_right
+      TYPE(dbcsr_distribution_type)          :: dist_right
       TYPE(dbcsr_distribution_type), INTENT(IN)           :: dist_left
       INTEGER, INTENT(IN)                                :: ncolumns
-      INTEGER, DIMENSION(:), INTENT(OUT), POINTER        :: right_col_blk_sizes
+      INTEGER, DIMENSION(:), POINTER        :: right_col_blk_sizes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_create_dist_r_unrot', &
          routineP = moduleN//':'//routineN
@@ -1160,7 +1160,7 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE rebin_distribution (new_bins, images, source_bins,&
        nbins, multiplicity, nimages)
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: new_bins, images
+      INTEGER, DIMENSION(:)                 :: new_bins, images
       INTEGER, DIMENSION(:), INTENT(IN)                  :: source_bins
       INTEGER, INTENT(IN)                                :: nbins, multiplicity, nimages
 
@@ -1210,11 +1210,11 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE dbcsr_create_dist_block_cyclic (dist, nrows, ncolumns,&
        nrow_block, ncol_block, group, pgrid, row_blk_sizes, col_blk_sizes)
-      TYPE(dbcsr_distribution_type), INTENT(OUT)          :: dist
+      TYPE(dbcsr_distribution_type)          :: dist
       INTEGER, INTENT(IN)                                :: nrows, ncolumns, nrow_block, ncol_block
       INTEGER, INTENT(IN)                                :: group
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
-      INTEGER, DIMENSION(:), INTENT(OUT), POINTER        :: row_blk_sizes, col_blk_sizes
+      INTEGER, DIMENSION(:), POINTER        :: row_blk_sizes, col_blk_sizes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dbcsr_create_dist_block_cyclic', &
          routineP = moduleN//':'//routineN

--- a/src/cp_ddapc_methods.F
+++ b/src/cp_ddapc_methods.F
@@ -551,7 +551,7 @@ CONTAINS
    SUBROUTINE ddapc_eval_AmI(GAmI, c0, gfunc, w, particle_set, gcut, &
                              rho_tot_g, radii, iw, Vol)
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: GAmI
-      REAL(KIND=dp), INTENT(OUT)                         :: c0
+      REAL(KIND=dp)                                      :: c0
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: gfunc
       REAL(KIND=dp), DIMENSION(:), POINTER               :: w
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set

--- a/src/cp_eri_mme_interface.F
+++ b/src/cp_eri_mme_interface.F
@@ -442,10 +442,9 @@ CONTAINS
          POINTER                                         :: qs_kind_set
       CHARACTER(len=*), INTENT(IN)                       :: basis_type_1
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: basis_type_2
-      REAL(KIND=dp), INTENT(OUT)                         :: zet_mm
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: zet_c
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: l_c
+      REAL(KIND=dp)                                      :: zet_mm
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zet_c
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: l_c
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'error_est_pgf_params_from_basis', &
          routineP = moduleN//':'//routineN

--- a/src/cp_external_control.F
+++ b/src/cp_external_control.F
@@ -88,7 +88,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE external_control(should_stop, flag, globenv, target_time, start_time)
 
-      LOGICAL, INTENT(OUT)                               :: should_stop
+      LOGICAL                                            :: should_stop
       CHARACTER(LEN=*), INTENT(IN)                       :: flag
       TYPE(global_environment_type), OPTIONAL, POINTER   :: globenv
       REAL(dp), OPTIONAL                                 :: target_time, start_time

--- a/src/cp_realspace_grid_init.F
+++ b/src/cp_realspace_grid_init.F
@@ -44,7 +44,7 @@ CONTAINS
 !>      if rs_grid_section is not present we setup for an replicated setup
 ! **************************************************************************************************
    SUBROUTINE init_input_type(input_settings, nsmax, rs_grid_section, ilevel, higher_grid_layout)
-      TYPE(realspace_grid_input_type), INTENT(OUT)       :: input_settings
+      TYPE(realspace_grid_input_type)                    :: input_settings
       INTEGER, INTENT(IN)                                :: nsmax
       TYPE(section_vals_type), OPTIONAL, POINTER         :: rs_grid_section
       INTEGER, INTENT(IN)                                :: ilevel

--- a/src/ct_methods.F
+++ b/src/ct_methods.F
@@ -526,7 +526,7 @@ CONTAINS
 
       TYPE(dbcsr_type), INTENT(IN)                       :: ks, p, t, v, q_index_down, p_index_up, &
                                                             q_index_up
-      TYPE(dbcsr_type), INTENT(OUT)                      :: pp, qq, qp, pq
+      TYPE(dbcsr_type)                                   :: pp, qq, qp, pq
       INTEGER, INTENT(IN)                                :: tensor_type
       LOGICAL, INTENT(IN)                                :: use_virt_orbs
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
@@ -724,11 +724,11 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(IN)                       :: pq
       TYPE(dbcsr_type), INTENT(IN), OPTIONAL             :: oo, vv
       TYPE(dbcsr_type), INTENT(INOUT)                    :: x
-      TYPE(dbcsr_type), INTENT(OUT)                      :: res
+      TYPE(dbcsr_type)                                   :: res
       LOGICAL, INTENT(IN)                                :: neglect_quadratic_term
       INTEGER, INTENT(IN)                                :: conjugator, max_iter
       REAL(KIND=dp), INTENT(IN)                          :: eps_convergence, eps_filter
-      LOGICAL, INTENT(OUT)                               :: converged
+      LOGICAL                                            :: converged
 
       CHARACTER(len=*), PARAMETER :: routineN = 'solve_riccati_equation', &
          routineP = moduleN//':'//routineN
@@ -1192,7 +1192,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE create_preconditioner(prec, pp, qq, eps_filter)
 
-      TYPE(dbcsr_type), INTENT(OUT)                      :: prec
+      TYPE(dbcsr_type)                                   :: prec
       TYPE(dbcsr_type), INTENT(IN)                       :: pp, qq
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
 
@@ -1366,8 +1366,8 @@ CONTAINS
    SUBROUTINE analytic_line_search(a, b, c, d, minima, nmins)
 
       REAL(KIND=dp), INTENT(IN)                          :: a, b, c, d
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: minima
-      INTEGER, INTENT(OUT)                               :: nmins
+      REAL(KIND=dp), DIMENSION(3)                        :: minima
+      INTEGER                                            :: nmins
 
       CHARACTER(len=*), PARAMETER :: routineN = 'analytic_line_search', &
          routineP = moduleN//':'//routineN
@@ -1492,8 +1492,8 @@ CONTAINS
    SUBROUTINE diagonalize_diagonal_blocks(matrix, c, e)
 
       TYPE(dbcsr_type), INTENT(IN)                       :: matrix
-      TYPE(dbcsr_type), INTENT(OUT)                      :: c
-      TYPE(dbcsr_type), INTENT(OUT), OPTIONAL            :: e
+      TYPE(dbcsr_type)                                   :: c
+      TYPE(dbcsr_type), OPTIONAL                         :: e
 
       CHARACTER(len=*), PARAMETER :: routineN = 'diagonalize_diagonal_blocks', &
          routineP = moduleN//':'//routineN

--- a/src/d3_poly.F
+++ b/src/d3_poly.F
@@ -825,7 +825,7 @@ CONTAINS
 !> \return ...
 ! **************************************************************************************************
    FUNCTION poly_random(p, maxSize, minSize) RESULT(res)
-      REAL(dp), DIMENSION(:), INTENT(out)                :: p
+      REAL(dp), DIMENSION(:)                             :: p
       INTEGER, INTENT(in)                                :: maxSize
       INTEGER, INTENT(in), OPTIONAL                      :: minSize
       INTEGER                                            :: res
@@ -864,7 +864,7 @@ CONTAINS
       REAL(dp), DIMENSION(:), INTENT(in)                 :: p
       REAL(dp), DIMENSION(3, 3), INTENT(in)              :: m
       REAL(dp), DIMENSION(3), INTENT(in)                 :: b
-      REAL(dp), DIMENSION(:), INTENT(out)                :: pRes
+      REAL(dp), DIMENSION(:)                             :: pRes
       INTEGER, INTENT(in), OPTIONAL                      :: npoly
 
       CHARACTER(len=*), PARAMETER :: routineN = 'poly_affine_t3t', &
@@ -1027,7 +1027,7 @@ CONTAINS
       REAL(dp), DIMENSION(:), INTENT(in)                 :: p
       REAL(dp), DIMENSION(3, 3), INTENT(in)              :: m
       REAL(dp), DIMENSION(3), INTENT(in)                 :: b
-      REAL(dp), DIMENSION(:), INTENT(out)                :: pRes
+      REAL(dp), DIMENSION(:)                             :: pRes
       INTEGER, INTENT(in), OPTIONAL                      :: npoly
 
       CHARACTER(len=*), PARAMETER :: routineN = 'poly_affine_t3', routineP = moduleN//':'//routineN
@@ -1875,7 +1875,7 @@ CONTAINS
    SUBROUTINE poly_cp2k2d3(poly_cp2k, grad, poly_d3)
       REAL(dp), DIMENSION(:), INTENT(in)                 :: poly_cp2k
       INTEGER, INTENT(in)                                :: grad
-      REAL(dp), DIMENSION(:), INTENT(out)                :: poly_d3
+      REAL(dp), DIMENSION(:)                             :: poly_d3
 
       CHARACTER(len=*), PARAMETER :: routineN = 'poly_cp2k2d3', routineP = moduleN//':'//routineN
 
@@ -1924,7 +1924,7 @@ CONTAINS
 !> \param poly_d3 ...
 ! **************************************************************************************************
    SUBROUTINE poly_d32cp2k(poly_cp2k, grad, poly_d3)
-      REAL(dp), DIMENSION(:), INTENT(out)                :: poly_cp2k
+      REAL(dp), DIMENSION(:)                             :: poly_cp2k
       INTEGER, INTENT(in)                                :: grad
       REAL(dp), DIMENSION(:), INTENT(in)                 :: poly_d3
 

--- a/src/distribution_2d_types.F
+++ b/src/distribution_2d_types.F
@@ -498,14 +498,14 @@ CONTAINS
                                   blacs_env, id_nr)
       TYPE(distribution_2d_type), POINTER                :: distribution_2d
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: row_distribution, col_distribution
-      INTEGER, INTENT(out), OPTIONAL                     :: n_row_distribution, n_col_distribution
+      INTEGER, OPTIONAL                                  :: n_row_distribution, n_col_distribution
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: n_local_rows, n_local_cols
       TYPE(cp_1d_i_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: local_rows, local_cols
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: flat_local_rows, flat_local_cols
-      INTEGER, INTENT(out), OPTIONAL                     :: n_flat_local_rows, n_flat_local_cols
+      INTEGER, OPTIONAL                                  :: n_flat_local_rows, n_flat_local_cols
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env
-      INTEGER, INTENT(out), OPTIONAL                     :: id_nr
+      INTEGER, OPTIONAL                                  :: id_nr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'distribution_2d_get', &
          routineP = moduleN//':'//routineN

--- a/src/distribution_methods.F
+++ b/src/distribution_methods.F
@@ -847,9 +847,9 @@ CONTAINS
                                       nprows, row_distribution, npcols, col_distribution)
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: cluster_list, cluster_prices
       INTEGER, INTENT(IN)                                :: nprows
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: row_distribution
+      INTEGER, DIMENSION(:)                              :: row_distribution
       INTEGER, INTENT(IN)                                :: npcols
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: col_distribution
+      INTEGER, DIMENSION(:)                              :: col_distribution
 
       CHARACTER(len=*), PARAMETER :: routineN = 'make_basic_distribution', &
          routineP = moduleN//':'//routineN
@@ -913,9 +913,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: pbc_scaled_coords
       INTEGER, DIMENSION(:), INTENT(IN)                  :: costs
       INTEGER, INTENT(IN)                                :: nprows
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: row_distribution
+      INTEGER, DIMENSION(:)                              :: row_distribution
       INTEGER, INTENT(IN)                                :: npcols
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: col_distribution
+      INTEGER, DIMENSION(:)                              :: col_distribution
 
       CHARACTER(len=*), PARAMETER :: routineN = 'make_basic_spatial_distribution', &
          routineP = moduleN//':'//routineN
@@ -1024,9 +1024,9 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       INTEGER, DIMENSION(:), INTENT(IN)                  :: costs
       INTEGER, INTENT(IN)                                :: nprows
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: row_distribution
+      INTEGER, DIMENSION(:, :)                           :: row_distribution
       INTEGER, INTENT(IN)                                :: npcols
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: col_distribution
+      INTEGER, DIMENSION(:, :)                           :: col_distribution
 
       CHARACTER(len=*), PARAMETER :: routineN = 'make_cluster_distribution', &
          routineP = moduleN//':'//routineN

--- a/src/dkh_main.F
+++ b/src/dkh_main.F
@@ -333,9 +333,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE kintegral(n, ev0t, tt, e, velit)
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: ev0t
+      REAL(KIND=dp), DIMENSION(:)                        :: ev0t
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tt
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: e
+      REAL(KIND=dp), DIMENSION(:)                        :: e
       REAL(KIND=dp), INTENT(IN)                          :: velit
 
       INTEGER                                            :: i
@@ -801,7 +801,7 @@ CONTAINS
       !***********************************************************************
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: ev4
+      REAL(KIND=dp), DIMENSION(:, :)                     :: ev4
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: e1, pe1p, vv, gg
 
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: o1w1, pvp, pvph, scr_1, scr_2, scr_3, &
@@ -1553,9 +1553,9 @@ CONTAINS
       !-----------------------------------------------------------------------
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: ev0t
+      REAL(KIND=dp), DIMENSION(:)                        :: ev0t
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tt
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: e
+      REAL(KIND=dp), DIMENSION(:)                        :: e
       REAL(KIND=dp), INTENT(IN)                          :: velit
 
       INTEGER                                            :: i
@@ -1622,7 +1622,7 @@ CONTAINS
       !-----------------------------------------------------------------------
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: ev1t
+      REAL(KIND=dp), DIMENSION(:, :)                     :: ev1t
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: vt, pvpt
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: aa, rr
 
@@ -1668,7 +1668,7 @@ CONTAINS
       !-----------------------------------------------------------------------
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: pev1tp
+      REAL(KIND=dp), DIMENSION(:, :)                     :: pev1tp
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: vt, pvpt
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: aa, rr, tt
 
@@ -1737,7 +1737,7 @@ CONTAINS
       !***********************************************************************
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: ev2
+      REAL(KIND=dp), DIMENSION(:, :)                     :: ev2
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: vv, gg
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: aa, rr, tt, e
 
@@ -1869,7 +1869,7 @@ CONTAINS
       !***********************************************************************
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: ev3
+      REAL(KIND=dp), DIMENSION(:, :)                     :: ev3
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: e1, pe1p, vv, gg
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: aa, rr, tt, e
 
@@ -2005,7 +2005,7 @@ CONTAINS
       !***********************************************************************
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: ev4
+      REAL(KIND=dp), DIMENSION(:, :)                     :: ev4
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: e1, pe1p, vv, gg
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: aa, rr, tt, e
 
@@ -2506,7 +2506,7 @@ CONTAINS
       !C                                                                      *
       !C***********************************************************************
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: p
+      REAL(KIND=dp), DIMENSION(:, :)                     :: p
       REAL(KIND=dp), INTENT(IN)                          :: alpha
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: q
       REAL(KIND=dp), INTENT(IN)                          :: beta
@@ -2634,8 +2634,8 @@ CONTAINS
    SUBROUTINE JACOB2(sogt, eigv, eigw, n, ic)
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(n), INTENT(OUT)           :: eigw
-      REAL(KIND=dp), DIMENSION(n, n), INTENT(OUT)        :: eigv
+      REAL(KIND=dp), DIMENSION(n)                        :: eigw
+      REAL(KIND=dp), DIMENSION(n, n)                     :: eigv
       REAL(KIND=dp), DIMENSION(n, n), INTENT(INOUT)      :: sogt
       INTEGER, INTENT(IN)                                :: ic
 

--- a/src/dm_ls_chebyshev.F
+++ b/src/dm_ls_chebyshev.F
@@ -54,7 +54,7 @@ CONTAINS
 !> \author Jinwoong Cha
 ! **************************************************************************************************
    SUBROUTINE chebyshev_poly(value, x, n)
-      REAL(KIND=dp), INTENT(OUT)                         :: value
+      REAL(KIND=dp)                                      :: value
       REAL(KIND=dp), INTENT(IN)                          :: x
       INTEGER, INTENT(IN)                                :: n
 
@@ -75,7 +75,7 @@ CONTAINS
 !> \author Jinwoong Cha
 ! **************************************************************************************************
    SUBROUTINE kernel(value, n, nc)
-      REAL(KIND=dp), INTENT(OUT)                         :: value
+      REAL(KIND=dp)                                      :: value
       INTEGER, INTENT(IN)                                :: n, nc
 
 !kernel at n

--- a/src/dm_ls_scf_methods.F
+++ b/src/dm_ls_scf_methods.F
@@ -436,7 +436,7 @@ CONTAINS
    SUBROUTINE density_matrix_sign_fixed_mu(matrix_p, trace, mu, matrix_ks, matrix_s, matrix_s_inv, threshold)
 
       TYPE(dbcsr_type), INTENT(INOUT)                    :: matrix_p
-      REAL(KIND=dp), INTENT(OUT)                         :: trace
+      REAL(KIND=dp)                                      :: trace
       REAL(KIND=dp), INTENT(INOUT)                       :: mu
       TYPE(dbcsr_type), INTENT(INOUT)                    :: matrix_ks, matrix_s, matrix_s_inv
       REAL(KIND=dp), INTENT(IN)                          :: threshold
@@ -531,7 +531,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(INOUT), OPTIONAL          :: matrix_ks_deviation
       INTEGER, INTENT(IN)                                :: max_iter_lanczos
       REAL(KIND=dp), INTENT(IN)                          :: eps_lanczos
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: converged
+      LOGICAL, OPTIONAL                                  :: converged
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_trs4', &
          routineP = moduleN//':'//routineN

--- a/src/domain_submatrix_methods.F
+++ b/src/domain_submatrix_methods.F
@@ -730,7 +730,7 @@ CONTAINS
 
       TYPE(domain_submatrix_type), DIMENSION(:), &
          INTENT(IN)                                      :: submatrices
-      REAL(KIND=dp), INTENT(OUT)                         :: norm
+      REAL(KIND=dp)                                      :: norm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'maxnorm_submatrices', &
          routineP = moduleN//':'//routineN
@@ -780,7 +780,7 @@ CONTAINS
 
       TYPE(domain_submatrix_type), DIMENSION(:), &
          INTENT(IN)                                      :: A, B
-      REAL(KIND=dp), INTENT(OUT)                         :: trace
+      REAL(KIND=dp)                                      :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'trace_submatrices', &
          routineP = moduleN//':'//routineN

--- a/src/eip_environment_types.F
+++ b/src/eip_environment_types.F
@@ -223,10 +223,10 @@ CONTAINS
                           virial)
 
       TYPE(eip_environment_type), POINTER                :: eip_env
-      INTEGER, INTENT(OUT), OPTIONAL                     :: id_nr, eip_model
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: eip_energy, eip_energy_var
+      INTEGER, OPTIONAL                                  :: id_nr, eip_model
+      REAL(KIND=dp), OPTIONAL                            :: eip_energy, eip_energy_var
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: eip_forces
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: coord_avg, coord_var, count
+      REAL(KIND=dp), OPTIONAL                            :: coord_avg, coord_var, count
       TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
       TYPE(atomic_kind_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: atomic_kind_set
@@ -240,8 +240,8 @@ CONTAINS
       TYPE(distribution_1d_type), OPTIONAL, POINTER      :: local_molecules
       TYPE(section_vals_type), OPTIONAL, POINTER         :: eip_input, force_env_input
       TYPE(cell_type), OPTIONAL, POINTER                 :: cell, cell_ref
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: use_ref_cell
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: eip_kinetic_energy, eip_potential_energy
+      LOGICAL, OPTIONAL                                  :: use_ref_cell
+      REAL(KIND=dp), OPTIONAL                            :: eip_kinetic_energy, eip_potential_energy
       TYPE(virial_type), OPTIONAL, POINTER               :: virial
 
       CHARACTER(len=*), PARAMETER :: routineN = 'eip_env_get', routineP = moduleN//':'//routineN

--- a/src/embed_types.F
+++ b/src/embed_types.F
@@ -206,7 +206,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE init_embed_env(embed_env, para_env)
 
-      TYPE(embed_env_type), INTENT(OUT)                  :: embed_env
+      TYPE(embed_env_type)                               :: embed_env
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       NULLIFY (embed_env%input)

--- a/src/emd/rt_propagation_methods.F
+++ b/src/emd/rt_propagation_methods.F
@@ -495,7 +495,7 @@ CONTAINS
 
    SUBROUTINE complex_frobenius_norm(frob_norm, mat_re, mat_im)
 
-      REAL(KIND=dp), INTENT(out)                         :: frob_norm
+      REAL(KIND=dp)                                      :: frob_norm
       TYPE(dbcsr_type), POINTER                          :: mat_re, mat_im
 
       CHARACTER(len=*), PARAMETER :: routineN = 'complex_frobenius_norm', &

--- a/src/emd/rt_propagation_output.F
+++ b/src/emd/rt_propagation_output.F
@@ -260,7 +260,7 @@ CONTAINS
 !> \author Florian Schiffmann (02.09)
 ! **************************************************************************************************
    SUBROUTINE rt_calculate_orthonormality(orthonormality, mos_new, matrix_s)
-      REAL(KIND=dp), INTENT(out)                         :: orthonormality
+      REAL(KIND=dp)                                      :: orthonormality
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mos_new
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_s
 
@@ -343,7 +343,7 @@ CONTAINS
       TYPE(rt_prop_type), POINTER                        :: rtp
       TYPE(dbcsr_type), POINTER                          :: matrix_s
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: delta_mos
-      REAL(dp), INTENT(out)                              :: delta_eps
+      REAL(dp)                                           :: delta_eps
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rt_convergence', routineP = moduleN//':'//routineN
       REAL(KIND=dp), PARAMETER                           :: one = 1.0_dp, zero = 0.0_dp
@@ -454,7 +454,7 @@ CONTAINS
 
       TYPE(rt_prop_type), POINTER                        :: rtp
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: delta_P
-      REAL(dp), INTENT(out)                              :: delta_eps
+      REAL(dp)                                           :: delta_eps
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rt_convergence_density', &
          routineP = moduleN//':'//routineN

--- a/src/environment.F
+++ b/src/environment.F
@@ -1043,7 +1043,7 @@ CONTAINS
    SUBROUTINE cp2k_get_walltime(section, keyword_name, walltime)
       TYPE(section_vals_type), POINTER                   :: section
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
-      REAL(KIND=dp), INTENT(out)                         :: walltime
+      REAL(KIND=dp)                                      :: walltime
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp2k_get_walltime', &
          routineP = moduleN//':'//routineN

--- a/src/eri_mme/eri_mme_error_control.F
+++ b/src/eri_mme/eri_mme_error_control.F
@@ -71,7 +71,7 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: l_c
       INTEGER, INTENT(IN)                                :: n_minimax
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_l, cutoff_r, tol, delta
-      REAL(KIND=dp), INTENT(OUT)                         :: cutoff, err_mm, err_c, C_mm
+      REAL(KIND=dp)                                      :: cutoff, err_mm, err_c, C_mm
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
       LOGICAL, INTENT(IN)                                :: print_calib
       INTEGER, INTENT(IN)                                :: unit_nr
@@ -215,8 +215,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: zet_ctff
       INTEGER, DIMENSION(:), INTENT(IN)                  :: l_ctff
       INTEGER, INTENT(IN)                                :: n_minimax
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: minimax_aw
-      REAL(KIND=dp), INTENT(OUT)                         :: err_mm, err_ctff, C_mm
+      REAL(KIND=dp), DIMENSION(:)                        :: minimax_aw
+      REAL(KIND=dp)                                      :: err_mm, err_ctff, C_mm
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cutoff_minimax_error', &
@@ -349,7 +349,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: G_min
       INTEGER, INTENT(IN)                                :: l_c
       REAL(KIND=dp), INTENT(IN)                          :: zet_c, C_mm
-      REAL(KIND=dp), INTENT(OUT)                         :: err_c
+      REAL(KIND=dp)                                      :: err_c
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cutoff_error_fixed_exp', &

--- a/src/eri_mme/eri_mme_gaussian.F
+++ b/src/eri_mme/eri_mme_gaussian.F
@@ -87,8 +87,8 @@ CONTAINS
    SUBROUTINE get_minimax_coeff_v_gspace(n_minimax, cutoff, G_min, minimax_aw, err_minimax)
       INTEGER, INTENT(IN)                                :: n_minimax
       REAL(KIND=dp), INTENT(IN)                          :: cutoff, G_min
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: minimax_aw
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: err_minimax
+      REAL(KIND=dp), DIMENSION(:)                        :: minimax_aw
+      REAL(KIND=dp), OPTIONAL                            :: err_minimax
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_minimax_coeff_v_gspace', &
          routineP = moduleN//':'//routineN

--- a/src/eri_mme/eri_mme_integrate.F
+++ b/src/eri_mme/eri_mme_integrate.F
@@ -71,7 +71,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: la_min, la_max, lb_min, lb_max
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rab
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: hab
+      REAL(KIND=dp), DIMENSION(:, :)                     :: hab
       INTEGER, INTENT(IN)                                :: o1, o2
       INTEGER, INTENT(INOUT), OPTIONAL                   :: G_count, R_count
       LOGICAL, INTENT(IN), OPTIONAL                      :: normalize, exact_method

--- a/src/eri_mme/eri_mme_lattice_summation.F
+++ b/src/eri_mme/eri_mme_lattice_summation.F
@@ -67,7 +67,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: la_max, lb_max
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb, a_mm, G_min, R_min, &
                                                             sum_precision
-      REAL(KIND=dp), INTENT(OUT)                         :: G_rad, R_rad
+      REAL(KIND=dp)                                      :: G_rad, R_rad
 
       INTEGER                                            :: l_max
       REAL(KIND=dp)                                      :: alpha_G, alpha_R, G_res, R_res
@@ -106,8 +106,8 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb, zetc, a_mm
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: G_min, R_min
       REAL(KIND=dp), INTENT(IN)                          :: sum_precision
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: G_rads_1, R_rads_2
-      REAL(KIND=dp), DIMENSION(2), INTENT(OUT), OPTIONAL :: R_rads_3
+      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: G_rads_1, R_rads_2
+      REAL(KIND=dp), DIMENSION(2), OPTIONAL              :: R_rads_3
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eri_mme_3c_get_rads', &
          routineP = moduleN//':'//routineN
@@ -177,12 +177,12 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: G_min, R_min
       INTEGER, INTENT(IN)                                :: la_max, lb_max
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb, a_mm, sum_precision
-      INTEGER(KIND=int_8), DIMENSION(2, 3), INTENT(OUT)  :: n_sum_1d
-      INTEGER(KIND=int_8), DIMENSION(2), INTENT(OUT)     :: n_sum_3d
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: G_bounds
-      REAL(KIND=dp), INTENT(OUT)                         :: G_rad
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: R_bounds
-      REAL(KIND=dp), INTENT(OUT)                         :: R_rad
+      INTEGER(KIND=int_8), DIMENSION(2, 3)               :: n_sum_1d
+      INTEGER(KIND=int_8), DIMENSION(2)                  :: n_sum_3d
+      REAL(KIND=dp), DIMENSION(3)                        :: G_bounds
+      REAL(KIND=dp)                                      :: G_rad
+      REAL(KIND=dp), DIMENSION(3)                        :: R_bounds
+      REAL(KIND=dp)                                      :: R_rad
 
       INTEGER                                            :: i_xyz
       REAL(KIND=dp)                                      :: ns_G, ns_R, vol_G
@@ -244,14 +244,14 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: G_min, R_min
       INTEGER, INTENT(IN)                                :: la_max, lb_max, lc_max
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb, zetc, a_mm, sum_precision
-      INTEGER(KIND=int_8), DIMENSION(3, 3), INTENT(OUT)  :: n_sum_1d
-      INTEGER(KIND=int_8), DIMENSION(3), INTENT(OUT)     :: n_sum_3d
+      INTEGER(KIND=int_8), DIMENSION(3, 3)               :: n_sum_1d
+      INTEGER(KIND=int_8), DIMENSION(3)                  :: n_sum_3d
       REAL(KIND=dp), DIMENSION(3, 3)                     :: G_bounds_1
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: G_rads_1
+      REAL(KIND=dp), DIMENSION(3)                        :: G_rads_1
       REAL(KIND=dp), DIMENSION(3, 3)                     :: R_bounds_2
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: R_rads_2
+      REAL(KIND=dp), DIMENSION(3)                        :: R_rads_2
       REAL(KIND=dp), DIMENSION(2, 3)                     :: R_bounds_3
-      REAL(KIND=dp), DIMENSION(2), INTENT(OUT)           :: R_rads_3
+      REAL(KIND=dp), DIMENSION(2)                        :: R_rads_3
 
       INTEGER                                            :: i, i_xyz, order_1, order_2
       REAL(KIND=dp)                                      :: ns1_G1, ns1_G2, ns2_G, ns2_R, ns3_R1, &
@@ -747,12 +747,12 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pgf_sum_3c_1d(S_G, RA, RB, RC, zeta, zetb, zetc, a_mm, lgth, &
                             G_bounds_1, R_bounds_2, R_bounds_3, method, method_out, order)
-      REAL(KIND=dp), DIMENSION(0:, 0:, 0:), INTENT(OUT)  :: S_G
+      REAL(KIND=dp), DIMENSION(0:, 0:, 0:)               :: S_G
       REAL(KIND=dp), INTENT(IN)                          :: RA, RB, RC, zeta, zetb, zetc, a_mm, lgth
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: G_bounds_1, R_bounds_2
       REAL(KIND=dp), DIMENSION(2), INTENT(IN)            :: R_bounds_3
       INTEGER, INTENT(IN)                                :: method
-      INTEGER, INTENT(OUT), OPTIONAL                     :: method_out
+      INTEGER, OPTIONAL                                  :: method_out
       INTEGER, INTENT(IN), OPTIONAL                      :: order
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'pgf_sum_3c_1d', routineP = moduleN//':'//routineN
@@ -1258,7 +1258,7 @@ CONTAINS
                             G_bounds_1, R_bounds_2, R_bounds_3, &
                             G_rads_1, R_rads_2, R_rads_3, &
                             method, method_out, order)
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: S_G
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: S_G
       INTEGER, INTENT(IN)                                :: la_max, lb_max, lc_max
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: RA, RB, RC
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb, zetc, a_mm
@@ -1269,7 +1269,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: G_rads_1, R_rads_2
       REAL(KIND=dp), DIMENSION(2), INTENT(IN)            :: R_rads_3
       INTEGER, INTENT(IN)                                :: method
-      INTEGER, INTENT(OUT), OPTIONAL                     :: method_out
+      INTEGER, OPTIONAL                                  :: method_out
       INTEGER, INTENT(IN), OPTIONAL                      :: order
 
       INTEGER                                            :: l_max, m_max, n_max, sum_method, &
@@ -1892,7 +1892,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pgf_sum_3c_rspace_3d(S_R, l_max, m_max, n_max, RA, RB, RC, zeta, zetb, zetc, a_mm, &
                                    hmat, h_inv, R_c, R_rad)
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: S_R
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: S_R
       INTEGER, INTENT(IN)                                :: l_max, m_max, n_max
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: RA, RB, RC
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb, zetc, a_mm

--- a/src/eri_mme/eri_mme_test.F
+++ b/src/eri_mme/eri_mme_test.F
@@ -58,7 +58,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: test_accuracy
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
       INTEGER, INTENT(IN)                                :: iw
-      INTEGER, INTENT(OUT), OPTIONAL                     :: G_count, R_count
+      INTEGER, OPTIONAL                                  :: G_count, R_count
 
       CHARACTER(len=*), PARAMETER :: routineN = 'eri_mme_2c_perf_acc_test', &
          routineP = moduleN//':'//routineN
@@ -180,7 +180,7 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: nsample
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
       INTEGER, INTENT(IN)                                :: iw
-      INTEGER, INTENT(OUT), OPTIONAL                     :: GG_count, GR_count, RR_count
+      INTEGER, OPTIONAL                                  :: GG_count, GR_count, RR_count
 
       CHARACTER(len=*), PARAMETER :: routineN = 'eri_mme_3c_perf_acc_test', &
          routineP = moduleN//':'//routineN

--- a/src/eri_mme/eri_mme_types.F
+++ b/src/eri_mme/eri_mme_types.F
@@ -84,7 +84,7 @@ CONTAINS
    SUBROUTINE eri_mme_init(param, n_minimax, cutoff, do_calib_cutoff, &
                            cutoff_min, cutoff_max, cutoff_eps, cutoff_delta, sum_precision, &
                            debug, debug_delta, debug_nsum, unit_nr, print_calib)
-      TYPE(eri_mme_param), INTENT(OUT)                   :: param
+      TYPE(eri_mme_param)                                :: param
       INTEGER, INTENT(IN)                                :: n_minimax
       REAL(KIND=dp), INTENT(IN)                          :: cutoff
       LOGICAL, INTENT(IN)                                :: do_calib_cutoff

--- a/src/ewald_environment_types.F
+++ b/src/ewald_environment_types.F
@@ -135,11 +135,11 @@ CONTAINS
       REAL(KIND=dp), OPTIONAL                            :: alpha, eps_pol, epsilon
       INTEGER, OPTIONAL                                  :: gmax(3), ns_max, o_spline, group
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
-      INTEGER, INTENT(OUT), OPTIONAL                     :: id_nr
+      INTEGER, OPTIONAL                                  :: id_nr
       TYPE(section_vals_type), OPTIONAL, POINTER         :: poisson_section
       REAL(KIND=dp), OPTIONAL                            :: precs, rcut
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: do_multipoles
-      INTEGER, INTENT(OUT), OPTIONAL                     :: max_multipole, do_ipol, max_ipol_iter
+      LOGICAL, OPTIONAL                                  :: do_multipoles
+      INTEGER, OPTIONAL                                  :: max_multipole, do_ipol, max_ipol_iter
       REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
          POINTER                                         :: interaction_cutoffs
       REAL(KIND=dp), DIMENSION(3, 3), OPTIONAL           :: cell_hmat

--- a/src/ewalds.F
+++ b/src/ewalds.F
@@ -81,9 +81,9 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fg_coulomb
-      REAL(KIND=dp), INTENT(OUT)                         :: vg_coulomb
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: pv_g
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fg_coulomb
+      REAL(KIND=dp)                                      :: vg_coulomb
+      REAL(KIND=dp), DIMENSION(:, :)                     :: pv_g
       LOGICAL, INTENT(IN)                                :: use_virial
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: charges, e_coulomb
       REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
@@ -304,7 +304,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      REAL(KIND=dp), INTENT(OUT)                         :: e_self, e_neut
+      REAL(KIND=dp)                                      :: e_self, e_neut
       REAL(KIND=dp), DIMENSION(:), POINTER               :: charges
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ewald_self', routineP = moduleN//':'//routineN

--- a/src/ewalds_multipole.F
+++ b/src/ewalds_multipole.F
@@ -131,7 +131,7 @@ CONTAINS
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
       REAL(KIND=dp), INTENT(INOUT)                       :: energy_local, energy_glob
-      REAL(KIND=dp), INTENT(OUT)                         :: e_neut, e_self
+      REAL(KIND=dp)                         :: e_neut, e_self
       LOGICAL, DIMENSION(3), INTENT(IN)                  :: task
       LOGICAL, INTENT(IN)                                :: do_correction_bonded, do_forces, &
                                                             do_stress, do_efield
@@ -142,8 +142,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
          OPTIONAL                                        :: forces_local, forces_glob, pv_local, &
                                                             pv_glob
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT), OPTIONAL :: efield0
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT), &
+      REAL(KIND=dp), DIMENSION(:), OPTIONAL :: efield0
+      REAL(KIND=dp), DIMENSION(:, :), &
          OPTIONAL                                        :: efield1, efield2
       INTEGER, INTENT(IN)                                :: iw
       LOGICAL, INTENT(IN)                                :: do_debug
@@ -976,7 +976,7 @@ $: ewalds_multipole_sr_macro(mode="SCREENED_COULOMB_ERF", store_energy=True, sto
 ! **************************************************************************************************
    SUBROUTINE get_atom_factor(atm_factor, pw_grid, gpt, iparticle, task, charges, &
                               dipoles, quadrupoles)
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: atm_factor
+      COMPLEX(KIND=dp)                      :: atm_factor
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       INTEGER, INTENT(IN)                                :: gpt
       INTEGER                                            :: iparticle
@@ -1033,7 +1033,7 @@ $: ewalds_multipole_sr_macro(mode="SCREENED_COULOMB_ERF", store_energy=True, sto
 ! **************************************************************************************************
    SUBROUTINE get_atom_factor_stress(atm_factor, pw_grid, gpt, iparticle, task, &
                                      dipoles, quadrupoles)
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: atm_factor(3)
+      COMPLEX(KIND=dp)                      :: atm_factor(3)
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       INTEGER, INTENT(IN)                                :: gpt
       INTEGER                                            :: iparticle
@@ -1094,7 +1094,7 @@ $: ewalds_multipole_sr_macro(mode="SCREENED_COULOMB_ERF", store_energy=True, sto
       TYPE(ewald_environment_type), POINTER              :: ewald_env
       TYPE(cell_type), INTENT(IN)                        :: cell
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      REAL(KIND=dp), INTENT(OUT)                         :: e_self, e_neut
+      REAL(KIND=dp)                         :: e_self, e_neut
       LOGICAL, DIMENSION(3, 3), INTENT(IN)               :: task
       LOGICAL, INTENT(IN)                                :: do_efield
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: radii, charges
@@ -1575,7 +1575,7 @@ $: ewalds_multipole_sr_macro(mode="SCREENED_COULOMB_ERF", store_energy=True, sto
       TYPE(cell_type), POINTER                           :: cell
       TYPE(fist_nonbond_env_type), POINTER               :: nonbond_env
       TYPE(multi_charge_type), DIMENSION(:), POINTER     :: multipoles
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                         :: energy
       LOGICAL, INTENT(IN)                                :: debug_r_space
 
       CHARACTER(len=*), PARAMETER :: routineN = 'debug_ewald_multipole_low', &

--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -210,7 +210,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE init_cp2k(init_mpi, ierr)
       LOGICAL, INTENT(in)                                :: init_mpi
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'init_cp2k', routineP = moduleN//':'//routineN
 
@@ -295,7 +295,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE finalize_cp2k(finalize_mpi, ierr)
       LOGICAL, INTENT(in)                                :: finalize_mpi
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'finalize_cp2k', routineP = moduleN//':'//routineN
 
@@ -432,7 +432,7 @@ CONTAINS
    SUBROUTINE f_env_add_defaults(f_env_id, f_env, handle)
       INTEGER, INTENT(in)                                :: f_env_id
       TYPE(f_env_type), POINTER                          :: f_env
-      INTEGER, INTENT(out), OPTIONAL                     :: handle
+      INTEGER, OPTIONAL                                  :: handle
 
       CHARACTER(len=*), PARAMETER :: routineN = 'f_env_add_defaults', &
          routineP = moduleN//':'//routineN
@@ -478,7 +478,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE f_env_rm_defaults(f_env, ierr, handle)
       TYPE(f_env_type), POINTER                          :: f_env
-      INTEGER, INTENT(out), OPTIONAL                     :: ierr
+      INTEGER, OPTIONAL                                  :: ierr
       INTEGER, INTENT(in), OPTIONAL                      :: handle
 
       CHARACTER(len=*), PARAMETER :: routineN = 'f_env_rm_defaults', &
@@ -552,14 +552,14 @@ CONTAINS
    RECURSIVE SUBROUTINE create_force_env(new_env_id, input_declaration, input_path, &
                                          output_path, mpi_comm, output_unit, owns_out_unit, &
                                          input, ierr, work_dir, initial_variables)
-      INTEGER, INTENT(out)                               :: new_env_id
+      INTEGER                                            :: new_env_id
       TYPE(section_type), POINTER                        :: input_declaration
       CHARACTER(len=*), INTENT(in)                       :: input_path
       CHARACTER(len=*), INTENT(in), OPTIONAL             :: output_path
       INTEGER, INTENT(in), OPTIONAL                      :: mpi_comm, output_unit
       LOGICAL, INTENT(in), OPTIONAL                      :: owns_out_unit
       TYPE(section_vals_type), OPTIONAL, POINTER         :: input
-      INTEGER, INTENT(out), OPTIONAL                     :: ierr
+      INTEGER, OPTIONAL                                  :: ierr
       CHARACTER(len=*), INTENT(in), OPTIONAL             :: work_dir
       CHARACTER(len=*), DIMENSION(:, :), OPTIONAL        :: initial_variables
 
@@ -930,7 +930,7 @@ CONTAINS
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE destroy_force_env(env_id, ierr, q_finalize)
       INTEGER, INTENT(in)                                :: env_id
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
       LOGICAL, INTENT(IN), OPTIONAL                      :: q_finalize
 
       CHARACTER(len=*), PARAMETER :: routineN = 'destroy_force_env', &
@@ -979,7 +979,7 @@ CONTAINS
    SUBROUTINE get_natom(env_id, n_atom, ierr)
 
       INTEGER, INTENT(IN)                                :: env_id
-      INTEGER, INTENT(OUT)                               :: n_atom, ierr
+      INTEGER                                            :: n_atom, ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_natom', routineP = moduleN//':'//routineN
 
@@ -1004,7 +1004,7 @@ CONTAINS
    SUBROUTINE get_nparticle(env_id, n_particle, ierr)
 
       INTEGER, INTENT(IN)                                :: env_id
-      INTEGER, INTENT(OUT)                               :: n_particle, ierr
+      INTEGER                                            :: n_particle, ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_nparticle', routineP = moduleN//':'//routineN
 
@@ -1031,7 +1031,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: env_id
       REAL(KIND=DP), DIMENSION(3, 3)                     :: cell
       INTEGER, DIMENSION(3), OPTIONAL                    :: per
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_cell', routineP = moduleN//':'//routineN
 
@@ -1108,7 +1108,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: env_id, n_el
       REAL(KIND=dp), DIMENSION(1:n_el)                   :: frc
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_force', routineP = moduleN//':'//routineN
 
@@ -1131,8 +1131,8 @@ CONTAINS
    SUBROUTINE get_stress_tensor(env_id, stress_tensor, ierr)
 
       INTEGER, INTENT(IN)                                :: env_id
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: stress_tensor
-      INTEGER, INTENT(OUT)                               :: ierr
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: stress_tensor
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_stress_tensor', &
          routineP = moduleN//':'//routineN
@@ -1168,7 +1168,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: env_id, n_el
       REAL(KIND=DP), DIMENSION(1:n_el)                   :: pos
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_pos', routineP = moduleN//':'//routineN
 
@@ -1194,7 +1194,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: env_id, n_el
       REAL(KIND=DP), DIMENSION(1:n_el)                   :: vel
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_vel', routineP = moduleN//':'//routineN
 
@@ -1218,7 +1218,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: env_id
       REAL(KIND=DP), DIMENSION(3, 3)                     :: new_cell
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_cell', routineP = moduleN//':'//routineN
 
@@ -1252,7 +1252,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: env_id, n_el
       REAL(KIND=dp), DIMENSION(1:n_el)                   :: new_pos
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_pos', routineP = moduleN//':'//routineN
 
@@ -1281,7 +1281,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: env_id, n_el
       REAL(kind=dp), DIMENSION(1:n_el)                   :: new_vel
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_vel', routineP = moduleN//':'//routineN
 
@@ -1309,7 +1309,7 @@ CONTAINS
 
       INTEGER, INTENT(in)                                :: env_id
       LOGICAL, INTENT(in)                                :: calc_force
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calc_energy_force', &
          routineP = moduleN//':'//routineN
@@ -1336,8 +1336,8 @@ CONTAINS
    SUBROUTINE get_energy(env_id, e_pot, ierr)
 
       INTEGER, INTENT(in)                                :: env_id
-      REAL(kind=dp), INTENT(out)                         :: e_pot
-      INTEGER, INTENT(out)                               :: ierr
+      REAL(kind=dp)                                      :: e_pot
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_energy', routineP = moduleN//':'//routineN
 
@@ -1366,8 +1366,8 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: env_id, n_el
       REAL(KIND=dp), DIMENSION(1:n_el), INTENT(IN)       :: pos
-      REAL(KIND=dp), INTENT(OUT)                         :: e_pot
-      INTEGER, INTENT(OUT)                               :: ierr
+      REAL(KIND=dp)                                      :: e_pot
+      INTEGER                                            :: ierr
 
       REAL(KIND=dp), DIMENSION(1)                        :: dummy_f
 
@@ -1396,11 +1396,11 @@ CONTAINS
 
       INTEGER, INTENT(in)                                :: env_id, n_el_pos
       REAL(kind=dp), DIMENSION(1:n_el_pos), INTENT(in)   :: pos
-      REAL(kind=dp), INTENT(out)                         :: e_pot
+      REAL(kind=dp)                                      :: e_pot
       INTEGER, INTENT(in)                                :: n_el_force
       REAL(kind=dp), DIMENSION(1:n_el_force), &
          INTENT(inout)                                   :: force
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       LOGICAL                                            :: calc_f
 
@@ -1431,7 +1431,7 @@ CONTAINS
       CHARACTER(len=*), INTENT(in)                       :: input_file_path, output_file_path
       LOGICAL, INTENT(in), OPTIONAL                      :: echo_input
       INTEGER, INTENT(in), OPTIONAL                      :: mpi_comm
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'check_input', routineP = moduleN//':'//routineN
 

--- a/src/farming_methods.F
+++ b/src/farming_methods.F
@@ -49,7 +49,7 @@ CONTAINS
       TYPE(farming_env_type), POINTER                    :: farming_env
       INTEGER, INTENT(IN)                                :: start, END
       INTEGER, INTENT(INOUT)                             :: current
-      INTEGER, INTENT(OUT)                               :: todo
+      INTEGER                                            :: todo
 
       INTEGER                                            :: icheck, idep, itry, ndep
       LOGICAL                                            :: dep_ok

--- a/src/fermi_utils.F
+++ b/src/fermi_utils.F
@@ -44,7 +44,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE Fermi(f, N, kTS, e, mu, T, maxocc, estate, festate)
 
-      REAL(KIND=dp), INTENT(out)                         :: f(:), N, kTS
+      REAL(KIND=dp)                                      :: f(:), N, kTS
       REAL(KIND=dp), INTENT(IN)                          :: e(:), mu, T, maxocc
       INTEGER, INTENT(IN), OPTIONAL                      :: estate
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: festate
@@ -115,8 +115,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE Fermi2(f, nel, kTS, e, mu, wk, t, maxocc)
 
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: f
-      REAL(KIND=dp), INTENT(OUT)                         :: nel, kTS
+      REAL(KIND=dp), DIMENSION(:, :)                     :: f
+      REAL(KIND=dp)                                      :: nel, kTS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: e
       REAL(KIND=dp), INTENT(IN)                          :: mu
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wk
@@ -201,7 +201,7 @@ CONTAINS
 !> \author  Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE FermiFixed(f, mu, kTS, e, N, T, maxocc, estate, festate)
-      REAL(KIND=dp), INTENT(OUT)                         :: f(:), mu, kTS
+      REAL(KIND=dp)                                      :: f(:), mu, kTS
       REAL(KIND=dp), INTENT(IN)                          :: e(:), N, T, maxocc
       INTEGER, INTENT(IN), OPTIONAL                      :: estate
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: festate
@@ -284,8 +284,8 @@ CONTAINS
 !> \param maxocc Maximum occupation
 ! **************************************************************************************************
    SUBROUTINE Fermikp(f, mu, kTS, e, nel, wk, t, maxocc)
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: f
-      REAL(KIND=dp), INTENT(OUT)                         :: mu, kTS
+      REAL(KIND=dp), DIMENSION(:, :)                     :: f
+      REAL(KIND=dp)                                      :: mu, kTS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: e
       REAL(KIND=dp), INTENT(IN)                          :: nel
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wk
@@ -338,8 +338,8 @@ CONTAINS
 !> \param t   Temperature
 ! **************************************************************************************************
    SUBROUTINE Fermikp2(f, mu, kTS, e, nel, wk, t)
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: f
-      REAL(KIND=dp), INTENT(OUT)                         :: mu, kTS
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: f
+      REAL(KIND=dp)                                      :: mu, kTS
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: e
       REAL(KIND=dp), INTENT(IN)                          :: nel
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wk
@@ -416,7 +416,7 @@ CONTAINS
 !> \author  Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE FermiFixedDeriv(dfde, f, mu, kTS, e, N, T, maxocc, l, estate, festate)
-      REAL(KIND=dp), INTENT(OUT)                         :: dfde(:, :), f(:), mu, kTS
+      REAL(KIND=dp)                                      :: dfde(:, :), f(:), mu, kTS
       REAL(KIND=dp), INTENT(IN)                          :: e(:), N, T, maxocc, l
       INTEGER, INTENT(IN), OPTIONAL                      :: estate
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: festate

--- a/src/fist_efield_methods.F
+++ b/src/fist_efield_methods.F
@@ -56,9 +56,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fist_efield_energy_force(qenergy, qforce, qpv, atomic_kind_set, particle_set, cell, &
                                        efield, use_virial, iunit, charges)
-      REAL(KIND=dp), INTENT(OUT)                         :: qenergy
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: qforce
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: qpv
+      REAL(KIND=dp)                                      :: qenergy
+      REAL(KIND=dp), DIMENSION(:, :)                     :: qforce
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: qpv
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(cell_type), POINTER                           :: cell

--- a/src/fist_environment_types.F
+++ b/src/fist_environment_types.F
@@ -239,7 +239,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE init_fist_env(fist_env, para_env)
 
-      TYPE(fist_environment_type), INTENT(OUT)           :: fist_env
+      TYPE(fist_environment_type)                        :: fist_env
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       NULLIFY (fist_env%input)

--- a/src/fist_neighbor_list_types.F
+++ b/src/fist_neighbor_list_types.F
@@ -231,7 +231,7 @@ CONTAINS
       TYPE(neighbor_kind_pairs_type), POINTER            :: neighbor_kind_pair
       INTEGER, INTENT(IN)                                :: atom_a, atom_b
       REAL(KIND=dp), DIMENSION(3)                        :: rab
-      LOGICAL, INTENT(OUT)                               :: check_spline
+      LOGICAL                                            :: check_spline
       INTEGER, INTENT(IN)                                :: id_kind
       LOGICAL, INTENT(IN)                                :: skip
       TYPE(cell_type), POINTER                           :: cell

--- a/src/fist_nonbond_env_types.F
+++ b/src/fist_nonbond_env_types.F
@@ -113,7 +113,7 @@ CONTAINS
       TYPE(fist_neighbor_type), OPTIONAL, POINTER        :: nonbonded
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: rlist_cut, rlist_lowsq
       REAL(KIND=dp), OPTIONAL                            :: aup, lup, ei_scale14, vdw_scale14
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: shift_cutoff
+      LOGICAL, OPTIONAL                                  :: shift_cutoff
       TYPE(pos_type), DIMENSION(:), OPTIONAL, POINTER    :: r_last_update, r_last_update_pbc, &
                                                             rshell_last_update_pbc, &
                                                             rcore_last_update_pbc

--- a/src/fist_nonbond_force.F
+++ b/src/fist_nonbond_force.F
@@ -87,10 +87,9 @@ CONTAINS
       TYPE(ewald_environment_type), POINTER              :: ewald_env
       TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: particle_set
       TYPE(cell_type), POINTER                           :: cell
-      REAL(KIND=dp), INTENT(OUT)                         :: pot_nonbond
+      REAL(KIND=dp)                                      :: pot_nonbond
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: f_nonbond, pv_nonbond
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT), &
-         OPTIONAL                                        :: fshell_nonbond, fcore_nonbond
+      REAL(KIND=dp), DIMENSION(:, :), OPTIONAL           :: fshell_nonbond, fcore_nonbond
       TYPE(atprop_type), POINTER                         :: atprop_env
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)
       LOGICAL, INTENT(IN)                                :: use_virial
@@ -649,8 +648,8 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_particles
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(ewald_environment_type), POINTER              :: ewald_env
-      REAL(KIND=dp), INTENT(OUT)                         :: v_bonded_corr
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: pv_bc
+      REAL(KIND=dp)                                      :: v_bonded_corr
+      REAL(KIND=dp), DIMENSION(:, :)                     :: pv_bc
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)
       TYPE(atprop_type), POINTER                         :: atprop_env

--- a/src/fist_pol_scf.F
+++ b/src/fist_pol_scf.F
@@ -680,7 +680,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      REAL(KIND=dp), INTENT(OUT)                         :: vg_coulomb, pot_nonbond
+      REAL(KIND=dp)                                      :: vg_coulomb, pot_nonbond
       TYPE(fist_energy_type), POINTER                    :: thermo
       TYPE(multipole_type), POINTER                      :: multipoles
       LOGICAL, INTENT(IN)                                :: do_correction_bonded, do_forces, &

--- a/src/fm/cp_blacs_calls.F
+++ b/src/fm/cp_blacs_calls.F
@@ -75,7 +75,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_gridinfo(context, nprow, npcol, myprow, mypcol)
       INTEGER, INTENT(IN)  :: context
-      INTEGER, INTENT(OUT) :: nprow, npcol, myprow, mypcol
+      INTEGER :: nprow, npcol, myprow, mypcol
 #if defined(__SCALAPACK)
       CALL blacs_gridinfo(context, nprow, npcol, myprow, mypcol)
 #else

--- a/src/fm/cp_blacs_env.F
+++ b/src/fm/cp_blacs_env.F
@@ -92,7 +92,7 @@ CONTAINS
                              number_of_process_columns, number_of_processes, &
                              para_env, blacs2mpi, mpi2blacs)
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      INTEGER, INTENT(OUT), OPTIONAL :: my_process_row, my_process_column, my_process_number, &
+      INTEGER, OPTIONAL :: my_process_row, my_process_column, my_process_number, &
          number_of_process_rows, number_of_process_columns, number_of_processes
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: blacs2mpi, mpi2blacs

--- a/src/fm/cp_cfm_basic_linalg.F
+++ b/src/fm/cp_cfm_basic_linalg.F
@@ -380,7 +380,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_lu_decompose(matrix_a, determinant)
       TYPE(cp_cfm_type), POINTER                         :: matrix_a
-      COMPLEX(kind=dp), INTENT(out)                      :: determinant
+      COMPLEX(kind=dp)                      :: determinant
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_lu_decompose', &
                                      routineP = moduleN//':'//routineN
@@ -766,7 +766,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_lu_invert(matrix, info_out)
       TYPE(cp_cfm_type), POINTER                         :: matrix
-      INTEGER, INTENT(out), OPTIONAL                     :: info_out
+      INTEGER, OPTIONAL                     :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_lu_invert', &
                                      routineP = moduleN//':'//routineN
@@ -853,7 +853,7 @@ CONTAINS
    SUBROUTINE cp_cfm_cholesky_decompose(matrix, n, info_out)
       TYPE(cp_cfm_type), POINTER                         :: matrix
       INTEGER, INTENT(in), OPTIONAL                      :: n
-      INTEGER, INTENT(out), OPTIONAL                     :: info_out
+      INTEGER, OPTIONAL                     :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_cholesky_decompose', &
                                      routineP = moduleN//':'//routineN
@@ -911,7 +911,7 @@ CONTAINS
    SUBROUTINE cp_cfm_cholesky_invert(matrix, n, info_out)
       TYPE(cp_cfm_type), POINTER                 :: matrix
       INTEGER, INTENT(in), OPTIONAL              :: n
-      INTEGER, INTENT(out), OPTIONAL             :: info_out
+      INTEGER, OPTIONAL             :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_cholesky_invert', &
                                      routineP = moduleN//':'//routineN
@@ -966,7 +966,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_trace(matrix_a, matrix_b, trace)
       TYPE(cp_cfm_type), POINTER                         :: matrix_a, matrix_b
-      COMPLEX(kind=dp), INTENT(out)                      :: trace
+      COMPLEX(kind=dp)                                   :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_trace', routineP = moduleN//':'//routineN
 
@@ -1119,7 +1119,7 @@ CONTAINS
    SUBROUTINE cp_cfm_triangular_invert(matrix_a, uplo, info_out)
       TYPE(cp_cfm_type), POINTER               :: matrix_a
       CHARACTER, INTENT(in), OPTIONAL          :: uplo
-      INTEGER, INTENT(out), OPTIONAL           :: info_out
+      INTEGER, OPTIONAL           :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_triangular_invert', &
                                      routineP = moduleN//':'//routineN

--- a/src/fm/cp_cfm_diag.F
+++ b/src/fm/cp_cfm_diag.F
@@ -49,7 +49,7 @@ CONTAINS
    SUBROUTINE cp_cfm_heevd(matrix, eigenvectors, eigenvalues)
 
       TYPE(cp_cfm_type), POINTER               :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:) :: eigenvalues
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_heevd', &
                                      routineP = moduleN//':'//routineN

--- a/src/fm/cp_cfm_types.F
+++ b/src/fm/cp_cfm_types.F
@@ -271,7 +271,7 @@ CONTAINS
    SUBROUTINE cp_cfm_get_element(matrix, irow_global, icol_global, alpha)
       TYPE(cp_cfm_type), POINTER                         :: matrix
       INTEGER, INTENT(in)                                :: irow_global, icol_global
-      COMPLEX(kind=dp), INTENT(out)                      :: alpha
+      COMPLEX(kind=dp)                      :: alpha
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_get_element', &
                                      routineP = moduleN//':'//routineN
@@ -377,7 +377,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_get_submatrix(fm, target_m, start_row, start_col, n_rows, n_cols, transpose)
       TYPE(cp_cfm_type), POINTER                         :: fm
-      COMPLEX(kind=dp), DIMENSION(:, :), INTENT(out)     :: target_m
+      COMPLEX(kind=dp), DIMENSION(:, :)                  :: target_m
       INTEGER, INTENT(in), OPTIONAL                      :: start_row, start_col, n_rows, n_cols
       LOGICAL, INTENT(in), OPTIONAL                      :: transpose
 
@@ -659,10 +659,10 @@ CONTAINS
                               row_indices, col_indices, local_data, context, &
                               matrix_struct, para_env)
       TYPE(cp_cfm_type), POINTER        :: matrix
-      CHARACTER(len=*), OPTIONAL, INTENT(OUT) :: name
-      INTEGER, OPTIONAL, INTENT(OUT)          :: ncol_block, ncol_global, &
-                                                 nrow_block, nrow_global, &
-                                                 nrow_local, ncol_local
+      CHARACTER(len=*), OPTIONAL :: name
+      INTEGER, OPTIONAL          :: ncol_block, ncol_global, &
+                                    nrow_block, nrow_global, &
+                                    nrow_local, ncol_local
       INTEGER, OPTIONAL, DIMENSION(:), POINTER   :: row_indices, col_indices
       TYPE(cp_para_env_type), POINTER, OPTIONAL :: para_env
       TYPE(cp_blacs_env_type), POINTER, OPTIONAL :: context
@@ -1000,7 +1000,7 @@ CONTAINS
    SUBROUTINE cp_cfm_start_copy_general(source, destination, para_env, info)
       TYPE(cp_cfm_type), POINTER                         :: source, destination
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(copy_cfm_info_type), INTENT(out)              :: info
+      TYPE(copy_cfm_info_type)                           :: info
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_start_copy_general', &
          routineP = moduleN//':'//routineN

--- a/src/fm/cp_fm_basic_linalg.F
+++ b/src/fm/cp_fm_basic_linalg.F
@@ -272,7 +272,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_lu_decompose(matrix_a, almost_determinant, correct_sign)
       TYPE(cp_fm_type), POINTER                :: matrix_a
-      REAL(KIND=dp), INTENT(OUT)               :: almost_determinant
+      REAL(KIND=dp)               :: almost_determinant
       LOGICAL, INTENT(IN), OPTIONAL            :: correct_sign
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_lu_decompose', &
@@ -705,7 +705,7 @@ CONTAINS
    SUBROUTINE cp_fm_trace_a0b0t0(matrix_a, matrix_b, trace)
 
       TYPE(cp_fm_type), POINTER                          :: matrix_a, matrix_b
-      REAL(KIND=dp), INTENT(OUT)                         :: trace
+      REAL(KIND=dp)                                      :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a0b0t0', &
          routineP = moduleN//':'//routineN
@@ -777,7 +777,7 @@ CONTAINS
    SUBROUTINE cp_fm_trace_a1b0t1(matrix_a, matrix_b, trace)
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: matrix_a
       TYPE(cp_fm_type), POINTER                          :: matrix_b
-      REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
+      REAL(kind=dp), DIMENSION(:)                        :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b0t1', &
          routineP = moduleN//':'//routineN
@@ -849,7 +849,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_trace_a1b1t1(matrix_a, matrix_b, trace)
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: matrix_a, matrix_b
-      REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
+      REAL(kind=dp), DIMENSION(:)                        :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b1t1', &
          routineP = moduleN//':'//routineN
@@ -905,7 +905,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_contracted_trace_a2b2t2(matrix_a, matrix_b, trace)
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: matrix_a, matrix_b
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: trace
+      REAL(kind=dp), DIMENSION(:, :)                     :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_contracted_trace_a2b2t2', &
          routineP = moduleN//':'//routineN
@@ -1375,7 +1375,7 @@ CONTAINS
    SUBROUTINE cp_fm_invert(matrix_a, matrix_inverse, det_a, eps_svd, eigval)
 
       TYPE(cp_fm_type), POINTER                :: matrix_a, matrix_inverse
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL     :: det_a
+      REAL(KIND=dp), OPTIONAL     :: det_a
       REAL(KIND=dp), INTENT(IN), OPTIONAL      :: eps_svd
       REAL(KIND=dp), DIMENSION(:), POINTER, &
          INTENT(INOUT), OPTIONAL               :: eigval
@@ -1818,7 +1818,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_lu_invert(matrix, info_out)
       TYPE(cp_fm_type), POINTER                :: matrix
-      INTEGER, INTENT(OUT), OPTIONAL           :: info_out
+      INTEGER, OPTIONAL           :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_lu_invert', &
                                      routineP = moduleN//':'//routineN

--- a/src/fm/cp_fm_cholesky.F
+++ b/src/fm/cp_fm_cholesky.F
@@ -44,7 +44,7 @@ CONTAINS
    SUBROUTINE cp_fm_cholesky_decompose(matrix, n, info_out)
       TYPE(cp_fm_type), POINTER                :: matrix
       INTEGER, INTENT(in), OPTIONAL            :: n
-      INTEGER, INTENT(out), OPTIONAL           :: info_out
+      INTEGER, OPTIONAL           :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_cholesky_decompose', &
                                      routineP = moduleN//':'//routineN
@@ -111,7 +111,7 @@ CONTAINS
    SUBROUTINE cp_fm_cholesky_invert(matrix, n, info_out)
       TYPE(cp_fm_type), POINTER                 :: matrix
       INTEGER, INTENT(in), OPTIONAL             :: n
-      INTEGER, INTENT(OUT), OPTIONAL            :: info_out
+      INTEGER, OPTIONAL            :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_cholesky_invert', &
                                      routineP = moduleN//':'//routineN

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -166,8 +166,8 @@ CONTAINS
    SUBROUTINE choose_eigv_solver(matrix, eigenvectors, eigenvalues, info)
 
       TYPE(cp_fm_type), POINTER                          :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
-      INTEGER, INTENT(OUT), OPTIONAL                     :: info
+      REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
+      INTEGER, OPTIONAL                                  :: info
 
       CHARACTER(len=*), PARAMETER :: routineN = 'choose_eigv_solver', &
          routineP = moduleN//':'//routineN
@@ -211,8 +211,8 @@ CONTAINS
    SUBROUTINE cp_fm_syevd(matrix, eigenvectors, eigenvalues, info)
 
       TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: eigenvalues
-      INTEGER, INTENT(OUT), OPTIONAL           :: info
+      REAL(KIND=dp), DIMENSION(:) :: eigenvalues
+      INTEGER, OPTIONAL           :: info
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_syevd', &
                                      routineP = moduleN//':'//routineN
@@ -316,7 +316,7 @@ CONTAINS
 
       TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
       REAL(KIND=dp), DIMENSION(:)              :: eig
-      INTEGER, INTENT(OUT)                     :: info
+      INTEGER                     :: info
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_syevd_base', &
                                      routineP = moduleN//':'//routineN
@@ -423,7 +423,7 @@ CONTAINS
       TYPE(cp_fm_type), POINTER, OPTIONAL          :: eigenvectors
       REAL(KIND=dp), OPTIONAL, INTENT(IN)        :: work_syevx
       INTEGER, INTENT(IN), OPTIONAL                :: neig
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)   :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:)   :: eigenvalues
 
       CHARACTER(LEN=*), PARAMETER :: routineN = "cp_fm_syevx", &
                                      routineP = moduleN//":"//routineN
@@ -658,7 +658,7 @@ CONTAINS
 
       TYPE(cp_fm_type), POINTER                    :: matrix
       TYPE(cp_fm_type), POINTER, OPTIONAL          :: eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)   :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:)   :: eigenvalues
       INTEGER, INTENT(IN), OPTIONAL                :: ilow, iup
 
       CHARACTER(LEN=*), PARAMETER :: routineN = "cp_fm_syevr", &
@@ -852,9 +852,9 @@ CONTAINS
 
       TYPE(cp_fm_type), POINTER                 :: matrix, work
       REAL(KIND=dp), INTENT(IN)                 :: exponent, threshold
-      INTEGER, INTENT(OUT)                      :: n_dependent
+      INTEGER                      :: n_dependent
       LOGICAL, INTENT(IN), OPTIONAL             :: verbose
-      REAL(KIND=dp), DIMENSION(2), INTENT(OUT), &
+      REAL(KIND=dp), DIMENSION(2), &
          OPTIONAL                               :: eigvals
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_power', &

--- a/src/fm/cp_fm_diag_utils.F
+++ b/src/fm/cp_fm_diag_utils.F
@@ -248,7 +248,7 @@ CONTAINS
                                        caller_is_elpa)
 
       TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
-      TYPE(cp_fm_type), POINTER, INTENT(OUT)   :: matrix_new, eigenvectors_new
+      TYPE(cp_fm_type), POINTER   :: matrix_new, eigenvectors_new
       LOGICAL, OPTIONAL, INTENT(IN)            :: caller_is_elpa
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_redistribute_start', &
@@ -413,7 +413,7 @@ CONTAINS
 
       TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
       REAL(KIND=dp), DIMENSION(:)              :: eig
-      TYPE(cp_fm_type), POINTER, INTENT(OUT)   :: matrix_new, eigenvectors_new
+      TYPE(cp_fm_type), POINTER   :: matrix_new, eigenvectors_new
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_redistribute_end', &
                                      routineP = moduleN//':'//routineN

--- a/src/fm/cp_fm_struct.F
+++ b/src/fm/cp_fm_struct.F
@@ -417,11 +417,11 @@ CONTAINS
       TYPE(cp_fm_struct_type), POINTER :: fmstruct
       TYPE(cp_para_env_type), POINTER, OPTIONAL :: para_env
       TYPE(cp_blacs_env_type), POINTER, OPTIONAL :: context
-      INTEGER, DIMENSION(9), INTENT(OUT), OPTIONAL :: descriptor
-      INTEGER, INTENT(out), OPTIONAL :: ncol_block, nrow_block, nrow_global, &
-                                        ncol_global, id_nr, ref_count, nrow_local, ncol_local, &
-                                        local_leading_dimension
-      INTEGER, DIMENSION(2), INTENT(out), OPTIONAL :: first_p_pos
+      INTEGER, DIMENSION(9), OPTIONAL :: descriptor
+      INTEGER, OPTIONAL :: ncol_block, nrow_block, nrow_global, &
+                           ncol_global, id_nr, ref_count, nrow_local, ncol_local, &
+                           local_leading_dimension
+      INTEGER, DIMENSION(2), OPTIONAL :: first_p_pos
       INTEGER, DIMENSION(:), POINTER, OPTIONAL :: row_indices, col_indices, &
                                                   nrow_locals, ncol_locals
 

--- a/src/fm/cp_fm_types.F
+++ b/src/fm/cp_fm_types.F
@@ -410,7 +410,7 @@ CONTAINS
 
       ! arguments
       TYPE(cp_fm_type), POINTER                  :: matrix
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: diag
+      REAL(KIND=dp), DIMENSION(:) :: diag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_get_diag', &
                                      routineP = moduleN//':'//routineN
@@ -488,10 +488,10 @@ CONTAINS
 
       ! arguments
       TYPE(cp_fm_type), POINTER          :: matrix
-      REAL(KIND=dp), INTENT(OUT)                     :: alpha
+      REAL(KIND=dp)                     :: alpha
       INTEGER, INTENT(IN)                       :: icol_global, &
                                                    irow_global
-      LOGICAL, INTENT(OUT), OPTIONAL            :: local
+      LOGICAL, OPTIONAL            :: local
 
       ! locals
 #if defined(__SCALAPACK)
@@ -753,7 +753,7 @@ CONTAINS
    SUBROUTINE cp_fm_get_submatrix(fm, target_m, start_row, &
                                   start_col, n_rows, n_cols, transpose)
       TYPE(cp_fm_type), POINTER                          :: fm
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(out)        :: target_m
+      REAL(KIND=dp), DIMENSION(:, :)                     :: target_m
       INTEGER, INTENT(in), OPTIONAL                      :: start_row, start_col, n_rows, n_cols
       LOGICAL, INTENT(in), OPTIONAL                      :: transpose
 
@@ -873,10 +873,10 @@ CONTAINS
                              nrow_locals, ncol_locals, matrix_struct, para_env)
 
       TYPE(cp_fm_type), POINTER                  :: matrix
-      CHARACTER(LEN=*), OPTIONAL, INTENT(OUT)    :: name
-      INTEGER, OPTIONAL, INTENT(OUT)             :: ncol_block, ncol_global, &
-                                                    nrow_block, nrow_global, &
-                                                    nrow_local, ncol_local
+      CHARACTER(LEN=*), OPTIONAL    :: name
+      INTEGER, OPTIONAL             :: ncol_block, ncol_global, &
+                                       nrow_block, nrow_global, &
+                                       nrow_local, ncol_local
       INTEGER, OPTIONAL, DIMENSION(:), POINTER   :: row_indices, col_indices, &
                                                     nrow_locals, ncol_locals
       TYPE(cp_para_env_type), POINTER, OPTIONAL  :: para_env
@@ -926,8 +926,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_maxabsval(matrix, a_max, ir_max, ic_max)
       TYPE(cp_fm_type), POINTER                          :: matrix
-      REAL(KIND=dp), INTENT(OUT)                         :: a_max
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ir_max, ic_max
+      REAL(KIND=dp)                                      :: a_max
+      INTEGER, OPTIONAL                                  :: ir_max, ic_max
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_maxabsval', &
          routineP = moduleN//':'//routineN
@@ -1029,7 +1029,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_maxabsrownorm(matrix, a_max)
       TYPE(cp_fm_type), POINTER                          :: matrix
-      REAL(KIND=dp), INTENT(OUT)                         :: a_max
+      REAL(KIND=dp)                                      :: a_max
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_maxabsrownorm', &
          routineP = moduleN//':'//routineN
@@ -1071,7 +1071,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_vectorsnorm(matrix, norm_array)
       TYPE(cp_fm_type), POINTER                          :: matrix
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: norm_array
+      REAL(KIND=dp), DIMENSION(:)                        :: norm_array
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_vectorsnorm', &
          routineP = moduleN//':'//routineN
@@ -1113,7 +1113,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_vectorssum(matrix, sum_array)
       TYPE(cp_fm_type), POINTER                          :: matrix
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: sum_array
+      REAL(KIND=dp), DIMENSION(:)                        :: sum_array
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_vectorssum', &
          routineP = moduleN//':'//routineN
@@ -1415,7 +1415,7 @@ CONTAINS
    SUBROUTINE cp_fm_start_copy_general(source, destination, para_env, info)
       TYPE(cp_fm_type), POINTER                          :: source, destination
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(copy_info_type), INTENT(OUT)                  :: info
+      TYPE(copy_info_type)                               :: info
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_start_copy_general', &
          routineP = moduleN//':'//routineN

--- a/src/force_env_types.F
+++ b/src/force_env_types.F
@@ -305,14 +305,14 @@ CONTAINS
                                       qmmm_env, qmmmx_env, eip_env, pwdft_env, globenv, input, force_env_section, &
                                       method_name_id, root_section, mixed_env, embed_env)
       TYPE(force_env_type), POINTER                      :: force_env
-      INTEGER, INTENT(out), OPTIONAL                     :: in_use
+      INTEGER, OPTIONAL                                  :: in_use
       TYPE(fist_environment_type), OPTIONAL, POINTER     :: fist_env
       TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
       TYPE(meta_env_type), OPTIONAL, POINTER             :: meta_env
       TYPE(fp_type), OPTIONAL, POINTER                   :: fp_env
       TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: potential_energy, additional_potential, &
+      REAL(KIND=dp), OPTIONAL                            :: potential_energy, additional_potential, &
                                                             kinetic_energy, harmonic_shell, &
                                                             kinetic_shell
       TYPE(cell_type), OPTIONAL, POINTER                 :: cell
@@ -324,7 +324,7 @@ CONTAINS
       TYPE(pwdft_environment_type), OPTIONAL, POINTER    :: pwdft_env
       TYPE(global_environment_type), OPTIONAL, POINTER   :: globenv
       TYPE(section_vals_type), OPTIONAL, POINTER         :: input, force_env_section
-      INTEGER, INTENT(out), OPTIONAL                     :: method_name_id
+      INTEGER, OPTIONAL                                  :: method_name_id
       TYPE(section_vals_type), OPTIONAL, POINTER         :: root_section
       TYPE(mixed_environment_type), OPTIONAL, POINTER    :: mixed_env
       TYPE(embed_env_type), OPTIONAL, POINTER            :: embed_env
@@ -530,7 +530,7 @@ CONTAINS
    SUBROUTINE force_env_get_frc(force_env, frc, n)
 
       TYPE(force_env_type), POINTER                      :: force_env
-      REAL(KIND=dp), DIMENSION(*), INTENT(OUT)           :: frc
+      REAL(KIND=dp), DIMENSION(*)                        :: frc
       INTEGER, INTENT(IN)                                :: n
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'force_env_get_frc', &
@@ -559,7 +559,7 @@ CONTAINS
    SUBROUTINE force_env_get_pos(force_env, pos, n)
 
       TYPE(force_env_type), POINTER                      :: force_env
-      REAL(kind=dp), DIMENSION(*), INTENT(OUT)           :: pos
+      REAL(kind=dp), DIMENSION(*)                        :: pos
       INTEGER, INTENT(IN)                                :: n
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'force_env_get_pos', &
@@ -588,7 +588,7 @@ CONTAINS
    SUBROUTINE force_env_get_vel(force_env, vel, n)
 
       TYPE(force_env_type), POINTER                      :: force_env
-      REAL(KIND=dp), DIMENSION(*), INTENT(OUT)           :: vel
+      REAL(KIND=dp), DIMENSION(*)                        :: vel
       INTEGER, INTENT(IN)                                :: n
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'force_env_get_vel', &

--- a/src/force_env_utils.F
+++ b/src/force_env_utils.F
@@ -497,7 +497,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: output_unit
       CHARACTER(LEN=*), INTENT(IN)                       :: label
       INTEGER, INTENT(IN)                                :: ndigits
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: total_force
+      REAL(KIND=dp), DIMENSION(3)                        :: total_force
       REAL(KIND=dp), DIMENSION(3), INTENT(INOUT), &
          OPTIONAL                                        :: grand_total_force
       LOGICAL, INTENT(IN), OPTIONAL                      :: zero_force_core_shell_atom

--- a/src/force_fields_util.F
+++ b/src/force_fields_util.F
@@ -1238,7 +1238,7 @@ CONTAINS
                                var_values, size_variables, i_rep_sec, input_variables)
       TYPE(section_vals_type), POINTER                   :: gen_section
       CHARACTER(LEN=*), INTENT(IN)                       :: func_name
-      CHARACTER(LEN=default_path_length), INTENT(OUT)    :: xfunction
+      CHARACTER(LEN=default_path_length)                 :: xfunction
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), POINTER                           :: parameters
       REAL(KIND=dp), DIMENSION(:), POINTER               :: values

--- a/src/fp_methods.F
+++ b/src/fp_methods.F
@@ -222,7 +222,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE smooth_count(r, r1, width, c, dcdr)
       REAL(KIND=dp), INTENT(IN)                          :: r, r1, width
-      REAL(KIND=dp), INTENT(OUT)                         :: c, dcdr
+      REAL(KIND=dp)                                      :: c, dcdr
 
       REAL(KIND=dp)                                      :: arg
 

--- a/src/graphcon.F
+++ b/src/graphcon.F
@@ -76,8 +76,8 @@ CONTAINS
 ! **************************************************************************************************
     SUBROUTINE hash_molecule(reference,kind_ref,hash)
       TYPE(vertex), DIMENSION(:), INTENT(IN)             :: reference
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: kind_ref
-      INTEGER, INTENT(OUT)                               :: hash
+      INTEGER, DIMENSION(:)                              :: kind_ref
+      INTEGER                                            :: hash
 
       INTEGER                                            :: I, Ihash, N, Nclasses, Nclasses_old, &
                                                             old_class
@@ -130,8 +130,8 @@ CONTAINS
 ! **************************************************************************************************
     SUBROUTINE reorder_graph(reference, unordered, order, matches)
       TYPE(vertex), DIMENSION(:), INTENT(IN)             :: reference, unordered
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: order
-      LOGICAL, INTENT(OUT)                               :: matches
+      INTEGER, DIMENSION(:)                              :: order
+      LOGICAL                                            :: matches
 
       INTEGER, PARAMETER                                 :: max_tries = 1000000
 

--- a/src/grid/integrate_fast_1.f90
+++ b/src/grid/integrate_fast_1.f90
@@ -14,7 +14,7 @@
   SUBROUTINE integrate_core_default(grid, coef_xyz, pol_x, pol_y, pol_z, map, sphere_bounds, lp, cmax, gridbounds)
      USE kinds, ONLY: dp
      INTEGER, INTENT(IN)                      :: sphere_bounds(*), lp
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
      INTEGER, INTENT(IN)                      :: cmax
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
@@ -123,7 +123,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -211,7 +211,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -306,7 +306,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -429,7 +429,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -592,7 +592,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -809,7 +809,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1096,7 +1096,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1471,7 +1471,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1954,7 +1954,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -2567,7 +2567,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &

--- a/src/grid/integrate_fast_2.f90
+++ b/src/grid/integrate_fast_2.f90
@@ -14,7 +14,7 @@
   SUBROUTINE integrate_core_default(grid, coef_xyz, pol_x, pol_y, pol_z, map, sphere_bounds, lp, cmax, gridbounds)
      USE kinds, ONLY: dp
      INTEGER, INTENT(IN)                      :: sphere_bounds(*), lp
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
      INTEGER, INTENT(IN)                      :: cmax
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
@@ -123,7 +123,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -200,7 +200,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -291,7 +291,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -385,7 +385,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -487,7 +487,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -657,7 +657,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -781,7 +781,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -919,7 +919,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1073,7 +1073,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1245,7 +1245,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &

--- a/src/grid/integrate_fast_3.f90
+++ b/src/grid/integrate_fast_3.f90
@@ -14,7 +14,7 @@
   SUBROUTINE integrate_core_default(grid, coef_xyz, pol_x, pol_y, pol_z, map, sphere_bounds, lp, cmax, gridbounds)
      USE kinds, ONLY: dp
      INTEGER, INTENT(IN)                      :: sphere_bounds(*), lp
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
      INTEGER, INTENT(IN)                      :: cmax
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
@@ -123,7 +123,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -209,7 +209,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -306,7 +306,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -398,7 +398,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -501,7 +501,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -638,7 +638,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -907,7 +907,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1261,7 +1261,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1648,7 +1648,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -2144,7 +2144,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &

--- a/src/grid/integrate_fast_4.f90
+++ b/src/grid/integrate_fast_4.f90
@@ -14,7 +14,7 @@
   SUBROUTINE integrate_core_default(grid, coef_xyz, pol_x, pol_y, pol_z, map, sphere_bounds, lp, cmax, gridbounds)
      USE kinds, ONLY: dp
      INTEGER, INTENT(IN)                      :: sphere_bounds(*), lp
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
      INTEGER, INTENT(IN)                      :: cmax
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
@@ -123,7 +123,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -208,7 +208,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -292,7 +292,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -397,7 +397,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -530,7 +530,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -733,7 +733,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -964,7 +964,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1339,7 +1339,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1796,7 +1796,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -2379,7 +2379,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &

--- a/src/grid/integrate_fast_5.f90
+++ b/src/grid/integrate_fast_5.f90
@@ -14,7 +14,7 @@
   SUBROUTINE integrate_core_default(grid, coef_xyz, pol_x, pol_y, pol_z, map, sphere_bounds, lp, cmax, gridbounds)
      USE kinds, ONLY: dp
      INTEGER, INTENT(IN)                      :: sphere_bounds(*), lp
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
      INTEGER, INTENT(IN)                      :: cmax
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
@@ -123,7 +123,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -200,7 +200,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -295,7 +295,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -386,7 +386,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -517,7 +517,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -668,7 +668,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -839,7 +839,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1189,7 +1189,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1347,7 +1347,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1523,7 +1523,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &

--- a/src/grid/integrate_fast_6.f90
+++ b/src/grid/integrate_fast_6.f90
@@ -14,7 +14,7 @@
   SUBROUTINE integrate_core_default(grid, coef_xyz, pol_x, pol_y, pol_z, map, sphere_bounds, lp, cmax, gridbounds)
      USE kinds, ONLY: dp
      INTEGER, INTENT(IN)                      :: sphere_bounds(*), lp
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
      INTEGER, INTENT(IN)                      :: cmax
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
@@ -123,7 +123,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -213,7 +213,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -296,7 +296,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -403,7 +403,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -536,7 +536,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -739,7 +739,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -928,7 +928,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1197,7 +1197,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -1656,7 +1656,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &
@@ -2242,7 +2242,7 @@
      REAL(dp), INTENT(IN)                     :: pol_x(0:lp, -cmax:cmax), &
                                                  pol_y(1:2, 0:lp, -cmax:0), &
                                                  pol_z(1:2, 0:lp, -cmax:0)
-     REAL(dp), INTENT(OUT) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
+     REAL(dp) :: coef_xyz(((lp+1)*(lp+2)*(lp+3))/6)
 
      INTEGER                                  :: i, ig, igmax, igmin, j, j2, &
                                                  jg, jg2, jgmin, k, k2, kg, &

--- a/src/hartree_local_methods.F
+++ b/src/hartree_local_methods.F
@@ -210,7 +210,7 @@ CONTAINS
    SUBROUTINE Vh_1c_gg_integrals(qs_env, energy_hartree_1c, tddft, do_triplet, p_env)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(kind=dp), INTENT(out)                         :: energy_hartree_1c
+      REAL(kind=dp)                                      :: energy_hartree_1c
       LOGICAL, INTENT(IN), OPTIONAL                      :: tddft, do_triplet
       TYPE(qs_p_env_type), OPTIONAL, POINTER             :: p_env
 

--- a/src/hfx_communication.F
+++ b/src/hfx_communication.F
@@ -439,8 +439,8 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: matrix
       TYPE(hfx_basis_type), DIMENSION(:)                 :: basis_parameter
       INTEGER, DIMENSION(:)                              :: kind_of
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: is_assoc_atomic_block
-      INTEGER, INTENT(OUT)                               :: number_of_p_entries
+      INTEGER, DIMENSION(:, :)                           :: is_assoc_atomic_block
+      INTEGER                                            :: number_of_p_entries
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, DIMENSION(:, :), POINTER                  :: atomic_block_offset
       INTEGER, DIMENSION(:, :, :, :), POINTER            :: set_offset

--- a/src/hfx_energy_potential.F
+++ b/src/hfx_energy_potential.F
@@ -138,7 +138,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: ks_matrix
-      REAL(KIND=dp), INTENT(OUT)                         :: ehfx
+      REAL(KIND=dp)                                      :: ehfx
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao
       TYPE(section_vals_type), POINTER                   :: hfx_section
       TYPE(cp_para_env_type), POINTER                    :: para_env

--- a/src/hfx_load_balance_methods.F
+++ b/src/hfx_load_balance_methods.F
@@ -1121,7 +1121,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE hfx_calculate_PQ(p, q, nBins, N)
 
-      INTEGER, INTENT(OUT)                               :: p, q, nBins
+      INTEGER                                            :: p, q, nBins
       INTEGER, INTENT(IN)                                :: N
 
       INTEGER                                            :: a, b, k
@@ -1419,8 +1419,8 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: nBins, maxbinsize
       REAL(dp), DIMENSION(maxbinsize), INTENT(IN)        :: costvector
-      INTEGER, DIMENSION(maxbinsize), INTENT(OUT)        :: perm
-      INTEGER, DIMENSION(nBins), INTENT(OUT)             :: block_count
+      INTEGER, DIMENSION(maxbinsize)                     :: perm
+      INTEGER, DIMENSION(nBins)                          :: block_count
 
       INTEGER                                            :: i, j, mod_idx, offset
       INTEGER, DIMENSION(nBins, maxbinsize)              :: bin

--- a/src/hfx_pair_list_methods.F
+++ b/src/hfx_pair_list_methods.F
@@ -68,7 +68,7 @@ CONTAINS
       TYPE(hfx_pgf_list)                                 :: list1, list2
       TYPE(hfx_pgf_product_list), ALLOCATABLE, &
          DIMENSION(:), INTENT(INOUT)                     :: product_list
-      INTEGER, INTENT(OUT)                               :: nproducts
+      INTEGER                                            :: nproducts
       REAL(dp), INTENT(IN)                               :: log10_pmax, log10_eps_schwarz
       TYPE(hfx_cell_type), DIMENSION(:), POINTER         :: neighbor_cells
       TYPE(cell_type), POINTER                           :: cell
@@ -336,7 +336,7 @@ CONTAINS
          POINTER                                         :: pgf, R_pgf
       REAL(dp), INTENT(IN)                               :: log10_pmax, log10_eps_schwarz, ra(3), &
                                                             rb(3)
-      INTEGER, INTENT(OUT)                               :: nelements
+      INTEGER                                            :: nelements
       TYPE(hfx_cell_type), DIMENSION(:), POINTER         :: neighbor_cells
       INTEGER                                            :: nimages(npgfa*npgfb)
       LOGICAL, INTENT(IN)                                :: do_periodic
@@ -448,9 +448,8 @@ CONTAINS
                               pmax_blocks, atomic_pair_list)
 
       INTEGER, INTENT(IN)                                :: natom
-      TYPE(pair_list_type), INTENT(OUT)                  :: list
-      TYPE(pair_set_list_type), DIMENSION(*), &
-         INTENT(OUT)                                     :: set_list
+      TYPE(pair_list_type)                               :: list
+      TYPE(pair_set_list_type), DIMENSION(*)             :: set_list
       INTEGER, INTENT(IN)                                :: i_start, i_end, j_start, j_end
       INTEGER                                            :: kind_of(*)
       TYPE(hfx_basis_type), DIMENSION(:), POINTER        :: basis_parameter
@@ -626,8 +625,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: natom
       TYPE(pair_list_type_mp2)                           :: list
-      TYPE(pair_set_list_type), DIMENSION(*), &
-         INTENT(OUT)                                     :: set_list
+      TYPE(pair_set_list_type), DIMENSION(*)             :: set_list
       INTEGER, INTENT(IN)                                :: i_start, i_end, j_start, j_end
       INTEGER                                            :: kind_of(*)
       TYPE(hfx_basis_type), DIMENSION(:), POINTER        :: basis_parameter

--- a/src/hfx_screening_methods.F
+++ b/src/hfx_screening_methods.F
@@ -815,7 +815,7 @@ CONTAINS
    SUBROUTINE optimize_it(DATA, x, fmin)
 
       REAL(KIND=dp), INTENT(IN)                          :: DATA(2, 0:100)
-      REAL(KIND=dp), INTENT(OUT)                         :: x(2)
+      REAL(KIND=dp)                                      :: x(2)
       REAL(KIND=dp), INTENT(IN)                          :: fmin
 
       INTEGER                                            :: i, k

--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -858,7 +858,7 @@ CONTAINS
       IMPLICIT NONE
 
       REAL(dp), INTENT(in)  :: eps, omg
-      REAL(dp), INTENT(out) :: r_cutoff
+      REAL(dp) :: r_cutoff
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'erfc_cutoff', &
                                      routineP = moduleN//':'//routineN
@@ -895,7 +895,7 @@ CONTAINS
 ! **************************************************************************************************
       SUBROUTINE eval_transc_func(r, eps, omega, fn, df)
       REAL(dp), INTENT(in)                               :: r, eps, omega
-      REAL(dp), INTENT(out)                              :: fn, df
+      REAL(dp)                                           :: fn, df
 
          fn = erfc(omega*r)-r*eps
          df = -omega*2*EXP(-omega**2*r**2)/SQRT(pi)-eps
@@ -1082,7 +1082,7 @@ CONTAINS
                                    i_thread, n_threads, para_env, irep, skip_disk, skip_in_core_forces)
       TYPE(hfx_memory_type)                              :: memory_parameter
       TYPE(section_vals_type), POINTER                   :: hf_sub_section
-      INTEGER, INTENT(OUT), OPTIONAL                     :: storage_id
+      INTEGER, OPTIONAL                                  :: storage_id
       INTEGER, INTENT(IN), OPTIONAL                      :: i_thread, n_threads
       TYPE(cp_para_env_type), OPTIONAL                   :: para_env
       INTEGER, INTENT(IN), OPTIONAL                      :: irep

--- a/src/hfxbase/hfx_compression_core_methods.F
+++ b/src/hfxbase/hfx_compression_core_methods.F
@@ -65,7 +65,7 @@ CONTAINS
    SUBROUTINE ints2ints(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       full_data(1:Ndata) = packed_data(1:Ndata)
    END SUBROUTINE
@@ -85,7 +85,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: Nbits, Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER                                            :: i_odd_bits, ibits_remaining, idata, ipack
       INTEGER(KIND=int_8)                                :: data_tmp, pack_tmp
@@ -134,7 +134,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_generic(Nbits, Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Nbits, Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER                                            :: i_odd_bits, ibits_remaining, idata, ipack
@@ -192,7 +192,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_1(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 1
@@ -543,7 +543,7 @@ CONTAINS
    SUBROUTINE bits2ints_1(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 1
 
@@ -827,7 +827,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_2(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 2
@@ -1183,7 +1183,7 @@ CONTAINS
    SUBROUTINE bits2ints_2(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 2
 
@@ -1469,7 +1469,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_3(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 3
@@ -1830,7 +1830,7 @@ CONTAINS
    SUBROUTINE bits2ints_3(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 3
 
@@ -2118,7 +2118,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_4(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 4
@@ -2484,7 +2484,7 @@ CONTAINS
    SUBROUTINE bits2ints_4(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 4
 
@@ -2774,7 +2774,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_5(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 5
@@ -3145,7 +3145,7 @@ CONTAINS
    SUBROUTINE bits2ints_5(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 5
 
@@ -3437,7 +3437,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_6(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 6
@@ -3813,7 +3813,7 @@ CONTAINS
    SUBROUTINE bits2ints_6(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 6
 
@@ -4107,7 +4107,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_7(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 7
@@ -4488,7 +4488,7 @@ CONTAINS
    SUBROUTINE bits2ints_7(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 7
 
@@ -4784,7 +4784,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_8(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 8
@@ -5170,7 +5170,7 @@ CONTAINS
    SUBROUTINE bits2ints_8(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 8
 
@@ -5468,7 +5468,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_9(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 9
@@ -5859,7 +5859,7 @@ CONTAINS
    SUBROUTINE bits2ints_9(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 9
 
@@ -6159,7 +6159,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_10(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 10
@@ -6555,7 +6555,7 @@ CONTAINS
    SUBROUTINE bits2ints_10(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 10
 
@@ -6857,7 +6857,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_11(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 11
@@ -7258,7 +7258,7 @@ CONTAINS
    SUBROUTINE bits2ints_11(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 11
 
@@ -7562,7 +7562,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_12(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 12
@@ -7968,7 +7968,7 @@ CONTAINS
    SUBROUTINE bits2ints_12(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 12
 
@@ -8274,7 +8274,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_13(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 13
@@ -8685,7 +8685,7 @@ CONTAINS
    SUBROUTINE bits2ints_13(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 13
 
@@ -8993,7 +8993,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_14(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 14
@@ -9409,7 +9409,7 @@ CONTAINS
    SUBROUTINE bits2ints_14(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 14
 
@@ -9719,7 +9719,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_15(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 15
@@ -10140,7 +10140,7 @@ CONTAINS
    SUBROUTINE bits2ints_15(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 15
 
@@ -10452,7 +10452,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_16(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 16
@@ -10878,7 +10878,7 @@ CONTAINS
    SUBROUTINE bits2ints_16(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 16
 
@@ -11192,7 +11192,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_17(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 17
@@ -11623,7 +11623,7 @@ CONTAINS
    SUBROUTINE bits2ints_17(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 17
 
@@ -11939,7 +11939,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_18(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 18
@@ -12375,7 +12375,7 @@ CONTAINS
    SUBROUTINE bits2ints_18(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 18
 
@@ -12693,7 +12693,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_19(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 19
@@ -13134,7 +13134,7 @@ CONTAINS
    SUBROUTINE bits2ints_19(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 19
 
@@ -13454,7 +13454,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_20(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 20
@@ -13900,7 +13900,7 @@ CONTAINS
    SUBROUTINE bits2ints_20(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 20
 
@@ -14222,7 +14222,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_21(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 21
@@ -14673,7 +14673,7 @@ CONTAINS
    SUBROUTINE bits2ints_21(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 21
 
@@ -14997,7 +14997,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_22(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 22
@@ -15453,7 +15453,7 @@ CONTAINS
    SUBROUTINE bits2ints_22(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 22
 
@@ -15779,7 +15779,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_23(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 23
@@ -16240,7 +16240,7 @@ CONTAINS
    SUBROUTINE bits2ints_23(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 23
 
@@ -16568,7 +16568,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_24(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 24
@@ -17034,7 +17034,7 @@ CONTAINS
    SUBROUTINE bits2ints_24(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 24
 
@@ -17364,7 +17364,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_25(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 25
@@ -17835,7 +17835,7 @@ CONTAINS
    SUBROUTINE bits2ints_25(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 25
 
@@ -18167,7 +18167,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_26(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 26
@@ -18643,7 +18643,7 @@ CONTAINS
    SUBROUTINE bits2ints_26(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 26
 
@@ -18977,7 +18977,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_27(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 27
@@ -19458,7 +19458,7 @@ CONTAINS
    SUBROUTINE bits2ints_27(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 27
 
@@ -19794,7 +19794,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_28(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 28
@@ -20280,7 +20280,7 @@ CONTAINS
    SUBROUTINE bits2ints_28(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 28
 
@@ -20618,7 +20618,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_29(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 29
@@ -21109,7 +21109,7 @@ CONTAINS
    SUBROUTINE bits2ints_29(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 29
 
@@ -21449,7 +21449,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_30(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 30
@@ -21945,7 +21945,7 @@ CONTAINS
    SUBROUTINE bits2ints_30(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 30
 
@@ -22287,7 +22287,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_31(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 31
@@ -22788,7 +22788,7 @@ CONTAINS
    SUBROUTINE bits2ints_31(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 31
 
@@ -23132,7 +23132,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_32(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 32
@@ -23638,7 +23638,7 @@ CONTAINS
    SUBROUTINE bits2ints_32(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 32
 
@@ -23984,7 +23984,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_33(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 33
@@ -24495,7 +24495,7 @@ CONTAINS
    SUBROUTINE bits2ints_33(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 33
 
@@ -24843,7 +24843,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_34(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 34
@@ -25359,7 +25359,7 @@ CONTAINS
    SUBROUTINE bits2ints_34(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 34
 
@@ -25709,7 +25709,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_35(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 35
@@ -26230,7 +26230,7 @@ CONTAINS
    SUBROUTINE bits2ints_35(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 35
 
@@ -26582,7 +26582,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_36(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 36
@@ -27108,7 +27108,7 @@ CONTAINS
    SUBROUTINE bits2ints_36(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 36
 
@@ -27462,7 +27462,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_37(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 37
@@ -27993,7 +27993,7 @@ CONTAINS
    SUBROUTINE bits2ints_37(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 37
 
@@ -28349,7 +28349,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_38(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 38
@@ -28885,7 +28885,7 @@ CONTAINS
    SUBROUTINE bits2ints_38(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 38
 
@@ -29243,7 +29243,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_39(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 39
@@ -29784,7 +29784,7 @@ CONTAINS
    SUBROUTINE bits2ints_39(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 39
 
@@ -30144,7 +30144,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_40(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 40
@@ -30690,7 +30690,7 @@ CONTAINS
    SUBROUTINE bits2ints_40(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 40
 
@@ -31052,7 +31052,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_41(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 41
@@ -31603,7 +31603,7 @@ CONTAINS
    SUBROUTINE bits2ints_41(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 41
 
@@ -31967,7 +31967,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_42(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 42
@@ -32523,7 +32523,7 @@ CONTAINS
    SUBROUTINE bits2ints_42(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 42
 
@@ -32889,7 +32889,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_43(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 43
@@ -33450,7 +33450,7 @@ CONTAINS
    SUBROUTINE bits2ints_43(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 43
 
@@ -33818,7 +33818,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_44(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 44
@@ -34384,7 +34384,7 @@ CONTAINS
    SUBROUTINE bits2ints_44(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 44
 
@@ -34754,7 +34754,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_45(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 45
@@ -35325,7 +35325,7 @@ CONTAINS
    SUBROUTINE bits2ints_45(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 45
 
@@ -35697,7 +35697,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_46(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 46
@@ -36273,7 +36273,7 @@ CONTAINS
    SUBROUTINE bits2ints_46(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 46
 
@@ -36647,7 +36647,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_47(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 47
@@ -37228,7 +37228,7 @@ CONTAINS
    SUBROUTINE bits2ints_47(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 47
 
@@ -37604,7 +37604,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_48(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 48
@@ -38190,7 +38190,7 @@ CONTAINS
    SUBROUTINE bits2ints_48(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 48
 
@@ -38568,7 +38568,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_49(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 49
@@ -39159,7 +39159,7 @@ CONTAINS
    SUBROUTINE bits2ints_49(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 49
 
@@ -39539,7 +39539,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_50(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 50
@@ -40135,7 +40135,7 @@ CONTAINS
    SUBROUTINE bits2ints_50(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 50
 
@@ -40517,7 +40517,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_51(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 51
@@ -41118,7 +41118,7 @@ CONTAINS
    SUBROUTINE bits2ints_51(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 51
 
@@ -41502,7 +41502,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_52(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 52
@@ -42108,7 +42108,7 @@ CONTAINS
    SUBROUTINE bits2ints_52(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 52
 
@@ -42494,7 +42494,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_53(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 53
@@ -43105,7 +43105,7 @@ CONTAINS
    SUBROUTINE bits2ints_53(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 53
 
@@ -43493,7 +43493,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_54(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 54
@@ -44109,7 +44109,7 @@ CONTAINS
    SUBROUTINE bits2ints_54(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 54
 
@@ -44499,7 +44499,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_55(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 55
@@ -45120,7 +45120,7 @@ CONTAINS
    SUBROUTINE bits2ints_55(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 55
 
@@ -45512,7 +45512,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_56(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 56
@@ -46138,7 +46138,7 @@ CONTAINS
    SUBROUTINE bits2ints_56(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 56
 
@@ -46532,7 +46532,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_57(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 57
@@ -47163,7 +47163,7 @@ CONTAINS
    SUBROUTINE bits2ints_57(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 57
 
@@ -47559,7 +47559,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_58(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 58
@@ -48195,7 +48195,7 @@ CONTAINS
    SUBROUTINE bits2ints_58(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 58
 
@@ -48593,7 +48593,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_59(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 59
@@ -49234,7 +49234,7 @@ CONTAINS
    SUBROUTINE bits2ints_59(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 59
 
@@ -49634,7 +49634,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_60(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 60
@@ -50280,7 +50280,7 @@ CONTAINS
    SUBROUTINE bits2ints_60(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 60
 
@@ -50682,7 +50682,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_61(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 61
@@ -51333,7 +51333,7 @@ CONTAINS
    SUBROUTINE bits2ints_61(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 61
 
@@ -51737,7 +51737,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_62(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 62
@@ -52393,7 +52393,7 @@ CONTAINS
    SUBROUTINE bits2ints_62(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 62
 
@@ -52799,7 +52799,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_63(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 63
@@ -53460,7 +53460,7 @@ CONTAINS
    SUBROUTINE bits2ints_63(Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       INTEGER, PARAMETER                                 :: Nbits = 63
 
@@ -53869,7 +53869,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ints2bits_specific(Nbits, Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Nbits, Ndata
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: packed_data(*)
+      INTEGER(KIND=int_8)                                :: packed_data(*)
       INTEGER(KIND=int_8), INTENT(IN)                    :: full_data(*)
 
       SELECT CASE (Nbits)
@@ -54012,7 +54012,7 @@ CONTAINS
    SUBROUTINE bits2ints_specific(Nbits, Ndata, packed_data, full_data)
       INTEGER, INTENT(IN)                                :: Nbits, Ndata
       INTEGER(KIND=int_8), INTENT(IN)                    :: packed_data(*)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: full_data(*)
+      INTEGER(KIND=int_8)                                :: full_data(*)
 
       SELECT CASE (Nbits)
       CASE (1)

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -285,7 +285,7 @@ CONTAINS
 !> \param fun2 ...
 ! **************************************************************************************************
    SUBROUTINE hfun_scale(fout, fun1, fun2)
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: fout
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: fout
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: fun1, fun2
 
       CHARACTER(len=*), PARAMETER :: routineN = 'hfun_scale', routineP = moduleN//':'//routineN

--- a/src/hirshfeld_types.F
+++ b/src/hirshfeld_types.F
@@ -140,12 +140,12 @@ CONTAINS
    SUBROUTINE get_hirshfeld_info(hirshfeld_env, shape_function_type, iterative, &
                                  ref_charge, fnorm, radius_type, use_bohr)
       TYPE(hirshfeld_type), POINTER                      :: hirshfeld_env
-      INTEGER, INTENT(OUT), OPTIONAL                     :: shape_function_type
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: iterative
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ref_charge
+      INTEGER, OPTIONAL                                  :: shape_function_type
+      LOGICAL, OPTIONAL                                  :: iterative
+      INTEGER, OPTIONAL                                  :: ref_charge
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: fnorm
-      INTEGER, INTENT(OUT), OPTIONAL                     :: radius_type
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: use_bohr
+      INTEGER, OPTIONAL                                  :: radius_type
+      LOGICAL, OPTIONAL                                  :: use_bohr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_hirshfeld_info', &
          routineP = moduleN//':'//routineN

--- a/src/input/cp_linked_list_input.F
+++ b/src/input/cp_linked_list_input.F
@@ -14,7 +14,7 @@ USE input_val_types,   only: val_type, val_p_type
 #:set nametype1 = ['int', 'real', 'logical', 'char', 'val']
 #:set type1 = ['integer', 'REAL(kind=dp)','logical', 'character(len=default_string_length)', 'type(val_type),pointer']
 #:set type1in = [_ + ', intent(in)' for _ in type1]
-#:set type1out = [_ + ', intent(out)' for _ in type1]
+#:set type1out = type1
 
 #:set eq = ['=', '=', '=', '=', '=>']
 #:set arrayeq = eq

--- a/src/input/cp_output_handling.F
+++ b/src/input/cp_output_handling.F
@@ -348,7 +348,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: basis_section
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: print_key_path
       TYPE(section_vals_type), OPTIONAL, POINTER         :: used_print_key
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: first_time
+      LOGICAL, OPTIONAL                                  :: first_time
       INTEGER                                            :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_print_key_should_output', &
@@ -470,7 +470,7 @@ CONTAINS
       RESULT(res)
       TYPE(cp_iteration_info_type), POINTER              :: iteration_info
       TYPE(section_vals_type), POINTER                   :: print_key
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: first_time
+      LOGICAL, OPTIONAL                                  :: first_time
       LOGICAL                                            :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_printkey_is_iter', &
@@ -593,7 +593,7 @@ CONTAINS
       TYPE(cp_iteration_info_type), POINTER              :: iteration_info
       LOGICAL, INTENT(IN), OPTIONAL                      :: last
       INTEGER, INTENT(IN), OPTIONAL                      :: iter_nr, increment
-      INTEGER, INTENT(OUT), OPTIONAL                     :: iter_nr_out
+      INTEGER, OPTIONAL                                  :: iter_nr_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_iterate', routineP = moduleN//':'//routineN
 
@@ -632,7 +632,7 @@ CONTAINS
    SUBROUTINE cp_add_iter_level(iteration_info, level_name, n_rlevel_new)
       TYPE(cp_iteration_info_type), POINTER              :: iteration_info
       CHARACTER(LEN=*), INTENT(IN)                       :: level_name
-      INTEGER, INTENT(OUT), OPTIONAL                     :: n_rlevel_new
+      INTEGER, OPTIONAL                                  :: n_rlevel_new
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_add_iter_level', &
          routineP = moduleN//':'//routineN
@@ -836,10 +836,9 @@ CONTAINS
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: file_form, file_position, file_action, &
                                                             file_status
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_backup, on_file
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: is_new_file
+      LOGICAL, OPTIONAL                                  :: is_new_file
       LOGICAL, INTENT(INOUT), OPTIONAL                   :: mpi_io
-      CHARACTER(len=default_path_length), INTENT(OUT), &
-         OPTIONAL                                        :: fout
+      CHARACTER(len=default_path_length), OPTIONAL       :: fout
       INTEGER                                            :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_print_key_unit_nr', &

--- a/src/input/cp_parser_methods.F
+++ b/src/input/cp_parser_methods.F
@@ -161,7 +161,7 @@ CONTAINS
 
       TYPE(cp_parser_type), POINTER                      :: parser
       INTEGER, INTENT(IN)                                :: nline
-      LOGICAL, INTENT(out), OPTIONAL                     :: at_end
+      LOGICAL, OPTIONAL                                  :: at_end
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_read_line', &
          routineP = moduleN//':'//routineN
@@ -216,7 +216,7 @@ CONTAINS
    SUBROUTINE parser_get_line_from_buffer(parser, istat)
 
       TYPE(cp_parser_type), POINTER                      :: parser
-      INTEGER, INTENT(OUT)                               :: istat
+      INTEGER                                            :: istat
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_get_line_from_buffer', &
          routineP = moduleN//':'//routineN
@@ -451,7 +451,7 @@ CONTAINS
 
       TYPE(cp_parser_type), POINTER                      :: parser
       INTEGER, INTENT(IN)                                :: nline
-      LOGICAL, INTENT(out), OPTIONAL                     :: at_end
+      LOGICAL, OPTIONAL                                  :: at_end
 
       CHARACTER(len=*), PARAMETER :: routineN = 'parser_get_next_line', &
          routineP = moduleN//':'//routineN
@@ -810,8 +810,8 @@ CONTAINS
       TYPE(cp_parser_type), POINTER                      :: parser
       CHARACTER(LEN=*), INTENT(IN)                       :: string
       LOGICAL, INTENT(IN)                                :: ignore_case
-      LOGICAL, INTENT(OUT)                               :: found
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: line
+      LOGICAL                                            :: found
+      CHARACTER(LEN=*), OPTIONAL                         :: line
       LOGICAL, INTENT(IN), OPTIONAL                      :: begin_line, search_from_begin_of_file
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_search_string', &
@@ -980,10 +980,10 @@ CONTAINS
                                  string_length, at_end)
 
       TYPE(cp_parser_type), POINTER                      :: parser
-      INTEGER, INTENT(OUT)                               :: object
+      INTEGER                                            :: object
       LOGICAL, INTENT(IN), OPTIONAL                      :: newline
       INTEGER, INTENT(IN), OPTIONAL                      :: skip_lines, string_length
-      LOGICAL, INTENT(out), OPTIONAL                     :: at_end
+      LOGICAL, OPTIONAL                                  :: at_end
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_get_integer', &
          routineP = moduleN//':'//routineN
@@ -1066,10 +1066,10 @@ CONTAINS
                                  string_length, at_end)
 
       TYPE(cp_parser_type), POINTER                      :: parser
-      LOGICAL, INTENT(OUT)                               :: object
+      LOGICAL                                            :: object
       LOGICAL, INTENT(IN), OPTIONAL                      :: newline
       INTEGER, INTENT(IN), OPTIONAL                      :: skip_lines, string_length
-      LOGICAL, INTENT(out), OPTIONAL                     :: at_end
+      LOGICAL, OPTIONAL                                  :: at_end
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_get_logical', &
          routineP = moduleN//':'//routineN
@@ -1144,10 +1144,10 @@ CONTAINS
                               at_end)
 
       TYPE(cp_parser_type), POINTER                      :: parser
-      REAL(KIND=dp), INTENT(OUT)                         :: object
+      REAL(KIND=dp)                                      :: object
       LOGICAL, INTENT(IN), OPTIONAL                      :: newline
       INTEGER, INTENT(IN), OPTIONAL                      :: skip_lines, string_length
-      LOGICAL, INTENT(out), OPTIONAL                     :: at_end
+      LOGICAL, OPTIONAL                                  :: at_end
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_get_real', &
          routineP = moduleN//':'//routineN
@@ -1213,10 +1213,10 @@ CONTAINS
                                 string_length, at_end)
 
       TYPE(cp_parser_type), POINTER                      :: parser
-      CHARACTER(LEN=*), INTENT(OUT)                      :: object
+      CHARACTER(LEN=*)                                   :: object
       LOGICAL, INTENT(IN), OPTIONAL                      :: lower_to_upper, newline
       INTEGER, INTENT(IN), OPTIONAL                      :: skip_lines, string_length
-      LOGICAL, INTENT(out), OPTIONAL                     :: at_end
+      LOGICAL, OPTIONAL                                  :: at_end
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_get_string', &
          routineP = moduleN//':'//routineN
@@ -1287,8 +1287,8 @@ CONTAINS
    SUBROUTINE read_float_object(string, object, error_message)
 
       CHARACTER(LEN=*), INTENT(IN)                       :: string
-      REAL(KIND=dp), INTENT(OUT)                         :: object
-      CHARACTER(LEN=*), INTENT(OUT)                      :: error_message
+      REAL(KIND=dp)                                      :: object
+      CHARACTER(LEN=*)                                   :: error_message
 
       INTEGER                                            :: i, iop, islash, istar, istat, n
       LOGICAL                                            :: parsing_done
@@ -1354,8 +1354,8 @@ CONTAINS
    SUBROUTINE read_integer_object(string, object, error_message)
 
       CHARACTER(LEN=*), INTENT(IN)                       :: string
-      INTEGER, INTENT(OUT)                               :: object
-      CHARACTER(LEN=*), INTENT(OUT)                      :: error_message
+      INTEGER                                            :: object
+      CHARACTER(LEN=*)                                   :: error_message
 
       CHARACTER(LEN=20)                                  :: fmtstr
       INTEGER                                            :: i, iop, istat, n

--- a/src/input/input_keyword_types.F
+++ b/src/input/input_keyword_types.F
@@ -450,10 +450,10 @@ CONTAINS
       TYPE(keyword_type), POINTER                        :: keyword
       CHARACTER(len=default_string_length), &
          DIMENSION(:), OPTIONAL, POINTER                 :: names
-      CHARACTER(len=*), INTENT(out), OPTIONAL            :: usage, description
-      INTEGER, INTENT(out), OPTIONAL                     :: type_of_var, n_var
+      CHARACTER(len=*), OPTIONAL                         :: usage, description
+      INTEGER, OPTIONAL                                  :: type_of_var, n_var
       TYPE(val_type), OPTIONAL, POINTER                  :: default_value, lone_keyword_value
-      LOGICAL, INTENT(out), OPTIONAL                     :: repeats
+      LOGICAL, OPTIONAL                                  :: repeats
       TYPE(enumeration_type), OPTIONAL, POINTER          :: enum
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: citations
 

--- a/src/input/input_parsing.F
+++ b/src/input/input_parsing.F
@@ -597,7 +597,7 @@ CONTAINS
 !> \author Teodoro Laino - 11.2007 [tlaino] - University of Zurich
 ! **************************************************************************************************
    SUBROUTINE get_r_val(r_val, parser, unit, default_units, c_val)
-      REAL(kind=dp), INTENT(OUT)                         :: r_val
+      REAL(kind=dp)                                      :: r_val
       TYPE(cp_parser_type), POINTER                      :: parser
       TYPE(cp_unit_type), POINTER                        :: unit
       TYPE(cp_unit_set_type), POINTER                    :: default_units

--- a/src/input/input_section_types.F
+++ b/src/input/input_section_types.F
@@ -851,10 +851,10 @@ CONTAINS
    SUBROUTINE section_vals_get(section_vals, ref_count, id_nr, n_repetition, &
                                n_subs_vals_rep, section, explicit)
       TYPE(section_vals_type), POINTER                   :: section_vals
-      INTEGER, INTENT(out), OPTIONAL                     :: ref_count, id_nr, n_repetition, &
+      INTEGER, OPTIONAL                                  :: ref_count, id_nr, n_repetition, &
                                                             n_subs_vals_rep
       TYPE(section_type), OPTIONAL, POINTER              :: section
-      LOGICAL, INTENT(out), OPTIONAL                     :: explicit
+      LOGICAL, OPTIONAL                                  :: explicit
 
       CHARACTER(len=*), PARAMETER :: routineN = 'section_vals_get', &
          routineP = moduleN//':'//routineN
@@ -1215,18 +1215,18 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       INTEGER, INTENT(in), OPTIONAL                      :: i_rep_section, i_rep_val
-      INTEGER, INTENT(out), OPTIONAL                     :: n_rep_val
+      INTEGER, OPTIONAL                                  :: n_rep_val
       TYPE(val_type), OPTIONAL, POINTER                  :: val
-      LOGICAL, INTENT(out), OPTIONAL                     :: l_val
-      INTEGER, INTENT(out), OPTIONAL                     :: i_val
-      REAL(KIND=DP), INTENT(out), OPTIONAL               :: r_val
-      CHARACTER(LEN=*), INTENT(out), OPTIONAL            :: c_val
+      LOGICAL, OPTIONAL                                  :: l_val
+      INTEGER, OPTIONAL                                  :: i_val
+      REAL(KIND=DP), OPTIONAL                            :: r_val
+      CHARACTER(LEN=*), OPTIONAL                         :: c_val
       LOGICAL, DIMENSION(:), OPTIONAL, POINTER           :: l_vals
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: i_vals
       REAL(KIND=DP), DIMENSION(:), OPTIONAL, POINTER     :: r_vals
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), OPTIONAL, POINTER                 :: c_vals
-      LOGICAL, INTENT(out), OPTIONAL                     :: explicit
+      LOGICAL, OPTIONAL                                  :: explicit
 
       CHARACTER(len=*), PARAMETER :: routineN = 'section_vals_val_get', &
          routineP = moduleN//':'//routineN

--- a/src/input/input_val_types.F
+++ b/src/input/input_val_types.F
@@ -347,16 +347,16 @@ CONTAINS
    SUBROUTINE val_get(val, has_l, has_i, has_r, has_lc, has_c, l_val, l_vals, i_val, &
                       i_vals, r_val, r_vals, c_val, c_vals, len_c, type_of_var, enum)
       TYPE(val_type), POINTER                            :: val
-      LOGICAL, INTENT(out), OPTIONAL                     :: has_l, has_i, has_r, has_lc, has_c, l_val
+      LOGICAL, OPTIONAL                                  :: has_l, has_i, has_r, has_lc, has_c, l_val
       LOGICAL, DIMENSION(:), OPTIONAL, POINTER           :: l_vals
-      INTEGER, INTENT(out), OPTIONAL                     :: i_val
+      INTEGER, OPTIONAL                                  :: i_val
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: i_vals
-      REAL(KIND=DP), INTENT(out), OPTIONAL               :: r_val
+      REAL(KIND=DP), OPTIONAL                            :: r_val
       REAL(KIND=DP), DIMENSION(:), OPTIONAL, POINTER     :: r_vals
-      CHARACTER(LEN=*), INTENT(out), OPTIONAL            :: c_val
+      CHARACTER(LEN=*), OPTIONAL                         :: c_val
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), OPTIONAL, POINTER                 :: c_vals
-      INTEGER, INTENT(out), OPTIONAL                     :: len_c, type_of_var
+      INTEGER, OPTIONAL                                  :: len_c, type_of_var
       TYPE(enumeration_type), OPTIONAL, POINTER          :: enum
 
       CHARACTER(len=*), PARAMETER :: routineN = 'val_get', routineP = moduleN//':'//routineN
@@ -652,7 +652,7 @@ CONTAINS
    SUBROUTINE val_write_internal(val, string, unit)
 
       TYPE(val_type), POINTER                            :: val
-      CHARACTER(LEN=*), INTENT(OUT)                      :: string
+      CHARACTER(LEN=*)                                   :: string
       TYPE(cp_unit_type), OPTIONAL, POINTER              :: unit
 
       CHARACTER(len=*), PARAMETER :: routineN = 'val_write_internal', &

--- a/src/input_cp2k_binary_restarts.F
+++ b/src/input_cp2k_binary_restarts.F
@@ -71,7 +71,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: root_section
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(section_vals_type), POINTER                   :: subsys_section
-      LOGICAL, INTENT(OUT)                               :: binary_file_read
+      LOGICAL                                            :: binary_file_read
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_binary_coordinates', &
          routineP = moduleN//':'//routineN
@@ -298,7 +298,7 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)                       :: prefix
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: root_section, subsys_section
-      LOGICAL, INTENT(OUT)                               :: binary_file_read
+      LOGICAL                                            :: binary_file_read
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_binary_cs_coordinates', &
          routineP = moduleN//':'//routineN
@@ -497,7 +497,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: root_section
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(section_vals_type), POINTER                   :: subsys_section
-      LOGICAL, INTENT(OUT)                               :: binary_file_read
+      LOGICAL                                            :: binary_file_read
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_binary_velocities', &
          routineP = moduleN//':'//routineN
@@ -680,7 +680,7 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)                       :: prefix
       TYPE(lnhc_parameters_type), POINTER                :: nhc
       CHARACTER(LEN=*), INTENT(IN)                       :: binary_restart_file_name
-      LOGICAL, INTENT(OUT)                               :: restart
+      LOGICAL                                            :: restart
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_binary_thermostats_nose', &

--- a/src/ipi_driver.F
+++ b/src/ipi_driver.F
@@ -206,7 +206,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE readbuffer_d(psockfd, fdata)
       INTEGER, INTENT(IN)                                :: psockfd
-      REAL(KIND=dp), INTENT(OUT)                         :: fdata
+      REAL(KIND=dp)                                      :: fdata
 
       CHARACTER(len=*), PARAMETER :: routineN = 'readbuffer_d', routineP = moduleN//':'//routineN
 
@@ -228,7 +228,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE readbuffer_i(psockfd, fdata)
       INTEGER, INTENT(IN)                                :: psockfd
-      INTEGER, INTENT(OUT)                               :: fdata
+      INTEGER                                            :: fdata
 
       CHARACTER(len=*), PARAMETER :: routineN = 'readbuffer_i', routineP = moduleN//':'//routineN
 
@@ -251,7 +251,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE readbuffer_s(psockfd, fstring, plen)
       INTEGER, INTENT(IN)                                :: psockfd
-      CHARACTER(LEN=*), INTENT(OUT)                      :: fstring
+      CHARACTER(LEN=*)                                   :: fstring
       INTEGER, INTENT(IN)                                :: plen
 
       CHARACTER(len=*), PARAMETER :: routineN = 'readbuffer_s', routineP = moduleN//':'//routineN
@@ -279,7 +279,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE readbuffer_dv(psockfd, fdata, plen)
       INTEGER, INTENT(IN)                                :: psockfd, plen
-      REAL(KIND=dp), INTENT(OUT), TARGET                 :: fdata(plen)
+      REAL(KIND=dp), TARGET                              :: fdata(plen)
 
       CHARACTER(len=*), PARAMETER :: routineN = 'readbuffer_dv', routineP = moduleN//':'//routineN
 

--- a/src/kg_correction.F
+++ b/src/kg_correction.F
@@ -75,7 +75,7 @@ CONTAINS
    SUBROUTINE kg_ekin_subset(qs_env, ks_matrix, ekin_mol, calc_force)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_matrix
-      REAL(KIND=dp), INTENT(out)                         :: ekin_mol
+      REAL(KIND=dp)                                      :: ekin_mol
       LOGICAL                                            :: calc_force
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kg_ekin_subset', routineP = moduleN//':'//routineN
@@ -117,7 +117,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(kg_environment_type), POINTER                 :: kg_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_matrix
-      REAL(KIND=dp), INTENT(out)                         :: ekin_mol
+      REAL(KIND=dp)                                      :: ekin_mol
       LOGICAL                                            :: calc_force
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kg_ekin_embed', routineP = moduleN//':'//routineN
@@ -239,7 +239,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(kg_environment_type), POINTER                 :: kg_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_matrix
-      REAL(KIND=dp), INTENT(out)                         :: ekin_mol
+      REAL(KIND=dp)                                      :: ekin_mol
       LOGICAL                                            :: calc_force
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kg_ekin_embed_lri', &
@@ -405,7 +405,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(kg_environment_type), POINTER                 :: kg_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_matrix
-      REAL(KIND=dp), INTENT(out)                         :: ekin_mol
+      REAL(KIND=dp)                                      :: ekin_mol
       LOGICAL                                            :: calc_force
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kg_ekin_ri_embed', &
@@ -564,7 +564,7 @@ CONTAINS
    SUBROUTINE kg_ekin_atomic(qs_env, ks_matrix, ekin_mol)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_matrix
-      REAL(KIND=dp), INTENT(out)                         :: ekin_mol
+      REAL(KIND=dp)                                      :: ekin_mol
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kg_ekin_atomic', routineP = moduleN//':'//routineN
 

--- a/src/kg_vertex_coloring_methods.F
+++ b/src/kg_vertex_coloring_methods.F
@@ -166,7 +166,7 @@ CONTAINS
    SUBROUTINE color_graph_greedy(graph, maxdegree, ncolors)
       TYPE(vertex_p_type), DIMENSION(:), POINTER         :: graph
       INTEGER, INTENT(in)                                :: maxdegree
-      INTEGER, INTENT(out)                               :: ncolors
+      INTEGER                                            :: ncolors
 
       CHARACTER(len=*), PARAMETER :: routineN = 'color_graph_greedy', &
          routineP = moduleN//':'//routineN
@@ -345,7 +345,7 @@ CONTAINS
    SUBROUTINE kg_dsatur(kg_env, graph, ncolors)
       TYPE(kg_environment_type), POINTER                 :: kg_env
       TYPE(vertex_p_type), DIMENSION(:), POINTER         :: graph
-      INTEGER(KIND=int_4), INTENT(OUT)                   :: ncolors
+      INTEGER(KIND=int_4)                                :: ncolors
 
       CHARACTER(len=*), PARAMETER :: routineN = 'kg_dsatur', routineP = moduleN//':'//routineN
 
@@ -460,7 +460,7 @@ CONTAINS
    SUBROUTINE kg_check_switch(this, neighbor, low_col, switchable, ncolors, color_present)
 
       TYPE(vertex), POINTER                              :: this, neighbor
-      INTEGER, INTENT(OUT)                               :: low_col
+      INTEGER                                            :: low_col
       LOGICAL                                            :: switchable
       INTEGER                                            :: ncolors
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: color_present
@@ -574,7 +574,7 @@ CONTAINS
    SUBROUTINE check_coloring(graph, valid)
       TYPE(vertex_p_type), DIMENSION(:), INTENT(in), &
          POINTER                                         :: graph
-      LOGICAL, INTENT(out)                               :: valid
+      LOGICAL                                            :: valid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'check_coloring', routineP = moduleN//':'//routineN
 
@@ -634,9 +634,8 @@ CONTAINS
       TYPE(kg_environment_type), POINTER                 :: kg_env
       INTEGER(KIND=int_4), ALLOCATABLE, &
          DIMENSION(:, :), INTENT(IN)                     :: pairs
-      INTEGER(KIND=int_4), INTENT(OUT)                   :: ncolors
-      INTEGER(KIND=int_4), ALLOCATABLE, DIMENSION(:), &
-         INTENT(out)                                     :: color_of_node
+      INTEGER(KIND=int_4)                                :: ncolors
+      INTEGER(KIND=int_4), ALLOCATABLE, DIMENSION(:)     :: color_of_node
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kg_vertex_coloring', &
          routineP = moduleN//':'//routineN

--- a/src/kpoint_io.F
+++ b/src/kpoint_io.F
@@ -304,7 +304,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: id_nr
       TYPE(section_vals_type), POINTER                   :: dft_section
-      LOGICAL, INTENT(OUT)                               :: natom_mismatch
+      LOGICAL                                            :: natom_mismatch
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_kpoints_restart', &
          routineP = moduleN//':'//routineN
@@ -375,7 +375,7 @@ CONTAINS
       TYPE(cp_fm_type), POINTER                          :: fmat
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: natom, rst_unit
-      LOGICAL, INTENT(OUT)                               :: natom_mismatch
+      LOGICAL                                            :: natom_mismatch
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_kpoints_restart_low', &
          routineP = moduleN//':'//routineN

--- a/src/linesearch.F
+++ b/src/linesearch.F
@@ -346,8 +346,8 @@ CONTAINS
    SUBROUTINE linesearch_2pnt(this, energy, slope, step_size, is_done, unit_nr, label)
       TYPE(linesearch_2pnt_type), INTENT(INOUT)          :: this
       REAL(KIND=dp), INTENT(IN)                          :: energy, slope
-      REAL(KIND=dp), INTENT(OUT)                         :: step_size
-      LOGICAL, INTENT(OUT)                               :: is_done
+      REAL(KIND=dp)                                      :: step_size
+      LOGICAL                                            :: is_done
       INTEGER, INTENT(IN)                                :: unit_nr
       CHARACTER(len=*), INTENT(IN)                       :: label
 
@@ -412,8 +412,8 @@ CONTAINS
    SUBROUTINE linesearch_3pnt(this, energy, step_size, is_done, unit_nr, label)
       TYPE(linesearch_3pnt_type), INTENT(INOUT)          :: this
       REAL(KIND=dp), INTENT(IN)                          :: energy
-      REAL(KIND=dp), INTENT(OUT)                         :: step_size
-      LOGICAL, INTENT(OUT)                               :: is_done
+      REAL(KIND=dp)                                      :: step_size
+      LOGICAL                                            :: is_done
       INTEGER, INTENT(IN)                                :: unit_nr
       CHARACTER(len=*), INTENT(IN)                       :: label
 
@@ -497,8 +497,8 @@ CONTAINS
    SUBROUTINE linesearch_adapt(this, energy, step_size, is_done, unit_nr, label)
       TYPE(linesearch_adapt_type), INTENT(INOUT)         :: this
       REAL(KIND=dp), INTENT(IN)                          :: energy
-      REAL(KIND=dp), INTENT(OUT)                         :: step_size
-      LOGICAL, INTENT(OUT)                               :: is_done
+      REAL(KIND=dp)                                      :: step_size
+      LOGICAL                                            :: is_done
       INTEGER, INTENT(IN)                                :: unit_nr
       CHARACTER(len=*), INTENT(IN)                       :: label
 
@@ -614,8 +614,8 @@ CONTAINS
    SUBROUTINE linesearch_gold(this, energy, step_size, is_done, unit_nr, label)
       TYPE(linesearch_gold_type), INTENT(INOUT)          :: this
       REAL(KIND=dp), INTENT(IN)                          :: energy
-      REAL(KIND=dp), INTENT(OUT)                         :: step_size
-      LOGICAL, INTENT(OUT)                               :: is_done
+      REAL(KIND=dp)                                      :: step_size
+      LOGICAL                                            :: is_done
       INTEGER, INTENT(IN)                                :: unit_nr
       CHARACTER(len=*), INTENT(IN)                       :: label
 

--- a/src/lri_compression.F
+++ b/src/lri_compression.F
@@ -38,7 +38,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE lri_comp(aval, amax, cont)
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: aval
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: amax
+      REAL(KIND=dp), DIMENSION(:)                        :: amax
       TYPE(int_container), INTENT(INOUT)                 :: cont
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'lri_comp', routineP = moduleN//':'//routineN

--- a/src/lri_optimize_ri_basis.F
+++ b/src/lri_optimize_ri_basis.F
@@ -660,7 +660,7 @@ CONTAINS
       TYPE(lri_opt_type), POINTER                        :: lri_opt
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: pmatrix
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), INTENT(OUT)                         :: fobj
+      REAL(KIND=dp)                                      :: fobj
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_objective', &
          routineP = moduleN//':'//routineN

--- a/src/manybody_eam.F
+++ b/src/manybody_eam.F
@@ -225,7 +225,7 @@ CONTAINS
       TYPE(eam_pot_type), POINTER                        :: eam_a, eam_b
       TYPE(eam_type), INTENT(IN)                         :: eam_data(:)
       INTEGER, INTENT(IN)                                :: atom_a, atom_b
-      REAL(dp), INTENT(OUT)                              :: f_eam
+      REAL(dp)                                           :: f_eam
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_force_eam', routineP = moduleN//':'//routineN
 

--- a/src/manybody_siepmann.F
+++ b/src/manybody_siepmann.F
@@ -69,7 +69,7 @@ CONTAINS
                               nloc_size, full_loc_list, cell_v, cell, drij, particle_set, &
                               nr_oh, nr_h3o, nr_o)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: pot_loc
+      REAL(KIND=dp)                                      :: pot_loc
       TYPE(siepmann_pot_type), POINTER                   :: siepmann
       TYPE(pos_type), DIMENSION(:), POINTER              :: r_last_update_pbc
       INTEGER, INTENT(IN)                                :: atom_a, atom_b, nloc_size

--- a/src/manybody_tersoff.F
+++ b/src/manybody_tersoff.F
@@ -50,7 +50,7 @@ CONTAINS
    SUBROUTINE tersoff_energy(pot_loc, tersoff, r_last_update_pbc, atom_a, atom_b, nloc_size, &
                              full_loc_list, loc_cell_v, cell_v, drij)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: pot_loc
+      REAL(KIND=dp)                                      :: pot_loc
       TYPE(tersoff_pot_type), POINTER                    :: tersoff
       TYPE(pos_type), DIMENSION(:), POINTER              :: r_last_update_pbc
       INTEGER, INTENT(IN)                                :: atom_a, atom_b, nloc_size

--- a/src/mao_methods.F
+++ b/src/mao_methods.F
@@ -202,7 +202,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mao_function(mao_coef, fval, qmat, smat, binv, reuse)
       TYPE(dbcsr_type)                                   :: mao_coef
-      REAL(KIND=dp), INTENT(OUT)                         :: fval
+      REAL(KIND=dp)                                      :: fval
       TYPE(dbcsr_type)                                   :: qmat, smat, binv
       LOGICAL, INTENT(IN)                                :: reuse
 
@@ -247,7 +247,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mao_function_gradient(mao_coef, fval, mao_grad, qmat, smat, binv, reuse)
       TYPE(dbcsr_type)                                   :: mao_coef
-      REAL(KIND=dp), INTENT(OUT)                         :: fval
+      REAL(KIND=dp)                                      :: fval
       TYPE(dbcsr_type)                                   :: mao_grad, qmat, smat, binv
       LOGICAL, INTENT(IN)                                :: reuse
 
@@ -715,7 +715,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_smm, matrix_smo
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: smm_list
-      REAL(KIND=dp), DIMENSION(2), INTENT(OUT)           :: electra
+      REAL(KIND=dp), DIMENSION(2)                        :: electra
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       INTEGER, INTENT(IN), OPTIONAL                      :: nimages
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints

--- a/src/matrix_exp.F
+++ b/src/matrix_exp.F
@@ -247,7 +247,7 @@ CONTAINS
    SUBROUTINE get_nsquare_norder(norm, nsquare, norder, eps_exp, method, do_emd)
 
       REAL(dp), INTENT(in)                               :: norm
-      INTEGER, INTENT(out)                               :: nsquare, norder
+      INTEGER                                            :: nsquare, norder
       REAL(dp), INTENT(in)                               :: eps_exp
       INTEGER, INTENT(in)                                :: method
       LOGICAL, INTENT(in)                                :: do_emd

--- a/src/metadyn_tools/graph_utils.F
+++ b/src/metadyn_tools/graph_utils.F
@@ -192,8 +192,8 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: unit
       CHARACTER(len=*)                                   :: section
       CHARACTER(len=*), OPTIONAL                         :: keyword, subsection
-      INTEGER, INTENT(OUT), OPTIONAL                     :: i_val
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: r_val
+      INTEGER, OPTIONAL                                  :: i_val
+      REAL(KIND=dp), OPTIONAL                            :: r_val
 
       CHARACTER(len=512)                                 :: line
       INTEGER                                            :: my_ind, stat
@@ -237,8 +237,8 @@ CONTAINS
   SUBROUTINE search(unit, key, line, stat)
       INTEGER, INTENT(in)                                :: unit
       CHARACTER(LEN=*), INTENT(IN)                       :: key
-      CHARACTER(LEN=512), INTENT(OUT)                    :: line
-      INTEGER, INTENT(out)                               :: stat
+      CHARACTER(LEN=512)                                 :: line
+      INTEGER                                            :: stat
 
     stat = 99
     DO WHILE (.TRUE.)

--- a/src/metadynamics_utils.F
+++ b/src/metadynamics_utils.F
@@ -864,7 +864,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_meta_iter_level(meta_env, iter_nr)
       TYPE(meta_env_type), POINTER                       :: meta_env
-      INTEGER, INTENT(OUT)                               :: iter_nr
+      INTEGER                                            :: iter_nr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_meta_iter_level', &
          routineP = moduleN//':'//routineN

--- a/src/minimax/minimax_exp.F
+++ b/src/minimax/minimax_exp.F
@@ -98,7 +98,7 @@ CONTAINS
    SUBROUTINE check_exp_minimax_range(k, Rc, ierr)
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), INTENT(IN)                          :: Rc
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
 
       ierr = 0
       IF (k .LE. 15) THEN
@@ -124,9 +124,9 @@ CONTAINS
    SUBROUTINE get_exp_minimax_coeff(k, Rc, aw, mm_error, which_coeffs)
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), INTENT(IN)                          :: Rc
-      REAL(KIND=dp), DIMENSION(2*k), INTENT(OUT)         :: aw
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: mm_error
-      INTEGER, INTENT(OUT), OPTIONAL                     :: which_coeffs
+      REAL(KIND=dp), DIMENSION(2*k)                      :: aw
+      REAL(KIND=dp), OPTIONAL                            :: mm_error
+      INTEGER, OPTIONAL                                  :: which_coeffs
 
       INTEGER                                            :: ierr
 
@@ -160,8 +160,8 @@ CONTAINS
    SUBROUTINE get_minimax_coeff_k53(k, Rc, aw, mm_error)
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), INTENT(IN)                          :: Rc
-      REAL(KIND=dp), DIMENSION(2*k), INTENT(OUT)         :: aw
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: mm_error
+      REAL(KIND=dp), DIMENSION(2*k)                      :: aw
+      REAL(KIND=dp), OPTIONAL                            :: mm_error
 
       INTEGER                                            :: i_mm
 
@@ -182,7 +182,7 @@ CONTAINS
    SUBROUTINE get_best_minimax_approx_k53(k, Rc, i_mm, ge_Rc)
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), INTENT(IN)                          :: Rc
-      INTEGER, INTENT(OUT)                               :: i_mm
+      INTEGER                                            :: i_mm
       LOGICAL, INTENT(IN), OPTIONAL                      :: ge_Rc
 
       INTEGER                                            :: i, i_k, i_l, i_r

--- a/src/minimax/minimax_exp_k15.F
+++ b/src/minimax/minimax_exp_k15.F
@@ -130,8 +130,8 @@ CONTAINS
    SUBROUTINE get_minimax_coeff_k15(k, Rc, aw, mm_error)
       INTEGER, INTENT(IN)                                :: k
       REAL(KIND=dp), INTENT(IN)                          :: Rc
-      REAL(KIND=dp), DIMENSION(2*k), INTENT(OUT)         :: aw
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: mm_error
+      REAL(KIND=dp), DIMENSION(2*k)                      :: aw
+      REAL(KIND=dp), OPTIONAL                            :: mm_error
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_minimax_coeff_k15', &
          routineP = moduleN//':'//routineN

--- a/src/minimax/minimax_exp_k53.F
+++ b/src/minimax/minimax_exp_k53.F
@@ -616,7 +616,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_minimax_coeff_low(i, aw)
       INTEGER, INTENT(IN)                                :: i
-      REAL(KIND=dp), DIMENSION(k_mm(i)*2), INTENT(OUT)   :: aw
+      REAL(KIND=dp), DIMENSION(k_mm(i)*2)                :: aw
 
       SELECT CASE (i)
 

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -2304,16 +2304,13 @@ CONTAINS
       TYPE(force_env_type), POINTER                      :: force_env
       TYPE(mixed_cdft_type), POINTER                     :: mixed_cdft
       LOGICAL, INTENT(IN)                                :: calculate_forces
-      LOGICAL, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: is_constraint
-      LOGICAL, INTENT(OUT)                               :: in_memory
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: is_constraint
+      LOGICAL                                            :: in_memory
       LOGICAL, INTENT(IN)                                :: store_vectors
-      REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(out)                                     :: R12, position_vecs
-      REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(out)                                     :: pair_dist_vecs
-      REAL(kind=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: coefficients
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(out)    :: catom
+      REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :)        :: R12, position_vecs
+      REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: pair_dist_vecs
+      REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: coefficients
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: catom
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mixed_becke_constraint_init', &
          routineP = moduleN//':'//routineN

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -1523,7 +1523,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE map_permutation_to_states(n, ipermutation, i, j)
       INTEGER, INTENT(IN)                                :: n, ipermutation
-      INTEGER, INTENT(OUT)                               :: i, j
+      INTEGER                                            :: i, j
 
       CHARACTER(len=*), PARAMETER :: routineN = 'map_permutation_to_states', &
          routineP = moduleN//':'//routineN
@@ -1631,10 +1631,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mixed_cdft_read_block_diag(force_env, blocks, ignore_excited, nrecursion)
       TYPE(force_env_type), POINTER                      :: force_env
-      TYPE(cp_1d_i_p_type), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: blocks
-      LOGICAL, INTENT(OUT)                               :: ignore_excited
-      INTEGER, INTENT(OUT)                               :: nrecursion
+      TYPE(cp_1d_i_p_type), ALLOCATABLE, DIMENSION(:)    :: blocks
+      LOGICAL                                            :: ignore_excited
+      INTEGER                                            :: nrecursion
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mixed_cdft_read_block_diag', &
          routineP = moduleN//':'//routineN
@@ -1727,8 +1726,7 @@ CONTAINS
    SUBROUTINE mixed_cdft_get_blocks(mixed_cdft, blocks, H_block, S_block)
       TYPE(mixed_cdft_type), POINTER                     :: mixed_cdft
       TYPE(cp_1d_i_p_type), ALLOCATABLE, DIMENSION(:)    :: blocks
-      TYPE(cp_2d_r_p_type), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: H_block, S_block
+      TYPE(cp_2d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: H_block, S_block
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mixed_cdft_get_blocks', &
          routineP = moduleN//':'//routineN
@@ -1777,8 +1775,7 @@ CONTAINS
    SUBROUTINE mixed_cdft_diagonalize_blocks(blocks, H_block, S_block, eigenvalues)
       TYPE(cp_1d_i_p_type), ALLOCATABLE, DIMENSION(:)    :: blocks
       TYPE(cp_2d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: H_block, S_block
-      TYPE(cp_1d_r_p_type), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: eigenvalues
+      TYPE(cp_1d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: eigenvalues
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mixed_cdft_diagonalize_blocks', &
          routineP = moduleN//':'//routineN

--- a/src/mixed_environment_types.F
+++ b/src/mixed_environment_types.F
@@ -198,7 +198,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE init_mixed_env(mixed_env, para_env)
 
-      TYPE(mixed_environment_type), INTENT(OUT)          :: mixed_env
+      TYPE(mixed_environment_type)                       :: mixed_env
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       NULLIFY (mixed_env%input)

--- a/src/mm_collocate_potential.F
+++ b/src/mm_collocate_potential.F
@@ -185,7 +185,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(2, bo(1, 3):bo(2, 3))     :: zdat
       REAL(KIND=dp), DIMENSION(2, bo(1, 2):bo(2, 2))     :: ydat
       REAL(KIND=dp), DIMENSION(2, bo(1, 1):bo(2, 1))     :: xdat
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: force
+      REAL(KIND=dp), DIMENSION(3)                        :: force
       INTEGER, DIMENSION(3), INTENT(IN)                  :: n_rep_real
       TYPE(cell_type), POINTER                           :: mm_cell
 

--- a/src/mol_force.F
+++ b/src/mol_force.F
@@ -41,7 +41,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: id_type
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: rij
       REAL(KIND=dp), INTENT(IN)                          :: r0, k(3), cs
-      REAL(KIND=dp), INTENT(OUT)                         :: energy, fscalar
+      REAL(KIND=dp)                                      :: energy, fscalar
 
       CHARACTER(len=*), PARAMETER :: routineN = 'force_bonds', routineP = moduleN//':'//routineN
       REAL(KIND=dp), PARAMETER                           :: f12 = 1.0_dp/2.0_dp, &
@@ -142,8 +142,8 @@ CONTAINS
                                                             theta0, k, cb, r012, r032, kbs12, &
                                                             kbs32, kss
       TYPE(legendre_data_type), INTENT(IN)               :: legendre
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: g1, g2, g3
-      REAL(KIND=dp), INTENT(OUT)                         :: energy, fscalar
+      REAL(KIND=dp), DIMENSION(:)                        :: g1, g2, g3
+      REAL(KIND=dp)                                      :: energy, fscalar
 
       CHARACTER(len=*), PARAMETER :: routineN = 'force_bends', routineP = moduleN//':'//routineN
       REAL(KIND=dp), PARAMETER                           :: f12 = 1.0_dp/2.0_dp
@@ -353,8 +353,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tm, tn, t12
       REAL(KIND=dp), INTENT(IN)                          :: k, phi0
       INTEGER, INTENT(IN)                                :: m
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: gt1, gt2, gt3, gt4
-      REAL(KIND=dp), INTENT(OUT)                         :: energy, fscalar
+      REAL(KIND=dp), DIMENSION(:)                        :: gt1, gt2, gt3, gt4
+      REAL(KIND=dp)                                      :: energy, fscalar
 
       CHARACTER(len=*), PARAMETER :: routineN = 'force_torsions', routineP = moduleN//':'//routineN
 
@@ -414,8 +414,8 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: s32, is32, ism, isn, dist1, dist2
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tm, tn, t12
       REAL(KIND=dp), INTENT(IN)                          :: k, phi0
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: gt1, gt2, gt3, gt4
-      REAL(KIND=dp), INTENT(OUT)                         :: energy, fscalar
+      REAL(KIND=dp), DIMENSION(:)                        :: gt1, gt2, gt3, gt4
+      REAL(KIND=dp)                                      :: energy, fscalar
 
       CHARACTER(len=*), PARAMETER :: routineN = 'force_imp_torsions', &
          routineP = moduleN//':'//routineN
@@ -483,8 +483,8 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: s32
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tm, t41, t42, t43
       REAL(KIND=dp), INTENT(IN)                          :: k, phi0
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: gt1, gt2, gt3, gt4
-      REAL(KIND=dp), INTENT(OUT)                         :: energy, fscalar
+      REAL(KIND=dp), DIMENSION(:)                        :: gt1, gt2, gt3, gt4
+      REAL(KIND=dp)                                      :: energy, fscalar
 
       CHARACTER(len=*), PARAMETER :: routineN = 'force_opbends', routineP = moduleN//':'//routineN
       REAL(KIND=dp), PARAMETER                           :: f12 = 1.0_dp/2.0_dp

--- a/src/moments_utils.F
+++ b/src/moments_utils.F
@@ -57,8 +57,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_reference_point(rpoint, drpoint, qs_env, fist_env, reference, ref_point, &
                                   ifirst, ilast)
-      REAL(dp), DIMENSION(3), INTENT(OUT)                :: rpoint
-      REAL(dp), DIMENSION(3), INTENT(OUT), OPTIONAL      :: drpoint
+      REAL(dp), DIMENSION(3)                             :: rpoint
+      REAL(dp), DIMENSION(3), OPTIONAL                   :: drpoint
       TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
       TYPE(fist_environment_type), OPTIONAL, POINTER     :: fist_env
       INTEGER, INTENT(IN)                                :: reference

--- a/src/motion/cell_opt_utils.F
+++ b/src/motion/cell_opt_utils.F
@@ -100,7 +100,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: new_logger
       TYPE(section_vals_type), POINTER                   :: root_section
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      CHARACTER(len=default_string_length), INTENT(OUT)  :: project_name
+      CHARACTER(len=default_string_length)               :: project_name
       INTEGER, INTENT(IN)                                :: id_run
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'gopt_new_logger_create', &
@@ -196,8 +196,8 @@ CONTAINS
    SUBROUTINE read_external_press_tensor(geo_section, cell, pres_ext, mtrx, rot)
       TYPE(section_vals_type), POINTER                   :: geo_section
       TYPE(cell_type), POINTER                           :: cell
-      REAL(KIND=dp), INTENT(OUT)                         :: pres_ext
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: mtrx
+      REAL(KIND=dp)                                      :: pres_ext
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: mtrx
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: rot
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_external_press_tensor', &
@@ -267,7 +267,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: mtrx
       LOGICAL, INTENT(IN), OPTIONAL                      :: keep_angles, keep_symmetry
-      REAL(KIND=dp), INTENT(OUT)                         :: pres_int
+      REAL(KIND=dp)                                      :: pres_int
       INTEGER, INTENT(IN), OPTIONAL                      :: constraint_id
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_dg_dh', routineP = moduleN//':'//routineN

--- a/src/motion/cg_optimizer.F
+++ b/src/motion/cg_optimizer.F
@@ -68,7 +68,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: geo_section
       TYPE(gopt_f_type), POINTER                         :: gopt_env
       REAL(KIND=dp), DIMENSION(:), POINTER               :: x0
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: do_update
+      LOGICAL, OPTIONAL                                  :: do_update
 
       CHARACTER(len=*), PARAMETER :: routineN = 'geoopt_cg', routineP = moduleN//':'//routineN
 
@@ -114,7 +114,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: output_unit
       TYPE(global_environment_type), POINTER             :: globenv
       TYPE(gopt_f_type), POINTER                         :: gopt_env
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: do_update
+      LOGICAL, OPTIONAL                                  :: do_update
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cg_main', routineP = moduleN//':'//routineN
 

--- a/src/motion/cp_lbfgs.F
+++ b/src/motion/cp_lbfgs.F
@@ -958,8 +958,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(in)                          :: lower_bound(n), upper_bound(n)
       INTEGER                                            :: nbd(n)
       REAL(KIND=dp)                                      :: x(n)
-      INTEGER, INTENT(out)                               :: iwhere(n)
-      INTEGER                                            :: iprint
+      INTEGER                                            :: iwhere(n), iprint
       LOGICAL                                            :: x_projected, constrained, boxed
 
       REAL(KIND=dp), PARAMETER                           :: zero = 0.0_dp
@@ -1057,8 +1056,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: sy(m, m), wt(m, m)
       INTEGER                                            :: col
       REAL(KIND=dp), INTENT(in)                          :: v(2*col)
-      REAL(KIND=dp), INTENT(out)                         :: p(2*col)
-      INTEGER, INTENT(out)                               :: info
+      REAL(KIND=dp)                                      :: p(2*col)
+      INTEGER                                            :: info
 
       INTEGER                                            :: i, i2, k
       REAL(KIND=dp)                                      :: sum
@@ -1595,7 +1594,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: n, m
       REAL(KIND=dp), INTENT(in)                          :: x(n), g(n), ws(n, m), wy(n, m), &
                                                             sy(m, m), wt(m, m), z(n)
-      REAL(KIND=dp), INTENT(out)                         :: r(n), wa(4*m)
+      REAL(KIND=dp)                                      :: r(n), wa(4*m)
       INTEGER, INTENT(in)                                :: INDEX(n)
       REAL(KIND=dp), INTENT(in)                          :: theta
       INTEGER, INTENT(in)                                :: col, head, nfree
@@ -1749,11 +1748,10 @@ CONTAINS
                                                             indx2(n), iupdat
       LOGICAL                                            :: updatd
       INTEGER, INTENT(in)                                :: m
-      REAL(KIND=dp)                                      :: wn1(2*m, 2*m)
-      REAL(KIND=dp), INTENT(out)                         :: wn(2*m, 2*m)
+      REAL(KIND=dp)                                      :: wn1(2*m, 2*m), wn(2*m, 2*m)
       REAL(KIND=dp), INTENT(in)                          :: ws(n, m), wy(n, m), sy(m, m), theta
       INTEGER, INTENT(in)                                :: col, head
-      INTEGER, INTENT(out)                               :: info
+      INTEGER                                            :: info
 
       REAL(KIND=dp), PARAMETER                           :: zero = 0.0_dp
 
@@ -2057,9 +2055,7 @@ CONTAINS
 
       INTEGER                                            :: n, nfree
       INTEGER, INTENT(inout)                             :: INDEX(n)
-      INTEGER                                            :: nenter, ileave
-      INTEGER, INTENT(out)                               :: indx2(n)
-      INTEGER                                            :: iwhere(n)
+      INTEGER                                            :: nenter, ileave, indx2(n), iwhere(n)
       LOGICAL                                            :: wrk, updatd, constrained
       INTEGER                                            :: iprint, iter
 
@@ -2905,11 +2901,10 @@ CONTAINS
       REAL(KIND=dp)                                      :: xp(n)
       REAL(KIND=dp), INTENT(in)                          :: ws(n, m), wy(n, m), theta, xx(n), gg(n)
       INTEGER, INTENT(in)                                :: col, head
-      INTEGER, INTENT(out)                               :: iword
+      INTEGER                                            :: iword
       REAL(KIND=dp)                                      :: wv(2*m)
       REAL(KIND=dp), INTENT(in)                          :: wn(2*m, 2*m)
-      INTEGER                                            :: iprint
-      INTEGER, INTENT(out)                               :: info
+      INTEGER                                            :: iprint, info
 
       REAL(KIND=dp), PARAMETER                           :: one = 1.0_dp, zero = 0.0_dp
 
@@ -3713,7 +3708,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: n
       REAL(KIND=dp), INTENT(inout)                       :: b(*)
       INTEGER, INTENT(in)                                :: job
-      INTEGER, INTENT(out)                               :: info
+      INTEGER                                            :: info
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dtrsl', routineP = moduleN//':'//routineN
 
@@ -3916,9 +3911,9 @@ CONTAINS
       SUBROUTINE save_local(lsave,isave,dsave,x_projected,constrained,boxed,updatd,nintol,itfile,iback,nskip,head,col,itail,&
                             iter,iupdat,nseg,nfgv,info,ifun,iword,nfree,nact,ileave,nenter,theta,fold,tol,dnorm,epsmch,cpu1,&
                             cachyt,sbtime,lnscht,time1,gd,step_max,g_inf_norm,stp,gdold,dtd)
-      LOGICAL, INTENT(out)                               :: lsave(4)
-      INTEGER, INTENT(out)                               :: isave(23)
-      REAL(KIND=dp), INTENT(out)                         :: dsave(29)
+      LOGICAL                                            :: lsave(4)
+      INTEGER                                            :: isave(23)
+      REAL(KIND=dp)                                      :: dsave(29)
       LOGICAL, INTENT(in)                                :: x_projected, constrained, boxed, updatd
       INTEGER, INTENT(in)                                :: nintol, itfile, iback, nskip, head, col, &
                                                             itail, iter, iupdat, nseg, nfgv, info, &

--- a/src/motion/cp_lbfgs_optimizer_gopt.F
+++ b/src/motion/cp_lbfgs_optimizer_gopt.F
@@ -408,16 +408,16 @@ CONTAINS
       TYPE(cp_lbfgs_opt_gopt_type), POINTER              :: optimizer
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
       TYPE(gopt_f_type), OPTIONAL, POINTER               :: obj_funct
-      INTEGER, INTENT(out), OPTIONAL                     :: m, print_every, id_nr
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: wanted_relative_f_delta, &
+      INTEGER, OPTIONAL                                  :: m, print_every, id_nr
+      REAL(kind=dp), OPTIONAL                            :: wanted_relative_f_delta, &
                                                             wanted_projected_gradient
       REAL(kind=dp), DIMENSION(:), OPTIONAL, POINTER     :: x, lower_bound, upper_bound
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: kind_of_bound
-      INTEGER, INTENT(out), OPTIONAL                     :: master
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: actual_projected_gradient
-      INTEGER, INTENT(out), OPTIONAL                     :: n_var, n_iter, status, max_f_per_iter
-      LOGICAL, INTENT(out), OPTIONAL                     :: at_end, is_master
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: last_f, f
+      INTEGER, OPTIONAL                                  :: master
+      REAL(kind=dp), OPTIONAL                            :: actual_projected_gradient
+      INTEGER, OPTIONAL                                  :: n_var, n_iter, status, max_f_per_iter
+      LOGICAL, OPTIONAL                                  :: at_end, is_master
+      REAL(kind=dp), OPTIONAL                            :: last_f, f
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_opt_gopt_get', &
          routineP = moduleN//':'//routineN
@@ -492,9 +492,9 @@ CONTAINS
                                          projected_gradient, converged, geo_section, force_env, &
                                          gopt_param)
       TYPE(cp_lbfgs_opt_gopt_type), POINTER              :: optimizer
-      INTEGER, INTENT(out), OPTIONAL                     :: n_iter
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: f, last_f, projected_gradient
-      LOGICAL, INTENT(out), OPTIONAL                     :: converged
+      INTEGER, OPTIONAL                                  :: n_iter
+      REAL(kind=dp), OPTIONAL                            :: f, last_f, projected_gradient
+      LOGICAL, OPTIONAL                                  :: converged
       TYPE(section_vals_type), POINTER                   :: geo_section
       TYPE(force_env_type), POINTER                      :: force_env
       TYPE(gopt_param_type), POINTER                     :: gopt_param
@@ -722,7 +722,7 @@ CONTAINS
    SUBROUTINE cp_opt_gopt_bcast_res(optimizer, n_iter, f, last_f, &
                                     projected_gradient)
       TYPE(cp_lbfgs_opt_gopt_type), POINTER              :: optimizer
-      INTEGER, INTENT(out), OPTIONAL                     :: n_iter
+      INTEGER, OPTIONAL                                  :: n_iter
       REAL(kind=dp), INTENT(inout), OPTIONAL             :: f, last_f, projected_gradient
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_opt_gopt_bcast_res', &
@@ -774,9 +774,9 @@ CONTAINS
                                        projected_gradient, converged, geo_section, force_env, &
                                        gopt_param) RESULT(res)
       TYPE(cp_lbfgs_opt_gopt_type), POINTER              :: optimizer
-      INTEGER, INTENT(out), OPTIONAL                     :: n_iter
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: f, last_f, projected_gradient
-      LOGICAL, INTENT(out)                               :: converged
+      INTEGER, OPTIONAL                                  :: n_iter
+      REAL(kind=dp), OPTIONAL                            :: f, last_f, projected_gradient
+      LOGICAL                                            :: converged
       TYPE(section_vals_type), POINTER                   :: geo_section
       TYPE(force_env_type), POINTER                      :: force_env
       TYPE(gopt_param_type), POINTER                     :: gopt_param

--- a/src/motion/dimer_methods.F
+++ b/src/motion/dimer_methods.F
@@ -62,7 +62,7 @@ CONTAINS
    RECURSIVE SUBROUTINE cp_eval_at_ts(gopt_env, x, f, gradient, calc_force)
       TYPE(gopt_f_type), POINTER                         :: gopt_env
       REAL(KIND=dp), DIMENSION(:), POINTER               :: x
-      REAL(KIND=dp), INTENT(OUT)                         :: f
+      REAL(KIND=dp)                                      :: f
       REAL(KIND=dp), DIMENSION(:), POINTER               :: gradient
       LOGICAL, INTENT(IN)                                :: calc_force
 
@@ -285,7 +285,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: dimer_index
       TYPE(dimer_env_type), POINTER                      :: dimer_env
       LOGICAL, INTENT(IN)                                :: calc_force
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: f
+      REAL(KIND=dp), OPTIONAL                            :: f
       REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: gradient
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_eval_at_ts_low', &

--- a/src/motion/dimer_utils.F
+++ b/src/motion/dimer_utils.F
@@ -120,7 +120,7 @@ CONTAINS
    SUBROUTINE get_theta(gradient, dimer_env, norm)
       REAL(KIND=dp), DIMENSION(:)                        :: gradient
       TYPE(dimer_env_type), POINTER                      :: dimer_env
-      REAL(KIND=dp), INTENT(OUT)                         :: norm
+      REAL(KIND=dp)                                      :: norm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_theta', routineP = moduleN//':'//routineN
 

--- a/src/motion/free_energy_methods.F
+++ b/src/motion/free_energy_methods.F
@@ -64,7 +64,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE free_energy_evaluate(md_env, converged, fe_section)
       TYPE(md_environment_type), POINTER                 :: md_env
-      LOGICAL, INTENT(OUT)                               :: converged
+      LOGICAL                                            :: converged
       TYPE(section_vals_type), POINTER                   :: fe_section
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'free_energy_evaluate', &
@@ -204,7 +204,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ui_check_trend(fe_env, trend_free, nr_points, output_unit)
       TYPE(free_energy_type), POINTER                    :: fe_env
-      LOGICAL, INTENT(OUT)                               :: trend_free
+      LOGICAL                                            :: trend_free
       INTEGER, INTENT(IN)                                :: nr_points, output_unit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ui_check_trend', routineP = moduleN//':'//routineN
@@ -391,7 +391,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ui_check_norm_sc(fe_env, test_passed, nr_points, output_unit)
       TYPE(free_energy_type), POINTER                    :: fe_env
-      LOGICAL, INTENT(OUT)                               :: test_passed
+      LOGICAL                                            :: test_passed
       INTEGER, INTENT(IN)                                :: nr_points, output_unit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ui_check_norm_sc', &
@@ -523,7 +523,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ui_check_convergence(fe_env, converged, nr_points, output_unit)
       TYPE(free_energy_type), POINTER                    :: fe_env
-      LOGICAL, INTENT(OUT)                               :: converged
+      LOGICAL                                            :: converged
       INTEGER, INTENT(IN)                                :: nr_points, output_unit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ui_check_convergence', &

--- a/src/motion/gopt_f77_methods.F
+++ b/src/motion/gopt_f77_methods.F
@@ -77,7 +77,7 @@ RECURSIVE SUBROUTINE cp_eval_at(gopt_env, x, f, gradient, master, &
    IMPLICIT NONE
    TYPE(gopt_f_type), POINTER               :: gopt_env
    REAL(KIND=dp), DIMENSION(:), POINTER     :: x
-   REAL(KIND=dp), INTENT(OUT), OPTIONAL     :: f
+   REAL(KIND=dp), OPTIONAL     :: f
    REAL(KIND=dp), DIMENSION(:), OPTIONAL, &
       POINTER                                :: gradient
    INTEGER, INTENT(IN)                      :: master

--- a/src/motion/gopt_f_methods.F
+++ b/src/motion/gopt_f_methods.F
@@ -504,7 +504,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: ndf
       REAL(KIND=dp), INTENT(IN)                          :: dr(ndf), g(ndf)
       INTEGER, INTENT(IN)                                :: output_unit
-      LOGICAL, INTENT(OUT)                               :: conv
+      LOGICAL                                            :: conv
       TYPE(gopt_param_type), POINTER                     :: gopt_param
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pres_diff, pres_tol
 
@@ -651,7 +651,7 @@ CONTAINS
 
       TYPE(dimer_env_type), POINTER                      :: dimer_env
       INTEGER, INTENT(IN)                                :: output_unit
-      LOGICAL, INTENT(OUT)                               :: conv
+      LOGICAL                                            :: conv
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'check_rot_conv', routineP = moduleN//':'//routineN
 

--- a/src/motion/helium_common.F
+++ b/src/motion/helium_common.F
@@ -287,7 +287,7 @@ CONTAINS
 
       TYPE(helium_solvent_type), POINTER                 :: helium
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: a, b
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: c
+      REAL(KIND=dp), DIMENSION(3)                        :: c
 
       c(:) = b(:)-a(:)
       CALL helium_pbc(helium, c)

--- a/src/motion/helium_interactions.F
+++ b/src/motion/helium_interactions.F
@@ -305,7 +305,7 @@ CONTAINS
       TYPE(helium_solvent_type), POINTER                 :: helium
       INTEGER, INTENT(IN)                                :: helium_part_index, helium_slice_index
       REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: helium_r_opt
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                                      :: energy
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
          OPTIONAL, POINTER                               :: force
 
@@ -375,7 +375,7 @@ CONTAINS
 
       TYPE(pint_env_type), POINTER                       :: pint_env
       TYPE(helium_solvent_type), POINTER                 :: helium
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                                      :: energy
 
       CHARACTER(len=*), PARAMETER :: routineN = 'helium_solute_e_f', &
          routineP = moduleN//':'//routineN
@@ -419,7 +419,7 @@ CONTAINS
 
       TYPE(pint_env_type), POINTER                       :: pint_env
       TYPE(helium_solvent_type), POINTER                 :: helium
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                                      :: energy
 
       INTEGER                                            :: ia, ib
       REAL(KIND=dp)                                      :: my_energy
@@ -555,7 +555,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: solute_x
       TYPE(helium_solvent_type), POINTER                 :: helium
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: helium_x
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                                      :: energy
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT), &
          OPTIONAL, POINTER                               :: force
 
@@ -854,7 +854,7 @@ CONTAINS
 
       TYPE(helium_solvent_type), POINTER                 :: helium
       INTEGER, INTENT(IN)                                :: part, ref_bead, delta_bead
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: d
+      REAL(KIND=dp), DIMENSION(3)                        :: d
 
       INTEGER                                            :: b, bead, db, nbead, np, p
       REAL(KIND=dp), DIMENSION(3)                        :: r

--- a/src/motion/helium_worm.F
+++ b/src/motion/helium_worm.F
@@ -324,7 +324,7 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: ip, ibi, l
-      INTEGER, INTENT(out)                               :: ac
+      INTEGER                                            :: ac
 
       INTEGER                                            :: ib, ibb, ibf, ipp, nbeads
       INTEGER, DIMENSION(:), POINTER                     :: perm
@@ -486,7 +486,7 @@ CONTAINS
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       REAL(KIND=dp), INTENT(in)                          :: r0(3), rl(3)
       INTEGER, INTENT(in)                                :: l
-      REAL(KIND=dp), INTENT(out)                         :: r(0:l, 3)
+      REAL(KIND=dp)                                      :: r(0:l, 3)
 
       INTEGER                                            :: id, k
       REAL(KIND=dp)                                      :: dr(3), mass, mk, ri(3), rp(3), xlk, &
@@ -532,7 +532,7 @@ CONTAINS
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: ip, l
       REAL(KIND=dp), INTENT(in)                          :: C
-      INTEGER, INTENT(out)                               :: ac
+      INTEGER                                            :: ac
 
       INTEGER                                            :: ib, id, nbeads
       INTEGER, DIMENSION(:), POINTER                     :: perm
@@ -625,7 +625,7 @@ CONTAINS
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: l
       REAL(KIND=dp), INTENT(in)                          :: C
-      INTEGER, INTENT(out)                               :: ac
+      INTEGER                                            :: ac
 
       INTEGER                                            :: ib, nbeads
       INTEGER, DIMENSION(:), POINTER                     :: perm
@@ -708,7 +708,7 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: l
-      INTEGER, INTENT(out)                               :: ac
+      INTEGER                                            :: ac
 
       INTEGER                                            :: ib, id, nbeads
       INTEGER, DIMENSION(:), POINTER                     :: perm
@@ -785,7 +785,7 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: l
-      INTEGER, INTENT(out)                               :: ac
+      INTEGER                                            :: ac
 
       INTEGER                                            :: ib, id, nbeads
       INTEGER, DIMENSION(:), POINTER                     :: perm
@@ -864,7 +864,7 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: l
-      INTEGER, INTENT(out)                               :: ac
+      INTEGER                                            :: ac
 
       INTEGER                                            :: ia, ib, ik, ip, natoms, nbeads
       INTEGER, DIMENSION(:), POINTER                     :: perm
@@ -997,7 +997,7 @@ CONTAINS
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: iatom
       REAL(KIND=dp), INTENT(in)                          :: drmax
-      INTEGER, INTENT(out)                               :: ac
+      INTEGER                                            :: ac
 
       INTEGER                                            :: ib, icycle, id, ip, nbeads
       REAL(KIND=dp)                                      :: dr(3), dU, expdU, U, U1, U2, xl, xr
@@ -1089,7 +1089,7 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: iparticle, ibead
-      REAL(kind=dp), INTENT(out)                         :: U
+      REAL(kind=dp)                                      :: U
 
       INTEGER                                            :: ip
       REAL(kind=dp)                                      :: V1, V2
@@ -1197,7 +1197,7 @@ CONTAINS
    SUBROUTINE centroid(helium, iatom, rc)
       TYPE(helium_solvent_type), INTENT(in), POINTER     :: helium
       INTEGER, INTENT(in)                                :: iatom
-      REAL(KIND=dp), INTENT(out)                         :: rc(3)
+      REAL(KIND=dp)                                      :: rc(3)
 
       INTEGER                                            :: ib, id
       REAL(KIND=dp)                                      :: x

--- a/src/motion/integrator_utils.F
+++ b/src/motion/integrator_utils.F
@@ -742,7 +742,7 @@ CONTAINS
       TYPE(simpar_type), INTENT(IN)                      :: simpar
       TYPE(virial_type), POINTER                         :: virial
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vector_v
-      REAL(KIND=dp), INTENT(OUT)                         :: roll_tol
+      REAL(KIND=dp)                                      :: roll_tol
       INTEGER, INTENT(INOUT)                             :: iroll
       REAL(KIND=dp), INTENT(IN)                          :: infree
       LOGICAL, INTENT(INOUT)                             :: first
@@ -815,8 +815,8 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      REAL(KIND=dp), INTENT(OUT)                         :: kin
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: pv_kin
+      REAL(KIND=dp)                                      :: kin
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: pv_kin
       TYPE(virial_type), INTENT(INOUT)                   :: virial
       INTEGER, INTENT(IN)                                :: int_group
 
@@ -889,8 +889,8 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      REAL(KIND=dp), INTENT(OUT)                         :: kin
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: pv_kin
+      REAL(KIND=dp)                                      :: kin
+      REAL(KIND=dp), DIMENSION(:, :)                     :: pv_kin
       TYPE(virial_type), INTENT(INOUT)                   :: virial
       INTEGER, INTENT(IN)                                :: int_group
 

--- a/src/motion/mc/mc_coordinates.F
+++ b/src/motion/mc/mc_coordinates.F
@@ -68,7 +68,7 @@ CONTAINS
 
       TYPE(force_env_type), POINTER                      :: force_env
       INTEGER, DIMENSION(:), INTENT(IN)                  :: nchains, nunits
-      LOGICAL, INTENT(OUT)                               :: loverlap
+      LOGICAL                                            :: loverlap
       INTEGER, DIMENSION(:), INTENT(IN)                  :: mol_type
       REAL(KIND=dp), DIMENSION(1:3), INTENT(IN), &
          OPTIONAL                                        :: cell_length
@@ -190,7 +190,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: coordinates
       INTEGER, INTENT(IN)                                :: natom
-      REAL(KIND=dp), DIMENSION(1:3), INTENT(OUT)         :: center_of_mass
+      REAL(KIND=dp), DIMENSION(1:3)                      :: center_of_mass
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: mass
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_center_of_mass', &
@@ -334,13 +334,13 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: BETA, max_val, min_val, exp_max_val, &
                                                             exp_min_val
       INTEGER, INTENT(IN)                                :: nswapmoves
-      REAL(KIND=dp), INTENT(OUT)                         :: rosenbluth_weight
+      REAL(KIND=dp)                                      :: rosenbluth_weight
       INTEGER, INTENT(IN)                                :: start_atom, natoms_tot
       INTEGER, DIMENSION(:), INTENT(IN)                  :: nunits
       INTEGER, INTENT(IN)                                :: nunits_mol
       REAL(dp), DIMENSION(1:nunits_mol), INTENT(IN)      :: mass
-      LOGICAL, INTENT(OUT)                               :: loverlap
-      REAL(KIND=dp), INTENT(OUT)                         :: choosen_energy
+      LOGICAL                                            :: loverlap
+      REAL(KIND=dp)                                      :: choosen_energy
       REAL(KIND=dp), INTENT(IN)                          :: old_energy
       LOGICAL, INTENT(IN)                                :: ionode, lremove
       INTEGER, DIMENSION(:), INTENT(IN)                  :: mol_type, nchains
@@ -718,7 +718,7 @@ CONTAINS
                                     box_number, molecule_type, rng_stream, box, molecule_type_old)
 
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
-      INTEGER, INTENT(OUT)                               :: start_atom, box_number, molecule_type
+      INTEGER                                            :: start_atom, box_number, molecule_type
       TYPE(rng_stream_type), POINTER                     :: rng_stream
       INTEGER, INTENT(IN), OPTIONAL                      :: box, molecule_type_old
 
@@ -873,7 +873,7 @@ CONTAINS
 ! 1 is for "yes, we can do the move", 0 is for no
 
       REAL(dp), DIMENSION(1:3), INTENT(IN)               :: cell
-      INTEGER, DIMENSION(1:3, 1:2), INTENT(OUT)          :: discrete_array
+      INTEGER, DIMENSION(1:3, 1:2)                       :: discrete_array
       REAL(dp), INTENT(IN)                               :: step_size
 
       INTEGER                                            :: iside
@@ -937,7 +937,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: rmin, rmax
       REAL(KIND=dp), DIMENSION(1:3), INTENT(IN)          :: r_target
       CHARACTER(LEN=*), INTENT(IN)                       :: move_type
-      REAL(KIND=dp), DIMENSION(1:3), INTENT(OUT)         :: r_insert
+      REAL(KIND=dp), DIMENSION(1:3)                      :: r_insert
       REAL(KIND=dp), DIMENSION(1:3), INTENT(IN)          :: abc
       TYPE(rng_stream_type), POINTER                     :: rng_stream
 

--- a/src/motion/mc/mc_moves.F
+++ b/src/motion/mc/mc_moves.F
@@ -143,7 +143,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: start_atom, molecule_type, box_number
       REAL(KIND=dp), INTENT(INOUT)                       :: bias_energy
       CHARACTER(LEN=*), INTENT(IN)                       :: move_type
-      LOGICAL, INTENT(OUT)                               :: lreject
+      LOGICAL                                            :: lreject
       TYPE(rng_stream_type), POINTER                     :: rng_stream
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mc_conformation_change', &
@@ -439,7 +439,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: start_atom, box_number
       REAL(KIND=dp), INTENT(INOUT)                       :: bias_energy
       INTEGER, INTENT(IN)                                :: molecule_type
-      LOGICAL, INTENT(OUT)                               :: lreject
+      LOGICAL                                            :: lreject
       TYPE(rng_stream_type), POINTER                     :: rng_stream
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mc_molecule_translation', &
@@ -662,7 +662,7 @@ CONTAINS
       TYPE(mc_moves_type), POINTER                       :: moves, move_updates
       INTEGER, INTENT(IN)                                :: box_number, start_atom, molecule_type
       REAL(KIND=dp), INTENT(INOUT)                       :: bias_energy
-      LOGICAL, INTENT(OUT)                               :: lreject
+      LOGICAL                                            :: lreject
       TYPE(rng_stream_type), POINTER                     :: rng_stream
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mc_molecule_rotation', &
@@ -1305,11 +1305,11 @@ CONTAINS
                                  dis_length, particles, rng_stream)
 
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: r_old
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: r_new
+      REAL(KIND=dp), DIMENSION(:, :)                     :: r_new
       TYPE(mc_simpar_type), POINTER                      :: mc_par
       INTEGER, INTENT(IN)                                :: molecule_type
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind
-      REAL(KIND=dp), INTENT(OUT)                         :: dis_length
+      REAL(KIND=dp)                                      :: dis_length
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(rng_stream_type), POINTER                     :: rng_stream
 
@@ -1473,7 +1473,7 @@ CONTAINS
                                 particles, rng_stream)
 
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: r_old
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: r_new
+      REAL(KIND=dp), DIMENSION(:, :)                     :: r_new
       TYPE(mc_simpar_type), POINTER                      :: mc_par
       INTEGER, INTENT(IN)                                :: molecule_type
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind
@@ -1733,7 +1733,7 @@ CONTAINS
                               particles, rng_stream)
 
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: r_old
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: r_new
+      REAL(KIND=dp), DIMENSION(:, :)                     :: r_new
       TYPE(mc_simpar_type), POINTER                      :: mc_par
       INTEGER, INTENT(IN)                                :: molecule_type
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind
@@ -2489,7 +2489,7 @@ CONTAINS
       TYPE(mc_moves_type), POINTER                       :: moves, move_updates
       INTEGER, INTENT(IN)                                :: box_number
       REAL(KIND=dp), INTENT(INOUT)                       :: bias_energy
-      LOGICAL, INTENT(OUT)                               :: lreject
+      LOGICAL                                            :: lreject
       TYPE(rng_stream_type), POINTER                     :: rng_stream
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mc_cluster_translation', &

--- a/src/motion/mc/mc_types.F
+++ b/src/motion/mc/mc_types.F
@@ -268,16 +268,16 @@ CONTAINS
                                 nunits_empty, coordinates_empty, motion_row_end, motion_row_start)
 
       TYPE(mc_input_file_type), POINTER                  :: mc_input_file
-      INTEGER, INTENT(OUT), OPTIONAL                     :: run_type_row, run_type_column, &
+      INTEGER, OPTIONAL                                  :: run_type_row, run_type_column, &
                                                             coord_row_start, coord_row_end, &
                                                             cell_row, cell_column, global_row_end
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: mol_set_nmol_row, mol_set_nmol_column
-      INTEGER, INTENT(OUT), OPTIONAL                     :: in_use
+      INTEGER, OPTIONAL                                  :: in_use
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), OPTIONAL, POINTER                 :: text, atom_names_empty
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nunits_empty
+      INTEGER, OPTIONAL                                  :: nunits_empty
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: coordinates_empty
-      INTEGER, INTENT(OUT), OPTIONAL                     :: motion_row_end, motion_row_start
+      INTEGER, OPTIONAL                                  :: motion_row_end, motion_row_start
 
       IF (PRESENT(in_use)) in_use = mc_input_file%in_use
       IF (PRESENT(run_type_row)) run_type_row = mc_input_file%run_type_row
@@ -397,22 +397,22 @@ CONTAINS
 !>    Suitable for parallel.
 !> \author MJM
       TYPE(mc_simpar_type), POINTER                      :: mc_par
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nstep, nvirial, iuptrans, iupcltrans, &
+      INTEGER, OPTIONAL                                  :: nstep, nvirial, iuptrans, iupcltrans, &
                                                             iupvolume, nmoves, nswapmoves, rm, cl, &
                                                             diff, nstart, source, group
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: lbias, ionode, lrestart, lstop
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: rmvolume, rmcltrans
+      LOGICAL, OPTIONAL                                  :: lbias, ionode, lrestart, lstop
+      REAL(KIND=dp), OPTIONAL                            :: rmvolume, rmcltrans
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: rmbond, rmangle, rmrot, rmtrans
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: temperature, pressure, rclus, BETA, &
+      REAL(KIND=dp), OPTIONAL                            :: temperature, pressure, rclus, BETA, &
                                                             pmswap, pmvolume, pmtraion, pmtrans, &
                                                             pmcltrans
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL :: ensemble, PROGRAM, restart_file_name, &
-         molecules_file, moves_file, coords_file, energy_file, displacement_file, cell_file, &
-         dat_file, data_file, box2_file, fft_lib
-      INTEGER, INTENT(OUT), OPTIONAL                     :: iprint
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: rcut
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: ldiscrete
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: discrete_step, pmavbmc
+      CHARACTER(LEN=*), OPTIONAL :: ensemble, PROGRAM, restart_file_name, molecules_file, &
+         moves_file, coords_file, energy_file, displacement_file, cell_file, dat_file, data_file, &
+         box2_file, fft_lib
+      INTEGER, OPTIONAL                                  :: iprint
+      REAL(KIND=dp), OPTIONAL                            :: rcut
+      LOGICAL, OPTIONAL                                  :: ldiscrete
+      REAL(KIND=dp), OPTIONAL                            :: discrete_step, pmavbmc
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: pbias
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: avbmc_atom
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: avbmc_rmin, avbmc_rmax, rmdihedral
@@ -422,14 +422,14 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: pmavbmc_mol, pmtrans_mol, pmrot_mol, &
                                                             pmtraion_mol
       TYPE(mc_input_file_type), OPTIONAL, POINTER        :: mc_input_file, mc_bias_file
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: pmvol_box, pmclus_box
+      REAL(KIND=dp), OPTIONAL                            :: pmvol_box, pmclus_box
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: virial_temps
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: exp_min_val, exp_max_val, min_val, &
+      REAL(KIND=dp), OPTIONAL                            :: exp_min_val, exp_max_val, min_val, &
                                                             max_val
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: eta
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: pmhmc, pmhmc_box
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: lhmc
-      INTEGER, INTENT(OUT), OPTIONAL                     :: rand2skip
+      REAL(KIND=dp), OPTIONAL                            :: pmhmc, pmhmc_box
+      LOGICAL, OPTIONAL                                  :: lhmc
+      INTEGER, OPTIONAL                                  :: rand2skip
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_mc_par', routineP = moduleN//':'//routineN
 
@@ -547,7 +547,7 @@ CONTAINS
 !>    Suitable for parallel.
 !> \author MJM
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nmol_types, nchain_total, nboxes
+      INTEGER, OPTIONAL                                  :: nmol_types, nchain_total, nboxes
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), OPTIONAL, POINTER                 :: names
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: conf_prob
@@ -1156,8 +1156,8 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: nstart, nend
       CHARACTER(LEN=*), INTENT(IN)                       :: string_search
       LOGICAL, INTENT(IN)                                :: lend
-      INTEGER, INTENT(OUT)                               :: row_number, column_number
-      INTEGER, INTENT(OUT), OPTIONAL                     :: start_row_number
+      INTEGER                                            :: row_number, column_number
+      INTEGER, OPTIONAL                                  :: start_row_number
 
       CHARACTER(default_string_length)                   :: text_temp
       INTEGER                                            :: iline, index_string, jline, string_size
@@ -1731,7 +1731,7 @@ CONTAINS
 
       TYPE(mc_simpar_type), INTENT(INOUT)                :: mc_par
       TYPE(force_env_type), POINTER                      :: force_env
-      LOGICAL, INTENT(OUT)                               :: lterminate
+      LOGICAL                                            :: lterminate
 
       CHARACTER(len=*), PARAMETER :: routineN = 'find_mc_rcut', routineP = moduleN//':'//routineN
 

--- a/src/motion/md_util.F
+++ b/src/motion/md_util.F
@@ -98,9 +98,9 @@ CONTAINS
                                         eigenvectors)
       TYPE(section_vals_type), POINTER                   :: md_section, vib_section
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(OUT)                               :: dof
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: eigenvectors
+      INTEGER                                            :: dof
+      REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:, :)                     :: eigenvectors
 
       CHARACTER(len=*), PARAMETER :: routineN = 'read_vib_eigs_unformatted', &
          routineP = moduleN//':'//routineN

--- a/src/motion/md_vel_utils.F
+++ b/src/motion/md_vel_utils.F
@@ -107,7 +107,7 @@ CONTAINS
   SUBROUTINE compute_rcom(part,is_fixed,rcom)
       TYPE(particle_type), DIMENSION(:), POINTER         :: part
       INTEGER, DIMENSION(:), INTENT(IN)                  :: is_fixed
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: rcom
+      REAL(KIND=dp), DIMENSION(3)                        :: rcom
 
       CHARACTER(len=*), PARAMETER :: routineN = 'compute_rcom', routineP = moduleN//':'//routineN
 
@@ -146,8 +146,8 @@ CONTAINS
   SUBROUTINE compute_vcom(part,is_fixed,vcom,ecom)
       TYPE(particle_type), DIMENSION(:), POINTER         :: part
       INTEGER, DIMENSION(:), INTENT(IN)                  :: is_fixed
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: vcom
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: ecom
+      REAL(KIND=dp), DIMENSION(3)                        :: vcom
+      REAL(KIND=dp), OPTIONAL                            :: ecom
 
       CHARACTER(len=*), PARAMETER :: routineN = 'compute_vcom', routineP = moduleN//':'//routineN
 
@@ -423,7 +423,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: part
       INTEGER, DIMENSION(:), INTENT(IN)                  :: is_fixed
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rcom
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: vang
+      REAL(KIND=dp), DIMENSION(3)                        :: vang
 
       CHARACTER(len=*), PARAMETER :: routineN = 'compute_vang', routineP = moduleN//':'//routineN
 
@@ -725,7 +725,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: force_rescaling
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: is_fixed
-      LOGICAL, INTENT(OUT)                               :: success
+      LOGICAL                                            :: success
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_input_velocities', &
          routineP = moduleN//':'//routineN
@@ -1624,7 +1624,7 @@ CONTAINS
       TYPE(cp_subsys_type), POINTER                      :: subsys
       REAL(KIND=dp), INTENT(IN)                          :: fscale
       INTEGER, INTENT(IN)                                :: ireg
-      REAL(KIND=dp), INTENT(OUT)                         :: ekin, vcom(3)
+      REAL(KIND=dp)                                      :: ekin, vcom(3)
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'scale_velocity_low', &
          routineP = moduleN//':'//routineN

--- a/src/motion/neb_md_utils.F
+++ b/src/motion/neb_md_utils.F
@@ -281,8 +281,8 @@ CONTAINS
 
       TYPE(neb_var_type), POINTER                        :: vels
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: temperatures
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT), OPTIONAL :: ekin
+      REAL(KIND=dp), DIMENSION(:)                        :: temperatures
+      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: ekin
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: factor
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_temperatures', &

--- a/src/motion/neb_utils.F
+++ b/src/motion/neb_utils.F
@@ -102,7 +102,7 @@ CONTAINS
          POINTER                                         :: particle_set
       TYPE(neb_var_type), POINTER                        :: coords
       INTEGER, INTENT(IN)                                :: i0, i
-      REAL(KIND=dp), INTENT(OUT)                         :: distance
+      REAL(KIND=dp)                                      :: distance
       INTEGER, INTENT(IN)                                :: iw
       LOGICAL, INTENT(IN), OPTIONAL                      :: rotate
 
@@ -368,7 +368,7 @@ CONTAINS
       TYPE(replica_env_type), POINTER                    :: rep_env
       TYPE(neb_type), OPTIONAL, POINTER                  :: neb_env
       TYPE(neb_var_type), POINTER                        :: coords
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: energies
+      REAL(KIND=dp), DIMENSION(:)                        :: energies
       TYPE(neb_var_type), POINTER                        :: forces
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       INTEGER, INTENT(IN)                                :: output_unit
@@ -511,7 +511,7 @@ CONTAINS
       TYPE(replica_env_type), POINTER                    :: rep_env
       TYPE(neb_var_type), POINTER                        :: coords
       INTEGER, INTENT(IN)                                :: irep, n_rep_neb
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: cvalues, Mmatrix
+      REAL(KIND=dp), DIMENSION(:, :)                     :: cvalues, Mmatrix
 
       CHARACTER(len=*), PARAMETER :: routineN = 'perform_replica_md', &
          routineP = moduleN//':'//routineN
@@ -587,7 +587,7 @@ CONTAINS
       TYPE(replica_env_type), POINTER                    :: rep_env
       TYPE(neb_var_type), POINTER                        :: coords
       INTEGER, INTENT(IN)                                :: irep, n_rep_neb
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: cvalues, Mmatrix
+      REAL(KIND=dp), DIMENSION(:, :)                     :: cvalues, Mmatrix
 
       CHARACTER(len=*), PARAMETER :: routineN = 'perform_replica_geo', &
          routineP = moduleN//':'//routineN
@@ -666,7 +666,7 @@ CONTAINS
       TYPE(neb_type), POINTER                            :: neb_env
       TYPE(neb_var_type), POINTER                        :: coords
       INTEGER, INTENT(IN)                                :: i
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: tangent
+      REAL(KIND=dp), DIMENSION(:)                        :: tangent
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: energies
       INTEGER, INTENT(IN)                                :: iw
 

--- a/src/motion/pint_methods.F
+++ b/src/motion/pint_methods.F
@@ -2067,7 +2067,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pint_calc_uf_h(pint_env, e_h)
       TYPE(pint_env_type), POINTER                       :: pint_env
-      REAL(KIND=dp), INTENT(OUT)                         :: e_h
+      REAL(KIND=dp)                                      :: e_h
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pint_calc_uf_h', routineP = moduleN//':'//routineN
 
@@ -2105,10 +2105,8 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       REAL(kind=dp), DIMENSION(:, :), INTENT(in), &
          OPTIONAL, TARGET                                :: x
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out), &
-         OPTIONAL, TARGET                                :: f
-      REAL(kind=dp), DIMENSION(:), INTENT(out), &
-         OPTIONAL, TARGET                                :: e
+      REAL(kind=dp), DIMENSION(:, :), OPTIONAL, TARGET   :: f
+      REAL(kind=dp), DIMENSION(:), OPTIONAL, TARGET      :: e
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pint_calc_f', routineP = moduleN//':'//routineN
 
@@ -2154,7 +2152,7 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       REAL(kind=dp), DIMENSION(:, :), INTENT(in), &
          OPTIONAL, TARGET                                :: uv
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: e_k
+      REAL(kind=dp), OPTIONAL                            :: e_k
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pint_calc_e_kin_beads_u', &
          routineP = moduleN//':'//routineN
@@ -2190,7 +2188,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pint_calc_e_vir(pint_env, e_vir)
       TYPE(pint_env_type), POINTER                       :: pint_env
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: e_vir
+      REAL(kind=dp), OPTIONAL                            :: e_vir
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pint_calc_e_vir', &
          routineP = moduleN//':'//routineN

--- a/src/motion/pint_normalmode.F
+++ b/src/motion/pint_normalmode.F
@@ -219,9 +219,8 @@ CONTAINS
 
       TYPE(normalmode_env_type), POINTER                 :: normalmode_env
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: mass
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out), &
-         OPTIONAL                                        :: mass_beads, mass_fict
-      REAL(kind=dp), DIMENSION(:), INTENT(out), OPTIONAL :: Q
+      REAL(kind=dp), DIMENSION(:, :), OPTIONAL           :: mass_beads, mass_fict
+      REAL(kind=dp), DIMENSION(:), OPTIONAL              :: Q
 
       CHARACTER(len=*), PARAMETER :: routineN = 'normalmode_init_masses', &
          routineP = moduleN//':'//routineN
@@ -263,7 +262,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE normalmode_x2u(normalmode_env, ux, x)
       TYPE(normalmode_env_type), POINTER                 :: normalmode_env
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: ux
+      REAL(kind=dp), DIMENSION(:, :)                     :: ux
       REAL(kind=dp), DIMENSION(:, :), INTENT(in)         :: x
 
       CHARACTER(len=*), PARAMETER :: routineN = 'normalmode_x2u', routineP = moduleN//':'//routineN
@@ -287,7 +286,7 @@ CONTAINS
    SUBROUTINE normalmode_u2x(normalmode_env, ux, x)
       TYPE(normalmode_env_type), POINTER                 :: normalmode_env
       REAL(kind=dp), DIMENSION(:, :), INTENT(in)         :: ux
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: x
+      REAL(kind=dp), DIMENSION(:, :)                     :: x
 
       CHARACTER(len=*), PARAMETER :: routineN = 'normalmode_u2x', routineP = moduleN//':'//routineN
 
@@ -308,7 +307,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE normalmode_f2uf(normalmode_env, uf, f)
       TYPE(normalmode_env_type), POINTER                 :: normalmode_env
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: uf
+      REAL(kind=dp), DIMENSION(:, :)                     :: uf
       REAL(kind=dp), DIMENSION(:, :), INTENT(in)         :: f
 
       CHARACTER(len=*), PARAMETER :: routineN = 'normalmode_f2uf', &
@@ -334,13 +333,13 @@ CONTAINS
    SUBROUTINE normalmode_calc_uf_h(normalmode_env, mass_beads, ux, uf_h, e_h)
       TYPE(normalmode_env_type), POINTER                 :: normalmode_env
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: mass_beads, ux, uf_h
-      REAL(KIND=dp), INTENT(OUT)                         :: e_h
+      REAL(KIND=dp)                                      :: e_h
 
       CHARACTER(len=*), PARAMETER :: routineN = 'normalmode_calc_uf_h', &
          routineP = moduleN//':'//routineN
 
       INTEGER                                            :: ibead, idim
-      REAL(kind=dp)                                      :: f
+      REAL(KIND=dp)                                      :: f
 
       e_h = 0.0_dp
       DO idim = 1, SIZE(mass_beads, 2)

--- a/src/motion/pint_piglet.F
+++ b/src/motion/pint_piglet.F
@@ -580,7 +580,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: a_mat
       INTEGER, INTENT(IN)                                :: p, nsp1
       CHARACTER(LEN=20), INTENT(IN)                      :: myunit
-      CHARACTER(default_string_length), INTENT(OUT)      :: msg
+      CHARACTER(default_string_length)                   :: msg
 
       CHARACTER(len=*), PARAMETER :: routineN = 'a_mat_to_cp2k', routineP = moduleN//':'//routineN
 
@@ -628,7 +628,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: c_mat
       INTEGER, INTENT(IN)                                :: p, nsp1
       CHARACTER(LEN=20), INTENT(IN)                      :: myunit
-      CHARACTER(default_string_length), INTENT(OUT)      :: msg
+      CHARACTER(default_string_length)                   :: msg
 
       CHARACTER(len=*), PARAMETER :: routineN = 'c_mat_to_cp2k', routineP = moduleN//':'//routineN
 
@@ -766,7 +766,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: n
       REAL(KIND=dp), DIMENSION(n, n), INTENT(IN)         :: SST
-      REAL(KIND=dp), DIMENSION(n, n), INTENT(OUT)        :: S
+      REAL(KIND=dp), DIMENSION(n, n)                     :: S
 
       CHARACTER(len=*), PARAMETER :: routineN = 'sqrt_pos_def_mat', &
          routineP = moduleN//':'//routineN

--- a/src/motion/pint_public.F
+++ b/src/motion/pint_public.F
@@ -124,7 +124,7 @@ CONTAINS
       REAL(kind=dp), INTENT(IN)                          :: t
       TYPE(rng_stream_type), POINTER                     :: rng_gaussian
       REAL(kind=dp), DIMENSION(:), POINTER               :: x
-      INTEGER, INTENT(OUT)                               :: nout
+      INTEGER                                            :: nout
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pint_free_part_bead_x', &
          routineP = moduleN//':'//routineN

--- a/src/motion/pint_staging.F
+++ b/src/motion/pint_staging.F
@@ -124,9 +124,8 @@ CONTAINS
                                   Q)
       TYPE(staging_env_type), POINTER                    :: staging_env
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: mass
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out), &
-         OPTIONAL                                        :: mass_beads, mass_fict
-      REAL(kind=dp), DIMENSION(:), INTENT(out), OPTIONAL :: Q
+      REAL(kind=dp), DIMENSION(:, :), OPTIONAL           :: mass_beads, mass_fict
+      REAL(kind=dp), DIMENSION(:), OPTIONAL              :: Q
 
       CHARACTER(len=*), PARAMETER :: routineN = 'staging_init_masses', &
          routineP = moduleN//':'//routineN
@@ -182,7 +181,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE staging_x2u(staging_env, ux, x)
       TYPE(staging_env_type), POINTER                    :: staging_env
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: ux
+      REAL(kind=dp), DIMENSION(:, :)                     :: ux
       REAL(kind=dp), DIMENSION(:, :), INTENT(in)         :: x
 
       CHARACTER(len=*), PARAMETER :: routineN = 'staging_x2u', routineP = moduleN//':'//routineN
@@ -214,7 +213,7 @@ CONTAINS
    SUBROUTINE staging_u2x(staging_env, ux, x)
       TYPE(staging_env_type), POINTER                    :: staging_env
       REAL(kind=dp), DIMENSION(:, :), INTENT(in)         :: ux
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: x
+      REAL(kind=dp), DIMENSION(:, :)                     :: x
 
       CHARACTER(len=*), PARAMETER :: routineN = 'staging_u2x', routineP = moduleN//':'//routineN
 
@@ -260,7 +259,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE staging_f2uf(staging_env, uf, f)
       TYPE(staging_env_type), POINTER                    :: staging_env
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: uf
+      REAL(kind=dp), DIMENSION(:, :)                     :: uf
       REAL(kind=dp), DIMENSION(:, :), INTENT(in)         :: f
 
       CHARACTER(len=*), PARAMETER :: routineN = 'staging_f2uf', routineP = moduleN//':'//routineN
@@ -315,14 +314,14 @@ CONTAINS
    SUBROUTINE staging_calc_uf_h(staging_env, mass_beads, ux, uf_h, e_h)
       TYPE(staging_env_type), POINTER                    :: staging_env
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: mass_beads, ux, uf_h
-      REAL(KIND=dp), INTENT(OUT)                         :: e_h
+      REAL(KIND=dp)                                      :: e_h
 
       CHARACTER(len=*), PARAMETER :: routineN = 'staging_calc_uf_h', &
          routineP = moduleN//':'//routineN
 
       INTEGER                                            :: idim, isg, ist
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii, jjj, kkk
-      REAL(kind=dp)                                      :: d, f
+      REAL(KIND=dp)                                      :: d, f
 
       e_h = 0.0_dp
 

--- a/src/motion/pint_transformations.F
+++ b/src/motion/pint_transformations.F
@@ -39,8 +39,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pint_x2u(pint_env, ux, x)
       TYPE(pint_env_type), POINTER                       :: pint_env
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out), &
-         OPTIONAL, TARGET                                :: ux
+      REAL(kind=dp), DIMENSION(:, :), OPTIONAL, TARGET   :: ux
       REAL(kind=dp), DIMENSION(:, :), INTENT(in), &
          OPTIONAL, TARGET                                :: x
 
@@ -78,8 +77,7 @@ CONTAINS
       TYPE(pint_env_type), POINTER                       :: pint_env
       REAL(kind=dp), DIMENSION(:, :), INTENT(in), &
          OPTIONAL, TARGET                                :: ux
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out), &
-         OPTIONAL, TARGET                                :: x
+      REAL(kind=dp), DIMENSION(:, :), OPTIONAL, TARGET   :: x
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pint_u2x', routineP = moduleN//':'//routineN
 
@@ -116,8 +114,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pint_f2uf(pint_env, uf, f)
       TYPE(pint_env_type), POINTER                       :: pint_env
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out), &
-         OPTIONAL, TARGET                                :: uf
+      REAL(kind=dp), DIMENSION(:, :), OPTIONAL, TARGET   :: uf
       REAL(kind=dp), DIMENSION(:, :), INTENT(in), &
          OPTIONAL, TARGET                                :: f
 

--- a/src/motion/thermostat/al_system_mapping.F
+++ b/src/motion/thermostat/al_system_mapping.F
@@ -150,9 +150,9 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(OUT)                               :: natoms_local
+      INTEGER                                            :: natoms_local
       TYPE(simpar_type), POINTER                         :: simpar
-      INTEGER, INTENT(OUT)                               :: sum_of_thermostats
+      INTEGER                                            :: sum_of_thermostats
       TYPE(global_constraint_type), POINTER              :: gci
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell
 

--- a/src/motion/thermostat/barostat_utils.F
+++ b/src/motion/thermostat/barostat_utils.F
@@ -55,7 +55,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(simpar_type), INTENT(IN)                      :: simpar
       TYPE(npt_info_type), DIMENSION(:, :), INTENT(IN)   :: npt
-      REAL(KIND=dp), INTENT(OUT)                         :: baro_kin, baro_pot
+      REAL(KIND=dp)                                      :: baro_kin, baro_pot
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_baro_energies', &
          routineP = moduleN//':'//routineN

--- a/src/motion/thermostat/csvr_system_mapping.F
+++ b/src/motion/thermostat/csvr_system_mapping.F
@@ -203,9 +203,9 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(OUT)                               :: natoms_local
+      INTEGER                                            :: natoms_local
       TYPE(simpar_type), POINTER                         :: simpar
-      INTEGER, INTENT(OUT)                               :: sum_of_thermostats
+      INTEGER                                            :: sum_of_thermostats
       TYPE(global_constraint_type), POINTER              :: gci
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell
 

--- a/src/motion/thermostat/extended_system_init.F
+++ b/src/motion/thermostat/extended_system_init.F
@@ -585,7 +585,7 @@ CONTAINS
       TYPE(lnhc_parameters_type), POINTER                :: nhc
       TYPE(section_vals_type), POINTER                   :: nose_section
       LOGICAL, INTENT(IN)                                :: save_mem
-      LOGICAL, INTENT(OUT)                               :: restart
+      LOGICAL                                            :: restart
       CHARACTER(LEN=*), INTENT(IN)                       :: binary_restart_file_name, thermostat_name
       TYPE(cp_para_env_type), POINTER                    :: para_env
 

--- a/src/motion/thermostat/extended_system_mapping.F
+++ b/src/motion/thermostat/extended_system_mapping.F
@@ -243,9 +243,9 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(OUT)                               :: natoms_local
+      INTEGER                                            :: natoms_local
       TYPE(simpar_type), POINTER                         :: simpar
-      INTEGER, INTENT(OUT)                               :: sum_of_thermostats
+      INTEGER                                            :: sum_of_thermostats
       TYPE(global_constraint_type), POINTER              :: gci
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell
 
@@ -504,9 +504,9 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(OUT)                               :: natoms_local
+      INTEGER                                            :: natoms_local
       TYPE(simpar_type), POINTER                         :: simpar
-      INTEGER, INTENT(OUT)                               :: sum_of_thermostats
+      INTEGER                                            :: sum_of_thermostats
       TYPE(global_constraint_type), POINTER              :: gci
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell
 

--- a/src/motion/thermostat/gle_system_dynamics.F
+++ b/src/motion/thermostat/gle_system_dynamics.F
@@ -237,7 +237,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: n
       REAL(dp), INTENT(in)                               :: M(n, n)
       INTEGER, INTENT(in)                                :: j, k
-      REAL(dp), INTENT(out)                              :: EM(n, n)
+      REAL(dp)                                           :: EM(n, n)
 
       INTEGER                                            :: i, p
       REAL(dp)                                           :: SM(n, n), tc(j+1)
@@ -281,7 +281,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE gle_cholesky_stab(SST, S, n)
       INTEGER, INTENT(in)                                :: n
-      REAL(dp), INTENT(out)                              :: S(n, n)
+      REAL(dp)                                           :: S(n, n)
       REAL(dp), INTENT(in)                               :: SST(n, n)
 
       INTEGER                                            :: i, j, k
@@ -426,7 +426,7 @@ CONTAINS
       TYPE(gle_type), POINTER                            :: gle
       TYPE(section_vals_type), POINTER                   :: gle_section
       LOGICAL, INTENT(IN)                                :: save_mem
-      LOGICAL, INTENT(OUT)                               :: restart
+      LOGICAL                                            :: restart
 
       CHARACTER(len=*), PARAMETER :: routineN = 'restart_gle', routineP = moduleN//':'//routineN
 

--- a/src/motion/thermostat/thermostat_mapping.F
+++ b/src/motion/thermostat/thermostat_mapping.F
@@ -82,7 +82,7 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(OUT)                               :: natoms_local
+      INTEGER                                            :: natoms_local
       TYPE(simpar_type), POINTER                         :: simpar
       INTEGER, INTENT(INOUT)                             :: number
       INTEGER, INTENT(IN)                                :: region
@@ -179,7 +179,7 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       INTEGER, DIMENSION(:), POINTER                     :: const_mol, massive_atom_list, tot_const
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
-      INTEGER, INTENT(OUT)                               :: ntherm
+      INTEGER                                            :: ntherm
       LOGICAL, INTENT(IN)                                :: shell
       TYPE(global_constraint_type), POINTER              :: gci
       INTEGER, DIMENSION(:), POINTER                     :: map_loc_thermo_gen
@@ -387,7 +387,7 @@ CONTAINS
    SUBROUTINE adiabatic_region_evaluate(dis_type, natoms_local, nmol_local, const_mol, &
                                         tot_const, point, local_molecules, molecule_kind_set, molecule_set, simpar, shell)
       INTEGER, INTENT(IN)                                :: dis_type
-      INTEGER, INTENT(OUT)                               :: natoms_local, nmol_local
+      INTEGER                                            :: natoms_local, nmol_local
       INTEGER, DIMENSION(:), POINTER                     :: const_mol, tot_const
       INTEGER, DIMENSION(:, :), POINTER                  :: point
       TYPE(distribution_1d_type), POINTER                :: local_molecules
@@ -540,7 +540,7 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(OUT)                               :: natoms_local
+      INTEGER                                            :: natoms_local
       TYPE(simpar_type), POINTER                         :: simpar
       INTEGER, INTENT(IN)                                :: number, region
       TYPE(global_constraint_type), POINTER              :: gci
@@ -632,7 +632,7 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       INTEGER, DIMENSION(:), POINTER                     :: const_mol, massive_atom_list, tot_const
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
-      INTEGER, INTENT(OUT)                               :: number
+      INTEGER                                            :: number
       LOGICAL, INTENT(IN)                                :: shell
       TYPE(global_constraint_type), POINTER              :: gci
       INTEGER, DIMENSION(:), POINTER                     :: map_loc_thermo_gen
@@ -815,7 +815,7 @@ CONTAINS
                                       tot_const, point, local_molecules, molecule_kind_set, molecule_set, region, &
                                       simpar, shell, map_loc_thermo_gen, sum_of_thermostats, para_env)
       INTEGER, INTENT(IN)                                :: dis_type
-      INTEGER, INTENT(OUT)                               :: natoms_local, nmol_local
+      INTEGER                                            :: natoms_local, nmol_local
       INTEGER, DIMENSION(:), POINTER                     :: const_mol, tot_const
       INTEGER, DIMENSION(:, :), POINTER                  :: point
       TYPE(distribution_1d_type), POINTER                :: local_molecules

--- a/src/motion/thermostat/thermostat_utils.F
+++ b/src/motion/thermostat/thermostat_utils.F
@@ -707,7 +707,7 @@ CONTAINS
                                       map_loc_thermo_gen, local_molecules, molecule_kind_set, molecules, particles, &
                                       qmmm_env)
       TYPE(section_vals_type), POINTER                   :: region_sections
-      INTEGER, INTENT(OUT), OPTIONAL                     :: number
+      INTEGER, OPTIONAL                                  :: number
       INTEGER, INTENT(INOUT), OPTIONAL                   :: sum_of_thermostats
       INTEGER, DIMENSION(:), POINTER                     :: map_loc_thermo_gen
       TYPE(distribution_1d_type), POINTER                :: local_molecules
@@ -1417,7 +1417,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_nhc_energies(nhc, nhc_pot, nhc_kin, para_env, array_kin, array_pot)
       TYPE(lnhc_parameters_type), POINTER                :: nhc
-      REAL(KIND=dp), INTENT(OUT)                         :: nhc_pot, nhc_kin
+      REAL(KIND=dp)                                      :: nhc_pot, nhc_kin
       TYPE(cp_para_env_type), POINTER                    :: para_env
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: array_kin, array_pot
 
@@ -1492,7 +1492,7 @@ CONTAINS
       TYPE(map_info_type), POINTER                       :: map_info
       INTEGER, INTENT(IN)                                :: loc_num, glob_num
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: thermo_energy
-      REAL(KIND=dp), INTENT(OUT)                         :: thermostat_kin
+      REAL(KIND=dp)                                      :: thermostat_kin
       TYPE(cp_para_env_type), POINTER                    :: para_env
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: array_pot, array_kin
 
@@ -1558,7 +1558,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: loc_num, glob_num
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: nkt, dof
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), INTENT(OUT)                         :: temp_tot
+      REAL(KIND=dp)                                      :: temp_tot
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: array_temp
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_temperatures', &
@@ -1623,7 +1623,7 @@ CONTAINS
    SUBROUTINE get_thermostat_energies(thermostat, thermostat_pot, thermostat_kin, para_env, &
                                       array_pot, array_kin)
       TYPE(thermostat_type), POINTER                     :: thermostat
-      REAL(KIND=dp), INTENT(OUT)                         :: thermostat_pot, thermostat_kin
+      REAL(KIND=dp)                                      :: thermostat_pot, thermostat_kin
       TYPE(cp_para_env_type), POINTER                    :: para_env
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: array_pot, array_kin
 
@@ -1682,7 +1682,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_region_temperatures(thermostat, tot_temperature, para_env, array_temp)
       TYPE(thermostat_type), POINTER                     :: thermostat
-      REAL(KIND=dp), INTENT(OUT)                         :: tot_temperature
+      REAL(KIND=dp)                                      :: tot_temperature
       TYPE(cp_para_env_type), POINTER                    :: para_env
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: array_temp
 

--- a/src/motion_utils.F
+++ b/src/motion_utils.F
@@ -78,12 +78,12 @@ CONTAINS
                       natoms, rot_dof, inertia)
       TYPE(particle_type), DIMENSION(:), POINTER         :: particles
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: mat
-      INTEGER, INTENT(OUT)                               :: dof
+      INTEGER                                            :: dof
       TYPE(section_vals_type), POINTER                   :: print_section
       LOGICAL, INTENT(IN)                                :: keep_rotations, mass_weighted
       INTEGER, INTENT(IN)                                :: natoms
-      INTEGER, INTENT(OUT), OPTIONAL                     :: rot_dof
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: inertia(3)
+      INTEGER, OPTIONAL                                  :: rot_dof
+      REAL(KIND=dp), OPTIONAL                            :: inertia(3)
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rot_ana', routineP = moduleN//':'//routineN
 
@@ -466,7 +466,7 @@ CONTAINS
 
       TYPE(section_vals_type), POINTER                   :: section
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: path
-      CHARACTER(LEN=*), INTENT(OUT)                      :: my_form, my_ext
+      CHARACTER(LEN=*)                                   :: my_form, my_ext
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_output_format', &
          routineP = moduleN//':'//routineN

--- a/src/mp2_eri.F
+++ b/src/mp2_eri.F
@@ -120,7 +120,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
          OPTIONAL                                        :: pab
       TYPE(mp2_eri_force), ALLOCATABLE, &
-         DIMENSION(:), INTENT(OUT), OPTIONAL             :: force_a, force_b
+         DIMENSION(:), OPTIONAL             :: force_a, force_b
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT), &
          OPTIONAL                                        :: hdab, hadb
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: reflection_z_a, reflection_z_b
@@ -366,7 +366,7 @@ $:                         'force_b=force_b(jkind)%forces(:, atom_b), &'*doforce
       INTEGER, INTENT(IN)                                :: npgfb
       REAL(KIND=dp), DIMENSION(npgfb), INTENT(IN)        :: zetb
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: ra, rb
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: hab
+      REAL(KIND=dp), DIMENSION(:, :)        :: hab
       INTEGER, INTENT(IN)                                :: n_hab_a, n_hab_b, offset_hab_a, &
                                                             offset_hab_b, offset_set_a, &
                                                             offset_set_b
@@ -378,7 +378,7 @@ $:                         'force_b=force_b(jkind)%forces(:, atom_b), &'*doforce
          OPTIONAL                                        :: pab
       REAL(KIND=dp), DIMENSION(3), INTENT(INOUT), &
          OPTIONAL                                        :: force_a, force_b
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT), &
+      REAL(KIND=dp), DIMENSION(:, :, :), &
          OPTIONAL                                        :: hdab, hadb
       INTEGER, INTENT(INOUT), OPTIONAL                   :: G_count, R_count
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_reflection_a, do_reflection_b
@@ -627,7 +627,7 @@ $:                         'force_b=force_b(jkind)%forces(:, atom_b), &'*doforce
       TYPE(dbcsr_p_type), DIMENSION(last_c-first_c+1), &
          INTENT(INOUT), OPTIONAL                         :: pabc
       TYPE(mp2_eri_force), ALLOCATABLE, &
-         DIMENSION(:), INTENT(OUT), OPTIONAL             :: force_a, force_b, force_c
+         DIMENSION(:), OPTIONAL             :: force_a, force_b, force_c
       TYPE(dbcsr_p_type), &
          DIMENSION(3, last_c-first_c+1), INTENT(INOUT), &
          OPTIONAL                                        :: mat_dabc, mat_adbc, mat_abdc
@@ -1094,7 +1094,7 @@ $:                         'habdc=habdc, &'*abdc
       LOGICAL, INTENT(IN)                                :: do_symmetric
       LOGICAL, INTENT(IN), OPTIONAL                      :: on_diagonal
       REAL(KIND=dp), DIMENSION(:, :, :, :), &
-         INTENT(OUT), OPTIONAL                           :: hdabc, hadbc, habdc
+          OPTIONAL                           :: hdabc, hadbc, habdc
       INTEGER, INTENT(INOUT), OPTIONAL                   :: GG_count, GR_count, RR_count
       LOGICAL, INTENT(IN), OPTIONAL                      :: transp
 
@@ -1407,7 +1407,7 @@ $:                         'habdc=habdc, &'*abdc
    SUBROUTINE get_eri_offsets(qs_env, basis_type, eri_offsets)
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: basis_type
-      INTEGER, ALLOCATABLE, DIMENSION(:, :), INTENT(OUT) :: eri_offsets
+      INTEGER, ALLOCATABLE, DIMENSION(:, :) :: eri_offsets
 
       INTEGER                                            :: dimen_basis, iatom, ikind, iset, isgf, &
                                                             natom, nkind, nset, nsgf, offset, &
@@ -1459,7 +1459,7 @@ $:                         'habdc=habdc, &'*abdc
 ! **************************************************************************************************
    SUBROUTINE mp2_eri_allocate_forces(force, natom_of_kind)
       TYPE(mp2_eri_force), ALLOCATABLE, &
-         DIMENSION(:), INTENT(OUT)                       :: force
+         DIMENSION(:)                       :: force
       INTEGER, DIMENSION(:), INTENT(IN)                  :: natom_of_kind
 
       INTEGER                                            :: ikind, n, nkind

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -726,7 +726,7 @@ CONTAINS
 !>      should only be called once
 ! **************************************************************************************************
    SUBROUTINE mp_world_init(mp_comm)
-      INTEGER, INTENT(OUT)                     :: mp_comm
+      INTEGER                     :: mp_comm
 #if defined(__parallel)
       INTEGER                                  :: ierr
 !$    INTEGER                                  :: provided_tsl
@@ -783,7 +783,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_reordering(mp_comm, mp_new_comm, ranks_order)
       INTEGER, INTENT(IN)                      :: mp_comm
-      INTEGER, INTENT(out)                     :: mp_new_comm
+      INTEGER                     :: mp_new_comm
       INTEGER, DIMENSION(:)                    :: ranks_order
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_reordering', &
@@ -1142,7 +1142,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_isync(group, request)
       INTEGER, INTENT(IN)                                :: group
-      INTEGER, INTENT(OUT)                               :: request
+      INTEGER                               :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isync', routineP = moduleN//':'//routineN
 
@@ -1180,7 +1180,7 @@ CONTAINS
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE mp_environ_l(numtask, taskid, groupid)
 
-      INTEGER, INTENT(OUT)                               :: numtask, taskid
+      INTEGER                               :: numtask, taskid
       INTEGER, INTENT(IN)                                :: groupid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_environ_l', routineP = moduleN//':'//routineN
@@ -1214,7 +1214,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_environ_c(numtask, dims, task_coor, groupid)
 
-      INTEGER, INTENT(OUT)                     :: numtask, dims(2), &
+      INTEGER                     :: numtask, dims(2), &
                                                   task_coor(2)
       INTEGER, INTENT(IN)                      :: groupid
 
@@ -1255,8 +1255,8 @@ CONTAINS
    SUBROUTINE mp_environ_c2(comm, ndims, dims, task_coor, periods)
 
       INTEGER, INTENT(IN)                                :: comm, ndims
-      INTEGER, INTENT(OUT)                               :: dims(ndims), task_coor(ndims)
-      LOGICAL, INTENT(out)                               :: periods(ndims)
+      INTEGER                               :: dims(ndims), task_coor(ndims)
+      LOGICAL                               :: periods(ndims)
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_environ_c2', routineP = moduleN//':'//routineN
 
@@ -1291,7 +1291,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                      :: comm_old, ndims
       INTEGER, INTENT(INOUT)                   :: dims(:)
-      INTEGER, INTENT(OUT)                     :: pos(:), comm_cart
+      INTEGER                     :: pos(:), comm_cart
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_cart_create', &
                                      routineP = moduleN//':'//routineN
@@ -1350,7 +1350,7 @@ CONTAINS
    SUBROUTINE mp_cart_coords(comm, rank, coords)
 
       INTEGER, INTENT(IN)                                :: comm, rank
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: coords
+      INTEGER, DIMENSION(:)                 :: coords
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_cart_coords', routineP = moduleN//':'//routineN
 
@@ -1382,7 +1382,7 @@ CONTAINS
    SUBROUTINE mp_comm_compare(comm1, comm2, res)
 
       INTEGER, INTENT(IN)                                :: comm1, comm2
-      INTEGER, INTENT(OUT)                               :: res
+      INTEGER                               :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_comm_compare', &
          routineP = moduleN//':'//routineN
@@ -1428,7 +1428,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: comm
       LOGICAL, DIMENSION(:), INTENT(IN)                  :: rdim
-      INTEGER, INTENT(OUT)                               :: sub_comm
+      INTEGER                               :: sub_comm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_cart_sub', routineP = moduleN//':'//routineN
 
@@ -1486,7 +1486,7 @@ CONTAINS
    SUBROUTINE mp_comm_dup(comm1, comm2)
 
       INTEGER, INTENT(IN)                                :: comm1
-      INTEGER, INTENT(OUT)                               :: comm2
+      INTEGER                               :: comm2
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_comm_dup', routineP = moduleN//':'//routineN
 
@@ -1516,7 +1516,7 @@ CONTAINS
    SUBROUTINE mp_rank_compare(comm1, comm2, rank)
 
       INTEGER, INTENT(IN)                      :: comm1, comm2
-      INTEGER, DIMENSION(:), INTENT(OUT)       :: rank
+      INTEGER, DIMENSION(:)       :: rank
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_rank_compare', &
                                      routineP = moduleN//':'//routineN
@@ -1605,7 +1605,7 @@ CONTAINS
    SUBROUTINE mp_cart_rank(group, pos, rank)
       INTEGER, INTENT(IN)                                :: group
       INTEGER, DIMENSION(:), INTENT(IN)                  :: pos
-      INTEGER, INTENT(OUT)                               :: rank
+      INTEGER                               :: rank
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_cart_rank', routineP = moduleN//':'//routineN
 
@@ -1744,9 +1744,8 @@ CONTAINS
    SUBROUTINE mpi_waitall_internal(count, array_of_requests, array_of_statuses, ierr)
       INTEGER, INTENT(in)                                :: count
       INTEGER, DIMENSION(count), INTENT(inout)           :: array_of_requests
-      INTEGER, DIMENSION(MPI_STATUS_SIZE, *), &
-         INTENT(out)                                     :: array_of_statuses
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER, DIMENSION(MPI_STATUS_SIZE, *)             :: array_of_statuses
+      INTEGER                                            :: ierr
 
       CALL mpi_waitall(count, array_of_requests, array_of_statuses, ierr)
 
@@ -1763,7 +1762,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_waitany(requests, completed)
       INTEGER, DIMENSION(:), INTENT(inout)     :: requests
-      INTEGER, INTENT(out)                     :: completed
+      INTEGER                     :: completed
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_waitany', &
                                      routineP = moduleN//':'//routineN
@@ -1836,7 +1835,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_test_1(request, flag)
       INTEGER, INTENT(inout)                             :: request
-      LOGICAL, INTENT(out)                               :: flag
+      LOGICAL                               :: flag
 
       INTEGER                                            :: ierr
 
@@ -1862,8 +1861,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_testany_1(requests, completed, flag)
       INTEGER, DIMENSION(:), INTENT(inout)  :: requests
-      INTEGER, INTENT(out), OPTIONAL           :: completed
-      LOGICAL, INTENT(out), OPTIONAL           :: flag
+      INTEGER, OPTIONAL           :: completed
+      LOGICAL, OPTIONAL           :: flag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_testany_1', &
                                      routineP = moduleN//':'//routineN
@@ -1902,8 +1901,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_testany_2(requests, completed, flag)
       INTEGER, DIMENSION(:, :), INTENT(inout)   :: requests
-      INTEGER, INTENT(out), OPTIONAL           :: completed
-      LOGICAL, INTENT(out), OPTIONAL           :: flag
+      INTEGER, OPTIONAL           :: completed
+      LOGICAL, OPTIONAL           :: flag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_testany_2', &
                                      routineP = moduleN//':'//routineN
@@ -1946,10 +1945,10 @@ CONTAINS
    SUBROUTINE mpi_testany_internal(count, array_of_requests, index, flag, status, ierr)
       INTEGER, INTENT(in)                                :: count
       INTEGER, DIMENSION(count), INTENT(inout)           :: array_of_requests
-      INTEGER, INTENT(out)                               :: index
-      LOGICAL, INTENT(out)                               :: flag
-      INTEGER, DIMENSION(MPI_STATUS_SIZE), INTENT(out)   :: status
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                               :: index
+      LOGICAL                               :: flag
+      INTEGER, DIMENSION(MPI_STATUS_SIZE)   :: status
+      INTEGER                               :: ierr
 
       CALL mpi_testany(count, array_of_requests, index, flag, status, ierr)
 
@@ -1967,7 +1966,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_comm_split_direct(comm, sub_comm, color, key)
       INTEGER, INTENT(in)                                :: comm
-      INTEGER, INTENT(OUT)                               :: sub_comm
+      INTEGER                               :: sub_comm
       INTEGER, INTENT(in)                                :: color
       INTEGER, INTENT(in), OPTIONAL                      :: key
 
@@ -2020,7 +2019,7 @@ CONTAINS
    SUBROUTINE mp_comm_split(comm, sub_comm, ngroups, group_distribution, &
                             subgroup_min_size, n_subgroups, group_partition, stride)
       INTEGER, INTENT(in)                      :: comm
-      INTEGER, INTENT(out)                     :: sub_comm, ngroups
+      INTEGER                     :: sub_comm, ngroups
       INTEGER, DIMENSION(0:)                    :: group_distribution
       INTEGER, INTENT(in), OPTIONAL            :: subgroup_min_size, n_subgroups
       INTEGER, DIMENSION(0:), OPTIONAL          :: group_partition
@@ -2136,7 +2135,7 @@ CONTAINS
    SUBROUTINE mp_probe(source, comm, tag)
       INTEGER                                  :: source
       INTEGER, INTENT(IN)                      :: comm
-      INTEGER, INTENT(OUT)                     :: tag
+      INTEGER                     :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_probe', &
                                      routineP = moduleN//':'//routineN
@@ -2257,7 +2256,7 @@ CONTAINS
    SUBROUTINE mp_isend_bv(msgin, dest, comm, request, tag)
       LOGICAL, DIMENSION(:)                    :: msgin
       INTEGER, INTENT(IN)                      :: dest, comm
-      INTEGER, INTENT(out)                     :: request
+      INTEGER                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_bv', &
@@ -2316,7 +2315,7 @@ CONTAINS
    SUBROUTINE mp_irecv_bv(msgout, source, comm, request, tag)
       LOGICAL, DIMENSION(:)                    :: msgout
       INTEGER, INTENT(IN)                      :: source, comm
-      INTEGER, INTENT(out)                     :: request
+      INTEGER                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_bv', &
@@ -2375,7 +2374,7 @@ CONTAINS
    SUBROUTINE mp_isend_bm3(msgin, dest, comm, request, tag)
       LOGICAL, DIMENSION(:, :, :)              :: msgin
       INTEGER, INTENT(IN)                      :: dest, comm
-      INTEGER, INTENT(out)                     :: request
+      INTEGER                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_bm3', &
@@ -2434,7 +2433,7 @@ CONTAINS
    SUBROUTINE mp_irecv_bm3(msgout, source, comm, request, tag)
       LOGICAL, DIMENSION(:, :, :)              :: msgout
       INTEGER, INTENT(IN)                      :: source, comm
-      INTEGER, INTENT(out)                     :: request
+      INTEGER                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_bm3', &
@@ -3061,8 +3060,8 @@ CONTAINS
 !>                            the result returned in version (integer)
 ! **************************************************************************************************
    SUBROUTINE mp_get_library_version(version, resultlen)
-      CHARACTER(len=*), INTENT(OUT)                      :: version
-      INTEGER, INTENT(OUT)                               :: resultlen
+      CHARACTER(len=*)                      :: version
+      INTEGER                               :: resultlen
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_get_library_version', &
          routineP = moduleN//':'//routineN
@@ -3104,7 +3103,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_open(groupid, fh, filepath, amode_status, info)
       INTEGER, INTENT(IN)                      :: groupid
-      INTEGER, INTENT(OUT)                     :: fh
+      INTEGER                     :: fh
       CHARACTER(len=*), INTENT(IN)             :: filepath
       INTEGER, INTENT(IN)                      :: amode_status
       INTEGER, INTENT(IN), OPTIONAL            :: info
@@ -3221,7 +3220,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_get_size(fh, file_size)
       INTEGER, INTENT(IN)                                :: fh
-      INTEGER(kind=file_offset), INTENT(OUT)             :: file_size
+      INTEGER(kind=file_offset)             :: file_size
 
       INTEGER                                            :: ierr
 
@@ -3247,7 +3246,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_get_position(fh, pos)
       INTEGER, INTENT(IN)                                :: fh
-      INTEGER(kind=file_offset), INTENT(OUT)             :: pos
+      INTEGER(kind=file_offset)             :: pos
 
       INTEGER                                            :: ierr
 
@@ -3390,7 +3389,7 @@ CONTAINS
 !> \param[in](optional) msglen  number of elements of data
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_chv(fh, offset, msg, msglen)
-      CHARACTER, INTENT(OUT)                     :: msg(:)
+      CHARACTER                     :: msg(:)
       INTEGER, INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
@@ -3419,7 +3418,7 @@ CONTAINS
 !> \param msg ...
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_ch(fh, offset, msg)
-      CHARACTER(LEN=*), INTENT(OUT)              :: msg
+      CHARACTER(LEN=*)              :: msg
       INTEGER, INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3448,7 +3447,7 @@ CONTAINS
 !> \par STREAM-I/O mapping   READ
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_all_chv(fh, offset, msg, msglen)
-      CHARACTER, INTENT(OUT)                     :: msg(:)
+      CHARACTER                     :: msg(:)
       INTEGER, INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
@@ -3477,7 +3476,7 @@ CONTAINS
 !> \param msg ...
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_all_ch(fh, offset, msg)
-      CHARACTER(LEN=*), INTENT(OUT)              :: msg
+      CHARACTER(LEN=*)              :: msg
       INTEGER, INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3505,7 +3504,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_type_size(type_descriptor, type_size)
       TYPE(mp_type_descriptor_type), INTENT(IN)          :: type_descriptor
-      INTEGER, INTENT(OUT)                               :: type_size
+      INTEGER                               :: type_size
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_type_size', routineP = moduleN//':'//routineN
 
@@ -3879,7 +3878,7 @@ CONTAINS
 ! **************************************************************************************************
       SUBROUTINE mp_file_get_amode(mpi_io, replace, amode, form, action, status, position)
       LOGICAL, INTENT(INOUT)                             :: mpi_io, replace
-      INTEGER, INTENT(OUT)                               :: amode
+      INTEGER                               :: amode
       CHARACTER(len=*), INTENT(IN)                       :: form, action, status, position
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_get_amode', &
@@ -4014,7 +4013,7 @@ CONTAINS
    SUBROUTINE mp_isend_custom(msgin, dest, comm, request, tag)
       TYPE(mp_type_descriptor_type), INTENT(IN)          :: msgin
       INTEGER, INTENT(IN)                                :: dest, comm
-      INTEGER, INTENT(out)                               :: request
+      INTEGER                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_custom', &
@@ -4054,7 +4053,7 @@ CONTAINS
    SUBROUTINE mp_irecv_custom(msgout, source, comm, request, tag)
       TYPE(mp_type_descriptor_type), INTENT(INOUT)       :: msgout
       INTEGER, INTENT(IN)                                :: source, comm
-      INTEGER, INTENT(out)                               :: request
+      INTEGER                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_custom', &
@@ -4609,7 +4608,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_timeset(routineN, handle)
       CHARACTER(len=*), INTENT(IN)                       :: routineN
-      INTEGER, INTENT(OUT)                               :: handle
+      INTEGER                               :: handle
 
       IF (mp_collect_timings) &
          CALL timeset(routineN, handle)

--- a/src/mpiwrap/message_passing.f90
+++ b/src/mpiwrap/message_passing.f90
@@ -244,7 +244,7 @@
   SUBROUTINE mp_alltoall_${nametype1}$ ( sb, rb, count, group )
 
     ${type1}$, DIMENSION(:), INTENT(IN)        :: sb
-    ${type1}$, DIMENSION(:), INTENT(OUT)       :: rb
+    ${type1}$, DIMENSION(:)       :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$', &
@@ -286,7 +286,7 @@
   SUBROUTINE mp_alltoall_${nametype1}$22 ( sb, rb, count, group )
 
     ${type1}$, DIMENSION(:, :), INTENT(IN)     :: sb
-    ${type1}$, DIMENSION(:, :), INTENT(OUT)    :: rb
+    ${type1}$, DIMENSION(:, :)    :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$22', &
@@ -328,7 +328,7 @@
   SUBROUTINE mp_alltoall_${nametype1}$33 ( sb, rb, count, group )
 
     ${type1}$, DIMENSION(:, :, :), INTENT(IN)  :: sb
-    ${type1}$, DIMENSION(:, :, :), INTENT(OUT) :: rb
+    ${type1}$, DIMENSION(:, :, :) :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$33', &
@@ -371,8 +371,7 @@
 
     ${type1}$, DIMENSION(:, :, :, :), &
       INTENT(IN)                             :: sb
-    ${type1}$, DIMENSION(:, :, :, :), &
-      INTENT(OUT)                            :: rb
+    ${type1}$, DIMENSION(:, :, :, :)         :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$44', &
@@ -415,8 +414,7 @@
 
     ${type1}$, DIMENSION(:, :, :, :, :), &
       INTENT(IN)                             :: sb
-    ${type1}$, DIMENSION(:, :, :, :, :), &
-      INTENT(OUT)                            :: rb
+    ${type1}$, DIMENSION(:, :, :, :, :)      :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$55', &
@@ -461,7 +459,7 @@
     ${type1}$, DIMENSION(:, :, :, :), &
       INTENT(IN)                             :: sb
     ${type1}$, &
-      DIMENSION(:, :, :, :, :), INTENT(OUT)  :: rb
+      DIMENSION(:, :, :, :, :)  :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$45', &
@@ -505,8 +503,7 @@
 
     ${type1}$, DIMENSION(:, :, :), &
       INTENT(IN)                             :: sb
-    ${type1}$, DIMENSION(:, :, :, :), &
-      INTENT(OUT)                            :: rb
+    ${type1}$, DIMENSION(:, :, :, :)         :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$34', &
@@ -550,8 +547,7 @@
 
     ${type1}$, &
       DIMENSION(:, :, :, :, :), INTENT(IN)   :: sb
-    ${type1}$, DIMENSION(:, :, :, :), &
-      INTENT(OUT)                            :: rb
+    ${type1}$, DIMENSION(:, :, :, :)         :: rb
     INTEGER, INTENT(IN)                      :: count, group
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$54', &
@@ -1276,7 +1272,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_sum_partial_${nametype1}$m(msg,res,gid)
     ${type1}$, INTENT(IN)         :: msg( :, : )
-    ${type1}$, INTENT(OUT)        :: res( :, : )
+    ${type1}$        :: res( :, : )
     INTEGER, INTENT(IN)         :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_partial_${nametype1}$m'   &
@@ -1478,7 +1474,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_scatter_${nametype1}$v(msg_scatter,msg,root,gid)
     ${type1}$, INTENT(IN)                      :: msg_scatter(:)
-    ${type1}$, INTENT(OUT)                     :: msg( : )
+    ${type1}$                     :: msg( : )
     INTEGER, INTENT(IN)                      :: root, gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_scatter_${nametype1}$v', &
@@ -1658,7 +1654,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_gather_${nametype1}$(msg,msg_gather,root,gid)
     ${type1}$, INTENT(IN)                      :: msg
-    ${type1}$, INTENT(OUT)                     :: msg_gather( : )
+    ${type1}$                     :: msg_gather( : )
     INTEGER, INTENT(IN)                      :: root, gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$', &
@@ -1697,7 +1693,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_gather_${nametype1}$v(msg,msg_gather,root,gid)
     ${type1}$, INTENT(IN)                      :: msg( : )
-    ${type1}$, INTENT(OUT)                     :: msg_gather( : )
+    ${type1}$                     :: msg_gather( : )
     INTEGER, INTENT(IN)                      :: root, gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$v', &
@@ -1736,7 +1732,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_gather_${nametype1}$m(msg,msg_gather,root,gid)
     ${type1}$, INTENT(IN)                      :: msg( :, : )
-    ${type1}$, INTENT(OUT)                     :: msg_gather( :, : )
+    ${type1}$                     :: msg_gather( :, : )
     INTEGER, INTENT(IN)                      :: root, gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$m', &
@@ -1779,7 +1775,7 @@
   SUBROUTINE mp_gatherv_${nametype1}$v(sendbuf,recvbuf,recvcounts,displs,root,comm)
 
     ${type1}$, DIMENSION(:), INTENT(IN)        :: sendbuf
-    ${type1}$, DIMENSION(:), INTENT(OUT)       :: recvbuf
+    ${type1}$, DIMENSION(:)       :: recvbuf
     INTEGER, DIMENSION(:), INTENT(IN)        :: recvcounts, displs
     INTEGER, INTENT(IN)                      :: root, comm
 
@@ -1829,7 +1825,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_igatherv_${nametype1}$v(sendbuf,sendcount,recvbuf,recvcounts,displs,root,comm,request)
     ${type1}$, DIMENSION(:), INTENT(IN)        :: sendbuf
-    ${type1}$, DIMENSION(:), INTENT(OUT)       :: recvbuf
+    ${type1}$, DIMENSION(:)       :: recvbuf
     INTEGER, DIMENSION(:), INTENT(IN)        :: recvcounts, displs
     INTEGER, INTENT(IN)                      :: sendcount, root, comm
     INTEGER, INTENT(INOUT)                   :: request
@@ -1887,7 +1883,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_allgather_${nametype1}$(msgout,msgin,gid)
     ${type1}$, INTENT(IN)                      :: msgout
-    ${type1}$, INTENT(OUT)                     :: msgin( : )
+    ${type1}$                     :: msgin( : )
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$', &
@@ -1928,7 +1924,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_allgather_${nametype1}$2(msgout,msgin,gid)
     ${type1}$, INTENT(IN)                      :: msgout
-    ${type1}$, INTENT(OUT)                     :: msgin( : , :)
+    ${type1}$                     :: msgin( : , :)
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$2', &
@@ -1969,7 +1965,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgather_${nametype1}$(msgout,msgin,gid,request)
     ${type1}$, INTENT(IN)                      :: msgout
-    ${type1}$, INTENT(OUT)                     :: msgin( : )
+    ${type1}$                     :: msgin( : )
     INTEGER, INTENT(IN)                      :: gid
     INTEGER, INTENT(INOUT)                   :: request
 
@@ -2020,7 +2016,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_allgather_${nametype1}$12(msgout, msgin,gid)
     ${type1}$, INTENT(IN)                      :: msgout(:)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :)
+    ${type1}$                     :: msgin(:, :)
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$12', &
@@ -2058,7 +2054,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_allgather_${nametype1}$23(msgout, msgin,gid)
     ${type1}$, INTENT(IN)                      :: msgout(:,:)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
+    ${type1}$                     :: msgin(:, :, :)
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$23', &
@@ -2096,7 +2092,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_allgather_${nametype1}$34(msgout, msgin,gid)
     ${type1}$, INTENT(IN)                      :: msgout(:,:, :)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :, :, :)
+    ${type1}$                     :: msgin(:, :, :, :)
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$34', &
@@ -2135,7 +2131,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_allgather_${nametype1}$22(msgout, msgin,gid)
     ${type1}$, INTENT(IN)                      :: msgout(:, :)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :)
+    ${type1}$                     :: msgin(:, :)
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$22', &
@@ -2174,9 +2170,9 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgather_${nametype1}$11(msgout, msgin, gid, request)
     ${type1}$, INTENT(IN)                      :: msgout(:)
-    ${type1}$, INTENT(OUT)                     :: msgin(:)
+    ${type1}$                     :: msgin(:)
     INTEGER, INTENT(IN)                      :: gid
-    INTEGER, INTENT(OUT)                     :: request
+    INTEGER                     :: request
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$11', &
       routineP = moduleN//':'//routineN
@@ -2225,9 +2221,9 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgather_${nametype1}$13(msgout, msgin, gid, request)
     ${type1}$, INTENT(IN)                      :: msgout(:)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
+    ${type1}$                     :: msgin(:, :, :)
     INTEGER, INTENT(IN)                      :: gid
-    INTEGER, INTENT(OUT)                     :: request
+    INTEGER                     :: request
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$13', &
       routineP = moduleN//':'//routineN
@@ -2276,9 +2272,9 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgather_${nametype1}$22(msgout, msgin, gid, request)
     ${type1}$, INTENT(IN)                      :: msgout(:, :)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :)
+    ${type1}$                     :: msgin(:, :)
     INTEGER, INTENT(IN)                      :: gid
-    INTEGER, INTENT(OUT)                     :: request
+    INTEGER                     :: request
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$22', &
       routineP = moduleN//':'//routineN
@@ -2327,9 +2323,9 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgather_${nametype1}$24(msgout, msgin, gid, request)
     ${type1}$, INTENT(IN)                      :: msgout(:, :)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :, :, :)
+    ${type1}$                     :: msgin(:, :, :, :)
     INTEGER, INTENT(IN)                      :: gid
-    INTEGER, INTENT(OUT)                     :: request
+    INTEGER                     :: request
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$24', &
       routineP = moduleN//':'//routineN
@@ -2378,9 +2374,9 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgather_${nametype1}$33(msgout, msgin, gid, request)
     ${type1}$, INTENT(IN)                      :: msgout(:, :, :)
-    ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
+    ${type1}$                     :: msgin(:, :, :)
     INTEGER, INTENT(IN)                      :: gid
-    INTEGER, INTENT(OUT)                     :: request
+    INTEGER                     :: request
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$33', &
       routineP = moduleN//':'//routineN
@@ -2437,7 +2433,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_allgatherv_${nametype1}$v(msgout,msgin,rcount,rdispl,gid)
     ${type1}$, INTENT(IN)                      :: msgout( : )
-    ${type1}$, INTENT(OUT)                     :: msgin( : )
+    ${type1}$                     :: msgin( : )
     INTEGER, INTENT(IN)                      :: rcount( : ), rdispl( : ), gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgatherv_${nametype1}$v', &
@@ -2484,7 +2480,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgatherv_${nametype1}$v(msgout,msgin,rcount,rdispl,gid,request)
     ${type1}$, INTENT(IN)                      :: msgout( : )
-    ${type1}$, INTENT(OUT)                     :: msgin( : )
+    ${type1}$                     :: msgin( : )
     INTEGER, INTENT(IN)                      :: rcount(:), rdispl(:), gid
     INTEGER, INTENT(INOUT)                   :: request
 
@@ -2543,7 +2539,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_iallgatherv_${nametype1}$v2(msgout,msgin,rcount,rdispl,gid,request)
     ${type1}$, INTENT(IN)                      :: msgout( : )
-    ${type1}$, INTENT(OUT)                     :: msgin( : )
+    ${type1}$                     :: msgin( : )
     INTEGER, INTENT(IN)                      :: rcount(:, :), rdispl(:, :), gid
     INTEGER, INTENT(INOUT)                   :: request
 
@@ -2595,7 +2591,7 @@
 #if defined(__parallel) && (__MPI_VERSION > 2)
   SUBROUTINE mp_iallgatherv_${nametype1}$v_internal(msgout,scount,msgin,rsize,rcount,rdispl,gid,request,ierr)
     ${type1}$, INTENT(IN)                      :: msgout( : )
-    ${type1}$, INTENT(OUT)                     :: msgin( : )
+    ${type1}$                     :: msgin( : )
     INTEGER, INTENT(IN)                      :: rsize
     INTEGER, INTENT(IN)                      :: rcount(rsize), rdispl(rsize), gid, scount
     INTEGER, INTENT(INOUT)                   :: request, ierr
@@ -2616,7 +2612,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_sum_scatter_${nametype1}$v(msgout,msgin,rcount,gid)
     ${type1}$, INTENT(IN)                      :: msgout( : )
-    ${type1}$, INTENT(OUT)                     :: msgin( : )
+    ${type1}$                     :: msgin( : )
     INTEGER, INTENT(IN)                      :: rcount( : ), gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_scatter_${nametype1}$v', &
@@ -2653,7 +2649,7 @@
   SUBROUTINE mp_sendrecv_${nametype1}$v(msgin,dest,msgout,source,comm)
     ${type1}$, INTENT(IN)                      :: msgin( : )
     INTEGER, INTENT(IN)                      :: dest
-    ${type1}$, INTENT(OUT)                     :: msgout( : )
+    ${type1}$                     :: msgout( : )
     INTEGER, INTENT(IN)                      :: source, comm
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$v', &
@@ -2699,7 +2695,7 @@
   SUBROUTINE mp_sendrecv_${nametype1}$m2(msgin,dest,msgout,source,comm)
     ${type1}$, INTENT(IN)                      :: msgin( :, : )
     INTEGER, INTENT(IN)                      :: dest
-    ${type1}$, INTENT(OUT)                     :: msgout( :, : )
+    ${type1}$                     :: msgout( :, : )
     INTEGER, INTENT(IN)                      :: source, comm
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$m2', &
@@ -2745,7 +2741,7 @@
   SUBROUTINE mp_sendrecv_${nametype1}$m3(msgin,dest,msgout,source,comm)
     ${type1}$, INTENT(IN)                      :: msgin( :, :, : )
     INTEGER, INTENT(IN)                      :: dest
-    ${type1}$, INTENT(OUT)                     :: msgout( :, :, : )
+    ${type1}$                     :: msgout( :, :, : )
     INTEGER, INTENT(IN)                      :: source, comm
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$m3', &
@@ -2791,7 +2787,7 @@
   SUBROUTINE mp_sendrecv_${nametype1}$m4(msgin,dest,msgout,source,comm)
     ${type1}$, INTENT(IN)                      :: msgin( :, :, :, : )
     INTEGER, INTENT(IN)                      :: dest
-    ${type1}$, INTENT(OUT)                     :: msgout( :, :, :, : )
+    ${type1}$                     :: msgout( :, :, :, : )
     INTEGER, INTENT(IN)                      :: source, comm
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$m4', &
@@ -2846,7 +2842,7 @@
     INTEGER, INTENT(IN)                      :: dest
     ${type1}$                                  :: msgout
     INTEGER, INTENT(IN)                      :: source, comm
-    INTEGER, INTENT(out)                     :: send_request, recv_request
+    INTEGER                     :: send_request, recv_request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_isendrecv_${nametype1}$', &
@@ -2908,7 +2904,7 @@
     INTEGER, INTENT(IN)                      :: dest
     ${type1}$, DIMENSION(:)                    :: msgout
     INTEGER, INTENT(IN)                      :: source, comm
-    INTEGER, INTENT(out)                     :: send_request, recv_request
+    INTEGER                     :: send_request, recv_request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_isendrecv_${nametype1}$v', &
@@ -2977,7 +2973,7 @@
   SUBROUTINE mp_isend_${nametype1}$v(msgin,dest,comm,request,tag)
     ${type1}$, DIMENSION(:)                    :: msgin
     INTEGER, INTENT(IN)                      :: dest, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$v', &
@@ -3038,7 +3034,7 @@
   SUBROUTINE mp_isend_${nametype1}$m2(msgin,dest,comm,request,tag)
     ${type1}$, DIMENSION(:, :)                 :: msgin
     INTEGER, INTENT(IN)                      :: dest, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$m2', &
@@ -3101,7 +3097,7 @@
   SUBROUTINE mp_isend_${nametype1}$m3(msgin,dest,comm,request,tag)
     ${type1}$, DIMENSION(:, :, :)              :: msgin
     INTEGER, INTENT(IN)                      :: dest, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$m3', &
@@ -3161,7 +3157,7 @@
   SUBROUTINE mp_isend_${nametype1}$m4(msgin,dest,comm,request,tag)
     ${type1}$, DIMENSION(:, :, :, :)           :: msgin
     INTEGER, INTENT(IN)                      :: dest, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$m4', &
@@ -3221,7 +3217,7 @@
   SUBROUTINE mp_irecv_${nametype1}$v(msgout,source,comm,request,tag)
     ${type1}$, DIMENSION(:)                    :: msgout
     INTEGER, INTENT(IN)                      :: source, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$v', &
@@ -3281,7 +3277,7 @@
   SUBROUTINE mp_irecv_${nametype1}$m2(msgout,source,comm,request,tag)
     ${type1}$, DIMENSION(:, :)                 :: msgout
     INTEGER, INTENT(IN)                      :: source, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$m2', &
@@ -3343,7 +3339,7 @@
   SUBROUTINE mp_irecv_${nametype1}$m3(msgout,source,comm,request,tag)
     ${type1}$, DIMENSION(:, :, :)              :: msgout
     INTEGER, INTENT(IN)                      :: source, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$m3', &
@@ -3402,7 +3398,7 @@
   SUBROUTINE mp_irecv_${nametype1}$m4(msgout,source,comm,request,tag)
     ${type1}$, DIMENSION(:, :, :, :)           :: msgout
     INTEGER, INTENT(IN)                      :: source, comm
-    INTEGER, INTENT(out)                     :: request
+    INTEGER                     :: request
     INTEGER, INTENT(in), OPTIONAL            :: tag
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$m4', &
@@ -3506,7 +3502,7 @@
     INTEGER, INTENT(IN)                                 :: source, win
     ${type1}$, DIMENSION(:)                               :: win_data
     INTEGER, INTENT(IN), OPTIONAL                       :: myproc, disp
-    INTEGER, INTENT(OUT)                                :: request
+    INTEGER                                :: request
     TYPE(mp_type_descriptor_type), INTENT(IN), OPTIONAL :: origin_datatype, target_datatype
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_rget_${nametype1}$v', &
@@ -3650,7 +3646,7 @@
   SUBROUTINE mp_allocate_${nametype1}$(DATA, len, stat)
     ${type1}$, DIMENSION(:), POINTER      :: DATA
     INTEGER, INTENT(IN)                 :: len
-    INTEGER, INTENT(OUT), OPTIONAL      :: stat
+    INTEGER, OPTIONAL      :: stat
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_allocate_${nametype1}$', &
          routineP = moduleN//':'//routineN
@@ -3683,7 +3679,7 @@
 ! *****************************************************************************
   SUBROUTINE mp_deallocate_${nametype1}$(DATA, stat)
     ${type1}$, DIMENSION(:), POINTER      :: DATA
-    INTEGER, INTENT(OUT), OPTIONAL      :: stat
+    INTEGER, OPTIONAL      :: stat
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_deallocate_${nametype1}$', &
          routineP = moduleN//':'//routineN
@@ -3841,7 +3837,7 @@
 !> \param[in](optional) msglen  number of elements of data
 ! *****************************************************************************
   SUBROUTINE mp_file_read_at_${nametype1}$v(fh, offset, msg, msglen)
-    ${type1}$, INTENT(OUT)                     :: msg(:)
+    ${type1}$                     :: msg(:)
     INTEGER, INTENT(IN)                        :: fh
     INTEGER, INTENT(IN), OPTIONAL              :: msglen
     INTEGER                                    :: msg_len
@@ -3871,7 +3867,7 @@
 !> \param msg ...
 ! *****************************************************************************
   SUBROUTINE mp_file_read_at_${nametype1}$(fh, offset, msg)
-    ${type1}$, INTENT(OUT)               :: msg
+    ${type1}$               :: msg
     INTEGER, INTENT(IN)                        :: fh
     INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3902,7 +3898,7 @@
 !> \par STREAM-I/O mapping   READ
 ! *****************************************************************************
   SUBROUTINE mp_file_read_at_all_${nametype1}$v(fh, offset, msg, msglen)
-    ${type1}$, INTENT(OUT)                     :: msg(:)
+    ${type1}$                     :: msg(:)
     INTEGER, INTENT(IN)                        :: fh
     INTEGER, INTENT(IN), OPTIONAL              :: msglen
     INTEGER(kind=file_offset), INTENT(IN)      :: offset
@@ -3931,7 +3927,7 @@
 !> \param msg ...
 ! *****************************************************************************
   SUBROUTINE mp_file_read_at_all_${nametype1}$(fh, offset, msg)
-    ${type1}$, INTENT(OUT)               :: msg
+    ${type1}$               :: msg
     INTEGER, INTENT(IN)                        :: fh
     INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3999,7 +3995,7 @@
   SUBROUTINE mp_alloc_mem_${nametype1}$(DATA, len, stat)
     ${type1}$, DIMENSION(:), POINTER           :: DATA
     INTEGER, INTENT(IN)                      :: len
-    INTEGER, INTENT(OUT), OPTIONAL           :: stat
+    INTEGER, OPTIONAL           :: stat
 
 #if defined(__parallel)
     INTEGER                                  :: size, ierr, length, &
@@ -4038,7 +4034,7 @@
    SUBROUTINE mp_free_mem_${nametype1}$(DATA, stat)
     ${type1}$, DIMENSION(:), &
       POINTER                                :: DATA
-    INTEGER, INTENT(OUT), OPTIONAL           :: stat
+    INTEGER, OPTIONAL           :: stat
 
 #if defined(__parallel)
     INTEGER                                  :: mp_res

--- a/src/mulliken.F
+++ b/src/mulliken.F
@@ -176,7 +176,7 @@ CONTAINS
                                    charges_deriv, energy, order_p)
       TYPE(mulliken_restraint_type), INTENT(IN)          :: mulliken_restraint_control
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: charges, charges_deriv
-      REAL(KIND=dp), INTENT(OUT)                         :: energy, order_p
+      REAL(KIND=dp)                                      :: energy, order_p
 
       INTEGER                                            :: I
       REAL(KIND=dp)                                      :: dum

--- a/src/negf_atom_map.F
+++ b/src/negf_atom_map.F
@@ -71,8 +71,7 @@ CONTAINS
 !>   * 08.2017 created [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE negf_map_atomic_indices(atom_map, atom_list, subsys_device, subsys_contact, eps_geometry)
-      TYPE(negf_atom_map_type), DIMENSION(:), &
-         INTENT(out)                                     :: atom_map
+      TYPE(negf_atom_map_type), DIMENSION(:)             :: atom_map
       INTEGER, DIMENSION(:), INTENT(in)                  :: atom_list
       TYPE(qs_subsys_type), POINTER                      :: subsys_device, subsys_contact
       REAL(kind=dp), INTENT(in)                          :: eps_geometry

--- a/src/negf_control_types.F
+++ b/src/negf_control_types.F
@@ -402,7 +402,7 @@ CONTAINS
 !> \return that indicates whether of not the subsection has been given explicitly
 ! **************************************************************************************************
    FUNCTION read_negf_atomlist(atomlist, negf_section, i_rep_section, subsection_name, subsys) RESULT(is_explicit)
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(out)    :: atomlist
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atomlist
       TYPE(section_vals_type), POINTER                   :: negf_section
       INTEGER, INTENT(in)                                :: i_rep_section
       CHARACTER(len=*), INTENT(in)                       :: subsection_name

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -807,7 +807,7 @@ CONTAINS
 !>   * 01.2017 created [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE negf_homo_energy_estimate(homo_energy, qs_env)
-      REAL(kind=dp), INTENT(out)                         :: homo_energy
+      REAL(kind=dp)                                      :: homo_energy
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'negf_homo_energy_estimate', &

--- a/src/negf_integr_cc.F
+++ b/src/negf_integr_cc.F
@@ -107,9 +107,9 @@ CONTAINS
 !>       Fermi function), so we do not actually need a fine grid spacing on this tail.
 ! **************************************************************************************************
    SUBROUTINE ccquad_init(cc_env, xnodes, nnodes, a, b, interval_id, shape_id, weights, tnodes_restart)
-      TYPE(ccquad_type), INTENT(out)                     :: cc_env
+      TYPE(ccquad_type)                                  :: cc_env
       INTEGER, INTENT(inout)                             :: nnodes
-      COMPLEX(kind=dp), DIMENSION(nnodes), INTENT(out)   :: xnodes
+      COMPLEX(kind=dp), DIMENSION(nnodes)                :: xnodes
       COMPLEX(kind=dp), INTENT(in)                       :: a, b
       INTEGER, INTENT(in)                                :: interval_id, shape_id
       TYPE(cp_fm_type), POINTER                          :: weights

--- a/src/negf_integr_simpson.F
+++ b/src/negf_integr_simpson.F
@@ -118,9 +118,9 @@ CONTAINS
 !>       ('conv') becomes the maximum error in the total number of electrons multiplied by pi.
 ! **************************************************************************************************
    SUBROUTINE simpsonrule_init(sr_env, xnodes, nnodes, a, b, shape_id, conv, weights, tnodes_restart)
-      TYPE(simpsonrule_type), INTENT(out)                :: sr_env
+      TYPE(simpsonrule_type)                             :: sr_env
       INTEGER, INTENT(inout)                             :: nnodes
-      COMPLEX(kind=dp), DIMENSION(nnodes), INTENT(out)   :: xnodes
+      COMPLEX(kind=dp), DIMENSION(nnodes)                :: xnodes
       COMPLEX(kind=dp), INTENT(in)                       :: a, b
       INTEGER, INTENT(in)                                :: shape_id
       REAL(kind=dp), INTENT(in)                          :: conv
@@ -232,7 +232,7 @@ CONTAINS
    SUBROUTINE simpsonrule_get_next_nodes(sr_env, xnodes_next, nnodes)
       TYPE(simpsonrule_type), INTENT(inout)              :: sr_env
       INTEGER, INTENT(inout)                             :: nnodes
-      COMPLEX(kind=dp), DIMENSION(nnodes), INTENT(out)   :: xnodes_next
+      COMPLEX(kind=dp), DIMENSION(nnodes)                :: xnodes_next
 
       CHARACTER(len=*), PARAMETER :: routineN = 'simpsonrule_get_next_nodes', &
          routineP = moduleN//':'//routineN
@@ -270,8 +270,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE simpsonrule_get_next_nodes_real(sr_env, xnodes_unity, nnodes)
       TYPE(simpsonrule_type), INTENT(in)                 :: sr_env
-      REAL(kind=dp), DIMENSION(:), INTENT(out)           :: xnodes_unity
-      INTEGER, INTENT(out)                               :: nnodes
+      REAL(kind=dp), DIMENSION(:)                        :: xnodes_unity
+      INTEGER                                            :: nnodes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'simpsonrule_get_next_nodes_real', &
          routineP = moduleN//':'//routineN

--- a/src/negf_integr_utils.F
+++ b/src/negf_integr_utils.F
@@ -47,7 +47,7 @@ CONTAINS
    SUBROUTINE equidistant_${nametype1}$nodes_a_b(a, b, nnodes, xnodes)
       ${type1}$, INTENT(in)                              :: a, b
       INTEGER, INTENT(in)                                :: nnodes
-      ${type1}$, DIMENSION(nnodes), INTENT(out)          :: xnodes
+      ${type1}$, DIMENSION(nnodes)          :: xnodes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'equidistant_${nametype1}$nodes_a_b', &
          routineP = moduleN//':'//routineN
@@ -69,7 +69,7 @@ CONTAINS
       REAL(kind=dp), DIMENSION(nnodes), INTENT(in)       :: tnodes
       COMPLEX(kind=dp), INTENT(in)                       :: a, b
       INTEGER, INTENT(in)                                :: shape_id
-      COMPLEX(kind=dp), DIMENSION(nnodes), INTENT(out), &
+      COMPLEX(kind=dp), DIMENSION(nnodes), &
          OPTIONAL                                        :: xnodes, weights
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rescale_normalised_nodes', &
@@ -211,7 +211,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: nnodes
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: tnodes_angle
       COMPLEX(kind=dp), INTENT(in)                       :: a, b
-      COMPLEX(kind=dp), DIMENSION(:), INTENT(out)        :: xnodes
+      COMPLEX(kind=dp), DIMENSION(:)        :: xnodes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rescale_nodes_arc', &
          routineP = moduleN//':'//routineN
@@ -259,7 +259,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: nnodes
       REAL(kind=dp), DIMENSION(nnodes), INTENT(in)       :: tnodes
       COMPLEX(kind=dp), INTENT(in)                       :: a, b
-      COMPLEX(kind=dp), DIMENSION(nnodes), INTENT(out)   :: xnodes
+      COMPLEX(kind=dp), DIMENSION(nnodes)   :: xnodes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rescale_nodes_linear', &
          routineP = moduleN//':'//routineN

--- a/src/negf_matrix_utils.F
+++ b/src/negf_matrix_utils.F
@@ -744,7 +744,7 @@ CONTAINS
    SUBROUTINE invert_cell_to_index(cell_to_index, nimages, index_to_cell)
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       INTEGER, INTENT(in)                                :: nimages
-      INTEGER, DIMENSION(3, nimages), INTENT(out)        :: index_to_cell
+      INTEGER, DIMENSION(3, nimages)                     :: index_to_cell
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'invert_cell_to_index', &
          routineP = moduleN//':'//routineN

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -1331,9 +1331,8 @@ CONTAINS
          OPTIONAL                                        :: g_ret_scale
       TYPE(cp_cfm_p_type), DIMENSION(:, :), INTENT(in), &
          OPTIONAL                                        :: gamma_contacts, gret_gamma_gadv
-      REAL(kind=dp), DIMENSION(:), INTENT(out), OPTIONAL :: dos
-      COMPLEX(kind=dp), DIMENSION(:), INTENT(out), &
-         OPTIONAL                                        :: transm_coeff
+      REAL(kind=dp), DIMENSION(:), OPTIONAL              :: dos
+      COMPLEX(kind=dp), DIMENSION(:), OPTIONAL           :: transm_coeff
       INTEGER, INTENT(in), OPTIONAL                      :: transm_contact1, transm_contact2, &
                                                             just_contact
 
@@ -2506,7 +2505,7 @@ CONTAINS
 !> \author Sergey Chulkov
 ! **************************************************************************************************
    SUBROUTINE integration_status_reset(stats)
-      TYPE(integration_status_type), INTENT(out)         :: stats
+      TYPE(integration_status_type)                      :: stats
 
       stats%npoints = 0
       stats%error = 0.0_dp

--- a/src/negf_subgroup_types.F
+++ b/src/negf_subgroup_types.F
@@ -70,7 +70,7 @@ CONTAINS
 !>    * 06.2017 created [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE negf_sub_env_create(sub_env, negf_control, blacs_env_global, blacs_grid_layout, blacs_repeatable)
-      TYPE(negf_subgroup_env_type), INTENT(out)          :: sub_env
+      TYPE(negf_subgroup_env_type)                       :: sub_env
       TYPE(negf_control_type), POINTER                   :: negf_control
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_global
       INTEGER, INTENT(in)                                :: blacs_grid_layout

--- a/src/negf_vectors.F
+++ b/src/negf_vectors.F
@@ -39,7 +39,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE contact_direction_vector(origin, direction_vector, origin_bias, direction_vector_bias, &
                                        atomlist_screening, atomlist_bulk, subsys)
-      REAL(kind=dp), DIMENSION(3), INTENT(out)           :: origin, direction_vector, origin_bias, &
+      REAL(kind=dp), DIMENSION(3)                        :: origin, direction_vector, origin_bias, &
                                                             direction_vector_bias
       INTEGER, DIMENSION(:), INTENT(in)                  :: atomlist_screening, atomlist_bulk
       TYPE(qs_subsys_type), POINTER                      :: subsys

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -799,7 +799,7 @@ CONTAINS
 !> \param section ...
 ! **************************************************************************************************
    SUBROUTINE embed_restart_file_name(filename, section)
-      CHARACTER(LEN=default_path_length), INTENT(OUT)    :: filename
+      CHARACTER(LEN=default_path_length)                 :: filename
       TYPE(section_vals_type), POINTER                   :: section
 
       LOGICAL                                            :: exist

--- a/src/pair_potential.F
+++ b/src/pair_potential.F
@@ -280,7 +280,7 @@ CONTAINS
 
       REAL(KIND=dp), INTENT(IN)                          :: hicut
       REAL(KIND=dp), INTENT(INOUT)                       :: locut
-      LOGICAL, INTENT(OUT)                               :: found_locut
+      LOGICAL                                            :: found_locut
       TYPE(pair_potential_single_type), OPTIONAL, &
          POINTER                                         :: pot
       LOGICAL, INTENT(IN)                                :: do_zbl
@@ -918,7 +918,7 @@ CONTAINS
 
       TYPE(pair_potential_pp_type), POINTER              :: potparm
       INTEGER, INTENT(IN)                                :: my_index(:), pot_target, ntype
-      INTEGER, INTENT(OUT)                               :: tmpij_out(2)
+      INTEGER                                            :: tmpij_out(2)
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       LOGICAL, INTENT(IN)                                :: shift_cutoff, do_zbl
 
@@ -1068,7 +1068,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_indexes(Inind, ndim, ij)
       INTEGER, INTENT(IN)                                :: Inind, ndim
-      INTEGER, DIMENSION(2), INTENT(OUT)                 :: ij
+      INTEGER, DIMENSION(2)                              :: ij
 
       INTEGER                                            :: i, tmp
 

--- a/src/pair_potential_types.F
+++ b/src/pair_potential_types.F
@@ -296,7 +296,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE compare_pot(pot1, pot2, compare)
       TYPE(pair_potential_single_type), POINTER          :: pot1, pot2
-      LOGICAL, INTENT(OUT)                               :: compare
+      LOGICAL                                            :: compare
 
       CHARACTER(len=*), PARAMETER :: routineN = 'compare_pot', routineP = moduleN//':'//routineN
 

--- a/src/pao_io.F
+++ b/src/pao_io.F
@@ -184,13 +184,13 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pao_read_raw(filename, param, hmat, kinds, atom2kind, positions, xblocks, ml_range)
       CHARACTER(LEN=default_path_length), INTENT(IN)     :: filename
-      CHARACTER(LEN=default_string_length), INTENT(OUT)  :: param
+      CHARACTER(LEN=default_string_length)               :: param
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: hmat
       TYPE(pao_iokind_type), ALLOCATABLE, DIMENSION(:)   :: kinds
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom2kind
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: positions
       TYPE(pao_ioblock_type), ALLOCATABLE, DIMENSION(:)  :: xblocks
-      INTEGER, DIMENSION(2), INTENT(OUT), OPTIONAL       :: ml_range
+      INTEGER, DIMENSION(2), OPTIONAL                    :: ml_range
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_read_raw', routineP = moduleN//':'//routineN
 

--- a/src/pao_linpot_full.F
+++ b/src/pao_linpot_full.F
@@ -35,7 +35,7 @@ CONTAINS
    SUBROUTINE linpot_full_count_terms(qs_env, ikind, nterms)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ikind
-      INTEGER, INTENT(OUT)                               :: nterms
+      INTEGER                                            :: nterms
 
       INTEGER                                            :: n
       TYPE(gto_basis_set_type), POINTER                  :: basis_set
@@ -53,7 +53,7 @@ CONTAINS
 !> \param V_blocks ...
 ! **************************************************************************************************
    SUBROUTINE linpot_full_calc_terms(V_blocks)
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT)          :: V_blocks
+      REAL(dp), DIMENSION(:, :, :)                       :: V_blocks
 
       INTEGER                                            :: i, j, kterm, n, nterms
 

--- a/src/pao_linpot_rotinv.F
+++ b/src/pao_linpot_rotinv.F
@@ -45,7 +45,7 @@ CONTAINS
    SUBROUTINE linpot_rotinv_count_terms(qs_env, ikind, nterms)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ikind
-      INTEGER, INTENT(OUT)                               :: nterms
+      INTEGER                                            :: nterms
 
       CHARACTER(len=*), PARAMETER :: routineN = 'linpot_rotinv_count_terms'
 
@@ -118,7 +118,7 @@ CONTAINS
    SUBROUTINE linpot_rotinv_calc_terms(qs_env, iatom, V_blocks)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: iatom
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT), TARGET  :: V_blocks
+      REAL(dp), DIMENSION(:, :, :), TARGET               :: V_blocks
 
       CHARACTER(len=*), PARAMETER :: routineN = 'linpot_rotinv_calc_terms'
 

--- a/src/pao_main.F
+++ b/src/pao_main.F
@@ -194,7 +194,7 @@ CONTAINS
    SUBROUTINE pao_update(qs_env, ls_scf_env, pao_is_done)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(ls_scf_env_type), TARGET                      :: ls_scf_env
-      LOGICAL, INTENT(OUT)                               :: pao_is_done
+      LOGICAL                                            :: pao_is_done
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pao_update'
 

--- a/src/pao_methods.F
+++ b/src/pao_methods.F
@@ -441,7 +441,7 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(ls_scf_env_type)                              :: ls_scf_env
       REAL(KIND=dp), INTENT(IN)                          :: new_energy
-      LOGICAL, INTENT(OUT)                               :: is_converged
+      LOGICAL                                            :: is_converged
 
       REAL(KIND=dp)                                      :: energy_diff, loop_eps, now, time_diff
 
@@ -482,7 +482,7 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(ls_scf_env_type), TARGET                      :: ls_scf_env
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                                      :: energy
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_calc_energy', &
          routineP = moduleN//':'//routineN

--- a/src/pao_ml.F
+++ b/src/pao_ml.F
@@ -599,8 +599,8 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       INTEGER, INTENT(IN)                                :: ikind
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: descriptor
-      REAL(dp), DIMENSION(:), INTENT(OUT)                :: output
-      REAL(dp), INTENT(OUT)                              :: variance
+      REAL(dp), DIMENSION(:)                             :: output
+      REAL(dp)                                           :: variance
 
       SELECT CASE (pao%ml_method)
       CASE (pao_ml_gp)

--- a/src/pao_ml_gaussprocess.F
+++ b/src/pao_ml_gaussprocess.F
@@ -79,8 +79,8 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       INTEGER, INTENT(IN)                                :: ikind
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: descriptor
-      REAL(dp), DIMENSION(:), INTENT(OUT)                :: output
-      REAL(dp), INTENT(OUT)                              :: variance
+      REAL(dp), DIMENSION(:)                             :: output
+      REAL(dp)                                           :: variance
 
       INTEGER                                            :: i, info, npoints
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: cov, weights
@@ -129,7 +129,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: ikind
       REAL(dp), DIMENSION(:), INTENT(IN), TARGET         :: descriptor
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: outer_deriv
-      REAL(dp), DIMENSION(:), INTENT(OUT)                :: gradient
+      REAL(dp), DIMENSION(:)                             :: gradient
 
       INTEGER                                            :: i, info, npoints
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: cov_deriv, weights_deriv

--- a/src/pao_ml_neuralnet.F
+++ b/src/pao_ml_neuralnet.F
@@ -45,8 +45,8 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       INTEGER, INTENT(IN)                                :: ikind
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: descriptor
-      REAL(dp), DIMENSION(:), INTENT(OUT)                :: output
-      REAL(dp), INTENT(OUT)                              :: variance
+      REAL(dp), DIMENSION(:)                             :: output
+      REAL(dp)                                           :: variance
 
       TYPE(training_matrix_type), POINTER                :: training_matrix
 
@@ -70,7 +70,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: ikind
       REAL(dp), DIMENSION(:), INTENT(IN), TARGET         :: descriptor
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: outer_deriv
-      REAL(dp), DIMENSION(:), INTENT(OUT)                :: gradient
+      REAL(dp), DIMENSION(:)                             :: gradient
 
       INTEGER                                            :: i, ilayer, j, nlayers, width, width_in, &
                                                             width_out
@@ -248,7 +248,7 @@ CONTAINS
    SUBROUTINE nn_eval(A, input, prediction)
       REAL(dp), DIMENSION(:, :, :), INTENT(IN)           :: A
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: input
-      REAL(dp), DIMENSION(:), INTENT(OUT)                :: prediction
+      REAL(dp), DIMENSION(:)                             :: prediction
 
       INTEGER                                            :: i, ilayer, j, nlayers, width, width_in, &
                                                             width_out

--- a/src/pao_param.F
+++ b/src/pao_param.F
@@ -63,7 +63,7 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(ls_mstruct_type)                              :: ls_mstruct
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: penalty
+      REAL(dp), OPTIONAL                                 :: penalty
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pao_update_AB'
 
@@ -186,7 +186,7 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ikind
-      INTEGER, INTENT(OUT)                               :: nparams
+      INTEGER                                            :: nparams
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_param_count', &
          routineP = moduleN//':'//routineN
@@ -267,7 +267,7 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_type), OPTIONAL                         :: matrix_M, matrix_G
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: penalty
+      REAL(dp), OPTIONAL                                 :: penalty
       REAL(dp), DIMENSION(:, :), INTENT(INOUT), OPTIONAL :: forces
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pao_calc_U'

--- a/src/pao_param_exp.F
+++ b/src/pao_param_exp.F
@@ -124,7 +124,7 @@ CONTAINS
    SUBROUTINE pao_param_count_exp(qs_env, ikind, nparams)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ikind
-      INTEGER, INTENT(OUT)                               :: nparams
+      INTEGER                                            :: nparams
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_param_count_exp', &
          routineP = moduleN//':'//routineN

--- a/src/pao_param_fock.F
+++ b/src/pao_param_fock.F
@@ -42,8 +42,8 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: iatom
       REAL(dp), DIMENSION(:, :), POINTER                 :: V, U
       REAL(dp), INTENT(INOUT), OPTIONAL                  :: penalty
-      REAL(dp), INTENT(OUT)                              :: gap
-      REAL(dp), DIMENSION(:), INTENT(OUT), OPTIONAL      :: evals
+      REAL(dp)                                           :: gap
+      REAL(dp), DIMENSION(:), OPTIONAL                   :: evals
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: M1, G
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_calc_U_block_fock', &

--- a/src/pao_param_gth.F
+++ b/src/pao_param_gth.F
@@ -365,7 +365,7 @@ CONTAINS
    SUBROUTINE pao_param_count_gth(qs_env, ikind, nparams)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ikind
-      INTEGER, INTENT(OUT)                               :: nparams
+      INTEGER                                            :: nparams
 
       INTEGER                                            :: max_projector, maxl, ncombis
       TYPE(pao_potential_type), DIMENSION(:), POINTER    :: pao_potentials
@@ -404,7 +404,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE gth_calc_term(qs_env, block_V, iatom, jatom, kterm)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: block_V
+      REAL(dp), DIMENSION(:, :)                          :: block_V
       INTEGER, INTENT(IN)                                :: iatom, jatom, kterm
 
       INTEGER                                            :: c, ikind, jkind, lpot, max_l, min_l, &

--- a/src/pao_param_linpot.F
+++ b/src/pao_param_linpot.F
@@ -311,7 +311,7 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ikind
-      INTEGER, INTENT(OUT)                               :: nparams
+      INTEGER                                            :: nparams
 
       INTEGER                                            :: pao_basis_size
       TYPE(gto_basis_set_type), POINTER                  :: basis_set
@@ -496,7 +496,7 @@ CONTAINS
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: iatom
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT)          :: V_blocks
+      REAL(dp), DIMENSION(:, :, :)                       :: V_blocks
 
       SELECT CASE (pao%parameterization)
       CASE (pao_fock_param)

--- a/src/pao_potentials.F
+++ b/src/pao_potentials.F
@@ -46,7 +46,7 @@ CONTAINS
    SUBROUTINE pao_guess_initial_potential(qs_env, iatom, block_V)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: iatom
-      REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: block_V
+      REAL(dp), DIMENSION(:, :)                          :: block_V
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_guess_initial_potential'
 
@@ -98,9 +98,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pao_calc_gaussian(basis_set, block_V, block_D, Rab, lpot, beta, weight, min_shell, max_shell, min_l, max_l)
       TYPE(gto_basis_set_type), POINTER                  :: basis_set
-      REAL(dp), DIMENSION(:, :), INTENT(OUT), OPTIONAL   :: block_V
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT), &
-         OPTIONAL                                        :: block_D
+      REAL(dp), DIMENSION(:, :), OPTIONAL                :: block_V
+      REAL(dp), DIMENSION(:, :, :), OPTIONAL             :: block_D
       REAL(dp), DIMENSION(3)                             :: Rab
       INTEGER, INTENT(IN)                                :: lpot
       REAL(dp), INTENT(IN)                               :: beta, weight
@@ -268,7 +267,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE my_contract(sab, block, basis_set, iset, ishell, jset, jshell)
       REAL(dp), DIMENSION(:, :), INTENT(IN), TARGET      :: sab
-      REAL(dp), DIMENSION(:, :), INTENT(OUT), TARGET     :: block
+      REAL(dp), DIMENSION(:, :), TARGET                  :: block
       TYPE(gto_basis_set_type), POINTER                  :: basis_set
       INTEGER, INTENT(IN)                                :: iset, ishell, jset, jshell
 

--- a/src/paw_proj_set_types.F
+++ b/src/paw_proj_set_types.F
@@ -811,9 +811,9 @@ CONTAINS
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: cprj, cprj_s, csprj
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: first_prj, first_prjs, last_prj
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: local_oce_sphi_h, local_oce_sphi_s
-      INTEGER, INTENT(OUT), OPTIONAL                     :: maxl, ncgauprj, nsgauprj, nsatbas, nsotot
+      INTEGER, OPTIONAL                                  :: maxl, ncgauprj, nsgauprj, nsatbas, nsotot
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: nprj, o2nindex, n2oindex
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: rcprj
+      REAL(dp), OPTIONAL                                 :: rcprj
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: rzetprj
       REAL(dp), DIMENSION(:), OPTIONAL, POINTER          :: zisomin
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: zetprj

--- a/src/pexsi_interface.F
+++ b/src/pexsi_interface.F
@@ -183,16 +183,16 @@ CONTAINS
                                    matrixType, isSymbolicFactorize, ordering, rowOrdering, &
                                    npSymbFact, verbosity)
       TYPE(cp_pexsi_options), INTENT(IN)       :: pexsi_options
-      REAL(KIND=real_8), INTENT(OUT), OPTIONAL :: temperature, gap, deltaE
-      INTEGER, INTENT(OUT), OPTIONAL           :: numPole, isInertiaCount, &
-                                                  maxPEXSIIter
-      REAL(KIND=real_8), INTENT(OUT), OPTIONAL :: muMin0, muMax0, mu0, &
-                                                  muInertiaTolerance, muInertiaExpansion, muPEXSISafeGuard, &
-                                                  numElectronPEXSITolerance
-      INTEGER, INTENT(OUT), OPTIONAL           :: matrixType, &
-                                                  isSymbolicFactorize, &
-                                                  ordering, rowOrdering, npSymbFact, &
-                                                  verbosity
+      REAL(KIND=real_8), OPTIONAL :: temperature, gap, deltaE
+      INTEGER, OPTIONAL           :: numPole, isInertiaCount, &
+                                     maxPEXSIIter
+      REAL(KIND=real_8), OPTIONAL :: muMin0, muMax0, mu0, &
+                                     muInertiaTolerance, muInertiaExpansion, muPEXSISafeGuard, &
+                                     numElectronPEXSITolerance
+      INTEGER, OPTIONAL           :: matrixType, &
+                                     isSymbolicFactorize, &
+                                     ordering, rowOrdering, npSymbFact, &
+                                     verbosity
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_pexsi_get_options', &
                                      routineP = moduleN//':'//routineN
@@ -253,7 +253,7 @@ CONTAINS
 !> \param pexsi_options ...
 ! **************************************************************************************************
    SUBROUTINE cp_pexsi_set_default_options(pexsi_options)
-      TYPE(cp_pexsi_options), INTENT(OUT)      :: pexsi_options
+      TYPE(cp_pexsi_options)      :: pexsi_options
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_pexsi_set_default_options', &
                                      routineP = moduleN//':'//routineN
@@ -261,6 +261,7 @@ CONTAINS
 #ifdef  __LIBPEXSI
       CALL f_ppexsi_set_default_options(pexsi_options%options)
 #else
+      MARK_USED(pexsi_options)
       CPABORT("Requires linking to the PEXSI library.")
 #endif
    END SUBROUTINE cp_pexsi_set_default_options
@@ -375,10 +376,10 @@ CONTAINS
       INTEGER(KIND=int_8), INTENT(IN)          :: plan
       TYPE(cp_pexsi_options), INTENT(IN)       :: pexsi_options
       REAL(KIND=real_8), INTENT(IN)            :: numElectronExact
-      REAL(KIND=real_8), INTENT(out)           :: muPEXSI, numElectronPEXSI, &
-                                                  muMinInertia, muMaxInertia
-      INTEGER, INTENT(out)                     :: numTotalInertiaIter, &
-                                                  numTotalPEXSIIter
+      REAL(KIND=real_8)           :: muPEXSI, numElectronPEXSI, &
+                                     muMinInertia, muMaxInertia
+      INTEGER                     :: numTotalInertiaIter, &
+                                     numTotalPEXSIIter
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_pexsi_dft_driver', &
                                      routineP = moduleN//':'//routineN
@@ -438,8 +439,8 @@ CONTAINS
                                                 FDMnzvalLocal, totalEnergyH, &
                                                 totalEnergyS, totalFreeEnergy)
       INTEGER(KIND=int_8), INTENT(IN)          :: plan
-      REAL(KIND=real_8), INTENT(out) :: DMnzvalLocal(*), EDMnzvalLocal(*), &
-                                        FDMnzvalLocal(*), totalEnergyH, totalEnergyS, totalFreeEnergy
+      REAL(KIND=real_8) :: DMnzvalLocal(*), EDMnzvalLocal(*), &
+                           FDMnzvalLocal(*), totalEnergyH, totalEnergyS, totalFreeEnergy
 
       CHARACTER(LEN=*), PARAMETER :: &
          routineN = 'cp_pexsi_retrieve_real_symmetric_dft_matrix', &

--- a/src/pexsi_methods.F
+++ b/src/pexsi_methods.F
@@ -305,10 +305,10 @@ CONTAINS
       TYPE(lib_pexsi_env), INTENT(INOUT)                 :: pexsi_env
       TYPE(dbcsr_type), INTENT(INOUT)                    :: matrix_p
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: matrix_w
-      REAL(KIND=dp), INTENT(OUT)                         :: kTS
+      REAL(KIND=dp)                                      :: kTS
       TYPE(dbcsr_type), INTENT(IN), TARGET               :: matrix_ks, matrix_s
       INTEGER, INTENT(IN)                                :: nelectron_exact
-      REAL(KIND=dp), INTENT(OUT)                         :: mu
+      REAL(KIND=dp)                                      :: mu
       INTEGER, INTENT(IN)                                :: iscf, ispin
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_pexsi', &
@@ -540,7 +540,7 @@ CONTAINS
       TYPE(lib_pexsi_env), INTENT(INOUT)                 :: pexsi_env
       REAL(KIND=dp), INTENT(IN)                          :: delta_scf, eps_scf
       LOGICAL, INTENT(IN)                                :: initialize
-      LOGICAL, INTENT(OUT)                               :: check_convergence
+      LOGICAL                                            :: check_convergence
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pexsi_set_convergence_tolerance', &
          routineP = moduleN//':'//routineN

--- a/src/pme.F
+++ b/src/pme.F
@@ -97,13 +97,11 @@ CONTAINS
       TYPE(ewald_pw_type), POINTER                       :: ewald_pw
       TYPE(cell_type), POINTER                           :: box
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      REAL(KIND=dp), INTENT(OUT)                         :: vg_coulomb
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT), &
-         OPTIONAL                                        :: fg_coulomb, pv_g
+      REAL(KIND=dp)                                      :: vg_coulomb
+      REAL(KIND=dp), DIMENSION(:, :), OPTIONAL           :: fg_coulomb, pv_g
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: shell_particle_set, core_particle_set
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT), &
-         OPTIONAL                                        :: fgshell_coulomb, fgcore_coulomb
+      REAL(KIND=dp), DIMENSION(:, :), OPTIONAL           :: fgshell_coulomb, fgcore_coulomb
       LOGICAL, INTENT(IN)                                :: use_virial
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: charges
       TYPE(atprop_type), POINTER                         :: atprop

--- a/src/pme_tools.F
+++ b/src/pme_tools.F
@@ -45,7 +45,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: part
       INTEGER, INTENT(IN)                                :: npart
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: center
-      INTEGER, INTENT(OUT)                               :: p1
+      INTEGER                                            :: p1
       TYPE(realspace_grid_type), POINTER                 :: rs
       INTEGER, INTENT(INOUT)                             :: ipart
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: core_center
@@ -128,7 +128,7 @@ CONTAINS
 
       TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: part
       TYPE(cell_type), POINTER                           :: box
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: center
+      INTEGER, DIMENSION(:, :)                           :: center
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts
       INTEGER, INTENT(IN)                                :: n
 

--- a/src/pw/cube_utils.F
+++ b/src/pw/cube_utils.F
@@ -65,7 +65,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE compute_cube_center(cube_center, rs_desc, zeta, zetb, ra, rab)
 
-      INTEGER, DIMENSION(3), INTENT(OUT)                 :: cube_center
+      INTEGER, DIMENSION(3)                              :: cube_center
       TYPE(realspace_grid_desc_type), POINTER            :: rs_desc
       REAL(KIND=dp), INTENT(IN)                          :: zeta, zetb, ra(3), rab(3)
 
@@ -216,7 +216,7 @@ CONTAINS
 !> \param max_radius ...
 ! **************************************************************************************************
    SUBROUTINE init_cube_info(info, dr, dh, dh_inv, ortho, max_radius)
-      TYPE(cube_info_type), INTENT(OUT)                  :: info
+      TYPE(cube_info_type)                               :: info
       REAL(KIND=dp), INTENT(IN)                          :: dr(3), dh(3, 3), dh_inv(3, 3)
       LOGICAL, INTENT(IN)                                :: ortho
       REAL(KIND=dp), INTENT(IN)                          :: max_radius

--- a/src/pw/dct.F
+++ b/src/pw/dct.F
@@ -270,7 +270,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: neumann_directions
       INTEGER, DIMENSION(:), INTENT(INOUT), POINTER      :: dests_expand, srcs_expand, flipg_stat, &
                                                             dests_shrink
-      INTEGER, INTENT(OUT)                               :: srcs_shrink
+      INTEGER                                            :: srcs_shrink
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_dests_srcs_pid', &
          routineP = moduleN//':'//routineN
@@ -832,7 +832,7 @@ CONTAINS
    SUBROUTINE flipud(cr3d_in, cr3d_out, bounds)
 
       REAL(dp), DIMENSION(:, :, :), INTENT(IN), POINTER  :: cr3d_in
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT), POINTER :: cr3d_out
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: cr3d_out
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'flipud', routineP = moduleN//':'//routineN
@@ -886,7 +886,7 @@ CONTAINS
    SUBROUTINE fliplr(cr3d_in, cr3d_out, bounds)
 
       REAL(dp), DIMENSION(:, :, :), INTENT(IN), POINTER  :: cr3d_in
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT), POINTER :: cr3d_out
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: cr3d_out
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fliplr', routineP = moduleN//':'//routineN
@@ -940,7 +940,7 @@ CONTAINS
    SUBROUTINE flipbf(cr3d_in, cr3d_out, bounds)
 
       REAL(dp), DIMENSION(:, :, :), INTENT(IN), POINTER  :: cr3d_in
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT), POINTER :: cr3d_out
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: cr3d_out
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'flipbf', routineP = moduleN//':'//routineN
@@ -994,7 +994,7 @@ CONTAINS
    SUBROUTINE rot180(cr3d_in, cr3d_out, bounds)
 
       REAL(dp), DIMENSION(:, :, :), INTENT(IN), POINTER  :: cr3d_in
-      REAL(dp), DIMENSION(:, :, :), INTENT(OUT), POINTER :: cr3d_out
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: cr3d_out
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rot180', routineP = moduleN//':'//routineN
@@ -1059,10 +1059,10 @@ CONTAINS
       TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
       INTEGER, INTENT(IN)                                :: neumann_directions
       INTEGER, DIMENSION(:), INTENT(IN), POINTER         :: srcs_expand, flipg_stat
-      INTEGER, DIMENSION(2, 3), INTENT(OUT)              :: bounds_shftd, bounds_local_shftd
+      INTEGER, DIMENSION(2, 3)                           :: bounds_shftd, bounds_local_shftd
       INTEGER, DIMENSION(:, :, :), INTENT(INOUT), &
          POINTER                                         :: recv_msgs_bnds
-      INTEGER, DIMENSION(2, 3), INTENT(OUT)              :: bounds_new, bounds_local_new
+      INTEGER, DIMENSION(2, 3)                           :: bounds_new, bounds_local_new
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'expansion_bounds', &
          routineP = moduleN//':'//routineN

--- a/src/pw/dgs.F
+++ b/src/pw/dgs.F
@@ -164,7 +164,7 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts_s
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_radius
       TYPE(pw_grid_type), POINTER                        :: grid_s, grid_b
-      REAL(KIND=dp), INTENT(OUT)                         :: cutoff
+      REAL(KIND=dp)                                      :: cutoff
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dg_find_cutoff', routineP = moduleN//':'//routineN
 
@@ -230,7 +230,7 @@ CONTAINS
 
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_radius
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: dr
+      REAL(KIND=dp), DIMENSION(:)                        :: dr
 
       dr(:) = cutoff_radius/(REAL(npts(:), KIND=dp)/2.0_dp)
 
@@ -263,7 +263,7 @@ CONTAINS
 
       REAL(KIND=dp), INTENT(INOUT)                       :: dr(3)
       REAL(KIND=dp), INTENT(IN)                          :: cell_lengths(3)
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: npts
+      INTEGER, DIMENSION(:)                              :: npts
 
       INTEGER, DIMENSION(3)                              :: nin
 
@@ -287,7 +287,7 @@ CONTAINS
    SUBROUTINE dg_find_basis(npts, cell_hmat, unit_cell_hmat)
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: cell_hmat
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: unit_cell_hmat
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: unit_cell_hmat
 
       INTEGER                                            :: i
 
@@ -308,7 +308,7 @@ CONTAINS
    SUBROUTINE dg_set_cell(npts, unit_cell_hmat, cell_hmat)
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: unit_cell_hmat
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: cell_hmat
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: cell_hmat
 
 ! computing the unit vector along a, b, c and scaling it to length dr:
 
@@ -334,11 +334,11 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: cell_hmat
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts_s, npts_b
-      INTEGER, INTENT(OUT)                               :: centre(3)
+      INTEGER                                            :: centre(3)
       INTEGER, INTENT(IN)                                :: lb(3)
-      COMPLEX(KIND=dp), DIMENSION(lb(1):), INTENT(OUT)   :: ex
-      COMPLEX(KIND=dp), DIMENSION(lb(2):), INTENT(OUT)   :: ey
-      COMPLEX(KIND=dp), DIMENSION(lb(3):), INTENT(OUT)   :: ez
+      COMPLEX(KIND=dp), DIMENSION(lb(1):)                :: ex
+      COMPLEX(KIND=dp), DIMENSION(lb(2):)                :: ey
+      COMPLEX(KIND=dp), DIMENSION(lb(3):)                :: ez
 
       REAL(KIND=dp)                                      :: delta(3)
 
@@ -361,8 +361,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: cell_hmat
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts_s, npts_b
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: centre
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: delta
+      INTEGER, DIMENSION(:)                              :: centre
+      REAL(KIND=dp), DIMENSION(:)                        :: delta
 
       CHARACTER(len=*), PARAMETER :: routineN = 'dg_get_delta', routineP = moduleN//':'//routineN
 
@@ -554,7 +554,7 @@ CONTAINS
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: drpot
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rhos
       INTEGER, DIMENSION(3), INTENT(IN)                  :: center
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: force
+      REAL(KIND=dp), DIMENSION(3)                        :: force
 
       INTEGER                                            :: i, ia, ii
       INTEGER, DIMENSION(3)                              :: lb, nc, ns, ub
@@ -633,7 +633,7 @@ CONTAINS
       TYPE(realspace_grid_type), POINTER                 :: drpot
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rhos
       INTEGER, DIMENSION(3), INTENT(IN)                  :: center
-      REAL(KIND=dp), INTENT(OUT)                         :: force
+      REAL(KIND=dp)                                      :: force
 
       INTEGER                                            :: i, ia, ii
       INTEGER, DIMENSION(3)                              :: lb, nc, ns, ub
@@ -710,7 +710,7 @@ CONTAINS
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: drpot
       TYPE(pw_p_type), INTENT(IN)                        :: rhos
       INTEGER, DIMENSION(3), INTENT(IN)                  :: center
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: force
+      REAL(KIND=dp), DIMENSION(3)                        :: force
 
       INTEGER                                            :: i, ia, ii
       INTEGER, DIMENSION(3)                              :: nc
@@ -784,7 +784,7 @@ CONTAINS
       TYPE(realspace_grid_type), POINTER                 :: drpot
       TYPE(pw_p_type), INTENT(IN)                        :: rhos
       INTEGER, DIMENSION(3), INTENT(IN)                  :: center
-      REAL(KIND=dp), INTENT(OUT)                         :: force
+      REAL(KIND=dp)                                      :: force
 
       INTEGER                                            :: i, ia, ii
       INTEGER, DIMENSION(3)                              :: nc
@@ -1017,7 +1017,7 @@ CONTAINS
    SUBROUTINE dg_int_patch_simple_3d(rbx, rby, rbz, rs, f, ns, nc)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rbx, rby, rbz, rs
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: f
+      REAL(KIND=dp), DIMENSION(3)                        :: f
       INTEGER, INTENT(IN)                                :: ns(3), nc(3)
 
       INTEGER                                            :: i, ii, j, jj, k, kk
@@ -1051,7 +1051,7 @@ CONTAINS
    SUBROUTINE dg_int_patch_simple_1d(rb, rs, f, ns, nc)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rb, rs
-      REAL(KIND=dp), INTENT(OUT)                         :: f
+      REAL(KIND=dp)                                      :: f
       INTEGER, INTENT(IN)                                :: ns(3), nc(3)
 
       INTEGER                                            :: i, ii, j, jj, k, kk

--- a/src/pw/dirichlet_bc_methods.F
+++ b/src/pw/dirichlet_bc_methods.F
@@ -1114,9 +1114,9 @@ CONTAINS
    SUBROUTINE rotate_translate_cuboid(cuboid_vtx, Rmat, Tpnt, cuboid_transfd_vtx)
 
       REAL(dp), DIMENSION(3, 8), INTENT(IN)              :: cuboid_vtx
-      REAL(dp), DIMENSION(3, 3), INTENT(OUT)             :: Rmat
-      REAL(dp), DIMENSION(3), INTENT(OUT)                :: Tpnt
-      REAL(dp), DIMENSION(3, 8), INTENT(OUT)             :: cuboid_transfd_vtx
+      REAL(dp), DIMENSION(3, 3)                          :: Rmat
+      REAL(dp), DIMENSION(3)                             :: Tpnt
+      REAL(dp), DIMENSION(3, 8)                          :: cuboid_transfd_vtx
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rotate_translate_cuboid', &
          routineP = moduleN//':'//routineN
@@ -1214,8 +1214,7 @@ CONTAINS
 
       REAL(dp), DIMENSION(3, 8), INTENT(IN)              :: dbc_vertices
       INTEGER, DIMENSION(3), INTENT(IN)                  :: n_prtn
-      TYPE(tile_p_type), DIMENSION(:), INTENT(OUT), &
-         POINTER                                         :: tiles
+      TYPE(tile_p_type), DIMENSION(:), POINTER           :: tiles
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'aa_dbc_partition', &
          routineP = moduleN//':'//routineN
@@ -1298,8 +1297,7 @@ CONTAINS
 
       REAL(dp), DIMENSION(3, 8), INTENT(IN)              :: dbc_vertices
       INTEGER, DIMENSION(2), INTENT(IN)                  :: n_prtn
-      TYPE(tile_p_type), DIMENSION(:), INTENT(OUT), &
-         POINTER                                         :: tiles
+      TYPE(tile_p_type), DIMENSION(:), POINTER           :: tiles
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'arbitrary_dbc_partition', &
          routineP = moduleN//':'//routineN

--- a/src/pw/fft/fft_lib.F
+++ b/src/pw/fft/fft_lib.F
@@ -173,7 +173,7 @@ CONTAINS
       TYPE(fft_plan_type), INTENT(IN)                    :: plan
       REAL(KIND=dp), INTENT(IN)                          :: scale
       COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT)      :: zin, zout
-      INTEGER, INTENT(OUT)                               :: stat
+      INTEGER                                            :: stat
 
       stat = plan%fsign
       IF (plan%n_3d(1)*plan%n_3d(2)*plan%n_3d(3) > 0) THEN
@@ -262,7 +262,7 @@ CONTAINS
       TYPE(fft_plan_type), INTENT(IN)                    :: plan
       COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT)      :: zin, zout
       REAL(KIND=dp), INTENT(IN)                          :: scale
-      INTEGER, INTENT(OUT)                               :: stat
+      INTEGER                                            :: stat
 
       stat = plan%fsign
       IF (plan%n*plan%m > 0) THEN

--- a/src/pw/fft/fftsg_lib.F
+++ b/src/pw/fft/fftsg_lib.F
@@ -136,7 +136,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: trans
       INTEGER, INTENT(IN)                                :: n, m
       COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT)      :: zin
-      COMPLEX(KIND=dp), DIMENSION(*), INTENT(OUT)        :: zout
+      COMPLEX(KIND=dp), DIMENSION(*)                     :: zout
       REAL(KIND=dp), INTENT(IN)                          :: scale
 
 !------------------------------------------------------------------------------

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -258,7 +258,7 @@ SUBROUTINE sortint ( iarr, n, index )
 
       INTEGER, INTENT(IN)                                :: n
       INTEGER, INTENT(INOUT)                             :: iarr(1:n)
-      INTEGER, INTENT(OUT)                               :: INDEX(1:n)
+      INTEGER                                            :: INDEX(1:n)
 
       INTEGER, PARAMETER                                 :: m = 7, nstack = 50
 
@@ -399,7 +399,7 @@ SUBROUTINE fftw3_create_guru_plan(plan, fft_rank, dim_n, &
   INTEGER, INTENT(IN) :: dim_n(2), dim_istride(2), dim_ostride(2), &
              hm_n(2), hm_istride(2), hm_ostride(2), fft_rank, &
              fft_direction, fftw_plan_type, hm_rank
-  LOGICAL, INTENT(OUT)                               :: valid
+  LOGICAL                               :: valid
 
 #if defined (__FFTW3)
 
@@ -501,7 +501,7 @@ SUBROUTINE fftw3_compute_rows_per_th(nrows,nt,rows_per_thread,rows_per_thread_r,
                                      th_planA, th_planB)
 
       INTEGER, INTENT(IN)                                :: nrows, nt
-      INTEGER, INTENT(OUT)                               :: rows_per_thread, rows_per_thread_r, &
+      INTEGER                                            :: rows_per_thread, rows_per_thread_r, &
                                                             th_planA, th_planB
 
          IF (MOD(nrows,nt) .EQ. 0) THEN
@@ -853,7 +853,7 @@ SUBROUTINE fftw33d ( plan, scale, zin, zout, stat )
   REAL(KIND=dp), INTENT(IN)                            :: scale
   COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT), TARGET:: zin
   COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT), TARGET:: zout
-  INTEGER, INTENT(OUT)                                 :: stat
+  INTEGER                                 :: stat
 #if defined ( __FFTW3 )
   COMPLEX(KIND=dp), POINTER                            :: xout(:)
   COMPLEX(KIND=dp), ALLOCATABLE                        :: tmp1(:)
@@ -1083,7 +1083,7 @@ SUBROUTINE fftw31dm ( plan, zin, zout, scale, stat )
       COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT), &
          TARGET                                          :: zout
       REAL(KIND=dp), INTENT(IN)                          :: scale
-      INTEGER, INTENT(OUT)                               :: stat
+      INTEGER                                            :: stat
 
       COMPLEX(KIND=dp), POINTER                          :: zin_ptr, zout_ptr, zscal_ptr
       INTEGER                                            :: in_offset, my_id, num_rows, out_offset, &

--- a/src/pw/fft/mltfftsg_tools.F
+++ b/src/pw/fft/mltfftsg_tools.F
@@ -3479,10 +3479,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ctrig(n, trig, after, before, now, isign, ic)
       INTEGER, INTENT(IN)                                :: n
-      REAL(dp), DIMENSION(2, ctrig_length), INTENT(OUT)  :: trig
-      INTEGER, DIMENSION(7), INTENT(OUT)                 :: after, before, now
+      REAL(dp), DIMENSION(2, ctrig_length)               :: trig
+      INTEGER, DIMENSION(7)                              :: after, before, now
       INTEGER, INTENT(IN)                                :: isign
-      INTEGER, INTENT(OUT)                               :: ic
+      INTEGER                                            :: ic
 
       INTEGER, PARAMETER                                 :: nt = 82
       INTEGER, DIMENSION(7, nt), PARAMETER :: idata = RESHAPE((/3, 3, 1, 1, 1, 1, 1, 4, 4, 1, 1, 1,&

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -252,7 +252,7 @@ CONTAINS
    SUBROUTINE fft_radix_operations(radix_in, radix_out, operation)
 
       INTEGER, INTENT(IN)                                :: radix_in
-      INTEGER, INTENT(OUT)                               :: radix_out
+      INTEGER                                            :: radix_out
       INTEGER, INTENT(IN)                                :: operation
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fft_radix_operations', &
@@ -348,7 +348,7 @@ CONTAINS
       LOGICAL, INTENT(in)                                :: trans
       COMPLEX(kind=dp), DIMENSION(*), INTENT(inout)      :: zin, zout
       REAL(kind=dp), INTENT(in)                          :: scale
-      INTEGER, INTENT(out)                               :: stat
+      INTEGER                                            :: stat
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fft_fw1d', routineP = moduleN//':'//routineN
 
@@ -392,7 +392,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :, :), &
          INTENT(INOUT), OPTIONAL, TARGET                 :: zout
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
-      INTEGER, INTENT(OUT), OPTIONAL                     :: status
+      INTEGER, OPTIONAL                                  :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fft3d_s', routineP = moduleN//':'//routineN
@@ -522,7 +522,7 @@ CONTAINS
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nyzray
       INTEGER, DIMENSION(:, :, 0:, :), INTENT(IN)        :: bo
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
-      INTEGER, INTENT(OUT), OPTIONAL                     :: status
+      INTEGER, OPTIONAL                                  :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fft3d_ps', routineP = moduleN//':'//routineN
@@ -967,7 +967,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: group
       INTEGER, DIMENSION(:, :, 0:, :), INTENT(IN)        :: bo
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
-      INTEGER, INTENT(OUT), OPTIONAL                     :: status
+      INTEGER, OPTIONAL                                  :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fft3d_pb', routineP = moduleN//':'//routineN
@@ -2008,7 +2008,7 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cube_transpose_1', &
@@ -2096,7 +2096,7 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cube_transpose_2', &
@@ -2182,7 +2182,7 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cube_transpose_3', &
@@ -2283,7 +2283,7 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cube_transpose_4', &
@@ -2382,7 +2382,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
       INTEGER, INTENT(IN)                                :: group
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cube_transpose_5', &
@@ -2476,7 +2476,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
       INTEGER, INTENT(IN)                                :: group
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cube_transpose_6', &

--- a/src/pw/ps_implicit_methods.F
+++ b/src/pw/ps_implicit_methods.F
@@ -191,7 +191,7 @@ CONTAINS
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_type), INTENT(IN), POINTER                 :: density
       TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: ehartree
+      REAL(dp), OPTIONAL                                 :: ehartree
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_periodic', &
          routineP = moduleN//':'//routineN
@@ -325,7 +325,7 @@ CONTAINS
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_type), INTENT(IN), POINTER                 :: density
       TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: ehartree
+      REAL(dp), OPTIONAL                                 :: ehartree
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_neumann', &
          routineP = moduleN//':'//routineN
@@ -494,7 +494,7 @@ CONTAINS
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_type), INTENT(IN), POINTER                 :: density
       TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: electric_enthalpy
+      REAL(dp), OPTIONAL                                 :: electric_enthalpy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_mixed_periodic', &
          routineP = moduleN//':'//routineN
@@ -754,7 +754,7 @@ CONTAINS
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_type), INTENT(IN), POINTER                 :: density
       TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: electric_enthalpy
+      REAL(dp), OPTIONAL                                 :: electric_enthalpy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_mixed', &
          routineP = moduleN//':'//routineN
@@ -1815,7 +1815,7 @@ CONTAINS
    SUBROUTINE compute_ehartree_periodic_bc(density, v, ehartree)
 
       TYPE(pw_type), INTENT(IN), POINTER                 :: density, v
-      REAL(dp), INTENT(OUT)                              :: ehartree
+      REAL(dp)                                           :: ehartree
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_ehartree_periodic_bc', &
          routineP = moduleN//':'//routineN
@@ -1851,7 +1851,7 @@ CONTAINS
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(IN)                                      :: Btxlambda
       TYPE(pw_type), INTENT(IN), POINTER                 :: v
-      REAL(dp), INTENT(OUT)                              :: ehartree, electric_enthalpy
+      REAL(dp)                                           :: ehartree, electric_enthalpy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_ehartree_mixed_bc', &
          routineP = moduleN//':'//routineN
@@ -1906,7 +1906,7 @@ CONTAINS
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
       TYPE(pw_type), INTENT(IN), POINTER                 :: res_new, v_old, v_new
       TYPE(pw_type), INTENT(INOUT), POINTER              :: QAinvxres_new
-      REAL(dp), INTENT(OUT)                              :: pres_error, nabs_error
+      REAL(dp)                                           :: pres_error, nabs_error
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ps_implicit_compute_error_fft', &
          routineP = moduleN//':'//routineN
@@ -1958,7 +1958,7 @@ CONTAINS
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
       TYPE(pw_type), INTENT(IN), POINTER                 :: res_new, v_old, v_new
       TYPE(pw_type), INTENT(INOUT), POINTER              :: QAinvxres_new
-      REAL(dp), INTENT(OUT)                              :: pres_error, nabs_error
+      REAL(dp)                                           :: pres_error, nabs_error
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ps_implicit_compute_error_dct', &
          routineP = moduleN//':'//routineN
@@ -2001,7 +2001,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: iter
       REAL(dp), INTENT(IN)                               :: pres_error, nabs_error
-      INTEGER, INTENT(OUT)                               :: outp_unit
+      INTEGER                                            :: outp_unit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ps_implicit_output', &
          routineP = moduleN//':'//routineN
@@ -2204,7 +2204,7 @@ CONTAINS
 
       REAL(dp), INTENT(IN)                               :: time
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: v_D, osc_frac, frequency, phase
-      REAL(dp), ALLOCATABLE, DIMENSION(:), INTENT(OUT)   :: v_D_new
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: v_D_new
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_voltage', routineP = moduleN//':'//routineN
 

--- a/src/pw/ps_wavelet_base.F
+++ b/src/pw/ps_wavelet_base.F
@@ -2106,7 +2106,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(2, lot, n3/2), INTENT(in) :: zw
       REAL(KIND=dp), DIMENSION(md1, md3), INTENT(inout)  :: zf
       REAL(KIND=dp), INTENT(in)                          :: scal
-      REAL(KIND=dp), INTENT(out)                         :: ehartreetmp
+      REAL(KIND=dp)                                      :: ehartreetmp
 
       INTEGER                                            :: i1, i3
       REAL(KIND=dp)                                      :: pot1

--- a/src/pw/ps_wavelet_fft3d.F
+++ b/src/pw/ps_wavelet_fft3d.F
@@ -31,7 +31,7 @@ CONTAINS
 ! **************************************************************************************************
   SUBROUTINE fourier_dim(n,n_next)
       INTEGER, INTENT(in)                                :: n
-      INTEGER, INTENT(out)                               :: n_next
+      INTEGER                                            :: n_next
 
       INTEGER, PARAMETER                                 :: ndata = 149, ndata1024 = 149
       INTEGER, DIMENSION(ndata), PARAMETER :: idata = (/   3,    4,   5,     6, 8,    9,   12,   15&

--- a/src/pw/ps_wavelet_kernel.F
+++ b/src/pw/ps_wavelet_kernel.F
@@ -224,8 +224,7 @@ SUBROUTINE Surfaces_Kernel(n1,n2,n3,m3,nker1,nker2,nker3,h1,h2,h3,&
       REAL(KIND=dp), INTENT(in)                          :: h1, h2, h3
       INTEGER, INTENT(in)                                :: itype_scf, nproc, iproc
       REAL(KIND=dp), &
-         DIMENSION(nker1, nker2, nker3/nproc), &
-         INTENT(out)                                     :: karray
+         DIMENSION(nker1, nker2, nker3/nproc)            :: karray
       INTEGER, INTENT(in)                                :: mpi_group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'Surfaces_Kernel', &
@@ -557,7 +556,7 @@ SUBROUTINE calculates_green_opt(n,n_scf,itype_scf,intorder,xval,yval,c,mu,hres,g
       REAL(KIND=dp), DIMENSION(0:n_scf), INTENT(in)      :: xval, yval
       REAL(KIND=dp), DIMENSION(intorder+1), INTENT(in)   :: c
       REAL(KIND=dp), INTENT(in)                          :: mu, hres
-      REAL(KIND=dp), DIMENSION(n), INTENT(out)           :: g_mu
+      REAL(KIND=dp), DIMENSION(n)                        :: g_mu
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculates_green_opt', &
          routineP = moduleN//':'//routineN
@@ -700,7 +699,7 @@ SUBROUTINE calculates_green_opt_muzero(n,n_scf,intorder,xval,yval,c,hres,green)
       REAL(KIND=dp), DIMENSION(0:n_scf), INTENT(in)      :: xval, yval
       REAL(KIND=dp), DIMENSION(intorder+1), INTENT(in)   :: c
       REAL(KIND=dp), INTENT(in)                          :: hres
-      REAL(KIND=dp), DIMENSION(n), INTENT(out)           :: green
+      REAL(KIND=dp), DIMENSION(n)                        :: green
 
       INTEGER                                            :: i, iend, ikern, ivalue, izero
       REAL(KIND=dp)                                      :: c0, c1, filter, gl0, gl1, gr0, gr1, x, y
@@ -791,9 +790,9 @@ END SUBROUTINE calculates_green_opt_muzero
 ! **************************************************************************************************
 SUBROUTINE indices(var_realimag,nelem,intrn,extrn,index)
 
-      INTEGER, INTENT(out)                               :: var_realimag
+      INTEGER                                            :: var_realimag
       INTEGER, INTENT(in)                                :: nelem, intrn, extrn
-      INTEGER, INTENT(out)                               :: index
+      INTEGER                                            :: index
 
       INTEGER                                            :: i
 
@@ -846,8 +845,7 @@ SUBROUTINE Free_Kernel(n01,n02,n03,nfft1,nfft2,nfft3,n1k,n2k,n3k,&
                                                             n2k, n3k
       REAL(KIND=dp), INTENT(in)                          :: hgrid
       INTEGER, INTENT(in)                                :: itype_scf, iproc, nproc
-      REAL(KIND=dp), DIMENSION(n1k, n2k, n3k/nproc), &
-         INTENT(out)                                     :: karray
+      REAL(KIND=dp), DIMENSION(n1k, n2k, n3k/nproc)      :: karray
       INTEGER, INTENT(in)                                :: mpi_group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'Free_Kernel', routineP = moduleN//':'//routineN
@@ -1048,8 +1046,7 @@ SUBROUTINE inserthalf(n1,n3,lot,nfft,i1,zf,zw)
       INTEGER, INTENT(in)                                :: n1, n3, lot, nfft, i1
       REAL(KIND=dp), DIMENSION(n1/2+1, n3/2+1), &
          INTENT(in)                                      :: zf
-      REAL(KIND=dp), DIMENSION(2, lot, n3/2), &
-         INTENT(out)                                     :: zw
+      REAL(KIND=dp), DIMENSION(2, lot, n3/2)             :: zw
 
       INTEGER                                            :: i01, i03i, i03r, i3, l1, l3
 

--- a/src/pw/ps_wavelet_scaling_function.F
+++ b/src/pw/ps_wavelet_scaling_function.F
@@ -33,8 +33,8 @@ CONTAINS
 
       !Type of interpolating functions
       INTEGER, INTENT(in)                                :: itype, nd
-      INTEGER, INTENT(out)                               :: nrange
-      REAL(KIND=dp), DIMENSION(0:nd), INTENT(out)        :: a, x
+      INTEGER                                            :: nrange
+      REAL(KIND=dp), DIMENSION(0:nd)                     :: a, x
 
       INTEGER                                            :: i, i_all, m, ni, nt
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: y
@@ -91,7 +91,7 @@ CONTAINS
 
       !Type of the interpolating scaling function
       INTEGER, INTENT(in)                                :: itype, nd
-      REAL(KIND=dp), DIMENSION(0:nd), INTENT(out)        :: a, x
+      REAL(KIND=dp), DIMENSION(0:nd)                     :: a, x
 
       INTEGER                                            :: i, i_all, m, ni, nt
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: y
@@ -148,7 +148,7 @@ CONTAINS
    SUBROUTINE scf_recursion(itype, n_iter, n_range, kernel_scf, kern_1_scf)
       INTEGER, INTENT(in)                                :: itype, n_iter, n_range
       REAL(KIND=dp), INTENT(inout)                       :: kernel_scf(-n_range:n_range)
-      REAL(KIND=dp), INTENT(out)                         :: kern_1_scf(-n_range:n_range)
+      REAL(KIND=dp)                                      :: kern_1_scf(-n_range:n_range)
 
       INTEGER                                            :: m
       REAL(KIND=dp), DIMENSION(:), POINTER               :: cg, cgt, ch, cht
@@ -168,7 +168,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE zero(n, x)
       INTEGER, INTENT(in)                                :: n
-      REAL(KIND=dp), INTENT(out)                         :: x(n)
+      REAL(KIND=dp)                                      :: x(n)
 
       INTEGER                                            :: i
 
@@ -194,7 +194,7 @@ CONTAINS
    SUBROUTINE for_trans(nd, nt, x, y, m, cgt, cht)
       INTEGER, INTENT(in)                                :: nd, nt
       REAL(KIND=dp), INTENT(in)                          :: x(0:nd-1)
-      REAL(KIND=dp), INTENT(out)                         :: y(0:nd-1)
+      REAL(KIND=dp)                                      :: y(0:nd-1)
       INTEGER                                            :: m
       REAL(KIND=dp), DIMENSION(:), POINTER               :: cgt, cht
 
@@ -247,7 +247,7 @@ CONTAINS
       ! x input data, y output data
       INTEGER, INTENT(in)                                :: nd, nt
       REAL(KIND=dp), INTENT(in)                          :: x(0:nd-1)
-      REAL(KIND=dp), INTENT(out)                         :: y(0:nd-1)
+      REAL(KIND=dp)                                      :: y(0:nd-1)
       INTEGER                                            :: m
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ch, cg
 
@@ -351,7 +351,7 @@ CONTAINS
    SUBROUTINE scf_recurs(n_iter, n_range, kernel_scf, kern_1_scf, m, ch)
       INTEGER, INTENT(in)                                :: n_iter, n_range
       REAL(KIND=dp), INTENT(inout)                       :: kernel_scf(-n_range:n_range)
-      REAL(KIND=dp), INTENT(out)                         :: kern_1_scf(-n_range:n_range)
+      REAL(KIND=dp)                                      :: kern_1_scf(-n_range:n_range)
       INTEGER                                            :: m
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ch
 

--- a/src/pw/ps_wavelet_util.F
+++ b/src/pw/ps_wavelet_util.F
@@ -234,7 +234,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE P_FFT_dimensions(n01, n02, n03, m1, m2, m3, n1, n2, n3, md1, md2, md3, nd1, nd2, nd3, nproc)
       INTEGER, INTENT(in)                                :: n01, n02, n03
-      INTEGER, INTENT(out)                               :: m1, m2, m3, n1, n2, n3, md1, md2, md3, &
+      INTEGER                                            :: m1, m2, m3, n1, n2, n3, md1, md2, md3, &
                                                             nd1, nd2, nd3
       INTEGER, INTENT(in)                                :: nproc
 
@@ -330,7 +330,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE S_FFT_dimensions(n01, n02, n03, m1, m2, m3, n1, n2, n3, md1, md2, md3, nd1, nd2, nd3, nproc)
       INTEGER, INTENT(in)                                :: n01, n02, n03
-      INTEGER, INTENT(out)                               :: m1, m2, m3, n1, n2, n3, md1, md2, md3, &
+      INTEGER                                            :: m1, m2, m3, n1, n2, n3, md1, md2, md3, &
                                                             nd1, nd2, nd3
       INTEGER, INTENT(in)                                :: nproc
 
@@ -438,7 +438,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE F_FFT_dimensions(n01, n02, n03, m1, m2, m3, n1, n2, n3, md1, md2, md3, nd1, nd2, nd3, nproc)
       INTEGER, INTENT(in)                                :: n01, n02, n03
-      INTEGER, INTENT(out)                               :: m1, m2, m3, n1, n2, n3, md1, md2, md3, &
+      INTEGER                                            :: m1, m2, m3, n1, n2, n3, md1, md2, md3, &
                                                             nd1, nd2, nd3
       INTEGER, INTENT(in)                                :: nproc
 

--- a/src/pw/pw_grids.F
+++ b/src/pw/pw_grids.F
@@ -214,13 +214,13 @@ CONTAINS
                                ngpts_cut, dr, cutoff, orthorhombic, gvectors, gsquare)
 
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      INTEGER, INTENT(OUT), OPTIONAL                     :: id_nr, mode
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: vol, dvol
-      INTEGER, DIMENSION(3), INTENT(OUT), OPTIONAL       :: npts
-      INTEGER(int_8), INTENT(OUT), OPTIONAL              :: ngpts, ngpts_cut
-      REAL(dp), DIMENSION(3), INTENT(OUT), OPTIONAL      :: dr
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: cutoff
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: orthorhombic
+      INTEGER, OPTIONAL                                  :: id_nr, mode
+      REAL(dp), OPTIONAL                                 :: vol, dvol
+      INTEGER, DIMENSION(3), OPTIONAL                    :: npts
+      INTEGER(int_8), OPTIONAL                           :: ngpts, ngpts_cut
+      REAL(dp), DIMENSION(3), OPTIONAL                   :: dr
+      REAL(dp), OPTIONAL                                 :: cutoff
+      LOGICAL, OPTIONAL                                  :: orthorhombic
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: gvectors
       REAL(dp), DIMENSION(:), OPTIONAL, POINTER          :: gsquare
 
@@ -1268,7 +1268,7 @@ CONTAINS
    SUBROUTINE order_mask(yz_mask, yz_index)
 
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: yz_mask
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: yz_index
+      INTEGER, DIMENSION(:, :)                           :: yz_index
 
       CHARACTER(len=*), PARAMETER :: routineN = 'order_mask', routineP = moduleN//':'//routineN
 
@@ -1354,7 +1354,7 @@ CONTAINS
    SUBROUTINE pw_vec_length(h_inv, length_x, length_y, length_z, length, l, m, n)
 
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: h_inv
-      REAL(KIND=dp), INTENT(OUT)                         :: length_x, length_y, length_z, length
+      REAL(KIND=dp)                                      :: length_x, length_y, length_z, length
       INTEGER, INTENT(IN)                                :: l, m, n
 
       length_x &
@@ -1401,7 +1401,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3)                     :: h_inv
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       REAL(KIND=dp), INTENT(IN)                          :: cutoff
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: yz_mask
+      INTEGER, DIMENSION(:, :)                           :: yz_mask
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_grid_count', routineP = moduleN//':'//routineN
 
@@ -2062,7 +2062,7 @@ CONTAINS
 
       ! Argument
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: yz
+      INTEGER, DIMENSION(:, :)                           :: yz
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_grid_remap', routineP = moduleN//':'//routineN
 

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -244,11 +244,10 @@ CONTAINS
 
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_type), POINTER                             :: density
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: ehartree
+      REAL(kind=dp), OPTIONAL                            :: ehartree
       TYPE(pw_type), OPTIONAL, POINTER                   :: vhartree
       TYPE(pw_p_type), DIMENSION(3), OPTIONAL            :: dvhartree
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
-         OPTIONAL                                        :: h_stress
+      REAL(KIND=dp), DIMENSION(3, 3), OPTIONAL           :: h_stress
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_core
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_poisson_solve', &

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -706,8 +706,7 @@ CONTAINS
    SUBROUTINE spme_coeff_calculate(n, coeff)
 
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), DIMENSION(-(n-1):n-1, 0:n-1), &
-         INTENT(OUT)                                     :: coeff
+      REAL(KIND=dp), DIMENSION(-(n-1):n-1, 0:n-1)        :: coeff
 
       INTEGER                                            :: i, j, l, m
       REAL(KIND=dp)                                      :: b

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -2156,7 +2156,7 @@ CONTAINS
 
       TYPE(realspace_grid_type), POINTER                 :: rs_grid
       INTEGER, INTENT(IN)                                :: dir, disp
-      INTEGER, INTENT(OUT)                               :: source, dest
+      INTEGER                                            :: source, dest
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cart_shift', routineP = moduleN//':'//routineN
 

--- a/src/pw/rs_methods.F
+++ b/src/pw/rs_methods.F
@@ -279,7 +279,7 @@ CONTAINS
    SUBROUTINE setup_grid_axes(pw_grid, x_glbl, y_glbl, z_glbl, x_locl, y_locl, z_locl)
 
       TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
-      REAL(dp), ALLOCATABLE, DIMENSION(:), INTENT(OUT)   :: x_glbl, y_glbl, z_glbl, x_locl, y_locl, &
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: x_glbl, y_glbl, z_glbl, x_locl, y_locl, &
                                                             z_locl
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'setup_grid_axes', &

--- a/src/pw_env_methods.F
+++ b/src/pw_env_methods.F
@@ -748,7 +748,7 @@ CONTAINS
 !> \author Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE compute_max_radius(radius, pw_env, qs_env)
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: radius
+      REAL(KIND=dp), DIMENSION(:)                        :: radius
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
 

--- a/src/pw_env_types.F
+++ b/src/pw_env_types.F
@@ -121,7 +121,7 @@ CONTAINS
          POINTER                                         :: cube_info
       TYPE(gridlevel_info_type), OPTIONAL, POINTER       :: gridlevel_info
       TYPE(pw_pool_type), OPTIONAL, POINTER              :: auxbas_pw_pool
-      INTEGER, INTENT(out), OPTIONAL                     :: auxbas_grid
+      INTEGER, OPTIONAL                                  :: auxbas_grid
       TYPE(realspace_grid_desc_type), OPTIONAL, POINTER  :: auxbas_rs_desc
       TYPE(realspace_grid_type), OPTIONAL, POINTER       :: auxbas_rs_grid
       TYPE(realspace_grid_desc_p_type), DIMENSION(:), &

--- a/src/pwdft_environment_types.F
+++ b/src/pwdft_environment_types.F
@@ -171,7 +171,7 @@ CONTAINS
                             sctx, gs_handler, ks_handler)
 
       TYPE(pwdft_environment_type), POINTER              :: pwdft_env
-      INTEGER, INTENT(OUT), OPTIONAL                     :: id_nr
+      INTEGER, OPTIONAL                                  :: id_nr
       TYPE(section_vals_type), OPTIONAL, POINTER         :: pwdft_input, force_env_input
       INTEGER, DIMENSION(3), OPTIONAL                    :: kgrid, kshift
       TYPE(cp_subsys_type), OPTIONAL, POINTER            :: cp_subsys

--- a/src/qmmm_ff_fist.F
+++ b/src/qmmm_ff_fist.F
@@ -38,7 +38,7 @@ CONTAINS
          INTENT(INOUT)                                   :: id1
       CHARACTER(LEN=default_string_length), &
          INTENT(INOUT), OPTIONAL                         :: id2, id3, id4
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: is_link
+      LOGICAL, OPTIONAL                                  :: is_link
       LOGICAL                                            :: only_qm
 
       CHARACTER(LEN=default_string_length)               :: tmp

--- a/src/qmmm_init.F
+++ b/src/qmmm_init.F
@@ -649,9 +649,9 @@ CONTAINS
          DIMENSION(:), POINTER                           :: qm_atom_type
       INTEGER, DIMENSION(:), POINTER                     :: qm_atom_index, mm_atom_index
       TYPE(cell_type), POINTER                           :: qm_cell_small
-      INTEGER, INTENT(OUT)                               :: qmmm_coupl_type
-      REAL(KIND=dp), INTENT(OUT)                         :: eps_mm_rspace
-      LOGICAL, INTENT(OUT)                               :: qmmm_link
+      INTEGER                                            :: qmmm_coupl_type
+      REAL(KIND=dp)                                      :: eps_mm_rspace
+      LOGICAL                                            :: qmmm_link
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_qmmm_vars_qm', &
@@ -873,8 +873,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: qm_atom_index, mm_link_atoms
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mm_link_scale_factor, &
                                                             fist_scale_charge_link
-      INTEGER, INTENT(OUT)                               :: qmmm_coupl_type
-      LOGICAL, INTENT(OUT)                               :: qmmm_link
+      INTEGER                                            :: qmmm_coupl_type
+      LOGICAL                                            :: qmmm_link
 
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_qmmm_vars_mm', &
          routineP = moduleN//':'//routineN
@@ -1010,7 +1010,7 @@ CONTAINS
          DIMENSION(:), OPTIONAL, POINTER                 :: qm_atom_type
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: mm_link_atoms
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: mm_link_scale_factor
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: qmmm_link
+      LOGICAL, OPTIONAL                                  :: qmmm_link
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: fist_scale_charge_link
 
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_qm_atom_list', &
@@ -1264,7 +1264,7 @@ CONTAINS
                                 mm_atom_chrg, mm_el_pot_radius, mm_el_pot_radius_corr, &
                                 added_charges, mm_atom_index)
       TYPE(section_vals_type), POINTER                   :: qmmm_section
-      LOGICAL, INTENT(OUT)                               :: move_mm_charges, add_mm_charges
+      LOGICAL                                            :: move_mm_charges, add_mm_charges
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mm_atom_chrg, mm_el_pot_radius, &
                                                             mm_el_pot_radius_corr
       TYPE(add_set_type), POINTER                        :: added_charges
@@ -1398,7 +1398,7 @@ CONTAINS
                                                             mm_el_pot_radius_corr
       INTEGER, DIMENSION(:), POINTER                     :: mm_atom_index
       INTEGER, INTENT(in), OPTIONAL                      :: move
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ind1
+      INTEGER, OPTIONAL                                  :: ind1
 
       CHARACTER(len=*), PARAMETER :: routineN = 'set_add_set_type', &
          routineP = moduleN//':'//routineN

--- a/src/qmmm_types.F
+++ b/src/qmmm_types.F
@@ -48,7 +48,7 @@ CONTAINS
    SUBROUTINE qmmm_env_get(qmmm_env, subsys, potential_energy, kinetic_energy)
       TYPE(qmmm_env_type), POINTER                       :: qmmm_env
       TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: potential_energy, kinetic_energy
+      REAL(KIND=dp), OPTIONAL                            :: potential_energy, kinetic_energy
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qmmm_env_get', routineP = moduleN//':'//routineN
 

--- a/src/qmmm_util.F
+++ b/src/qmmm_util.F
@@ -633,7 +633,7 @@ CONTAINS
    SUBROUTINE spherical_cutoff_factor(spherical_cutoff, rij, factor)
       REAL(KIND=dp), DIMENSION(2), INTENT(IN)            :: spherical_cutoff
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rij
-      REAL(KIND=dp), INTENT(OUT)                         :: factor
+      REAL(KIND=dp)                                      :: factor
 
       CHARACTER(len=*), PARAMETER :: routineN = 'spherical_cutoff_factor', &
          routineP = moduleN//':'//routineN

--- a/src/qmmmx_types.F
+++ b/src/qmmmx_types.F
@@ -40,7 +40,7 @@ CONTAINS
    SUBROUTINE qmmmx_env_get(qmmmx_env, subsys, potential_energy, kinetic_energy)
       TYPE(qmmmx_env_type), POINTER                      :: qmmmx_env
       TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: potential_energy, kinetic_energy
+      REAL(KIND=dp), OPTIONAL                            :: potential_energy, kinetic_energy
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qmmmx_env_get', routineP = moduleN//':'//routineN
 

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -267,7 +267,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE csr_idx_from_combined(ij, n, i, j)
       INTEGER, INTENT(IN)                                :: ij, n
-      INTEGER, INTENT(OUT)                               :: i, j
+      INTEGER                                            :: i, j
 
       INTEGER                                            :: m, m0
 

--- a/src/qs_cdft_scf_utils.F
+++ b/src/qs_cdft_scf_utils.F
@@ -373,8 +373,8 @@ CONTAINS
    SUBROUTINE create_tmp_logger(para_env, project_name, suffix, output_unit, tmp_logger)
       TYPE(cp_para_env_type), POINTER                    :: para_env
       CHARACTER(len=*)                                   :: project_name, suffix
-      INTEGER, INTENT(OUT)                               :: output_unit
-      TYPE(cp_logger_type), INTENT(OUT), POINTER         :: tmp_logger
+      INTEGER                                            :: output_unit
+      TYPE(cp_logger_type), POINTER                      :: tmp_logger
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_tmp_logger', &
          routineP = moduleN//':'//routineN

--- a/src/qs_cdft_utils.F
+++ b/src/qs_cdft_utils.F
@@ -851,7 +851,7 @@ CONTAINS
 !> \param divide logical that decides whether to divide or multiply the input potentials
 ! **************************************************************************************************
    SUBROUTINE hfun_scale(fout, fun1, fun2, divide)
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: fout
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: fout
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: fun1, fun2
       LOGICAL, INTENT(IN)                                :: divide
 

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -546,7 +546,7 @@ CONTAINS
       TYPE(pw_p_type), INTENT(INOUT)                     :: lri_rho_g, lri_rho_r
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri_coef
-      REAL(KIND=dp), INTENT(OUT)                         :: total_rho
+      REAL(KIND=dp)                                      :: total_rho
       CHARACTER(len=*), INTENT(IN)                       :: basis_type
       LOGICAL, INTENT(IN)                                :: exact_1c_terms
       TYPE(dbcsr_type), OPTIONAL                         :: pmat
@@ -893,7 +893,7 @@ CONTAINS
    SUBROUTINE calculate_rho_core(rho_core, total_rho, qs_env, only_nopaw)
 
       TYPE(pw_p_type), INTENT(INOUT)                     :: rho_core
-      REAL(KIND=dp), INTENT(OUT)                         :: total_rho
+      REAL(KIND=dp)                                      :: total_rho
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: only_nopaw
 
@@ -1112,7 +1112,7 @@ CONTAINS
 
       TYPE(pw_p_type), INTENT(INOUT)                     :: rho_metal
       REAL(KIND=dp), DIMENSION(:), POINTER               :: coeff
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: total_rho_metal
+      REAL(KIND=dp), OPTIONAL                            :: total_rho_metal
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_rho_metal', &
@@ -1424,7 +1424,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
       TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
-      REAL(KIND=dp), INTENT(OUT)                         :: total_rho
+      REAL(KIND=dp)                                      :: total_rho
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: soft_valid, compute_tau, compute_grad
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: basis_type

--- a/src/qs_condnum.F
+++ b/src/qs_condnum.F
@@ -198,7 +198,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE estimate_norm_invmat(amat, anorm)
       TYPE(dbcsr_type), POINTER                          :: amat
-      REAL(KIND=dp), INTENT(OUT)                         :: anorm
+      REAL(KIND=dp)                                      :: anorm
 
       INTEGER                                            :: i, k, nbas
       INTEGER, DIMENSION(1)                              :: r

--- a/src/qs_core_energies.F
+++ b/src/qs_core_energies.F
@@ -78,7 +78,7 @@ CONTAINS
    SUBROUTINE calculate_ptrace_gamma(hmat, pmat, ecore, nspin)
 
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: hmat, pmat
-      REAL(KIND=dp), INTENT(OUT)                         :: ecore
+      REAL(KIND=dp)                                      :: ecore
       INTEGER, INTENT(IN)                                :: nspin
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_ptrace_gamma', &
@@ -115,7 +115,7 @@ CONTAINS
    SUBROUTINE calculate_ptrace_kp(hmat, pmat, ecore, nspin)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: hmat, pmat
-      REAL(KIND=dp), INTENT(OUT)                         :: ecore
+      REAL(KIND=dp)                                      :: ecore
       INTEGER, INTENT(IN)                                :: nspin
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_ptrace_kp', &
@@ -161,7 +161,7 @@ CONTAINS
    SUBROUTINE calculate_ptrace_1(h, p, ecore)
 
       TYPE(dbcsr_type), POINTER                          :: h, p
-      REAL(KIND=dp), INTENT(OUT)                         :: ecore
+      REAL(KIND=dp)                                      :: ecore
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_ptrace_1', &
          routineP = moduleN//':'//routineN
@@ -199,7 +199,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       LOGICAL, INTENT(IN)                                :: calculate_forces
       LOGICAL, INTENT(IN), OPTIONAL                      :: molecular
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: E_overlap_core
+      REAL(KIND=dp), OPTIONAL                            :: E_overlap_core
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_ecore_overlap', &
          routineP = moduleN//':'//routineN
@@ -343,7 +343,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_ecore_self(qs_env, E_self_core)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: E_self_core
+      REAL(KIND=dp), OPTIONAL                            :: E_self_core
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_ecore_self', &
          routineP = moduleN//':'//routineN

--- a/src/qs_dftb_matrices.F
+++ b/src/qs_dftb_matrices.F
@@ -2389,7 +2389,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: ngrd, ngrdcut
       REAL(dp), INTENT(in)                               :: dgrd
       INTEGER, INTENT(in)                                :: llm
-      REAL(dp), INTENT(out)                              :: skpar(llm)
+      REAL(dp)                                           :: skpar(llm)
 
       INTEGER                                            :: clgp
 
@@ -2435,7 +2435,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: ngrd
       REAL(dp), INTENT(in)                               :: dgrd
       INTEGER, INTENT(in)                                :: llm
-      REAL(dp), INTENT(out)                              :: skpar(llm)
+      REAL(dp)                                           :: skpar(llm)
       INTEGER, INTENT(in)                                :: clgp
 
       INTEGER                                            :: fgpm, k, l, lgpm
@@ -2472,7 +2472,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: ngrd
       REAL(dp), INTENT(in)                               :: dgrd
       INTEGER, INTENT(in)                                :: llm
-      REAL(dp), INTENT(out)                              :: skpar(llm)
+      REAL(dp)                                           :: skpar(llm)
 
       INTEGER                                            :: fgp, k, l, lgp, ntable, nzero
       REAL(dp)                                           :: error, xa(max_extra), ya(max_extra)
@@ -2922,7 +2922,7 @@ CONTAINS
    SUBROUTINE polint(xa, ya, n, x, y, dy)
       INTEGER, INTENT(in)                                :: n
       REAL(dp), INTENT(in)                               :: ya(n), xa(n), x
-      REAL(dp), INTENT(out)                              :: y, dy
+      REAL(dp)                              :: y, dy
 
       CHARACTER(len=*), PARAMETER :: routineN = 'polint', routineP = moduleN//':'//routineN
 

--- a/src/qs_dftb_utils.F
+++ b/src/qs_dftb_utils.F
@@ -109,12 +109,11 @@ CONTAINS
                                   lmax, skself, occupation, eta, energy, cutoff, xi, di, rcdisp, dudq)
 
       TYPE(qs_dftb_atom_type), POINTER                   :: dftb_parameter
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name, typ
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: defined
-      INTEGER, INTENT(OUT), OPTIONAL                     :: z
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: zeff
-      INTEGER, INTENT(OUT), OPTIONAL                     :: natorb, lmax
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name, typ
+      LOGICAL, OPTIONAL                                  :: defined
+      INTEGER, OPTIONAL                                  :: z
+      REAL(KIND=dp), OPTIONAL                            :: zeff
+      INTEGER, OPTIONAL                                  :: natorb, lmax
       REAL(KIND=dp), DIMENSION(0:3), OPTIONAL            :: skself, occupation, eta
       REAL(KIND=dp), OPTIONAL                            :: energy, cutoff, xi, di, rcdisp, dudq
 

--- a/src/qs_diis.F
+++ b/src/qs_diis.F
@@ -229,8 +229,8 @@ CONTAINS
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: kc
       TYPE(cp_fm_type), POINTER                          :: sc
       REAL(KIND=dp), INTENT(IN)                          :: delta
-      REAL(KIND=dp), INTENT(OUT)                         :: error_max
-      LOGICAL, INTENT(OUT)                               :: diis_step
+      REAL(KIND=dp)                                      :: error_max
+      LOGICAL                                            :: diis_step
       REAL(KIND=dp), INTENT(IN)                          :: eps_diis
       INTEGER, INTENT(IN), OPTIONAL                      :: nmixing
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
@@ -560,7 +560,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(ls_scf_env_type)                              :: ls_scf_env
       INTEGER, INTENT(IN)                                :: unit_nr, iscf
-      LOGICAL, INTENT(OUT)                               :: diis_step
+      LOGICAL                                            :: diis_step
       REAL(KIND=dp), INTENT(IN)                          :: eps_diis
       INTEGER, INTENT(IN), OPTIONAL                      :: nmixing
       TYPE(dbcsr_type), OPTIONAL                         :: s_matrix

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -169,7 +169,7 @@ CONTAINS
    SUBROUTINE calculate_dispersion_nonloc(vxc_rho, rho_r, rho_g, edispersion, &
                                           dispersion_env, energy_only, pw_pool, xc_pw_pool, para_env, virial)
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rho, rho_r, rho_g
-      REAL(KIND=dp), INTENT(OUT)                         :: edispersion
+      REAL(KIND=dp)                                      :: edispersion
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
       LOGICAL, INTENT(IN)                                :: energy_only
       TYPE(pw_pool_type), POINTER                        :: pw_pool, xc_pw_pool
@@ -582,7 +582,7 @@ CONTAINS
    SUBROUTINE vdW_energy(thetas_g, dispersion_env, vdW_xc_energy, energy_only, virial)
       TYPE(pw_p_type), ALLOCATABLE, DIMENSION(:)         :: thetas_g
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
-      REAL(KIND=dp), INTENT(OUT)                         :: vdW_xc_energy
+      REAL(KIND=dp)                                      :: vdW_xc_energy
       LOGICAL, INTENT(IN)                                :: energy_only
       TYPE(virial_type), OPTIONAL, POINTER               :: virial
 
@@ -748,7 +748,7 @@ CONTAINS
 
       REAL(dp), DIMENSION(:), INTENT(in)                 :: q0, dq0_drho, dq0_dgradrho, total_rho
       REAL(dp), DIMENSION(:, :), INTENT(in)              :: u_vdW
-      REAL(dp), DIMENSION(:), INTENT(out)                :: potential, h_prefactor
+      REAL(dp), DIMENSION(:)                             :: potential, h_prefactor
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
       REAL(dp), DIMENSION(:, :), INTENT(in), OPTIONAL    :: drho
       REAL(dp), INTENT(IN), OPTIONAL                     :: dvol
@@ -905,7 +905,7 @@ CONTAINS
    SUBROUTINE calculate_exponent(hi, alpha, exponent)
       INTEGER, INTENT(in)                                :: hi
       REAL(dp), INTENT(in)                               :: alpha
-      REAL(dp), INTENT(out)                              :: exponent
+      REAL(dp)                                           :: exponent
 
       INTEGER                                            :: i
       REAL(dp)                                           :: multiplier
@@ -932,7 +932,7 @@ CONTAINS
    SUBROUTINE calculate_exponent_derivative(hi, alpha, exponent, derivative)
       INTEGER, INTENT(in)                                :: hi
       REAL(dp), INTENT(in)                               :: alpha
-      REAL(dp), INTENT(out)                              :: exponent, derivative
+      REAL(dp)                                           :: exponent, derivative
 
       INTEGER                                            :: i
       REAL(dp)                                           :: multiplier
@@ -969,7 +969,7 @@ CONTAINS
       !!     dq0_dgradrho = total_rho / |gradient_rho| * d q0 / d |gradient_rho|
       !!
       REAL(dp), INTENT(IN)                               :: total_rho(:), gradient_rho(:, :)
-      REAL(dp), INTENT(OUT)                              :: q0(:), dq0_drho(:), dq0_dgradrho(:)
+      REAL(dp)                                           :: q0(:), dq0_drho(:), dq0_dgradrho(:)
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_q0_on_grid_vdw', &
@@ -1081,7 +1081,7 @@ CONTAINS
       !!     dq0_dgradrho = total_rho / |gradient_rho| * d q0 / d |gradient_rho|
       !!
       REAL(dp), INTENT(IN)                               :: total_rho(:), gradient_rho(:, :)
-      REAL(dp), INTENT(OUT)                              :: q0(:), dq0_drho(:), dq0_dgradrho(:)
+      REAL(dp)                                           :: q0(:), dq0_drho(:), dq0_dgradrho(:)
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
 
       INTEGER, PARAMETER                                 :: m_cut = 12
@@ -1154,7 +1154,7 @@ CONTAINS
    SUBROUTINE get_q0_on_grid_eo_vdw(total_rho, gradient_rho, q0, dispersion_env)
 
       REAL(dp), INTENT(IN)                               :: total_rho(:), gradient_rho(:, :)
-      REAL(dp), INTENT(OUT)                              :: q0(:)
+      REAL(dp)                                           :: q0(:)
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_q0_on_grid_eo_vdw', &
@@ -1235,7 +1235,7 @@ CONTAINS
    SUBROUTINE get_q0_on_grid_eo_rvv10(total_rho, gradient_rho, q0, dispersion_env)
 
       REAL(dp), INTENT(IN)                               :: total_rho(:), gradient_rho(:, :)
-      REAL(dp), INTENT(OUT)                              :: q0(:)
+      REAL(dp)                                           :: q0(:)
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
 
       INTEGER, PARAMETER                                 :: m_cut = 12
@@ -1299,7 +1299,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE spline_interpolation(x, d2y_dx2, evaluation_points, values)
       REAL(dp), INTENT(in)                               :: x(:), d2y_dx2(:, :), evaluation_points(:)
-      REAL(dp), INTENT(out)                              :: values(:, :)
+      REAL(dp)                                           :: values(:, :)
 
       INTEGER                                            :: i_grid, index, lower_bound, &
                                                             Ngrid_points, Nx, P_i, upper_bound
@@ -1427,7 +1427,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE interpolate_kernel(k, kernel_of_k, dispersion_env)
       REAL(dp), INTENT(in)                               :: k
-      REAL(dp), INTENT(out)                              :: kernel_of_k(:, :)
+      REAL(dp)                                           :: kernel_of_k(:, :)
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'interpolate_kernel', &
@@ -1496,7 +1496,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE interpolate_dkernel_dk(k, dkernel_of_dk, dispersion_env)
       REAL(dp), INTENT(in)                               :: k
-      REAL(dp), INTENT(out)                              :: dkernel_of_dk(:, :)
+      REAL(dp)                                           :: dkernel_of_dk(:, :)
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'interpolate_dkernel_dk', &

--- a/src/qs_dispersion_pairpot.F
+++ b/src/qs_dispersion_pairpot.F
@@ -851,7 +851,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
+      REAL(KIND=dp)                                      :: energy
       LOGICAL, INTENT(IN)                                :: calculate_forces
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_dispersion_pairpot', &
@@ -2872,7 +2872,7 @@ CONTAINS
    SUBROUTINE cnparam_d3(rab, rcova, rcovb, k1, cnab, dcnab)
 
       REAL(KIND=dp), INTENT(IN)                          :: rab, rcova, rcovb, k1
-      REAL(KIND=dp), INTENT(OUT)                         :: cnab, dcnab
+      REAL(KIND=dp)                                      :: cnab, dcnab
 
       REAL(KIND=dp)                                      :: dfz, ee, fz, rco, rr
 
@@ -2905,7 +2905,7 @@ CONTAINS
    SUBROUTINE damping_d3(rab, rcutab, srn, alpn, rcut, fdab, dfdab)
 
       REAL(KIND=dp), INTENT(IN)                          :: rab, rcutab, srn, alpn, rcut
-      REAL(KIND=dp), INTENT(OUT)                         :: fdab, dfdab
+      REAL(KIND=dp)                                      :: fdab, dfdab
 
       REAL(KIND=dp)                                      :: a, b, c, d, dd, dfab, dfcc, dz, fab, &
                                                             fcc, rl, rr, ru, z, zz
@@ -2960,7 +2960,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN) :: c6ab(max_elem, max_elem, maxc, maxc, 3)
       INTEGER, INTENT(IN)                                :: mxc(max_elem), iat, jat
       REAL(KIND=dp), INTENT(IN)                          :: nci, ncj, k3
-      REAL(KIND=dp), INTENT(OUT)                         :: c6, dc6a, dc6b
+      REAL(KIND=dp)                                      :: c6, dc6a, dc6b
 
       INTEGER                                            :: i, j
       REAL(KIND=dp)                                      :: c6mem, cn1, cn2, csum, dtmpa, dtmpb, &

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -567,7 +567,7 @@ CONTAINS
       TYPE(qs_ks_qmmm_env_type), OPTIONAL, POINTER       :: ks_qmmm_env
       TYPE(qs_wf_history_type), OPTIONAL, POINTER        :: wf_history
       TYPE(qs_scf_env_type), OPTIONAL, POINTER           :: scf_env
-      INTEGER, INTENT(out), OPTIONAL                     :: id_nr
+      INTEGER, OPTIONAL                                  :: id_nr
       TYPE(distribution_1d_type), OPTIONAL, POINTER      :: local_particles, local_molecules
       TYPE(distribution_2d_type), OPTIONAL, POINTER      :: distribution_2d
       TYPE(dbcsr_distribution_type), OPTIONAL, POINTER   :: dbcsr_dist
@@ -605,7 +605,7 @@ CONTAINS
       TYPE(cp_ddapc_type), OPTIONAL, POINTER             :: cp_ddapc_env
       TYPE(cp_ddapc_ewald_type), OPTIONAL, POINTER       :: cp_ddapc_ewald
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: outer_scf_history
-      INTEGER, INTENT(out), OPTIONAL                     :: outer_scf_ihistory
+      INTEGER, OPTIONAL                                  :: outer_scf_ihistory
       TYPE(hfx_type), DIMENSION(:, :), OPTIONAL, POINTER :: x_data
       TYPE(et_coupling_type), OPTIONAL, POINTER          :: et_coupling
       TYPE(qs_dftb_pairpot_type), DIMENSION(:, :), &

--- a/src/qs_external_potential.F
+++ b/src/qs_external_potential.F
@@ -224,7 +224,7 @@ CONTAINS
    SUBROUTINE get_external_potential(r, ext_pot_section, func, dfunc, calc_derivatives)
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
       TYPE(section_vals_type), POINTER                   :: ext_pot_section
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: func, dfunc(3)
+      REAL(KIND=dp), OPTIONAL                            :: func, dfunc(3)
       LOGICAL, INTENT(IN), OPTIONAL                      :: calc_derivatives
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_external_potential', &
@@ -291,7 +291,7 @@ CONTAINS
    SUBROUTINE interpolate_external_potential(r, grid, func, dfunc, calc_derivatives)
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
       TYPE(pw_type), POINTER                             :: grid
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: func, dfunc(3)
+      REAL(KIND=dp), OPTIONAL                            :: func, dfunc(3)
       LOGICAL, INTENT(IN), OPTIONAL                      :: calc_derivatives
 
       CHARACTER(len=*), PARAMETER :: routineN = 'interpolate_external_potential', &
@@ -414,8 +414,7 @@ CONTAINS
    SUBROUTINE d_finite_difference(grid, dr, dgrid)
       REAL(KIND=dp), DIMENSION(0:, 0:, 0:), INTENT(IN)   :: grid
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: dr
-      REAL(KIND=dp), DIMENSION(1:, 1:, 1:, :), &
-         INTENT(OUT)                                     :: dgrid
+      REAL(KIND=dp), DIMENSION(1:, 1:, 1:, :)            :: dgrid
 
       INTEGER                                            :: i, j, k
 

--- a/src/qs_fb_atomic_halo_types.F
+++ b/src/qs_fb_atomic_halo_types.F
@@ -205,7 +205,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_atomic_halo_associate(a, b)
-      TYPE(fb_atomic_halo_obj), INTENT(OUT)              :: a
+      TYPE(fb_atomic_halo_obj)                           :: a
       TYPE(fb_atomic_halo_obj), INTENT(IN)               :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_atomic_halo_associate', &
@@ -307,11 +307,11 @@ CONTAINS
                                  sorted, &
                                  cost)
       TYPE(fb_atomic_halo_obj), INTENT(IN)               :: atomic_halo
-      INTEGER, INTENT(OUT), OPTIONAL                     :: owner_atom, owner_id_in_halo, natoms, &
+      INTEGER, OPTIONAL                                  :: owner_atom, owner_id_in_halo, natoms, &
                                                             nelectrons
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: halo_atoms
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: sorted
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: cost
+      LOGICAL, OPTIONAL                                  :: sorted
+      REAL(KIND=dp), OPTIONAL                            :: cost
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_atomic_halo_get', &
          routineP = moduleN//':'//routineN
@@ -416,8 +416,8 @@ CONTAINS
                                               found)
       TYPE(fb_atomic_halo_obj), INTENT(IN)               :: atomic_halo
       INTEGER, INTENT(IN)                                :: iatom_global
-      INTEGER, INTENT(OUT)                               :: iatom_halo
-      LOGICAL, INTENT(OUT)                               :: found
+      INTEGER                                            :: iatom_halo
+      LOGICAL                                            :: found
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_atomic_halo_atom_global2halo', &
          routineP = moduleN//':'//routineN
@@ -540,7 +540,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: pair_radii
       INTEGER, DIMENSION(:), POINTER                     :: halo_atoms
-      INTEGER, INTENT(OUT)                               :: nhalo_atoms, owner_id_in_halo
+      INTEGER                                            :: nhalo_atoms, owner_id_in_halo
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_atomic_halo_build_halo_atoms', &
          routineP = moduleN//':'//routineN
@@ -679,7 +679,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_atomic_halo_list_associate(a, b)
-      TYPE(fb_atomic_halo_list_obj), INTENT(OUT)         :: a
+      TYPE(fb_atomic_halo_list_obj)                      :: a
       TYPE(fb_atomic_halo_list_obj), INTENT(IN)          :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_atomic_halo_list_associate', &
@@ -749,7 +749,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fb_atomic_halo_list_get(atomic_halos, nhalos, max_nhalos, halos)
       TYPE(fb_atomic_halo_list_obj), INTENT(IN)          :: atomic_halos
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nhalos, max_nhalos
+      INTEGER, OPTIONAL                                  :: nhalos, max_nhalos
       TYPE(fb_atomic_halo_obj), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: halos
 

--- a/src/qs_fb_atomic_matrix_methods.F
+++ b/src/qs_fb_atomic_matrix_methods.F
@@ -69,8 +69,8 @@ CONTAINS
                                     blk_col_start)
       TYPE(dbcsr_type), POINTER                          :: dbcsr_mat
       TYPE(fb_atomic_halo_obj), INTENT(IN)               :: atomic_halo
-      INTEGER, INTENT(OUT)                               :: nrows, ncols
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: blk_row_start, blk_col_start
+      INTEGER                                            :: nrows, ncols
+      INTEGER, DIMENSION(:)                              :: blk_row_start, blk_col_start
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_atmatrix_calc_size', &
          routineP = moduleN//':'//routineN
@@ -133,7 +133,7 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: dbcsr_mat
       TYPE(fb_atomic_halo_obj), INTENT(IN)               :: atomic_halo
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: atomic_matrix
+      REAL(KIND=dp), DIMENSION(:, :)                     :: atomic_matrix
       INTEGER, DIMENSION(:), INTENT(IN)                  :: blk_row_start, blk_col_start
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_atmatrix_construct', &
@@ -344,7 +344,7 @@ CONTAINS
                                       blk_col_start)
       TYPE(fb_matrix_data_obj), INTENT(IN)               :: matrix_storage
       TYPE(fb_atomic_halo_obj), INTENT(IN)               :: atomic_halo
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: atomic_matrix
+      REAL(KIND=dp), DIMENSION(:, :)                     :: atomic_matrix
       INTEGER, DIMENSION(:), INTENT(IN)                  :: blk_row_start, blk_col_start
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_atmatrix_construct_2', &

--- a/src/qs_fb_buffer_types.F
+++ b/src/qs_fb_buffer_types.F
@@ -211,7 +211,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_buffer_i_associate(a, b)
-      TYPE(fb_buffer_i_obj), INTENT(OUT)                 :: a
+      TYPE(fb_buffer_i_obj)                              :: a
       TYPE(fb_buffer_i_obj), INTENT(IN)                  :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_buffer_i_associate', &
@@ -379,7 +379,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fb_buffer_i_calc_sizes(buffer, sizes)
       TYPE(fb_buffer_i_obj), INTENT(IN)                  :: buffer
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: sizes
+      INTEGER, DIMENSION(:)                              :: sizes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_buffer_i_calc_sizes', &
          routineP = moduleN//':'//routineN
@@ -421,8 +421,8 @@ CONTAINS
                               data_2d_ld)
       TYPE(fb_buffer_i_obj), INTENT(IN)                  :: buffer
       INTEGER, INTENT(IN), OPTIONAL                      :: i_slice
-      INTEGER, INTENT(OUT), OPTIONAL                     :: n, data_size
-      INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL       :: sizes, disps
+      INTEGER, OPTIONAL                                  :: n, data_size
+      INTEGER, DIMENSION(:), OPTIONAL                    :: sizes, disps
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: data_1d
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: data_2d
       INTEGER, INTENT(IN), OPTIONAL                      :: data_2d_ld
@@ -559,7 +559,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_buffer_d_associate(a, b)
-      TYPE(fb_buffer_d_obj), INTENT(OUT)                 :: a
+      TYPE(fb_buffer_d_obj)                              :: a
       TYPE(fb_buffer_d_obj), INTENT(IN)                  :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_buffer_d_associate', &
@@ -729,7 +729,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fb_buffer_d_calc_sizes(buffer, sizes)
       TYPE(fb_buffer_d_obj), INTENT(IN)                  :: buffer
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: sizes
+      INTEGER, DIMENSION(:)                              :: sizes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_buffer_d_calc_sizes', &
          routineP = moduleN//':'//routineN
@@ -771,8 +771,8 @@ CONTAINS
                               data_2d_ld)
       TYPE(fb_buffer_d_obj), INTENT(IN)                  :: buffer
       INTEGER, INTENT(IN), OPTIONAL                      :: i_slice
-      INTEGER, INTENT(OUT), OPTIONAL                     :: n, data_size
-      INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL       :: sizes, disps
+      INTEGER, OPTIONAL                                  :: n, data_size
+      INTEGER, DIMENSION(:), OPTIONAL                    :: sizes, disps
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: data_1d
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: data_2d
       INTEGER, INTENT(IN), OPTIONAL                      :: data_2d_ld

--- a/src/qs_fb_com_tasks_types.F
+++ b/src/qs_fb_com_tasks_types.F
@@ -281,7 +281,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_com_tasks_associate(a, b)
-      TYPE(fb_com_tasks_obj), INTENT(OUT)                :: a
+      TYPE(fb_com_tasks_obj)                             :: a
       TYPE(fb_com_tasks_obj), INTENT(IN)                 :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_com_tasks_associate', &
@@ -297,7 +297,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_com_atom_pairs_associate(a, b)
-      TYPE(fb_com_atom_pairs_obj), INTENT(OUT)           :: a
+      TYPE(fb_com_atom_pairs_obj)                        :: a
       TYPE(fb_com_atom_pairs_obj), INTENT(IN)            :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_com_atom_pairs_associate', &
@@ -444,7 +444,7 @@ CONTAINS
                                nencode, &
                                tasks)
       TYPE(fb_com_tasks_obj), INTENT(IN)                 :: com_tasks
-      INTEGER, INTENT(OUT), OPTIONAL                     :: task_dim, ntasks, nencode
+      INTEGER, OPTIONAL                                  :: task_dim, ntasks, nencode
       INTEGER(KIND=int_8), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: tasks
 
@@ -474,7 +474,7 @@ CONTAINS
                                     natoms_encode, &
                                     pairs)
       TYPE(fb_com_atom_pairs_obj), INTENT(IN)            :: atom_pairs
-      INTEGER, INTENT(OUT), OPTIONAL                     :: npairs, natoms_encode
+      INTEGER, OPTIONAL                                  :: npairs, natoms_encode
       INTEGER(KIND=int_8), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: pairs
 
@@ -840,7 +840,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_com_tasks_encode_pair(ind, iatom, jatom, natoms)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: ind
+      INTEGER(KIND=int_8)                                :: ind
       INTEGER, INTENT(IN)                                :: iatom, jatom, natoms
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_com_tasks_encode_pair', &
@@ -866,7 +866,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fb_com_tasks_decode_pair(ind, iatom, jatom, natoms)
       INTEGER(KIND=int_8), INTENT(IN)                    :: ind
-      INTEGER, INTENT(OUT)                               :: iatom, jatom
+      INTEGER                                            :: iatom, jatom
       INTEGER, INTENT(IN)                                :: natoms
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_com_tasks_decode_pair', &
@@ -893,7 +893,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_com_atom_pairs_encode(ind, pe, iatom, jatom, natoms)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: ind
+      INTEGER(KIND=int_8)                                :: ind
       INTEGER, INTENT(IN)                                :: pe, iatom, jatom, natoms
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_com_atom_pairs_encode', &
@@ -922,7 +922,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fb_com_atom_pairs_decode(ind, pe, iatom, jatom, natoms)
       INTEGER(KIND=int_8), INTENT(IN)                    :: ind
-      INTEGER, INTENT(OUT)                               :: pe, iatom, jatom
+      INTEGER                                            :: pe, iatom, jatom
       INTEGER, INTENT(IN)                                :: natoms
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_com_atom_pairs_decode', &
@@ -981,7 +981,7 @@ CONTAINS
       TYPE(fb_com_atom_pairs_obj), INTENT(IN)            :: atom_pairs
       INTEGER, INTENT(IN)                                :: nprocs
       INTEGER, DIMENSION(:), INTENT(IN)                  :: row_blk_sizes, col_blk_sizes
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: sendrecv_sizes, sendrecv_disps, &
+      INTEGER, DIMENSION(:)                              :: sendrecv_sizes, sendrecv_disps, &
                                                             sendrecv_pair_counts, &
                                                             sendrecv_pair_disps
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: row_map, col_map

--- a/src/qs_fb_distribution_methods.F
+++ b/src/qs_fb_distribution_methods.F
@@ -453,8 +453,8 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: natoms
       TYPE(fb_preferred_procs_list), DIMENSION(:), &
          INTENT(INOUT)                                   :: preferred_procs_set
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: common_set_ids
-      INTEGER, INTENT(OUT)                               :: n_common_sets
+      INTEGER, DIMENSION(:)                              :: common_set_ids
+      INTEGER                                            :: n_common_sets
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_build_preferred_procs', &
          routineP = moduleN//':'//routineN
@@ -527,7 +527,7 @@ CONTAINS
                                              local_atoms_sizes)
       TYPE(fb_distribution_list), DIMENSION(:), &
          INTENT(IN)                                      :: dist_set
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: local_atoms, local_atoms_starts, &
+      INTEGER, DIMENSION(:)                              :: local_atoms, local_atoms_starts, &
                                                             local_atoms_sizes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_distribution_to_local_atoms', &

--- a/src/qs_fb_env_methods.F
+++ b/src/qs_fb_env_methods.F
@@ -616,7 +616,7 @@ CONTAINS
       TYPE(mo_set_type), POINTER                         :: mo_set
       TYPE(cp_fm_type), POINTER                          :: fm_ortho, fm_work
       REAL(KIND=dp), INTENT(IN)                          :: eps_eigval
-      INTEGER, INTENT(OUT)                               :: ndep
+      INTEGER                                            :: ndep
       INTEGER, INTENT(IN)                                :: method
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_env_eigensolver', &

--- a/src/qs_fb_env_types.F
+++ b/src/qs_fb_env_types.F
@@ -162,7 +162,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_env_associate(a, b)
-      TYPE(fb_env_obj), INTENT(OUT)                      :: a
+      TYPE(fb_env_obj)                                   :: a
       TYPE(fb_env_obj), INTENT(IN)                       :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_env_associate', &
@@ -275,14 +275,13 @@ CONTAINS
                          nlocal_atoms)
       TYPE(fb_env_obj), INTENT(IN)                       :: fb_env
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: rcut
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: filter_temperature, auto_cutoff_scale, &
+      REAL(KIND=dp), OPTIONAL                            :: filter_temperature, auto_cutoff_scale, &
                                                             eps_default
-      TYPE(fb_atomic_halo_list_obj), INTENT(OUT), &
-         OPTIONAL                                        :: atomic_halos
-      TYPE(fb_trial_fns_obj), INTENT(OUT), OPTIONAL      :: trial_fns
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: collective_com
+      TYPE(fb_atomic_halo_list_obj), OPTIONAL            :: atomic_halos
+      TYPE(fb_trial_fns_obj), OPTIONAL                   :: trial_fns
+      LOGICAL, OPTIONAL                                  :: collective_com
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: local_atoms
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nlocal_atoms
+      INTEGER, OPTIONAL                                  :: nlocal_atoms
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_env_get', routineP = moduleN//':'//routineN
 

--- a/src/qs_fb_filter_matrix_methods.F
+++ b/src/qs_fb_filter_matrix_methods.F
@@ -1264,7 +1264,7 @@ CONTAINS
                                               tolerance)
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: atomic_H, atomic_S
       REAL(KIND=dp), INTENT(IN)                          :: fermi_level, filter_temp
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: atomic_filter_mat
+      REAL(KIND=dp), DIMENSION(:, :)                     :: atomic_filter_mat
       REAL(KIND=dp), INTENT(IN)                          :: tolerance
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_fltrmat_build_atomic_fltrmat', &
@@ -1415,7 +1415,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_fltrmat_fermi_dirac_mu(f, eigenvals, T, mu)
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: f
+      REAL(KIND=dp), DIMENSION(:)                        :: f
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: eigenvals
       REAL(KIND=dp), INTENT(IN)                          :: T, mu
 
@@ -1440,7 +1440,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_fltrmat_fermi_dirac_ne(f, eigenvals, T, ne, maxocc)
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: f
+      REAL(KIND=dp), DIMENSION(:)                        :: f
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: eigenvals
       REAL(KIND=dp), INTENT(IN)                          :: T, ne, maxocc
 

--- a/src/qs_fb_hash_table_types.F
+++ b/src/qs_fb_hash_table_types.F
@@ -181,8 +181,8 @@ CONTAINS
    SUBROUTINE fb_hash_table_get(hash_table, key, val, found)
       TYPE(fb_hash_table_obj), INTENT(IN)                :: hash_table
       INTEGER(KIND=int_8), INTENT(IN)                    :: key
-      INTEGER, INTENT(OUT)                               :: val
-      LOGICAL, INTENT(OUT)                               :: found
+      INTEGER                                            :: val
+      LOGICAL                                            :: found
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_hash_table_get', &
          routineP = moduleN//':'//routineN
@@ -413,7 +413,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fb_hash_table_status(hash_table, nelements, nmax, prime)
       TYPE(fb_hash_table_obj), INTENT(INOUT)             :: hash_table
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nelements, nmax, prime
+      INTEGER, OPTIONAL                                  :: nelements, nmax, prime
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_hash_table_status', &
          routineP = moduleN//':'//routineN

--- a/src/qs_fb_matrix_data_types.F
+++ b/src/qs_fb_matrix_data_types.F
@@ -140,7 +140,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_matrix_data_associate(a, b)
-      TYPE(fb_matrix_data_obj), INTENT(OUT)              :: a
+      TYPE(fb_matrix_data_obj)                           :: a
       TYPE(fb_matrix_data_obj), INTENT(IN)               :: b
 
       a%obj => b%obj
@@ -195,7 +195,7 @@ CONTAINS
       TYPE(fb_matrix_data_obj), INTENT(IN)               :: matrix_data
       INTEGER, INTENT(IN)                                :: row, col
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: blk_p
-      LOGICAL, INTENT(OUT)                               :: found
+      LOGICAL                                            :: found
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_matrix_data_get', &
          routineP = moduleN//':'//routineN
@@ -351,8 +351,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fb_matrix_data_status(matrix_data, nmax, nblks, nencode, blk_sizes)
       TYPE(fb_matrix_data_obj), INTENT(INOUT)            :: matrix_data
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nmax, nblks, nencode
-      INTEGER, DIMENSION(:, :), INTENT(OUT), OPTIONAL    :: blk_sizes
+      INTEGER, OPTIONAL                                  :: nmax, nblks, nencode
+      INTEGER, DIMENSION(:, :), OPTIONAL                 :: blk_sizes
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_matrix_data_status', &
          routineP = moduleN//':'//routineN

--- a/src/qs_fb_trial_fns_types.F
+++ b/src/qs_fb_trial_fns_types.F
@@ -129,7 +129,7 @@ CONTAINS
 !> \author Lianheng Tong (LT) lianheng.tong@kcl.ac.uk
 ! **************************************************************************************************
    SUBROUTINE fb_trial_fns_associate(a, b)
-      TYPE(fb_trial_fns_obj), INTENT(OUT)                :: a
+      TYPE(fb_trial_fns_obj)                             :: a
       TYPE(fb_trial_fns_obj), INTENT(IN)                 :: b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fb_trial_fns_associate', &

--- a/src/qs_harmonics_atom.F
+++ b/src/qs_harmonics_atom.F
@@ -492,9 +492,9 @@ CONTAINS
       REAL(dp), DIMENSION(:, :, :, :), INTENT(IN)        :: cgc
       INTEGER, INTENT(IN)                                :: lmin1, lmax1, lmin2, lmax2, max_s_harm, &
                                                             llmax
-      INTEGER, DIMENSION(:, :, :), INTENT(OUT), OPTIONAL :: list
-      INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL       :: n_list
-      INTEGER, INTENT(OUT)                               :: max_iso_not0
+      INTEGER, DIMENSION(:, :, :), OPTIONAL              :: list
+      INTEGER, DIMENSION(:), OPTIONAL                    :: n_list
+      INTEGER                                            :: max_iso_not0
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_none0_cg_list4', &
          routineP = moduleN//':'//routineN
@@ -553,9 +553,9 @@ CONTAINS
       REAL(dp), DIMENSION(:, :, :), INTENT(IN)           :: cgc
       INTEGER, INTENT(IN)                                :: lmin1, lmax1, lmin2, lmax2, max_s_harm, &
                                                             llmax
-      INTEGER, DIMENSION(:, :, :), INTENT(OUT), OPTIONAL :: list
-      INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL       :: n_list
-      INTEGER, INTENT(OUT)                               :: max_iso_not0
+      INTEGER, DIMENSION(:, :, :), OPTIONAL              :: list
+      INTEGER, DIMENSION(:), OPTIONAL                    :: n_list
+      INTEGER                                            :: max_iso_not0
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_none0_cg_list3', &
          routineP = moduleN//':'//routineN

--- a/src/qs_kind_types.F
+++ b/src/qs_kind_types.F
@@ -423,7 +423,7 @@ CONTAINS
       TYPE(qs_kind_type)                                 :: qs_kind
       TYPE(gto_basis_set_type), OPTIONAL, POINTER        :: basis_set
       CHARACTER(len=*), OPTIONAL                         :: basis_type
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ncgf, nsgf
+      INTEGER, OPTIONAL                                  :: ncgf, nsgf
       TYPE(all_potential_type), OPTIONAL, POINTER        :: all_potential
       TYPE(local_potential_type), OPTIONAL, POINTER      :: tnadd_potential
       TYPE(gth_potential_type), OPTIONAL, POINTER        :: gth_potential
@@ -431,42 +431,41 @@ CONTAINS
       TYPE(atom_upfpot_type), OPTIONAL, POINTER          :: upf_potential
       TYPE(semi_empirical_type), OPTIONAL, POINTER       :: se_parameter
       TYPE(qs_dftb_atom_type), OPTIONAL, POINTER         :: dftb_parameter
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: dftb3_param, zeff
+      REAL(KIND=dp), OPTIONAL                            :: dftb3_param, zeff
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: elec_conf
-      INTEGER, INTENT(OUT), OPTIONAL                     :: mao, lmax_dftb
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: alpha_core_charge, ccore_charge, &
+      INTEGER, OPTIONAL                                  :: mao, lmax_dftb
+      REAL(KIND=dp), OPTIONAL                            :: alpha_core_charge, ccore_charge, &
                                                             core_charge, core_charge_radius
       TYPE(gto_basis_set_type), OPTIONAL, POINTER        :: soft_basis_set, hard_basis_set
       TYPE(paw_proj_set_type), OPTIONAL, POINTER         :: paw_proj_set
       LOGICAL, INTENT(IN), OPTIONAL                      :: softb
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: paw_atom
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: hard_radius, hard0_radius, max_rad_local
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: gpw_type_forced
+      LOGICAL, OPTIONAL                                  :: paw_atom
+      REAL(dp), OPTIONAL                                 :: hard_radius, hard0_radius, max_rad_local
+      LOGICAL, OPTIONAL                                  :: gpw_type_forced
       TYPE(harmonics_atom_type), OPTIONAL, POINTER       :: harmonics
-      INTEGER, INTENT(OUT), OPTIONAL                     :: max_iso_not0, max_s_harm
+      INTEGER, OPTIONAL                                  :: max_iso_not0, max_s_harm
       TYPE(grid_atom_type), OPTIONAL, POINTER            :: grid_atom
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ngrid_ang, ngrid_rad, lmax_rho0
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: dft_plus_u_atom
-      INTEGER, INTENT(OUT), OPTIONAL                     :: l_of_dft_plus_u
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: u_minus_j
+      INTEGER, OPTIONAL                                  :: ngrid_ang, ngrid_rad, lmax_rho0
+      LOGICAL, OPTIONAL                                  :: dft_plus_u_atom
+      INTEGER, OPTIONAL                                  :: l_of_dft_plus_u
+      REAL(KIND=dp), OPTIONAL                            :: u_minus_j
       TYPE(qs_atom_dispersion_type), OPTIONAL, POINTER   :: dispersion
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: bs_occupation
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: magnetization
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: no_optimize
+      LOGICAL, OPTIONAL                                  :: bs_occupation
+      REAL(KIND=dp), OPTIONAL                            :: magnetization
+      LOGICAL, OPTIONAL                                  :: no_optimize
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: addel, laddel, naddel
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: orbitals
       INTEGER, OPTIONAL                                  :: max_scf
       REAL(KIND=dp), OPTIONAL                            :: eps_scf
       LOGICAL, OPTIONAL                                  :: smear
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: u_ramping, u_minus_j_target, &
+      REAL(KIND=dp), OPTIONAL                            :: u_ramping, u_minus_j_target, &
                                                             eps_u_ramping
       LOGICAL, OPTIONAL                                  :: init_u_ramping_each_scf
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: reltmat
       LOGICAL, OPTIONAL                                  :: ghost, floating
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      CHARACTER(LEN=2), INTENT(OUT), OPTIONAL            :: element_symbol
-      INTEGER, INTENT(OUT), OPTIONAL                     :: pao_basis_size
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
+      CHARACTER(LEN=2), OPTIONAL                         :: element_symbol
+      INTEGER, OPTIONAL                                  :: pao_basis_size
       TYPE(pao_potential_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: pao_potentials
       TYPE(pao_descriptor_type), DIMENSION(:), &
@@ -789,13 +788,12 @@ CONTAINS
                               basis_type)
 
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      LOGICAL, INTENT(OUT), OPTIONAL :: all_potential_present, tnadd_potential_present, &
-         gth_potential_present, sgp_potential_present, paw_atom_present, dft_plus_u_atom_present
-      INTEGER, INTENT(OUT), OPTIONAL :: maxcgf, maxsgf, maxco, maxco_proj, maxgtops, maxlgto, &
-         maxlprj, maxnset, maxsgf_set, ncgf, npgf, nset, nsgf, nshell, maxpol, maxlppl, maxlppnl, &
-         maxppnl, nelectron
+      LOGICAL, OPTIONAL :: all_potential_present, tnadd_potential_present, gth_potential_present, &
+         sgp_potential_present, paw_atom_present, dft_plus_u_atom_present
+      INTEGER, OPTIONAL :: maxcgf, maxsgf, maxco, maxco_proj, maxgtops, maxlgto, maxlprj, maxnset, &
+         maxsgf_set, ncgf, npgf, nset, nsgf, nshell, maxpol, maxlppl, maxlppnl, maxppnl, nelectron
       INTEGER, INTENT(IN), OPTIONAL                      :: maxder
-      INTEGER, INTENT(OUT), OPTIONAL                     :: max_ngrid_rad, max_sph_harm, &
+      INTEGER, OPTIONAL                                  :: max_ngrid_rad, max_sph_harm, &
                                                             maxg_iso_not0, lmax_rho0
       CHARACTER(len=*), OPTIONAL                         :: basis_type
 
@@ -2807,9 +2805,8 @@ CONTAINS
 
       TYPE(atomic_kind_type), INTENT(IN)                 :: atomic_kind
       TYPE(qs_kind_type), INTENT(IN)                     :: qs_kind
-      INTEGER, DIMENSION(0:lmat, 10), INTENT(OUT)        :: ncalc, ncore, nelem
-      REAL(KIND=dp), DIMENSION(0:lmat, 10, 2), &
-         INTENT(OUT)                                     :: edelta
+      INTEGER, DIMENSION(0:lmat, 10)                     :: ncalc, ncore, nelem
+      REAL(KIND=dp), DIMENSION(0:lmat, 10, 2)            :: edelta
 
       CHARACTER(len=*), PARAMETER :: routineN = 'init_atom_electronic_state', &
          routineP = moduleN//':'//routineN
@@ -2942,7 +2939,7 @@ CONTAINS
    SUBROUTINE set_pseudo_state(econf, z, ncalc, ncore, nelem)
       INTEGER, DIMENSION(:), POINTER                     :: econf
       INTEGER, INTENT(IN)                                :: z
-      INTEGER, DIMENSION(0:lmat, 10), INTENT(OUT)        :: ncalc, ncore, nelem
+      INTEGER, DIMENSION(0:lmat, 10)                     :: ncalc, ncore, nelem
 
       CHARACTER(len=*), PARAMETER :: routineN = 'set_pseudo_state', &
          routineP = moduleN//':'//routineN

--- a/src/qs_ks_atom.F
+++ b/src/qs_ks_atom.F
@@ -578,7 +578,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: nconta
       INTEGER, DIMENSION(:), INTENT(IN)                  :: listb
       INTEGER, INTENT(IN)                                :: ncontb
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: C_int_h, C_int_s
+      REAL(KIND=dp), DIMENSION(:)                        :: C_int_h, C_int_s
       REAL(dp), DIMENSION(:, :)                          :: a_matrix
       LOGICAL, INTENT(IN)                                :: dista, distb
       REAL(dp), DIMENSION(:)                             :: coc

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -254,7 +254,7 @@ CONTAINS
       TYPE(qs_p_env_type), POINTER                       :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1, h1_psi0, psi0_order
-      LOGICAL, INTENT(OUT)                               :: should_stop
+      LOGICAL                                            :: should_stop
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'linres_solver', routineP = moduleN//':'//routineN
 

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -882,7 +882,7 @@ CONTAINS
    SUBROUTINE set_vecp(i1, i2, i3)
 
       INTEGER, INTENT(IN)                                :: i1
-      INTEGER, INTENT(OUT)                               :: i2, i3
+      INTEGER                                            :: i2, i3
 
       IF (i1 == 1) THEN
          i2 = 2
@@ -906,7 +906,7 @@ CONTAINS
    SUBROUTINE set_vecp_rev(i1, i2, i3)
 
       INTEGER, INTENT(IN)                                :: i1, i2
-      INTEGER, INTENT(OUT)                               :: i3
+      INTEGER                                            :: i3
 
       IF ((i1+i2) == 3) THEN
          i3 = 3

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -478,7 +478,7 @@ CONTAINS
          POINTER                                         :: jrho1_atom_set
       TYPE(qs_rho_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: jrho1_set
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: chi_tensor(3, 3, 2), &
+      REAL(dp), OPTIONAL                                 :: chi_tensor(3, 3, 2), &
                                                             chi_tensor_loc(3, 3, 2), &
                                                             gauge_atom_radius
       TYPE(realspaces_grid_p_type), DIMENSION(:), &
@@ -547,14 +547,14 @@ CONTAINS
                           shift_gapw_radius, do_nics, interpolate_shift)
 
       TYPE(nmr_env_type)                                 :: nmr_env
-      INTEGER, INTENT(OUT), OPTIONAL                     :: n_nics
+      INTEGER, OPTIONAL                                  :: n_nics
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: cs_atom_list, do_calc_cs_atom
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: r_nics
       REAL(dp), DIMENSION(:, :, :), OPTIONAL, POINTER    :: chemical_shift, chemical_shift_loc, &
                                                             chemical_shift_nics_loc, &
                                                             chemical_shift_nics
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: shift_gapw_radius
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: do_nics, interpolate_shift
+      REAL(dp), OPTIONAL                                 :: shift_gapw_radius
+      LOGICAL, OPTIONAL                                  :: do_nics, interpolate_shift
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_nmr_env', routineP = moduleN//':'//routineN
 

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -383,7 +383,7 @@ CONTAINS
    SUBROUTINE check_tolerance_real(zij_fm_set, tolerance)
 
       TYPE(cp_fm_p_type), DIMENSION(:, :)                :: zij_fm_set
-      REAL(dp), INTENT(OUT)                              :: tolerance
+      REAL(dp)                                           :: tolerance
 
       CHARACTER(len=*), PARAMETER :: routineN = 'check_tolerance_real', &
          routineP = moduleN//':'//routineN
@@ -1409,7 +1409,7 @@ CONTAINS
 
       TYPE(localized_wfn_control_type), POINTER          :: localized_wfn_control
       TYPE(section_vals_type), POINTER                   :: loc_section
-      LOGICAL, INTENT(OUT)                               :: localize
+      LOGICAL                                            :: localize
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_xas
       INTEGER, INTENT(IN), OPTIONAL                      :: nloc_xas, spin_channel_xas
 

--- a/src/qs_localization_methods.F
+++ b/src/qs_localization_methods.F
@@ -491,7 +491,7 @@ CONTAINS
    SUBROUTINE get_angle(mii, mjj, mij, weights, theta)
       COMPLEX(KIND=dp), POINTER                          :: mii(:), mjj(:), mij(:)
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      REAL(KIND=dp), INTENT(OUT)                         :: theta
+      REAL(KIND=dp)                                      :: theta
 
       COMPLEX(KIND=dp)                                   :: z11, z12, z22
       INTEGER                                            :: dim_m, idim
@@ -536,7 +536,7 @@ CONTAINS
    SUBROUTINE check_tolerance(zij, weights, tolerance)
       TYPE(cp_cfm_p_type)                                :: zij(:)
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      REAL(KIND=dp), INTENT(OUT)                         :: tolerance
+      REAL(KIND=dp)                                      :: tolerance
 
       CHARACTER(len=*), PARAMETER :: routineN = 'check_tolerance', &
          routineP = moduleN//':'//routineN
@@ -742,7 +742,7 @@ CONTAINS
       LOGICAL                                            :: crazy_use_diag
       REAL(KIND=dp), INTENT(IN)                          :: eps_localization
       INTEGER                                            :: iterations
-      LOGICAL, INTENT(out), OPTIONAL                     :: converged
+      LOGICAL, OPTIONAL                                  :: converged
 
       CHARACTER(len=*), PARAMETER :: routineN = 'crazy_rotations', &
          routineP = moduleN//':'//routineN

--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -433,8 +433,8 @@ CONTAINS
 !> \param rtp ...
 ! **************************************************************************************************
    SUBROUTINE wfn_restart_file_name(filename, exist, section, logger, kp, xas, rtp)
-      CHARACTER(LEN=default_path_length), INTENT(OUT)    :: filename
-      LOGICAL, INTENT(OUT)                               :: exist
+      CHARACTER(LEN=default_path_length)                 :: filename
+      LOGICAL                                            :: exist
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(cp_logger_type), POINTER                      :: logger
       LOGICAL, INTENT(IN), OPTIONAL                      :: kp, xas, rtp
@@ -507,7 +507,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: id_nr, multiplicity
       TYPE(section_vals_type), POINTER                   :: dft_section
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: natom_mismatch
+      LOGICAL, OPTIONAL                                  :: natom_mismatch
       LOGICAL, INTENT(IN), OPTIONAL                      :: cdft
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_mo_set_from_restart', &
@@ -675,7 +675,7 @@ CONTAINS
       INTEGER, INTENT(in), OPTIONAL                      :: multiplicity
       TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: rt_mos
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: natom_mismatch
+      LOGICAL, OPTIONAL                                  :: natom_mismatch
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_mos_restart_low', &
          routineP = moduleN//':'//routineN

--- a/src/qs_mo_types.F
+++ b/src/qs_mo_types.F
@@ -356,15 +356,15 @@ CONTAINS
                          uniform_occupation, kTS, mu, flexible_electron_count)
 
       TYPE(mo_set_type), POINTER                         :: mo_set
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: maxocc
-      INTEGER, INTENT(OUT), OPTIONAL                     :: homo, lfomo, nao, nelectron
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: n_el_f
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nmo
+      REAL(KIND=dp), OPTIONAL                            :: maxocc
+      INTEGER, OPTIONAL                                  :: homo, lfomo, nao, nelectron
+      REAL(KIND=dp), OPTIONAL                            :: n_el_f
+      INTEGER, OPTIONAL                                  :: nmo
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: eigenvalues, occupation_numbers
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: mo_coeff
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: mo_coeff_b
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: uniform_occupation
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: kTS, mu, flexible_electron_count
+      LOGICAL, OPTIONAL                                  :: uniform_occupation
+      REAL(KIND=dp), OPTIONAL                            :: kTS, mu, flexible_electron_count
 
       IF (PRESENT(maxocc)) maxocc = mo_set%maxocc
       IF (PRESENT(homo)) homo = mo_set%homo

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -1640,7 +1640,7 @@ CONTAINS
 !> \param iz ...
 ! **************************************************************************************************
    SUBROUTINE set_label(label, ix, iy, iz)
-      CHARACTER(LEN=*), INTENT(OUT)                      :: label
+      CHARACTER(LEN=*)                                   :: label
       INTEGER, INTENT(IN)                                :: ix, iy, iz
 
       INTEGER                                            :: i

--- a/src/qs_neighbor_list_types.F
+++ b/src/qs_neighbor_list_types.F
@@ -551,7 +551,7 @@ CONTAINS
    SUBROUTINE get_iterator_task(iterator_set, task, mepos)
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: iterator_set
-      TYPE(neighbor_list_task_type), INTENT(OUT)         :: task
+      TYPE(neighbor_list_task_type)                      :: task
       INTEGER, OPTIONAL                                  :: mepos
 
       IF (PRESENT(mepos)) THEN
@@ -910,7 +910,7 @@ CONTAINS
    SUBROUTINE get_neighbor_list(neighbor_list, atom, nnode)
 
       TYPE(neighbor_list_type), POINTER                  :: neighbor_list
-      INTEGER, INTENT(OUT), OPTIONAL                     :: atom, nnode
+      INTEGER, OPTIONAL                                  :: atom, nnode
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_neighbor_list', &
          routineP = moduleN//':'//routineN
@@ -940,8 +940,8 @@ CONTAINS
    SUBROUTINE get_neighbor_list_set(neighbor_list_set, nlist, symmetric)
 
       TYPE(neighbor_list_set_type), POINTER              :: neighbor_list_set
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nlist
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: symmetric
+      INTEGER, OPTIONAL                                  :: nlist
+      LOGICAL, OPTIONAL                                  :: symmetric
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_neighbor_list_set', &
          routineP = moduleN//':'//routineN
@@ -972,8 +972,8 @@ CONTAINS
 
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: neighbor_list_sets
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nlist
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: symmetric
+      INTEGER, OPTIONAL                                  :: nlist
+      LOGICAL, OPTIONAL                                  :: symmetric
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_neighbor_list_set_p', &
          routineP = moduleN//':'//routineN
@@ -1018,9 +1018,9 @@ CONTAINS
    SUBROUTINE get_neighbor_node(neighbor_node, neighbor, cell, r)
 
       TYPE(neighbor_node_type), POINTER                  :: neighbor_node
-      INTEGER, INTENT(OUT), OPTIONAL                     :: neighbor
-      INTEGER, DIMENSION(3), INTENT(OUT), OPTIONAL       :: cell
-      REAL(dp), DIMENSION(3), INTENT(OUT), OPTIONAL      :: r
+      INTEGER, OPTIONAL                                  :: neighbor
+      INTEGER, DIMENSION(3), OPTIONAL                    :: cell
+      REAL(dp), DIMENSION(3), OPTIONAL                   :: r
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_neighbor_node', &
          routineP = moduleN//':'//routineN

--- a/src/qs_neighbor_lists.F
+++ b/src/qs_neighbor_lists.F
@@ -1415,7 +1415,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE combine_lists(list, n, ikind, atom)
       INTEGER, DIMENSION(:), POINTER                     :: list
-      INTEGER, INTENT(OUT)                               :: n
+      INTEGER                                            :: n
       INTEGER, INTENT(IN)                                :: ikind
       TYPE(local_atoms_type), DIMENSION(:), INTENT(IN)   :: atom
 
@@ -1469,7 +1469,7 @@ CONTAINS
    SUBROUTINE pair_radius_setup(present_a, present_b, radius_a, radius_b, pair_radius)
       LOGICAL, DIMENSION(:), INTENT(IN)                  :: present_a, present_b
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: radius_a, radius_b
-      REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: pair_radius
+      REAL(dp), DIMENSION(:, :)                          :: pair_radius
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pair_radius_setup', &
          routineP = moduleN//':'//routineN

--- a/src/qs_nl_hash_table_types.F
+++ b/src/qs_nl_hash_table_types.F
@@ -181,8 +181,7 @@ CONTAINS
    SUBROUTINE nl_hash_table_get_from_index(hash_table, idx, val)
       TYPE(nl_hash_table_obj), INTENT(IN)                :: hash_table
       INTEGER, INTENT(IN)                                :: idx
-      TYPE(neighbor_list_task_type), INTENT(OUT), &
-         POINTER                                         :: val
+      TYPE(neighbor_list_task_type), POINTER             :: val
 
       CHARACTER(len=*), PARAMETER :: routineN = 'nl_hash_table_get_from_index', &
          routineP = moduleN//':'//routineN
@@ -266,7 +265,7 @@ CONTAINS
    SUBROUTINE nl_hash_table_is_null(hash_table, key, is_null)
       TYPE(nl_hash_table_obj), INTENT(IN)                :: hash_table
       INTEGER, INTENT(IN)                                :: key
-      LOGICAL, INTENT(OUT)                               :: is_null
+      LOGICAL                                            :: is_null
 
       CHARACTER(len=*), PARAMETER :: routineN = 'nl_hash_table_is_null', &
          routineP = moduleN//':'//routineN
@@ -364,7 +363,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE nl_hash_table_status(hash_table, nelements, nmax, prime)
       TYPE(nl_hash_table_obj), INTENT(INOUT)             :: hash_table
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nelements, nmax, prime
+      INTEGER, OPTIONAL                                  :: nelements, nmax, prime
 
       CHARACTER(len=*), PARAMETER :: routineN = 'nl_hash_table_status', &
          routineP = moduleN//':'//routineN

--- a/src/qs_oce_methods.F
+++ b/src/qs_oce_methods.F
@@ -77,9 +77,9 @@ CONTAINS
       TYPE(qs_kind_type), POINTER                        :: atom_ka, atom_kb
       REAL(dp), DIMENSION(3)                             :: rab
       INTEGER, INTENT(IN)                                :: nder
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: sgf_list
-      INTEGER, INTENT(OUT)                               :: nsgf_cnt
-      LOGICAL, INTENT(OUT)                               :: sgf_soft_only
+      INTEGER, DIMENSION(:)                              :: sgf_list
+      INTEGER                                            :: nsgf_cnt
+      LOGICAL                                            :: sgf_soft_only
       REAL(dp), INTENT(IN)                               :: eps_fit
 
       CHARACTER(len=*), PARAMETER :: routineN = 'build_oce_block', &
@@ -270,8 +270,8 @@ CONTAINS
 
       TYPE(block_p_type), DIMENSION(:), POINTER          :: oceh, oces
       TYPE(qs_kind_type), POINTER                        :: atom_ka
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: sgf_list
-      INTEGER, INTENT(OUT)                               :: nsgf_cnt
+      INTEGER, DIMENSION(:)                              :: sgf_list
+      INTEGER                                            :: nsgf_cnt
 
       CHARACTER(len=*), PARAMETER :: routineN = 'build_oce_block_local', &
          routineP = moduleN//':'//routineN

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -92,7 +92,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(rho0_mpole_type), POINTER                     :: rho0
-      REAL(dp), INTENT(OUT)                              :: tot_rs_int
+      REAL(dp)                                           :: tot_rs_int
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'put_rho0_on_grid', &
          routineP = moduleN//':'//routineN

--- a/src/qs_rho0_types.F
+++ b/src/qs_rho0_types.F
@@ -451,16 +451,16 @@ CONTAINS
       TYPE(rho0_mpole_type), POINTER                     :: rho0_mpole
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: g0_h, vg0_h
       INTEGER, INTENT(IN), OPTIONAL                      :: iat, ikind
-      INTEGER, INTENT(OUT), OPTIONAL                     :: lmax_0, l0_ikind
+      INTEGER, OPTIONAL                                  :: lmax_0, l0_ikind
       TYPE(mpole_gau_overlap), OPTIONAL, POINTER         :: mp_gau_ikind
       TYPE(mpole_rho_atom), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: mp_rho
       REAL(dp), DIMENSION(:), OPTIONAL, POINTER          :: norm_g0l_h
       REAL(dp), DIMENSION(:, :, :), OPTIONAL, POINTER    :: Qlm_gg
       REAL(dp), DIMENSION(:), OPTIONAL, POINTER          :: Qlm_car, Qlm_tot
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: zet0_h
-      INTEGER, INTENT(OUT), OPTIONAL                     :: igrid_zet0_s
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: rpgf0_h, rpgf0_s, max_rpgf0_s
+      REAL(dp), OPTIONAL                                 :: zet0_h
+      INTEGER, OPTIONAL                                  :: igrid_zet0_s
+      REAL(dp), OPTIONAL                                 :: rpgf0_h, rpgf0_s, max_rpgf0_s
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho0_s_rs, rho0_s_gs
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_rho0_mpole', routineP = moduleN//':'//routineN

--- a/src/qs_rho_types.F
+++ b/src/qs_rho_types.F
@@ -265,12 +265,12 @@ CONTAINS
          POINTER                                         :: rho_ao_kp
       TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_r, drho_r, rho_g, drho_g, tau_r, &
                                                             tau_g
-      LOGICAL, INTENT(out), OPTIONAL                     :: rho_r_valid, drho_r_valid, rho_g_valid, &
+      LOGICAL, OPTIONAL                                  :: rho_r_valid, drho_r_valid, rho_g_valid, &
                                                             drho_g_valid, tau_r_valid, tau_g_valid
-      INTEGER, INTENT(out), OPTIONAL                     :: rebuild_each
+      INTEGER, OPTIONAL                                  :: rebuild_each
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: tot_rho_r, tot_rho_g
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_r_sccs
-      LOGICAL, INTENT(out), OPTIONAL                     :: soft_valid
+      LOGICAL, OPTIONAL                                  :: soft_valid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qs_rho_get', routineP = moduleN//':'//routineN
 

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -125,8 +125,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_type), POINTER                             :: rho_tot_gspace, v_hartree_gspace, v_sccs
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
-         OPTIONAL                                        :: h_stress
+      REAL(KIND=dp), DIMENSION(3, 3), OPTIONAL           :: h_stress
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'sccs', routineP = moduleN//':'//routineN
       REAL(KIND=dp), PARAMETER                           :: tol = 1.0E-12_dp

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -314,7 +314,7 @@ CONTAINS
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(scf_control_type), POINTER                    :: scf_control
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL, INTENT(OUT)                               :: converged, should_stop
+      LOGICAL                                            :: converged, should_stop
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'scf_env_do_scf', routineP = moduleN//':'//routineN
 
@@ -898,7 +898,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cdft_scf(qs_env, should_stop)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL, INTENT(OUT)                               :: should_stop
+      LOGICAL                                            :: should_stop
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cdft_scf', routineP = moduleN//':'//routineN
 

--- a/src/qs_scf_methods.F
+++ b/src/qs_scf_methods.F
@@ -480,7 +480,7 @@ CONTAINS
 
       TYPE(dbcsr_type), POINTER                          :: m1, m2
       REAL(KIND=dp), INTENT(IN)                          :: p_mix
-      REAL(KIND=dp), INTENT(OUT)                         :: delta
+      REAL(KIND=dp)                                      :: delta
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: m3
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -892,8 +892,7 @@ CONTAINS
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: unoccupied_orbs
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: unoccupied_evals
-      INTEGER                                            :: nlumo
-      INTEGER, INTENT(OUT)                               :: nlumos
+      INTEGER                                            :: nlumo, nlumos
 
       CHARACTER(len=*), PARAMETER :: routineN = 'make_lumo', routineP = moduleN//':'//routineN
 
@@ -3057,7 +3056,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE project_function_a(ca, a, cb, b, l)
       ! project function cb on ca
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: ca
+      REAL(KIND=dp), DIMENSION(:)                        :: ca
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: a, cb, b
       INTEGER, INTENT(IN)                                :: l
 
@@ -3092,7 +3091,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE project_function_b(ca, a, bfun, grid_atom, l)
       ! project function f on ca
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: ca
+      REAL(KIND=dp), DIMENSION(:)                        :: ca
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: a, bfun
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       INTEGER, INTENT(IN)                                :: l

--- a/src/qs_subsys_types.F
+++ b/src/qs_subsys_types.F
@@ -177,7 +177,7 @@ CONTAINS
       TYPE(particle_list_type), OPTIONAL, POINTER        :: shell_particles, core_particles
       TYPE(global_constraint_type), OPTIONAL, POINTER    :: gci
       TYPE(multipole_type), OPTIONAL, POINTER            :: multipoles
-      INTEGER, INTENT(out), OPTIONAL                     :: natom, nparticle, ncore, nshell, nkind
+      INTEGER, OPTIONAL                                  :: natom, nparticle, ncore, nshell, nkind
       TYPE(atprop_type), OPTIONAL, POINTER               :: atprop
       TYPE(virial_type), OPTIONAL, POINTER               :: virial
       TYPE(cp_result_type), OPTIONAL, POINTER            :: results

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -588,7 +588,7 @@ CONTAINS
 !>    * 02.2017 created [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE tddfpt_create_work_matrices(work_matrices, gs_mos, nstates, do_hfx, qs_env, sub_env)
-      TYPE(tddfpt_work_matrices), INTENT(out)            :: work_matrices
+      TYPE(tddfpt_work_matrices)                         :: work_matrices
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       INTEGER, INTENT(in)                                :: nstates
@@ -909,7 +909,7 @@ CONTAINS
 !>    * 06.2018 the charge density needs to be provided via a dummy argument [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE tddfpt_create_kernel_env(kernel_env, rho_struct_sub, xc_section, is_rks_triplets, sub_env)
-      TYPE(tddfpt_kernel_env_type), INTENT(out)          :: kernel_env
+      TYPE(tddfpt_kernel_env_type)                       :: kernel_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct_sub
       TYPE(section_vals_type), POINTER                   :: xc_section
       LOGICAL, INTENT(in)                                :: is_rks_triplets
@@ -1035,7 +1035,7 @@ CONTAINS
 !>    * 06.2016 renamed, altered prototype [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE tddfpt_init_ground_state_mos(gs_mos, mo_set, blacs_env, cholesky_method, matrix_ks, matrix_s)
-      TYPE(tddfpt_ground_state_mos), INTENT(out)         :: gs_mos
+      TYPE(tddfpt_ground_state_mos)                      :: gs_mos
       TYPE(mo_set_type), POINTER                         :: mo_set
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       INTEGER, INTENT(in)                                :: cholesky_method
@@ -2319,7 +2319,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_compute_ritz_vects(ritz_vects, Aop_ritz, evals, krylov_vects, Aop_krylov)
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: ritz_vects, Aop_ritz
-      REAL(kind=dp), DIMENSION(:), INTENT(out)           :: evals
+      REAL(kind=dp), DIMENSION(:)                        :: evals
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: krylov_vects, Aop_krylov
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_compute_ritz_vects', &
@@ -3533,7 +3533,7 @@ CONTAINS
    FUNCTION tddfpt_read_restart(evects, evals, gs_mos, logger, tddfpt_section, tddfpt_print_section, &
                                 fm_pool_ao_mo_occ, blacs_env_global) RESULT(nstates_read)
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
-      REAL(kind=dp), DIMENSION(:), INTENT(out)           :: evals
+      REAL(kind=dp), DIMENSION(:)                        :: evals
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(cp_logger_type), POINTER                      :: logger

--- a/src/qs_tddfpt2_subgroups.F
+++ b/src/qs_tddfpt2_subgroups.F
@@ -162,7 +162,7 @@ CONTAINS
 !>              [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE tddfpt_sub_env_init(sub_env, qs_env, mos_occ)
-      TYPE(tddfpt_subgroup_env_type), INTENT(out)        :: sub_env
+      TYPE(tddfpt_subgroup_env_type)                     :: sub_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: mos_occ
 
@@ -388,7 +388,7 @@ CONTAINS
    SUBROUTINE init_tddfpt_mgrid(qs_control, tddfpt_control, mgrid_saved)
       TYPE(qs_control_type), POINTER                     :: qs_control
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
-      TYPE(mgrid_saved_parameters), INTENT(out)          :: mgrid_saved
+      TYPE(mgrid_saved_parameters)                       :: mgrid_saved
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'init_tddfpt_mgrid', &
          routineP = moduleN//':'//routineN

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -76,7 +76,7 @@ CONTAINS
    SUBROUTINE tddfpt_init(p_env, t_env, qs_env)
 
       TYPE(qs_p_env_type), POINTER                       :: p_env
-      TYPE(tddfpt_env_type), INTENT(out)                 :: t_env
+      TYPE(tddfpt_env_type)                              :: t_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_init', routineP = moduleN//':'//routineN
@@ -154,7 +154,7 @@ CONTAINS
    SUBROUTINE co_initial_guess(matrices, energies, n_v, qs_env)
 
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: matrices
-      REAL(kind=DP), DIMENSION(:), INTENT(OUT)           :: energies
+      REAL(kind=DP), DIMENSION(:)                        :: energies
       INTEGER, INTENT(IN)                                :: n_v
       TYPE(qs_environment_type), POINTER                 :: qs_env
 

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -103,9 +103,9 @@ CONTAINS
       TYPE(qs_rho_type), POINTER                         :: rho_struct
       TYPE(section_vals_type), POINTER                   :: xc_section
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rho, vxc_tau
-      REAL(KIND=dp), INTENT(out)                         :: exc
+      REAL(KIND=dp)                                      :: exc
       LOGICAL, INTENT(in), OPTIONAL                      :: just_energy
-      REAL(KIND=dp), INTENT(out), OPTIONAL               :: edisp
+      REAL(KIND=dp), OPTIONAL                            :: edisp
       TYPE(qs_dispersion_type), OPTIONAL, POINTER        :: dispersion_env
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: adiabatic_rescale_factor
       TYPE(pw_env_type), OPTIONAL, POINTER               :: pw_env_external

--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -477,8 +477,8 @@ CONTAINS
       TYPE(qs_wf_history_type), POINTER                  :: wf_history
       TYPE(qs_environment_type), POINTER                 :: qs_env
       REAL(KIND=dp), INTENT(IN)                          :: dt
-      INTEGER, INTENT(OUT), OPTIONAL                     :: extrapolation_method_nr
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: orthogonal_wf
+      INTEGER, OPTIONAL                                  :: extrapolation_method_nr
+      LOGICAL, OPTIONAL                                  :: orthogonal_wf
 
       CHARACTER(len=*), PARAMETER :: routineN = 'wfi_extrapolate', &
          routineP = moduleN//':'//routineN

--- a/src/replica_methods.F
+++ b/src/replica_methods.F
@@ -289,7 +289,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE rep_env_init_low(rep_env_id, ierr)
       INTEGER, INTENT(in)                                :: rep_env_id
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rep_env_init_low', &
          routineP = moduleN//':'//routineN
@@ -406,7 +406,7 @@ CONTAINS
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE rep_env_calc_e_f_low(rep_env_id, calc_f, ierr)
       INTEGER, INTENT(in)                                :: rep_env_id, calc_f
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rep_env_calc_e_f_low', &
          routineP = moduleN//':'//routineN

--- a/src/replica_types.F
+++ b/src/replica_types.F
@@ -198,7 +198,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE rep_env_destroy_low(rep_env_id, ierr)
       INTEGER, INTENT(in)                                :: rep_env_id
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                                            :: ierr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rep_env_destroy_low', &
          routineP = moduleN//':'//routineN
@@ -290,7 +290,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION rep_envs_get_rep_env(id_nr, ierr) RESULT(res)
       INTEGER, INTENT(in)                                :: id_nr
-      INTEGER, INTENT(OUT)                               :: ierr
+      INTEGER                                            :: ierr
       TYPE(replica_env_type), POINTER                    :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rep_envs_get_rep_env', &

--- a/src/ri_environment_methods.F
+++ b/src/ri_environment_methods.F
@@ -291,7 +291,7 @@ CONTAINS
 
       TYPE(dbcsr_type)                                   :: mat
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vecr
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: vecx
+      REAL(KIND=dp), DIMENSION(:)                        :: vecx
       TYPE(dbcsr_type)                                   :: matp
       CHARACTER(LEN=*), INTENT(IN)                       :: solver
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: ptr
@@ -590,7 +590,7 @@ CONTAINS
 
       TYPE(dbcsr_type)                                   :: mat
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vi
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: vo
+      REAL(KIND=dp), DIMENSION(:)                        :: vo
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: ptr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ri_matvec', routineP = moduleN//':'//routineN

--- a/src/rmsd.F
+++ b/src/rmsd.F
@@ -53,9 +53,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: r, r0
       INTEGER, INTENT(IN)                                :: output_unit
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: weights
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: my_val
+      REAL(KIND=dp), OPTIONAL                            :: my_val
       LOGICAL, INTENT(IN), OPTIONAL                      :: rotate
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT), OPTIONAL :: transl
+      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: transl
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
          OPTIONAL                                        :: rot, drmsd3
 

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -8980,7 +8980,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: x_val
       INTEGER, INTENT(IN)                                :: nparam
       COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: func_val
+      COMPLEX(KIND=dp)                                   :: func_val
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'evaluate_pade_function', &
          routineP = moduleN//':'//routineN
@@ -9018,7 +9018,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: x_val
       INTEGER, INTENT(IN)                                :: nparam
       COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: z_value, m_value
+      REAL(KIND=dp), OPTIONAL                            :: z_value, m_value
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_z_and_m_value_pade', &
          routineP = moduleN//':'//routineN
@@ -9067,7 +9067,7 @@ CONTAINS
    SUBROUTINE get_sigma_c_bisection_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
                                          nparam_pade, omega_points_pade, coeff_pade, start_val)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
+      REAL(KIND=dp)                                      :: gw_energ
       REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
                                                             e_fermi
       INTEGER, INTENT(IN)                                :: nparam_pade
@@ -9132,7 +9132,7 @@ CONTAINS
    SUBROUTINE get_sigma_c_newton_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
                                       nparam_pade, omega_points_pade, coeff_pade, start_val)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
+      REAL(KIND=dp)                                      :: gw_energ
       REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
                                                             e_fermi
       INTEGER, INTENT(IN)                                :: nparam_pade

--- a/src/rt_propagation_types.F
+++ b/src/rt_propagation_types.F
@@ -330,11 +330,11 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: C_mat, propagator_matrix
       LOGICAL, OPTIONAL                                  :: mixing
-      REAL(dp), INTENT(out), OPTIONAL                    :: mixing_factor
+      REAL(dp), OPTIONAL                                 :: mixing_factor
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: S_der
-      REAL(dp), INTENT(out), OPTIONAL                    :: dt
-      INTEGER, INTENT(out), OPTIONAL                     :: nsteps
+      REAL(dp), OPTIONAL                                 :: dt
+      INTEGER, OPTIONAL                                  :: nsteps
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: SinvH, SinvB
       TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &

--- a/src/sap_kind_types.F
+++ b/src/sap_kind_types.F
@@ -110,7 +110,7 @@ CONTAINS
    SUBROUTINE get_alist(sap_int, alist, atom)
 
       TYPE(sap_int_type), INTENT(IN)                     :: sap_int
-      TYPE(alist_type), INTENT(OUT), POINTER             :: alist
+      TYPE(alist_type), POINTER                          :: alist
       INTEGER, INTENT(IN)                                :: atom
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_alist', routineP = moduleN//':'//routineN

--- a/src/se_fock_matrix_integrals.F
+++ b/src/se_fock_matrix_integrals.F
@@ -1074,12 +1074,12 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: charges
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: dipoles
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: quadrupoles
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: force_ab
+      REAL(KIND=dp), DIMENSION(3)           :: force_ab
       REAL(KIND=dp), DIMENSION(:), POINTER               :: efield0
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: efield1, efield2
       REAL(KIND=dp), INTENT(IN)                          :: rab2
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rab
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: integral_value
+      REAL(KIND=dp), OPTIONAL               :: integral_value
       REAL(KIND=dp), INTENT(INOUT)                       :: ptens11, ptens12, ptens13, ptens21, &
                                                             ptens22, ptens23, ptens31, ptens32, &
                                                             ptens33

--- a/src/semi_empirical_int_ana.F
+++ b/src/semi_empirical_int_ana.F
@@ -89,8 +89,8 @@ CONTAINS
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
       INTEGER, INTENT(IN)                                :: itype
-      REAL(dp), DIMENSION(45), INTENT(OUT), OPTIONAL     :: e1b, e2a
-      REAL(dp), DIMENSION(3, 45), INTENT(OUT), OPTIONAL  :: de1b, de2a
+      REAL(dp), DIMENSION(45), OPTIONAL                  :: e1b, e2a
+      REAL(dp), DIMENSION(3, 45), OPTIONAL               :: de1b, de2a
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
 
@@ -348,8 +348,8 @@ CONTAINS
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
       INTEGER, INTENT(IN)                                :: itype
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: enuc
-      REAL(dp), DIMENSION(3), INTENT(OUT), OPTIONAL      :: denuc
+      REAL(dp), OPTIONAL                                 :: enuc
+      REAL(dp), DIMENSION(3), OPTIONAL                   :: denuc
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
 
@@ -659,8 +659,8 @@ CONTAINS
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
       INTEGER, INTENT(IN)                                :: itype
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: enuc
-      REAL(dp), DIMENSION(3), INTENT(OUT), OPTIONAL      :: denuc
+      REAL(dp), OPTIONAL                                 :: enuc
+      REAL(dp), DIMENSION(3), OPTIONAL                   :: denuc
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
 
@@ -894,7 +894,7 @@ CONTAINS
                                lgrad)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), INTENT(IN)                               :: rij
-      REAL(dp), INTENT(OUT)                              :: ssss, dssss
+      REAL(dp)                                           :: ssss, dssss
       INTEGER, INTENT(IN)                                :: itype
       TYPE(se_taper_type), POINTER                       :: se_taper
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -978,7 +978,7 @@ CONTAINS
                                se_int_control, lgrad)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), INTENT(IN)                               :: rij
-      REAL(dp), DIMENSION(10, 2), INTENT(OUT)            :: core, dcore
+      REAL(dp), DIMENSION(10, 2)                         :: core, dcore
       INTEGER, INTENT(IN)                                :: itype
       TYPE(se_taper_type), POINTER                       :: se_taper
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -1249,9 +1249,8 @@ CONTAINS
    RECURSIVE SUBROUTINE rotint_ana(sepi, sepj, rijv, w, dw, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
-      REAL(dp), DIMENSION(2025), INTENT(OUT), OPTIONAL   :: w
-      REAL(dp), DIMENSION(3, 2025), INTENT(OUT), &
-         OPTIONAL                                        :: dw
+      REAL(dp), DIMENSION(2025), OPTIONAL                :: w
+      REAL(dp), DIMENSION(3, 2025), OPTIONAL             :: dw
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
 
@@ -1579,7 +1578,7 @@ CONTAINS
                                    se_int_control, lgrad)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(KIND=dp), INTENT(IN)                          :: rij
-      REAL(KIND=dp), DIMENSION(491), INTENT(OUT)         :: rep, rep_d
+      REAL(KIND=dp), DIMENSION(491)                      :: rep, rep_d
       TYPE(se_taper_type), POINTER                       :: se_taper
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       LOGICAL, INTENT(IN)                                :: lgrad
@@ -1685,7 +1684,7 @@ CONTAINS
                             se_int_screen, ft, dft)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), INTENT(IN)                               :: rij
-      REAL(dp), DIMENSION(491), INTENT(OUT)              :: drep
+      REAL(dp), DIMENSION(491)                           :: drep
       REAL(dp), DIMENSION(491), INTENT(IN)               :: rep
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_int_screen_type), INTENT(IN)               :: se_int_screen

--- a/src/semi_empirical_int_gks.F
+++ b/src/semi_empirical_int_gks.F
@@ -57,7 +57,7 @@ CONTAINS
    SUBROUTINE rotnuc_gks(sepi, sepj, rij, e1b, e2a, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(45), INTENT(OUT), OPTIONAL     :: e1b, e2a
+      REAL(dp), DIMENSION(45), OPTIONAL                  :: e1b, e2a
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rotnuc_gks', routineP = moduleN//':'//routineN
@@ -107,7 +107,7 @@ CONTAINS
    SUBROUTINE rotint_gks(sepi, sepj, rij, w, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(2025), INTENT(OUT), OPTIONAL   :: w
+      REAL(dp), DIMENSION(2025), OPTIONAL                :: w
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rotint_gks', routineP = moduleN//':'//routineN
@@ -158,7 +158,7 @@ CONTAINS
    SUBROUTINE drotnuc_gks(sepi, sepj, rij, de1b, de2a, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(3, 45), INTENT(OUT), OPTIONAL  :: de1b, de2a
+      REAL(dp), DIMENSION(3, 45), OPTIONAL               :: de1b, de2a
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'drotnuc_gks', routineP = moduleN//':'//routineN
@@ -208,7 +208,7 @@ CONTAINS
    SUBROUTINE drotint_gks(sepi, sepj, rij, dw, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(3, 2025), INTENT(OUT)          :: dw
+      REAL(dp), DIMENSION(3, 2025)                       :: dw
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'drotint_gks', routineP = moduleN//':'//routineN
@@ -256,7 +256,7 @@ CONTAINS
    SUBROUTINE makeCoul(RAB, sepi, sepj, Coul, se_int_control)
       REAL(kind=dp), DIMENSION(3)                        :: RAB
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
-      REAL(kind=dp), DIMENSION(45, 45), INTENT(OUT)      :: Coul
+      REAL(kind=dp), DIMENSION(45, 45)                   :: Coul
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'makeCoul', routineP = moduleN//':'//routineN
@@ -363,7 +363,7 @@ CONTAINS
    SUBROUTINE makedCoul(RAB, sepi, sepj, dCoul, se_int_control)
       REAL(kind=dp), DIMENSION(3)                        :: RAB
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
-      REAL(kind=dp), DIMENSION(3, 45, 45), INTENT(OUT)   :: dCoul
+      REAL(kind=dp), DIMENSION(3, 45, 45)                :: dCoul
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'makedCoul', routineP = moduleN//':'//routineN
@@ -488,8 +488,8 @@ CONTAINS
    SUBROUTINE corecore_gks(sepi, sepj, rijv, enuc, denuc, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: enuc
-      REAL(dp), DIMENSION(3), INTENT(OUT), OPTIONAL      :: denuc
+      REAL(dp), OPTIONAL                                 :: enuc
+      REAL(dp), DIMENSION(3), OPTIONAL                   :: denuc
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'corecore_gks', routineP = moduleN//':'//routineN
@@ -571,7 +571,7 @@ CONTAINS
    SUBROUTINE makeCoulE(RAB, sepi, sepj, Coul, se_int_control)
       REAL(KIND=dp), DIMENSION(3)                        :: RAB
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
-      REAL(KIND=dp), DIMENSION(45, 45), INTENT(OUT)      :: Coul
+      REAL(KIND=dp), DIMENSION(45, 45)                   :: Coul
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'makeCoulE', routineP = moduleN//':'//routineN
@@ -789,7 +789,7 @@ CONTAINS
    SUBROUTINE makedCoulE(RAB, sepi, sepj, dCoul, se_int_control)
       REAL(KIND=dp), DIMENSION(3)                        :: RAB
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
-      REAL(KIND=dp), DIMENSION(3, 45, 45), INTENT(OUT)   :: dCoul
+      REAL(KIND=dp), DIMENSION(3, 45, 45)                :: dCoul
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'makedCoulE', routineP = moduleN//':'//routineN
@@ -1053,12 +1053,11 @@ CONTAINS
 !> \param d5 ...
 ! **************************************************************************************************
    SUBROUTINE build_d_tensor_gks(d1f, d2f, d3f, d4f, d5f, v, d1, d2, d3, d4, d5)
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: d1f
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: d2f
-      REAL(KIND=dp), DIMENSION(3, 3, 3), INTENT(OUT)     :: d3f
-      REAL(KIND=dp), DIMENSION(3, 3, 3, 3), INTENT(OUT)  :: d4f
-      REAL(KIND=dp), DIMENSION(3, 3, 3, 3, 3), &
-         INTENT(OUT), OPTIONAL                           :: d5f
+      REAL(KIND=dp), DIMENSION(3)                        :: d1f
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: d2f
+      REAL(KIND=dp), DIMENSION(3, 3, 3)                  :: d3f
+      REAL(KIND=dp), DIMENSION(3, 3, 3, 3)               :: d4f
+      REAL(KIND=dp), DIMENSION(3, 3, 3, 3, 3), OPTIONAL  :: d5f
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: v
       REAL(KIND=dp), INTENT(IN)                          :: d1, d2, d3, d4
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: d5
@@ -1161,7 +1160,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE makeCoulE0(sepi, Coul, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi
-      REAL(KIND=dp), DIMENSION(45, 45), INTENT(OUT)      :: Coul
+      REAL(KIND=dp), DIMENSION(45, 45)                   :: Coul
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
       CHARACTER(len=*), PARAMETER :: routineN = 'makeCoulE0', routineP = moduleN//':'//routineN
@@ -1293,10 +1292,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_se_slater_multipole(sepi, M0, M1, M2, ACOUL)
       TYPE(semi_empirical_type), POINTER                 :: sepi
-      REAL(kind=dp), DIMENSION(45), INTENT(OUT)          :: M0
-      REAL(kind=dp), DIMENSION(3, 45), INTENT(OUT)       :: M1
-      REAL(kind=dp), DIMENSION(3, 3, 45), INTENT(OUT)    :: M2
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: ACOUL
+      REAL(kind=dp), DIMENSION(45)                       :: M0
+      REAL(kind=dp), DIMENSION(3, 45)                    :: M1
+      REAL(kind=dp), DIMENSION(3, 3, 45)                 :: M2
+      REAL(KIND=dp), OPTIONAL                            :: ACOUL
 
       INTEGER                                            :: i, j, jint, size_1c_int
       TYPE(semi_empirical_mpole_type), POINTER           :: mpole

--- a/src/semi_empirical_int_num.F
+++ b/src/semi_empirical_int_num.F
@@ -75,7 +75,7 @@ CONTAINS
    SUBROUTINE rotint_num(sepi, sepj, rijv, w, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
-      REAL(dp), DIMENSION(2025), INTENT(OUT)             :: w
+      REAL(dp), DIMENSION(2025)                          :: w
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
 
@@ -226,7 +226,7 @@ CONTAINS
    SUBROUTINE terep_num(sepi, sepj, rij, rep, se_taper, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), INTENT(IN)                               :: rij
-      REAL(dp), DIMENSION(491), INTENT(OUT)              :: rep
+      REAL(dp), DIMENSION(491)                           :: rep
       TYPE(se_taper_type), POINTER                       :: se_taper
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
 
@@ -271,7 +271,7 @@ CONTAINS
                            ft)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), INTENT(IN)                               :: rij
-      REAL(dp), DIMENSION(491), INTENT(OUT)              :: rep
+      REAL(dp), DIMENSION(491)                           :: rep
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_int_screen_type), INTENT(IN)               :: se_int_screen
       REAL(dp), INTENT(IN)                               :: ft
@@ -400,7 +400,7 @@ CONTAINS
    SUBROUTINE rotnuc_num(sepi, sepj, rijv, e1b, e2a, itype, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
-      REAL(dp), DIMENSION(45), INTENT(OUT), OPTIONAL     :: e1b, e2a
+      REAL(dp), DIMENSION(45), OPTIONAL                  :: e1b, e2a
       INTEGER, INTENT(IN)                                :: itype
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
@@ -508,7 +508,7 @@ CONTAINS
    SUBROUTINE corecore_num(sepi, sepj, rijv, enuc, itype, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
-      REAL(dp), INTENT(OUT)                              :: enuc
+      REAL(dp)                                           :: enuc
       INTEGER, INTENT(IN)                                :: itype
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
@@ -684,7 +684,7 @@ CONTAINS
    SUBROUTINE corecore_el_num(sepi, sepj, rijv, enuc, itype, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rijv
-      REAL(dp), INTENT(OUT)                              :: enuc
+      REAL(dp)                                           :: enuc
       INTEGER, INTENT(IN)                                :: itype
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
@@ -736,7 +736,7 @@ CONTAINS
    SUBROUTINE ssss_nucint_num(sepi, sepj, rij, ssss, itype, se_taper, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), INTENT(IN)                               :: rij
-      REAL(dp), INTENT(OUT)                              :: ssss
+      REAL(dp)                                           :: ssss
       INTEGER, INTENT(IN)                                :: itype
       TYPE(se_taper_type), POINTER                       :: se_taper
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -790,7 +790,7 @@ CONTAINS
    SUBROUTINE core_nucint_num(sepi, sepj, rij, core, itype, se_taper, se_int_control)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), INTENT(IN)                               :: rij
-      REAL(dp), DIMENSION(10, 2), INTENT(OUT)            :: core
+      REAL(dp), DIMENSION(10, 2)                         :: core
       INTEGER, INTENT(IN)                                :: itype
       TYPE(se_taper_type), POINTER                       :: se_taper
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -1011,7 +1011,7 @@ CONTAINS
    SUBROUTINE drotint_num(sepi, sepj, r, dw, delta, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: r
-      REAL(dp), DIMENSION(3, 2025), INTENT(OUT)          :: dw
+      REAL(dp), DIMENSION(3, 2025)                       :: dw
       REAL(dp), INTENT(IN)                               :: delta
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
@@ -1053,7 +1053,7 @@ CONTAINS
    SUBROUTINE drotnuc_num(sepi, sepj, r, de1b, de2a, itype, delta, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: r
-      REAL(dp), DIMENSION(3, 45), INTENT(OUT), OPTIONAL  :: de1b, de2a
+      REAL(dp), DIMENSION(3, 45), OPTIONAL               :: de1b, de2a
       INTEGER, INTENT(IN)                                :: itype
       REAL(dp), INTENT(IN)                               :: delta
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -1104,7 +1104,7 @@ CONTAINS
    SUBROUTINE dcorecore_num(sepi, sepj, r, denuc, itype, delta, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: r
-      REAL(dp), DIMENSION(3), INTENT(OUT)                :: denuc
+      REAL(dp), DIMENSION(3)                             :: denuc
       INTEGER, INTENT(IN)                                :: itype
       REAL(dp), INTENT(IN)                               :: delta
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -1141,7 +1141,7 @@ CONTAINS
    SUBROUTINE dcorecore_el_num(sepi, sepj, r, denuc, itype, delta, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: r
-      REAL(dp), DIMENSION(3), INTENT(OUT)                :: denuc
+      REAL(dp), DIMENSION(3)                             :: denuc
       INTEGER, INTENT(IN)                                :: itype
       REAL(dp), INTENT(IN)                               :: delta
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control

--- a/src/semi_empirical_int_utils.F
+++ b/src/semi_empirical_int_utils.F
@@ -1663,7 +1663,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: r
       TYPE(rotmat_type), POINTER                         :: ij_matrix
       LOGICAL, INTENT(IN)                                :: do_derivatives
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: do_invert
+      LOGICAL, OPTIONAL                                  :: do_invert
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug_invert
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rotmat', routineP = moduleN//':'//routineN
@@ -2079,15 +2079,14 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: invert
       INTEGER, INTENT(IN)                                :: ii, kk
       REAL(KIND=dp), DIMENSION(491), INTENT(IN)          :: rep
-      LOGICAL, DIMENSION(45, 45), INTENT(OUT)            :: logv
+      LOGICAL, DIMENSION(45, 45)                         :: logv
       TYPE(rotmat_type), POINTER                         :: ij_matrix
-      REAL(KIND=dp), DIMENSION(45, 45), INTENT(OUT)      :: v
+      REAL(KIND=dp), DIMENSION(45, 45)                   :: v
       LOGICAL, INTENT(IN)                                :: lgrad
       REAL(KIND=dp), DIMENSION(491), INTENT(IN), &
          OPTIONAL                                        :: rep_d
-      REAL(KIND=dp), DIMENSION(3, 45, 45), INTENT(OUT), &
-         OPTIONAL                                        :: v_d
-      LOGICAL, DIMENSION(45, 45), INTENT(OUT), OPTIONAL  :: logv_d
+      REAL(KIND=dp), DIMENSION(3, 45, 45), OPTIONAL      :: v_d
+      LOGICAL, DIMENSION(45, 45), OPTIONAL               :: logv_d
       REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: drij
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rot_2el_2c_first', &

--- a/src/semi_empirical_integrals.F
+++ b/src/semi_empirical_integrals.F
@@ -69,7 +69,7 @@ CONTAINS
    SUBROUTINE rotint(sepi, sepj, rij, w, anag, se_int_control, se_taper, store_int_env)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(2025), INTENT(OUT)             :: w
+      REAL(dp), DIMENSION(2025)                          :: w
       LOGICAL                                            :: anag
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
       TYPE(se_taper_type), POINTER                       :: se_taper
@@ -221,7 +221,7 @@ CONTAINS
    SUBROUTINE rotnuc(sepi, sepj, rij, e1b, e2a, itype, anag, se_int_control, se_taper, store_int_env)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(45), INTENT(OUT), OPTIONAL     :: e1b, e2a
+      REAL(dp), DIMENSION(45), OPTIONAL                  :: e1b, e2a
       INTEGER, INTENT(IN)                                :: itype
       LOGICAL, INTENT(IN)                                :: anag
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -399,7 +399,7 @@ CONTAINS
    SUBROUTINE corecore(sepi, sepj, rij, enuc, itype, anag, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), INTENT(OUT)                              :: enuc
+      REAL(dp)                                           :: enuc
       INTEGER, INTENT(IN)                                :: itype
       LOGICAL, INTENT(IN)                                :: anag
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -440,7 +440,7 @@ CONTAINS
    SUBROUTINE corecore_el(sepi, sepj, rij, enuc, itype, anag, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), INTENT(OUT)                              :: enuc
+      REAL(dp)                                           :: enuc
       INTEGER, INTENT(IN)                                :: itype
       LOGICAL, INTENT(IN)                                :: anag
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -475,7 +475,7 @@ CONTAINS
    SUBROUTINE drotint(sepi, sepj, rij, dw, delta, anag, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(3, 2025), INTENT(OUT)          :: dw
+      REAL(dp), DIMENSION(3, 2025)                       :: dw
       REAL(dp), INTENT(IN)                               :: delta
       LOGICAL, INTENT(IN)                                :: anag
       TYPE(se_int_control_type), INTENT(IN)              :: se_int_control
@@ -514,7 +514,7 @@ CONTAINS
    SUBROUTINE drotnuc(sepi, sepj, rij, de1b, de2a, itype, delta, anag, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(3, 45), INTENT(OUT), OPTIONAL  :: de1b, de2a
+      REAL(dp), DIMENSION(3, 45), OPTIONAL               :: de1b, de2a
       INTEGER, INTENT(IN)                                :: itype
       REAL(dp), INTENT(IN)                               :: delta
       LOGICAL, INTENT(IN)                                :: anag
@@ -557,7 +557,7 @@ CONTAINS
    SUBROUTINE dcorecore(sepi, sepj, rij, denuc, itype, delta, anag, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(3), INTENT(OUT)                :: denuc
+      REAL(dp), DIMENSION(3)                             :: denuc
       INTEGER, INTENT(IN)                                :: itype
       REAL(dp), INTENT(IN)                               :: delta
       LOGICAL, INTENT(IN)                                :: anag
@@ -600,7 +600,7 @@ CONTAINS
    SUBROUTINE dcorecore_el(sepi, sepj, rij, denuc, itype, delta, anag, se_int_control, se_taper)
       TYPE(semi_empirical_type), POINTER                 :: sepi, sepj
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rij
-      REAL(dp), DIMENSION(3), INTENT(OUT)                :: denuc
+      REAL(dp), DIMENSION(3)                             :: denuc
       INTEGER, INTENT(IN)                                :: itype
       REAL(dp), INTENT(IN)                               :: delta
       LOGICAL, INTENT(IN)                                :: anag

--- a/src/semi_empirical_mpole_methods.F
+++ b/src/semi_empirical_mpole_methods.F
@@ -234,7 +234,7 @@ CONTAINS
 !> \author Teodoro Laino [tlaino] - University of Zurich
 ! **************************************************************************************************
    SUBROUTINE quadrupole_sph_to_cart(qcart, qsph)
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: qcart
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: qcart
       REAL(KIND=dp), DIMENSION(5), INTENT(IN)            :: qsph
 
       CHARACTER(len=*), PARAMETER :: routineN = 'quadrupole_sph_to_cart', &

--- a/src/semi_empirical_par_utils.F
+++ b/src/semi_empirical_par_utils.F
@@ -541,7 +541,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE amn_l1(sep, amn)
       TYPE(semi_empirical_type), POINTER                 :: sep
-      REAL(KIND=dp), DIMENSION(6), INTENT(OUT)           :: amn
+      REAL(KIND=dp), DIMENSION(6)                        :: amn
 
       CHARACTER(len=*), PARAMETER :: routineN = 'amn_l1', routineP = moduleN//':'//routineN
 
@@ -590,7 +590,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE amn_l2(sep, amn)
       TYPE(semi_empirical_type), POINTER                 :: sep
-      REAL(KIND=dp), DIMENSION(6, 0:2), INTENT(OUT)      :: amn
+      REAL(KIND=dp), DIMENSION(6, 0:2)                   :: amn
 
       CHARACTER(len=*), PARAMETER :: routineN = 'amn_l2', routineP = moduleN//':'//routineN
 
@@ -820,7 +820,7 @@ CONTAINS
    SUBROUTINE sc_param(sep, r066, r266, r466, r016, r244, r036, r236, r155, r355, &
                        r125, r234, r246)
       TYPE(semi_empirical_type), POINTER                 :: sep
-      REAL(KIND=dp), INTENT(out)                         :: r066, r266, r466, r016, r244, r036, &
+      REAL(KIND=dp)                                      :: r066, r266, r466, r016, r244, r036, &
                                                             r236, r155, r355, r125, r234, r246
 
       CHARACTER(len=*), PARAMETER :: routineN = 'sc_param', routineP = moduleN//':'//routineN

--- a/src/semi_empirical_types.F
+++ b/src/semi_empirical_types.F
@@ -368,21 +368,20 @@ CONTAINS
                            acoul, nr, de, ass, asp, app, hsp, gsd, gpd, gdd, ppddg, dpddg, ngauss)
 
       TYPE(semi_empirical_type), POINTER                 :: sep
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      INTEGER, INTENT(OUT), OPTIONAL                     :: typ
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: defined
-      INTEGER, INTENT(OUT), OPTIONAL                     :: z
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: zeff
-      INTEGER, INTENT(OUT), OPTIONAL                     :: natorb
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
+      INTEGER, OPTIONAL                                  :: typ
+      LOGICAL, OPTIONAL                                  :: defined
+      INTEGER, OPTIONAL                                  :: z
+      REAL(KIND=dp), OPTIONAL                            :: zeff
+      INTEGER, OPTIONAL                                  :: natorb
       REAL(KIND=dp), OPTIONAL                            :: eheat
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: beta, sto_exponents
       REAL(KIND=dp), OPTIONAL                            :: uss, upp, udd, uff, alp, eisol, gss, &
                                                             gsp, gpp, gp2, acoul
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nr
+      INTEGER, OPTIONAL                                  :: nr
       REAL(KIND=dp), OPTIONAL                            :: de, ass, asp, app, hsp, gsd, gpd, gdd
       REAL(KIND=dp), DIMENSION(2), OPTIONAL              :: ppddg, dpddg
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ngauss
+      INTEGER, OPTIONAL                                  :: ngauss
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_se_param', routineP = moduleN//':'//routineN
 

--- a/src/shg_int/construct_shg.F
+++ b/src/shg_int/construct_shg.F
@@ -47,8 +47,7 @@ CONTAINS
    SUBROUTINE get_real_scaled_solid_harmonic(Rlm_c, Rlm_s, l, r, r2)
 
       INTEGER, INTENT(IN)                                :: l
-      REAL(KIND=dp), DIMENSION(0:l, -2*l:2*l), &
-         INTENT(OUT)                                     :: Rlm_s, Rlm_c
+      REAL(KIND=dp), DIMENSION(0:l, -2*l:2*l)            :: Rlm_s, Rlm_c
       REAL(KIND=dp), DIMENSION(3)                        :: r
       REAL(KIND=dp)                                      :: r2
 

--- a/src/shg_int/generic_shg_integrals.F
+++ b/src/shg_int/generic_shg_integrals.F
@@ -364,10 +364,8 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: la_max, lb_max
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rab
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(OUT)                                     :: Waux_mat
-      REAL(KIND=dp), ALLOCATABLE, &
-         DIMENSION(:, :, :, :), INTENT(OUT)              :: dWaux_mat
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: Waux_mat
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: dWaux_mat
       LOGICAL, INTENT(IN)                                :: calculate_forces
 
       CHARACTER(len=*), PARAMETER :: routineN = 'precalc_angular_shg_part', &
@@ -1274,10 +1272,8 @@ CONTAINS
 
       TYPE(gto_basis_set_type), POINTER                  :: oba, obb, fba, fbb
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rab
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(OUT)                                     :: Waux_mat
-      REAL(KIND=dp), ALLOCATABLE, &
-         DIMENSION(:, :, :, :), INTENT(OUT)              :: dWaux_mat
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: Waux_mat
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: dWaux_mat
       LOGICAL, INTENT(IN)                                :: calculate_forces
 
       CHARACTER(len=*), PARAMETER :: routineN = 'lri_precalc_angular_shg_part', &

--- a/src/shg_integrals_test.F
+++ b/src/shg_integrals_test.F
@@ -812,7 +812,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: vab_shg, vab_os
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: dvab_shg, dvab_os
-      REAL(KIND=dp), INTENT(OUT)                         :: dmax, ddmax
+      REAL(KIND=dp)                                      :: dmax, ddmax
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_deviation_ab', &
          routineP = moduleN//':'//routineN
@@ -856,7 +856,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: vab_shg, vab_os
       REAL(KIND=dp), DIMENSION(:, :, :, :), INTENT(IN)   :: dvab_shg, dvab_os
-      REAL(KIND=dp), INTENT(OUT)                         :: dmax, ddmax
+      REAL(KIND=dp)                                      :: dmax, ddmax
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_deviation_abx', &
          routineP = moduleN//':'//routineN

--- a/src/spglib_f08.F
+++ b/src/spglib_f08.F
@@ -45,7 +45,7 @@
 
          FUNCTION spg_get_international(symbol, lattice, position, types, num_atom, symprec) bind(c)
             import c_char, c_int, c_double
-            CHARACTER(kind=c_char), INTENT(out) :: symbol(11)
+            CHARACTER(kind=c_char) :: symbol(11)
             REAL(c_double), INTENT(in) :: lattice(3, 3), position(3, *)
             INTEGER(c_int), INTENT(in) :: types(*)
             INTEGER(c_int), INTENT(in), value :: num_atom
@@ -55,7 +55,7 @@
 
          FUNCTION spg_get_schoenflies(symbol, lattice, position, types, num_atom, symprec) bind(c)
             import c_char, c_int, c_double
-            CHARACTER(kind=c_char), INTENT(out) :: symbol(7)
+            CHARACTER(kind=c_char) :: symbol(7)
             REAL(c_double), INTENT(in) :: lattice(3, 3), position(3, *)
             INTEGER(c_int), INTENT(in) :: types(*)
             INTEGER(c_int), INTENT(in), value :: num_atom
@@ -76,7 +76,7 @@
                                              is_shift, is_time_reversal, lattice, position, types, num_atom, symprec) bind(c)
             import c_int, c_double
 !   Beware the map refers to positions starting at 0
-            INTEGER(c_int), INTENT(out) :: grid_point(3, *), map(*) ! size is product(mesh)
+            INTEGER(c_int) :: grid_point(3, *), map(*) ! size is product(mesh)
             INTEGER(c_int), INTENT(in) :: mesh(3), is_shift(3)
             INTEGER(c_int), INTENT(in), value :: is_time_reversal
             REAL(c_double), INTENT(in) :: lattice(3, 3), position(3, *)
@@ -197,7 +197,7 @@
 !> \return ...
 ! **************************************************************************************************
       FUNCTION spg_get_international(symbol, lattice, position, types, num_atom, symprec)
-      CHARACTER, INTENT(out)                             :: symbol(11)
+      CHARACTER                                          :: symbol(11)
       REAL(KIND=dp), INTENT(in)                          :: lattice(:, :), position(:, :)
       INTEGER, INTENT(in)                                :: types(:), num_atom
       REAL(KIND=dp), INTENT(in)                          :: symprec
@@ -225,7 +225,7 @@
 !> \return ...
 ! **************************************************************************************************
       FUNCTION spg_get_schoenflies(symbol, lattice, position, types, num_atom, symprec)
-      CHARACTER, INTENT(out)                             :: symbol(7)
+      CHARACTER                                          :: symbol(7)
       REAL(KIND=dp), INTENT(in)                          :: lattice(:, :), position(:, :)
       INTEGER, INTENT(in)                                :: types(:), num_atom
       REAL(KIND=dp), INTENT(in)                          :: symprec
@@ -280,7 +280,7 @@
 ! **************************************************************************************************
       FUNCTION spg_get_ir_reciprocal_mesh(grid_point, map, mesh, &
                                           is_shift, is_time_reversal, lattice, position, types, num_atom, symprec)
-      INTEGER, INTENT(out)                               :: grid_point(:, :), map(:)
+      INTEGER                                            :: grid_point(:, :), map(:)
       INTEGER, INTENT(in)                                :: mesh(:), is_shift(:), is_time_reversal
       REAL(KIND=dp), INTENT(in)                          :: lattice(:, :), position(:, :)
       INTEGER, INTENT(in)                                :: types(:), num_atom

--- a/src/splines_methods.F
+++ b/src/splines_methods.F
@@ -163,7 +163,7 @@ CONTAINS
    FUNCTION potential_s(spl_p, xxi, y1, spl_f, logger)
       TYPE(spline_data_p_type), DIMENSION(:), POINTER    :: spl_p
       REAL(KIND=dp), INTENT(IN)                          :: xxi
-      REAL(KIND=dp), INTENT(OUT)                         :: y1
+      REAL(KIND=dp)                                      :: y1
       TYPE(spline_factor_type), POINTER                  :: spl_f
       TYPE(cp_logger_type), POINTER                      :: logger
       REAL(KIND=dp)                                      :: potential_s
@@ -220,7 +220,7 @@ CONTAINS
       ! Return value
       TYPE(spline_data_type), POINTER                    :: spl
       REAL(KIND=dp), INTENT(IN)                          :: xx
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: y1
+      REAL(KIND=dp), OPTIONAL                            :: y1
       REAL(KIND=dp)                                      :: spline_value
 
       REAL(KIND=dp), PARAMETER                           :: f13 = 1.0_dp/3.0_dp

--- a/src/spme.F
+++ b/src/spme.F
@@ -95,13 +95,12 @@ CONTAINS
       TYPE(ewald_pw_type), POINTER                       :: ewald_pw
       TYPE(cell_type), POINTER                           :: box
       TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: particle_set
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fg_coulomb
-      REAL(KIND=dp), INTENT(OUT)                         :: vg_coulomb
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: pv_g
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fg_coulomb
+      REAL(KIND=dp)                                      :: vg_coulomb
+      REAL(KIND=dp), DIMENSION(:, :)                     :: pv_g
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: shell_particle_set, core_particle_set
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT), &
-         OPTIONAL                                        :: fgshell_coulomb, fgcore_coulomb
+      REAL(KIND=dp), DIMENSION(:, :), OPTIONAL           :: fgshell_coulomb, fgcore_coulomb
       LOGICAL, INTENT(IN)                                :: use_virial
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: charges
       TYPE(atprop_type), POINTER                         :: atprop
@@ -758,7 +757,7 @@ CONTAINS
       TYPE(greens_fn_type), POINTER                      :: green
       INTEGER, DIMENSION(3), INTENT(IN)                  :: npts
       INTEGER, INTENT(IN)                                :: p
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: rhos
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: rhos
       LOGICAL, INTENT(IN)                                :: is_core, is_shell, unit_charge
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: charges
 
@@ -817,7 +816,7 @@ CONTAINS
       TYPE(greens_fn_type), POINTER                      :: green
       INTEGER, DIMENSION(3), INTENT(IN)                  :: npts
       INTEGER, INTENT(IN)                                :: p
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: rhos
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: rhos
       REAL(KIND=dp), DIMENSION(:), POINTER               :: charges
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_patch_b', routineP = moduleN//':'//routineN
@@ -847,7 +846,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE spme_get_patch(rhos, n, delta, q, coeff)
 
-      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)     :: rhos
+      REAL(KIND=dp), DIMENSION(:, :, :)                  :: rhos
       INTEGER, INTENT(IN)                                :: n
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: delta
       REAL(KIND=dp), INTENT(IN)                          :: q
@@ -918,7 +917,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: box
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
       INTEGER, DIMENSION(3), INTENT(IN)                  :: npts
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: delta
+      REAL(KIND=dp), DIMENSION(3)                        :: delta
       INTEGER, INTENT(IN)                                :: n
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_delta', routineP = moduleN//':'//routineN

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -1081,7 +1081,7 @@ CONTAINS
    SUBROUTINE run_input(input_declaration, input_file_path, output_file_path, ierr, mpi_comm)
       TYPE(section_type), POINTER                        :: input_declaration
       CHARACTER(len=*), INTENT(in)                       :: input_file_path, output_file_path
-      INTEGER, INTENT(out)                               :: ierr
+      INTEGER                               :: ierr
       INTEGER, INTENT(in), OPTIONAL                      :: mpi_comm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'run_input', routineP = moduleN//':'//routineN

--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -60,7 +60,7 @@ CONTAINS
 !> \param str_length ...
 ! **************************************************************************************************
    SUBROUTINE cp2k_get_version(version_str, str_length) BIND(C)
-      CHARACTER(LEN=1, KIND=C_CHAR), INTENT(OUT)         :: version_str(*)
+      CHARACTER(LEN=1, KIND=C_CHAR)                      :: version_str(*)
       INTEGER(C_INT), VALUE                              :: str_length
 
       INTEGER                                            :: i, n
@@ -122,7 +122,7 @@ CONTAINS
 !> \param output_file_path ...
 ! **************************************************************************************************
    SUBROUTINE cp2k_create_force_env(new_env_id, input_file_path, output_file_path) BIND(C)
-      INTEGER(C_INT), INTENT(OUT)                        :: new_env_id
+      INTEGER(C_INT)                                     :: new_env_id
       CHARACTER(LEN=1, KIND=C_CHAR), INTENT(IN)          :: input_file_path(*), output_file_path(*)
 
       CHARACTER(LEN=default_path_length)                 :: ifp, ofp
@@ -148,7 +148,7 @@ CONTAINS
 !> \param mpi_comm ...
 ! **************************************************************************************************
    SUBROUTINE cp2k_create_force_env_comm(new_env_id, input_file_path, output_file_path, mpi_comm) BIND(C)
-      INTEGER(C_INT), INTENT(OUT)                        :: new_env_id
+      INTEGER(C_INT)                                     :: new_env_id
       CHARACTER(LEN=1, KIND=C_CHAR), INTENT(IN)          :: input_file_path(*), output_file_path(*)
       INTEGER(C_INT), VALUE                              :: mpi_comm
 
@@ -223,7 +223,7 @@ CONTAINS
       INTEGER(C_INT), VALUE                              :: env_id
       CHARACTER(LEN=1, KIND=C_CHAR), INTENT(IN)          :: description(*)
       INTEGER(C_INT), VALUE                              :: n_el
-      REAL(C_DOUBLE), DIMENSION(1:n_el), INTENT(OUT)     :: RESULT
+      REAL(C_DOUBLE), DIMENSION(1:n_el)                  :: RESULT
 
       CHARACTER(LEN=default_string_length)               :: desc_low
       INTEGER                                            :: ierr
@@ -242,7 +242,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp2k_get_natom(env_id, natom) BIND(C)
       INTEGER(C_INT), VALUE                              :: env_id
-      INTEGER(C_INT), INTENT(OUT)                        :: natom
+      INTEGER(C_INT)                                     :: natom
 
       INTEGER                                            :: ierr
 
@@ -257,7 +257,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp2k_get_nparticle(env_id, nparticle) BIND(C)
       INTEGER(C_INT), VALUE                              :: env_id
-      INTEGER(C_INT), INTENT(OUT)                        :: nparticle
+      INTEGER(C_INT)                                     :: nparticle
 
       INTEGER                                            :: ierr
 
@@ -273,7 +273,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp2k_get_positions(env_id, pos, n_el) BIND(C)
       INTEGER(C_INT), VALUE                              :: env_id, n_el
-      REAL(C_DOUBLE), DIMENSION(1:n_el), INTENT(OUT)     :: pos
+      REAL(C_DOUBLE), DIMENSION(1:n_el)                  :: pos
 
       INTEGER                                            :: ierr
 
@@ -289,7 +289,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp2k_get_forces(env_id, force, n_el) BIND(C)
       INTEGER(C_INT), VALUE                              :: env_id, n_el
-      REAL(C_DOUBLE), DIMENSION(1:n_el), INTENT(OUT)     :: force
+      REAL(C_DOUBLE), DIMENSION(1:n_el)                  :: force
 
       INTEGER                                            :: ierr
 
@@ -304,7 +304,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp2k_get_potential_energy(env_id, e_pot) BIND(C)
       INTEGER(C_INT), VALUE                              :: env_id
-      REAL(C_DOUBLE), INTENT(OUT)                        :: e_pot
+      REAL(C_DOUBLE)                                     :: e_pot
 
       INTEGER                                            :: ierr
 
@@ -457,8 +457,7 @@ CONTAINS
       USE qs_environment_types, ONLY: get_qs_env
       INTEGER(C_INT), VALUE                              :: f_env_id
       INTEGER(C_LONG), VALUE                             :: buf_len
-      REAL(C_DOUBLE), DIMENSION(0:buf_len-1), &
-         INTENT(OUT)                                     :: buf
+      REAL(C_DOUBLE), DIMENSION(0:buf_len-1)             :: buf
 
       INTEGER                                            :: i, ierr, j, norb
       REAL(C_DOUBLE)                                     :: mval
@@ -545,9 +544,9 @@ CONTAINS
       USE qs_environment_types, ONLY: get_qs_env
       INTEGER(C_INT), INTENT(IN), VALUE                  :: f_env_id
       INTEGER(C_LONG), INTENT(IN), VALUE                 :: buf_coords_len
-      INTEGER(C_INT), INTENT(OUT), TARGET                :: buf_coords(1:buf_coords_len)
+      INTEGER(C_INT), TARGET                             :: buf_coords(1:buf_coords_len)
       INTEGER(C_LONG), INTENT(IN), VALUE                 :: buf_values_len
-      REAL(C_DOUBLE), INTENT(OUT), TARGET                :: buf_values(1:buf_values_len)
+      REAL(C_DOUBLE), TARGET                             :: buf_values(1:buf_values_len)
 
       INTEGER                                            :: ierr
       TYPE(active_space_type), POINTER                   :: active_space_env
@@ -587,7 +586,7 @@ CONTAINS
 !> \author Tiziano Mueller
 ! **************************************************************************************************
    SUBROUTINE strncpy_c2f(fstring, cstring)
-      CHARACTER(LEN=*), INTENT(OUT)                      :: fstring
+      CHARACTER(LEN=*)                                   :: fstring
       CHARACTER(LEN=1, KIND=C_CHAR), INTENT(IN)          :: cstring(*)
 
       INTEGER                                            :: i

--- a/src/statistical_methods.F
+++ b/src/statistical_methods.F
@@ -46,7 +46,7 @@ CONTAINS
    SUBROUTINE sw_test(ix, n, w, pw)
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ix
       INTEGER, INTENT(IN)                                :: n
-      REAL(KIND=dp), INTENT(OUT)                         :: w, pw
+      REAL(KIND=dp)                                      :: w, pw
 
       CHARACTER(len=*), PARAMETER :: routineN = 'sw_test', routineP = moduleN//':'//routineN
       REAL(KIND=dp), PARAMETER :: c1(6) = (/0.000000_dp, 0.221157_dp, -0.147981_dp, -2.071190_dp, &
@@ -208,7 +208,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ppnd7(p, normal_dev)
       REAL(KIND=dp), INTENT(IN)                          :: p
-      REAL(KIND=dp), INTENT(OUT)                         :: normal_dev
+      REAL(KIND=dp)                                      :: normal_dev
 
       REAL(KIND=dp), PARAMETER :: a0 = 3.3871327179E+00_dp, a1 = 5.0434271938E+01_dp, &
          a2 = 1.5929113202E+02_dp, a3 = 5.9109374720E+01_dp, b1 = 1.7895169469E+01_dp, &

--- a/src/subcell_types.F
+++ b/src/subcell_types.F
@@ -193,7 +193,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE give_ijk_subcell(r, i, j, k, cell, nsubcell)
       REAL(KIND=dp)                                      :: r(3)
-      INTEGER, INTENT(OUT)                               :: i, j, k
+      INTEGER                                            :: i, j, k
       TYPE(cell_type), POINTER                           :: cell
       INTEGER, DIMENSION(3), INTENT(IN)                  :: nsubcell
 

--- a/src/subsys/atomic_kind_types.F
+++ b/src/subsys/atomic_kind_types.F
@@ -143,17 +143,16 @@ CONTAINS
 
       TYPE(atomic_kind_type)                             :: atomic_kind
       TYPE(fist_potential_type), OPTIONAL, POINTER       :: fist_potential
-      CHARACTER(LEN=2), INTENT(OUT), OPTIONAL            :: element_symbol
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: mass
-      INTEGER, INTENT(OUT), OPTIONAL                     :: kind_number, natom
+      CHARACTER(LEN=2), OPTIONAL                         :: element_symbol
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
+      REAL(KIND=dp), OPTIONAL                            :: mass
+      INTEGER, OPTIONAL                                  :: kind_number, natom
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: atom_list
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: rcov, rvdw
-      INTEGER, INTENT(OUT), OPTIONAL                     :: z
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: qeff, apol, cpol, mm_radius
+      REAL(KIND=dp), OPTIONAL                            :: rcov, rvdw
+      INTEGER, OPTIONAL                                  :: z
+      REAL(KIND=dp), OPTIONAL                            :: qeff, apol, cpol, mm_radius
       TYPE(shell_kind_type), OPTIONAL, POINTER           :: shell
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: shell_active
+      LOGICAL, OPTIONAL                                  :: shell_active
       TYPE(damping_p_type), OPTIONAL, POINTER            :: damping
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_atomic_kind', &
@@ -236,9 +235,9 @@ CONTAINS
                                   damping_present)
 
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL       :: atom_of_kind, kind_of, natom_of_kind
-      INTEGER, INTENT(OUT), OPTIONAL                     :: maxatom, natom, nshell
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: fist_potential_present, shell_present, &
+      INTEGER, DIMENSION(:), OPTIONAL                    :: atom_of_kind, kind_of, natom_of_kind
+      INTEGER, OPTIONAL                                  :: maxatom, natom, nshell
+      LOGICAL, OPTIONAL                                  :: fist_potential_present, shell_present, &
                                                             shell_adiabatic, shell_check_distance, &
                                                             damping_present
 

--- a/src/subsys/cell_types.F
+++ b/src/subsys/cell_types.F
@@ -150,10 +150,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE parse_cell_line(input_line, cell_itimes, cell_time, h, vol)
       CHARACTER(LEN=*), INTENT(IN)                       :: input_line
-      INTEGER, INTENT(OUT)                               :: cell_itimes
-      REAL(KIND=dp), INTENT(OUT)                         :: cell_time
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: h
-      REAL(KIND=dp), INTENT(OUT)                         :: vol
+      INTEGER                                            :: cell_itimes
+      REAL(KIND=dp)                                      :: cell_time
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: h
+      REAL(KIND=dp)                                      :: vol
 
       CHARACTER(len=*), PARAMETER :: routineN = 'parse_cell_line', &
          routineP = moduleN//':'//routineN
@@ -192,13 +192,12 @@ CONTAINS
                        h, h_inv, id_nr, symmetry_id)
 
       TYPE(cell_type), POINTER                           :: cell
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: alpha, beta, gamma, deth
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: orthorhombic
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: abc
-      INTEGER, DIMENSION(3), INTENT(OUT), OPTIONAL       :: periodic
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
-         OPTIONAL                                        :: h, h_inv
-      INTEGER, INTENT(out), OPTIONAL                     :: id_nr, symmetry_id
+      REAL(KIND=dp), OPTIONAL                            :: alpha, beta, gamma, deth
+      LOGICAL, OPTIONAL                                  :: orthorhombic
+      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: abc
+      INTEGER, DIMENSION(3), OPTIONAL                    :: periodic
+      REAL(KIND=dp), DIMENSION(3, 3), OPTIONAL           :: h, h_inv
+      INTEGER, OPTIONAL                                  :: id_nr, symmetry_id
 
       IF (PRESENT(deth)) deth = cell%deth ! the volume
       IF (PRESENT(orthorhombic)) orthorhombic = cell%orthorhombic
@@ -245,10 +244,10 @@ CONTAINS
    SUBROUTINE get_cell_param(cell, cell_length, cell_angle, units_angle, periodic)
 
       TYPE(cell_type), POINTER                           :: cell
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: cell_length
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: cell_angle
+      REAL(KIND=dp), DIMENSION(3)                        :: cell_length
+      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: cell_angle
       INTEGER, INTENT(IN), OPTIONAL                      :: units_angle
-      INTEGER, DIMENSION(3), INTENT(OUT), OPTIONAL       :: periodic
+      INTEGER, DIMENSION(3), OPTIONAL                    :: periodic
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_cell_param', routineP = moduleN//':'//routineN
 
@@ -713,7 +712,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE real_to_scaled(s, r, cell)
 
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: s
+      REAL(KIND=dp), DIMENSION(3)                        :: s
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
       TYPE(cell_type), POINTER                           :: cell
 
@@ -741,7 +740,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE scaled_to_real(r, s, cell)
 
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: r
+      REAL(KIND=dp), DIMENSION(3)                        :: r
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: s
       TYPE(cell_type), POINTER                           :: cell
 

--- a/src/subsys/colvar_types.F
+++ b/src/subsys/colvar_types.F
@@ -1931,7 +1931,7 @@ CONTAINS
    SUBROUTINE eval_point_pos(point, particles, r)
       TYPE(point_type)                                   :: point
       TYPE(particle_type), DIMENSION(:), POINTER         :: particles
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: r
+      REAL(KIND=dp), DIMENSION(3)                        :: r
 
       INTEGER                                            :: i
 
@@ -1956,7 +1956,7 @@ CONTAINS
    SUBROUTINE eval_point_mass(point, particles, m)
       TYPE(point_type)                                   :: point
       TYPE(particle_type), DIMENSION(:), POINTER         :: particles
-      REAL(KIND=dp), INTENT(OUT)                         :: m
+      REAL(KIND=dp)                                      :: m
 
       INTEGER                                            :: i
 

--- a/src/subsys/cp_subsys_types.F
+++ b/src/subsys/cp_subsys_types.F
@@ -347,7 +347,7 @@ CONTAINS
                             natom, nparticle, ncore, nshell, nkind, atprop, virial, &
                             results, cell)
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      INTEGER, INTENT(out), OPTIONAL                     :: ref_count
+      INTEGER, OPTIONAL                                  :: ref_count
       TYPE(atomic_kind_list_type), OPTIONAL, POINTER     :: atomic_kinds
       TYPE(atomic_kind_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: atomic_kind_set
@@ -368,7 +368,7 @@ CONTAINS
       TYPE(particle_list_type), OPTIONAL, POINTER        :: shell_particles, core_particles
       TYPE(global_constraint_type), OPTIONAL, POINTER    :: gci
       TYPE(multipole_type), OPTIONAL, POINTER            :: multipoles
-      INTEGER, INTENT(out), OPTIONAL                     :: natom, nparticle, ncore, nshell, nkind
+      INTEGER, OPTIONAL                                  :: natom, nparticle, ncore, nshell, nkind
       TYPE(atprop_type), OPTIONAL, POINTER               :: atprop
       TYPE(virial_type), OPTIONAL, POINTER               :: virial
       TYPE(cp_result_type), OPTIONAL, POINTER            :: results
@@ -451,7 +451,7 @@ CONTAINS
    SUBROUTINE pack_subsys_particles(subsys, f, r, s, v, fscale, cell)
 
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT), OPTIONAL :: f, r, s, v
+      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: f, r, s, v
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: fscale
       TYPE(cell_type), OPTIONAL, POINTER                 :: cell
 

--- a/src/subsys/external_potential_types.F
+++ b/src/subsys/external_potential_types.F
@@ -671,12 +671,11 @@ CONTAINS
                                 ccore_charge, core_charge_radius, z, zeff, &
                                 zeff_correction, elec_conf)
       TYPE(all_potential_type), POINTER                  :: potential
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: alpha_core_charge, ccore_charge, &
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
+      REAL(KIND=dp), OPTIONAL                            :: alpha_core_charge, ccore_charge, &
                                                             core_charge_radius
-      INTEGER, INTENT(OUT), OPTIONAL                     :: z
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: zeff, zeff_correction
+      INTEGER, OPTIONAL                                  :: z
+      REAL(KIND=dp), OPTIONAL                            :: zeff, zeff_correction
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: elec_conf
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_all_potential', &
@@ -720,9 +719,8 @@ CONTAINS
    SUBROUTINE get_fist_potential(potential, name, apol, cpol, mm_radius, qeff, &
                                  qmmm_corr_radius, qmmm_radius)
       TYPE(fist_potential_type), POINTER                 :: potential
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: apol, cpol, mm_radius, qeff, &
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
+      REAL(KIND=dp), OPTIONAL                            :: apol, cpol, mm_radius, qeff, &
                                                             qmmm_corr_radius, qmmm_radius
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_fist_potential', &
@@ -761,12 +759,11 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_local_potential(potential, name, ngau, npol, alpha, cval, radius)
       TYPE(local_potential_type), POINTER                :: potential
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      INTEGER, INTENT(OUT), OPTIONAL                     :: ngau, npol
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
+      INTEGER, OPTIONAL                                  :: ngau, npol
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: alpha
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: cval
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: radius
+      REAL(KIND=dp), OPTIONAL                            :: radius
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_local_potential', &
          routineP = moduleN//':'//routineN
@@ -850,33 +847,32 @@ CONTAINS
                                 nlcc_present, nexp_nlcc, alpha_nlcc, nct_nlcc, cval_nlcc)
 
       TYPE(gth_potential_type), POINTER                  :: potential
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name, aliases
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: alpha_core_charge, alpha_ppl, &
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name, aliases
+      REAL(KIND=dp), OPTIONAL                            :: alpha_core_charge, alpha_ppl, &
                                                             ccore_charge, cerf_ppl, &
                                                             core_charge_radius, ppl_radius, &
                                                             ppnl_radius
-      INTEGER, INTENT(OUT), OPTIONAL                     :: lppnl, lprj_ppnl_max, nexp_ppl, nppnl, &
+      INTEGER, OPTIONAL                                  :: lppnl, lprj_ppnl_max, nexp_ppl, nppnl, &
                                                             nprj_ppnl_max, z
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: zeff, zeff_correction
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: ppl_present, ppnl_present
+      REAL(KIND=dp), OPTIONAL                            :: zeff, zeff_correction
+      LOGICAL, OPTIONAL                                  :: ppl_present, ppnl_present
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: alpha_ppnl, cexp_ppl
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: elec_conf, nprj_ppnl
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: cprj, cprj_ppnl, vprj_ppnl
       REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
          POINTER                                         :: hprj_ppnl
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: lpot_present
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nexp_lpot
+      LOGICAL, OPTIONAL                                  :: lpot_present
+      INTEGER, OPTIONAL                                  :: nexp_lpot
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: alpha_lpot
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: nct_lpot
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: cval_lpot
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: lsd_present
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nexp_lsd
+      LOGICAL, OPTIONAL                                  :: lsd_present
+      INTEGER, OPTIONAL                                  :: nexp_lsd
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: alpha_lsd
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: nct_lsd
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: cval_lsd
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: nlcc_present
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nexp_nlcc
+      LOGICAL, OPTIONAL                                  :: nlcc_present
+      INTEGER, OPTIONAL                                  :: nexp_nlcc
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: alpha_nlcc
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: nct_nlcc
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: cval_nlcc
@@ -991,25 +987,23 @@ CONTAINS
                                 cprj_ppnl, vprj_ppnl, has_nlcc, n_nlcc, a_nlcc, c_nlcc)
 
       TYPE(sgp_potential_type), POINTER                  :: potential
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
       CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
-      CHARACTER(LEN=default_string_length), &
-         DIMENSION(4), INTENT(OUT), OPTIONAL             :: description
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: aliases
+         DIMENSION(4), OPTIONAL                          :: description
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: aliases
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: elec_conf
-      INTEGER, INTENT(OUT), OPTIONAL                     :: z
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: zeff, zeff_correction, &
+      INTEGER, OPTIONAL                                  :: z
+      REAL(KIND=dp), OPTIONAL                            :: zeff, zeff_correction, &
                                                             alpha_core_charge, ccore_charge, &
                                                             core_charge_radius, ppl_radius, &
                                                             ppnl_radius
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: ppl_present, ppnl_present, ecp_local
-      INTEGER, INTENT(OUT), OPTIONAL                     :: n_local
+      LOGICAL, OPTIONAL                                  :: ppl_present, ppnl_present, ecp_local
+      INTEGER, OPTIONAL                                  :: n_local
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: a_local, c_local
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nloc
-      INTEGER, DIMENSION(1:10), INTENT(OUT), OPTIONAL    :: nrloc
-      REAL(dp), DIMENSION(1:10), INTENT(OUT), OPTIONAL   :: aloc, bloc
-      INTEGER, INTENT(OUT), OPTIONAL                     :: n_nonlocal, nppnl, lmax
+      INTEGER, OPTIONAL                                  :: nloc
+      INTEGER, DIMENSION(1:10), OPTIONAL                 :: nrloc
+      REAL(dp), DIMENSION(1:10), OPTIONAL                :: aloc, bloc
+      INTEGER, OPTIONAL                                  :: n_nonlocal, nppnl, lmax
       LOGICAL, DIMENSION(0:5), OPTIONAL                  :: is_nonlocal
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: a_nonlocal
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: h_nonlocal
@@ -1017,8 +1011,8 @@ CONTAINS
          POINTER                                         :: c_nonlocal
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: cprj_ppnl
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: vprj_ppnl
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: has_nlcc
-      INTEGER, INTENT(OUT), OPTIONAL                     :: n_nlcc
+      LOGICAL, OPTIONAL                                  :: has_nlcc
+      INTEGER, OPTIONAL                                  :: n_nlcc
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: a_nlcc, c_nlcc
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_sgp_potential', &

--- a/src/subsys/molecule_kind_types.F
+++ b/src/subsys/molecule_kind_types.F
@@ -598,17 +598,16 @@ CONTAINS
       TYPE(torsion_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: torsion_list
       TYPE(shell_type), DIMENSION(:), OPTIONAL, POINTER  :: shell_list
-      CHARACTER(LEN=default_string_length), &
-         INTENT(OUT), OPTIONAL                           :: name
+      CHARACTER(LEN=default_string_length), OPTIONAL     :: name
       REAL(KIND=dp), OPTIONAL                            :: mass, charge
-      INTEGER, INTENT(OUT), OPTIONAL                     :: kind_number, natom, nbend, nbond, nub, &
+      INTEGER, OPTIONAL                                  :: kind_number, natom, nbend, nbond, nub, &
                                                             nimpr, nopbend, nconstraint, &
                                                             nconstraint_fixd, nfixd
-      TYPE(colvar_counters), INTENT(out), OPTIONAL       :: ncolv
-      INTEGER, INTENT(OUT), OPTIONAL :: ng3x3, ng4x6, nvsite, nfixd_restraint, ng3x3_restraint, &
+      TYPE(colvar_counters), OPTIONAL                    :: ncolv
+      INTEGER, OPTIONAL :: ng3x3, ng4x6, nvsite, nfixd_restraint, ng3x3_restraint, &
          ng4x6_restraint, nvsite_restraint, nrestraints, nmolecule, nsgf, nshell, ntorsion
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: molecule_list
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nelectron, nelectron_alpha, &
+      INTEGER, OPTIONAL                                  :: nelectron, nelectron_alpha, &
                                                             nelectron_beta
       TYPE(bond_kind_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: bond_kind_set
@@ -622,7 +621,7 @@ CONTAINS
          POINTER                                         :: opbend_kind_set
       TYPE(torsion_kind_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: torsion_kind_set
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: molname_generated
+      LOGICAL, OPTIONAL                                  :: molname_generated
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_molecule_kind', &
          routineP = moduleN//':'//routineN
@@ -738,7 +737,7 @@ CONTAINS
                                     nrestraints)
 
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
-      INTEGER, INTENT(OUT), OPTIONAL                     :: maxatom, natom, nbond, nbend, nub, &
+      INTEGER, OPTIONAL                                  :: maxatom, natom, nbond, nbend, nub, &
                                                             ntorsion, nimpr, nopbend, nconstraint, &
                                                             nconstraint_fixd, nmolecule, &
                                                             nrestraints

--- a/src/subsys/molecule_types.F
+++ b/src/subsys/molecule_types.F
@@ -469,7 +469,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE molecule_of_atom(molecule_set, atom_to_mol)
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
-      INTEGER, DIMENSION(:), INTENT(OUT)                 :: atom_to_mol
+      INTEGER, DIMENSION(:)                              :: atom_to_mol
 
       CHARACTER(len=*), PARAMETER :: routineN = 'molecule_of_atom', &
          routineP = moduleN//':'//routineN
@@ -506,8 +506,8 @@ CONTAINS
                                     mol_to_multiplicity)
 
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
-      INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL :: atom_to_mol, mol_to_first_atom, &
-         mol_to_last_atom, mol_to_nelectrons, mol_to_nbasis, mol_to_charge, mol_to_multiplicity
+      INTEGER, DIMENSION(:), OPTIONAL :: atom_to_mol, mol_to_first_atom, mol_to_last_atom, &
+         mol_to_nelectrons, mol_to_nbasis, mol_to_charge, mol_to_multiplicity
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_molecule_set_info', &
          routineP = moduleN//':'//routineN

--- a/src/subsys/shell_potential_types.F
+++ b/src/subsys/shell_potential_types.F
@@ -69,7 +69,7 @@ CONTAINS
                         mass_shell, k2_spring, k4_spring, max_dist, shell_cutoff)
 
       TYPE(shell_kind_type), POINTER                     :: shell
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: charge, charge_core, charge_shell, &
+      REAL(KIND=dp), OPTIONAL                            :: charge, charge_core, charge_shell, &
                                                             mass_core, mass_shell, k2_spring, &
                                                             k4_spring, max_dist, shell_cutoff
 

--- a/src/subsys/virial_types.F
+++ b/src/subsys/virial_types.F
@@ -111,7 +111,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE zero_virial(virial, reset)
 
-      TYPE(virial_type), INTENT(OUT)                     :: virial
+      TYPE(virial_type)                                  :: virial
       LOGICAL, INTENT(IN), OPTIONAL                      :: reset
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'zero_virial', routineP = moduleN//':'//routineN

--- a/src/swarm/glbopt_history.F
+++ b/src/swarm/glbopt_history.F
@@ -241,8 +241,8 @@ CONTAINS
    SUBROUTINE history_lookup(history, fingerprint, found, id)
       TYPE(history_type), INTENT(IN)                     :: history
       TYPE(history_fingerprint_type), INTENT(IN)         :: fingerprint
-      LOGICAL, INTENT(OUT)                               :: found
-      INTEGER, INTENT(OUT), OPTIONAL                     :: id
+      LOGICAL                                            :: found
+      INTEGER, OPTIONAL                                  :: id
 
       INTEGER                                            :: found_i, handle, i, k, k_max, k_min
       REAL(KIND=dp)                                      :: best_match, dist, Epot

--- a/src/swarm/swarm_master.F
+++ b/src/swarm/swarm_master.F
@@ -228,7 +228,7 @@ CONTAINS
    SUBROUTINE swarm_master_steer(master, report, cmd)
       TYPE(swarm_master_type), INTENT(INOUT)             :: master
       TYPE(swarm_message_type), INTENT(IN)               :: report
-      TYPE(swarm_message_type), INTENT(OUT)              :: cmd
+      TYPE(swarm_message_type)                           :: cmd
 
       CHARACTER(len=*), PARAMETER :: routineN = 'swarm_master_steer', &
          routineP = moduleN//':'//routineN

--- a/src/swarm/swarm_message.F
+++ b/src/swarm/swarm_message.F
@@ -305,7 +305,7 @@ CONTAINS
 !> \author Ole Schuett
 ! **************************************************************************************************
    SUBROUTINE swarm_message_file_read(msg, parser, at_end)
-      TYPE(swarm_message_type), INTENT(OUT)              :: msg
+      TYPE(swarm_message_type)              :: msg
       TYPE(cp_parser_type), POINTER                      :: parser
       LOGICAL, INTENT(INOUT)                             :: at_end
 
@@ -324,7 +324,7 @@ CONTAINS
 !> \author Ole Schuett
 ! **************************************************************************************************
    SUBROUTINE swarm_message_file_read_low(msg, parser, at_end)
-      TYPE(swarm_message_type), INTENT(OUT)              :: msg
+      TYPE(swarm_message_type)              :: msg
       TYPE(cp_parser_type), POINTER                      :: parser
       LOGICAL, INTENT(INOUT)                             :: at_end
 
@@ -935,7 +935,7 @@ CONTAINS
 #:elif label.startswith("1d_")
    ${type}$, POINTER                     :: value
 #:else
-   ${type}$, INTENT(OUT)                 :: value
+   ${type}$                 :: value
 #:endif
 
    TYPE(message_entry_type), POINTER :: curr_entry

--- a/src/swarm/swarm_mpi.F
+++ b/src/swarm/swarm_mpi.F
@@ -76,7 +76,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: world_para_env
       TYPE(section_vals_type), POINTER                   :: root_section
       INTEGER, INTENT(IN)                                :: n_workers
-      INTEGER, INTENT(OUT)                               :: worker_id
+      INTEGER                                            :: worker_id
       INTEGER, INTENT(IN)                                :: iw
 
       CHARACTER(len=*), PARAMETER :: routineN = 'swarm_mpi_init', routineP = moduleN//':'//routineN
@@ -356,7 +356,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_mpi_recv_report(swarm_mpi, report)
       TYPE(swarm_mpi_type)                               :: swarm_mpi
-      TYPE(swarm_message_type), INTENT(OUT)              :: report
+      TYPE(swarm_message_type)                           :: report
 
       INTEGER                                            :: src, tag
 
@@ -395,7 +395,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_mpi_recv_command(swarm_mpi, cmd)
       TYPE(swarm_mpi_type)                               :: swarm_mpi
-      TYPE(swarm_message_type), INTENT(OUT)              :: cmd
+      TYPE(swarm_message_type)                           :: cmd
 
       INTEGER                                            :: src, tag
 

--- a/src/swarm/swarm_worker.F
+++ b/src/swarm/swarm_worker.F
@@ -102,7 +102,7 @@ CONTAINS
    SUBROUTINE swarm_worker_execute(worker, cmd, report, should_stop)
       TYPE(swarm_worker_type), INTENT(INOUT)             :: worker
       TYPE(swarm_message_type), INTENT(IN)               :: cmd
-      TYPE(swarm_message_type), INTENT(OUT)              :: report
+      TYPE(swarm_message_type)                           :: report
       LOGICAL, INTENT(INOUT)                             :: should_stop
 
       CHARACTER(len=*), PARAMETER :: routineN = 'swarm_worker_execute', &

--- a/src/t_c_g0.F
+++ b/src/t_c_g0.F
@@ -70,8 +70,8 @@ CONTAINS
 !> \param NDERIV ...
 ! **************************************************************************************************
    SUBROUTINE t_c_g0_n(RES, use_gamma, R, T, NDERIV)
-      REAL(KIND=dp), INTENT(OUT)                         :: RES(*)
-      LOGICAL, INTENT(OUT)                               :: use_gamma
+      REAL(KIND=dp)                                      :: RES(*)
+      LOGICAL                                            :: use_gamma
       REAL(KIND=dp), INTENT(IN)                          :: R, T
       INTEGER, INTENT(IN)                                :: NDERIV
 
@@ -1384,7 +1384,7 @@ CONTAINS
 !> \param C0 ...
 ! **************************************************************************************************
    SUBROUTINE PD2VAL(RES, NDERIV, TG1, TG2, C0)
-      REAL(KIND=dp), INTENT(OUT)                         :: res(*)
+      REAL(KIND=dp)                                      :: res(*)
       INTEGER, INTENT(IN)                                :: NDERIV
       REAL(KIND=dp), INTENT(IN)                          :: TG1, TG2, C0(105, *)
 

--- a/src/t_sh_p_s_c.F
+++ b/src/t_sh_p_s_c.F
@@ -46,7 +46,7 @@ CONTAINS
 !> \param NDERIV ...
 ! **************************************************************************************************
    SUBROUTINE trunc_CS_poly_n20(RES, R, T, NDERIV)
-      REAL(KIND=dp), INTENT(OUT)                         :: RES(*)
+      REAL(KIND=dp)                                      :: RES(*)
       REAL(KIND=dp), INTENT(IN)                          :: R, T
       INTEGER, INTENT(IN)                                :: NDERIV
 
@@ -1135,7 +1135,7 @@ CONTAINS
 !> \param C0 ...
 ! **************************************************************************************************
    SUBROUTINE PD2VAL(RES, NDERIV, TG1, TG2, C0)
-      REAL(KIND=dp), INTENT(OUT)                         :: res(*)
+      REAL(KIND=dp)                                      :: res(*)
       INTEGER, INTENT(IN)                                :: NDERIV
       REAL(KIND=dp), INTENT(IN)                          :: TG1, TG2, C0(136, *)
 

--- a/src/task_list_methods.F
+++ b/src/task_list_methods.F
@@ -587,8 +587,8 @@ CONTAINS
    SUBROUTINE compute_pgf_properties(cube_center, lb_cube, ub_cube, radius, &
                                      rs_desc, cube_info, la_max, zeta, la_min, lb_max, zetb, lb_min, ra, rab, rab2, eps)
 
-      INTEGER, DIMENSION(3), INTENT(OUT)                 :: cube_center, lb_cube, ub_cube
-      REAL(KIND=dp), INTENT(OUT)                         :: radius
+      INTEGER, DIMENSION(3)                              :: cube_center, lb_cube, ub_cube
+      REAL(KIND=dp)                                      :: radius
       TYPE(realspace_grid_desc_type), POINTER            :: rs_desc
       TYPE(cube_info_type), INTENT(IN)                   :: cube_info
       INTEGER, INTENT(IN)                                :: la_max
@@ -810,7 +810,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pair2int(res, ilevel, image, iatom, jatom, iset, jset, ipgf, jpgf, &
                        nimages, natom, maxset, maxpgf)
-      INTEGER(KIND=int_8), INTENT(OUT)                   :: res
+      INTEGER(KIND=int_8)                                :: res
       INTEGER, INTENT(IN)                                :: ilevel, image, iatom, jatom, iset, jset, &
                                                             ipgf, jpgf, nimages, natom, maxset, &
                                                             maxpgf
@@ -858,7 +858,7 @@ CONTAINS
    SUBROUTINE int2pair(res, ilevel, image, iatom, jatom, iset, jset, ipgf, jpgf, &
                        nimages, natom, maxset, maxpgf)
       INTEGER(KIND=int_8), INTENT(IN)                    :: res
-      INTEGER, INTENT(OUT)                               :: ilevel, image, iatom, jatom, iset, jset, &
+      INTEGER                                            :: ilevel, image, iatom, jatom, iset, jset, &
                                                             ipgf, jpgf
       INTEGER, INTENT(IN)                                :: nimages, natom, maxset, maxpgf
 
@@ -2547,7 +2547,7 @@ CONTAINS
       INTEGER, INTENT(INOUT)                             :: ntasks
       INTEGER(KIND=int_8), DIMENSION(:, :), POINTER      :: tasks
       INTEGER, DIMENSION(3), INTENT(IN)                  :: lb_cube, ub_cube
-      INTEGER, INTENT(OUT)                               :: added_tasks
+      INTEGER                                            :: added_tasks
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rs_find_node', routineP = moduleN//':'//routineN
       INTEGER, PARAMETER                                 :: add_tasks = 1000

--- a/src/tmc/tmc_calculations.F
+++ b/src/tmc/tmc_calculations.F
@@ -160,8 +160,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3), OPTIONAL           :: scaled_hmat
       TYPE(cell_type), OPTIONAL, POINTER                 :: scaled_cell
       REAL(KIND=dp), OPTIONAL                            :: vol
-      REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: abc
-      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: vec
+      REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: abc, vec
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_scaled_cell', &
          routineP = moduleN//':'//routineN
@@ -208,7 +207,7 @@ CONTAINS
    SUBROUTINE get_cell_scaling(cell, scaled_hmat, box_scale)
       TYPE(cell_type), INTENT(IN), POINTER               :: cell
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: scaled_hmat
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: box_scale
+      REAL(KIND=dp), DIMENSION(:)                        :: box_scale
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_cell_scaling', &
          routineP = moduleN//':'//routineN
@@ -431,7 +430,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE three_point_extrapolate(v1, v2, v3, extrapolate, res_err)
       REAL(KIND=dp)                            :: v1, v2, v3
-      REAL(KIND=dp), INTENT(OUT)               :: extrapolate, res_err
+      REAL(KIND=dp)               :: extrapolate, res_err
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'three_point_extrapolate', &
                                      routineP = moduleN//':'//routineN

--- a/src/tmc/tmc_moves.F
+++ b/src/tmc/tmc_moves.F
@@ -370,7 +370,7 @@ CONTAINS
       TYPE(tmc_param_type), POINTER                      :: tmc_params
       INTEGER, DIMENSION(:), INTENT(IN), POINTER         :: mol_arr
       INTEGER, INTENT(IN)                                :: mol
-      INTEGER, INTENT(OUT)                               :: start_ind, end_ind
+      INTEGER                                            :: start_ind, end_ind
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_mol_indeces', &
          routineP = moduleN//':'//routineN
@@ -474,7 +474,7 @@ CONTAINS
       TYPE(tmc_param_type), POINTER                      :: tmc_params
       TYPE(rng_stream_type), POINTER                     :: rng_stream
       TYPE(tree_type), POINTER                           :: elem
-      INTEGER, INTENT(OUT)                               :: nr_of_sub_box_elements
+      INTEGER                                            :: nr_of_sub_box_elements
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'elements_in_new_subbox', &
          routineP = moduleN//':'//routineN

--- a/src/tmc/tmc_tree_build.F
+++ b/src/tmc/tmc_tree_build.F
@@ -491,8 +491,8 @@ CONTAINS
    SUBROUTINE create_new_gt_tree_node(tmc_env, stat, new_elem, &
                                       reactivation_cc_count)
       TYPE(tmc_env_type), POINTER                        :: tmc_env
-      INTEGER, INTENT(OUT)                               :: stat
-      TYPE(global_tree_type), INTENT(OUT), POINTER       :: new_elem
+      INTEGER                                            :: stat
+      TYPE(global_tree_type), POINTER                    :: new_elem
       INTEGER                                            :: reactivation_cc_count
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_new_gt_tree_node', &

--- a/src/tmc/tmc_tree_search.F
+++ b/src/tmc/tmc_tree_search.F
@@ -64,7 +64,7 @@ CONTAINS
    RECURSIVE SUBROUTINE most_prob_end(global_tree_elem, prob, n_acc, &
                                       search_energy_node)
       TYPE(global_tree_type), POINTER                    :: global_tree_elem
-      REAL(KIND=dp), INTENT(OUT)                         :: prob
+      REAL(KIND=dp)                                      :: prob
       LOGICAL, INTENT(INOUT)                             :: n_acc
       LOGICAL, OPTIONAL                                  :: search_energy_node
 
@@ -366,7 +366,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_subtree_elements_to_check(gt_act_elem, elem1, elem2)
       TYPE(global_tree_type), POINTER                    :: gt_act_elem
-      TYPE(tree_type), INTENT(OUT), POINTER              :: elem1, elem2
+      TYPE(tree_type), POINTER                           :: elem1, elem2
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_subtree_elements_to_check', &
          routineP = moduleN//':'//routineN

--- a/src/tmc/tmc_worker.F
+++ b/src/tmc/tmc_worker.F
@@ -598,7 +598,7 @@ CONTAINS
       TYPE(tree_type), POINTER                           :: conf
       INTEGER, INTENT(IN)                                :: env_id
       TYPE(tmc_env_type), POINTER                        :: tmc_env
-      INTEGER, INTENT(OUT)                               :: calc_status
+      INTEGER                                            :: calc_status
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'nested_markov_chain_MC', &
          routineP = moduleN//':'//routineN

--- a/src/topology_amber.F
+++ b/src/topology_amber.F
@@ -1289,7 +1289,7 @@ CONTAINS
 ! **************************************************************************************************
   FUNCTION  get_section_parmtop(parser, section, input_format) RESULT(another_section)
       TYPE(cp_parser_type), POINTER                      :: parser
-      CHARACTER(LEN=default_string_length), INTENT(OUT)  :: section, input_format
+      CHARACTER(LEN=default_string_length)               :: section, input_format
       LOGICAL                                            :: another_section
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_section_parmtop', &

--- a/src/topology_cif.F
+++ b/src/topology_cif.F
@@ -418,7 +418,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cif_get_real(parser, r)
       TYPE(cp_parser_type), POINTER                      :: parser
-      REAL(KIND=dp), INTENT(OUT)                         :: r
+      REAL(KIND=dp)                                      :: r
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cif_get_real', routineP = moduleN//':'//routineN
 

--- a/src/topology_constraint_util.F
+++ b/src/topology_constraint_util.F
@@ -970,7 +970,7 @@ CONTAINS
       TYPE(g3x3_constraint_type), DIMENSION(:), POINTER  :: g3x3_list
       INTEGER, DIMENSION(:), POINTER                     :: ilist
       TYPE(constraint_info_type), POINTER                :: cons_info
-      INTEGER, INTENT(OUT)                               :: ng3x3_restraint
+      INTEGER                                            :: ng3x3_restraint
 
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_g3x3_list', &
          routineP = moduleN//':'//routineN
@@ -1008,7 +1008,7 @@ CONTAINS
       TYPE(g4x6_constraint_type), DIMENSION(:), POINTER  :: g4x6_list
       INTEGER, DIMENSION(:), POINTER                     :: ilist
       TYPE(constraint_info_type), POINTER                :: cons_info
-      INTEGER, INTENT(OUT)                               :: ng4x6_restraint
+      INTEGER                                            :: ng4x6_restraint
 
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_g4x6_list', &
          routineP = moduleN//':'//routineN
@@ -1050,7 +1050,7 @@ CONTAINS
       TYPE(vsite_constraint_type), DIMENSION(:), POINTER :: vsite_list
       INTEGER, DIMENSION(:), POINTER                     :: ilist
       TYPE(constraint_info_type), POINTER                :: cons_info
-      INTEGER, INTENT(OUT)                               :: nvsite_restraint
+      INTEGER                                            :: nvsite_restraint
 
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_vsite_list', &
          routineP = moduleN//':'//routineN

--- a/src/topology_generate_util.F
+++ b/src/topology_generate_util.F
@@ -1309,7 +1309,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE check_element_list(do_it, do_action, atlist, Ilist1, Ilist2, Ilist3, Ilist4, &
                                  is_impr)
-      INTEGER, INTENT(OUT)                               :: do_it
+      INTEGER                                            :: do_it
       INTEGER, INTENT(IN)                                :: do_action
       INTEGER, DIMENSION(:), POINTER                     :: atlist, Ilist1, Ilist2
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: Ilist3, Ilist4

--- a/src/topology_input.F
+++ b/src/topology_input.F
@@ -579,8 +579,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE check_restraint(cons_section, is_restraint, k0, i_rep_section, label)
       TYPE(section_vals_type), POINTER                   :: cons_section
-      LOGICAL, INTENT(OUT)                               :: is_restraint
-      REAL(KIND=dp), INTENT(OUT)                         :: k0
+      LOGICAL                                            :: is_restraint
+      REAL(KIND=dp)                                      :: k0
       INTEGER, INTENT(IN), OPTIONAL                      :: i_rep_section
       CHARACTER(LEN=*), INTENT(IN)                       :: label
 

--- a/src/topology_util.F
+++ b/src/topology_util.F
@@ -1153,7 +1153,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE check_subsys_element(element_in, atom_name_in, element_out, subsys_section, use_mm_map_first)
       CHARACTER(len=*), INTENT(IN)                       :: element_in, atom_name_in
-      CHARACTER(len=default_string_length), INTENT(OUT)  :: element_out
+      CHARACTER(len=default_string_length)               :: element_out
       TYPE(section_vals_type), POINTER                   :: subsys_section
       LOGICAL                                            :: use_mm_map_first
 

--- a/src/transport.F
+++ b/src/transport.F
@@ -529,7 +529,7 @@ CONTAINS
 ! **************************************************************************************************
       SUBROUTINE cumsum_i(arr, cumsum)
       INTEGER, DIMENSION(:), INTENT(IN)                  :: arr
-      INTEGER, DIMENSION(SIZE(arr)), INTENT(OUT)         :: cumsum
+      INTEGER, DIMENSION(SIZE(arr))                      :: cumsum
 
       INTEGER                                            :: i
 

--- a/src/transport_env_types.F
+++ b/src/transport_env_types.F
@@ -221,13 +221,11 @@ CONTAINS
                                           first_row, rowptr_local, colind_local, nzerow_local, nzvals_local)
 
       TYPE(cp2k_csr_interop_type), INTENT(IN)            :: csr_interop_mat
-      INTEGER, INTENT(OUT), OPTIONAL                     :: nrows_total, ncols_total, nze_local, &
+      INTEGER, OPTIONAL                                  :: nrows_total, ncols_total, nze_local, &
                                                             nze_total, nrows_local, data_type, &
                                                             first_row
-      INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL, &
-         POINTER                                         :: rowptr_local, colind_local, nzerow_local
-      REAL(dp), DIMENSION(:), INTENT(OUT), OPTIONAL, &
-         POINTER                                         :: nzvals_local
+      INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: rowptr_local, colind_local, nzerow_local
+      REAL(dp), DIMENSION(:), OPTIONAL, POINTER          :: nzvals_local
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'csr_interop_matrix_get_info', &
          routineP = moduleN//':'//routineN

--- a/src/wannier90.F
+++ b/src/wannier90.F
@@ -141,11 +141,9 @@ CONTAINS
       REAL(kind=dp), DIMENSION(3, 3), INTENT(in)         :: real_lattice_loc, recip_lattice_loc
       REAL(kind=dp), DIMENSION(3, num_kpts_loc), &
          INTENT(in)                                      :: kpt_latt_loc
-      INTEGER, INTENT(out)                               :: nntot_loc
-      INTEGER, DIMENSION(num_kpts_loc, num_nnmax), &
-         INTENT(out)                                     :: nnlist_loc
-      INTEGER, DIMENSION(3, num_kpts_loc, num_nnmax), &
-         INTENT(out)                                     :: nncell_loc
+      INTEGER                                            :: nntot_loc
+      INTEGER, DIMENSION(num_kpts_loc, num_nnmax)        :: nnlist_loc
+      INTEGER, DIMENSION(3, num_kpts_loc, num_nnmax)     :: nncell_loc
       INTEGER, INTENT(in)                                :: iounit
 
       INTEGER                                            :: nkp
@@ -742,7 +740,7 @@ CONTAINS
 
       INTEGER, INTENT(in)                                :: multi(search_shells)
       REAL(kind=dp), INTENT(in)                          :: dnn(search_shells)
-      REAL(kind=dp), INTENT(out)                         :: bweight(max_shells)
+      REAL(kind=dp)                                      :: bweight(max_shells)
 
       INTEGER, PARAMETER                                 :: lwork = max_shells*10
       REAL(kind=dp), PARAMETER :: TARGET(6) = (/1.0_dp, 1.0_dp, 1.0_dp, 0.0_dp, 0.0_dp, 0.0_dp/)
@@ -912,7 +910,7 @@ CONTAINS
 
       INTEGER, INTENT(in)                                :: multi, kpt
       REAL(kind=dp), INTENT(in)                          :: shell_dist
-      REAL(kind=dp), INTENT(out)                         :: bvector(3, multi)
+      REAL(kind=dp)                                      :: bvector(3, multi)
 
       INTEGER                                            :: loop, nkp2, num_bvec
       REAL(kind=dp)                                      :: dist, vkpp(3), vkpp2(3)

--- a/src/xas_env_types.F
+++ b/src/xas_env_types.F
@@ -160,7 +160,7 @@ CONTAINS
                           scf_env, scf_control)
 
       TYPE(xas_environment_type), POINTER                :: xas_env
-      INTEGER, INTENT(OUT), OPTIONAL                     :: iter_count, exc_state, nao, nvirtual, &
+      INTEGER, OPTIONAL                                  :: iter_count, exc_state, nao, nvirtual, &
                                                             nvirtual2
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: centers_wfn
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: atom_of_state, exc_atoms, nexc_states, &
@@ -177,7 +177,7 @@ CONTAINS
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: excvec_coeff, excvec_overlap, &
                                                             unoccupied_orbs
       REAL(dp), DIMENSION(:), OPTIONAL, POINTER          :: unoccupied_evals
-      INTEGER, INTENT(OUT), OPTIONAL                     :: unoccupied_max_iter
+      INTEGER, OPTIONAL                                  :: unoccupied_max_iter
       REAL(dp), OPTIONAL                                 :: unoccupied_eps
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: all_vectors
       REAL(dp), DIMENSION(:), OPTIONAL, POINTER          :: all_evals
@@ -186,8 +186,8 @@ CONTAINS
       TYPE(qs_loc_env_new_type), OPTIONAL, POINTER       :: qs_loc_env
       TYPE(cp_2d_r_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: stogto_overlap
-      REAL(dp), INTENT(OUT), OPTIONAL                    :: occ_estate, xas_nelectron
-      INTEGER, INTENT(OUT), OPTIONAL                     :: xas_estate, nexc_atoms, nexc_search, &
+      REAL(dp), OPTIONAL                                 :: occ_estate, xas_nelectron
+      INTEGER, OPTIONAL                                  :: xas_estate, nexc_atoms, nexc_search, &
                                                             spin_channel
       TYPE(qs_scf_env_type), OPTIONAL, POINTER           :: scf_env
       TYPE(scf_control_type), OPTIONAL, POINTER          :: scf_control

--- a/src/xas_restart.F
+++ b/src/xas_restart.F
@@ -101,7 +101,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: xas_section
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: xas_method, iatom
-      INTEGER, INTENT(OUT)                               :: estate
+      INTEGER                                            :: estate
       INTEGER, INTENT(IN)                                :: istate
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'xas_read_restart', &

--- a/src/xas_tp_scf.F
+++ b/src/xas_tp_scf.F
@@ -139,7 +139,7 @@ CONTAINS
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: xas_section, scf_section
-      LOGICAL, INTENT(OUT)                               :: converged, should_stop
+      LOGICAL                                            :: converged, should_stop
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'xas_do_tp_scf', routineP = moduleN//':'//routineN
 
@@ -640,7 +640,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(xas_environment_type), POINTER                :: xas_env
-      LOGICAL, INTENT(OUT)                               :: converged, should_stop
+      LOGICAL                                            :: converged, should_stop
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'xes_scf_once', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -112,11 +112,11 @@ CONTAINS
    SUBROUTINE xc_vxc_pw_create1(vxc_rho, vxc_tau, rho_r, rho_g, tau, exc, xc_section, &
                                 pw_pool, compute_virial, virial_xc)
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rho, vxc_tau, rho_r, rho_g, tau
-      REAL(KIND=dp), INTENT(out)                         :: exc
+      REAL(KIND=dp)                                      :: exc
       TYPE(section_vals_type), POINTER                   :: xc_section
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       LOGICAL                                            :: compute_virial
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: virial_xc
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xc_vxc_pw_create1', &
          routineP = moduleN//':'//routineN
@@ -172,7 +172,7 @@ CONTAINS
    SUBROUTINE xc_vxc_pw_create_test_lsd(vxc_rho, vxc_tau, rho_r, rho_g, tau, &
                                         exc, xc_section, pw_pool)
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rho, vxc_tau, rho_r, rho_g, tau
-      REAL(KIND=dp), INTENT(out)                         :: exc
+      REAL(KIND=dp)                                      :: exc
       TYPE(section_vals_type), POINTER                   :: xc_section
       TYPE(pw_pool_type), POINTER                        :: pw_pool
 
@@ -185,7 +185,7 @@ CONTAINS
          POINTER                                         :: split_desc
       INTEGER                                            :: i, ii, ispin, j, k
       INTEGER, DIMENSION(2, 3)                           :: bo
-      REAL(kind=dp)                                      :: diff, exc2, maxdiff, tmp
+      REAL(KIND=dp)                                      :: diff, exc2, maxdiff, tmp
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc
       REAL(kind=dp), DIMENSION(:, :, :), POINTER         :: pot, pot2, pot3
       TYPE(cp_sll_xc_deriv_type), POINTER                :: deriv_iter
@@ -512,7 +512,7 @@ CONTAINS
    SUBROUTINE xc_vxc_pw_create_debug(vxc_rho, vxc_tau, rho_r, rho_g, tau, exc, &
                                      xc_section, pw_pool)
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rho, vxc_tau, rho_r, rho_g, tau
-      REAL(KIND=dp), INTENT(out)                         :: exc
+      REAL(KIND=dp)                                      :: exc
       TYPE(section_vals_type), POINTER                   :: xc_section
       TYPE(pw_pool_type), POINTER                        :: pw_pool
 
@@ -1060,12 +1060,12 @@ CONTAINS
    SUBROUTINE xc_vxc_pw_create(vxc_rho, vxc_tau, exc, rho_r, rho_g, tau, xc_section, &
                                pw_pool, compute_virial, virial_xc)
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rho, vxc_tau
-      REAL(KIND=dp), INTENT(out)                         :: exc
+      REAL(KIND=dp)                                      :: exc
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, rho_g, tau
       TYPE(section_vals_type), POINTER                   :: xc_section
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       LOGICAL                                            :: compute_virial
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: virial_xc
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xc_vxc_pw_create', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_b97.F
+++ b/src/xc/xc_b97.F
@@ -72,7 +72,7 @@ CONTAINS
       INTEGER                                            :: param
       LOGICAL                                            :: lda
       REAL(dp), INTENT(in)                               :: sx, sc
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
 
       CHARACTER(len=*), PARAMETER :: routineN = 'b97_ref', routineP = moduleN//':'//routineN
 
@@ -179,9 +179,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE b97_lda_info(b97_params, reference, shortform, needs, max_deriv)
       TYPE(section_vals_type), POINTER                   :: b97_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'b97_lda_info', routineP = moduleN//':'//routineN
 
@@ -213,9 +213,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE b97_lsd_info(b97_params, reference, shortform, needs, max_deriv)
       TYPE(section_vals_type), POINTER                   :: b97_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'b97_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_cs1.F
+++ b/src/xc/xc_cs1.F
@@ -61,9 +61,9 @@ CONTAINS
 !> \param max_deriv ...
 ! **************************************************************************************************
    SUBROUTINE cs1_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cs1_lda_info', routineP = moduleN//':'//routineN
 
@@ -92,9 +92,9 @@ CONTAINS
 !> \param max_deriv ...
 ! **************************************************************************************************
    SUBROUTINE cs1_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cs1_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_derivative_desc.F
+++ b/src/xc/xc_derivative_desc.F
@@ -53,8 +53,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE standardize_derivative_desc(deriv_desc, res)
       CHARACTER(len=*), INTENT(in)                       :: deriv_desc
-      CHARACTER(LEN=MAX_DERIVATIVE_DESC_LENGTH), &
-         INTENT(OUT)                                     :: res
+      CHARACTER(LEN=MAX_DERIVATIVE_DESC_LENGTH)          :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'standardize_derivative_desc', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_derivative_types.F
+++ b/src/xc/xc_derivative_types.F
@@ -154,10 +154,10 @@ CONTAINS
                                 order, deriv_data, accept_null_data)
       TYPE(xc_derivative_type), POINTER                  :: deriv
       CHARACTER(len=MAX_DERIVATIVE_DESC_LENGTH), &
-         INTENT(out), OPTIONAL                           :: desc
+         OPTIONAL                                        :: desc
       CHARACTER(len=MAX_LABEL_LENGTH), DIMENSION(:), &
          OPTIONAL, POINTER                               :: split_desc
-      INTEGER, INTENT(out), OPTIONAL                     :: order
+      INTEGER, OPTIONAL                                  :: order
       REAL(kind=dp), DIMENSION(:, :, :), OPTIONAL, &
          POINTER                                         :: deriv_data
       LOGICAL, INTENT(in), OPTIONAL                      :: accept_null_data

--- a/src/xc/xc_derivatives.F
+++ b/src/xc/xc_derivatives.F
@@ -147,9 +147,9 @@ CONTAINS
                                      needs, max_deriv)
       TYPE(section_vals_type), POINTER                   :: functional
       LOGICAL, INTENT(in)                                :: lsd
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xc_functional_get_info', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_exchange_gga.F
+++ b/src/xc/xc_exchange_gga.F
@@ -69,9 +69,9 @@ CONTAINS
    SUBROUTINE xgga_info(functional, lsd, reference, shortform, needs, max_deriv)
       INTEGER, INTENT(in)                                :: functional
       LOGICAL, INTENT(in)                                :: lsd
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xgga_info', routineP = moduleN//':'//routineN
 
@@ -808,7 +808,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_optx(s, fs, m)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'efactor_optx', routineP = moduleN//':'//routineN
@@ -862,7 +862,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_pw91(s, fs, m)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m
 
       INTEGER                                            :: ip
@@ -1052,7 +1052,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_pbex(s, fs, m, pset)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m, pset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'efactor_pbex', routineP = moduleN//':'//routineN

--- a/src/xc/xc_functionals_utilities.F
+++ b/src/xc/xc_functionals_utilities.F
@@ -66,8 +66,8 @@ CONTAINS
    SUBROUTINE setup_calculation(order, m, calc, tag)
 
       INTEGER, INTENT(IN)                                :: order
-      INTEGER, INTENT(OUT)                               :: m(0:, :)
-      LOGICAL, INTENT(OUT)                               :: calc(0:)
+      INTEGER                                            :: m(0:, :)
+      LOGICAL                                            :: calc(0:)
       INTEGER, INTENT(IN)                                :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_calculation', &
@@ -156,7 +156,7 @@ CONTAINS
 !   rs parameter : f*rho**(-1/3)
 
       REAL(KIND=dp), INTENT(IN)                          :: rho
-      REAL(KIND=dp), INTENT(OUT)                         :: rs
+      REAL(KIND=dp)                                      :: rs
 
       IF (rho < eps_rho) THEN
          rs = 0.0_dp
@@ -176,7 +176,7 @@ CONTAINS
 !   rs parameter : f*rho**(-1/3)
 
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: rho
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: rs
+      REAL(KIND=dp), DIMENSION(:)                        :: rs
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calc_rs_array', routineP = moduleN//':'//routineN
 
@@ -208,7 +208,7 @@ CONTAINS
 !   rs parameter : f*rho**(-1/3)
 
       REAL(KIND=dp), DIMENSION(*), INTENT(IN)            :: rho
-      REAL(KIND=dp), DIMENSION(*), INTENT(OUT)           :: rs
+      REAL(KIND=dp), DIMENSION(*)                        :: rs
       INTEGER, INTENT(IN)                                :: n
 
       INTEGER                                            :: k
@@ -236,7 +236,7 @@ CONTAINS
 !   x = sqrt(rs)
 
       REAL(KIND=dp), DIMENSION(*), INTENT(IN)            :: rho
-      REAL(KIND=dp), DIMENSION(*), INTENT(OUT)           :: x
+      REAL(KIND=dp), DIMENSION(*)                        :: x
       INTEGER, INTENT(in)                                :: n
 
       INTEGER                                            :: ip
@@ -263,7 +263,7 @@ CONTAINS
 
       CHARACTER(len=*), INTENT(IN)                       :: tag
       REAL(KIND=dp), DIMENSION(*), INTENT(IN)            :: rho, grho
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: s
+      REAL(KIND=dp), DIMENSION(:)                        :: s
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calc_wave_vector', &
          routineP = moduleN//':'//routineN
@@ -315,7 +315,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: n
       REAL(KIND=dp), DIMENSION(*), INTENT(IN)            :: rhoa, rhob
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fx
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fx
       INTEGER, INTENT(IN)                                :: m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calc_fx_array', routineP = moduleN//':'//routineN
@@ -388,7 +388,7 @@ CONTAINS
 !
 
       REAL(KIND=dp), INTENT(IN)                          :: rhoa, rhob
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: fx
+      REAL(KIND=dp), DIMENSION(:)                        :: fx
       INTEGER, INTENT(IN)                                :: m
 
       REAL(KIND=dp)                                      :: rhoab, x
@@ -434,7 +434,7 @@ CONTAINS
    SUBROUTINE calc_z(a, b, z, order)
 
       REAL(KIND=dp), INTENT(IN)                          :: a, b
-      REAL(KIND=dp), DIMENSION(0:, 0:), INTENT(OUT)      :: z
+      REAL(KIND=dp), DIMENSION(0:, 0:)                   :: z
       INTEGER, INTENT(IN)                                :: order
 
       REAL(KIND=dp)                                      :: c, d

--- a/src/xc/xc_hcth.F
+++ b/src/xc/xc_hcth.F
@@ -43,9 +43,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE hcth_lda_info(iparset, reference, shortform, needs, max_deriv)
       INTEGER, INTENT(in)                                :: iparset
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'hcth_lda_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_ke_gga.F
+++ b/src/xc/xc_ke_gga.F
@@ -88,9 +88,9 @@ CONTAINS
    SUBROUTINE ke_gga_info(functional, lsd, reference, shortform, needs, max_deriv)
       INTEGER, INTENT(in)                                :: functional
       LOGICAL, INTENT(in)                                :: lsd
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'ke_gga_info', routineP = moduleN//':'//routineN
 
@@ -666,7 +666,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_ol1(s, fs, m)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'efactor_ol1', routineP = moduleN//':'//routineN
@@ -710,7 +710,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_ol2(s, fs, m)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'efactor_ol2', routineP = moduleN//':'//routineN
@@ -759,7 +759,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_llp(s, fs, m)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'efactor_llp', routineP = moduleN//':'//routineN
@@ -928,7 +928,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_pw86(s, fs, m, f2_lsd)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m
       REAL(dp), OPTIONAL                                 :: f2_lsd
 
@@ -999,7 +999,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_t92(s, fs, m)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m
 
       CHARACTER(len=*), PARAMETER :: routineN = 'efactor_t92', routineP = moduleN//':'//routineN
@@ -1094,7 +1094,7 @@ CONTAINS
    SUBROUTINE efactor_pbex(s, fs, m, pset, f2_lsd)
 
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m, pset
       REAL(dp), OPTIONAL                                 :: f2_lsd
 
@@ -1153,7 +1153,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE efactor_pw91(s, fs, m, pset, f2_lsd)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: s
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: fs
+      REAL(KIND=dp), DIMENSION(:, :)                     :: fs
       INTEGER, INTENT(IN)                                :: m, pset
       REAL(dp), OPTIONAL                                 :: f2_lsd
 

--- a/src/xc/xc_libxc.F
+++ b/src/xc/xc_libxc.F
@@ -104,10 +104,10 @@ CONTAINS
    SUBROUTINE libxc_lda_info(libxc_params, reference, shortform, needs, max_deriv)
 
       TYPE(section_vals_type), POINTER         :: libxc_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL  :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL  :: reference, shortform
       TYPE(xc_rho_cflags_type), &
          INTENT(inout), OPTIONAL               :: needs
-      INTEGER, INTENT(out), OPTIONAL           :: max_deriv
+      INTEGER, OPTIONAL           :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'libxc_lda_info', &
                                      routineP = moduleN//':'//routineN
@@ -204,10 +204,10 @@ CONTAINS
    SUBROUTINE libxc_lsd_info(libxc_params, reference, shortform, needs, max_deriv)
 
       TYPE(section_vals_type), POINTER         :: libxc_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL  :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL  :: reference, shortform
       TYPE(xc_rho_cflags_type), &
          INTENT(inout), OPTIONAL               :: needs
-      INTEGER, INTENT(out), OPTIONAL           :: max_deriv
+      INTEGER, OPTIONAL           :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'libxc_lsd_info', &
                                      routineP = moduleN//':'//routineN
@@ -299,7 +299,7 @@ CONTAINS
 !> \author A. Gloess (agloess)
 ! **************************************************************************************************
    SUBROUTINE libxc_version_info(version)
-      CHARACTER(LEN=*), INTENT(OUT)      :: version ! the string that is output
+      CHARACTER(LEN=*)      :: version ! the string that is output
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'libxc_version_info', &
                                      routineP = moduleN//':'//routineN

--- a/src/xc/xc_libxc_wrap.F
+++ b/src/xc/xc_libxc_wrap.F
@@ -133,7 +133,7 @@ CONTAINS
       TYPE(xc_f03_func_info_t), INTENT(IN)               :: xc_info
       INTEGER, INTENT(IN)                                :: polarized
       REAL(KIND=dp), INTENT(IN)                          :: sc
-      CHARACTER(LEN=*), INTENT(OUT)                      :: reference
+      CHARACTER(LEN=*)                      :: reference
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'xc_libxc_wrap_info_refs', &
          routineP = moduleN//':'//routineN
@@ -211,7 +211,7 @@ CONTAINS
 !>
 ! **************************************************************************************************
    SUBROUTINE xc_libxc_wrap_version(version)
-      CHARACTER(LEN=*), INTENT(OUT)                      :: version
+      CHARACTER(LEN=*)                      :: version
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'xc_libxc_wrap_version', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_lyp.F
+++ b/src/xc/xc_lyp.F
@@ -48,9 +48,9 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE lyp_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'lyp_lda_info', routineP = moduleN//':'//routineN
 
@@ -81,9 +81,9 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE lyp_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'lyp_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_lyp_adiabatic.F
+++ b/src/xc/xc_lyp_adiabatic.F
@@ -54,9 +54,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE lyp_adiabatic_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'lyp_adiabatic_lda_info', &
          routineP = moduleN//':'//routineN
@@ -88,9 +88,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE lyp_adiabatic_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'lyp_adiabatic_lsd_info', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_optx.F
+++ b/src/xc/xc_optx.F
@@ -41,9 +41,9 @@ CONTAINS
 !> \author Joost
 ! **************************************************************************************************
    SUBROUTINE optx_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'optx_lda_info', routineP = moduleN//':'//routineN
 
@@ -70,9 +70,9 @@ CONTAINS
 !> \author Joost
 ! **************************************************************************************************
    SUBROUTINE optx_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'optx_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_pade.F
+++ b/src/xc/xc_pade.F
@@ -98,10 +98,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pade_info(reference, shortform, lsd, needs, max_deriv)
 
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       LOGICAL, INTENT(IN), OPTIONAL                      :: lsd
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'pade_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_pbe.F
+++ b/src/xc/xc_pbe.F
@@ -60,9 +60,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pbe_lda_info(pbe_params, reference, shortform, needs, max_deriv)
       TYPE(section_vals_type), POINTER                   :: pbe_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pbe_lda_info', routineP = moduleN//':'//routineN
 
@@ -168,9 +168,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pbe_lsd_info(pbe_params, reference, shortform, needs, max_deriv)
       TYPE(section_vals_type), POINTER                   :: pbe_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pbe_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_perdew86.F
+++ b/src/xc/xc_perdew86.F
@@ -87,9 +87,9 @@ CONTAINS
 !> \param max_deriv ...
 ! **************************************************************************************************
    SUBROUTINE p86_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "J. P. Perdew, Phys. Rev. B, 33, 8822 (1986) {LDA version}"

--- a/src/xc/xc_perdew_wang.F
+++ b/src/xc/xc_perdew_wang.F
@@ -62,9 +62,9 @@ CONTAINS
                                max_deriv, scale)
       INTEGER, INTENT(in)                                :: method
       LOGICAL, INTENT(in)                                :: lsd
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
       REAL(kind=dp), INTENT(in)                          :: scale
 
       CHARACTER(len=*), PARAMETER :: routineN = 'perdew_wang_info', &
@@ -517,7 +517,7 @@ CONTAINS
 
       REAL(KIND=dp), INTENT(IN)                          :: r
       INTEGER, INTENT(IN)                                :: z
-      REAL(KIND=dp), DIMENSION(0:), INTENT(OUT)          :: g
+      REAL(KIND=dp), DIMENSION(0:)                       :: g
       INTEGER, INTENT(IN)                                :: order
 
       REAL(KIND=dp)                                      :: a1_, A_, b1_, b2_, b3_, b4_, rr, rsr, &
@@ -614,7 +614,7 @@ CONTAINS
    SUBROUTINE pw_lda_ed_loc(rho, ed, order)
 
       REAL(KIND=dp), INTENT(IN)                          :: rho
-      REAL(KIND=dp), DIMENSION(0:), INTENT(OUT)          :: ed
+      REAL(KIND=dp), DIMENSION(0:)                       :: ed
       INTEGER, INTENT(IN)                                :: order
 
       INTEGER                                            :: m, order_
@@ -668,7 +668,7 @@ CONTAINS
    SUBROUTINE pw_lsd_ed_loc(a, b, ed, order)
 
       REAL(KIND=dp), INTENT(IN)                          :: a, b
-      REAL(KIND=dp), DIMENSION(0:), INTENT(OUT)          :: ed
+      REAL(KIND=dp), DIMENSION(0:)                       :: ed
       INTEGER, INTENT(IN)                                :: order
 
       INTEGER                                            :: m, order_

--- a/src/xc/xc_perdew_zunger.F
+++ b/src/xc/xc_perdew_zunger.F
@@ -54,8 +54,8 @@ CONTAINS
 !> \brief Return some info on the functionals.
 !> \param method ...
 !> \param lsd ...
-!> \param reference CHARACTER(*), INTENT(OUT), OPTIONAL - full reference
-!> \param shortform CHARACTER(*), INTENT(OUT), OPTIONAL - short reference
+!> \param reference CHARACTER(*), OPTIONAL - full reference
+!> \param shortform CHARACTER(*), OPTIONAL - short reference
 !> \param needs ...
 !> \param max_deriv ...
 !> \par History
@@ -64,9 +64,9 @@ CONTAINS
    SUBROUTINE pz_info(method, lsd, reference, shortform, needs, max_deriv)
       INTEGER, INTENT(in)                                :: method
       LOGICAL, INTENT(in)                                :: lsd
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pz_info', routineP = moduleN//':'//routineN
 
@@ -493,7 +493,7 @@ CONTAINS
 
       REAL(KIND=dp), INTENT(IN)                          :: r
       INTEGER, INTENT(IN)                                :: z
-      REAL(KIND=dp), DIMENSION(0:), INTENT(OUT)          :: g
+      REAL(KIND=dp), DIMENSION(0:)                       :: g
       INTEGER, INTENT(IN)                                :: order
 
       REAL(KIND=dp)                                      :: rr, rsr, sr
@@ -554,7 +554,7 @@ CONTAINS
    SUBROUTINE pz_lda_ed_loc(rho, ed, order, sc)
 
       REAL(KIND=dp), INTENT(IN)                          :: rho
-      REAL(KIND=dp), DIMENSION(0:), INTENT(OUT)          :: ed
+      REAL(KIND=dp), DIMENSION(0:)                       :: ed
       INTEGER, INTENT(IN)                                :: order
       REAL(dp), INTENT(IN)                               :: sc
 
@@ -609,7 +609,7 @@ CONTAINS
    SUBROUTINE pz_lsd_ed_loc(a, b, ed, order, sc)
 
       REAL(KIND=dp), INTENT(IN)                          :: a, b
-      REAL(KIND=dp), DIMENSION(0:), INTENT(OUT)          :: ed
+      REAL(KIND=dp), DIMENSION(0:)                       :: ed
       INTEGER, INTENT(IN), OPTIONAL                      :: order
       REAL(KIND=dp), INTENT(IN)                          :: sc
 

--- a/src/xc/xc_rho_cflags_types.F
+++ b/src/xc/xc_rho_cflags_types.F
@@ -59,7 +59,7 @@ CONTAINS
 !> \param value the value to set
 ! **************************************************************************************************
    SUBROUTINE xc_rho_cflags_setall(cflags, value)
-      TYPE(xc_rho_cflags_type), INTENT(out)              :: cflags
+      TYPE(xc_rho_cflags_type)                           :: cflags
       LOGICAL, INTENT(in)                                :: value
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xc_rho_cflags_setall', &

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -330,7 +330,7 @@ CONTAINS
          laplace_rhob
       TYPE(cp_3d_r_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: drhoa, drhob
-      REAL(kind=dp), INTENT(out), OPTIONAL               :: rho_cutoff, drho_cutoff, tau_cutoff
+      REAL(kind=dp), OPTIONAL                            :: rho_cutoff, drho_cutoff, tau_cutoff
       REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
          POINTER                                         :: tau, tau_a, tau_b
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: local_bounds

--- a/src/xc/xc_tfw.F
+++ b/src/xc/xc_tfw.F
@@ -70,9 +70,9 @@ CONTAINS
 !> \param max_deriv ...
 ! **************************************************************************************************
    SUBROUTINE tfw_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "Thomas-Fermi-Weizsaecker kinetic energy functional {LDA version}"
@@ -97,9 +97,9 @@ CONTAINS
 !> \param max_deriv ...
 ! **************************************************************************************************
    SUBROUTINE tfw_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "Thomas-Fermi-Weizsaecker kinetic energy functional"
@@ -214,7 +214,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calc_s(rho, grho, s, npoints)
       REAL(KIND=dp), DIMENSION(*), INTENT(in)            :: rho, grho
-      REAL(KIND=dp), DIMENSION(*), INTENT(out)           :: s
+      REAL(KIND=dp), DIMENSION(*)                        :: s
       INTEGER, INTENT(in)                                :: npoints
 
       INTEGER                                            :: ip

--- a/src/xc/xc_thomas_fermi.F
+++ b/src/xc/xc_thomas_fermi.F
@@ -74,9 +74,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE thomas_fermi_info(lsd, reference, shortform, needs, max_deriv)
       LOGICAL, INTENT(in)                                :: lsd
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "Thomas-Fermi kinetic energy functional: see Parr and Yang"

--- a/src/xc/xc_tpss.F
+++ b/src/xc/xc_tpss.F
@@ -53,9 +53,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tpss_lda_info(tpss_params, reference, shortform, needs, max_deriv)
       TYPE(section_vals_type), POINTER                   :: tpss_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'tpss_lda_info', routineP = moduleN//':'//routineN
 
@@ -103,9 +103,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tpss_lsd_info(tpss_params, reference, shortform, needs, max_deriv)
       TYPE(section_vals_type), POINTER                   :: tpss_params
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'tpss_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_vwn.F
+++ b/src/xc/xc_vwn.F
@@ -109,9 +109,9 @@ CONTAINS
 !> \param max_deriv ...
 ! **************************************************************************************************
    SUBROUTINE vwn_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "S. H. Vosko, L. Wilk and M. Nusair,"// &

--- a/src/xc/xc_xalpha.F
+++ b/src/xc/xc_xalpha.F
@@ -84,9 +84,9 @@ CONTAINS
    SUBROUTINE xalpha_info(lsd, reference, shortform, needs, max_deriv, &
                           xa_parameter, scaling)
       LOGICAL, INTENT(in)                                :: lsd
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: xa_parameter, scaling
 
       REAL(KIND=dp)                                      :: my_scaling, my_xparam

--- a/src/xc/xc_xbecke88.F
+++ b/src/xc/xc_xbecke88.F
@@ -48,9 +48,9 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE xb88_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xb88_lda_info', routineP = moduleN//':'//routineN
 
@@ -81,9 +81,9 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE xb88_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xb88_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_xbecke88_long_range.F
+++ b/src/xc/xc_xbecke88_long_range.F
@@ -50,9 +50,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE xb88_lr_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xb88_lr_lda_info', &
          routineP = moduleN//':'//routineN
@@ -83,9 +83,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE xb88_lr_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xb88_lr_lsd_info', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_xbecke88_lr_adiabatic.F
+++ b/src/xc/xc_xbecke88_lr_adiabatic.F
@@ -57,9 +57,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE xb88_lr_adiabatic_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xb88_lr_adiabatic_lda_info', &
          routineP = moduleN//':'//routineN
@@ -90,9 +90,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE xb88_lr_adiabatic_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xb88_lr_adiabatic_lsd_info', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_xbecke_roussel.F
+++ b/src/xc/xc_xbecke_roussel.F
@@ -82,9 +82,9 @@ CONTAINS
 !> \author mguidon
 ! **************************************************************************************************
    SUBROUTINE xbecke_roussel_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xbecke_roussel_lda_info', &
          routineP = moduleN//':'//routineN
@@ -122,9 +122,9 @@ CONTAINS
 !> \author mguidon
 ! **************************************************************************************************
    SUBROUTINE xbecke_roussel_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xbecke_roussel_lsd_info', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_xbeef.F
+++ b/src/xc/xc_xbeef.F
@@ -62,9 +62,9 @@ CONTAINS
 ! **************************************************************************************************
 
    SUBROUTINE xbeef_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xbeef_lda_info', routineP = moduleN//':'//routineN
 
@@ -95,9 +95,9 @@ CONTAINS
 !> \author rkoitz
 ! **************************************************************************************************
    SUBROUTINE xbeef_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xbeef_lsd_info', routineP = moduleN//':'//routineN
 

--- a/src/xc/xc_xbr_pbe_lda_hole_t_c_lr.F
+++ b/src/xc/xc_xbr_pbe_lda_hole_t_c_lr.F
@@ -106,9 +106,9 @@ CONTAINS
 !> \author mguidon (01.2009)
 ! **************************************************************************************************
    SUBROUTINE xbr_pbe_lda_hole_tc_lr_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xbr_pbe_lda_hole_tc_lr_lda_info', &
          routineP = moduleN//':'//routineN
@@ -141,9 +141,9 @@ CONTAINS
 !> \author mguidon (01.2009)
 ! **************************************************************************************************
    SUBROUTINE xbr_pbe_lda_hole_tc_lr_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xbr_pbe_lda_hole_tc_lr_lsd_info', &
          routineP = moduleN//':'//routineN

--- a/src/xc/xc_xlda_hole_t_c_lr.F
+++ b/src/xc/xc_xlda_hole_t_c_lr.F
@@ -59,9 +59,9 @@ CONTAINS
 !> \author mguidon
 ! **************************************************************************************************
    SUBROUTINE xlda_hole_t_c_lr_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "{LDA version}"
@@ -88,9 +88,9 @@ CONTAINS
 !> \author mguidon
 ! **************************************************************************************************
    SUBROUTINE xlda_hole_t_c_lr_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "{LSD version}"

--- a/src/xc/xc_xpbe_hole_t_c_lr.F
+++ b/src/xc/xc_xpbe_hole_t_c_lr.F
@@ -81,9 +81,9 @@ CONTAINS
 !> \author mguidon
 ! **************************************************************************************************
    SUBROUTINE xpbe_hole_t_c_lr_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "{LDA version}"
@@ -111,9 +111,9 @@ CONTAINS
 !> \author mguidon
 ! **************************************************************************************************
    SUBROUTINE xpbe_hole_t_c_lr_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "{LSD version}"

--- a/src/xc/xc_xwpbe.F
+++ b/src/xc/xc_xwpbe.F
@@ -103,9 +103,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE xwpbe_lda_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "Jochen Heyd and Gustavo E. Scuseria, J. Chem. Phys., 120, 7274 {LDA version}"
@@ -5211,9 +5211,9 @@ CONTAINS
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE xwpbe_lsd_info(reference, shortform, needs, max_deriv)
-      CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: reference, shortform
+      CHARACTER(LEN=*), OPTIONAL                         :: reference, shortform
       TYPE(xc_rho_cflags_type), INTENT(inout), OPTIONAL  :: needs
-      INTEGER, INTENT(out), OPTIONAL                     :: max_deriv
+      INTEGER, OPTIONAL                                  :: max_deriv
 
       IF (PRESENT(reference)) THEN
          reference = "Jochen Heyd and Gustavo E. Scuseria, J. Chem. Phys., 120, 7274 {LSD version}"

--- a/src/xray_diffraction.F
+++ b/src/xray_diffraction.F
@@ -501,7 +501,7 @@ CONTAINS
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_p_type), INTENT(INOUT)                     :: rhotot_elec_gspace
       REAL(KIND=dp), INTENT(IN)                          :: q_max
-      REAL(KIND=dp), INTENT(OUT)                         :: rho_hard, rho_soft
+      REAL(KIND=dp)                                      :: rho_hard, rho_soft
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: fsign
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_rhotot_elec_gspace', &

--- a/tools/conventions/analyze_gfortran_ast.py
+++ b/tools/conventions/analyze_gfortran_ast.py
@@ -50,6 +50,7 @@ def process_log_file(fn, public_symbols, used_symbols):
     loc = path.basename(fn)[:-4]
     lines = ast.split("\n")
     module_name = None
+    pure_subroutines = set()
 
     curr_symbol = curr_procedure = stat_var = stat_stm = None
     skip_until_DT_END = False
@@ -101,6 +102,10 @@ def process_log_file(fn, public_symbols, used_symbols):
                 print(loc+': Symbol "'+curr_symbol+'" in procedure "'+curr_procedure+'" is THREADPRIVATE')
             if("PUBLIC" in line):
                 public_symbols.add(module_name+"::"+curr_symbol)
+            if("SUBROUTINE PURE" in line or "SUBROUTINE ELEMENTAL PURE" in line):
+                pure_subroutines.add(curr_symbol)
+            if("DUMMY(OUT)" in line and curr_procedure not in pure_subroutines):
+                print(loc+': Symbol "'+curr_symbol+'" in procedure "'+curr_procedure+'" is INTENT(OUT)')
 
         elif(line.startswith("!$OMP PARALLEL")):
             if("DEFAULT(NONE)" not in line):
@@ -142,7 +147,6 @@ def process_log_file(fn, public_symbols, used_symbols):
 
     # check for run-away DT_END search
     assert(skip_until_DT_END==False)
-
 
 #===============================================================================
 def parse_args(line):

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -381,3 +381,5 @@ libcp2k.F: Found GOTO statement in procedure "cp2k_active_space_get_eri"
 libcp2k.F: Found GOTO statement in procedure "cp2k_active_space_get_eri_nze_count"
 libcp2k.F: Found GOTO statement in procedure "cp2k_active_space_get_fock_sub"
 libcp2k.F: Found GOTO statement in procedure "cp2k_active_space_get_mo_count"
+base_hooks.F: Symbol "handle" in procedure "timeset" is INTENT(OUT)
+timings.F: Symbol "handle" in procedure "timeset_handler" is INTENT(OUT)


### PR DESCRIPTION
Dummy arguments with `INTENT(OUT)` are a common pitfall because they require a full initialization. 

Unfortunately, these missing initializations are not detectable via Valgrind. And there is no help from the [compiler side](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=31447) either. 

On the other hand, there seems to be very little upside to using `INTENT(OUT)` and the Fortran language really only requires it for `PURE` subroutines. Hence, I was wondering if we could just remove  `INTENT(OUT)` altogether?
