### PR TITLE
Accelerate lapack and scalapack lib build

### DIFF
--- a/tools/toolchain/scripts/install_reflapack.sh
+++ b/tools/toolchain/scripts/install_reflapack.sh
@@ -55,7 +55,10 @@ TMGLIB       = libtmglib.a
 LAPACKELIB   = liblapacke.a
 EOF
             # lapack/blas build is *not* parallel safe (updates to the archive race)
-            make -j 1 lib blaslib > make.log 2>&1
+            # Run first in parallel which will result most likely in an incomplete library
+            make -j $NPROCS lib blaslib > make.log 2>&1
+            # Complete library in non-parallel mode
+            make -j 1 lib blaslib > make1.log 2>&1
             # no make install, so have to do this manually
             ! [ -d "${pkg_install_dir}/lib" ] && mkdir -p "${pkg_install_dir}/lib"
             cp libblas.a liblapack.a "${pkg_install_dir}/lib"

--- a/tools/toolchain/scripts/install_scalapack.sh
+++ b/tools/toolchain/scripts/install_scalapack.sh
@@ -55,7 +55,10 @@ LAPACKLIB     = ${MATH_LIBS}
 LIBS          = \$(LAPACKLIB) \$(BLASLIB)
 EOF
             # scalapack build not parallel safe (update to the archive race)
-            make -j 1 lib > make.log 2>&1
+            # Run first in parallel which will result most likely in an incomplete library
+            make -j $NPROCS lib > make.log 2>&1
+            # Complete library in non-parallel mode
+            make -j 1 lib > make1.log 2>&1
             # does not have make install, so install manually
             ! [ -d "${pkg_install_dir}/lib" ] && mkdir -p "${pkg_install_dir}/lib"
             cp libscalapack.a "${pkg_install_dir}/lib"


### PR DESCRIPTION
Perform a parallel make followed by a serial one to complete the library build which can reduce the build times significantly.