### PR TITLE
Build system: minor fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -205,7 +205,6 @@ You'll need to modify one of these files to match your system's settings.
 
 You can now build CP2K using these settings (where -j N allows for a parallel build using N processes):
 ```
-> cd cp2k/makefiles
 > make -j N ARCH=architecture VERSION=version
 ```
 e.g.

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ endif
 # Declare PHONY targets =====================================================
 .PHONY : $(VERSION) $(EXE_NAMES) \
          dirs makedep default_target all \
-         toolversions extversions libcp2k exts \
+         toolversions extversions extclean libcp2k exts \
          doxify doxifyclean \
          pretty prettyclean doxygen/clean doxygen \
          install clean realclean distclean mrproper help \
@@ -111,7 +111,7 @@ ORIG_TARGET = default_target
 fes :
 	@+$(MAKE) --no-print-directory -f $(MAKEFILE) $(VERSION) ORIG_TARGET=graph
 
-$(EXE_NAMES) all toolversions extversions libcp2k exts $(EXTSPACKAGES) test testbg:
+$(EXE_NAMES) all toolversions extversions extclean libcp2k exts $(EXTSPACKAGES) test testbg:
 	@+$(MAKE) --no-print-directory -f $(MAKEFILE) $(VERSION) ORIG_TARGET=$@
 
 # stage 2: Store the version target in $(ONEVERSION),
@@ -215,6 +215,7 @@ OTHER_HELP += "testbg : run the regression tests in background"
 OTHER_HELP += "toolversions : Print versions of build tools"
 
 OTHER_HELP += "extversions : Print versions of external modules"
+OTHER_HELP += "extclean : Clean build of external modules"
 
 #   extract help text from doxygen "\brief"-tag
 help:
@@ -267,7 +268,7 @@ OTHER_HELP += "execlean : Remove the executables, for given ARCH and VERSION"
 # delete the intermediate files, the programs and libraries and anything that might be in the objdir or libdir directory
 # Use this if you want to fully rebuild an executable (for a given compiler and or VERSION)
 #
-realclean: clean execlean
+realclean: extclean clean execlean
 	rm -rf $(foreach v, $(VERSION), $(MAINOBJDIR)/$(ARCH)/$(v))
 	rm -rf $(foreach v, $(VERSION), $(MAINLIBDIR)/$(ARCH)/$(v))
 OTHER_HELP += "realclean : Remove all files for given ARCH and VERSION"

--- a/exts/Makefile.inc
+++ b/exts/Makefile.inc
@@ -9,6 +9,9 @@ $(EXTSDEPS_MOD) : ; # override builtin .mod rule to prevent circular dependency
 
 extversions: dbcsrversion
 
+extclean: dbcsrclean
+	@echo "Clean EXT"
+
 dbcsr:
 	$(MAKE) -C $(EXTSHOME)/$@ \
 	   INCLUDEMAKE=$(ARCHDIR)/$(ARCH).$(ONEVERSION) \
@@ -20,3 +23,7 @@ dbcsrversion:
 	@$(MAKE) -C $(EXTSHOME)/dbcsr \
 	   FYPPEXE=$(TOOLSRC)/build_utils/fypp \
 	   version
+
+dbcsrclean:
+	@echo "Clean DBCSR"
+	@$(MAKE) -C $(EXTSHOME)/dbcsr clean


### PR DESCRIPTION
`INSTALL.md`
- Remove an obsolete instruction 

`Makefile` and `exts/Makefile.inc`
- One would expect a build of CP2K after a `realclean` to re-build DBCSR as well, but it does not. Fix target `realclean` so that it cleans DBCSR as well. 