### PR TITLE
Cubic scaling RPA with DBCSR tensors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "exts/dbcsr"]
 	path = exts/dbcsr
-	url = https://github.com/cp2k/dbcsr
-	branch = master
+	url = https://github.com/pseewald/dbcsr
+	branch = tensors-pr

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "exts/dbcsr"]
 	path = exts/dbcsr
-	url = https://github.com/pseewald/dbcsr
-	branch = tensors-pr
+	url = https://github.com/cp2k/dbcsr
+	branch = master

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -1261,6 +1261,26 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create( &
+         keyword=keyword, &
+         name="DO_DBCSR_T", &
+         description="Uses DBCSR tensors for cubic scaling RPA/L-SOS-MP2", &
+         usage="DO_DBCSR_T", &
+         default_l_val=.TRUE., &
+         lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword=keyword, &
+         name="MAX_BLOCK_SIZE_SQRT", &
+         description="Square root of maximum block size for splitting blocks of matrix representation of large tensors "// &
+         "along the combined dimension. "// &
+         "Atomic blocks are split in order to allow for better load balance.", &
+         default_i_val=10)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
       ! here we generate a RPA imag. time subsection to use for MAOs
       CALL create_mao_section(subsection)
       CALL section_add_subsection(section, subsection)

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -337,6 +337,15 @@ CONTAINS
 
          END IF
 
+         IF (mp2_env%ri_rpa_im_time%group_size_P > para_env%num_pe) THEN
+            mp2_env%ri_rpa_im_time%group_size_P = para_env%num_pe
+         END IF
+
+         group_size_P = mp2_env%ri_rpa_im_time%group_size_P
+
+         ! only allow group_size_P which is a factor of the total number of MPI tasks
+         CPASSERT(MODULO(para_env%num_pe, group_size_P) == 0)
+
          ! only allow group_size_3c which is a factor of the total number of MPI tasks
          CPASSERT(MODULO(para_env%num_pe, group_size_3c) == 0)
 
@@ -689,16 +698,6 @@ CONTAINS
             DEALLOCATE (sab_orb_all)
 
             group_size_P = mp2_env%ri_rpa_im_time%group_size_P
-
-            IF (group_size_P > para_env%num_pe) THEN
-
-               group_size_P = para_env%num_pe
-               mp2_env%ri_rpa_im_time%group_size_P = para_env%num_pe
-
-            END IF
-
-            ! only allow group_size_P which is a factor of the total number of MPI tasks
-            CPASSERT(MODULO(para_env%num_pe, group_size_P) == 0)
 
             mp2_env%ri_rpa_im_time_util(1)%n_group_P = para_env%num_pe/group_size_P
 

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -59,6 +59,7 @@ MODULE mp2_gpw
         dbcsr_p_type, dbcsr_release, dbcsr_reserve_all_blocks, dbcsr_reserve_diag_blocks, &
         dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_real_default, &
         dbcsr_type_symmetric
+   USE dbcsr_tensor_api,                ONLY: dbcsr_t_type
    USE distribution_1d_types,           ONLY: distribution_1d_release,&
                                               distribution_1d_type
    USE distribution_2d_types,           ONLY: distribution_2d_release,&
@@ -181,16 +182,18 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_gpw_main', routineP = moduleN//':'//routineN
 
       INTEGER :: blacs_grid_layout, color_sub, color_sub_3c, comm_sub, comm_sub_3c, dimen, &
-         dimen_RI, group_size_3c, gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_virt, &
-         gw_corr_lev_virt_beta, handle, homo, homo_beta, i, i_multigrid, local_unit_nr, &
-         my_group_L_end, my_group_L_size, my_group_L_start, n_multigrid, nelectron, &
+         dimen_RI, group_size_3c, group_size_P, gw_corr_lev_occ, gw_corr_lev_occ_beta, &
+         gw_corr_lev_virt, gw_corr_lev_virt_beta, handle, homo, homo_beta, i, i_multigrid, &
+         local_unit_nr, my_group_L_end, my_group_L_size, my_group_L_start, n_multigrid, nelectron, &
          nelectron_beta, nmo, nspins, ri_metric
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: ends_array, ends_B_all, ends_B_occ_bse, &
-         ends_B_virt_bse, ends_B_virtual, ends_B_virtual_beta, sizes_array, sizes_B_all, &
-         sizes_B_occ_bse, sizes_B_virt_bse, sizes_B_virtual, sizes_B_virtual_beta, starts_array, &
-         starts_B_all, starts_B_occ_bse, starts_B_virt_bse, starts_B_virtual, starts_B_virtual_beta
-      LOGICAL :: blacs_repeatable, do_bse, do_im_time, do_kpoints_cubic_RPA, do_mao, my_do_gw, &
-         my_do_ri_mp2, my_do_ri_rpa, my_do_ri_sos_laplace_mp2, skip_load_balance_distributed
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: ends_array, ends_array_mc_t, ends_B_all, &
+         ends_B_occ_bse, ends_B_virt_bse, ends_B_virtual, ends_B_virtual_beta, sizes_array, &
+         sizes_B_all, sizes_B_occ_bse, sizes_B_virt_bse, sizes_B_virtual, sizes_B_virtual_beta, &
+         starts_array, starts_array_mc_t, starts_B_all, starts_B_occ_bse, starts_B_virt_bse, &
+         starts_B_virtual, starts_B_virtual_beta
+      LOGICAL :: blacs_repeatable, do_bse, do_dbcsr_t, do_im_time, do_kpoints_cubic_RPA, do_mao, &
+         my_do_gw, my_do_ri_mp2, my_do_ri_rpa, my_do_ri_sos_laplace_mp2, &
+         skip_load_balance_distributed
       REAL(KIND=dp) :: cutoff_old, Emp2_AB, Emp2_BB, Emp2_Cou_BB, Emp2_d2_AB, Emp2_d_AB, &
          Emp2_EX_BB, eps_gvg_rspace_old, eps_pgf_orb_old, eps_rho_rspace_old, progression_factor, &
          relative_cutoff_old
@@ -219,6 +222,8 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int, &
                                                             mat_3c_overl_int_mao_for_occ, &
                                                             mat_3c_overl_int_mao_for_virt
+      TYPE(dbcsr_t_type)                                 :: t_3c_M
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :)   :: t_3c_O
       TYPE(dbcsr_type), POINTER :: mo_coeff_all, mo_coeff_all_beta, mo_coeff_gw, mo_coeff_gw_beta, &
          mo_coeff_o, mo_coeff_o_beta, mo_coeff_v, mo_coeff_v_beta
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -254,6 +259,7 @@ CONTAINS
 
       ! check if we want to do imaginary time
       do_im_time = mp2_env%do_im_time
+      do_dbcsr_t = mp2_env%ri_rpa_im_time%do_dbcsr_t
       do_mao = mp2_env%ri_rpa_im_time%do_mao
       do_bse = qs_env%mp2_env%ri_g0w0%do_bse
       do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
@@ -501,9 +507,11 @@ CONTAINS
                task_list_sub, mo_coeff_o, mo_coeff_v, mo_coeff_all, mo_coeff_gw, &
                mp2_env%mp2_gpw%eps_filter, unit_nr, &
                mp2_env%mp2_memory, mp2_env%calc_PQ_cond_num, calc_forces, blacs_env_sub, my_do_gw, &
-               do_bse, starts_B_all, sizes_B_all, ends_B_all, gw_corr_lev_occ, gw_corr_lev_virt, &
+               do_bse, starts_B_all, sizes_B_all, ends_B_all, starts_array_mc_t, ends_array_mc_t, &
+               gw_corr_lev_occ, gw_corr_lev_virt, &
                do_im_time, do_mao, do_kpoints_cubic_RPA, &
-               mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
+               mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, mat_3c_overl_int_mao_for_occ, &
+               mat_3c_overl_int_mao_for_virt, &
                mao_coeff_occ, mao_coeff_virt, ri_metric, &
                starts_B_occ_bse, sizes_B_occ_bse, ends_B_occ_bse, &
                starts_B_virt_bse, sizes_B_virt_bse, ends_B_virt_bse, &
@@ -523,9 +531,10 @@ CONTAINS
                                        mp2_env%mp2_gpw%eps_filter, unit_nr, &
                                        mp2_env%mp2_memory, mp2_env%calc_PQ_cond_num, calc_forces, &
                                        blacs_env_sub, my_do_gw, do_bse, starts_B_all, sizes_B_all, &
-                                       ends_B_all, gw_corr_lev_occ, gw_corr_lev_virt, &
+                                       ends_B_all, starts_array_mc_t, ends_array_mc_t, &
+                                       gw_corr_lev_occ, gw_corr_lev_virt, &
                                        do_im_time, do_mao, do_kpoints_cubic_RPA, &
-                                       mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, &
+                                       mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, mat_3c_overl_int_mao_for_occ, &
                                        mat_3c_overl_int_mao_for_virt, mao_coeff_occ, mao_coeff_virt, &
                                        ri_metric, &
                                        starts_B_occ_bse, sizes_B_occ_bse, ends_B_occ_bse, &
@@ -673,11 +682,39 @@ CONTAINS
                blacs_env_sub_RPA => blacs_env_sub_im_time_3c
             END IF
 
-            CALL create_dbcsr_matrices_im_time(mat_munu, mat_P_local, mat_P_global, mat_M, mat_dm_occ_global_mao, &
-                                               mat_dm_virt_global_mao, mat_dm_occ_local, mat_dm_virt_local, &
-                                               do_mao, qs_env, mp2_env, para_env, dft_control, atomic_kind_set, qs_kind_set, &
-                                               atom2d, molecule_kind_set, molecule_set, particle_set, cell, &
-                                               para_env_sub_im_time_P, blacs_env_sub_RPA, sab_orb_all)
+            ! release sab_orb_all
+            DO i = 1, SIZE(sab_orb_all)
+               CALL deallocate_neighbor_list_set(sab_orb_all(i)%neighbor_list_set)
+            END DO
+            DEALLOCATE (sab_orb_all)
+
+            group_size_P = mp2_env%ri_rpa_im_time%group_size_P
+
+            IF (group_size_P > para_env%num_pe) THEN
+
+               group_size_P = para_env%num_pe
+               mp2_env%ri_rpa_im_time%group_size_P = para_env%num_pe
+
+            END IF
+
+            ! only allow group_size_P which is a factor of the total number of MPI tasks
+            CPASSERT(MODULO(para_env%num_pe, group_size_P) == 0)
+
+            mp2_env%ri_rpa_im_time_util(1)%n_group_P = para_env%num_pe/group_size_P
+
+            ! a para_env with P groups
+            mp2_env%ri_rpa_im_time_util(1)%color_sub_P = para_env%mepos/group_size_P
+
+            IF (do_dbcsr_t) THEN
+               CALL create_matrix_P(mat_P_global, qs_env, mp2_env, para_env, dft_control, atomic_kind_set, &
+                                    qs_kind_set, atom2d, molecule_kind_set, molecule_set, particle_set, cell)
+            ELSE
+               CALL create_dbcsr_matrices_im_time(mat_munu, mat_P_local, mat_P_global, mat_M, mat_dm_occ_global_mao, &
+                                                  mat_dm_virt_global_mao, mat_dm_occ_local, mat_dm_virt_local, &
+                                                  do_mao, qs_env, mp2_env, para_env, dft_control, atomic_kind_set, qs_kind_set, &
+                                                  atom2d, molecule_kind_set, molecule_set, particle_set, cell, &
+                                                  para_env_sub_im_time_P, blacs_env_sub_RPA)
+            ENDIF
 
             CALL cp_blacs_env_release(blacs_env_sub_im_time_3c)
 
@@ -700,7 +737,9 @@ CONTAINS
                                    mao_coeff_occ, mao_coeff_virt, mao_coeff_occ_A, mao_coeff_virt_A, &
                                    mat_munu, mat_dm_occ_local, mat_dm_virt_local, &
                                    mat_P_local, mat_P_global, mat_M, &
-                                   mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
+                                   mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, starts_array_mc_t, &
+                                   ends_array_mc_t, &
+                                   mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
                                    mp2_env%mp2_gpw%eps_filter, BIb_C_beta, homo_beta, Eigenval_beta, &
                                    ends_B_virtual_beta, sizes_B_virtual_beta, starts_B_virtual_beta, &
                                    mo_coeff_beta, BIb_C_gw_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta)
@@ -716,16 +755,23 @@ CONTAINS
                                    mao_coeff_occ, mao_coeff_virt, mao_coeff_occ_A, mao_coeff_virt_A, &
                                    mat_munu, mat_dm_occ_local, mat_dm_virt_local, &
                                    mat_P_local, mat_P_global, mat_M, &
-                                   mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
+                                   mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, &
+                                   starts_array_mc_t, ends_array_mc_t, &
+                                   mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
                                    mp2_env%mp2_gpw%eps_filter)
          END IF
 
          IF (do_im_time) THEN
-            CALL clean_up_im_time(mat_munu, mat_P_local, mat_P_global, mat_M, mat_dm_occ_global_mao, &
-                                  mat_dm_virt_global_mao, mat_munu_mao_occ_virt, mat_munu_mao_virt_occ, &
-                                  mat_dm_occ_local, mat_dm_virt_local, para_env_sub_im_time_3c, &
-                                  para_env_sub_im_time_P, mao_coeff_occ, mao_coeff_virt, &
-                                  mao_coeff_occ_A, mao_coeff_virt_A, mp2_env)
+            IF (do_dbcsr_t) THEN
+               CALL clean_up_im_time_t(mat_P_global, mat_dm_occ_global_mao, mat_dm_virt_global_mao, &
+                                       para_env_sub_im_time_3c)
+            ELSE
+               CALL clean_up_im_time(mat_munu, mat_P_local, mat_P_global, mat_M, mat_dm_occ_global_mao, &
+                                     mat_dm_virt_global_mao, mat_munu_mao_occ_virt, mat_munu_mao_virt_occ, &
+                                     mat_dm_occ_local, mat_dm_virt_local, para_env_sub_im_time_3c, &
+                                     para_env_sub_im_time_P, mao_coeff_occ, mao_coeff_virt, &
+                                     mao_coeff_occ_A, mao_coeff_virt_A, mp2_env)
+            ENDIF
          END IF
 
          ! Release some memory for AXK
@@ -2480,6 +2526,71 @@ CONTAINS
    END SUBROUTINE create_mat_munu
 
 ! **************************************************************************************************
+!> \brief ...
+!> \param mat_P_global ...
+!> \param qs_env ...
+!> \param mp2_env ...
+!> \param para_env ...
+!> \param dft_control ...
+!> \param atomic_kind_set ...
+!> \param qs_kind_set ...
+!> \param atom2d ...
+!> \param molecule_kind_set ...
+!> \param molecule_set ...
+!> \param particle_set ...
+!> \param cell ...
+! **************************************************************************************************
+   SUBROUTINE create_matrix_P(mat_P_global, qs_env, mp2_env, para_env, dft_control, atomic_kind_set, &
+                              qs_kind_set, atom2d, molecule_kind_set, molecule_set, particle_set, cell)
+
+      TYPE(dbcsr_p_type)                                 :: mat_P_global
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(mp2_type), POINTER                            :: mp2_env
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(local_atoms_type), ALLOCATABLE, DIMENSION(:)  :: atom2d
+      TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
+      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(cell_type), POINTER                           :: cell
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'create_matrix_P', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: blacs_grid_layout, handle, i
+      LOGICAL                                            :: blacs_repeatable
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_global
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb_sub
+
+      CALL timeset(routineN, handle)
+
+      blacs_grid_layout = BLACS_GRID_SQUARE
+      blacs_repeatable = .TRUE.
+      NULLIFY (blacs_env_global)
+      CALL cp_blacs_env_create(blacs_env_global, para_env, &
+                               blacs_grid_layout, &
+                               blacs_repeatable)
+
+      CALL create_mat_munu(mat_P_global, qs_env, mp2_env, para_env, dft_control, &
+                           atomic_kind_set, qs_kind_set, atom2d, molecule_kind_set, &
+                           molecule_set, sab_orb_sub, particle_set, cell, blacs_env_global, &
+                           do_ri_aux_basis=.TRUE.)
+
+      CALL dbcsr_reserve_all_blocks(mat_P_global%matrix)
+      CALL cp_blacs_env_release(blacs_env_global)
+
+      DO i = 1, SIZE(sab_orb_sub)
+         CALL deallocate_neighbor_list_set(sab_orb_sub(i)%neighbor_list_set)
+      END DO
+      DEALLOCATE (sab_orb_sub)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+! **************************************************************************************************
 !> \brief Set up dbcsr matrices for imaginary time
 !> \param mat_munu ...
 !> \param mat_P_local ...
@@ -2503,14 +2614,13 @@ CONTAINS
 !> \param cell ...
 !> \param para_env_sub_im_time_P ...
 !> \param blacs_env_sub_im_time_3c ...
-!> \param sab_orb_all ...
 !> \author Jan Wilhelm
 ! **************************************************************************************************
    SUBROUTINE create_dbcsr_matrices_im_time(mat_munu, mat_P_local, mat_P_global, mat_M, mat_dm_occ_global_mao, &
                                             mat_dm_virt_global_mao, mat_dm_occ_local, mat_dm_virt_local, do_mao, &
                                             qs_env, mp2_env, para_env, dft_control, atomic_kind_set, qs_kind_set, &
                                             atom2d, molecule_kind_set, molecule_set, particle_set, cell, &
-                                            para_env_sub_im_time_P, blacs_env_sub_im_time_3c, sab_orb_all)
+                                            para_env_sub_im_time_P, blacs_env_sub_im_time_3c)
 
       TYPE(dbcsr_p_type) :: mat_munu, mat_P_local, mat_P_global, mat_M, mat_dm_occ_global_mao, &
          mat_dm_virt_global_mao, mat_dm_occ_local, mat_dm_virt_local
@@ -2528,8 +2638,6 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub_im_time_P
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_sub_im_time_3c
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_orb_all
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_dbcsr_matrices_im_time', &
          routineP = moduleN//':'//routineN
@@ -2555,38 +2663,12 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      ! release sab_orb_all
-      DO i = 1, SIZE(sab_orb_all)
-         CALL deallocate_neighbor_list_set(sab_orb_all(i)%neighbor_list_set)
-      END DO
-      DEALLOCATE (sab_orb_all)
-
       CALL create_mat_munu(mat_munu, qs_env, mp2_env, para_env, dft_control, atomic_kind_set, qs_kind_set, &
                            atom2d, molecule_kind_set, &
                            molecule_set, sab_orb_sub, particle_set, cell, blacs_env_sub_im_time_3c, &
                            do_im_time=.TRUE.)
 
-!      CALL cp_blacs_env_release(blacs_env_sub_im_time_3c)
-
-      group_size_P = mp2_env%ri_rpa_im_time%group_size_P
-
-      IF (group_size_P > para_env%num_pe) THEN
-
-         group_size_P = para_env%num_pe
-         mp2_env%ri_rpa_im_time%group_size_P = para_env%num_pe
-
-      END IF
-
-      ! only allow group_size_P which is a factor of the total number of MPI tasks
-      CPASSERT(MODULO(para_env%num_pe, group_size_P) == 0)
-
-      n_group_P = para_env%num_pe/group_size_P
-      mp2_env%ri_rpa_im_time_util(1)%n_group_P = n_group_P
-
-      ! a para_env with P groups
-      color_sub_P = para_env%mepos/group_size_P
-      mp2_env%ri_rpa_im_time_util(1)%color_sub_P = color_sub_P
-
+      color_sub_P = mp2_env%ri_rpa_im_time_util(1)%color_sub_P
       CALL mp_comm_split_direct(para_env%group, comm_sub_P, color_sub_P)
       NULLIFY (para_env_sub_im_time_P)
       CALL cp_para_env_create(para_env_sub_im_time_P, comm_sub_P)
@@ -2609,6 +2691,8 @@ CONTAINS
                            molecule_set, sab_orb_sub, particle_set, cell, blacs_env_sub_P, &
                            do_ri_aux_basis=.TRUE.)
 
+      group_size_P = mp2_env%ri_rpa_im_time%group_size_P
+      n_group_P = para_env%num_pe/group_size_P
       ! fragment n_group_P in product of integers of similar size, n_group_row*n_group_col=n_group_P
       ! employing Fermat's factorization method
       CALL generate_integer_product(n_group_P, n_group_row, n_group_col)
@@ -3453,6 +3537,32 @@ CONTAINS
       END DO
 
       CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_P_global ...
+!> \param mat_dm_occ_global_mao ...
+!> \param mat_dm_virt_global_mao ...
+!> \param para_env_sub_im_time_3c ...
+! **************************************************************************************************
+   SUBROUTINE clean_up_im_time_t(mat_P_global, mat_dm_occ_global_mao, mat_dm_virt_global_mao, &
+                                 para_env_sub_im_time_3c)
+      TYPE(dbcsr_p_type)                                 :: mat_P_global, mat_dm_occ_global_mao, &
+                                                            mat_dm_virt_global_mao
+      TYPE(cp_para_env_type), POINTER                    :: para_env_sub_im_time_3c
+
+      CALL dbcsr_release(mat_P_global%matrix)
+      DEALLOCATE (mat_P_global%matrix)
+
+      ! we are just releasing due to lecacy mao code, this should go away
+      CALL dbcsr_release(mat_dm_occ_global_mao%matrix)
+      DEALLOCATE (mat_dm_occ_global_mao%matrix)
+      CALL dbcsr_release(mat_dm_virt_global_mao%matrix)
+      DEALLOCATE (mat_dm_virt_global_mao%matrix)
+
+      CALL cp_para_env_release(para_env_sub_im_time_3c)
 
    END SUBROUTINE
 

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -363,10 +363,6 @@ CONTAINS
       TYPE(two_dim_real_array), ALLOCATABLE, &
          DIMENSION(:)                                    :: mao_coeff_repl_occ, mao_coeff_repl_virt
 
-!INTEGER, ALLOCATABLE, DIMENSION(:,:)               :: eri_offsets
-
-      !INTEGER, ALLOCATABLE, DIMENSION(:)                 :: nblk_RI_offset
-
       CALL timeset(routineN, handle)
 
       CALL cite_reference(DelBen2013)
@@ -900,20 +896,17 @@ CONTAINS
             ALLOCATE (local_atoms_for_mao_basis(natom))
             local_atoms_for_mao_basis = 0
 
-            MARK_USED(mat_munu_mao_virt_occ)
-            MARK_USED(mat_munu_mao_occ_virt)
+            CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_occ, mat_munu_mao_occ_virt, qs_env, &
+                                   dimen_RI, cut_RI, unit_nr, &
+                                   my_group_L_starts_im_time, my_group_L_ends_im_time, &
+                                   my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
+                                   local_atoms_for_mao_basis=local_atoms_for_mao_basis)
 
-            !CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_occ, mat_munu_mao_occ_virt, qs_env, &
-            !                       dimen_RI, cut_RI, unit_nr, &
-            !                       my_group_L_starts_im_time, my_group_L_ends_im_time, &
-            !                       my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
-            !                       local_atoms_for_mao_basis=local_atoms_for_mao_basis)
-
-            !CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_virt, mat_munu_mao_virt_occ, qs_env, &
-            !                       dimen_RI, cut_RI, unit_nr, &
-            !                       my_group_L_starts_im_time, my_group_L_ends_im_time, &
-            !                       my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
-            !                       local_atoms_for_mao_basis=local_atoms_for_mao_basis)
+            CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_virt, mat_munu_mao_virt_occ, qs_env, &
+                                   dimen_RI, cut_RI, unit_nr, &
+                                   my_group_L_starts_im_time, my_group_L_ends_im_time, &
+                                   my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
+                                   local_atoms_for_mao_basis=local_atoms_for_mao_basis)
 
             CALL replicate_mao_coeff(mao_coeff_repl_occ, mao_coeff_occ, local_atoms_for_mao_basis, natom, para_env)
 
@@ -948,7 +941,6 @@ CONTAINS
 
                   CALL dbcsr_t_copy(t_3c_overl_int(i, j), t_3c_O(i, j), move_data=.TRUE.)
                   CALL dbcsr_t_filter(t_3c_O(i, j), qs_env%mp2_env%mp2_gpw%eps_filter)
-                  !PRINT *, "COMPARING CHECKSUMS", dbcsr_t_checksum(t_3c_overl_int(i,j)), dbcsr_t_checksum(t_3c_O(i,j))
                   CALL dbcsr_t_destroy(t_3c_overl_int(i, j))
                ENDDO
             ENDDO
@@ -1266,16 +1258,15 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'contract_B_L', routineP = moduleN//':'//routineN
       LOGICAL, PARAMETER                                 :: debug = .FALSE.
 
-      INTEGER                                            :: check_proc, handle, i, iend, ierr, ii, &
-                                                            ioff, iproc, iproc_glob, istart, &
-                                                            loc_a, loc_P, nproc, nproc_glob
+      INTEGER                                            :: check_proc, handle, i, iend, ii, ioff, &
+                                                            iproc, iproc_glob, istart, loc_a, &
+                                                            loc_P, nproc, nproc_glob
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: block_ind_L_P, block_ind_L_R
       INTEGER, DIMENSION(1)                              :: dist_B_i, map_B_1, map_L_1, map_L_2, &
                                                             sizes_i
       INTEGER, DIMENSION(2)                              :: map_B_2, pdims_L
       INTEGER, DIMENSION(3)                              :: pdims_B
-      LOGICAL, DIMENSION(3)                              :: period_2d, period_3d
-      LOGICAL                                            :: found, reorder
+      LOGICAL                                            :: found
       INTEGER, DIMENSION(ngroup)                         :: dist_L_P, dist_L_R
       INTEGER, DIMENSION(para_env_sub%num_pe)            :: dist_B_a
       TYPE(dbcsr_t_distribution_type)                    :: dist_B, dist_L
@@ -1322,11 +1313,6 @@ CONTAINS
       ! (R|P) on process grid NG x Nw
       pdims_B = [ngroup, nproc, 1]
       pdims_L = [nproc, ngroup]
-
-      reorder = .FALSE.
-      period_3d = .FALSE.
-      period_2d = .FALSE.
-      ierr = 0
 
       CALL dbcsr_t_pgrid_create(mp_comm, pdims_B, mp_comm_B)
       CALL dbcsr_t_pgrid_create(mp_comm, pdims_L, mp_comm_L)
@@ -1398,7 +1384,6 @@ CONTAINS
                             map_1=[2, 3], map_2=[1], optimize_dist=.TRUE.)
 
       ! retrieve local block of contraction result (P|ai)
-      !CALL dbcsr_t_split_copyback(tB_out_split, tB_out)
       CALL dbcsr_t_copy(tB_out_split, tB_out)
 
       CALL dbcsr_t_get_block(tB_out, [loc_P, loc_a, 1], SHAPE(BIb_C), BIb_C, found)
@@ -7746,8 +7731,6 @@ CONTAINS
                CALL get_iterator_info(nl_iterator, &
                                       iatom=iatom, jatom=jatom, r=rab, cell=cell_vec)
 
-               !PRINT *, "nl", atom_RI, iatom, jatom
-
                DO i_img_outer = 1, nimg
                   DO j_img_outer = 1, nimg
 
@@ -8863,14 +8846,6 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
-!bcount, fa, la, &
-!   fa_offset, la_offset, a
-!INTEGER, DIMENSION(2)                              :: group_limits
-!INTEGER, DIMENSION(0:ngroup - 1)            :: first_atom, last_atom, nblk_RI
-!INTEGER, DIMENSION(:), ALLOCATABLE          :: nblk_RI_offset
-
-      !INTEGER, ALLOCATABLE, DIMENSION(:,:), INTENT(OUT)  :: eri_offsets
-
       CALL timeset(routineN, handle)
 
       ALLOCATE (sizes_array_mem_cut(0:cut_memory-1))
@@ -8936,39 +8911,6 @@ CONTAINS
 
       ALLOCATE (row_blk_sizes_RI_t(natom))
       row_blk_sizes_RI_t(:) = row_blk_sizes_RI(:)
-
-      !CALL get_eri_offsets(qs_env, "RI_AUX", eri_offsets)
-
-      !ALLOCATE(nblk_RI_offset(0:ngroup-1))
-      !DO igroup = 0, ngroup - 1
-      !   group_limits = get_limit(dimen_RI, ngroup, igroup)
-      !   first_atom(igroup) = eri_offsets(group_limits(1), 1)
-      !   last_atom(igroup) = eri_offsets(group_limits(2), 1)
-      !   nblk_RI(igroup) = last_atom(igroup) - first_atom(igroup) + 1
-      !   IF (igroup == 0) THEN
-      !      nblk_RI_offset(igroup) = 0
-      !   ELSE
-      !      nblk_RI_offset(igroup) = nblk_RI_offset(igroup - 1) + nblk_RI(igroup - 1)
-      !   ENDIF
-      !ENDDO
-
-      !ALLOCATE(row_blk_sizes_RI_t(SUM(nblk_RI))
-      !ALLOCATE(row_dist_RI_t(SUM(nblk_RI)))
-
-      !bcount = 0
-      !DO igroup = 0, ngroup = 1
-      !   group_limits = get_limit(dimen_RI, ngroup, igroup)
-      !   fa = first_atom(igroup); la = last_atom(igroup)
-      !   fa_offset = eri_offsets(group_limits(1), 4)
-      !   la_offset = eri_offsets(group_limits(2), 4)
-      !   row_blk_sizes_RI_t(bcount + 1) = row_blk_sizes_RI(bcount + 1) - fa_offset + 1
-      !   DO a = fa + 1, la - 1
-      !      row_blk_sizes_RI_t(bcount + 1 + a - fa) = row_blk_sizes_RI(a)
-      !   ENDDO
-      !   row_blk_sizes_RI_t(bcount + 1 + la - fa) = la_offset
-      !   row_dist_RI_t(bcount + 1:bcount + 1 + la - fa) = igroup
-      !   bcount = bcount + 1 + la - fa
-      !ENDDO
 
       ! check whether my_group_L_im_time covers different atoms. In this case, cut my_group_L_im_time
       ! especially improves memory a bit

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -56,20 +56,19 @@ MODULE mp2_ri_gpw
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
         dbcsr_complete_redistribute, dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, &
-        dbcsr_desymmetrize, dbcsr_distribution_type, dbcsr_filter, dbcsr_finalize, &
-        dbcsr_get_block_p, dbcsr_get_info, dbcsr_get_stored_coordinates, &
+        dbcsr_desymmetrize, dbcsr_distribution_get, dbcsr_distribution_type, dbcsr_filter, &
+        dbcsr_finalize, dbcsr_get_block_p, dbcsr_get_info, dbcsr_get_stored_coordinates, &
         dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
         dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_p_type, dbcsr_put_block, &
-        dbcsr_release, dbcsr_release_p, dbcsr_reserve_all_blocks, dbcsr_reserve_blocks, dbcsr_set, &
-        dbcsr_type, dbcsr_type_antisymmetric, dbcsr_type_no_symmetry, dbcsr_type_real_8, &
-        dbcsr_type_symmetric
+        dbcsr_release, dbcsr_release_p, dbcsr_reserve_all_blocks, dbcsr_reserve_blocks, &
+        dbcsr_scalar, dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric, dbcsr_type_no_symmetry, &
+        dbcsr_type_real_8, dbcsr_type_symmetric
    USE dbcsr_tensor_api,                ONLY: &
-        dbcsr_t_contract, dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_distribution_destroy, &
-        dbcsr_t_distribution_new, dbcsr_t_distribution_type, dbcsr_t_get_block, &
-        dbcsr_t_get_stored_coordinates, dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_next_block, &
-        dbcsr_t_iterator_start, dbcsr_t_iterator_stop, dbcsr_t_iterator_type, dbcsr_t_nd_mp_comm, &
-        dbcsr_t_nd_mp_free, dbcsr_t_put_block, dbcsr_t_reserve_blocks, dbcsr_t_split_blocks, &
-        dbcsr_t_type
+        dbcsr_t_blk_sizes, dbcsr_t_contract, dbcsr_t_copy, dbcsr_t_create, dbcsr_t_destroy, &
+        dbcsr_t_distribution_destroy, dbcsr_t_distribution_new, dbcsr_t_distribution_type, &
+        dbcsr_t_filter, dbcsr_t_get_block, dbcsr_t_get_stored_coordinates, dbcsr_t_pgrid_create, &
+        dbcsr_t_pgrid_destroy, dbcsr_t_pgrid_type, dbcsr_t_put_block, dbcsr_t_reserve_blocks, &
+        dbcsr_t_set, dbcsr_t_split_blocks, dbcsr_t_type, mp_environ_pgrid
    USE gaussian_gridlevels,             ONLY: gaussian_gridlevel
    USE input_constants,                 ONLY: do_eri_gpw,&
                                               do_eri_mme,&
@@ -87,8 +86,8 @@ MODULE mp2_ri_gpw
                                               m_memory,&
                                               m_walltime
    USE message_passing,                 ONLY: &
-        mp_allgather, mp_alltoall, mp_cart_create, mp_comm_free, mp_comm_split_direct, mp_environ, &
-        mp_max, mp_min, mp_sendrecv, mp_sum, mp_sync
+        mp_allgather, mp_alltoall, mp_comm_split_direct, mp_dims_create, mp_environ, mp_max, &
+        mp_min, mp_sendrecv, mp_sum, mp_sync
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_types,                  ONLY: molecule_type
    USE mp2_eri,                         ONLY: mp2_eri_2c_integrate,&
@@ -206,12 +205,17 @@ CONTAINS
 !> \param starts_B_all ...
 !> \param sizes_B_all ...
 !> \param ends_B_all ...
+!> \param starts_array_mc_t ...
+!> \param ends_array_mc_t ...
 !> \param gw_corr_lev_occ ...
 !> \param gw_corr_lev_virt ...
 !> \param do_im_time ...
 !> \param do_mao ...
 !> \param do_kpoints_cubic_RPA ...
 !> \param mat_3c_overl_int ...
+!> \param do_dbcsr_t ...
+!> \param t_3c_M ...
+!> \param t_3c_O ...
 !> \param mat_3c_overl_int_mao_for_occ ...
 !> \param mat_3c_overl_int_mao_for_virt ...
 !> \param mao_coeff_occ ...
@@ -245,9 +249,10 @@ CONTAINS
                                     poisson_env, auxbas_pw_pool, task_list_sub, mo_coeff_o, mo_coeff_v, mo_coeff_all, &
                                     mo_coeff_gw, eps_filter, unit_nr, &
                                     mp2_memory, calc_PQ_cond_num, calc_forces, blacs_env_sub, my_do_gw, do_bse, &
-                                    starts_B_all, sizes_B_all, ends_B_all, gw_corr_lev_occ, gw_corr_lev_virt, &
+                                    starts_B_all, sizes_B_all, ends_B_all, starts_array_mc_t, ends_array_mc_t, &
+                                    gw_corr_lev_occ, gw_corr_lev_virt, &
                                     do_im_time, do_mao, do_kpoints_cubic_RPA, &
-                                    mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, &
+                                    mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, mat_3c_overl_int_mao_for_occ, &
                                     mat_3c_overl_int_mao_for_virt, mao_coeff_occ, mao_coeff_virt, &
                                     ri_metric, ends_B_occ_bse, sizes_B_occ_bse, &
                                     starts_B_occ_bse, ends_B_virt_bse, sizes_B_virt_bse, &
@@ -290,11 +295,15 @@ CONTAINS
       LOGICAL                                            :: calc_PQ_cond_num, calc_forces
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_sub
       LOGICAL                                            :: my_do_gw, do_bse
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: starts_B_all, sizes_B_all, ends_B_all
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: starts_B_all, sizes_B_all, ends_B_all, &
+                                                            starts_array_mc_t, ends_array_mc_t
       INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt
       LOGICAL                                            :: do_im_time, do_mao, do_kpoints_cubic_RPA
-      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int, &
-                                                            mat_3c_overl_int_mao_for_occ, &
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
+      LOGICAL, INTENT(IN)                                :: do_dbcsr_t
+      TYPE(dbcsr_t_type)                                 :: t_3c_M
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :)   :: t_3c_O
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_mao_for_occ, &
                                                             mat_3c_overl_int_mao_for_virt
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mao_coeff_occ, mao_coeff_virt
       INTEGER                                            :: ri_metric
@@ -314,19 +323,24 @@ CONTAINS
          routineP = moduleN//':'//routineN
 
       INTEGER :: color_sub_3c, cut_memory, cut_RI, eri_method, gw_corr_lev_total, handle, handle2, &
-         handle3, i, i_counter, itmp(2), LLL, max_row_col_local, max_row_col_local_beta, &
-         max_row_col_local_gw, max_row_col_local_occ_bse, max_row_col_local_virt_bse, mp_comm_2d, &
-         my_B_all_end, my_B_all_size, my_B_all_start, my_B_occ_bse_end, my_B_occ_bse_size, &
-         my_B_occ_bse_start, my_B_size, my_B_size_beta, my_B_virt_bse_end, my_B_virt_bse_size, &
-         my_B_virt_bse_start, my_B_virtual_end, my_B_virtual_end_beta, my_B_virtual_start, &
-         my_B_virtual_start_beta, my_group_L_end, my_group_L_size, my_group_L_start, natom
-      INTEGER :: ngroup, ngroup_im_time, num_diff_blk, num_small_eigen, virtual, virtual_beta
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: local_atoms_for_mao_basis, my_group_L_ends_im_time, &
-         my_group_L_sizes_im_time, my_group_L_starts_im_time, sub_proc_map
+         handle3, handle4, i, i_counter, itmp(2), j, LLL, max_row_col_local, &
+         max_row_col_local_beta, max_row_col_local_gw, max_row_col_local_occ_bse, &
+         max_row_col_local_virt_bse, my_B_all_end, my_B_all_size, my_B_all_start, &
+         my_B_occ_bse_end, my_B_occ_bse_size, my_B_occ_bse_start, my_B_size, my_B_size_beta, &
+         my_B_virt_bse_end, my_B_virt_bse_size, my_B_virt_bse_start, my_B_virtual_end, &
+         my_B_virtual_end_beta, my_B_virtual_start, my_B_virtual_start_beta, my_group_L_end, &
+         my_group_L_size, my_group_L_start, natom
+      INTEGER :: ngroup, ngroup_im_time, ngroup_im_time_P, nproc_sub, num_diff_blk, &
+         num_small_eigen, sqrt_max_bsize, virtual, virtual_beta
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: ao_blk_sizes_split, local_atoms_for_mao_basis, &
+         local_atoms_RI, my_group_L_ends_im_time, my_group_L_sizes_im_time, &
+         my_group_L_starts_im_time, row_blk_sizes_RI_t, row_blk_sizes_RI_t_split, row_dist_RI_t, &
+         sub_proc_map
       INTEGER, ALLOCATABLE, DIMENSION(:, :) :: local_col_row_info, local_col_row_info_beta, &
          local_col_row_info_gw, local_col_row_info_occ_bse, local_col_row_info_virt_bse
-      INTEGER, DIMENSION(2)                              :: myploc, pdims
-      INTEGER, DIMENSION(3)                              :: periodic
+      INTEGER, DIMENSION(2)                              :: pdims_2_2d, pdims_sub_2d
+      INTEGER, DIMENSION(3)                              :: pdims_t3c, periodic
+      INTEGER, DIMENSION(:), POINTER                     :: ao_blk_sizes
       LOGICAL                                            :: do_alpha_beta, memory_info
       REAL(KIND=dp)                                      :: cond_num, mem_for_iaK, pair_energy, &
                                                             wfn_size
@@ -336,7 +350,11 @@ CONTAINS
                                                             fm_BIb_gw_beta, fm_BIb_jb, &
                                                             fm_BIb_jb_beta, fm_matrix_L
       TYPE(cp_para_env_type), POINTER                    :: para_env_L
+      TYPE(dbcsr_distribution_type)                      :: dist_sub
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_munu_local_L
+      TYPE(dbcsr_t_pgrid_type)                           :: mp_comm_t3c_m, mp_comm_t3c_overl, &
+                                                            mp_comm_t3c_overl_2
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :)   :: t_3c_overl_int
       TYPE(dbcsr_type) :: matrix_bse_ab, matrix_bse_anu, matrix_bse_ij, matrix_bse_inu, &
          matrix_ia_jb, matrix_ia_jb_beta, matrix_ia_jnu, matrix_ia_jnu_beta, matrix_in_jm, &
          matrix_in_jm_beta, matrix_in_jnu, matrix_in_jnu_beta
@@ -344,6 +362,10 @@ CONTAINS
       TYPE(pw_p_type)                                    :: psi_L
       TYPE(two_dim_real_array), ALLOCATABLE, &
          DIMENSION(:)                                    :: mao_coeff_repl_occ, mao_coeff_repl_virt
+
+!INTEGER, ALLOCATABLE, DIMENSION(:,:)               :: eri_offsets
+
+      !INTEGER, ALLOCATABLE, DIMENSION(:)                 :: nblk_RI_offset
 
       CALL timeset(routineN, handle)
 
@@ -635,10 +657,6 @@ CONTAINS
                                       basis_type_c="RI_AUX", &
                                       sab_nl=sab_orb_sub, eri_method=eri_method)
 
-            ! create a NG x Nw process grid for contraction
-            pdims = [ngroup, para_env_sub%num_pe]
-            CALL mp_cart_create(para_env%group, 2, pdims, myploc, mp_comm_2d)
-
             DO LLL = 1, my_group_L_size
                CALL ao_to_mo_and_store_B(para_env_sub, mat_munu_local_L(LLL), matrix_ia_jnu, matrix_ia_jb, &
                                          fm_BIb_jb, BIb_C(LLL, 1:my_B_size, 1:homo), &
@@ -646,7 +664,7 @@ CONTAINS
                                          local_col_row_info, my_B_virtual_end, my_B_virtual_start, "alpha")
             ENDDO
             CALL contract_B_L(BIb_C, my_Lrows, sizes_B_virtual, sizes_array, qs_env%mp2_env%eri_blksize, &
-                              ngroup, color_sub, mp_comm_2d, para_env_sub)
+                              ngroup, color_sub, para_env%group, para_env_sub)
 
             IF (do_alpha_beta) THEN
 
@@ -657,7 +675,7 @@ CONTAINS
                                             local_col_row_info_beta, my_B_virtual_end_beta, my_B_virtual_start_beta, "beta")
                ENDDO
                CALL contract_B_L(BIb_C_beta, my_Lrows, sizes_B_virtual_beta, sizes_array, qs_env%mp2_env%eri_blksize, &
-                                 ngroup, color_sub, mp_comm_2d, para_env_sub)
+                                 ngroup, color_sub, para_env%group, para_env_sub)
 
             ENDIF
 
@@ -670,7 +688,7 @@ CONTAINS
                                             local_col_row_info_gw, my_B_all_end, my_B_all_start, "gw_alpha")
                ENDDO
                CALL contract_B_L(BIb_C_gw, my_Lrows, sizes_B_all, sizes_array, qs_env%mp2_env%eri_blksize, &
-                                 ngroup, color_sub, mp_comm_2d, para_env_sub)
+                                 ngroup, color_sub, para_env%group, para_env_sub)
 
                IF (do_alpha_beta) THEN
 
@@ -681,7 +699,7 @@ CONTAINS
                                                sub_proc_map, local_col_row_info_gw, my_B_all_end, my_B_all_start, "gw_beta")
                   ENDDO
                   CALL contract_B_L(BIb_C_gw_beta, my_Lrows, sizes_B_all, sizes_array, qs_env%mp2_env%eri_blksize, &
-                                    ngroup, color_sub, mp_comm_2d, para_env_sub)
+                                    ngroup, color_sub, para_env%group, para_env_sub)
 
                ENDIF
             ENDIF
@@ -696,7 +714,7 @@ CONTAINS
                                             sub_proc_map, local_col_row_info_virt_bse, my_B_all_end, my_B_all_start, "bse_ab")
                ENDDO
                CALL contract_B_L(BIb_C_bse_ab, my_Lrows, sizes_B_virt_bse, sizes_array, qs_env%mp2_env%eri_blksize, &
-                                 ngroup, color_sub, mp_comm_2d, para_env_sub)
+                                 ngroup, color_sub, para_env%group, para_env_sub)
 
                ! B^ij_P matrix elements for BSE
                DO LLL = 1, my_group_L_size
@@ -707,14 +725,13 @@ CONTAINS
                                             my_B_occ_bse_end, my_B_occ_bse_start, "bse_ij")
                ENDDO
                CALL contract_B_L(BIb_C_bse_ij, my_Lrows, sizes_B_occ_bse, sizes_array, qs_env%mp2_env%eri_blksize, &
-                                 ngroup, color_sub, mp_comm_2d, para_env_sub)
+                                 ngroup, color_sub, para_env%group, para_env_sub)
 
             END IF
 
             DO LLL = 1, my_group_L_size
                CALL dbcsr_release_p(mat_munu_local_L(LLL)%matrix)
             ENDDO
-            CALL mp_comm_free(mp_comm_2d)
             DEALLOCATE (mat_munu_local_L)
 
          ELSE IF (eri_method == do_eri_gpw) THEN
@@ -790,19 +807,90 @@ CONTAINS
          cut_memory = qs_env%mp2_env%ri_rpa_im_time%cut_memory
 
          ngroup_im_time = para_env%num_pe/qs_env%mp2_env%ri_rpa_im_time%group_size_3c
+         ngroup_im_time_P = para_env%num_pe/qs_env%mp2_env%ri_rpa_im_time%group_size_p
 
          color_sub_3c = para_env%mepos/qs_env%mp2_env%ri_rpa_im_time%group_size_3c
 
          CALL setup_group_L_im_time(my_group_L_starts_im_time, my_group_L_ends_im_time, my_group_L_sizes_im_time, &
-                                    dimen_RI, ngroup_im_time, cut_memory, cut_RI, color_sub_3c, qs_env)
+                                    local_atoms_RI, row_blk_sizes_RI_t, row_dist_RI_t, dimen_RI, ngroup_im_time, cut_memory, &
+                                    cut_RI, &
+                                    color_sub_3c, qs_env)
 
          qs_env%mp2_env%ri_rpa_im_time_util(1)%n_group_RI_orig = ngroup
 
          memory_info = qs_env%mp2_env%ri_rpa_im_time%memory_info
 
-         CALL reserve_blocks_3c(mat_3c_overl_int, mat_munu, qs_env, dimen_RI, cut_RI, unit_nr, &
-                                my_group_L_starts_im_time, my_group_L_ends_im_time, &
-                                my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk)
+         IF (do_dbcsr_t) THEN
+
+            CALL get_qs_env(qs_env, natom=natom)
+            !IF(ngroup_im_time .GT. natom) THEN
+            !   CPABORT("Increase GROUP_SIZE_3C for this number of MPI ranks")
+            !ENDIF
+
+            CALL dbcsr_get_info(mat_munu%matrix, &
+                                distribution=dist_sub)
+            CALL dbcsr_distribution_get(dist_sub, nprows=pdims_sub_2d(1), npcols=pdims_sub_2d(2))
+
+            pdims_t3c = [ngroup_im_time, pdims_sub_2d(1), pdims_sub_2d(2)]
+
+            CALL dbcsr_t_pgrid_create(para_env%group, pdims_t3c, mp_comm_t3c_overl, map1_2d=[1, 2], map2_2d=[3])
+
+            nproc_sub = para_env%num_pe/ngroup_im_time
+            pdims_sub_2d = 0
+            CALL mp_dims_create(nproc_sub, pdims_sub_2d)
+            pdims_2_2d = 0
+            CALL mp_dims_create(pdims_sub_2d(2)*ngroup_im_time, pdims_2_2d)
+            pdims_t3c = [pdims_2_2d(1), pdims_2_2d(2), pdims_sub_2d(1)]
+            CALL dbcsr_t_pgrid_create(para_env%group, pdims_t3c, mp_comm_t3c_overl_2, map1_2d=[1, 2], map2_2d=[3])
+
+            nproc_sub = para_env%num_pe/ngroup_im_time_P
+            pdims_sub_2d = 0
+            CALL mp_dims_create(nproc_sub, pdims_sub_2d)
+            pdims_2_2d = 0
+            CALL mp_dims_create(pdims_sub_2d(2)*ngroup_im_time_P, pdims_2_2d)
+            pdims_t3c = [pdims_sub_2d(1), pdims_2_2d(1), pdims_2_2d(2)]
+            CALL dbcsr_t_pgrid_create(para_env%group, pdims_t3c, mp_comm_t3c_m, map1_2d=[1], map2_2d=[2, 3])
+
+         ENDIF
+
+         IF (do_dbcsr_t) THEN
+            CALL reserve_blocks_3c_t(t_3c_overl_int, mp_comm_t3c_overl, &
+                                     ngroup_im_time, mat_munu, qs_env, &
+                                     unit_nr, local_atoms_RI, row_blk_sizes_RI_t, row_dist_RI_t, &
+                                     sab_orb_sub, sab_orb_all, para_env, num_diff_blk)
+         ELSE
+            CALL reserve_blocks_3c(mat_3c_overl_int, &
+                                   mat_munu, qs_env, &
+                                   dimen_RI, cut_RI, unit_nr, &
+                                   my_group_L_starts_im_time, my_group_L_ends_im_time, &
+                                   my_group_L_sizes_im_time, & !nblk_RI_offset(color_sub_3c), &
+                                   sab_orb_sub, sab_orb_all, para_env, num_diff_blk)
+
+         ENDIF
+
+         IF (do_dbcsr_t) THEN
+
+            CALL dbcsr_get_info(mat_munu%matrix, row_blk_size=ao_blk_sizes)
+
+            sqrt_max_bsize = qs_env%mp2_env%ri_rpa_im_time%max_bsize_sqrt
+
+            CALL split_block_sizes(ao_blk_sizes, ao_blk_sizes_split, sqrt_max_bsize)
+            CALL split_block_sizes(row_blk_sizes_RI_t, row_blk_sizes_RI_t_split, sqrt_max_bsize)
+
+            CALL create_tensor_M_3c(t_3c_M, mp_comm_t3c_m, &
+                                    cut_memory, ngroup_im_time_P, &
+                                    ao_blk_sizes_split, row_blk_sizes_RI_t, starts_array_mc_t, ends_array_mc_t)
+
+            ALLOCATE (t_3c_O(SIZE(t_3c_overl_int, 1), SIZE(t_3c_overl_int, 2)))
+            CALL create_tensor_O_3c(t_3c_O(1, 1), mp_comm_t3c_overl_2, ngroup_im_time, ao_blk_sizes_split, &
+                                    ao_blk_sizes, row_blk_sizes_RI_t_split)
+            DO i = 1, SIZE(t_3c_O, 1)
+               DO j = 1, SIZE(t_3c_O, 2)
+                  IF (i > 1 .OR. j > 1) CALL dbcsr_t_create(t_3c_O(1, 1), t_3c_O(i, j))
+               ENDDO
+            ENDDO
+
+         ENDIF
 
          ! if we do modified atomic orbitals for the primary basis (one MAO basis for D^occ one for D^virt, then
          ! we also need different 3-center overlap matrix elements!
@@ -812,17 +900,20 @@ CONTAINS
             ALLOCATE (local_atoms_for_mao_basis(natom))
             local_atoms_for_mao_basis = 0
 
-            CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_occ, mat_munu_mao_occ_virt, qs_env, &
-                                   dimen_RI, cut_RI, unit_nr, &
-                                   my_group_L_starts_im_time, my_group_L_ends_im_time, &
-                                   my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
-                                   local_atoms_for_mao_basis=local_atoms_for_mao_basis)
+            MARK_USED(mat_munu_mao_virt_occ)
+            MARK_USED(mat_munu_mao_occ_virt)
 
-            CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_virt, mat_munu_mao_virt_occ, qs_env, &
-                                   dimen_RI, cut_RI, unit_nr, &
-                                   my_group_L_starts_im_time, my_group_L_ends_im_time, &
-                                   my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
-                                   local_atoms_for_mao_basis=local_atoms_for_mao_basis)
+            !CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_occ, mat_munu_mao_occ_virt, qs_env, &
+            !                       dimen_RI, cut_RI, unit_nr, &
+            !                       my_group_L_starts_im_time, my_group_L_ends_im_time, &
+            !                       my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
+            !                       local_atoms_for_mao_basis=local_atoms_for_mao_basis)
+
+            !CALL reserve_blocks_3c(mat_3c_overl_int_mao_for_virt, mat_munu_mao_virt_occ, qs_env, &
+            !                       dimen_RI, cut_RI, unit_nr, &
+            !                       my_group_L_starts_im_time, my_group_L_ends_im_time, &
+            !                       my_group_L_sizes_im_time, sab_orb_sub, sab_orb_all, para_env, num_diff_blk, &
+            !                       local_atoms_for_mao_basis=local_atoms_for_mao_basis)
 
             CALL replicate_mao_coeff(mao_coeff_repl_occ, mao_coeff_occ, local_atoms_for_mao_basis, natom, para_env)
 
@@ -830,14 +921,39 @@ CONTAINS
 
          END IF
 
-         CALL compute_3c_overlap_int(mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, &
-                                     mat_3c_overl_int_mao_for_virt, &
-                                     mat_munu, mat_munu_mao_occ_virt, &
-                                     qs_env, my_group_L_starts_im_time, &
-                                     my_group_L_ends_im_time, my_group_L_sizes_im_time, &
-                                     dimen_RI, cut_RI, sab_orb_sub, sab_orb_all, do_mao, &
-                                     mao_coeff_repl_occ, mao_coeff_repl_virt, &
-                                     num_diff_blk)
+         IF (do_dbcsr_t) THEN
+            CALL compute_3c_overlap_int_t(t_3c_overl_int, &
+                                          qs_env%mp2_env%mp2_gpw%eps_filter, &
+                                          mat_munu, &
+                                          qs_env, &
+                                          local_atoms_RI, &
+                                          sab_orb_sub, sab_orb_all, &
+                                          num_diff_blk)
+         ELSE
+            CALL compute_3c_overlap_int(mat_3c_overl_int, &
+                                        mat_3c_overl_int_mao_for_occ, &
+                                        mat_3c_overl_int_mao_for_virt, &
+                                        mat_munu, mat_munu_mao_occ_virt, &
+                                        qs_env, my_group_L_starts_im_time, &
+                                        my_group_L_ends_im_time, my_group_L_sizes_im_time, &
+                                        dimen_RI, cut_RI, sab_orb_sub, sab_orb_all, do_mao, &
+                                        mao_coeff_repl_occ, mao_coeff_repl_virt, &
+                                        num_diff_blk)
+         ENDIF
+
+         IF (do_dbcsr_t) THEN
+            CALL timeset(routineN//"_copy_3c", handle4)
+            DO i = 1, SIZE(t_3c_overl_int, 1)
+               DO j = 1, SIZE(t_3c_overl_int, 2)
+
+                  CALL dbcsr_t_copy(t_3c_overl_int(i, j), t_3c_O(i, j), move_data=.TRUE.)
+                  CALL dbcsr_t_filter(t_3c_O(i, j), qs_env%mp2_env%mp2_gpw%eps_filter)
+                  !PRINT *, "COMPARING CHECKSUMS", dbcsr_t_checksum(t_3c_overl_int(i,j)), dbcsr_t_checksum(t_3c_O(i,j))
+                  CALL dbcsr_t_destroy(t_3c_overl_int(i, j))
+               ENDDO
+            ENDDO
+            CALL timestop(handle4)
+         ENDIF
 
          CALL cp_para_env_release(para_env_L)
 
@@ -897,6 +1013,237 @@ CONTAINS
    END SUBROUTINE mp2_ri_gpw_compute_in
 
 ! **************************************************************************************************
+!> \brief ...
+!> \param blk_sizes ...
+!> \param blk_sizes_split ...
+!> \param max_size ...
+! **************************************************************************************************
+   SUBROUTINE split_block_sizes(blk_sizes, blk_sizes_split, max_size)
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: blk_sizes
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: blk_sizes_split
+      INTEGER, INTENT(IN)                                :: max_size
+
+      INTEGER                                            :: blk_remainder, i, isplit, isplit_sum, &
+                                                            nsplit
+
+      isplit_sum = 0
+      DO i = 1, SIZE(blk_sizes)
+         nsplit = (blk_sizes(i)+max_size-1)/max_size
+         isplit_sum = isplit_sum+nsplit
+      ENDDO
+
+      ALLOCATE (blk_sizes_split(isplit_sum))
+
+      isplit_sum = 0
+      DO i = 1, SIZE(blk_sizes)
+         nsplit = (blk_sizes(i)+max_size-1)/max_size
+         blk_remainder = blk_sizes(i)
+         DO isplit = 1, nsplit
+            isplit_sum = isplit_sum+1
+            blk_sizes_split(isplit_sum) = MIN(max_size, blk_remainder)
+            blk_remainder = blk_remainder-max_size
+         ENDDO
+      ENDDO
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param t_3c_M ...
+!> \param mp_comm_t3c_m ...
+!> \param mem_cut ...
+!> \param ngroup ...
+!> \param ao_blk_sizes ...
+!> \param row_blk_sizes_RI_t ...
+!> \param starts_array_mc ...
+!> \param ends_array_mc ...
+! **************************************************************************************************
+   SUBROUTINE create_tensor_M_3c(t_3c_M, mp_comm_t3c_m, mem_cut, ngroup, ao_blk_sizes, row_blk_sizes_RI_t, &
+                                 starts_array_mc, ends_array_mc)
+      TYPE(dbcsr_t_type), INTENT(OUT)                    :: t_3c_M
+      TYPE(dbcsr_t_pgrid_type), INTENT(IN)               :: mp_comm_t3c_m
+      INTEGER, INTENT(IN)                                :: mem_cut, ngroup
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: ao_blk_sizes, row_blk_sizes_RI_t
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: starts_array_mc, ends_array_mc
+
+      INTEGER                                            :: bsum, imem, size_AO, size_AO_cut, size_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist_ao_1, dist_ao_2, dist_RI, &
+                                                            ends_array_mc_block, &
+                                                            starts_array_mc_block
+      INTEGER, DIMENSION(3)                              :: pcoord, pdims
+      TYPE(dbcsr_t_distribution_type)                    :: dist
+
+      CALL mp_environ_pgrid(mp_comm_t3c_m, pdims, pcoord)
+
+      size_RI = SIZE(row_blk_sizes_RI_t)
+      size_AO = SIZE(ao_blk_sizes)
+
+      ALLOCATE (dist_RI(size_RI))
+      CALL cyclic_dist(size_RI, pdims(1), row_blk_sizes_RI_t, dist_RI)
+
+      ALLOCATE (starts_array_mc(mem_cut))
+      ALLOCATE (ends_array_mc(mem_cut))
+      ALLOCATE (starts_array_mc_block(mem_cut))
+      ALLOCATE (ends_array_mc_block(mem_cut))
+
+      IF (size_AO < mem_cut) THEN
+         CPABORT("Use smaller MEMORY_CUT")
+      ENDIF
+
+      CALL contiguous_dist(size_AO, mem_cut, ao_blk_sizes, limits_start=starts_array_mc_block, limits_end=ends_array_mc_block)
+
+      bsum = 0
+      DO imem = 1, mem_cut
+         starts_array_mc(imem) = bsum+1
+         bsum = bsum+SUM(ao_blk_sizes(starts_array_mc_block(imem):ends_array_mc_block(imem)))
+         ends_array_mc(imem) = bsum
+      ENDDO
+
+      ALLOCATE (dist_ao_1(size_AO))
+      ALLOCATE (dist_ao_2(size_AO))
+      DO imem = 1, mem_cut
+
+         size_AO_cut = ends_array_mc_block(imem)-starts_array_mc_block(imem)+1
+
+         IF (size_AO_cut < MIN(pdims(2), pdims(3))) THEN
+            CPABORT("Increment GROUP_SIZE_P, use smaller MEMORY_CUT or use less MPI ranks")
+         ENDIF
+         CALL cyclic_dist(size_AO_cut, pdims(2), ao_blk_sizes(starts_array_mc_block(imem):ends_array_mc_block(imem)), &
+                          dist=dist_ao_1(starts_array_mc_block(imem):ends_array_mc_block(imem)))
+         CALL cyclic_dist(size_AO_cut, pdims(3), ao_blk_sizes(starts_array_mc_block(imem):ends_array_mc_block(imem)), &
+                          dist=dist_ao_2(starts_array_mc_block(imem):ends_array_mc_block(imem)))
+      ENDDO
+
+      CALL dbcsr_t_distribution_new(dist, mp_comm_t3c_m, [1], [2, 3], dist_RI, dist_ao_1, dist_ao_2, &
+                                    ngroup=ngroup, dimsplit=2, own_comm=.TRUE.)
+      CALL dbcsr_t_create(t_3c_M, "M (RI | AO AO)", dist, [1], [2, 3], dbcsr_type_real_8, row_blk_sizes_RI_t, &
+                          ao_blk_sizes, ao_blk_sizes)
+      CALL dbcsr_t_distribution_destroy(dist)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param t_3c_O ...
+!> \param mp_comm_t3c ...
+!> \param ngroup ...
+!> \param ao_blk_sizes_1 ...
+!> \param ao_blk_sizes_2 ...
+!> \param row_blk_sizes_RI_t ...
+! **************************************************************************************************
+   SUBROUTINE create_tensor_O_3c(t_3c_O, mp_comm_t3c, ngroup, ao_blk_sizes_1, ao_blk_sizes_2, row_blk_sizes_RI_t)
+      TYPE(dbcsr_t_type), INTENT(OUT)                    :: t_3c_O
+      TYPE(dbcsr_t_pgrid_type), INTENT(IN)               :: mp_comm_t3c
+      INTEGER, INTENT(IN)                                :: ngroup
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: ao_blk_sizes_1, ao_blk_sizes_2, &
+                                                            row_blk_sizes_RI_t
+
+      INTEGER                                            :: size_AO_1, size_AO_2, size_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist_ao_1, dist_ao_2, dist_RI
+      INTEGER, DIMENSION(3)                              :: pcoord, pdims
+      TYPE(dbcsr_t_distribution_type)                    :: dist
+
+      CALL mp_environ_pgrid(mp_comm_t3c, pdims, pcoord)
+
+      size_AO_1 = SIZE(ao_blk_sizes_1)
+      size_AO_2 = SIZE(ao_blk_sizes_2)
+      size_RI = SIZE(row_blk_sizes_RI_t)
+
+      ALLOCATE (dist_RI(size_RI))
+      ALLOCATE (dist_ao_1(size_AO_1))
+      ALLOCATE (dist_ao_2(size_AO_2))
+
+      CALL cyclic_dist(size_RI, pdims(1), row_blk_sizes_RI_t, dist_RI)
+      CALL cyclic_dist(size_AO_1, pdims(2), ao_blk_sizes_1, dist_ao_1)
+      CALL cyclic_dist(size_AO_2, pdims(3), ao_blk_sizes_2, dist_ao_2)
+
+      CALL dbcsr_t_distribution_new(dist, mp_comm_t3c, [1, 2], [3], dist_RI, dist_ao_1, dist_ao_2, &
+                                    ngroup=ngroup, dimsplit=1, own_comm=.TRUE.)
+      CALL dbcsr_t_create(t_3c_O, "O (RI AO | AO)", dist, [1, 2], [3], dbcsr_type_real_8, row_blk_sizes_RI_t, &
+                          ao_blk_sizes_1, ao_blk_sizes_2)
+      CALL dbcsr_t_distribution_destroy(dist)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param nel ...
+!> \param nbin ...
+!> \param weights ...
+!> \param limits_start ...
+!> \param limits_end ...
+!> \param dist ...
+! **************************************************************************************************
+   SUBROUTINE contiguous_dist(nel, nbin, weights, limits_start, limits_end, dist)
+      INTEGER, INTENT(IN)                                :: nel, nbin
+      INTEGER, DIMENSION(nel), INTENT(IN)                :: weights
+      INTEGER, DIMENSION(nbin), INTENT(OUT), OPTIONAL    :: limits_start, limits_end
+      INTEGER, DIMENSION(nel), INTENT(OUT), OPTIONAL     :: dist
+
+      INTEGER                                            :: el_end, el_start, end_weight, ibin, &
+                                                            nel_div, nel_rem, nel_split, nel_w, &
+                                                            w_partialsum
+
+      nel_w = SUM(weights)
+      nel_div = nel_w/nbin
+      nel_rem = MOD(nel_w, nbin)
+
+      w_partialsum = 0
+      el_end = 0
+      end_weight = 0
+      DO ibin = 1, nbin
+         nel_split = nel_div
+         IF (ibin <= nel_rem) THEN
+            nel_split = nel_split+1
+         ENDIF
+         el_start = el_end+1
+         el_end = el_start
+         w_partialsum = w_partialsum+weights(el_end)
+         end_weight = end_weight+nel_split
+         DO WHILE (w_partialsum < end_weight)
+            !IF (ABS(w_partialsum + weights(el_end) - end_weight) > ABS(w_partialsum - end_weight)) EXIT
+            el_end = el_end+1
+            w_partialsum = w_partialsum+weights(el_end)
+         ENDDO
+         IF (PRESENT(dist)) dist(el_start:el_end) = ibin-1
+         IF (PRESENT(limits_start)) limits_start(ibin) = el_start
+         IF (PRESENT(limits_end)) limits_end(ibin) = el_end
+      ENDDO
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param nel ...
+!> \param nbin ...
+!> \param weights ...
+!> \param dist ...
+! **************************************************************************************************
+   SUBROUTINE cyclic_dist(nel, nbin, weights, dist)
+      INTEGER, INTENT(IN)                                :: nel, nbin
+      INTEGER, DIMENSION(nel), INTENT(IN)                :: weights
+      INTEGER, DIMENSION(nel), INTENT(OUT)               :: dist
+
+      INTEGER                                            :: ibin, iel, niter
+      INTEGER, DIMENSION(nbin)                           :: occup
+
+      occup(:) = 0
+      ibin = 0
+      DO iel = 1, nel
+         niter = 0
+         ibin = MOD(ibin+1, nbin)
+         DO WHILE (occup(ibin+1)+weights(iel) .GE. MAXVAL(occup))
+            IF (MINLOC(occup, DIM=1) == ibin+1) EXIT
+            ibin = MOD(ibin+1, nbin)
+            niter = niter+1
+         ENDDO
+         dist(iel) = ibin
+         occup(ibin+1) = occup(ibin+1)+weights(iel)
+      ENDDO
+
+   END SUBROUTINE
+
+! **************************************************************************************************
 !> \brief Contract (P|ai) = (R|P) x (R|ai)
 !> \param BIb_C (R|ai)
 !> \param my_Lrows (R|P)
@@ -905,37 +1252,38 @@ CONTAINS
 !> \param blk_size ...
 !> \param ngroup how many subgroups (NG)
 !> \param igroup subgroup color
-!> \param mp_comm_2d communicator with 2d Cartesian grid with dimensions (NG x Nw)
+!> \param mp_comm communicator
 !> \param para_env_sub ...
 ! **************************************************************************************************
-   SUBROUTINE contract_B_L(BIb_C, my_Lrows, sizes_B, sizes_L, blk_size, ngroup, igroup, mp_comm_2d, para_env_sub)
+   SUBROUTINE contract_B_L(BIb_C, my_Lrows, sizes_B, sizes_L, blk_size, ngroup, igroup, mp_comm, para_env_sub)
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT)   :: BIb_C
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: my_Lrows
       INTEGER, DIMENSION(:), INTENT(IN)                  :: sizes_B, sizes_L
       INTEGER, DIMENSION(2), INTENT(IN)                  :: blk_size
-      INTEGER, INTENT(IN)                                :: ngroup, igroup, mp_comm_2d
+      INTEGER, INTENT(IN)                                :: ngroup, igroup, mp_comm
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
 
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'contract_B_L', routineP = moduleN//':'//routineN
       LOGICAL, PARAMETER                                 :: debug = .FALSE.
 
-      INTEGER                                            :: blk, check_proc, i, iend, ii, ioff, &
-                                                            iproc, iproc_glob, istart, loc_a, &
-                                                            loc_P, mp_comm_B, mp_comm_L, nproc, &
-                                                            nproc_glob
+      INTEGER                                            :: check_proc, handle, i, iend, ierr, ii, &
+                                                            ioff, iproc, iproc_glob, istart, &
+                                                            loc_a, loc_P, nproc, nproc_glob
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: block_ind_L_P, block_ind_L_R
       INTEGER, DIMENSION(1)                              :: dist_B_i, map_B_1, map_L_1, map_L_2, &
                                                             sizes_i
-      INTEGER, DIMENSION(2)                              :: map_B_2
-      INTEGER, DIMENSION(3)                              :: blk_ind, blk_offset, blk_offset_first, &
-                                                            blk_sizes, offset_B
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: blk_data
-      LOGICAL                                            :: first_block
+      INTEGER, DIMENSION(2)                              :: map_B_2, pdims_L
+      INTEGER, DIMENSION(3)                              :: pdims_B
+      LOGICAL, DIMENSION(3)                              :: period_2d, period_3d
+      LOGICAL                                            :: found, reorder
       INTEGER, DIMENSION(ngroup)                         :: dist_L_P, dist_L_R
       INTEGER, DIMENSION(para_env_sub%num_pe)            :: dist_B_a
       TYPE(dbcsr_t_distribution_type)                    :: dist_B, dist_L
-      TYPE(dbcsr_t_iterator_type)                        :: iter
+      TYPE(dbcsr_t_pgrid_type)                           :: mp_comm_B, mp_comm_L
       TYPE(dbcsr_t_type)                                 :: tB_in, tB_in_split, tB_out, &
                                                             tB_out_split, tL, tL_split
+
+      CALL timeset(routineN, handle)
 
       sizes_i(1) = SIZE(BIb_C, 3)
 
@@ -943,7 +1291,7 @@ CONTAINS
       iproc = para_env_sub%mepos ! subgroup-local process ID
 
       ! Total number of processes and global process ID
-      CALL mp_environ(nproc_glob, iproc_glob, mp_comm_2d)
+      CALL mp_environ(nproc_glob, iproc_glob, mp_comm)
 
       ! local block index for R/P and a
       loc_P = igroup+1; loc_a = iproc+1
@@ -972,8 +1320,16 @@ CONTAINS
       ! derive nd process grid that is compatible with distributions and 2d process grid
       ! (R|ai) / (P|ai) on process grid NG x Nw x 1
       ! (R|P) on process grid NG x Nw
-      mp_comm_B = dbcsr_t_nd_mp_comm(mp_comm_2d, map_B_1, map_B_2, dims_nd=[ngroup, nproc, 1])
-      mp_comm_L = dbcsr_t_nd_mp_comm(mp_comm_2d, map_L_1, map_L_2, dims_nd=[nproc, ngroup])
+      pdims_B = [ngroup, nproc, 1]
+      pdims_L = [nproc, ngroup]
+
+      reorder = .FALSE.
+      period_3d = .FALSE.
+      period_2d = .FALSE.
+      ierr = 0
+
+      CALL dbcsr_t_pgrid_create(mp_comm, pdims_B, mp_comm_B)
+      CALL dbcsr_t_pgrid_create(mp_comm, pdims_L, mp_comm_L)
 
       ! setup distribution vectors such that distribution matches parallel data layout of BIb_C and my_Lrows
       dist_B_i = [0]
@@ -982,8 +1338,8 @@ CONTAINS
       dist_L_P = (/(i, i=0, ngroup-1)/)
 
       ! create distributions and tensors
-      CALL dbcsr_t_distribution_new(dist_B, mp_comm_B, mp_comm_2d, map_B_1, map_B_2, dist_L_P, dist_B_a, dist_B_i)
-      CALL dbcsr_t_distribution_new(dist_L, mp_comm_L, mp_comm_2d, map_L_1, map_L_2, dist_L_R, dist_L_P)
+      CALL dbcsr_t_distribution_new(dist_B, mp_comm_B, map_B_1, map_B_2, dist_L_P, dist_B_a, dist_B_i)
+      CALL dbcsr_t_distribution_new(dist_L, mp_comm_L, map_L_1, map_L_2, dist_L_R, dist_L_P)
 
       CALL dbcsr_t_create(tB_in, "(R|ai)", dist_B, map_B_1, map_B_2, dbcsr_type_real_8, sizes_L, sizes_B, sizes_i)
       CALL dbcsr_t_create(tB_out, "(P|ai)", dist_B, map_B_1, map_B_2, dbcsr_type_real_8, sizes_L, sizes_B, sizes_i)
@@ -1035,29 +1391,18 @@ CONTAINS
       CALL dbcsr_t_split_blocks(tB_out, tB_out_split, [blk_size(2), blk_size(1), blk_size(1)])
 
       ! contract
-      CALL dbcsr_t_contract(tensor_1=tB_in_split, tensor_2=tL_split, tensor_3=tB_out_split, &
+      CALL dbcsr_t_contract(alpha=dbcsr_scalar(1.0_dp), tensor_1=tB_in_split, tensor_2=tL_split, &
+                            beta=dbcsr_scalar(0.0_dp), tensor_3=tB_out_split, &
                             contract_1=[1], notcontract_1=[2, 3], &
                             contract_2=[1], notcontract_2=[2], &
-                            map_1=[2, 3], map_2=[1])
+                            map_1=[2, 3], map_2=[1], optimize_dist=.TRUE.)
 
       ! retrieve local block of contraction result (P|ai)
-      CALL dbcsr_t_iterator_start(iter, tB_out_split)
-      first_block = .TRUE.
-      DO WHILE (dbcsr_t_iterator_blocks_left(iter))
-         CALL dbcsr_t_iterator_next_block(iter, blk_ind, blk, blk_size=blk_sizes, blk_offset=blk_offset)
-         IF (first_block) THEN
-            blk_offset_first(:) = blk_offset(:)
-            first_block = .FALSE.
-         ENDIF
-         offset_B(:) = blk_offset(:)-blk_offset_first(:)
-         CALL dbcsr_t_get_block(tB_out_split, blk_ind, blk_data)
-         BIb_C(offset_B(1)+1:offset_B(1)+blk_sizes(1), &
-               offset_B(2)+1:offset_B(2)+blk_sizes(2), &
-               offset_B(3)+1:offset_B(3)+blk_sizes(3)) = &
-            blk_data(:, :, :)
-         DEALLOCATE (blk_data)
-      END DO
-      CALL dbcsr_t_iterator_stop(iter)
+      !CALL dbcsr_t_split_copyback(tB_out_split, tB_out)
+      CALL dbcsr_t_copy(tB_out_split, tB_out)
+
+      CALL dbcsr_t_get_block(tB_out, [loc_P, loc_a, 1], SHAPE(BIb_C), BIb_C, found)
+      CPASSERT(found)
 
       ! cleanup
       CALL dbcsr_t_destroy(tB_in)
@@ -1070,8 +1415,10 @@ CONTAINS
       CALL dbcsr_t_distribution_destroy(dist_B)
       CALL dbcsr_t_distribution_destroy(dist_L)
 
-      CALL dbcsr_t_nd_mp_free(mp_comm_B)
-      CALL dbcsr_t_nd_mp_free(mp_comm_L)
+      CALL dbcsr_t_pgrid_destroy(mp_comm_B)
+      CALL dbcsr_t_pgrid_destroy(mp_comm_L)
+
+      CALL timestop(handle)
 
    END SUBROUTINE
 
@@ -6138,6 +6485,392 @@ CONTAINS
    END SUBROUTINE Find_quasi_degenerate_ij
 
 ! **************************************************************************************************
+!> \brief ...
+!> \param t_3c_overl_int ...
+!> \param filter_eps ...
+!> \param mat_munu ...
+!> \param qs_env ...
+!> \param local_atoms_RI ...
+!> \param sab_orb_sub ...
+!> \param sab_orb_all ...
+!> \param num_diff_blk ...
+! **************************************************************************************************
+   SUBROUTINE compute_3c_overlap_int_t(t_3c_overl_int, filter_eps, mat_munu, qs_env, local_atoms_RI, &
+                                       sab_orb_sub, sab_orb_all, num_diff_blk)
+
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: t_3c_overl_int
+      REAL(KIND=dp), INTENT(IN)                          :: filter_eps
+      TYPE(dbcsr_p_type)                                 :: mat_munu
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: local_atoms_RI
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb_sub, sab_orb_all
+      INTEGER                                            :: num_diff_blk
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_3c_overlap_int_t', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: acell, atom_RI, bcell, block_end_col, block_end_RI, block_end_row, &
+         block_start_col, block_start_RI, block_start_row, col, handle, handle2, i_img, iatom, &
+         iatom_outer, iatom_RI, iblk_send, ikind, img_col, img_row, iset, j_img, jatom, &
+         jatom_outer, jkind, jset, kind_RI, maxval_1, maxval_2, maxval_3, mepos, minval_1, &
+         minval_2, minval_3, natom, nco_RI, ncoa, ncob, nimg, nset_RI, nseta, nsetb, nthread, row, &
+         set_RI, sgf_RI, sgfa, sgfb
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: indices_for_uncommon_blocks
+      INTEGER, DIMENSION(3)                              :: bcellvec, blk_size, cell_vec, &
+                                                            outer_cell_vec, size_cell_to_index
+      INTEGER, DIMENSION(:), POINTER :: col_blk_sizes, l_max_RI, l_min_RI, la_max, la_min, lb_max, &
+         lb_min, npgf_RI, npgfa, npgfb, nsgf_RI, nsgfa, nsgfb, row_blk_sizes
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_RI, first_sgfa, first_sgfb
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: debug, do_kpoints_cubic_RPA, found
+      REAL(KIND=dp)                                      :: dab, daRI, dbRI, prefac
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: block_t, dummy_block_t, s_abRI, &
+                                                            s_abRI_contr
+      REAL(KIND=dp), DIMENSION(3)                        :: rab, rab_outer, raRI, rbRI
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a, set_radius_b, set_radius_RI
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgf_RI, rpgfa, rpgfb, sphi_a, sphi_b, &
+                                                            sphi_RI, zet_RI, zeta, zetb
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(dbcsr_t_type)                                 :: t_3c_tmp
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_type), POINTER                  :: basis_set_a, basis_set_b, basis_set_RI
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator, nl_iterator_outer
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(two_dim_real_array), ALLOCATABLE, &
+         DIMENSION(:)                                    :: blocks_to_send_around
+
+      CALL timeset(routineN, handle)
+
+      debug = .FALSE.
+
+      NULLIFY (qs_kind_set, atomic_kind_set, basis_set_RI, basis_set_a, basis_set_b, &
+               nl_iterator)
+
+      ! get stuff
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
+                      natom=natom, kpoints=kpoints, dft_control=dft_control)
+
+      do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
+      IF (do_kpoints_cubic_RPA) THEN
+         CPABORT("k points not yet implemented with DBCSR tensors")
+      ENDIF
+
+      IF (do_kpoints_cubic_RPA) THEN
+         ! No MAOs kpoints
+         nimg = dft_control%nimages
+         CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
+         size_cell_to_index(1) = SIZE(cell_to_index, 1)
+         size_cell_to_index(2) = SIZE(cell_to_index, 2)
+         size_cell_to_index(3) = SIZE(cell_to_index, 3)
+         ! 1: row, 2: col, 3: i_img, 4: j_img, 5: cut_RI, 6: proc_to_send
+         ALLOCATE (indices_for_uncommon_blocks(num_diff_blk, 6))
+         indices_for_uncommon_blocks(:, :) = 0
+         ALLOCATE (blocks_to_send_around(num_diff_blk))
+         iblk_send = 0
+         minval_1 = MINVAL(kpoints%index_to_cell(1, :))
+         maxval_1 = MAXVAL(kpoints%index_to_cell(1, :))
+         minval_2 = MINVAL(kpoints%index_to_cell(2, :))
+         maxval_2 = MAXVAL(kpoints%index_to_cell(2, :))
+         minval_3 = MINVAL(kpoints%index_to_cell(3, :))
+         maxval_3 = MAXVAL(kpoints%index_to_cell(3, :))
+      ELSE
+         nimg = 1
+      END IF
+
+      CALL dbcsr_get_info(mat_munu%matrix, &
+                          row_blk_size=row_blk_sizes, &
+                          col_blk_size=col_blk_sizes)
+
+      ALLOCATE (kind_of(natom))
+
+      CALL get_atomic_kind_set(atomic_kind_set, kind_of=kind_of)
+
+      DO iatom_RI = 1, SIZE(local_atoms_RI)
+         atom_RI = local_atoms_RI(iatom_RI)
+
+         kind_RI = kind_of(atom_RI)
+         CALL get_qs_kind(qs_kind=qs_kind_set(kind_RI), basis_set=basis_set_RI, basis_type="RI_AUX")
+
+         first_sgf_RI => basis_set_RI%first_sgf
+         l_max_RI => basis_set_RI%lmax
+         l_min_RI => basis_set_RI%lmin
+         npgf_RI => basis_set_RI%npgf
+         nset_RI = basis_set_RI%nset
+         nsgf_RI => basis_set_RI%nsgf_set
+         rpgf_RI => basis_set_RI%pgf_radius
+         set_radius_RI => basis_set_RI%set_radius
+         sphi_RI => basis_set_RI%sphi
+         zet_RI => basis_set_RI%zet
+
+         CALL neighbor_list_iterator_create(nl_iterator_outer, sab_orb_all)
+
+         DO WHILE (neighbor_list_iterate(nl_iterator_outer) == 0)
+
+            CALL get_iterator_info(nl_iterator_outer, &
+                                   iatom=iatom_outer, jatom=jatom_outer, r=rab_outer, &
+                                   cell=outer_cell_vec)
+
+            IF (iatom_outer .NE. atom_RI .AND. jatom_outer .NE. atom_RI) CYCLE
+
+            nthread = 1
+
+            CALL neighbor_list_iterator_create(nl_iterator, sab_orb_sub, nthread=nthread)
+
+            mepos = 0
+
+            DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+
+               CALL get_iterator_info(nl_iterator, mepos=mepos, &
+                                      iatom=iatom, jatom=jatom, r=rab, &
+                                      cell=cell_vec)
+
+               DO i_img = 1, nimg
+
+                  DO j_img = 1, nimg
+
+                     IF (atom_RI .EQ. iatom_outer .AND. &
+                         iatom .NE. jatom_outer .AND. &
+                         jatom .NE. jatom_outer) &
+                        CYCLE
+
+                     IF (atom_RI .EQ. jatom_outer .AND. &
+                         iatom .NE. iatom_outer .AND. &
+                         jatom .NE. iatom_outer) &
+                        CYCLE
+
+                     IF (iatom .EQ. iatom_outer .AND. &
+                         atom_RI .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+
+                           IF (outer_cell_vec(1) < minval_1) CYCLE
+                           IF (outer_cell_vec(1) > maxval_1) CYCLE
+                           IF (outer_cell_vec(2) < minval_2) CYCLE
+                           IF (outer_cell_vec(2) > maxval_2) CYCLE
+                           IF (outer_cell_vec(3) < minval_1) CYCLE
+                           IF (outer_cell_vec(3) > maxval_2) CYCLE
+
+                           acell = cell_to_index(-outer_cell_vec(1), -outer_cell_vec(2), -outer_cell_vec(3))
+
+                           IF (.NOT. (acell == i_img)) CYCLE
+
+                           bcellvec = -outer_cell_vec+cell_vec
+
+                           IF (bcellvec(1) < minval_1) CYCLE
+                           IF (bcellvec(1) > maxval_1) CYCLE
+                           IF (bcellvec(2) < minval_2) CYCLE
+                           IF (bcellvec(2) > maxval_2) CYCLE
+                           IF (bcellvec(3) < minval_3) CYCLE
+                           IF (bcellvec(3) > maxval_3) CYCLE
+
+                           bcell = cell_to_index(bcellvec(1), bcellvec(2), bcellvec(3))
+
+                           IF (.NOT. (bcell == j_img)) CYCLE
+
+                        END IF
+
+                        raRI = rab_outer
+                        rbRI = raRI-rab
+
+                     ELSE IF (atom_RI .EQ. iatom_outer .AND. &
+                              iatom .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+                           ! for kpoints we have the non-symmetric neighbor list
+                           CYCLE
+                        END IF
+
+                        raRI = -rab_outer
+                        rbRI = raRI-rab
+
+                     ELSE IF (jatom .EQ. iatom_outer .AND. &
+                              atom_RI .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+                           ! for kpoints we have the non-symmetric neighbor list
+                           CYCLE
+                        END IF
+
+                        rbRI = rab_outer
+                        raRI = rbRI+rab
+
+                     ELSE IF (atom_RI .EQ. iatom_outer .AND. &
+                              jatom .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+                           ! for kpoints we have the non-symmetric neighbor list
+                           CYCLE
+                        END IF
+
+                        rbRI = -rab_outer
+                        raRI = rbRI+rab
+
+                     END IF
+
+                     row = iatom
+                     col = jatom
+                     img_row = i_img
+                     img_col = j_img
+
+                     CALL dbcsr_t_blk_sizes(t_3c_overl_int(img_row, img_col), [atom_RI, row, col], blk_size)
+                     ALLOCATE (block_t(blk_size(1), blk_size(2), blk_size(3)))
+                     block_t = 0.0_dp
+
+                     DO set_RI = 1, nset_RI
+
+                        dab = SQRT(SUM(rab**2))
+                        daRI = SQRT(SUM(raRI**2))
+                        dbRI = SQRT(SUM(rbRI**2))
+
+                        ikind = kind_of(iatom)
+                        CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=basis_set_a)
+                        first_sgfa => basis_set_a%first_sgf
+                        la_max => basis_set_a%lmax
+                        la_min => basis_set_a%lmin
+                        npgfa => basis_set_a%npgf
+                        nseta = basis_set_a%nset
+                        nsgfa => basis_set_a%nsgf_set
+                        rpgfa => basis_set_a%pgf_radius
+                        set_radius_a => basis_set_a%set_radius
+                        sphi_a => basis_set_a%sphi
+                        zeta => basis_set_a%zet
+
+                        jkind = kind_of(jatom)
+                        CALL get_qs_kind(qs_kind=qs_kind_set(jkind), basis_set=basis_set_b)
+                        first_sgfb => basis_set_b%first_sgf
+                        lb_max => basis_set_b%lmax
+                        lb_min => basis_set_b%lmin
+                        npgfb => basis_set_b%npgf
+                        nsetb = basis_set_b%nset
+                        nsgfb => basis_set_b%nsgf_set
+                        rpgfb => basis_set_b%pgf_radius
+                        set_radius_b => basis_set_b%set_radius
+                        sphi_b => basis_set_b%sphi
+                        zetb => basis_set_b%zet
+
+                        DO iset = 1, nseta
+
+                           IF (set_radius_a(iset)+set_radius_RI(set_RI) < daRI) CYCLE
+
+                           DO jset = 1, nsetb
+
+                              IF (set_radius_a(iset)+set_radius_b(jset) < dab) CYCLE
+                              IF (set_radius_b(jset)+set_radius_RI(set_RI) < dbRI) CYCLE
+
+                              nco_RI = npgf_RI(set_RI)*ncoset(l_max_RI(set_RI))
+                              ncoa = npgfa(iset)*ncoset(la_max(iset))
+                              ncob = npgfb(jset)*ncoset(lb_max(jset))
+
+                              sgf_RI = first_sgf_RI(1, set_RI)
+                              sgfa = first_sgfa(1, iset)
+                              sgfb = first_sgfb(1, jset)
+
+                              IF (ncoa*ncob*nco_RI > 0) THEN
+
+                                 ALLOCATE (s_abRI(nco_RI, ncoa, ncob))
+                                 s_abRI(:, :, :) = 0.0_dp
+
+                                 CALL overlap3(l_max_RI(set_RI), npgf_RI(set_RI), zet_RI(:, set_RI), rpgf_RI(:, set_RI), &
+                                               l_min_RI(set_RI), &
+                                               la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                                               lb_max(jset), npgfb(jset), zetb(:, jset), rpgfb(:, jset), lb_min(jset), &
+                                               -raRI, daRI, -rbRI, dbRI, rab, dab, s_abRI)
+
+                                 ALLOCATE (s_abRI_contr(nsgf_RI(set_RI), nsgfa(iset), nsgfb(jset)))
+
+                                 CALL abc_contract(s_abRI_contr, s_abRI, &
+                                                   sphi_RI(:, sgf_RI:), sphi_a(:, sgfa:), sphi_b(:, sgfb:), &
+                                                   nco_RI, ncoa, ncob, nsgf_RI(set_RI), nsgfa(iset), nsgfb(jset))
+
+                                 block_start_row = sgfa
+                                 block_end_row = sgfa+nsgfa(iset)-1
+                                 block_start_col = sgfb
+                                 block_end_col = sgfb+nsgfb(jset)-1
+                                 block_start_RI = sgf_RI
+                                 block_end_RI = sgf_RI+nsgf_RI(set_RI)-1
+
+                                 IF (iatom == jatom) THEN
+                                    ! factor 0.5 is necessary because matrix is added to its transpose
+                                    prefac = 0.5_dp
+                                 ELSE
+                                    ! factor 0.5 is necessary due to double filling due to double iterate loop
+                                    prefac = 0.5_dp
+                                 ENDIF
+
+                                 block_t(block_start_RI:block_end_RI, &
+                                         block_start_row:block_end_row, &
+                                         block_start_col:block_end_col) = &
+                                    block_t(block_start_RI:block_end_RI, &
+                                            block_start_row:block_end_row, &
+                                            block_start_col:block_end_col)+ &
+                                    prefac*s_abRI_contr(:, :, :)
+                                 DEALLOCATE (s_abRI, s_abRI_contr)
+
+                              END IF ! number of triples > 0
+
+                           END DO ! jset
+
+                        END DO ! iset
+
+                     END DO ! set RI
+                     CALL timeset(routineN//"_put_dbcsr", handle2)
+
+                     IF (debug) THEN
+                        CALL dbcsr_t_get_block(t_3c_overl_int(img_row, img_col), &
+                                               [atom_RI, row, col], dummy_block_t, found=found)
+                        CPASSERT(found)
+                     ENDIF
+
+                     CALL dbcsr_t_put_block(t_3c_overl_int(img_row, img_col), &
+                                            [atom_RI, row, col], SHAPE(block_t), block_t, summation=.TRUE.)
+
+                     !mao not supported with dbcsr_t
+
+                     CALL timestop(handle2)
+
+                     DEALLOCATE (block_t)
+
+                  END DO ! j_img
+
+               END DO ! i_img
+
+            END DO ! inner neighbor list
+
+            CALL neighbor_list_iterator_release(nl_iterator)
+
+         END DO ! outer neighbor list
+
+         CALL neighbor_list_iterator_release(nl_iterator_outer)
+
+      END DO ! atom_RI
+
+      ! add transposed of overlap integrals:
+      DO img_row = 1, nimg
+         DO img_col = 1, nimg
+            ! we need to take half of filter_eps, since we are adding tensor to its transpose afterwards
+            CALL dbcsr_t_filter(t_3c_overl_int(img_row, img_col), filter_eps/2)
+         ENDDO
+      ENDDO
+      CALL dbcsr_t_create(t_3c_overl_int(1, 1), t_3c_tmp)
+      DO img_row = 1, nimg
+         DO img_col = 1, nimg
+            CALL dbcsr_t_copy(t_3c_overl_int(img_row, img_col), t_3c_tmp)
+            CALL dbcsr_t_copy(t_3c_tmp, t_3c_overl_int(img_row, img_col), order=[1, 3, 2], summation=.TRUE., move_data=.TRUE.)
+            CALL dbcsr_t_filter(t_3c_overl_int(img_row, img_col), filter_eps)
+         ENDDO
+      ENDDO
+      CALL dbcsr_t_set(t_3c_tmp, 0.0_dp)
+      CALL dbcsr_t_filter(t_3c_tmp, 1.0_dp)
+      CALL dbcsr_t_destroy(t_3c_tmp)
+
+      CALL timestop(handle)
+   END SUBROUTINE
+! **************************************************************************************************
 !> \brief compute three center overlap integrals and write them to mat_3_overl_int
 !> \param mat_3c_overl_int ...
 !> \param mat_3c_overl_int_mao_for_occ ...
@@ -6854,6 +7587,401 @@ CONTAINS
    END SUBROUTINE
 
 ! **************************************************************************************************
+!> \brief ...
+!> \param t_3c_overl_int ...
+!> \param mp_comm_t3c_overl ...
+!> \param ngroup ...
+!> \param mat_munu ...
+!> \param qs_env ...
+!> \param unit_nr ...
+!> \param local_atoms_RI ...
+!> \param row_blk_sizes_RI_t ...
+!> \param row_dist_RI_t ...
+!> \param sab_orb_sub ...
+!> \param sab_orb_all ...
+!> \param para_env ...
+!> \param num_diff_blk ...
+! **************************************************************************************************
+   SUBROUTINE reserve_blocks_3c_t(t_3c_overl_int, mp_comm_t3c_overl, ngroup, mat_munu, qs_env, &
+                       unit_nr, local_atoms_RI, row_blk_sizes_RI_t, row_dist_RI_t, sab_orb_sub, sab_orb_all, para_env, num_diff_blk)
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: t_3c_overl_int
+      TYPE(dbcsr_t_pgrid_type), INTENT(IN)               :: mp_comm_t3c_overl
+      INTEGER, INTENT(IN)                                :: ngroup
+      TYPE(dbcsr_p_type)                                 :: mat_munu
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: unit_nr
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: local_atoms_RI
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: row_blk_sizes_RI_t, row_dist_RI_t
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb_sub, sab_orb_all
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      INTEGER                                            :: num_diff_blk
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'reserve_blocks_3c_t', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: acell, atom_RI, bcell, blk_cnt, col, handle, i, i_img, i_img_outer, i_loop, &
+         iatom, iatom_outer, iatom_RI, iblk, ikind, iproc, j_img, j_img_outer, jatom, jatom_outer, &
+         jkind, kind_RI, maxval_1, maxval_2, maxval_3, minval_1, minval_2, minval_3, natom, nimg, &
+         nset_RI, nseta, nsetb, num_loops, row
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of, tmp
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: old_col, old_row
+      INTEGER, DIMENSION(3)                              :: cell_vec, outer_cell_vec
+      INTEGER, DIMENSION(:), POINTER :: ao_blk_sizes, dist_ao1, dist_ao2, l_max_RI, l_min_RI, &
+         la_max, la_min, lb_max, lb_min, npgf_RI, npgfa, npgfb, nsgf_RI, nsgfa, nsgfb
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_RI, first_sgfa, first_sgfb
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: do_kpoints_cubic_RPA, new_block
+      REAL(KIND=dp)                                      :: dab, daRI, dbRI, kind_radius_a, &
+                                                            kind_radius_b, kind_radius_RI
+      REAL(KIND=dp), DIMENSION(3)                        :: rab, rab_outer, raRI, rbRI
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a, set_radius_b, set_radius_RI
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgf_RI, rpgfa, rpgfb, sphi_a, sphi_b, &
+                                                            sphi_RI, zet_RI, zeta, zetb
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(dbcsr_distribution_type)                      :: dist_sub
+      TYPE(dbcsr_t_distribution_type)                    :: dist_o3c
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_type), POINTER                  :: basis_set_a, basis_set_b, basis_set_RI
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator, nl_iterator_outer
+      TYPE(one_dim_int_array), ALLOCATABLE, &
+         DIMENSION(:, :)                                 :: alloc_ao1, alloc_ao2, alloc_RI
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      CALL timeset(routineN, handle)
+      NULLIFY (qs_kind_set, atomic_kind_set, basis_set_RI, basis_set_a, basis_set_b, nl_iterator)
+
+      do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
+      IF (do_kpoints_cubic_RPA) THEN
+         CPABORT("k points not yet implemented with DBCSR tensors")
+      ENDIF
+
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, natom=natom, &
+                      dft_control=dft_control, kpoints=kpoints)
+
+      IF (do_kpoints_cubic_RPA) THEN
+         ! set up new kpoint type with periodic images according to eps_grid from MP2 section
+         ! instead of eps_pgf_orb from QS section
+         CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
+
+         CALL kpoint_init_cell_index(kpoints, sab_orb_sub, para_env, dft_control)
+
+         nimg = dft_control%nimages
+         CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
+
+         IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
+            "3C_OVERLAP_INTEGRALS_INFO| Number of periodic images considered:", nimg
+
+         num_diff_blk = 0
+      ELSE
+         nimg = 1
+      END IF
+
+      ALLOCATE (t_3c_overl_int(nimg, nimg))
+
+      CALL dbcsr_get_info(mat_munu%matrix, &
+                          row_blk_size=ao_blk_sizes, &
+                          distribution=dist_sub)
+
+      CALL dbcsr_distribution_get(dist_sub, row_dist=dist_ao1, col_dist=dist_ao2)
+
+      CALL dbcsr_t_distribution_new(dist_o3c, mp_comm_t3c_overl, [1, 2], [3], &
+                                    row_dist_RI_t, dist_ao1, dist_ao2, ngroup=ngroup, dimsplit=1, own_comm=.TRUE.)
+
+      DO i_img = 1, nimg
+         DO j_img = 1, nimg
+            IF (i_img > j_img) CYCLE
+            CALL dbcsr_t_create(t_3c_overl_int(i_img, j_img), "O (RI AO | AO)", dist_o3c, [1, 2], [3], &
+                                dbcsr_type_real_8, row_blk_sizes_RI_t, ao_blk_sizes, ao_blk_sizes)
+         ENDDO
+      ENDDO
+
+      CALL dbcsr_t_distribution_destroy(dist_o3c)
+
+      ALLOCATE (alloc_RI(nimg, nimg))
+      ALLOCATE (alloc_ao1(nimg, nimg))
+      ALLOCATE (alloc_ao2(nimg, nimg))
+      !ALLOCATE (old_ri(nimg, nimg))
+      !old_ri = -1
+      ALLOCATE (old_row(nimg, nimg))
+      old_row = -1
+      ALLOCATE (old_col(nimg, nimg))
+      old_col = -1
+
+      ALLOCATE (kind_of(natom))
+      CALL get_atomic_kind_set(atomic_kind_set, kind_of=kind_of)
+
+      DO iatom_RI = 1, SIZE(local_atoms_RI)
+         atom_RI = local_atoms_RI(iatom_RI)
+         kind_RI = kind_of(atom_RI)
+         CALL get_qs_kind(qs_kind=qs_kind_set(kind_RI), basis_set=basis_set_RI, basis_type="RI_AUX")
+
+         first_sgf_RI => basis_set_RI%first_sgf
+
+         l_max_RI => basis_set_RI%lmax
+         l_min_RI => basis_set_RI%lmin
+         npgf_RI => basis_set_RI%npgf
+         nset_RI = basis_set_RI%nset
+         nsgf_RI => basis_set_RI%nsgf_set
+         rpgf_RI => basis_set_RI%pgf_radius
+         set_radius_RI => basis_set_RI%set_radius
+         sphi_RI => basis_set_RI%sphi
+         zet_RI => basis_set_RI%zet
+         kind_radius_RI = basis_set_RI%kind_radius
+
+         CALL neighbor_list_iterator_create(nl_iterator_outer, sab_orb_all)
+         DO WHILE (neighbor_list_iterate(nl_iterator_outer) == 0)
+
+            CALL get_iterator_info(nl_iterator_outer, &
+                                   iatom=iatom_outer, jatom=jatom_outer, r=rab_outer, cell=outer_cell_vec)
+
+            IF (iatom_outer .NE. atom_RI .AND. jatom_outer .NE. atom_RI) CYCLE
+
+            CALL neighbor_list_iterator_create(nl_iterator, sab_orb_sub)
+            DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+
+               CALL get_iterator_info(nl_iterator, &
+                                      iatom=iatom, jatom=jatom, r=rab, cell=cell_vec)
+
+               !PRINT *, "nl", atom_RI, iatom, jatom
+
+               DO i_img_outer = 1, nimg
+                  DO j_img_outer = 1, nimg
+
+                     IF (i_img_outer > j_img_outer) CYCLE
+                     IF (i_img_outer < j_img_outer) THEN
+                        num_loops = 2
+                     ELSE IF (i_img_outer == j_img_outer) THEN
+                        num_loops = 1
+                     END IF
+
+                     DO i_loop = 1, num_loops
+
+                        IF (i_loop == 1) THEN
+                           i_img = i_img_outer
+                           j_img = j_img_outer
+                        ELSE IF (i_loop == 2) THEN
+                           i_img = j_img_outer
+                           j_img = i_img_outer
+                        END IF
+
+                        IF (atom_RI .EQ. iatom_outer .AND. &
+                            iatom .NE. jatom_outer .AND. &
+                            jatom .NE. jatom_outer) &
+                           CYCLE
+
+                        IF (atom_RI .EQ. jatom_outer .AND. &
+                            iatom .NE. iatom_outer .AND. &
+                            jatom .NE. iatom_outer) &
+                           CYCLE
+
+                        IF (iatom .EQ. iatom_outer .AND. &
+                            atom_RI .EQ. jatom_outer) THEN
+
+                           IF (do_kpoints_cubic_RPA) THEN
+
+                              IF (outer_cell_vec(1) < minval_1) CYCLE
+                              IF (outer_cell_vec(1) > maxval_1) CYCLE
+                              IF (outer_cell_vec(2) < minval_2) CYCLE
+                              IF (outer_cell_vec(2) > maxval_2) CYCLE
+                              IF (outer_cell_vec(3) < minval_3) CYCLE
+                              IF (outer_cell_vec(3) > maxval_3) CYCLE
+
+                              IF (-outer_cell_vec(1)+cell_vec(1) < minval_1) CYCLE
+                              IF (-outer_cell_vec(1)+cell_vec(1) > maxval_1) CYCLE
+                              IF (-outer_cell_vec(2)+cell_vec(2) < minval_2) CYCLE
+                              IF (-outer_cell_vec(2)+cell_vec(2) > maxval_2) CYCLE
+                              IF (-outer_cell_vec(3)+cell_vec(3) < minval_3) CYCLE
+                              IF (-outer_cell_vec(3)+cell_vec(3) > maxval_3) CYCLE
+
+                              acell = cell_to_index(-outer_cell_vec(1), -outer_cell_vec(2), -outer_cell_vec(3))
+                              IF (.NOT. (acell == i_img)) CYCLE
+                              bcell = cell_to_index(-outer_cell_vec(1)+cell_vec(1), &
+                                                    -outer_cell_vec(2)+cell_vec(2), &
+                                                    -outer_cell_vec(3)+cell_vec(3))
+                              IF (.NOT. (bcell == j_img)) CYCLE
+
+                           END IF
+
+                           raRI = rab_outer
+                           rbRI = raRI-rab
+
+                        ELSE IF (atom_RI .EQ. iatom_outer .AND. &
+                                 iatom .EQ. jatom_outer) THEN
+
+                           IF (do_kpoints_cubic_RPA) THEN
+                              ! for kpoints we have the non-symmetric neighbor list
+                              CYCLE
+                           END IF
+
+                           raRI = -rab_outer
+                           rbRI = raRI-rab
+
+                        ELSE IF (jatom .EQ. iatom_outer .AND. &
+                                 atom_RI .EQ. jatom_outer) THEN
+
+                           IF (do_kpoints_cubic_RPA) THEN
+                              ! for kpoints we have the non-symmetric neighbor list
+                              CYCLE
+                           END IF
+
+                           rbRI = rab_outer
+                           raRI = rbRI+rab
+
+                        ELSE IF (atom_RI .EQ. iatom_outer .AND. &
+                                 jatom .EQ. jatom_outer) THEN
+
+                           IF (do_kpoints_cubic_RPA) THEN
+                              ! for kpoints we have the non-symmetric neighbor list
+                              CYCLE
+                           END IF
+
+                           rbRI = -rab_outer
+                           raRI = rbRI+rab
+
+                        END IF
+
+                        dab = SQRT(SUM(rab**2))
+                        daRI = SQRT(SUM(raRI**2))
+                        dbRI = SQRT(SUM(rbRI**2))
+
+                        ikind = kind_of(iatom)
+                        CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=basis_set_a)
+                        first_sgfa => basis_set_a%first_sgf
+                        la_max => basis_set_a%lmax
+                        la_min => basis_set_a%lmin
+                        npgfa => basis_set_a%npgf
+                        nseta = basis_set_a%nset
+                        nsgfa => basis_set_a%nsgf_set
+                        rpgfa => basis_set_a%pgf_radius
+                        set_radius_a => basis_set_a%set_radius
+                        sphi_a => basis_set_a%sphi
+                        zeta => basis_set_a%zet
+                        kind_radius_a = basis_set_a%kind_radius
+
+                        jkind = kind_of(jatom)
+                        CALL get_qs_kind(qs_kind=qs_kind_set(jkind), basis_set=basis_set_b)
+                        first_sgfb => basis_set_b%first_sgf
+                        lb_max => basis_set_b%lmax
+                        lb_min => basis_set_b%lmin
+                        npgfb => basis_set_b%npgf
+                        nsetb = basis_set_b%nset
+                        nsgfb => basis_set_b%nsgf_set
+                        rpgfb => basis_set_b%pgf_radius
+                        set_radius_b => basis_set_b%set_radius
+                        kind_radius_b = basis_set_b%kind_radius
+                        sphi_b => basis_set_b%sphi
+                        zetb => basis_set_b%zet
+
+                        IF (kind_radius_a+kind_radius_RI < daRI) CYCLE
+                        IF (kind_radius_a+kind_radius_b < dab) CYCLE
+                        IF (kind_radius_b+kind_radius_RI < dbRI) CYCLE
+
+                        ! tensor is not symmetric therefore need to allocate rows and columns in
+                        ! correspondence with neighborlist. Note that this only allocates half
+                        ! of the blocks (since neighborlist is symmetric). After filling the blocks,
+                        ! tensor will be added to its transposed
+
+                        row = iatom; col = jatom
+
+                        IF (old_row(i_img_outer, j_img_outer) == row .AND. &
+                            old_col(i_img_outer, j_img_outer) == col) CYCLE
+
+                        ASSOCIATE (aRI=>alloc_RI(i_img_outer, j_img_outer))
+                           ASSOCIATE (a_ao1=>alloc_ao1(i_img_outer, j_img_outer))
+                              ASSOCIATE (a_ao2=>alloc_ao2(i_img_outer, j_img_outer))
+
+                                 new_block = .TRUE.
+                                 IF (ALLOCATED(a_ao1%array)) THEN
+                                    DO iblk = 1, SIZE(a_ao1%array)
+                                       IF (aRI%array(iblk) == atom_RI .AND. &
+                                           a_ao1%array(iblk) == row .AND. &
+                                           a_ao2%array(iblk) == col) THEN
+                                          new_block = .FALSE.
+                                          EXIT
+                                       ENDIF
+                                    ENDDO
+                                 ENDIF
+                                 IF (.NOT. new_block) CYCLE
+
+                                 IF (ALLOCATED(aRI%array)) THEN
+                                    blk_cnt = SIZE(aRI%array)
+                                    ALLOCATE (tmp(blk_cnt))
+                                    tmp(:) = aRI%array(:)
+                                    DEALLOCATE (aRI%array)
+                                    ALLOCATE (aRI%array(blk_cnt+1))
+                                    aRI%array(1:blk_cnt) = tmp(:)
+                                    aRI%array(blk_cnt+1) = atom_RI
+                                 ELSE
+                                    ALLOCATE (aRI%array(1))
+                                    aRI%array(1) = atom_RI
+                                 ENDIF
+
+                                 IF (ALLOCATED(a_ao1%array)) THEN
+                                    tmp(:) = a_ao1%array(:)
+                                    DEALLOCATE (a_ao1%array)
+                                    ALLOCATE (a_ao1%array(blk_cnt+1))
+                                    a_ao1%array(1:blk_cnt) = tmp(:)
+                                    a_ao1%array(blk_cnt+1) = row
+                                 ELSE
+                                    ALLOCATE (a_ao1%array(1))
+                                    a_ao1%array(1) = row
+                                 ENDIF
+
+                                 IF (ALLOCATED(a_ao2%array)) THEN
+                                    tmp(:) = a_ao2%array(:)
+                                    DEALLOCATE (a_ao2%array)
+                                    ALLOCATE (a_ao2%array(blk_cnt+1))
+                                    a_ao2%array(1:blk_cnt) = tmp(:)
+                                    a_ao2%array(blk_cnt+1) = col
+                                 ELSE
+                                    ALLOCATE (a_ao2%array(1))
+                                    a_ao2%array(1) = col
+                                 ENDIF
+
+                                 old_row(i_img_outer, j_img_outer) = row
+                                 old_col(i_img_outer, j_img_outer) = col
+
+                                 IF (ALLOCATED(tmp)) DEALLOCATE (tmp)
+                              END ASSOCIATE
+                           END ASSOCIATE
+                        END ASSOCIATE
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
+            CALL neighbor_list_iterator_release(nl_iterator)
+         ENDDO
+         CALL neighbor_list_iterator_release(nl_iterator_outer)
+      ENDDO
+
+      DO i_img = 1, nimg
+         DO j_img = 1, nimg
+            IF (i_img > j_img) CYCLE
+            IF (ALLOCATED(alloc_RI(i_img, j_img)%array)) THEN
+               DO i = 1, SIZE(alloc_RI(i_img, j_img)%array)
+                  CALL dbcsr_t_get_stored_coordinates(t_3c_overl_int(i_img, j_img), &
+                                                      [alloc_RI(i_img, j_img)%array(i), alloc_ao1(i_img, j_img)%array(i), &
+                                                       alloc_ao2(i_img, j_img)%array(i)], &
+                                                      iproc)
+                  CPASSERT(iproc .EQ. para_env%mepos)
+               ENDDO
+
+               CALL dbcsr_t_reserve_blocks(t_3c_overl_int(i_img, j_img), &
+                                           alloc_RI(i_img, j_img)%array, &
+                                           alloc_ao1(i_img, j_img)%array, &
+                                           alloc_ao2(i_img, j_img)%array)
+            ENDIF
+         ENDDO
+      ENDDO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+! **************************************************************************************************
 !> \brief compute three center overlap integrals and write them to mat_3_overl_int
 !> \param mat_3c_overl_int ...
 !> \param mat_munu ...
@@ -7004,6 +8132,7 @@ CONTAINS
       ALLOCATE (kind_of(natom))
       ALLOCATE (rows_to_alloc(nimg, nimg))
       ALLOCATE (cols_to_alloc(nimg, nimg))
+
       ALLOCATE (old_row(nimg, nimg))
       old_row = -1
       ALLOCATE (old_col(nimg, nimg))
@@ -7443,16 +8572,13 @@ CONTAINS
       END DO ! cut_RI
 
       DEALLOCATE (rows_to_alloc, cols_to_alloc)
-
       DEALLOCATE (atom_from_RI_index)
-
       DEALLOCATE (row_blk_start, row_blk_end)
 
       CALL timestop(handle)
 
    END SUBROUTINE
 
-!***************************************************************************************************
 ! **************************************************************************************************
 !> \brief ...
 !> \param mao_coeff_repl ...
@@ -7699,6 +8825,9 @@ CONTAINS
 !> \param my_group_L_starts_im_time ...
 !> \param my_group_L_ends_im_time ...
 !> \param my_group_L_sizes_im_time ...
+!> \param local_atoms_RI ...
+!> \param row_blk_sizes_RI_t ...
+!> \param row_dist_RI_t ...
 !> \param dimen_RI ...
 !> \param ngroup ...
 !> \param cut_memory ...
@@ -7707,11 +8836,14 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE setup_group_L_im_time(my_group_L_starts_im_time, my_group_L_ends_im_time, my_group_L_sizes_im_time, &
+                                    local_atoms_RI, row_blk_sizes_RI_t, row_dist_RI_t, &
                                     dimen_RI, ngroup, cut_memory, cut_RI, color_sub, qs_env)
 
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: my_group_L_starts_im_time, &
                                                             my_group_L_ends_im_time, &
-                                                            my_group_L_sizes_im_time
+                                                            my_group_L_sizes_im_time, &
+                                                            local_atoms_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: row_blk_sizes_RI_t, row_dist_RI_t
       INTEGER                                            :: dimen_RI, ngroup, cut_memory, cut_RI, &
                                                             color_sub
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -7719,17 +8851,25 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'setup_group_L_im_time', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: cut_RI_old, handle, iblk_RI, icut, &
-                                                            itmp(2), natom, nblks_RI, nkind, &
-                                                            size_RI, start_RI
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: ends_array_mem_cut, my_group_L_ends_im_time_tmp, &
-         my_group_L_starts_im_time_tmp, row_blk_end_RI, row_blk_offset_RI, sizes_array_mem_cut, &
-         starts_array_mem_cut
+      INTEGER                                            :: cut_RI_old, handle, iatom, iblk_RI, &
+                                                            icount, icut, itmp(2), natom, &
+                                                            nblks_RI, nkind, size_RI, start_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: ends_array_mem_cut, local_atom_RI_tmp, &
+         my_group_L_ends_im_time_tmp, my_group_L_starts_im_time_tmp, row_blk_end_RI, &
+         row_blk_offset_RI, sizes_array_mem_cut, starts_array_mem_cut
       INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes_RI
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_ri_aux
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+!bcount, fa, la, &
+!   fa_offset, la_offset, a
+!INTEGER, DIMENSION(2)                              :: group_limits
+!INTEGER, DIMENSION(0:ngroup - 1)            :: first_atom, last_atom, nblk_RI
+!INTEGER, DIMENSION(:), ALLOCATABLE          :: nblk_RI_offset
+
+      !INTEGER, ALLOCATABLE, DIMENSION(:,:), INTENT(OUT)  :: eri_offsets
 
       CALL timeset(routineN, handle)
 
@@ -7780,6 +8920,55 @@ CONTAINS
       CALL basis_set_list_setup(basis_set_ri_aux, "RI_AUX", qs_kind_set)
       CALL get_particle_set(particle_set, qs_kind_set, nsgf=row_blk_sizes_RI, basis=basis_set_ri_aux)
       DEALLOCATE (basis_set_ri_aux)
+
+      ALLOCATE (row_dist_RI_t(natom))
+      ALLOCATE (local_atom_RI_tmp(natom))
+      icount = 0
+      DO iatom = 1, natom
+         row_dist_RI_t(iatom) = MOD(iatom-1, ngroup)
+         IF (row_dist_RI_t(iatom) == color_sub) THEN
+            icount = icount+1
+            local_atom_RI_tmp(icount) = iatom
+         ENDIF
+      ENDDO
+      ALLOCATE (local_atoms_RI(icount))
+      local_atoms_RI(:) = local_atom_RI_tmp(1:icount)
+
+      ALLOCATE (row_blk_sizes_RI_t(natom))
+      row_blk_sizes_RI_t(:) = row_blk_sizes_RI(:)
+
+      !CALL get_eri_offsets(qs_env, "RI_AUX", eri_offsets)
+
+      !ALLOCATE(nblk_RI_offset(0:ngroup-1))
+      !DO igroup = 0, ngroup - 1
+      !   group_limits = get_limit(dimen_RI, ngroup, igroup)
+      !   first_atom(igroup) = eri_offsets(group_limits(1), 1)
+      !   last_atom(igroup) = eri_offsets(group_limits(2), 1)
+      !   nblk_RI(igroup) = last_atom(igroup) - first_atom(igroup) + 1
+      !   IF (igroup == 0) THEN
+      !      nblk_RI_offset(igroup) = 0
+      !   ELSE
+      !      nblk_RI_offset(igroup) = nblk_RI_offset(igroup - 1) + nblk_RI(igroup - 1)
+      !   ENDIF
+      !ENDDO
+
+      !ALLOCATE(row_blk_sizes_RI_t(SUM(nblk_RI))
+      !ALLOCATE(row_dist_RI_t(SUM(nblk_RI)))
+
+      !bcount = 0
+      !DO igroup = 0, ngroup = 1
+      !   group_limits = get_limit(dimen_RI, ngroup, igroup)
+      !   fa = first_atom(igroup); la = last_atom(igroup)
+      !   fa_offset = eri_offsets(group_limits(1), 4)
+      !   la_offset = eri_offsets(group_limits(2), 4)
+      !   row_blk_sizes_RI_t(bcount + 1) = row_blk_sizes_RI(bcount + 1) - fa_offset + 1
+      !   DO a = fa + 1, la - 1
+      !      row_blk_sizes_RI_t(bcount + 1 + a - fa) = row_blk_sizes_RI(a)
+      !   ENDDO
+      !   row_blk_sizes_RI_t(bcount + 1 + la - fa) = la_offset
+      !   row_dist_RI_t(bcount + 1:bcount + 1 + la - fa) = igroup
+      !   bcount = bcount + 1 + la - fa
+      !ENDDO
 
       ! check whether my_group_L_im_time covers different atoms. In this case, cut my_group_L_im_time
       ! especially improves memory a bit

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -68,7 +68,7 @@ MODULE mp2_ri_gpw
         dbcsr_t_distribution_destroy, dbcsr_t_distribution_new, dbcsr_t_distribution_type, &
         dbcsr_t_filter, dbcsr_t_get_block, dbcsr_t_get_stored_coordinates, dbcsr_t_pgrid_create, &
         dbcsr_t_pgrid_destroy, dbcsr_t_pgrid_type, dbcsr_t_put_block, dbcsr_t_reserve_blocks, &
-        dbcsr_t_set, dbcsr_t_split_blocks, dbcsr_t_type, mp_environ_pgrid
+        dbcsr_t_split_blocks, dbcsr_t_type, mp_environ_pgrid
    USE gaussian_gridlevels,             ONLY: gaussian_gridlevel
    USE input_constants,                 ONLY: do_eri_gpw,&
                                               do_eri_mme,&
@@ -853,7 +853,7 @@ CONTAINS
             CALL reserve_blocks_3c_t(t_3c_overl_int, mp_comm_t3c_overl, &
                                      ngroup_im_time, mat_munu, qs_env, &
                                      unit_nr, local_atoms_RI, row_blk_sizes_RI_t, row_dist_RI_t, &
-                                     sab_orb_sub, sab_orb_all, para_env, num_diff_blk)
+                                     sab_orb_sub, sab_orb_all, para_env)
          ELSE
             CALL reserve_blocks_3c(mat_3c_overl_int, &
                                    mat_munu, qs_env, &
@@ -920,8 +920,7 @@ CONTAINS
                                           mat_munu, &
                                           qs_env, &
                                           local_atoms_RI, &
-                                          sab_orb_sub, sab_orb_all, &
-                                          num_diff_blk)
+                                          sab_orb_sub, sab_orb_all)
          ELSE
             CALL compute_3c_overlap_int(mat_3c_overl_int, &
                                         mat_3c_overl_int_mao_for_occ, &
@@ -939,7 +938,7 @@ CONTAINS
             DO i = 1, SIZE(t_3c_overl_int, 1)
                DO j = 1, SIZE(t_3c_overl_int, 2)
 
-                  CALL dbcsr_t_copy(t_3c_overl_int(i, j), t_3c_O(i, j), move_data=.TRUE.)
+                  CALL dbcsr_t_copy(t_3c_overl_int(i, j), t_3c_O(i, j), order=[1, 3, 2], move_data=.TRUE.)
                   CALL dbcsr_t_filter(t_3c_O(i, j), qs_env%mp2_env%mp2_gpw%eps_filter)
                   CALL dbcsr_t_destroy(t_3c_overl_int(i, j))
                ENDDO
@@ -6478,10 +6477,9 @@ CONTAINS
 !> \param local_atoms_RI ...
 !> \param sab_orb_sub ...
 !> \param sab_orb_all ...
-!> \param num_diff_blk ...
 ! **************************************************************************************************
    SUBROUTINE compute_3c_overlap_int_t(t_3c_overl_int, filter_eps, mat_munu, qs_env, local_atoms_RI, &
-                                       sab_orb_sub, sab_orb_all, num_diff_blk)
+                                       sab_orb_sub, sab_orb_all)
 
       TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: t_3c_overl_int
@@ -6491,19 +6489,16 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: local_atoms_RI
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb_sub, sab_orb_all
-      INTEGER                                            :: num_diff_blk
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_3c_overlap_int_t', &
          routineP = moduleN//':'//routineN
 
       INTEGER :: acell, atom_RI, bcell, block_end_col, block_end_RI, block_end_row, &
          block_start_col, block_start_RI, block_start_row, col, handle, handle2, i_img, iatom, &
-         iatom_outer, iatom_RI, iblk_send, ikind, img_col, img_row, iset, j_img, jatom, &
-         jatom_outer, jkind, jset, kind_RI, maxval_1, maxval_2, maxval_3, mepos, minval_1, &
-         minval_2, minval_3, natom, nco_RI, ncoa, ncob, nimg, nset_RI, nseta, nsetb, nthread, row, &
-         set_RI, sgf_RI, sgfa, sgfb
+         iatom_outer, iatom_RI, ikind, img_col, img_row, iset, j_img, jatom, jatom_outer, jkind, &
+         jset, kind_RI, maxval_1, maxval_2, maxval_3, minval_1, minval_2, minval_3, natom, nco_RI, &
+         ncoa, ncob, nimg, nset_RI, nseta, nsetb, row, set_RI, sgf_RI, sgfa, sgfb
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: indices_for_uncommon_blocks
       INTEGER, DIMENSION(3)                              :: bcellvec, blk_size, cell_vec, &
                                                             outer_cell_vec, size_cell_to_index
       INTEGER, DIMENSION(:), POINTER :: col_blk_sizes, l_max_RI, l_min_RI, la_max, la_min, lb_max, &
@@ -6511,7 +6506,8 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_RI, first_sgfa, first_sgfb
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: debug, do_kpoints_cubic_RPA, found
-      REAL(KIND=dp)                                      :: dab, daRI, dbRI, prefac
+      REAL(KIND=dp)                                      :: dab, daRI, dbRI, kind_radius_a, &
+                                                            kind_radius_b, kind_radius_RI, prefac
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: block_t, dummy_block_t, s_abRI, &
                                                             s_abRI_contr
       REAL(KIND=dp), DIMENSION(3)                        :: rab, rab_outer, raRI, rbRI
@@ -6526,8 +6522,6 @@ CONTAINS
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: nl_iterator, nl_iterator_outer
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(two_dim_real_array), ALLOCATABLE, &
-         DIMENSION(:)                                    :: blocks_to_send_around
 
       CALL timeset(routineN, handle)
 
@@ -6541,9 +6535,6 @@ CONTAINS
                       natom=natom, kpoints=kpoints, dft_control=dft_control)
 
       do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
-      IF (do_kpoints_cubic_RPA) THEN
-         CPABORT("k points not yet implemented with DBCSR tensors")
-      ENDIF
 
       IF (do_kpoints_cubic_RPA) THEN
          ! No MAOs kpoints
@@ -6553,10 +6544,6 @@ CONTAINS
          size_cell_to_index(2) = SIZE(cell_to_index, 2)
          size_cell_to_index(3) = SIZE(cell_to_index, 3)
          ! 1: row, 2: col, 3: i_img, 4: j_img, 5: cut_RI, 6: proc_to_send
-         ALLOCATE (indices_for_uncommon_blocks(num_diff_blk, 6))
-         indices_for_uncommon_blocks(:, :) = 0
-         ALLOCATE (blocks_to_send_around(num_diff_blk))
-         iblk_send = 0
          minval_1 = MINVAL(kpoints%index_to_cell(1, :))
          maxval_1 = MAXVAL(kpoints%index_to_cell(1, :))
          minval_2 = MINVAL(kpoints%index_to_cell(2, :))
@@ -6591,9 +6578,9 @@ CONTAINS
          set_radius_RI => basis_set_RI%set_radius
          sphi_RI => basis_set_RI%sphi
          zet_RI => basis_set_RI%zet
+         kind_radius_RI = basis_set_RI%kind_radius
 
          CALL neighbor_list_iterator_create(nl_iterator_outer, sab_orb_all)
-
          DO WHILE (neighbor_list_iterate(nl_iterator_outer) == 0)
 
             CALL get_iterator_info(nl_iterator_outer, &
@@ -6602,20 +6589,13 @@ CONTAINS
 
             IF (iatom_outer .NE. atom_RI .AND. jatom_outer .NE. atom_RI) CYCLE
 
-            nthread = 1
-
-            CALL neighbor_list_iterator_create(nl_iterator, sab_orb_sub, nthread=nthread)
-
-            mepos = 0
-
-            DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
-
-               CALL get_iterator_info(nl_iterator, mepos=mepos, &
+            CALL neighbor_list_iterator_create(nl_iterator, sab_orb_sub)
+            DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+               CALL get_iterator_info(nl_iterator, &
                                       iatom=iatom, jatom=jatom, r=rab, &
                                       cell=cell_vec)
 
                DO i_img = 1, nimg
-
                   DO j_img = 1, nimg
 
                      IF (atom_RI .EQ. iatom_outer .AND. &
@@ -6637,8 +6617,8 @@ CONTAINS
                            IF (outer_cell_vec(1) > maxval_1) CYCLE
                            IF (outer_cell_vec(2) < minval_2) CYCLE
                            IF (outer_cell_vec(2) > maxval_2) CYCLE
-                           IF (outer_cell_vec(3) < minval_1) CYCLE
-                           IF (outer_cell_vec(3) > maxval_2) CYCLE
+                           IF (outer_cell_vec(3) < minval_3) CYCLE
+                           IF (outer_cell_vec(3) > maxval_3) CYCLE
 
                            acell = cell_to_index(-outer_cell_vec(1), -outer_cell_vec(2), -outer_cell_vec(3))
 
@@ -6702,41 +6682,47 @@ CONTAINS
                      img_row = i_img
                      img_col = j_img
 
+                     ikind = kind_of(iatom)
+                     CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=basis_set_a)
+                     kind_radius_a = basis_set_a%kind_radius
+                     first_sgfa => basis_set_a%first_sgf
+                     la_max => basis_set_a%lmax
+                     la_min => basis_set_a%lmin
+                     npgfa => basis_set_a%npgf
+                     nseta = basis_set_a%nset
+                     nsgfa => basis_set_a%nsgf_set
+                     rpgfa => basis_set_a%pgf_radius
+                     set_radius_a => basis_set_a%set_radius
+                     sphi_a => basis_set_a%sphi
+                     zeta => basis_set_a%zet
+
+                     jkind = kind_of(jatom)
+                     CALL get_qs_kind(qs_kind=qs_kind_set(jkind), basis_set=basis_set_b)
+                     kind_radius_b = basis_set_b%kind_radius
+                     first_sgfb => basis_set_b%first_sgf
+                     lb_max => basis_set_b%lmax
+                     lb_min => basis_set_b%lmin
+                     npgfb => basis_set_b%npgf
+                     nsetb = basis_set_b%nset
+                     nsgfb => basis_set_b%nsgf_set
+                     rpgfb => basis_set_b%pgf_radius
+                     set_radius_b => basis_set_b%set_radius
+                     sphi_b => basis_set_b%sphi
+                     zetb => basis_set_b%zet
+
+                     dab = SQRT(SUM(rab**2))
+                     daRI = SQRT(SUM(raRI**2))
+                     dbRI = SQRT(SUM(rbRI**2))
+
+                     IF (kind_radius_a+kind_radius_RI < daRI) CYCLE
+                     IF (kind_radius_a+kind_radius_b < dab) CYCLE
+                     IF (kind_radius_b+kind_radius_RI < dbRI) CYCLE
+
                      CALL dbcsr_t_blk_sizes(t_3c_overl_int(img_row, img_col), [atom_RI, row, col], blk_size)
                      ALLOCATE (block_t(blk_size(1), blk_size(2), blk_size(3)))
                      block_t = 0.0_dp
 
                      DO set_RI = 1, nset_RI
-
-                        dab = SQRT(SUM(rab**2))
-                        daRI = SQRT(SUM(raRI**2))
-                        dbRI = SQRT(SUM(rbRI**2))
-
-                        ikind = kind_of(iatom)
-                        CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=basis_set_a)
-                        first_sgfa => basis_set_a%first_sgf
-                        la_max => basis_set_a%lmax
-                        la_min => basis_set_a%lmin
-                        npgfa => basis_set_a%npgf
-                        nseta = basis_set_a%nset
-                        nsgfa => basis_set_a%nsgf_set
-                        rpgfa => basis_set_a%pgf_radius
-                        set_radius_a => basis_set_a%set_radius
-                        sphi_a => basis_set_a%sphi
-                        zeta => basis_set_a%zet
-
-                        jkind = kind_of(jatom)
-                        CALL get_qs_kind(qs_kind=qs_kind_set(jkind), basis_set=basis_set_b)
-                        first_sgfb => basis_set_b%first_sgf
-                        lb_max => basis_set_b%lmax
-                        lb_min => basis_set_b%lmin
-                        npgfb => basis_set_b%npgf
-                        nsetb = basis_set_b%nset
-                        nsgfb => basis_set_b%nsgf_set
-                        rpgfb => basis_set_b%pgf_radius
-                        set_radius_b => basis_set_b%set_radius
-                        sphi_b => basis_set_b%sphi
-                        zetb => basis_set_b%zet
 
                         DO iset = 1, nseta
 
@@ -6779,13 +6765,7 @@ CONTAINS
                                  block_start_RI = sgf_RI
                                  block_end_RI = sgf_RI+nsgf_RI(set_RI)-1
 
-                                 IF (iatom == jatom) THEN
-                                    ! factor 0.5 is necessary because matrix is added to its transpose
-                                    prefac = 0.5_dp
-                                 ELSE
-                                    ! factor 0.5 is necessary due to double filling due to double iterate loop
-                                    prefac = 0.5_dp
-                                 ENDIF
+                                 prefac = 0.5_dp
 
                                  block_t(block_start_RI:block_end_RI, &
                                          block_start_row:block_end_row, &
@@ -6834,23 +6814,29 @@ CONTAINS
 
       END DO ! atom_RI
 
-      ! add transposed of overlap integrals:
       DO img_row = 1, nimg
          DO img_col = 1, nimg
-            ! we need to take half of filter_eps, since we are adding tensor to its transpose afterwards
+            ! need half of filter eps because afterwards we add transposed tensor
             CALL dbcsr_t_filter(t_3c_overl_int(img_row, img_col), filter_eps/2)
          ENDDO
       ENDDO
+
+      ! add transposed of overlap integrals
       CALL dbcsr_t_create(t_3c_overl_int(1, 1), t_3c_tmp)
       DO img_row = 1, nimg
-         DO img_col = 1, nimg
+         DO img_col = 1, img_row
             CALL dbcsr_t_copy(t_3c_overl_int(img_row, img_col), t_3c_tmp)
-            CALL dbcsr_t_copy(t_3c_tmp, t_3c_overl_int(img_row, img_col), order=[1, 3, 2], summation=.TRUE., move_data=.TRUE.)
-            CALL dbcsr_t_filter(t_3c_overl_int(img_row, img_col), filter_eps)
+            CALL dbcsr_t_copy(t_3c_tmp, t_3c_overl_int(img_col, img_row), order=[1, 3, 2], summation=.TRUE., move_data=.TRUE.)
+            CALL dbcsr_t_filter(t_3c_overl_int(img_col, img_row), filter_eps)
          ENDDO
       ENDDO
-      CALL dbcsr_t_set(t_3c_tmp, 0.0_dp)
-      CALL dbcsr_t_filter(t_3c_tmp, 1.0_dp)
+      DO img_row = 1, nimg
+         DO img_col = img_row+1, nimg
+            CALL dbcsr_t_copy(t_3c_overl_int(img_row, img_col), t_3c_tmp)
+            CALL dbcsr_t_copy(t_3c_tmp, t_3c_overl_int(img_col, img_row), order=[1, 3, 2], summation=.FALSE., move_data=.TRUE.)
+            CALL dbcsr_t_filter(t_3c_overl_int(img_col, img_row), filter_eps)
+         ENDDO
+      ENDDO
       CALL dbcsr_t_destroy(t_3c_tmp)
 
       CALL timestop(handle)
@@ -7585,10 +7571,9 @@ CONTAINS
 !> \param sab_orb_sub ...
 !> \param sab_orb_all ...
 !> \param para_env ...
-!> \param num_diff_blk ...
 ! **************************************************************************************************
    SUBROUTINE reserve_blocks_3c_t(t_3c_overl_int, mp_comm_t3c_overl, ngroup, mat_munu, qs_env, &
-                       unit_nr, local_atoms_RI, row_blk_sizes_RI_t, row_dist_RI_t, sab_orb_sub, sab_orb_all, para_env, num_diff_blk)
+                                  unit_nr, local_atoms_RI, row_blk_sizes_RI_t, row_dist_RI_t, sab_orb_sub, sab_orb_all, para_env)
       TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(OUT)                                     :: t_3c_overl_int
       TYPE(dbcsr_t_pgrid_type), INTENT(IN)               :: mp_comm_t3c_overl
@@ -7601,15 +7586,14 @@ CONTAINS
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb_sub, sab_orb_all
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER                                            :: num_diff_blk
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'reserve_blocks_3c_t', &
          routineP = moduleN//':'//routineN
 
-      INTEGER :: acell, atom_RI, bcell, blk_cnt, col, handle, i, i_img, i_img_outer, i_loop, &
-         iatom, iatom_outer, iatom_RI, iblk, ikind, iproc, j_img, j_img_outer, jatom, jatom_outer, &
-         jkind, kind_RI, maxval_1, maxval_2, maxval_3, minval_1, minval_2, minval_3, natom, nimg, &
-         nset_RI, nseta, nsetb, num_loops, row
+      INTEGER :: acell, atom_RI, bcell, blk_cnt, col, handle, i, i_img, i_img_outer, iatom, &
+         iatom_outer, iatom_RI, iblk, ikind, iproc, j_img, j_img_outer, jatom, jatom_outer, jkind, &
+         kind_RI, maxval_1, maxval_2, maxval_3, minval_1, minval_2, minval_3, natom, nimg, &
+         nset_RI, nseta, nsetb, row
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of, tmp
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: old_col, old_row
       INTEGER, DIMENSION(3)                              :: cell_vec, outer_cell_vec
@@ -7640,9 +7624,6 @@ CONTAINS
       NULLIFY (qs_kind_set, atomic_kind_set, basis_set_RI, basis_set_a, basis_set_b, nl_iterator)
 
       do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
-      IF (do_kpoints_cubic_RPA) THEN
-         CPABORT("k points not yet implemented with DBCSR tensors")
-      ENDIF
 
       CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, natom=natom, &
                       dft_control=dft_control, kpoints=kpoints)
@@ -7650,8 +7631,6 @@ CONTAINS
       IF (do_kpoints_cubic_RPA) THEN
          ! set up new kpoint type with periodic images according to eps_grid from MP2 section
          ! instead of eps_pgf_orb from QS section
-         CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
-
          CALL kpoint_init_cell_index(kpoints, sab_orb_sub, para_env, dft_control)
 
          nimg = dft_control%nimages
@@ -7659,8 +7638,6 @@ CONTAINS
 
          IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
             "3C_OVERLAP_INTEGRALS_INFO| Number of periodic images considered:", nimg
-
-         num_diff_blk = 0
       ELSE
          nimg = 1
       END IF
@@ -7678,7 +7655,6 @@ CONTAINS
 
       DO i_img = 1, nimg
          DO j_img = 1, nimg
-            IF (i_img > j_img) CYCLE
             CALL dbcsr_t_create(t_3c_overl_int(i_img, j_img), "O (RI AO | AO)", dist_o3c, [1, 2], [3], &
                                 dbcsr_type_real_8, row_blk_sizes_RI_t, ao_blk_sizes, ao_blk_sizes)
          ENDDO
@@ -7686,20 +7662,31 @@ CONTAINS
 
       CALL dbcsr_t_distribution_destroy(dist_o3c)
 
+      IF (do_kpoints_cubic_RPA) THEN
+
+         minval_1 = MINVAL(kpoints%index_to_cell(1, :))
+         maxval_1 = MAXVAL(kpoints%index_to_cell(1, :))
+         minval_2 = MINVAL(kpoints%index_to_cell(2, :))
+         maxval_2 = MAXVAL(kpoints%index_to_cell(2, :))
+         minval_3 = MINVAL(kpoints%index_to_cell(3, :))
+         maxval_3 = MAXVAL(kpoints%index_to_cell(3, :))
+
+      END IF
+
       ALLOCATE (alloc_RI(nimg, nimg))
       ALLOCATE (alloc_ao1(nimg, nimg))
       ALLOCATE (alloc_ao2(nimg, nimg))
       !ALLOCATE (old_ri(nimg, nimg))
       !old_ri = -1
-      ALLOCATE (old_row(nimg, nimg))
-      old_row = -1
       ALLOCATE (old_col(nimg, nimg))
       old_col = -1
 
       ALLOCATE (kind_of(natom))
       CALL get_atomic_kind_set(atomic_kind_set, kind_of=kind_of)
 
+      ALLOCATE (old_row(nimg, nimg))
       DO iatom_RI = 1, SIZE(local_atoms_RI)
+         old_row = -1
          atom_RI = local_atoms_RI(iatom_RI)
          kind_RI = kind_of(atom_RI)
          CALL get_qs_kind(qs_kind=qs_kind_set(kind_RI), basis_set=basis_set_RI, basis_type="RI_AUX")
@@ -7734,205 +7721,190 @@ CONTAINS
                DO i_img_outer = 1, nimg
                   DO j_img_outer = 1, nimg
 
-                     IF (i_img_outer > j_img_outer) CYCLE
-                     IF (i_img_outer < j_img_outer) THEN
-                        num_loops = 2
-                     ELSE IF (i_img_outer == j_img_outer) THEN
-                        num_loops = 1
+                     i_img = i_img_outer
+                     j_img = j_img_outer
+
+                     IF (atom_RI .EQ. iatom_outer .AND. &
+                         iatom .NE. jatom_outer .AND. &
+                         jatom .NE. jatom_outer) &
+                        CYCLE
+
+                     IF (atom_RI .EQ. jatom_outer .AND. &
+                         iatom .NE. iatom_outer .AND. &
+                         jatom .NE. iatom_outer) &
+                        CYCLE
+
+                     IF (iatom .EQ. iatom_outer .AND. &
+                         atom_RI .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+
+                           IF (outer_cell_vec(1) < minval_1) CYCLE
+                           IF (outer_cell_vec(1) > maxval_1) CYCLE
+                           IF (outer_cell_vec(2) < minval_2) CYCLE
+                           IF (outer_cell_vec(2) > maxval_2) CYCLE
+                           IF (outer_cell_vec(3) < minval_3) CYCLE
+                           IF (outer_cell_vec(3) > maxval_3) CYCLE
+
+                           IF (-outer_cell_vec(1)+cell_vec(1) < minval_1) CYCLE
+                           IF (-outer_cell_vec(1)+cell_vec(1) > maxval_1) CYCLE
+                           IF (-outer_cell_vec(2)+cell_vec(2) < minval_2) CYCLE
+                           IF (-outer_cell_vec(2)+cell_vec(2) > maxval_2) CYCLE
+                           IF (-outer_cell_vec(3)+cell_vec(3) < minval_3) CYCLE
+                           IF (-outer_cell_vec(3)+cell_vec(3) > maxval_3) CYCLE
+
+                           acell = cell_to_index(-outer_cell_vec(1), -outer_cell_vec(2), -outer_cell_vec(3))
+                           IF (.NOT. (acell == i_img)) CYCLE
+                           bcell = cell_to_index(-outer_cell_vec(1)+cell_vec(1), &
+                                                 -outer_cell_vec(2)+cell_vec(2), &
+                                                 -outer_cell_vec(3)+cell_vec(3))
+                           IF (.NOT. (bcell == j_img)) CYCLE
+
+                        END IF
+
+                        raRI = rab_outer
+                        rbRI = raRI-rab
+
+                     ELSE IF (atom_RI .EQ. iatom_outer .AND. &
+                              iatom .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+                           ! for kpoints we have the non-symmetric neighbor list
+                           CYCLE
+                        END IF
+
+                        raRI = -rab_outer
+                        rbRI = raRI-rab
+
+                     ELSE IF (jatom .EQ. iatom_outer .AND. &
+                              atom_RI .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+                           ! for kpoints we have the non-symmetric neighbor list
+                           CYCLE
+                        END IF
+
+                        rbRI = rab_outer
+                        raRI = rbRI+rab
+
+                     ELSE IF (atom_RI .EQ. iatom_outer .AND. &
+                              jatom .EQ. jatom_outer) THEN
+
+                        IF (do_kpoints_cubic_RPA) THEN
+                           ! for kpoints we have the non-symmetric neighbor list
+                           CYCLE
+                        END IF
+
+                        rbRI = -rab_outer
+                        raRI = rbRI+rab
+
                      END IF
 
-                     DO i_loop = 1, num_loops
+                     dab = SQRT(SUM(rab**2))
+                     daRI = SQRT(SUM(raRI**2))
+                     dbRI = SQRT(SUM(rbRI**2))
 
-                        IF (i_loop == 1) THEN
-                           i_img = i_img_outer
-                           j_img = j_img_outer
-                        ELSE IF (i_loop == 2) THEN
-                           i_img = j_img_outer
-                           j_img = i_img_outer
-                        END IF
+                     ikind = kind_of(iatom)
+                     CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=basis_set_a)
+                     first_sgfa => basis_set_a%first_sgf
+                     la_max => basis_set_a%lmax
+                     la_min => basis_set_a%lmin
+                     npgfa => basis_set_a%npgf
+                     nseta = basis_set_a%nset
+                     nsgfa => basis_set_a%nsgf_set
+                     rpgfa => basis_set_a%pgf_radius
+                     set_radius_a => basis_set_a%set_radius
+                     sphi_a => basis_set_a%sphi
+                     zeta => basis_set_a%zet
+                     kind_radius_a = basis_set_a%kind_radius
 
-                        IF (atom_RI .EQ. iatom_outer .AND. &
-                            iatom .NE. jatom_outer .AND. &
-                            jatom .NE. jatom_outer) &
-                           CYCLE
+                     jkind = kind_of(jatom)
+                     CALL get_qs_kind(qs_kind=qs_kind_set(jkind), basis_set=basis_set_b)
+                     first_sgfb => basis_set_b%first_sgf
+                     lb_max => basis_set_b%lmax
+                     lb_min => basis_set_b%lmin
+                     npgfb => basis_set_b%npgf
+                     nsetb = basis_set_b%nset
+                     nsgfb => basis_set_b%nsgf_set
+                     rpgfb => basis_set_b%pgf_radius
+                     set_radius_b => basis_set_b%set_radius
+                     kind_radius_b = basis_set_b%kind_radius
+                     sphi_b => basis_set_b%sphi
+                     zetb => basis_set_b%zet
 
-                        IF (atom_RI .EQ. jatom_outer .AND. &
-                            iatom .NE. iatom_outer .AND. &
-                            jatom .NE. iatom_outer) &
-                           CYCLE
+                     IF (kind_radius_a+kind_radius_RI < daRI) CYCLE
+                     IF (kind_radius_a+kind_radius_b < dab) CYCLE
+                     IF (kind_radius_b+kind_radius_RI < dbRI) CYCLE
 
-                        IF (iatom .EQ. iatom_outer .AND. &
-                            atom_RI .EQ. jatom_outer) THEN
+                     ! tensor is not symmetric therefore need to allocate rows and columns in
+                     ! correspondence with neighborlist. Note that this only allocates half
+                     ! of the blocks (since neighborlist is symmetric). After filling the blocks,
+                     ! tensor will be added to its transposed
 
-                           IF (do_kpoints_cubic_RPA) THEN
+                     row = iatom; col = jatom
 
-                              IF (outer_cell_vec(1) < minval_1) CYCLE
-                              IF (outer_cell_vec(1) > maxval_1) CYCLE
-                              IF (outer_cell_vec(2) < minval_2) CYCLE
-                              IF (outer_cell_vec(2) > maxval_2) CYCLE
-                              IF (outer_cell_vec(3) < minval_3) CYCLE
-                              IF (outer_cell_vec(3) > maxval_3) CYCLE
+                     IF (old_row(i_img_outer, j_img_outer) == row .AND. &
+                         old_col(i_img_outer, j_img_outer) == col) CYCLE
 
-                              IF (-outer_cell_vec(1)+cell_vec(1) < minval_1) CYCLE
-                              IF (-outer_cell_vec(1)+cell_vec(1) > maxval_1) CYCLE
-                              IF (-outer_cell_vec(2)+cell_vec(2) < minval_2) CYCLE
-                              IF (-outer_cell_vec(2)+cell_vec(2) > maxval_2) CYCLE
-                              IF (-outer_cell_vec(3)+cell_vec(3) < minval_3) CYCLE
-                              IF (-outer_cell_vec(3)+cell_vec(3) > maxval_3) CYCLE
+                     ASSOCIATE (aRI=>alloc_RI(i_img_outer, j_img_outer))
+                        ASSOCIATE (a_ao1=>alloc_ao1(i_img_outer, j_img_outer))
+                           ASSOCIATE (a_ao2=>alloc_ao2(i_img_outer, j_img_outer))
 
-                              acell = cell_to_index(-outer_cell_vec(1), -outer_cell_vec(2), -outer_cell_vec(3))
-                              IF (.NOT. (acell == i_img)) CYCLE
-                              bcell = cell_to_index(-outer_cell_vec(1)+cell_vec(1), &
-                                                    -outer_cell_vec(2)+cell_vec(2), &
-                                                    -outer_cell_vec(3)+cell_vec(3))
-                              IF (.NOT. (bcell == j_img)) CYCLE
+                              new_block = .TRUE.
+                              IF (ALLOCATED(a_ao1%array)) THEN
+                                 DO iblk = 1, SIZE(a_ao1%array)
+                                    IF (aRI%array(iblk) == atom_RI .AND. &
+                                        a_ao1%array(iblk) == row .AND. &
+                                        a_ao2%array(iblk) == col) THEN
+                                       new_block = .FALSE.
+                                       EXIT
+                                    ENDIF
+                                 ENDDO
+                              ENDIF
+                              IF (.NOT. new_block) CYCLE
 
-                           END IF
+                              IF (ALLOCATED(aRI%array)) THEN
+                                 blk_cnt = SIZE(aRI%array)
+                                 ALLOCATE (tmp(blk_cnt))
+                                 tmp(:) = aRI%array(:)
+                                 DEALLOCATE (aRI%array)
+                                 ALLOCATE (aRI%array(blk_cnt+1))
+                                 aRI%array(1:blk_cnt) = tmp(:)
+                                 aRI%array(blk_cnt+1) = atom_RI
+                              ELSE
+                                 ALLOCATE (aRI%array(1))
+                                 aRI%array(1) = atom_RI
+                              ENDIF
 
-                           raRI = rab_outer
-                           rbRI = raRI-rab
+                              IF (ALLOCATED(a_ao1%array)) THEN
+                                 tmp(:) = a_ao1%array(:)
+                                 DEALLOCATE (a_ao1%array)
+                                 ALLOCATE (a_ao1%array(blk_cnt+1))
+                                 a_ao1%array(1:blk_cnt) = tmp(:)
+                                 a_ao1%array(blk_cnt+1) = row
+                              ELSE
+                                 ALLOCATE (a_ao1%array(1))
+                                 a_ao1%array(1) = row
+                              ENDIF
 
-                        ELSE IF (atom_RI .EQ. iatom_outer .AND. &
-                                 iatom .EQ. jatom_outer) THEN
+                              IF (ALLOCATED(a_ao2%array)) THEN
+                                 tmp(:) = a_ao2%array(:)
+                                 DEALLOCATE (a_ao2%array)
+                                 ALLOCATE (a_ao2%array(blk_cnt+1))
+                                 a_ao2%array(1:blk_cnt) = tmp(:)
+                                 a_ao2%array(blk_cnt+1) = col
+                              ELSE
+                                 ALLOCATE (a_ao2%array(1))
+                                 a_ao2%array(1) = col
+                              ENDIF
 
-                           IF (do_kpoints_cubic_RPA) THEN
-                              ! for kpoints we have the non-symmetric neighbor list
-                              CYCLE
-                           END IF
+                              old_row(i_img_outer, j_img_outer) = row
+                              old_col(i_img_outer, j_img_outer) = col
 
-                           raRI = -rab_outer
-                           rbRI = raRI-rab
-
-                        ELSE IF (jatom .EQ. iatom_outer .AND. &
-                                 atom_RI .EQ. jatom_outer) THEN
-
-                           IF (do_kpoints_cubic_RPA) THEN
-                              ! for kpoints we have the non-symmetric neighbor list
-                              CYCLE
-                           END IF
-
-                           rbRI = rab_outer
-                           raRI = rbRI+rab
-
-                        ELSE IF (atom_RI .EQ. iatom_outer .AND. &
-                                 jatom .EQ. jatom_outer) THEN
-
-                           IF (do_kpoints_cubic_RPA) THEN
-                              ! for kpoints we have the non-symmetric neighbor list
-                              CYCLE
-                           END IF
-
-                           rbRI = -rab_outer
-                           raRI = rbRI+rab
-
-                        END IF
-
-                        dab = SQRT(SUM(rab**2))
-                        daRI = SQRT(SUM(raRI**2))
-                        dbRI = SQRT(SUM(rbRI**2))
-
-                        ikind = kind_of(iatom)
-                        CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=basis_set_a)
-                        first_sgfa => basis_set_a%first_sgf
-                        la_max => basis_set_a%lmax
-                        la_min => basis_set_a%lmin
-                        npgfa => basis_set_a%npgf
-                        nseta = basis_set_a%nset
-                        nsgfa => basis_set_a%nsgf_set
-                        rpgfa => basis_set_a%pgf_radius
-                        set_radius_a => basis_set_a%set_radius
-                        sphi_a => basis_set_a%sphi
-                        zeta => basis_set_a%zet
-                        kind_radius_a = basis_set_a%kind_radius
-
-                        jkind = kind_of(jatom)
-                        CALL get_qs_kind(qs_kind=qs_kind_set(jkind), basis_set=basis_set_b)
-                        first_sgfb => basis_set_b%first_sgf
-                        lb_max => basis_set_b%lmax
-                        lb_min => basis_set_b%lmin
-                        npgfb => basis_set_b%npgf
-                        nsetb = basis_set_b%nset
-                        nsgfb => basis_set_b%nsgf_set
-                        rpgfb => basis_set_b%pgf_radius
-                        set_radius_b => basis_set_b%set_radius
-                        kind_radius_b = basis_set_b%kind_radius
-                        sphi_b => basis_set_b%sphi
-                        zetb => basis_set_b%zet
-
-                        IF (kind_radius_a+kind_radius_RI < daRI) CYCLE
-                        IF (kind_radius_a+kind_radius_b < dab) CYCLE
-                        IF (kind_radius_b+kind_radius_RI < dbRI) CYCLE
-
-                        ! tensor is not symmetric therefore need to allocate rows and columns in
-                        ! correspondence with neighborlist. Note that this only allocates half
-                        ! of the blocks (since neighborlist is symmetric). After filling the blocks,
-                        ! tensor will be added to its transposed
-
-                        row = iatom; col = jatom
-
-                        IF (old_row(i_img_outer, j_img_outer) == row .AND. &
-                            old_col(i_img_outer, j_img_outer) == col) CYCLE
-
-                        ASSOCIATE (aRI=>alloc_RI(i_img_outer, j_img_outer))
-                           ASSOCIATE (a_ao1=>alloc_ao1(i_img_outer, j_img_outer))
-                              ASSOCIATE (a_ao2=>alloc_ao2(i_img_outer, j_img_outer))
-
-                                 new_block = .TRUE.
-                                 IF (ALLOCATED(a_ao1%array)) THEN
-                                    DO iblk = 1, SIZE(a_ao1%array)
-                                       IF (aRI%array(iblk) == atom_RI .AND. &
-                                           a_ao1%array(iblk) == row .AND. &
-                                           a_ao2%array(iblk) == col) THEN
-                                          new_block = .FALSE.
-                                          EXIT
-                                       ENDIF
-                                    ENDDO
-                                 ENDIF
-                                 IF (.NOT. new_block) CYCLE
-
-                                 IF (ALLOCATED(aRI%array)) THEN
-                                    blk_cnt = SIZE(aRI%array)
-                                    ALLOCATE (tmp(blk_cnt))
-                                    tmp(:) = aRI%array(:)
-                                    DEALLOCATE (aRI%array)
-                                    ALLOCATE (aRI%array(blk_cnt+1))
-                                    aRI%array(1:blk_cnt) = tmp(:)
-                                    aRI%array(blk_cnt+1) = atom_RI
-                                 ELSE
-                                    ALLOCATE (aRI%array(1))
-                                    aRI%array(1) = atom_RI
-                                 ENDIF
-
-                                 IF (ALLOCATED(a_ao1%array)) THEN
-                                    tmp(:) = a_ao1%array(:)
-                                    DEALLOCATE (a_ao1%array)
-                                    ALLOCATE (a_ao1%array(blk_cnt+1))
-                                    a_ao1%array(1:blk_cnt) = tmp(:)
-                                    a_ao1%array(blk_cnt+1) = row
-                                 ELSE
-                                    ALLOCATE (a_ao1%array(1))
-                                    a_ao1%array(1) = row
-                                 ENDIF
-
-                                 IF (ALLOCATED(a_ao2%array)) THEN
-                                    tmp(:) = a_ao2%array(:)
-                                    DEALLOCATE (a_ao2%array)
-                                    ALLOCATE (a_ao2%array(blk_cnt+1))
-                                    a_ao2%array(1:blk_cnt) = tmp(:)
-                                    a_ao2%array(blk_cnt+1) = col
-                                 ELSE
-                                    ALLOCATE (a_ao2%array(1))
-                                    a_ao2%array(1) = col
-                                 ENDIF
-
-                                 old_row(i_img_outer, j_img_outer) = row
-                                 old_col(i_img_outer, j_img_outer) = col
-
-                                 IF (ALLOCATED(tmp)) DEALLOCATE (tmp)
-                              END ASSOCIATE
+                              IF (ALLOCATED(tmp)) DEALLOCATE (tmp)
                            END ASSOCIATE
                         END ASSOCIATE
-                     ENDDO
+                     END ASSOCIATE
                   ENDDO
                ENDDO
             ENDDO
@@ -7943,7 +7915,6 @@ CONTAINS
 
       DO i_img = 1, nimg
          DO j_img = 1, nimg
-            IF (i_img > j_img) CYCLE
             IF (ALLOCATED(alloc_RI(i_img, j_img)%array)) THEN
                DO i = 1, SIZE(alloc_RI(i_img, j_img)%array)
                   CALL dbcsr_t_get_stored_coordinates(t_3c_overl_int(i_img, j_img), &

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -296,6 +296,11 @@ CONTAINS
       CALL section_vals_val_get(im_time_section, "RI_G0W0", &
                                 l_val=mp2_env%ri_rpa_im_time%do_gw_im_time)
 
+      CALL section_vals_val_get(mp2_section, "IM_TIME%DO_DBCSR_T", &
+                                l_val=mp2_env%ri_rpa_im_time%do_dbcsr_t)
+      CALL section_vals_val_get(mp2_section, "IM_TIME%MAX_BLOCK_SIZE_SQRT", &
+                                i_val=mp2_env%ri_rpa_im_time%max_bsize_sqrt)
+
       CALL section_vals_val_get(mp2_section, "RI_LAPLACE%QUADRATURE_POINTS", &
                                 i_val=mp2_env%ri_laplace%n_quadrature)
       CALL section_vals_val_get(mp2_section, "RI_LAPLACE%SIZE_INTEG_GROUP", &

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -145,6 +145,8 @@ MODULE mp2_types
       INTEGER, DIMENSION(:), POINTER     :: nmao_occ, nmao_virt
       LOGICAL                  :: do_gw_im_time, do_im_time_kpoints
       REAL(KIND=dp)            :: stabilize_exp
+      LOGICAL  :: do_dbcsr_t
+      INTEGER  :: max_bsize_sqrt
    END TYPE
 
    TYPE ri_g0w0_type

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -32,8 +32,14 @@ MODULE rpa_im_time
         dbcsr_get_info, dbcsr_get_num_blocks, dbcsr_get_occupation, dbcsr_get_stored_coordinates, &
         dbcsr_init_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
         dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_p_type, dbcsr_release_p, &
-        dbcsr_reserve_all_blocks, dbcsr_reserve_blocks, dbcsr_scale, dbcsr_set, dbcsr_transposed, &
-        dbcsr_type, dbcsr_type_no_symmetry
+        dbcsr_reserve_all_blocks, dbcsr_reserve_blocks, dbcsr_scalar, dbcsr_scale, dbcsr_set, &
+        dbcsr_transposed, dbcsr_type, dbcsr_type_no_symmetry
+   USE dbcsr_tensor_api,                ONLY: &
+        dbcsr_t_contract, dbcsr_t_copy, dbcsr_t_copy_matrix_to_tensor, &
+        dbcsr_t_copy_tensor_to_matrix, dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_filter, &
+        dbcsr_t_get_block, dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_next_block, &
+        dbcsr_t_iterator_start, dbcsr_t_iterator_stop, dbcsr_t_iterator_type, &
+        dbcsr_t_need_contract, dbcsr_t_put_block, dbcsr_t_reserve_blocks, dbcsr_t_set, dbcsr_t_type
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE kpoint_types,                    ONLY: get_kpoint_info,&
@@ -70,9 +76,353 @@ MODULE rpa_im_time
              get_mat_3c_overl_int_gw, &
              reflect_mat_row, &
              zero_mat_P_omega, &
-             gap_and_max_eig_diff_kpoints
+             gap_and_max_eig_diff_kpoints, &
+             setup_tensor_for_mem_cut_3c
 
 CONTAINS
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_P_omega ...
+!> \param mat_P_omega_im_part ...
+!> \param fm_scaled_dm_occ_tau ...
+!> \param fm_scaled_dm_virt_tau ...
+!> \param fm_mo_coeff_occ ...
+!> \param fm_mo_coeff_virt ...
+!> \param fm_mo_coeff_occ_scaled ...
+!> \param fm_mo_coeff_virt_scaled ...
+!> \param mat_P_global ...
+!> \param matrix_s ...
+!> \param mao_coeff_occ ...
+!> \param mao_coeff_virt ...
+!> \param ispin ...
+!> \param t_3c_M ...
+!> \param t_3c_O_cut ...
+!> \param starts_array_mc_t ...
+!> \param ends_array_mc_t ...
+!> \param weights_cos_tf_t_to_w ...
+!> \param tj ...
+!> \param tau_tj ...
+!> \param e_fermi ...
+!> \param eps_filter ...
+!> \param alpha ...
+!> \param eps_filter_im_time ...
+!> \param Eigenval ...
+!> \param nmo ...
+!> \param num_integ_points ...
+!> \param jquad ...
+!> \param cut_memory ...
+!> \param unit_nr ...
+!> \param mp2_env ...
+!> \param para_env ...
+!> \param stabilize_exp ...
+!> \param qs_env ...
+!> \param index_to_cell_3c ...
+!> \param cell_to_index_3c ...
+!> \param do_ri_sos_laplace_mp2 ...
+! **************************************************************************************************
+   SUBROUTINE compute_mat_P_omega_t(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+                                    fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                    mat_P_global, &
+                                    matrix_s, mao_coeff_occ, &
+                                    mao_coeff_virt, ispin, &
+                                    t_3c_M, t_3c_O_cut, &
+                                    starts_array_mc_t, ends_array_mc_t, &
+                                    weights_cos_tf_t_to_w, &
+                                    tj, tau_tj, e_fermi, eps_filter, &
+                                    alpha, eps_filter_im_time, Eigenval, nmo, &
+                                    num_integ_points, jquad, cut_memory, unit_nr, &
+                                    mp2_env, para_env, &
+                                    stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
+                                    do_ri_sos_laplace_mp2)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_im_part
+      TYPE(cp_fm_type), POINTER :: fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, fm_mo_coeff_occ, &
+         fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled
+      TYPE(dbcsr_p_type)                                 :: mat_P_global
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mao_coeff_occ, mao_coeff_virt
+      INTEGER                                            :: ispin
+      TYPE(dbcsr_t_type), INTENT(INOUT)                  :: t_3c_M
+      TYPE(dbcsr_t_type), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(INOUT)               :: t_3c_O_cut
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc_t, ends_array_mc_t
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj, tau_tj
+      REAL(KIND=dp)                                      :: e_fermi, eps_filter, alpha, &
+                                                            eps_filter_im_time
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      INTEGER                                            :: nmo, num_integ_points, jquad, &
+                                                            cut_memory, unit_nr
+      TYPE(mp2_type), POINTER                            :: mp2_env
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      REAL(KIND=dp)                                      :: stabilize_exp
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_3c
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
+      LOGICAL                                            :: do_ri_sos_laplace_mp2
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_P_omega_t', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: handle, handle4, handle5, handle6, i_cell, i_cell_R_1, i_cell_R_1_minus_S, &
+         i_cell_R_1_minus_T, i_cell_R_2, i_cell_R_2_minus_S_minus_T, i_cell_S, i_cell_T, i_mem, &
+         iquad, j_mem, num_3c_repl, num_cells_dm, unit_nr_prv
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
+      LOGICAL :: do_Gamma_RPA, do_kpoints_cubic_RPA, first_cycle_im_time, first_cycle_omega_loop, &
+         memory_info, R_1_minus_S_needed, R_1_minus_T_needed, R_2_minus_S_minus_T_needed
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: does_mat_P_T_tau_have_blocks
+      REAL(KIND=dp)                                      :: omega, omega_old, tau, weight, weight_old
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
+      TYPE(dbcsr_t_type)                                 :: t_3c_M_occ, t_3c_M_tmp, t_3c_M_virt, t_P
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:)      :: t_dm_occ, t_dm_virt
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :)   :: t_dm_occ_cut, t_dm_virt_cut
+
+      memory_info = mp2_env%ri_rpa_im_time%memory_info
+      do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
+      do_Gamma_RPA = .NOT. do_kpoints_cubic_RPA
+      num_3c_repl = MAXVAL(cell_to_index_3c)
+
+      CALL timeset(routineN, handle)
+
+      first_cycle_im_time = .TRUE.
+
+      DO jquad = 1, num_integ_points
+
+         CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, nmo, &
+                                    fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
+                                    fm_mo_coeff_virt_scaled, mat_dm_occ_global, mat_dm_virt_global, &
+                                    matrix_s, mao_coeff_occ, mao_coeff_virt, ispin, &
+                                    Eigenval, e_fermi, eps_filter, memory_info, &
+                                    unit_nr, para_env, &
+                                    jquad, .FALSE., stabilize_exp, do_kpoints_cubic_RPA, qs_env, &
+                                    num_cells_dm, index_to_cell_dm, &
+                                    does_mat_P_T_tau_have_blocks)
+
+         CALL timeset(routineN//"_im_time_repl_subgr", handle4)
+
+         CALL mp_sync(para_env%group)
+
+         CALL timestop(handle4)
+
+         ! loop over T for chi^T(it)
+         IF (memory_info .AND. first_cycle_im_time) THEN
+            unit_nr_prv = unit_nr
+         ELSE
+            unit_nr_prv = 0
+         ENDIF
+
+         CALL timeset(routineN//"_dbcsr_t", handle6)
+         ALLOCATE (t_dm_virt(num_cells_dm))
+         ALLOCATE (t_dm_occ(num_cells_dm))
+         CALL dbcsr_t_create(mat_P_global%matrix, t_P, name="P (RI | RI)")
+         DO i_cell = 1, num_cells_dm
+            CALL dbcsr_t_create(mat_dm_virt_global(jquad, i_cell)%matrix, t_dm_virt(i_cell), name="D virt (AO | AO)")
+            CALL dbcsr_t_copy_matrix_to_tensor(mat_dm_virt_global(jquad, i_cell)%matrix, t_dm_virt(i_cell))
+            CALL dbcsr_set(mat_dm_virt_global(jquad, i_cell)%matrix, 0.0_dp)
+            CALL dbcsr_filter(mat_dm_virt_global(jquad, i_cell)%matrix, 1.0_dp)
+            CALL dbcsr_t_create(mat_dm_occ_global(jquad, i_cell)%matrix, t_dm_occ(i_cell), name="D occ (AO | AO)")
+            CALL dbcsr_t_copy_matrix_to_tensor(mat_dm_occ_global(jquad, i_cell)%matrix, t_dm_occ(i_cell))
+            CALL dbcsr_set(mat_dm_occ_global(jquad, i_cell)%matrix, 0.0_dp)
+            CALL dbcsr_filter(mat_dm_occ_global(jquad, i_cell)%matrix, 1.0_dp)
+         ENDDO
+         CALL dbcsr_t_create(t_3c_O_cut(1, 1, 1), t_3c_M_tmp, name="M (RI AO | AO)")
+         CALL dbcsr_t_create(t_3c_M, t_3c_M_occ, name="M occ (RI | AO AO)")
+         CALL dbcsr_t_create(t_3c_M, t_3c_M_virt, name="M virt (RI | AO AO)")
+
+         CALL setup_dm_for_mem_cut(t_dm_occ_cut, t_dm_occ, cut_memory, starts_array_mc_t, ends_array_mc_t, &
+                                   eps_filter)
+         CALL setup_dm_for_mem_cut(t_dm_virt_cut, t_dm_virt, cut_memory, starts_array_mc_t, ends_array_mc_t, &
+                                   eps_filter)
+         DO i_cell_T = 1, num_cells_dm/2+1
+
+            DO j_mem = 1, cut_memory
+               DO i_mem = 1, cut_memory
+                  IF (unit_nr_prv > 0) WRITE (UNIT=unit_nr_prv, FMT="(T3,A,I2,1X,I2)") &
+                     "RPA_IM_TIME_INFO| Memory Cut iteration", i_mem, j_mem
+
+                  IF (do_gamma_RPA) THEN
+                     IF (.NOT. dbcsr_t_need_contract(t_3c_O_cut(j_mem, 1, 1), &
+                                                     t_dm_occ_cut(i_mem, 1), &
+                                                     [3], [1])) CYCLE
+                     IF (.NOT. dbcsr_t_need_contract(t_3c_O_cut( &
+                                                     i_mem, 1, 1), &
+                                                     t_dm_virt_cut(j_mem, 1), &
+                                                     [3], [1])) CYCLE
+                  ENDIF
+
+                  DO i_cell_R_1 = 1, num_3c_repl
+
+                     DO i_cell_R_2 = 1, num_3c_repl
+
+                        CALL get_diff_index_3c(i_cell_R_1, i_cell_T, i_cell_R_1_minus_T, &
+                                               index_to_cell_3c, cell_to_index_3c, index_to_cell_dm, &
+                                               R_1_minus_T_needed, do_kpoints_cubic_RPA)
+
+                        DO i_cell_S = 1, num_cells_dm
+                           CALL get_diff_index_3c(i_cell_R_1, i_cell_S, i_cell_R_1_minus_S, index_to_cell_3c, &
+                                                  cell_to_index_3c, index_to_cell_dm, R_1_minus_S_needed, &
+                                                  do_kpoints_cubic_RPA)
+
+                           IF (R_1_minus_S_needed) THEN
+
+                              CALL timeset(routineN//"_calc_M_t", handle5)
+                              CALL dbcsr_t_contract(alpha=dbcsr_scalar(1.0_dp), &
+                                                    tensor_1=t_3c_O_cut(j_mem, i_cell_R_1_minus_S, i_cell_R_2), &
+                                                    tensor_2=t_dm_occ_cut(i_mem, i_cell_S), &
+                                                    beta=dbcsr_scalar(1.0_dp), &
+                                                    tensor_3=t_3c_M_tmp, &
+                                                    contract_1=[3], notcontract_1=[1, 2], &
+                                                    contract_2=[1], notcontract_2=[2], &
+                                                    map_1=[1, 2], map_2=[3], &
+                                                    filter_eps=eps_filter, unit_nr=unit_nr_prv)
+                              CALL timestop(handle5)
+
+                           ENDIF
+                        ENDDO
+
+                        CALL timeset(routineN//"_copy_M_t", handle5)
+
+                        ! copy matrix to optimal contraction layout - copy is done manually in order
+                        ! to better control memory allocations (we can release data of previous
+                        ! representation)
+                        CALL dbcsr_t_copy(t_3c_M_tmp, t_3c_M_occ, order=[1, 3, 2], move_data=.TRUE.)
+                        CALL dbcsr_t_filter(t_3c_M_occ, eps_filter)
+                        CALL dbcsr_t_set(t_3c_M_tmp, 0.0_dp)
+                        CALL dbcsr_t_filter(t_3c_M_tmp, 1.0_dp)
+                        CALL timestop(handle5)
+
+                        DO i_cell_S = 1, num_cells_dm
+                           CALL get_diff_diff_index_3c(i_cell_R_2, i_cell_S, i_cell_T, i_cell_R_2_minus_S_minus_T, &
+                                                       index_to_cell_3c, cell_to_index_3c, index_to_cell_dm, &
+                                                       R_2_minus_S_minus_T_needed, do_kpoints_cubic_RPA)
+
+                           IF (R_1_minus_T_needed .AND. R_2_minus_S_minus_T_needed) THEN
+
+                              CALL timeset(routineN//"_calc_M_t", handle5)
+
+                              CALL dbcsr_t_contract(alpha=dbcsr_scalar(alpha/2.0_dp), &
+                                                    tensor_1=t_3c_O_cut( &
+                                                    i_mem, i_cell_R_2_minus_S_minus_T, i_cell_R_1_minus_T), &
+                                                    tensor_2=t_dm_virt_cut(j_mem, i_cell_S), &
+                                                    beta=dbcsr_scalar(1.0_dp), &
+                                                    tensor_3=t_3c_M_tmp, &
+                                                    contract_1=[3], notcontract_1=[1, 2], &
+                                                    contract_2=[1], notcontract_2=[2], &
+                                                    map_1=[1, 2], map_2=[3], &
+                                                    filter_eps=eps_filter, unit_nr=unit_nr_prv)
+                              CALL timestop(handle5)
+                           ENDIF
+                        ENDDO
+
+                        CALL timeset(routineN//"_copy_M_t", handle5)
+                        CALL dbcsr_t_copy(t_3c_M_tmp, t_3c_M_virt, order=[1, 2, 3], move_data=.TRUE.)
+                        CALL dbcsr_t_filter(t_3c_M_virt, eps_filter)
+                        CALL dbcsr_t_set(t_3c_M_tmp, 0.0_dp)
+                        CALL dbcsr_t_filter(t_3c_M_tmp, 1.0_dp)
+                        CALL timestop(handle5)
+
+                        IF (.NOT. dbcsr_t_need_contract(t_3c_M_occ, t_3c_M_virt, &
+                                                        [2, 3], [2, 3])) CYCLE
+
+                        CALL timeset(routineN//"_calc_P_t", handle5)
+
+                        CALL dbcsr_t_contract(alpha=dbcsr_scalar(1.0_dp), tensor_1=t_3c_M_occ, &
+                                              tensor_2=t_3c_M_virt, &
+                                              beta=dbcsr_scalar(0.0_dp), &
+                                              tensor_3=t_P, &
+                                              contract_1=[2, 3], notcontract_1=[1], &
+                                              contract_2=[2, 3], notcontract_2=[1], &
+                                              map_1=[1], map_2=[2], &
+                                              filter_eps=eps_filter_im_time/REAL(cut_memory**2, KIND=dp), &
+                                              move_data=.TRUE., &
+                                              unit_nr=unit_nr_prv)
+
+                        CALL dbcsr_t_copy_tensor_to_matrix(t_P, mat_P_global%matrix)
+
+                        CALL dbcsr_t_set(t_3c_M_occ, 0.0_dp)
+                        CALL dbcsr_t_filter(t_3c_M_occ, 1.0_dp)
+                        CALL dbcsr_t_set(t_3c_M_virt, 0.0_dp)
+                        CALL dbcsr_t_filter(t_3c_M_virt, 1.0_dp)
+                        CALL dbcsr_t_set(t_P, 0.0_dp)
+                        CALL dbcsr_t_filter(t_P, 1.0_dp)
+
+                        CALL timestop(handle5)
+
+                        IF (do_ri_sos_laplace_mp2) THEN
+                           ! For RI-SOS-Laplace-MP2 we do not perform a cosine transform,
+                           ! but we have to copy P_local to the output matrix
+
+                           CALL dbcsr_add(mat_P_omega(jquad, i_cell_T)%matrix, mat_P_global%matrix, 1.0_dp, 1.0_dp)
+                        ELSE
+                           CALL timeset(routineN//"_Fourier_transform", handle5)
+
+                           ! Fourier transform of P(it) to P(iw)
+                           first_cycle_omega_loop = .TRUE.
+
+                           tau = tau_tj(jquad)
+
+                           DO iquad = 1, num_integ_points
+
+                              omega = tj(iquad)
+                              weight = weights_cos_tf_t_to_w(iquad, jquad)
+
+                              IF (first_cycle_omega_loop) THEN
+                                 ! no multiplication with 2.0 as in Kresses paper (Kaltak, JCTC 10, 2498 (2014), Eq. 12)
+                                 ! because this factor is already absorbed in the weight w_j
+                                 CALL dbcsr_scale(mat_P_global%matrix, COS(omega*tau)*weight)
+                              ELSE
+                                 CALL dbcsr_scale(mat_P_global%matrix, COS(omega*tau)/COS(omega_old*tau)*weight/weight_old)
+                              END IF
+
+                              CALL dbcsr_add(mat_P_omega(iquad, i_cell_T)%matrix, mat_P_global%matrix, 1.0_dp, 1.0_dp)
+
+                              first_cycle_omega_loop = .FALSE.
+
+                              omega_old = omega
+                              weight_old = weight
+
+                           END DO
+
+                           CALL timestop(handle5)
+
+                           first_cycle_im_time = .FALSE.
+
+                        END IF ! do_ri_sos_laplace_mp2
+                     ENDDO
+                  ENDDO
+               ENDDO
+            ENDDO
+         ENDDO
+
+         CALL dbcsr_t_destroy(t_P)
+         DO i_cell = 1, num_cells_dm
+            DO i_mem = 1, cut_memory
+               CALL dbcsr_t_destroy(t_dm_virt_cut(i_mem, i_cell))
+               CALL dbcsr_t_destroy(t_dm_occ_cut(i_mem, i_cell))
+            ENDDO
+         ENDDO
+         CALL dbcsr_t_destroy(t_3c_M_tmp)
+         CALL dbcsr_t_destroy(t_3c_M_occ)
+         CALL dbcsr_t_destroy(t_3c_M_virt)
+         DEALLOCATE (t_dm_virt_cut)
+         DEALLOCATE (t_dm_occ_cut)
+
+         CALL timestop(handle6)
+
+      END DO ! time points
+
+      IF (do_kpoints_cubic_RPA) THEN
+
+         CALL transform_P_from_real_space_to_kpoints(mat_P_omega, mat_P_omega_im_part, qs_env)
+
+      END IF
+
+      CALL clean_up(mat_dm_occ_global, mat_dm_virt_global, does_mat_P_T_tau_have_blocks)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief compute the matrix Q(it) (intermediate) and Fourier transform it
@@ -99,6 +449,11 @@ CONTAINS
 !> \param mat_3c_overl_int_cut ...
 !> \param mat_3c_overl_int_mao_for_occ_cut ...
 !> \param mat_3c_overl_int_mao_for_virt_cut ...
+!> \param do_dbcsr_t ...
+!> \param t_3c_M ...
+!> \param t_3c_O_cut ...
+!> \param starts_array_mc_t ...
+!> \param ends_array_mc_t ...
 !> \param mat_dm_loc_occ_cut ...
 !> \param mat_dm_loc_virt_cut ...
 !> \param weights_cos_tf_t_to_w ...
@@ -159,8 +514,10 @@ CONTAINS
                                   mat_M_mu_Pnu_virt, matrix_s, mao_coeff_occ, &
                                   mao_coeff_virt, ispin, mat_M_P_munu_occ, &
                                   mat_M_P_munu_virt, mat_3c_overl_int_cut, mat_3c_overl_int_mao_for_occ_cut, &
-                                  mat_3c_overl_int_mao_for_virt_cut, mat_dm_loc_occ_cut, &
-                                  mat_dm_loc_virt_cut, weights_cos_tf_t_to_w, tj, tau_tj, e_fermi, eps_filter, &
+                                  mat_3c_overl_int_mao_for_virt_cut, do_dbcsr_t, t_3c_M, t_3c_O_cut, &
+                                  starts_array_mc_t, ends_array_mc_t, &
+                                  mat_dm_loc_occ_cut, mat_dm_loc_virt_cut, weights_cos_tf_t_to_w, &
+                                  tj, tau_tj, e_fermi, eps_filter, &
                                   alpha, eps_filter_im_time, Eigenval, nmo, n_group_col, &
                                   group_size_P, num_integ_points, jquad, cut_memory, cut_RI, unit_nr, &
                                   mp2_env, para_env, para_env_sub, &
@@ -189,6 +546,11 @@ CONTAINS
       TYPE(dbcsr_p_type)                                 :: mat_M_P_munu_occ, mat_M_P_munu_virt
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut, &
          mat_3c_overl_int_mao_for_occ_cut, mat_3c_overl_int_mao_for_virt_cut
+      LOGICAL, INTENT(IN)                                :: do_dbcsr_t
+      TYPE(dbcsr_t_type), INTENT(INOUT)                  :: t_3c_M
+      TYPE(dbcsr_t_type), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(INOUT)               :: t_3c_O_cut
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc_t, ends_array_mc_t
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_dm_loc_occ_cut, mat_dm_loc_virt_cut
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj, tau_tj
@@ -207,7 +569,7 @@ CONTAINS
                                                             my_group_L_sizes_im_time
       TYPE(two_dim_int_array), ALLOCATABLE, &
          DIMENSION(:, :)                                 :: offset_combi_block
-      INTEGER, DIMENSION(:)                              :: starts_array_cm_mao_occ, &
+      INTEGER, DIMENSION(:), POINTER                     :: starts_array_cm_mao_occ, &
                                                             starts_array_cm_mao_virt, &
                                                             ends_array_cm_mao_occ, &
                                                             ends_array_cm_mao_virt
@@ -241,6 +603,25 @@ CONTAINS
       REAL(KIND=dp)                                      :: omega, omega_old, tau, weight, weight_old
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
 
+      IF (do_dbcsr_t) THEN
+         CALL compute_mat_P_omega_t(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+                                    fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                    mat_P_global, &
+                                    matrix_s, mao_coeff_occ, &
+                                    mao_coeff_virt, ispin, &
+                                    t_3c_M, t_3c_O_cut, &
+                                    starts_array_mc_t, ends_array_mc_t, &
+                                    weights_cos_tf_t_to_w, &
+                                    tj, tau_tj, e_fermi, eps_filter, &
+                                    alpha, eps_filter_im_time, Eigenval, nmo, &
+                                    num_integ_points, jquad, cut_memory, unit_nr, &
+                                    mp2_env, para_env, &
+                                    stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
+                                    do_ri_sos_laplace_mp2)
+         RETURN
+      ENDIF
+
       memory_info = mp2_env%ri_rpa_im_time%memory_info
       do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
       do_Gamma_RPA = .NOT. do_kpoints_cubic_RPA
@@ -257,12 +638,17 @@ CONTAINS
                                     fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
                                     fm_mo_coeff_virt_scaled, mat_dm_occ_global, mat_dm_virt_global, &
                                     matrix_s, mao_coeff_occ, mao_coeff_virt, ispin, &
-                                    mat_3c_overl_int_cut, Eigenval, e_fermi, eps_filter, memory_info, &
-                                    unit_nr, para_env, cycle_due_to_sparse_dm, &
-                                    starts_array_cm_mao_occ, starts_array_cm_mao_virt, ends_array_cm_mao_occ, &
-                                    ends_array_cm_mao_virt, my_group_L_sizes_im_time, cut_memory, cut_RI, jquad, do_mao, &
+                                    Eigenval, e_fermi, eps_filter, memory_info, &
+                                    unit_nr, para_env, &
+                                    jquad, do_mao, &
                                     stabilize_exp, do_kpoints_cubic_RPA, qs_env, num_cells_dm, index_to_cell_dm, &
                                     does_mat_P_T_tau_have_blocks)
+
+         CALL get_cycle_due_to_sparse_dm(cycle_due_to_sparse_dm, mat_dm_occ_global, mat_dm_virt_global, &
+                                         mat_3c_overl_int_cut, num_integ_points, cut_memory, cut_RI, &
+                                         starts_array_cm_mao_occ, starts_array_cm_mao_virt, &
+                                         ends_array_cm_mao_occ, ends_array_cm_mao_virt, &
+                                         my_group_L_sizes_im_time, para_env, jquad)
 
          CALL timeset(routineN//"_im_time_repl_subgr", handle4)
 
@@ -1618,21 +2004,12 @@ CONTAINS
 !> \param mao_coeff_occ ...
 !> \param mao_coeff_virt ...
 !> \param ispin ...
-!> \param mat_3c_overl_int_cut ...
 !> \param Eigenval ...
 !> \param e_fermi ...
 !> \param eps_filter ...
 !> \param memory_info ...
 !> \param unit_nr ...
 !> \param para_env ...
-!> \param cycle_due_to_sparse_dm ...
-!> \param starts_array_cm_mao_occ ...
-!> \param starts_array_cm_mao_virt ...
-!> \param ends_array_cm_mao_occ ...
-!> \param ends_array_cm_mao_virt ...
-!> \param my_group_L_sizes_im_time ...
-!> \param cut_memory ...
-!> \param cut_RI ...
 !> \param jquad ...
 !> \param do_mao ...
 !> \param stabilize_exp ...
@@ -1646,11 +2023,9 @@ CONTAINS
                                     fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
                                     fm_mo_coeff_virt_scaled, mat_dm_occ_global, mat_dm_virt_global, &
                                     matrix_s, mao_coeff_occ, mao_coeff_virt, ispin, &
-                                    mat_3c_overl_int_cut, Eigenval, e_fermi, eps_filter, memory_info, &
-                                    unit_nr, para_env, cycle_due_to_sparse_dm, &
-                                    starts_array_cm_mao_occ, starts_array_cm_mao_virt, ends_array_cm_mao_occ, &
-                                    ends_array_cm_mao_virt, my_group_L_sizes_im_time, cut_memory, &
-                                    cut_RI, jquad, do_mao, stabilize_exp, do_kpoints_cubic_RPA, qs_env, &
+                                    Eigenval, e_fermi, eps_filter, memory_info, &
+                                    unit_nr, para_env, &
+                                    jquad, do_mao, stabilize_exp, do_kpoints_cubic_RPA, qs_env, &
                                     num_cells_dm, index_to_cell_dm, does_mat_P_T_tau_have_blocks)
 
       TYPE(cp_fm_type), POINTER                          :: fm_scaled_dm_occ_tau, &
@@ -1663,16 +2038,12 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mao_coeff_occ, mao_coeff_virt
       INTEGER                                            :: ispin
-      TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut
       REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
       REAL(KIND=dp)                                      :: e_fermi, eps_filter
       LOGICAL                                            :: memory_info
       INTEGER                                            :: unit_nr
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: cycle_due_to_sparse_dm
-      INTEGER, DIMENSION(:) :: starts_array_cm_mao_occ, starts_array_cm_mao_virt, &
-         ends_array_cm_mao_occ, ends_array_cm_mao_virt, my_group_L_sizes_im_time
-      INTEGER                                            :: cut_memory, cut_RI, jquad
+      INTEGER                                            :: jquad
       LOGICAL                                            :: do_mao
       REAL(KIND=dp)                                      :: stabilize_exp
       LOGICAL                                            :: do_kpoints_cubic_RPA
@@ -1847,12 +2218,6 @@ CONTAINS
             CALL dbcsr_filter(mat_dm_occ_global(jquad-1, 1)%matrix, 0.0_dp)
             CALL dbcsr_filter(mat_dm_virt_global(jquad-1, 1)%matrix, 0.0_dp)
          END IF
-
-         CALL get_cycle_due_to_sparse_dm(cycle_due_to_sparse_dm, mat_dm_occ_global, mat_dm_virt_global, &
-                                         mat_3c_overl_int_cut, num_integ_points, cut_memory, cut_RI, &
-                                         starts_array_cm_mao_occ, starts_array_cm_mao_virt, &
-                                         ends_array_cm_mao_occ, ends_array_cm_mao_virt, &
-                                         my_group_L_sizes_im_time, para_env, jquad)
 
          IF (memory_info) THEN
             CALL print_occupation_2c(mat_dm_occ_global(jquad, 1)%matrix, unit_nr, &
@@ -2989,6 +3354,140 @@ CONTAINS
 
       CALL timestop(handle)
 
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param t_3c_overl_int_cut ...
+!> \param t_3c_overl_int ...
+!> \param cut_memory ...
+!> \param starts_array_mc_t ...
+!> \param ends_array_mc_t ...
+!> \param eps_filter ...
+! **************************************************************************************************
+   SUBROUTINE setup_tensor_for_mem_cut_3c(t_3c_overl_int_cut, t_3c_overl_int, cut_memory, &
+                                          starts_array_mc_t, ends_array_mc_t, eps_filter)
+      TYPE(dbcsr_t_type), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(OUT)                 :: t_3c_overl_int_cut
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: t_3c_overl_int
+      INTEGER, INTENT(IN)                                :: cut_memory
+      INTEGER, DIMENSION(cut_memory), INTENT(IN)         :: starts_array_mc_t, ends_array_mc_t
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'setup_tensor_for_mem_cut_3c', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: blk, handle, i_cell, i_mem, j_cell, &
+                                                            num_3c_repl
+      INTEGER, DIMENSION(3)                              :: blk_ind, blk_off
+      LOGICAL                                            :: found
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: t_block
+      TYPE(dbcsr_t_iterator_type)                        :: iter
+
+      CALL timeset(routineN, handle)
+
+      num_3c_repl = SIZE(t_3c_overl_int, 2)
+
+      ALLOCATE (t_3c_overl_int_cut(cut_memory, num_3c_repl, num_3c_repl))
+
+      DO i_mem = 1, cut_memory
+         DO i_cell = 1, num_3c_repl
+            DO j_cell = 1, num_3c_repl
+               CALL dbcsr_t_create(t_3c_overl_int(i_cell, j_cell), t_3c_overl_int_cut(i_mem, i_cell, j_cell))
+               CALL dbcsr_t_reserve_blocks(t_3c_overl_int(i_cell, j_cell), t_3c_overl_int_cut(i_mem, i_cell, j_cell))
+
+               CALL dbcsr_t_iterator_start(iter, t_3c_overl_int(i_cell, j_cell))
+               DO WHILE (dbcsr_t_iterator_blocks_left(iter))
+                  CALL dbcsr_t_iterator_next_block(iter, blk_ind, blk, blk_offset=blk_off)
+                  IF (blk_off(2) >= starts_array_mc_t(i_mem) .AND. blk_off(2) <= ends_array_mc_t(i_mem)) THEN
+                     CALL dbcsr_t_get_block(t_3c_overl_int(i_cell, j_cell), blk_ind, t_block, found)
+                     CALL dbcsr_t_put_block(t_3c_overl_int_cut(i_mem, i_cell, j_cell), blk_ind, SHAPE(t_block), t_block)
+                     DEALLOCATE (t_block)
+                  ENDIF
+               ENDDO
+               CALL dbcsr_t_iterator_stop(iter)
+               CALL dbcsr_t_filter(t_3c_overl_int_cut(i_mem, i_cell, j_cell), eps_filter)
+            ENDDO
+         ENDDO
+      ENDDO
+
+      DO i_cell = 1, num_3c_repl
+         DO j_cell = 1, num_3c_repl
+            CALL dbcsr_t_destroy(t_3c_overl_int(i_cell, j_cell))
+         ENDDO
+      ENDDO
+
+      DEALLOCATE (t_3c_overl_int)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param t_dm_cut ...
+!> \param t_dm ...
+!> \param cut_memory ...
+!> \param starts_array_mc_t ...
+!> \param ends_array_mc_t ...
+!> \param eps_filter ...
+! **************************************************************************************************
+   SUBROUTINE setup_dm_for_mem_cut(t_dm_cut, t_dm, cut_memory, starts_array_mc_t, ends_array_mc_t, eps_filter)
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: t_dm_cut
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: t_dm
+      INTEGER, INTENT(IN)                                :: cut_memory
+      INTEGER, DIMENSION(cut_memory), INTENT(IN)         :: starts_array_mc_t, ends_array_mc_t
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'setup_dm_for_mem_cut', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: blk, handle, i_cell, i_mem, num_3c_repl
+      INTEGER, DIMENSION(2)                              :: blk_ind, blk_off, blk_size, &
+                                                            inblock_offset
+      LOGICAL                                            :: found
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: t_block
+      TYPE(dbcsr_t_iterator_type)                        :: iter
+
+      CALL timeset(routineN, handle)
+
+      num_3c_repl = SIZE(t_dm, 1)
+
+      ALLOCATE (t_dm_cut(cut_memory, num_3c_repl))
+
+      DO i_mem = 1, cut_memory
+         DO i_cell = 1, num_3c_repl
+            CALL dbcsr_t_create(t_dm(i_cell), t_dm_cut(i_mem, i_cell))
+            CALL dbcsr_t_reserve_blocks(t_dm(i_cell), t_dm_cut(i_mem, i_cell))
+
+            CALL dbcsr_t_iterator_start(iter, t_dm(i_cell))
+            DO WHILE (dbcsr_t_iterator_blocks_left(iter))
+               CALL dbcsr_t_iterator_next_block(iter, blk_ind, blk, blk_size=blk_size, blk_offset=blk_off)
+               IF (blk_off(2)-1+blk_size(2) >= starts_array_mc_t(i_mem) .AND. blk_off(2) <= ends_array_mc_t(i_mem)) THEN
+                  CALL dbcsr_t_get_block(t_dm(i_cell), blk_ind, t_block, found)
+                  inblock_offset(1) = MAX(starts_array_mc_t(i_mem)-blk_off(2), 0)
+                  inblock_offset(2) = MIN(inblock_offset(1)+ends_array_mc_t(i_mem)-starts_array_mc_t(i_mem)+1, blk_size(2))
+                  t_block(:, :inblock_offset(1)) = 0.0_dp
+                  t_block(:, inblock_offset(2)+1:) = 0.0_dp
+                  CALL dbcsr_t_put_block(t_dm_cut(i_mem, i_cell), blk_ind, SHAPE(t_block), t_block)
+                  DEALLOCATE (t_block)
+               ENDIF
+            ENDDO
+            CALL dbcsr_t_iterator_stop(iter)
+            CALL dbcsr_t_filter(t_dm_cut(i_mem, i_cell), eps_filter)
+         ENDDO
+      ENDDO
+
+      DO i_cell = 1, num_3c_repl
+         CALL dbcsr_t_destroy(t_dm(i_cell))
+      ENDDO
+
+      DEALLOCATE (t_dm)
+
+      CALL timestop(handle)
    END SUBROUTINE
 
 ! **************************************************************************************************

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -119,6 +119,7 @@ CONTAINS
 !> \param qs_env ...
 !> \param index_to_cell_3c ...
 !> \param cell_to_index_3c ...
+!> \param has_mat_P_blocks ...
 !> \param do_ri_sos_laplace_mp2 ...
 ! **************************************************************************************************
    SUBROUTINE compute_mat_P_omega_t(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
@@ -135,7 +136,7 @@ CONTAINS
                                     num_integ_points, jquad, cut_memory, unit_nr, &
                                     mp2_env, para_env, &
                                     stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
-                                    do_ri_sos_laplace_mp2)
+                                    has_mat_P_blocks, do_ri_sos_laplace_mp2)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_im_part
       TYPE(cp_fm_type), POINTER :: fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, fm_mo_coeff_occ, &
@@ -160,6 +161,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :)     :: has_mat_P_blocks
       LOGICAL                                            :: do_ri_sos_laplace_mp2
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_P_omega_t', &
@@ -168,6 +170,7 @@ CONTAINS
       INTEGER :: handle, handle4, handle5, handle6, i_cell, i_cell_R_1, i_cell_R_1_minus_S, &
          i_cell_R_1_minus_T, i_cell_R_2, i_cell_R_2_minus_S_minus_T, i_cell_S, i_cell_T, i_mem, &
          iquad, j_mem, num_3c_repl, num_cells_dm, unit_nr_prv
+      INTEGER(KIND=int_8)                                :: num_flops_mat_P
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
       LOGICAL :: do_Gamma_RPA, do_kpoints_cubic_RPA, first_cycle_im_time, first_cycle_omega_loop, &
          memory_info, R_1_minus_S_needed, R_1_minus_T_needed, R_2_minus_S_minus_T_needed
@@ -236,6 +239,8 @@ CONTAINS
                                    eps_filter)
          DO i_cell_T = 1, num_cells_dm/2+1
 
+            IF (.NOT. does_mat_P_T_tau_have_blocks(i_cell_T)) CYCLE
+
             DO j_mem = 1, cut_memory
                DO i_mem = 1, cut_memory
                   IF (unit_nr_prv > 0) WRITE (UNIT=unit_nr_prv, FMT="(T3,A,I2,1X,I2)") &
@@ -255,16 +260,19 @@ CONTAINS
 
                      DO i_cell_R_2 = 1, num_3c_repl
 
+                        IF (.NOT. has_mat_P_blocks(i_cell_T, i_mem, j_mem, i_cell_R_1, i_cell_R_2)) CYCLE
+
                         CALL get_diff_index_3c(i_cell_R_1, i_cell_T, i_cell_R_1_minus_T, &
                                                index_to_cell_3c, cell_to_index_3c, index_to_cell_dm, &
                                                R_1_minus_T_needed, do_kpoints_cubic_RPA)
-
                         DO i_cell_S = 1, num_cells_dm
                            CALL get_diff_index_3c(i_cell_R_1, i_cell_S, i_cell_R_1_minus_S, index_to_cell_3c, &
                                                   cell_to_index_3c, index_to_cell_dm, R_1_minus_S_needed, &
                                                   do_kpoints_cubic_RPA)
-
                            IF (R_1_minus_S_needed) THEN
+                           IF (dbcsr_t_need_contract(t_3c_O_cut(j_mem, i_cell_R_1_minus_S, i_cell_R_2), &
+                                                     t_dm_occ_cut(i_mem, i_cell_S), &
+                                                     [3], [2])) THEN
 
                               CALL timeset(routineN//"_calc_M_t", handle5)
                               CALL dbcsr_t_contract(alpha=dbcsr_scalar(1.0_dp), &
@@ -273,11 +281,12 @@ CONTAINS
                                                     beta=dbcsr_scalar(1.0_dp), &
                                                     tensor_3=t_3c_M_tmp, &
                                                     contract_1=[3], notcontract_1=[1, 2], &
-                                                    contract_2=[1], notcontract_2=[2], &
+                                                    contract_2=[2], notcontract_2=[1], &
                                                     map_1=[1, 2], map_2=[3], &
                                                     filter_eps=eps_filter, unit_nr=unit_nr_prv)
                               CALL timestop(handle5)
 
+                           ENDIF
                            ENDIF
                         ENDDO
 
@@ -298,9 +307,13 @@ CONTAINS
                                                        R_2_minus_S_minus_T_needed, do_kpoints_cubic_RPA)
 
                            IF (R_1_minus_T_needed .AND. R_2_minus_S_minus_T_needed) THEN
+                           IF (dbcsr_t_need_contract(t_3c_O_cut( &
+                                                     i_mem, i_cell_R_2_minus_S_minus_T, &
+                                                     i_cell_R_1_minus_T), &
+                                                     t_dm_virt_cut(j_mem, i_cell_S), &
+                                                     [3], [2])) THEN
 
                               CALL timeset(routineN//"_calc_M_t", handle5)
-
                               CALL dbcsr_t_contract(alpha=dbcsr_scalar(alpha/2.0_dp), &
                                                     tensor_1=t_3c_O_cut( &
                                                     i_mem, i_cell_R_2_minus_S_minus_T, i_cell_R_1_minus_T), &
@@ -308,10 +321,11 @@ CONTAINS
                                                     beta=dbcsr_scalar(1.0_dp), &
                                                     tensor_3=t_3c_M_tmp, &
                                                     contract_1=[3], notcontract_1=[1, 2], &
-                                                    contract_2=[1], notcontract_2=[2], &
+                                                    contract_2=[2], notcontract_2=[1], &
                                                     map_1=[1, 2], map_2=[3], &
                                                     filter_eps=eps_filter, unit_nr=unit_nr_prv)
                               CALL timestop(handle5)
+                           ENDIF
                            ENDIF
                         ENDDO
 
@@ -322,23 +336,29 @@ CONTAINS
                         CALL dbcsr_t_filter(t_3c_M_tmp, 1.0_dp)
                         CALL timestop(handle5)
 
-                        IF (.NOT. dbcsr_t_need_contract(t_3c_M_occ, t_3c_M_virt, &
-                                                        [2, 3], [2, 3])) CYCLE
+                        num_flops_mat_P = 0
+                        CALL dbcsr_set(mat_P_global%matrix, 0.0_dp)
+                        IF (dbcsr_t_need_contract(t_3c_M_occ, t_3c_M_virt, &
+                                                  [2, 3], [2, 3])) THEN
 
-                        CALL timeset(routineN//"_calc_P_t", handle5)
+                           CALL timeset(routineN//"_calc_P_t", handle5)
 
-                        CALL dbcsr_t_contract(alpha=dbcsr_scalar(1.0_dp), tensor_1=t_3c_M_occ, &
-                                              tensor_2=t_3c_M_virt, &
-                                              beta=dbcsr_scalar(0.0_dp), &
-                                              tensor_3=t_P, &
-                                              contract_1=[2, 3], notcontract_1=[1], &
-                                              contract_2=[2, 3], notcontract_2=[1], &
-                                              map_1=[1], map_2=[2], &
-                                              filter_eps=eps_filter_im_time/REAL(cut_memory**2, KIND=dp), &
-                                              move_data=.TRUE., &
-                                              unit_nr=unit_nr_prv)
+                           CALL dbcsr_t_contract(alpha=dbcsr_scalar(1.0_dp), tensor_1=t_3c_M_occ, &
+                                                 tensor_2=t_3c_M_virt, &
+                                                 beta=dbcsr_scalar(0.0_dp), &
+                                                 tensor_3=t_P, &
+                                                 contract_1=[2, 3], notcontract_1=[1], &
+                                                 contract_2=[2, 3], notcontract_2=[1], &
+                                                 map_1=[1], map_2=[2], &
+                                                 filter_eps=eps_filter_im_time/REAL(cut_memory**2, KIND=dp), &
+                                                 flop=num_flops_mat_P, &
+                                                 move_data=.TRUE., &
+                                                 unit_nr=unit_nr_prv)
 
-                        CALL dbcsr_t_copy_tensor_to_matrix(t_P, mat_P_global%matrix)
+                           CALL dbcsr_t_copy_tensor_to_matrix(t_P, mat_P_global%matrix)
+
+                           CALL timestop(handle5)
+                        ENDIF
 
                         CALL dbcsr_t_set(t_3c_M_occ, 0.0_dp)
                         CALL dbcsr_t_filter(t_3c_M_occ, 1.0_dp)
@@ -346,8 +366,6 @@ CONTAINS
                         CALL dbcsr_t_filter(t_3c_M_virt, 1.0_dp)
                         CALL dbcsr_t_set(t_P, 0.0_dp)
                         CALL dbcsr_t_filter(t_P, 1.0_dp)
-
-                        CALL timestop(handle5)
 
                         IF (do_ri_sos_laplace_mp2) THEN
                            ! For RI-SOS-Laplace-MP2 we do not perform a cosine transform,
@@ -388,11 +406,18 @@ CONTAINS
 
                            first_cycle_im_time = .FALSE.
 
+                           CALL check_if_mat_P_T_tau_has_blocks(does_mat_P_T_tau_have_blocks, mat_P_global, i_cell_T, &
+                                                                jquad, i_mem, j_mem, i_cell_R_1, i_cell_R_2, &
+                                                                para_env, has_mat_P_blocks, num_flops_mat_P)
+
                         END IF ! do_ri_sos_laplace_mp2
                      ENDDO
                   ENDDO
                ENDDO
             ENDDO
+
+            CALL sync_does_mat_P_T_tau_have_blocks(does_mat_P_T_tau_have_blocks, para_env, unit_nr, &
+                                                   i_cell_T, jquad, index_to_cell_dm)
          ENDDO
 
          CALL dbcsr_t_destroy(t_P)
@@ -618,7 +643,7 @@ CONTAINS
                                     num_integ_points, jquad, cut_memory, unit_nr, &
                                     mp2_env, para_env, &
                                     stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
-                                    do_ri_sos_laplace_mp2)
+                                    has_mat_P_blocks, do_ri_sos_laplace_mp2)
          RETURN
       ENDIF
 
@@ -3471,12 +3496,12 @@ CONTAINS
             CALL dbcsr_t_iterator_start(iter, t_dm(i_cell))
             DO WHILE (dbcsr_t_iterator_blocks_left(iter))
                CALL dbcsr_t_iterator_next_block(iter, blk_ind, blk, blk_size=blk_size, blk_offset=blk_off)
-               IF (blk_off(2)-1+blk_size(2) >= starts_array_mc_t(i_mem) .AND. blk_off(2) <= ends_array_mc_t(i_mem)) THEN
+               IF (blk_off(1)-1+blk_size(1) >= starts_array_mc_t(i_mem) .AND. blk_off(1) <= ends_array_mc_t(i_mem)) THEN
                   CALL dbcsr_t_get_block(t_dm(i_cell), blk_ind, t_block, found)
-                  inblock_offset(1) = MAX(starts_array_mc_t(i_mem)-blk_off(2), 0)
-                  inblock_offset(2) = MIN(inblock_offset(1)+ends_array_mc_t(i_mem)-starts_array_mc_t(i_mem)+1, blk_size(2))
-                  t_block(:, :inblock_offset(1)) = 0.0_dp
-                  t_block(:, inblock_offset(2)+1:) = 0.0_dp
+                  inblock_offset(1) = MAX(starts_array_mc_t(i_mem)-blk_off(1), 0)
+                  inblock_offset(2) = MIN(inblock_offset(1)+ends_array_mc_t(i_mem)-starts_array_mc_t(i_mem)+1, blk_size(1))
+                  t_block(:inblock_offset(1), :) = 0.0_dp
+                  t_block(inblock_offset(2)+1:, :) = 0.0_dp
                   CALL dbcsr_t_put_block(t_dm_cut(i_mem, i_cell), blk_ind, SHAPE(t_block), t_block)
                   DEALLOCATE (t_block)
                ENDIF

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -663,21 +663,25 @@ CONTAINS
 
             DO j_mem = 1, cut_memory
 
+               CALL timeset(routineN//"_calc_M", handle5)
                CALL replicate_dm_to_subgroup(para_env, para_env_sub, mat_dm_virt_global, nmo, jquad, &
                                              mat_dm_loc_virt_cut, starts_array_cm_mao_virt, ends_array_cm_mao_virt, &
                                              j_mem, cut_memory, cut_RI, non_zero_blocks_3c, &
                                              non_zero_blocks_3c_cut_col, multiply_needed_virt, do_kpoints_cubic_RPA, &
                                              cell_to_index_3c, index_to_cell_dm)
+               CALL timestop(handle5)
 
                DO i_mem = 1, cut_memory
 
                   IF (cycle_due_to_sparse_dm(i_mem, j_mem, jquad) .AND. do_Gamma_RPA) CYCLE
 
+                  CALL timeset(routineN//"_calc_M", handle5)
                   CALL replicate_dm_to_subgroup(para_env, para_env_sub, mat_dm_occ_global, nmo, jquad, &
                                                 mat_dm_loc_occ_cut, starts_array_cm_mao_occ, ends_array_cm_mao_occ, &
                                                 i_mem, cut_memory, cut_RI, non_zero_blocks_3c, &
                                                 non_zero_blocks_3c_cut_col, multiply_needed_occ, do_kpoints_cubic_RPA, &
                                                 cell_to_index_3c, index_to_cell_dm)
+                  CALL timestop(handle5)
 
                   DO i_cell_R_1 = 1, num_3c_repl
 
@@ -716,7 +720,7 @@ CONTAINS
                                                      ! last_row=ends_array_cm(i_mem), &
                                                      ! first_column=(starts_array_cm(j_mem)-1)*my_group_L_size+1, &
                                                      ! last_column=ends_array_cm(j_mem)*my_group_L_size, &
-                                                     filter_eps=eps_filter*SQRT(REAL(my_group_L_size, KIND=dp)), &
+                                                     filter_eps=eps_filter, &
                                                      flop=flop_occ)
 
                               END IF
@@ -746,7 +750,7 @@ CONTAINS
                                                      ! last_row=ends_array_cm(j_mem), &
                                                      ! first_column=(starts_array_cm(i_mem)-1)*my_group_L_size+1, &
                                                      ! last_column=ends_array_cm(i_mem)*my_group_L_size, &
-                                                     filter_eps=eps_filter*SQRT(REAL(my_group_L_size, KIND=dp)), &
+                                                     filter_eps=eps_filter, &
                                                      flop=flop_virt)
 
                               END IF
@@ -818,7 +822,8 @@ CONTAINS
                         ! P_RT = sum_mu sigma M^occ_P_mu_sigma M^virt_R_mu_sigma
                         CALL dbcsr_multiply("N", "T", 1.0_dp, mat_M_P_munu_occ%matrix, mat_M_P_munu_virt%matrix, &
                                             0.0_dp, mat_P_local%matrix, &
-                                            filter_eps=eps_filter_im_time/REAL(cut_memory, KIND=dp), &
+                                            filter_eps= &
+                                            eps_filter_im_time/REAL(cut_memory**2*(para_env%num_pe/group_size_P), KIND=dp), &
                                             flop=num_flops_mat_P)
 
                         IF (first_cycle_im_time .AND. memory_info) THEN
@@ -838,10 +843,10 @@ CONTAINS
 
                         CALL mp_sync(para_env%group)
 
-                        CALL timestop(handle5)
-
                         CALL fill_mat_P_global_from_mat_P_local(mat_P_global, mat_P_global_copy, mat_P_local, para_env, &
                                                                 eps_filter_im_time)
+
+                        CALL timestop(handle5)
 
                         IF (do_ri_sos_laplace_mp2) THEN
                            ! For RI-SOS-Laplace-MP2 we do not perform a cosine transform,

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -28,18 +28,19 @@ MODULE rpa_im_time
    USE cp_gemm_interface,               ONLY: cp_gemm
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
-        dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_filter, dbcsr_finalize, dbcsr_get_diag, &
-        dbcsr_get_info, dbcsr_get_num_blocks, dbcsr_get_occupation, dbcsr_get_stored_coordinates, &
-        dbcsr_init_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
-        dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_p_type, dbcsr_release_p, &
-        dbcsr_reserve_all_blocks, dbcsr_reserve_blocks, dbcsr_scalar, dbcsr_scale, dbcsr_set, &
-        dbcsr_transposed, dbcsr_type, dbcsr_type_no_symmetry
+        dbcsr_add, dbcsr_clear, dbcsr_copy, dbcsr_create, dbcsr_filter, dbcsr_finalize, &
+        dbcsr_get_diag, dbcsr_get_info, dbcsr_get_num_blocks, dbcsr_get_occupation, &
+        dbcsr_get_stored_coordinates, dbcsr_init_p, dbcsr_iterator_blocks_left, &
+        dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
+        dbcsr_multiply, dbcsr_p_type, dbcsr_release_p, dbcsr_reserve_all_blocks, &
+        dbcsr_reserve_blocks, dbcsr_scalar, dbcsr_scale, dbcsr_set, dbcsr_transposed, dbcsr_type, &
+        dbcsr_type_no_symmetry
    USE dbcsr_tensor_api,                ONLY: &
-        dbcsr_t_contract, dbcsr_t_copy, dbcsr_t_copy_matrix_to_tensor, &
+        dbcsr_t_clear, dbcsr_t_contract, dbcsr_t_copy, dbcsr_t_copy_matrix_to_tensor, &
         dbcsr_t_copy_tensor_to_matrix, dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_filter, &
         dbcsr_t_get_block, dbcsr_t_iterator_blocks_left, dbcsr_t_iterator_next_block, &
         dbcsr_t_iterator_start, dbcsr_t_iterator_stop, dbcsr_t_iterator_type, &
-        dbcsr_t_need_contract, dbcsr_t_put_block, dbcsr_t_reserve_blocks, dbcsr_t_set, dbcsr_t_type
+        dbcsr_t_need_contract, dbcsr_t_put_block, dbcsr_t_reserve_blocks, dbcsr_t_type
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE kpoint_types,                    ONLY: get_kpoint_info,&
@@ -222,12 +223,10 @@ CONTAINS
          DO i_cell = 1, num_cells_dm
             CALL dbcsr_t_create(mat_dm_virt_global(jquad, i_cell)%matrix, t_dm_virt(i_cell), name="D virt (AO | AO)")
             CALL dbcsr_t_copy_matrix_to_tensor(mat_dm_virt_global(jquad, i_cell)%matrix, t_dm_virt(i_cell))
-            CALL dbcsr_set(mat_dm_virt_global(jquad, i_cell)%matrix, 0.0_dp)
-            CALL dbcsr_filter(mat_dm_virt_global(jquad, i_cell)%matrix, 1.0_dp)
+            CALL dbcsr_clear(mat_dm_virt_global(jquad, i_cell)%matrix)
             CALL dbcsr_t_create(mat_dm_occ_global(jquad, i_cell)%matrix, t_dm_occ(i_cell), name="D occ (AO | AO)")
             CALL dbcsr_t_copy_matrix_to_tensor(mat_dm_occ_global(jquad, i_cell)%matrix, t_dm_occ(i_cell))
-            CALL dbcsr_set(mat_dm_occ_global(jquad, i_cell)%matrix, 0.0_dp)
-            CALL dbcsr_filter(mat_dm_occ_global(jquad, i_cell)%matrix, 1.0_dp)
+            CALL dbcsr_clear(mat_dm_occ_global(jquad, i_cell)%matrix)
          ENDDO
          CALL dbcsr_t_create(t_3c_O_cut(1, 1, 1), t_3c_M_tmp, name="M (RI AO | AO)")
          CALL dbcsr_t_create(t_3c_M, t_3c_M_occ, name="M occ (RI | AO AO)")
@@ -297,8 +296,7 @@ CONTAINS
                         ! representation)
                         CALL dbcsr_t_copy(t_3c_M_tmp, t_3c_M_occ, order=[1, 3, 2], move_data=.TRUE.)
                         CALL dbcsr_t_filter(t_3c_M_occ, eps_filter)
-                        CALL dbcsr_t_set(t_3c_M_tmp, 0.0_dp)
-                        CALL dbcsr_t_filter(t_3c_M_tmp, 1.0_dp)
+                        CALL dbcsr_t_clear(t_3c_M_tmp)
                         CALL timestop(handle5)
 
                         DO i_cell_S = 1, num_cells_dm
@@ -332,12 +330,10 @@ CONTAINS
                         CALL timeset(routineN//"_copy_M_t", handle5)
                         CALL dbcsr_t_copy(t_3c_M_tmp, t_3c_M_virt, order=[1, 2, 3], move_data=.TRUE.)
                         CALL dbcsr_t_filter(t_3c_M_virt, eps_filter)
-                        CALL dbcsr_t_set(t_3c_M_tmp, 0.0_dp)
-                        CALL dbcsr_t_filter(t_3c_M_tmp, 1.0_dp)
+                        CALL dbcsr_t_clear(t_3c_M_tmp)
                         CALL timestop(handle5)
 
                         num_flops_mat_P = 0
-                        CALL dbcsr_set(mat_P_global%matrix, 0.0_dp)
                         IF (dbcsr_t_need_contract(t_3c_M_occ, t_3c_M_virt, &
                                                   [2, 3], [2, 3])) THEN
 
@@ -360,12 +356,9 @@ CONTAINS
                            CALL timestop(handle5)
                         ENDIF
 
-                        CALL dbcsr_t_set(t_3c_M_occ, 0.0_dp)
-                        CALL dbcsr_t_filter(t_3c_M_occ, 1.0_dp)
-                        CALL dbcsr_t_set(t_3c_M_virt, 0.0_dp)
-                        CALL dbcsr_t_filter(t_3c_M_virt, 1.0_dp)
-                        CALL dbcsr_t_set(t_P, 0.0_dp)
-                        CALL dbcsr_t_filter(t_P, 1.0_dp)
+                        CALL dbcsr_t_clear(t_3c_M_occ)
+                        CALL dbcsr_t_clear(t_3c_M_virt)
+                        CALL dbcsr_t_clear(t_P)
 
                         IF (do_ri_sos_laplace_mp2) THEN
                            ! For RI-SOS-Laplace-MP2 we do not perform a cosine transform,

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -404,6 +404,8 @@ CONTAINS
                                                                 para_env, has_mat_P_blocks, num_flops_mat_P)
 
                         END IF ! do_ri_sos_laplace_mp2
+
+                        CALL dbcsr_clear(mat_P_global%matrix)
                      ENDDO
                   ENDDO
                ENDDO

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -68,6 +68,8 @@ MODULE rpa_ri_gpw
         dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_p_type, dbcsr_release, &
         dbcsr_release_p, dbcsr_reserve_all_blocks, dbcsr_scale, dbcsr_set, dbcsr_trace, &
         dbcsr_transposed, dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_real_default
+   USE dbcsr_tensor_api,                ONLY: dbcsr_t_destroy,&
+                                              dbcsr_t_type
    USE input_constants,                 ONLY: gw_pade_approx,&
                                               gw_two_pole_model,&
                                               ri_rpa_g0w0_crossing_bisection,&
@@ -127,6 +129,7 @@ MODULE rpa_ri_gpw
                                               gap_and_max_eig_diff_kpoints,&
                                               get_mat_3c_overl_int_gw,&
                                               setup_mat_for_mem_cut_3c,&
+                                              setup_tensor_for_mem_cut_3c,&
                                               zero_mat_P_omega
    USE util,                            ONLY: get_limit
 #include "./base/base_uses.f90"
@@ -194,6 +197,11 @@ CONTAINS
 !> \param mat_P_global ...
 !> \param mat_M ...
 !> \param mat_3c_overl_int ...
+!> \param do_dbcsr_t ...
+!> \param t_3c_M ...
+!> \param t_3c_O ...
+!> \param starts_array_mc_t ...
+!> \param ends_array_mc_t ...
 !> \param mat_3c_overl_int_mao_for_occ ...
 !> \param mat_3c_overl_int_mao_for_virt ...
 !> \param eps_filter ...
@@ -219,7 +227,9 @@ CONTAINS
                                 mao_coeff_occ, mao_coeff_virt, mao_coeff_occ_A, mao_coeff_virt_A, &
                                 mat_munu, mat_dm_occ_local, mat_dm_virt_local, &
                                 mat_P_local, mat_P_global, &
-                                mat_M, mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, &
+                                mat_M, mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, &
+                                starts_array_mc_t, ends_array_mc_t, &
+                                mat_3c_overl_int_mao_for_occ, &
                                 mat_3c_overl_int_mao_for_virt, &
                                 eps_filter, BIb_C_beta, homo_beta, Eigenval_beta, &
                                 ends_B_virtual_beta, sizes_B_virtual_beta, starts_B_virtual_beta, &
@@ -249,8 +259,12 @@ CONTAINS
       TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_munu, mat_dm_occ_local, &
                                                             mat_dm_virt_local, mat_P_local, &
                                                             mat_P_global, mat_M
-      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int, &
-                                                            mat_3c_overl_int_mao_for_occ, &
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
+      LOGICAL, INTENT(IN)                                :: do_dbcsr_t
+      TYPE(dbcsr_t_type)                                 :: t_3c_M
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :)   :: t_3c_O
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc_t, ends_array_mc_t
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_mao_for_occ, &
                                                             mat_3c_overl_int_mao_for_virt
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
@@ -751,7 +765,10 @@ CONTAINS
                              do_im_time, do_mao, fm_mo_coeff_occ, fm_mo_coeff_virt, mo_coeff, fm_matrix_L_RI_metric, &
                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
                              mat_munu, mat_dm_occ_local, mat_dm_virt_local, mat_P_local, mat_P_global, mat_M, &
-                             mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, matrix_s, &
+                             mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
+                             do_dbcsr_t, t_3c_M, t_3c_O, &
+                             starts_array_mc_t, ends_array_mc_t, &
+                             matrix_s, &
                              mao_coeff_occ, mao_coeff_virt, eps_filter, &
                              starts_array, ends_array, sizes_array, color_sub, &
                              fm_mo_coeff_occ_beta=fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta=fm_mo_coeff_virt_beta, &
@@ -781,7 +798,10 @@ CONTAINS
                              do_im_time, do_mao, fm_mo_coeff_occ, fm_mo_coeff_virt, mo_coeff, fm_matrix_L_RI_metric, &
                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
                              mat_munu, mat_dm_occ_local, mat_dm_virt_local, mat_P_local, mat_P_global, mat_M, &
-                             mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, matrix_s, &
+                             mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
+                             do_dbcsr_t, t_3c_M, t_3c_O, &
+                             starts_array_mc_t, ends_array_mc_t, &
+                             matrix_s, &
                              mao_coeff_occ, mao_coeff_virt, &
                              eps_filter, starts_array, ends_array, sizes_array, color_sub, &
                              do_ri_sos_laplace_mp2=do_ri_sos_laplace_mp2)
@@ -1933,6 +1953,11 @@ CONTAINS
 !> \param mat_3c_overl_int ...
 !> \param mat_3c_overl_int_mao_for_occ ...
 !> \param mat_3c_overl_int_mao_for_virt ...
+!> \param do_dbcsr_t ...
+!> \param t_3c_M ...
+!> \param t_3c_O ...
+!> \param starts_array_mc_t ...
+!> \param ends_array_mc_t ...
 !> \param matrix_s ...
 !> \param mao_coeff_occ ...
 !> \param mao_coeff_virt ...
@@ -1967,7 +1992,10 @@ CONTAINS
                           fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, mat_munu, mat_dm_occ_local, &
                           mat_dm_virt_local, mat_P_local, &
                           mat_P_global, mat_M, mat_3c_overl_int, mat_3c_overl_int_mao_for_occ, &
-                          mat_3c_overl_int_mao_for_virt, matrix_s, mao_coeff_occ, mao_coeff_virt, &
+                          mat_3c_overl_int_mao_for_virt, &
+                          do_dbcsr_t, t_3c_M, t_3c_O, &
+                          starts_array_mc_t, ends_array_mc_t, &
+                          matrix_s, mao_coeff_occ, mao_coeff_virt, &
                           eps_filter, starts_array, ends_array, sizes_array, color_sub, &
                           fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
                           homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta, &
@@ -2000,6 +2028,11 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int, &
                                                             mat_3c_overl_int_mao_for_occ, &
                                                             mat_3c_overl_int_mao_for_virt
+      LOGICAL, INTENT(IN)                                :: do_dbcsr_t
+      TYPE(dbcsr_t_type), INTENT(INOUT)                  :: t_3c_M
+      TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: t_3c_O
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc_t, ends_array_mc_t
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mao_coeff_occ, mao_coeff_virt
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array, ends_array, sizes_array
@@ -2023,13 +2056,13 @@ CONTAINS
       INTEGER :: col_start_local, color_sub_col, color_sub_row, count_ev_sc_GW, crossing_search, &
          cut_memory, cut_RI, group_size_P, gw_corr_lev_tot, handle, handle2, handle3, handle4, &
          i_cell, i_cut_RI, i_dim, i_global, i_kp, i_mem, i_size, ierr, iiB, ikp, info_chol, iquad, &
-         iter_ev_sc, j_cell, j_global, j_mem, j_size, jjB, jquad, LLL, m_global, m_global_beta, &
-         max_iter_bse, max_iter_fit, mm_style, my_group_L_size_im_time, my_num_dgemm_call, &
-         n_global, n_global_beta, n_group_col, n_group_row, n_level_gw, n_level_gw_ref, &
-         n_local_col, n_local_row, nblkrows_total, ncol_local, ngroup_RI_orig, nkp
-      INTEGER :: nm_global, nmo, nrow_local, num_3c_repl, num_cells_dm, num_fit_points, &
-         num_points_corr, num_points_per_magnitude, num_poles, num_Z_vectors, number_of_rec, &
-         number_of_rec_axk, number_of_rec_beta, number_of_send, number_of_send_axk, &
+         isize, iter_ev_sc, j_cell, j_global, j_mem, j_size, jjB, jquad, jsize, ksize, LLL, &
+         m_global, m_global_beta, max_iter_bse, max_iter_fit, mm_style, my_group_L_size_im_time, &
+         my_num_dgemm_call, n_global, n_global_beta, n_group_col, n_group_row, n_level_gw, &
+         n_level_gw_ref, n_local_col, n_local_row, nblkrows_total, ncol_local
+      INTEGER :: ngroup_RI_orig, nkp, nm_global, nmo, nrow_local, num_3c_repl, num_cells_dm, &
+         num_fit_points, num_points_corr, num_points_per_magnitude, num_poles, num_Z_vectors, &
+         number_of_rec, number_of_rec_axk, number_of_rec_beta, number_of_send, number_of_send_axk, &
          number_of_send_beta, row, row_start_local, size_P
       INTEGER, ALLOCATABLE, DIMENSION(:) :: map_rec_size, map_rec_size_axk, map_rec_size_beta, &
          map_send_size, map_send_size_axk, map_send_size_beta, mepos_P_from_RI_row, &
@@ -2091,6 +2124,8 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_dm_loc_occ_cut, mat_dm_loc_virt_cut
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut, &
          mat_3c_overl_int_mao_for_occ_cut, mat_3c_overl_int_mao_for_virt_cut
+      TYPE(dbcsr_t_type), ALLOCATABLE, &
+         DIMENSION(:, :, :)                              :: t_3c_O_cut
       TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ, mat_contr_gf_virt, &
                                                             mat_contr_W, mat_dm_loc_occ, &
                                                             mat_dm_loc_virt
@@ -2190,38 +2225,43 @@ CONTAINS
          ALLOCATE (my_group_L_sizes_im_time(cut_RI))
          my_group_L_sizes_im_time(:) = mp2_env%ri_rpa_im_time_util(1)%my_group_L_sizes_im_time
 
-         num_3c_repl = SIZE(mat_3c_overl_int, 3)
+         IF (.NOT. do_dbcsr_t) THEN
+            num_3c_repl = SIZE(mat_3c_overl_int, 3)
+         ELSE
+            num_3c_repl = SIZE(t_3c_O, 2)
+         ENDIF
 
-         DO i_cut_RI = 1, cut_RI
+         IF (.NOT. do_dbcsr_t) THEN
+            DO i_cut_RI = 1, cut_RI
 
-            my_group_L_size_im_time = my_group_L_sizes_im_time(i_cut_RI)
+               my_group_L_size_im_time = my_group_L_sizes_im_time(i_cut_RI)
 
-            DO i_cell = 1, num_3c_repl
-               DO j_cell = 1, num_3c_repl
+               DO i_cell = 1, num_3c_repl
+                  DO j_cell = 1, num_3c_repl
 
-                  CALL dbcsr_filter(mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, &
-                                    eps_filter*SQRT(REAL(my_group_L_size_im_time, KIND=dp)))
+                     CALL dbcsr_filter(mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, &
+                                       eps_filter)
 
+                  END DO
                END DO
+
             END DO
 
-         END DO
+            CALL timestop(handle4)
 
-         CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_1", handle4)
 
-         CALL timeset(routineN//"_im_t_alloc_mat_1", handle4)
+            NULLIFY (mat_dm_loc_occ)
+            CALL dbcsr_init_p(mat_dm_loc_occ)
+            CALL dbcsr_desymmetrize(mat_dm_occ_local%matrix, mat_dm_loc_occ)
 
-         NULLIFY (mat_dm_loc_occ)
-         CALL dbcsr_init_p(mat_dm_loc_occ)
-         CALL dbcsr_desymmetrize(mat_dm_occ_local%matrix, mat_dm_loc_occ)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_2", handle4)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_2", handle4)
-
-         CALL get_non_zero_blocks_3c(mat_3c_overl_int, para_env_sub, cut_RI, non_zero_blocks_3c)
-
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_3", handle4)
+            CALL get_non_zero_blocks_3c(mat_3c_overl_int, para_env_sub, cut_RI, non_zero_blocks_3c)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_3", handle4)
+         ENDIF
 
          IF (do_kpoints_cubic_RPA) THEN
             CALL get_qs_env(qs_env, &
@@ -2252,101 +2292,104 @@ CONTAINS
             num_cells_dm = 1
          END IF
 
-         NULLIFY (mat_dm_loc_occ_cut)
-         CALL dbcsr_allocate_matrix_set(mat_dm_loc_occ_cut, cut_RI, cut_memory, num_cells_dm)
+         IF (.NOT. do_dbcsr_t) THEN
+            NULLIFY (mat_dm_loc_occ_cut)
+            CALL dbcsr_allocate_matrix_set(mat_dm_loc_occ_cut, cut_RI, cut_memory, num_cells_dm)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_4", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_4", handle4)
 
-         DO i_mem = 1, cut_memory
-            DO i_cut_RI = 1, cut_RI
-               DO i_cell = 1, num_cells_dm
+            DO i_mem = 1, cut_memory
+               DO i_cut_RI = 1, cut_RI
+                  DO i_cell = 1, num_cells_dm
 
-                  ALLOCATE (mat_dm_loc_occ_cut(i_cut_RI, i_mem, i_cell)%matrix)
-                  CALL dbcsr_create(matrix=mat_dm_loc_occ_cut(i_cut_RI, i_mem, i_cell)%matrix, &
-                                    template=mat_dm_loc_occ)
+                     ALLOCATE (mat_dm_loc_occ_cut(i_cut_RI, i_mem, i_cell)%matrix)
+                     CALL dbcsr_create(matrix=mat_dm_loc_occ_cut(i_cut_RI, i_mem, i_cell)%matrix, &
+                                       template=mat_dm_loc_occ)
 
+                  END DO
                END DO
             END DO
-         END DO
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_5", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_5", handle4)
 
-         NULLIFY (mat_dm_loc_virt)
-         CALL dbcsr_init_p(mat_dm_loc_virt)
-         CALL dbcsr_desymmetrize(mat_dm_virt_local%matrix, mat_dm_loc_virt)
+            NULLIFY (mat_dm_loc_virt)
+            CALL dbcsr_init_p(mat_dm_loc_virt)
+            CALL dbcsr_desymmetrize(mat_dm_virt_local%matrix, mat_dm_loc_virt)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_6", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_6", handle4)
 
-         NULLIFY (mat_dm_loc_virt_cut)
-         CALL dbcsr_allocate_matrix_set(mat_dm_loc_virt_cut, cut_RI, cut_memory, num_cells_dm)
+            NULLIFY (mat_dm_loc_virt_cut)
+            CALL dbcsr_allocate_matrix_set(mat_dm_loc_virt_cut, cut_RI, cut_memory, num_cells_dm)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_7", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_7", handle4)
 
-         DO i_mem = 1, cut_memory
-            DO i_cut_RI = 1, cut_RI
-               DO i_cell = 1, num_cells_dm
+            DO i_mem = 1, cut_memory
+               DO i_cut_RI = 1, cut_RI
+                  DO i_cell = 1, num_cells_dm
 
-                  ALLOCATE (mat_dm_loc_virt_cut(i_cut_RI, i_mem, i_cell)%matrix)
-                  CALL dbcsr_create(matrix=mat_dm_loc_virt_cut(i_cut_RI, i_mem, i_cell)%matrix, &
-                                    template=mat_dm_loc_virt)
+                     ALLOCATE (mat_dm_loc_virt_cut(i_cut_RI, i_mem, i_cell)%matrix)
+                     CALL dbcsr_create(matrix=mat_dm_loc_virt_cut(i_cut_RI, i_mem, i_cell)%matrix, &
+                                       template=mat_dm_loc_virt)
 
+                  END DO
                END DO
             END DO
-         END DO
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_8", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_8", handle4)
 
-         CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-         CALL dbcsr_filter(mat_munu%matrix, 1.0_dp)
+            CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
+            CALL dbcsr_filter(mat_munu%matrix, 1.0_dp)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_9", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_9", handle4)
 
-         NULLIFY (mat_M_P_munu_occ%matrix)
-         ALLOCATE (mat_M_P_munu_occ%matrix)
-         CALL dbcsr_create(mat_M_P_munu_occ%matrix, template=mat_M%matrix)
+            NULLIFY (mat_M_P_munu_occ%matrix)
+            ALLOCATE (mat_M_P_munu_occ%matrix)
+            CALL dbcsr_create(mat_M_P_munu_occ%matrix, template=mat_M%matrix)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_10", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_10", handle4)
 
-         NULLIFY (mat_M_P_munu_virt%matrix)
-         ALLOCATE (mat_M_P_munu_virt%matrix)
-         CALL dbcsr_create(mat_M_P_munu_virt%matrix, template=mat_M%matrix)
+            NULLIFY (mat_M_P_munu_virt%matrix)
+            ALLOCATE (mat_M_P_munu_virt%matrix)
+            CALL dbcsr_create(mat_M_P_munu_virt%matrix, template=mat_M%matrix)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_11", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_11", handle4)
 
-         IF (.NOT. do_mao) THEN
-            mat_3c_overl_int_mao_for_occ => mat_3c_overl_int
-            mat_3c_overl_int_mao_for_virt => mat_3c_overl_int
-         END IF
+            IF (.NOT. do_mao) THEN
+               mat_3c_overl_int_mao_for_occ => mat_3c_overl_int
+               mat_3c_overl_int_mao_for_virt => mat_3c_overl_int
+            END IF
 
-         NULLIFY (mat_M_mu_Pnu_occ)
-         CALL dbcsr_allocate_matrix_set(mat_M_mu_Pnu_occ, cut_RI)
-         DO i_cut_RI = 1, cut_RI
-            ALLOCATE (mat_M_mu_Pnu_occ(i_cut_RI)%matrix)
-            CALL dbcsr_create(matrix=mat_M_mu_Pnu_occ(i_cut_RI)%matrix, &
-                              template=mat_3c_overl_int_mao_for_occ(i_cut_RI, 1, 1)%matrix)
-         END DO
+            NULLIFY (mat_M_mu_Pnu_occ)
+            CALL dbcsr_allocate_matrix_set(mat_M_mu_Pnu_occ, cut_RI)
+            DO i_cut_RI = 1, cut_RI
+               ALLOCATE (mat_M_mu_Pnu_occ(i_cut_RI)%matrix)
+               CALL dbcsr_create(matrix=mat_M_mu_Pnu_occ(i_cut_RI)%matrix, &
+                                 template=mat_3c_overl_int_mao_for_occ(i_cut_RI, 1, 1)%matrix)
+            END DO
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_12", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_12", handle4)
 
-         NULLIFY (mat_M_mu_Pnu_virt)
-         CALL dbcsr_allocate_matrix_set(mat_M_mu_Pnu_virt, cut_RI)
-         DO i_cut_RI = 1, cut_RI
-            ALLOCATE (mat_M_mu_Pnu_virt(i_cut_RI)%matrix)
-            CALL dbcsr_create(matrix=mat_M_mu_Pnu_virt(i_cut_RI)%matrix, &
-                              template=mat_3c_overl_int_mao_for_virt(i_cut_RI, 1, 1)%matrix)
-         END DO
+            NULLIFY (mat_M_mu_Pnu_virt)
+            CALL dbcsr_allocate_matrix_set(mat_M_mu_Pnu_virt, cut_RI)
+            DO i_cut_RI = 1, cut_RI
+               ALLOCATE (mat_M_mu_Pnu_virt(i_cut_RI)%matrix)
+               CALL dbcsr_create(matrix=mat_M_mu_Pnu_virt(i_cut_RI)%matrix, &
+                                 template=mat_3c_overl_int_mao_for_virt(i_cut_RI, 1, 1)%matrix)
+            END DO
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_13", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_13", handle4)
+
+         ENDIF
 
          ! if we do kpoints, mat_P has a kpoint and mat_P_omega has the inted
          ! mat_P(tau, kpoint)
@@ -2399,118 +2442,120 @@ CONTAINS
          CALL timestop(handle4)
          CALL timeset(routineN//"_im_t_alloc_mat_14", handle4)
 
-         NULLIFY (mat_P_global_copy%matrix)
-         ALLOCATE (mat_P_global_copy%matrix)
-         CALL dbcsr_create(mat_P_global_copy%matrix, template=mat_P_global%matrix)
-         CALL dbcsr_copy(mat_P_global_copy%matrix, mat_P_global%matrix)
+         IF (.NOT. do_dbcsr_t) THEN
+            NULLIFY (mat_P_global_copy%matrix)
+            ALLOCATE (mat_P_global_copy%matrix)
+            CALL dbcsr_create(mat_P_global_copy%matrix, template=mat_P_global%matrix)
+            CALL dbcsr_copy(mat_P_global_copy%matrix, mat_P_global%matrix)
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_15", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_15", handle4)
 
-         n_group_row = mp2_env%ri_rpa_im_time_util(1)%n_group_row
-         ALLOCATE (sizes_array_prim_row(0:n_group_row-1, cut_memory))
-         DO i_mem = 1, cut_memory
-            sizes_array_prim_row(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%sizes_array_prim_row(:)
-         END DO
-         ALLOCATE (starts_array_prim_row(0:n_group_row-1, cut_memory))
-         DO i_mem = 1, cut_memory
-            starts_array_prim_row(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%starts_array_prim_row(:)
-         END DO
-         ALLOCATE (ends_array_prim_row(0:n_group_row-1, cut_memory))
-         DO i_mem = 1, cut_memory
-            ends_array_prim_row(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%ends_array_prim_row(:)
-         END DO
-
-         ALLOCATE (starts_array_prim_fullrow(0:n_group_row-1, cut_memory))
-         DO i_mem = 1, cut_memory
-            starts_array_prim_fullrow(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%starts_array_prim_fullrow(:)
-         END DO
-         ALLOCATE (ends_array_prim_fullrow(0:n_group_row-1, cut_memory))
-         DO i_mem = 1, cut_memory
-            ends_array_prim_fullrow(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%ends_array_prim_fullrow(:)
-         END DO
-
-         n_group_col = mp2_env%ri_rpa_im_time_util(1)%n_group_col
-         ALLOCATE (sizes_array_prim_col(0:n_group_col-1, cut_memory))
-         DO j_mem = 1, cut_memory
-            sizes_array_prim_col(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%sizes_array_prim_col(:)
-         END DO
-         ALLOCATE (starts_array_prim_col(0:n_group_col-1, cut_memory))
-         DO j_mem = 1, cut_memory
-            starts_array_prim_col(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%starts_array_prim_col(:)
-         END DO
-         ALLOCATE (ends_array_prim_col(0:n_group_col-1, cut_memory))
-         DO j_mem = 1, cut_memory
-            ends_array_prim_col(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%ends_array_prim_col(:)
-         END DO
-
-         ALLOCATE (starts_array_prim_fullcol(0:n_group_col-1, cut_memory))
-         DO j_mem = 1, cut_memory
-            starts_array_prim_fullcol(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%starts_array_prim_fullcol(:)
-         END DO
-         ALLOCATE (ends_array_prim_fullcol(0:n_group_col-1, cut_memory))
-         DO j_mem = 1, cut_memory
-            ends_array_prim_fullcol(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%ends_array_prim_fullcol(:)
-         END DO
-
-         ALLOCATE (offset_combi_block(cut_memory, cut_memory))
-
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_16", handle4)
-
-         color_sub_row = mp2_env%ri_rpa_im_time_util(1)%color_sub_row
-         color_sub_col = mp2_env%ri_rpa_im_time_util(1)%color_sub_col
-
-         DO i_mem = 1, cut_memory
-            DO j_mem = 1, cut_memory
-
-               n_local_row = sizes_array_prim_row(color_sub_row, i_mem)
-               row_start_local = starts_array_prim_row(color_sub_row, i_mem)
-
-               n_local_col = sizes_array_prim_col(color_sub_col, j_mem)
-               col_start_local = starts_array_prim_col(color_sub_col, j_mem)
-
-               ALLOCATE (offset_combi_block(i_mem, j_mem)%array(row_start_local:row_start_local+n_local_row-1, &
-                                                                col_start_local:col_start_local+n_local_col-1))
-               offset_combi_block(i_mem, j_mem)%array(:, :) = &
-                  mp2_env%ri_rpa_im_time_2d_util(i_mem, j_mem)%offset_combi_block(:, :)
-
+            n_group_row = mp2_env%ri_rpa_im_time_util(1)%n_group_row
+            ALLOCATE (sizes_array_prim_row(0:n_group_row-1, cut_memory))
+            DO i_mem = 1, cut_memory
+               sizes_array_prim_row(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%sizes_array_prim_row(:)
             END DO
-         END DO
+            ALLOCATE (starts_array_prim_row(0:n_group_row-1, cut_memory))
+            DO i_mem = 1, cut_memory
+               starts_array_prim_row(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%starts_array_prim_row(:)
+            END DO
+            ALLOCATE (ends_array_prim_row(0:n_group_row-1, cut_memory))
+            DO i_mem = 1, cut_memory
+               ends_array_prim_row(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%ends_array_prim_row(:)
+            END DO
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_17", handle4)
+            ALLOCATE (starts_array_prim_fullrow(0:n_group_row-1, cut_memory))
+            DO i_mem = 1, cut_memory
+               starts_array_prim_fullrow(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%starts_array_prim_fullrow(:)
+            END DO
+            ALLOCATE (ends_array_prim_fullrow(0:n_group_row-1, cut_memory))
+            DO i_mem = 1, cut_memory
+               ends_array_prim_fullrow(:, i_mem) = mp2_env%ri_rpa_im_time_util(i_mem)%ends_array_prim_fullrow(:)
+            END DO
 
-         NULLIFY (starts_array_cm, ends_array_cm)
-         starts_array_cm => mp2_env%ri_rpa_im_time%starts_array_cm
-         ends_array_cm => mp2_env%ri_rpa_im_time%ends_array_cm
+            n_group_col = mp2_env%ri_rpa_im_time_util(1)%n_group_col
+            ALLOCATE (sizes_array_prim_col(0:n_group_col-1, cut_memory))
+            DO j_mem = 1, cut_memory
+               sizes_array_prim_col(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%sizes_array_prim_col(:)
+            END DO
+            ALLOCATE (starts_array_prim_col(0:n_group_col-1, cut_memory))
+            DO j_mem = 1, cut_memory
+               starts_array_prim_col(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%starts_array_prim_col(:)
+            END DO
+            ALLOCATE (ends_array_prim_col(0:n_group_col-1, cut_memory))
+            DO j_mem = 1, cut_memory
+               ends_array_prim_col(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%ends_array_prim_col(:)
+            END DO
 
-         NULLIFY (starts_array_cm_mao_occ, starts_array_cm_mao_virt, ends_array_cm_mao_occ, ends_array_cm_mao_virt)
-         IF (do_mao) THEN
-            starts_array_cm_mao_occ => mp2_env%ri_rpa_im_time%starts_array_cm_mao_occ
-            starts_array_cm_mao_virt => mp2_env%ri_rpa_im_time%starts_array_cm_mao_virt
-            ends_array_cm_mao_occ => mp2_env%ri_rpa_im_time%ends_array_cm_mao_occ
-            ends_array_cm_mao_virt => mp2_env%ri_rpa_im_time%ends_array_cm_mao_virt
-         ELSE
-            starts_array_cm_mao_occ => starts_array_cm
-            starts_array_cm_mao_virt => starts_array_cm
-            ends_array_cm_mao_occ => ends_array_cm
-            ends_array_cm_mao_virt => ends_array_cm
-         END IF
+            ALLOCATE (starts_array_prim_fullcol(0:n_group_col-1, cut_memory))
+            DO j_mem = 1, cut_memory
+               starts_array_prim_fullcol(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%starts_array_prim_fullcol(:)
+            END DO
+            ALLOCATE (ends_array_prim_fullcol(0:n_group_col-1, cut_memory))
+            DO j_mem = 1, cut_memory
+               ends_array_prim_fullcol(:, j_mem) = mp2_env%ri_rpa_im_time_util(j_mem)%ends_array_prim_fullcol(:)
+            END DO
 
-         ! allocatable arrays for fast filling of dbcsr matrices
-         CALL dbcsr_get_info(mat_M_P_munu_occ%matrix, row_blk_size=row_blk_size, &
-                             col_blk_size=col_blk_size, nblkrows_total=nblkrows_total)
-         ALLOCATE (buffer_mat_M(MAXVAL(row_blk_size), MAXVAL(col_blk_size)))
+            ALLOCATE (offset_combi_block(cut_memory, cut_memory))
 
-         ALLOCATE (mepos_P_from_RI_row(nblkrows_total))
-         mepos_P_from_RI_row(:) = mp2_env%ri_rpa_im_time_util(1)%mepos_P_from_RI_row(:)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_16", handle4)
 
-         ! allocatable arrays for fast filling of dbcsr matrices
-         CALL dbcsr_get_info(mat_P_global%matrix, row_blk_size=row_blk_size, col_blk_size=col_blk_size)
+            color_sub_row = mp2_env%ri_rpa_im_time_util(1)%color_sub_row
+            color_sub_col = mp2_env%ri_rpa_im_time_util(1)%color_sub_col
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_18", handle4)
+            DO i_mem = 1, cut_memory
+               DO j_mem = 1, cut_memory
+
+                  n_local_row = sizes_array_prim_row(color_sub_row, i_mem)
+                  row_start_local = starts_array_prim_row(color_sub_row, i_mem)
+
+                  n_local_col = sizes_array_prim_col(color_sub_col, j_mem)
+                  col_start_local = starts_array_prim_col(color_sub_col, j_mem)
+
+                  ALLOCATE (offset_combi_block(i_mem, j_mem)%array(row_start_local:row_start_local+n_local_row-1, &
+                                                                   col_start_local:col_start_local+n_local_col-1))
+                  offset_combi_block(i_mem, j_mem)%array(:, :) = &
+                     mp2_env%ri_rpa_im_time_2d_util(i_mem, j_mem)%offset_combi_block(:, :)
+
+               END DO
+            END DO
+
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_17", handle4)
+
+            NULLIFY (starts_array_cm, ends_array_cm)
+            starts_array_cm => mp2_env%ri_rpa_im_time%starts_array_cm
+            ends_array_cm => mp2_env%ri_rpa_im_time%ends_array_cm
+
+            NULLIFY (starts_array_cm_mao_occ, starts_array_cm_mao_virt, ends_array_cm_mao_occ, ends_array_cm_mao_virt)
+            IF (do_mao) THEN
+               starts_array_cm_mao_occ => mp2_env%ri_rpa_im_time%starts_array_cm_mao_occ
+               starts_array_cm_mao_virt => mp2_env%ri_rpa_im_time%starts_array_cm_mao_virt
+               ends_array_cm_mao_occ => mp2_env%ri_rpa_im_time%ends_array_cm_mao_occ
+               ends_array_cm_mao_virt => mp2_env%ri_rpa_im_time%ends_array_cm_mao_virt
+            ELSE
+               starts_array_cm_mao_occ => starts_array_cm
+               starts_array_cm_mao_virt => starts_array_cm
+               ends_array_cm_mao_occ => ends_array_cm
+               ends_array_cm_mao_virt => ends_array_cm
+            END IF
+
+            ! allocatable arrays for fast filling of dbcsr matrices
+            CALL dbcsr_get_info(mat_M_P_munu_occ%matrix, row_blk_size=row_blk_size, &
+                                col_blk_size=col_blk_size, nblkrows_total=nblkrows_total)
+            ALLOCATE (buffer_mat_M(MAXVAL(row_blk_size), MAXVAL(col_blk_size)))
+
+            ALLOCATE (mepos_P_from_RI_row(nblkrows_total))
+            mepos_P_from_RI_row(:) = mp2_env%ri_rpa_im_time_util(1)%mepos_P_from_RI_row(:)
+
+            ! allocatable arrays for fast filling of dbcsr matrices
+            CALL dbcsr_get_info(mat_P_global%matrix, row_blk_size=row_blk_size, col_blk_size=col_blk_size)
+
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_18", handle4)
+         ENDIF
 
          NULLIFY (fm_mat_work)
          CALL cp_fm_create(fm_mat_work, fm_mat_Q%matrix_struct)
@@ -2528,24 +2573,26 @@ CONTAINS
             END DO
          END DO
 
-         ALLOCATE (row_from_LLL(dimen_RI))
-         row_from_LLL = 0
+         IF (.NOT. do_dbcsr_t) THEN
+            ALLOCATE (row_from_LLL(dimen_RI))
+            row_from_LLL = 0
 
-         CALL timestop(handle4)
-         CALL timeset(routineN//"_im_t_alloc_mat_20", handle4)
+            CALL timestop(handle4)
+            CALL timeset(routineN//"_im_t_alloc_mat_20", handle4)
 
-         CALL dbcsr_get_info(mat_M_P_munu_occ%matrix, &
-                             nblkrows_total=nblkrows_total, &
-                             row_blk_offset=row_blk_offset, &
-                             row_blk_size=row_blk_size)
+            CALL dbcsr_get_info(mat_M_P_munu_occ%matrix, &
+                                nblkrows_total=nblkrows_total, &
+                                row_blk_offset=row_blk_offset, &
+                                row_blk_size=row_blk_size)
 
-         DO LLL = 1, dimen_RI
-            DO row = 1, nblkrows_total
-               IF (row_blk_offset(row) <= LLL .AND. LLL < row_blk_offset(row)+row_blk_size(row)) THEN
-                  row_from_LLL(LLL) = row
-               END IF
+            DO LLL = 1, dimen_RI
+               DO row = 1, nblkrows_total
+                  IF (row_blk_offset(row) <= LLL .AND. LLL < row_blk_offset(row)+row_blk_size(row)) THEN
+                     row_from_LLL(LLL) = row
+                  END IF
+               END DO
             END DO
-         END DO
+         ENDIF
 
          CALL timestop(handle4)
          CALL timeset(routineN//"_im_t_alloc_mat_20", handle4)
@@ -2715,8 +2762,13 @@ CONTAINS
 
          CALL timeset(routineN//"_im_t_alloc_mat_21", handle4)
 
-         CALL setup_mat_for_mem_cut_3c(mat_3c_overl_int_cut, mat_3c_overl_int, cut_memory, cut_RI, &
-                                       starts_array_cm, ends_array_cm, my_group_L_sizes_im_time, eps_filter)
+         IF (do_dbcsr_t) THEN
+            CALL setup_tensor_for_mem_cut_3c(t_3c_O_cut, t_3c_O, cut_memory, &
+                                             starts_array_mc_t, ends_array_mc_t, eps_filter)
+         ELSE
+            CALL setup_mat_for_mem_cut_3c(mat_3c_overl_int_cut, mat_3c_overl_int, cut_memory, cut_RI, &
+                                          starts_array_cm, ends_array_cm, my_group_L_sizes_im_time, eps_filter)
+         ENDIF
 
          CALL timestop(handle4)
          CALL timeset(routineN//"_im_t_alloc_mat_22", handle4)
@@ -2733,30 +2785,30 @@ CONTAINS
                                           my_group_L_sizes_im_time, eps_filter)
 
          ELSE
+            IF (.NOT. do_dbcsr_t) THEN
 
-            mat_3c_overl_int_mao_for_occ_cut => mat_3c_overl_int_cut
-            mat_3c_overl_int_mao_for_virt_cut => mat_3c_overl_int_cut
-
+               mat_3c_overl_int_mao_for_occ_cut => mat_3c_overl_int_cut
+               mat_3c_overl_int_mao_for_virt_cut => mat_3c_overl_int_cut
+            ENDIF
          END IF
 
-         CALL get_non_zero_blocks_3c_cut_col(mat_3c_overl_int_cut, para_env_sub, cut_RI, &
-                                             cut_memory, non_zero_blocks_3c_cut_col)
+         IF (.NOT. do_dbcsr_t) THEN
+            CALL get_non_zero_blocks_3c_cut_col(mat_3c_overl_int_cut, para_env_sub, cut_RI, &
+                                                cut_memory, non_zero_blocks_3c_cut_col)
 
-         CALL check_sparsity_arrays_for_kp(needed_cutRI_mem_R1vec_R2vec_for_kp, &
-                                           mat_3c_overl_int_cut, cut_RI, cut_memory, para_env_sub, &
-                                           do_kpoints_cubic_RPA)
+            CALL check_sparsity_arrays_for_kp(needed_cutRI_mem_R1vec_R2vec_for_kp, &
+                                              mat_3c_overl_int_cut, cut_RI, cut_memory, para_env_sub, &
+                                              do_kpoints_cubic_RPA)
 
-         ALLOCATE (cycle_due_to_sparse_dm(cut_memory, cut_memory, num_integ_points))
-         cycle_due_to_sparse_dm = .FALSE.
+            ALLOCATE (cycle_due_to_sparse_dm(cut_memory, cut_memory, num_integ_points))
+            cycle_due_to_sparse_dm = .FALSE.
 
-         ALLOCATE (multiply_needed_occ(cut_memory, cut_RI, num_cells_dm))
-         multiply_needed_occ = .TRUE.
+            ALLOCATE (multiply_needed_occ(cut_memory, cut_RI, num_cells_dm))
+            multiply_needed_occ = .TRUE.
 
-         ALLOCATE (multiply_needed_virt(cut_memory, cut_RI, num_cells_dm))
-         multiply_needed_virt = .TRUE.
-
-         ALLOCATE (has_mat_P_blocks(num_cells_dm/2+1, cut_memory, cut_memory, num_3c_repl, num_3c_repl))
-         has_mat_P_blocks = .TRUE.
+            ALLOCATE (multiply_needed_virt(cut_memory, cut_RI, num_cells_dm))
+            multiply_needed_virt = .TRUE.
+         ENDIF
 
          CALL timestop(handle4)
          CALL timeset(routineN//"_im_t_alloc_mat_23", handle4)
@@ -2809,6 +2861,9 @@ CONTAINS
          END IF
 
          CALL timestop(handle4)
+
+         ALLOCATE (has_mat_P_blocks(num_cells_dm/2+1, cut_memory, cut_memory, num_3c_repl, num_3c_repl))
+         has_mat_P_blocks = .TRUE.
 
          IF (do_ri_Sigma_x .OR. do_ic_model) THEN
 
@@ -3356,6 +3411,8 @@ CONTAINS
                                      mao_coeff_occ, mao_coeff_virt, 1, &
                                      mat_M_P_munu_occ, mat_M_P_munu_virt, mat_3c_overl_int_cut, &
                                      mat_3c_overl_int_mao_for_occ_cut, mat_3c_overl_int_mao_for_virt_cut, &
+                                     do_dbcsr_t, t_3c_M, t_3c_O_cut, &
+                                     starts_array_mc_t, ends_array_mc_t, &
                                      mat_dm_loc_occ_cut, mat_dm_loc_virt_cut, &
                                      weights_cos_tf_t_to_w, tj, tau_tj, e_fermi, eps_filter, alpha, &
                                      eps_filter_im_time, Eigenval, nmo, n_group_col, &
@@ -3389,6 +3446,8 @@ CONTAINS
                                            mao_coeff_occ, mao_coeff_virt, 2, &
                                            mat_M_P_munu_occ, mat_M_P_munu_virt, mat_3c_overl_int_cut, &
                                            mat_3c_overl_int_mao_for_occ_cut, mat_3c_overl_int_mao_for_virt_cut, &
+                                           do_dbcsr_t, t_3c_M, t_3c_O_cut, &
+                                           starts_array_mc_t, ends_array_mc_t, &
                                            mat_dm_loc_occ_cut, mat_dm_loc_virt_cut, &
                                            weights_cos_tf_t_to_w, tj, tau_tj, e_fermi_beta, eps_filter, alpha, &
                                            eps_filter_im_time, Eigenval_beta, nmo, n_group_col, &
@@ -3416,6 +3475,8 @@ CONTAINS
                                            mao_coeff_occ, mao_coeff_virt, 2, &
                                            mat_M_P_munu_occ, mat_M_P_munu_virt, mat_3c_overl_int_cut, &
                                            mat_3c_overl_int_mao_for_occ_cut, mat_3c_overl_int_mao_for_virt_cut, &
+                                           do_dbcsr_t, t_3c_M, t_3c_O_cut, &
+                                           starts_array_mc_t, ends_array_mc_t, &
                                            mat_dm_loc_occ_cut, mat_dm_loc_virt_cut, &
                                            weights_cos_tf_t_to_w, tj, tau_tj, e_fermi_beta, eps_filter, alpha, &
                                            eps_filter_im_time, Eigenval_beta, nmo, n_group_col, &
@@ -4224,18 +4285,23 @@ CONTAINS
          DEALLOCATE (fm_mat_L)
          CALL cp_fm_release(fm_mat_work)
 
-         CALL dbcsr_release_p(mat_dm_loc_occ)
-         CALL dbcsr_release_p(mat_dm_loc_virt)
+         IF (.NOT. do_dbcsr_t) THEN
+            CALL dbcsr_release_p(mat_dm_loc_occ)
+            CALL dbcsr_release_p(mat_dm_loc_virt)
 
-         CALL dbcsr_deallocate_matrix_set(mat_dm_loc_occ_cut)
-         CALL dbcsr_deallocate_matrix_set(mat_dm_loc_virt_cut)
+            CALL dbcsr_deallocate_matrix_set(mat_dm_loc_occ_cut)
+            CALL dbcsr_deallocate_matrix_set(mat_dm_loc_virt_cut)
 
-         CALL dbcsr_release(mat_M_P_munu_occ%matrix)
-         DEALLOCATE (mat_M_P_munu_occ%matrix)
-         CALL dbcsr_release(mat_M_P_munu_virt%matrix)
-         DEALLOCATE (mat_M_P_munu_virt%matrix)
-         CALL dbcsr_release(mat_P_global_copy%matrix)
-         DEALLOCATE (mat_P_global_copy%matrix)
+            CALL dbcsr_release(mat_M_P_munu_occ%matrix)
+            DEALLOCATE (mat_M_P_munu_occ%matrix)
+
+            CALL dbcsr_release(mat_M_P_munu_virt%matrix)
+            DEALLOCATE (mat_M_P_munu_virt%matrix)
+
+            CALL dbcsr_release(mat_P_global_copy%matrix)
+            DEALLOCATE (mat_P_global_copy%matrix)
+         ENDIF
+
          CALL dbcsr_release(mat_L%matrix)
          DEALLOCATE (mat_L%matrix)
          IF (do_ri_Sigma_x .OR. do_ic_model) THEN
@@ -4249,24 +4315,43 @@ CONTAINS
 
          DEALLOCATE (index_to_cell_3c, cell_to_index_3c)
 
-         CALL dbcsr_deallocate_matrix_set(mat_M_mu_Pnu_occ)
-         CALL dbcsr_deallocate_matrix_set(mat_M_mu_Pnu_virt)
+         IF (.NOT. do_dbcsr_t) THEN
+            CALL dbcsr_deallocate_matrix_set(mat_M_mu_Pnu_occ)
+            CALL dbcsr_deallocate_matrix_set(mat_M_mu_Pnu_virt)
+         ENDIF
 
          CALL dbcsr_deallocate_matrix_set(mat_P_omega)
          IF (my_open_shell .AND. do_im_time .AND. do_ri_sos_laplace_mp2) CALL dbcsr_deallocate_matrix_set(mat_P_omega_beta)
 
-         CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_cut)
-         IF (do_mao) THEN
-            CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_mao_for_occ_cut)
-            CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_mao_for_virt_cut)
-         END IF
+         IF (.NOT. do_dbcsr_t) THEN
+            CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_cut)
 
-         DEALLOCATE (buffer_mat_M)
-         DEALLOCATE (non_zero_blocks_3c)
-         DEALLOCATE (non_zero_blocks_3c_cut_col)
-         DEALLOCATE (cycle_due_to_sparse_dm, multiply_needed_occ, multiply_needed_virt)
-         DEALLOCATE (row_from_LLL)
-         DEALLOCATE (needed_cutRI_mem_R1vec_R2vec_for_kp)
+            IF (do_mao) THEN
+               CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_mao_for_occ_cut)
+               CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_mao_for_virt_cut)
+            END IF
+         ELSE
+            DO isize = 1, SIZE(t_3c_O_cut, 1)
+               DO jsize = 1, SIZE(t_3c_O_cut, 2)
+                  DO ksize = 1, SIZE(t_3c_O_cut, 3)
+                     CALL dbcsr_t_destroy(t_3c_O_cut(isize, jsize, ksize))
+                  ENDDO
+               ENDDO
+            ENDDO
+
+            DEALLOCATE (t_3c_O_cut)
+
+            CALL dbcsr_t_destroy(t_3c_M)
+         ENDIF
+
+         IF (.NOT. do_dbcsr_t) THEN
+            DEALLOCATE (buffer_mat_M)
+            DEALLOCATE (non_zero_blocks_3c)
+            DEALLOCATE (non_zero_blocks_3c_cut_col)
+            DEALLOCATE (cycle_due_to_sparse_dm, multiply_needed_occ, multiply_needed_virt)
+            DEALLOCATE (row_from_LLL)
+            DEALLOCATE (needed_cutRI_mem_R1vec_R2vec_for_kp)
+         ENDIF
          DEALLOCATE (has_mat_P_blocks)
 
          IF (do_gw_im_time) THEN

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -58,6 +58,7 @@
         ERI_METHOD OS
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           GW
           GROUP_SIZE_3c 1
           GROUP_SIZE_P 1
@@ -71,11 +72,11 @@
             &END SCREENING
           &END HF
           RPA_NUM_QUAD_POINTS 10
-          MINIMAX 
+          MINIMAX
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
-          &END RI_G0W0 
+          &END RI_G0W0
         &END RI_RPA
         MEMORY  200.
         NUMBER_PROC  1

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE_periodic.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE_periodic.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -51,6 +51,7 @@
         ERI_METHOD OS
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           GW
           GROUP_SIZE_3c 1
           GROUP_SIZE_P 1
@@ -73,7 +74,7 @@
             &PERIODIC
               NUM_OMEGA_POINTS   100
             &END
-          &END RI_G0W0 
+          &END RI_G0W0
         &END RI_RPA
         MEMORY  200.
         NUMBER_PROC  1

--- a/tests/QS/regtest-gw-cubic/G0W0_OH_PBE.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_OH_PBE.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -48,6 +48,7 @@
         RI OVERLAP
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           GW
         &END IM_TIME
         &RI_RPA
@@ -65,12 +66,12 @@
             CORR_MOS_VIRT         10
             NUMB_POLES            2
             MAX_ITER_FIT          10000
-            CROSSING_SEARCH       Z_SHOT 
+            CROSSING_SEARCH       Z_SHOT
             FERMI_LEVEL_OFFSET    2.0E-2
             EV_SC_ITER            1
             HF_LIKE_EV_START      FALSE
             PRINT_GW_DETAILS
-          &END RI_G0W0 
+          &END RI_G0W0
         &END RI_RPA
         MEMORY  200.
         NUMBER_PROC  1
@@ -93,7 +94,7 @@
       POTENTIAL  GTH-PBE-q6
     &END KIND
     &TOPOLOGY
-      COORD_FILE_NAME  OH_radical_gas.xyz 
+      COORD_FILE_NAME  OH_radical_gas.xyz
       COORD_FILE_FORMAT xyz
       &CENTER_COORDINATES
       &END

--- a/tests/QS/regtest-gw-ic-model/IC_no_wf_update.inp
+++ b/tests/QS/regtest-gw-ic-model/IC_no_wf_update.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O_minimax
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -47,7 +47,7 @@
       &WF_CORRELATION
         METHOD  RI_RPA_GPW
         &WFC_GPW
-          ! normally, this EPS_FILTER controls the accuracy and 
+          ! normally, this EPS_FILTER controls the accuracy and
           ! the time for the cubic_scaling RPA calculation
           EPS_FILTER  1.0E-6
         &END
@@ -55,6 +55,7 @@
         RI OVERLAP
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           GW
         &END
         &RI_RPA

--- a/tests/QS/regtest-gw-ic-model/IC_wavefunction_update.inp
+++ b/tests/QS/regtest-gw-ic-model/IC_wavefunction_update.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O_minimax
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -47,7 +47,7 @@
       &WF_CORRELATION
         METHOD  RI_RPA_GPW
         &WFC_GPW
-          ! normally, this EPS_FILTER controls the accuracy and 
+          ! normally, this EPS_FILTER controls the accuracy and
           ! the time for the cubic_scaling RPA calculation
           EPS_FILTER  1.0E-6
         &END
@@ -55,6 +55,7 @@
         RI OVERLAP
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           GW
         &END
         &RI_RPA

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RPA_H2O_kpoints
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -56,6 +56,7 @@
         NUMBER_PROC  1
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           MEMORY_CUT 1
           MEMORY_INFO
           GROUP_SIZE_P  1

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O.inp
@@ -56,7 +56,6 @@
         NUMBER_PROC  1
         IM_TIME
         &IM_TIME
-          DO_DBCSR_T .FALSE.
           MEMORY_CUT 1
           MEMORY_INFO
           GROUP_SIZE_P  1

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O_non_zero_group_sizes.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O_non_zero_group_sizes.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RPA_H2O_kpoints
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -56,6 +56,7 @@
         NUMBER_PROC  1
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           MEMORY_CUT 2
           GROUP_SIZE_3C 2
           MEMORY_INFO

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O_non_zero_group_sizes.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O_non_zero_group_sizes.inp
@@ -56,7 +56,6 @@
         NUMBER_PROC  1
         IM_TIME
         &IM_TIME
-          DO_DBCSR_T .FALSE.
           MEMORY_CUT 2
           GROUP_SIZE_3C 2
           MEMORY_INFO

--- a/tests/QS/regtest-rpa-cubic-scaling/Cubic_RPA_check_PAOs.inp
+++ b/tests/QS/regtest-rpa-cubic-scaling/Cubic_RPA_check_PAOs.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O_minimax
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -40,7 +40,7 @@
         METHOD  RI_RPA_GPW
         RI OVERLAP
         &WFC_GPW
-          ! normally, this EPS_FILTER controls the accuracy and 
+          ! normally, this EPS_FILTER controls the accuracy and
           ! the time for the cubic_scaling RPA calculation
           EPS_FILTER  1.0E-6
         &END
@@ -48,6 +48,7 @@
         ERI_METHOD OS
         IM_TIME
         &IM_TIME
+          DO_DBCSR_T .FALSE.
           ! normally, increase MEMORY_CUT for large systems
           ! not to run out of memory
           MEMORY_CUT 2


### PR DESCRIPTION
This uses DBCSR tensors for cubic scaling RPA. This is not yet ready for merge, we need to wait for cp2k/dbcsr#149.

This does not change the input in `IM_TIME` section but parameters `EPS_FILTER_IM_TIME`, `EPS_FILTER`, `GROUP_SIZE_3C` and `GROUP_SIZE_P` need to be chosen differently for optimal performance and accuracy than with old implementation.

The following features are not yet implemented:
* Cubic scaling GW
* PAOs

This pull request will not remove the old implementation of cubic scaling RPA since Cubic scaling GW is still based on the old code. PAOs appear to be not useful in the current implementation so it should be removed at a later time.