### PR TITLE
Stabilise regression test case 2d_pot

### DIFF
--- a/tests/Fist/regtest-3/2d_pot.inp
+++ b/tests/Fist/regtest-3/2d_pot.inp
@@ -7,7 +7,7 @@
      # FUNCTION exp(-((X-1)**2+(Y-1)**2))
      # FUNCTION 1./((X-1)**2+(Y-1)**2+10.)
      # FUNCTION -((X-1)**2+5.0*(Y-1)**2)
-     DX 1.0E-5
+     DX 1.0E-6
      ERROR_LIMIT 1.0E-12
   &END
   METHOD FIST


### PR DESCRIPTION
The regression test Fist/regtest-3/2d_pot.inp gives a wrong result when the toolchain is compiled with -O2 or higher. Results are fine for -O1. That seems to be a numerical issue which can be resolved for opt level (hopefully) with this change.