### PR TITLE
[exts/dbcsr] enable V100 support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,9 +108,9 @@ FFTW can be used to improve FFT speed on a wide range of architectures. It is st
   * Use the `-D__DBCSR_ACC` to enable accelerator support for matrix multiplications.
   * Add `-lcudart -lrt -lnvrtc` to LIBS.
   * Specify the GPU type (e.g. `GPUVER   = P100`)
-  * Specify the C++ compiler (e.g. `CXX = g++`). Rember to set the flags to support C++11 standard.
+  * Specify the C++ compiler (e.g. `CXX = g++`). Remember to set the flags to support C++11 standard.
   * Use `-D__PW_CUDA` for CUDA support for PW (gather/scatter/fft) calculations.
-  * CUFFT 7.0 has a known bug and is therefore disabled by default. NVidia's webpage list a patch (an upgraded version cufft i.e. >= 7.0.35) - use this together with `-D__HAS_PATCHED_CUFFT_70`.
+  * CUFFT 7.0 has a known bug and is therefore disabled by default. NVIDIA's webpage list a patch (an upgraded version cufft i.e. >= 7.0.35) - use this together with `-D__HAS_PATCHED_CUFFT_70`.
   * Use `-D__CUDA_PROFILING` to turn on Nvidia Tools Extensions.
   * Link to a blas/scalapack library that accelerates large DGEMMs (e.g. libsci_acc)
 

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -94,7 +94,7 @@ OPTIONS:
                           switch --math-mode to the respective modes, BUT
                           --with-reflapack option do not have this effect.
 --gpu-ver                 Selects the GPU architecture for which to compile. Available
-                          options are: K20X, K40, K80, P100, no. Default: no.
+                          options are: K20X, K40, K80, P100, V100, no. Default: no.
                           The script will determine the correct corresponding value for
                           nvcc's '-arch' flag.
 --libint-lmax             Maximum supported angular momentum by libint.
@@ -445,13 +445,16 @@ while [ $# -ge 1 ] ; do
                 P100)
                     export GPUVER=P100
                     ;;
+                V100)
+                    export GPUVER=V100
+                    ;;
                 no)
                     export GPUVER=no
                     ;;
                 *)
                     export GPUVER=no
                     report_error ${LINENO} \
-                    "--gpu-ver currently only supports K20X, K40, K80, P100 and no as options"
+                    "--gpu-ver currently only supports K20X, K40, K80, P100, V100 and no as options"
                     exit 1
             esac
             ;;
@@ -889,12 +892,15 @@ case $GPUVER in
     P100)
         export ARCH_NUM=60
         ;;
+    V100)
+        export ARCH_NUM=70
+        ;;
     no)
         export ARCH_NUM=no
         ;;
     *)
         report_error ${LINENO} \
-        "--gpu-ver currently only supports K20X, K40, K80, P100 as options"
+        "--gpu-ver currently only supports K20X, K40, K80, P100, V100 as options"
 esac
 
 # write toolchain environment

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -160,7 +160,7 @@ gen_arch_file() {
 CXX         = \${CC}
 CXXFLAGS    = \${CXXFLAGS} -I\\\${CUDA_PATH}/include -std=c++11 IF_OMP(-fopenmp|)
 GPUVER      = \${GPUVER}
-NVCC        = \${NVCC} -D__GNUC__=4 -D__GNUC_MINOR__=9
+NVCC        = \${NVCC}
 NVFLAGS     = \${NVFLAGS}
 EOF
     fi


### PR DESCRIPTION
Extend the build system to enable compiling DBCSR with support for NVIDIA's V100. 

This PR should be merged once CP2K's DBCSR is updated to a version posterior to [PR#172](https://github.com/cp2k/dbcsr/pull/172). 