### PR TITLE
Apply -fPIC flag only for gcc built

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -867,12 +867,12 @@ echo "Compiling with $NPROCS processes."
 
 # set environment for compiling compilers and tools required for CP2K
 # and libraries it depends on
-export CFLAGS=${CFLAGS:-"-O2 -fPIC -g -Wno-error"}
-export FFLAGS=${FFLAGS:-"-O2 -fPIC -g -Wno-error"}
-export FCLAGS=${FCLAGS:-"-O2 -fPIC -g -Wno-error"}
-export F90FLAGS=${F90FLAGS:-"-O2 -fPIC -g -Wno-error"}
-export F77FLAGS=${F77FLAGS:-"-O2 -fPIC -g -Wno-error"}
-export CXXFLAGS=${CXXFLAGS:-"-O2 -fPIC -g -Wno-error"}
+export CFLAGS=${CFLAGS:-"-O2 -g -Wno-error"}
+export FFLAGS=${FFLAGS:-"-O2 -g -Wno-error"}
+export FCLAGS=${FCLAGS:-"-O2 -g -Wno-error"}
+export F90FLAGS=${F90FLAGS:-"-O2 -g -Wno-error"}
+export F77FLAGS=${F77FLAGS:-"-O2 -g -Wno-error"}
+export CXXFLAGS=${CXXFLAGS:-"-O2 -g -Wno-error"}
 
 # Select the correct compute number based on the GPU architecture
 case $GPUVER in
@@ -916,12 +916,12 @@ done
 
 # setup compiler flags, leading to nice stack traces on crashes but
 # still optimised
-CFLAGS="-O2 -fPIC -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
-FFLAGS="-O2 -fPIC -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
-F77FLAGS="-O2 -fPIC -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
-F90FLAGS="-O2 -fPIC -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
-FCFLAGS="-O2 -fPIC -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
-CXXFLAGS="-O2 -fPIC -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
+CFLAGS="-O2 -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
+FFLAGS="-O2 -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
+F77FLAGS="-O2 -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
+F90FLAGS="-O2 -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
+FCFLAGS="-O2 -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
+CXXFLAGS="-O2 -ftree-vectorize -g -fno-omit-frame-pointer -march=native -ffast-math $TSANFLAGS"
 
 export CFLAGS=$(allowed_gcc_flags $CFLAGS)
 export FFLAGS=$(allowed_gfortran_flags $FFLAGS)

--- a/tools/toolchain/scripts/install_gcc.sh
+++ b/tools/toolchain/scripts/install_gcc.sh
@@ -50,7 +50,10 @@ case "$with_gcc" in
                                  --enable-lto \
                                  --enable-plugins \
                                  > configure.log 2>&1
-            make -j $NPROCS > make.log 2>&1
+            make -j $NPROCS \
+                 CFLAGS="-fPIC $CFLAGS"\
+                 CXXFLAGS="-fPIC $CXXFLAGS"\
+                 > make.log 2>&1
             make -j $NPROCS install > install.log 2>&1
             # thread sanitizer
             if [ $ENABLE_TSAN = "__TRUE__" ] ; then


### PR DESCRIPTION
There is no need to use the -fPIC flag for the toolchain in general. The gcc built on OpenSUSE Leap 15.0 showed a relocation error which can be resolved by adding -fPIC to the CFLAGS and CXXFLAGS.