### PR TITLE
S-ALMO bibliography added

### DIFF
--- a/src/almo_scf.F
+++ b/src/almo_scf.F
@@ -38,6 +38,7 @@ MODULE almo_scf
    USE bibliography,                    ONLY: Khaliullin2013,&
                                               Kolafa2004,&
                                               Scheiber2018,&
+                                              Staub2019,&
                                               cite_reference
    USE cp_blacs_env,                    ONLY: cp_blacs_env_release,&
                                               cp_blacs_env_retain
@@ -222,6 +223,7 @@ CONTAINS
       !! retrieve smearing parameters, and check compatibility of methods requested
       almo_scf_env%smear = dft_control%smear
       IF (almo_scf_env%smear) THEN
+         CALL cite_reference(Staub2019)
          IF ((almo_scf_env%almo_update_algorithm .NE. almo_scf_diag) .OR. &
              ((almo_scf_env%deloc_method .NE. almo_deloc_none) .AND. &
               (almo_scf_env%xalmo_update_algorithm .NE. almo_scf_diag))) THEN

--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -83,7 +83,7 @@ MODULE bibliography
                             Becke1988b, Migliore2009, Mavros2015, Holmberg2017, Marek2014, &
                             Stoychev2016, Futera2017, Bailey2006, Papior2017, Lehtola2018, &
                             Brieuc2016, Barca2018, Scheiber2018, Huang2011, Heaton_Burgess2007, &
-                            Schuett2018, Holmberg2018, Togo2018
+                            Schuett2018, Holmberg2018, Togo2018, Staub2019
 
 CONTAINS
 
@@ -3923,6 +3923,25 @@ CONTAINS
                          "AR 1808.01590 ", &
                          "ER"), &
                          DOI="xxx")
+
+      CALL add_reference(key=Staub2019, ISI_record=s2a( &
+                         "AU Staub, R", &
+                         "   Iannuzzi, M", &
+                         "   Khaliullin, RZ", &
+                         "   Steinmann, SN", &
+                         "AF Staub, Ruben", &
+                         "   Iannuzzi, Marcella", &
+                         "   Khaliullin, Rustam Z.", &
+                         "   Steinmann, Stephan N.", &
+                         "TI Energy Decomposition Analysis for Metal Surface-Adsorbate Interactions", &
+                         "   by Block Localized Wave Functions", &
+                         "SO Journal of Chemical Theory and Computation", &
+                         "SN 1549-9618", &
+                         "PY 2019", &
+                         "VL 15", &
+                         "DI 10.1021/acs.jctc.8b00957", &
+                         "ER"), &
+                         DOI="10.1021/acs.jctc.8b00957")
 
    END SUBROUTINE add_all_references
 


### PR DESCRIPTION
Adding citation for the S-ALMO feature in CP2K (with DOI).

I could not find a reference on the ISI citation format (the corresponding URL link is broken in the bibliography.F source code), so I tried my best for the new citation...

Tested on my local workstation (Skylake CPU, gcc version 7.3.0) with local arch files: sopt, ssmp, popt, psmp. I hope this commit won't break anything...