### PR TITLE
add pkg-config in the docker ci image

### DIFF
--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtool \
     autoconf \
     automake \
+    pkg-config \
    && rm -rf /var/lib/apt/lists/*
 
 # build toolchain


### PR DESCRIPTION
Well, unfortunately things that work on all computers I have at disposal do not work with the docker image by default. 