### PR TITLE
Include FYPP path when printing DBCSR version

### DIFF
--- a/exts/Makefile.inc
+++ b/exts/Makefile.inc
@@ -17,4 +17,6 @@ dbcsr:
 	   FYPPEXE=$(TOOLSRC)/build_utils/fypp
 
 dbcsrversion:
-	@$(MAKE) -C $(EXTSHOME)/dbcsr version
+	@$(MAKE) -C $(EXTSHOME)/dbcsr \
+	   FYPPEXE=$(TOOLSRC)/build_utils/fypp \
+	   version


### PR DESCRIPTION
When calling 

make extversions

it will not print the DBCSR version if FYPP is not installed under DBCSR, so we can force to use FYPP from CP2K instead. This is related to #154 