### PR TITLE
Fix input parsing for quotes

### DIFF
--- a/src/atom_upf.F
+++ b/src/atom_upf.F
@@ -210,7 +210,7 @@ CONTAINS
                ! read UPF file version
                CALL parser_get_object(parser, nametag, lower_to_upper=.TRUE.)
                pot%version = TRIM(nametag)
-               CPASSERT(nametag(2:6) == "2.0.1")
+               CPASSERT(nametag(1:5) == "2.0.1")
                CALL parser_get_object(parser, nametag, lower_to_upper=.TRUE.)
                CPASSERT(nametag(1:1) == ">")
                ntag = 1
@@ -321,8 +321,7 @@ CONTAINS
       TYPE(cp_parser_type), POINTER                      :: parser
       TYPE(atom_upfpot_type)                             :: pot
 
-      CHARACTER(LEN=default_string_length)               :: line, string
-      INTEGER                                            :: il
+      CHARACTER(LEN=default_string_length)               :: string
       LOGICAL                                            :: at_end
 
       DO
@@ -342,114 +341,50 @@ CONTAINS
          CASE ("COMMENT")
             CALL parser_get_object(parser, pot%comment)
          CASE ("ELEMENT")
-            CALL parser_get_object(parser, line)
+            CALL parser_get_object(parser, pot%symbol)
             CPASSERT(2 <= LEN(pot%symbol))
-            pot%symbol = line(2:3)
          CASE ("PSEUDO_TYPE")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%pseudo_type
+            CALL parser_get_object(parser, pot%pseudo_type)
          CASE ("RELATIVISTIC")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%relativistic
+            CALL parser_get_object(parser, pot%relativistic)
          CASE ("IS_ULTRASOFT")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%is_ultrasoft
+            CALL parser_get_object(parser, pot%is_ultrasoft)
          CASE ("IS_PAW")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%is_paw
+            CALL parser_get_object(parser, pot%is_paw)
          CASE ("IS_COULOMB")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%is_coulomb
+            CALL parser_get_object(parser, pot%is_coulomb)
          CASE ("HAS_SO")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%has_so
+            CALL parser_get_object(parser, pot%has_so)
          CASE ("HAS_WFC")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%has_wfc
+            CALL parser_get_object(parser, pot%has_wfc)
          CASE ("HAS_GIPAW")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%has_gipaw
+            CALL parser_get_object(parser, pot%has_gipaw)
          CASE ("PAW_AS_GIPAW")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%paw_as_gipaw
+            CALL parser_get_object(parser, pot%paw_as_gipaw)
          CASE ("CORE_CORRECTION")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%core_correction
+            CALL parser_get_object(parser, pot%core_correction)
          CASE ("FUNCTIONAL")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%functional
+            CALL parser_get_object(parser, pot%functional)
          CASE ("Z_VALENCE")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%zion
+            CALL parser_get_object(parser, pot%zion)
          CASE ("TOTAL_PSENERGY")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%total_psenergy
+            CALL parser_get_object(parser, pot%total_psenergy)
          CASE ("WFC_CUTOFF")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%wfc_cutoff
+            CALL parser_get_object(parser, pot%wfc_cutoff)
          CASE ("RHO_CUTOFF")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%rho_cutoff
+            CALL parser_get_object(parser, pot%rho_cutoff)
          CASE ("L_MAX")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%l_max
+            CALL parser_get_object(parser, pot%l_max)
          CASE ("L_MAX_RHO")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%l_max_rho
+            CALL parser_get_object(parser, pot%l_max_rho)
          CASE ("L_LOCAL")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%l_local
+            CALL parser_get_object(parser, pot%l_local)
          CASE ("MESH_SIZE")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%mesh_size
+            CALL parser_get_object(parser, pot%mesh_size)
          CASE ("NUMBER_OF_WFC")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%number_of_wfc
+            CALL parser_get_object(parser, pot%number_of_wfc)
          CASE ("NUMBER_OF_PROJ")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%number_of_proj
+            CALL parser_get_object(parser, pot%number_of_proj)
          CASE DEFAULT
             CPWARN(string)
             CALL cp_abort(__LOCATION__, "Error while parsing UPF header: "// &
@@ -468,8 +403,8 @@ CONTAINS
       TYPE(cp_parser_type), POINTER                      :: parser
       TYPE(atom_upfpot_type)                             :: pot
 
-      CHARACTER(LEN=default_string_length)               :: line, string
-      INTEGER                                            :: il, jj
+      CHARACTER(LEN=default_string_length)               :: string
+      INTEGER                                            :: jj
       LOGICAL                                            :: at_end
 
       DO
@@ -481,33 +416,18 @@ CONTAINS
          IF (string == ">") EXIT
          SELECT CASE (string)
          CASE ("DX")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%dx
+            CALL parser_get_object(parser, pot%dx)
          CASE ("XMIN")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%xmin
+            CALL parser_get_object(parser, pot%xmin)
          CASE ("RMAX")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%rmax
+            CALL parser_get_object(parser, pot%rmax)
          CASE ("MESH")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) jj
+            CALL parser_get_object(parser, jj)
             CPASSERT(pot%mesh_size == jj)
          CASE ("ZMESH")
-            CALL parser_get_object(parser, line)
-            line = ADJUSTL(line)
-            il = LEN_TRIM(line)
-            READ (line(2:il-1), *) pot%zmesh
+            CALL parser_get_object(parser, pot%zmesh)
          CASE DEFAULT
-            CPASSERT(.FALSE.)
+            CPABORT("Unknown UPF PP_MESH option <"//TRIM(string)//"> found")
          END SELECT
 
       END DO
@@ -524,7 +444,7 @@ CONTAINS
       TYPE(atom_upfpot_type)                             :: pot
 
       CHARACTER(LEN=default_string_length)               :: line, string, string2
-      INTEGER                                            :: icount, il, m, mc, ms
+      INTEGER                                            :: icount, m, mc, ms
       LOGICAL                                            :: at_end
 
       DO
@@ -548,20 +468,14 @@ CONTAINS
                   SELECT CASE (string2)
                   CASE ("TYPE")
                      CALL parser_get_object(parser, line, lower_to_upper=.TRUE.)
-                     CPASSERT(line == '"REAL"')
+                     CPASSERT(line == "REAL")
                   CASE ("SIZE")
-                     CALL parser_get_object(parser, line)
-                     line = ADJUSTL(line)
-                     il = LEN_TRIM(line)
-                     READ (line(2:il-1), *) ms
+                     CALL parser_get_object(parser, ms)
                      CPASSERT(ms <= m)
                   CASE ("COLUMNS")
-                     CALL parser_get_object(parser, line)
-                     line = ADJUSTL(line)
-                     il = LEN_TRIM(line)
-                     READ (line(2:il-1), *) mc
+                     CALL parser_get_object(parser, mc)
                   CASE DEFAULT
-                     CPASSERT(.FALSE.)
+                     CPABORT("Unknown UPF PP_R option <"//TRIM(string2)//"> found")
                   END SELECT
                END DO
             END IF
@@ -591,20 +505,14 @@ CONTAINS
                   SELECT CASE (string2)
                   CASE ("TYPE")
                      CALL parser_get_object(parser, line, lower_to_upper=.TRUE.)
-                     CPASSERT(line == '"REAL"')
+                     CPASSERT(line == "REAL")
                   CASE ("SIZE")
-                     CALL parser_get_object(parser, line)
-                     line = ADJUSTL(line)
-                     il = LEN_TRIM(line)
-                     READ (line(2:il-1), *) ms
+                     CALL parser_get_object(parser, ms)
                      CPASSERT(ms <= m)
                   CASE ("COLUMNS")
-                     CALL parser_get_object(parser, line)
-                     line = ADJUSTL(line)
-                     il = LEN_TRIM(line)
-                     READ (line(2:il-1), *) mc
+                     CALL parser_get_object(parser, mc)
                   CASE DEFAULT
-                     CPASSERT(.FALSE.)
+                     CPABORT("Unknown UPF PP_RAB option <"//TRIM(string2)//"> found")
                   END SELECT
                END DO
             END IF
@@ -642,7 +550,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: options
 
       CHARACTER(LEN=default_string_length)               :: line, string
-      INTEGER                                            :: icount, il, m, mc, ms
+      INTEGER                                            :: icount, m, mc, ms
       LOGICAL                                            :: at_end
 
       m = pot%mesh_size
@@ -659,20 +567,14 @@ CONTAINS
             SELECT CASE (string)
             CASE ("TYPE")
                CALL parser_get_object(parser, line, lower_to_upper=.TRUE.)
-               CPASSERT(line == '"REAL"')
+               CPASSERT(line == "REAL")
             CASE ("SIZE")
-               CALL parser_get_object(parser, line)
-               line = ADJUSTL(line)
-               il = LEN_TRIM(line)
-               READ (line(2:il-1), *) ms
+               CALL parser_get_object(parser, ms)
                CPASSERT(ms <= m)
             CASE ("COLUMNS")
-               CALL parser_get_object(parser, line)
-               line = ADJUSTL(line)
-               il = LEN_TRIM(line)
-               READ (line(2:il-1), *) mc
+               CALL parser_get_object(parser, mc)
             CASE DEFAULT
-               CPASSERT(.FALSE.)
+               CPABORT("Unknown UPF PP_NLCC option <"//TRIM(string)//"> found")
             END SELECT
          END DO
       END IF
@@ -710,7 +612,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: options
 
       CHARACTER(LEN=default_string_length)               :: line, string
-      INTEGER                                            :: icount, il, m, mc, ms
+      INTEGER                                            :: icount, m, mc, ms
       LOGICAL                                            :: at_end
 
       m = pot%mesh_size
@@ -727,20 +629,14 @@ CONTAINS
             SELECT CASE (string)
             CASE ("TYPE")
                CALL parser_get_object(parser, line, lower_to_upper=.TRUE.)
-               CPASSERT(line == '"REAL"')
+               CPASSERT(line == "REAL")
             CASE ("SIZE")
-               CALL parser_get_object(parser, line)
-               line = ADJUSTL(line)
-               il = LEN_TRIM(line)
-               READ (line(2:il-1), *) ms
+               CALL parser_get_object(parser, ms)
                CPASSERT(ms <= m)
             CASE ("COLUMNS")
-               CALL parser_get_object(parser, line)
-               line = ADJUSTL(line)
-               il = LEN_TRIM(line)
-               READ (line(2:il-1), *) mc
+               CALL parser_get_object(parser, mc)
             CASE DEFAULT
-               CPASSERT(.FALSE.)
+               CPABORT("Unknown UPF PP_LOCAL option <"//TRIM(string)//"> found")
             END SELECT
          END DO
       END IF
@@ -779,7 +675,7 @@ CONTAINS
       TYPE(atom_upfpot_type)                             :: pot
 
       CHARACTER(LEN=default_string_length)               :: line, string
-      INTEGER                                            :: i1, i2, ibeta, icount, il, la, m, mc, &
+      INTEGER                                            :: i1, i2, ibeta, icount, la, m, mc, &
                                                             ms, nbeta
       LOGICAL                                            :: at_end
 
@@ -811,29 +707,17 @@ CONTAINS
                SELECT CASE (string)
                CASE ("TYPE")
                   CALL parser_get_object(parser, line, lower_to_upper=.TRUE.)
-                  CPASSERT(line == '"REAL"')
+                  CPASSERT(line == "REAL")
                CASE ("SIZE")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) ms
+                  CALL parser_get_object(parser, ms)
                   CPASSERT(ms <= m)
                CASE ("COLUMNS")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) mc
+                  CALL parser_get_object(parser, mc)
                CASE ("INDEX")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) i1
+                  CALL parser_get_object(parser, i1)
                   CPASSERT(i1 <= nbeta)
                CASE ("ANGULAR_MOMENTUM")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) la
+                  CALL parser_get_object(parser, la)
                CASE ("LABEL")
                   CALL parser_get_object(parser, line)
                   ! not used currently
@@ -847,7 +731,7 @@ CONTAINS
                   CALL parser_get_object(parser, line)
                   ! not used currently
                CASE DEFAULT
-                  CPASSERT(.FALSE.)
+                  CPABORT("Unknown UPF PP_BETA option <"//TRIM(string)//"> found")
                END SELECT
             END DO
             pot%lbeta(i1) = la
@@ -874,20 +758,14 @@ CONTAINS
                SELECT CASE (string)
                CASE ("TYPE")
                   CALL parser_get_object(parser, line, lower_to_upper=.TRUE.)
-                  CPASSERT(line == '"REAL"')
+                  CPASSERT(line == "REAL")
                CASE ("SIZE")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) ms
+                  CALL parser_get_object(parser, ms)
                   CPASSERT(ms <= m)
                CASE ("COLUMNS")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) mc
+                  CALL parser_get_object(parser, mc)
                CASE DEFAULT
-                  CPASSERT(.FALSE.)
+                  CPABORT("Unknown UPF PP_DIJ option <"//TRIM(string)//"> found")
                END SELECT
             END DO
             icount = 1
@@ -926,7 +804,7 @@ CONTAINS
       TYPE(atom_upfpot_type)                             :: pot
 
       CHARACTER(LEN=default_string_length)               :: line, string
-      INTEGER                                            :: i1, ib, icount, il, la, lmax, m, mc, ms
+      INTEGER                                            :: i1, ib, icount, la, lmax, m, mc, ms
       LOGICAL                                            :: at_end
 
       m = pot%mesh_size
@@ -955,25 +833,16 @@ CONTAINS
                SELECT CASE (string)
                CASE ("TYPE")
                   CALL parser_get_object(parser, line, lower_to_upper=.TRUE.)
-                  CPASSERT(line == '"REAL"')
+                  CPASSERT(line == "REAL")
                CASE ("SIZE")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) ms
+                  CALL parser_get_object(parser, ms)
                   CPASSERT(ms <= m)
                CASE ("COLUMNS")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) mc
+                  CALL parser_get_object(parser, mc)
                CASE ("L")
-                  CALL parser_get_object(parser, line)
-                  line = ADJUSTL(line)
-                  il = LEN_TRIM(line)
-                  READ (line(2:il-1), *) la
+                  CALL parser_get_object(parser, la)
                CASE DEFAULT
-                  CPASSERT(.FALSE.)
+                  CPABORT("Unknown UPF PP_VNL option <"//TRIM(string)//"> found")
                END SELECT
             END DO
             i1 = la+1

--- a/src/atom_upf.F
+++ b/src/atom_upf.F
@@ -675,8 +675,8 @@ CONTAINS
       TYPE(atom_upfpot_type)                             :: pot
 
       CHARACTER(LEN=default_string_length)               :: line, string
-      INTEGER                                            :: i1, i2, ibeta, icount, la, m, mc, &
-                                                            ms, nbeta
+      INTEGER                                            :: i1, i2, ibeta, icount, la, m, mc, ms, &
+                                                            nbeta
       LOGICAL                                            :: at_end
 
       m = pot%mesh_size

--- a/src/common/cp_files.F
+++ b/src/common/cp_files.F
@@ -83,7 +83,7 @@ CONTAINS
                CALL print_preconnection_list()
                CALL cp_abort(__LOCATION__, &
                              "Attempt to connect the already connected file <"// &
-                             TRIM(ADJUSTL(file_name))//"> to another unit")
+                             TRIM(file_name)//"> to another unit")
             END IF
          END IF
       END DO
@@ -102,7 +102,7 @@ CONTAINS
          CPABORT("No free slot found in the list of preconnected units")
       END IF
 
-      preconnected(islot)%file_name = TRIM(ADJUSTL(file_name))
+      preconnected(islot)%file_name = TRIM(file_name)
       preconnected(islot)%unit_number = unit_number
 
    END SUBROUTINE assign_preconnection
@@ -162,7 +162,7 @@ CONTAINS
          END IF
          ! Define status after closing the file
          IF (PRESENT(file_status)) THEN
-            status_string = TRIM(ADJUSTL(file_status))
+            status_string = TRIM(file_status)
          ELSE
             status_string = "KEEP"
          END IF
@@ -222,7 +222,7 @@ CONTAINS
                CALL print_preconnection_list()
                CALL cp_abort(__LOCATION__, &
                              "Attempt to disconnect the file <"// &
-                             TRIM(ADJUSTL(file_name))// &
+                             TRIM(file_name)// &
                              "> from an unlisted unit")
             END IF
          END IF
@@ -378,9 +378,14 @@ CONTAINS
          debug_unit = 0 ! use default_output_unit for debugging
       END IF
 
-      real_file_name = file_name
-      IF (status_string == "OLD") &
-         real_file_name = discover_file(file_name)
+      IF (file_name(1:1) == " ") THEN
+         WRITE (UNIT=message, FMT="(A)") &
+            "The file name <"//TRIM(file_name)//"> has leading blanks."
+         CPWARN(TRIM(message))
+      END IF
+
+      real_file_name = ADJUSTL(file_name)
+      IF (status_string == "OLD") real_file_name = discover_file(file_name)
 
       ! Check the specified input file name
       INQUIRE (FILE=TRIM(real_file_name), EXIST=exists, OPENED=is_open, IOSTAT=istat)
@@ -393,7 +398,7 @@ CONTAINS
       ELSE IF (status_string == "OLD") THEN
          IF (.NOT. exists) THEN
             WRITE (UNIT=message, FMT="(A)") &
-               "The specified OLD file <"//TRIM(ADJUSTL(real_file_name))// &
+               "The specified OLD file <"//TRIM(real_file_name)// &
                "> cannot be opened. It does not exist. "// &
                "Data directory path: "//TRIM(get_data_dir())
             CPABORT(TRIM(message))
@@ -432,7 +437,7 @@ CONTAINS
          IF (get_a_new_unit) unit_number = get_unit_number(TRIM(real_file_name))
          IF (unit_number < 1) THEN
             WRITE (UNIT=message, FMT="(A)") &
-               "Cannot open the file <"//TRIM(ADJUSTL(real_file_name))// &
+               "Cannot open the file <"//TRIM(real_file_name)// &
                ">, because no unused logical unit number could be obtained."
             CPABORT(TRIM(message))
          END IF
@@ -461,7 +466,7 @@ CONTAINS
          IF (istat /= 0) THEN
             CALL m_getcwd(cwd)
             WRITE (UNIT=message, FMT="(A,I0,A,I0,A)") &
-               "An error occurred opening the file '"//TRIM(ADJUSTL(real_file_name))// &
+               "An error occurred opening the file '"//TRIM(real_file_name)// &
                "' (UNIT = ", unit_number, ", IOSTAT = ", istat, "). "//TRIM(iomsgstr)//". "// &
                "Current working directory: "//TRIM(cwd)
 
@@ -473,15 +478,15 @@ CONTAINS
          INQUIRE (FILE=TRIM(real_file_name), OPENED=is_open, NUMBER=unit_number, &
                   POSITION=position_string, NAME=message, ACCESS=access_string, &
                   FORM=form_string, ACTION=action_string)
-         WRITE (UNIT=debug_unit, FMT="(T2,A)") "BEGIN DEBUG "//TRIM(ADJUSTL(routineN))
+         WRITE (UNIT=debug_unit, FMT="(T2,A)") "BEGIN DEBUG "//TRIM(routineN)
          WRITE (UNIT=debug_unit, FMT="(T3,A,I0)") "NUMBER  : ", unit_number
          WRITE (UNIT=debug_unit, FMT="(T3,A,L1)") "OPENED  : ", is_open
-         WRITE (UNIT=debug_unit, FMT="(T3,A)") "NAME    : "//TRIM(ADJUSTL(message))
-         WRITE (UNIT=debug_unit, FMT="(T3,A)") "POSITION: "//TRIM(ADJUSTL(position_string))
-         WRITE (UNIT=debug_unit, FMT="(T3,A)") "ACCESS  : "//TRIM(ADJUSTL(access_string))
-         WRITE (UNIT=debug_unit, FMT="(T3,A)") "FORM    : "//TRIM(ADJUSTL(form_string))
-         WRITE (UNIT=debug_unit, FMT="(T3,A)") "ACTION  : "//TRIM(ADJUSTL(action_string))
-         WRITE (UNIT=debug_unit, FMT="(T2,A)") "END DEBUG "//TRIM(ADJUSTL(routineN))
+         WRITE (UNIT=debug_unit, FMT="(T3,A)") "NAME    : "//TRIM(message)
+         WRITE (UNIT=debug_unit, FMT="(T3,A)") "POSITION: "//TRIM(position_string)
+         WRITE (UNIT=debug_unit, FMT="(T3,A)") "ACCESS  : "//TRIM(access_string)
+         WRITE (UNIT=debug_unit, FMT="(T3,A)") "FORM    : "//TRIM(form_string)
+         WRITE (UNIT=debug_unit, FMT="(T3,A)") "ACTION  : "//TRIM(action_string)
+         WRITE (UNIT=debug_unit, FMT="(T2,A)") "END DEBUG "//TRIM(routineN)
          CALL print_preconnection_list(debug_unit)
       END IF
 
@@ -517,28 +522,22 @@ CONTAINS
       INTEGER                                            :: stat
       LOGICAL                                            :: exists
 
-      real_file_name = TRIM(file_name)
+      real_file_name = TRIM(ADJUSTL(file_name))
 
       ! first try file-name directly
-      INQUIRE (file=TRIM(file_name), exist=exists, iostat=stat)
-      IF (stat == 0 .AND. exists) THEN
-         real_file_name = file_name
-         RETURN
-      ENDIF
+      INQUIRE (file=TRIM(real_file_name), exist=exists, iostat=stat)
+      IF (stat == 0 .AND. exists) RETURN
 
       ! then try the data-dir
       data_dir = get_data_dir()
       IF (LEN_TRIM(data_dir) > 0) THEN
-         candidate = join_paths(data_dir, file_name)
+         candidate = join_paths(data_dir, real_file_name)
          INQUIRE (file=TRIM(candidate), exist=exists, iostat=stat)
          IF (stat == 0 .AND. exists) THEN
             real_file_name = candidate
             RETURN
-         ENDIF
-      ENDIF
-
-      ! fall back in case file not found
-      real_file_name = file_name
+         END IF
+      END IF
 
    END FUNCTION discover_file
 
@@ -618,7 +617,7 @@ CONTAINS
             IF (preconnected(ic)%unit_number > 0) THEN
                WRITE (UNIT=output_unit, FMT="(I6,3X,I6,8X,A)") &
                   ic, preconnected(ic)%unit_number, &
-                  TRIM(ADJUSTL(preconnected(ic)%file_name))
+                  TRIM(preconnected(ic)%file_name)
             ELSE
                WRITE (UNIT=output_unit, FMT="(I6,17X,A)") &
                   ic, "UNUSED"

--- a/src/input/cp_parser_methods.F
+++ b/src/input/cp_parser_methods.F
@@ -487,6 +487,7 @@ CONTAINS
          routineP = moduleN//':'//routineN
 
       INTEGER                                            :: i
+      LOGICAL                                            :: at_end
 
       CPASSERT(ASSOCIATED(parser))
       CPASSERT(parser%ref_count > 0)
@@ -500,7 +501,8 @@ CONTAINS
       END IF
 
       ! Search for the beginning of the next input string
-      DO
+      outer_loop: DO
+
          ! Increment the column counter
          parser%icol = parser%icol+1
 
@@ -512,37 +514,39 @@ CONTAINS
             RETURN
          END IF
 
-         ! Check for input line continuation
-         ! Ignore all white space and accept only one
-         ! separator token or a string in quotation marks
+         ! Ignore all white space
          IF (.NOT. is_whitespace(parser%input_line(parser%icol:parser%icol))) THEN
-
+            ! Check for input line continuation
             IF (parser%input_line(parser%icol:parser%icol) == parser%continuation_character) THEN
-               DO i = LEN(parser%input_line), 1, -1
-                  IF (.NOT. is_whitespace(parser%input_line(i:i))) EXIT
-               END DO
-               IF (parser%icol == i .OR. &
-                   is_comment(parser, parser%input_line(i:i))) THEN
-                  CALL parser_get_next_line(parser, 1)
-                  ! does not pass at_end, it is an error to continue to EOF, change this behavoiur?
-                  CYCLE
-               ELSE
-                  parser%icol1 = i
-                  parser%icol2 = i
+               inner_loop: DO i = parser%icol+1, LEN_TRIM(parser%input_line)
+                  IF (is_whitespace(parser%input_line(i:i))) CYCLE inner_loop
+                  IF (is_comment(parser, parser%input_line(i:i))) THEN
+                     EXIT inner_loop
+                  ELSE
+                     parser%icol1 = i
+                     parser%icol2 = LEN_TRIM(parser%input_line)
+                     CALL cp_abort(__LOCATION__, &
+                                   "Found a non-blank token which is not a comment after the line continuation character '"// &
+                                   parser%continuation_character//"'"//TRIM(parser_location(parser)))
+                  END IF
+               END DO inner_loop
+               CALL parser_get_next_line(parser, 1, at_end=at_end)
+               IF (at_end) THEN
                   CALL cp_abort(__LOCATION__, &
-                                "Found non-blank tokens after the line continuation character '"// &
-                                parser%continuation_character//"' "// &
+                                "Unexpected end of file (EOF) found after line continuation"// &
                                 TRIM(parser_location(parser)))
-                  EXIT
                END IF
+               parser%icol = 0
+               CYCLE outer_loop
             ELSE
                parser%icol = parser%icol-1
                parser%icol1 = parser%icol
                parser%icol2 = parser%icol
-               EXIT
+               RETURN
             END IF
          END IF
-      END DO
+
+      END DO outer_loop
 
    END SUBROUTINE parser_skip_space
 
@@ -563,29 +567,44 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'parser_next_token', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: i, len_inputline, len_trim_inputline, &
-                                                            length
+      CHARACTER(LEN=1)                                   :: token
+      INTEGER                                            :: i, len_trim_inputline, length
+      LOGICAL                                            :: at_end
 
       CPASSERT(ASSOCIATED(parser))
       CPASSERT(parser%ref_count > 0)
       IF (PRESENT(string_length)) THEN
-         length = MIN(string_length, max_line_length)
+         IF (string_length > max_line_length) THEN
+            CPABORT("string length > max_line_length")
+         ELSE
+            length = string_length
+         END IF
       ELSE
          length = 0
       END IF
 
+      ! Precompute trimmed line length
+      len_trim_inputline = LEN_TRIM(parser%input_line)
+
       IF (length > 0) THEN
-         ! Fixed input string length
+
+         ! Read input string of fixed length (single line)
+
+         ! Check for EOF
          IF (parser%icol == -1) &
             CPABORT("Unexpectetly reached EOF"//TRIM(parser_location(parser)))
 
-         length = MIN(LEN_TRIM(parser%input_line)-parser%icol1+1, length)
+         length = MIN(len_trim_inputline-parser%icol1+1, length)
          parser%icol1 = parser%icol+1
          parser%icol2 = parser%icol+length
+         i = INDEX(parser%input_line(parser%icol1:parser%icol2), '"')
+         IF (i > 0) parser%icol2 = parser%icol+i
          parser%icol = parser%icol2
+
       ELSE
 
-         ! Variable input string length (automatic search)
+         ! Variable input string length (automatic multi-line search)
+
          ! Check for EOF
          IF (parser%icol == -1) THEN
             parser%icol1 = 1
@@ -594,95 +613,97 @@ CONTAINS
          END IF
 
          ! Search for the beginning of the next input string
-         ! we precompute those, they are expensive to get
-         len_inputline = LEN(parser%input_line)
-         len_trim_inputline = LEN_TRIM(parser%input_line)
-
-         DO
+         outer_loop1: DO
 
             ! Increment the column counter
             parser%icol = parser%icol+1
 
             ! Quick return, if the end of line is found
-            IF ((parser%icol > len_trim_inputline) .OR. &
-                is_comment(parser, parser%input_line(parser%icol:parser%icol))) THEN
+            IF (parser%icol > len_trim_inputline) THEN
                parser%icol1 = 1
                parser%icol2 = -1
                RETURN
             END IF
 
-            ! Check for input line continuation
-            IF (parser%input_line(parser%icol:parser%icol) == &
-                parser%continuation_character) THEN
-               DO i = LEN(parser%input_line), 1, -1
-                  IF (.NOT. is_whitespace(parser%input_line(i:i))) EXIT
-               END DO
-               IF (parser%icol == i .OR. &
-                   is_comment(parser, parser%input_line(i:i))) THEN
-                  CALL parser_get_next_line(parser, 1)
-                  ! does not pass at_end, it is an error to continue to EOF, change this behavoiur?
-                  CYCLE
-               ELSE
-                  parser%icol1 = i
-                  parser%icol2 = i
-                  CALL cp_abort(__LOCATION__, &
-                                "Found non-blank tokens after the line continuation character '"// &
-                                parser%continuation_character//"' "//TRIM(parser_location(parser)))
-                  EXIT
-               END IF
-            END IF
-            ! Ignore all white space and accept only one
-            ! separator token or a string in quotation marks
-            IF (is_whitespace(parser%input_line(parser%icol:parser%icol))) THEN
-               CYCLE
-            ELSE IF (INDEX(parser%separators, parser%input_line(parser%icol:parser%icol)) > 0) THEN
-               IF (parser%first_separator) THEN
-                  parser%first_separator = .FALSE.
-                  CYCLE
-               ELSE
-                  parser%icol1 = parser%icol
-                  parser%icol2 = parser%icol
-                  CALL cp_abort(__LOCATION__, &
-                                "Unexpected separator token <"//parser%input_line(parser%icol:parser%icol)// &
-                                "> found"//TRIM(parser_location(parser)))
-                  EXIT
-               END IF
-            ELSE IF (parser%input_line(parser%icol:parser%icol) == '"') THEN
-               ! identify quotes and preserve them through-out the execution..
+            token = parser%input_line(parser%icol:parser%icol)
+
+            IF (is_whitespace(token)) THEN
+               ! Ignore white space
+               CYCLE outer_loop1
+            ELSE IF (is_comment(parser, token)) THEN
+               parser%icol1 = 1
+               parser%icol2 = -1
                parser%first_separator = .TRUE.
+               RETURN
+            ELSE IF (token == '"') THEN
+               ! Read quoted string
                parser%icol1 = parser%icol+1
                parser%icol2 = parser%icol+INDEX(parser%input_line(parser%icol1:), '"')
                IF (parser%icol2 == parser%icol) THEN
                   parser%icol1 = parser%icol
                   parser%icol2 = parser%icol
-                  CPABORT("Unmatched quotation mark found"//TRIM(parser_location(parser)))
+                  CALL cp_abort(__LOCATION__, &
+                                "Unmatched quotation mark found"//TRIM(parser_location(parser)))
                ELSE
-                  parser%icol1 = parser%icol1-1
                   parser%icol = parser%icol2
+                  parser%icol2 = parser%icol2-1
+                  parser%first_separator = .TRUE.
                   RETURN
                END IF
+            ELSE IF (token == parser%continuation_character) THEN
+               ! Check for input line continuation
+               inner_loop1: DO i = parser%icol+1, len_trim_inputline
+                  IF (is_whitespace(parser%input_line(i:i))) THEN
+                     CYCLE inner_loop1
+                  ELSE IF (is_comment(parser, parser%input_line(i:i))) THEN
+                     EXIT inner_loop1
+                  ELSE
+                     parser%icol1 = i
+                     parser%icol2 = len_trim_inputline
+                     CALL cp_abort(__LOCATION__, &
+                                   "Found a non-blank token which is not a comment after the line continuation character '"// &
+                                   parser%continuation_character//"'"//TRIM(parser_location(parser)))
+                  END IF
+               END DO inner_loop1
+               CALL parser_get_next_line(parser, 1, at_end=at_end)
+               IF (at_end) THEN
+                  CALL cp_abort(__LOCATION__, &
+                                "Unexpected end of file (EOF) found after line continuation"//TRIM(parser_location(parser)))
+               END IF
+               len_trim_inputline = LEN_TRIM(parser%input_line)
+               CYCLE outer_loop1
+            ELSE IF (INDEX(parser%separators, token) > 0) THEN
+               IF (parser%first_separator) THEN
+                  parser%first_separator = .FALSE.
+                  CYCLE outer_loop1
+               ELSE
+                  parser%icol1 = parser%icol
+                  parser%icol2 = parser%icol
+                  CALL cp_abort(__LOCATION__, &
+                                "Unexpected separator token '"//token// &
+                                "' found"//TRIM(parser_location(parser)))
+               END IF
             ELSE
-               parser%first_separator = .TRUE.
                parser%icol1 = parser%icol
-               EXIT
+               parser%first_separator = .TRUE.
+               EXIT outer_loop1
             END IF
 
-         END DO
+         END DO outer_loop1
 
          ! Search for the end of the next input string
-         DO
-            IF (parser%icol > len_trim_inputline .OR. parser%icol == len_inputline) EXIT
+         outer_loop2: DO
             parser%icol = parser%icol+1
-            IF ((parser%icol > len_trim_inputline) .OR. &
-                is_whitespace(parser%input_line(parser%icol:parser%icol)) .OR. &
-                is_comment(parser, parser%input_line(parser%icol:parser%icol)) .OR. &
-                (parser%input_line(parser%icol:parser%icol) == parser%continuation_character)) THEN
-               EXIT
-            ELSE IF (INDEX(parser%separators, parser%input_line(parser%icol:parser%icol)) > 0) THEN
+            IF (parser%icol > len_trim_inputline) EXIT outer_loop2
+            token = parser%input_line(parser%icol:parser%icol)
+            IF (is_whitespace(token) .OR. is_comment(parser, token) .OR. &
+                (token == parser%continuation_character)) THEN
+               EXIT outer_loop2
+            ELSE IF (INDEX(parser%separators, token) > 0) THEN
                parser%first_separator = .FALSE.
-               EXIT
+               EXIT outer_loop2
             END IF
-         END DO
+         END DO outer_loop2
 
          parser%icol2 = parser%icol-1
 
@@ -739,7 +760,11 @@ CONTAINS
       END IF
 
       ! Otherwise continue normally
-      CALL parser_next_token(parser, string_length=string_length)
+      IF (PRESENT(string_length)) THEN
+         CALL parser_next_token(parser, string_length=string_length)
+      ELSE
+         CALL parser_next_token(parser)
+      END IF
 
       ! End of line
       IF (parser%icol1 > parser%icol2) THEN
@@ -1015,7 +1040,11 @@ CONTAINS
       IF (parser%ilist%in_use) THEN
          CALL ilist_update(parser%ilist)
       ELSE
-         CALL parser_next_token(parser, string_length=string_length)
+         IF (PRESENT(string_length)) THEN
+            CALL parser_next_token(parser, string_length=string_length)
+         ELSE
+            CALL parser_next_token(parser)
+         END IF
          IF (parser%icol1 > parser%icol2) THEN
             parser%icol1 = parser%icol
             parser%icol2 = parser%icol
@@ -1099,7 +1128,11 @@ CONTAINS
          CPABORT("Unexpected EOF"//TRIM(parser_location(parser)))
       END IF
 
-      CALL parser_next_token(parser, string_length=string_length)
+      IF (PRESENT(string_length)) THEN
+         CALL parser_next_token(parser, string_length=string_length)
+      ELSE
+         CALL parser_next_token(parser)
+      END IF
 
       input_string_length = parser%icol2-parser%icol1+1
 
@@ -1178,7 +1211,11 @@ CONTAINS
          CPABORT("Unexpected EOF"//TRIM(parser_location(parser)))
       END IF
 
-      CALL parser_next_token(parser, string_length=string_length)
+      IF (PRESENT(string_length)) THEN
+         CALL parser_next_token(parser, string_length=string_length)
+      ELSE
+         CALL parser_next_token(parser)
+      END IF
 
       IF (parser%icol1 > parser%icol2) THEN
          parser%icol1 = parser%icol
@@ -1243,10 +1280,15 @@ CONTAINS
          at_end = my_at_end
          IF (my_at_end) RETURN
       ELSE IF (my_at_end) THEN
-         CPABORT("Unexpected EOF"//TRIM(parser_location(parser)))
+         CALL cp_abort(__LOCATION__, &
+                       "Unexpected EOF"//TRIM(parser_location(parser)))
       END IF
 
-      CALL parser_next_token(parser, string_length)
+      IF (PRESENT(string_length)) THEN
+         CALL parser_next_token(parser, string_length=string_length)
+      ELSE
+         CALL parser_next_token(parser)
+      END IF
 
       input_string_length = parser%icol2-parser%icol1+1
 
@@ -1255,11 +1297,11 @@ CONTAINS
                        "A string type object was expected, found end of line"// &
                        TRIM(parser_location(parser)))
       ELSE IF (input_string_length > LEN(object)) THEN
-         CALL cp_warn(__LOCATION__, &
-                      "The input string <"//parser%input_line(parser%icol1:parser%icol2)// &
-                      "> has more than "//cp_to_string(LEN(object))// &
-                      " characters and is therefore too long to fit in the "// &
-                      "specified variable"//TRIM(parser_location(parser)))
+         CALL cp_abort(__LOCATION__, &
+                       "The input string <"//parser%input_line(parser%icol1:parser%icol2)// &
+                       "> has more than "//cp_to_string(LEN(object))// &
+                       " characters and is therefore too long to fit in the "// &
+                       "specified variable"//TRIM(parser_location(parser)))
          object = parser%input_line(parser%icol1:parser%icol1+LEN(object)-1)
       ELSE
          object(:input_string_length) = parser%input_line(parser%icol1:parser%icol2)

--- a/src/input/input_enumeration_types.F
+++ b/src/input/input_enumeration_types.F
@@ -210,7 +210,7 @@ CONTAINS
 
       CPASSERT(ASSOCIATED(enum))
       CPASSERT(enum%ref_count > 0)
-      upc = c
+      upc = TRIM(ADJUSTL(c)) !MK Ignore leading and trailing blanks
       CALL uppercase(upc)
       found = .FALSE.
       DO j = 1, SIZE(enum%c_vals)

--- a/src/input/input_parsing.F
+++ b/src/input/input_parsing.F
@@ -100,7 +100,7 @@ CONTAINS
                        //TRIM(parser_location(parser)))
       section => section_vals%section
       IF (root_sect) THEN
-         token = parser%input_line(parser%icol1:parser%icol2)
+         token = TRIM(ADJUSTL(parser%input_line(parser%icol1:parser%icol2))) ! Ignore leading or trailing blanks
          CALL uppercase(token)
          IF (token /= parser%section_character//section%name) &
             CALL cp_abort(__LOCATION__, &
@@ -130,6 +130,7 @@ CONTAINS
       DO WHILE (.TRUE.)
          CALL parser_get_object(parser, token, newline=.TRUE., &
                                 lower_to_upper=.TRUE., at_end=at_end)
+         token = TRIM(ADJUSTL(token)) ! Ignore leading or trailing blanks
          IF (at_end) THEN
             IF (root_sect) &
                CALL cp_abort(__LOCATION__, &
@@ -319,7 +320,7 @@ CONTAINS
          DIMENSION(:), POINTER                           :: c_val_p
       INTEGER                                            :: handle, i, i_val
       INTEGER, DIMENSION(:), POINTER                     :: i_val_p
-      LOGICAL                                            :: check, l_val
+      LOGICAL                                            :: check, eol, l_val, quoted
       LOGICAL, DIMENSION(:), POINTER                     :: l_val_p
       REAL(kind=dp)                                      :: r_val
       REAL(kind=dp), DIMENSION(:), POINTER               :: r_val_p
@@ -516,10 +517,38 @@ CONTAINS
          ELSE
             NULLIFY (c_last, c_first)
             CALL parser_get_object(parser, c_val, string_length=LEN(c_val))
+            IF (c_val(1:1) == '"') THEN
+               quoted = .TRUE.
+               c_val(1:) = c_val(2:) ! Drop first quotation mark
+               i = INDEX(c_val, '"') ! Check for second quotation mark
+               IF (i > 0) THEN
+                  c_val(i:) = "" ! Discard stuff after second quotation mark
+                  eol = .TRUE. ! Enforce end of line
+               ELSE
+                  eol = .FALSE.
+               END IF
+            ELSE
+               quoted = .FALSE.
+               eol = .FALSE.
+            END IF
             CALL cp_create(c_first, c_val)
             c_last => c_first
-            DO WHILE (parser_test_next_token(parser) /= "EOL")
+            DO WHILE ((.NOT. eol) .AND. (parser_test_next_token(parser) /= "EOL"))
                CALL parser_get_object(parser, c_val, string_length=LEN(c_val))
+               i = INDEX(c_val, '"') ! Check for quotation mark
+               IF (i > 0) THEN
+                  IF (quoted) THEN
+                     c_val(i:) = "" ! Discard stuff after second quotation mark
+                     eol = .TRUE. ! Enforce end of line
+                  ELSE
+                     CALL cp_abort(__LOCATION__, &
+                                   "Quotation mark found which is not the first non-blank character. "// &
+                                   "Possibly the first quotation mark is missing?"// &
+                                   TRIM(parser_location(parser)))
+                  END IF
+               ELSE
+                  eol = .FALSE.
+               END IF
                CALL cp_create(c_new, c_val)
                c_last%rest => c_new
                c_last => c_new

--- a/tests/Fist/regtest-4/lewis.inp
+++ b/tests/Fist/regtest-4/lewis.inp
@@ -58,15 +58,15 @@
       &NONBONDED
         &GENPOT
           atoms O O
-          FUNCTION qO^2 / x - kappaOO / ( 1 + tauOO *  ( x / rhoOO )^3 + ( x / rhoOO )^6 )
-          PARAMETERS qO kappaOO tauOO rhoOO
-          VALUES    ${QO} ${KAPPAOO} ${TAUOO} ${RHOOO}
-          VARIABLES x
-          RCUT    [angstrom] ${RCUTOFF}
+          FUNCTION  "qO^2 / x - kappaOO / ( 1 + tauOO *  ( x / rhoOO )^3 + ( x / rhoOO )^6 )"  # Function O O
+          PARAMETERS qO  kappaOO tauOO rhoOO
+          VALUES    "${QO}" ${KAPPAOO} ${TAUOO} "${RHOOO}" # Quotation test
+          VARIABLES "x"
+          "RCUT"    [angstrom] ${RCUTOFF}
         &END GENPOT
         &GENPOT
           atoms O H
-          FUNCTION qO*qH / x - kappaOH / ( 1 + tauOH *  ( x / rhoOH )^3 + ( x / rhoOH )^6 )
+          FUNCTION " qO*qH / x - kappaOH / ( 1 + tauOH *  ( x / rhoOH )^3 + ( x / rhoOH )^6 ) " # Function O H
           PARAMETERS qO qH kappaOH tauOH rhoOH
           VALUES   ${QO} ${QH} ${KAPPAOH} ${TAUOH} ${RHOOH}
           VARIABLES x
@@ -82,7 +82,7 @@
         &END GENPOT
         &GENPOT
           atoms E E
-          FUNCTION qV^2 / ( ( x^8 + rhoVV1^4 * x^4 + rhoVV2^8 )^(1./8.) ) + kappaVV / ( 1 + ( x / rhoVV3 )^6 )
+          FUNCTION   "        qV^2 / ( ( x^8 + rhoVV1^4 * x^4 + rhoVV2^8 )^(1./8.) ) + kappaVV / ( 1 + ( x / rhoVV3 )^6 )             " # Quotation test
           PARAMETERS qV rhoVV1 rhoVV2 kappaVV rhoVV3
           VALUES ${QV} ${RHOVV1} ${RHOVV2} ${KAPPAVV} ${RHOVV3}
           VARIABLES x

--- a/tests/QS/regtest-gpw-1/Ar.inp
+++ b/tests/QS/regtest-gpw-1/Ar.inp
@@ -1,10 +1,10 @@
 &FORCE_EVAL
   METHOD Quickstep
   &DFT
-    BASIS_SET_FILE_NAME BASIS_SET
+    BASIS_SET_FILE_NAME "BASIS_SET" # Test parser: allow for comments using quotation marks
     POTENTIAL_FILE_NAME POTENTIAL
     &MGRID
-      CUTOFF 200
+      "CUTOFF"  "200" # Test parser
       REL_CUTOFF 40
     &END MGRID
     &QS
@@ -37,12 +37,12 @@
     Ar     0.000000  0.000000  0.000000
     &END COORD
     &KIND Ar
-      BASIS_SET DZVP-GTH-PADE
-      POTENTIAL GTH-PADE-q8
+      BASIS_SET "DZVP-GTH-PADE" # Test parser
+      POTENTIAL "GTH-PADE-q8"
     &END KIND
   &END SUBSYS
 &END FORCE_EVAL
 &GLOBAL
-  PROJECT Ar
+  PROJECT "Ar"
   PRINT_LEVEL MEDIUM
 &END GLOBAL


### PR DESCRIPTION
- optionally lchar variables can be quoted now which allows then for a comment at the end of the line
- the quotes are dropped on reading and are no longer part of the input variable
- quoting of basis set and pseudopotential names should work now which impoves syntax highlighting
- improved multi-line parsing for non-lchar variables
- some tests added to check the parsing behaviour