### PR TITLE
Add hybrid-meta-GGA functionals from Libxc

### DIFF
--- a/src/xc/xc_libxc.F
+++ b/src/xc/xc_libxc.F
@@ -78,7 +78,8 @@ MODULE xc_libxc
       xc_libxc_wrap_version, &
       xc_libxc_wrap_functional_get_number, &
       xc_libxc_wrap_needs_laplace, &
-      xc_libxc_wrap_functional_set_params
+      xc_libxc_wrap_functional_set_params, &
+      xc_libxc_wrap_is_stable
 #endif
 
 #include "../base/base_uses.f90"
@@ -179,6 +180,9 @@ CONTAINS
          CASE default
             CPABORT(TRIM(func_name)//": this XC_FAMILY is currently not supported.")
          END SELECT
+      END IF
+      IF (.NOT. (xc_libxc_wrap_is_stable(xc_info))) THEN
+         CPWARN(TRIM(func_name)//" is not considered stable. Use with caution.")
       END IF
 
       CALL xc_f03_func_end(xc_func)
@@ -281,6 +285,9 @@ CONTAINS
          CASE default
             CPABORT(TRIM(func_name)//": this XC_FAMILY is currently not supported.")
          END SELECT
+      END IF
+      IF (.NOT. (xc_libxc_wrap_is_stable(xc_info))) THEN
+         CPWARN(TRIM(func_name)//" is not considered stable. Use with caution.")
       END IF
 
       CALL xc_f03_func_end(xc_func)

--- a/src/xc/xc_libxc.F
+++ b/src/xc/xc_libxc.F
@@ -20,6 +20,7 @@
 !>      07.2014 updates to versions 2.1 [JGH]
 !>      08.2015 refactoring [A. Gloess (agloess)]
 !>      01.2018 refactoring [A. Gloess (agloess)]
+!>      10.2018/04.2019 added hyb_mgga [S. Simko, included by F. Stein]
 !> \author F. Tran
 ! **************************************************************************************************
 MODULE xc_libxc
@@ -68,6 +69,7 @@ MODULE xc_libxc
       XC_FAMILY_GGA, &
       XC_FAMILY_MGGA, &
       XC_FAMILY_HYB_GGA, &
+      XC_FAMILY_HYB_MGGA, &
       XC_CORRELATION, &
       XC_EXCHANGE, &
       XC_EXCHANGE_CORRELATION, &
@@ -157,7 +159,7 @@ CONTAINS
          CASE (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA)
             needs%rho = .TRUE.
             needs%norm_drho = .TRUE.
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             needs%rho = .TRUE.
             needs%norm_drho = .TRUE.
             needs%tau = .TRUE.
@@ -172,7 +174,7 @@ CONTAINS
             max_deriv = 3
          CASE (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA)
             max_deriv = 2
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             max_deriv = 1
          CASE default
             CPABORT(TRIM(func_name)//": this XC_FAMILY is currently not supported.")
@@ -258,7 +260,7 @@ CONTAINS
             needs%rho_spin = .TRUE.
             needs%norm_drho = .TRUE.
             needs%norm_drho_spin = .TRUE.
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             needs%rho_spin = .TRUE.
             needs%norm_drho = .TRUE.
             needs%norm_drho_spin = .TRUE.
@@ -274,7 +276,7 @@ CONTAINS
             max_deriv = 3
          CASE (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA)
             max_deriv = 2
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             max_deriv = 1
          CASE default
             CPABORT(TRIM(func_name)//": this XC_FAMILY is currently not supported.")
@@ -427,7 +429,7 @@ CONTAINS
             deriv => xc_dset_get_derivative(deriv_set, "(norm_drho)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_ndrho)
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             deriv => xc_dset_get_derivative(deriv_set, "(rho)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_rho)
@@ -462,7 +464,7 @@ CONTAINS
             deriv => xc_dset_get_derivative(deriv_set, "(norm_drho)(norm_drho)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_ndrho_ndrho)
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             ! not implemented ...
             CPABORT("derivatives larger than 1 not implemented or checked")
 
@@ -508,7 +510,7 @@ CONTAINS
             deriv => xc_dset_get_derivative(deriv_set, "(rho)(rho)(rho)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_rho_rho_rho)
-         CASE (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA, XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA, XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             CPABORT("derivatives larger than 2 not implemented")
          CASE default
             CPABORT(TRIM(func_name)//": this XC_FAMILY is currently not supported.")
@@ -747,7 +749,7 @@ CONTAINS
             deriv => xc_dset_get_derivative(deriv_set, "(norm_drhob)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_ndrhob)
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             deriv => xc_dset_get_derivative(deriv_set, "(rhoa)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_rhoa)
@@ -839,7 +841,7 @@ CONTAINS
             deriv => xc_dset_get_derivative(deriv_set, "(norm_drhob)(norm_drhob)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_ndrhob_ndrhob)
-         CASE (XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             ! not implemented ...
             CPABORT("derivatives larger than 1 not implemented or checked")
 
@@ -999,7 +1001,7 @@ CONTAINS
             deriv => xc_dset_get_derivative(deriv_set, "(rhob)(rhob)(rhob)", &
                                             allocate_deriv=.TRUE.)
             CALL xc_derivative_get(deriv, deriv_data=e_rhob_rhob_rhob)
-         CASE (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA, XC_FAMILY_MGGA)
+         CASE (XC_FAMILY_GGA, XC_FAMILY_HYB_GGA, XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
             CPABORT("derivatives larger than 2 not implemented")
          CASE default
             CPABORT(TRIM(func_name)//": this XC_FAMILY is currently not supported.")
@@ -1330,7 +1332,7 @@ CONTAINS
             END DO
 !$OMP           END DO
          END IF
-      CASE (XC_FAMILY_MGGA)
+      CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
          IF (grad_deriv == 0) THEN
 !$OMP           DO
             DO ii = 1, npoints
@@ -1935,7 +1937,7 @@ CONTAINS
             END DO
 !$OMP           END DO
          END IF
-      CASE (XC_FAMILY_MGGA)
+      CASE (XC_FAMILY_MGGA, XC_FAMILY_HYB_MGGA)
          IF (grad_deriv == 0) THEN
 !$OMP           DO
             DO ii = 1, npoints

--- a/src/xc/xc_libxc_wrap.F
+++ b/src/xc/xc_libxc_wrap.F
@@ -83,7 +83,8 @@ MODULE xc_libxc_wrap
       XC_KINETIC, &
       !
       XC_FLAGS_NEEDS_LAPLACIAN, &
-      XC_FLAGS_HAVE_EXC
+      XC_FLAGS_HAVE_EXC, &
+      XC_FLAGS_STABLE
 
 #include "../base/base_uses.f90"
 
@@ -118,7 +119,8 @@ MODULE xc_libxc_wrap
              xc_libxc_wrap_version, &
              xc_libxc_wrap_functional_get_number, &
              xc_libxc_wrap_needs_laplace, &
-             xc_libxc_wrap_functional_set_params
+             xc_libxc_wrap_functional_set_params, &
+             xc_libxc_wrap_is_stable
 
 CONTAINS
 
@@ -262,6 +264,33 @@ CONTAINS
       CALL timestop(handle)
 
    END FUNCTION xc_libxc_wrap_functional_get_number
+
+! **************************************************************************************************
+!> \brief Wrapper to test wether functional is considered stable in Libxc
+!> \param xc_info ...
+!>
+!> \return ...
+!> \author F. Stein (fstein93)
+! **************************************************************************************************
+   LOGICAL FUNCTION xc_libxc_wrap_is_stable(xc_info)
+      TYPE(xc_f03_func_info_t)                           :: xc_info
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'xc_libxc_wrap_is_stable', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      IF (IAND(xc_f03_func_info_get_flags(xc_info), XC_FLAGS_STABLE) == XC_FLAGS_STABLE) THEN
+         xc_libxc_wrap_is_stable = .TRUE.
+      ELSE
+         xc_libxc_wrap_is_stable = .FALSE.
+      END IF
+
+      CALL timestop(handle)
+
+   END FUNCTION xc_libxc_wrap_is_stable
 
 ! **************************************************************************************************
 !> \brief Wrapper for functionals that need the Laplacian, all others can use

--- a/src/xc/xc_libxc_wrap.F
+++ b/src/xc/xc_libxc_wrap.F
@@ -14,6 +14,7 @@
 !> \par History
 !>      08.2015 created [A. Gloess (agloess)]
 !>      01.2018 refactoring [A. Gloess (agloess)]
+!>      10.2018/04.2019 added hyb_mgga [S. Simko, included by F. Stein]
 !> \author A. Gloess (agloess)
 ! **************************************************************************************************
 MODULE xc_libxc_wrap
@@ -71,6 +72,7 @@ MODULE xc_libxc_wrap
       XC_FAMILY_GGA, &
       XC_FAMILY_MGGA, &
       XC_FAMILY_HYB_GGA, &
+      XC_FAMILY_HYB_MGGA, &
       !
       XC_UNPOLARIZED, &
       XC_POLARIZED, &
@@ -105,7 +107,7 @@ MODULE xc_libxc_wrap
              xc_f03_mgga_vxc
 
    PUBLIC :: XC_FAMILY_LDA, XC_FAMILY_GGA, XC_FAMILY_MGGA, &
-             XC_FAMILY_HYB_GGA
+             XC_FAMILY_HYB_GGA, XC_FAMILY_HYB_MGGA
 
    PUBLIC :: XC_UNPOLARIZED, XC_POLARIZED
 

--- a/tests/QS/regtest-libxc/H2O-hybrid-tpssh_libxc.inp
+++ b/tests/QS/regtest-libxc/H2O-hybrid-tpssh_libxc.inp
@@ -1,0 +1,70 @@
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME EMSL_BASIS_SETS
+    POTENTIAL_FILE_NAME POTENTIAL
+    &MGRID
+      CUTOFF 250
+      REL_CUTOFF 50
+    &END MGRID
+    &QS
+      METHOD GAPW
+    &END QS
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END
+    &SCF
+      EPS_SCF 1.0E-6
+      SCF_GUESS ATOMIC 
+      MAX_SCF 2
+    &END SCF
+    &XC
+      DENSITY_CUTOFF 1.0e-9
+      DENSITY_SMOOTH_CUTOFF_RANGE 0
+      FUNCTIONAL_ROUTINE NEW
+      &XC_FUNCTIONAL      
+        &LIBXC
+          FUNCTIONAL XC_HYB_MGGA_XC_TPSSH
+        &END LIBXC
+      &END XC_FUNCTIONAL
+      &XC_GRID
+        XC_DERIV NN50_SMOOTH
+        XC_SMOOTH_RHO NONE
+      &END XC_GRID
+      &HF
+        &SCREENING
+          EPS_SCHWARZ 1.0E-10 
+        &END
+        &MEMORY
+          MAX_MEMORY  5 
+        &END
+        FRACTION 0.10
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 6.0 6.0 6.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+    O   0.000000    0.000000   -0.065587
+    H   0.000000   -0.757136    0.520545
+    H   0.000000    0.757136    0.520545
+    &END COORD
+    &KIND H
+      BASIS_SET 6-31Gxx
+      POTENTIAL ALL
+    &END KIND
+    &KIND O
+      BASIS_SET 6-31Gxx
+      POTENTIAL ALL
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+  PROJECT H2O-hybrid-tpssh_libxc
+#  TRACE
+  PRINT_LEVEL MEDIUM 
+&END GLOBAL

--- a/tests/QS/regtest-libxc/TEST_FILES
+++ b/tests/QS/regtest-libxc/TEST_FILES
@@ -8,6 +8,7 @@ H2O_pbe_libxc_tddfpt-s.inp                             1      6e-14             
 H2O_lda_libxc_tddfpt-s.inp                             1      2e-14            -17.132898334541299
 H2O_pbe_libxc_tddfpt-t_uks.inp                         1      2e-14            -17.231162514734059
 H2O-hybrid-b3lyp_libxc.inp                             1      3e-14             -76.41035426581175
+H2O-hybrid-tpssh_libxc.inp                             1      3e-14             -76.40464600997517
 H2O_lda_libxc_tddfpt-t_uks.inp                         1    1.0E-14              -17.1328983345452
 H2O-tpssx_libxc.inp                                    1      3e-13            -33.883009632073247
 diamond_br89_libxc_uks.inp                             1      7e-14             -11.06581614935769


### PR DESCRIPTION
I applied the patches from Stanislaw Simko to Libxc such that we can use hybrid meta-GGAs from Libxc plus some regtests. See https://groups.google.com/forum/#!topic/cp2k/ARya5uM-pA4