### PR TITLE
kpoints for GW, kpoints from Gamma-only DFT for RPA/GW, refactoring

### DIFF
--- a/src/fm/cp_cfm_basic_linalg.F
+++ b/src/fm/cp_cfm_basic_linalg.F
@@ -45,7 +45,8 @@ MODULE cp_cfm_basic_linalg
              cp_cfm_trace, &
              cp_cfm_transpose, &
              cp_cfm_triangular_invert, &
-             cp_cfm_triangular_multiply
+             cp_cfm_triangular_multiply, &
+             cp_cfm_cholesky_invert
 
    REAL(kind=dp), EXTERNAL :: zlange, pzlange
 

--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -957,7 +957,11 @@ MODULE input_constants
    INTEGER, PARAMETER, PUBLIC               :: ri_rpa_g0w0_crossing_none = 0, &
                                                ri_rpa_g0w0_crossing_z_shot = 1, &
                                                ri_rpa_g0w0_crossing_newton = 2, &
-                                               ri_rpa_g0w0_crossing_bisection = 3
+                                               ri_rpa_g0w0_crossing_bisection = 3, &
+                                               gw_no_print_exx = 5, &
+                                               gw_print_exx = 6, &
+                                               gw_read_exx = 7, &
+                                               gw_skip_for_regtest = 8
 
    INTEGER, PARAMETER, PUBLIC               :: gw_pade_approx = 0, &
                                                gw_two_pole_model = 1

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -26,11 +26,12 @@ MODULE input_cp2k_mp2
                                               silent_print_level
    USE input_constants,                 ONLY: &
         do_eri_gpw, do_eri_mme, do_eri_os, do_hfx_potential_coulomb, do_mp2_potential_tshpsc, &
-        gaussian, gw_pade_approx, gw_two_pole_model, mp2_method_direct, mp2_method_gpw, &
-        mp2_method_none, mp2_ri_optimize_basis, numerical, ri_coulomb, ri_mp2_laplace, &
-        ri_mp2_method_gpw, ri_overlap, ri_rpa_g0w0_crossing_bisection, &
-        ri_rpa_g0w0_crossing_newton, ri_rpa_g0w0_crossing_none, ri_rpa_g0w0_crossing_z_shot, &
-        ri_rpa_method_gpw, wfc_mm_style_gemm, wfc_mm_style_syrk
+        gaussian, gw_no_print_exx, gw_pade_approx, gw_print_exx, gw_read_exx, gw_skip_for_regtest, &
+        gw_two_pole_model, mp2_method_direct, mp2_method_gpw, mp2_method_none, &
+        mp2_ri_optimize_basis, numerical, ri_coulomb, ri_mp2_laplace, ri_mp2_method_gpw, &
+        ri_overlap, ri_rpa_g0w0_crossing_bisection, ri_rpa_g0w0_crossing_newton, &
+        ri_rpa_g0w0_crossing_none, ri_rpa_g0w0_crossing_z_shot, ri_rpa_method_gpw, &
+        wfc_mm_style_gemm, wfc_mm_style_syrk
    USE input_cp2k_hfx,                  ONLY: create_hfx_section
    USE input_keyword_types,             ONLY: keyword_create,&
                                               keyword_release,&
@@ -806,8 +807,37 @@ CONTAINS
       CALL keyword_create(keyword, name="PRINT_GW_DETAILS", &
                           description="If true, prints additional information on the quasiparticle energies.", &
                           usage="PRINT_GW_DETAILS", &
-                          default_l_val=.FALSE., &
+                          default_l_val=.TRUE., &
                           lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, name="PRINT_EXX", &
+                          description="Print exchange self-energy minus exchange correlation potential for Gamma-only "// &
+                          "calculation (PRINT). For a GW calculation with k-points we use this output as "// &
+                          "exchange self-energy (READ). This is a temporary solution because the hybrid MPI/OMP "// &
+                          "parallelization in the HFX by Manuel Guidon conflicts with the parallelization in "// &
+                          "low-scaling GW k-points which is most efficient with maximum number of MPI tasks and "// &
+                          "minimum number of OMP threads. For HFX by M. Guidon, the density matrix is "// &
+                          "fully replicated on every MPI rank which necessitates a high number of OMP threads per MPI "// &
+                          "rank for large systems to prevent out of memory. "// &
+                          "Such a high number of OMP threads would slow down the GW calculation "// &
+                          "severely. Therefore, it was decided to temporarily divide the GW k-point calculation in a "// &
+                          "Gamma-only HF calculation with high number of OMP threads to prevent out of memory and "// &
+                          "a GW k-point calculation with 1 OMP thread per MPI rank reading the previousHF output.", &
+                          usage="PRINT_EXX TRUE", &
+                          enum_c_vals=s2a("TRUE", "FALSE", "READ", "SKIP_FOR_REGTEST"), &
+                          enum_i_vals=(/gw_print_exx, gw_no_print_exx, gw_read_exx, gw_skip_for_regtest/), &
+                          enum_desc=s2a("Please, put TRUE for Gamma only calculation to get the exchange self-energy. "// &
+                                        "If 'SIGMA_X' and the corresponding values for the exchange-energy are written, "// &
+                                        "the writing has been successful", &
+                                        "FALSE is needed if you want to do nothing here.", &
+                                        "Please, put READ for the k-point GW calculation to read the exact exchange. "// &
+                                        "You have to provide an output file including the exact exchange. This file "// &
+                                        "has to be named 'exx.dat'.", &
+                                        "SKIP_FOR_REGTEST is only used for the GW k-point regtest where no exchange "// &
+                                        "self-energy is computed."), &
+                          default_i_val=gw_no_print_exx)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -888,6 +918,16 @@ CONTAINS
                           "are recommended.", &
                           usage="NPARAM_PADE 16", &
                           default_i_val=16)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, name="GAMMA_ONLY_SIGMA", &
+                          variants=(/"GAMMA"/), &
+                          description="If true, the correlation self-energy is only computed at the Gamma point. "// &
+                          "The Gamma point itself is obtained by averaging over all kpoints of the DFT mesh.", &
+                          usage="GAMMA TRUE", &
+                          default_l_val=.FALSE., &
+                          lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1268,6 +1308,41 @@ CONTAINS
          usage="DO_DBCSR_T", &
          default_l_val=.TRUE., &
          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword=keyword, &
+         name="CUTOFF_W", &
+         description="Cutoff for screened Coulomb interaction for GW kpoints.", &
+         usage="CUTOFF_W 0.5", &
+         default_r_val=0.5_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, name="KPOINTS", &
+         description="For periodic calculations, using kpoints for the density response and the "// &
+         "Coulomb operator are strongly recommended. For 2d periodic systems (e.g. xy "// &
+         "periodicity, please specify KPOINTS  N_x  0  N_z.", &
+         usage="KPOINTS  N_x  N_y  N_z", &
+         n_var=3, type_of_var=integer_t, default_i_vals=(/0, 0, 0/))
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword=keyword, &
+         name="EXP_KPOINTS", &
+         description="For kpoints in low-scaling GW, a Monkhorst-Pack mesh is used. Because the screened Coulomb "// &
+         "interaction W(k) diverges at the Gamma point with W(k) ~ k^alpha, we adapt the weights of the "// &
+         "Monkhorst-Pack mesh to compute int_BZ k^alpha dk (BZ=Brllouin zone) correctly with the Monkhorst-Pack "// &
+         "mesh. You can enter here the exponent alpha. For solids, the exponent is -2 (known from plane waves), "// &
+         "for 2d periodic systems -1 and for 1d systems W(k) ~ log(1-cos(a*k)) where a is the length of the unit "// &
+         "cell in periodic direction. If you enter 1.0, one of these three functions are picked according to the "// &
+         "periodicity. If you enter a value bigger than 2.0, the ordinary Monkhorst-Pack mesh with identical "// &
+         "weights is chosen.", &
+         usage="EXP_KPOINTS -2.0", &
+         default_r_val=1.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/kpoint_coulomb_2c.F
+++ b/src/kpoint_coulomb_2c.F
@@ -17,7 +17,6 @@ MODULE kpoint_coulomb_2c
    USE cell_types,                      ONLY: cell_type,&
                                               get_cell,&
                                               pbc
-   USE constants_operator,              ONLY: operator_coulomb
    USE dbcsr_api,                       ONLY: &
         dbcsr_create, dbcsr_init_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
         dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, &
@@ -59,9 +58,11 @@ CONTAINS
 !> \param qs_kind_set ...
 !> \param atomic_kind_set ...
 !> \param size_lattice_sum ...
+!> \param operator_type ...
+!> \param cutoff ...
 ! **************************************************************************************************
    SUBROUTINE build_2c_coulomb_matrix_kp(matrix_v_kp, kpoints, basis_type, cell, particle_set, qs_kind_set, &
-                                         atomic_kind_set, size_lattice_sum)
+                                         atomic_kind_set, size_lattice_sum, operator_type, cutoff)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_v_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -70,7 +71,8 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      INTEGER                                            :: size_lattice_sum
+      INTEGER                                            :: size_lattice_sum, operator_type
+      REAL(dp)                                           :: cutoff
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_2c_coulomb_matrix_kp', &
          routineP = moduleN//':'//routineN
@@ -85,7 +87,8 @@ CONTAINS
       CALL allocate_tmp(matrix_v_L_tmp, matrix_v_kp)
 
       CALL lattice_sum(matrix_v_kp, kpoints, basis_type, cell, particle_set, &
-                       qs_kind_set, atomic_kind_set, size_lattice_sum, matrix_v_L_tmp)
+                       qs_kind_set, atomic_kind_set, size_lattice_sum, matrix_v_L_tmp, &
+                       operator_type, cutoff)
 
       CALL deallocate_tmp(matrix_v_L_tmp)
 
@@ -104,9 +107,12 @@ CONTAINS
 !> \param atomic_kind_set ...
 !> \param size_lattice_sum ...
 !> \param matrix_v_L_tmp ...
+!> \param operator_type ...
+!> \param cutoff ...
 ! **************************************************************************************************
    SUBROUTINE lattice_sum(matrix_v_kp, kpoints, basis_type, cell, particle_set, &
-                          qs_kind_set, atomic_kind_set, size_lattice_sum, matrix_v_L_tmp)
+                          qs_kind_set, atomic_kind_set, size_lattice_sum, matrix_v_L_tmp, &
+                          operator_type, cutoff)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_v_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -117,6 +123,8 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       INTEGER                                            :: size_lattice_sum
       TYPE(dbcsr_type), POINTER                          :: matrix_v_L_tmp
+      INTEGER                                            :: operator_type
+      REAL(dp)                                           :: cutoff
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'lattice_sum', routineP = moduleN//':'//routineN
 
@@ -181,39 +189,6 @@ CONTAINS
       CALL allocate_blocks_of_v_L(blocks_of_v_L, matrix_v_L_tmp)
       CALL allocate_blocks_of_v_L(blocks_of_v_L_store, matrix_v_L_tmp)
 
-!      DO i_x = x_min, x_max
-!         DO j_y = y_min, y_max
-!            DO k_z = z_min, z_max
-!
-!               vec_s = [REAL(i_x, dp), REAL(j_y, dp), REAL(k_z, dp)]
-!
-!               vec_L = MATMUL(hmat, vec_s)
-!
-!               ! Compute (P 0 | Q vec_L) and store it in matrix_v_L_tmp
-!               CALL compute_v_transl(matrix_v_L_tmp, blocks_of_v_L, vec_L, particle_set, &
-!                                     qs_kind_set, atomic_kind_set, basis_type, cell)
-!
-!               ! add exp(iq*vec_L) * (P 0 | Q vec_L) to V_PQ(q)
-!               DO ik = 1, nkp
-!
-!                  coskl = COS(twopi*DOT_PRODUCT(vec_s(1:3),kpoints%xkp(1:3,ik)))
-!                  sinkl = SIN(twopi*DOT_PRODUCT(vec_s(1:3),kpoints%xkp(1:3,ik)))
-!
-!                  DO i_block = 1, SIZE(blocks_of_v_L)
-!
-!                    blocks_of_v_kp(ik,1,i_block)%block(:,:) = blocks_of_v_kp(ik,1,i_block)%block(:,:) &
-!                                                              + coskl*blocks_of_v_L(i_block)%block(:,:)
-!                    blocks_of_v_kp(ik,2,i_block)%block(:,:) = blocks_of_v_kp(ik,2,i_block)%block(:,:) &
-!                                                              + sinkl*blocks_of_v_L(i_block)%block(:,:)
-!
-!                  END DO
-!
-!               END DO
-!
-!            END DO
-!         END DO
-!      END DO
-
       DO i_x_inner = 0, 2*nkp_grid(1)-1
          DO j_y_inner = 0, 2*nkp_grid(2)-1
             DO k_z_inner = 0, 2*nkp_grid(3)-1
@@ -236,7 +211,8 @@ CONTAINS
 
                         ! Compute (P 0 | Q vec_L) and store it in matrix_v_L_tmp
                         CALL compute_v_transl(matrix_v_L_tmp, blocks_of_v_L, vec_L, particle_set, &
-                                              qs_kind_set, atomic_kind_set, basis_type, cell)
+                                              qs_kind_set, atomic_kind_set, basis_type, cell, &
+                                              operator_type, cutoff)
 
                         DO i_block = 1, SIZE(blocks_of_v_L)
                            blocks_of_v_L_store(i_block)%block(:, :) = blocks_of_v_L_store(i_block)%block(:, :) &
@@ -343,9 +319,11 @@ CONTAINS
 !> \param atomic_kind_set ...
 !> \param basis_type ...
 !> \param cell ...
+!> \param operator_type ...
+!> \param cutoff ...
 ! **************************************************************************************************
    SUBROUTINE compute_v_transl(matrix_v_L_tmp, blocks_of_v_L, vec_L, particle_set, &
-                               qs_kind_set, atomic_kind_set, basis_type, cell)
+                               qs_kind_set, atomic_kind_set, basis_type, cell, operator_type, cutoff)
 
       TYPE(dbcsr_type), POINTER                          :: matrix_v_L_tmp
       TYPE(two_d_util_type), ALLOCATABLE, DIMENSION(:)   :: blocks_of_v_L
@@ -355,6 +333,8 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       CHARACTER(LEN=*), INTENT(IN)                       :: basis_type
       TYPE(cell_type), POINTER                           :: cell
+      INTEGER                                            :: operator_type
+      REAL(dp)                                           :: cutoff
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_v_transl', &
          routineP = moduleN//':'//routineN
@@ -404,8 +384,8 @@ CONTAINS
 
          blocks_of_v_L(i_block)%block = 0.0_dp
 
-         CALL int_operators_r12_ab_shg(operator_coulomb, blocks_of_v_L(i_block)%block, dummy_force, rab_L, &
-                                       basis_set_a, basis_set_b, contr_a, contr_b, &
+         CALL int_operators_r12_ab_shg(operator_type, blocks_of_v_L(i_block)%block, dummy_force, rab_L, &
+                                       basis_set_a, basis_set_b, contr_a, contr_b, omega=cutoff, &
                                        calculate_forces=.FALSE.)
 
          i_block = i_block+1

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -1963,8 +1963,6 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'transform_matrix_ks_to_kp', &
          routineP = moduleN//':'//routineN
-      COMPLEX(KIND=dp), PARAMETER :: cone = CMPLX(1.0_dp, 0.0_dp, KIND=dp), &
-         czero = CMPLX(0.0_dp, 0.0_dp, KIND=dp), ione = CMPLX(0.0_dp, 1.0_dp, KIND=dp)
 
       INTEGER                                            :: handle, ikp, ispin, nkp, nspin
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
@@ -2013,8 +2011,6 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'allocate_matrix_ks_kp', &
          routineP = moduleN//':'//routineN
-      COMPLEX(KIND=dp), PARAMETER :: cone = CMPLX(1.0_dp, 0.0_dp, KIND=dp), &
-         czero = CMPLX(0.0_dp, 0.0_dp, KIND=dp), ione = CMPLX(0.0_dp, 1.0_dp, KIND=dp)
 
       INTEGER                                            :: handle, ikp, ispin, nkp, nspin
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -25,9 +25,20 @@ MODULE mp2
                                               Rybkin2016,&
                                               cite_reference
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm,&
+                                              cp_cfm_scale_and_add_fm
+   USE cp_cfm_types,                    ONLY: cp_cfm_create,&
+                                              cp_cfm_get_info,&
+                                              cp_cfm_release,&
+                                              cp_cfm_type
    USE cp_control_types,                ONLY: dft_control_type
+   USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
-                                              copy_fm_to_dbcsr
+                                              copy_fm_to_dbcsr,&
+                                              dbcsr_allocate_matrix_set,&
+                                              dbcsr_deallocate_matrix_set
+   USE cp_files,                        ONLY: close_file,&
+                                              open_file
    USE cp_fm_basic_linalg,              ONLY: cp_fm_triangular_invert
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -40,8 +51,7 @@ MODULE mp2
                                               cp_fm_set_all,&
                                               cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
-                                              cp_logger_type,&
-                                              cp_to_string
+                                              cp_logger_type
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
                                               cp_print_key_unit_nr
    USE cp_para_env,                     ONLY: cp_para_env_create,&
@@ -49,21 +59,16 @@ MODULE mp2
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
         dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_desymmetrize, dbcsr_get_diag, dbcsr_get_info, &
-        dbcsr_init_p, dbcsr_multiply, dbcsr_p_type, dbcsr_release, dbcsr_release_p, dbcsr_set, &
-        dbcsr_type
+        dbcsr_multiply, dbcsr_p_type, dbcsr_release, dbcsr_release_p, dbcsr_set, dbcsr_type, &
+        dbcsr_type_antisymmetric, dbcsr_type_symmetric
    USE hfx_energy_potential,            ONLY: integrate_four_center
    USE hfx_types,                       ONLY: &
         alloc_containers, dealloc_containers, hfx_basis_info_type, hfx_basis_type, &
         hfx_container_type, hfx_create_basis_types, hfx_init_container, hfx_release_basis_types, &
         hfx_type
-   USE input_constants,                 ONLY: cholesky_inverse,&
-                                              do_admm_basis_projection,&
-                                              do_admm_purify_none,&
-                                              do_eri_gpw,&
-                                              do_eri_mme,&
-                                              do_mp2_potential_TShPSC,&
-                                              hfx_do_eval_energy,&
-                                              xc_none
+   USE input_constants,                 ONLY: &
+        cholesky_inverse, do_admm_basis_projection, do_admm_purify_none, do_eri_gpw, do_eri_mme, &
+        do_mp2_potential_TShPSC, gw_print_exx, gw_read_exx, hfx_do_eval_energy, xc_none
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -71,10 +76,16 @@ MODULE mp2
                                               section_vals_val_set
    USE kinds,                           ONLY: dp,&
                                               int_8
-   USE kpoint_types,                    ONLY: kpoint_type
+   USE kpoint_methods,                  ONLY: rskp_transform
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_env_type,&
+                                              kpoint_type
    USE machine,                         ONLY: m_flush,&
                                               m_memory,&
                                               m_walltime
+   USE mathconstants,                   ONLY: gaussi,&
+                                              z_one,&
+                                              z_zero
    USE message_passing,                 ONLY: mp_comm_split_direct,&
                                               mp_max,&
                                               mp_sum,&
@@ -86,6 +97,7 @@ MODULE mp2
         mp2_biel_type, mp2_method_direct, mp2_method_gpw, mp2_method_laplace, &
         mp2_ri_optimize_basis, mp2_type, ri_mp2_laplace, ri_mp2_method_gpw, ri_rpa_method_gpw
    USE particle_types,                  ONLY: particle_type
+   USE physcon,                         ONLY: evolt
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -102,7 +114,9 @@ MODULE mp2
                                               deallocate_mo_set,&
                                               get_mo_set,&
                                               init_mo_set,&
-                                              mo_set_p_type
+                                              mo_set_p_type,&
+                                              mo_set_type
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
    USE qs_scf_methods,                  ONLY: eigensolver
@@ -158,7 +172,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_aux, matrix_s
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_kp, matrix_s_kp
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_transl, matrix_s_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(gto_basis_set_type), POINTER                  :: ri_aux_basis_set
       TYPE(hfx_basis_info_type)                          :: basis_info
@@ -209,12 +223,12 @@ CONTAINS
                          rho=rho, &
                          kpoints=kpoints, &
                          scf_env=scf_env, &
-                         matrix_ks_kp=matrix_ks_kp, &
+                         matrix_ks_kp=matrix_ks_transl, &
                          matrix_s_kp=matrix_s_kp, &
                          mp2_env=mp2_env)
 
          CALL get_gamma(matrix_s, matrix_ks, mos, &
-                        matrix_s_kp, matrix_ks_kp, kpoints)
+                        matrix_s_kp, matrix_ks_transl, kpoints)
 
       ELSE
 
@@ -356,7 +370,7 @@ CONTAINS
       END DO
 
       CALL get_mo_set(mo_set=mos(1)%mo_set, nao=nao)
-      CPASSERT(dimen == nao)
+!      CPASSERT(dimen == nao)
 
       ! diagonalize the KS matrix in order to have the full set of MO's
       ! get S and KS matrices in fm_type (create also a working array)
@@ -466,7 +480,7 @@ CONTAINS
       ! calculate the matrix sigma_x - vxc for G0W0
       t3 = 0
       IF (mp2_env%ri_rpa%do_ri_g0w0 .OR. mp2_env%ri_rpa_im_time%do_gw_im_time) THEN
-         CALL compute_vec_Sigma_x_minus_vxc_gw(qs_env, mp2_env, mos_mp2, E_ex_from_GW, t3)
+         CALL compute_vec_Sigma_x_minus_vxc_gw(qs_env, mp2_env, mos_mp2, E_ex_from_GW, t3, unit_nr)
       END IF
       IF (free_hfx_buffer) THEN
          CALL timeset(routineN//"_free_hfx", handle2)
@@ -785,7 +799,7 @@ CONTAINS
          hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%WF_CORRELATION%RI_RPA%HF")
          CALL section_vals_get(hfx_sections, explicit=do_exx)
          IF (do_exx) THEN
-            do_gw = mp2_env%ri_rpa%do_ri_g0w0
+            do_gw = mp2_env%ri_rpa%do_ri_g0w0 .OR. mp2_env%ri_rpa_im_time%do_gw_im_time
             do_admm = mp2_env%ri_rpa%do_admm
             CALL calculate_exx(qs_env, unit_nr, do_gw, do_admm, E_ex_from_GW, t3)
          END IF
@@ -1245,35 +1259,43 @@ CONTAINS
 !> \param mos_mp2 ...
 !> \param energy_ex ...
 !> \param t3 ...
+!> \param unit_nr ...
 !> \par History
 !>      04.2015 created
 !> \author Jan Wilhelm
 ! **************************************************************************************************
-   SUBROUTINE compute_vec_Sigma_x_minus_vxc_gw(qs_env, mp2_env, mos_mp2, energy_ex, t3)
+   SUBROUTINE compute_vec_Sigma_x_minus_vxc_gw(qs_env, mp2_env, mos_mp2, energy_ex, t3, unit_nr)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos_mp2
       REAL(KIND=dp)                                      :: energy_ex, t3
+      INTEGER                                            :: unit_nr
 
       CHARACTER(len=*), PARAMETER :: routineN = 'compute_vec_Sigma_x_minus_vxc_gw', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: dimen, gw_corr_lev_occ, &
-                                                            gw_corr_lev_virt, homo, irep, ispin, &
-                                                            myfun, myfun_aux, myfun_prim, &
-                                                            n_rep_hf, nmo, ns
+      CHARACTER(4)                                       :: occ_virt
+      CHARACTER(LEN=40)                                  :: line
+      INTEGER :: dimen, gw_corr_lev_occ, gw_corr_lev_virt, handle, homo, i_img, ikp, irep, ispin, &
+         iunit, myfun, myfun_aux, myfun_prim, n_level_gw, n_level_gw_ref, n_rep_hf, nkp, nmo, ns, &
+         nspins, print_exx
       LOGICAL                                            :: charge_constrain_tmp, do_admm_rpa, &
-                                                            do_hfx, do_ri_Sigma_x
-      REAL(KIND=dp)                                      :: eh1, ehfx, hfx_fraction, t1, t2
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vec_Sigma_x_minus_vxc_gw
+                                                            do_hfx, do_kpoints_cubic_RPA, &
+                                                            do_ri_Sigma_x, really_read_line
+      REAL(KIND=dp)                                      :: eh1, ehfx, exx_minus_vxc, hfx_fraction, &
+                                                            t1, t2, tmp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: vec_Sigma_x_minus_vxc_gw, &
+                                                            vec_Sigma_x_minus_vxc_gw_im
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_aux_fit, &
-                                                            matrix_sigma_x_minus_vxc, rho_ao
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_2d, rho_ao_2d
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_aux_fit, rho_ao
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER :: matrix_ks_2d, matrix_ks_kp_im, &
+         matrix_ks_kp_re, matrix_ks_transl, matrix_sigma_x_minus_vxc, matrix_sigma_x_minus_vxc_im, &
+         rho_ao_2d
       TYPE(dbcsr_type)                                   :: matrix_tmp, matrix_tmp_2, mo_coeff_b
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: hfx_sections, input, xc_section, &
@@ -1282,12 +1304,19 @@ CONTAINS
 
       NULLIFY (admm_env, matrix_ks, matrix_ks_aux_fit, rho_ao, matrix_sigma_x_minus_vxc, input, &
                xc_section, xc_section_admm_aux, xc_section_admm_prim, hfx_sections, rho, &
-               dft_control, para_env, ks_env, mo_coeff)
+               dft_control, para_env, ks_env, mo_coeff, matrix_sigma_x_minus_vxc_im)
+
+      CALL timeset(routineN, handle)
 
       t1 = m_walltime()
 
       do_admm_rpa = mp2_env%ri_rpa%do_admm
       do_ri_Sigma_x = mp2_env%ri_g0w0%do_ri_Sigma_x
+      do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
+
+      IF (do_kpoints_cubic_RPA) THEN
+         CPASSERT(do_ri_Sigma_x)
+      END IF
 
       ! In case we do admm for RPA/GW, get the aux. density matrix rho_aux_fit, otherwise
       ! just the normal density matrix rho
@@ -1311,40 +1340,108 @@ CONTAINS
 
       ELSE
 
-         CALL get_qs_env(qs_env, &
-                         admm_env=admm_env, &
-                         matrix_ks=matrix_ks, &
-                         matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                         rho=rho, &
-                         input=input, &
-                         dft_control=dft_control, &
-                         para_env=para_env, &
-                         ks_env=ks_env)
+         IF (do_kpoints_cubic_RPA) THEN
+
+            CALL get_qs_env(qs_env, &
+                            matrix_ks_kp=matrix_ks_transl, &
+                            rho=rho, &
+                            input=input, &
+                            dft_control=dft_control, &
+                            para_env=para_env, &
+                            kpoints=kpoints, &
+                            ks_env=ks_env)
+
+            nkp = kpoints%nkp
+
+         ELSE
+
+            CALL get_qs_env(qs_env, &
+                            matrix_ks=matrix_ks, &
+                            rho=rho, &
+                            input=input, &
+                            dft_control=dft_control, &
+                            para_env=para_env, &
+                            ks_env=ks_env)
+
+            nkp = 1
+
+         END IF
 
       END IF
 
-      CALL qs_rho_get(rho, rho_ao=rho_ao)
+      nspins = dft_control%nspins
 
+      IF (.NOT. do_kpoints_cubic_RPA) THEN
+         CALL qs_rho_get(rho, rho_ao=rho_ao)
+      END IF
+
+      ! If ADMM we should make the ks matrix up-to-date
+      IF (dft_control%do_admm) THEN
       DO ispin = 1, SIZE(matrix_ks)
-         ! If ADMM we should make the ks matrix up-to-date
-         IF (dft_control%do_admm) THEN
-            CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks(ispin)%matrix)
-         END IF
+         CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks(ispin)%matrix)
       END DO
+      END IF
+
+      IF (do_kpoints_cubic_RPA) THEN
+
+         CALL allocate_matrix_ks_kp(matrix_ks_transl, matrix_ks_kp_re, matrix_ks_kp_im, kpoints)
+         CALL transform_matrix_ks_to_kp(matrix_ks_transl, matrix_ks_kp_re, matrix_ks_kp_im, kpoints)
+
+         DO ispin = 1, nspins
+         DO i_img = 1, SIZE(matrix_ks_transl, 2)
+            CALL dbcsr_set(matrix_ks_transl(ispin, i_img)%matrix, 0.0_dp)
+         END DO
+         END DO
+
+      END IF
 
       ! initialize matrix_sigma_x_minus_vxc
-      ALLOCATE (matrix_sigma_x_minus_vxc(SIZE(matrix_ks)))
-      DO ispin = 1, SIZE(matrix_ks)
-         NULLIFY (matrix_sigma_x_minus_vxc(ispin)%matrix)
-         CALL dbcsr_init_p(matrix_sigma_x_minus_vxc(ispin)%matrix)
-         CALL dbcsr_copy(matrix_sigma_x_minus_vxc(ispin)%matrix, matrix_ks(ispin)%matrix, &
-                         name="Matrix VXC of spin "//cp_to_string(ispin))
-         CALL dbcsr_set(matrix_ks(ispin)%matrix, 0.0_dp)
+      NULLIFY (matrix_sigma_x_minus_vxc)
+      CALL dbcsr_allocate_matrix_set(matrix_sigma_x_minus_vxc, nspins, nkp)
+      IF (do_kpoints_cubic_RPA) THEN
+         NULLIFY (matrix_sigma_x_minus_vxc_im)
+         CALL dbcsr_allocate_matrix_set(matrix_sigma_x_minus_vxc_im, nspins, nkp)
+      END IF
+
+      DO ispin = 1, nspins
+         DO ikp = 1, nkp
+
+            IF (do_kpoints_cubic_RPA) THEN
+
+               ALLOCATE (matrix_sigma_x_minus_vxc(ispin, ikp)%matrix)
+               CALL dbcsr_create(matrix_sigma_x_minus_vxc(ispin, ikp)%matrix, &
+                                 template=matrix_ks_kp_re(1, 1)%matrix, &
+                                 matrix_type=dbcsr_type_symmetric)
+
+               CALL dbcsr_copy(matrix_sigma_x_minus_vxc(ispin, ikp)%matrix, matrix_ks_kp_re(ispin, ikp)%matrix)
+               CALL dbcsr_set(matrix_ks_kp_re(ispin, ikp)%matrix, 0.0_dp)
+
+               ALLOCATE (matrix_sigma_x_minus_vxc_im(ispin, ikp)%matrix)
+               CALL dbcsr_create(matrix_sigma_x_minus_vxc_im(ispin, ikp)%matrix, &
+                                 template=matrix_ks_kp_im(1, 1)%matrix, &
+                                 matrix_type=dbcsr_type_antisymmetric)
+
+               CALL dbcsr_copy(matrix_sigma_x_minus_vxc_im(ispin, ikp)%matrix, matrix_ks_kp_im(ispin, ikp)%matrix)
+               CALL dbcsr_set(matrix_ks_kp_im(ispin, ikp)%matrix, 0.0_dp)
+
+            ELSE
+
+               ALLOCATE (matrix_sigma_x_minus_vxc(ispin, ikp)%matrix)
+               CALL dbcsr_create(matrix_sigma_x_minus_vxc(ispin, ikp)%matrix, &
+                                 template=matrix_ks(1)%matrix)
+
+               CALL dbcsr_copy(matrix_sigma_x_minus_vxc(ispin, ikp)%matrix, matrix_ks(ispin)%matrix)
+               CALL dbcsr_set(matrix_ks(ispin)%matrix, 0.0_dp)
+
+            END IF
+
+         ENDDO
       ENDDO
 
       ! set DFT functional to none and hfx_fraction to zero
       hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%HF")
       CALL section_vals_get(hfx_sections, explicit=do_hfx)
+
       IF (do_hfx) THEN
          hfx_fraction = qs_env%x_data(1, 1)%general_parameter%fraction
          qs_env%x_data(:, :)%general_parameter%fraction = 0.0_dp
@@ -1385,21 +1482,9 @@ CONTAINS
       ! if we do ADMM for Sigma_x, we write the ADMM correction into matrix_ks_aux_fit
       ! and therefore we should set it to zero
       IF (do_admm_rpa) THEN
-         DO ispin = 1, dft_control%nspins
+         DO ispin = 1, nspins
             CALL dbcsr_set(matrix_ks_aux_fit(ispin)%matrix, 0.0_dp)
          END DO
-
-!      ! set the hf fraction to minus one to get the ADMM correction negatively
-!      ! this is correct because we need ADMM for the exchange self energy Sigma_x
-!      ! but it is calculated in -vxc
-!      qs_env%x_data(:,:)%general_parameter%fraction = -1.0_dp
-!
-!      ! do not search for already existing functionals because in Sigma_x we
-!      ! have 100 % Fock exchange
-!      CALL create_admm_xc_section(qs_env, xc_section, admm_env, error, search_func=.FALSE.)
-!
-!      qs_env%x_data(:,:)%general_parameter%fraction = 0.0_dp
-
       END IF
 
       ! calculate KS-matrix without XC and without HF
@@ -1428,87 +1513,383 @@ CONTAINS
          END IF
       END IF
 
-      ! remove the single-particle part (kin. En + Hartree pot) and change the sign
-      DO ispin = 1, dft_control%nspins
-         CALL dbcsr_add(matrix_sigma_x_minus_vxc(ispin)%matrix, matrix_ks(ispin)%matrix, -1.0_dp, 1.0_dp)
-      END DO
+      IF (do_kpoints_cubic_RPA) THEN
+         CALL transform_matrix_ks_to_kp(matrix_ks_transl, matrix_ks_kp_re, matrix_ks_kp_im, kpoints)
+      END IF
 
-      DO ispin = 1, dft_control%nspins
-         CALL dbcsr_set(matrix_ks(ispin)%matrix, 0.0_dp)
-         IF (do_admm_rpa) THEN
-            CALL dbcsr_set(matrix_ks_aux_fit(ispin)%matrix, 0.0_dp)
+      ! remove the single-particle part (kin. En + Hartree pot) and change the sign
+      DO ispin = 1, nspins
+         IF (do_kpoints_cubic_RPA) THEN
+            DO ikp = 1, nkp
+               CALL dbcsr_add(matrix_sigma_x_minus_vxc(ispin, ikp)%matrix, matrix_ks_kp_re(ispin, ikp)%matrix, -1.0_dp, 1.0_dp)
+               CALL dbcsr_add(matrix_sigma_x_minus_vxc_im(ispin, ikp)%matrix, matrix_ks_kp_im(ispin, ikp)%matrix, -1.0_dp, 1.0_dp)
+            END DO
+         ELSE
+            CALL dbcsr_add(matrix_sigma_x_minus_vxc(ispin, 1)%matrix, matrix_ks(ispin)%matrix, -1.0_dp, 1.0_dp)
          END IF
       END DO
 
-      hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%WF_CORRELATION%RI_RPA%HF")
+      IF (do_kpoints_cubic_RPA) THEN
 
-      CALL section_vals_get(hfx_sections, n_repetition=n_rep_hf)
+         CALL transform_sigma_x_minus_vxc_to_MO_basis(kpoints, matrix_sigma_x_minus_vxc, &
+                                                      matrix_sigma_x_minus_vxc_im, &
+                                                      vec_Sigma_x_minus_vxc_gw, &
+                                                      vec_Sigma_x_minus_vxc_gw_im, &
+                                                      para_env, nmo, mp2_env)
 
-      ! in most cases, we calculate the exchange self-energy here. But if we do only RI for
-      ! the exchange self-energy, we do not calculate exchange here
-      ehfx = 0.0_dp
-      IF (.NOT. do_ri_Sigma_x) THEN
+      ELSE
 
-         ! add here HFX (=Sigma_exchange) to matrix_sigma_x_minus_vxc
-         DO irep = 1, n_rep_hf
-            ns = SIZE(rho_ao)
-            rho_ao_2d(1:ns, 1:1) => rho_ao(1:ns)
-            ns = SIZE(matrix_ks)
+         DO ispin = 1, nspins
+            CALL dbcsr_set(matrix_ks(ispin)%matrix, 0.0_dp)
             IF (do_admm_rpa) THEN
-               matrix_ks_2d(1:ns, 1:1) => matrix_ks_aux_fit(1:ns)
-            ELSE
-               matrix_ks_2d(1:ns, 1:1) => matrix_ks(1:ns)
+               CALL dbcsr_set(matrix_ks_aux_fit(ispin)%matrix, 0.0_dp)
+            END IF
+         END DO
+
+         hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%WF_CORRELATION%RI_RPA%HF")
+
+         CALL section_vals_get(hfx_sections, n_repetition=n_rep_hf)
+
+         ! in most cases, we calculate the exchange self-energy here. But if we do only RI for
+         ! the exchange self-energy, we do not calculate exchange here
+         ehfx = 0.0_dp
+         IF (.NOT. do_ri_Sigma_x) THEN
+
+            ! add here HFX (=Sigma_exchange) to matrix_sigma_x_minus_vxc
+            DO irep = 1, n_rep_hf
+               ns = SIZE(rho_ao)
+               rho_ao_2d(1:ns, 1:1) => rho_ao(1:ns)
+               ns = SIZE(matrix_ks)
+               IF (do_admm_rpa) THEN
+                  matrix_ks_2d(1:ns, 1:1) => matrix_ks_aux_fit(1:ns)
+               ELSE
+                  matrix_ks_2d(1:ns, 1:1) => matrix_ks(1:ns)
+               END IF
+
+               CALL integrate_four_center(qs_env, matrix_ks_2d, eh1, rho_ao_2d, hfx_sections, &
+                                          para_env, .TRUE., irep, .TRUE., &
+                                          ispin=1, do_exx=.TRUE.)
+               ehfx = ehfx+eh1
+            END DO
+         END IF
+         energy_ex = ehfx
+
+         ! transform Fock-Matrix (calculated in integrate_four_center, written in matrix_ks_aux_fit in case
+         ! of ADMM) from ADMM basis to primary basis
+         IF (do_admm_rpa) THEN
+            CALL admm_mo_merge_ks_matrix(qs_env)
+         END IF
+
+         DO ispin = 1, nspins
+            CALL dbcsr_add(matrix_sigma_x_minus_vxc(ispin, 1)%matrix, matrix_ks(ispin)%matrix, 1.0_dp, 1.0_dp)
+         END DO
+
+         CALL dbcsr_desymmetrize(matrix_ks(1)%matrix, mo_coeff_b)
+         CALL dbcsr_set(mo_coeff_b, 0.0_dp)
+
+         ! Transform matrix_sigma_x_minus_vxc to MO basis
+         DO ispin = 1, nspins
+
+            CALL get_mo_set(mo_set=mos_mp2(ispin)%mo_set, &
+                            mo_coeff=mo_coeff, &
+                            nmo=nmo, &
+                            homo=homo, &
+                            nao=dimen)
+
+            IF (ispin == 1) THEN
+
+               ALLOCATE (vec_Sigma_x_minus_vxc_gw(nmo, nspins, nkp))
+               vec_Sigma_x_minus_vxc_gw = 0.0_dp
             END IF
 
-            CALL integrate_four_center(qs_env, matrix_ks_2d, eh1, rho_ao_2d, hfx_sections, &
-                                       para_env, .TRUE., irep, .TRUE., &
-                                       ispin=1, do_exx=.TRUE.)
-            ehfx = ehfx+eh1
+            CALL dbcsr_set(mo_coeff_b, 0.0_dp)
+            CALL copy_fm_to_dbcsr(mo_coeff, mo_coeff_b, keep_sparsity=.FALSE.)
+
+            ! initialize matrix_tmp and matrix_tmp2
+            IF (ispin == 1) THEN
+               CALL dbcsr_create(matrix_tmp, template=mo_coeff_b)
+               CALL dbcsr_copy(matrix_tmp, mo_coeff_b)
+               CALL dbcsr_set(matrix_tmp, 0.0_dp)
+
+               CALL dbcsr_create(matrix_tmp_2, template=mo_coeff_b)
+               CALL dbcsr_copy(matrix_tmp_2, mo_coeff_b)
+               CALL dbcsr_set(matrix_tmp_2, 0.0_dp)
+            END IF
+
+            gw_corr_lev_occ = mp2_env%ri_g0w0%corr_mos_occ
+            gw_corr_lev_virt = mp2_env%ri_g0w0%corr_mos_virt
+            ! if corrected occ/virt levels exceed the number of occ/virt levels,
+            ! correct all occ/virt level energies
+            IF (gw_corr_lev_occ > homo) gw_corr_lev_occ = homo
+            IF (gw_corr_lev_virt > dimen-homo) gw_corr_lev_virt = dimen-homo
+            IF (ispin == 1) THEN
+               mp2_env%ri_g0w0%corr_mos_occ = gw_corr_lev_occ
+               mp2_env%ri_g0w0%corr_mos_virt = gw_corr_lev_virt
+            ELSE IF (ispin == 2) THEN
+               ! ensure that the total number of corrected MOs is the same for alpha and beta, important
+               ! for parallelization
+               IF (mp2_env%ri_g0w0%corr_mos_occ+mp2_env%ri_g0w0%corr_mos_virt /= &
+                   gw_corr_lev_occ+gw_corr_lev_virt) THEN
+                  gw_corr_lev_virt = mp2_env%ri_g0w0%corr_mos_occ+mp2_env%ri_g0w0%corr_mos_virt-gw_corr_lev_occ
+               END IF
+               mp2_env%ri_g0w0%corr_mos_occ_beta = gw_corr_lev_occ
+               mp2_env%ri_g0w0%corr_mos_virt_beta = gw_corr_lev_virt
+
+            END IF
+
+            CALL dbcsr_multiply('N', 'N', 1.0_dp, matrix_sigma_x_minus_vxc(ispin, 1)%matrix, &
+                                mo_coeff_b, 0.0_dp, matrix_tmp, first_column=homo+1-gw_corr_lev_occ, &
+                                last_column=homo+gw_corr_lev_virt)
+
+            CALL dbcsr_multiply('T', 'N', 1.0_dp, mo_coeff_b, &
+                                matrix_tmp, 0.0_dp, matrix_tmp_2, first_row=homo+1-gw_corr_lev_occ, &
+                                last_row=homo+gw_corr_lev_virt)
+
+            CALL dbcsr_get_diag(matrix_tmp_2, vec_Sigma_x_minus_vxc_gw(:, ispin, 1))
+
+            CALL dbcsr_set(matrix_tmp, 0.0_dp)
+            CALL dbcsr_set(matrix_tmp_2, 0.0_dp)
+
          END DO
-      END IF
-      energy_ex = ehfx
 
-      ! transform Fock-Matrix (calculated in integrate_four_center, written in matrix_ks_aux_fit in case
-      ! of ADMM) from ADMM basis to primary basis
-      IF (do_admm_rpa) THEN
-         CALL admm_mo_merge_ks_matrix(qs_env)
+         CALL mp_sum(vec_Sigma_x_minus_vxc_gw, para_env%group)
+
       END IF
 
-      DO ispin = 1, dft_control%nspins
-         CALL dbcsr_add(matrix_sigma_x_minus_vxc(ispin)%matrix, matrix_ks(ispin)%matrix, 1.0_dp, 1.0_dp)
+      CALL dbcsr_release(mo_coeff_b)
+      CALL dbcsr_release(matrix_tmp)
+      CALL dbcsr_release(matrix_tmp_2)
+      IF (do_kpoints_cubic_RPA) THEN
+         CALL dbcsr_deallocate_matrix_set(matrix_ks_kp_re)
+         CALL dbcsr_deallocate_matrix_set(matrix_ks_kp_im)
+      END IF
+
+      DO ispin = 1, nspins
+         DO ikp = 1, nkp
+            CALL dbcsr_release_p(matrix_sigma_x_minus_vxc(ispin, ikp)%matrix)
+            IF (do_kpoints_cubic_RPA) THEN
+               CALL dbcsr_release_p(matrix_sigma_x_minus_vxc_im(ispin, ikp)%matrix)
+            END IF
+         END DO
       END DO
 
-      CALL dbcsr_desymmetrize(matrix_ks(1)%matrix, mo_coeff_b)
-      CALL dbcsr_set(mo_coeff_b, 0.0_dp)
+      ALLOCATE (mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(nmo, nspins, nkp))
+
+      print_exx = mp2_env%ri_g0w0%print_exx
+
+      IF (print_exx == gw_print_exx) THEN
+
+         IF (unit_nr > 0) THEN
+
+            WRITE (unit_nr, '(T3,A)') 'Exchange energies'
+            WRITE (unit_nr, '(T3,A)') '-----------------'
+            WRITE (unit_nr, '(T3,A)') ''
+            WRITE (unit_nr, '(T6,2A)') 'MO                    Sigma_x-vxc'
+            DO n_level_gw = 1, gw_corr_lev_occ+gw_corr_lev_virt
+
+               n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+               IF (n_level_gw <= gw_corr_lev_occ) THEN
+                  occ_virt = 'occ'
+               ELSE
+                  occ_virt = 'vir'
+               END IF
+
+               exx_minus_vxc = REAL(vec_Sigma_x_minus_vxc_gw(n_level_gw_ref, 1, 1)*evolt)
+
+               WRITE (unit_nr, '(T4,I4,3A,3F21.3)') &
+                  n_level_gw_ref, ' ( ', occ_virt, ')  ', exx_minus_vxc
+
+            END DO
+            WRITE (unit_nr, '(T3,A)') 'End of exchange energies'
+            WRITE (unit_nr, '(T3,A)') '------------------------'
+            WRITE (unit_nr, '(T3,A)') ''
+         END IF
+
+      END IF
+
+      IF (print_exx == gw_read_exx) THEN
+
+         CALL open_file(unit_number=iunit, file_name="exx.out")
+
+         really_read_line = .FALSE.
+
+         DO WHILE (.TRUE.)
+
+            READ (iunit, '(A)') line
+
+            IF (line == "  End of exchange energies              ") EXIT
+
+            IF (really_read_line) THEN
+
+               READ (line(1:7), *) n_level_gw_ref
+               READ (line(17:40), *) tmp
+
+               DO ikp = 1, SIZE(vec_Sigma_x_minus_vxc_gw, 3)
+                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref, 1, ikp) = tmp/evolt
+               END DO
+
+            END IF
+
+            IF (line == "     MO                    Sigma_x-vxc  ") really_read_line = .TRUE.
+
+         END DO
+
+         CALL close_file(iunit)
+
+      END IF
+
+      ! store vec_Sigma_x_minus_vxc_gw in the mp2_environment
+      mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, :, :) = vec_Sigma_x_minus_vxc_gw(:, :, :)
+
+      ! clean up
+      DEALLOCATE (matrix_sigma_x_minus_vxc, vec_Sigma_x_minus_vxc_gw)
+      IF (do_kpoints_cubic_RPA) THEN
+         DEALLOCATE (matrix_sigma_x_minus_vxc_im)
+      END IF
+
+      t2 = m_walltime()
+
+      t3 = t2-t1
+
+      CALL timestop(handle)
+
+   END SUBROUTINE compute_vec_Sigma_x_minus_vxc_gw
+
+! **************************************************************************************************
+!> \brief ...
+!> \param kpoints ...
+!> \param matrix_sigma_x_minus_vxc ...
+!> \param matrix_sigma_x_minus_vxc_im ...
+!> \param vec_Sigma_x_minus_vxc_gw ...
+!> \param vec_Sigma_x_minus_vxc_gw_im ...
+!> \param para_env ...
+!> \param nmo ...
+!> \param mp2_env ...
+! **************************************************************************************************
+   SUBROUTINE transform_sigma_x_minus_vxc_to_MO_basis(kpoints, matrix_sigma_x_minus_vxc, &
+                                                      matrix_sigma_x_minus_vxc_im, vec_Sigma_x_minus_vxc_gw, &
+                                                      vec_Sigma_x_minus_vxc_gw_im, para_env, nmo, mp2_env)
+
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_sigma_x_minus_vxc, &
+                                                            matrix_sigma_x_minus_vxc_im
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: vec_Sigma_x_minus_vxc_gw, &
+                                                            vec_Sigma_x_minus_vxc_gw_im
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      INTEGER                                            :: nmo
+      TYPE(mp2_type), POINTER                            :: mp2_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'transform_sigma_x_minus_vxc_to_MO_basis', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: dimen, gw_corr_lev_occ, gw_corr_lev_virt, handle, homo, i_global, iiB, ikp, &
+         ispin, j_global, jjB, ncol_local, nkp, nrow_local, nspins
+      INTEGER, DIMENSION(2)                              :: kp_range
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+      REAL(KIND=dp)                                      :: imval, reval
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mos, cfm_sigma_x_minus_vxc, &
+                                                            cfm_sigma_x_minus_vxc_mo_basis, cfm_tmp
+      TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
+      TYPE(cp_fm_type), POINTER                          :: fwork_im, fwork_re
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(mo_set_type), POINTER                         :: mo_set, mo_set_im, mo_set_re
+
+      CALL timeset(routineN, handle)
+
+      mo_set => kpoints%kp_env(1)%kpoint_env%mos(1, 1)%mo_set
+      CALL get_mo_set(mo_set, nmo=nmo)
+
+      nspins = SIZE(matrix_sigma_x_minus_vxc, 1)
+      CALL get_kpoint_info(kpoints, nkp=nkp, kp_range=kp_range)
+
+      ! if this CPASSERT is wrong, please make sure that the kpoint group size PARALLEL_GROUP_SIZE
+      ! in the kpoint environment &DFT &KPOINTS is -1
+      CPASSERT(kp_range(1) == 1 .AND. kp_range(2) == nkp)
+
+      ALLOCATE (vec_Sigma_x_minus_vxc_gw(nmo, nspins, nkp))
+      vec_Sigma_x_minus_vxc_gw = 0.0_dp
+
+      ALLOCATE (vec_Sigma_x_minus_vxc_gw_im(nmo, nspins, nkp))
+      vec_Sigma_x_minus_vxc_gw_im = 0.0_dp
+
+      NULLIFY (fwork_re, fwork_im, cfm_mos, cfm_sigma_x_minus_vxc, &
+               cfm_sigma_x_minus_vxc_mo_basis, cfm_tmp)
+      CALL cp_fm_get_info(mo_set%mo_coeff, matrix_struct=matrix_struct)
+      CALL cp_fm_create(fwork_re, matrix_struct)
+      CALL cp_fm_create(fwork_im, matrix_struct)
+      CALL cp_cfm_create(cfm_mos, matrix_struct)
+      CALL cp_cfm_create(cfm_sigma_x_minus_vxc, matrix_struct)
+      CALL cp_cfm_create(cfm_sigma_x_minus_vxc_mo_basis, matrix_struct)
+      CALL cp_cfm_create(cfm_tmp, matrix_struct)
+
+      CALL cp_cfm_get_info(matrix=cfm_sigma_x_minus_vxc_mo_basis, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
 
       ! Transform matrix_sigma_x_minus_vxc to MO basis
-      DO ispin = 1, dft_control%nspins
+      DO ikp = 1, nkp
 
-         CALL get_mo_set(mo_set=mos_mp2(ispin)%mo_set, &
-                         mo_coeff=mo_coeff, &
-                         nmo=nmo, &
-                         homo=homo, &
-                         nao=dimen)
+         kp => kpoints%kp_env(ikp)%kpoint_env
 
-         IF (ispin == 1) THEN
-            ALLOCATE (vec_Sigma_x_minus_vxc_gw(nmo, dft_control%nspins))
-            vec_Sigma_x_minus_vxc_gw = 0.0_dp
-         END IF
+         DO ispin = 1, nspins
 
-         CALL dbcsr_set(mo_coeff_b, 0.0_dp)
-         CALL copy_fm_to_dbcsr(mo_coeff, mo_coeff_b, keep_sparsity=.FALSE.)
+            ! v_xc_n to fm matrix
+            CALL copy_dbcsr_to_fm(matrix_sigma_x_minus_vxc(ispin, ikp)%matrix, fwork_re)
+            CALL copy_dbcsr_to_fm(matrix_sigma_x_minus_vxc_im(ispin, ikp)%matrix, fwork_im)
 
-         ! initialize matrix_tmp and matrix_tmp2
-         IF (ispin == 1) THEN
-            CALL dbcsr_create(matrix_tmp, template=mo_coeff_b)
-            CALL dbcsr_copy(matrix_tmp, mo_coeff_b)
-            CALL dbcsr_set(matrix_tmp, 0.0_dp)
+            CALL cp_cfm_scale_and_add_fm(z_zero, cfm_sigma_x_minus_vxc, z_one, fwork_re)
+            CALL cp_cfm_scale_and_add_fm(z_one, cfm_sigma_x_minus_vxc, gaussi, fwork_im)
 
-            CALL dbcsr_create(matrix_tmp_2, template=mo_coeff_b)
-            CALL dbcsr_copy(matrix_tmp_2, mo_coeff_b)
-            CALL dbcsr_set(matrix_tmp_2, 0.0_dp)
-         END IF
+            ! get real part (1) and imag. part (2) of the mo coeffs
+            mo_set_re => kp%mos(1, ispin)%mo_set
+            mo_set_im => kp%mos(2, ispin)%mo_set
 
+            CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mos, z_one, mo_set_re%mo_coeff)
+            CALL cp_cfm_scale_and_add_fm(z_one, cfm_mos, gaussi, mo_set_im%mo_coeff)
+
+            ! tmp = V(k)*C(k)
+            CALL cp_cfm_gemm('N', 'N', nmo, nmo, nmo, z_one, cfm_sigma_x_minus_vxc, &
+                             cfm_mos, z_zero, cfm_tmp)
+
+            ! V_n(k) = C^H(k)*tmp
+            CALL cp_cfm_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mos, cfm_tmp, &
+                             z_zero, cfm_sigma_x_minus_vxc_mo_basis)
+
+            DO jjB = 1, ncol_local
+
+               j_global = col_indices(jjB)
+
+               DO iiB = 1, nrow_local
+
+                  i_global = row_indices(iiB)
+
+                  IF (j_global == i_global .AND. i_global <= nmo) THEN
+
+                     reval = REAL(cfm_sigma_x_minus_vxc_mo_basis%local_data(iiB, jjB))
+                     imval = AIMAG(cfm_sigma_x_minus_vxc_mo_basis%local_data(iiB, jjB))
+
+                     vec_Sigma_x_minus_vxc_gw(i_global, ispin, ikp) = reval
+                     vec_Sigma_x_minus_vxc_gw_im(i_global, ispin, ikp) = imval
+
+                  END IF
+
+               END DO
+
+            END DO
+
+         END DO
+
+      END DO
+
+      CALL mp_sum(vec_Sigma_x_minus_vxc_gw, para_env%group)
+      CALL mp_sum(vec_Sigma_x_minus_vxc_gw_im, para_env%group)
+
+      ! also adjust in the case of kpoints too big gw_corr_lev_occ and gw_corr_lev_virt
+      DO ispin = 1, nspins
+         CALL get_mo_set(mo_set=kpoints%kp_env(1)%kpoint_env%mos(ispin, 1)%mo_set, &
+                         homo=homo, nao=dimen)
          gw_corr_lev_occ = mp2_env%ri_g0w0%corr_mos_occ
          gw_corr_lev_virt = mp2_env%ri_g0w0%corr_mos_virt
          ! if corrected occ/virt levels exceed the number of occ/virt levels,
@@ -1527,73 +1908,156 @@ CONTAINS
             END IF
             mp2_env%ri_g0w0%corr_mos_occ_beta = gw_corr_lev_occ
             mp2_env%ri_g0w0%corr_mos_virt_beta = gw_corr_lev_virt
-
          END IF
-
-         CALL dbcsr_multiply('N', 'N', 1.0_dp, matrix_sigma_x_minus_vxc(ispin)%matrix, &
-                             mo_coeff_b, 0.0_dp, matrix_tmp, first_column=homo+1-gw_corr_lev_occ, &
-                             last_column=homo+gw_corr_lev_virt)
-
-         CALL dbcsr_multiply('T', 'N', 1.0_dp, mo_coeff_b, &
-                             matrix_tmp, 0.0_dp, matrix_tmp_2, first_row=homo+1-gw_corr_lev_occ, &
-                             last_row=homo+gw_corr_lev_virt)
-
-         CALL dbcsr_get_diag(matrix_tmp_2, vec_Sigma_x_minus_vxc_gw(:, ispin))
-
-         CALL dbcsr_set(matrix_tmp, 0.0_dp)
-         CALL dbcsr_set(matrix_tmp_2, 0.0_dp)
-
       END DO
 
-      CALL mp_sum(vec_Sigma_x_minus_vxc_gw, para_env%group)
+      CALL cp_fm_release(fwork_re)
+      CALL cp_fm_release(fwork_im)
+      CALL cp_cfm_release(cfm_mos)
+      CALL cp_cfm_release(cfm_sigma_x_minus_vxc)
+      CALL cp_cfm_release(cfm_sigma_x_minus_vxc_mo_basis)
+      CALL cp_cfm_release(cfm_tmp)
 
-      CALL dbcsr_release(mo_coeff_b)
-      CALL dbcsr_release(matrix_tmp)
-      CALL dbcsr_release(matrix_tmp_2)
+      CALL timestop(handle)
 
-      DO ispin = 1, SIZE(matrix_ks)
-         CALL dbcsr_release_p(matrix_sigma_x_minus_vxc(ispin)%matrix)
-      END DO
+   END SUBROUTINE
 
-      ALLOCATE (mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(nmo, dft_control%nspins))
-
-      ! store vec_Sigma_x_minus_vxc_gw in the mp2_environment
-      mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, :) = vec_Sigma_x_minus_vxc_gw(:, :)
-
-      ! clean up
-      DEALLOCATE (matrix_sigma_x_minus_vxc, vec_Sigma_x_minus_vxc_gw)
-
-      t2 = m_walltime()
-
-      t3 = t2-t1
-
-   END SUBROUTINE compute_vec_Sigma_x_minus_vxc_gw
-
-!*********************************************************************
 ! **************************************************************************************************
 !> \brief ...
 !> \param matrix_s ...
 !> \param matrix_ks ...
 !> \param mos ...
 !> \param matrix_s_kp ...
-!> \param matrix_ks_kp ...
+!> \param matrix_ks_transl ...
 !> \param kpoints ...
 ! **************************************************************************************************
-   SUBROUTINE get_gamma(matrix_s, matrix_ks, mos, &
-                        matrix_s_kp, matrix_ks_kp, kpoints)
+   SUBROUTINE get_gamma(matrix_s, matrix_ks, mos, matrix_s_kp, matrix_ks_transl, kpoints)
 
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, matrix_ks
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrix_ks_kp
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrix_ks_transl
       TYPE(kpoint_type), POINTER                         :: kpoints
 
       INTEGER                                            :: nspins
 
-      nspins = SIZE(matrix_ks_kp, 1)
+      nspins = SIZE(matrix_ks_transl, 1)
 
-      matrix_ks(1:nspins) => matrix_ks_kp(1:nspins, 1)
+      matrix_ks(1:nspins) => matrix_ks_transl(1:nspins, 1)
       matrix_s(1:1) => matrix_s_kp(1:1, 1)
       mos(1:nspins) => kpoints%kp_env(1)%kpoint_env%mos(1:nspins, 1)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param matrix_ks_transl ...
+!> \param matrix_ks_kp_re ...
+!> \param matrix_ks_kp_im ...
+!> \param kpoints ...
+! **************************************************************************************************
+   SUBROUTINE transform_matrix_ks_to_kp(matrix_ks_transl, matrix_ks_kp_re, matrix_ks_kp_im, kpoints)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_transl, matrix_ks_kp_re, &
+                                                            matrix_ks_kp_im
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'transform_matrix_ks_to_kp', &
+         routineP = moduleN//':'//routineN
+      COMPLEX(KIND=dp), PARAMETER :: cone = CMPLX(1.0_dp, 0.0_dp, KIND=dp), &
+         czero = CMPLX(0.0_dp, 0.0_dp, KIND=dp), ione = CMPLX(0.0_dp, 1.0_dp, KIND=dp)
+
+      INTEGER                                            :: handle, ikp, ispin, nkp, nspin
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_nl
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (sab_nl)
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, sab_nl=sab_nl, cell_to_index=cell_to_index)
+
+      CPASSERT(ASSOCIATED(sab_nl))
+
+      nspin = SIZE(matrix_ks_transl, 1)
+
+      DO ikp = 1, nkp
+         DO ispin = 1, nspin
+
+            CALL dbcsr_set(matrix_ks_kp_re(ispin, ikp)%matrix, 0.0_dp)
+            CALL dbcsr_set(matrix_ks_kp_im(ispin, ikp)%matrix, 0.0_dp)
+            CALL rskp_transform(rmatrix=matrix_ks_kp_re(ispin, ikp)%matrix, &
+                                cmatrix=matrix_ks_kp_im(ispin, ikp)%matrix, &
+                                rsmat=matrix_ks_transl, ispin=ispin, &
+                                xkp=xkp(1:3, ikp), cell_to_index=cell_to_index, sab_nl=sab_nl)
+
+         END DO
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param matrix_ks_transl ...
+!> \param matrix_ks_kp_re ...
+!> \param matrix_ks_kp_im ...
+!> \param kpoints ...
+! **************************************************************************************************
+   SUBROUTINE allocate_matrix_ks_kp(matrix_ks_transl, matrix_ks_kp_re, matrix_ks_kp_im, kpoints)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_transl, matrix_ks_kp_re, &
+                                                            matrix_ks_kp_im
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'allocate_matrix_ks_kp', &
+         routineP = moduleN//':'//routineN
+      COMPLEX(KIND=dp), PARAMETER :: cone = CMPLX(1.0_dp, 0.0_dp, KIND=dp), &
+         czero = CMPLX(0.0_dp, 0.0_dp, KIND=dp), ione = CMPLX(0.0_dp, 1.0_dp, KIND=dp)
+
+      INTEGER                                            :: handle, ikp, ispin, nkp, nspin
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_nl
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (sab_nl)
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, sab_nl=sab_nl, cell_to_index=cell_to_index)
+
+      CPASSERT(ASSOCIATED(sab_nl))
+
+      nspin = SIZE(matrix_ks_transl, 1)
+
+      NULLIFY (matrix_ks_kp_re, matrix_ks_kp_im)
+      CALL dbcsr_allocate_matrix_set(matrix_ks_kp_re, nspin, nkp)
+      CALL dbcsr_allocate_matrix_set(matrix_ks_kp_im, nspin, nkp)
+
+      DO ikp = 1, nkp
+      DO ispin = 1, nspin
+
+         ALLOCATE (matrix_ks_kp_re(ispin, ikp)%matrix)
+         ALLOCATE (matrix_ks_kp_im(ispin, ikp)%matrix)
+
+         CALL dbcsr_create(matrix_ks_kp_re(ispin, ikp)%matrix, &
+                           template=matrix_ks_transl(1, 1)%matrix, &
+                           matrix_type=dbcsr_type_symmetric)
+         CALL dbcsr_create(matrix_ks_kp_im(ispin, ikp)%matrix, &
+                           template=matrix_ks_transl(1, 1)%matrix, &
+                           matrix_type=dbcsr_type_antisymmetric)
+
+         CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_kp_re(ispin, ikp)%matrix, sab_nl)
+         CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_kp_im(ispin, ikp)%matrix, sab_nl)
+
+         CALL dbcsr_set(matrix_ks_kp_re(ispin, ikp)%matrix, 0.0_dp)
+         CALL dbcsr_set(matrix_ks_kp_im(ispin, ikp)%matrix, 0.0_dp)
+
+      END DO
+      END DO
+
+      CALL timestop(handle)
 
    END SUBROUTINE
 

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -227,7 +227,7 @@ CONTAINS
       TYPE(dbcsr_type), POINTER :: mo_coeff_all, mo_coeff_all_beta, mo_coeff_gw, mo_coeff_gw_beta, &
          mo_coeff_o, mo_coeff_o_beta, mo_coeff_v, mo_coeff_v_beta
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(kpoint_type), POINTER                         :: kpoints, kpoints_from_DFT
       TYPE(local_atoms_type), ALLOCATABLE, DIMENSION(:)  :: atom2d
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
@@ -269,8 +269,8 @@ CONTAINS
 
       ! ... setup needed to be able to qs_integrate in a subgroup.
       IF (do_kpoints_cubic_RPA) THEN
-         CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, kpoints=kpoints)
-         mos(1:nspins) => kpoints%kp_env(1)%kpoint_env%mos(1:nspins, 1)
+         CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, kpoints=kpoints_from_DFT)
+         mos(1:nspins) => kpoints_from_DFT%kp_env(1)%kpoint_env%mos(1:nspins, 1)
       ELSE
          CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, mos=mos)
       END IF
@@ -517,10 +517,9 @@ CONTAINS
                mp2_env%mp2_gpw%eps_filter, unit_nr, &
                mp2_env%mp2_memory, mp2_env%calc_PQ_cond_num, calc_forces, blacs_env_sub, my_do_gw, &
                do_bse, starts_B_all, sizes_B_all, ends_B_all, starts_array_mc_t, ends_array_mc_t, &
-               gw_corr_lev_occ, gw_corr_lev_virt, &
-               do_im_time, do_mao, do_kpoints_cubic_RPA, &
-               mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, mat_3c_overl_int_mao_for_occ, &
-               mat_3c_overl_int_mao_for_virt, &
+               gw_corr_lev_occ, gw_corr_lev_virt, do_im_time, do_mao, do_kpoints_cubic_RPA, kpoints, &
+               mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, &
+               mat_3c_overl_int_mao_for_occ, mat_3c_overl_int_mao_for_virt, &
                mao_coeff_occ, mao_coeff_virt, ri_metric, &
                starts_B_occ_bse, sizes_B_occ_bse, ends_B_occ_bse, &
                starts_B_virt_bse, sizes_B_virt_bse, ends_B_virt_bse, &
@@ -542,7 +541,7 @@ CONTAINS
                                        blacs_env_sub, my_do_gw, do_bse, starts_B_all, sizes_B_all, &
                                        ends_B_all, starts_array_mc_t, ends_array_mc_t, &
                                        gw_corr_lev_occ, gw_corr_lev_virt, &
-                                       do_im_time, do_mao, do_kpoints_cubic_RPA, &
+                                       do_im_time, do_mao, do_kpoints_cubic_RPA, kpoints, &
                                        mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, mat_3c_overl_int_mao_for_occ, &
                                        mat_3c_overl_int_mao_for_virt, mao_coeff_occ, mao_coeff_virt, &
                                        ri_metric, &
@@ -730,7 +729,7 @@ CONTAINS
                                    ends_array, ends_B_virtual, ends_B_all, sizes_array, sizes_B_virtual, sizes_B_all, &
                                    starts_array, starts_B_virtual, starts_B_all, starts_B_occ_bse, sizes_B_occ_bse, &
                                    ends_B_occ_bse, starts_B_virt_bse, sizes_B_virt_bse, ends_B_virt_bse, &
-                                   mo_coeff, fm_matrix_L_RI_metric, &
+                                   mo_coeff, fm_matrix_L_RI_metric, kpoints, &
                                    Eigenval, nmo, homo, dimen_RI, gw_corr_lev_occ, gw_corr_lev_virt, &
                                    unit_nr, my_do_ri_sos_laplace_mp2, my_do_gw, do_im_time, do_mao, do_bse, matrix_s, &
                                    mao_coeff_occ, mao_coeff_virt, mao_coeff_occ_A, mao_coeff_virt_A, &
@@ -748,7 +747,7 @@ CONTAINS
                                    ends_array, ends_B_virtual, ends_B_all, sizes_array, sizes_B_virtual, sizes_B_all, &
                                    starts_array, starts_B_virtual, starts_B_all, starts_B_occ_bse, sizes_B_occ_bse, &
                                    ends_B_occ_bse, starts_B_virt_bse, sizes_B_virt_bse, ends_B_virt_bse, &
-                                   mo_coeff, fm_matrix_L_RI_metric, &
+                                   mo_coeff, fm_matrix_L_RI_metric, kpoints, &
                                    Eigenval, nmo, homo, dimen_RI, gw_corr_lev_occ, gw_corr_lev_virt, &
                                    unit_nr, my_do_ri_sos_laplace_mp2, my_do_gw, do_im_time, do_mao, do_bse, matrix_s, &
                                    mao_coeff_occ, mao_coeff_virt, mao_coeff_occ_A, mao_coeff_virt_A, &
@@ -2259,7 +2258,7 @@ CONTAINS
       INTEGER                                            :: blacs_grid_layout, color_sub_1, &
                                                             comm_sub_1, handle, ikind, natom, nkind
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
-      LOGICAL                                            :: blacs_repeatable, do_kpoints_cubic_RPA, &
+      LOGICAL                                            :: blacs_repeatable, do_kpoints, &
                                                             my_do_im_time, my_do_mixed_basis, &
                                                             my_do_ri_aux_basis
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: orb_present
@@ -2293,8 +2292,11 @@ CONTAINS
          my_do_im_time = do_im_time
       END IF
 
-      do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
-      IF (do_kpoints_cubic_RPA) THEN
+!      do_kpoints = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints .OR. &
+!                             SUM(qs_env%mp2_env%ri_rpa_im_time%kp_grid) > 0
+      do_kpoints = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
+
+      IF (do_kpoints) THEN
          ! please choose EPS_PGF_ORB in QS section smaller than EPS_GRID in WFC_GPW section
          CPASSERT(mp2_env%mp2_gpw%eps_grid .GE. dft_control%qs_control%eps_pgf_orb)
       END IF
@@ -2354,7 +2356,7 @@ CONTAINS
       CALL pair_radius_setup(orb_present, orb_present, orb_radius, orb_radius, pair_radius)
 
       ! for cubic RPA/GW with kpoints, we need all neighbors and not only the symmetric ones
-      IF (do_kpoints_cubic_RPA) THEN
+      IF (do_kpoints) THEN
          CALL build_neighbor_lists(sab_orb_sub, particle_set, atom2d, cell, pair_radius, &
                                    mic=.FALSE., subcells=subcells, molecular=.FALSE., nlname="sab_orb_sub", &
                                    symmetric=.FALSE.)
@@ -2497,7 +2499,7 @@ CONTAINS
          CALL pair_radius_setup(orb_present, orb_present, orb_radius, orb_radius, pair_radius)
 
          ! for kpoints in cubic RPA/GW we need all neighbor cells
-         IF (do_kpoints_cubic_RPA) THEN
+         IF (do_kpoints) THEN
             CALL build_neighbor_lists(sab_orb_all, particle_set, atom2d, cell, pair_radius, &
                                       mic=.FALSE., subcells=subcells, molecular=.FALSE., nlname="sab_orb_sub", &
                                       symmetric=.FALSE.)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -80,6 +80,7 @@ MODULE mp2_ri_gpw
                                               int_8
    USE kpoint_coulomb_2c,               ONLY: build_2c_coulomb_matrix_kp
    USE kpoint_methods,                  ONLY: kpoint_init_cell_index,&
+                                              kpoint_initialize,&
                                               rskp_transform
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_create,&
@@ -116,7 +117,8 @@ MODULE mp2_ri_gpw
                                               pw_p_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
-                                              qs_environment_type
+                                              qs_environment_type,&
+                                              set_qs_env
    USE qs_integral_utils,               ONLY: basis_set_list_setup
    USE qs_integrate_potential,          ONLY: integrate_pgf_product_rspace,&
                                               integrate_v_rspace
@@ -363,7 +365,6 @@ CONTAINS
       TYPE(dbcsr_type) :: matrix_bse_ab, matrix_bse_anu, matrix_bse_ij, matrix_bse_inu, &
          matrix_ia_jb, matrix_ia_jb_beta, matrix_ia_jnu, matrix_ia_jnu_beta, matrix_in_jm, &
          matrix_in_jm_beta, matrix_in_jnu, matrix_in_jnu_beta
-      TYPE(kpoint_type), POINTER                         :: kpoints_from_DFT
       TYPE(pw_p_type)                                    :: psi_L
       TYPE(two_dim_real_array), ALLOCATABLE, &
          DIMENSION(:)                                    :: mao_coeff_repl_occ, mao_coeff_repl_virt
@@ -371,9 +372,6 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       CALL cite_reference(DelBen2013)
-
-      CALL get_qs_env(qs_env=qs_env, &
-                      kpoints=kpoints_from_DFT)
 
       do_alpha_beta = .FALSE.
       IF (PRESENT(BIb_C_beta) .AND. &
@@ -401,11 +399,12 @@ CONTAINS
       do_kpoints_from_Gamma = SUM(qs_env%mp2_env%ri_rpa_im_time%kp_grid) > 0
       IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
          CPASSERT(eri_method == do_eri_os)
-         IF (do_kpoints_cubic_RPA) THEN
-            kpoints => kpoints_from_DFT
-         ELSE
-            CALL compute_kpoints(qs_env, kpoints_from_DFT, kpoints, unit_nr)
-         END IF
+      END IF
+      IF (do_kpoints_cubic_RPA) THEN
+         CALL get_qs_env(qs_env=qs_env, &
+                         kpoints=kpoints)
+      ELSE IF (do_kpoints_from_Gamma) THEN
+         CALL compute_kpoints(qs_env, kpoints, unit_nr)
       END IF
 
       ! in case of imaginary time, we do not need the intermediate matrices
@@ -1923,20 +1922,19 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
-!> \param kpoints_from_DFT ...
 !> \param kpoints ...
 !> \param unit_nr ...
 ! **************************************************************************************************
-   SUBROUTINE compute_kpoints(qs_env, kpoints_from_DFT, kpoints, unit_nr)
+   SUBROUTINE compute_kpoints(qs_env, kpoints, unit_nr)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(kpoint_type), POINTER                         :: kpoints_from_DFT, kpoints
+      TYPE(kpoint_type), POINTER                         :: kpoints
       INTEGER                                            :: unit_nr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_kpoints', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i, i_dim, ikp, ix, iy, iz, nkp, &
+      INTEGER                                            :: handle, i, i_dim, ix, iy, iz, nkp, &
                                                             num_dim
       INTEGER, DIMENSION(3)                              :: nkp_grid, periodic
       TYPE(cell_type), POINTER                           :: cell
@@ -1944,6 +1942,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       CALL timeset(routineN, handle)
 
@@ -2005,30 +2004,11 @@ CONTAINS
          END DO
       END DO
 
-      ALLOCATE (kpoints%kp_sym(nkp))
-      DO ikp = 1, nkp
-         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym)
+      CALL kpoint_initialize(kpoints, particle_set, cell)
 
-         ! the following is instead of kpoint_sym_create because
-         ! it crashes with some cryptical pointer fault
-         CPASSERT(.NOT. ASSOCIATED(kpoints%kp_sym(ikp)%kpoint_sym))
-
-         ALLOCATE (kpoints%kp_sym(ikp)%kpoint_sym)
-
-         kpoints%kp_sym(ikp)%kpoint_sym%nwght = 0
-         kpoints%kp_sym(ikp)%kpoint_sym%apply_symmetry = .FALSE.
-
-         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym%rot)
-         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym%xkp)
-         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym%f0)
-      END DO
-
-!      CALL kpoint_init_cell_index(kpoints, sab_orb_sub, para_env, dft_control)
       CALL kpoint_init_cell_index(kpoints, sab_orb, para_env, dft_control)
 
-      CALL set_ks_env(qs_env%ks_env, kpoints=kpoints)
-
-      kpoints_from_DFT => kpoints
+      CALL set_qs_env(qs_env, kpoints=kpoints)
 
       CALL timestop(handle)
 

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -21,6 +21,7 @@ MODULE mp2_ri_gpw
    USE cell_types,                      ONLY: cell_type,&
                                               get_cell,&
                                               pbc
+   USE constants_operator,              ONLY: operator_coulomb
    USE cp_blacs_env,                    ONLY: cp_blacs_env_create,&
                                               cp_blacs_env_release,&
                                               cp_blacs_env_type
@@ -81,6 +82,7 @@ MODULE mp2_ri_gpw
    USE kpoint_methods,                  ONLY: kpoint_init_cell_index,&
                                               rskp_transform
    USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_create,&
                                               kpoint_type
    USE machine,                         ONLY: m_flush,&
                                               m_memory,&
@@ -212,6 +214,7 @@ CONTAINS
 !> \param do_im_time ...
 !> \param do_mao ...
 !> \param do_kpoints_cubic_RPA ...
+!> \param kpoints ...
 !> \param mat_3c_overl_int ...
 !> \param do_dbcsr_t ...
 !> \param t_3c_M ...
@@ -251,7 +254,7 @@ CONTAINS
                                     mp2_memory, calc_PQ_cond_num, calc_forces, blacs_env_sub, my_do_gw, do_bse, &
                                     starts_B_all, sizes_B_all, ends_B_all, starts_array_mc_t, ends_array_mc_t, &
                                     gw_corr_lev_occ, gw_corr_lev_virt, &
-                                    do_im_time, do_mao, do_kpoints_cubic_RPA, &
+                                    do_im_time, do_mao, do_kpoints_cubic_RPA, kpoints, &
                                     mat_3c_overl_int, do_dbcsr_t, t_3c_M, t_3c_O, mat_3c_overl_int_mao_for_occ, &
                                     mat_3c_overl_int_mao_for_virt, mao_coeff_occ, mao_coeff_virt, &
                                     ri_metric, ends_B_occ_bse, sizes_B_occ_bse, &
@@ -299,6 +302,7 @@ CONTAINS
                                                             starts_array_mc_t, ends_array_mc_t
       INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt
       LOGICAL                                            :: do_im_time, do_mao, do_kpoints_cubic_RPA
+      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
       LOGICAL, INTENT(IN)                                :: do_dbcsr_t
       TYPE(dbcsr_t_type)                                 :: t_3c_M
@@ -341,7 +345,8 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: pdims_2_2d, pdims_sub_2d
       INTEGER, DIMENSION(3)                              :: pdims_t3c, periodic
       INTEGER, DIMENSION(:), POINTER                     :: ao_blk_sizes
-      LOGICAL                                            :: do_alpha_beta, memory_info
+      LOGICAL                                            :: do_alpha_beta, do_kpoints_from_Gamma, &
+                                                            memory_info
       REAL(KIND=dp)                                      :: cond_num, mem_for_iaK, pair_energy, &
                                                             wfn_size
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: my_Lrows
@@ -358,7 +363,7 @@ CONTAINS
       TYPE(dbcsr_type) :: matrix_bse_ab, matrix_bse_anu, matrix_bse_ij, matrix_bse_inu, &
          matrix_ia_jb, matrix_ia_jb_beta, matrix_ia_jnu, matrix_ia_jnu_beta, matrix_in_jm, &
          matrix_in_jm_beta, matrix_in_jnu, matrix_in_jnu_beta
-      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(kpoint_type), POINTER                         :: kpoints_from_DFT
       TYPE(pw_p_type)                                    :: psi_L
       TYPE(two_dim_real_array), ALLOCATABLE, &
          DIMENSION(:)                                    :: mao_coeff_repl_occ, mao_coeff_repl_virt
@@ -368,7 +373,7 @@ CONTAINS
       CALL cite_reference(DelBen2013)
 
       CALL get_qs_env(qs_env=qs_env, &
-                      kpoints=kpoints)
+                      kpoints=kpoints_from_DFT)
 
       do_alpha_beta = .FALSE.
       IF (PRESENT(BIb_C_beta) .AND. &
@@ -393,9 +398,14 @@ CONTAINS
       eri_method = qs_env%mp2_env%eri_method
       eri_param => qs_env%mp2_env%eri_mme_param
 
-      do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
-      IF (do_kpoints_cubic_RPA) THEN
+      do_kpoints_from_Gamma = SUM(qs_env%mp2_env%ri_rpa_im_time%kp_grid) > 0
+      IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
          CPASSERT(eri_method == do_eri_os)
+         IF (do_kpoints_cubic_RPA) THEN
+            kpoints => kpoints_from_DFT
+         ELSE
+            CALL compute_kpoints(qs_env, kpoints_from_DFT, kpoints, unit_nr)
+         END IF
       END IF
 
       ! in case of imaginary time, we do not need the intermediate matrices
@@ -518,18 +528,15 @@ CONTAINS
       ! for minimax Ewald summation, full periodicity is required
       IF (eri_method == do_eri_mme) THEN
          CPASSERT(periodic(1) == 1 .AND. periodic(2) == 1 .AND. periodic(3) == 1)
-         ! for Obara-Saika for two-center Coulomb matrix, only gas phase calculations are supported
-      ELSE IF (eri_method == do_eri_os .AND. (.NOT. do_kpoints_cubic_RPA)) THEN
-         CPASSERT(periodic(1) == 0 .AND. periodic(2) == 0 .AND. periodic(3) == 0)
       END IF
 
       CALL calculate_Lmin1(qs_env, eri_method, eri_param, para_env, para_env_sub, para_env_L, mp2_memory, &
-                           fm_matrix_L, ngroup, color_sub, dimen_RI, &
+                           fm_matrix_L, ngroup, color_sub, dimen_RI, kpoints, &
                            mo_coeff, dft_control, psi_L, rho_r, rho_g, pot_g, pw_env_sub, poisson_env, &
                            my_group_L_size, my_group_L_start, my_group_L_end, &
                            sizes_array, starts_array, ends_array, calc_PQ_cond_num, cond_num, &
-                           num_small_eigen, ri_metric, &
-                           fm_matrix_L_RI_metric, do_im_time, do_kpoints_cubic_RPA, qs_env%mp2_env%mp2_gpw%eps_pgf_orb_S, &
+                           num_small_eigen, ri_metric, fm_matrix_L_RI_metric, do_im_time, &
+                           do_kpoints_from_Gamma .OR. do_kpoints_cubic_RPA, qs_env%mp2_env%mp2_gpw%eps_pgf_orb_S, &
                            atomic_kind_set, qs_kind_set)
 
       IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
@@ -796,6 +803,7 @@ CONTAINS
             END DO
          END IF
       ENDIF
+
       CALL timestop(handle2)
 
       IF (do_im_time) THEN
@@ -1618,6 +1626,7 @@ CONTAINS
 !> \param ngroup ...
 !> \param color_sub ...
 !> \param dimen_RI ...
+!> \param kpoints ...
 !> \param mo_coeff ...
 !> \param dft_control ...
 !> \param psi_L ...
@@ -1638,19 +1647,18 @@ CONTAINS
 !> \param ri_metric ...
 !> \param fm_matrix_L_RI_metric ...
 !> \param do_im_time ...
-!> \param do_kpoints_cubic_RPA ...
+!> \param do_kpoints ...
 !> \param mp2_eps_pgf_orb_S ...
 !> \param atomic_kind_set ...
 !> \param qs_kind_set ...
 ! **************************************************************************************************
    SUBROUTINE calculate_Lmin1(qs_env, eri_method, eri_param, para_env, para_env_sub, para_env_L, mp2_memory, &
-                              fm_matrix_L, ngroup, color_sub, dimen_RI, &
+                              fm_matrix_L, ngroup, color_sub, dimen_RI, kpoints, &
                               mo_coeff, dft_control, psi_L, rho_r, rho_g, pot_g, pw_env_sub, poisson_env, &
                               my_group_L_size, my_group_L_start, my_group_L_end, &
                               sizes_array, starts_array, ends_array, calc_PQ_cond_num, cond_num, &
-                              num_small_eigen, &
-                              ri_metric, fm_matrix_L_RI_metric, do_im_time, do_kpoints_cubic_RPA, mp2_eps_pgf_orb_S, &
-                              atomic_kind_set, qs_kind_set)
+                              num_small_eigen, ri_metric, fm_matrix_L_RI_metric, do_im_time, &
+                              do_kpoints, mp2_eps_pgf_orb_S, atomic_kind_set, qs_kind_set)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER                                            :: eri_method
@@ -1659,6 +1667,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: mp2_memory
       TYPE(cp_fm_type), POINTER                          :: fm_matrix_L
       INTEGER                                            :: ngroup, color_sub, dimen_RI
+      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_p_type)                                    :: psi_L, rho_r, rho_g, pot_g
@@ -1671,7 +1680,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: cond_num
       INTEGER                                            :: num_small_eigen, ri_metric
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_RI_metric
-      LOGICAL                                            :: do_im_time, do_kpoints_cubic_RPA
+      LOGICAL                                            :: do_im_time, do_kpoints
       REAL(KIND=dp)                                      :: mp2_eps_pgf_orb_S
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -1713,7 +1722,7 @@ CONTAINS
             CALL init_interaction_radii(dft_control%qs_control, atomic_kind_set, qs_kind_set)
 
             ! Gamma-point overlap matrix or kpoint dependent overlap matrix
-            CALL Obara_Saika_overlap_mat(qs_env, fm_matrix_L_RI_metric, fm_matrix_L, dimen_RI)
+            CALL Obara_Saika_overlap_mat(qs_env, fm_matrix_L_RI_metric, fm_matrix_L, dimen_RI, do_kpoints, kpoints)
 
             ! re-init the radii to previous values
             dft_control%qs_control%eps_pgf_orb = eps_pgf_orb_old
@@ -1739,11 +1748,12 @@ CONTAINS
 
          END IF
 
-         IF (do_kpoints_cubic_RPA) THEN
+         IF (do_kpoints) THEN
 
-            CALL compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_L_RI_metric)
+            CALL compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_L_RI_metric, kpoints)
 
-            CALL inversion_of_S_and_mult_with_chol_dec_of_V(fm_matrix_L_RI_metric, fm_matrix_L_kpoints, dimen_RI, qs_env)
+            CALL inversion_of_S_and_mult_with_chol_dec_of_V(fm_matrix_L_RI_metric, fm_matrix_L_kpoints, &
+                                                            dimen_RI, kpoints)
 
          ELSE
 
@@ -1786,7 +1796,7 @@ CONTAINS
 
       END IF
 
-      IF (do_kpoints_cubic_RPA) THEN
+      IF (do_kpoints) THEN
 
          DO i_size = 1, SIZE(fm_matrix_L_kpoints, 1)
          DO i_real_imag = 1, SIZE(fm_matrix_L_kpoints, 2)
@@ -1807,33 +1817,35 @@ CONTAINS
 !> \param qs_env ...
 !> \param fm_matrix_L_kpoints ...
 !> \param fm_matrix_L_RI_metric ...
+!> \param kpoints ...
 ! **************************************************************************************************
-   SUBROUTINE compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_L_RI_metric)
+   SUBROUTINE compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_L_RI_metric, kpoints)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_kpoints, &
                                                             fm_matrix_L_RI_metric
+      TYPE(kpoint_type), POINTER                         :: kpoints
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_V_by_lattice_sum', &
          routineP = moduleN//':'//routineN
 
       INTEGER                                            :: handle, i_dim, i_real_imag, ikp, nkp
       INTEGER, DIMENSION(3)                              :: periodic
+      REAL(dp)                                           :: cutoff
+      REAL(KIND=dp), DIMENSION(3)                        :: abc
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_RI_aux_transl, matrix_v_RI_kp
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (matrix_s_RI_aux_transl, particle_set, cell, kpoints, qs_kind_set)
+      NULLIFY (matrix_s_RI_aux_transl, particle_set, cell, qs_kind_set)
 
       CALL get_qs_env(qs_env=qs_env, &
                       matrix_s_RI_aux_kp=matrix_s_RI_aux_transl, &
                       particle_set=particle_set, &
                       cell=cell, &
-                      kpoints=kpoints, &
                       qs_kind_set=qs_kind_set, &
                       atomic_kind_set=atomic_kind_set)
 
@@ -1842,14 +1854,10 @@ CONTAINS
       DO i_dim = 1, 3
          IF (periodic(i_dim) == 1) THEN
             CPASSERT(MODULO(kpoints%nkp_grid(i_dim), 2) == 0)
-            CPASSERT(kpoints%nkp_grid(i_dim) > 3)
          END IF
       END DO
 
       nkp = kpoints%nkp
-
-      NULLIFY (matrix_v_RI_kp)
-      CALL dbcsr_allocate_matrix_set(matrix_v_RI_kp, nkp, 2)
 
       NULLIFY (fm_matrix_L_kpoints)
       ALLOCATE (fm_matrix_L_kpoints(nkp, 2))
@@ -1860,6 +1868,9 @@ CONTAINS
             CALL cp_fm_set_all(fm_matrix_L_kpoints(ikp, i_real_imag)%matrix, 0.0_dp)
          END DO
       END DO
+
+      NULLIFY (matrix_v_RI_kp)
+      CALL dbcsr_allocate_matrix_set(matrix_v_RI_kp, nkp, 2)
 
       DO ikp = 1, nkp
 
@@ -1877,10 +1888,24 @@ CONTAINS
 
       END DO
 
+      CALL get_cell(cell=cell, abc=abc, periodic=periodic)
+      IF (periodic(1) == 0) THEN
+         abc(1) = 1.0E10_dp
+      END IF
+      IF (periodic(2) == 0) THEN
+         abc(2) = 1.0E10_dp
+      END IF
+      IF (periodic(3) == 0) THEN
+         abc(3) = 1.0E10_dp
+      END IF
+!      cutoff = qs_env%mp2_env%ri_rpa_im_time%cutoff*MIN(abc(1), abc(2), abc(3))
+      cutoff = 1.0_dp/(qs_env%mp2_env%ri_rpa_im_time%cutoff*MIN(abc(1), abc(2), abc(3)))
+
       CALL build_2c_coulomb_matrix_kp(matrix_v_RI_kp, kpoints, basis_type="RI_AUX", &
                                       cell=cell, particle_set=particle_set, qs_kind_set=qs_kind_set, &
                                       atomic_kind_set=atomic_kind_set, &
-                                      size_lattice_sum=qs_env%mp2_env%mp2_gpw%size_lattice_sum)
+                                      size_lattice_sum=qs_env%mp2_env%mp2_gpw%size_lattice_sum, &
+                                      operator_type=operator_coulomb, cutoff=cutoff)
 
       DO ikp = 1, nkp
 
@@ -1898,16 +1923,135 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
+!> \param kpoints_from_DFT ...
+!> \param kpoints ...
+!> \param unit_nr ...
+! **************************************************************************************************
+   SUBROUTINE compute_kpoints(qs_env, kpoints_from_DFT, kpoints, unit_nr)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(kpoint_type), POINTER                         :: kpoints_from_DFT, kpoints
+      INTEGER                                            :: unit_nr
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_kpoints', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i, i_dim, ikp, ix, iy, iz, nkp, &
+                                                            num_dim
+      INTEGER, DIMENSION(3)                              :: nkp_grid, periodic
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (cell, dft_control, para_env)
+      CALL get_qs_env(qs_env=qs_env, cell=cell, para_env=para_env, dft_control=dft_control, sab_orb=sab_orb)
+      CALL get_cell(cell=cell, periodic=periodic)
+
+      NULLIFY (kpoints)
+      CALL kpoint_create(kpoints)
+
+      ! general because we augment a Monkhorst-Pack mesh by additional points in the BZ
+      kpoints%kp_scheme = "GENERAL"
+      kpoints%symmetry = .FALSE.
+      kpoints%verbose = .FALSE.
+      kpoints%full_grid = .FALSE.
+      kpoints%use_real_wfn = .FALSE.
+      kpoints%eps_geo = 1.e-6_dp
+      kpoints%full_grid = .TRUE.
+      nkp_grid(1:3) = qs_env%mp2_env%ri_rpa_im_time%kp_grid(1:3)
+      kpoints%nkp_grid(1:3) = nkp_grid(1:3)
+
+      num_dim = periodic(1)+periodic(2)+periodic(3)
+
+      DO i_dim = 1, 3
+         IF (periodic(i_dim) == 1) THEN
+            CPASSERT(MODULO(kpoints%nkp_grid(i_dim), 2) == 0)
+         END IF
+      END DO
+
+      IF (num_dim == 3) THEN
+         nkp = nkp_grid(1)*nkp_grid(2)*nkp_grid(3)/2
+      ELSE IF (num_dim == 2) THEN
+         nkp = MAX(nkp_grid(1)*nkp_grid(2)/2, nkp_grid(1)*nkp_grid(3)/2, nkp_grid(2)*nkp_grid(3)/2)
+      ELSE IF (num_dim == 1) THEN
+         nkp = MAX(nkp_grid(1)/2, nkp_grid(2)/2, nkp_grid(3)/2)
+      END IF
+
+      kpoints%nkp = nkp
+
+      IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
+         "KPOINT_INFO| Number of kpoints for V and W:", nkp
+
+      ALLOCATE (kpoints%xkp(3, nkp), kpoints%wkp(nkp))
+      kpoints%wkp(:) = 1.0_dp/REAL(nkp, KIND=dp)
+
+      i = 0
+      DO ix = 1, nkp_grid(1)
+         DO iy = 1, nkp_grid(2)
+            DO iz = 1, nkp_grid(3)
+
+               i = i+1
+               IF (i > nkp) CYCLE
+
+               kpoints%xkp(1, i) = REAL(2*ix-nkp_grid(1)-1, KIND=dp)/(2._dp*REAL(nkp_grid(1), KIND=dp))
+               kpoints%xkp(2, i) = REAL(2*iy-nkp_grid(2)-1, KIND=dp)/(2._dp*REAL(nkp_grid(2), KIND=dp))
+               kpoints%xkp(3, i) = REAL(2*iz-nkp_grid(3)-1, KIND=dp)/(2._dp*REAL(nkp_grid(3), KIND=dp))
+
+            END DO
+         END DO
+      END DO
+
+      ALLOCATE (kpoints%kp_sym(nkp))
+      DO ikp = 1, nkp
+         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym)
+
+         ! the following is instead of kpoint_sym_create because
+         ! it crashes with some cryptical pointer fault
+         CPASSERT(.NOT. ASSOCIATED(kpoints%kp_sym(ikp)%kpoint_sym))
+
+         ALLOCATE (kpoints%kp_sym(ikp)%kpoint_sym)
+
+         kpoints%kp_sym(ikp)%kpoint_sym%nwght = 0
+         kpoints%kp_sym(ikp)%kpoint_sym%apply_symmetry = .FALSE.
+
+         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym%rot)
+         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym%xkp)
+         NULLIFY (kpoints%kp_sym(ikp)%kpoint_sym%f0)
+      END DO
+
+!      CALL kpoint_init_cell_index(kpoints, sab_orb_sub, para_env, dft_control)
+      CALL kpoint_init_cell_index(kpoints, sab_orb, para_env, dft_control)
+
+      CALL set_ks_env(qs_env%ks_env, kpoints=kpoints)
+
+      kpoints_from_DFT => kpoints
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param qs_env ...
 !> \param fm_matrix_L_RI_metric ...
 !> \param fm_matrix_L ...
 !> \param dimen_RI ...
+!> \param do_kpoints ...
+!> \param kpoints ...
 ! **************************************************************************************************
-   SUBROUTINE Obara_Saika_overlap_mat(qs_env, fm_matrix_L_RI_metric, fm_matrix_L, dimen_RI)
+   SUBROUTINE Obara_Saika_overlap_mat(qs_env, fm_matrix_L_RI_metric, fm_matrix_L, dimen_RI, &
+                                      do_kpoints, kpoints)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_RI_metric
       TYPE(cp_fm_type), POINTER                          :: fm_matrix_L
       INTEGER                                            :: dimen_RI
+      LOGICAL                                            :: do_kpoints
+      TYPE(kpoint_type), POINTER                         :: kpoints
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'Obara_Saika_overlap_mat', &
          routineP = moduleN//':'//routineN
@@ -1915,7 +2059,6 @@ CONTAINS
       INTEGER                                            :: handle, i_real_imag, i_size, ikp, &
                                                             n_real_imag, nkp
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      LOGICAL                                            :: do_kpoints_cubic_RPA
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
@@ -1924,7 +2067,6 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_RI_aux_transl
       TYPE(dbcsr_type), POINTER                          :: cmatrix, matrix_s_RI_aux_desymm, &
                                                             rmatrix, tmpmat
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
 
@@ -1936,10 +2078,7 @@ CONTAINS
                       sab_orb=sab_orb, &
                       para_env=para_env, &
                       blacs_env=blacs_env, &
-                      matrix_s_RI_aux_kp=matrix_s_RI_aux_transl, &
-                      kpoints=kpoints)
-
-      do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
+                      matrix_s_RI_aux_kp=matrix_s_RI_aux_transl)
 
       CALL build_overlap_matrix(qs_env%ks_env, &
                                 matrixkp_s=matrix_s_RI_aux_transl, &
@@ -1949,7 +2088,7 @@ CONTAINS
 
       CALL set_ks_env(qs_env%ks_env, matrix_s_RI_aux_kp=matrix_s_RI_aux_transl)
 
-      IF (do_kpoints_cubic_RPA) THEN
+      IF (do_kpoints) THEN
          CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, &
                               cell_to_index=cell_to_index)
          n_real_imag = 2
@@ -1975,7 +2114,7 @@ CONTAINS
       CALL cp_fm_create(fm_matrix_S_global, fm_struct)
       CALL cp_fm_set_all(fm_matrix_S_global, 0.0_dp)
 
-      IF (do_kpoints_cubic_RPA) THEN
+      IF (do_kpoints) THEN
 
          ALLOCATE (rmatrix, cmatrix, tmpmat)
          CALL dbcsr_create(rmatrix, template=matrix_s_RI_aux_transl(1, 1)%matrix, &
@@ -2859,14 +2998,15 @@ CONTAINS
 !> \param fm_matrix_L_RI_metric ...
 !> \param fm_matrix_L_kpoints ...
 !> \param dimen_RI ...
-!> \param qs_env ...
+!> \param kpoints ...
 ! **************************************************************************************************
-   SUBROUTINE inversion_of_S_and_mult_with_chol_dec_of_V(fm_matrix_L_RI_metric, fm_matrix_L_kpoints, dimen_RI, qs_env)
+   SUBROUTINE inversion_of_S_and_mult_with_chol_dec_of_V(fm_matrix_L_RI_metric, fm_matrix_L_kpoints, &
+                                                         dimen_RI, kpoints)
 
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_RI_metric, &
                                                             fm_matrix_L_kpoints
       INTEGER                                            :: dimen_RI
-      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(kpoint_type), POINTER                         :: kpoints
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'inversion_of_S_and_mult_with_chol_dec_of_V', &
          routineP = moduleN//':'//routineN
@@ -2880,7 +3020,6 @@ CONTAINS
       TYPE(cp_cfm_type), POINTER                         :: cfm_matrix_K_tmp, cfm_matrix_L_tmp, &
                                                             cfm_matrix_S_inv_tmp, cfm_matrix_S_tmp
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
-      TYPE(kpoint_type), POINTER                         :: kpoints
 
       CALL timeset(routineN, handle)
 
@@ -2892,8 +3031,6 @@ CONTAINS
       CALL cp_cfm_create(cfm_matrix_S_inv_tmp, matrix_struct)
       CALL cp_cfm_create(cfm_matrix_L_tmp, matrix_struct)
       CALL cp_cfm_create(cfm_matrix_K_tmp, matrix_struct)
-
-      CALL get_qs_env(qs_env=qs_env, kpoints=kpoints)
 
       CALL get_kpoint_info(kpoints, nkp=nkp)
 
@@ -8023,8 +8160,6 @@ CONTAINS
       IF (do_kpoints_cubic_RPA) THEN
          ! set up new kpoint type with periodic images according to eps_grid from MP2 section
          ! instead of eps_pgf_orb from QS section
-         CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
-
          CALL kpoint_init_cell_index(kpoints, sab_orb_sub, para_env, dft_control)
 
          nimg = dft_control%nimages

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -80,10 +80,8 @@ MODULE mp2_ri_gpw
                                               int_8
    USE kpoint_coulomb_2c,               ONLY: build_2c_coulomb_matrix_kp
    USE kpoint_methods,                  ONLY: kpoint_init_cell_index,&
-                                              kpoint_initialize,&
                                               rskp_transform
    USE kpoint_types,                    ONLY: get_kpoint_info,&
-                                              kpoint_create,&
                                               kpoint_type
    USE machine,                         ONLY: m_flush,&
                                               m_memory,&
@@ -399,11 +397,10 @@ CONTAINS
       do_kpoints_from_Gamma = SUM(qs_env%mp2_env%ri_rpa_im_time%kp_grid) > 0
       IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
          CPASSERT(eri_method == do_eri_os)
-      END IF
-      IF (do_kpoints_cubic_RPA) THEN
          CALL get_qs_env(qs_env=qs_env, &
                          kpoints=kpoints)
-      ELSE IF (do_kpoints_from_Gamma) THEN
+      END IF
+      IF (do_kpoints_from_Gamma) THEN
          CALL compute_kpoints(qs_env, kpoints, unit_nr)
       END IF
 
@@ -1942,16 +1939,12 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       CALL timeset(routineN, handle)
 
       NULLIFY (cell, dft_control, para_env)
       CALL get_qs_env(qs_env=qs_env, cell=cell, para_env=para_env, dft_control=dft_control, sab_orb=sab_orb)
       CALL get_cell(cell=cell, periodic=periodic)
-
-      NULLIFY (kpoints)
-      CALL kpoint_create(kpoints)
 
       ! general because we augment a Monkhorst-Pack mesh by additional points in the BZ
       kpoints%kp_scheme = "GENERAL"
@@ -2003,8 +1996,6 @@ CONTAINS
             END DO
          END DO
       END DO
-
-      CALL kpoint_initialize(kpoints, particle_set, cell)
 
       CALL kpoint_init_cell_index(kpoints, sab_orb, para_env, dft_control)
 

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -149,13 +149,16 @@ CONTAINS
                                 l_val=mp2_env%ri_g0w0%hf_like_ev_start)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%PRINT_GW_DETAILS", &
                                 l_val=mp2_env%ri_g0w0%print_gw_details)
+      CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%PRINT_EXX", &
+                                i_val=mp2_env%ri_g0w0%print_exx)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%RI_SIGMA_X", &
                                 l_val=mp2_env%ri_g0w0%do_ri_Sigma_x)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%IC_CORR_LIST", &
                                 r_vals=mp2_env%ri_g0w0%ic_corr_list)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%IC_CORR_LIST_BETA", &
                                 r_vals=mp2_env%ri_g0w0%ic_corr_list_beta)
-
+      CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%GAMMA_ONLY_SIGMA", &
+                                l_val=mp2_env%ri_g0w0%do_gamma_only_sigma)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%BSE", &
                                 l_val=mp2_env%ri_g0w0%do_bse)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%BSE%NUM_Z_VECTORS", &
@@ -293,8 +296,14 @@ CONTAINS
                                 r_val=mp2_env%ri_rpa_im_time%stabilize_exp)
       CALL section_vals_val_get(im_time_section, "DO_KPOINTS", &
                                 l_val=mp2_env%ri_rpa_im_time%do_im_time_kpoints)
+      CALL section_vals_val_get(im_time_section, "CUTOFF_W", &
+                                r_val=mp2_env%ri_rpa_im_time%cutoff)
       CALL section_vals_val_get(im_time_section, "RI_G0W0", &
                                 l_val=mp2_env%ri_rpa_im_time%do_gw_im_time)
+      CALL section_vals_val_get(im_time_section, "KPOINTS", &
+                                i_vals=mp2_env%ri_rpa_im_time%kp_grid)
+      CALL section_vals_val_get(im_time_section, "EXP_KPOINTS", &
+                                r_val=mp2_env%ri_rpa_im_time%exp_kpoints)
 
       CALL section_vals_val_get(mp2_section, "IM_TIME%DO_DBCSR_T", &
                                 l_val=mp2_env%ri_rpa_im_time%do_dbcsr_t)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -134,15 +134,16 @@ MODULE mp2_types
    TYPE ri_rpa_im_time_type
       INTEGER                  :: cut_memory
       LOGICAL                  :: memory_info, do_mao, opt_sc_dm_occ, opt_sc_dm_virt, do_lr
-      REAL(KIND=dp)            :: eps_filter_im_time, eps_grad_occ, eps_grad_virt, lr_fraction
-      INTEGER                  :: group_size_P, group_size_3c, num_points_per_magnitude, &
+      REAL(KIND=dp)            :: eps_filter_im_time, eps_grad_occ, eps_grad_virt, lr_fraction, cutoff, &
+                                  exp_kpoints
+      INTEGER                  :: group_size_P, group_size_3c, num_points_per_magnitude, extrapol_fac, &
                                   max_iter_occ, max_iter_virt, group_size_Q
       INTEGER, ALLOCATABLE, DIMENSION(:) :: sizes_array_cm, starts_array_cm, &
                                             ends_array_cm, sizes_array_cm_mao_occ, &
                                             starts_array_cm_mao_occ, ends_array_cm_mao_occ, &
                                             sizes_array_cm_mao_virt, starts_array_cm_mao_virt, &
                                             ends_array_cm_mao_virt
-      INTEGER, DIMENSION(:), POINTER     :: nmao_occ, nmao_virt
+      INTEGER, DIMENSION(:), POINTER     :: nmao_occ, nmao_virt, kp_grid
       LOGICAL                  :: do_gw_im_time, do_im_time_kpoints
       REAL(KIND=dp)            :: stabilize_exp
       LOGICAL  :: do_dbcsr_t
@@ -169,7 +170,7 @@ MODULE mp2_types
                                   do_ri_Sigma_x, &
                                   remove_neg_virt_energies
       LOGICAL                  :: do_periodic
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_x_minus_vxc_gw
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :) :: vec_Sigma_x_minus_vxc_gw
       INTEGER, DIMENSION(:), POINTER    :: kp_grid
       INTEGER                  :: num_kp_grids
       REAL(KIND=dp)            :: eps_kpoint
@@ -187,6 +188,8 @@ MODULE mp2_types
       REAL(KIND=dp)            :: eps_dist
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list, ic_corr_list_beta, &
                                                             gw_eigenvalues, gw_eigenvalues_beta
+      INTEGER :: print_exx
+      LOGICAL :: do_gamma_only_sigma
    END TYPE
 
    TYPE ri_basis_opt

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -4,9 +4,9 @@
 !--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
-!> \brief Routines for kpoint treatment in GW
+!> \brief Routines for GW
 !> \par History
-!>      04.2019 created [Jan Wilhelm]
+!>      03.2019 created [Frederick Stein]
 ! **************************************************************************************************
 MODULE rpa_gw
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
@@ -144,8 +144,8 @@ CONTAINS
                                            mat_3c_overl_int, mat_contr_gf_occ, mat_contr_gf_virt, &
                                            mat_contr_W, qs_env)
 
-      INTEGER :: cut_RI, gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_tot, gw_corr_lev_virt, &
-         gw_corr_lev_virt_beta, homo, homo_beta, nmo, num_integ_points, unit_nr
+      INTEGER, INTENT(IN) :: cut_RI, gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_tot, &
+         gw_corr_lev_virt, gw_corr_lev_virt_beta, homo, homo_beta, nmo, num_integ_points, unit_nr
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: my_group_L_sizes_im_time, &
                                                             my_group_L_starts_im_time, row_from_LLL
       INTEGER, DIMENSION(:), POINTER                     :: prim_blk_sizes, RI_blk_sizes
@@ -1464,24 +1464,25 @@ CONTAINS
                                        first_cycle_periodic_correction, kpoints, do_mo_coeff_Gamma_only, &
                                        num_kp_grids, eps_kpoint, do_extra_kpoints, do_aux_bas, frac_aux_mos)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: delta_corr
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
       INTEGER, DIMENSION(:), POINTER                     :: kp_grid
-      INTEGER                                            :: homo, nmo, gw_corr_lev_occ, &
+      INTEGER, INTENT(IN)                                :: homo, nmo, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt
-      REAL(KIND=dp)                                      :: omega
+      REAL(KIND=dp), INTENT(IN)                          :: omega
       TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
                                                             matrix_berry_im_mo_mo
-      LOGICAL :: first_cycle_periodic_correction
+      LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
       TYPE(kpoint_type), POINTER                         :: kpoints
-      LOGICAL                                            :: do_mo_coeff_Gamma_only
-      INTEGER                                            :: num_kp_grids
-      REAL(KIND=dp)                                      :: eps_kpoint
-      LOGICAL                                            :: do_extra_kpoints, do_aux_bas
-      REAL(KIND=dp)                                      :: frac_aux_mos
+      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only
+      INTEGER, INTENT(IN)                                :: num_kp_grids
+      REAL(KIND=dp), INTENT(IN)                          :: eps_kpoint
+      LOGICAL, INTENT(IN)                                :: do_extra_kpoints, do_aux_bas
+      REAL(KIND=dp), INTENT(IN)                          :: frac_aux_mos
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_periodic_correction', &
          routineP = moduleN//':'//routineN
@@ -2852,17 +2853,18 @@ CONTAINS
                                          num_fit_points, max_iter_fit, crossing_search, homo, check_fit, stop_crit, &
                                          fermi_level_offset, do_gw_im_time)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_gw_energ, vec_gw_energ_error_fit, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: vec_gw_energ, vec_gw_energ_error_fit, &
                                                             vec_omega_fit_gw, z_value, m_value
-      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:)                        :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: vec_Sigma_c_gw
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
                                                             Eigenval_scf
-      INTEGER                                            :: n_level_gw, gw_corr_lev_occ, num_poles, &
+      INTEGER, INTENT(IN)                                :: n_level_gw, gw_corr_lev_occ, num_poles, &
                                                             num_fit_points, max_iter_fit, &
                                                             crossing_search, homo
-      LOGICAL                                            :: check_fit
-      REAL(KIND=dp)                                      :: stop_crit, fermi_level_offset
-      LOGICAL                                            :: do_gw_im_time
+      LOGICAL, INTENT(IN)                                :: check_fit
+      REAL(KIND=dp), INTENT(IN)                          :: stop_crit, fermi_level_offset
+      LOGICAL, INTENT(IN)                                :: do_gw_im_time
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fit_and_continuation_2pole', &
          routineP = moduleN//':'//routineN
@@ -3858,18 +3860,20 @@ CONTAINS
                                          count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, print_gw_details, &
                                          remove_neg_virt_energies, ikp, nkp_self_energy, kpoints, do_alpha, do_beta)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_gw_energ, vec_gw_energ_error_fit, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: vec_gw_energ, vec_gw_energ_error_fit, &
                                                             z_value, m_value
-      REAL(KIND=dp), DIMENSION(:)                        :: vec_Sigma_x_minus_vxc_gw, Eigenval
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: Eigenval_last, Eigenval_scf
-      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, &
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: vec_Sigma_x_minus_vxc_gw, Eigenval
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: Eigenval_last, Eigenval_scf
+      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, gw_corr_lev_virt, &
                                                             gw_corr_lev_tot, count_ev_sc_GW, &
                                                             crossing_search, homo, nmo, unit_nr
-      LOGICAL                                            :: print_gw_details, &
+      LOGICAL, INTENT(IN)                                :: print_gw_details, &
                                                             remove_neg_virt_energies
-      INTEGER                                            :: ikp, nkp_self_energy
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      LOGICAL, OPTIONAL                                  :: do_alpha, do_beta
+      INTEGER, INTENT(IN)                                :: ikp, nkp_self_energy
+      TYPE(kpoint_type), INTENT(IN), POINTER             :: kpoints
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_alpha, do_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'print_and_update_for_ev_sc', &
          routineP = moduleN//':'//routineN
@@ -4136,13 +4140,15 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calc_mat_N(N_ij, Lambda, Sigma_c, vec_omega_fit_gw, i, j, &
                          num_poles, num_fit_points, n_level_gw, h)
-      REAL(KIND=dp)                                      :: N_ij
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda
-      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: Sigma_c
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw
-      INTEGER                                            :: i, j, num_poles, num_fit_points, &
+      REAL(KIND=dp), INTENT(OUT)                         :: N_ij
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: Lambda
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: Sigma_c
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: vec_omega_fit_gw
+      INTEGER, INTENT(IN)                                :: i, j, num_poles, num_fit_points, &
                                                             n_level_gw
-      REAL(KIND=dp)                                      :: h
+      REAL(KIND=dp), INTENT(IN)                          :: h
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_mat_N', routineP = moduleN//':'//routineN
 
@@ -4229,11 +4235,13 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calc_chi2(chi2, Lambda, Sigma_c, vec_omega_fit_gw, num_poles, &
                         num_fit_points, n_level_gw)
-      REAL(KIND=dp)                                      :: chi2
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda
-      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: Sigma_c
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw
-      INTEGER                                            :: num_poles, num_fit_points, n_level_gw
+      REAL(KIND=dp), INTENT(INOUT)                       :: chi2
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: Lambda
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: Sigma_c
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: vec_omega_fit_gw
+      INTEGER, INTENT(IN)                                :: num_poles, num_fit_points, n_level_gw
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_chi2', routineP = moduleN//':'//routineN
 
@@ -4473,16 +4481,17 @@ CONTAINS
                                              mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
                                              first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
                                              do_GW_corr, do_ri_Sigma_x, vec_Sigma_x_gw, do_beta)
-      INTEGER                                            :: num_integ_points, nmo
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tj
+      INTEGER, INTENT(IN)                                :: num_integ_points, nmo
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj, tj
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt, &
                                                             matrix_s
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
          fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      REAL(KIND=dp)                                      :: eps_filter, e_fermi
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
-      INTEGER                                            :: gw_corr_lev_tot, gw_corr_lev_occ, &
+      INTEGER, INTENT(IN)                                :: gw_corr_lev_tot, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, homo, count_ev_sc_GW
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_int_gw
       TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ, mat_contr_gf_virt, &
@@ -4493,22 +4502,23 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw
-      LOGICAL                                            :: do_periodic
-      INTEGER                                            :: num_points_corr
+      LOGICAL, INTENT(IN)                                :: do_periodic
+      INTEGER, INTENT(IN)                                :: num_points_corr
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
       TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
                                                             matrix_berry_im_mo_mo
-      LOGICAL :: first_cycle_periodic_correction
+      LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
       TYPE(kpoint_type), POINTER                         :: kpoints
-      INTEGER                                            :: num_fit_points
+      INTEGER, INTENT(IN)                                :: num_fit_points
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
-      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: do_GW_corr
-      LOGICAL                                            :: do_ri_Sigma_x
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vec_Sigma_x_gw
-      LOGICAL, OPTIONAL                                  :: do_beta
+      LOGICAL, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: do_GW_corr
+      LOGICAL, INTENT(IN)                                :: do_ri_Sigma_x
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: vec_Sigma_x_gw
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_self_energy_im_time_gw', &
          routineP = moduleN//':'//routineN

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -4,9 +4,9 @@
 !--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
-!> \brief Routines to calculate RI-RPA energy
+!> \brief Routines for kpoint treatment in GW
 !> \par History
-!>      03.2019 Refactored from rpa_ri_gpw.F [Frederick Stein]
+!>      04.2019 created [Jan Wilhelm]
 ! **************************************************************************************************
 MODULE rpa_gw
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
@@ -48,18 +48,16 @@ MODULE rpa_gw
                                               ri_rpa_g0w0_crossing_none,&
                                               ri_rpa_g0w0_crossing_z_shot
    USE kinds,                           ONLY: dp
-   USE kpoint_types,                    ONLY: kpoint_create,&
-                                              kpoint_release,&
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_create,&
                                               kpoint_sym_create,&
                                               kpoint_type
    USE mathconstants,                   ONLY: fourpi,&
                                               pi,&
                                               twopi
-   USE message_passing,                 ONLY: mp_alltoall,&
-                                              mp_sum,&
+   USE message_passing,                 ONLY: mp_sum,&
                                               mp_sync
-   USE mp2_types,                       ONLY: integ_mat_buffer_type,&
-                                              mp2_type
+   USE mp2_types,                       ONLY: mp2_type
    USE particle_types,                  ONLY: particle_type
    USE physcon,                         ONLY: evolt
    USE qs_band_structure,               ONLY: calculate_kp_orbitals
@@ -71,13 +69,14 @@ MODULE rpa_gw
    USE qs_kind_types,                   ONLY: get_qs_kind,&
                                               qs_kind_type
    USE qs_ks_types,                     ONLY: qs_ks_env_type
+   USE qs_mo_types,                     ONLY: get_mo_set,&
+                                              mo_set_type
    USE qs_moments,                      ONLY: build_berry_moment_matrix
    USE qs_neighbor_list_types,          ONLY: deallocate_neighbor_list_set,&
                                               neighbor_list_set_p_type
    USE qs_neighbor_lists,               ONLY: setup_neighbor_list
    USE qs_overlap,                      ONLY: build_overlap_matrix_simple
-   USE rpa_im_time,                     ONLY: communicate_buffer,&
-                                              get_mat_3c_overl_int_gw
+   USE rpa_im_time,                     ONLY: get_mat_3c_overl_int_gw
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -86,7 +85,8 @@ MODULE rpa_gw
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'rpa_gw'
 
-   PUBLIC :: allocate_matrices_gw_im_time, get_weights_gw, allocate_matrices_gw, GW_matrix_operations, gw_postprocessing, gw_cleanup
+   PUBLIC :: allocate_matrices_gw_im_time, allocate_matrices_gw, GW_matrix_operations, GW_postprocessing, &
+             compute_self_energy_im_time_gw
 
 CONTAINS
 
@@ -118,7 +118,6 @@ CONTAINS
 !> \param mo_coeff ...
 !> \param mo_coeff_beta ...
 !> \param mat_dm_virt_local ...
-!> \param mat_P_global ...
 !> \param mat_3c_overl_int_gw ...
 !> \param mat_3c_overl_int_gw_beta ...
 !> \param mat_3c_overl_nnP_ic ...
@@ -131,7 +130,6 @@ CONTAINS
 !> \param mat_contr_gf_occ ...
 !> \param mat_contr_gf_virt ...
 !> \param mat_contr_W ...
-!> \param mp2_env ...
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE allocate_matrices_gw_im_time(cut_RI, gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_tot, &
@@ -139,19 +137,15 @@ CONTAINS
                                            num_integ_points, unit_nr, my_group_L_sizes_im_time, my_group_L_starts_im_time, &
                                            row_from_LLL, prim_blk_sizes, RI_blk_sizes, do_ic_model, do_ic_opt_homo_lumo, &
                                            my_open_shell, para_env, para_env_sub, fm_mat_W_tau, fm_mat_Q, &
-                                           mo_coeff, mo_coeff_beta, mat_dm_virt_local, mat_P_global, mat_3c_overl_int_gw, &
+                                           mo_coeff, mo_coeff_beta, mat_dm_virt_local, mat_3c_overl_int_gw, &
                                            mat_3c_overl_int_gw_beta, mat_3c_overl_nnP_ic, &
                                            mat_3c_overl_nnP_ic_beta, mat_3c_overl_nnP_ic_reflected, &
                                            mat_3c_overl_nnP_ic_reflected_beta, matrix_s, mat_W, &
                                            mat_3c_overl_int, mat_contr_gf_occ, mat_contr_gf_virt, &
-                                           mat_contr_W, mp2_env, qs_env)
+                                           mat_contr_W, qs_env)
 
-      INTEGER, INTENT(IN)                                :: cut_RI, gw_corr_lev_occ, &
-                                                            gw_corr_lev_occ_beta
-      INTEGER, INTENT(INOUT)                             :: gw_corr_lev_tot
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_virt, gw_corr_lev_virt_beta, &
-                                                            homo, homo_beta, nmo, &
-                                                            num_integ_points, unit_nr
+      INTEGER :: cut_RI, gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_tot, gw_corr_lev_virt, &
+         gw_corr_lev_virt_beta, homo, homo_beta, nmo, num_integ_points, unit_nr
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: my_group_L_sizes_im_time, &
                                                             my_group_L_starts_im_time, row_from_LLL
       INTEGER, DIMENSION(:), POINTER                     :: prim_blk_sizes, RI_blk_sizes
@@ -160,51 +154,118 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
       TYPE(cp_fm_type), POINTER                          :: fm_mat_Q, mo_coeff, mo_coeff_beta
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_dm_virt_local, mat_P_global
+      TYPE(dbcsr_p_type)                                 :: mat_dm_virt_local
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: mat_3c_overl_int_gw, mat_3c_overl_int_gw_beta, &
          mat_3c_overl_nnP_ic, mat_3c_overl_nnP_ic_beta, mat_3c_overl_nnP_ic_reflected, &
          mat_3c_overl_nnP_ic_reflected_beta, matrix_s, mat_W
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
       TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ, mat_contr_gf_virt, &
                                                             mat_contr_W
-      TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_matrices_gw_im_time', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, jquad, num_points_corr
+      INTEGER                                            :: handle, jquad, n_level_gw
 
       CALL timeset(routineN, handle)
 
-      num_points_corr = mp2_env%ri_g0w0%num_omega_points
+      NULLIFY (mat_3c_overl_int_gw)
+      CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw, gw_corr_lev_tot)
 
-      CALL dbcsr_get_info(mat_P_global%matrix, &
-                          row_blk_size=RI_blk_sizes)
+      IF (do_ic_model) THEN
 
-      CALL dbcsr_get_info(matrix_s(1)%matrix, &
-                          row_blk_size=prim_blk_sizes)
+         NULLIFY (mat_3c_overl_nnP_ic)
+         CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic, gw_corr_lev_tot)
 
-      gw_corr_lev_tot = gw_corr_lev_occ+gw_corr_lev_virt
+         NULLIFY (mat_3c_overl_nnP_ic_reflected)
+         CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic_reflected, gw_corr_lev_tot)
 
-      CALL alloc_mat_gw_im_time(mat_3c_overl_int_gw, gw_corr_lev_tot, do_ic_model, &
-                                mat_3c_overl_nnP_ic, &
-                                mat_3c_overl_nnP_ic_reflected, matrix_s, RI_blk_sizes, &
-                                prim_blk_sizes, mat_3c_overl_int, mo_coeff, &
-                                gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, &
-                                mat_dm_virt_local, para_env, para_env_sub, cut_RI, row_from_LLL, &
-                                my_group_L_starts_im_time, my_group_L_sizes_im_time, &
-                                do_ic_opt_homo_lumo, qs_env, unit_nr, .FALSE.)
+      END IF
+
+      DO n_level_gw = 1, gw_corr_lev_tot
+
+         ALLOCATE (mat_3c_overl_int_gw(n_level_gw)%matrix)
+         CALL dbcsr_create(matrix=mat_3c_overl_int_gw(n_level_gw)%matrix, &
+                           template=matrix_s(1)%matrix, &
+                           matrix_type=dbcsr_type_no_symmetry, &
+                           row_blk_size=RI_blk_sizes, &
+                           col_blk_size=prim_blk_sizes)
+
+         IF (do_ic_model) THEN
+            ALLOCATE (mat_3c_overl_nnP_ic(n_level_gw)%matrix)
+            CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic(n_level_gw)%matrix, &
+                              template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry, &
+                              row_blk_size=RI_blk_sizes, &
+                              col_blk_size=prim_blk_sizes)
+
+            ALLOCATE (mat_3c_overl_nnP_ic_reflected(n_level_gw)%matrix)
+            CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic_reflected(n_level_gw)%matrix, &
+                              template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry, &
+                              row_blk_size=RI_blk_sizes, &
+                              col_blk_size=prim_blk_sizes)
+
+         END IF
+
+      END DO
+
+      CALL get_mat_3c_overl_int_gw(mat_3c_overl_int, mat_3c_overl_int_gw, mo_coeff, matrix_s, &
+                                   gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, mat_dm_virt_local, &
+                                   para_env, para_env_sub, cut_RI, row_from_LLL, &
+                                   my_group_L_starts_im_time, my_group_L_sizes_im_time, do_ic_model, &
+                                   do_ic_opt_homo_lumo, mat_3c_overl_nnP_ic, &
+                                   mat_3c_overl_nnP_ic_reflected, qs_env, unit_nr)
 
       IF (my_open_shell) THEN
-         CALL alloc_mat_gw_im_time(mat_3c_overl_int_gw_beta, gw_corr_lev_tot, do_ic_model, &
-                                   mat_3c_overl_nnP_ic_beta, &
-                                   mat_3c_overl_nnP_ic_reflected_beta, matrix_s, RI_blk_sizes, &
-                                   prim_blk_sizes, mat_3c_overl_int, mo_coeff_beta, &
-                                   gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, nmo, &
-                                   mat_dm_virt_local, para_env, para_env_sub, cut_RI, row_from_LLL, &
-                                   my_group_L_starts_im_time, my_group_L_sizes_im_time, &
-                                   do_ic_opt_homo_lumo, qs_env, unit_nr, .TRUE.)
+
+         NULLIFY (mat_3c_overl_int_gw_beta)
+         CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw_beta, gw_corr_lev_tot)
+
+         IF (do_ic_model) THEN
+
+            NULLIFY (mat_3c_overl_nnP_ic_beta)
+            CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic_beta, gw_corr_lev_tot)
+
+            NULLIFY (mat_3c_overl_nnP_ic_reflected_beta)
+            CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic_reflected_beta, gw_corr_lev_tot)
+
+         END IF
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+
+            ALLOCATE (mat_3c_overl_int_gw_beta(n_level_gw)%matrix)
+            CALL dbcsr_create(matrix=mat_3c_overl_int_gw_beta(n_level_gw)%matrix, &
+                              template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry, &
+                              row_blk_size=RI_blk_sizes, &
+                              col_blk_size=prim_blk_sizes)
+
+            IF (do_ic_model) THEN
+               ALLOCATE (mat_3c_overl_nnP_ic_beta(n_level_gw)%matrix)
+               CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic_beta(n_level_gw)%matrix, &
+                                 template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry, &
+                                 row_blk_size=RI_blk_sizes, &
+                                 col_blk_size=prim_blk_sizes)
+
+               ALLOCATE (mat_3c_overl_nnP_ic_reflected_beta(n_level_gw)%matrix)
+               CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic_reflected_beta(n_level_gw)%matrix, &
+                                 template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry, &
+                                 row_blk_size=RI_blk_sizes, &
+                                 col_blk_size=prim_blk_sizes)
+            END IF
+
+         END DO
+
+         CALL get_mat_3c_overl_int_gw(mat_3c_overl_int, mat_3c_overl_int_gw_beta, mo_coeff_beta, matrix_s, &
+                                      gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, nmo, mat_dm_virt_local, &
+                                      para_env, para_env_sub, cut_RI, row_from_LLL, &
+                                      my_group_L_starts_im_time, my_group_L_sizes_im_time, do_ic_model, &
+                                      do_ic_opt_homo_lumo, mat_3c_overl_nnP_ic_beta, &
+                                      mat_3c_overl_nnP_ic_reflected_beta, qs_env, unit_nr, do_beta=.TRUE.)
 
       END IF
 
@@ -247,172 +308,8 @@ CONTAINS
       END DO
 
       CALL timestop(handle)
+
    END SUBROUTINE allocate_matrices_gw_im_time
-
-! **************************************************************************************************
-!> \brief ...
-!> \param mat_3c_overl_int_gw ...
-!> \param gw_corr_lev_tot ...
-!> \param do_ic_model ...
-!> \param mat_3c_overl_nnP_ic ...
-!> \param mat_3c_overl_nnP_ic_reflected ...
-!> \param matrix_s ...
-!> \param RI_blk_sizes ...
-!> \param prim_blk_sizes ...
-!> \param mat_3c_overl_int ...
-!> \param mo_coeff ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param homo ...
-!> \param nmo ...
-!> \param mat_dm_virt_local ...
-!> \param para_env ...
-!> \param para_env_sub ...
-!> \param cut_RI ...
-!> \param row_from_LLL ...
-!> \param my_group_L_starts_im_time ...
-!> \param my_group_L_sizes_im_time ...
-!> \param do_ic_opt_homo_lumo ...
-!> \param qs_env ...
-!> \param unit_nr ...
-!> \param do_beta ...
-! **************************************************************************************************
-   SUBROUTINE alloc_mat_gw_im_time(mat_3c_overl_int_gw, gw_corr_lev_tot, do_ic_model, mat_3c_overl_nnP_ic, &
-                                   mat_3c_overl_nnP_ic_reflected, matrix_s, RI_blk_sizes, &
-                                   prim_blk_sizes, mat_3c_overl_int, mo_coeff, &
-                                   gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, &
-                                   mat_dm_virt_local, para_env, para_env_sub, cut_RI, row_from_LLL, &
-                                   my_group_L_starts_im_time, my_group_L_sizes_im_time, &
-                                   do_ic_opt_homo_lumo, qs_env, unit_nr, do_beta)
-
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_int_gw
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_tot
-      LOGICAL, INTENT(IN)                                :: do_ic_model
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_nnP_ic, &
-                                                            mat_3c_overl_nnP_ic_reflected, matrix_s
-      INTEGER, DIMENSION(:), POINTER                     :: RI_blk_sizes, prim_blk_sizes
-      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, gw_corr_lev_virt, homo, &
-                                                            nmo
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_dm_virt_local
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
-      INTEGER, INTENT(IN)                                :: cut_RI
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: row_from_LLL, my_group_L_starts_im_time, &
-                                                            my_group_L_sizes_im_time
-      LOGICAL, INTENT(IN)                                :: do_ic_opt_homo_lumo
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      INTEGER, INTENT(IN)                                :: unit_nr
-      LOGICAL, INTENT(IN)                                :: do_beta
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'alloc_mat_gw_im_time', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, n_level_gw
-
-      CALL timeset(routineN, handle)
-
-      NULLIFY (mat_3c_overl_int_gw)
-      CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw, gw_corr_lev_tot)
-
-      IF (do_ic_model) THEN
-         NULLIFY (mat_3c_overl_nnP_ic)
-         CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic, gw_corr_lev_tot)
-
-         NULLIFY (mat_3c_overl_nnP_ic_reflected)
-         CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic_reflected, gw_corr_lev_tot)
-      END IF
-
-      DO n_level_gw = 1, gw_corr_lev_tot
-
-         ALLOCATE (mat_3c_overl_int_gw(n_level_gw)%matrix)
-         CALL dbcsr_create(matrix=mat_3c_overl_int_gw(n_level_gw)%matrix, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry, &
-                           row_blk_size=RI_blk_sizes, &
-                           col_blk_size=prim_blk_sizes)
-
-         IF (do_ic_model) THEN
-            ALLOCATE (mat_3c_overl_nnP_ic(n_level_gw)%matrix)
-            CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic(n_level_gw)%matrix, &
-                              template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry, &
-                              row_blk_size=RI_blk_sizes, &
-                              col_blk_size=prim_blk_sizes)
-
-            ALLOCATE (mat_3c_overl_nnP_ic_reflected(n_level_gw)%matrix)
-            CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic_reflected(n_level_gw)%matrix, &
-                              template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry, &
-                              row_blk_size=RI_blk_sizes, &
-                              col_blk_size=prim_blk_sizes)
-         END IF
-      END DO
-
-      CALL get_mat_3c_overl_int_gw(mat_3c_overl_int, mat_3c_overl_int_gw, mo_coeff, matrix_s, &
-                                   gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, mat_dm_virt_local, &
-                                   para_env, para_env_sub, cut_RI, row_from_LLL, &
-                                   my_group_L_starts_im_time, my_group_L_sizes_im_time, do_ic_model, &
-                                   do_ic_opt_homo_lumo, mat_3c_overl_nnP_ic, &
-                                   mat_3c_overl_nnP_ic_reflected, qs_env, unit_nr, do_beta)
-
-      CALL timestop(handle)
-   END SUBROUTINE alloc_mat_gw_im_time
-
-! **************************************************************************************************
-!> \brief ...
-!> \param num_integ_points ...
-!> \param num_points_per_magnitude ...
-!> \param unit_nr ...
-!> \param Emin ...
-!> \param Emax ...
-!> \param max_error_min ...
-!> \param tau_tj ...
-!> \param tj ...
-!> \param weights_cos_tf_w_to_t ...
-!> \param weights_sin_tf_t_to_w ...
-! **************************************************************************************************
-   SUBROUTINE get_weights_gw(num_integ_points, num_points_per_magnitude, unit_nr, Emin, Emax, &
-                             max_error_min, tau_tj, tj, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)
-
-      INTEGER, INTENT(IN)                                :: num_integ_points, &
-                                                            num_points_per_magnitude, unit_nr
-      REAL(KIND=dp), INTENT(IN)                          :: Emin, Emax
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error_min
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: weights_cos_tf_w_to_t, &
-                                                            weights_sin_tf_t_to_w
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_weights_gw', routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
-
-      ! get the weights for the cosine transform W^c(iw) -> W^c(it)
-      ALLOCATE (weights_cos_tf_w_to_t(num_integ_points, num_integ_points))
-      weights_cos_tf_w_to_t = 0.0_dp
-
-      CALL get_l_sq_wghts_cos_tf_w_to_t(num_integ_points, tau_tj, weights_cos_tf_w_to_t, tj, &
-                                        Emin, Emax, max_error_min, num_points_per_magnitude)
-
-      ! get the weights for the sine transform Sigma^sin(it) -> Sigma^sin(iw) (PRB 94, 165109 (2016), Eq. 71)
-      ALLOCATE (weights_sin_tf_t_to_w(num_integ_points, num_integ_points))
-      weights_sin_tf_t_to_w = 0.0_dp
-
-      CALL get_l_sq_wghts_sin_tf_t_to_w(num_integ_points, tau_tj, weights_sin_tf_t_to_w, tj, &
-                                        Emin, Emax, max_error_min, num_points_per_magnitude)
-
-      IF (unit_nr > 0) THEN
-         WRITE (UNIT=unit_nr, FMT="(T3,A,T66,ES15.2)") &
-            "INTEG_INFO| Maximum deviation of the imag. time fit:", max_error_min
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_weights_gw
 
 ! **************************************************************************************************
 !> \brief ...
@@ -431,6 +328,7 @@ CONTAINS
 !> \param unit_nr ...
 !> \param gw_corr_lev_tot ...
 !> \param num_fit_points ...
+!> \param omega_max_fit ...
 !> \param do_minimax_quad ...
 !> \param do_periodic ...
 !> \param do_ri_Sigma_x ...
@@ -466,11 +364,16 @@ CONTAINS
 !> \param fm_mat_S_gw_beta ...
 !> \param para_env ...
 !> \param mp2_env ...
+!> \param kpoints ...
+!> \param nkp ...
+!> \param nkp_self_energy ...
+!> \param do_kpoints_cubic_RPA ...
+!> \param do_kpoints_from_Gamma ...
 ! **************************************************************************************************
    SUBROUTINE allocate_matrices_gw(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, color_rpa_group, dimen_nm_gw, &
                                    gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_virt, homo, homo_beta, &
                                    nmo, num_integ_points, num_integ_group, unit_nr, &
-                                   gw_corr_lev_tot, num_fit_points, &
+                                   gw_corr_lev_tot, num_fit_points, omega_max_fit, &
                                    do_minimax_quad, do_periodic, do_ri_Sigma_x, my_do_gw, my_open_shell, &
                                    first_cycle_periodic_correction, do_GW_corr, &
                                    a_scaling, Eigenval, Eigenval_beta, &
@@ -480,13 +383,15 @@ CONTAINS
                                    vec_gw_energ, vec_gw_energ_beta, vec_gw_energ_error_fit, vec_gw_energ_error_fit_beta, &
                                    vec_W_gw, vec_W_gw_beta, z_value, z_value_beta, &
                                    fm_mat_S_gw, fm_mat_S_gw_work, fm_mat_S_gw_work_beta, &
-                                   fm_mat_S_gw_beta, para_env, mp2_env)
+                                   fm_mat_S_gw_beta, para_env, mp2_env, kpoints, nkp, nkp_self_energy, &
+                                   do_kpoints_cubic_RPA, do_kpoints_from_Gamma)
 
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(OUT)                                     :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
+      COMPLEX(KIND=dp), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(OUT)                 :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
       INTEGER, INTENT(IN) :: color_rpa_group, dimen_nm_gw, gw_corr_lev_occ, gw_corr_lev_occ_beta, &
          gw_corr_lev_virt, homo, homo_beta, nmo, num_integ_points, num_integ_group, unit_nr
       INTEGER, INTENT(INOUT)                             :: gw_corr_lev_tot, num_fit_points
+      REAL(kind=dp)                                      :: omega_max_fit
       LOGICAL, INTENT(IN)                                :: do_minimax_quad, do_periodic, &
                                                             do_ri_Sigma_x, my_do_gw, my_open_shell
       LOGICAL, INTENT(OUT) :: first_cycle_periodic_correction
@@ -496,8 +401,9 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tj
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: vec_omega_fit_gw, vec_Sigma_x_gw, &
-                                                            vec_Sigma_x_gw_beta
+         INTENT(OUT)                                     :: vec_omega_fit_gw
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: vec_Sigma_x_gw, vec_Sigma_x_gw_beta
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), INTENT(INOUT) :: delta_corr, Eigenval_last, &
          Eigenval_last_beta, Eigenval_scf, Eigenval_scf_beta, m_value, m_value_beta, vec_gw_energ, &
          vec_gw_energ_beta, vec_gw_energ_error_fit, vec_gw_energ_error_fit_beta, vec_W_gw, &
@@ -506,19 +412,24 @@ CONTAINS
                                                             fm_mat_S_gw_work_beta, fm_mat_S_gw_beta
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mp2_type), POINTER                            :: mp2_env
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: nkp, nkp_self_energy
+      LOGICAL                                            :: do_kpoints_cubic_RPA, &
+                                                            do_kpoints_from_Gamma
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_matrices_gw', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, iquad, jquad, nrow_local
+      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
+      INTEGER :: handle, iiB, iquad, jjB, jquad, m_global, m_global_beta, n_global, n_global_beta, &
+         n_level_gw, n_level_gw_ref, ncol_local, nm_global, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: row_indices
-      REAL(KIND=dp)                                      :: omega, omega_max_fit
+      REAL(kind=dp)                                      :: omega
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_gw
 
       CALL timeset(routineN, handle)
 
       gw_corr_lev_tot = gw_corr_lev_occ+gw_corr_lev_virt
-      omega_max_fit = mp2_env%ri_g0w0%omega_max_fit
 
       ! fill the omega_frequency vector
       ALLOCATE (vec_omega_gw(num_integ_points))
@@ -566,25 +477,83 @@ CONTAINS
 
       DEALLOCATE (vec_omega_gw)
 
-      IF (my_do_gw) THEN
-
-         ! minimax grids not implemented for O(N^4) GW
-         CPASSERT(.NOT. do_minimax_quad)
-
+      IF (do_kpoints_cubic_RPA) THEN
+         CALL get_kpoint_info(kpoints, nkp=nkp)
+         IF (mp2_env%ri_g0w0%do_gamma_only_sigma) THEN
+            nkp_self_energy = 1
+         ELSE
+            nkp_self_energy = nkp
+         END IF
+      ELSE IF (do_kpoints_from_Gamma) THEN
+         CALL get_kpoint_info(kpoints, nkp=nkp)
+         nkp_self_energy = 1
+      ELSE
+         nkp = 1
+         nkp_self_energy = 1
       END IF
-
-      CALL alloc_mat_gw(vec_Sigma_c_gw, dimen_nm_gw, gw_corr_lev_occ, gw_corr_lev_tot, &
-                        homo, nmo, num_fit_points, do_ri_Sigma_x, &
-                        my_do_gw, Eigenval, Eigenval_last, Eigenval_scf, m_value, vec_gw_energ, &
-                        vec_gw_energ_error_fit, vec_Sigma_x_gw, vec_W_gw, z_value, &
-                        fm_mat_S_gw, fm_mat_S_gw_work, mp2_env)
+      ALLOCATE (vec_Sigma_c_gw(gw_corr_lev_tot, num_fit_points, nkp_self_energy))
+      vec_Sigma_c_gw = (0.0_dp, 0.0_dp)
 
       IF (my_open_shell) THEN
-         CALL alloc_mat_gw(vec_Sigma_c_gw_beta, dimen_nm_gw, gw_corr_lev_occ, gw_corr_lev_tot, &
-                           homo, nmo, num_fit_points, do_ri_Sigma_x, &
-                           my_do_gw, Eigenval_beta, Eigenval_last_beta, Eigenval_scf_beta, m_value_beta, vec_gw_energ_beta, &
-                           vec_gw_energ_error_fit_beta, vec_Sigma_x_gw_beta, vec_W_gw_beta, &
-                           z_value_beta, fm_mat_S_gw, fm_mat_S_gw_work_beta, mp2_env)
+         ALLOCATE (vec_Sigma_c_gw_beta(gw_corr_lev_tot, num_fit_points, nkp_self_energy))
+         vec_Sigma_c_gw_beta = (0.0_dp, 0.0_dp)
+      END IF
+
+      ! arrays storing the correlation self-energy, stat. error and z-shot value
+      ALLOCATE (vec_gw_energ(gw_corr_lev_tot))
+      vec_gw_energ = 0.0_dp
+      ALLOCATE (vec_gw_energ_error_fit(gw_corr_lev_tot))
+      vec_gw_energ_error_fit = 0.0_dp
+      ALLOCATE (z_value(gw_corr_lev_tot))
+      z_value = 0.0_dp
+      ALLOCATE (m_value(gw_corr_lev_tot))
+      m_value = 0.0_dp
+
+      ! the same for beta
+      IF (my_open_shell) THEN
+         ALLOCATE (vec_gw_energ_beta(gw_corr_lev_tot))
+         vec_gw_energ_beta = 0.0_dp
+         ALLOCATE (vec_gw_energ_error_fit_beta(gw_corr_lev_tot))
+         vec_gw_energ_error_fit_beta = 0.0_dp
+         ALLOCATE (z_value_beta(gw_corr_lev_tot))
+         z_value_beta = 0.0_dp
+         ALLOCATE (m_value_beta(gw_corr_lev_tot))
+         m_value_beta = 0.0_dp
+      END IF
+
+      ALLOCATE (Eigenval_scf(nmo))
+      Eigenval_scf(:) = Eigenval(:)
+
+      ALLOCATE (Eigenval_last(nmo))
+      Eigenval_last(:) = Eigenval(:)
+
+      ! in the case of HF_diag approach of X. Blase (PRB 83, 115103 (2011), Sec. IV), we subtract the
+      ! XC potential and add exact exchange
+      IF (mp2_env%ri_g0w0%hf_like_ev_start) THEN
+         DO n_level_gw = 1, gw_corr_lev_tot
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+            Eigenval(n_level_gw_ref) = Eigenval(n_level_gw_ref)+ &
+                                       mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(n_level_gw_ref, 1, 1)
+         END DO
+      END IF
+
+      ! Eigenval for beta
+      IF (my_open_shell) THEN
+         ALLOCATE (Eigenval_scf_beta(nmo))
+         Eigenval_scf_beta(:) = Eigenval_beta(:)
+
+         ALLOCATE (Eigenval_last_beta(nmo))
+         Eigenval_last_beta(:) = Eigenval_beta(:)
+
+         ! in the case of HF_diag approach of X. Blase (PRB 83, 115103 (2011), Sec. IV), we subtract the
+         ! XC potential and add exact exchange
+         IF (mp2_env%ri_g0w0%hf_like_ev_start) THEN
+            DO n_level_gw = 1, gw_corr_lev_tot
+               n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+               Eigenval_beta(n_level_gw_ref) = Eigenval_beta(n_level_gw_ref)+ &
+                                               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(n_level_gw_ref, 2, 1)
+            END DO
+         END IF
       END IF
 
       IF (do_periodic) THEN
@@ -599,195 +568,126 @@ CONTAINS
       ALLOCATE (do_GW_corr(1:gw_corr_lev_tot))
       do_GW_corr(:) = .TRUE.
 
-      IF (my_do_gw) THEN
-
-         ! in case we do RI for Sigma_x, we calculate Sigma_x right here
-         IF (do_ri_Sigma_x) THEN
-
-            CALL cp_fm_get_info(matrix=fm_mat_S_gw, &
-                                nrow_local=nrow_local, &
-                                row_indices=row_indices)
-
-            CALL mp_sync(para_env%group)
-
-            CALL calc_vec_Sigma_x_gw(color_rpa_group, gw_corr_lev_occ, homo, 1, nmo, nrow_local, num_integ_group, &
-                                     row_indices, vec_Sigma_x_gw, &
-                                     fm_mat_S_gw, para_env, mp2_env)
-
-            IF (my_open_shell) THEN
-               CALL calc_vec_Sigma_x_gw(color_rpa_group, gw_corr_lev_occ_beta, homo_beta, 2, nmo, nrow_local, &
-                                        num_integ_group, row_indices, vec_Sigma_x_gw_beta, &
-                                        fm_mat_S_gw_beta, para_env, mp2_env)
-            END IF
-
-         END IF ! do_ri_Sigma_x
-      END IF ! my_do_gw
-
-      CALL timestop(handle)
-   END SUBROUTINE allocate_matrices_gw
-
-! **************************************************************************************************
-!> \brief ...
-!> \param vec_Sigma_c_gw ...
-!> \param dimen_nm_gw ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_tot ...
-!> \param homo ...
-!> \param nmo ...
-!> \param num_fit_points ...
-!> \param do_ri_Sigma_x ...
-!> \param my_do_gw ...
-!> \param Eigenval ...
-!> \param Eigenval_last ...
-!> \param Eigenval_scf ...
-!> \param m_value ...
-!> \param vec_gw_energ ...
-!> \param vec_gw_energ_error_fit ...
-!> \param vec_Sigma_x_gw ...
-!> \param vec_W_gw ...
-!> \param z_value ...
-!> \param fm_mat_S_gw ...
-!> \param fm_mat_S_gw_work ...
-!> \param mp2_env ...
-! **************************************************************************************************
-   SUBROUTINE alloc_mat_gw(vec_Sigma_c_gw, dimen_nm_gw, gw_corr_lev_occ, gw_corr_lev_tot, &
-                           homo, nmo, num_fit_points, do_ri_Sigma_x, &
-                           my_do_gw, Eigenval, Eigenval_last, Eigenval_scf, m_value, vec_gw_energ, &
-                           vec_gw_energ_error_fit, vec_Sigma_x_gw, vec_W_gw, &
-                           z_value, fm_mat_S_gw, fm_mat_S_gw_work, mp2_env)
-
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(OUT)                                     :: vec_Sigma_c_gw
-      INTEGER, INTENT(IN)                                :: dimen_nm_gw, gw_corr_lev_occ, &
-                                                            gw_corr_lev_tot, homo, nmo, &
-                                                            num_fit_points
-      LOGICAL, INTENT(IN)                                :: do_ri_Sigma_x, my_do_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: Eigenval_last, Eigenval_scf, m_value, &
-                                                            vec_gw_energ, vec_gw_energ_error_fit, &
-                                                            vec_Sigma_x_gw, vec_W_gw, z_value
-      TYPE(cp_fm_type), POINTER                          :: fm_mat_S_gw, fm_mat_S_gw_work
-      TYPE(mp2_type), POINTER                            :: mp2_env
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'alloc_mat_gw', routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, n_level_gw, n_level_gw_ref
-
-      CALL timeset(routineN, handle)
-
-      ALLOCATE (vec_Sigma_c_gw(gw_corr_lev_tot, num_fit_points))
-      vec_Sigma_c_gw = (0.0_dp, 0.0_dp)
-
-      ! arrays storing the correlation self-energy, stat. error and z-shot value
-      ALLOCATE (vec_gw_energ(gw_corr_lev_tot))
-      vec_gw_energ = 0.0_dp
-      ALLOCATE (vec_gw_energ_error_fit(gw_corr_lev_tot))
-      vec_gw_energ_error_fit = 0.0_dp
-      ALLOCATE (z_value(gw_corr_lev_tot))
-      z_value = 0.0_dp
-      ALLOCATE (m_value(gw_corr_lev_tot))
-      m_value = 0.0_dp
-
-      ALLOCATE (Eigenval_scf(nmo))
-      Eigenval_scf(:) = Eigenval(:)
-
-      ALLOCATE (Eigenval_last(nmo))
-      Eigenval_last(:) = Eigenval(:)
-
-      ! in the case of HF_diag approach of X. Blase (PRB 83, 115103 (2011), Sec. IV), we subtract the
-      ! XC potential and add exact exchange
-      IF (mp2_env%ri_g0w0%hf_like_ev_start) THEN
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            Eigenval(n_level_gw_ref) = Eigenval(n_level_gw_ref)+ &
-                                       mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(n_level_gw_ref, 1)
-         END DO
-      END IF
-
       IF (do_ri_Sigma_x) THEN
-         ALLOCATE (vec_Sigma_x_gw(nmo))
+         ALLOCATE (vec_Sigma_x_gw(nmo, nkp_self_energy))
          vec_Sigma_x_gw = 0.0_dp
+
+         IF (my_open_shell) THEN
+            ALLOCATE (vec_Sigma_x_gw_beta(nmo, nkp_self_energy))
+            vec_Sigma_x_gw_beta = 0.0_dp
+         END IF
       END IF
 
       IF (my_do_gw) THEN
+
+         ! minimax grids not implemented for O(N^4) GW
+         CPASSERT(.NOT. do_minimax_quad)
 
          ! create temporary matrix to store B*([1+Q(iw')]^-1-1), has the same size as B
          NULLIFY (fm_mat_S_gw_work)
          CALL cp_fm_create(fm_mat_S_gw_work, fm_mat_S_gw%matrix_struct)
          CALL cp_fm_set_all(matrix=fm_mat_S_gw_work, alpha=0.0_dp)
 
+         IF (my_open_shell) THEN
+            NULLIFY (fm_mat_S_gw_work_beta)
+            CALL cp_fm_create(fm_mat_S_gw_work_beta, fm_mat_S_gw%matrix_struct)
+            CALL cp_fm_set_all(matrix=fm_mat_S_gw_work_beta, alpha=0.0_dp)
+         END IF
+
          ALLOCATE (vec_W_gw(dimen_nm_gw))
          vec_W_gw = 0.0_dp
+
+         IF (my_open_shell) THEN
+            ALLOCATE (vec_W_gw_beta(dimen_nm_gw))
+            vec_W_gw_beta = 0.0_dp
+         END IF
+
+         im_unit = (0.0_dp, 1.0_dp)
+         re_unit = (1.0_dp, 0.0_dp)
+
+         ! in case we do RI for Sigma_x, we calculate Sigma_x right here
+         IF (do_ri_Sigma_x) THEN
+
+            CALL cp_fm_get_info(matrix=fm_mat_S_gw, &
+                                nrow_local=nrow_local, &
+                                ncol_local=ncol_local, &
+                                row_indices=row_indices)
+
+            CALL mp_sync(para_env%group)
+
+            ! loop over (nm) index
+            DO iiB = 1, nrow_local
+
+               ! this is needed for correct values within parallelization, see analogue
+               ! statement below
+               IF (MODULO(1, num_integ_group) /= color_rpa_group) CYCLE
+
+               nm_global = row_indices(iiB)
+
+               ! transform the index nm to n and m, formulae copied from Mauro's code
+               n_global = MAX(1, nm_global-1)/nmo+1
+               m_global = nm_global-(n_global-1)*nmo
+               n_global = n_global+homo-gw_corr_lev_occ
+
+               IF (my_open_shell) THEN
+                  n_global_beta = MAX(1, nm_global-1)/nmo+1
+                  m_global_beta = nm_global-(n_global_beta-1)*nmo
+                  n_global_beta = n_global_beta+homo_beta-gw_corr_lev_occ_beta
+               END IF
+
+               IF (m_global <= homo) THEN
+
+                  ! loop over auxiliary basis functions
+                  DO jjB = 1, ncol_local
+
+                     ! Sigma_x_n = -sum_m^occ sum_P (B_(nm)^P)^2
+                     vec_Sigma_x_gw(n_global, 1) = &
+                        vec_Sigma_x_gw(n_global, 1)- &
+                        fm_mat_S_gw%local_data(iiB, jjB)**2
+
+                  END DO
+
+               END IF
+
+               ! The same for beta
+               IF (my_open_shell) THEN
+                  IF (m_global_beta <= homo_beta) THEN
+                     ! loop over auxiliary basis functions
+                     DO jjB = 1, ncol_local
+
+                        ! Sigma_x_n = -sum_m^occ sum_P (B_(nm)^P)^2
+                        vec_Sigma_x_gw_beta(n_global_beta, 1) = &
+                           vec_Sigma_x_gw_beta(n_global_beta, 1)- &
+                           fm_mat_S_gw_beta%local_data(iiB, jjB)**2
+
+                     END DO
+                  END IF
+               END IF
+            END DO
+
+            CALL mp_sum(vec_Sigma_x_gw, para_env%group)
+
+            mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, 1) = &
+               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, 1)+ &
+               vec_Sigma_x_gw(:, 1)
+
+            IF (my_open_shell) THEN
+
+               CALL mp_sum(vec_Sigma_x_gw_beta, para_env%group)
+
+               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2, 1) = &
+                  mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2, 1)+ &
+                  vec_Sigma_x_gw_beta(:, 1)
+
+            END IF
+
+         END IF
+
       END IF
 
       CALL timestop(handle)
-   END SUBROUTINE alloc_mat_gw
 
-! **************************************************************************************************
-!> \brief ...
-!> \param color_rpa_group ...
-!> \param gw_corr_lev_occ ...
-!> \param homo ...
-!> \param idx ...
-!> \param nmo ...
-!> \param nrow_local ...
-!> \param num_integ_group ...
-!> \param row_indices ...
-!> \param vec_Sigma_x_gw ...
-!> \param fm_mat_S_gw ...
-!> \param para_env ...
-!> \param mp2_env ...
-! **************************************************************************************************
-   SUBROUTINE calc_vec_Sigma_x_gw(color_rpa_group, gw_corr_lev_occ, homo, idx, nmo, nrow_local, num_integ_group, &
-                                  row_indices, vec_Sigma_x_gw, &
-                                  fm_mat_S_gw, para_env, mp2_env)
-
-      INTEGER, INTENT(IN)                                :: color_rpa_group, gw_corr_lev_occ, homo, &
-                                                            idx, nmo, nrow_local, num_integ_group
-      INTEGER, DIMENSION(:), POINTER                     :: row_indices
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: vec_Sigma_x_gw
-      TYPE(cp_fm_type), POINTER                          :: fm_mat_S_gw
-      TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(mp2_type), POINTER                            :: mp2_env
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_vec_Sigma_x_gw', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, iiB, m_global, n_global, &
-                                                            nm_global
-
-      CALL timeset(routineN, handle)
-
-      ! loop over (nm) index
-      DO iiB = 1, nrow_local
-         IF (MODULO(1, num_integ_group) /= color_rpa_group) CYCLE
-
-         nm_global = row_indices(iiB)
-
-         ! transform the index nm to n and m, formulae copied from Mauro's code
-         n_global = MAX(1, nm_global-1)/nmo+1
-         m_global = nm_global-(n_global-1)*nmo
-         n_global = n_global+homo-gw_corr_lev_occ
-
-         IF (m_global <= homo) THEN
-
-            ! Sigma_x_n = -sum_m^occ sum_P (B_(nm)^P)^2
-            vec_Sigma_x_gw(n_global) = &
-               vec_Sigma_x_gw(n_global)-NORM2(fm_mat_S_gw%local_data(iiB, :))**2
-
-         END IF
-      END DO
-
-      CALL mp_sum(vec_Sigma_x_gw, para_env%group)
-
-      mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, idx) = &
-         mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, idx)+ &
-         vec_Sigma_x_gw(:)
-
-      CALL timestop(handle)
-   END SUBROUTINE calc_vec_Sigma_x_gw
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief ...
@@ -844,6 +744,8 @@ CONTAINS
 !> \param kpoints ...
 !> \param qs_env ...
 !> \param mp2_env ...
+!> \param do_kpoints_cubic_RPA ...
+!> \param do_kpoints_from_Gamma ...
 ! **************************************************************************************************
    SUBROUTINE GW_matrix_operations(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, &
                                    dimen_nm_gw, dimen_RI, gw_corr_lev_occ, &
@@ -857,10 +759,10 @@ CONTAINS
                                    fm_mat_Q, fm_mat_Q_static_bse, fm_mat_R_gw, fm_mat_S_gw, fm_mat_S_gw_beta, &
                                    fm_mat_S_gw_work, fm_mat_S_gw_work_beta, fm_mat_work, mo_coeff, para_env, &
                                    para_env_RPA, matrix_berry_im_mo_mo, matrix_berry_re_mo_mo, &
-                                   kpoints, qs_env, mp2_env)
+                                   kpoints, qs_env, mp2_env, do_kpoints_cubic_RPA, do_kpoints_from_Gamma)
 
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
+      COMPLEX(KIND=dp), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(INOUT)               :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
       INTEGER, INTENT(IN) :: dimen_nm_gw, dimen_RI, gw_corr_lev_occ, gw_corr_lev_occ_beta, &
          gw_corr_lev_virt, homo, homo_beta, jquad, nmo, num_fit_points, num_integ_points
       INTEGER, INTENT(INOUT)                             :: ncol_local, nrow_local
@@ -891,22 +793,23 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(mp2_type), POINTER                            :: mp2_env
+      LOGICAL                                            :: do_kpoints_cubic_RPA, &
+                                                            do_kpoints_from_Gamma
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'GW_matrix_operations', &
          routineP = moduleN//':'//routineN
 
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
-      INTEGER                                            :: handle, handle2, i_global, iiB, iquad, &
-                                                            j_global, jjB, m_global, &
-                                                            m_global_beta, n_global, &
-                                                            n_global_beta, nm_global
+      COMPLEX(KIND=dp)                                   :: im_unit
+      INTEGER :: handle, handle2, handle3, i_global, iiB, iquad, j_global, jjB, m_global, &
+         m_global_beta, n_global, n_global_beta, nm_global
       REAL(KIND=dp)                                      :: delta_corr_nn, delta_corr_nn_beta, &
-                                                            e_fermi, omega_i, tau, weight
+                                                            e_fermi, omega_i, sign_occ_virt, tau, &
+                                                            weight
 
       CALL timeset(routineN, handle)
 
-      ! the actual G0W0 calculation
       IF (my_do_gw) THEN
+         CALL timeset(routineN//"_G0W0_matrix_operations", handle2)
 
          ! calculate [1+Q(iw')]^-1
          CALL cp_fm_cholesky_invert(fm_mat_Q)
@@ -944,7 +847,7 @@ CONTAINS
          END DO
 
          ! S_work_(nm)Q = B_(nm)P * ([1+Q]^-1-1)_PQ
-         CALL timeset(routineN//"_mult_B_f(Pi)_gw", handle2)
+         CALL timeset(routineN//"_mult_B_f(Pi)_gw", handle3)
          CALL cp_gemm(transa="N", transb="N", m=dimen_nm_gw, n=dimen_RI, k=dimen_RI, alpha=1.0_dp, &
                       matrix_a=fm_mat_S_gw, matrix_b=fm_mat_Q, beta=0.0_dp, &
                       matrix_c=fm_mat_S_gw_work)
@@ -954,7 +857,7 @@ CONTAINS
                          matrix_c=fm_mat_S_gw_work_beta)
          END IF
 
-         CALL timestop(handle2)
+         CALL timestop(handle3)
 
          ! vector W_(nm) = S_work_(nm)Q * [B_(nm)Q]^T
 
@@ -970,7 +873,6 @@ CONTAINS
          END IF
 
          im_unit = (0.0_dp, 1.0_dp)
-         re_unit = (1.0_dp, 0.0_dp)
 
          IF (jquad == 1) THEN
 
@@ -987,11 +889,14 @@ CONTAINS
 
          DO iiB = 1, nrow_local
             nm_global = row_indices(iiB)
-          vec_W_gw(nm_global) = vec_W_gw(nm_global)+DOT_PRODUCT(fm_mat_S_gw_work%local_data(iiB, :), fm_mat_S_gw%local_data(iiB, :))
-            IF (my_open_shell) THEN
-               vec_W_gw_beta(nm_global) = vec_W_gw_beta(nm_global)+ &
-                                          DOT_PRODUCT(fm_mat_S_gw_work_beta%local_data(iiB, :), fm_mat_S_gw_beta%local_data(iiB, :))
-            END IF
+            DO jjB = 1, ncol_local
+               vec_W_gw(nm_global) = vec_W_gw(nm_global)+ &
+                                     fm_mat_S_gw_work%local_data(iiB, jjB)*fm_mat_S_gw%local_data(iiB, jjB)
+               IF (my_open_shell) THEN
+                  vec_W_gw_beta(nm_global) = vec_W_gw_beta(nm_global)+ &
+                                             fm_mat_S_gw_work_beta%local_data(iiB, jjB)*fm_mat_S_gw_beta%local_data(iiB, jjB)
+               END IF
+            END DO
 
             ! transform the index nm of vec_W_gw back to n and m, formulae copied from Mauro's code
             n_global = MAX(1, nm_global-1)/nmo+1
@@ -1008,13 +913,19 @@ CONTAINS
             DO iquad = 1, num_fit_points
 
                ! for occ orbitals, we compute the self-energy for negative frequencies
+               IF (n_global <= homo) THEN
+                  sign_occ_virt = -1.0_dp
+               ELSE
+                  sign_occ_virt = 1.0_dp
+               END IF
+
+               omega_i = vec_omega_fit_gw(iquad)*sign_occ_virt
+
                ! set the Fermi energy for occ orbitals slightly above the HOMO and
                ! for virt orbitals slightly below the LUMO
                IF (n_global <= homo) THEN
-                  omega_i = -vec_omega_fit_gw(iquad)
                   e_fermi = Eigenval(homo)+fermi_level_offset
                ELSE
-                  omega_i = vec_omega_fit_gw(iquad)
                   e_fermi = Eigenval(homo+1)-fermi_level_offset
                END IF
 
@@ -1028,23 +939,28 @@ CONTAINS
                ! update the self-energy (use that vec_W_gw(iw) is symmetric), divide the integration
                ! weight by 2, because the integration is from -infty to +infty and not just 0 to +infty
                ! as for RPA, also we need for virtual orbitals a complex conjugate
-               vec_Sigma_c_gw(n_global-homo+gw_corr_lev_occ, iquad) = &
-                  vec_Sigma_c_gw(n_global-homo+gw_corr_lev_occ, iquad)- &
+               vec_Sigma_c_gw(n_global-homo+gw_corr_lev_occ, iquad, 1) = &
+                  vec_Sigma_c_gw(n_global-homo+gw_corr_lev_occ, iquad, 1)- &
                   0.5_dp/pi*wj(jquad)/2.0_dp*(vec_W_gw(nm_global)+delta_corr_nn)* &
                   (1.0_dp/(im_unit*(omega+omega_i)+e_fermi-Eigenval(m_global))+ &
                    1.0_dp/(im_unit*(-omega+omega_i)+e_fermi-Eigenval(m_global)))
 
                ! the same for beta
                IF (my_open_shell) THEN
-
                   ! for occ orbitals, we compute the self-energy for negative frequencies
+                  IF (n_global_beta <= homo_beta) THEN
+                     sign_occ_virt = -1.0_dp
+                  ELSE
+                     sign_occ_virt = 1.0_dp
+                  END IF
+
+                  omega_i = vec_omega_fit_gw(iquad)*sign_occ_virt
+
                   ! set the Fermi energy for occ orbitals slightly above the HOMO and
                   ! for virt orbitals slightly below the LUMO
                   IF (n_global_beta <= homo_beta) THEN
-                     omega_i = -vec_omega_fit_gw(iquad)
                      e_fermi = Eigenval_beta(homo_beta)+fermi_level_offset
                   ELSE
-                     omega_i = vec_omega_fit_gw(iquad)
                      e_fermi = Eigenval_beta(homo_beta+1)-fermi_level_offset
                   END IF
 
@@ -1058,8 +974,12 @@ CONTAINS
                   ! update the self-energy (use that vec_W_gw(iw) is symmetric), divide the integration
                   ! weight by 2, because the integration is from -infty to +infty and not just 0 to +infty
                   ! as for RPA, also we need for virtual orbitals a complex conjugate
-                  vec_Sigma_c_gw_beta(n_global_beta-homo_beta+gw_corr_lev_occ_beta, iquad) = &
-                     vec_Sigma_c_gw_beta(n_global_beta-homo_beta+gw_corr_lev_occ_beta, iquad)- &
+                  vec_Sigma_c_gw_beta(n_global_beta-homo_beta+gw_corr_lev_occ_beta, iquad, 1) = &
+                     vec_Sigma_c_gw_beta(n_global_beta-homo_beta+gw_corr_lev_occ_beta, iquad, 1)- &
+                     !                              0.5_dp/pi*wj(jquad)/2.0_dp*vec_W_gw_beta(nm_global)/ &
+                     !                              (im_unit*(omega+omega_i)+e_fermi-Eigenval_beta(m_global))- &
+                     !                              0.5_dp/pi*wj(jquad)/2.0_dp*vec_W_gw_beta(nm_global)/ &
+                     !                              (im_unit*(-omega+omega_i)+e_fermi-Eigenval_beta(m_global))
                      0.5_dp/pi*wj(jquad)/2.0_dp*(vec_W_gw_beta(nm_global)+delta_corr_nn_beta)* &
                      (1.0_dp/(im_unit*(omega+omega_i)+e_fermi-Eigenval_beta(m_global))+ &
                       1.0_dp/(im_unit*(-omega+omega_i)+e_fermi-Eigenval_beta(m_global)))
@@ -1069,11 +989,14 @@ CONTAINS
 
          END DO ! iiB
 
+         CALL timestop(handle2)
+
       END IF ! GW
 
-      ! cubic scaling GW calculation
-      IF (do_gw_im_time) THEN
-         CALL timeset(routineN//"_cholesky_inv", handle2)
+      ! cubic scaling GW calculation for molecules
+      IF (do_gw_im_time .AND. .NOT. (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma)) THEN
+
+         CALL timeset(routineN//"_cholesky_inv", handle3)
 
          ! calculate [1+Q(iw')]^-1
          CALL cp_fm_cholesky_invert(fm_mat_Q)
@@ -1081,7 +1004,7 @@ CONTAINS
          ! symmetrize the result
          CALL cp_fm_upper_to_full(fm_mat_Q, fm_mat_work)
 
-         CALL timestop(handle2)
+         CALL timestop(handle3)
 
          ! subtract 1 from the diagonal to get rid of exchange self-energy
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(jjB,iiB,i_global,j_global) &
@@ -1096,7 +1019,7 @@ CONTAINS
             END DO
          END DO
 
-         CALL timeset(routineN//"_multiply_L^TQL", handle2)
+         CALL timeset(routineN//"_multiply_L^TQL", handle3)
 
          ! multiply with L from the left and the right to get the screened Coulomb interaction
          CALL cp_gemm('T', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_mat_L(1, 1)%matrix, fm_mat_Q, &
@@ -1104,9 +1027,9 @@ CONTAINS
          CALL cp_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_mat_work, fm_mat_L(1, 1)%matrix, &
                       0.0_dp, fm_mat_Q)
 
-         CALL timestop(handle2)
+         CALL timestop(handle3)
 
-         CALL timeset(routineN//"_cos_tf_W", handle2)
+         CALL timeset(routineN//"_cos_tf_W", handle3)
 
          ! Fourier transform from w to t
          DO iquad = 1, num_integ_points
@@ -1116,17 +1039,22 @@ CONTAINS
             weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
 
             IF (jquad == 1) THEN
+
                CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad)%matrix, alpha=0.0_dp)
+
             END IF
 
             CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad)%matrix, beta=weight, matrix_b=fm_mat_Q)
 
          END DO
-         CALL timestop(handle2)
+
+         CALL timestop(handle3)
+
       END IF
 
       CALL timestop(handle)
-   END SUBROUTINE GW_matrix_operations
+
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief ...
@@ -1212,8 +1140,13 @@ CONTAINS
 !> \param kpoints ...
 !> \param mp2_env ...
 !> \param qs_env ...
+!> \param nkp_self_energy ...
+!> \param do_kpoints_cubic_RPA ...
+!> \param Eigenval_kp ...
+!> \param Eigenval_scf_kp ...
+!> \param iter_ev_sc ...
 ! **************************************************************************************************
-   SUBROUTINE gw_postprocessing(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, count_ev_sc_GW, &
+   SUBROUTINE GW_postprocessing(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, count_ev_sc_GW, &
                                 gw_corr_lev_occ, gw_corr_lev_occ_beta, &
                                 gw_corr_lev_tot, gw_corr_lev_virt, gw_corr_lev_virt_beta, &
                                 homo, homo_beta, &
@@ -1239,10 +1172,11 @@ CONTAINS
                                 mat_3c_overl_int_gw, mat_3c_overl_int_gw_beta, matrix_berry_im_mo_mo, &
                                 matrix_berry_re_mo_mo, mat_greens_fct_occ, mat_greens_fct_occ_beta, &
                                 mat_greens_fct_virt, mat_greens_fct_virt_beta, mat_W, matrix_s, &
-                                mat_contr_gf_occ, mat_contr_gf_virt, mat_contr_W, kpoints, mp2_env, qs_env)
+                                mat_contr_gf_occ, mat_contr_gf_virt, mat_contr_W, kpoints, mp2_env, qs_env, &
+                                nkp_self_energy, do_kpoints_cubic_RPA, Eigenval_kp, Eigenval_scf_kp, iter_ev_sc)
 
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
+      COMPLEX(KIND=dp), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(INOUT)               :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
       INTEGER, INTENT(IN) :: count_ev_sc_GW, gw_corr_lev_occ, gw_corr_lev_occ_beta, &
          gw_corr_lev_tot, gw_corr_lev_virt, gw_corr_lev_virt_beta, homo, homo_beta, nmo, &
          num_fit_points, num_integ_points
@@ -1261,10 +1195,12 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), INTENT(INOUT) :: Eigenval_last, &
          Eigenval_last_beta, Eigenval_scf, Eigenval_scf_beta, m_value, m_value_beta, tau_tj, tj, &
          vec_gw_energ, vec_gw_energ_beta, vec_gw_energ_error_fit, vec_gw_energ_error_fit_beta, &
-         vec_omega_fit_gw, vec_Sigma_x_gw, vec_Sigma_x_gw_beta, z_value, z_value_beta
+         vec_omega_fit_gw
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vec_Sigma_x_gw, vec_Sigma_x_gw_beta
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: z_value, z_value_beta
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list, ic_corr_list_beta
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(IN)                                      :: weights_cos_tf_t_to_w, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
          fm_mo_coeff_occ, fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
@@ -1280,18 +1216,25 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: nkp_self_energy
+      LOGICAL                                            :: do_kpoints_cubic_RPA
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: Eigenval_kp, Eigenval_scf_kp
+      INTEGER                                            :: iter_ev_sc
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'gw_postprocessing', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'GW_postprocessing', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: crossing_search, handle, max_iter_fit, &
-                                                            n_level_gw, num_poles
+      INTEGER                                            :: crossing_search, handle, ikp, &
+                                                            max_iter_fit, n_level_gw, num_poles
       LOGICAL                                            :: check_fit, remove_neg_virt_energies
+      REAL(kind=dp)                                      :: stop_crit
 
       CALL timeset(routineN, handle)
 
+      stop_crit = 1.0e-7
+
       ! postprocessing for cubic scaling GW calculation
-      IF (do_gw_im_time) THEN
+      IF (do_gw_im_time .AND. .NOT. do_kpoints_cubic_RPA) THEN
          num_points_corr = mp2_env%ri_g0w0%num_omega_points
 
          CALL compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ, mat_greens_fct_virt, &
@@ -1356,2790 +1299,139 @@ CONTAINS
       check_fit = mp2_env%ri_g0w0%check_fit
       crossing_search = mp2_env%ri_g0w0%crossing_search
 
-      ! fit the self-energy on imaginary frequency axis and evaluate the fit on the MO energy of the SCF
-      DO n_level_gw = 1, gw_corr_lev_tot
-         ! processes perform different fits
-         IF (MODULO(n_level_gw, para_env%num_pe) /= para_env%mepos) CYCLE
+      ! for the normal code for molecules or Gamma only: nkp = 1
+      DO ikp = 1, nkp_self_energy
 
-         SELECT CASE (mp2_env%ri_g0w0%analytic_continuation)
-         CASE (gw_two_pole_model)
-            CALL fit_and_continuation_2pole(vec_gw_energ, vec_gw_energ_error_fit, vec_omega_fit_gw, &
-                                            z_value, m_value, vec_Sigma_c_gw, &
-                                            mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), &
-                                            Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, num_poles, &
-                                            num_fit_points, max_iter_fit, crossing_search, homo, check_fit, &
-                                            fermi_level_offset, do_gw_im_time)
-         CASE (gw_pade_approx)
-            CALL continuation_pade(vec_gw_energ, vec_omega_fit_gw, &
-                                   z_value, m_value, vec_Sigma_c_gw, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), &
-                                   Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, mp2_env%ri_g0w0%nparam_pade, &
-                                   num_fit_points, crossing_search, homo, check_fit, &
-                                   fermi_level_offset, do_gw_im_time)
+         IF (do_kpoints_cubic_RPA) THEN
 
-         CASE DEFAULT
-            CPABORT("Only two-model and Pade approximation are implemented.")
-         END SELECT
+            vec_gw_energ_error_fit = 0.0_dp
+            vec_gw_energ = 0.0_dp
+            z_value = 0.0_dp
+            m_value = 0.0_dp
 
-         IF (my_open_shell) THEN
+            CALL get_eigenval_for_conti(Eigenval, Eigenval_scf, Eigenval_kp, Eigenval_scf_kp, kpoints, &
+                                        ikp, iter_ev_sc, my_open_shell)
+         END IF
+
+         ! fit the self-energy on imaginary frequency axis and evaluate the fit on the MO energy of the SCF
+         DO n_level_gw = 1, gw_corr_lev_tot
+            ! processes perform different fits
+            IF (MODULO(n_level_gw, para_env%num_pe) /= para_env%mepos) CYCLE
+
             SELECT CASE (mp2_env%ri_g0w0%analytic_continuation)
             CASE (gw_two_pole_model)
-               CALL fit_and_continuation_2pole( &
-                  vec_gw_energ_beta, vec_gw_energ_error_fit_beta, vec_omega_fit_gw, &
-                  z_value_beta, m_value_beta, vec_Sigma_c_gw_beta, &
-                  mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2), &
-                  Eigenval_beta, Eigenval_scf_beta, n_level_gw, &
-                  gw_corr_lev_occ_beta, num_poles, &
-                  num_fit_points, max_iter_fit, crossing_search, homo_beta, check_fit, &
-                  fermi_level_offset, do_gw_im_time)
+               CALL fit_and_continuation_2pole(vec_gw_energ, vec_gw_energ_error_fit, vec_omega_fit_gw, &
+                                               z_value, m_value, vec_Sigma_c_gw(:, :, ikp), &
+                                               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp), &
+                                               Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, num_poles, &
+                                               num_fit_points, max_iter_fit, crossing_search, homo, check_fit, stop_crit, &
+                                               fermi_level_offset, do_gw_im_time)
             CASE (gw_pade_approx)
-               CALL continuation_pade(vec_gw_energ_beta, vec_omega_fit_gw, &
-                                      z_value_beta, m_value_beta, vec_Sigma_c_gw_beta, &
-                                      mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2), &
-                                      Eigenval_beta, Eigenval_scf_beta, n_level_gw, &
-                                      gw_corr_lev_occ_beta, mp2_env%ri_g0w0%nparam_pade, &
-                                      num_fit_points, crossing_search, homo_beta, check_fit, &
+               CALL continuation_pade(vec_gw_energ, vec_omega_fit_gw, &
+                                      z_value, m_value, vec_Sigma_c_gw(:, :, ikp), &
+                                      mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp), &
+                                      Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, mp2_env%ri_g0w0%nparam_pade, &
+                                      num_fit_points, crossing_search, homo, check_fit, &
                                       fermi_level_offset, do_gw_im_time)
+
             CASE DEFAULT
                CPABORT("Only two-model and Pade approximation are implemented.")
             END SELECT
 
-         END IF
-
-      END DO ! n_level_gw
-
-      CALL mp_sum(vec_gw_energ_error_fit, para_env%group)
-      CALL mp_sum(vec_gw_energ, para_env%group)
-      CALL mp_sum(z_value, para_env%group)
-      CALL mp_sum(m_value, para_env%group)
-
-      IF (my_open_shell) THEN
-         CALL mp_sum(vec_gw_energ_error_fit_beta, para_env%group)
-         CALL mp_sum(vec_gw_energ_beta, para_env%group)
-         CALL mp_sum(z_value_beta, para_env%group)
-         CALL mp_sum(m_value_beta, para_env%group)
-      END IF
-
-      remove_neg_virt_energies = mp2_env%ri_g0w0%remove_neg_virt_energies
-
-      ! print the quasiparticle energies and update Eigenval in case you do eigenvalue self-consistent GW
-      IF (my_open_shell) THEN
-
-         CALL print_and_update_for_ev_sc( &
-            vec_gw_energ, vec_gw_energ_error_fit, &
-            z_value, m_value, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), Eigenval, &
-            Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-            count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
-            remove_neg_virt_energies, do_alpha=.TRUE.)
-
-         CALL print_and_update_for_ev_sc( &
-            vec_gw_energ_beta, vec_gw_energ_error_fit_beta, &
-            z_value_beta, m_value_beta, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2), Eigenval_beta, &
-            Eigenval_last_beta, Eigenval_scf_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, gw_corr_lev_tot, &
-            count_ev_sc_GW, crossing_search, homo_beta, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
-            remove_neg_virt_energies, do_beta=.TRUE.)
-
-         IF (do_apply_ic_corr_to_gw .AND. count_ev_sc_GW == 1) THEN
-
-            CALL apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
-                               gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                               homo, nmo, unit_nr, do_alpha=.TRUE.)
-
-            CALL apply_ic_corr(Eigenval_beta, Eigenval_scf_beta, ic_corr_list_beta, &
-                               gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, gw_corr_lev_tot, &
-                               homo_beta, nmo, unit_nr, do_beta=.TRUE.)
-
-         END IF
-
-      ELSE
-
-         CALL print_and_update_for_ev_sc( &
-            vec_gw_energ, vec_gw_energ_error_fit, &
-            z_value, m_value, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), Eigenval, &
-            Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-            count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
-            remove_neg_virt_energies)
-
-         IF (do_apply_ic_corr_to_gw .AND. count_ev_sc_GW == 1) THEN
-
-            CALL apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
-                               gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                               homo, nmo, unit_nr)
-
-         END IF
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE gw_postprocessing
-
-! **************************************************************************************************
-!> \brief ...
-!> \param vec_Sigma_c_gw ...
-!> \param vec_Sigma_c_gw_beta ...
-!> \param num_integ_points ...
-!> \param do_gw_im_time ...
-!> \param do_ic_model ...
-!> \param do_im_time ...
-!> \param do_periodic ...
-!> \param do_ri_Sigma_x ...
-!> \param my_do_gw ...
-!> \param my_open_shell ...
-!> \param do_GW_corr ...
-!> \param vec_omega_fit_gw ...
-!> \param vec_Sigma_x_gw ...
-!> \param vec_Sigma_x_gw_beta ...
-!> \param Eigenval_last ...
-!> \param Eigenval_last_beta ...
-!> \param Eigenval_scf ...
-!> \param Eigenval_scf_beta ...
-!> \param m_value ...
-!> \param m_value_beta ...
-!> \param vec_gw_energ ...
-!> \param vec_gw_energ_beta ...
-!> \param vec_gw_energ_error_fit ...
-!> \param vec_gw_energ_error_fit_beta ...
-!> \param vec_W_gw ...
-!> \param vec_W_gw_beta ...
-!> \param z_value ...
-!> \param z_value_beta ...
-!> \param weights_cos_tf_w_to_t ...
-!> \param weights_sin_tf_t_to_w ...
-!> \param fm_mat_W_tau ...
-!> \param fm_mat_S_gw_work ...
-!> \param fm_mat_S_gw_work_beta ...
-!> \param mat_3c_overl_int_gw ...
-!> \param mat_3c_overl_int_gw_beta ...
-!> \param mat_3c_overl_nnP_ic ...
-!> \param mat_3c_overl_nnP_ic_beta ...
-!> \param mat_3c_overl_nnP_ic_reflected ...
-!> \param mat_3c_overl_nnP_ic_reflected_beta ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_occ_beta ...
-!> \param mat_greens_fct_virt ...
-!> \param mat_greens_fct_virt_beta ...
-!> \param matrix_berry_im_mo_mo ...
-!> \param matrix_berry_re_mo_mo ...
-!> \param mat_W ...
-!> \param mat_contr_gf_occ ...
-!> \param mat_contr_gf_virt ...
-!> \param mat_contr_W ...
-!> \param kpoints ...
-!> \param mp2_env ...
-! **************************************************************************************************
-   SUBROUTINE gw_cleanup(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, num_integ_points, &
-                         do_gw_im_time, do_ic_model, do_im_time, do_periodic, do_ri_Sigma_x, &
-                         my_do_gw, my_open_shell, do_GW_corr, vec_omega_fit_gw, vec_Sigma_x_gw, &
-                         vec_Sigma_x_gw_beta, Eigenval_last, Eigenval_last_beta, Eigenval_scf, &
-                         Eigenval_scf_beta, m_value, m_value_beta, vec_gw_energ, &
-                         vec_gw_energ_beta, vec_gw_energ_error_fit, vec_gw_energ_error_fit_beta, &
-                         vec_W_gw, vec_W_gw_beta, z_value, z_value_beta, weights_cos_tf_w_to_t, &
-                         weights_sin_tf_t_to_w, fm_mat_W_tau, &
-                         fm_mat_S_gw_work, fm_mat_S_gw_work_beta, &
-                         mat_3c_overl_int_gw, mat_3c_overl_int_gw_beta, mat_3c_overl_nnP_ic, &
-                         mat_3c_overl_nnP_ic_beta, mat_3c_overl_nnP_ic_reflected, &
-                         mat_3c_overl_nnP_ic_reflected_beta, mat_greens_fct_occ, mat_greens_fct_occ_beta, &
-                         mat_greens_fct_virt, mat_greens_fct_virt_beta, matrix_berry_im_mo_mo, &
-                         matrix_berry_re_mo_mo, mat_W, mat_contr_gf_occ, mat_contr_gf_virt, &
-                         mat_contr_W, kpoints, mp2_env)
-
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      LOGICAL, INTENT(IN)                                :: do_gw_im_time, do_ic_model, do_im_time, &
-                                                            do_periodic, do_ri_Sigma_x, my_do_gw, &
-                                                            my_open_shell
-      LOGICAL, ALLOCATABLE, DIMENSION(:), INTENT(INOUT)  :: do_GW_corr
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), INTENT(INOUT) :: vec_omega_fit_gw, vec_Sigma_x_gw, &
-         vec_Sigma_x_gw_beta, Eigenval_last, Eigenval_last_beta, Eigenval_scf, Eigenval_scf_beta, &
-         m_value, m_value_beta, vec_gw_energ, vec_gw_energ_beta, vec_gw_energ_error_fit, &
-         vec_gw_energ_error_fit_beta, vec_W_gw, vec_W_gw_beta, z_value, z_value_beta
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: weights_cos_tf_w_to_t, &
-                                                            weights_sin_tf_t_to_w
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
-      TYPE(cp_fm_type), POINTER                          :: fm_mat_S_gw_work, fm_mat_S_gw_work_beta
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: mat_3c_overl_int_gw, mat_3c_overl_int_gw_beta, &
-         mat_3c_overl_nnP_ic, mat_3c_overl_nnP_ic_beta, mat_3c_overl_nnP_ic_reflected, &
-         mat_3c_overl_nnP_ic_reflected_beta, mat_greens_fct_occ, mat_greens_fct_occ_beta, &
-         mat_greens_fct_virt, mat_greens_fct_virt_beta, matrix_berry_im_mo_mo, &
-         matrix_berry_re_mo_mo, mat_W
-      TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ, mat_contr_gf_virt, &
-                                                            mat_contr_W
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(mp2_type), POINTER                            :: mp2_env
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'gw_cleanup', routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, jquad
-
-      CALL timeset(routineN, handle)
-
-      IF (do_periodic) THEN
-         CALL dbcsr_deallocate_matrix_set(matrix_berry_re_mo_mo)
-         CALL dbcsr_deallocate_matrix_set(matrix_berry_im_mo_mo)
-         CALL kpoint_release(kpoints)
-      END IF
-      DEALLOCATE (vec_omega_fit_gw)
-      DEALLOCATE (do_GW_corr)
-
-      IF (my_do_gw) THEN
-         DEALLOCATE (mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw)
-      END IF
-
-      IF (do_im_time) THEN
-         IF (do_gw_im_time) THEN
-
-            DEALLOCATE (weights_cos_tf_w_to_t)
-            DEALLOCATE (weights_sin_tf_t_to_w)
-            DO jquad = 1, num_integ_points
-               CALL cp_fm_release(fm_mat_W_tau(jquad)%matrix)
-            END DO
-            DEALLOCATE (fm_mat_W_tau)
-
-            CALL dbcsr_release_P(mat_contr_gf_occ)
-            CALL dbcsr_release_P(mat_contr_gf_virt)
-            CALL dbcsr_release_P(mat_contr_W)
-            CALL dbcsr_deallocate_matrix_set(mat_W)
-
-         END IF
-      END IF
-
-      CALL gw_cleanup_helper(vec_Sigma_c_gw, do_gw_im_time, do_ic_model, do_im_time, &
-                             do_ri_Sigma_x, my_do_gw, &
-                             vec_Sigma_x_gw, Eigenval_last, Eigenval_scf, m_value, &
-                             vec_gw_energ, vec_gw_energ_error_fit, vec_W_gw, z_value, &
-                             fm_mat_S_gw_work, mat_3c_overl_int_gw, &
-                             mat_3c_overl_nnP_ic, mat_3c_overl_nnP_ic_reflected, mat_greens_fct_occ, mat_greens_fct_virt)
-      IF (my_open_shell) THEN
-         CALL gw_cleanup_helper(vec_Sigma_c_gw_beta, do_gw_im_time, do_ic_model, do_im_time, &
-                                do_ri_Sigma_x, my_do_gw, &
-                                vec_Sigma_x_gw_beta, Eigenval_last_beta, Eigenval_scf_beta, m_value_beta, &
-                                vec_gw_energ_beta, vec_gw_energ_error_fit_beta, vec_W_gw_beta, z_value_beta, &
-                                fm_mat_S_gw_work_beta, mat_3c_overl_int_gw_beta, &
-                    mat_3c_overl_nnP_ic_beta, mat_3c_overl_nnP_ic_reflected_beta, mat_greens_fct_occ_beta, mat_greens_fct_virt_beta)
-      END IF
-      CALL timestop(handle)
-   END SUBROUTINE gw_cleanup
-
-! **************************************************************************************************
-!> \brief ...
-!> \param vec_Sigma_c_gw ...
-!> \param do_gw_im_time ...
-!> \param do_ic_model ...
-!> \param do_im_time ...
-!> \param do_ri_Sigma_x ...
-!> \param my_do_gw ...
-!> \param vec_Sigma_x_gw ...
-!> \param Eigenval_last ...
-!> \param Eigenval_scf ...
-!> \param m_value ...
-!> \param vec_gw_energ ...
-!> \param vec_gw_energ_error_fit ...
-!> \param vec_W_gw ...
-!> \param z_value ...
-!> \param fm_mat_S_gw_work ...
-!> \param mat_3c_overl_int_gw ...
-!> \param mat_3c_overl_nnP_ic ...
-!> \param mat_3c_overl_nnP_ic_reflected ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
-! **************************************************************************************************
-   SUBROUTINE gw_cleanup_helper(vec_Sigma_c_gw, do_gw_im_time, do_ic_model, do_im_time, &
-                                do_ri_Sigma_x, my_do_gw, &
-                                vec_Sigma_x_gw, Eigenval_last, Eigenval_scf, m_value, &
-                                vec_gw_energ, vec_gw_energ_error_fit, vec_W_gw, z_value, &
-                                fm_mat_S_gw_work, mat_3c_overl_int_gw, &
-                                mat_3c_overl_nnP_ic, mat_3c_overl_nnP_ic_reflected, mat_greens_fct_occ, &
-                                mat_greens_fct_virt)
-
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: vec_Sigma_c_gw
-      LOGICAL, INTENT(IN)                                :: do_gw_im_time, do_ic_model, do_im_time, &
-                                                            do_ri_Sigma_x, my_do_gw
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: vec_Sigma_x_gw, Eigenval_last, &
-                                                            Eigenval_scf, m_value, vec_gw_energ, &
-                                                            vec_gw_energ_error_fit, vec_W_gw, &
-                                                            z_value
-      TYPE(cp_fm_type), POINTER                          :: fm_mat_S_gw_work
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: mat_3c_overl_int_gw, mat_3c_overl_nnP_ic, &
-         mat_3c_overl_nnP_ic_reflected, mat_greens_fct_occ, mat_greens_fct_virt
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'gw_cleanup_helper', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
-
-      IF (do_ri_Sigma_x) THEN
-         DEALLOCATE (vec_Sigma_x_gw)
-      END IF
-
-      DEALLOCATE (vec_Sigma_c_gw)
-      DEALLOCATE (z_value)
-      DEALLOCATE (m_value)
-      DEALLOCATE (vec_gw_energ)
-      DEALLOCATE (vec_gw_energ_error_fit)
-
-      IF (my_do_gw) THEN
-         CALL cp_fm_release(fm_mat_S_gw_work)
-         DEALLOCATE (vec_W_gw)
-         DEALLOCATE (Eigenval_last)
-         DEALLOCATE (Eigenval_scf)
-      END IF
-
-      IF (do_im_time) THEN
-         IF (do_gw_im_time) THEN
-
-            CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_gw)
-            IF (.NOT. do_ic_model) THEN
-               CALL dbcsr_deallocate_matrix_set(mat_greens_fct_occ)
-               CALL dbcsr_deallocate_matrix_set(mat_greens_fct_virt)
-            END IF
-
-            IF (do_ic_model) THEN
-               CALL dbcsr_deallocate_matrix_set(mat_3c_overl_nnP_ic)
-               CALL dbcsr_deallocate_matrix_set(mat_3c_overl_nnP_ic_reflected)
-            END IF
-
-         END IF
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE gw_cleanup_helper
-
-! **************************************************************************************************
-!> \brief ...
-!> \param Eigenval ...
-!> \param Eigenval_scf ...
-!> \param ic_corr_list ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param gw_corr_lev_tot ...
-!> \param homo ...
-!> \param nmo ...
-!> \param unit_nr ...
-!> \param do_alpha ...
-!> \param do_beta ...
-! **************************************************************************************************
-   SUBROUTINE apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
-                            gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                            homo, nmo, unit_nr, do_alpha, do_beta)
-
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval, Eigenval_scf
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: ic_corr_list
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, gw_corr_lev_virt, &
-                                                            gw_corr_lev_tot, homo, nmo, unit_nr
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_alpha, do_beta
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_ic_corr', routineP = moduleN//':'//routineN
-
-      CHARACTER(4)                                       :: occ_virt
-      INTEGER                                            :: handle, n_level_gw, n_level_gw_ref
-      LOGICAL                                            :: do_closed_shell, my_do_alpha, my_do_beta
-      REAL(KIND=dp)                                      :: eigen_diff
-
-      CALL timeset(routineN, handle)
-
-      IF (PRESENT(do_alpha)) THEN
-         my_do_alpha = do_alpha
-      ELSE
-         my_do_alpha = .FALSE.
-      END IF
-
-      IF (PRESENT(do_beta)) THEN
-         my_do_beta = do_beta
-      ELSE
-         my_do_beta = .FALSE.
-      END IF
-
-      do_closed_shell = .NOT. (my_do_alpha .OR. my_do_beta)
-
-      ! check the number of input image charge corrected levels
-      CPASSERT(SIZE(ic_corr_list) == gw_corr_lev_tot)
-
-      IF (unit_nr > 0) THEN
-
-         WRITE (unit_nr, *) ' '
-
-         IF (do_closed_shell) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies with image charge (ic) correction'
-            WRITE (unit_nr, '(T3,A)') '-----------------------------------------------------------'
-         ELSE IF (my_do_alpha) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of alpha spins with image charge (ic) correction'
-            WRITE (unit_nr, '(T3,A)') '--------------------------------------------------------------------------'
-         ELSE IF (my_do_beta) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of beta spins with image charge (ic) correction'
-            WRITE (unit_nr, '(T3,A)') '-------------------------------------------------------------------------'
-         END IF
-
-         WRITE (unit_nr, *) ' '
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            IF (n_level_gw <= gw_corr_lev_occ) THEN
-               occ_virt = 'occ'
-            ELSE
-               occ_virt = 'vir'
-            END IF
-
-            WRITE (unit_nr, '(T4,I4,3A,3F21.3)') &
-               n_level_gw_ref, ' ( ', occ_virt, ')  ', &
-               Eigenval(n_level_gw_ref)*evolt, &
-               ic_corr_list(n_level_gw)*evolt, &
-               (Eigenval(n_level_gw_ref)+ic_corr_list(n_level_gw))*evolt
-
-         END DO
-
-         WRITE (unit_nr, *) ' '
-
-      END IF
-
-      Eigenval(homo-gw_corr_lev_occ+1:homo+gw_corr_lev_virt) = Eigenval(homo-gw_corr_lev_occ+1: &
-                                                                        homo+gw_corr_lev_virt) &
-                                                               +ic_corr_list(1:gw_corr_lev_tot)
-
-      Eigenval_scf(homo-gw_corr_lev_occ+1:homo+gw_corr_lev_virt) = Eigenval_scf(homo-gw_corr_lev_occ+1: &
-                                                                                homo+gw_corr_lev_virt) &
-                                                                   +ic_corr_list(1:gw_corr_lev_tot)
-
-      IF (unit_nr > 0) THEN
-
-         IF (do_closed_shell) THEN
-            WRITE (unit_nr, '(T3,A,F52.2)') 'G0W0 IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
-         ELSE IF (my_do_alpha) THEN
-            WRITE (unit_nr, '(T3,A,F46.2)') 'G0W0 Alpha IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
-         ELSE IF (my_do_beta) THEN
-            WRITE (unit_nr, '(T3,A,F47.2)') 'G0W0 Beta IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
-         END IF
-
-         WRITE (unit_nr, *) ' '
-
-      END IF
-
-      ! for eigenvalue self-consistent GW, all eigenvalues have to be corrected
-      ! 1) the occupied; check if there are occupied MOs not being corrected by the IC model
-      IF (gw_corr_lev_occ < homo .AND. gw_corr_lev_occ > 0) THEN
-
-         ! calculate average IC contribution for occupied orbitals
-         eigen_diff = 0.0_dp
-
-         DO n_level_gw = 1, gw_corr_lev_occ
-            eigen_diff = eigen_diff+ic_corr_list(n_level_gw)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_occ
-
-         ! correct the eigenvalues of the occupied orbitals which have not been corrected by the IC model
-         DO n_level_gw = 1, homo-gw_corr_lev_occ
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-            Eigenval_scf(n_level_gw) = Eigenval_scf(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      ! 2) the virtual: check if there are virtual orbitals not being corrected by the IC model
-      IF (gw_corr_lev_virt < nmo-homo .AND. gw_corr_lev_virt > 0) THEN
-
-         ! calculate average IC correction for virtual orbitals
-         eigen_diff = 0.0_dp
-         DO n_level_gw = gw_corr_lev_occ+1, gw_corr_lev_tot
-            eigen_diff = eigen_diff+ic_corr_list(n_level_gw)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_virt
-
-         ! correct the eigenvalues of the virtual orbitals which have not been corrected by the IC model
-         DO n_level_gw = homo+gw_corr_lev_virt+1, nmo
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-            Eigenval_scf(n_level_gw) = Eigenval_scf(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE apply_ic_corr
-
-! **************************************************************************************************
-!> \brief ...
-!> \param num_integ_points ...
-!> \param nmo ...
-!> \param tau_tj ...
-!> \param tj ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
-!> \param matrix_s ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
-!> \param Eigenval ...
-!> \param eps_filter ...
-!> \param e_fermi ...
-!> \param fm_mat_W_tau ...
-!> \param gw_corr_lev_tot ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param homo ...
-!> \param count_ev_sc_GW ...
-!> \param mat_3c_overl_int_gw ...
-!> \param mat_contr_gf_occ ...
-!> \param mat_contr_gf_virt ...
-!> \param mat_contr_W ...
-!> \param mat_W ...
-!> \param mat_SinvVSinv ...
-!> \param mat_dm ...
-!> \param stabilize_exp ...
-!> \param weights_cos_tf_t_to_w ...
-!> \param weights_sin_tf_t_to_w ...
-!> \param vec_Sigma_c_gw ...
-!> \param do_periodic ...
-!> \param num_points_corr ...
-!> \param delta_corr ...
-!> \param qs_env ...
-!> \param para_env ...
-!> \param para_env_RPA ...
-!> \param mp2_env ...
-!> \param matrix_berry_re_mo_mo ...
-!> \param matrix_berry_im_mo_mo ...
-!> \param first_cycle_periodic_correction ...
-!> \param kpoints ...
-!> \param num_fit_points ...
-!> \param mo_coeff ...
-!> \param do_GW_corr ...
-!> \param do_ri_Sigma_x ...
-!> \param vec_Sigma_x_gw ...
-!> \param do_beta ...
-! **************************************************************************************************
-   SUBROUTINE compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ, mat_greens_fct_virt, &
-                                             matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                             fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                             fm_scaled_dm_virt_tau, Eigenval, eps_filter, e_fermi, fm_mat_W_tau, &
-                                             gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, count_ev_sc_GW, &
-                                             mat_3c_overl_int_gw, mat_contr_gf_occ, mat_contr_gf_virt, &
-                                             mat_contr_W, mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
-                                             weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, do_periodic, &
-                                             num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
-                                             mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                             first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
-                                             do_GW_corr, do_ri_Sigma_x, vec_Sigma_x_gw, do_beta)
-
-      INTEGER, INTENT(IN)                                :: num_integ_points, nmo
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tj
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt, &
-                                                            matrix_s
-      TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-         fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_tot, gw_corr_lev_occ, &
-                                                            gw_corr_lev_virt, homo, count_ev_sc_GW
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_int_gw
-      TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ, mat_contr_gf_virt, &
-                                                            mat_contr_W
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_W
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_SinvVSinv, mat_dm
-      REAL(KIND=dp), INTENT(IN)                          :: stabilize_exp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(IN)                                      :: weights_cos_tf_t_to_w, &
-                                                            weights_sin_tf_t_to_w
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: vec_Sigma_c_gw
-      LOGICAL, INTENT(IN)                                :: do_periodic
-      INTEGER, INTENT(IN)                                :: num_points_corr
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: delta_corr
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
-      TYPE(mp2_type), POINTER                            :: mp2_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
-                                                            matrix_berry_im_mo_mo
-      LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      INTEGER, INTENT(IN)                                :: num_fit_points
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
-      LOGICAL, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: do_GW_corr
-      LOGICAL, INTENT(IN)                                :: do_ri_Sigma_x
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: vec_Sigma_x_gw
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_beta
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_self_energy_im_time_gw', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: delta_corr_omega
-      INTEGER                                            :: gw_lev_end, gw_lev_start, handle, &
-                                                            handle3, iquad, jquad, n_level_gw, &
-                                                            n_level_gw_ref
-      LOGICAL                                            :: my_do_beta
-      REAL(KIND=dp)                                      :: ext_scaling, omega, omega_i, omega_sign, &
-                                                            sign_occ_virt, t_i_Clenshaw, tau, &
-                                                            weight_cos, weight_i, weight_sin
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_c_gw_cos_omega, &
-         vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
-         vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
-
-      CALL timeset(routineN, handle)
-
-      my_do_beta = .FALSE.
-      IF (PRESENT(do_beta)) my_do_beta = do_beta
-
-      im_unit = (0.0_dp, 1.0_dp)
-
-      ALLOCATE (vec_Sigma_c_gw_pos_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_pos_tau = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_neg_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_neg_tau = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_cos_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_cos_tau = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_sin_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_sin_tau = 0.0_dp
-
-      ALLOCATE (vec_Sigma_c_gw_cos_omega(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_cos_omega = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_sin_omega(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_sin_omega = 0.0_dp
-
-      ALLOCATE (delta_corr_omega(1+homo-gw_corr_lev_occ:homo+gw_corr_lev_virt, num_integ_points))
-      delta_corr_omega(:, :) = (0.0_dp, 0.0_dp)
-
-      DO jquad = 1, num_integ_points
-
-         tau = tau_tj(jquad)
-
-         CALL compute_Greens_function(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                      fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, num_integ_points, nmo, &
-                                      eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
-
-         CALL copy_fm_to_dbcsr(fm_mat_W_tau(jquad)%matrix, mat_W(jquad)%matrix, keep_sparsity=.FALSE.)
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-
-            IF (.NOT. do_GW_corr(n_level_gw)) CYCLE
-
-            ! the following formulas are partially taken from Liu et al. PRB 94, 165109 (2016), Eq. (63) - (69)
-
-            CALL timeset(routineN//"_cubic_GW_operation_1", handle3)
-
-            ! the occ Gf has no minus, but already include the minus from Sigma = -GW
-            CALL dbcsr_multiply("N", "N", -1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, mat_greens_fct_occ(jquad)%matrix, &
-                                0.0_dp, mat_contr_gf_occ)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_2", handle3)
-
-            ! the virt Gf has a minus, but already include the minus from Sigma = -GW
-            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, mat_greens_fct_virt(jquad)%matrix, &
-                                0.0_dp, mat_contr_gf_virt)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_3", handle3)
-
-            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_W(jquad)%matrix, mat_3c_overl_int_gw(n_level_gw)%matrix, &
-                                0.0_dp, mat_contr_W)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_4", handle3)
-
-            CALL dbcsr_trace(mat_contr_gf_virt, &
-                             mat_contr_W, &
-                             vec_Sigma_c_gw_pos_tau(n_level_gw, jquad))
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_5", handle3)
-
-            CALL dbcsr_trace(mat_contr_gf_occ, &
-                             mat_contr_W, &
-                             vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_5", handle3)
-
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_7", handle3)
-
-            vec_Sigma_c_gw_cos_tau(n_level_gw, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(n_level_gw, jquad)+ &
-                                                                vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
-
-            vec_Sigma_c_gw_sin_tau(n_level_gw, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(n_level_gw, jquad)- &
-                                                                vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
-
-            CALL timestop(handle3)
-
-         END DO ! n_levl_gw
-
-         CALL dbcsr_set(mat_W(jquad)%matrix, 0.0_dp)
-
-         CALL dbcsr_filter(mat_W(jquad)%matrix, 1.0_dp)
-
-      END DO ! jquad (tau)
-
-      ! Fourier transform from time to frequency
-      DO jquad = 1, num_integ_points
-
-         DO iquad = 1, num_integ_points
-
-            omega = tj(jquad)
-            tau = tau_tj(iquad)
-            weight_cos = weights_cos_tf_t_to_w(jquad, iquad)*COS(omega*tau)
-            weight_sin = weights_sin_tf_t_to_w(jquad, iquad)*SIN(omega*tau)
-
-            vec_Sigma_c_gw_cos_omega(:, jquad) = vec_Sigma_c_gw_cos_omega(:, jquad)+ &
-                                                 weight_cos*vec_Sigma_c_gw_cos_tau(:, iquad)
-
-            vec_Sigma_c_gw_sin_omega(:, jquad) = vec_Sigma_c_gw_sin_omega(:, jquad)+ &
-                                                 weight_sin*vec_Sigma_c_gw_sin_tau(:, iquad)
-
-         END DO
-
-      END DO
-
-      ! for occupied levels, we need the correlation self-energy for negative omega. Therefore, weight_sin
-      ! should be computed with -omega, which results in an additional minus for vec_Sigma_c_gw_sin_omega:
-      vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :) = -vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :)
-
-      vec_Sigma_c_gw(:, 1:num_fit_points) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points)+ &
-                                            im_unit*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
-
-      IF (do_ri_Sigma_x .AND. count_ev_sc_GW == 1) THEN
-
-         CALL timeset(routineN//"_RI_HFX_operation_1", handle3)
-
-         ! get density matrix
-         CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
-                      matrix_a=fm_mo_coeff_occ, matrix_b=fm_mo_coeff_occ, beta=0.0_dp, &
-                      matrix_c=fm_scaled_dm_occ_tau)
-
-         CALL timestop(handle3)
-
-         CALL timeset(routineN//"_RI_HFX_operation_2", handle3)
-
-         CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
-                               mat_dm%matrix, &
-                               keep_sparsity=.FALSE.)
-
-         CALL timestop(handle3)
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-
-            IF (.NOT. do_GW_corr(n_level_gw)) CYCLE
-
-            CALL timeset(routineN//"_RI_HFX_operation_3", handle3)
-
-            ! the occ Gf has no minus, but already include the minus from Sigma = -GW
-            CALL dbcsr_multiply("N", "N", -1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, mat_dm%matrix, &
-                                0.0_dp, mat_contr_gf_occ)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_RI_HFX_operation_4", handle3)
-
-            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_SinvVSinv%matrix, mat_3c_overl_int_gw(n_level_gw)%matrix, &
-                                0.0_dp, mat_contr_W)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_RI_HFX_operation_5", handle3)
-
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-            CALL dbcsr_trace(mat_contr_gf_occ, &
-                             mat_contr_W, &
-                             vec_Sigma_x_gw(n_level_gw_ref))
-
-            CALL timestop(handle3)
-
-         END DO
-      END IF
-
-      ! compute and add the periodic correction
-      IF (do_periodic) THEN
-         ext_scaling = 0.2_dp
-
-         ! loop over omega' (integration)
-         DO iquad = 1, num_points_corr
-
-            ! use the Clenshaw-grid
-            t_i_Clenshaw = iquad*pi/(2.0_dp*num_points_corr)
-            omega_i = ext_scaling/TAN(t_i_Clenshaw)
-
-            IF (iquad < num_points_corr) THEN
-               weight_i = ext_scaling*pi/(num_points_corr*SIN(t_i_Clenshaw)**2)
-            ELSE
-               weight_i = ext_scaling*pi/(2.0_dp*num_points_corr*SIN(t_i_Clenshaw)**2)
-            END IF
-
-            CALL calc_periodic_correction(delta_corr, qs_env, para_env, para_env_RPA, &
-                                          mp2_env%ri_g0w0%kp_grid, homo, nmo, gw_corr_lev_occ, &
-                                          gw_corr_lev_virt, omega_i, mo_coeff, Eigenval, &
-                                          matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                          first_cycle_periodic_correction, kpoints, &
-                                          mp2_env%ri_g0w0%do_mo_coeff_gamma, &
-                                          mp2_env%ri_g0w0%num_kp_grids, mp2_env%ri_g0w0%eps_kpoint, &
-                                          mp2_env%ri_g0w0%do_extra_kpoints, &
-                                          mp2_env%ri_g0w0%do_aux_bas_gw, mp2_env%ri_g0w0%frac_aux_mos)
-
-            DO n_level_gw = 1, gw_corr_lev_tot
-
-               n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-               IF (n_level_gw <= gw_corr_lev_occ) THEN
-                  sign_occ_virt = -1.0_dp
-               ELSE
-                  sign_occ_virt = 1.0_dp
-               END IF
-
-               DO jquad = 1, num_integ_points
-
-                  omega_sign = tj(jquad)*sign_occ_virt
-
-                  delta_corr_omega(n_level_gw_ref, jquad) = &
-                     delta_corr_omega(n_level_gw_ref, jquad)- &
-                     0.5_dp/pi*weight_i/2.0_dp*delta_corr(n_level_gw_ref)* &
-                     (1.0_dp/(im_unit*(omega_i+omega_sign)+e_fermi-Eigenval(n_level_gw_ref))+ &
-                      1.0_dp/(im_unit*(-omega_i+omega_sign)+e_fermi-Eigenval(n_level_gw_ref)))
-               END DO
-            END DO
-         END DO
-
-         gw_lev_start = 1+homo-gw_corr_lev_occ
-         gw_lev_end = homo+gw_corr_lev_virt
-
-         ! add the periodic correction
-         vec_Sigma_c_gw(1:gw_corr_lev_tot, :) = vec_Sigma_c_gw(1:gw_corr_lev_tot, :)+ &
-                                                delta_corr_omega(gw_lev_start:gw_lev_end, 1:num_fit_points)
-
-      END IF
-
-      DEALLOCATE (vec_Sigma_c_gw_pos_tau)
-      DEALLOCATE (vec_Sigma_c_gw_neg_tau)
-      DEALLOCATE (vec_Sigma_c_gw_cos_tau)
-      DEALLOCATE (vec_Sigma_c_gw_sin_tau)
-      DEALLOCATE (vec_Sigma_c_gw_cos_omega)
-      DEALLOCATE (vec_Sigma_c_gw_sin_omega)
-      DEALLOCATE (delta_corr_omega)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE compute_self_energy_im_time_gw
-
-! **************************************************************************************************
-!> \brief Calculate integration weights for the tau grid (in dependency of the omega node)
-!> \param num_integ_points ...
-!> \param tau_tj ...
-!> \param weights_cos_tf_t_to_w ...
-!> \param omega_tj ...
-!> \param E_min ...
-!> \param E_max ...
-!> \param max_error ...
-!> \param num_points_per_magnitude ...
-! **************************************************************************************************
-   SUBROUTINE get_l_sq_wghts_cos_tf_t_to_w(num_integ_points, tau_tj, weights_cos_tf_t_to_w, omega_tj, &
-                                           E_min, E_max, max_error, num_points_per_magnitude)
-
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: weights_cos_tf_t_to_w
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj
-      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_cos_tf_t_to_w', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, iii, info, jjj, jquad, lwork, &
-                                                            num_x_nodes
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
-      REAL(KIND=dp)                                      :: chi2_min_jquad, multiplicator, omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: sing_values, tau_wj_work, vec_UTy, work, &
-                                                            work_array, x_values, y_values
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: mat_A, mat_SinvVSinvSigma, &
-                                                            mat_SinvVSinvT, mat_U
-
-      CALL timeset(routineN, handle)
-
-      ! take num_points_per_magnitude points per 10-interval
-      num_x_nodes = (INT(LOG10(E_max/E_min))+1)*num_points_per_magnitude
-
-      ! take at least as many x points as integration points to have clear
-      ! input for the singular value decomposition
-      num_x_nodes = MAX(num_x_nodes, num_integ_points)
-
-      ALLOCATE (x_values(num_x_nodes))
-      x_values = 0.0_dp
-      ALLOCATE (y_values(num_x_nodes))
-      y_values = 0.0_dp
-      ALLOCATE (mat_A(num_x_nodes, num_integ_points))
-      mat_A = 0.0_dp
-      ALLOCATE (tau_wj_work(num_integ_points))
-      tau_wj_work = 0.0_dp
-      ALLOCATE (work_array(2*num_integ_points))
-      work_array = 0.0_dp
-      ALLOCATE (sing_values(num_integ_points))
-      sing_values = 0.0_dp
-      ALLOCATE (mat_U(num_x_nodes, num_x_nodes))
-      mat_U = 0.0_dp
-      ALLOCATE (mat_SinvVSinvT(num_x_nodes, num_integ_points))
-
-      mat_SinvVSinvT = 0.0_dp
-      ! double the value nessary for 'A' to achieve good performance
-      lwork = 8*num_integ_points*num_integ_points+12*num_integ_points+2*num_x_nodes
-      ALLOCATE (work(lwork))
-      work = 0.0_dp
-      ALLOCATE (iwork(8*num_integ_points))
-      iwork = 0
-      ALLOCATE (mat_SinvVSinvSigma(num_integ_points, num_x_nodes))
-      mat_SinvVSinvSigma = 0.0_dp
-      ALLOCATE (vec_UTy(num_x_nodes))
-      vec_UTy = 0.0_dp
-
-      max_error = 0.0_dp
-
-      ! loop over all omega frequency points
-      DO jquad = 1, num_integ_points
-
-         chi2_min_jquad = 100.0_dp
-
-         ! set the x-values logarithmically in the interval [Emin,Emax]
-         multiplicator = (E_max/E_min)**(1.0_dp/(REAL(num_x_nodes, KIND=dp)-1.0_dp))
-         DO iii = 1, num_x_nodes
-            x_values(iii) = E_min*multiplicator**(iii-1)
-         END DO
-
-         omega = omega_tj(jquad)
-
-         ! y=2x/(x^2+omega_k^2)
-         DO iii = 1, num_x_nodes
-            y_values(iii) = 2.0_dp*x_values(iii)/((x_values(iii))**2+omega**2)
-         END DO
-
-         ! calculate mat_A
-         DO jjj = 1, num_integ_points
-            DO iii = 1, num_x_nodes
-               mat_A(iii, jjj) = COS(omega*tau_tj(jjj))*EXP(-x_values(iii)*tau_tj(jjj))
-            END DO
-         END DO
-
-         ! Singular value decomposition of mat_A
-         CALL DGESDD('A', num_x_nodes, num_integ_points, mat_A, num_x_nodes, sing_values, mat_U, num_x_nodes, &
-                     mat_SinvVSinvT, num_x_nodes, work, lwork, iwork, info)
-
-         CPASSERT(info == 0)
-
-         ! integration weights = V Sigma U^T y
-         ! 1) V*Sigma
-         DO jjj = 1, num_integ_points
-            DO iii = 1, num_integ_points
-               mat_SinvVSinvSigma(iii, jjj) = mat_SinvVSinvT(jjj, iii)/sing_values(jjj)
-            END DO
-         END DO
-
-         ! 2) U^T y
-         CALL DGEMM('T', 'N', num_x_nodes, 1, num_x_nodes, 1.0_dp, mat_U, num_x_nodes, y_values, num_x_nodes, &
-                    0.0_dp, vec_UTy, num_x_nodes)
-
-         ! 3) (V*Sigma) * (U^T y)
-         CALL DGEMM('N', 'N', num_integ_points, 1, num_x_nodes, 1.0_dp, mat_SinvVSinvSigma, num_integ_points, vec_UTy, &
-                    num_x_nodes, 0.0_dp, tau_wj_work, num_integ_points)
-
-         weights_cos_tf_t_to_w(jquad, :) = tau_wj_work(:)
-
-         CALL calc_max_error_fit_tau_grid_with_cosine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                      y_values, num_integ_points, num_x_nodes)
-
-      END DO ! jquad
-
-      DEALLOCATE (x_values, y_values, mat_A, tau_wj_work, work_array, sing_values, mat_U, mat_SinvVSinvT, &
-                  work, iwork, mat_SinvVSinvSigma, vec_UTy)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_l_sq_wghts_cos_tf_t_to_w
-
-! **************************************************************************************************
-!> \brief Calculate integration weights for the tau grid (in dependency of the omega node)
-!> \param num_integ_points ...
-!> \param tau_tj ...
-!> \param weights_sin_tf_t_to_w ...
-!> \param omega_tj ...
-!> \param E_min ...
-!> \param E_max ...
-!> \param max_error ...
-!> \param num_points_per_magnitude ...
-! **************************************************************************************************
-   SUBROUTINE get_l_sq_wghts_sin_tf_t_to_w(num_integ_points, tau_tj, weights_sin_tf_t_to_w, omega_tj, &
-                                           E_min, E_max, max_error, num_points_per_magnitude)
-
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: weights_sin_tf_t_to_w
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj
-      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_sin_tf_t_to_w', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, iii, info, jjj, jquad, lwork, &
-                                                            num_x_nodes
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
-      REAL(KIND=dp)                                      :: chi2_min_jquad, multiplicator, omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: sing_values, tau_wj_work, vec_UTy, work, &
-                                                            work_array, x_values, y_values
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: mat_A, mat_SinvVSinvSigma, &
-                                                            mat_SinvVSinvT, mat_U
-
-      CALL timeset(routineN, handle)
-
-      ! take num_points_per_magnitude points per 10-interval
-      num_x_nodes = (INT(LOG10(E_max/E_min))+1)*num_points_per_magnitude
-
-      ! take at least as many x points as integration points to have clear
-      ! input for the singular value decomposition
-      num_x_nodes = MAX(num_x_nodes, num_integ_points)
-
-      ALLOCATE (x_values(num_x_nodes))
-      x_values = 0.0_dp
-      ALLOCATE (y_values(num_x_nodes))
-      y_values = 0.0_dp
-      ALLOCATE (mat_A(num_x_nodes, num_integ_points))
-      mat_A = 0.0_dp
-      ALLOCATE (tau_wj_work(num_integ_points))
-      tau_wj_work = 0.0_dp
-      ALLOCATE (work_array(2*num_integ_points))
-      work_array = 0.0_dp
-      ALLOCATE (sing_values(num_integ_points))
-      sing_values = 0.0_dp
-      ALLOCATE (mat_U(num_x_nodes, num_x_nodes))
-      mat_U = 0.0_dp
-      ALLOCATE (mat_SinvVSinvT(num_x_nodes, num_integ_points))
-
-      mat_SinvVSinvT = 0.0_dp
-      ! double the value nessary for 'A' to achieve good performance
-      lwork = 8*num_integ_points*num_integ_points+12*num_integ_points+2*num_x_nodes
-      ALLOCATE (work(lwork))
-      work = 0.0_dp
-      ALLOCATE (iwork(8*num_integ_points))
-      iwork = 0
-      ALLOCATE (mat_SinvVSinvSigma(num_integ_points, num_x_nodes))
-      mat_SinvVSinvSigma = 0.0_dp
-      ALLOCATE (vec_UTy(num_x_nodes))
-      vec_UTy = 0.0_dp
-
-      max_error = 0.0_dp
-
-      ! loop over all omega frequency points
-      DO jquad = 1, num_integ_points
-
-         chi2_min_jquad = 100.0_dp
-
-         ! set the x-values logarithmically in the interval [Emin,Emax]
-         multiplicator = (E_max/E_min)**(1.0_dp/(REAL(num_x_nodes, KIND=dp)-1.0_dp))
-         DO iii = 1, num_x_nodes
-            x_values(iii) = E_min*multiplicator**(iii-1)
-         END DO
-
-         omega = omega_tj(jquad)
-
-         ! y=2x/(x^2+omega_k^2)
-         DO iii = 1, num_x_nodes
-!            y_values(iii) = 2.0_dp*x_values(iii)/((x_values(iii))**2+omega**2)
-            y_values(iii) = 2.0_dp*omega/((x_values(iii))**2+omega**2)
-         END DO
-
-         ! calculate mat_A
-         DO jjj = 1, num_integ_points
-            DO iii = 1, num_x_nodes
-               mat_A(iii, jjj) = SIN(omega*tau_tj(jjj))*EXP(-x_values(iii)*tau_tj(jjj))
-            END DO
-         END DO
-
-         ! Singular value decomposition of mat_A
-         CALL DGESDD('A', num_x_nodes, num_integ_points, mat_A, num_x_nodes, sing_values, mat_U, num_x_nodes, &
-                     mat_SinvVSinvT, num_x_nodes, work, lwork, iwork, info)
-
-         CPASSERT(info == 0)
-
-         ! integration weights = V Sigma U^T y
-         ! 1) V*Sigma
-         DO jjj = 1, num_integ_points
-            DO iii = 1, num_integ_points
-               mat_SinvVSinvSigma(iii, jjj) = mat_SinvVSinvT(jjj, iii)/sing_values(jjj)
-            END DO
-         END DO
-
-         ! 2) U^T y
-         CALL DGEMM('T', 'N', num_x_nodes, 1, num_x_nodes, 1.0_dp, mat_U, num_x_nodes, y_values, num_x_nodes, &
-                    0.0_dp, vec_UTy, num_x_nodes)
-
-         ! 3) (V*Sigma) * (U^T y)
-         CALL DGEMM('N', 'N', num_integ_points, 1, num_x_nodes, 1.0_dp, mat_SinvVSinvSigma, num_integ_points, vec_UTy, &
-                    num_x_nodes, 0.0_dp, tau_wj_work, num_integ_points)
-
-         weights_sin_tf_t_to_w(jquad, :) = tau_wj_work(:)
-
-         CALL calc_max_error_fit_tau_grid_with_sine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                    y_values, num_integ_points, num_x_nodes)
-
-      END DO ! jquad
-
-      DEALLOCATE (x_values, y_values, mat_A, tau_wj_work, work_array, sing_values, mat_U, mat_SinvVSinvT, &
-                  work, iwork, mat_SinvVSinvSigma, vec_UTy)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_l_sq_wghts_sin_tf_t_to_w
-
-! **************************************************************************************************
-!> \brief Calculate the matrix mat_N_gw containing the second derivatives
-!>        with respect to the fitting parameters. The second derivatives are
-!>        calculated numerically by finite differences.
-!> \param N_ij matrix element
-!> \param Lambda fitting parameters
-!> \param Sigma_c ...
-!> \param vec_omega_fit_gw ...
-!> \param i ...
-!> \param j ...
-!> \param num_poles ...
-!> \param num_fit_points ...
-!> \param n_level_gw ...
-!> \param h  ...
-! **************************************************************************************************
-   PURE SUBROUTINE calc_mat_N(N_ij, Lambda, Sigma_c, vec_omega_fit_gw, i, j, &
-                              num_poles, num_fit_points, n_level_gw, h)
-      REAL(KIND=dp), INTENT(OUT)                         :: N_ij
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: Lambda
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(IN)                                      :: Sigma_c
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: vec_omega_fit_gw
-      INTEGER, INTENT(IN)                                :: i, j, num_poles, num_fit_points, &
-                                                            n_level_gw
-      REAL(KIND=dp), INTENT(IN)                          :: h
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_mat_N', routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda_tmp
-      INTEGER                                            :: num_var
-      REAL(KIND=dp)                                      :: chi2, chi2_sum
-
-      num_var = 2*num_poles+1
-      ALLOCATE (Lambda_tmp(num_var))
-      Lambda_tmp = (0.0_dp, 0.0_dp)
-      chi2_sum = 0.0_dp
-      re_unit = (1.0_dp, 0.0_dp)
-      im_unit = (0.0_dp, 1.0_dp)
-
-      !test
-      Lambda_tmp(:) = Lambda(:)
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-
-      ! Fitting parameters with offset h
-      Lambda_tmp(:) = Lambda(:)
-      IF (MODULO(i, 2) == 0) THEN
-         Lambda_tmp(i/2) = Lambda_tmp(i/2)+h*re_unit
-      ELSE
-         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)+h*im_unit
-      END IF
-      IF (MODULO(j, 2) == 0) THEN
-         Lambda_tmp(j/2) = Lambda_tmp(j/2)+h*re_unit
-      ELSE
-         Lambda_tmp((j+1)/2) = Lambda_tmp((j+1)/2)+h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum+chi2
-
-      IF (MODULO(i, 2) == 0) THEN
-         Lambda_tmp(i/2) = Lambda_tmp(i/2)-2.0_dp*h*re_unit
-      ELSE
-         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)-2.0_dp*h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum-chi2
-
-      IF (MODULO(j, 2) == 0) THEN
-         Lambda_tmp(j/2) = Lambda_tmp(j/2)-2.0_dp*h*re_unit
-      ELSE
-         Lambda_tmp((j+1)/2) = Lambda_tmp((j+1)/2)-2.0_dp*h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum+chi2
-
-      IF (MODULO(i, 2) == 0) THEN
-         Lambda_tmp(i/2) = Lambda_tmp(i/2)+2.0_dp*h*re_unit
-      ELSE
-         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)+2.0_dp*h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum-chi2
-
-      ! Second derivative with symmetric difference quotient
-      N_ij = 1.0_dp/2.0_dp*chi2_sum/(4.0_dp*h*h)
-
-      DEALLOCATE (Lambda_tmp)
-
-   END SUBROUTINE calc_mat_N
-
-! **************************************************************************************************
-!> \brief Calculate chi2
-!> \param chi2 ...
-!> \param Lambda fitting parameters
-!> \param Sigma_c ...
-!> \param vec_omega_fit_gw ...
-!> \param num_poles ...
-!> \param num_fit_points ...
-!> \param n_level_gw ...
-! **************************************************************************************************
-   PURE SUBROUTINE calc_chi2(chi2, Lambda, Sigma_c, vec_omega_fit_gw, num_poles, &
-                             num_fit_points, n_level_gw)
-      REAL(KIND=dp), INTENT(INOUT)                       :: chi2
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: Lambda
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(IN)                                      :: Sigma_c
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: vec_omega_fit_gw
-      INTEGER, INTENT(IN)                                :: num_poles, num_fit_points, n_level_gw
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_chi2', routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: func_val, im_unit
-      INTEGER                                            :: iii, jjj, kkk
-
-      im_unit = (0.0_dp, 1.0_dp)
-      chi2 = 0.0_dp
-      DO kkk = 1, num_fit_points
-         func_val = Lambda(1)
-         DO iii = 1, num_poles
-            jjj = iii*2
-            ! calculate value of the fit function
-            func_val = func_val+Lambda(jjj)/(im_unit*vec_omega_fit_gw(kkk)-Lambda(jjj+1))
-         END DO
-         chi2 = chi2+(ABS(Sigma_c(n_level_gw, kkk)-func_val))**2
-      END DO
-
-   END SUBROUTINE calc_chi2
-
-! **************************************************************************************************
-!> \brief ...
-!> \param max_error ...
-!> \param omega ...
-!> \param tau_tj ...
-!> \param tau_wj_work ...
-!> \param x_values ...
-!> \param y_values ...
-!> \param num_integ_points ...
-!> \param num_x_nodes ...
-! **************************************************************************************************
-   SUBROUTINE calc_max_error_fit_tau_grid_with_cosine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                      y_values, num_integ_points, num_x_nodes)
-
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work, x_values, y_values
-      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_cosine', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, kkk
-      REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
-
-      CALL timeset(routineN, handle)
-
-      max_error_tmp = 0.0_dp
-
-      DO kkk = 1, num_x_nodes
-
-         func_val = 0.0_dp
-
-         CALL eval_fit_func_tau_grid_cosine(func_val, x_values(kkk), num_integ_points, tau_tj, tau_wj_work, omega)
-
-         IF (ABS(y_values(kkk)-func_val) > max_error_tmp) THEN
-            max_error_tmp = ABS(y_values(kkk)-func_val)
-            func_val_temp = func_val
-         END IF
-
-      END DO
-
-      IF (max_error_tmp > max_error) THEN
-
-         max_error = max_error_tmp
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE calc_max_error_fit_tau_grid_with_cosine
-
-! **************************************************************************************************
-!> \brief ...
-!> \param max_error ...
-!> \param omega ...
-!> \param tau_tj ...
-!> \param tau_wj_work ...
-!> \param x_values ...
-!> \param y_values ...
-!> \param num_integ_points ...
-!> \param num_x_nodes ...
-! **************************************************************************************************
-   SUBROUTINE calc_max_error_fit_tau_grid_with_sine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                    y_values, num_integ_points, num_x_nodes)
-
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work, x_values, y_values
-      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_sine', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, kkk
-      REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
-
-      CALL timeset(routineN, handle)
-
-      max_error_tmp = 0.0_dp
-
-      DO kkk = 1, num_x_nodes
-
-         func_val = 0.0_dp
-
-         CALL eval_fit_func_tau_grid_sine(func_val, x_values(kkk), num_integ_points, tau_tj, tau_wj_work, omega)
-
-         IF (ABS(y_values(kkk)-func_val) > max_error_tmp) THEN
-            max_error_tmp = ABS(y_values(kkk)-func_val)
-            func_val_temp = func_val
-         END IF
-
-      END DO
-
-      IF (max_error_tmp > max_error) THEN
-
-         max_error = max_error_tmp
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE calc_max_error_fit_tau_grid_with_sine
-
-! **************************************************************************************************
-!> \brief Fits the complex self-energy of n_level_gw to a multi-pole model and evaluates the
-!>        fit at the energy eigenvalue of the SCF. Real part of the correlation self-energy
-!>        is written to vec_gw_energ. Also calculates the statistical error of the correlation
-!>        self-energy due to the fit
-!> \param vec_gw_energ ...
-!> \param vec_gw_energ_error_fit ...
-!> \param vec_omega_fit_gw ...
-!> \param z_value ...
-!> \param m_value ...
-!> \param vec_Sigma_c_gw ...
-!> \param vec_Sigma_x_minus_vxc_gw ...
-!> \param Eigenval ...
-!> \param Eigenval_scf ...
-!> \param n_level_gw ...
-!> \param gw_corr_lev_occ ...
-!> \param num_poles ...
-!> \param num_fit_points ...
-!> \param max_iter_fit ...
-!> \param crossing_search ...
-!> \param homo ...
-!> \param check_fit ...
-!> \param fermi_level_offset ...
-!> \param do_gw_im_time ...
-! **************************************************************************************************
-   SUBROUTINE fit_and_continuation_2pole(vec_gw_energ, vec_gw_energ_error_fit, vec_omega_fit_gw, &
-                                         z_value, m_value, vec_Sigma_c_gw, vec_Sigma_x_minus_vxc_gw, &
-                                         Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, num_poles, &
-                                         num_fit_points, max_iter_fit, crossing_search, homo, check_fit, &
+            IF (my_open_shell) THEN
+               SELECT CASE (mp2_env%ri_g0w0%analytic_continuation)
+               CASE (gw_two_pole_model)
+                  CALL fit_and_continuation_2pole( &
+                     vec_gw_energ_beta, vec_gw_energ_error_fit_beta, vec_omega_fit_gw, &
+                     z_value_beta, m_value_beta, vec_Sigma_c_gw_beta(:, :, ikp), &
+                     mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2, ikp), &
+                     Eigenval_beta, Eigenval_scf_beta, n_level_gw, &
+                     gw_corr_lev_occ_beta, num_poles, &
+                     num_fit_points, max_iter_fit, crossing_search, homo_beta, check_fit, stop_crit, &
+                     fermi_level_offset, do_gw_im_time)
+               CASE (gw_pade_approx)
+                  CALL continuation_pade(vec_gw_energ_beta, vec_omega_fit_gw, &
+                                         z_value_beta, m_value_beta, vec_Sigma_c_gw_beta(:, :, ikp), &
+                                         mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2, ikp), &
+                                         Eigenval_beta, Eigenval_scf_beta, n_level_gw, &
+                                         gw_corr_lev_occ_beta, mp2_env%ri_g0w0%nparam_pade, &
+                                         num_fit_points, crossing_search, homo_beta, check_fit, &
                                          fermi_level_offset, do_gw_im_time)
+               CASE DEFAULT
+                  CPABORT("Only two-model and Pade approximation are implemented.")
+               END SELECT
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: vec_gw_energ, vec_gw_energ_error_fit
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: vec_omega_fit_gw
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: z_value, m_value
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(IN)                                      :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
-                                                            Eigenval_scf
-      INTEGER, INTENT(IN)                                :: n_level_gw, gw_corr_lev_occ, num_poles, &
-                                                            num_fit_points, max_iter_fit, &
-                                                            crossing_search, homo
-      LOGICAL, INTENT(IN)                                :: check_fit
-      REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
-      LOGICAL, INTENT(IN)                                :: do_gw_im_time
+            END IF
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'fit_and_continuation_2pole', &
-         routineP = moduleN//':'//routineN
+         END DO ! n_level_gw
 
-      CHARACTER(5)                                       :: MO_number
-      COMPLEX(KIND=dp)                                   :: func_val, im_unit, one, re_unit, rho1, &
-                                                            zero
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: dLambda, dLambda_2, Lambda, &
-                                                            Lambda_without_offset, vec_b_gw, &
-                                                            vec_b_gw_copy
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: mat_A_gw, mat_B_gw
-      INTEGER                                            :: handle, handle2, ierr, iii, iiter, info, &
-                                                            integ_range, jjj, jquad, kkk, &
-                                                            n_level_gw_ref, num_var, output_unit, &
-                                                            xpos
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ipiv
-      LOGICAL                                            :: could_exit
-      REAL(KIND=dp) :: chi2, chi2_old, delta, deriv_val_real, e_fermi, gw_energ, Ldown, &
-         level_energ_GW, Lup, range_step, ScalParam, sign_occ_virt, stat_error, stop_crit
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: Lambda_Im, Lambda_Re, stat_errors, &
-                                                            vec_N_gw, vec_omega_fit_gw_sign
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: mat_N_gw
+         CALL mp_sum(vec_gw_energ_error_fit, para_env%group)
+         CALL mp_sum(vec_gw_energ, para_env%group)
+         CALL mp_sum(z_value, para_env%group)
+         CALL mp_sum(m_value, para_env%group)
 
-      CALL timeset(routineN, handle)
+         IF (my_open_shell) THEN
+            CALL mp_sum(vec_gw_energ_error_fit_beta, para_env%group)
+            CALL mp_sum(vec_gw_energ_beta, para_env%group)
+            CALL mp_sum(z_value_beta, para_env%group)
+            CALL mp_sum(m_value_beta, para_env%group)
+         END IF
 
-      output_unit = cp_logger_get_default_io_unit()
+         remove_neg_virt_energies = mp2_env%ri_g0w0%remove_neg_virt_energies
 
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
+         ! print the quasiparticle energies and update Eigenval in case you do eigenvalue self-consistent GW
+         IF (my_open_shell) THEN
 
-      num_var = 2*num_poles+1
-      ALLOCATE (Lambda(num_var))
-      Lambda = (0.0_dp, 0.0_dp)
-      ALLOCATE (Lambda_without_offset(num_var))
-      Lambda_without_offset = (0.0_dp, 0.0_dp)
-      ALLOCATE (Lambda_Re(num_var))
-      Lambda_Re = 0.0_dp
-      ALLOCATE (Lambda_Im(num_var))
-      Lambda_Im = 0.0_dp
+            CALL print_and_update_for_ev_sc( &
+               vec_gw_energ, vec_gw_energ_error_fit, &
+               z_value, m_value, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp), Eigenval, &
+               Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
+               count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
+               remove_neg_virt_energies, ikp, nkp_self_energy, kpoints, do_alpha=.TRUE.)
 
-      ALLOCATE (vec_omega_fit_gw_sign(num_fit_points))
+            CALL print_and_update_for_ev_sc( &
+               vec_gw_energ_beta, vec_gw_energ_error_fit_beta, &
+               z_value_beta, m_value_beta, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2, ikp), Eigenval_beta, &
+               Eigenval_last_beta, Eigenval_scf_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, gw_corr_lev_tot, &
+               count_ev_sc_GW, crossing_search, homo_beta, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
+               remove_neg_virt_energies, ikp, nkp_self_energy, kpoints, do_beta=.TRUE.)
 
-      IF (n_level_gw <= gw_corr_lev_occ) THEN
-         sign_occ_virt = -1.0_dp
-      ELSE
-         sign_occ_virt = 1.0_dp
-      END IF
+            IF (do_apply_ic_corr_to_gw .AND. count_ev_sc_GW == 1) THEN
 
-      DO jquad = 1, num_fit_points
-         vec_omega_fit_gw_sign(jquad) = ABS(vec_omega_fit_gw(jquad))*sign_occ_virt
-      END DO
+               CALL apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
+                                  gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
+                                  homo, nmo, unit_nr, do_alpha=.TRUE.)
 
-      ! initial guess
-      range_step = (vec_omega_fit_gw_sign(num_fit_points)-vec_omega_fit_gw_sign(1))/(num_poles-1)
-      DO iii = 1, num_poles
-         Lambda_Im(2*iii+1) = vec_omega_fit_gw_sign(1)+(iii-1)*range_step
-      END DO
-      range_step = (vec_omega_fit_gw_sign(num_fit_points)-vec_omega_fit_gw_sign(1))/num_poles
-      DO iii = 1, num_poles
-         Lambda_Re(2*iii+1) = ABS(vec_omega_fit_gw_sign(1)+(iii-0.5_dp)*range_step)
-      END DO
+               CALL apply_ic_corr(Eigenval_beta, Eigenval_scf_beta, ic_corr_list_beta, &
+                                  gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, gw_corr_lev_tot, &
+                                  homo_beta, nmo, unit_nr, do_beta=.TRUE.)
 
-      DO iii = 1, num_var
-         Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)
-      END DO
+            END IF
 
-      CALL calc_chi2(chi2_old, Lambda, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
-                     num_fit_points, n_level_gw)
-
-      ALLOCATE (mat_A_gw(num_poles+1, num_poles+1))
-      ALLOCATE (vec_b_gw(num_poles+1))
-      ALLOCATE (ipiv(num_poles+1))
-      mat_A_gw = (0.0_dp, 0.0_dp)
-      vec_b_gw = 0.0_dp
-
-      DO iii = 1, num_poles+1
-         mat_A_gw(iii, 1) = (1.0_dp, 0.0_dp)
-      END DO
-      integ_range = num_fit_points/num_poles
-      DO kkk = 1, num_poles+1
-         xpos = (kkk-1)*integ_range+1
-         xpos = MIN(xpos, num_fit_points)
-         ! calculate coefficient at this point
-         DO iii = 1, num_poles
-            jjj = iii*2
-            func_val = (1.0_dp, 0.0_dp)/(im_unit*vec_omega_fit_gw_sign(xpos)- &
-                                         CMPLX(Lambda_Re(jjj+1), Lambda_Im(jjj+1), KIND=dp))
-            mat_A_gw(kkk, iii+1) = func_val
-         END DO
-         vec_b_gw(kkk) = vec_Sigma_c_gw(n_level_gw, xpos)
-      END DO
-
-      ! Solve system of linear equations
-      CALL ZGETRF(num_poles+1, num_poles+1, mat_A_gw, num_poles+1, ipiv, info)
-
-      CALL ZGETRS('N', num_poles+1, 1, mat_A_gw, num_poles+1, ipiv, vec_b_gw, num_poles+1, info)
-
-      Lambda_Re(1) = REAL(vec_b_gw(1))
-      Lambda_Im(1) = AIMAG(vec_b_gw(1))
-      DO iii = 1, num_poles
-         jjj = iii*2
-         Lambda_Re(jjj) = REAL(vec_b_gw(iii+1))
-         Lambda_Im(jjj) = AIMAG(vec_b_gw(iii+1))
-      END DO
-
-      DEALLOCATE (mat_A_gw)
-      DEALLOCATE (vec_b_gw)
-      DEALLOCATE (ipiv)
-
-      ALLOCATE (mat_A_gw(num_var*2, num_var*2))
-      ALLOCATE (mat_B_gw(num_fit_points, num_var*2))
-      ALLOCATE (dLambda(num_fit_points))
-      ALLOCATE (dLambda_2(num_fit_points))
-      ALLOCATE (vec_b_gw(num_var*2))
-      ALLOCATE (vec_b_gw_copy(num_var*2))
-      ALLOCATE (ipiv(num_var*2))
-
-      ScalParam = 0.01_dp
-      Ldown = 1.5_dp
-      Lup = 10.0_dp
-      stop_crit = 1.0e-7
-      could_exit = .FALSE.
-
-      ! iteration loop for fitting
-      DO iiter = 1, max_iter_fit
-
-         CALL timeset(routineN//"_fit_loop_1", handle2)
-
-         ! calc delta lambda
-         DO iii = 1, num_var
-            Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)
-         END DO
-         dLambda = (0.0_dp, 0.0_dp)
-
-         DO kkk = 1, num_fit_points
-            func_val = Lambda(1)
-            DO iii = 1, num_poles
-               jjj = iii*2
-               func_val = func_val+Lambda(jjj)/(vec_omega_fit_gw_sign(kkk)*im_unit-Lambda(jjj+1))
-            END DO
-            dLambda(kkk) = vec_Sigma_c_gw(n_level_gw, kkk)-func_val
-         END DO
-         rho1 = SUM(dLambda*dLambda)
-
-         ! fill matrix
-         mat_B_gw = (0.0_dp, 0.0_dp)
-         DO iii = 1, num_fit_points
-            mat_B_gw(iii, 1) = 1.0_dp
-            mat_B_gw(iii, num_var+1) = im_unit
-         END DO
-         DO iii = 1, num_poles
-            jjj = iii*2
-            DO kkk = 1, num_fit_points
-               mat_B_gw(kkk, jjj) = 1.0_dp/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
-               mat_B_gw(kkk, jjj+num_var) = im_unit/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
-               mat_B_gw(kkk, jjj+1) = Lambda(jjj)/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))**2
-               mat_B_gw(kkk, jjj+1+num_var) = (-Lambda_Im(jjj)+im_unit*Lambda_Re(jjj))/ &
-                                              (im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))**2
-            END DO
-         END DO
-
-         CALL timestop(handle2)
-
-         CALL timeset(routineN//"_fit_matmul_1", handle2)
-
-         one = (1.0_dp, 0.0_dp)
-         zero = (0.0_dp, 0.0_dp)
-         CALL zgemm('C', 'N', num_var*2, num_var*2, num_fit_points, one, mat_B_gw, num_fit_points, mat_B_gw, num_fit_points, &
-                    zero, mat_A_gw, num_var*2)
-         CALL timestop(handle2)
-
-         CALL timeset(routineN//"_fit_zgemv_1", handle2)
-         CALL zgemv('C', num_fit_points, num_var*2, one, mat_B_gw, num_fit_points, dLambda, 1, &
-                    zero, vec_b_gw, 1)
-
-         CALL timestop(handle2)
-
-         ! scale diagonal elements of a_mat
-         DO iii = 1, num_var*2
-            mat_A_gw(iii, iii) = mat_A_gw(iii, iii)+ScalParam*mat_A_gw(iii, iii)
-         END DO
-
-         ! solve linear system
-         ierr = 0
-         ipiv = 0
-
-         CALL timeset(routineN//"_fit_lin_eq_2", handle2)
-
-         CALL ZGETRF(2*num_var, 2*num_var, mat_A_gw, 2*num_var, ipiv, info)
-
-         CALL ZGETRS('N', 2*num_var, 1, mat_A_gw, 2*num_var, ipiv, vec_b_gw, 2*num_var, info)
-
-         CALL timestop(handle2)
-
-         DO iii = 1, num_var
-            Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)+vec_b_gw(iii)+vec_b_gw(iii+num_var)
-         END DO
-
-         ! calculate chi2
-         CALL calc_chi2(chi2, Lambda, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
-                        num_fit_points, n_level_gw)
-
-         IF (chi2 < chi2_old) THEN
-            ScalParam = MAX(ScalParam/Ldown, 1E-12_dp)
-            DO iii = 1, num_var
-               Lambda_Re(iii) = Lambda_Re(iii)+REAL(vec_b_gw(iii)+vec_b_gw(iii+num_var))
-               Lambda_Im(iii) = Lambda_Im(iii)+AIMAG(vec_b_gw(iii)+vec_b_gw(iii+num_var))
-            END DO
-            IF (chi2_old/chi2-1.0_dp < stop_crit) could_exit = .TRUE.
-            chi2_old = chi2
          ELSE
-            ScalParam = ScalParam*Lup
-         END IF
-         IF (ScalParam > 100.0_dp .AND. could_exit) EXIT
 
-         IF (ScalParam > 1E+10_dp) ScalParam = 1E-4_dp
+            CALL print_and_update_for_ev_sc( &
+               vec_gw_energ, vec_gw_energ_error_fit, &
+               z_value, m_value, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp), Eigenval, &
+               Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
+               count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
+               remove_neg_virt_energies, ikp, nkp_self_energy, kpoints)
 
-         n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-         IF (iiter == max_iter_fit) THEN
-            WRITE (MO_number, "(I3)") n_level_gw_ref
-            CALL cp_warn(__LOCATION__, &
-                         "The fit for corrected level n ="//MO_number//" did not converge. "// &
-                         "For levels close to HOMO or LUMO, this is normally no issue. "// &
-                         "To avoid this warning, you can (1) increase the "// &
-                         "number of fit iterations MAX_ITER_FIT, or you can (2) increase the number "// &
-                         "of RPA integration points (then, Sigma_c(i*omega) is more accurate) "// &
-                         "or  you can (3) decrease "// &
-                         "the fit range by setting the keyword OMEGA_MAX_FIT (in Hartree). ")
+            IF (do_apply_ic_corr_to_gw .AND. count_ev_sc_GW == 1) THEN
+
+               CALL apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
+                                  gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
+                                  homo, nmo, unit_nr)
+
+            END IF
 
          END IF
 
-      END DO
-
-      IF (.NOT. do_gw_im_time) THEN
-
-         ! change a_0 [Lambda(1)], so that Sigma(i0) = Fit(i0)
-         ! do not do this for imaginary time since we do not have many fit points and the fit should be perfect
-         func_val = Lambda(1)
-         DO iii = 1, num_poles
-            jjj = iii*2
-            ! calculate value of the fit function
-            func_val = func_val+Lambda(jjj)/(-Lambda(jjj+1))
-         END DO
-
-         Lambda_Re(1) = Lambda_Re(1)-REAL(func_val)+REAL(vec_Sigma_c_gw(n_level_gw, num_fit_points))
-         Lambda_Im(1) = Lambda_Im(1)-AIMAG(func_val)+AIMAG(vec_Sigma_c_gw(n_level_gw, num_fit_points))
-
-      END IF
-
-      Lambda_without_offset(:) = Lambda(:)
-
-      DO iii = 1, num_var
-         Lambda(iii) = CMPLX(Lambda_Re(iii), Lambda_Im(iii), KIND=dp)
-      END DO
-
-      ! print self_energy and fit on the imaginary frequency axis if required
-      IF (check_fit) THEN
-
-         IF (output_unit > 0) THEN
-
-            WRITE (output_unit, *) ' '
-            WRITE (output_unit, '(T3,A,I5)') 'Check the GW fit for molecular orbital', n_level_gw_ref
-            WRITE (output_unit, '(T3,A)') '-------------------------------------------'
-            WRITE (output_unit, *)
-            WRITE (output_unit, '(T3,5A)') '  omega (i*eV)    ', 'Re(fit) (eV)    ', &
-               'Im(fit) (eV)  ', 'Re(Sig_c) (eV)  ', &
-               'Im(Sig_c) (eV)'
-
-         END IF
-
-         DO kkk = 1, num_fit_points
-            func_val = Lambda(1)
-            DO iii = 1, num_poles
-               jjj = iii*2
-               ! calculate value of the fit function
-               func_val = func_val+Lambda(jjj)/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
-            END DO
-            WRITE (output_unit, '(1F16.3,4F16.5)') vec_omega_fit_gw_sign(kkk)*evolt, REAL(func_val)*evolt, &
-               AIMAG(func_val)*evolt, REAL(vec_Sigma_c_gw(n_level_gw, kkk))*evolt, &
-               AIMAG(vec_Sigma_c_gw(n_level_gw, kkk))*evolt
-         END DO
-
-         WRITE (output_unit, *) ' '
-
-      END IF
-
-      IF (do_gw_im_time) THEN
-         ! for cubic-scaling GW, we have one Green's function for occ and virt states with the Fermi level
-         ! in the middle of homo and lumo
-         e_fermi = 0.5_dp*(Eigenval(homo)+Eigenval(homo+1))
-      ELSE
-         ! in case of O(N^4) GW, we have the Fermi level differently for occ and virt states, see
-         ! Fig. 1 in JCTC 12, 3623-3635 (2016)
-         IF (n_level_gw <= gw_corr_lev_occ) THEN
-            e_fermi = Eigenval(homo)+fermi_level_offset
-         ELSE
-            e_fermi = Eigenval(homo+1)-fermi_level_offset
-         END IF
-      END IF
-
-      ! either Z-shot or no crossing search for evaluating Sigma_c
-      IF (crossing_search == ri_rpa_g0w0_crossing_none) THEN
-
-         ! calculate func val on the real axis
-         ! gw_energ = only correlation part of the self energy
-         func_val = Lambda(1)
-         DO iii = 1, num_poles
-            jjj = iii*2
-            func_val = func_val+Lambda(jjj)/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))
-         END DO
-
-         gw_energ = REAL(func_val)
-         vec_gw_energ(n_level_gw) = gw_energ
-
-      ELSE IF (crossing_search == ri_rpa_g0w0_crossing_z_shot .OR. &
-               crossing_search == ri_rpa_g0w0_crossing_newton) THEN
-
-         ! calculate Sigma_c_fit(e_n) and Z
-         func_val = Lambda(1)
-         z_value(n_level_gw) = 1.0_dp
-         DO iii = 1, num_poles
-            jjj = iii*2
-            z_value(n_level_gw) = z_value(n_level_gw)+REAL(Lambda(jjj)/ &
-                                                           (Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))**2)
-            func_val = func_val+Lambda(jjj)/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))
-         END DO
-         ! m is the slope of the correl self-energy
-         m_value(n_level_gw) = 1.0_dp-z_value(n_level_gw)
-         z_value(n_level_gw) = 1.0_dp/z_value(n_level_gw)
-         gw_energ = REAL(func_val)
-         vec_gw_energ(n_level_gw) = gw_energ
-
-         ! in case one wants to do Newton-Raphson on top of the Z-shot
-         IF (crossing_search == ri_rpa_g0w0_crossing_newton) THEN
-
-            level_energ_GW = (Eigenval_scf(n_level_gw_ref)- &
-                              m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
-                              vec_gw_energ(n_level_gw)+ &
-                              vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
-                             z_value(n_level_gw)
-
-            ! Newton-Raphson iteration
-            DO kkk = 1, 1000
-
-               ! calculate the value of the fit function for level_energ_GW
-               func_val = Lambda(1)
-               z_value(n_level_gw) = 1.0_dp
-               DO iii = 1, num_poles
-                  jjj = iii*2
-                  func_val = func_val+Lambda(jjj)/(level_energ_GW-e_fermi-Lambda(jjj+1))
-               END DO
-
-               ! calculate the derivative of the fit function for level_energ_GW
-               deriv_val_real = -1.0_dp
-               DO iii = 1, num_poles
-                  jjj = iii*2
-                  deriv_val_real = deriv_val_real+REAL(Lambda(jjj))/((ABS(level_energ_GW-e_fermi-Lambda(jjj+1)))**2) &
-                                   -(REAL(Lambda(jjj))*(level_energ_GW-e_fermi)-REAL(Lambda(jjj)*CONJG(Lambda(jjj+1))))* &
-                                   2.0_dp*(level_energ_GW-e_fermi-REAL(Lambda(jjj+1)))/ &
-                                   ((ABS(level_energ_GW-e_fermi-Lambda(jjj+1)))**2)
-
-               END DO
-
-               delta = (Eigenval_scf(n_level_gw_ref)+vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)+REAL(func_val)-level_energ_GW)/ &
-                       deriv_val_real
-
-               level_energ_GW = level_energ_GW-delta
-
-               IF (ABS(delta) < 1.0E-08) EXIT
-
-            END DO
-
-            ! update the GW-energy by Newton-Raphson and set the Z-value to 1
-
-            vec_gw_energ(n_level_gw) = REAL(func_val)
-            z_value(n_level_gw) = 1.0_dp
-            m_value(n_level_gw) = 0.0_dp
-
-         END IF ! Newton-Raphson on top of Z-shot
-
-      ELSE
-         CPABORT("Only NONE, ZSHOT and NEWTON implemented for 2-pole model")
-      END IF ! decision crossing search none, Z-shot
-
-      !   --------------------------------------------
-      !  | calculate statistical error due to fitting |
-      !   --------------------------------------------
-
-      ! estimate the statistical error of the calculated Sigma_c(i*omega)
-      ! by sqrt(chi2/n), where n is the number of fit points
-
-      CALL calc_chi2(chi2, Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
-                     num_fit_points, n_level_gw)
-
-      ! Estimate the statistical error of every fit point
-      stat_error = SQRT(chi2/num_fit_points)
-
-      ! allocate N array containing the second derivatives of chi^2
-      ALLOCATE (vec_N_gw(num_var*2))
-      vec_N_gw = 0.0_dp
-
-      ALLOCATE (mat_N_gw(num_var*2, num_var*2))
-      mat_N_gw = 0.0_dp
-
-      DO iii = 1, num_var*2
-         CALL calc_mat_N(vec_N_gw(iii), Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, &
-                         iii, iii, num_poles, num_fit_points, n_level_gw, 0.001_dp)
-      END DO
-
-      DO iii = 1, num_var*2
-         DO jjj = 1, num_var*2
-            CALL calc_mat_N(mat_N_gw(iii, jjj), Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, &
-                            iii, jjj, num_poles, num_fit_points, n_level_gw, 0.001_dp)
-         END DO
-      END DO
-
-      CALL DGETRF(2*num_var, 2*num_var, mat_N_gw, 2*num_var, ipiv, info)
-
-      ! vec_b_gw is only working array
-      CALL DGETRI(2*num_var, mat_N_gw, 2*num_var, ipiv, vec_b_gw, 2*num_var, info)
-
-      ALLOCATE (stat_errors(2*num_var))
-      stat_errors = 0.0_dp
-
-      DO iii = 1, 2*num_var
-         stat_errors(iii) = SQRT(ABS(mat_N_gw(iii, iii)))*stat_error
-      END DO
-
-      ! Compute error of Sigma_c on real axis according to error propagation
-
-      vec_gw_energ_error_fit(n_level_gw) = 0.0_dp
-
-      DO kkk = 1, num_poles
-         vec_gw_energ_error_fit(n_level_gw) = vec_gw_energ_error_fit(n_level_gw)+ &
-                                              (stat_errors(4*kkk-1)+stat_errors(4*kkk))* &
-                                              ABS(1.0_dp/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(2*kkk+1))- &
-                                                  1.0_dp/(-Lambda(2*kkk+1)))+ &
-                                              (stat_errors(4*kkk+1)+stat_errors(4*kkk+2))*ABS(Lambda(2*kkk))* &
-                                              ABS(1.0_dp/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(2*kkk+1))**2- &
-                                                  1.0_dp/(-Lambda(2*kkk+1))**2)
-      END DO
-
-      DEALLOCATE (mat_N_gw)
-      DEALLOCATE (vec_N_gw)
-      DEALLOCATE (mat_A_gw)
-      DEALLOCATE (mat_B_gw)
-      DEALLOCATE (stat_errors)
-      DEALLOCATE (dLambda)
-      DEALLOCATE (dLambda_2)
-      DEALLOCATE (vec_b_gw)
-      DEALLOCATE (vec_b_gw_copy)
-      DEALLOCATE (ipiv)
-      DEALLOCATE (vec_omega_fit_gw_sign)
-      DEALLOCATE (Lambda)
-      DEALLOCATE (Lambda_without_offset)
-      DEALLOCATE (Lambda_Re)
-      DEALLOCATE (Lambda_Im)
+      END DO ! ikp
 
       CALL timestop(handle)
 
-   END SUBROUTINE fit_and_continuation_2pole
-
-! **************************************************************************************************
-!> \brief perform analytic continuation with pade approximation
-!> \param vec_gw_energ real Sigma_c
-!> \param vec_omega_fit_gw frequency points for Sigma_c(iomega)
-!> \param z_value 1/(1-dev)
-!> \param m_value derivative of real Sigma_c
-!> \param vec_Sigma_c_gw complex Sigma_c(iomega)
-!> \param vec_Sigma_x_minus_vxc_gw ...
-!> \param Eigenval quasiparticle energy during ev self-consistent GW
-!> \param Eigenval_scf KS/HF eigenvalue
-!> \param n_level_gw ...
-!> \param gw_corr_lev_occ ...
-!> \param nparam_pade number of pade parameters
-!> \param num_fit_points number of fit points for Sigma_c(iomega)
-!> \param crossing_search type ofr cross search to find quasiparticle energies
-!> \param homo ...
-!> \param check_fit ...
-!> \param fermi_level_offset ...
-!> \param do_gw_im_time ...
-! **************************************************************************************************
-   SUBROUTINE continuation_pade(vec_gw_energ, vec_omega_fit_gw, &
-                                z_value, m_value, vec_Sigma_c_gw, vec_Sigma_x_minus_vxc_gw, &
-                                Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, nparam_pade, &
-                                num_fit_points, crossing_search, homo, check_fit, &
-                                fermi_level_offset, do_gw_im_time)
-
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: vec_gw_energ
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_omega_fit_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: z_value, m_value
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
-                                                            Eigenval_scf
-      INTEGER, INTENT(IN)                                :: n_level_gw, gw_corr_lev_occ, &
-                                                            nparam_pade, num_fit_points, &
-                                                            crossing_search, homo
-      LOGICAL, INTENT(IN)                                :: check_fit
-      REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
-      LOGICAL, INTENT(IN)                                :: do_gw_im_time
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'continuation_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit, sigma_c_pade
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: coeff_pade, omega_points_pade, &
-                                                            Sigma_c_gw_reorder
-      INTEGER                                            :: handle, jquad, n_level_gw_ref, &
-                                                            output_unit
-      REAL(KIND=dp)                                      :: e_fermi, energy_val, level_energ_GW, &
-                                                            sign_occ_virt
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw_sign, &
-                                                            vec_omega_fit_gw_sign_reorder
-
-      CALL timeset(routineN, handle)
-
-      output_unit = cp_logger_get_default_io_unit()
-
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
-
-      ALLOCATE (vec_omega_fit_gw_sign(num_fit_points))
-
-      IF (n_level_gw <= gw_corr_lev_occ) THEN
-         sign_occ_virt = -1.0_dp
-      ELSE
-         sign_occ_virt = 1.0_dp
-      END IF
-
-      DO jquad = 1, num_fit_points
-         vec_omega_fit_gw_sign(jquad) = ABS(vec_omega_fit_gw(jquad))*sign_occ_virt
-      END DO
-
-      IF (do_gw_im_time) THEN
-         ! for cubic-scaling GW, we have one Green's function for occ and virt states with the Fermi level
-         ! in the middle of homo and lumo
-         e_fermi = 0.5_dp*(Eigenval(homo)+Eigenval(homo+1))
-      ELSE
-         ! in case of O(N^4) GW, we have the Fermi level differently for occ and virt states, see
-         ! Fig. 1 in JCTC 12, 3623-3635 (2016)
-         IF (n_level_gw <= gw_corr_lev_occ) THEN
-            e_fermi = Eigenval(homo)+fermi_level_offset
-         ELSE
-            e_fermi = Eigenval(homo+1)-fermi_level_offset
-         END IF
-      END IF
-
-      n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-      !*** reorder, such that omega=i*0 is first entry
-      ALLOCATE (Sigma_c_gw_reorder(num_fit_points))
-      ALLOCATE (vec_omega_fit_gw_sign_reorder(num_fit_points))
-      ! for cubic scaling GW fit points are ordered differently than in N^4 GW
-      IF (do_gw_im_time) THEN
-         Sigma_c_gw_reorder(:) = vec_Sigma_c_gw(n_level_gw, :)
-         vec_omega_fit_gw_sign_reorder(:) = vec_omega_fit_gw_sign(:)
-      ELSE
-         DO jquad = 1, num_fit_points
-            Sigma_c_gw_reorder(jquad) = vec_Sigma_c_gw(n_level_gw, num_fit_points-jquad+1)
-            vec_omega_fit_gw_sign_reorder(jquad) = vec_omega_fit_gw_sign(num_fit_points-jquad+1)
-         ENDDO
-      ENDIF
-
-      !*** evaluate parameters for pade approximation
-      ALLOCATE (coeff_pade(nparam_pade))
-      ALLOCATE (omega_points_pade(nparam_pade))
-      coeff_pade = 0.0_dp
-      CALL get_pade_parameters(Sigma_c_gw_reorder, vec_omega_fit_gw_sign_reorder, &
-                               num_fit_points, nparam_pade, omega_points_pade, coeff_pade)
-      IF (check_fit) THEN
-         CALL check_fit_pade(vec_omega_fit_gw_sign, vec_Sigma_c_gw(n_level_gw, :), &
-                             nparam_pade, omega_points_pade, coeff_pade, &
-                             num_fit_points, n_level_gw_ref, output_unit)
-      ENDIF
-
-      !*** calculate start_value for iterative cross-searching methods
-      IF ((crossing_search == ri_rpa_g0w0_crossing_bisection) .OR. &
-          (crossing_search == ri_rpa_g0w0_crossing_newton)) THEN
-         energy_val = Eigenval(n_level_gw_ref)-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c_pade)
-         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, z_value(n_level_gw), m_value(n_level_gw))
-         level_energ_GW = (Eigenval_scf(n_level_gw_ref)- &
-                           m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
-                           REAL(sigma_c_pade)+ &
-                           vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
-                          z_value(n_level_gw)
-      ENDIF
-
-      !*** perform crossing search
-      SELECT CASE (crossing_search)
-      CASE (ri_rpa_g0w0_crossing_none)
-         energy_val = Eigenval(n_level_gw_ref)-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c_pade)
-         vec_gw_energ(n_level_gw) = REAL(sigma_c_pade)
-
-      CASE (ri_rpa_g0w0_crossing_z_shot)
-         energy_val = Eigenval(n_level_gw_ref)-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c_pade)
-         vec_gw_energ(n_level_gw) = REAL(sigma_c_pade)
-
-         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, z_value(n_level_gw), m_value(n_level_gw))
-
-      CASE (ri_rpa_g0w0_crossing_bisection)
-         CALL get_sigma_c_bisection_pade(vec_gw_energ(n_level_gw), Eigenval_scf(n_level_gw_ref), &
-                                         vec_Sigma_x_minus_vxc_gw(n_level_gw_ref), e_fermi, &
-                                         nparam_pade, omega_points_pade, coeff_pade, &
-                                         start_val=level_energ_GW)
-         z_value(n_level_gw) = 1.0_dp
-         m_value(n_level_gw) = 0.0_dp
-
-      CASE (ri_rpa_g0w0_crossing_newton)
-         CALL get_sigma_c_newton_pade(vec_gw_energ(n_level_gw), Eigenval_scf(n_level_gw_ref), &
-                                      vec_Sigma_x_minus_vxc_gw(n_level_gw_ref), e_fermi, &
-                                      nparam_pade, omega_points_pade, coeff_pade, &
-                                      start_val=level_energ_GW)
-         z_value(n_level_gw) = 1.0_dp
-         m_value(n_level_gw) = 0.0_dp
-
-      CASE DEFAULT
-         CPABORT("Only NONE, Z_SHOT, NEWTON, and BISECTION crossing search implemented.")
-      END SELECT
-
-      DEALLOCATE (vec_omega_fit_gw_sign)
-      DEALLOCATE (Sigma_c_gw_reorder)
-      DEALLOCATE (vec_omega_fit_gw_sign_reorder)
-      DEALLOCATE (coeff_pade, omega_points_pade)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE continuation_pade
-
-! **************************************************************************************************
-!> \brief calculate pade parameter recursively as in  Eq. (A2) in J. Low Temp. Phys., Vol. 29,
-!>          1977, pp. 179
-!> \param y f(x), here: Sigma_c(iomega)
-!> \param x the frequency points omega
-!> \param num_fit_points ...
-!> \param nparam number of pade parameters
-!> \param xpoints set of points used in pade approximation, selection of x
-!> \param coeff pade coefficients
-! **************************************************************************************************
-   SUBROUTINE get_pade_parameters(y, x, num_fit_points, nparam, xpoints, coeff)
-
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: y
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: x
-      INTEGER, INTENT(IN)                                :: num_fit_points, nparam
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(INOUT)      :: xpoints, coeff
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_pade_parameters', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: ypoints
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: g_mat
-      INTEGER                                            :: handle, idat, iparam, nstep
-
-      CALL timeset(routineN, handle)
-
-      im_unit = (0.0_dp, 1.0_dp)
-
-      nstep = INT(num_fit_points/(nparam-1))
-      CPASSERT(LBOUND(x, 1) == 1)
-      CPASSERT(LBOUND(y, 1) == 1)
-
-      ALLOCATE (ypoints(nparam))
-      !omega=i0 is in element x(1)
-      idat = 1
-      DO iparam = 1, nparam-1
-         xpoints(iparam) = im_unit*x(idat)
-         ypoints(iparam) = y(idat)
-         idat = idat+nstep
-      ENDDO
-      xpoints(nparam) = im_unit*x(num_fit_points)
-      ypoints(nparam) = y(num_fit_points)
-
-      !*** generate parameters recursively
-
-      ALLOCATE (g_mat(nparam, nparam))
-      g_mat(:, 1) = ypoints(:)
-      DO iparam = 2, nparam
-         DO idat = iparam, nparam
-            g_mat(idat, iparam) = (g_mat(iparam-1, iparam-1)-g_mat(idat, iparam-1))/ &
-                                  ((xpoints(idat)-xpoints(iparam-1))*g_mat(idat, iparam-1))
-         ENDDO
-      ENDDO
-
-      DO iparam = 1, nparam
-         coeff(iparam) = g_mat(iparam, iparam)
-      ENDDO
-
-      DEALLOCATE (ypoints)
-      DEALLOCATE (g_mat)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_pade_parameters
-
-! **************************************************************************************************
-!> \brief evalute pade function for a real value x_val
-!> \param x_val real value
-!> \param nparam number of pade parameters
-!> \param xpoints selection of points of the original complex function, i.e. here of Sigma_c(iomega)
-!> \param coeff pade coefficients
-!> \param func_val function value
-! **************************************************************************************************
-   PURE SUBROUTINE evaluate_pade_function(x_val, nparam, xpoints, coeff, func_val)
-
-      REAL(KIND=dp), INTENT(IN)                          :: x_val
-      INTEGER, INTENT(IN)                                :: nparam
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: func_val
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'evaluate_pade_function', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
-      INTEGER                                            :: iparam
-
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
-
-      func_val = re_unit
-      DO iparam = nparam, 2, -1
-         func_val = re_unit+coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))/func_val
-      ENDDO
-
-      func_val = coeff(1)/func_val
-
-   END SUBROUTINE evaluate_pade_function
-
-! **************************************************************************************************
-!> \brief get the z-value and the m-value (derivative) of the pade function
-!> \param x_val real value
-!> \param nparam number of pade parameters
-!> \param xpoints selection of points of the original complex function, i.e. here of Sigma_c(iomega)
-!> \param coeff pade coefficients
-!> \param z_value 1/(1-dev)
-!> \param m_value derivative
-! **************************************************************************************************
-   PURE SUBROUTINE get_z_and_m_value_pade(x_val, nparam, xpoints, coeff, z_value, m_value)
-
-      REAL(KIND=dp), INTENT(IN)                          :: x_val
-      INTEGER, INTENT(IN)                                :: nparam
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: z_value, m_value
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_z_and_m_value_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: denominator, dev_denominator, &
-                                                            dev_numerator, dev_val, func_val, &
-                                                            im_unit, numerator, re_unit
-      INTEGER                                            :: iparam
-
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
-
-      func_val = re_unit
-      dev_val = (0.0_dp, 0.0_dp)
-      DO iparam = nparam, 2, -1
-         numerator = coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))
-         dev_numerator = coeff(iparam)*re_unit
-         denominator = func_val
-         dev_denominator = dev_val
-         dev_val = dev_numerator/denominator-(numerator*dev_denominator)/(denominator**2)
-         func_val = re_unit+coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))/func_val
-      ENDDO
-
-      dev_val = -1.0_dp*coeff(1)/(func_val**2)*dev_val
-      func_val = coeff(1)/func_val
-
-      IF (PRESENT(z_value)) THEN
-         z_value = 1.0_dp-REAL(dev_val)
-         z_value = 1.0_dp/z_value
-      ENDIF
-      IF (PRESENT(m_value)) m_value = REAL(dev_val)
-
-   END SUBROUTINE get_z_and_m_value_pade
-
-! **************************************************************************************************
-!> \brief crossing search using the bisection method to find the quasiparticle energy
-!> \param gw_energ real Sigma_c
-!> \param Eigenval_scf Eigenvalue from the SCF
-!> \param Sigma_x_minus_vxc_gw ...
-!> \param e_fermi fermi level
-!> \param nparam_pade number of pade parameters
-!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
-!> \param coeff_pade pade coefficients
-!> \param start_val start value for the quasiparticle iteration
-! **************************************************************************************************
-   SUBROUTINE get_sigma_c_bisection_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
-                                         nparam_pade, omega_points_pade, coeff_pade, start_val)
-
-      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
-      REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
-                                                            e_fermi
-      INTEGER, INTENT(IN)                                :: nparam_pade
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: start_val
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_sigma_c_bisection_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: sigma_c
-      INTEGER                                            :: handle, icount
-      REAL(KIND=dp)                                      :: delta, energy_val, my_start_val, &
-                                                            qp_energy, qp_energy_old, threshold
-
-      CALL timeset(routineN, handle)
-
-      threshold = 1.0E-7_dp
-
-      IF (PRESENT(start_val)) THEN
-         my_start_val = start_val
-      ELSE
-         my_start_val = Eigenval_scf
-      ENDIF
-
-      qp_energy = my_start_val
-      qp_energy_old = my_start_val
-      delta = 1.0E-3_dp
-
-      icount = 0
-      DO WHILE (ABS(delta) > threshold)
-         icount = icount+1
-         qp_energy = qp_energy_old+0.5_dp*delta
-         qp_energy_old = qp_energy
-         energy_val = qp_energy-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c)
-         qp_energy = Eigenval_scf+REAL(sigma_c)+Sigma_x_minus_vxc_gw
-         delta = qp_energy-qp_energy_old
-         IF (icount > 500) THEN
-            CPABORT("Self-consistent quasi-particle solution not found")
-            EXIT
-         ENDIF
-      ENDDO
-
-      gw_energ = REAL(sigma_c)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_sigma_c_bisection_pade
-
-! **************************************************************************************************
-!> \brief crossing search using the Newton method to find the quasiparticle energy
-!> \param gw_energ real Sigma_c
-!> \param Eigenval_scf Eigenvalue from the SCF
-!> \param Sigma_x_minus_vxc_gw ...
-!> \param e_fermi fermi level
-!> \param nparam_pade number of pade parameters
-!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
-!> \param coeff_pade pade coefficients
-!> \param start_val start value for the quasiparticle iteration
-! **************************************************************************************************
-   SUBROUTINE get_sigma_c_newton_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
-                                      nparam_pade, omega_points_pade, coeff_pade, start_val)
-
-      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
-      REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
-                                                            e_fermi
-      INTEGER, INTENT(IN)                                :: nparam_pade
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: start_val
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_sigma_c_newton_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: sigma_c
-      INTEGER                                            :: handle, icount
-      REAL(KIND=dp)                                      :: delta, energy_val, m_value, &
-                                                            my_start_val, qp_energy, &
-                                                            qp_energy_old, threshold
-
-      CALL timeset(routineN, handle)
-
-      threshold = 1.0E-7_dp
-
-      IF (PRESENT(start_val)) THEN
-         my_start_val = start_val
-      ELSE
-         my_start_val = Eigenval_scf
-      ENDIF
-
-      qp_energy = my_start_val
-      qp_energy_old = my_start_val
-      delta = 1.0E-3_dp
-
-      icount = 0
-      DO WHILE (ABS(delta) > threshold)
-         icount = icount+1
-         energy_val = qp_energy-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c)
-         !get m_value --> derivative of function
-         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, m_value=m_value)
-         qp_energy_old = qp_energy
-         qp_energy = qp_energy-(Eigenval_scf+Sigma_x_minus_vxc_gw+REAL(sigma_c)-qp_energy)/ &
-                     (m_value-1.0_dp)
-         delta = qp_energy-qp_energy_old
-         IF (icount > 500) THEN
-            CPABORT("Self-consistent quasi-particle solution not found")
-            EXIT
-         ENDIF
-      ENDDO
-
-      gw_energ = REAL(sigma_c)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_sigma_c_newton_pade
-
-! **************************************************************************************************
-!> \brief check "fit" for analytic continuation with pade approximation
-!> \param vec_omega_fit_gw_sign ...
-!> \param Sigma_c_gw complex Sigma_c(iomega) for n_level_gw
-!> \param nparam_pade number of pade parameters
-!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
-!> \param coeff_pade pade coefficients
-!> \param num_fit_points total number of frequency points for the complex Sigma_c
-!> \param n_level_gw_ref n_level_gw+homo-gw_corr_lev_occ
-!> \param output_unit ...
-! **************************************************************************************************
-   SUBROUTINE check_fit_pade(vec_omega_fit_gw_sign, Sigma_c_gw, &
-                             nparam_pade, omega_points_pade, coeff_pade, &
-                             num_fit_points, n_level_gw_ref, output_unit)
-
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_omega_fit_gw_sign
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: Sigma_c_gw
-      INTEGER, INTENT(IN)                                :: nparam_pade
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
-      INTEGER, INTENT(IN)                                :: num_fit_points, n_level_gw_ref, &
-                                                            output_unit
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'check_fit_pade', routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: func_val, im_unit, re_unit
-      INTEGER                                            :: iparam, kkk
-
-      re_unit = (1.0_dp, 0.0_dp)
-      im_unit = (0.0_dp, 1.0_dp)
-
-      WRITE (output_unit, *) ' '
-      WRITE (output_unit, '(T3,A,I5)') 'Check the GW fit for molecular orbital', n_level_gw_ref
-      WRITE (output_unit, '(T3,A)') '-------------------------------------------'
-      WRITE (output_unit, *)
-      WRITE (output_unit, '(T3,5A)') '  omega (i*eV)    ', 'Re(fit) (eV)    ', &
-         'Im(fit) (eV)  ', 'Re(Sig_c) (eV)  ', &
-         'Im(Sig_c) (eV)'
-
-      DO kkk = 1, num_fit_points
-         func_val = re_unit
-         DO iparam = nparam_pade, 2, -1
-            func_val = re_unit+coeff_pade(iparam) &
-                       *(im_unit*vec_omega_fit_gw_sign(kkk)-omega_points_pade(iparam-1))/func_val
-         ENDDO
-
-         func_val = coeff_pade(1)/func_val
-
-         WRITE (output_unit, '(1F16.3,4F16.5)') vec_omega_fit_gw_sign(kkk)*evolt, REAL(func_val)*evolt, &
-            AIMAG(func_val)*evolt, REAL(Sigma_c_gw(kkk))*evolt, &
-            AIMAG(Sigma_c_gw(kkk))*evolt
-      END DO
-
-      WRITE (output_unit, *) ' '
-
-   END SUBROUTINE check_fit_pade
-
-! **************************************************************************************************
-!> \brief Evaluate fit function when calculating tau grid for cosine transform
-!> \param func_val ...
-!> \param x_value ...
-!> \param num_integ_points ...
-!> \param tau_tj ...
-!> \param tau_wj_work ...
-!> \param omega ...
-! **************************************************************************************************
-   PURE SUBROUTINE eval_fit_func_tau_grid_cosine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
-
-      REAL(KIND=dp), INTENT(OUT)                         :: func_val
-      REAL(KIND=dp), INTENT(IN)                          :: x_value
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_tau_grid_cosine', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: iii
-
-      func_val = 0.0_dp
-
-      DO iii = 1, num_integ_points
-
-         ! calculate value of the fit function
-         func_val = func_val+tau_wj_work(iii)*COS(omega*tau_tj(iii))*EXP(-x_value*tau_tj(iii))
-
-      END DO
-
-   END SUBROUTINE eval_fit_func_tau_grid_cosine
-
-! **************************************************************************************************
-!> \brief Evaluate fit function when calculating tau grid for sine transform
-!> \param func_val ...
-!> \param x_value ...
-!> \param num_integ_points ...
-!> \param tau_tj ...
-!> \param tau_wj_work ...
-!> \param omega ...
-! **************************************************************************************************
-   PURE SUBROUTINE eval_fit_func_tau_grid_sine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
-
-      REAL(KIND=dp), INTENT(OUT)                         :: func_val
-      REAL(KIND=dp), INTENT(IN)                          :: x_value
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_tau_grid_sine', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: iii
-
-      func_val = 0.0_dp
-
-      DO iii = 1, num_integ_points
-
-         ! calculate value of the fit function
-         func_val = func_val+tau_wj_work(iii)*SIN(omega*tau_tj(iii))*EXP(-x_value*tau_tj(iii))
-
-      END DO
-
-   END SUBROUTINE eval_fit_func_tau_grid_sine
-
-! **************************************************************************************************
-!> \brief Prints the GW stuff to the output and optinally to an external file.
-!>        Also updates the eigenvalues for eigenvalue-self-consistent GW
-!> \param vec_gw_energ ...
-!> \param vec_gw_energ_error_fit ...
-!> \param z_value ...
-!> \param m_value ...
-!> \param vec_Sigma_x_minus_vxc_gw ...
-!> \param Eigenval ...
-!> \param Eigenval_last ...
-!> \param Eigenval_scf ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param gw_corr_lev_tot ...
-!> \param count_ev_sc_GW ...
-!> \param crossing_search ...
-!> \param homo ...
-!> \param nmo ...
-!> \param unit_nr ...
-!> \param print_gw_details ...
-!> \param remove_neg_virt_energies ...
-!> \param do_alpha ...
-!> \param do_beta ...
-! **************************************************************************************************
-   SUBROUTINE print_and_update_for_ev_sc(vec_gw_energ, vec_gw_energ_error_fit, &
-                                         z_value, m_value, vec_Sigma_x_minus_vxc_gw, Eigenval, &
-                                         Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                                         count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, print_gw_details, &
-                                         remove_neg_virt_energies, do_alpha, do_beta)
-
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: vec_gw_energ, vec_gw_energ_error_fit, &
-                                                            z_value, m_value
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: Eigenval_last
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: Eigenval_scf
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, gw_corr_lev_virt, &
-                                                            gw_corr_lev_tot, count_ev_sc_GW, &
-                                                            crossing_search, homo, nmo, unit_nr
-      LOGICAL, INTENT(IN)                                :: print_gw_details, &
-                                                            remove_neg_virt_energies
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_alpha, do_beta
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'print_and_update_for_ev_sc', &
-         routineP = moduleN//':'//routineN
-
-      CHARACTER(4)                                       :: occ_virt
-      INTEGER                                            :: handle, n_level_gw, n_level_gw_ref
-      LOGICAL                                            :: do_closed_shell, is_energy_okay, &
-                                                            my_do_alpha, my_do_beta
-      REAL(KIND=dp)                                      :: eigen_diff, new_energy
-
-      CALL timeset(routineN, handle)
-
-      IF (PRESENT(do_alpha)) THEN
-         my_do_alpha = do_alpha
-      ELSE
-         my_do_alpha = .FALSE.
-      END IF
-
-      IF (PRESENT(do_beta)) THEN
-         my_do_beta = do_beta
-      ELSE
-         my_do_beta = .FALSE.
-      END IF
-
-      do_closed_shell = .NOT. (my_do_alpha .OR. my_do_beta)
-
-      Eigenval_last(:) = Eigenval(:)
-
-      IF (unit_nr > 0) THEN
-
-         WRITE (unit_nr, *) ' '
-
-         IF (do_closed_shell) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies'
-            WRITE (unit_nr, '(T3,A)') '-------------------------'
-         ELSE IF (my_do_alpha) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of alpha spins'
-            WRITE (unit_nr, '(T3,A)') '----------------------------------------'
-         ELSE IF (my_do_beta) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of beta spins'
-            WRITE (unit_nr, '(T3,A)') '---------------------------------------'
-         END IF
-
-      END IF
-
-      IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
-         WRITE (unit_nr, *) ' '
-         WRITE (unit_nr, '(T5,A)') 'Molecular orbital        MO energy after SCF (eV)        G0W0 QP energy (eV)'
-      END IF
-
-      IF (unit_nr > 0 .AND. print_gw_details) THEN
-         WRITE (unit_nr, '(T3,A)') ' '
-         WRITE (unit_nr, '(T3,A)') 'The GW quasiparticle energies are calculated according to: '
-      END IF
-
-      IF (crossing_search == ri_rpa_g0w0_crossing_none) THEN
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            new_energy = Eigenval_scf(n_level_gw_ref)+vec_gw_energ(n_level_gw)+ &
-                         vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)
-
-            is_energy_okay = .TRUE.
-
-            IF (remove_neg_virt_energies .AND. (n_level_gw_ref > homo .AND. new_energy < Eigenval(homo))) THEN
-               is_energy_okay = .FALSE.
-            END IF
-
-            IF (is_energy_okay) THEN
-               Eigenval(n_level_gw_ref) = new_energy
-            END IF
-         END DO
-
-         IF (unit_nr > 0 .AND. print_gw_details) THEN
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A)') 'E_GW = E_SCF +  Sigc(E_SCF) + Sigx - vxc'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A)') 'The energy unit of the following table is eV. Sigc_fit is a very conservative'
-            WRITE (unit_nr, '(T3,A)') 'estimate of the statistical error of the correlation self-energy caused by the'
-            WRITE (unit_nr, '(T3,A)') 'fitting.'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T14,2A)') 'MO        E_SCF         Sigc', &
-               '     Sigc_fit     Sigx-vxc         E_GW'
-         END IF
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            IF (n_level_gw <= gw_corr_lev_occ) THEN
-               occ_virt = 'occ'
-            ELSE
-               occ_virt = 'vir'
-            END IF
-
-            IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
-               WRITE (unit_nr, '(T5,I9,3A,2F27.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')     ', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-
-            IF (unit_nr > 0 .AND. print_gw_details) THEN
-               WRITE (unit_nr, '(T4,I4,3A,5F13.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  vec_gw_energ(n_level_gw)*evolt, &
-                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
-                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-         END DO
-
-         ! z-shot
-      ELSE
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-            new_energy = (Eigenval_scf(n_level_gw_ref)- &
-                          m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
-                          vec_gw_energ(n_level_gw)+ &
-                          vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
-                         z_value(n_level_gw)
-
-            is_energy_okay = .TRUE.
-
-            IF (remove_neg_virt_energies .AND. (n_level_gw_ref > homo .AND. new_energy < Eigenval(homo))) THEN
-               is_energy_okay = .FALSE.
-            END IF
-
-            IF (is_energy_okay) THEN
-               Eigenval(n_level_gw_ref) = new_energy
-            END IF
-
-         END DO
-
-         IF (unit_nr > 0 .AND. print_gw_details) THEN
-            WRITE (unit_nr, '(T3,A)') 'E_GW = E_SCF + Z * ( Sigc(E_SCF) + Sigx - vxc )'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A)') 'The energy unit of the following table is eV.  Sigc_fit is a very conservative'
-            WRITE (unit_nr, '(T3,2A)') 'estimate of the statistical error of the fitting.'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T13,2A)') 'MO      E_SCF       Sigc', &
-               '   Sigc_fit   Sigx-vxc          Z       E_GW'
-         END IF
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            IF (n_level_gw <= gw_corr_lev_occ) THEN
-               occ_virt = 'occ'
-            ELSE
-               occ_virt = 'vir'
-            END IF
-
-            IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
-               WRITE (unit_nr, '(T5,I9,3A,2F27.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')     ', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-
-            IF (unit_nr > 0 .AND. print_gw_details .AND. MAXVAL(vec_gw_energ_error_fit) < 0.3_dp) THEN
-               WRITE (unit_nr, '(T3,I4,3A,6F11.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  vec_gw_energ(n_level_gw)*evolt, &
-                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
-                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
-                  z_value(n_level_gw), &
-                  Eigenval(n_level_gw_ref)*evolt
-            ELSE IF (unit_nr > 0 .AND. print_gw_details .AND. MAXVAL(vec_gw_energ_error_fit) .GE. 0.3_dp) THEN
-               WRITE (unit_nr, '(T3,I4,3A,2F11.3, ES11.1, 2F11.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  vec_gw_energ(n_level_gw)*evolt, &
-                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
-                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
-                  z_value(n_level_gw), &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-         END DO
-
-         IF (unit_nr > 0) THEN
-            IF (do_closed_shell) THEN
-               WRITE (unit_nr, '(T3,A)') ' '
-               WRITE (unit_nr, '(T3,A,F57.2)') 'GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
-            ELSE IF (my_do_alpha) THEN
-               WRITE (unit_nr, '(T3,A)') ' '
-               WRITE (unit_nr, '(T3,A,F51.2)') 'Alpha GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
-            ELSE IF (my_do_beta) THEN
-               WRITE (unit_nr, '(T3,A)') ' '
-               WRITE (unit_nr, '(T3,A,F52.2)') 'Beta GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
-            END IF
-         END IF
-
-      END IF ! z-shot vs. no crossing
-
-      IF (unit_nr > 0) THEN
-         WRITE (unit_nr, *) ' '
-      END IF
-
-      ! for eigenvalue self-consistent GW, all eigenvalues have to be corrected
-      ! 1) the occupied; check if there are occupied MOs not being corrected by GW
-      IF (gw_corr_lev_occ < homo .AND. gw_corr_lev_occ > 0) THEN
-
-         ! calculate average GW correction for occupied orbitals
-         eigen_diff = 0.0_dp
-
-         DO n_level_gw = 1, gw_corr_lev_occ
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            eigen_diff = eigen_diff+Eigenval(n_level_gw_ref)-Eigenval_last(n_level_gw_ref)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_occ
-
-         ! correct the eigenvalues of the occupied orbitals which have not been corrected by GW
-         DO n_level_gw = 1, homo-gw_corr_lev_occ
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      ! 2) the virtual: check if there are virtual orbitals not being corrected by GW
-      IF (gw_corr_lev_virt < nmo-homo .AND. gw_corr_lev_virt > 0) THEN
-
-         ! calculate average GW correction for virtual orbitals
-         eigen_diff = 0.0_dp
-         DO n_level_gw = 1, gw_corr_lev_virt
-            n_level_gw_ref = n_level_gw+homo
-            eigen_diff = eigen_diff+Eigenval(n_level_gw_ref)-Eigenval_last(n_level_gw_ref)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_virt
-
-         ! correct the eigenvalues of the virtual orbitals which have not been corrected by GW
-         DO n_level_gw = homo+gw_corr_lev_virt+1, nmo
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      IF ((gw_corr_lev_occ == 0 .OR. gw_corr_lev_virt == 0) .AND. count_ev_sc_GW > 1) THEN
-         CALL cp_warn(__LOCATION__, &
-                      "Please increase for eigenvalue-self-consistent GW, the number of "// &
-                      "corrected occupied and/or virtual orbitals above 0.")
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE print_and_update_for_ev_sc
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief ...
@@ -4172,25 +1464,24 @@ CONTAINS
                                        first_cycle_periodic_correction, kpoints, do_mo_coeff_Gamma_only, &
                                        num_kp_grids, eps_kpoint, do_extra_kpoints, do_aux_bas, frac_aux_mos)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: delta_corr
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
       INTEGER, DIMENSION(:), POINTER                     :: kp_grid
-      INTEGER, INTENT(IN)                                :: homo, nmo, gw_corr_lev_occ, &
+      INTEGER                                            :: homo, nmo, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt
-      REAL(KIND=dp), INTENT(IN)                          :: omega
+      REAL(KIND=dp)                                      :: omega
       TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
                                                             matrix_berry_im_mo_mo
-      LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
+      LOGICAL :: first_cycle_periodic_correction
       TYPE(kpoint_type), POINTER                         :: kpoints
-      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only
-      INTEGER, INTENT(IN)                                :: num_kp_grids
-      REAL(KIND=dp), INTENT(IN)                          :: eps_kpoint
-      LOGICAL, INTENT(IN)                                :: do_extra_kpoints, do_aux_bas
-      REAL(KIND=dp), INTENT(IN)                          :: frac_aux_mos
+      LOGICAL                                            :: do_mo_coeff_Gamma_only
+      INTEGER                                            :: num_kp_grids
+      REAL(KIND=dp)                                      :: eps_kpoint
+      LOGICAL                                            :: do_extra_kpoints, do_aux_bas
+      REAL(KIND=dp)                                      :: frac_aux_mos
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_periodic_correction', &
          routineP = moduleN//':'//routineN
@@ -4245,16 +1536,15 @@ CONTAINS
    SUBROUTINE compute_eps_head_Berry(eps_head, kpoints, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, para_env_RPA, &
                                      qs_env, homo, Eigenval, omega)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: eps_head
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eps_head
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
                                                             matrix_berry_im_mo_mo
       TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      INTEGER, INTENT(IN)                                :: homo
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      REAL(KIND=dp), INTENT(IN)                          :: omega
+      INTEGER                                            :: homo
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      REAL(KIND=dp)                                      :: omega
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_eps_head_Berry', &
          routineP = moduleN//':'//routineN
@@ -4412,11 +1702,11 @@ CONTAINS
                                                             matrix_berry_im_mo_mo
       TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only
-      INTEGER, INTENT(IN)                                :: homo, nmo, gw_corr_lev_virt
-      REAL(KIND=dp), INTENT(IN)                          :: eps_kpoint
-      LOGICAL, INTENT(IN)                                :: do_aux_bas
-      REAL(KIND=dp), INTENT(IN)                          :: frac_aux_mos
+      LOGICAL                                            :: do_mo_coeff_Gamma_only
+      INTEGER                                            :: homo, nmo, gw_corr_lev_virt
+      REAL(KIND=dp)                                      :: eps_kpoint
+      LOGICAL                                            :: do_aux_bas
+      REAL(KIND=dp)                                      :: frac_aux_mos
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_berry_phase', &
          routineP = moduleN//':'//routineN
@@ -4927,7 +2217,7 @@ CONTAINS
    SUBROUTINE remove_unnecessary_blocks(mat_mo_coeff_Gamma_occ_and_GW, homo, gw_corr_lev_virt)
 
       TYPE(dbcsr_type), POINTER                          :: mat_mo_coeff_Gamma_occ_and_GW
-      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_virt
+      INTEGER                                            :: homo, gw_corr_lev_virt
 
       INTEGER                                            :: col, col_offset, row
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
@@ -4956,284 +2246,6 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param Berry_nn_local ...
-!> \param matrix_berry_mo_mo ...
-!> \param para_env ...
-!> \param homo ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-! **************************************************************************************************
-   SUBROUTINE replicate_Berry_nn(Berry_nn_local, matrix_berry_mo_mo, para_env, homo, gw_corr_lev_occ, gw_corr_lev_virt)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: Berry_nn_local
-      TYPE(dbcsr_type), POINTER                          :: matrix_berry_mo_mo
-      TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_occ, gw_corr_lev_virt
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'replicate_Berry_nn', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: col, handle, i_row, n_level_gw, row, &
-                                                            row_offset, row_size
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
-      TYPE(dbcsr_iterator_type)                          :: iter
-
-      CALL timeset(routineN, handle)
-
-      Berry_nn_local = 0.0_dp
-
-      ! fill buffer_send
-      CALL dbcsr_iterator_start(iter, matrix_berry_mo_mo)
-      DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-         CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                        row_size=row_size, row_offset=row_offset)
-
-         IF (row .NE. col) CYCLE
-
-         DO i_row = 1, row_size
-
-            n_level_gw = i_row+row_offset-1
-
-            IF (n_level_gw < 1+homo-gw_corr_lev_occ .OR. n_level_gw > homo+gw_corr_lev_virt) CYCLE
-
-            Berry_nn_local(n_level_gw) = data_block(i_row, i_row)
-
-         END DO
-
-      END DO
-
-      CALL dbcsr_iterator_stop(iter)
-
-      CALL mp_sum(Berry_nn_local, para_env%group)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE replicate_Berry_nn
-
-! **************************************************************************************************
-!> \brief ...
-!> \param Berry_ia_local ...
-!> \param matrix_berry_mo_mo ...
-!> \param para_env ...
-!> \param homo ...
-! **************************************************************************************************
-   SUBROUTINE replicate_Berry_ia(Berry_ia_local, matrix_berry_mo_mo, para_env, homo)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: Berry_ia_local
-      TYPE(dbcsr_type), POINTER                          :: matrix_berry_mo_mo
-      TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: homo
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'replicate_Berry_ia', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER :: block_counter, block_size, col, col_offset, col_size, col_size_modified, &
-         col_start_loc_array, entry_counter, handle, iblk, imepos, msg_offset, num_blocks_send, &
-         num_entries_send, row, row_offset, row_offset_modified, row_size, row_size_modified, &
-         row_start_block, row_start_loc_array
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_rec, num_entries_rec, &
-                                                            sizes_rec, sizes_send
-      INTEGER, DIMENSION(:, :), POINTER                  :: req_array
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
-      TYPE(dbcsr_iterator_type)                          :: iter
-      TYPE(integ_mat_buffer_type), ALLOCATABLE, &
-         DIMENSION(:)                                    :: buffer_rec, buffer_send
-
-      CALL timeset(routineN, handle)
-
-      num_blocks_send = 0
-      num_entries_send = 0
-
-      NULLIFY (data_block)
-
-      CALL dbcsr_iterator_start(iter, matrix_berry_mo_mo)
-      DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-         CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                        row_size=row_size, col_size=col_size, &
-                                        row_offset=row_offset, col_offset=col_offset)
-
-         IF (row_offset+row_size <= homo .OR. col_offset > homo) CYCLE
-
-         IF (row_offset <= homo) THEN
-            row_size_modified = row_size+row_offset-homo-1
-         ELSE
-            row_size_modified = row_size
-         END IF
-
-         IF (col_offset+col_size-1 > homo) THEN
-            col_size_modified = homo-col_offset+1
-         ELSE
-            col_size_modified = col_size
-         END IF
-
-         num_blocks_send = num_blocks_send+1
-         num_entries_send = num_entries_send+row_size_modified*col_size_modified
-
-      END DO
-
-      CALL dbcsr_iterator_stop(iter)
-
-      ALLOCATE (buffer_rec(0:para_env%num_pe-1))
-      ALLOCATE (buffer_send(0:para_env%num_pe-1))
-
-      ALLOCATE (num_entries_rec(0:para_env%num_pe-1))
-      ALLOCATE (num_blocks_rec(0:para_env%num_pe-1))
-
-      IF (para_env%num_pe > 1) THEN
-
-         ALLOCATE (sizes_rec(0:2*para_env%num_pe-1))
-         ALLOCATE (sizes_send(0:2*para_env%num_pe-1))
-
-         DO imepos = 0, para_env%num_pe-1
-            sizes_send(2*imepos) = num_entries_send
-            sizes_send(2*imepos+1) = num_blocks_send
-         END DO
-
-         CALL mp_alltoall(sizes_send, sizes_rec, 2, para_env%group)
-
-         DO imepos = 0, para_env%num_pe-1
-            num_entries_rec(imepos) = sizes_rec(2*imepos)
-            num_blocks_rec(imepos) = sizes_rec(2*imepos+1)
-         END DO
-
-         DEALLOCATE (sizes_rec, sizes_send)
-
-      ELSE
-
-         num_entries_rec(0) = num_entries_send
-         num_blocks_rec(0) = num_blocks_send
-
-      END IF
-
-      ! allocate data message and corresponding indices
-      DO imepos = 0, para_env%num_pe-1
-
-         ALLOCATE (buffer_rec(imepos)%msg(num_entries_rec(imepos)))
-         buffer_rec(imepos)%msg = 0.0_dp
-
-         ALLOCATE (buffer_send(imepos)%msg(num_entries_send))
-         buffer_send(imepos)%msg = 0.0_dp
-
-         ALLOCATE (buffer_rec(imepos)%indx(num_blocks_rec(imepos), 5))
-         buffer_rec(imepos)%indx = 0
-
-         ALLOCATE (buffer_send(imepos)%indx(num_blocks_send, 5))
-         buffer_send(imepos)%indx = 0
-
-      END DO
-
-      entry_counter = 0
-      block_counter = 0
-
-      NULLIFY (data_block)
-
-      ! fill buffer_send
-      CALL dbcsr_iterator_start(iter, matrix_berry_mo_mo)
-      DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-         CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                        row_size=row_size, col_size=col_size, &
-                                        row_offset=row_offset, col_offset=col_offset)
-
-         IF (row_offset+row_size <= homo .OR. col_offset > homo) CYCLE
-
-         IF (row_offset <= homo) THEN
-            row_size_modified = row_size+row_offset-homo-1
-            row_start_block = row_size-row_size_modified+1
-            row_offset_modified = homo+1
-         ELSE
-            row_start_block = 1
-            row_size_modified = row_size
-            row_offset_modified = row_offset
-         END IF
-
-         IF (col_offset+col_size-1 > homo) THEN
-            col_size_modified = homo-col_offset+1
-         ELSE
-            col_size_modified = col_size
-         END IF
-
-         block_size = row_size_modified*col_size_modified
-
-         DO imepos = 0, para_env%num_pe-1
-
-            buffer_send(imepos)%msg(entry_counter+1:entry_counter+block_size) = &
-               RESHAPE(data_block(row_start_block:row_size, 1:col_size_modified), (/block_size/))
-
-            buffer_send(imepos)%indx(block_counter+1, 1) = row_offset_modified
-            buffer_send(imepos)%indx(block_counter+1, 2) = row_size_modified
-            buffer_send(imepos)%indx(block_counter+1, 3) = col_offset
-            buffer_send(imepos)%indx(block_counter+1, 4) = col_size_modified
-            buffer_send(imepos)%indx(block_counter+1, 5) = entry_counter
-
-         END DO
-
-         entry_counter = entry_counter+block_size
-
-         block_counter = block_counter+1
-
-      END DO
-
-      CALL dbcsr_iterator_stop(iter)
-
-      ALLOCATE (req_array(1:para_env%num_pe, 4))
-
-      ALLOCATE (sizes_rec(0:para_env%num_pe-1))
-      ALLOCATE (sizes_send(0:para_env%num_pe-1))
-
-      DO imepos = 0, para_env%num_pe-1
-
-         sizes_send(imepos) = num_entries_send
-         sizes_rec(imepos) = num_entries_rec(imepos)
-
-      END DO
-
-      CALL communicate_buffer(para_env, sizes_rec, sizes_send, buffer_rec, buffer_send, req_array)
-
-      DEALLOCATE (req_array, sizes_rec, sizes_send)
-
-      Berry_ia_local = 0.0_dp
-
-      ! fill Berry_ia_local
-      DO imepos = 0, para_env%num_pe-1
-
-         DO iblk = 1, num_blocks_rec(imepos)
-
-            row_start_loc_array = buffer_rec(imepos)%indx(iblk, 1)-homo
-            row_size = buffer_rec(imepos)%indx(iblk, 2)
-            col_start_loc_array = buffer_rec(imepos)%indx(iblk, 3)
-            col_size = buffer_rec(imepos)%indx(iblk, 4)
-            msg_offset = buffer_rec(imepos)%indx(iblk, 5)
-
-            Berry_ia_local(row_start_loc_array:row_start_loc_array+row_size-1, &
-                           col_start_loc_array:col_start_loc_array+col_size-1) = &
-               RESHAPE(buffer_rec(imepos)%msg(msg_offset+1:msg_offset+row_size*col_size), &
-                       (/row_size, col_size/))
-
-         END DO
-
-      END DO
-
-      ! deallocate data message and corresponding indices
-      DO imepos = 0, para_env%num_pe-1
-
-         DEALLOCATE (buffer_rec(imepos)%msg)
-         DEALLOCATE (buffer_send(imepos)%msg)
-         DEALLOCATE (buffer_rec(imepos)%indx)
-         DEALLOCATE (buffer_send(imepos)%indx)
-
-      END DO
-
-      CALL timestop(handle)
-
-   END SUBROUTINE replicate_Berry_ia
-
-! **************************************************************************************************
-! ...
-! **************************************************************************************************
-!> \brief ...
 !> \param delta_corr ...
 !> \param eps_inv_head ...
 !> \param kpoints ...
@@ -5250,25 +2262,18 @@ CONTAINS
                                                 matrix_berry_im_mo_mo, homo, gw_corr_lev_occ, gw_corr_lev_virt, &
                                                 para_env_RPA, do_extra_kpoints)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: delta_corr
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: eps_inv_head
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr, eps_inv_head
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
                                                             matrix_berry_im_mo_mo
-      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_occ, gw_corr_lev_virt
+      INTEGER                                            :: homo, gw_corr_lev_occ, gw_corr_lev_virt
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env_RPA
-      LOGICAL, INTENT(IN)                                :: do_extra_kpoints
+      LOGICAL                                            :: do_extra_kpoints
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_sum_for_eps_inv_head_Berry', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: col, col_offset, col_size, handle, &
-                                                            i_col, i_row, ikp, m_level, &
-                                                            n_level_gw, nkp, row, row_offset, &
-                                                            row_size
+      INTEGER                                            :: col, col_offset, col_size, i_col, i_row, &
+                                                            ikp, m_level, n_level_gw, nkp, row, &
+                                                            row_offset, row_size
       REAL(KIND=dp)                                      :: abs_k_square, cell_volume, &
                                                             check_int_one_over_ksq, contribution, &
                                                             weight
@@ -5277,8 +2282,6 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dbcsr_iterator_type)                          :: iter, iter_new
-
-      CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env=qs_env, cell=cell)
 
@@ -5433,29 +2436,24 @@ CONTAINS
 
       END IF
 
-      CALL timestop(handle)
-
    END SUBROUTINE kpoint_sum_for_eps_inv_head_Berry
 
-! **************************************************************************************************
-! ...
 ! **************************************************************************************************
 !> \brief ...
 !> \param eps_inv_head ...
 !> \param eps_head ...
 !> \param kpoints ...
 ! **************************************************************************************************
-   PURE SUBROUTINE compute_eps_inv_head(eps_inv_head, eps_head, kpoints)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: eps_inv_head
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: eps_head
+   SUBROUTINE compute_eps_inv_head(eps_inv_head, eps_head, kpoints)
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eps_inv_head, eps_head
       TYPE(kpoint_type), POINTER                         :: kpoints
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_eps_inv_head', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: ikp, nkp
+      INTEGER                                            :: handle, ikp, nkp
+
+      CALL timeset(routineN, handle)
 
       nkp = kpoints%nkp
 
@@ -5467,10 +2465,10 @@ CONTAINS
 
       END DO
 
+      CALL timestop(handle)
+
    END SUBROUTINE compute_eps_inv_head
 
-! **************************************************************************************************
-! ...
 ! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
@@ -5488,16 +2486,14 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(kpoint_type), POINTER                         :: kpoints
       INTEGER, DIMENSION(:), POINTER                     :: kp_grid
-      INTEGER, INTENT(IN)                                :: num_kp_grids
+      INTEGER                                            :: num_kp_grids
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT)      :: h_inv
-      INTEGER, INTENT(IN)                                :: nmo
-      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only, do_extra_kpoints
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: h_inv
+      INTEGER                                            :: nmo
+      LOGICAL                                            :: do_mo_coeff_Gamma_only, do_extra_kpoints
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_kpoints', routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: end_kp, handle, i, i_grid_level, ix, iy, &
-                                                            iz, nkp_inner_grid, nkp_outer_grid, &
+      INTEGER                                            :: end_kp, i, i_grid_level, ix, iy, iz, &
+                                                            nkp_inner_grid, nkp_outer_grid, &
                                                             npoints, start_kp
       INTEGER, DIMENSION(3)                              :: outer_kp_grid
       REAL(KIND=dp)                                      :: kpoint_weight_left, single_weight
@@ -5505,8 +2501,6 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_environment_type), POINTER                 :: qs_env_kp_Gamma_only
-
-      CALL timeset(routineN, handle)
 
       NULLIFY (kpoints, cell, particle_set, qs_env_kp_Gamma_only)
 
@@ -5681,8 +2675,6 @@ CONTAINS
 
       END IF
 
-      CALL timestop(handle)
-
    END SUBROUTINE get_kpoints
 
 ! **************************************************************************************************
@@ -5691,11 +2683,10 @@ CONTAINS
 !> \param Eigenval_DFT ...
 !> \param eps_eigenval ...
 ! **************************************************************************************************
-   PURE SUBROUTINE average_degenerate_levels(vec_Sigma_c_gw, Eigenval_DFT, eps_eigenval)
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval_DFT
-      REAL(KIND=dp), INTENT(IN)                          :: eps_eigenval
+   SUBROUTINE average_degenerate_levels(vec_Sigma_c_gw, Eigenval_DFT, eps_eigenval)
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval_DFT
+      REAL(KIND=dp)                                      :: eps_eigenval
 
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: avg_self_energy
       INTEGER :: degeneracy, first_degenerate_level, i_deg_level, i_level_gw, j_deg_level, jquad, &
@@ -5749,14 +2740,14 @@ CONTAINS
 
          DO jquad = 1, num_integ_points
 
-            avg_self_energy(jquad) = SUM(vec_Sigma_c_gw(first_degenerate_level:first_degenerate_level+degeneracy-1, jquad)) &
+            avg_self_energy(jquad) = SUM(vec_Sigma_c_gw(first_degenerate_level:first_degenerate_level+degeneracy-1, jquad, 1)) &
                                      /REAL(degeneracy, KIND=dp)
 
          END DO
 
          DO j_deg_level = 0, degeneracy-1
 
-            vec_Sigma_c_gw(first_degenerate_level+j_deg_level, :) = avg_self_energy(:)
+            vec_Sigma_c_gw(first_degenerate_level+j_deg_level, :, 1) = avg_self_energy(:)
 
          END DO
 
@@ -5766,228 +2757,2048 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param num_integ_points ...
-!> \param tau_tj ...
-!> \param weights_cos_tf_w_to_t ...
-!> \param omega_tj ...
-!> \param E_min ...
-!> \param E_max ...
-!> \param max_error ...
-!> \param num_points_per_magnitude ...
+!> \param Eigenval ...
+!> \param Eigenval_scf ...
+!> \param Eigenval_kp ...
+!> \param Eigenval_scf_kp ...
+!> \param kpoints ...
+!> \param ikp ...
+!> \param iter_ev_sc ...
+!> \param my_open_shell ...
 ! **************************************************************************************************
-   SUBROUTINE get_l_sq_wghts_cos_tf_w_to_t(num_integ_points, tau_tj, weights_cos_tf_w_to_t, omega_tj, &
-                                           E_min, E_max, max_error, num_points_per_magnitude)
+   SUBROUTINE get_eigenval_for_conti(Eigenval, Eigenval_scf, Eigenval_kp, Eigenval_scf_kp, kpoints, ikp, iter_ev_sc, my_open_shell)
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval, Eigenval_scf
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: Eigenval_kp, Eigenval_scf_kp
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: ikp, iter_ev_sc
+      LOGICAL                                            :: my_open_shell
 
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: weights_cos_tf_w_to_t
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj
-      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_cos_tf_w_to_t', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_eigenval_for_conti', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, iii, info, jjj, jquad, lwork, &
-                                                            num_x_nodes
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
-      REAL(KIND=dp)                                      :: chi2_min_jquad, multiplicator, omega, &
-                                                            tau, x_value
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_wj_work, sing_values, vec_UTy, &
-                                                            work, work_array, x_values, y_values
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: mat_A, mat_SinvVSinvSigma, &
-                                                            mat_SinvVSinvT, mat_U
+      INTEGER                                            :: handle, ispin, jkp, nkp, nmo, nspin
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
+      TYPE(mo_set_type), POINTER                         :: mo_set
 
       CALL timeset(routineN, handle)
 
-      ! take num_points_per_magnitude points per 10-interval
-      num_x_nodes = (INT(LOG10(E_max/E_min))+1)*num_points_per_magnitude
+      ! only implemented for non-evscGW
+      CPASSERT(iter_ev_sc == 1)
 
-      ! take at least as many x points as integration points to have clear
-      ! input for the singular value decomposition
-      num_x_nodes = MAX(num_x_nodes, num_integ_points)
+      CALL get_kpoint_info(kpoints, nkp=nkp)
 
-      ALLOCATE (x_values(num_x_nodes))
-      x_values = 0.0_dp
-      ALLOCATE (y_values(num_x_nodes))
-      y_values = 0.0_dp
-      ALLOCATE (mat_A(num_x_nodes, num_integ_points))
-      mat_A = 0.0_dp
-      ALLOCATE (omega_wj_work(num_integ_points))
-      omega_wj_work = 0.0_dp
-      ALLOCATE (work_array(2*num_integ_points))
-      work_array = 0.0_dp
-      ALLOCATE (sing_values(num_integ_points))
-      sing_values = 0.0_dp
-      ALLOCATE (mat_U(num_x_nodes, num_x_nodes))
-      mat_U = 0.0_dp
-      ALLOCATE (mat_SinvVSinvT(num_x_nodes, num_integ_points))
+      nmo = SIZE(Eigenval)
 
-      mat_SinvVSinvT = 0.0_dp
-      ! double the value nessary for 'A' to achieve good performance
-      lwork = 8*num_integ_points*num_integ_points+12*num_integ_points+2*num_x_nodes
-      ALLOCATE (work(lwork))
-      work = 0.0_dp
-      ALLOCATE (iwork(8*num_integ_points))
-      iwork = 0
-      ALLOCATE (mat_SinvVSinvSigma(num_integ_points, num_x_nodes))
-      mat_SinvVSinvSigma = 0.0_dp
-      ALLOCATE (vec_UTy(num_x_nodes))
-      vec_UTy = 0.0_dp
+      IF (my_open_shell) THEN
+         nspin = 2
+      ELSE
+         nspin = 1
+      END IF
 
-      ! set the x-values logarithmically in the interval [Emin,Emax]
-      multiplicator = (E_max/E_min)**(1.0_dp/(REAL(num_x_nodes, KIND=dp)-1.0_dp))
-      DO iii = 1, num_x_nodes
-         x_values(iii) = E_min*multiplicator**(iii-1)
-      END DO
+      IF (ikp == 1) THEN
+         ALLOCATE (Eigenval_kp(SIZE(Eigenval), nkp))
+         ALLOCATE (Eigenval_scf_kp(SIZE(Eigenval), nkp))
 
-      max_error = 0.0_dp
+         DO jkp = 1, nkp
 
-      ! loop over all tau time points
-      DO jquad = 1, num_integ_points
+            DO ispin = 1, nspin
 
-         chi2_min_jquad = 100.0_dp
+               mo_set => kpoints%kp_env(jkp)%kpoint_env%mos(1, ispin)%mo_set
 
-         tau = tau_tj(jquad)
+               CALL get_mo_set(mo_set=mo_set, eigenvalues=mo_eigenvalues)
 
-         ! y=exp(-x*|tau_k|)
-         DO iii = 1, num_x_nodes
-            y_values(iii) = EXP(-x_values(iii)*tau)
-         END DO
+               Eigenval_kp(1:nmo, jkp) = mo_eigenvalues(1:nmo)
+               Eigenval_scf_kp(1:nmo, jkp) = mo_eigenvalues(1:nmo)
 
-         ! calculate mat_A
-         DO jjj = 1, num_integ_points
-            DO iii = 1, num_x_nodes
-               omega = omega_tj(jjj)
-               x_value = x_values(iii)
-               mat_A(iii, jjj) = COS(tau*omega)*2.0_dp*x_value/(x_value**2+omega**2)
             END DO
+
          END DO
-
-         ! Singular value decomposition of mat_A
-         CALL DGESDD('A', num_x_nodes, num_integ_points, mat_A, num_x_nodes, sing_values, mat_U, num_x_nodes, &
-                     mat_SinvVSinvT, num_x_nodes, work, lwork, iwork, info)
-
-         CPASSERT(info == 0)
-
-         ! integration weights = V Sigma U^T y
-         ! 1) V*Sigma
-         DO jjj = 1, num_integ_points
-            DO iii = 1, num_integ_points
-               mat_SinvVSinvSigma(iii, jjj) = mat_SinvVSinvT(jjj, iii)/sing_values(jjj)
-            END DO
-         END DO
-
-         ! 2) U^T y
-         CALL DGEMM('T', 'N', num_x_nodes, 1, num_x_nodes, 1.0_dp, mat_U, num_x_nodes, y_values, num_x_nodes, &
-                    0.0_dp, vec_UTy, num_x_nodes)
-
-         ! 3) (V*Sigma) * (U^T y)
-         CALL DGEMM('N', 'N', num_integ_points, 1, num_x_nodes, 1.0_dp, mat_SinvVSinvSigma, num_integ_points, vec_UTy, &
-                    num_x_nodes, 0.0_dp, omega_wj_work, num_integ_points)
-
-         weights_cos_tf_w_to_t(jquad, :) = omega_wj_work(:)
-
-         CALL calc_max_error_fit_omega_grid_with_cosine(max_error, tau, omega_tj, omega_wj_work, x_values, &
-                                                        y_values, num_integ_points, num_x_nodes)
-
-      END DO ! jquad
-
-      DEALLOCATE (x_values, y_values, mat_A, omega_wj_work, work_array, sing_values, mat_U, mat_SinvVSinvT, &
-                  work, iwork, mat_SinvVSinvSigma, vec_UTy)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_l_sq_wghts_cos_tf_w_to_t
-
-! **************************************************************************************************
-!> \brief ...
-!> \param max_error ...
-!> \param tau ...
-!> \param omega_tj ...
-!> \param omega_wj_work ...
-!> \param x_values ...
-!> \param y_values ...
-!> \param num_integ_points ...
-!> \param num_x_nodes ...
-! **************************************************************************************************
-   PURE SUBROUTINE calc_max_error_fit_omega_grid_with_cosine(max_error, tau, omega_tj, omega_wj_work, x_values, &
-                                                             y_values, num_integ_points, num_x_nodes)
-
-      REAL(KIND=dp), INTENT(OUT)                         :: max_error
-      REAL(KIND=dp), INTENT(IN)                          :: tau
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj, omega_wj_work, x_values, &
-                                                            y_values
-      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_omega_grid_with_cosine', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: kkk
-      REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
-
-      max_error_tmp = 0.0_dp
-
-      DO kkk = 1, num_x_nodes
-
-         func_val = 0.0_dp
-
-         CALL eval_fit_func_omega_grid_cosine(func_val, x_values(kkk), num_integ_points, omega_tj, omega_wj_work, tau)
-
-         IF (ABS(y_values(kkk)-func_val) > max_error_tmp) THEN
-            max_error_tmp = ABS(y_values(kkk)-func_val)
-            func_val_temp = func_val
-         END IF
-
-      END DO
-
-      IF (max_error_tmp > max_error) THEN
-
-         max_error = max_error_tmp
 
       END IF
 
-   END SUBROUTINE calc_max_error_fit_omega_grid_with_cosine
+      Eigenval(1:nmo) = Eigenval_kp(1:nmo, ikp)
+      Eigenval_scf(1:nmo) = Eigenval_scf_kp(1:nmo, ikp)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param func_val ...
-!> \param x_value ...
-!> \param num_integ_points ...
-!> \param omega_tj ...
-!> \param omega_wj_work ...
-!> \param tau ...
+!> \param vec_gw_energ ...
+!> \param vec_gw_energ_error_fit ...
+!> \param vec_omega_fit_gw ...
+!> \param z_value ...
+!> \param m_value ...
+!> \param vec_Sigma_c_gw ...
+!> \param vec_Sigma_x_minus_vxc_gw ...
+!> \param Eigenval ...
+!> \param Eigenval_scf ...
+!> \param n_level_gw ...
+!> \param gw_corr_lev_occ ...
+!> \param num_poles ...
+!> \param num_fit_points ...
+!> \param max_iter_fit ...
+!> \param crossing_search ...
+!> \param homo ...
+!> \param check_fit ...
+!> \param stop_crit ...
+!> \param fermi_level_offset ...
+!> \param do_gw_im_time ...
 ! **************************************************************************************************
-   PURE SUBROUTINE eval_fit_func_omega_grid_cosine(func_val, x_value, num_integ_points, omega_tj, omega_wj_work, tau)
-      REAL(KIND=dp), INTENT(OUT)                         :: func_val
-      REAL(KIND=dp), INTENT(IN)                          :: x_value
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj, omega_wj_work
-      REAL(KIND=dp), INTENT(IN)                          :: tau
+   SUBROUTINE fit_and_continuation_2pole(vec_gw_energ, vec_gw_energ_error_fit, vec_omega_fit_gw, &
+                                         z_value, m_value, vec_Sigma_c_gw, vec_Sigma_x_minus_vxc_gw, &
+                                         Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, num_poles, &
+                                         num_fit_points, max_iter_fit, crossing_search, homo, check_fit, stop_crit, &
+                                         fermi_level_offset, do_gw_im_time)
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_omega_grid_cosine', &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_gw_energ, vec_gw_energ_error_fit, &
+                                                            vec_omega_fit_gw, z_value, m_value
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: vec_Sigma_c_gw
+      REAL(KIND=dp), DIMENSION(:)                        :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
+                                                            Eigenval_scf
+      INTEGER                                            :: n_level_gw, gw_corr_lev_occ, num_poles, &
+                                                            num_fit_points, max_iter_fit, &
+                                                            crossing_search, homo
+      LOGICAL                                            :: check_fit
+      REAL(KIND=dp)                                      :: stop_crit, fermi_level_offset
+      LOGICAL                                            :: do_gw_im_time
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'fit_and_continuation_2pole', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: iii
-      REAL(KIND=dp)                                      :: omega
+      COMPLEX(KIND=dp)                                   :: func_val, im_unit, one, re_unit, rho1, &
+                                                            zero
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: dLambda, dLambda_2, Lambda, &
+                                                            Lambda_without_offset, vec_b_gw, &
+                                                            vec_b_gw_copy
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: mat_A_gw, mat_B_gw
+      INTEGER                                            :: handle4, ierr, iii, iiter, info, &
+                                                            integ_range, jjj, jquad, kkk, &
+                                                            n_level_gw_ref, num_var, output_unit, &
+                                                            xpos
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ipiv
+      LOGICAL                                            :: could_exit
+      REAL(KIND=dp) :: chi2, chi2_old, delta, deriv_val_real, e_fermi, gw_energ, Ldown, &
+         level_energ_GW, Lup, range_step, ScalParam, sign_occ_virt, stat_error
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: Lambda_Im, Lambda_Re, stat_errors, &
+                                                            vec_N_gw, vec_omega_fit_gw_sign
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: mat_N_gw
 
-      func_val = 0.0_dp
+      output_unit = cp_logger_get_default_io_unit()
 
-      DO iii = 1, num_integ_points
+      im_unit = (0.0_dp, 1.0_dp)
+      re_unit = (1.0_dp, 0.0_dp)
 
-         ! calculate value of the fit function
-         omega = omega_tj(iii)
-         func_val = func_val+omega_wj_work(iii)*COS(tau*omega)*2.0_dp*x_value/(x_value**2+omega**2)
+      num_var = 2*num_poles+1
+      ALLOCATE (Lambda(num_var))
+      Lambda = (0.0_dp, 0.0_dp)
+      ALLOCATE (Lambda_without_offset(num_var))
+      Lambda_without_offset = (0.0_dp, 0.0_dp)
+      ALLOCATE (Lambda_Re(num_var))
+      Lambda_Re = 0.0_dp
+      ALLOCATE (Lambda_Im(num_var))
+      Lambda_Im = 0.0_dp
+
+      ALLOCATE (vec_omega_fit_gw_sign(num_fit_points))
+
+      IF (n_level_gw <= gw_corr_lev_occ) THEN
+         sign_occ_virt = -1.0_dp
+      ELSE
+         sign_occ_virt = 1.0_dp
+      END IF
+
+      DO jquad = 1, num_fit_points
+         vec_omega_fit_gw_sign(jquad) = ABS(vec_omega_fit_gw(jquad))*sign_occ_virt
+      END DO
+
+      ! initial guess
+      range_step = (vec_omega_fit_gw_sign(num_fit_points)-vec_omega_fit_gw_sign(1))/(num_poles-1)
+      DO iii = 1, num_poles
+         Lambda_Im(2*iii+1) = vec_omega_fit_gw_sign(1)+(iii-1)*range_step
+      END DO
+      range_step = (vec_omega_fit_gw_sign(num_fit_points)-vec_omega_fit_gw_sign(1))/num_poles
+      DO iii = 1, num_poles
+         Lambda_Re(2*iii+1) = ABS(vec_omega_fit_gw_sign(1)+(iii-0.5_dp)*range_step)
+      END DO
+
+      DO iii = 1, num_var
+         Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)
+      END DO
+
+      CALL calc_chi2(chi2_old, Lambda, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
+                     num_fit_points, n_level_gw)
+
+      ALLOCATE (mat_A_gw(num_poles+1, num_poles+1))
+      ALLOCATE (vec_b_gw(num_poles+1))
+      ALLOCATE (ipiv(num_poles+1))
+      mat_A_gw = (0.0_dp, 0.0_dp)
+      vec_b_gw = 0.0_dp
+
+      DO iii = 1, num_poles+1
+         mat_A_gw(iii, 1) = (1.0_dp, 0.0_dp)
+      END DO
+      integ_range = num_fit_points/num_poles
+      DO kkk = 1, num_poles+1
+         xpos = (kkk-1)*integ_range+1
+         xpos = MIN(xpos, num_fit_points)
+         ! calculate coefficient at this point
+         DO iii = 1, num_poles
+            jjj = iii*2
+            func_val = (1.0_dp, 0.0_dp)/(im_unit*vec_omega_fit_gw_sign(xpos)- &
+                                         CMPLX(Lambda_Re(jjj+1), Lambda_Im(jjj+1), KIND=dp))
+            mat_A_gw(kkk, iii+1) = func_val
+         END DO
+         vec_b_gw(kkk) = vec_Sigma_c_gw(n_level_gw, xpos)
+      END DO
+
+      ! Solve system of linear equations
+      CALL ZGETRF(num_poles+1, num_poles+1, mat_A_gw, num_poles+1, ipiv, info)
+
+      CALL ZGETRS('N', num_poles+1, 1, mat_A_gw, num_poles+1, ipiv, vec_b_gw, num_poles+1, info)
+
+      Lambda_Re(1) = REAL(vec_b_gw(1))
+      Lambda_Im(1) = AIMAG(vec_b_gw(1))
+      DO iii = 1, num_poles
+         jjj = iii*2
+         Lambda_Re(jjj) = REAL(vec_b_gw(iii+1))
+         Lambda_Im(jjj) = AIMAG(vec_b_gw(iii+1))
+      END DO
+
+      DEALLOCATE (mat_A_gw)
+      DEALLOCATE (vec_b_gw)
+      DEALLOCATE (ipiv)
+
+      ALLOCATE (mat_A_gw(num_var*2, num_var*2))
+      ALLOCATE (mat_B_gw(num_fit_points, num_var*2))
+      ALLOCATE (dLambda(num_fit_points))
+      ALLOCATE (dLambda_2(num_fit_points))
+      ALLOCATE (vec_b_gw(num_var*2))
+      ALLOCATE (vec_b_gw_copy(num_var*2))
+      ALLOCATE (ipiv(num_var*2))
+
+      ScalParam = 0.01_dp
+      Ldown = 1.5_dp
+      Lup = 10.0_dp
+      could_exit = .FALSE.
+
+      ! iteration loop for fitting
+      DO iiter = 1, max_iter_fit
+
+         CALL timeset(routineN//"_fit_loop_1", handle4)
+
+         ! calc delta lambda
+         DO iii = 1, num_var
+            Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)
+         END DO
+         dLambda = (0.0_dp, 0.0_dp)
+
+         DO kkk = 1, num_fit_points
+            func_val = Lambda(1)
+            DO iii = 1, num_poles
+               jjj = iii*2
+               func_val = func_val+Lambda(jjj)/(vec_omega_fit_gw_sign(kkk)*im_unit-Lambda(jjj+1))
+            END DO
+            dLambda(kkk) = vec_Sigma_c_gw(n_level_gw, kkk)-func_val
+         END DO
+         rho1 = SUM(dLambda*dLambda)
+
+         ! fill matrix
+         mat_B_gw = (0.0_dp, 0.0_dp)
+         DO iii = 1, num_fit_points
+            mat_B_gw(iii, 1) = 1.0_dp
+            mat_B_gw(iii, num_var+1) = im_unit
+         END DO
+         DO iii = 1, num_poles
+            jjj = iii*2
+            DO kkk = 1, num_fit_points
+               mat_B_gw(kkk, jjj) = 1.0_dp/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
+               mat_B_gw(kkk, jjj+num_var) = im_unit/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
+               mat_B_gw(kkk, jjj+1) = Lambda(jjj)/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))**2
+               mat_B_gw(kkk, jjj+1+num_var) = (-Lambda_Im(jjj)+im_unit*Lambda_Re(jjj))/ &
+                                              (im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))**2
+            END DO
+         END DO
+
+         CALL timestop(handle4)
+
+         CALL timeset(routineN//"_fit_matmul_1", handle4)
+
+         one = (1.0_dp, 0.0_dp)
+         zero = (0.0_dp, 0.0_dp)
+         CALL zgemm('C', 'N', num_var*2, num_var*2, num_fit_points, one, mat_B_gw, num_fit_points, mat_B_gw, num_fit_points, &
+                    zero, mat_A_gw, num_var*2)
+         CALL timestop(handle4)
+
+         CALL timeset(routineN//"_fit_zgemv_1", handle4)
+         CALL zgemv('C', num_fit_points, num_var*2, one, mat_B_gw, num_fit_points, dLambda, 1, &
+                    zero, vec_b_gw, 1)
+
+         CALL timestop(handle4)
+
+         ! scale diagonal elements of a_mat
+         DO iii = 1, num_var*2
+            mat_A_gw(iii, iii) = mat_A_gw(iii, iii)+ScalParam*mat_A_gw(iii, iii)
+         END DO
+
+         ! solve linear system
+         ierr = 0
+         ipiv = 0
+
+         CALL timeset(routineN//"_fit_lin_eq_2", handle4)
+
+         CALL ZGETRF(2*num_var, 2*num_var, mat_A_gw, 2*num_var, ipiv, info)
+
+         CALL ZGETRS('N', 2*num_var, 1, mat_A_gw, 2*num_var, ipiv, vec_b_gw, 2*num_var, info)
+
+         CALL timestop(handle4)
+
+         DO iii = 1, num_var
+            Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)+vec_b_gw(iii)+vec_b_gw(iii+num_var)
+         END DO
+
+         ! calculate chi2
+         CALL calc_chi2(chi2, Lambda, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
+                        num_fit_points, n_level_gw)
+
+         IF (chi2 < chi2_old) THEN
+            ScalParam = MAX(ScalParam/Ldown, 1E-12_dp)
+            DO iii = 1, num_var
+               Lambda_Re(iii) = Lambda_Re(iii)+REAL(vec_b_gw(iii)+vec_b_gw(iii+num_var))
+               Lambda_Im(iii) = Lambda_Im(iii)+AIMAG(vec_b_gw(iii)+vec_b_gw(iii+num_var))
+            END DO
+            IF (chi2_old/chi2-1.0_dp < stop_crit) could_exit = .TRUE.
+            chi2_old = chi2
+         ELSE
+            ScalParam = ScalParam*Lup
+         END IF
+         IF (ScalParam > 100.0_dp .AND. could_exit) EXIT
+
+         IF (ScalParam > 1E+10_dp) ScalParam = 1E-4_dp
+
+         n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
 
       END DO
 
-   END SUBROUTINE eval_fit_func_omega_grid_cosine
+      IF (.NOT. do_gw_im_time) THEN
+
+         ! change a_0 [Lambda(1)], so that Sigma(i0) = Fit(i0)
+         ! do not do this for imaginary time since we do not have many fit points and the fit should be perfect
+         func_val = Lambda(1)
+         DO iii = 1, num_poles
+            jjj = iii*2
+            ! calculate value of the fit function
+            func_val = func_val+Lambda(jjj)/(-Lambda(jjj+1))
+         END DO
+
+         Lambda_Re(1) = Lambda_Re(1)-REAL(func_val)+REAL(vec_Sigma_c_gw(n_level_gw, num_fit_points))
+         Lambda_Im(1) = Lambda_Im(1)-AIMAG(func_val)+AIMAG(vec_Sigma_c_gw(n_level_gw, num_fit_points))
+
+      END IF
+
+      Lambda_without_offset(:) = Lambda(:)
+
+      DO iii = 1, num_var
+         Lambda(iii) = CMPLX(Lambda_Re(iii), Lambda_Im(iii), KIND=dp)
+      END DO
+
+      ! print self_energy and fit on the imaginary frequency axis if required
+      IF (check_fit) THEN
+
+         IF (output_unit > 0) THEN
+
+            WRITE (output_unit, *) ' '
+            WRITE (output_unit, '(T3,A,I5)') 'Check the GW fit for molecular orbital', n_level_gw_ref
+            WRITE (output_unit, '(T3,A)') '-------------------------------------------'
+            WRITE (output_unit, *)
+            WRITE (output_unit, '(T3,5A)') '  omega (i*eV)    ', 'Re(fit) (eV)    ', &
+               'Im(fit) (eV)  ', 'Re(Sig_c) (eV)  ', &
+               'Im(Sig_c) (eV)'
+
+         END IF
+
+         DO kkk = 1, num_fit_points
+            func_val = Lambda(1)
+            DO iii = 1, num_poles
+               jjj = iii*2
+               ! calculate value of the fit function
+               func_val = func_val+Lambda(jjj)/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
+            END DO
+            WRITE (output_unit, '(1F16.3,4F16.5)') vec_omega_fit_gw_sign(kkk)*evolt, REAL(func_val)*evolt, &
+               AIMAG(func_val)*evolt, REAL(vec_Sigma_c_gw(n_level_gw, kkk))*evolt, &
+               AIMAG(vec_Sigma_c_gw(n_level_gw, kkk))*evolt
+         END DO
+
+         WRITE (output_unit, *) ' '
+
+      END IF
+
+      IF (do_gw_im_time) THEN
+         ! for cubic-scaling GW, we have one Green's function for occ and virt states with the Fermi level
+         ! in the middle of homo and lumo
+         e_fermi = 0.5_dp*(Eigenval(homo)+Eigenval(homo+1))
+      ELSE
+         ! in case of O(N^4) GW, we have the Fermi level differently for occ and virt states, see
+         ! Fig. 1 in JCTC 12, 3623-3635 (2016)
+         IF (n_level_gw <= gw_corr_lev_occ) THEN
+            e_fermi = Eigenval(homo)+fermi_level_offset
+         ELSE
+            e_fermi = Eigenval(homo+1)-fermi_level_offset
+         END IF
+      END IF
+
+      ! either Z-shot or no crossing search for evaluating Sigma_c
+      IF (crossing_search == ri_rpa_g0w0_crossing_none) THEN
+
+         ! calculate func val on the real axis
+         ! gw_energ = only correlation part of the self energy
+         func_val = Lambda(1)
+         DO iii = 1, num_poles
+            jjj = iii*2
+            func_val = func_val+Lambda(jjj)/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))
+         END DO
+
+         gw_energ = REAL(func_val)
+         vec_gw_energ(n_level_gw) = gw_energ
+
+      ELSE IF (crossing_search == ri_rpa_g0w0_crossing_z_shot .OR. &
+               crossing_search == ri_rpa_g0w0_crossing_newton) THEN
+
+         ! calculate Sigma_c_fit(e_n) and Z
+         func_val = Lambda(1)
+         z_value(n_level_gw) = 1.0_dp
+         DO iii = 1, num_poles
+            jjj = iii*2
+            z_value(n_level_gw) = z_value(n_level_gw)+REAL(Lambda(jjj)/ &
+                                                           (Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))**2)
+            func_val = func_val+Lambda(jjj)/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))
+         END DO
+         ! m is the slope of the correl self-energy
+         m_value(n_level_gw) = 1.0_dp-z_value(n_level_gw)
+         z_value(n_level_gw) = 1.0_dp/z_value(n_level_gw)
+         gw_energ = REAL(func_val)
+         vec_gw_energ(n_level_gw) = gw_energ
+
+         ! in case one wants to do Newton-Raphson on top of the Z-shot
+         IF (crossing_search == ri_rpa_g0w0_crossing_newton) THEN
+
+            level_energ_GW = (Eigenval_scf(n_level_gw_ref)- &
+                              m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
+                              vec_gw_energ(n_level_gw)+ &
+                              vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
+                             z_value(n_level_gw)
+
+            ! Newton-Raphson iteration
+            DO kkk = 1, 1000
+
+               ! calculate the value of the fit function for level_energ_GW
+               func_val = Lambda(1)
+               z_value(n_level_gw) = 1.0_dp
+               DO iii = 1, num_poles
+                  jjj = iii*2
+                  func_val = func_val+Lambda(jjj)/(level_energ_GW-e_fermi-Lambda(jjj+1))
+               END DO
+
+               ! calculate the derivative of the fit function for level_energ_GW
+               deriv_val_real = -1.0_dp
+               DO iii = 1, num_poles
+                  jjj = iii*2
+                  deriv_val_real = deriv_val_real+REAL(Lambda(jjj))/((ABS(level_energ_GW-e_fermi-Lambda(jjj+1)))**2) &
+                                   -(REAL(Lambda(jjj))*(level_energ_GW-e_fermi)-REAL(Lambda(jjj)*CONJG(Lambda(jjj+1))))* &
+                                   2.0_dp*(level_energ_GW-e_fermi-REAL(Lambda(jjj+1)))/ &
+                                   ((ABS(level_energ_GW-e_fermi-Lambda(jjj+1)))**2)
+
+               END DO
+
+               delta = (Eigenval_scf(n_level_gw_ref)+vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)+REAL(func_val)-level_energ_GW)/ &
+                       deriv_val_real
+
+               level_energ_GW = level_energ_GW-delta
+
+               IF (ABS(delta) < 1.0E-08) EXIT
+
+            END DO
+
+            ! update the GW-energy by Newton-Raphson and set the Z-value to 1
+
+            vec_gw_energ(n_level_gw) = REAL(func_val)
+            z_value(n_level_gw) = 1.0_dp
+            m_value(n_level_gw) = 0.0_dp
+
+         END IF ! Newton-Raphson on top of Z-shot
+
+      ELSE
+         CPABORT("Only NONE, ZSHOT and NEWTON implemented for 2-pole model")
+      END IF ! decision crossing search none, Z-shot
+
+      !   --------------------------------------------
+      !  | calculate statistical error due to fitting |
+      !   --------------------------------------------
+
+      ! estimate the statistical error of the calculated Sigma_c(i*omega)
+      ! by sqrt(chi2/n), where n is the number of fit points
+
+      CALL calc_chi2(chi2, Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
+                     num_fit_points, n_level_gw)
+
+      ! Estimate the statistical error of every fit point
+      stat_error = SQRT(chi2/num_fit_points)
+
+      ! allocate N array containing the second derivatives of chi^2
+      ALLOCATE (vec_N_gw(num_var*2))
+      vec_N_gw = 0.0_dp
+
+      ALLOCATE (mat_N_gw(num_var*2, num_var*2))
+      mat_N_gw = 0.0_dp
+
+      DO iii = 1, num_var*2
+         CALL calc_mat_N(vec_N_gw(iii), Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, &
+                         iii, iii, num_poles, num_fit_points, n_level_gw, 0.001_dp)
+      END DO
+
+      DO iii = 1, num_var*2
+         DO jjj = 1, num_var*2
+            CALL calc_mat_N(mat_N_gw(iii, jjj), Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, &
+                            iii, jjj, num_poles, num_fit_points, n_level_gw, 0.001_dp)
+         END DO
+      END DO
+
+      CALL DGETRF(2*num_var, 2*num_var, mat_N_gw, 2*num_var, ipiv, info)
+
+      ! vec_b_gw is only working array
+      CALL DGETRI(2*num_var, mat_N_gw, 2*num_var, ipiv, vec_b_gw, 2*num_var, info)
+
+      ALLOCATE (stat_errors(2*num_var))
+      stat_errors = 0.0_dp
+
+      DO iii = 1, 2*num_var
+         stat_errors(iii) = SQRT(ABS(mat_N_gw(iii, iii)))*stat_error
+      END DO
+
+      ! Compute error of Sigma_c on real axis according to error propagation
+
+      vec_gw_energ_error_fit(n_level_gw) = 0.0_dp
+
+      DO kkk = 1, num_poles
+         vec_gw_energ_error_fit(n_level_gw) = vec_gw_energ_error_fit(n_level_gw)+ &
+                                              (stat_errors(4*kkk-1)+stat_errors(4*kkk))* &
+                                              ABS(1.0_dp/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(2*kkk+1))- &
+                                                  1.0_dp/(-Lambda(2*kkk+1)))+ &
+                                              (stat_errors(4*kkk+1)+stat_errors(4*kkk+2))*ABS(Lambda(2*kkk))* &
+                                              ABS(1.0_dp/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(2*kkk+1))**2- &
+                                                  1.0_dp/(-Lambda(2*kkk+1))**2)
+      END DO
+
+      DEALLOCATE (mat_N_gw)
+      DEALLOCATE (vec_N_gw)
+      DEALLOCATE (mat_A_gw)
+      DEALLOCATE (mat_B_gw)
+      DEALLOCATE (stat_errors)
+      DEALLOCATE (dLambda)
+      DEALLOCATE (dLambda_2)
+      DEALLOCATE (vec_b_gw)
+      DEALLOCATE (vec_b_gw_copy)
+      DEALLOCATE (ipiv)
+      DEALLOCATE (vec_omega_fit_gw_sign)
+      DEALLOCATE (Lambda)
+      DEALLOCATE (Lambda_without_offset)
+      DEALLOCATE (Lambda_Re)
+      DEALLOCATE (Lambda_Im)
+
+   END SUBROUTINE fit_and_continuation_2pole
+
+! **************************************************************************************************
+!> \brief perform analytic continuation with pade approximation
+!> \param vec_gw_energ real Sigma_c
+!> \param vec_omega_fit_gw frequency points for Sigma_c(iomega)
+!> \param z_value 1/(1-dev)
+!> \param m_value derivative of real Sigma_c
+!> \param vec_Sigma_c_gw complex Sigma_c(iomega)
+!> \param vec_Sigma_x_minus_vxc_gw ...
+!> \param Eigenval quasiparticle energy during ev self-consistent GW
+!> \param Eigenval_scf KS/HF eigenvalue
+!> \param n_level_gw ...
+!> \param gw_corr_lev_occ ...
+!> \param nparam_pade number of pade parameters
+!> \param num_fit_points number of fit points for Sigma_c(iomega)
+!> \param crossing_search type ofr cross search to find quasiparticle energies
+!> \param homo ...
+!> \param check_fit ...
+!> \param fermi_level_offset ...
+!> \param do_gw_im_time ...
+! **************************************************************************************************
+   SUBROUTINE continuation_pade(vec_gw_energ, vec_omega_fit_gw, &
+                                z_value, m_value, vec_Sigma_c_gw, vec_Sigma_x_minus_vxc_gw, &
+                                Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, nparam_pade, &
+                                num_fit_points, crossing_search, homo, check_fit, &
+                                fermi_level_offset, do_gw_im_time)
+
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: vec_gw_energ
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_omega_fit_gw
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: z_value, m_value
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: vec_Sigma_c_gw
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
+                                                            Eigenval_scf
+      INTEGER, INTENT(IN)                                :: n_level_gw, gw_corr_lev_occ, &
+                                                            nparam_pade, num_fit_points, &
+                                                            crossing_search, homo
+      LOGICAL, INTENT(IN)                                :: check_fit
+      REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
+      LOGICAL, INTENT(IN)                                :: do_gw_im_time
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'continuation_pade', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: im_unit, re_unit, sigma_c_pade
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: coeff_pade, omega_points_pade, &
+                                                            Sigma_c_gw_reorder
+      INTEGER                                            :: handle, jquad, n_level_gw_ref, &
+                                                            output_unit
+      REAL(KIND=dp)                                      :: e_fermi, energy_val, level_energ_GW, &
+                                                            sign_occ_virt
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw_sign, &
+                                                            vec_omega_fit_gw_sign_reorder
+
+      CALL timeset(routineN, handle)
+
+      output_unit = cp_logger_get_default_io_unit()
+
+      im_unit = (0.0_dp, 1.0_dp)
+      re_unit = (1.0_dp, 0.0_dp)
+
+      ALLOCATE (vec_omega_fit_gw_sign(num_fit_points))
+
+      IF (n_level_gw <= gw_corr_lev_occ) THEN
+         sign_occ_virt = -1.0_dp
+      ELSE
+         sign_occ_virt = 1.0_dp
+      END IF
+
+      DO jquad = 1, num_fit_points
+         vec_omega_fit_gw_sign(jquad) = ABS(vec_omega_fit_gw(jquad))*sign_occ_virt
+      END DO
+
+      IF (do_gw_im_time) THEN
+         ! for cubic-scaling GW, we have one Green's function for occ and virt states with the Fermi level
+         ! in the middle of homo and lumo
+         e_fermi = 0.5_dp*(Eigenval(homo)+Eigenval(homo+1))
+      ELSE
+         ! in case of O(N^4) GW, we have the Fermi level differently for occ and virt states, see
+         ! Fig. 1 in JCTC 12, 3623-3635 (2016)
+         IF (n_level_gw <= gw_corr_lev_occ) THEN
+            e_fermi = Eigenval(homo)+fermi_level_offset
+         ELSE
+            e_fermi = Eigenval(homo+1)-fermi_level_offset
+         END IF
+      END IF
+
+      n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+
+      !*** reorder, such that omega=i*0 is first entry
+      ALLOCATE (Sigma_c_gw_reorder(num_fit_points))
+      ALLOCATE (vec_omega_fit_gw_sign_reorder(num_fit_points))
+      ! for cubic scaling GW fit points are ordered differently than in N^4 GW
+      IF (do_gw_im_time) THEN
+         DO jquad = 1, num_fit_points
+            Sigma_c_gw_reorder(jquad) = vec_Sigma_c_gw(n_level_gw, jquad)
+            vec_omega_fit_gw_sign_reorder(jquad) = vec_omega_fit_gw_sign(jquad)
+         ENDDO
+      ELSE
+         DO jquad = 1, num_fit_points
+            Sigma_c_gw_reorder(jquad) = vec_Sigma_c_gw(n_level_gw, num_fit_points-jquad+1)
+            vec_omega_fit_gw_sign_reorder(jquad) = vec_omega_fit_gw_sign(num_fit_points-jquad+1)
+         ENDDO
+      ENDIF
+
+      !*** evaluate parameters for pade approximation
+      ALLOCATE (coeff_pade(nparam_pade))
+      ALLOCATE (omega_points_pade(nparam_pade))
+      coeff_pade = 0.0_dp
+      CALL get_pade_parameters(Sigma_c_gw_reorder, vec_omega_fit_gw_sign_reorder, &
+                               num_fit_points, nparam_pade, omega_points_pade, coeff_pade)
+      IF (check_fit) THEN
+         CALL check_fit_pade(vec_omega_fit_gw_sign, vec_Sigma_c_gw(n_level_gw, :), &
+                             nparam_pade, omega_points_pade, coeff_pade, &
+                             num_fit_points, n_level_gw_ref, output_unit)
+      ENDIF
+
+      !*** calculate start_value for iterative cross-searching methods
+      IF ((crossing_search == ri_rpa_g0w0_crossing_bisection) .OR. &
+          (crossing_search == ri_rpa_g0w0_crossing_newton)) THEN
+         energy_val = Eigenval(n_level_gw_ref)-e_fermi
+         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, sigma_c_pade)
+         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, z_value(n_level_gw), m_value(n_level_gw))
+         level_energ_GW = (Eigenval_scf(n_level_gw_ref)- &
+                           m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
+                           REAL(sigma_c_pade)+ &
+                           vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
+                          z_value(n_level_gw)
+      ENDIF
+
+      !*** perform crossing search
+      SELECT CASE (crossing_search)
+      CASE (ri_rpa_g0w0_crossing_none)
+         energy_val = Eigenval(n_level_gw_ref)-e_fermi
+         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, sigma_c_pade)
+         vec_gw_energ(n_level_gw) = REAL(sigma_c_pade)
+
+      CASE (ri_rpa_g0w0_crossing_z_shot)
+         energy_val = Eigenval(n_level_gw_ref)-e_fermi
+         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, sigma_c_pade)
+         vec_gw_energ(n_level_gw) = REAL(sigma_c_pade)
+
+         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, z_value(n_level_gw), m_value(n_level_gw))
+
+      CASE (ri_rpa_g0w0_crossing_bisection)
+         CALL get_sigma_c_bisection_pade(vec_gw_energ(n_level_gw), Eigenval_scf(n_level_gw_ref), &
+                                         vec_Sigma_x_minus_vxc_gw(n_level_gw_ref), e_fermi, &
+                                         nparam_pade, omega_points_pade, coeff_pade, &
+                                         start_val=level_energ_GW)
+         z_value(n_level_gw) = 1.0_dp
+         m_value(n_level_gw) = 0.0_dp
+
+      CASE (ri_rpa_g0w0_crossing_newton)
+         CALL get_sigma_c_newton_pade(vec_gw_energ(n_level_gw), Eigenval_scf(n_level_gw_ref), &
+                                      vec_Sigma_x_minus_vxc_gw(n_level_gw_ref), e_fermi, &
+                                      nparam_pade, omega_points_pade, coeff_pade, &
+                                      start_val=level_energ_GW)
+         z_value(n_level_gw) = 1.0_dp
+         m_value(n_level_gw) = 0.0_dp
+
+      CASE DEFAULT
+         CPABORT("Only NONE, Z_SHOT, NEWTON, and BISECTION crossing search implemented.")
+      END SELECT
+
+      DEALLOCATE (vec_omega_fit_gw_sign)
+      DEALLOCATE (Sigma_c_gw_reorder)
+      DEALLOCATE (vec_omega_fit_gw_sign_reorder)
+      DEALLOCATE (coeff_pade, omega_points_pade)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE continuation_pade
+
+! **************************************************************************************************
+!> \brief calculate pade parameter recursively as in  Eq. (A2) in J. Low Temp. Phys., Vol. 29,
+!>          1977, pp. 179
+!> \param y f(x), here: Sigma_c(iomega)
+!> \param x the frequency points omega
+!> \param num_fit_points ...
+!> \param nparam number of pade parameters
+!> \param xpoints set of points used in pade approximation, selection of x
+!> \param coeff pade coefficients
+! **************************************************************************************************
+   SUBROUTINE get_pade_parameters(y, x, num_fit_points, nparam, xpoints, coeff)
+
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: y
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: x
+      INTEGER, INTENT(IN)                                :: num_fit_points, nparam
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(INOUT)      :: xpoints, coeff
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_pade_parameters', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: im_unit
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: ypoints
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: g_mat
+      INTEGER                                            :: handle, idat, iparam, nstep
+
+      CALL timeset(routineN, handle)
+
+      im_unit = (0.0_dp, 1.0_dp)
+
+      nstep = INT(num_fit_points/(nparam-1))
+      CPASSERT(LBOUND(x, 1) == 1)
+      CPASSERT(LBOUND(y, 1) == 1)
+
+      ALLOCATE (ypoints(nparam))
+      !omega=i0 is in element x(1)
+      idat = 1
+      DO iparam = 1, nparam-1
+         xpoints(iparam) = im_unit*x(idat)
+         ypoints(iparam) = y(idat)
+         idat = idat+nstep
+      ENDDO
+      xpoints(nparam) = im_unit*x(num_fit_points)
+      ypoints(nparam) = y(num_fit_points)
+
+      !*** generate parameters recursively
+
+      ALLOCATE (g_mat(nparam, nparam))
+      g_mat(:, 1) = ypoints(:)
+      DO iparam = 2, nparam
+         DO idat = iparam, nparam
+            g_mat(idat, iparam) = (g_mat(iparam-1, iparam-1)-g_mat(idat, iparam-1))/ &
+                                  ((xpoints(idat)-xpoints(iparam-1))*g_mat(idat, iparam-1))
+         ENDDO
+      ENDDO
+
+      DO iparam = 1, nparam
+         coeff(iparam) = g_mat(iparam, iparam)
+      ENDDO
+
+      DEALLOCATE (ypoints)
+      DEALLOCATE (g_mat)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_pade_parameters
+
+! **************************************************************************************************
+!> \brief evalute pade function for a real value x_val
+!> \param x_val real value
+!> \param nparam number of pade parameters
+!> \param xpoints selection of points of the original complex function, i.e. here of Sigma_c(iomega)
+!> \param coeff pade coefficients
+!> \param func_val function value
+! **************************************************************************************************
+   SUBROUTINE evaluate_pade_function(x_val, nparam, xpoints, coeff, func_val)
+
+      REAL(KIND=dp), INTENT(IN)                          :: x_val
+      INTEGER, INTENT(IN)                                :: nparam
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
+      COMPLEX(KIND=dp), INTENT(OUT)                      :: func_val
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'evaluate_pade_function', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
+      INTEGER                                            :: handle, iparam
+
+      CALL timeset(routineN, handle)
+
+      im_unit = (0.0_dp, 1.0_dp)
+      re_unit = (1.0_dp, 0.0_dp)
+
+      func_val = re_unit
+      DO iparam = nparam, 2, -1
+         func_val = re_unit+coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))/func_val
+      ENDDO
+
+      func_val = coeff(1)/func_val
+
+      CALL timestop(handle)
+
+   END SUBROUTINE evaluate_pade_function
+
+! **************************************************************************************************
+!> \brief get the z-value and the m-value (derivative) of the pade function
+!> \param x_val real value
+!> \param nparam number of pade parameters
+!> \param xpoints selection of points of the original complex function, i.e. here of Sigma_c(iomega)
+!> \param coeff pade coefficients
+!> \param z_value 1/(1-dev)
+!> \param m_value derivative
+! **************************************************************************************************
+   SUBROUTINE get_z_and_m_value_pade(x_val, nparam, xpoints, coeff, z_value, m_value)
+
+      REAL(KIND=dp), INTENT(IN)                          :: x_val
+      INTEGER, INTENT(IN)                                :: nparam
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
+      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: z_value, m_value
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_z_and_m_value_pade', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: denominator, dev_denominator, &
+                                                            dev_numerator, dev_val, func_val, &
+                                                            im_unit, numerator, re_unit
+      INTEGER                                            :: iparam
+
+      im_unit = (0.0_dp, 1.0_dp)
+      re_unit = (1.0_dp, 0.0_dp)
+
+      func_val = re_unit
+      dev_val = (0.0_dp, 0.0_dp)
+      DO iparam = nparam, 2, -1
+         numerator = coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))
+         dev_numerator = coeff(iparam)*re_unit
+         denominator = func_val
+         dev_denominator = dev_val
+         dev_val = dev_numerator/denominator-(numerator*dev_denominator)/(denominator**2)
+         func_val = re_unit+coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))/func_val
+      ENDDO
+
+      dev_val = -1.0_dp*coeff(1)/(func_val**2)*dev_val
+      func_val = coeff(1)/func_val
+
+      IF (PRESENT(z_value)) THEN
+         z_value = 1.0_dp-REAL(dev_val)
+         z_value = 1.0_dp/z_value
+      ENDIF
+      IF (PRESENT(m_value)) m_value = REAL(dev_val)
+
+   END SUBROUTINE get_z_and_m_value_pade
+
+! **************************************************************************************************
+!> \brief crossing search using the bisection method to find the quasiparticle energy
+!> \param gw_energ real Sigma_c
+!> \param Eigenval_scf Eigenvalue from the SCF
+!> \param Sigma_x_minus_vxc_gw ...
+!> \param e_fermi fermi level
+!> \param nparam_pade number of pade parameters
+!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
+!> \param coeff_pade pade coefficients
+!> \param start_val start value for the quasiparticle iteration
+! **************************************************************************************************
+   SUBROUTINE get_sigma_c_bisection_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
+                                         nparam_pade, omega_points_pade, coeff_pade, start_val)
+
+      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
+      REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
+                                                            e_fermi
+      INTEGER, INTENT(IN)                                :: nparam_pade
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: start_val
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_sigma_c_bisection_pade', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: sigma_c
+      INTEGER                                            :: handle, icount
+      REAL(KIND=dp)                                      :: delta, energy_val, my_start_val, &
+                                                            qp_energy, qp_energy_old, threshold
+
+      CALL timeset(routineN, handle)
+
+      threshold = 1.0E-7_dp
+
+      IF (PRESENT(start_val)) THEN
+         my_start_val = start_val
+      ELSE
+         my_start_val = Eigenval_scf
+      ENDIF
+
+      qp_energy = my_start_val
+      qp_energy_old = my_start_val
+      delta = 1.0E-3_dp
+
+      icount = 0
+      DO WHILE (ABS(delta) > threshold)
+         icount = icount+1
+         qp_energy = qp_energy_old+0.5_dp*delta
+         qp_energy_old = qp_energy
+         energy_val = qp_energy-e_fermi
+         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, sigma_c)
+         qp_energy = Eigenval_scf+REAL(sigma_c)+Sigma_x_minus_vxc_gw
+         delta = qp_energy-qp_energy_old
+         IF (icount > 500) THEN
+            CPABORT("Self-consistent quasi-particle solution not found")
+            EXIT
+         ENDIF
+      ENDDO
+
+      gw_energ = REAL(sigma_c)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_sigma_c_bisection_pade
+
+! **************************************************************************************************
+!> \brief crossing search using the Newton method to find the quasiparticle energy
+!> \param gw_energ real Sigma_c
+!> \param Eigenval_scf Eigenvalue from the SCF
+!> \param Sigma_x_minus_vxc_gw ...
+!> \param e_fermi fermi level
+!> \param nparam_pade number of pade parameters
+!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
+!> \param coeff_pade pade coefficients
+!> \param start_val start value for the quasiparticle iteration
+! **************************************************************************************************
+   SUBROUTINE get_sigma_c_newton_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
+                                      nparam_pade, omega_points_pade, coeff_pade, start_val)
+
+      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
+      REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
+                                                            e_fermi
+      INTEGER, INTENT(IN)                                :: nparam_pade
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: start_val
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_sigma_c_newton_pade', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: sigma_c
+      INTEGER                                            :: handle, icount
+      REAL(KIND=dp)                                      :: delta, energy_val, m_value, &
+                                                            my_start_val, qp_energy, &
+                                                            qp_energy_old, threshold
+
+      CALL timeset(routineN, handle)
+
+      threshold = 1.0E-7_dp
+
+      IF (PRESENT(start_val)) THEN
+         my_start_val = start_val
+      ELSE
+         my_start_val = Eigenval_scf
+      ENDIF
+
+      qp_energy = my_start_val
+      qp_energy_old = my_start_val
+      delta = 1.0E-3_dp
+
+      icount = 0
+      DO WHILE (ABS(delta) > threshold)
+         icount = icount+1
+         energy_val = qp_energy-e_fermi
+         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, sigma_c)
+         !get m_value --> derivative of function
+         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
+                                     coeff_pade, m_value=m_value)
+         qp_energy_old = qp_energy
+         qp_energy = qp_energy-(Eigenval_scf+Sigma_x_minus_vxc_gw+REAL(sigma_c)-qp_energy)/ &
+                     (m_value-1.0_dp)
+         delta = qp_energy-qp_energy_old
+         IF (icount > 500) THEN
+            CPABORT("Self-consistent quasi-particle solution not found")
+            EXIT
+         ENDIF
+      ENDDO
+
+      gw_energ = REAL(sigma_c)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_sigma_c_newton_pade
+
+! **************************************************************************************************
+!> \brief check "fit" for analytic continuation with pade approximation
+!> \param vec_omega_fit_gw_sign ...
+!> \param Sigma_c_gw complex Sigma_c(iomega) for n_level_gw
+!> \param nparam_pade number of pade parameters
+!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
+!> \param coeff_pade pade coefficients
+!> \param num_fit_points total number of frequency points for the complex Sigma_c
+!> \param n_level_gw_ref n_level_gw+homo-gw_corr_lev_occ
+!> \param output_unit ...
+! **************************************************************************************************
+   SUBROUTINE check_fit_pade(vec_omega_fit_gw_sign, Sigma_c_gw, &
+                             nparam_pade, omega_points_pade, coeff_pade, &
+                             num_fit_points, n_level_gw_ref, output_unit)
+
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_omega_fit_gw_sign
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: Sigma_c_gw
+      INTEGER, INTENT(IN)                                :: nparam_pade
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
+      INTEGER, INTENT(IN)                                :: num_fit_points, n_level_gw_ref, &
+                                                            output_unit
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'check_fit_pade', routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: func_val, im_unit, re_unit
+      INTEGER                                            :: iparam, kkk
+
+      re_unit = (1.0_dp, 0.0_dp)
+      im_unit = (0.0_dp, 1.0_dp)
+
+      WRITE (output_unit, *) ' '
+      WRITE (output_unit, '(T3,A,I5)') 'Check the GW fit for molecular orbital', n_level_gw_ref
+      WRITE (output_unit, '(T3,A)') '-------------------------------------------'
+      WRITE (output_unit, *)
+      WRITE (output_unit, '(T3,5A)') '  omega (i*eV)    ', 'Re(fit) (eV)    ', &
+         'Im(fit) (eV)  ', 'Re(Sig_c) (eV)  ', &
+         'Im(Sig_c) (eV)'
+
+      DO kkk = 1, num_fit_points
+         func_val = re_unit
+         DO iparam = nparam_pade, 2, -1
+            func_val = re_unit+coeff_pade(iparam) &
+                       *(im_unit*vec_omega_fit_gw_sign(kkk)-omega_points_pade(iparam-1))/func_val
+         ENDDO
+
+         func_val = coeff_pade(1)/func_val
+
+         WRITE (output_unit, '(1F16.3,4F16.5)') vec_omega_fit_gw_sign(kkk)*evolt, REAL(func_val)*evolt, &
+            AIMAG(func_val)*evolt, REAL(Sigma_c_gw(kkk))*evolt, &
+            AIMAG(Sigma_c_gw(kkk))*evolt
+      END DO
+
+      WRITE (output_unit, *) ' '
+
+   END SUBROUTINE check_fit_pade
+
+! **************************************************************************************************
+!> \brief Prints the GW stuff to the output and optinally to an external file.
+!>        Also updates the eigenvalues for eigenvalue-self-consistent GW
+!> \param vec_gw_energ ...
+!> \param vec_gw_energ_error_fit ...
+!> \param z_value ...
+!> \param m_value ...
+!> \param vec_Sigma_x_minus_vxc_gw ...
+!> \param Eigenval ...
+!> \param Eigenval_last ...
+!> \param Eigenval_scf ...
+!> \param gw_corr_lev_occ ...
+!> \param gw_corr_lev_virt ...
+!> \param gw_corr_lev_tot ...
+!> \param count_ev_sc_GW ...
+!> \param crossing_search ...
+!> \param homo ...
+!> \param nmo ...
+!> \param unit_nr ...
+!> \param print_gw_details ...
+!> \param remove_neg_virt_energies ...
+!> \param ikp ...
+!> \param nkp_self_energy ...
+!> \param kpoints ...
+!> \param do_alpha ...
+!> \param do_beta ...
+! **************************************************************************************************
+   SUBROUTINE print_and_update_for_ev_sc(vec_gw_energ, vec_gw_energ_error_fit, &
+                                         z_value, m_value, vec_Sigma_x_minus_vxc_gw, Eigenval, &
+                                         Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
+                                         count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, print_gw_details, &
+                                         remove_neg_virt_energies, ikp, nkp_self_energy, kpoints, do_alpha, do_beta)
+
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_gw_energ, vec_gw_energ_error_fit, &
+                                                            z_value, m_value
+      REAL(KIND=dp), DIMENSION(:)                        :: vec_Sigma_x_minus_vxc_gw, Eigenval
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: Eigenval_last, Eigenval_scf
+      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, &
+                                                            gw_corr_lev_tot, count_ev_sc_GW, &
+                                                            crossing_search, homo, nmo, unit_nr
+      LOGICAL                                            :: print_gw_details, &
+                                                            remove_neg_virt_energies
+      INTEGER                                            :: ikp, nkp_self_energy
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      LOGICAL, OPTIONAL                                  :: do_alpha, do_beta
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'print_and_update_for_ev_sc', &
+         routineP = moduleN//':'//routineN
+
+      CHARACTER(4)                                       :: occ_virt
+      INTEGER                                            :: handle, n_level_gw, n_level_gw_ref
+      LOGICAL                                            :: do_closed_shell, do_kpoints, &
+                                                            is_energy_okay, my_do_alpha, my_do_beta
+      REAL(KIND=dp)                                      :: eigen_diff, new_energy
+
+      CALL timeset(routineN, handle)
+
+      IF (PRESENT(do_alpha)) THEN
+         my_do_alpha = do_alpha
+      ELSE
+         my_do_alpha = .FALSE.
+      END IF
+
+      IF (PRESENT(do_beta)) THEN
+         my_do_beta = do_beta
+      ELSE
+         my_do_beta = .FALSE.
+      END IF
+
+      do_closed_shell = .NOT. (my_do_alpha .OR. my_do_beta)
+      do_kpoints = (nkp_self_energy > 1)
+
+      Eigenval_last(:) = Eigenval(:)
+
+      IF (unit_nr > 0) THEN
+
+         WRITE (unit_nr, *) ' '
+
+         IF (do_closed_shell) THEN
+            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies'
+            WRITE (unit_nr, '(T3,A)') '-------------------------'
+         ELSE IF (my_do_alpha) THEN
+            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of alpha spins'
+            WRITE (unit_nr, '(T3,A)') '----------------------------------------'
+         ELSE IF (my_do_beta) THEN
+            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of beta spins'
+            WRITE (unit_nr, '(T3,A)') '---------------------------------------'
+         END IF
+
+         IF (do_kpoints) THEN
+            WRITE (unit_nr, *) ' '
+            WRITE (unit_nr, '(T3,A7,I3,A3,I3,A8,3F7.3,A12,3F7.3)') 'Kpoint ', ikp, '  /', nkp_self_energy, &
+               '   xkp =', kpoints%xkp(1, ikp), kpoints%xkp(2, ikp), kpoints%xkp(3, ikp), &
+               '  and  xkp =', -kpoints%xkp(1, ikp), -kpoints%xkp(2, ikp), -kpoints%xkp(3, ikp)
+            WRITE (unit_nr, '(T3,A72)') '(Relative Brillouin zone size: [-0.5, 0.5] x [-0.5, 0.5] x [-0.5, 0.5])'
+         END IF
+
+      END IF
+
+      IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
+         WRITE (unit_nr, *) ' '
+         WRITE (unit_nr, '(T5,A)') 'Molecular orbital        MO energy after SCF (eV)        G0W0 QP energy (eV)'
+      END IF
+
+      IF (unit_nr > 0 .AND. print_gw_details) THEN
+         WRITE (unit_nr, '(T3,A)') ' '
+         WRITE (unit_nr, '(T3,A)') 'The GW quasiparticle energies are calculated according to: '
+      END IF
+
+      IF (crossing_search == ri_rpa_g0w0_crossing_none) THEN
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+            new_energy = Eigenval_scf(n_level_gw_ref)+vec_gw_energ(n_level_gw)+ &
+                         vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)
+
+            is_energy_okay = .TRUE.
+
+            IF (remove_neg_virt_energies .AND. (n_level_gw_ref > homo .AND. new_energy < Eigenval(homo))) THEN
+               is_energy_okay = .FALSE.
+            END IF
+
+            IF (is_energy_okay) THEN
+               Eigenval(n_level_gw_ref) = new_energy
+            END IF
+         END DO
+
+         IF (unit_nr > 0 .AND. print_gw_details) THEN
+            WRITE (unit_nr, '(T3,A)') ' '
+            WRITE (unit_nr, '(T3,A)') 'E_GW = E_SCF +  Sigc(E_SCF) + Sigx - vxc'
+            WRITE (unit_nr, '(T3,A)') ' '
+            WRITE (unit_nr, '(T3,A)') 'The energy unit of the following table is eV. Sigc_fit is a very conservative'
+            WRITE (unit_nr, '(T3,A)') 'estimate of the statistical error of the correlation self-energy caused by the'
+            WRITE (unit_nr, '(T3,A)') 'fitting.'
+            WRITE (unit_nr, '(T3,A)') ' '
+            WRITE (unit_nr, '(T14,2A)') 'MO        E_SCF         Sigc', &
+               '     Sigc_fit     Sigx-vxc         E_GW'
+         END IF
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+            IF (n_level_gw <= gw_corr_lev_occ) THEN
+               occ_virt = 'occ'
+            ELSE
+               occ_virt = 'vir'
+            END IF
+
+            IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
+               WRITE (unit_nr, '(T5,I9,3A,2F27.3)') &
+                  n_level_gw_ref, ' ( ', occ_virt, ')     ', &
+                  Eigenval_last(n_level_gw_ref)*evolt, &
+                  Eigenval(n_level_gw_ref)*evolt
+            END IF
+
+            IF (unit_nr > 0 .AND. print_gw_details) THEN
+               WRITE (unit_nr, '(T4,I4,3A,5F13.3)') &
+                  n_level_gw_ref, ' ( ', occ_virt, ')', &
+                  Eigenval_last(n_level_gw_ref)*evolt, &
+                  vec_gw_energ(n_level_gw)*evolt, &
+                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
+                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
+                  Eigenval(n_level_gw_ref)*evolt
+            END IF
+         END DO
+
+         ! z-shot
+      ELSE
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+
+            new_energy = (Eigenval_scf(n_level_gw_ref)- &
+                          m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
+                          vec_gw_energ(n_level_gw)+ &
+                          vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
+                         z_value(n_level_gw)
+
+            is_energy_okay = .TRUE.
+
+            IF (remove_neg_virt_energies .AND. (n_level_gw_ref > homo .AND. new_energy < Eigenval(homo))) THEN
+               is_energy_okay = .FALSE.
+            END IF
+
+            IF (is_energy_okay) THEN
+               Eigenval(n_level_gw_ref) = new_energy
+            END IF
+
+         END DO
+
+         IF (unit_nr > 0 .AND. print_gw_details) THEN
+            WRITE (unit_nr, '(T3,A)') 'E_GW = E_SCF + Z * ( Sigc(E_SCF) + Sigx - vxc )'
+            WRITE (unit_nr, '(T3,A)') ' '
+            WRITE (unit_nr, '(T3,A)') 'The energy unit of the following table is eV.  Sigc_fit is a very conservative'
+            WRITE (unit_nr, '(T3,2A)') 'estimate of the statistical error of the fitting.'
+            WRITE (unit_nr, '(T3,A)') ' '
+            WRITE (unit_nr, '(T13,2A)') 'MO      E_SCF       Sigc', &
+               '   Sigc_fit   Sigx-vxc          Z       E_GW'
+         END IF
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+            IF (n_level_gw <= gw_corr_lev_occ) THEN
+               occ_virt = 'occ'
+            ELSE
+               occ_virt = 'vir'
+            END IF
+
+            IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
+               WRITE (unit_nr, '(T5,I9,3A,2F27.3)') &
+                  n_level_gw_ref, ' ( ', occ_virt, ')     ', &
+                  Eigenval_last(n_level_gw_ref)*evolt, &
+                  Eigenval(n_level_gw_ref)*evolt
+            END IF
+
+            IF (unit_nr > 0 .AND. print_gw_details) THEN
+               WRITE (unit_nr, '(T3,I4,3A,6F11.3)') &
+                  n_level_gw_ref, ' ( ', occ_virt, ')', &
+                  Eigenval_last(n_level_gw_ref)*evolt, &
+                  vec_gw_energ(n_level_gw)*evolt, &
+                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
+                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
+                  z_value(n_level_gw), &
+                  Eigenval(n_level_gw_ref)*evolt
+            END IF
+         END DO
+
+         IF (unit_nr > 0) THEN
+            IF (do_closed_shell) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F57.2)') 'GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
+            ELSE IF (my_do_alpha) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F51.2)') 'Alpha GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
+            ELSE IF (my_do_beta) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F52.2)') 'Beta GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
+            END IF
+         END IF
+
+      END IF ! z-shot vs. no crossing
+
+      IF (unit_nr > 0) THEN
+         WRITE (unit_nr, *) ' '
+      END IF
+
+      ! for eigenvalue self-consistent GW, all eigenvalues have to be corrected
+      ! 1) the occupied; check if there are occupied MOs not being corrected by GW
+      IF (gw_corr_lev_occ < homo .AND. gw_corr_lev_occ > 0) THEN
+
+         ! calculate average GW correction for occupied orbitals
+         eigen_diff = 0.0_dp
+
+         DO n_level_gw = 1, gw_corr_lev_occ
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+            eigen_diff = eigen_diff+Eigenval(n_level_gw_ref)-Eigenval_last(n_level_gw_ref)
+         END DO
+         eigen_diff = eigen_diff/gw_corr_lev_occ
+
+         ! correct the eigenvalues of the occupied orbitals which have not been corrected by GW
+         DO n_level_gw = 1, homo-gw_corr_lev_occ
+            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
+         END DO
+
+      END IF
+
+      ! 2) the virtual: check if there are virtual orbitals not being corrected by GW
+      IF (gw_corr_lev_virt < nmo-homo .AND. gw_corr_lev_virt > 0) THEN
+
+         ! calculate average GW correction for virtual orbitals
+         eigen_diff = 0.0_dp
+         DO n_level_gw = 1, gw_corr_lev_virt
+            n_level_gw_ref = n_level_gw+homo
+            eigen_diff = eigen_diff+Eigenval(n_level_gw_ref)-Eigenval_last(n_level_gw_ref)
+         END DO
+         eigen_diff = eigen_diff/gw_corr_lev_virt
+
+         ! correct the eigenvalues of the virtual orbitals which have not been corrected by GW
+         DO n_level_gw = homo+gw_corr_lev_virt+1, nmo
+            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
+         END DO
+
+      END IF
+
+      IF ((gw_corr_lev_occ == 0 .OR. gw_corr_lev_virt == 0) .AND. count_ev_sc_GW > 1) THEN
+         CALL cp_warn(__LOCATION__, &
+                      "Please increase for eigenvalue-self-consistent GW, the number of "// &
+                      "corrected occupied and/or virtual orbitals above 0.")
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE print_and_update_for_ev_sc
+
+! **************************************************************************************************
+!> \brief Calculate the matrix mat_N_gw containing the second derivatives
+!>        with respect to the fitting parameters. The second derivatives are
+!>        calculated numerically by finite differences.
+!> \param N_ij matrix element
+!> \param Lambda fitting parameters
+!> \param Sigma_c ...
+!> \param vec_omega_fit_gw ...
+!> \param i ...
+!> \param j ...
+!> \param num_poles ...
+!> \param num_fit_points ...
+!> \param n_level_gw ...
+!> \param h  ...
+! **************************************************************************************************
+   SUBROUTINE calc_mat_N(N_ij, Lambda, Sigma_c, vec_omega_fit_gw, i, j, &
+                         num_poles, num_fit_points, n_level_gw, h)
+      REAL(KIND=dp)                                      :: N_ij
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: Sigma_c
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw
+      INTEGER                                            :: i, j, num_poles, num_fit_points, &
+                                                            n_level_gw
+      REAL(KIND=dp)                                      :: h
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_mat_N', routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda_tmp
+      INTEGER                                            :: handle, num_var
+      REAL(KIND=dp)                                      :: chi2, chi2_sum
+
+      CALL timeset(routineN, handle)
+
+      num_var = 2*num_poles+1
+      ALLOCATE (Lambda_tmp(num_var))
+      Lambda_tmp = (0.0_dp, 0.0_dp)
+      chi2_sum = 0.0_dp
+      re_unit = (1.0_dp, 0.0_dp)
+      im_unit = (0.0_dp, 1.0_dp)
+
+      !test
+      Lambda_tmp(:) = Lambda(:)
+      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
+                     num_fit_points, n_level_gw)
+
+      ! Fitting parameters with offset h
+      Lambda_tmp(:) = Lambda(:)
+      IF (MODULO(i, 2) == 0) THEN
+         Lambda_tmp(i/2) = Lambda_tmp(i/2)+h*re_unit
+      ELSE
+         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)+h*im_unit
+      END IF
+      IF (MODULO(j, 2) == 0) THEN
+         Lambda_tmp(j/2) = Lambda_tmp(j/2)+h*re_unit
+      ELSE
+         Lambda_tmp((j+1)/2) = Lambda_tmp((j+1)/2)+h*im_unit
+      END IF
+      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
+                     num_fit_points, n_level_gw)
+      chi2_sum = chi2_sum+chi2
+
+      IF (MODULO(i, 2) == 0) THEN
+         Lambda_tmp(i/2) = Lambda_tmp(i/2)-2.0_dp*h*re_unit
+      ELSE
+         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)-2.0_dp*h*im_unit
+      END IF
+      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
+                     num_fit_points, n_level_gw)
+      chi2_sum = chi2_sum-chi2
+
+      IF (MODULO(j, 2) == 0) THEN
+         Lambda_tmp(j/2) = Lambda_tmp(j/2)-2.0_dp*h*re_unit
+      ELSE
+         Lambda_tmp((j+1)/2) = Lambda_tmp((j+1)/2)-2.0_dp*h*im_unit
+      END IF
+      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
+                     num_fit_points, n_level_gw)
+      chi2_sum = chi2_sum+chi2
+
+      IF (MODULO(i, 2) == 0) THEN
+         Lambda_tmp(i/2) = Lambda_tmp(i/2)+2.0_dp*h*re_unit
+      ELSE
+         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)+2.0_dp*h*im_unit
+      END IF
+      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
+                     num_fit_points, n_level_gw)
+      chi2_sum = chi2_sum-chi2
+
+      ! Second derivative with symmetric difference quotient
+      N_ij = 1.0_dp/2.0_dp*chi2_sum/(4.0_dp*h*h)
+
+      DEALLOCATE (Lambda_tmp)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE calc_mat_N
+
+! **************************************************************************************************
+!> \brief Calculate chi2
+!> \param chi2 ...
+!> \param Lambda fitting parameters
+!> \param Sigma_c ...
+!> \param vec_omega_fit_gw ...
+!> \param num_poles ...
+!> \param num_fit_points ...
+!> \param n_level_gw ...
+! **************************************************************************************************
+   SUBROUTINE calc_chi2(chi2, Lambda, Sigma_c, vec_omega_fit_gw, num_poles, &
+                        num_fit_points, n_level_gw)
+      REAL(KIND=dp)                                      :: chi2
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: Sigma_c
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw
+      INTEGER                                            :: num_poles, num_fit_points, n_level_gw
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_chi2', routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: func_val, im_unit
+      INTEGER                                            :: handle, iii, jjj, kkk
+
+      CALL timeset(routineN, handle)
+
+      im_unit = (0.0_dp, 1.0_dp)
+      chi2 = 0.0_dp
+      DO kkk = 1, num_fit_points
+         func_val = Lambda(1)
+         DO iii = 1, num_poles
+            jjj = iii*2
+            ! calculate value of the fit function
+            func_val = func_val+Lambda(jjj)/(im_unit*vec_omega_fit_gw(kkk)-Lambda(jjj+1))
+         END DO
+         chi2 = chi2+(ABS(Sigma_c(n_level_gw, kkk)-func_val))**2
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE calc_chi2
+
+! **************************************************************************************************
+!> \brief ...
+!> \param Eigenval ...
+!> \param Eigenval_scf ...
+!> \param ic_corr_list ...
+!> \param gw_corr_lev_occ ...
+!> \param gw_corr_lev_virt ...
+!> \param gw_corr_lev_tot ...
+!> \param homo ...
+!> \param nmo ...
+!> \param unit_nr ...
+!> \param do_alpha ...
+!> \param do_beta ...
+! **************************************************************************************************
+   SUBROUTINE apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
+                            gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
+                            homo, nmo, unit_nr, do_alpha, do_beta)
+
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval, Eigenval_scf, ic_corr_list
+      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, &
+                                                            gw_corr_lev_tot, homo, nmo, unit_nr
+      LOGICAL, OPTIONAL                                  :: do_alpha, do_beta
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_ic_corr', routineP = moduleN//':'//routineN
+
+      CHARACTER(4)                                       :: occ_virt
+      INTEGER                                            :: handle, n_level_gw, n_level_gw_ref
+      LOGICAL                                            :: do_closed_shell, my_do_alpha, my_do_beta
+      REAL(KIND=dp)                                      :: eigen_diff
+
+      CALL timeset(routineN, handle)
+
+      IF (PRESENT(do_alpha)) THEN
+         my_do_alpha = do_alpha
+      ELSE
+         my_do_alpha = .FALSE.
+      END IF
+
+      IF (PRESENT(do_beta)) THEN
+         my_do_beta = do_beta
+      ELSE
+         my_do_beta = .FALSE.
+      END IF
+
+      do_closed_shell = .NOT. (my_do_alpha .OR. my_do_beta)
+
+      ! check the number of input image charge corrected levels
+      CPASSERT(SIZE(ic_corr_list) == gw_corr_lev_tot)
+
+      IF (unit_nr > 0) THEN
+
+         WRITE (unit_nr, *) ' '
+
+         IF (do_closed_shell) THEN
+            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies with image charge (ic) correction'
+            WRITE (unit_nr, '(T3,A)') '-----------------------------------------------------------'
+         ELSE IF (my_do_alpha) THEN
+            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of alpha spins with image charge (ic) correction'
+            WRITE (unit_nr, '(T3,A)') '--------------------------------------------------------------------------'
+         ELSE IF (my_do_beta) THEN
+            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of beta spins with image charge (ic) correction'
+            WRITE (unit_nr, '(T3,A)') '-------------------------------------------------------------------------'
+         END IF
+
+         WRITE (unit_nr, *) ' '
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+            IF (n_level_gw <= gw_corr_lev_occ) THEN
+               occ_virt = 'occ'
+            ELSE
+               occ_virt = 'vir'
+            END IF
+
+            WRITE (unit_nr, '(T4,I4,3A,3F21.3)') &
+               n_level_gw_ref, ' ( ', occ_virt, ')  ', &
+               Eigenval(n_level_gw_ref)*evolt, &
+               ic_corr_list(n_level_gw)*evolt, &
+               (Eigenval(n_level_gw_ref)+ic_corr_list(n_level_gw))*evolt
+
+         END DO
+
+         WRITE (unit_nr, *) ' '
+
+      END IF
+
+      Eigenval(homo-gw_corr_lev_occ+1:homo+gw_corr_lev_virt) = Eigenval(homo-gw_corr_lev_occ+1: &
+                                                                        homo+gw_corr_lev_virt) &
+                                                               +ic_corr_list(1:gw_corr_lev_tot)
+
+      Eigenval_scf(homo-gw_corr_lev_occ+1:homo+gw_corr_lev_virt) = Eigenval_scf(homo-gw_corr_lev_occ+1: &
+                                                                                homo+gw_corr_lev_virt) &
+                                                                   +ic_corr_list(1:gw_corr_lev_tot)
+
+      IF (unit_nr > 0) THEN
+
+         IF (do_closed_shell) THEN
+            WRITE (unit_nr, '(T3,A,F52.2)') 'G0W0 IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
+         ELSE IF (my_do_alpha) THEN
+            WRITE (unit_nr, '(T3,A,F46.2)') 'G0W0 Alpha IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
+         ELSE IF (my_do_beta) THEN
+            WRITE (unit_nr, '(T3,A,F47.2)') 'G0W0 Beta IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
+         END IF
+
+         WRITE (unit_nr, *) ' '
+
+      END IF
+
+      ! for eigenvalue self-consistent GW, all eigenvalues have to be corrected
+      ! 1) the occupied; check if there are occupied MOs not being corrected by the IC model
+      IF (gw_corr_lev_occ < homo .AND. gw_corr_lev_occ > 0) THEN
+
+         ! calculate average IC contribution for occupied orbitals
+         eigen_diff = 0.0_dp
+
+         DO n_level_gw = 1, gw_corr_lev_occ
+            eigen_diff = eigen_diff+ic_corr_list(n_level_gw)
+         END DO
+         eigen_diff = eigen_diff/gw_corr_lev_occ
+
+         ! correct the eigenvalues of the occupied orbitals which have not been corrected by the IC model
+         DO n_level_gw = 1, homo-gw_corr_lev_occ
+            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
+            Eigenval_scf(n_level_gw) = Eigenval_scf(n_level_gw)+eigen_diff
+         END DO
+
+      END IF
+
+      ! 2) the virtual: check if there are virtual orbitals not being corrected by the IC model
+      IF (gw_corr_lev_virt < nmo-homo .AND. gw_corr_lev_virt > 0) THEN
+
+         ! calculate average IC correction for virtual orbitals
+         eigen_diff = 0.0_dp
+         DO n_level_gw = gw_corr_lev_occ+1, gw_corr_lev_tot
+            eigen_diff = eigen_diff+ic_corr_list(n_level_gw)
+         END DO
+         eigen_diff = eigen_diff/gw_corr_lev_virt
+
+         ! correct the eigenvalues of the virtual orbitals which have not been corrected by the IC model
+         DO n_level_gw = homo+gw_corr_lev_virt+1, nmo
+            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
+            Eigenval_scf(n_level_gw) = Eigenval_scf(n_level_gw)+eigen_diff
+         END DO
+
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE apply_ic_corr
+
+! **************************************************************************************************
+!> \brief ...
+!> \param num_integ_points ...
+!> \param nmo ...
+!> \param tau_tj ...
+!> \param tj ...
+!> \param mat_greens_fct_occ ...
+!> \param mat_greens_fct_virt ...
+!> \param matrix_s ...
+!> \param fm_mo_coeff_occ ...
+!> \param fm_mo_coeff_virt ...
+!> \param fm_mo_coeff_occ_scaled ...
+!> \param fm_mo_coeff_virt_scaled ...
+!> \param fm_scaled_dm_occ_tau ...
+!> \param fm_scaled_dm_virt_tau ...
+!> \param Eigenval ...
+!> \param eps_filter ...
+!> \param e_fermi ...
+!> \param fm_mat_W_tau ...
+!> \param gw_corr_lev_tot ...
+!> \param gw_corr_lev_occ ...
+!> \param gw_corr_lev_virt ...
+!> \param homo ...
+!> \param count_ev_sc_GW ...
+!> \param mat_3c_overl_int_gw ...
+!> \param mat_contr_gf_occ ...
+!> \param mat_contr_gf_virt ...
+!> \param mat_contr_W ...
+!> \param mat_W ...
+!> \param mat_SinvVSinv ...
+!> \param mat_dm ...
+!> \param stabilize_exp ...
+!> \param weights_cos_tf_t_to_w ...
+!> \param weights_sin_tf_t_to_w ...
+!> \param vec_Sigma_c_gw ...
+!> \param do_periodic ...
+!> \param num_points_corr ...
+!> \param delta_corr ...
+!> \param qs_env ...
+!> \param para_env ...
+!> \param para_env_RPA ...
+!> \param mp2_env ...
+!> \param matrix_berry_re_mo_mo ...
+!> \param matrix_berry_im_mo_mo ...
+!> \param first_cycle_periodic_correction ...
+!> \param kpoints ...
+!> \param num_fit_points ...
+!> \param mo_coeff ...
+!> \param do_GW_corr ...
+!> \param do_ri_Sigma_x ...
+!> \param vec_Sigma_x_gw ...
+!> \param do_beta ...
+! **************************************************************************************************
+   SUBROUTINE compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ, mat_greens_fct_virt, &
+                                             matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
+                                             fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
+                                             fm_scaled_dm_virt_tau, Eigenval, eps_filter, e_fermi, fm_mat_W_tau, &
+                                             gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, count_ev_sc_GW, &
+                                             mat_3c_overl_int_gw, mat_contr_gf_occ, mat_contr_gf_virt, mat_contr_W, &
+                                             mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
+                                             weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, do_periodic, &
+                                             num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
+                                             mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
+                                             first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
+                                             do_GW_corr, do_ri_Sigma_x, vec_Sigma_x_gw, do_beta)
+      INTEGER                                            :: num_integ_points, nmo
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tj
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt, &
+                                                            matrix_s
+      TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
+         fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      REAL(KIND=dp)                                      :: eps_filter, e_fermi
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      INTEGER                                            :: gw_corr_lev_tot, gw_corr_lev_occ, &
+                                                            gw_corr_lev_virt, homo, count_ev_sc_GW
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_int_gw
+      TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ, mat_contr_gf_virt, &
+                                                            mat_contr_W
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_W
+      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv, mat_dm
+      REAL(KIND=dp)                                      :: stabilize_exp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w, &
+                                                            weights_sin_tf_t_to_w
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw
+      LOGICAL                                            :: do_periodic
+      INTEGER                                            :: num_points_corr
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
+      TYPE(mp2_type), POINTER                            :: mp2_env
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
+                                                            matrix_berry_im_mo_mo
+      LOGICAL :: first_cycle_periodic_correction
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: num_fit_points
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: do_GW_corr
+      LOGICAL                                            :: do_ri_Sigma_x
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vec_Sigma_x_gw
+      LOGICAL, OPTIONAL                                  :: do_beta
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_self_energy_im_time_gw', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: im_unit
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: delta_corr_omega
+      INTEGER                                            :: gw_lev_end, gw_lev_start, handle, &
+                                                            handle3, iquad, jquad, n_level_gw, &
+                                                            n_level_gw_ref
+      LOGICAL                                            :: my_do_beta
+      REAL(KIND=dp)                                      :: ext_scaling, omega, omega_i, omega_sign, &
+                                                            sign_occ_virt, t_i_Clenshaw, tau, &
+                                                            weight_cos, weight_i, weight_sin
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_c_gw_cos_omega, &
+         vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
+         vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
+
+      CALL timeset(routineN, handle)
+
+      my_do_beta = .FALSE.
+      IF (PRESENT(do_beta)) my_do_beta = do_beta
+
+      im_unit = (0.0_dp, 1.0_dp)
+
+      ALLOCATE (vec_Sigma_c_gw_pos_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_pos_tau = 0.0_dp
+      ALLOCATE (vec_Sigma_c_gw_neg_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_neg_tau = 0.0_dp
+      ALLOCATE (vec_Sigma_c_gw_cos_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_cos_tau = 0.0_dp
+      ALLOCATE (vec_Sigma_c_gw_sin_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_sin_tau = 0.0_dp
+
+      ALLOCATE (vec_Sigma_c_gw_cos_omega(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_cos_omega = 0.0_dp
+      ALLOCATE (vec_Sigma_c_gw_sin_omega(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_sin_omega = 0.0_dp
+
+      ALLOCATE (delta_corr_omega(1+homo-gw_corr_lev_occ:homo+gw_corr_lev_virt, num_integ_points))
+      delta_corr_omega(:, :) = (0.0_dp, 0.0_dp)
+
+      DO jquad = 1, num_integ_points
+
+         tau = tau_tj(jquad)
+
+         CALL compute_Greens_function(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                      fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, num_integ_points, nmo, &
+                                      eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
+
+         CALL copy_fm_to_dbcsr(fm_mat_W_tau(jquad)%matrix, mat_W(jquad)%matrix, keep_sparsity=.FALSE.)
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+
+            IF (.NOT. do_GW_corr(n_level_gw)) CYCLE
+
+            ! the following formulas are partially taken from Liu et al. PRB 94, 165109 (2016), Eq. (63) - (69)
+
+            CALL timeset(routineN//"_cubic_GW_operation_1", handle3)
+
+            ! the occ Gf has no minus, but already include the minus from Sigma = -GW
+            CALL dbcsr_multiply("N", "N", -1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, &
+                                mat_greens_fct_occ(jquad)%matrix, &
+                                0.0_dp, mat_contr_gf_occ)
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_cubic_GW_operation_2", handle3)
+
+            ! the virt Gf has a minus, but already include the minus from Sigma = -GW
+            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, &
+                                mat_greens_fct_virt(jquad)%matrix, &
+                                0.0_dp, mat_contr_gf_virt)
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_cubic_GW_operation_3", handle3)
+
+            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_W(jquad)%matrix, mat_3c_overl_int_gw(n_level_gw)%matrix, &
+                                0.0_dp, mat_contr_W)
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_cubic_GW_operation_4", handle3)
+
+            CALL dbcsr_trace(mat_contr_gf_virt, &
+                             mat_contr_W, &
+                             vec_Sigma_c_gw_pos_tau(n_level_gw, jquad))
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_cubic_GW_operation_5", handle3)
+
+            CALL dbcsr_trace(mat_contr_gf_occ, &
+                             mat_contr_W, &
+                             vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_cubic_GW_operation_5", handle3)
+
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_cubic_GW_operation_7", handle3)
+
+            vec_Sigma_c_gw_cos_tau(n_level_gw, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(n_level_gw, jquad)+ &
+                                                                vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
+
+            vec_Sigma_c_gw_sin_tau(n_level_gw, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(n_level_gw, jquad)- &
+                                                                vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
+
+            CALL timestop(handle3)
+
+         END DO ! n_levl_gw
+
+         CALL dbcsr_set(mat_W(jquad)%matrix, 0.0_dp)
+
+         CALL dbcsr_filter(mat_W(jquad)%matrix, 1.0_dp)
+
+      END DO ! jquad (tau)
+
+      ! Fourier transform from time to frequency
+      DO jquad = 1, num_fit_points
+
+         DO iquad = 1, num_integ_points
+
+            omega = tj(jquad)
+            tau = tau_tj(iquad)
+            weight_cos = weights_cos_tf_t_to_w(jquad, iquad)*COS(omega*tau)
+            weight_sin = weights_sin_tf_t_to_w(jquad, iquad)*SIN(omega*tau)
+
+            vec_Sigma_c_gw_cos_omega(:, jquad) = vec_Sigma_c_gw_cos_omega(:, jquad)+ &
+                                                 weight_cos*vec_Sigma_c_gw_cos_tau(:, iquad)
+
+            vec_Sigma_c_gw_sin_omega(:, jquad) = vec_Sigma_c_gw_sin_omega(:, jquad)+ &
+                                                 weight_sin*vec_Sigma_c_gw_sin_tau(:, iquad)
+
+         END DO
+
+      END DO
+
+      ! for occupied levels, we need the correlation self-energy for negative omega. Therefore, weight_sin
+      ! should be computed with -omega, which results in an additional minus for vec_Sigma_c_gw_sin_omega:
+      vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :) = -vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :)
+
+      vec_Sigma_c_gw(:, 1:num_fit_points, 1) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points)+ &
+                                               im_unit*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
+
+      IF (do_ri_Sigma_x .AND. count_ev_sc_GW == 1) THEN
+
+         CALL timeset(routineN//"_RI_HFX_operation_1", handle3)
+
+         ! get density matrix
+         CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
+                      matrix_a=fm_mo_coeff_occ, matrix_b=fm_mo_coeff_occ, beta=0.0_dp, &
+                      matrix_c=fm_scaled_dm_occ_tau)
+
+         CALL timestop(handle3)
+
+         CALL timeset(routineN//"_RI_HFX_operation_2", handle3)
+
+         CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
+                               mat_dm%matrix, &
+                               keep_sparsity=.FALSE.)
+
+         CALL timestop(handle3)
+
+         DO n_level_gw = 1, gw_corr_lev_tot
+
+            IF (.NOT. do_GW_corr(n_level_gw)) CYCLE
+
+            CALL timeset(routineN//"_RI_HFX_operation_3", handle3)
+
+            ! the occ Gf has no minus, but already include the minus from Sigma = -GW
+            CALL dbcsr_multiply("N", "N", -1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, mat_dm%matrix, &
+                                0.0_dp, mat_contr_gf_occ)
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_RI_HFX_operation_4", handle3)
+
+            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_SinvVSinv%matrix, mat_3c_overl_int_gw(n_level_gw)%matrix, &
+                                0.0_dp, mat_contr_W)
+
+            CALL timestop(handle3)
+
+            CALL timeset(routineN//"_RI_HFX_operation_5", handle3)
+
+            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+
+            CALL dbcsr_trace(mat_contr_gf_occ, &
+                             mat_contr_W, &
+                             vec_Sigma_x_gw(n_level_gw_ref, 1))
+
+            CALL timestop(handle3)
+
+         END DO
+
+         IF (my_do_beta) THEN
+
+            mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2, 1) = &
+               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2, 1)+ &
+               vec_Sigma_x_gw(:, 1)
+
+         ELSE
+
+            mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, 1) = &
+               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, 1)+ &
+               vec_Sigma_x_gw(:, 1)
+
+         END IF
+
+      END IF
+
+      ! compute and add the periodic correction
+      IF (do_periodic) THEN
+
+         ext_scaling = 0.2_dp
+
+         ! loop over omega' (integration)
+         DO iquad = 1, num_points_corr
+
+            ! use the Clenshaw-grid
+            t_i_Clenshaw = iquad*pi/(2.0_dp*num_points_corr)
+            omega_i = ext_scaling/TAN(t_i_Clenshaw)
+
+            IF (iquad < num_points_corr) THEN
+               weight_i = ext_scaling*pi/(num_points_corr*SIN(t_i_Clenshaw)**2)
+            ELSE
+               weight_i = ext_scaling*pi/(2.0_dp*num_points_corr*SIN(t_i_Clenshaw)**2)
+            END IF
+
+            CALL calc_periodic_correction(delta_corr, qs_env, para_env, para_env_RPA, &
+                                          mp2_env%ri_g0w0%kp_grid, homo, nmo, gw_corr_lev_occ, &
+                                          gw_corr_lev_virt, omega_i, mo_coeff, Eigenval, &
+                                          matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
+                                          first_cycle_periodic_correction, kpoints, &
+                                          mp2_env%ri_g0w0%do_mo_coeff_gamma, &
+                                          mp2_env%ri_g0w0%num_kp_grids, mp2_env%ri_g0w0%eps_kpoint, &
+                                          mp2_env%ri_g0w0%do_extra_kpoints, &
+                                          mp2_env%ri_g0w0%do_aux_bas_gw, mp2_env%ri_g0w0%frac_aux_mos)
+
+            DO n_level_gw = 1, gw_corr_lev_tot
+
+               n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+
+               IF (n_level_gw <= gw_corr_lev_occ) THEN
+                  sign_occ_virt = -1.0_dp
+               ELSE
+                  sign_occ_virt = 1.0_dp
+               END IF
+
+               DO jquad = 1, num_integ_points
+
+                  omega_sign = tj(jquad)*sign_occ_virt
+
+                  delta_corr_omega(n_level_gw_ref, jquad) = &
+                     delta_corr_omega(n_level_gw_ref, jquad)- &
+                     0.5_dp/pi*weight_i/2.0_dp*delta_corr(n_level_gw_ref)* &
+                     (1.0_dp/(im_unit*(omega_i+omega_sign)+e_fermi-Eigenval(n_level_gw_ref))+ &
+                      1.0_dp/(im_unit*(-omega_i+omega_sign)+e_fermi-Eigenval(n_level_gw_ref)))
+
+               END DO
+
+            END DO
+
+         END DO
+
+         gw_lev_start = 1+homo-gw_corr_lev_occ
+         gw_lev_end = homo+gw_corr_lev_virt
+
+         ! add the periodic correction
+         vec_Sigma_c_gw(1:gw_corr_lev_tot, :, 1) = vec_Sigma_c_gw(1:gw_corr_lev_tot, :, 1)+ &
+                                                   delta_corr_omega(gw_lev_start:gw_lev_end, 1:num_fit_points)
+
+      END IF
+
+      DEALLOCATE (vec_Sigma_c_gw_pos_tau)
+      DEALLOCATE (vec_Sigma_c_gw_neg_tau)
+      DEALLOCATE (vec_Sigma_c_gw_cos_tau)
+      DEALLOCATE (vec_Sigma_c_gw_sin_tau)
+      DEALLOCATE (vec_Sigma_c_gw_cos_omega)
+      DEALLOCATE (vec_Sigma_c_gw_sin_omega)
+      DEALLOCATE (delta_corr_omega)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE compute_self_energy_im_time_gw
 
 ! **************************************************************************************************
 !> \brief ...
@@ -6019,12 +4830,11 @@ CONTAINS
                                                             matrix_s
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
          fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: jquad, num_integ_points, nmo
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, stabilize_exp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj
-      INTEGER, INTENT(IN)                                :: count_ev_sc_GW
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      INTEGER                                            :: jquad, num_integ_points, nmo
+      REAL(KIND=dp)                                      :: eps_filter, e_fermi, stabilize_exp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
+      INTEGER                                            :: count_ev_sc_GW
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function', &
          routineP = moduleN//':'//routineN
@@ -6142,3 +4952,4 @@ CONTAINS
    END SUBROUTINE compute_Greens_function
 
 END MODULE rpa_gw
+

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -2910,6 +2910,8 @@ CONTAINS
          sign_occ_virt = 1.0_dp
       END IF
 
+      n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+
       DO jquad = 1, num_fit_points
          vec_omega_fit_gw_sign(jquad) = ABS(vec_omega_fit_gw(jquad))*sign_occ_virt
       END DO
@@ -3080,8 +3082,6 @@ CONTAINS
          IF (ScalParam > 100.0_dp .AND. could_exit) EXIT
 
          IF (ScalParam > 1E+10_dp) ScalParam = 1E-4_dp
-
-         n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
 
       END DO
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -3063,6 +3063,9 @@ CONTAINS
          CALL calc_chi2(chi2, Lambda, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
                         num_fit_points, n_level_gw)
 
+         ! if the fit is already super accurate, exit. otherwise maybe issues when dividing by 0
+         IF (chi2 < 1.0E-30_dp) EXIT
+
          IF (chi2 < chi2_old) THEN
             ScalParam = MAX(ScalParam/Ldown, 1E-12_dp)
             DO iii = 1, num_var

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -154,7 +154,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
       TYPE(cp_fm_type), POINTER                          :: fm_mat_Q, mo_coeff, mo_coeff_beta
-      TYPE(dbcsr_p_type)                                 :: mat_dm_virt_local
+      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_dm_virt_local
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: mat_3c_overl_int_gw, mat_3c_overl_int_gw_beta, &
          mat_3c_overl_nnP_ic, mat_3c_overl_nnP_ic_beta, mat_3c_overl_nnP_ic_reflected, &
          mat_3c_overl_nnP_ic_reflected_beta, matrix_s, mat_W

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -391,7 +391,7 @@ CONTAINS
       INTEGER, INTENT(IN) :: color_rpa_group, dimen_nm_gw, gw_corr_lev_occ, gw_corr_lev_occ_beta, &
          gw_corr_lev_virt, homo, homo_beta, nmo, num_integ_points, num_integ_group, unit_nr
       INTEGER, INTENT(INOUT)                             :: gw_corr_lev_tot, num_fit_points
-      REAL(kind=dp)                                      :: omega_max_fit
+      REAL(KIND=dp)                                      :: omega_max_fit
       LOGICAL, INTENT(IN)                                :: do_minimax_quad, do_periodic, &
                                                             do_ri_Sigma_x, my_do_gw, my_open_shell
       LOGICAL, INTENT(OUT) :: first_cycle_periodic_correction
@@ -413,8 +413,8 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(kpoint_type), POINTER                         :: kpoints
-      INTEGER                                            :: nkp, nkp_self_energy
-      LOGICAL                                            :: do_kpoints_cubic_RPA, &
+      INTEGER, INTENT(OUT)                               :: nkp, nkp_self_energy
+      LOGICAL, INTENT(IN)                                :: do_kpoints_cubic_RPA, &
                                                             do_kpoints_from_Gamma
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_matrices_gw', &
@@ -424,7 +424,7 @@ CONTAINS
       INTEGER :: handle, iiB, iquad, jjB, jquad, m_global, m_global_beta, n_global, n_global_beta, &
          n_level_gw, n_level_gw_ref, ncol_local, nm_global, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: row_indices
-      REAL(kind=dp)                                      :: omega
+      REAL(KIND=dp)                                      :: omega
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_gw
 
       CALL timeset(routineN, handle)
@@ -793,7 +793,7 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(mp2_type), POINTER                            :: mp2_env
-      LOGICAL                                            :: do_kpoints_cubic_RPA, &
+      LOGICAL, INTENT(IN)                                :: do_kpoints_cubic_RPA, &
                                                             do_kpoints_from_Gamma
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'GW_matrix_operations', &
@@ -1196,11 +1196,13 @@ CONTAINS
          Eigenval_last_beta, Eigenval_scf, Eigenval_scf_beta, m_value, m_value_beta, tau_tj, tj, &
          vec_gw_energ, vec_gw_energ_beta, vec_gw_energ_error_fit, vec_gw_energ_error_fit_beta, &
          vec_omega_fit_gw
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vec_Sigma_x_gw, vec_Sigma_x_gw_beta
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: vec_Sigma_x_gw, vec_Sigma_x_gw_beta
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(INOUT)                                   :: z_value, z_value_beta
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list, ic_corr_list_beta
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(IN)                                      :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
          fm_mo_coeff_occ, fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
@@ -1216,10 +1218,11 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      INTEGER                                            :: nkp_self_energy
-      LOGICAL                                            :: do_kpoints_cubic_RPA
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: Eigenval_kp, Eigenval_scf_kp
-      INTEGER                                            :: iter_ev_sc
+      INTEGER, INTENT(IN)                                :: nkp_self_energy
+      LOGICAL, INTENT(IN)                                :: do_kpoints_cubic_RPA
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: Eigenval_kp, Eigenval_scf_kp
+      INTEGER, INTENT(INOUT)                             :: iter_ev_sc
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'GW_postprocessing', &
          routineP = moduleN//':'//routineN
@@ -1227,7 +1230,7 @@ CONTAINS
       INTEGER                                            :: crossing_search, handle, ikp, &
                                                             max_iter_fit, n_level_gw, num_poles
       LOGICAL                                            :: check_fit, remove_neg_virt_energies
-      REAL(kind=dp)                                      :: stop_crit
+      REAL(KIND=dp)                                      :: stop_crit
 
       CALL timeset(routineN, handle)
 
@@ -1537,15 +1540,16 @@ CONTAINS
    SUBROUTINE compute_eps_head_Berry(eps_head, kpoints, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, para_env_RPA, &
                                      qs_env, homo, Eigenval, omega)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eps_head
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: eps_head
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
                                                             matrix_berry_im_mo_mo
       TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      INTEGER                                            :: homo
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      REAL(KIND=dp)                                      :: omega
+      INTEGER, INTENT(IN)                                :: homo
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      REAL(KIND=dp), INTENT(IN)                          :: omega
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_eps_head_Berry', &
          routineP = moduleN//':'//routineN
@@ -1703,11 +1707,11 @@ CONTAINS
                                                             matrix_berry_im_mo_mo
       TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      LOGICAL                                            :: do_mo_coeff_Gamma_only
-      INTEGER                                            :: homo, nmo, gw_corr_lev_virt
-      REAL(KIND=dp)                                      :: eps_kpoint
-      LOGICAL                                            :: do_aux_bas
-      REAL(KIND=dp)                                      :: frac_aux_mos
+      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only
+      INTEGER, INTENT(IN)                                :: homo, nmo, gw_corr_lev_virt
+      REAL(KIND=dp), INTENT(IN)                          :: eps_kpoint
+      LOGICAL, INTENT(IN)                                :: do_aux_bas
+      REAL(KIND=dp), INTENT(IN)                          :: frac_aux_mos
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_berry_phase', &
          routineP = moduleN//':'//routineN
@@ -2218,7 +2222,7 @@ CONTAINS
    SUBROUTINE remove_unnecessary_blocks(mat_mo_coeff_Gamma_occ_and_GW, homo, gw_corr_lev_virt)
 
       TYPE(dbcsr_type), POINTER                          :: mat_mo_coeff_Gamma_occ_and_GW
-      INTEGER                                            :: homo, gw_corr_lev_virt
+      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_virt
 
       INTEGER                                            :: col, col_offset, row
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
@@ -2263,14 +2267,17 @@ CONTAINS
                                                 matrix_berry_im_mo_mo, homo, gw_corr_lev_occ, gw_corr_lev_virt, &
                                                 para_env_RPA, do_extra_kpoints)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr, eps_inv_head
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: delta_corr
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: eps_inv_head
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
                                                             matrix_berry_im_mo_mo
-      INTEGER                                            :: homo, gw_corr_lev_occ, gw_corr_lev_virt
+      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_occ, gw_corr_lev_virt
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env_RPA
-      LOGICAL                                            :: do_extra_kpoints
+      LOGICAL, INTENT(IN)                                :: do_extra_kpoints
 
       INTEGER                                            :: col, col_offset, col_size, i_col, i_row, &
                                                             ikp, m_level, n_level_gw, nkp, row, &
@@ -2446,7 +2453,10 @@ CONTAINS
 !> \param kpoints ...
 ! **************************************************************************************************
    SUBROUTINE compute_eps_inv_head(eps_inv_head, eps_head, kpoints)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eps_inv_head, eps_head
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: eps_inv_head
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: eps_head
       TYPE(kpoint_type), POINTER                         :: kpoints
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_eps_inv_head', &
@@ -2487,11 +2497,11 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(kpoint_type), POINTER                         :: kpoints
       INTEGER, DIMENSION(:), POINTER                     :: kp_grid
-      INTEGER                                            :: num_kp_grids
+      INTEGER, INTENT(IN)                                :: num_kp_grids
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), DIMENSION(3, 3)                     :: h_inv
-      INTEGER                                            :: nmo
-      LOGICAL                                            :: do_mo_coeff_Gamma_only, do_extra_kpoints
+      REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT)      :: h_inv
+      INTEGER, INTENT(IN)                                :: nmo
+      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only, do_extra_kpoints
 
       INTEGER                                            :: end_kp, i, i_grid_level, ix, iy, iz, &
                                                             nkp_inner_grid, nkp_outer_grid, &
@@ -2685,9 +2695,10 @@ CONTAINS
 !> \param eps_eigenval ...
 ! **************************************************************************************************
    SUBROUTINE average_degenerate_levels(vec_Sigma_c_gw, Eigenval_DFT, eps_eigenval)
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval_DFT
-      REAL(KIND=dp)                                      :: eps_eigenval
+      COMPLEX(KIND=dp), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(INOUT)               :: vec_Sigma_c_gw
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval_DFT
+      REAL(KIND=dp), INTENT(IN)                          :: eps_eigenval
 
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: avg_self_energy
       INTEGER :: degeneracy, first_degenerate_level, i_deg_level, i_level_gw, j_deg_level, jquad, &
@@ -2768,11 +2779,12 @@ CONTAINS
 !> \param my_open_shell ...
 ! **************************************************************************************************
    SUBROUTINE get_eigenval_for_conti(Eigenval, Eigenval_scf, Eigenval_kp, Eigenval_scf_kp, kpoints, ikp, iter_ev_sc, my_open_shell)
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval, Eigenval_scf
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: Eigenval_kp, Eigenval_scf_kp
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval, Eigenval_scf
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: Eigenval_kp, Eigenval_scf_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
-      INTEGER                                            :: ikp, iter_ev_sc
-      LOGICAL                                            :: my_open_shell
+      INTEGER, INTENT(IN)                                :: ikp, iter_ev_sc
+      LOGICAL, INTENT(IN)                                :: my_open_shell
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_eigenval_for_conti', &
          routineP = moduleN//':'//routineN
@@ -4287,10 +4299,11 @@ CONTAINS
                             gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
                             homo, nmo, unit_nr, do_alpha, do_beta)
 
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval, Eigenval_scf, ic_corr_list
-      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, &
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval, Eigenval_scf
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: ic_corr_list
+      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, gw_corr_lev_virt, &
                                                             gw_corr_lev_tot, homo, nmo, unit_nr
-      LOGICAL, OPTIONAL                                  :: do_alpha, do_beta
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_alpha, do_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_ic_corr', routineP = moduleN//':'//routineN
 
@@ -4501,13 +4514,16 @@ CONTAINS
                                                             mat_contr_W
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_W
       TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv, mat_dm
-      REAL(KIND=dp)                                      :: stabilize_exp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w, &
+      REAL(KIND=dp), INTENT(IN)                          :: stabilize_exp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(IN)                                      :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw
+      COMPLEX(KIND=dp), ALLOCATABLE, &
+         DIMENSION(:, :, :), INTENT(INOUT)               :: vec_Sigma_c_gw
       LOGICAL, INTENT(IN)                                :: do_periodic
       INTEGER, INTENT(IN)                                :: num_points_corr
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: delta_corr
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
       TYPE(mp2_type), POINTER                            :: mp2_env
@@ -4843,11 +4859,12 @@ CONTAINS
                                                             matrix_s
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
          fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      INTEGER                                            :: jquad, num_integ_points, nmo
-      REAL(KIND=dp)                                      :: eps_filter, e_fermi, stabilize_exp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
-      INTEGER                                            :: count_ev_sc_GW
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      INTEGER, INTENT(IN)                                :: jquad, num_integ_points, nmo
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, stabilize_exp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj
+      INTEGER, INTENT(IN)                                :: count_ev_sc_GW
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function', &
          routineP = moduleN//':'//routineN

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -2781,7 +2781,7 @@ CONTAINS
    SUBROUTINE get_eigenval_for_conti(Eigenval, Eigenval_scf, Eigenval_kp, Eigenval_scf_kp, kpoints, ikp, iter_ev_sc, my_open_shell)
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval, Eigenval_scf
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(OUT)                                     :: Eigenval_kp, Eigenval_scf_kp
+         INTENT(INOUT)                                   :: Eigenval_kp, Eigenval_scf_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
       INTEGER, INTENT(IN)                                :: ikp, iter_ev_sc
       LOGICAL, INTENT(IN)                                :: my_open_shell

--- a/src/rpa_gw_kpoints.F
+++ b/src/rpa_gw_kpoints.F
@@ -398,6 +398,8 @@ CONTAINS
       CALL cp_fm_release(fm_mat_work_global)
       CALL cp_fm_release(fm_mat_work_local)
       DEALLOCATE (atom_from_RI_index)
+      DEALLOCATE (row_blk_start)
+      DEALLOCATE (row_blk_end)
 
       CALL timestop(handle2)
 

--- a/src/rpa_gw_kpoints.F
+++ b/src/rpa_gw_kpoints.F
@@ -1,0 +1,2685 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief Routines for kpoint treatment in GW
+!> \par History
+!>      04.2019 created [Jan Wilhelm]
+! **************************************************************************************************
+MODULE rpa_gw_kpoints
+   USE basis_set_types,                 ONLY: gto_basis_set_p_type
+   USE cell_types,                      ONLY: cell_type,&
+                                              get_cell,&
+                                              pbc
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_cholesky_invert,&
+                                              cp_cfm_gemm,&
+                                              cp_cfm_scale_and_add,&
+                                              cp_cfm_scale_and_add_fm,&
+                                              cp_cfm_transpose
+   USE cp_cfm_types,                    ONLY: cp_cfm_create,&
+                                              cp_cfm_get_info,&
+                                              cp_cfm_p_type,&
+                                              cp_cfm_release,&
+                                              cp_cfm_set_all,&
+                                              cp_cfm_to_fm,&
+                                              cp_cfm_type
+   USE cp_dbcsr_operations,             ONLY: copy_fm_to_dbcsr,&
+                                              dbcsr_allocate_matrix_set,&
+                                              dbcsr_deallocate_matrix_set
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_scale_and_add
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
+                                              cp_fm_struct_release,&
+                                              cp_fm_struct_type
+   USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
+                                              cp_fm_create,&
+                                              cp_fm_p_type,&
+                                              cp_fm_release,&
+                                              cp_fm_set_all,&
+                                              cp_fm_set_element,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type
+   USE cp_gemm_interface,               ONLY: cp_gemm
+   USE cp_para_types,                   ONLY: cp_para_env_type
+   USE dbcsr_api,                       ONLY: &
+        dbcsr_add, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_filter, dbcsr_get_block_p, &
+        dbcsr_get_num_blocks, dbcsr_init_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
+        dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, &
+        dbcsr_p_type, dbcsr_release, dbcsr_release_p, dbcsr_reserve_all_blocks, dbcsr_set, &
+        dbcsr_trace, dbcsr_type, dbcsr_type_no_symmetry
+   USE input_constants,                 ONLY: gw_read_exx
+   USE kinds,                           ONLY: dp,&
+                                              int_8
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_type
+   USE mathconstants,                   ONLY: gaussi,&
+                                              twopi,&
+                                              z_one,&
+                                              z_zero
+   USE mathlib,                         ONLY: invmat
+   USE message_passing,                 ONLY: mp_sum
+   USE particle_methods,                ONLY: get_particle_set
+   USE particle_types,                  ONLY: particle_type
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_integral_utils,               ONLY: basis_set_list_setup
+   USE qs_kind_types,                   ONLY: qs_kind_type
+   USE rpa_im_time,                     ONLY: compute_transl_dm,&
+                                              fill_mat_3c_overl_int_gw,&
+                                              replicate_mat_to_subgroup_simple
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+
+   PRIVATE
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'rpa_gw_kpoints'
+
+   PUBLIC :: compute_Wc_real_space_tau_GW, compute_Wc_kp_tau_GW, &
+             compute_wkp_W, compute_self_energy_im_time_gw_kp
+
+CONTAINS
+
+! **************************************************************************************************
+!> \brief ...
+!> \param fm_mat_W_tau ...
+!> \param cfm_mat_Q ...
+!> \param fm_mat_L_re ...
+!> \param fm_mat_L_im ...
+!> \param dimen_RI ...
+!> \param num_integ_points ...
+!> \param jquad ...
+!> \param ikp ...
+!> \param tj ...
+!> \param tau_tj ...
+!> \param weights_cos_tf_w_to_t ...
+!> \param ikp_local ...
+!> \param para_env ...
+!> \param kpoints ...
+!> \param qs_env ...
+!> \param wkp_W ...
+!> \param mat_SinvVSinv ...
+!> \param do_W_and_not_V ...
+! **************************************************************************************************
+   SUBROUTINE compute_Wc_real_space_tau_GW(fm_mat_W_tau, cfm_mat_Q, fm_mat_L_re, fm_mat_L_im, &
+                                           dimen_RI, num_integ_points, jquad, &
+                                           ikp, tj, tau_tj, weights_cos_tf_w_to_t, ikp_local, &
+                                           para_env, kpoints, qs_env, wkp_W, mat_SinvVSinv, do_W_and_not_V)
+
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
+      TYPE(cp_fm_type), POINTER                          :: fm_mat_L_re, fm_mat_L_im
+      INTEGER                                            :: dimen_RI, num_integ_points, jquad, ikp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj, tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp_W
+      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv
+      LOGICAL                                            :: do_W_and_not_V
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Wc_real_space_tau_GW', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: handle, handle2, i_global, iatom, iatom_old, icell, iiB, iquad, irow, j_global, &
+         jatom, jatom_old, jcol, jjB, jkp, LLL, natom, ncol_local, nkind, nkp, nrow_local, &
+         num_cells, xcell, ycell, zcell
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_from_RI_index
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_blk_end, row_blk_start, &
+                                                            row_indices
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      LOGICAL                                            :: do_V_and_not_W
+      REAL(KIND=dp) :: abs_rab_cell, arg, contribution, coskl, cutoff_exp, d_0, omega, sinkl, &
+         sum_exp, sum_exp_k_im, sum_exp_k_re, tau, weight, weight_im, weight_re
+      REAL(KIND=dp), DIMENSION(3)                        :: cell_vector, rab_cell_i
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_L, cfm_mat_work, cfm_mat_work_2
+      TYPE(cp_fm_type), POINTER                          :: fm_dummy, fm_mat_work_global, &
+                                                            fm_mat_work_local
+      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_RI_tmp
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      CALL timeset(routineN, handle)
+
+      CALL timeset(routineN//"_1", handle2)
+
+      NULLIFY (cfm_mat_work)
+      CALL cp_cfm_create(cfm_mat_work, cfm_mat_Q%matrix_struct)
+      CALL cp_cfm_set_all(cfm_mat_work, z_zero)
+
+      NULLIFY (cfm_mat_work_2)
+      CALL cp_cfm_create(cfm_mat_work_2, cfm_mat_Q%matrix_struct)
+      CALL cp_cfm_set_all(cfm_mat_work_2, z_zero)
+
+      NULLIFY (cfm_mat_L)
+      CALL cp_cfm_create(cfm_mat_L, cfm_mat_Q%matrix_struct)
+      CALL cp_cfm_set_all(cfm_mat_L, z_zero)
+
+      ! Copy fm_mat_L_re and fm_mat_L_re to cfm_mat_L
+      CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_L, z_one, fm_mat_L_re)
+      CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_L, gaussi, fm_mat_L_im)
+
+      NULLIFY (fm_mat_work_global)
+      CALL cp_fm_create(fm_mat_work_global, fm_mat_W_tau(1)%matrix%matrix_struct)
+      CALL cp_fm_set_all(fm_mat_work_global, 0.0_dp)
+
+      NULLIFY (fm_mat_work_local)
+      CALL cp_fm_create(fm_mat_work_local, cfm_mat_Q%matrix_struct)
+      CALL cp_fm_set_all(fm_mat_work_local, 0.0_dp)
+
+      CALL timestop(handle2)
+
+      IF (do_W_and_not_V) THEN
+
+         CALL timeset(routineN//"_2", handle2)
+
+         ! calculate [1+Q(iw')]^-1
+         CALL cp_cfm_cholesky_invert(cfm_mat_Q)
+
+         ! symmetrize the result
+         CALL own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
+
+         ! subtract exchange part by subtracing identity matrix from epsilon
+         CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
+                              nrow_local=nrow_local, &
+                              ncol_local=ncol_local, &
+                              row_indices=row_indices, &
+                              col_indices=col_indices)
+
+         DO jjB = 1, ncol_local
+            j_global = col_indices(jjB)
+            DO iiB = 1, nrow_local
+               i_global = row_indices(iiB)
+               IF (j_global == i_global .AND. i_global <= dimen_RI) THEN
+                  cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB)-z_one
+               END IF
+            END DO
+         END DO
+
+         CALL timestop(handle2)
+
+         CALL timeset(routineN//"_3.1", handle2)
+
+         ! work = epsilon(iw,k)*L^H(k)
+         CALL cp_cfm_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
+                          z_zero, cfm_mat_work)
+
+         ! W(iw,k) = L(k)*work
+         CALL cp_cfm_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
+                          z_zero, cfm_mat_work_2)
+
+         CALL timestop(handle2)
+
+      ELSE
+
+         ! S^-1(k)V(k)S^-1(k) = L(k)*L(k)^H
+         CALL cp_cfm_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_L, &
+                          z_zero, cfm_mat_work_2)
+
+      END IF
+
+      CALL timeset(routineN//"_4", handle2)
+
+      CALL get_kpoint_info(kpoints, xkp=xkp, wkp=wkp, nkp=nkp)
+      index_to_cell => kpoints%index_to_cell
+      num_cells = SIZE(index_to_cell, 2)
+      d_0 = qs_env%mp2_env%ri_rpa_im_time%cutoff
+      cutoff_exp = 10000.0_dp
+      CALL cp_cfm_set_all(cfm_mat_work, z_zero)
+
+      NULLIFY (qs_kind_set, cell, particle_set)
+      CALL get_qs_env(qs_env, qs_kind_set=qs_kind_set, cell=cell, natom=natom, nkind=nkind, &
+                      particle_set=particle_set)
+
+      ALLOCATE (row_blk_start(natom))
+      ALLOCATE (row_blk_end(natom))
+      ALLOCATE (basis_set_RI_tmp(nkind))
+      CALL basis_set_list_setup(basis_set_RI_tmp, "RI_AUX", qs_kind_set)
+      CALL get_particle_set(particle_set, qs_kind_set, first_sgf=row_blk_start, last_sgf=row_blk_end, &
+                            basis=basis_set_RI_tmp)
+      DEALLOCATE (basis_set_RI_tmp)
+      ALLOCATE (atom_from_RI_index(dimen_RI))
+      DO LLL = 1, dimen_RI
+         DO iatom = 1, natom
+            IF (LLL >= row_blk_start(iatom) .AND. LLL <= row_blk_end(iatom)) THEN
+               atom_from_RI_index(LLL) = iatom
+            END IF
+         END DO
+      END DO
+      CALL get_cell(cell=cell, h=hmat)
+      iatom_old = 0
+      jatom_old = 0
+
+      CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
+
+      DO irow = 1, nrow_local
+         DO jcol = 1, ncol_local
+
+            iatom = atom_from_RI_index(row_indices(irow))
+            jatom = atom_from_RI_index(col_indices(jcol))
+
+            IF (iatom .NE. iatom_old .OR. jatom .NE. jatom_old) THEN
+
+               sum_exp = 0.0_dp
+               sum_exp_k_re = 0.0_dp
+               sum_exp_k_im = 0.0_dp
+
+               DO icell = 1, num_cells
+
+                  xcell = index_to_cell(1, icell)
+                  ycell = index_to_cell(2, icell)
+                  zcell = index_to_cell(3, icell)
+
+                  arg = REAL(xcell, dp)*xkp(1, ikp)+REAL(ycell, dp)*xkp(2, ikp)+REAL(zcell, dp)*xkp(3, ikp)
+
+                  coskl = wkp_W(ikp)*COS(twopi*arg)
+                  sinkl = wkp_W(ikp)*SIN(twopi*arg)
+
+                  cell_vector(1:3) = MATMUL(hmat, REAL(index_to_cell(1:3, icell), dp))
+
+                  rab_cell_i(1:3) = pbc(particle_set(iatom)%r(1:3), cell)- &
+                                    (pbc(particle_set(jatom)%r(1:3), cell)+cell_vector(1:3))
+
+                  abs_rab_cell = SQRT(rab_cell_i(1)**2+rab_cell_i(2)**2+rab_cell_i(3)**2)
+
+                  IF (abs_rab_cell/d_0 < cutoff_exp) THEN
+                     sum_exp = sum_exp+EXP(-abs_rab_cell/d_0)
+                     sum_exp_k_re = sum_exp_k_re+EXP(-abs_rab_cell/d_0)*coskl
+                     sum_exp_k_im = sum_exp_k_im+EXP(-abs_rab_cell/d_0)*sinkl
+                  END IF
+
+               END DO
+
+               weight_re = sum_exp_k_re/sum_exp
+               weight_im = sum_exp_k_im/sum_exp
+
+               iatom_old = iatom
+               jatom_old = jatom
+
+            END IF
+
+            contribution = weight_re*REAL(cfm_mat_work_2%local_data(irow, jcol))+ &
+                           weight_im*AIMAG(cfm_mat_work_2%local_data(irow, jcol))
+
+            fm_mat_work_local%local_data(irow, jcol) = fm_mat_work_local%local_data(irow, jcol)+contribution
+
+         END DO
+      END DO
+
+      CALL timestop(handle2)
+
+      CALL timeset(routineN//"_5", handle2)
+
+      IF (do_W_and_not_V) THEN
+
+         IF (SUM(ikp_local) > nkp) THEN
+
+            CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
+
+            DO iquad = 1, num_integ_points
+
+               omega = tj(jquad)
+               tau = tau_tj(iquad)
+               weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
+
+               IF (jquad == 1 .AND. ikp == 1) THEN
+                  CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad)%matrix, alpha=0.0_dp)
+               END IF
+
+               CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad)%matrix, beta=weight, matrix_b=fm_mat_work_global)
+
+            END DO
+
+         ELSE
+
+            DO jkp = 1, nkp
+
+               IF (ANY(ikp_local(:) == jkp)) THEN
+                  CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
+               ELSE
+                  NULLIFY (fm_dummy)
+                  CALL cp_fm_copy_general(fm_dummy, fm_mat_work_global, para_env)
+               END IF
+
+               DO iquad = 1, num_integ_points
+
+                  omega = tj(jquad)
+                  tau = tau_tj(iquad)
+                  weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
+
+                  IF (jquad == 1 .AND. jkp == 1) THEN
+                     CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad)%matrix, alpha=0.0_dp)
+                  END IF
+
+                  CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad)%matrix, beta=weight, &
+                                           matrix_b=fm_mat_work_global)
+
+               END DO
+
+            END DO
+
+         END IF
+
+      END IF
+
+      do_V_and_not_W = .NOT. do_W_and_not_V
+      IF (do_V_and_not_W) THEN
+
+         IF (SUM(ikp_local) > nkp) THEN
+            CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
+            CALL fm_mat_work_global_to_mat_SinvVSinv(mat_SinvVSinv, fm_mat_work_global)
+         ELSE
+            DO jkp = 1, nkp
+               IF (ANY(ikp_local(:) == jkp)) THEN
+                  CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
+               ELSE
+                  NULLIFY (fm_dummy)
+                  CALL cp_fm_copy_general(fm_dummy, fm_mat_work_global, para_env)
+               END IF
+               CALL fm_mat_work_global_to_mat_SinvVSinv(mat_SinvVSinv, fm_mat_work_global)
+            END DO
+         END IF
+      END IF
+
+      CALL cp_cfm_release(cfm_mat_work)
+      CALL cp_cfm_release(cfm_mat_work_2)
+      CALL cp_cfm_release(cfm_mat_L)
+      CALL cp_fm_release(fm_mat_work_global)
+      CALL cp_fm_release(fm_mat_work_local)
+      DEALLOCATE (atom_from_RI_index)
+
+      CALL timestop(handle2)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_SinvVSinv ...
+!> \param fm_mat_work_global ...
+! **************************************************************************************************
+   SUBROUTINE fm_mat_work_global_to_mat_SinvVSinv(mat_SinvVSinv, fm_mat_work_global)
+
+      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv
+      TYPE(cp_fm_type), POINTER                          :: fm_mat_work_global
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'fm_mat_work_global_to_mat_SinvVSinv', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle
+      TYPE(dbcsr_p_type)                                 :: mat_work
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (mat_work%matrix)
+      ALLOCATE (mat_work%matrix)
+      CALL dbcsr_create(mat_work%matrix, template=mat_SinvVSinv%matrix)
+
+      CALL copy_fm_to_dbcsr(fm_mat_work_global, mat_work%matrix, keep_sparsity=.FALSE.)
+
+      CALL dbcsr_add(mat_SinvVSinv%matrix, mat_work%matrix, 1.0_dp, 1.0_dp)
+
+      CALL dbcsr_release(mat_work%matrix)
+      DEALLOCATE (mat_work%matrix)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param cfm_mat_W_kp_tau ...
+!> \param cfm_mat_Q ...
+!> \param fm_mat_L_re ...
+!> \param fm_mat_L_im ...
+!> \param dimen_RI ...
+!> \param num_integ_points ...
+!> \param jquad ...
+!> \param ikp ...
+!> \param tj ...
+!> \param tau_tj ...
+!> \param weights_cos_tf_w_to_t ...
+! **************************************************************************************************
+   SUBROUTINE compute_Wc_kp_tau_GW(cfm_mat_W_kp_tau, cfm_mat_Q, fm_mat_L_re, fm_mat_L_im, &
+                                   dimen_RI, num_integ_points, jquad, &
+                                   ikp, tj, tau_tj, weights_cos_tf_w_to_t)
+
+      TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
+      TYPE(cp_fm_type), POINTER                          :: fm_mat_L_re, fm_mat_L_im
+      INTEGER                                            :: dimen_RI, num_integ_points, jquad, ikp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj, tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Wc_kp_tau_GW', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, handle2, i_global, iiB, iquad, &
+                                                            j_global, jjB, ncol_local, nrow_local
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+      REAL(KIND=dp)                                      :: omega, tau, weight
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_L, cfm_mat_work
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (cfm_mat_work)
+      CALL cp_cfm_create(cfm_mat_work, fm_mat_L_re%matrix_struct)
+      CALL cp_cfm_set_all(cfm_mat_work, z_zero)
+
+      NULLIFY (cfm_mat_L)
+      CALL cp_cfm_create(cfm_mat_L, fm_mat_L_re%matrix_struct)
+      CALL cp_cfm_set_all(cfm_mat_L, z_zero)
+
+      CALL timeset(routineN//"_cholesky_inv", handle2)
+
+      ! calculate [1+Q(iw')]^-1
+      CALL cp_cfm_cholesky_invert(cfm_mat_Q)
+
+      ! symmetrize the result
+      CALL own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
+
+      ! subtract exchange part by subtracing identity matrix from epsilon
+      CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
+
+      DO jjB = 1, ncol_local
+         j_global = col_indices(jjB)
+         DO iiB = 1, nrow_local
+            i_global = row_indices(iiB)
+            IF (j_global == i_global .AND. i_global <= dimen_RI) THEN
+               cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB)-z_one
+            END IF
+         END DO
+      END DO
+
+      CALL timestop(handle2)
+
+      ! Copy fm_mat_L_re and fm_mat_L_re to cfm_mat_L
+      CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_L, z_one, fm_mat_L_re)
+      CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_L, gaussi, fm_mat_L_im)
+
+      ! work = epsilon(iw,k)*L^H(k)
+      CALL cp_cfm_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
+                       z_zero, cfm_mat_work)
+
+      ! W(iw,k) = L(k)*work
+      CALL cp_cfm_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
+                       z_zero, cfm_mat_Q)
+
+      DO iquad = 1, num_integ_points
+         omega = tj(jquad)
+         tau = tau_tj(iquad)
+         weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
+         CALL cp_cfm_scale_and_add(alpha=z_one, matrix_a=cfm_mat_W_kp_tau(ikp, iquad)%matrix, &
+                                   beta=CMPLX(weight, KIND=dp), matrix_b=cfm_mat_Q)
+      END DO
+
+      CALL cp_cfm_release(cfm_mat_work)
+      CALL cp_cfm_release(cfm_mat_L)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param wkp_W ...
+!> \param kpoints ...
+!> \param h_mat ...
+!> \param h_inv ...
+!> \param exp_kpoints ...
+!> \param periodic ...
+! **************************************************************************************************
+   SUBROUTINE compute_wkp_W(wkp_W, kpoints, h_mat, h_inv, exp_kpoints, periodic)
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp_W
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: h_mat, h_inv
+      REAL(KIND=dp)                                      :: exp_kpoints
+      INTEGER, DIMENSION(3)                              :: periodic
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_wkp_W', routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i_dim, i_x, ikp, info, j_y, k_z, &
+                                                            n_x, n_y, n_z, nkp, nsuperfine, &
+                                                            num_lin_eqs
+      REAL(KIND=dp)                                      :: a_vec_dot_k_vec, integral, k_sq, weight
+      REAL(KIND=dp), DIMENSION(3)                        :: a_vec, k_vec, x_vec
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: right_side, wkp
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: matrix_lin_eqs, xkp
+
+      CALL timeset(routineN, handle)
+
+      CALL get_kpoint_info(kpoints, xkp=xkp, wkp=wkp, nkp=nkp)
+
+      ! we determine the kpoint weights of the Monkhors Pack mesh new
+      ! such that the functions 1/k^2, 1/k and const are integrated exactly
+      ! in the Brillouin zone
+      ! this is done by minimizing sum_i |w_i|^2 where w_i are the weights of
+      ! the i-th kpoint under the following constraints:
+      ! 1) 1/k^2, 1/k and const are integrated exactly
+      ! 2) the kpoint weights of kpoints with identical absolute value are
+      !    the same, of e.g. (1/8,3/8,3/8) same weight as for (3/8,1/8,3/8)
+      ! for 1d and 2d materials: we use normal Monkhorst-Pack mesh, checked
+      ! by SUM(periodic) == 3
+
+      IF (exp_kpoints < 2.0_dp .AND. SUM(periodic) == 3) THEN
+
+         ! first, compute the integral of f(k)=1/k^2 and 1/k on super fine grid
+         nsuperfine = 500
+         integral = 0.0_dp
+         IF (exp_kpoints > 0.0_dp) exp_kpoints = -2.0_dp
+
+         ! actually, there is the factor *det_3x3(h_inv) missing to account for the
+         ! integration volume but for wkp det_3x3(h_inv) is needed
+         weight = 2.0_dp/(REAL(nsuperfine, dp))**3
+         DO i_x = 1, nsuperfine
+            DO j_y = 1, nsuperfine
+               DO k_z = 1, nsuperfine/2
+
+                  x_vec = (/REAL(i_x-nsuperfine/2, dp)-0.5_dp, &
+                            REAL(j_y-nsuperfine/2, dp)-0.5_dp, &
+                            REAL(k_z-nsuperfine/2, dp)-0.5_dp/)/ &
+                          REAL(nsuperfine, dp)
+                  k_vec = MATMUL(h_inv(1:3, 1:3), x_vec)
+                  k_sq = k_vec(1)**2+k_vec(2)**2+k_vec(3)**2
+                  integral = integral+weight*k_sq**(exp_kpoints*0.5_dp)
+               END DO
+            END DO
+         END DO
+
+         num_lin_eqs = nkp+2
+
+         ALLOCATE (matrix_lin_eqs(num_lin_eqs, num_lin_eqs))
+         matrix_lin_eqs(:, :) = 0.0_dp
+
+         DO ikp = 1, nkp
+
+            k_vec = MATMUL(h_inv(1:3, 1:3), xkp(1:3, ikp))
+            k_sq = k_vec(1)**2+k_vec(2)**2+k_vec(3)**2
+
+            matrix_lin_eqs(ikp, ikp) = 2.0_dp
+            matrix_lin_eqs(ikp, nkp+1) = 1.0_dp
+            matrix_lin_eqs(ikp, nkp+2) = 1.0_dp*k_sq**(exp_kpoints*0.5_dp)
+
+            matrix_lin_eqs(nkp+1, ikp) = 1.0_dp
+            matrix_lin_eqs(nkp+2, ikp) = 1.0_dp*k_sq**(exp_kpoints*0.5_dp)
+
+         END DO
+
+         CALL invmat(matrix_lin_eqs, info)
+         ! check whether inversion was successfull
+         CPASSERT(info == 0)
+
+         ALLOCATE (wkp_W(num_lin_eqs))
+
+         ALLOCATE (right_side(num_lin_eqs))
+         right_side = 0.0_dp
+         right_side(nkp+1) = 1.0_dp
+         right_side(nkp+2) = integral
+
+         wkp_W(1:num_lin_eqs) = MATMUL(matrix_lin_eqs, right_side)
+
+         DEALLOCATE (matrix_lin_eqs, right_side)
+
+      ELSE IF (exp_kpoints < 2.0_dp .AND. SUM(periodic) == 1) THEN
+
+         ! first, compute the integral of f(k)=1/k^2 and 1/k on super fine grid
+         nsuperfine = 5000
+         integral = 0.0_dp
+
+         ! actually, there is the factor *det_3x3(h_inv) missing to account for the
+         ! integration volume but for wkp det_3x3(h_inv) is needed
+         weight = 1.0_dp/REAL(nsuperfine, dp)
+         IF (periodic(1) == 1) THEN
+            n_x = nsuperfine
+         ELSE
+            n_x = 1
+         END IF
+         IF (periodic(2) == 1) THEN
+            n_y = nsuperfine
+         ELSE
+            n_y = 1
+         END IF
+         IF (periodic(3) == 1) THEN
+            n_z = nsuperfine
+         ELSE
+            n_z = 1
+         END IF
+
+         a_vec = MATMUL(h_mat(1:3, 1:3), &
+                        (/REAL(periodic(1), dp), REAL(periodic(2), dp), REAL(periodic(3), dp)/))
+
+         DO i_x = 1, n_x
+            DO j_y = 1, n_y
+               DO k_z = 1, n_z
+
+                  x_vec = (/REAL(i_x-nsuperfine/2, dp)-0.5_dp, &
+                            REAL(j_y-nsuperfine/2, dp)-0.5_dp, &
+                            REAL(k_z-nsuperfine/2, dp)-0.5_dp/)/ &
+                          REAL(nsuperfine, dp)
+
+                  DO i_dim = 1, 3
+                     IF (periodic(i_dim) == 0) THEN
+                        x_vec(i_dim) = 0.0_dp
+                     END IF
+                  END DO
+
+                  k_vec = MATMUL(h_inv(1:3, 1:3), x_vec)
+                  a_vec_dot_k_vec = a_vec(1)*k_vec(1)+a_vec(2)*k_vec(2)+a_vec(3)*k_vec(3)
+                  integral = integral+weight*LOG(2.0_dp-2.0_dp*COS(a_vec_dot_k_vec))
+               END DO
+            END DO
+         END DO
+
+         num_lin_eqs = nkp+2
+
+         ALLOCATE (matrix_lin_eqs(num_lin_eqs, num_lin_eqs))
+         matrix_lin_eqs(:, :) = 0.0_dp
+
+         DO ikp = 1, nkp
+
+            k_vec = MATMUL(h_inv(1:3, 1:3), xkp(1:3, ikp))
+            k_sq = k_vec(1)**2+k_vec(2)**2+k_vec(3)**2
+
+            matrix_lin_eqs(ikp, ikp) = 2.0_dp
+            matrix_lin_eqs(ikp, nkp+1) = 1.0_dp
+
+            a_vec_dot_k_vec = a_vec(1)*k_vec(1)+a_vec(2)*k_vec(2)+a_vec(3)*k_vec(3)
+            matrix_lin_eqs(ikp, nkp+2) = LOG(2.0_dp-2.0_dp*COS(a_vec_dot_k_vec))
+
+            matrix_lin_eqs(nkp+1, ikp) = 1.0_dp
+            matrix_lin_eqs(nkp+2, ikp) = LOG(2.0_dp-2.0_dp*COS(a_vec_dot_k_vec))
+
+         END DO
+
+         CALL invmat(matrix_lin_eqs, info)
+         ! check whether inversion was successfull
+         CPASSERT(info == 0)
+
+         ALLOCATE (wkp_W(num_lin_eqs))
+
+         ALLOCATE (right_side(num_lin_eqs))
+         right_side = 0.0_dp
+         right_side(nkp+1) = 1.0_dp
+         right_side(nkp+2) = integral
+
+         wkp_W(1:num_lin_eqs) = MATMUL(matrix_lin_eqs, right_side)
+
+         DEALLOCATE (matrix_lin_eqs, right_side)
+
+      ELSE
+
+         ALLOCATE (wkp_W(nkp))
+         wkp_W(:) = wkp(:)
+
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param cfm_mat_Q ...
+!> \param cfm_mat_work ...
+! **************************************************************************************************
+   SUBROUTINE own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
+
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q, cfm_mat_work
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'own_cfm_upper_to_full', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i_global, iiB, j_global, jjB, &
+                                                            ncol_local, nrow_local
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+
+      CALL timeset(routineN, handle)
+
+      ! get info of fm_mat_Q
+      CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
+
+      DO jjB = 1, ncol_local
+         j_global = col_indices(jjB)
+         DO iiB = 1, nrow_local
+            i_global = row_indices(iiB)
+            IF (j_global < i_global) THEN
+               cfm_mat_Q%local_data(iiB, jjB) = z_zero
+            END IF
+            IF (j_global == i_global) THEN
+               cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB)/(2.0_dp, 0.0_dp)
+            END IF
+         END DO
+      END DO
+
+      CALL cp_cfm_transpose(cfm_mat_Q, 'C', cfm_mat_work)
+
+      CALL cp_cfm_scale_and_add(z_one, cfm_mat_Q, z_one, cfm_mat_work)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param vec_Sigma_c_gw ...
+!> \param vec_Sigma_x_gw ...
+!> \param vec_Sigma_x_minus_vxc_gw ...
+!> \param mat_3c_overl_int ...
+!> \param cell_to_index_3c ...
+!> \param index_to_cell_3c ...
+!> \param num_cells_dm ...
+!> \param kpoints ...
+!> \param unit_nr ...
+!> \param gw_corr_lev_tot ...
+!> \param num_3c_repl ...
+!> \param nkp_self_energy ...
+!> \param num_fit_points ...
+!> \param RI_blk_sizes ...
+!> \param prim_blk_sizes ...
+!> \param matrix_s ...
+!> \param para_env ...
+!> \param para_env_sub ...
+!> \param gw_corr_lev_occ ...
+!> \param gw_corr_lev_virt ...
+!> \param dimen_RI ...
+!> \param homo ...
+!> \param nmo ...
+!> \param cut_RI ...
+!> \param mat_dm_virt_local ...
+!> \param row_from_LLL ...
+!> \param my_group_L_starts_im_time ...
+!> \param my_group_L_sizes_im_time ...
+!> \param cfm_mat_Q ...
+!> \param cfm_mat_W_kp_tau ...
+!> \param qs_env ...
+!> \param e_fermi ...
+!> \param eps_filter ...
+!> \param tj ...
+!> \param tau_tj ...
+!> \param weights_sin_tf_t_to_w ...
+!> \param weights_cos_tf_t_to_w ...
+!> \param num_integ_points ...
+!> \param stabilize_exp ...
+!> \param fm_mat_L ...
+!> \param wkp_W ...
+! **************************************************************************************************
+   SUBROUTINE compute_self_energy_im_time_gw_kp(vec_Sigma_c_gw, vec_Sigma_x_gw, vec_Sigma_x_minus_vxc_gw, &
+                                                mat_3c_overl_int, cell_to_index_3c, index_to_cell_3c, &
+                                                num_cells_dm, kpoints, &
+                                                unit_nr, gw_corr_lev_tot, num_3c_repl, nkp_self_energy, num_fit_points, &
+                                                RI_blk_sizes, prim_blk_sizes, matrix_s, para_env, para_env_sub, &
+                                                gw_corr_lev_occ, gw_corr_lev_virt, dimen_RI, homo, nmo, cut_RI, mat_dm_virt_local, &
+                                                row_from_LLL, my_group_L_starts_im_time, my_group_L_sizes_im_time, &
+                                                cfm_mat_Q, cfm_mat_W_kp_tau, qs_env, e_fermi, eps_filter, tj, tau_tj, &
+                                                weights_sin_tf_t_to_w, weights_cos_tf_t_to_w, &
+                                                num_integ_points, stabilize_exp, fm_mat_L, wkp_W)
+
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vec_Sigma_x_gw
+      REAL(KIND=dp), DIMENSION(:, :)                     :: vec_Sigma_x_minus_vxc_gw
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_3c
+      INTEGER                                            :: num_cells_dm
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: unit_nr, gw_corr_lev_tot, num_3c_repl, &
+                                                            nkp_self_energy, num_fit_points
+      INTEGER, DIMENSION(:), POINTER                     :: RI_blk_sizes, prim_blk_sizes
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
+      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, &
+                                                            dimen_RI, homo, nmo, cut_RI
+      TYPE(dbcsr_p_type)                                 :: mat_dm_virt_local
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: row_from_LLL, my_group_L_starts_im_time, &
+                                                            my_group_L_sizes_im_time
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
+      TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(KIND=dp)                                      :: e_fermi, eps_filter
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj, tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_sin_tf_t_to_w, &
+                                                            weights_cos_tf_t_to_w
+      INTEGER                                            :: num_integ_points
+      REAL(KIND=dp)                                      :: stabilize_exp
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_mat_L
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp_W
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_self_energy_im_time_gw_kp', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, ikp, maxcell, &
+                                                            num_cells_R1_plus_S2, num_cells_R2, &
+                                                            start_jquad
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_R1, &
+                                                            index_to_cell_R1_plus_S2, &
+                                                            index_to_cell_R2
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_R2
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: has_blocks_mat_dm_occ_S, &
+                                                            has_blocks_mat_dm_virt_S
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: cycle_R1_plus_S2_n_level, &
+                                                            has_3c_blocks_im, has_3c_blocks_re
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :)        :: cycle_R1_S2_n_level
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :) :: are_flops_I_T_R1_plus_S2_S1_n_level
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_I_muP_occ_im, mat_I_muP_occ_re, &
+                                                            mat_I_muP_virt_im, mat_I_muP_virt_re
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_S, mat_dm_virt_S, mat_W_R
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_im, &
+                                                            mat_3c_overl_int_gw_kp_re
+      TYPE(dbcsr_type), POINTER :: mat_contr_gf_occ_im, mat_contr_gf_occ_re, mat_contr_gf_virt_im, &
+         mat_contr_gf_virt_re, mat_contr_W_im, mat_contr_W_re
+
+      CALL timeset(routineN, handle)
+
+      ! R2 is index on W^R2
+      CALL compute_cell_vec_for_R2(index_to_cell_R2, cell_to_index_R2, num_cells_R2, unit_nr, &
+                                   index_to_cell_dm, qs_env)
+
+      ! R1+S2 is index on 3c integral
+      CALL compute_cell_vec_for_R1_plus_S2_or_R1(index_to_cell_R1_plus_S2, cell_to_index_3c, &
+                                                 num_cells_R1_plus_S2, kpoints, &
+                                                 unit_nr, maxcell, num_cells_dm)
+
+      CALL allocate_mat_3c_gw(mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                              gw_corr_lev_tot, num_3c_repl, num_cells_dm, num_cells_R1_plus_S2, num_integ_points, &
+                              dimen_RI, nmo, RI_blk_sizes, prim_blk_sizes, matrix_s, cfm_mat_Q, &
+                              mat_contr_gf_occ_re, mat_contr_gf_occ_im, mat_contr_gf_virt_re, mat_contr_gf_virt_im, &
+                              mat_contr_W_re, mat_contr_W_im, mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                              mat_I_muP_occ_im, mat_I_muP_virt_im, has_3c_blocks_re, has_3c_blocks_im, &
+                              cycle_R1_S2_n_level, &
+                              has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, cycle_R1_plus_S2_n_level, &
+                              are_flops_I_T_R1_plus_S2_S1_n_level)
+
+      ! get W^R2
+      CALL trafo_W_from_k_to_R(index_to_cell_R2, mat_W_R, mat_3c_overl_int_gw_kp_re, cfm_mat_W_kp_tau, &
+                               kpoints, RI_blk_sizes, fm_mat_L, dimen_RI, qs_env, &
+                               start_jquad, wkp_W)
+      ! get G^S1
+      CALL compute_G_real_space(mat_dm_occ_S, mat_dm_virt_S, qs_env, num_integ_points, stabilize_exp, &
+                                e_fermi, eps_filter, tau_tj, num_cells_dm, index_to_cell_dm, &
+                                has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, para_env)
+
+      DO ikp = 1, nkp_self_energy
+
+         CALL get_mat_3c_gw_kp(mat_3c_overl_int, ikp, &
+                               mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                               kpoints, para_env, para_env_sub, matrix_s, mat_dm_virt_local, &
+                               gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, cut_RI, num_3c_repl, &
+                               row_from_LLL, my_group_L_starts_im_time, &
+                               my_group_L_sizes_im_time, has_3c_blocks_re, has_3c_blocks_im)
+
+         CALL cell_sum_self_ener(vec_Sigma_c_gw(:, :, ikp), vec_Sigma_x_gw(:, ikp), &
+                                 vec_Sigma_x_minus_vxc_gw(:, ikp), &
+                                 mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                 mat_dm_occ_S, mat_dm_virt_S, mat_W_R, &
+                                 mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                 mat_contr_gf_virt_re, mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im, &
+                                 mat_I_muP_occ_re, mat_I_muP_virt_re, mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                 index_to_cell_R1, index_to_cell_R2, index_to_cell_3c, &
+                                 index_to_cell_dm, index_to_cell_R1_plus_S2, cell_to_index_3c, &
+                                 cell_to_index_R2, gw_corr_lev_occ, gw_corr_lev_tot, &
+                                 homo, num_integ_points, num_fit_points, tj, tau_tj, ikp, &
+                                 has_3c_blocks_re, has_3c_blocks_im, &
+                                 cycle_R1_S2_n_level, has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, &
+                                 cycle_R1_plus_S2_n_level, kpoints, &
+                                 weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, eps_filter, para_env, &
+                                 are_flops_I_T_R1_plus_S2_S1_n_level, start_jquad)
+
+      END DO
+
+      CALL clean_up_self_energy_kp(mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                   index_to_cell_R2, index_to_cell_R1_plus_S2, &
+                                   mat_W_R, mat_dm_occ_S, mat_dm_virt_S, &
+                                   mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                   mat_contr_gf_virt_re, mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im, &
+                                   mat_I_muP_occ_re, mat_I_muP_virt_re, mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                   has_3c_blocks_re, has_3c_blocks_im, cycle_R1_S2_n_level, &
+                                   has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, cycle_R1_plus_S2_n_level, &
+                                   are_flops_I_T_R1_plus_S2_S1_n_level)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param vec_Sigma_c_gw ...
+!> \param vec_Sigma_x_gw ...
+!> \param vec_Sigma_x_minus_vxc_gw ...
+!> \param mat_3c_overl_int_gw_kp_re ...
+!> \param mat_3c_overl_int_gw_kp_im ...
+!> \param mat_dm_occ_S ...
+!> \param mat_dm_virt_S ...
+!> \param mat_W_R ...
+!> \param mat_contr_gf_occ_re ...
+!> \param mat_contr_gf_occ_im ...
+!> \param mat_contr_gf_virt_re ...
+!> \param mat_contr_gf_virt_im ...
+!> \param mat_contr_W_re ...
+!> \param mat_contr_W_im ...
+!> \param mat_I_muP_occ_re ...
+!> \param mat_I_muP_virt_re ...
+!> \param mat_I_muP_occ_im ...
+!> \param mat_I_muP_virt_im ...
+!> \param index_to_cell_R1 ...
+!> \param index_to_cell_R2 ...
+!> \param index_to_cell_3c ...
+!> \param index_to_cell_dm ...
+!> \param index_to_cell_R1_plus_S2 ...
+!> \param cell_to_index_3c ...
+!> \param cell_to_index_R2 ...
+!> \param gw_corr_lev_occ ...
+!> \param gw_corr_lev_tot ...
+!> \param homo ...
+!> \param num_integ_points ...
+!> \param num_fit_points ...
+!> \param tj ...
+!> \param tau_tj ...
+!> \param ikp ...
+!> \param has_3c_blocks_re ...
+!> \param has_3c_blocks_im ...
+!> \param cycle_R1_S2_n_level ...
+!> \param has_blocks_mat_dm_occ_S ...
+!> \param has_blocks_mat_dm_virt_S ...
+!> \param cycle_R1_plus_S2_n_level ...
+!> \param kpoints ...
+!> \param weights_cos_tf_t_to_w ...
+!> \param weights_sin_tf_t_to_w ...
+!> \param eps_filter ...
+!> \param para_env ...
+!> \param are_flops_I_T_R1_plus_S2_S1_n_level ...
+!> \param start_jquad ...
+! **************************************************************************************************
+   SUBROUTINE cell_sum_self_ener(vec_Sigma_c_gw, vec_Sigma_x_gw, vec_Sigma_x_minus_vxc_gw, &
+                                 mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                 mat_dm_occ_S, mat_dm_virt_S, mat_W_R, &
+                                 mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                 mat_contr_gf_virt_re, mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im, &
+                                 mat_I_muP_occ_re, mat_I_muP_virt_re, mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                 index_to_cell_R1, index_to_cell_R2, index_to_cell_3c, &
+                                 index_to_cell_dm, index_to_cell_R1_plus_S2, cell_to_index_3c, &
+                                 cell_to_index_R2, gw_corr_lev_occ, gw_corr_lev_tot, &
+                                 homo, num_integ_points, num_fit_points, tj, tau_tj, ikp, &
+                                 has_3c_blocks_re, has_3c_blocks_im, &
+                                 cycle_R1_S2_n_level, has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, &
+                                 cycle_R1_plus_S2_n_level, kpoints, &
+                                 weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, eps_filter, para_env, &
+                                 are_flops_I_T_R1_plus_S2_S1_n_level, start_jquad)
+
+      COMPLEX(KIND=dp), DIMENSION(:, :)                  :: vec_Sigma_c_gw
+      REAL(KIND=dp), DIMENSION(:)                        :: vec_Sigma_x_gw, vec_Sigma_x_minus_vxc_gw
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_re, &
+                                                            mat_3c_overl_int_gw_kp_im
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_S, mat_dm_virt_S, mat_W_R
+      TYPE(dbcsr_type), POINTER :: mat_contr_gf_occ_re, mat_contr_gf_occ_im, mat_contr_gf_virt_re, &
+         mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                                                            mat_I_muP_occ_im, mat_I_muP_virt_im
+      INTEGER, DIMENSION(:, :)                           :: index_to_cell_R1, index_to_cell_R2, &
+                                                            index_to_cell_3c, index_to_cell_dm, &
+                                                            index_to_cell_R1_plus_S2
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c, cell_to_index_R2
+      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_tot, homo, &
+                                                            num_integ_points, num_fit_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj, tau_tj
+      INTEGER                                            :: ikp
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: has_3c_blocks_re, has_3c_blocks_im
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :)        :: cycle_R1_S2_n_level
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: has_blocks_mat_dm_occ_S, &
+                                                            has_blocks_mat_dm_virt_S
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: cycle_R1_plus_S2_n_level
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w, &
+                                                            weights_sin_tf_t_to_w
+      REAL(KIND=dp)                                      :: eps_filter
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :) :: are_flops_I_T_R1_plus_S2_S1_n_level
+      INTEGER                                            :: start_jquad
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'cell_sum_self_ener', &
+         routineP = moduleN//':'//routineN
+
+      COMPLEX(KIND=dp)                                   :: im_unit
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_c_gw_cos_omega, &
+         vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
+         vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
+      INTEGER :: bound_1, bound_2, bound_3, bound_4, bound_5, bound_6, handle, i_cell_R1_plus_S2, &
+         i_cell_S2, iquad, jquad, n_level_gw, num_cells_3c, num_cells_dm, num_cells_R1, &
+         num_cells_R1_plus_S2, num_cells_R2, x_cell_R1, x_cell_R1_plus_S2, y_cell_R1, &
+         y_cell_R1_plus_S2, z_cell_R1, z_cell_R1_plus_S2
+      REAL(KIND=dp)                                      :: omega, tau, weight_cos, weight_sin
+
+      CALL timeset(routineN, handle)
+
+      ALLOCATE (vec_Sigma_c_gw_pos_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_pos_tau = z_zero
+      ALLOCATE (vec_Sigma_c_gw_neg_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_neg_tau = z_zero
+      ALLOCATE (vec_Sigma_c_gw_cos_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_cos_tau = z_zero
+      ALLOCATE (vec_Sigma_c_gw_sin_tau(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_sin_tau = z_zero
+
+      ALLOCATE (vec_Sigma_c_gw_cos_omega(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_cos_omega = z_zero
+      ALLOCATE (vec_Sigma_c_gw_sin_omega(gw_corr_lev_tot, num_integ_points))
+      vec_Sigma_c_gw_sin_omega = z_zero
+
+      num_cells_R1 = SIZE(index_to_cell_R1, 2)
+      num_cells_R2 = SIZE(index_to_cell_R2, 2)
+      num_cells_dm = SIZE(index_to_cell_dm, 2)
+      num_cells_R1_plus_S2 = SIZE(index_to_cell_R1_plus_S2, 2)
+      num_cells_3c = SIZE(index_to_cell_3c, 2)
+
+      bound_1 = LBOUND(cell_to_index_3c, 1)
+      bound_2 = UBOUND(cell_to_index_3c, 1)
+      bound_3 = LBOUND(cell_to_index_3c, 2)
+      bound_4 = UBOUND(cell_to_index_3c, 2)
+      bound_5 = LBOUND(cell_to_index_3c, 3)
+      bound_6 = UBOUND(cell_to_index_3c, 3)
+
+      ! jquad = 0 corresponds to exact exchange self-energy
+      DO jquad = start_jquad, num_integ_points
+
+         DO i_cell_R1_plus_S2 = 1, num_cells_R1_plus_S2
+
+            x_cell_R1_plus_S2 = index_to_cell_R1_plus_S2(1, i_cell_R1_plus_S2)
+            y_cell_R1_plus_S2 = index_to_cell_R1_plus_S2(2, i_cell_R1_plus_S2)
+            z_cell_R1_plus_S2 = index_to_cell_R1_plus_S2(3, i_cell_R1_plus_S2)
+
+            tau = tau_tj(jquad)
+
+            DO n_level_gw = 1, gw_corr_lev_tot
+
+               IF (cycle_R1_plus_S2_n_level(i_cell_R1_plus_S2, n_level_gw, jquad)) CYCLE
+
+               CALL compute_I_muP_T_R1_plus_S2(i_cell_R1_plus_S2, x_cell_R1_plus_S2, y_cell_R1_plus_S2, z_cell_R1_plus_S2, &
+                                               mat_I_muP_occ_re, mat_I_muP_virt_re, mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                               mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                               mat_dm_occ_S, mat_dm_virt_S, jquad, n_level_gw, cell_to_index_3c, &
+                                               index_to_cell_dm, has_3c_blocks_re, has_3c_blocks_im, &
+                                               has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, num_cells_dm, para_env, &
+                                               are_flops_I_T_R1_plus_S2_S1_n_level, eps_filter)
+
+               DO i_cell_S2 = 1, num_cells_3c
+
+                  IF (cycle_R1_S2_n_level(i_cell_R1_plus_S2, i_cell_S2, n_level_gw, jquad)) CYCLE
+
+                  x_cell_R1 = x_cell_R1_plus_S2-index_to_cell_3c(1, i_cell_S2)
+                  y_cell_R1 = y_cell_R1_plus_S2-index_to_cell_3c(2, i_cell_S2)
+                  z_cell_R1 = z_cell_R1_plus_S2-index_to_cell_3c(3, i_cell_S2)
+
+                  CALL trafo_I_T_R1_plus_S2_to_M_R1_S2(mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                                                       mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                                       mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                                       mat_contr_gf_virt_re, mat_contr_gf_virt_im, &
+                                                       index_to_cell_3c, kpoints, ikp, &
+                                                       x_cell_R1, y_cell_R1, z_cell_R1)
+
+                  ! perform multiplication with W
+                  CALL mult_3c_with_W(mat_W_R, mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                      mat_contr_W_re, mat_contr_W_im, n_level_gw, jquad, num_cells_3c, &
+                                      x_cell_R1, y_cell_R1, z_cell_R1, x_cell_R1_plus_S2, y_cell_R1_plus_S2, &
+                                      z_cell_R1_plus_S2, index_to_cell_3c, cell_to_index_3c, &
+                                      cell_to_index_R2, has_3c_blocks_re, has_3c_blocks_im)
+
+                  ! perform contraction to self-energy and do the FT from im. time to im. frequency
+                  CALL trace_for_self_ener(mat_contr_W_re, mat_contr_W_im, n_level_gw, jquad, &
+                                           gw_corr_lev_occ, homo, &
+                                           mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                           mat_contr_gf_virt_re, mat_contr_gf_virt_im, &
+                                           vec_Sigma_c_gw_pos_tau, vec_Sigma_c_gw_neg_tau, &
+                                           vec_Sigma_x_gw, ikp, &
+                                           cycle_R1_S2_n_level, cycle_R1_plus_S2_n_level, &
+                                           eps_filter, i_cell_R1_plus_S2, i_cell_S2, &
+                                           start_jquad)
+
+               END DO ! R1 (or S2=(R1+S2)-R1
+            END DO ! n_level_gw
+         END DO ! jquad
+      END DO ! R1+S2
+
+      vec_Sigma_x_minus_vxc_gw(:) = vec_Sigma_x_minus_vxc_gw(:)+vec_Sigma_x_gw(:)
+
+      im_unit = (0.0_dp, 1.0_dp)
+
+      vec_Sigma_c_gw_cos_tau(:, 1:num_integ_points) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(:, 1:num_integ_points)+ &
+                                                              vec_Sigma_c_gw_neg_tau(:, 1:num_integ_points))
+      vec_Sigma_c_gw_sin_tau(:, 1:num_integ_points) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(:, 1:num_integ_points)- &
+                                                              vec_Sigma_c_gw_neg_tau(:, 1:num_integ_points))
+
+      ! Fourier transform from time to frequency
+      DO jquad = 1, num_integ_points
+
+         DO iquad = 1, num_integ_points
+
+            omega = tj(jquad)
+            tau = tau_tj(iquad)
+            weight_cos = weights_cos_tf_t_to_w(jquad, iquad)*COS(omega*tau)
+            weight_sin = weights_sin_tf_t_to_w(jquad, iquad)*SIN(omega*tau)
+
+            vec_Sigma_c_gw_cos_omega(:, jquad) = vec_Sigma_c_gw_cos_omega(:, jquad)+ &
+                                                 weight_cos*vec_Sigma_c_gw_cos_tau(:, iquad)
+
+            vec_Sigma_c_gw_sin_omega(:, jquad) = vec_Sigma_c_gw_sin_omega(:, jquad)+ &
+                                                 weight_sin*vec_Sigma_c_gw_sin_tau(:, iquad)
+
+         END DO
+
+      END DO
+
+      ! for occupied levels, we need the correlation self-energy for negative omega. Therefore, weight_sin
+      ! should be computed with -omega, which results in an additional minus for vec_Sigma_c_gw_sin_omega:
+      vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :) = -vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :)
+
+      ! the third index k-point is already absorbed when calling the subroutine
+      vec_Sigma_c_gw(:, 1:num_fit_points) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points)+ &
+                                            im_unit*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
+
+      DEALLOCATE (vec_Sigma_c_gw_pos_tau)
+      DEALLOCATE (vec_Sigma_c_gw_neg_tau)
+      DEALLOCATE (vec_Sigma_c_gw_cos_tau)
+      DEALLOCATE (vec_Sigma_c_gw_sin_tau)
+      DEALLOCATE (vec_Sigma_c_gw_cos_omega)
+      DEALLOCATE (vec_Sigma_c_gw_sin_omega)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_contr_W_re ...
+!> \param mat_contr_W_im ...
+!> \param n_level_gw ...
+!> \param jquad ...
+!> \param gw_corr_lev_occ ...
+!> \param homo ...
+!> \param mat_contr_gf_occ_re ...
+!> \param mat_contr_gf_occ_im ...
+!> \param mat_contr_gf_virt_re ...
+!> \param mat_contr_gf_virt_im ...
+!> \param vec_Sigma_c_gw_pos_tau ...
+!> \param vec_Sigma_c_gw_neg_tau ...
+!> \param vec_Sigma_x_gw ...
+!> \param ikp ...
+!> \param cycle_R1_S2_n_level ...
+!> \param cycle_R1_plus_S2_n_level ...
+!> \param eps_filter ...
+!> \param i_cell_R1_plus_S2 ...
+!> \param i_cell_S2 ...
+!> \param start_jquad ...
+! **************************************************************************************************
+   SUBROUTINE trace_for_self_ener(mat_contr_W_re, mat_contr_W_im, n_level_gw, jquad, &
+                                  gw_corr_lev_occ, homo, &
+                                  mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                  mat_contr_gf_virt_re, mat_contr_gf_virt_im, &
+                                  vec_Sigma_c_gw_pos_tau, vec_Sigma_c_gw_neg_tau, &
+                                  vec_Sigma_x_gw, ikp, &
+                                  cycle_R1_S2_n_level, cycle_R1_plus_S2_n_level, &
+                                  eps_filter, i_cell_R1_plus_S2, i_cell_S2, &
+                                  start_jquad)
+
+      TYPE(dbcsr_type), POINTER                          :: mat_contr_W_re, mat_contr_W_im
+      INTEGER                                            :: n_level_gw, jquad, gw_corr_lev_occ, homo
+      TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ_re, &
+                                                            mat_contr_gf_occ_im, &
+                                                            mat_contr_gf_virt_re, &
+                                                            mat_contr_gf_virt_im
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: vec_Sigma_c_gw_pos_tau, &
+                                                            vec_Sigma_c_gw_neg_tau
+      REAL(KIND=dp), DIMENSION(:)                        :: vec_Sigma_x_gw
+      INTEGER                                            :: ikp
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :)        :: cycle_R1_S2_n_level
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: cycle_R1_plus_S2_n_level
+      REAL(KIND=dp)                                      :: eps_filter
+      INTEGER                                            :: i_cell_R1_plus_S2, i_cell_S2, start_jquad
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'trace_for_self_ener', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, n_level_gw_ref
+      REAL(KIND=dp) :: trace_neg_tau_im_1, trace_neg_tau_im_2, trace_neg_tau_re_1, &
+         trace_neg_tau_re_2, trace_pos_tau_im_1, trace_pos_tau_im_2, trace_pos_tau_re_1, &
+         trace_pos_tau_re_2
+
+      CALL timeset(routineN, handle)
+
+      CALL dbcsr_trace(mat_contr_gf_occ_re, &
+                       mat_contr_W_re, &
+                       trace_neg_tau_re_1)
+
+      CALL dbcsr_trace(mat_contr_gf_occ_im, &
+                       mat_contr_W_im, &
+                       trace_neg_tau_re_2)
+
+      CALL dbcsr_trace(mat_contr_gf_occ_re, &
+                       mat_contr_W_im, &
+                       trace_neg_tau_im_1)
+
+      CALL dbcsr_trace(mat_contr_gf_occ_im, &
+                       mat_contr_W_re, &
+                       trace_neg_tau_im_2)
+
+      IF (ABS(trace_neg_tau_re_1)+ABS(trace_neg_tau_re_2)+ABS(trace_neg_tau_im_1)+ &
+          ABS(trace_neg_tau_im_2) < eps_filter) THEN
+         cycle_R1_S2_n_level(i_cell_R1_plus_S2, i_cell_S2, n_level_gw, jquad) = .TRUE.
+      END IF
+
+      IF (ikp == 1 .AND. jquad == start_jquad .AND. i_cell_S2 == 1) THEN
+         cycle_R1_plus_S2_n_level(i_cell_R1_plus_S2, n_level_gw, jquad) = .TRUE.
+      END IF
+
+      IF (ABS(trace_neg_tau_re_1)+ABS(trace_neg_tau_re_2)+ABS(trace_neg_tau_im_1)+ &
+          ABS(trace_neg_tau_im_2) > eps_filter) THEN
+         cycle_R1_plus_S2_n_level(i_cell_R1_plus_S2, n_level_gw, jquad) = .FALSE.
+      END IF
+
+      IF (jquad == 0) THEN
+
+         n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
+
+         vec_Sigma_x_gw(n_level_gw_ref) = vec_Sigma_x_gw(n_level_gw_ref)+trace_neg_tau_re_1-trace_neg_tau_re_2
+
+      ELSE
+
+         vec_Sigma_c_gw_neg_tau(n_level_gw, jquad) = vec_Sigma_c_gw_neg_tau(n_level_gw, jquad)+ &
+                                                     CMPLX(trace_neg_tau_re_1-trace_neg_tau_re_2, &
+                                                           trace_neg_tau_im_1+trace_neg_tau_im_2, dp)
+
+      END IF
+
+      CALL dbcsr_trace(mat_contr_gf_virt_re, &
+                       mat_contr_W_re, &
+                       trace_pos_tau_re_1)
+
+      CALL dbcsr_trace(mat_contr_gf_virt_im, &
+                       mat_contr_W_im, &
+                       trace_pos_tau_re_2)
+
+      CALL dbcsr_trace(mat_contr_gf_virt_re, &
+                       mat_contr_W_im, &
+                       trace_pos_tau_im_1)
+
+      CALL dbcsr_trace(mat_contr_gf_virt_im, &
+                       mat_contr_W_re, &
+                       trace_pos_tau_im_2)
+
+      IF (jquad > 0) THEN
+
+         vec_Sigma_c_gw_pos_tau(n_level_gw, jquad) = vec_Sigma_c_gw_pos_tau(n_level_gw, jquad)+ &
+                                                     CMPLX(trace_pos_tau_re_1-trace_pos_tau_re_2, &
+                                                           trace_pos_tau_im_1+trace_pos_tau_im_2, dp)
+
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_W_R ...
+!> \param mat_3c_overl_int_gw_kp_re ...
+!> \param mat_3c_overl_int_gw_kp_im ...
+!> \param mat_contr_W_re ...
+!> \param mat_contr_W_im ...
+!> \param n_level_gw ...
+!> \param jquad ...
+!> \param num_cells_3c ...
+!> \param x_cell_R1 ...
+!> \param y_cell_R1 ...
+!> \param z_cell_R1 ...
+!> \param x_cell_R1_plus_S2 ...
+!> \param y_cell_R1_plus_S2 ...
+!> \param z_cell_R1_plus_S2 ...
+!> \param index_to_cell_3c ...
+!> \param cell_to_index_3c ...
+!> \param cell_to_index_R2 ...
+!> \param has_3c_blocks_re ...
+!> \param has_3c_blocks_im ...
+! **************************************************************************************************
+   SUBROUTINE mult_3c_with_W(mat_W_R, mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                             mat_contr_W_re, mat_contr_W_im, n_level_gw, jquad, num_cells_3c, &
+                             x_cell_R1, y_cell_R1, z_cell_R1, &
+                             x_cell_R1_plus_S2, y_cell_R1_plus_S2, z_cell_R1_plus_S2, &
+                             index_to_cell_3c, cell_to_index_3c, &
+                             cell_to_index_R2, has_3c_blocks_re, has_3c_blocks_im)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_W_R
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_re, &
+                                                            mat_3c_overl_int_gw_kp_im
+      TYPE(dbcsr_type), POINTER                          :: mat_contr_W_re, mat_contr_W_im
+      INTEGER :: n_level_gw, jquad, num_cells_3c, x_cell_R1, y_cell_R1, z_cell_R1, &
+         x_cell_R1_plus_S2, y_cell_R1_plus_S2, z_cell_R1_plus_S2
+      INTEGER, DIMENSION(:, :)                           :: index_to_cell_3c
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c, cell_to_index_R2
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: has_3c_blocks_re, has_3c_blocks_im
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'mult_3c_with_W', routineP = moduleN//':'//routineN
+
+      INTEGER :: bound_1, bound_2, bound_3, bound_4, bound_5, bound_6, bound_R2_1, bound_R2_2, &
+         bound_R2_3, bound_R2_4, bound_R2_5, bound_R2_6, handle, i_cell_R1_minus_R2, &
+         i_cell_R1_plus_S2_minus_R2, i_cell_R2, x_cell_R1_plus_S2_minus_R2, x_cell_R2, &
+         y_cell_R1_plus_S2_minus_R2, y_cell_R2, z_cell_R1_plus_S2_minus_R2, z_cell_R2
+
+      CALL timeset(routineN, handle)
+
+      bound_1 = LBOUND(cell_to_index_3c, 1)
+      bound_2 = UBOUND(cell_to_index_3c, 1)
+      bound_3 = LBOUND(cell_to_index_3c, 2)
+      bound_4 = UBOUND(cell_to_index_3c, 2)
+      bound_5 = LBOUND(cell_to_index_3c, 3)
+      bound_6 = UBOUND(cell_to_index_3c, 3)
+
+      bound_R2_1 = LBOUND(cell_to_index_R2, 1)
+      bound_R2_2 = UBOUND(cell_to_index_R2, 1)
+      bound_R2_3 = LBOUND(cell_to_index_R2, 2)
+      bound_R2_4 = UBOUND(cell_to_index_R2, 2)
+      bound_R2_5 = LBOUND(cell_to_index_R2, 3)
+      bound_R2_6 = UBOUND(cell_to_index_R2, 3)
+
+      CALL dbcsr_set(mat_contr_W_re, 0.0_dp)
+      CALL dbcsr_set(mat_contr_W_im, 0.0_dp)
+
+      DO i_cell_R1_minus_R2 = 1, num_cells_3c
+
+         x_cell_R2 = x_cell_R1-index_to_cell_3c(1, i_cell_R1_minus_R2)
+         y_cell_R2 = y_cell_R1-index_to_cell_3c(2, i_cell_R1_minus_R2)
+         z_cell_R2 = z_cell_R1-index_to_cell_3c(3, i_cell_R1_minus_R2)
+
+         IF (x_cell_R2 < bound_R2_1 .OR. &
+             x_cell_R2 > bound_R2_2 .OR. &
+             y_cell_R2 < bound_R2_3 .OR. &
+             y_cell_R2 > bound_R2_4 .OR. &
+             z_cell_R2 < bound_R2_5 .OR. &
+             z_cell_R2 > bound_R2_6) THEN
+
+            CYCLE
+
+         END IF
+
+         i_cell_R2 = cell_to_index_R2(x_cell_R2, y_cell_R2, z_cell_R2)
+
+         x_cell_R1_plus_S2_minus_R2 = x_cell_R1_plus_S2-x_cell_R2
+         y_cell_R1_plus_S2_minus_R2 = y_cell_R1_plus_S2-y_cell_R2
+         z_cell_R1_plus_S2_minus_R2 = z_cell_R1_plus_S2-z_cell_R2
+
+         IF (x_cell_R1_plus_S2_minus_R2 < bound_1 .OR. &
+             x_cell_R1_plus_S2_minus_R2 > bound_2 .OR. &
+             y_cell_R1_plus_S2_minus_R2 < bound_3 .OR. &
+             y_cell_R1_plus_S2_minus_R2 > bound_4 .OR. &
+             z_cell_R1_plus_S2_minus_R2 < bound_5 .OR. &
+             z_cell_R1_plus_S2_minus_R2 > bound_6) THEN
+
+            CYCLE
+
+         END IF
+
+         i_cell_R1_plus_S2_minus_R2 = cell_to_index_3c(x_cell_R1_plus_S2_minus_R2, &
+                                                       y_cell_R1_plus_S2_minus_R2, &
+                                                       z_cell_R1_plus_S2_minus_R2)
+
+         IF (i_cell_R1_plus_S2_minus_R2 == 0) CYCLE
+
+         IF (has_3c_blocks_re(n_level_gw, i_cell_R1_minus_R2, i_cell_R1_plus_S2_minus_R2)) THEN
+
+            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_W_R(i_cell_R2, jquad)%matrix, &
+                                mat_3c_overl_int_gw_kp_re(n_level_gw, i_cell_R1_minus_R2, i_cell_R1_plus_S2_minus_R2)%matrix, &
+                                1.0_dp, mat_contr_W_re)
+
+         END IF
+
+         IF (has_3c_blocks_im(n_level_gw, i_cell_R1_minus_R2, i_cell_R1_plus_S2_minus_R2)) THEN
+
+            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_W_R(i_cell_R2, jquad)%matrix, &
+                                mat_3c_overl_int_gw_kp_im(n_level_gw, i_cell_R1_minus_R2, i_cell_R1_plus_S2_minus_R2)%matrix, &
+                                1.0_dp, mat_contr_W_im)
+
+         END IF
+
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_I_muP_occ_re ...
+!> \param mat_I_muP_virt_re ...
+!> \param mat_I_muP_occ_im ...
+!> \param mat_I_muP_virt_im ...
+!> \param mat_contr_gf_occ_re ...
+!> \param mat_contr_gf_occ_im ...
+!> \param mat_contr_gf_virt_re ...
+!> \param mat_contr_gf_virt_im ...
+!> \param index_to_cell_3c ...
+!> \param kpoints ...
+!> \param ikp ...
+!> \param x_cell_R1 ...
+!> \param y_cell_R1 ...
+!> \param z_cell_R1 ...
+! **************************************************************************************************
+   SUBROUTINE trafo_I_T_R1_plus_S2_to_M_R1_S2(mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                                              mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                              mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                              mat_contr_gf_virt_re, mat_contr_gf_virt_im, &
+                                              index_to_cell_3c, kpoints, ikp, &
+                                              x_cell_R1, y_cell_R1, z_cell_R1)
+
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                                                            mat_I_muP_occ_im, mat_I_muP_virt_im
+      TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ_re, &
+                                                            mat_contr_gf_occ_im, &
+                                                            mat_contr_gf_virt_re, &
+                                                            mat_contr_gf_virt_im
+      INTEGER, DIMENSION(:, :)                           :: index_to_cell_3c
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: ikp, x_cell_R1, y_cell_R1, z_cell_R1
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'trafo_I_T_R1_plus_S2_to_M_R1_S2', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i_cell_T, num_cells_3c, xcell, &
+                                                            ycell, zcell
+      REAL(KIND=dp)                                      :: arg, coskl, sinkl
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+
+      CALL timeset(routineN, handle)
+
+      num_cells_3c = SIZE(mat_I_muP_occ_re)
+      CALL get_kpoint_info(kpoints, xkp=xkp)
+
+      CALL dbcsr_set(mat_contr_gf_occ_re, 0.0_dp)
+      CALL dbcsr_set(mat_contr_gf_occ_im, 0.0_dp)
+      CALL dbcsr_set(mat_contr_gf_virt_re, 0.0_dp)
+      CALL dbcsr_set(mat_contr_gf_virt_im, 0.0_dp)
+
+      DO i_cell_T = 1, num_cells_3c
+
+         xcell = index_to_cell_3c(1, i_cell_T)-x_cell_R1
+         ycell = index_to_cell_3c(2, i_cell_T)-y_cell_R1
+         zcell = index_to_cell_3c(3, i_cell_T)-z_cell_R1
+         arg = REAL(xcell, dp)*xkp(1, ikp)+REAL(ycell, dp)*xkp(2, ikp)+REAL(zcell, dp)*xkp(3, ikp)
+         coskl = COS(twopi*arg)
+         sinkl = SIN(twopi*arg)
+
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_occ_re, mat_I_muP_occ_re(i_cell_T)%matrix, coskl)
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_occ_re, mat_I_muP_occ_im(i_cell_T)%matrix, -sinkl)
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_occ_im, mat_I_muP_occ_re(i_cell_T)%matrix, sinkl)
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_occ_im, mat_I_muP_occ_im(i_cell_T)%matrix, coskl)
+
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_virt_re, mat_I_muP_virt_re(i_cell_T)%matrix, coskl)
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_virt_re, mat_I_muP_virt_im(i_cell_T)%matrix, -sinkl)
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_virt_im, mat_I_muP_virt_re(i_cell_T)%matrix, sinkl)
+         CALL dbcsr_scale_and_add_local(mat_contr_gf_virt_im, mat_I_muP_virt_im(i_cell_T)%matrix, coskl)
+
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_A ...
+!> \param mat_B ...
+!> \param beta ...
+! **************************************************************************************************
+   SUBROUTINE dbcsr_scale_and_add_local(mat_A, mat_B, beta)
+      TYPE(dbcsr_type), POINTER                          :: mat_A, mat_B
+      REAL(KIND=dp)                                      :: beta
+
+      INTEGER                                            :: col, row
+      LOGICAL                                            :: found
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block_to_compute, data_block
+      TYPE(dbcsr_iterator_type)                          :: iter
+
+      CALL dbcsr_iterator_start(iter, mat_B)
+      DO WHILE (dbcsr_iterator_blocks_left(iter))
+
+         CALL dbcsr_iterator_next_block(iter, row, col, data_block)
+
+         NULLIFY (block_to_compute)
+         CALL dbcsr_get_block_p(matrix=mat_A, &
+                                row=row, col=col, block=block_to_compute, found=found)
+
+         CPASSERT(found)
+
+         block_to_compute(:, :) = block_to_compute(:, :)+beta*data_block(:, :)
+
+      END DO
+
+      CALL dbcsr_iterator_stop(iter)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param i_cell_R1_plus_S2 ...
+!> \param x_cell_R1_plus_S2 ...
+!> \param y_cell_R1_plus_S2 ...
+!> \param z_cell_R1_plus_S2 ...
+!> \param mat_I_muP_occ_re ...
+!> \param mat_I_muP_virt_re ...
+!> \param mat_I_muP_occ_im ...
+!> \param mat_I_muP_virt_im ...
+!> \param mat_3c_overl_int_gw_kp_re ...
+!> \param mat_3c_overl_int_gw_kp_im ...
+!> \param mat_dm_occ_S ...
+!> \param mat_dm_virt_S ...
+!> \param jquad ...
+!> \param n_level_gw ...
+!> \param cell_to_index_3c ...
+!> \param index_to_cell_dm ...
+!> \param has_3c_blocks_re ...
+!> \param has_3c_blocks_im ...
+!> \param has_blocks_mat_dm_occ_S ...
+!> \param has_blocks_mat_dm_virt_S ...
+!> \param num_cells_dm ...
+!> \param para_env ...
+!> \param are_flops_I_T_R1_plus_S2_S1_n_level ...
+!> \param eps_filter ...
+! **************************************************************************************************
+   SUBROUTINE compute_I_muP_T_R1_plus_S2(i_cell_R1_plus_S2, x_cell_R1_plus_S2, y_cell_R1_plus_S2, z_cell_R1_plus_S2, &
+                                         mat_I_muP_occ_re, mat_I_muP_virt_re, mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                         mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                         mat_dm_occ_S, mat_dm_virt_S, jquad, n_level_gw, cell_to_index_3c, &
+                                         index_to_cell_dm, has_3c_blocks_re, has_3c_blocks_im, &
+                                         has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, num_cells_dm, para_env, &
+                                         are_flops_I_T_R1_plus_S2_S1_n_level, eps_filter)
+
+      INTEGER                                            :: i_cell_R1_plus_S2, x_cell_R1_plus_S2, &
+                                                            y_cell_R1_plus_S2, z_cell_R1_plus_S2
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                                                            mat_I_muP_occ_im, mat_I_muP_virt_im
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_re, &
+                                                            mat_3c_overl_int_gw_kp_im
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_S, mat_dm_virt_S
+      INTEGER                                            :: jquad, n_level_gw
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
+      INTEGER, DIMENSION(:, :)                           :: index_to_cell_dm
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: has_3c_blocks_re, has_3c_blocks_im
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: has_blocks_mat_dm_occ_S, &
+                                                            has_blocks_mat_dm_virt_S
+      INTEGER                                            :: num_cells_dm
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :) :: are_flops_I_T_R1_plus_S2_S1_n_level
+      REAL(KIND=dp)                                      :: eps_filter
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_I_muP_T_R1_plus_S2', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: bound_1, bound_2, bound_3, bound_4, bound_5, bound_6, handle, i_cell_S1, &
+         i_cell_T, index_2, num_cells_3c, x_cell_2, y_cell_2, z_cell_2
+      INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :)  :: flops_occ_im, flops_occ_re, &
+                                                            flops_virt_im, flops_virt_re
+
+      CALL timeset(routineN, handle)
+
+      num_cells_3c = SIZE(mat_I_muP_occ_re)
+
+      bound_1 = LBOUND(cell_to_index_3c, 1)
+      bound_2 = UBOUND(cell_to_index_3c, 1)
+      bound_3 = LBOUND(cell_to_index_3c, 2)
+      bound_4 = UBOUND(cell_to_index_3c, 2)
+      bound_5 = LBOUND(cell_to_index_3c, 3)
+      bound_6 = UBOUND(cell_to_index_3c, 3)
+
+      ALLOCATE (flops_occ_re(num_cells_3c, num_cells_dm))
+      flops_occ_re = 0
+      ALLOCATE (flops_occ_im(num_cells_3c, num_cells_dm))
+      flops_occ_im = 0
+      ALLOCATE (flops_virt_re(num_cells_3c, num_cells_dm))
+      flops_virt_re = 0
+      ALLOCATE (flops_virt_im(num_cells_3c, num_cells_dm))
+      flops_virt_im = 0
+
+      DO i_cell_T = 1, num_cells_3c
+
+         CALL dbcsr_set(mat_I_muP_occ_re(i_cell_T)%matrix, 0.0_dp)
+         CALL dbcsr_set(mat_I_muP_occ_im(i_cell_T)%matrix, 0.0_dp)
+         CALL dbcsr_set(mat_I_muP_virt_re(i_cell_T)%matrix, 0.0_dp)
+         CALL dbcsr_set(mat_I_muP_virt_im(i_cell_T)%matrix, 0.0_dp)
+
+         DO i_cell_S1 = 1, num_cells_dm
+
+            x_cell_2 = x_cell_R1_plus_S2+index_to_cell_dm(1, i_cell_S1)
+            y_cell_2 = y_cell_R1_plus_S2+index_to_cell_dm(2, i_cell_S1)
+            z_cell_2 = z_cell_R1_plus_S2+index_to_cell_dm(3, i_cell_S1)
+
+            IF (x_cell_2 < bound_1 .OR. &
+                x_cell_2 > bound_2 .OR. &
+                y_cell_2 < bound_3 .OR. &
+                y_cell_2 > bound_4 .OR. &
+                z_cell_2 < bound_5 .OR. &
+                z_cell_2 > bound_6) THEN
+
+               CYCLE
+
+            END IF
+
+            index_2 = cell_to_index_3c(x_cell_2, y_cell_2, z_cell_2)
+            IF (index_2 == 0) CYCLE
+
+            IF (has_3c_blocks_re(n_level_gw, i_cell_T, index_2) .AND. &
+                has_blocks_mat_dm_occ_S(jquad, i_cell_S1) .AND. &
+                are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 1)) THEN
+
+               ! the occ Gf has no minus, but already include the minus from Sigma = -GW
+               CALL dbcsr_multiply("N", "N", -1.0_dp, &
+                                   mat_3c_overl_int_gw_kp_re(n_level_gw, i_cell_T, index_2)%matrix, &
+                                   mat_dm_occ_S(jquad, i_cell_S1)%matrix, &
+                                   1.0_dp, mat_I_muP_occ_re(i_cell_T)%matrix, flop=flops_occ_re(i_cell_T, i_cell_S1), &
+                                   filter_eps=eps_filter)
+
+            END IF
+
+            IF (has_3c_blocks_im(n_level_gw, i_cell_T, index_2) .AND. &
+                has_blocks_mat_dm_occ_S(jquad, i_cell_S1) .AND. &
+                are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 2)) THEN
+
+               ! other sign as real part because there is a complexe conjugate on the 3c integral
+               CALL dbcsr_multiply("N", "N", 1.0_dp, &
+                                   mat_3c_overl_int_gw_kp_im(n_level_gw, i_cell_T, index_2)%matrix, &
+                                   mat_dm_occ_S(jquad, i_cell_S1)%matrix, &
+                                   1.0_dp, mat_I_muP_occ_im(i_cell_T)%matrix, flop=flops_occ_im(i_cell_T, i_cell_S1), &
+                                   filter_eps=eps_filter)
+
+            END IF
+
+            IF (has_3c_blocks_re(n_level_gw, i_cell_T, index_2) .AND. &
+                has_blocks_mat_dm_virt_S(jquad, i_cell_S1) .AND. &
+                are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 3) .AND. &
+                jquad > 0) THEN
+
+               ! the virt Gf has a minus, but already include the minus from Sigma = -GW
+               CALL dbcsr_multiply("N", "N", 1.0_dp, &
+                                   mat_3c_overl_int_gw_kp_re(n_level_gw, i_cell_T, index_2)%matrix, &
+                                   mat_dm_virt_S(jquad, i_cell_S1)%matrix, &
+                                   1.0_dp, mat_I_muP_virt_re(i_cell_T)%matrix, flop=flops_virt_re(i_cell_T, i_cell_S1), &
+                                   filter_eps=eps_filter)
+
+            END IF
+
+            IF (has_3c_blocks_im(n_level_gw, i_cell_T, index_2) .AND. &
+                has_blocks_mat_dm_virt_S(jquad, i_cell_S1) .AND. &
+                are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 4) .AND. &
+                jquad > 0) THEN
+
+               ! other sign as real part because there is a complexe conjugate on the 3c integral
+               CALL dbcsr_multiply("N", "N", -1.0_dp, &
+                                   mat_3c_overl_int_gw_kp_im(n_level_gw, i_cell_T, index_2)%matrix, &
+                                   mat_dm_virt_S(jquad, i_cell_S1)%matrix, &
+                                   1.0_dp, mat_I_muP_virt_im(i_cell_T)%matrix, flop=flops_virt_im(i_cell_T, i_cell_S1), &
+                                   filter_eps=eps_filter)
+
+            END IF
+
+         END DO
+
+      END DO
+
+      CALL mp_sum(flops_occ_re, para_env%group)
+      CALL mp_sum(flops_occ_im, para_env%group)
+      CALL mp_sum(flops_virt_re, para_env%group)
+      CALL mp_sum(flops_virt_im, para_env%group)
+
+      DO i_cell_T = 1, num_cells_3c
+         DO i_cell_S1 = 1, num_cells_dm
+
+            IF (flops_occ_re(i_cell_T, i_cell_S1) > 0) THEN
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 1) = .TRUE.
+            ELSE
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 1) = .FALSE.
+            END IF
+
+            IF (flops_occ_im(i_cell_T, i_cell_S1) > 0) THEN
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 2) = .TRUE.
+            ELSE
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 2) = .FALSE.
+            END IF
+
+            IF (flops_virt_re(i_cell_T, i_cell_S1) > 0 .OR. jquad == 0) THEN
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 3) = .TRUE.
+            ELSE
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 3) = .FALSE.
+            END IF
+
+            IF (flops_virt_im(i_cell_T, i_cell_S1) > 0 .OR. jquad == 0) THEN
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 4) = .TRUE.
+            ELSE
+               are_flops_I_T_R1_plus_S2_S1_n_level(i_cell_T, i_cell_R1_plus_S2, i_cell_S1, n_level_gw, 4) = .FALSE.
+            END IF
+
+         END DO
+      END DO
+
+      DEALLOCATE (flops_occ_re, flops_occ_im, flops_virt_re, flops_virt_im)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_dm_occ_S ...
+!> \param mat_dm_virt_S ...
+!> \param qs_env ...
+!> \param num_integ_points ...
+!> \param stabilize_exp ...
+!> \param e_fermi ...
+!> \param eps_filter ...
+!> \param tau_tj ...
+!> \param num_cells_dm ...
+!> \param index_to_cell_dm ...
+!> \param has_blocks_mat_dm_occ_S ...
+!> \param has_blocks_mat_dm_virt_S ...
+!> \param para_env ...
+! **************************************************************************************************
+   SUBROUTINE compute_G_real_space(mat_dm_occ_S, mat_dm_virt_S, qs_env, num_integ_points, stabilize_exp, &
+                                   e_fermi, eps_filter, tau_tj, num_cells_dm, index_to_cell_dm, &
+                                   has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, para_env)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_S, mat_dm_virt_S
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: num_integ_points
+      REAL(KIND=dp)                                      :: stabilize_exp, e_fermi, eps_filter
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
+      INTEGER                                            :: num_cells_dm
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: has_blocks_mat_dm_occ_S, &
+                                                            has_blocks_mat_dm_virt_S
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_G_real_space', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i_cell, ispin, jquad, nblks
+      REAL(KIND=dp)                                      :: tau
+
+      CALL timeset(routineN, handle)
+
+      ispin = 1
+
+      ! get denity matrix for exchange self-energy
+      tau = 0.0_dp
+      CALL compute_transl_dm(mat_dm_occ_S, qs_env, ispin, num_integ_points, 0, e_fermi, tau, &
+                             stabilize_exp, eps_filter, num_cells_dm, index_to_cell_dm, &
+                             remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=0)
+
+      DO i_cell = 1, num_cells_dm
+
+         nblks = dbcsr_get_num_blocks(mat_dm_occ_S(0, i_cell)%matrix)
+         CALL mp_sum(nblks, para_env%group)
+         IF (nblks == 0) has_blocks_mat_dm_occ_S(0, i_cell) = .FALSE.
+         IF (nblks > 0) has_blocks_mat_dm_occ_S(0, i_cell) = .TRUE.
+
+      END DO
+
+      DO jquad = 1, num_integ_points
+
+         tau = tau_tj(jquad)
+
+         CALL compute_transl_dm(mat_dm_occ_S, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
+                                stabilize_exp, eps_filter, num_cells_dm, index_to_cell_dm, &
+                                remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=0)
+
+         CALL compute_transl_dm(mat_dm_virt_S, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
+                                stabilize_exp, eps_filter, num_cells_dm, index_to_cell_dm, &
+                                remove_occ=.TRUE., remove_virt=.FALSE., first_jquad=1)
+
+         DO i_cell = 1, num_cells_dm
+
+            nblks = dbcsr_get_num_blocks(mat_dm_occ_S(jquad, i_cell)%matrix)
+            CALL mp_sum(nblks, para_env%group)
+            IF (nblks == 0) has_blocks_mat_dm_occ_S(jquad, i_cell) = .FALSE.
+            IF (nblks > 0) has_blocks_mat_dm_occ_S(jquad, i_cell) = .TRUE.
+
+            nblks = dbcsr_get_num_blocks(mat_dm_virt_S(jquad, i_cell)%matrix)
+            CALL mp_sum(nblks, para_env%group)
+            IF (nblks == 0) has_blocks_mat_dm_virt_S(jquad, i_cell) = .FALSE.
+            IF (nblks > 0) has_blocks_mat_dm_virt_S(jquad, i_cell) = .TRUE.
+
+         END DO
+
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_3c_overl_int_gw_kp_re ...
+!> \param mat_3c_overl_int_gw_kp_im ...
+!> \param gw_corr_lev_tot ...
+!> \param num_3c_repl ...
+!> \param num_cells_dm ...
+!> \param num_cells_R1_plus_S2 ...
+!> \param num_integ_points ...
+!> \param dimen_RI ...
+!> \param nmo ...
+!> \param RI_blk_sizes ...
+!> \param prim_blk_sizes ...
+!> \param matrix_s ...
+!> \param cfm_mat_Q ...
+!> \param mat_contr_gf_occ_re ...
+!> \param mat_contr_gf_occ_im ...
+!> \param mat_contr_gf_virt_re ...
+!> \param mat_contr_gf_virt_im ...
+!> \param mat_contr_W_re ...
+!> \param mat_contr_W_im ...
+!> \param mat_I_muP_occ_re ...
+!> \param mat_I_muP_virt_re ...
+!> \param mat_I_muP_occ_im ...
+!> \param mat_I_muP_virt_im ...
+!> \param has_3c_blocks_re ...
+!> \param has_3c_blocks_im ...
+!> \param cycle_R1_S2_n_level ...
+!> \param has_blocks_mat_dm_occ_S ...
+!> \param has_blocks_mat_dm_virt_S ...
+!> \param cycle_R1_plus_S2_n_level ...
+!> \param are_flops_I_T_R1_plus_S2_S1_n_level ...
+! **************************************************************************************************
+   SUBROUTINE allocate_mat_3c_gw(mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                 gw_corr_lev_tot, num_3c_repl, num_cells_dm, num_cells_R1_plus_S2, num_integ_points, &
+                                 dimen_RI, nmo, RI_blk_sizes, prim_blk_sizes, matrix_s, cfm_mat_Q, &
+                                 mat_contr_gf_occ_re, mat_contr_gf_occ_im, &
+                                 mat_contr_gf_virt_re, mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im, &
+                                 mat_I_muP_occ_re, mat_I_muP_virt_re, mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                 has_3c_blocks_re, has_3c_blocks_im, cycle_R1_S2_n_level, &
+                                 has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, cycle_R1_plus_S2_n_level, &
+                                 are_flops_I_T_R1_plus_S2_S1_n_level)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_re, &
+                                                            mat_3c_overl_int_gw_kp_im
+      INTEGER                                            :: gw_corr_lev_tot, num_3c_repl, &
+                                                            num_cells_dm, num_cells_R1_plus_S2, &
+                                                            num_integ_points, dimen_RI, nmo
+      INTEGER, DIMENSION(:), POINTER                     :: RI_blk_sizes, prim_blk_sizes
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
+      TYPE(dbcsr_type), POINTER :: mat_contr_gf_occ_re, mat_contr_gf_occ_im, mat_contr_gf_virt_re, &
+         mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                                                            mat_I_muP_occ_im, mat_I_muP_virt_im
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: has_3c_blocks_re, has_3c_blocks_im
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :)        :: cycle_R1_S2_n_level
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: has_blocks_mat_dm_occ_S, &
+                                                            has_blocks_mat_dm_virt_S
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: cycle_R1_plus_S2_n_level
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :) :: are_flops_I_T_R1_plus_S2_S1_n_level
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_mat_3c_gw', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i_cell, j_cell, n_level_gw
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (mat_3c_overl_int_gw_kp_re)
+      CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw_kp_re, gw_corr_lev_tot, num_3c_repl, num_3c_repl)
+
+      NULLIFY (mat_3c_overl_int_gw_kp_im)
+      CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw_kp_im, gw_corr_lev_tot, num_3c_repl, num_3c_repl)
+
+      DO n_level_gw = 1, gw_corr_lev_tot
+
+         DO i_cell = 1, num_3c_repl
+
+            DO j_cell = 1, num_3c_repl
+
+               ALLOCATE (mat_3c_overl_int_gw_kp_re(n_level_gw, i_cell, j_cell)%matrix)
+               CALL dbcsr_create(matrix=mat_3c_overl_int_gw_kp_re(n_level_gw, i_cell, j_cell)%matrix, &
+                                 template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry, &
+                                 row_blk_size=RI_blk_sizes, &
+                                 col_blk_size=prim_blk_sizes)
+
+               ALLOCATE (mat_3c_overl_int_gw_kp_im(n_level_gw, i_cell, j_cell)%matrix)
+               CALL dbcsr_create(matrix=mat_3c_overl_int_gw_kp_im(n_level_gw, i_cell, j_cell)%matrix, &
+                                 template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry, &
+                                 row_blk_size=RI_blk_sizes, &
+                                 col_blk_size=prim_blk_sizes)
+
+            END DO
+
+         END DO
+
+      END DO
+
+      NULLIFY (mat_contr_gf_occ_re)
+      CALL dbcsr_init_p(mat_contr_gf_occ_re)
+      CALL dbcsr_create(matrix=mat_contr_gf_occ_re, &
+                        template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      CALL dbcsr_reserve_all_blocks(mat_contr_gf_occ_re)
+
+      NULLIFY (mat_contr_gf_occ_im)
+      CALL dbcsr_init_p(mat_contr_gf_occ_im)
+      CALL dbcsr_create(matrix=mat_contr_gf_occ_im, &
+                        template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      CALL dbcsr_reserve_all_blocks(mat_contr_gf_occ_im)
+
+      NULLIFY (mat_contr_gf_virt_re)
+      CALL dbcsr_init_p(mat_contr_gf_virt_re)
+      CALL dbcsr_create(matrix=mat_contr_gf_virt_re, &
+                        template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      CALL dbcsr_reserve_all_blocks(mat_contr_gf_virt_re)
+
+      NULLIFY (mat_contr_gf_virt_im)
+      CALL dbcsr_init_p(mat_contr_gf_virt_im)
+      CALL dbcsr_create(matrix=mat_contr_gf_virt_im, &
+                        template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      CALL dbcsr_reserve_all_blocks(mat_contr_gf_virt_im)
+
+      NULLIFY (mat_contr_W_re)
+      CALL dbcsr_init_p(mat_contr_W_re)
+      CALL dbcsr_create(matrix=mat_contr_W_re, &
+                        template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+
+      NULLIFY (mat_contr_W_im)
+      CALL dbcsr_init_p(mat_contr_W_im)
+      CALL dbcsr_create(matrix=mat_contr_W_im, &
+                        template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+
+      NULLIFY (mat_I_muP_occ_re)
+      CALL dbcsr_allocate_matrix_set(mat_I_muP_occ_re, num_3c_repl)
+      DO i_cell = 1, num_3c_repl
+         ALLOCATE (mat_I_muP_occ_re(i_cell)%matrix)
+         CALL dbcsr_create(matrix=mat_I_muP_occ_re(i_cell)%matrix, &
+                           template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      END DO
+
+      NULLIFY (mat_I_muP_virt_re)
+      CALL dbcsr_allocate_matrix_set(mat_I_muP_virt_re, num_3c_repl)
+      DO i_cell = 1, num_3c_repl
+         ALLOCATE (mat_I_muP_virt_re(i_cell)%matrix)
+         CALL dbcsr_create(matrix=mat_I_muP_virt_re(i_cell)%matrix, &
+                           template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      END DO
+
+      NULLIFY (mat_I_muP_occ_im)
+      CALL dbcsr_allocate_matrix_set(mat_I_muP_occ_im, num_3c_repl)
+      DO i_cell = 1, num_3c_repl
+         ALLOCATE (mat_I_muP_occ_im(i_cell)%matrix)
+         CALL dbcsr_create(matrix=mat_I_muP_occ_im(i_cell)%matrix, &
+                           template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      END DO
+
+      NULLIFY (mat_I_muP_virt_im)
+      CALL dbcsr_allocate_matrix_set(mat_I_muP_virt_im, num_3c_repl)
+      DO i_cell = 1, num_3c_repl
+         ALLOCATE (mat_I_muP_virt_im(i_cell)%matrix)
+         CALL dbcsr_create(matrix=mat_I_muP_virt_im(i_cell)%matrix, &
+                           template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix)
+      END DO
+
+      NULLIFY (fm_struct)
+      CALL cp_fm_struct_create(fm_struct, context=cfm_mat_Q%matrix_struct%context, nrow_global=dimen_RI, &
+                               ncol_global=nmo, para_env=cfm_mat_Q%matrix_struct%para_env)
+
+      CALL cp_fm_struct_release(fm_struct)
+
+      ALLOCATE (has_3c_blocks_re(gw_corr_lev_tot, num_3c_repl, num_3c_repl))
+      has_3c_blocks_re = .FALSE.
+      ALLOCATE (has_3c_blocks_im(gw_corr_lev_tot, num_3c_repl, num_3c_repl))
+      has_3c_blocks_im = .FALSE.
+      ALLOCATE (has_blocks_mat_dm_occ_S(0:num_integ_points, num_cells_dm))
+      has_blocks_mat_dm_occ_S = .FALSE.
+      ALLOCATE (has_blocks_mat_dm_virt_S(0:num_integ_points, num_cells_dm))
+      has_blocks_mat_dm_virt_S = .FALSE.
+      ALLOCATE (cycle_R1_S2_n_level(num_cells_R1_plus_S2, num_3c_repl, gw_corr_lev_tot, 0:num_integ_points))
+      cycle_R1_S2_n_level = .FALSE.
+      ALLOCATE (cycle_R1_plus_S2_n_level(num_cells_R1_plus_S2, gw_corr_lev_tot, 0:num_integ_points))
+      cycle_R1_plus_S2_n_level = .FALSE.
+      ! 4 is for occ_re, occ_im, virt_re, virt_im
+      ALLOCATE (are_flops_I_T_R1_plus_S2_S1_n_level(num_3c_repl, num_cells_R1_plus_S2, num_cells_dm, gw_corr_lev_tot, 4))
+      are_flops_I_T_R1_plus_S2_S1_n_level = .TRUE.
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_3c_overl_int_gw_kp_re ...
+!> \param mat_3c_overl_int_gw_kp_im ...
+!> \param index_to_cell_R2 ...
+!> \param index_to_cell_R1_plus_S2 ...
+!> \param mat_W_R ...
+!> \param mat_dm_occ_S ...
+!> \param mat_dm_virt_S ...
+!> \param mat_contr_gf_occ_re ...
+!> \param mat_contr_gf_virt_re ...
+!> \param mat_contr_gf_occ_im ...
+!> \param mat_contr_gf_virt_im ...
+!> \param mat_contr_W_re ...
+!> \param mat_contr_W_im ...
+!> \param mat_I_muP_occ_re ...
+!> \param mat_I_muP_virt_re ...
+!> \param mat_I_muP_occ_im ...
+!> \param mat_I_muP_virt_im ...
+!> \param has_3c_blocks_re ...
+!> \param has_3c_blocks_im ...
+!> \param cycle_R1_S2_n_level ...
+!> \param has_blocks_mat_dm_occ_S ...
+!> \param has_blocks_mat_dm_virt_S ...
+!> \param cycle_R1_plus_S2_n_level ...
+!> \param are_flops_I_T_R1_plus_S2_S1_n_level ...
+! **************************************************************************************************
+   SUBROUTINE clean_up_self_energy_kp(mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, &
+                                      index_to_cell_R2, index_to_cell_R1_plus_S2, &
+                                      mat_W_R, mat_dm_occ_S, mat_dm_virt_S, &
+                                      mat_contr_gf_occ_re, mat_contr_gf_virt_re, &
+                                      mat_contr_gf_occ_im, mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im, &
+                                      mat_I_muP_occ_re, mat_I_muP_virt_re, mat_I_muP_occ_im, mat_I_muP_virt_im, &
+                                      has_3c_blocks_re, has_3c_blocks_im, cycle_R1_S2_n_level, &
+                                      has_blocks_mat_dm_occ_S, has_blocks_mat_dm_virt_S, cycle_R1_plus_S2_n_level, &
+                                      are_flops_I_T_R1_plus_S2_S1_n_level)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_re, &
+                                                            mat_3c_overl_int_gw_kp_im
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_R2, &
+                                                            index_to_cell_R1_plus_S2
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_W_R, mat_dm_occ_S, mat_dm_virt_S
+      TYPE(dbcsr_type), POINTER :: mat_contr_gf_occ_re, mat_contr_gf_virt_re, mat_contr_gf_occ_im, &
+         mat_contr_gf_virt_im, mat_contr_W_re, mat_contr_W_im
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_I_muP_occ_re, mat_I_muP_virt_re, &
+                                                            mat_I_muP_occ_im, mat_I_muP_virt_im
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: has_3c_blocks_re, has_3c_blocks_im
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :)        :: cycle_R1_S2_n_level
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: has_blocks_mat_dm_occ_S, &
+                                                            has_blocks_mat_dm_virt_S
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: cycle_R1_plus_S2_n_level
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :) :: are_flops_I_T_R1_plus_S2_S1_n_level
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'clean_up_self_energy_kp', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, imatrix, jmatrix
+
+      CALL timeset(routineN, handle)
+
+      CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_gw_kp_re)
+      CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_gw_kp_im)
+      DEALLOCATE (index_to_cell_R2)
+      DEALLOCATE (index_to_cell_R1_plus_S2)
+
+!     CALL dbcsr_deallocate_matrix_set(mat_dm_occ_S)
+      DO imatrix = LBOUND(mat_dm_occ_S, 1), UBOUND(mat_dm_occ_S, 1)
+      DO jmatrix = 1, SIZE(mat_dm_occ_S, 2)
+         CALL dbcsr_deallocate_matrix(mat_dm_occ_S(imatrix, jmatrix)%matrix)
+      END DO
+      END DO
+      DEALLOCATE (mat_dm_occ_S)
+
+      CALL dbcsr_deallocate_matrix_set(mat_dm_virt_S)
+
+!     CALL dbcsr_deallocate_matrix_set(mat_W_R)
+      DO imatrix = 1, SIZE(mat_W_R, 1)
+      DO jmatrix = LBOUND(mat_W_R, 2), UBOUND(mat_W_R, 2)
+         CALL dbcsr_deallocate_matrix(mat_W_R(imatrix, jmatrix)%matrix)
+      END DO
+      END DO
+      DEALLOCATE (mat_W_R)
+
+      CALL dbcsr_release_P(mat_contr_gf_occ_re)
+      CALL dbcsr_release_P(mat_contr_gf_virt_re)
+      CALL dbcsr_release_P(mat_contr_gf_occ_im)
+      CALL dbcsr_release_P(mat_contr_gf_virt_im)
+      CALL dbcsr_release_P(mat_contr_W_re)
+      CALL dbcsr_release_P(mat_contr_W_im)
+      CALL dbcsr_deallocate_matrix_set(mat_I_muP_occ_re)
+      CALL dbcsr_deallocate_matrix_set(mat_I_muP_virt_re)
+      CALL dbcsr_deallocate_matrix_set(mat_I_muP_occ_im)
+      CALL dbcsr_deallocate_matrix_set(mat_I_muP_virt_im)
+      DEALLOCATE (has_3c_blocks_re)
+      DEALLOCATE (has_3c_blocks_im)
+      DEALLOCATE (cycle_R1_S2_n_level)
+      DEALLOCATE (cycle_R1_plus_S2_n_level)
+      DEALLOCATE (has_blocks_mat_dm_occ_S)
+      DEALLOCATE (has_blocks_mat_dm_virt_S)
+      DEALLOCATE (are_flops_I_T_R1_plus_S2_S1_n_level)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param index_to_cell_R1_plus_S2 ...
+!> \param cell_to_index_3c ...
+!> \param num_cells_R1_plus_S2 ...
+!> \param kpoints ...
+!> \param unit_nr ...
+!> \param maxcell ...
+!> \param num_cells_dm ...
+! **************************************************************************************************
+   SUBROUTINE compute_cell_vec_for_R1_plus_S2_or_R1(index_to_cell_R1_plus_S2, cell_to_index_3c, &
+                                                    num_cells_R1_plus_S2, kpoints, &
+                                                    unit_nr, maxcell, num_cells_dm)
+
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_R1_plus_S2
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
+      INTEGER                                            :: num_cells_R1_plus_S2
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: unit_nr, maxcell, num_cells_dm
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_cell_vec_for_R1_plus_S2_or_R1', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: bound_1, bound_2, bound_3, bound_4, bound_5, bound_6, handle, i_cell_S_1, &
+         size_set, x_cell_R1_plus_S2, x_cell_R1_plus_S2_minus_S1, y_cell_R1_plus_S2, &
+         y_cell_R1_plus_S2_minus_S1, z_cell_R1_plus_S2, z_cell_R1_plus_S2_minus_S1
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_tmp
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
+      LOGICAL                                            :: already_there
+
+      CALL timeset(routineN, handle)
+
+      index_to_cell_dm => kpoints%index_to_cell
+
+      ALLOCATE (index_to_cell_R1_plus_S2(3, 1))
+      index_to_cell_R1_plus_S2 = 0
+
+      bound_1 = LBOUND(cell_to_index_3c, 1)
+      bound_2 = UBOUND(cell_to_index_3c, 1)
+      bound_3 = LBOUND(cell_to_index_3c, 2)
+      bound_4 = UBOUND(cell_to_index_3c, 2)
+      bound_5 = LBOUND(cell_to_index_3c, 3)
+      bound_6 = UBOUND(cell_to_index_3c, 3)
+
+      maxcell = 8
+
+      DO x_cell_R1_plus_S2 = -maxcell, maxcell
+         DO y_cell_R1_plus_S2 = -maxcell, maxcell
+            DO z_cell_R1_plus_S2 = -maxcell, maxcell
+
+               already_there = .FALSE.
+
+               DO i_cell_S_1 = 1, num_cells_dm
+
+                  IF (already_there) CYCLE
+
+                  x_cell_R1_plus_S2_minus_S1 = x_cell_R1_plus_S2-index_to_cell_dm(1, i_cell_S_1)
+                  y_cell_R1_plus_S2_minus_S1 = y_cell_R1_plus_S2-index_to_cell_dm(2, i_cell_S_1)
+                  z_cell_R1_plus_S2_minus_S1 = z_cell_R1_plus_S2-index_to_cell_dm(3, i_cell_S_1)
+
+                  IF (x_cell_R1_plus_S2_minus_S1 .GE. bound_1 .AND. &
+                      x_cell_R1_plus_S2_minus_S1 .LE. bound_2 .AND. &
+                      y_cell_R1_plus_S2_minus_S1 .GE. bound_3 .AND. &
+                      y_cell_R1_plus_S2_minus_S1 .LE. bound_4 .AND. &
+                      z_cell_R1_plus_S2_minus_S1 .GE. bound_5 .AND. &
+                      z_cell_R1_plus_S2_minus_S1 .LE. bound_6) THEN
+
+                     size_set = SIZE(index_to_cell_R1_plus_S2, 2)
+
+                     IF (size_set == 1 .AND. &
+                         index_to_cell_R1_plus_S2(1, size_set) == 0 .AND. &
+                         index_to_cell_R1_plus_S2(2, size_set) == 0 .AND. &
+                         index_to_cell_R1_plus_S2(3, size_set) == 0) THEN
+
+                        index_to_cell_R1_plus_S2(1, size_set) = x_cell_R1_plus_S2
+                        index_to_cell_R1_plus_S2(2, size_set) = y_cell_R1_plus_S2
+                        index_to_cell_R1_plus_S2(3, size_set) = z_cell_R1_plus_S2
+
+                     ELSE
+
+                        ALLOCATE (index_to_cell_tmp(3, size_set))
+                        index_to_cell_tmp(1:3, 1:size_set) = index_to_cell_R1_plus_S2(1:3, 1:size_set)
+                        DEALLOCATE (index_to_cell_R1_plus_S2)
+                        ALLOCATE (index_to_cell_R1_plus_S2(3, size_set+1))
+                        index_to_cell_R1_plus_S2(1:3, 1:size_set) = index_to_cell_tmp(1:3, 1:size_set)
+                        index_to_cell_R1_plus_S2(1, size_set+1) = x_cell_R1_plus_S2
+                        index_to_cell_R1_plus_S2(2, size_set+1) = y_cell_R1_plus_S2
+                        index_to_cell_R1_plus_S2(3, size_set+1) = z_cell_R1_plus_S2
+                        DEALLOCATE (index_to_cell_tmp)
+                        already_there = .TRUE.
+
+                     END IF
+
+                  END IF
+
+               END DO
+
+            END DO
+         END DO
+      END DO
+
+      num_cells_R1_plus_S2 = SIZE(index_to_cell_R1_plus_S2, 2)
+
+      IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
+         "GW_INFO| Number of periodic images for R_1+S_2 and R_2 sum in self-energy:", num_cells_R1_plus_S2
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param index_to_cell_R2 ...
+!> \param cell_to_index_R2 ...
+!> \param num_cells_R2 ...
+!> \param unit_nr ...
+!> \param index_to_cell_dm ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE compute_cell_vec_for_R2(index_to_cell_R2, cell_to_index_R2, num_cells_R2, unit_nr, &
+                                      index_to_cell_dm, qs_env)
+
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_R2
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_R2
+      INTEGER                                            :: num_cells_R2, unit_nr
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_cell_vec_for_R2', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: bound_1, bound_2, bound_3, bound_4, &
+                                                            bound_5, bound_6, handle, icell, &
+                                                            num_cells_dm
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, kpoints=kpoints)
+
+      index_to_cell_dm => kpoints%index_to_cell
+
+      num_cells_dm = SIZE(index_to_cell_dm, 2)
+
+      ALLOCATE (index_to_cell_R2(3, num_cells_dm))
+      index_to_cell_R2(1:3, 1:num_cells_dm) = index_to_cell_dm(1:3, 1:num_cells_dm)
+
+      num_cells_R2 = SIZE(index_to_cell_R2, 2)
+
+      IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
+         "GW_INFO| Number of periodic images for R_2 W-sum in self-energy:", num_cells_R2
+
+      bound_1 = MINVAL(index_to_cell_R2(1, :))
+      bound_2 = MAXVAL(index_to_cell_R2(1, :))
+      bound_3 = MINVAL(index_to_cell_R2(2, :))
+      bound_4 = MAXVAL(index_to_cell_R2(2, :))
+      bound_5 = MINVAL(index_to_cell_R2(3, :))
+      bound_6 = MAXVAL(index_to_cell_R2(3, :))
+
+      ALLOCATE (cell_to_index_R2(bound_1:bound_2, bound_3:bound_4, bound_5:bound_6))
+      cell_to_index_R2(:, :, :) = 0
+
+      DO icell = 1, SIZE(index_to_cell_R2, 2)
+
+         cell_to_index_R2(index_to_cell_R2(1, icell), &
+                          index_to_cell_R2(2, icell), &
+                          index_to_cell_R2(3, icell)) = icell
+
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_3c_overl_int ...
+!> \param ikp ...
+!> \param mat_3c_overl_int_gw_kp_re ...
+!> \param mat_3c_overl_int_gw_kp_im ...
+!> \param kpoints ...
+!> \param para_env ...
+!> \param para_env_sub ...
+!> \param matrix_s ...
+!> \param mat_dm_virt_local ...
+!> \param gw_corr_lev_occ ...
+!> \param gw_corr_lev_virt ...
+!> \param homo ...
+!> \param nmo ...
+!> \param cut_RI ...
+!> \param num_3c_repl ...
+!> \param row_from_LLL ...
+!> \param my_group_L_starts_im_time ...
+!> \param my_group_L_sizes_im_time ...
+!> \param has_3c_blocks_re ...
+!> \param has_3c_blocks_im ...
+! **************************************************************************************************
+   SUBROUTINE get_mat_3c_gw_kp(mat_3c_overl_int, ikp, &
+                               mat_3c_overl_int_gw_kp_re, mat_3c_overl_int_gw_kp_im, kpoints, &
+                               para_env, para_env_sub, matrix_s, mat_dm_virt_local, &
+                               gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, cut_RI, num_3c_repl, &
+                               row_from_LLL, my_group_L_starts_im_time, &
+                               my_group_L_sizes_im_time, has_3c_blocks_re, has_3c_blocks_im)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
+      INTEGER                                            :: ikp
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_re, &
+                                                            mat_3c_overl_int_gw_kp_im
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(dbcsr_p_type)                                 :: mat_dm_virt_local
+      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, homo, &
+                                                            nmo, cut_RI, num_3c_repl
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: row_from_LLL, my_group_L_starts_im_time, &
+                                                            my_group_L_sizes_im_time
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: has_3c_blocks_re, has_3c_blocks_im
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_mat_3c_gw_kp', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i_cell, i_cut_RI, icol_global, &
+                                                            irow_global, j_cell, n_level_gw, nblks
+      REAL(KIND=dp)                                      :: minus_one
+      TYPE(cp_fm_type), POINTER                          :: fm_mat_mo_coeff_gw_im, &
+                                                            fm_mat_mo_coeff_gw_re, &
+                                                            fm_mat_mo_coeff_im, fm_mat_mo_coeff_re
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: mat_3c_overl_int_gw_for_mult_tmp
+      TYPE(dbcsr_type), POINTER                          :: mat_mo_coeff_gw_local_tmp, &
+                                                            mat_mo_coeff_gw_tmp
+
+      CALL timeset(routineN, handle)
+
+      fm_mat_mo_coeff_re => kpoints%kp_env(ikp)%kpoint_env%mos(1, 1)%mo_set%mo_coeff
+      fm_mat_mo_coeff_im => kpoints%kp_env(ikp)%kpoint_env%mos(2, 1)%mo_set%mo_coeff
+
+      NULLIFY (fm_mat_mo_coeff_gw_re)
+      CALL cp_fm_create(fm_mat_mo_coeff_gw_re, fm_mat_mo_coeff_re%matrix_struct)
+      CALL cp_fm_set_all(fm_mat_mo_coeff_gw_re, 0.0_dp)
+
+      NULLIFY (fm_mat_mo_coeff_gw_im)
+      CALL cp_fm_create(fm_mat_mo_coeff_gw_im, fm_mat_mo_coeff_im%matrix_struct)
+      CALL cp_fm_set_all(fm_mat_mo_coeff_gw_im, 0.0_dp)
+
+      CALL cp_fm_to_fm(fm_mat_mo_coeff_re, fm_mat_mo_coeff_gw_re)
+      CALL cp_fm_to_fm(fm_mat_mo_coeff_im, fm_mat_mo_coeff_gw_im)
+
+      ! set MO coeffs to zero for non-GW corrected levels
+      DO irow_global = 1, nmo
+         DO icol_global = 1, homo-gw_corr_lev_occ
+            CALL cp_fm_set_element(fm_mat_mo_coeff_gw_re, irow_global, icol_global, 0.0_dp)
+            CALL cp_fm_set_element(fm_mat_mo_coeff_gw_im, irow_global, icol_global, 0.0_dp)
+         END DO
+         DO icol_global = homo+gw_corr_lev_virt+1, nmo
+            CALL cp_fm_set_element(fm_mat_mo_coeff_gw_re, irow_global, icol_global, 0.0_dp)
+            CALL cp_fm_set_element(fm_mat_mo_coeff_gw_im, irow_global, icol_global, 0.0_dp)
+         END DO
+      END DO
+
+      NULLIFY (mat_mo_coeff_gw_tmp)
+      CALL dbcsr_init_p(mat_mo_coeff_gw_tmp)
+      CALL dbcsr_create(matrix=mat_mo_coeff_gw_tmp, &
+                        template=matrix_s(1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+
+      NULLIFY (mat_mo_coeff_gw_local_tmp)
+      CALL dbcsr_init_p(mat_mo_coeff_gw_local_tmp)
+      CALL dbcsr_create(matrix=mat_mo_coeff_gw_local_tmp, &
+                        template=mat_dm_virt_local%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+
+      NULLIFY (mat_3c_overl_int_gw_for_mult_tmp)
+      CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw_for_mult_tmp, cut_RI)
+      DO i_cut_RI = 1, cut_RI
+         ALLOCATE (mat_3c_overl_int_gw_for_mult_tmp(i_cut_RI)%matrix)
+         CALL dbcsr_create(matrix=mat_3c_overl_int_gw_for_mult_tmp(i_cut_RI)%matrix, &
+                           template=mat_3c_overl_int(i_cut_RI, 1, 1)%matrix)
+      END DO
+
+      ! ****************************** 1. REAL PART OF (nk_R muS P0) *************************************
+      CALL copy_fm_to_dbcsr(fm_mat_mo_coeff_gw_re, &
+                            mat_mo_coeff_gw_tmp, &
+                            keep_sparsity=.FALSE.)
+
+      ! just remove the blocks which have been set to zero
+      CALL dbcsr_filter(mat_mo_coeff_gw_tmp, 1.0E-20_dp)
+
+      CALL dbcsr_set(mat_mo_coeff_gw_local_tmp, 0.0_dp)
+
+      CALL replicate_mat_to_subgroup_simple(para_env, para_env_sub, mat_mo_coeff_gw_tmp, nmo, &
+                                            mat_mo_coeff_gw_local_tmp)
+
+      DO i_cell = 1, num_3c_repl
+         DO j_cell = 1, num_3c_repl
+
+            DO i_cut_RI = 1, cut_RI
+               CALL dbcsr_multiply("T", "N", 1.0_dp, mat_mo_coeff_gw_local_tmp, &
+                                   mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, &
+                                   0.0_dp, mat_3c_overl_int_gw_for_mult_tmp(i_cut_RI)%matrix)
+            END DO
+
+            CALL fill_mat_3c_overl_int_gw(mat_3c_overl_int_gw_kp_re(:, i_cell, j_cell), &
+                                          mat_3c_overl_int_gw_for_mult_tmp, row_from_LLL, &
+                                          my_group_L_starts_im_time, my_group_L_sizes_im_time, cut_RI, &
+                                          para_env, gw_corr_lev_occ, gw_corr_lev_virt, homo)
+
+         END DO
+      END DO
+
+      ! ****************************** 2. IMAG PART OF (nk_R muS P0) *************************************
+      CALL copy_fm_to_dbcsr(fm_mat_mo_coeff_gw_im, &
+                            mat_mo_coeff_gw_tmp, &
+                            keep_sparsity=.FALSE.)
+
+      ! just remove the blocks which have been set to zero
+      CALL dbcsr_filter(mat_mo_coeff_gw_tmp, 1.0E-20_dp)
+
+      CALL dbcsr_set(mat_mo_coeff_gw_local_tmp, 0.0_dp)
+
+      CALL replicate_mat_to_subgroup_simple(para_env, para_env_sub, mat_mo_coeff_gw_tmp, nmo, &
+                                            mat_mo_coeff_gw_local_tmp)
+
+      DO i_cell = 1, num_3c_repl
+         DO j_cell = 1, num_3c_repl
+
+            DO i_cut_RI = 1, cut_RI
+               ! minus one because MO coeffs are Hermitian conjugate
+               minus_one = -1.0_dp
+               CALL dbcsr_multiply("T", "N", minus_one, mat_mo_coeff_gw_local_tmp, &
+                                   mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, &
+                                   0.0_dp, mat_3c_overl_int_gw_for_mult_tmp(i_cut_RI)%matrix)
+            END DO
+
+            CALL fill_mat_3c_overl_int_gw(mat_3c_overl_int_gw_kp_im(:, i_cell, j_cell), &
+                                          mat_3c_overl_int_gw_for_mult_tmp, row_from_LLL, &
+                                          my_group_L_starts_im_time, my_group_L_sizes_im_time, cut_RI, &
+                                          para_env, gw_corr_lev_occ, gw_corr_lev_virt, homo)
+
+            DO n_level_gw = 1, gw_corr_lev_occ+gw_corr_lev_virt
+
+               nblks = dbcsr_get_num_blocks(mat_3c_overl_int_gw_kp_re(n_level_gw, i_cell, j_cell)%matrix)
+               CALL mp_sum(nblks, para_env%group)
+               IF (nblks == 0) has_3c_blocks_re(n_level_gw, i_cell, j_cell) = .FALSE.
+               IF (nblks > 0) has_3c_blocks_re(n_level_gw, i_cell, j_cell) = .TRUE.
+
+               nblks = dbcsr_get_num_blocks(mat_3c_overl_int_gw_kp_im(n_level_gw, i_cell, j_cell)%matrix)
+               CALL mp_sum(nblks, para_env%group)
+               IF (nblks == 0) has_3c_blocks_im(n_level_gw, i_cell, j_cell) = .FALSE.
+               IF (nblks > 0) has_3c_blocks_im(n_level_gw, i_cell, j_cell) = .TRUE.
+
+            END DO
+
+         END DO
+      END DO
+
+      CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_gw_for_mult_tmp)
+      CALL dbcsr_release_p(mat_mo_coeff_gw_tmp)
+      CALL dbcsr_release_p(mat_mo_coeff_gw_local_tmp)
+      CALL cp_fm_release(fm_mat_mo_coeff_gw_re)
+      CALL cp_fm_release(fm_mat_mo_coeff_gw_im)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param index_to_cell_R2 ...
+!> \param mat_W_R ...
+!> \param mat_3c_overl_int_gw_kp_re ...
+!> \param cfm_mat_W_kp_tau ...
+!> \param kpoints ...
+!> \param RI_blk_sizes ...
+!> \param fm_mat_L ...
+!> \param dimen_RI ...
+!> \param qs_env ...
+!> \param start_jquad ...
+!> \param wkp_W ...
+! **************************************************************************************************
+   SUBROUTINE trafo_W_from_k_to_R(index_to_cell_R2, mat_W_R, mat_3c_overl_int_gw_kp_re, &
+                                  cfm_mat_W_kp_tau, kpoints, &
+                                  RI_blk_sizes, fm_mat_L, dimen_RI, qs_env, start_jquad, wkp_W)
+
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_R2
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_W_R
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_gw_kp_re
+      TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER, DIMENSION(:), POINTER                     :: RI_blk_sizes
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_mat_L
+      INTEGER                                            :: dimen_RI
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: start_jquad
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp_W
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'trafo_W_from_k_to_R', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, icell, ik, jquad, nkp, &
+                                                            num_cells_R2, num_integ_points, xcell, &
+                                                            ycell, zcell
+      REAL(KIND=dp)                                      :: arg, check, check_2, coskl, sinkl
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(cp_fm_type), POINTER                          :: fm_tmp_im, fm_tmp_re
+      TYPE(dbcsr_type), POINTER                          :: mat_work_im, mat_work_re
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (xkp)
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp)
+
+      num_integ_points = SIZE(cfm_mat_W_kp_tau, 2)
+
+      IF (qs_env%mp2_env%ri_g0w0%print_exx == gw_read_exx) THEN
+         ! we do not do HFX here, so we do not need jquad = 0 what corresponds to HFX
+         start_jquad = 1
+      ELSE
+         start_jquad = 0
+      END IF
+
+      num_cells_R2 = SIZE(index_to_cell_R2, 2)
+
+      NULLIFY (mat_W_R)
+      ALLOCATE (mat_W_R(num_cells_R2, start_jquad:num_integ_points))
+      DO jquad = start_jquad, num_integ_points
+         DO icell = 1, num_cells_R2
+            ALLOCATE (mat_W_R(icell, jquad)%matrix)
+            CALL dbcsr_create(matrix=mat_W_R(icell, jquad)%matrix, &
+                              template=mat_3c_overl_int_gw_kp_re(1, 1, 1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry, &
+                              row_blk_size=RI_blk_sizes, &
+                              col_blk_size=RI_blk_sizes)
+            CALL dbcsr_set(mat_W_R(icell, jquad)%matrix, 0.0_dp)
+         END DO
+      END DO
+
+      NULLIFY (fm_tmp_re)
+      CALL cp_fm_create(fm_tmp_re, cfm_mat_W_kp_tau(1, 1)%matrix%matrix_struct)
+      NULLIFY (fm_tmp_im)
+      CALL cp_fm_create(fm_tmp_im, cfm_mat_W_kp_tau(1, 1)%matrix%matrix_struct)
+
+      NULLIFY (mat_work_re)
+      CALL dbcsr_init_p(mat_work_re)
+      CALL dbcsr_create(matrix=mat_work_re, &
+                        template=mat_W_R(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+
+      NULLIFY (mat_work_im)
+      CALL dbcsr_init_p(mat_work_im)
+      CALL dbcsr_create(matrix=mat_work_im, &
+                        template=mat_W_R(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+
+      check = 0.0_dp
+      check_2 = 0.0_dp
+
+      DO jquad = start_jquad, num_integ_points
+
+         DO ik = 1, nkp
+
+            IF (jquad == 0) THEN
+               ! jquad = 0 corresponds to exact exchange self-energy
+               ! V(ik) = L(ik)*L^H(ik)
+
+               CALL cp_gemm('N', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, &
+                            fm_mat_L(ik, 1)%matrix, fm_mat_L(ik, 1)%matrix, &
+                            0.0_dp, fm_tmp_re)
+               CALL cp_gemm('N', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, &
+                            fm_mat_L(ik, 2)%matrix, fm_mat_L(ik, 2)%matrix, &
+                            1.0_dp, fm_tmp_re)
+               CALL cp_gemm('N', 'T', dimen_RI, dimen_RI, dimen_RI, -1.0_dp, &
+                            fm_mat_L(ik, 1)%matrix, fm_mat_L(ik, 2)%matrix, &
+                            0.0_dp, fm_tmp_im)
+               CALL cp_gemm('N', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, &
+                            fm_mat_L(ik, 2)%matrix, fm_mat_L(ik, 1)%matrix, &
+                            1.0_dp, fm_tmp_im)
+
+            ELSE
+
+               CALL cp_cfm_to_fm(cfm_mat_W_kp_tau(ik, jquad)%matrix, fm_tmp_re, fm_tmp_im)
+
+            END IF
+
+            CALL copy_fm_to_dbcsr(fm_tmp_re, mat_work_re, keep_sparsity=.FALSE.)
+            CALL copy_fm_to_dbcsr(fm_tmp_im, mat_work_im, keep_sparsity=.FALSE.)
+
+            DO icell = 1, num_cells_R2
+
+               xcell = index_to_cell_R2(1, icell)
+               ycell = index_to_cell_R2(2, icell)
+               zcell = index_to_cell_R2(3, icell)
+
+               arg = REAL(xcell, dp)*xkp(1, ik)+REAL(ycell, dp)*xkp(2, ik)+REAL(zcell, dp)*xkp(3, ik)
+               coskl = wkp_W(ik)*COS(twopi*arg)
+               sinkl = wkp_W(ik)*SIN(twopi*arg)
+
+               CALL dbcsr_add(mat_W_R(icell, jquad)%matrix, mat_work_re, 1.0_dp, coskl)
+               CALL dbcsr_add(mat_W_R(icell, jquad)%matrix, mat_work_im, 1.0_dp, sinkl)
+
+            END DO ! icell
+
+         END DO ! ik
+
+      END DO ! jquad
+
+      CALL cp_fm_release(fm_tmp_re)
+      CALL cp_fm_release(fm_tmp_im)
+      CALL dbcsr_release_p(mat_work_re)
+      CALL dbcsr_release_p(mat_work_im)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+END MODULE rpa_gw_kpoints

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -9,6 +9,7 @@
 !>      10.2015 created [Jan Wilhelm]
 ! **************************************************************************************************
 MODULE rpa_im_time
+
    USE cell_types,                      ONLY: cell_type,&
                                               get_cell,&
                                               pbc
@@ -29,12 +30,12 @@ MODULE rpa_im_time
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
         dbcsr_add, dbcsr_clear, dbcsr_copy, dbcsr_create, dbcsr_filter, dbcsr_finalize, &
-        dbcsr_get_diag, dbcsr_get_info, dbcsr_get_num_blocks, dbcsr_get_occupation, &
-        dbcsr_get_stored_coordinates, dbcsr_init_p, dbcsr_iterator_blocks_left, &
-        dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
-        dbcsr_multiply, dbcsr_p_type, dbcsr_release_p, dbcsr_reserve_all_blocks, &
-        dbcsr_reserve_blocks, dbcsr_scalar, dbcsr_scale, dbcsr_set, dbcsr_transposed, dbcsr_type, &
-        dbcsr_type_no_symmetry
+        dbcsr_get_block_p, dbcsr_get_diag, dbcsr_get_info, dbcsr_get_num_blocks, &
+        dbcsr_get_occupation, dbcsr_get_stored_coordinates, dbcsr_init_p, &
+        dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
+        dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_p_type, dbcsr_release_p, &
+        dbcsr_reserve_all_blocks, dbcsr_reserve_blocks, dbcsr_scalar, dbcsr_scale, dbcsr_set, &
+        dbcsr_transposed, dbcsr_type, dbcsr_type_no_symmetry
    USE dbcsr_tensor_api,                ONLY: &
         dbcsr_t_clear, dbcsr_t_contract, dbcsr_t_copy, dbcsr_t_copy_matrix_to_tensor, &
         dbcsr_t_copy_tensor_to_matrix, dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_filter, &
@@ -78,14 +79,14 @@ MODULE rpa_im_time
              reflect_mat_row, &
              zero_mat_P_omega, &
              gap_and_max_eig_diff_kpoints, &
-             setup_tensor_for_mem_cut_3c
-
+             compute_transl_dm, dbcsr_add_local, &
+             get_P_cell_T_from_P_gamma, transform_P_from_real_space_to_kpoints, &
+             setup_tensor_for_mem_cut_3c, replicate_mat_to_subgroup_simple, fill_mat_3c_overl_int_gw
 CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
 !> \param mat_P_omega ...
-!> \param mat_P_omega_im_part ...
 !> \param fm_scaled_dm_occ_tau ...
 !> \param fm_scaled_dm_virt_tau ...
 !> \param fm_mo_coeff_occ ...
@@ -123,7 +124,7 @@ CONTAINS
 !> \param has_mat_P_blocks ...
 !> \param do_ri_sos_laplace_mp2 ...
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_P_omega_t(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+   SUBROUTINE compute_mat_P_omega_t(mat_P_omega, fm_scaled_dm_occ_tau, &
                                     fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                     fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                     mat_P_global, &
@@ -139,7 +140,7 @@ CONTAINS
                                     stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                     has_mat_P_blocks, do_ri_sos_laplace_mp2)
 
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_im_part
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega
       TYPE(cp_fm_type), POINTER :: fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, fm_mo_coeff_occ, &
          fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled
       TYPE(dbcsr_p_type)                                 :: mat_P_global
@@ -184,7 +185,6 @@ CONTAINS
 
       memory_info = mp2_env%ri_rpa_im_time%memory_info
       do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
-      do_Gamma_RPA = .NOT. do_kpoints_cubic_RPA
       num_3c_repl = MAXVAL(cell_to_index_3c)
 
       CALL timeset(routineN, handle)
@@ -432,12 +432,6 @@ CONTAINS
 
       END DO ! time points
 
-      IF (do_kpoints_cubic_RPA) THEN
-
-         CALL transform_P_from_real_space_to_kpoints(mat_P_omega, mat_P_omega_im_part, qs_env)
-
-      END IF
-
       CALL clean_up(mat_dm_occ_global, mat_dm_virt_global, does_mat_P_T_tau_have_blocks)
 
       CALL timestop(handle)
@@ -448,7 +442,6 @@ CONTAINS
 !> \brief compute the matrix Q(it) (intermediate) and Fourier transform it
 !>        directly to fm_mat_P_omega(iw) (output)
 !> \param mat_P_omega ...
-!> \param mat_P_omega_im_part ...
 !> \param fm_scaled_dm_occ_tau ...
 !> \param fm_scaled_dm_virt_tau ...
 !> \param fm_mo_coeff_occ ...
@@ -525,9 +518,10 @@ CONTAINS
 !> \param cell_to_index_3c ...
 !> \param needed_cutRI_mem_R1vec_R2vec_for_kp ...
 !> \param has_mat_P_blocks ...
+!> \param num_3c_repl ...
 !> \param do_ri_sos_laplace_mp2 whether we perform ri-laplace-sos mp2
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_P_omega(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+   SUBROUTINE compute_mat_P_omega(mat_P_omega, fm_scaled_dm_occ_tau, &
                                   fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                   fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                   mat_P_local, mat_P_global, mat_P_global_copy, mat_M_mu_Pnu_occ, &
@@ -553,9 +547,8 @@ CONTAINS
                                   non_zero_blocks_3c, non_zero_blocks_3c_cut_col, buffer_mat_M, do_mao, &
                                   stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                   needed_cutRI_mem_R1vec_R2vec_for_kp, &
-                                  has_mat_P_blocks, do_ri_sos_laplace_mp2)
-
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_im_part
+                                  has_mat_P_blocks, num_3c_repl, do_ri_sos_laplace_mp2)
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega
       TYPE(cp_fm_type), POINTER :: fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, fm_mo_coeff_occ, &
          fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled
       TYPE(dbcsr_p_type)                                 :: mat_P_local, mat_P_global, &
@@ -607,6 +600,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :) :: needed_cutRI_mem_R1vec_R2vec_for_kp
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :)     :: has_mat_P_blocks
+      INTEGER                                            :: num_3c_repl
       LOGICAL                                            :: do_ri_sos_laplace_mp2
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_P_omega', &
@@ -614,17 +608,17 @@ CONTAINS
 
       INTEGER :: handle, handle4, handle5, i_cell, i_cell_R_1, i_cell_R_1_minus_S, &
          i_cell_R_1_minus_T, i_cell_R_2, i_cell_R_2_minus_S_minus_T, i_cell_S, i_cell_T, i_cut_RI, &
-         i_mem, iquad, j_mem, my_group_L_size, num_3c_repl, num_cells_dm
+         i_mem, iquad, j_mem, my_group_L_size, num_cells_dm
       INTEGER(KIND=int_8)                                :: flop_occ, flop_virt, num_flops_mat_P
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
-      LOGICAL :: do_Gamma_RPA, do_kpoints_cubic_RPA, first_cycle_im_time, first_cycle_omega_loop, &
-         memory_info, R_1_minus_S_needed, R_1_minus_T_needed, R_2_minus_S_minus_T_needed
+      LOGICAL :: do_kpoints_cubic_RPA, first_cycle_im_time, first_cycle_omega_loop, memory_info, &
+         R_1_minus_S_needed, R_1_minus_T_needed, R_2_minus_S_minus_T_needed
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: does_mat_P_T_tau_have_blocks
       REAL(KIND=dp)                                      :: omega, omega_old, tau, weight, weight_old
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
 
       IF (do_dbcsr_t) THEN
-         CALL compute_mat_P_omega_t(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+         CALL compute_mat_P_omega_t(mat_P_omega, fm_scaled_dm_occ_tau, &
                                     fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                     fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                     mat_P_global, &
@@ -644,8 +638,6 @@ CONTAINS
 
       memory_info = mp2_env%ri_rpa_im_time%memory_info
       do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
-      do_Gamma_RPA = .NOT. do_kpoints_cubic_RPA
-      num_3c_repl = MAXVAL(cell_to_index_3c)
 
       CALL timeset(routineN, handle)
 
@@ -693,7 +685,7 @@ CONTAINS
 
                DO i_mem = 1, cut_memory
 
-                  IF (cycle_due_to_sparse_dm(i_mem, j_mem, jquad) .AND. do_Gamma_RPA) CYCLE
+                  IF (cycle_due_to_sparse_dm(i_mem, j_mem, jquad) .AND. (.NOT. do_kpoints_cubic_RPA)) CYCLE
 
                   CALL timeset(routineN//"_calc_M", handle5)
                   CALL replicate_dm_to_subgroup(para_env, para_env_sub, mat_dm_occ_global, nmo, jquad, &
@@ -934,12 +926,6 @@ CONTAINS
          END DO ! neighbor cell T
 
       END DO ! time points
-
-      IF (do_kpoints_cubic_RPA) THEN
-
-         CALL transform_P_from_real_space_to_kpoints(mat_P_omega, mat_P_omega_im_part, qs_env)
-
-      END IF
 
       CALL clean_up(mat_dm_occ_global, mat_dm_virt_global, does_mat_P_T_tau_have_blocks)
 
@@ -1788,8 +1774,6 @@ CONTAINS
       CALL dbcsr_copy(mat_P_global%matrix, mat_P_global_copy%matrix)
 
       ! just remove the blocks which are exactly zero from mat_P_global
-!      CALL dbcsr_filter(mat_P_global%matrix, 1.0E-30_dp)
-
       CALL dbcsr_filter(mat_P_global%matrix, eps_filter_im_time)
 
       DO imepos = 0, para_env%num_pe-1
@@ -2101,11 +2085,11 @@ CONTAINS
 
          CALL compute_transl_dm(mat_dm_occ_global, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
                                 stabilize_exp, eps_filter, num_cells_dm, index_to_cell_dm, &
-                                remove_occ=.FALSE., remove_virt=.TRUE.)
+                                remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=1)
 
          CALL compute_transl_dm(mat_dm_virt_global, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
                                 stabilize_exp, eps_filter, num_cells_dm, index_to_cell_dm, &
-                                remove_occ=.TRUE., remove_virt=.FALSE.)
+                                remove_occ=.TRUE., remove_virt=.FALSE., first_jquad=1)
 
       ELSE
 
@@ -3281,10 +3265,13 @@ CONTAINS
 !> \param ends_array_cm ...
 !> \param my_group_L_sizes_im_time ...
 !> \param eps_filter ...
+!> \param do_kpoints_cubic_RPA ...
+!> \param do_gw_im_time ...
+!> \param num_3c_repl ...
 ! **************************************************************************************************
    SUBROUTINE setup_mat_for_mem_cut_3c(mat_3c_overl_int_cut, mat_3c_overl_int, cut_memory, cut_RI, &
-                                       starts_array_cm, ends_array_cm, &
-                                       my_group_L_sizes_im_time, eps_filter)
+                                       starts_array_cm, ends_array_cm, my_group_L_sizes_im_time, &
+                                       eps_filter, do_kpoints_cubic_RPA, do_gw_im_time, num_3c_repl)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
@@ -3292,18 +3279,18 @@ CONTAINS
       INTEGER, DIMENSION(:)                              :: starts_array_cm, ends_array_cm, &
                                                             my_group_L_sizes_im_time
       REAL(KIND=dp)                                      :: eps_filter
+      LOGICAL                                            :: do_kpoints_cubic_RPA, do_gw_im_time
+      INTEGER                                            :: num_3c_repl
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'setup_mat_for_mem_cut_3c', &
          routineP = moduleN//':'//routineN
 
       INTEGER :: blk, col, col_end_in_data_block, col_offset, col_size, col_start_in_data_block, &
-         handle, i_cell, i_cut_RI, i_mem, j_cell, my_group_L_size, num_3c_repl, row
+         handle, i_cell, i_cut_RI, i_mem, j_cell, my_group_L_size, row
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
       TYPE(dbcsr_iterator_type)                          :: iter
 
       CALL timeset(routineN, handle)
-
-      num_3c_repl = SIZE(mat_3c_overl_int, 3)
 
       NULLIFY (mat_3c_overl_int_cut)
       CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_cut, cut_RI, cut_memory, num_3c_repl, num_3c_repl)
@@ -3362,20 +3349,26 @@ CONTAINS
 
                END DO
             END DO
+
          END DO
       END DO
 
-      ! to be 100 % safe, set original three center overlap integrals to zero and filter
-      DO i_cut_RI = 1, cut_RI
-         DO i_cell = 1, num_3c_repl
-            DO j_cell = 1, num_3c_repl
-               CALL dbcsr_set(mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, 0.0_dp)
-               CALL dbcsr_filter(mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, 1.0_dp)
+      ! we need to keep the 3c integrals in case we are doing k-points for GW
+      IF (.NOT. (do_gw_im_time .AND. do_kpoints_cubic_RPA)) THEN
+
+         ! to be 100 % safe, set original three center overlap integrals to zero and filter
+         DO i_cut_RI = 1, cut_RI
+            DO i_cell = 1, num_3c_repl
+               DO j_cell = 1, num_3c_repl
+                  CALL dbcsr_set(mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, 0.0_dp)
+                  CALL dbcsr_filter(mat_3c_overl_int(i_cut_RI, i_cell, j_cell)%matrix, 1.0_dp)
+               END DO
             END DO
          END DO
-      END DO
 
-      CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int)
+         CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int)
+
+      END IF
 
       CALL timestop(handle)
 
@@ -3723,13 +3716,13 @@ CONTAINS
 
       END DO
 
-      CALL fill_mat_3c_overl_int_gw(mat_3c_overl_int_gw, mat_3c_overl_int_gw_for_mult, row_from_LLL, &
+      CALL fill_mat_3c_overl_int_gw(mat_3c_overl_int_gw(:), mat_3c_overl_int_gw_for_mult, row_from_LLL, &
                                     my_group_L_starts_im_time, my_group_L_sizes_im_time, cut_RI, &
                                     para_env, gw_corr_lev_occ, gw_corr_lev_virt, homo)
 
       IF (do_ic_model) THEN
 
-         CALL fill_mat_3c_overl_nnP_ic(mat_3c_overl_nnP_ic, mat_3c_overl_int_gw, &
+         CALL fill_mat_3c_overl_nnP_ic(mat_3c_overl_nnP_ic, mat_3c_overl_int_gw(:), &
                                        mat_mo_coeff_gw, gw_corr_lev_occ, gw_corr_lev_virt, homo, &
                                        do_ic_opt_homo_lumo)
 
@@ -3811,7 +3804,7 @@ CONTAINS
          CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_gw_dummy)
          CALL dbcsr_release_p(mat_mo_coeff_gw_reflected)
 
-      END IF
+      END IF ! IC Model
 
       CALL dbcsr_release_p(mat_mo_coeff_gw)
       CALL dbcsr_release_p(mat_mo_coeff_gw_local)
@@ -3835,7 +3828,7 @@ CONTAINS
    SUBROUTINE fill_mat_3c_overl_nnP_ic(mat_3c_overl_nnP_ic, mat_3c_overl_int_gw, mat_mo_coeff_gw, &
                                        gw_corr_lev_occ, gw_corr_lev_virt, homo, do_ic_opt_homo_lumo)
 
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_nnP_ic, mat_3c_overl_int_gw
+      TYPE(dbcsr_p_type), DIMENSION(:)                   :: mat_3c_overl_nnP_ic, mat_3c_overl_int_gw
       TYPE(dbcsr_type), POINTER                          :: mat_mo_coeff_gw
       INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, homo
       LOGICAL                                            :: do_ic_opt_homo_lumo
@@ -3954,7 +3947,7 @@ CONTAINS
                                        my_group_L_starts_im_time, my_group_L_sizes_im_time, cut_RI, &
                                        para_env, gw_corr_lev_occ, gw_corr_lev_virt, homo)
 
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_int_gw, &
+      TYPE(dbcsr_p_type), DIMENSION(:)                   :: mat_3c_overl_int_gw, &
                                                             mat_3c_overl_int_gw_for_mult
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: row_from_LLL, my_group_L_starts_im_time, &
                                                             my_group_L_sizes_im_time
@@ -5058,7 +5051,6 @@ CONTAINS
 
    END SUBROUTINE
 
-!*********************************************************************
 ! **************************************************************************************************
 !> \brief ...
 !> \param mat_dm_global ...
@@ -5074,9 +5066,11 @@ CONTAINS
 !> \param index_to_cell_dm ...
 !> \param remove_occ ...
 !> \param remove_virt ...
+!> \param first_jquad ...
 ! **************************************************************************************************
    SUBROUTINE compute_transl_dm(mat_dm_global, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
-                                stabilize_exp, eps_filter, num_cells_dm, index_to_cell_dm, remove_occ, remove_virt)
+                                stabilize_exp, eps_filter, num_cells_dm, index_to_cell_dm, remove_occ, remove_virt, &
+                                first_jquad)
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER                                            :: ispin, num_integ_points, jquad
@@ -5084,6 +5078,7 @@ CONTAINS
       INTEGER                                            :: num_cells_dm
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
       LOGICAL                                            :: remove_occ, remove_virt
+      INTEGER                                            :: first_jquad
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_transl_dm', &
          routineP = moduleN//':'//routineN
@@ -5091,7 +5086,6 @@ CONTAINS
       INTEGER                                            :: handle, i_dim, i_img, iquad, jspin, nspin
       INTEGER, DIMENSION(3)                              :: cell_grid_dm
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work, matrix_s_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -5108,8 +5102,6 @@ CONTAINS
                       dft_control=dft_control, &
                       cell=cell, &
                       kpoints=kpoints)
-
-      CALL get_mo_set(mos(1)%mo_set, mo_coeff=mo_coeff)
 
       nspin = SIZE(mos)
 
@@ -5156,13 +5148,16 @@ CONTAINS
       ! we need the index to cell for the density matrices later
       index_to_cell_dm => kpoints%index_to_cell
 
-      IF (jquad == 1) THEN
+      ! normally, jquad = 1 to allocate the matrix set, but for GW jquad = 0 is the exchange self-energy
+      IF (jquad == first_jquad) THEN
 
          NULLIFY (mat_dm_global)
-         CALL dbcsr_allocate_matrix_set(mat_dm_global, num_integ_points, num_cells_dm)
+!         CALL dbcsr_allocate_matrix_set(mat_dm_global, jquad:num_integ_points, num_cells_dm)
+         ALLOCATE (mat_dm_global(first_jquad:num_integ_points, num_cells_dm))
 
-         DO iquad = 1, num_integ_points
+         DO iquad = first_jquad, num_integ_points
             DO i_img = 1, num_cells_dm
+               NULLIFY (mat_dm_global(iquad, i_img)%matrix)
                ALLOCATE (mat_dm_global(iquad, i_img)%matrix)
                CALL dbcsr_create(matrix=mat_dm_global(iquad, i_img)%matrix, &
                                  template=matrix_s_kp(1, 1)%matrix, &
@@ -5189,7 +5184,6 @@ CONTAINS
 
    END SUBROUTINE
 
-!*********************************************************************
 ! **************************************************************************************************
 !> \brief ...
 !> \param kpoints ...
@@ -5284,7 +5278,6 @@ CONTAINS
 
    END SUBROUTINE
 
-!*********************************************************************
 ! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
@@ -5580,8 +5573,6 @@ CONTAINS
    END SUBROUTINE
 
 ! **************************************************************************************************
-
-! **************************************************************************************************
 !> \brief ...
 !> \param i_cell_R ...
 !> \param i_cell_S ...
@@ -5680,22 +5671,23 @@ CONTAINS
 !> \param imag_mat_kp ...
 !> \param mat_real_space ...
 !> \param kpoints ...
+!> \param index_to_cell ...
+!> \param eps_filter_im_time ...
 ! **************************************************************************************************
    SUBROUTINE real_space_to_kpoint_transform_rpa(real_mat_kp, imag_mat_kp, mat_real_space, &
-                                                 kpoints)
+                                                 kpoints, index_to_cell, eps_filter_im_time)
 
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: real_mat_kp, imag_mat_kp, mat_real_space
+      TYPE(dbcsr_p_type), DIMENSION(:)                   :: real_mat_kp, imag_mat_kp, mat_real_space
       TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      REAL(kind=dp)                                      :: eps_filter_im_time
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'real_space_to_kpoint_transform_rpa', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i_cell, ik, iquad, nkp, &
-                                                            num_cells, num_integ_points
+      INTEGER                                            :: handle, i_cell, ik, nkp, num_cells
       INTEGER, DIMENSION(3)                              :: cell
-      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
-      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      REAL(KIND=dp)                                      :: arg, coskl, sinkl
+      REAL(kind=dp)                                      :: arg, coskl, sinkl
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(dbcsr_type), POINTER                          :: mat_work
 
@@ -5704,55 +5696,53 @@ CONTAINS
       NULLIFY (mat_work)
       CALL dbcsr_init_p(mat_work)
       CALL dbcsr_create(matrix=mat_work, &
-                        template=real_mat_kp(1, 1)%matrix, &
+                        template=real_mat_kp(1)%matrix, &
                         matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_reserve_all_blocks(mat_work)
       CALL dbcsr_set(mat_work, 0.0_dp)
 
       ! this kpoint environme t should be the kpoints for D(it) and X(it) created in init_cell_index_rpa
-      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, cell_to_index=cell_to_index)
-      index_to_cell => kpoints%index_to_cell
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp)
 
       num_cells = SIZE(index_to_cell, 2)
 
-      CPASSERT(SIZE(mat_real_space, 2) >= num_cells/2+1)
-
-      num_integ_points = SIZE(real_mat_kp, 1)
-      CPASSERT(SIZE(imag_mat_kp, 1) == num_integ_points)
-      CPASSERT(SIZE(mat_real_space, 1) == num_integ_points)
+      CPASSERT(SIZE(mat_real_space) >= num_cells/2+1)
 
       DO ik = 1, nkp
 
-         DO iquad = 1, num_integ_points
+         CALL dbcsr_set(real_mat_kp(ik)%matrix, 0.0_dp)
+         CALL dbcsr_set(imag_mat_kp(ik)%matrix, 0.0_dp)
 
-            CALL dbcsr_set(real_mat_kp(iquad, ik)%matrix, 0.0_dp)
-            CALL dbcsr_set(imag_mat_kp(iquad, ik)%matrix, 0.0_dp)
+         ! JW to check: high memory consumption
+         CALL dbcsr_reserve_all_blocks(real_mat_kp(ik)%matrix)
+         CALL dbcsr_reserve_all_blocks(imag_mat_kp(ik)%matrix)
 
-            DO i_cell = 1, num_cells/2+1
+         DO i_cell = 1, num_cells/2+1
 
-               cell(:) = index_to_cell(:, i_cell)
+            cell(:) = index_to_cell(:, i_cell)
 
-               arg = REAL(cell(1), dp)*xkp(1, ik)+REAL(cell(2), dp)*xkp(2, ik)+REAL(cell(3), dp)*xkp(3, ik)
-               coskl = COS(twopi*arg)
-               sinkl = SIN(twopi*arg)
+            arg = REAL(cell(1), dp)*xkp(1, ik)+REAL(cell(2), dp)*xkp(2, ik)+REAL(cell(3), dp)*xkp(3, ik)
+            coskl = COS(twopi*arg)
+            sinkl = SIN(twopi*arg)
 
-               CALL dbcsr_add(real_mat_kp(iquad, ik)%matrix, mat_real_space(iquad, i_cell)%matrix, 1.0_dp, coskl)
-               CALL dbcsr_add(imag_mat_kp(iquad, ik)%matrix, mat_real_space(iquad, i_cell)%matrix, 1.0_dp, sinkl)
+            CALL dbcsr_add_local(real_mat_kp(ik)%matrix, mat_real_space(i_cell)%matrix, 1.0_dp, coskl)
+            CALL dbcsr_add_local(imag_mat_kp(ik)%matrix, mat_real_space(i_cell)%matrix, 1.0_dp, sinkl)
 
-               IF (.NOT. (cell(1) == 0 .AND. cell(2) == 0 .AND. cell(3) == 0)) THEN
+            IF (.NOT. (cell(1) == 0 .AND. cell(2) == 0 .AND. cell(3) == 0)) THEN
 
-                  CALL dbcsr_transposed(mat_work, mat_real_space(iquad, i_cell)%matrix)
+               CALL dbcsr_transposed(mat_work, mat_real_space(i_cell)%matrix)
 
-                  CALL dbcsr_add(real_mat_kp(iquad, ik)%matrix, mat_work, 1.0_dp, coskl)
-                  CALL dbcsr_add(imag_mat_kp(iquad, ik)%matrix, mat_work, 1.0_dp, -sinkl)
+               CALL dbcsr_add_local(real_mat_kp(ik)%matrix, mat_work, 1.0_dp, coskl)
+               CALL dbcsr_add_local(imag_mat_kp(ik)%matrix, mat_work, 1.0_dp, -sinkl)
 
-                  CALL dbcsr_set(mat_work, 0.0_dp)
+               CALL dbcsr_set(mat_work, 0.0_dp)
 
-               END IF
-
-            END DO
+            END IF
 
          END DO
+
+         CALL dbcsr_filter(real_mat_kp(ik)%matrix, eps_filter_im_time)
+         CALL dbcsr_filter(imag_mat_kp(ik)%matrix, eps_filter_im_time)
 
       END DO
 
@@ -5764,48 +5754,197 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param mat_P_omega ...
-!> \param mat_P_omega_im_part ...
-!> \param qs_env ...
+!> \param mat_a ...
+!> \param mat_b ...
+!> \param alpha ...
+!> \param beta ...
 ! **************************************************************************************************
-   SUBROUTINE transform_P_from_real_space_to_kpoints(mat_P_omega, mat_P_omega_im_part, qs_env)
+   SUBROUTINE dbcsr_add_local(mat_a, mat_b, alpha, beta)
+      TYPE(dbcsr_type), POINTER                          :: mat_a, mat_b
+      REAL(kind=dp)                                      :: alpha, beta
 
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_im_part
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_add_local', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: col, row
+      LOGICAL                                            :: found
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block_to_compute, data_block
+      TYPE(dbcsr_iterator_type)                          :: iter
+
+      CALL dbcsr_iterator_start(iter, mat_b)
+      DO WHILE (dbcsr_iterator_blocks_left(iter))
+         CALL dbcsr_iterator_next_block(iter, row, col, data_block)
+
+         NULLIFY (block_to_compute)
+         CALL dbcsr_get_block_p(matrix=mat_a, &
+                                row=row, col=col, block=block_to_compute, found=found)
+
+         CPASSERT(found)
+
+         block_to_compute(:, :) = alpha*block_to_compute(:, :)+beta*data_block(:, :)
+
+      END DO
+      CALL dbcsr_iterator_stop(iter)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_P_omega ...
+!> \param qs_env ...
+!> \param kpoints ...
+!> \param jquad ...
+! **************************************************************************************************
+   SUBROUTINE get_P_cell_T_from_P_gamma(mat_P_omega, qs_env, kpoints, jquad)
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega
       TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: jquad
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_P_cell_T_from_P_gamma', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: col, handle, i_cell, i_dim, num_cells_P, &
+                                                            num_integ_points, row
+      INTEGER, DIMENSION(3)                              :: cell_grid_P, periodic
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_P
+      LOGICAL                                            :: found
+      REAL(KIND=dp)                                      :: cutoff_exp, d_0, sum_exp, weight
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: abs_rab_cell
+      REAL(KIND=dp), DIMENSION(3)                        :: cell_vector, rab_cell_i
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block_to_compute, data_block
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (cell, particle_set)
+      CALL get_qs_env(qs_env, cell=cell, &
+                      particle_set=particle_set)
+      CALL get_cell(cell=cell, h=hmat, periodic=periodic)
+
+      DO i_dim = 1, 3
+         ! we have at most 3 neigboring cells per dimension and at least one because
+         ! the density response at Gamma is only divided to neighboring
+         IF (periodic(i_dim) == 1) THEN
+            cell_grid_P(i_dim) = MAX(MIN((kpoints%nkp_grid(i_dim)/2)*2-1, 1), 3)
+         ELSE
+            cell_grid_P(i_dim) = 1
+         END IF
+      END DO
+
+      ! overwrite the cell indices in kpoints
+      CALL init_cell_index_rpa(cell_grid_P, kpoints%cell_to_index, kpoints%index_to_cell, cell)
+
+      index_to_cell_P => kpoints%index_to_cell
+
+      num_cells_P = SIZE(index_to_cell_P, 2)
+
+      num_integ_points = SIZE(mat_P_omega, 1)
+
+      ! first, copy the Gamma-only result from mat_P_omega(1) into all other matrices and
+      ! remove the blocks later which do not belong to the cell index
+      DO i_cell = 2, num_cells_P
+         CALL dbcsr_copy(mat_P_omega(jquad, i_cell)%matrix, &
+                         mat_P_omega(jquad, 1)%matrix)
+      END DO
+
+      ! exponential decay parameter
+!      d_0 = 0.5_dp
+      d_0 = qs_env%mp2_env%ri_rpa_im_time%cutoff
+      cutoff_exp = 100.0_dp
+
+      ALLOCATE (abs_rab_cell(1:num_cells_P))
+
+      ! loop over blocks of mat_P_omega(i_cell=1)
+      CALL dbcsr_iterator_start(iter, mat_P_omega(jquad, 1)%matrix)
+      DO WHILE (dbcsr_iterator_blocks_left(iter))
+         CALL dbcsr_iterator_next_block(iter, row, col, data_block)
+
+         sum_exp = 0.0_dp
+
+         DO i_cell = 1, num_cells_P
+
+            cell_vector(1:3) = MATMUL(hmat, REAL(index_to_cell_P(1:3, i_cell), dp))
+            rab_cell_i(1:3) = pbc(particle_set(row)%r(1:3), cell)- &
+                              (pbc(particle_set(col)%r(1:3), cell)+cell_vector(1:3))
+            abs_rab_cell(i_cell) = SQRT(rab_cell_i(1)**2+rab_cell_i(2)**2+rab_cell_i(3)**2)
+            IF (abs_rab_cell(i_cell)/d_0 < cutoff_exp) THEN
+               sum_exp = sum_exp+EXP(-abs_rab_cell(i_cell)/d_0)
+            END IF
+
+         END DO
+
+         IF (abs_rab_cell(1)/d_0 < cutoff_exp) THEN
+            weight = EXP(-abs_rab_cell(1)/d_0)/sum_exp
+         ELSE
+            weight = 0.0_dp
+         END IF
+         data_block(:, :) = data_block(:, :)*weight
+
+         DO i_cell = 2, num_cells_P
+
+            ! THE SYMMETRY EQUIVALENT LATTICE VECTORS ENTER HERE: ONLY LATT. VEC. WITH POS. X-COMP ARE CONSIDERED
+            IF (abs_rab_cell(i_cell)/d_0 < cutoff_exp .AND. index_to_cell_P(1, i_cell) .LE. 0) THEN
+               weight = EXP(-abs_rab_cell(i_cell)/d_0)/sum_exp
+            ELSE
+               weight = 0.0_dp
+            END IF
+
+            NULLIFY (block_to_compute)
+            CALL dbcsr_get_block_p(matrix=mat_P_omega(jquad, i_cell)%matrix, &
+                                   row=row, col=col, block=block_to_compute, found=found)
+            CPASSERT(found)
+            block_to_compute(:, :) = block_to_compute(:, :)*weight
+
+         END DO
+
+      END DO
+      CALL dbcsr_iterator_stop(iter)
+
+      DEALLOCATE (abs_rab_cell)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_P_omega ...
+!> \param mat_P_omega_kp ...
+!> \param kpoints ...
+!> \param eps_filter_im_time ...
+!> \param jquad ...
+! **************************************************************************************************
+   SUBROUTINE transform_P_from_real_space_to_kpoints(mat_P_omega, mat_P_omega_kp, &
+                                                     kpoints, eps_filter_im_time, jquad)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_kp
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      REAL(kind=dp)                                      :: eps_filter_im_time
+      INTEGER                                            :: jquad
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'transform_P_from_real_space_to_kpoints', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i_kp, jquad, nkp, &
-                                                            num_integ_points
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_real_space_tmp
-      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER                                            :: handle, icell, nkp, num_integ_points
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
 
       CALL timeset(routineN, handle)
 
-      CALL get_qs_env(qs_env, &
-                      kpoints=kpoints)
-
       num_integ_points = SIZE(mat_P_omega, 1)
       nkp = SIZE(mat_P_omega, 2)
+      index_to_cell_dm => kpoints%index_to_cell
 
-      NULLIFY (mat_P_real_space_tmp)
-      CALL dbcsr_allocate_matrix_set(mat_P_real_space_tmp, num_integ_points, nkp)
-      DO jquad = 1, num_integ_points
-         DO i_kp = 1, nkp
-            ALLOCATE (mat_P_real_space_tmp(jquad, i_kp)%matrix)
-            CALL dbcsr_create(matrix=mat_P_real_space_tmp(jquad, i_kp)%matrix, &
-                              template=mat_P_omega(jquad, i_kp)%matrix)
-            CALL dbcsr_copy(mat_P_real_space_tmp(jquad, i_kp)%matrix, &
-                            mat_P_omega(jquad, i_kp)%matrix)
-            CALL dbcsr_set(mat_P_omega(jquad, i_kp)%matrix, 0.0_dp)
-            CALL dbcsr_set(mat_P_omega_im_part(jquad, i_kp)%matrix, 0.0_dp)
-         END DO
+      CALL real_space_to_kpoint_transform_rpa(mat_P_omega_kp(1, :), mat_P_omega_kp(2, :), mat_P_omega(jquad, :), &
+                                              kpoints, index_to_cell_dm, eps_filter_im_time)
+
+      DO icell = 1, SIZE(mat_P_omega, 2)
+         CALL dbcsr_set(mat_P_omega(jquad, icell)%matrix, 0.0_dp)
+         CALL dbcsr_filter(mat_P_omega(jquad, icell)%matrix, 1.0_dp)
       END DO
-
-      CALL real_space_to_kpoint_transform_rpa(mat_P_omega, mat_P_omega_im_part, mat_P_real_space_tmp, kpoints)
-
-      CALL dbcsr_deallocate_matrix_set(mat_P_real_space_tmp)
 
       CALL timestop(handle)
 

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -3630,7 +3630,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, homo, &
                                                             nmo
-      TYPE(dbcsr_p_type)                                 :: mat_dm_virt_local
+      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_dm_virt_local
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
       INTEGER                                            :: cut_RI
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: row_from_LLL, my_group_L_starts_im_time, &

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -10,11 +10,8 @@
 !>      04.2015 GW routines added [Jan Wilhelm]
 !>      10.2015 Cubic-scaling RPA routines added [Jan Wilhelm]
 !>      10.2018 Cubic-scaling SOS-MP2 added [Frederick Stein]
-!>      03.2019 Refactoring [Frederick Stein]
 ! **************************************************************************************************
 MODULE rpa_ri_gpw
-   USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
-                                              gto_basis_set_type
    USE bibliography,                    ONLY: Bates2013,&
                                               DelBen2013,&
                                               DelBen2015,&
@@ -31,6 +28,7 @@ MODULE rpa_ri_gpw
                                               cp_cfm_scale_and_add_fm
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
+                                              cp_cfm_p_type,&
                                               cp_cfm_release,&
                                               cp_cfm_set_all,&
                                               cp_cfm_type
@@ -40,16 +38,12 @@ MODULE rpa_ri_gpw
                                               cp_dbcsr_m_by_n_from_template,&
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_invert,&
-                                              cp_fm_scale,&
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_scale,&
                                               cp_fm_scale_and_add,&
                                               cp_fm_syrk,&
-                                              cp_fm_transpose,&
-                                              cp_fm_upper_to_full
-   USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
-                                              cp_fm_cholesky_invert
-   USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
-                                              cp_fm_syevd
+                                              cp_fm_transpose
+   USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
+   USE cp_fm_diag,                      ONLY: choose_eigv_solver
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -57,46 +51,35 @@ MODULE rpa_ri_gpw
         cp_fm_copy_general, cp_fm_create, cp_fm_get_info, cp_fm_indxg2l, cp_fm_indxg2p, &
         cp_fm_p_type, cp_fm_release, cp_fm_set_all, cp_fm_set_element, cp_fm_to_fm, cp_fm_type
    USE cp_gemm_interface,               ONLY: cp_gemm
-   USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE cp_para_env,                     ONLY: cp_para_env_create,&
                                               cp_para_env_release
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
-        dbcsr_add, dbcsr_add_on_diag, dbcsr_copy, dbcsr_create, dbcsr_desymmetrize, dbcsr_filter, &
-        dbcsr_get_info, dbcsr_get_occupation, dbcsr_get_stored_coordinates, dbcsr_init_p, &
+        dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_desymmetrize, dbcsr_filter, dbcsr_get_info, &
+        dbcsr_get_occupation, dbcsr_get_stored_coordinates, dbcsr_init_p, &
         dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
         dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_p_type, dbcsr_release, &
-        dbcsr_release_p, dbcsr_reserve_all_blocks, dbcsr_scale, dbcsr_set, dbcsr_trace, &
-        dbcsr_transposed, dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_real_default
+        dbcsr_release_p, dbcsr_reserve_all_blocks, dbcsr_set, dbcsr_trace, dbcsr_transposed, &
+        dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_real_default
    USE dbcsr_tensor_api,                ONLY: dbcsr_t_destroy,&
                                               dbcsr_t_type
-   USE input_constants,                 ONLY: gw_pade_approx,&
-                                              gw_two_pole_model,&
-                                              ri_rpa_g0w0_crossing_bisection,&
-                                              ri_rpa_g0w0_crossing_newton,&
-                                              ri_rpa_g0w0_crossing_none,&
-                                              ri_rpa_g0w0_crossing_z_shot,&
-                                              wfc_mm_style_gemm,&
+   USE input_constants,                 ONLY: wfc_mm_style_gemm,&
                                               wfc_mm_style_syrk
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE kpoint_types,                    ONLY: get_kpoint_info,&
-                                              kpoint_create,&
                                               kpoint_release,&
-                                              kpoint_sym_create,&
                                               kpoint_type
    USE machine,                         ONLY: m_flush,&
                                               m_memory,&
                                               m_walltime
-   USE mathconstants,                   ONLY: fourpi,&
-                                              gaussi,&
+   USE mathconstants,                   ONLY: gaussi,&
                                               pi,&
-                                              twopi,&
                                               z_one,&
                                               z_zero
    USE message_passing,                 ONLY: &
         mp_alltoall, mp_bcast, mp_comm_split_direct, mp_irecv, mp_isend, mp_min, mp_sendrecv, &
-        mp_sum, mp_sync, mp_wait, mp_waitall
+        mp_sum, mp_wait, mp_waitall
    USE minimax_exp,                     ONLY: check_exp_minimax_range,&
                                               get_exp_minimax_coeff
    USE minimax_rpa,                     ONLY: get_rpa_minimax_coeff
@@ -104,32 +87,28 @@ MODULE rpa_ri_gpw
    USE mp2_types,                       ONLY: integ_mat_buffer_type,&
                                               mp2_type,&
                                               two_dim_int_array
-   USE particle_types,                  ONLY: particle_type
    USE physcon,                         ONLY: evolt
-   USE qs_band_structure,               ONLY: calculate_kp_orbitals
    USE qs_environment_types,            ONLY: get_qs_env,&
-                                              qs_env_release,&
                                               qs_environment_type
-   USE qs_gamma2kp,                     ONLY: create_kp_from_gamma
-   USE qs_integral_utils,               ONLY: basis_set_list_setup
-   USE qs_kind_types,                   ONLY: get_qs_kind,&
-                                              qs_kind_type
-   USE qs_ks_types,                     ONLY: qs_ks_env_type
-   USE qs_moments,                      ONLY: build_berry_moment_matrix
-   USE qs_neighbor_list_types,          ONLY: deallocate_neighbor_list_set,&
-                                              neighbor_list_set_p_type
-   USE qs_neighbor_lists,               ONLY: setup_neighbor_list
-   USE qs_overlap,                      ONLY: build_overlap_matrix_simple
    USE rpa_axk,                         ONLY: compute_axk_ener
    USE rpa_communication,               ONLY: fm_redistribute,&
                                               initialize_buffer,&
                                               release_buffer
+   USE rpa_gw,                          ONLY: GW_matrix_operations,&
+                                              GW_postprocessing,&
+                                              allocate_matrices_gw,&
+                                              allocate_matrices_gw_im_time
+   USE rpa_gw_kpoints,                  ONLY: compute_Wc_kp_tau_GW,&
+                                              compute_Wc_real_space_tau_GW,&
+                                              compute_self_energy_im_time_gw_kp,&
+                                              compute_wkp_W
    USE rpa_im_time,                     ONLY: communicate_buffer,&
                                               compute_mat_P_omega,&
                                               gap_and_max_eig_diff_kpoints,&
-                                              get_mat_3c_overl_int_gw,&
+                                              get_P_cell_T_from_P_gamma,&
                                               setup_mat_for_mem_cut_3c,&
                                               setup_tensor_for_mem_cut_3c,&
+                                              transform_P_from_real_space_to_kpoints,&
                                               zero_mat_P_omega
    USE util,                            ONLY: get_limit
 #include "./base/base_uses.f90"
@@ -173,6 +152,7 @@ CONTAINS
 !> \param ends_B_virt_bse ...
 !> \param mo_coeff ...
 !> \param fm_matrix_L_RI_metric ...
+!> \param kpoints ...
 !> \param Eigenval ...
 !> \param nmo ...
 !> \param homo ...
@@ -221,7 +201,7 @@ CONTAINS
                                 ends_array, ends_B_virtual, ends_B_all, sizes_array, sizes_B_virtual, sizes_B_all, &
                                 starts_array, starts_B_virtual, starts_B_all, starts_B_occ_bse, sizes_B_occ_bse, &
                                 ends_B_occ_bse, starts_B_virt_bse, sizes_B_virt_bse, ends_B_virt_bse, &
-                                mo_coeff, fm_matrix_L_RI_metric, &
+                                mo_coeff, fm_matrix_L_RI_metric, kpoints, &
                                 Eigenval, nmo, homo, dimen_RI, gw_corr_lev_occ, gw_corr_lev_virt, &
                                 unit_nr, do_ri_sos_laplace_mp2, my_do_gw, do_im_time, do_mao, do_bse, matrix_s, &
                                 mao_coeff_occ, mao_coeff_virt, mao_coeff_occ_A, mao_coeff_virt_A, &
@@ -236,27 +216,27 @@ CONTAINS
                                 mo_coeff_beta, BIb_C_gw_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(KIND=dp), INTENT(OUT)                         :: Erpa
+      REAL(KIND=dp)                                      :: Erpa
       TYPE(mp2_type), POINTER                            :: mp2_env
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(INOUT)                                   :: BIb_C, BIb_C_gw, BIb_C_bse_ij, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: BIb_C, BIb_C_gw, BIb_C_bse_ij, &
                                                             BIb_C_bse_ab
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
-      INTEGER, INTENT(INOUT)                             :: color_sub
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(INOUT) :: ends_array, ends_B_virtual, ends_B_all, &
-         sizes_array, sizes_B_virtual, sizes_B_all, starts_array, starts_B_virtual, starts_B_all, &
+      INTEGER                                            :: color_sub
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: ends_array, ends_B_virtual, ends_B_all, sizes_array, &
+         sizes_B_virtual, sizes_B_all, starts_array, starts_B_virtual, starts_B_all, &
          starts_B_occ_bse, sizes_B_occ_bse, ends_B_occ_bse, starts_B_virt_bse, sizes_B_virt_bse, &
          ends_B_virt_bse
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_RI_metric
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
-      INTEGER, INTENT(IN)                                :: nmo, homo, dimen_RI, gw_corr_lev_occ, &
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      INTEGER                                            :: nmo, homo, dimen_RI, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, unit_nr
-      LOGICAL, INTENT(IN)                                :: do_ri_sos_laplace_mp2, my_do_gw, &
+      LOGICAL                                            :: do_ri_sos_laplace_mp2, my_do_gw, &
                                                             do_im_time, do_mao, do_bse
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mao_coeff_occ, mao_coeff_virt, &
                                                             mao_coeff_occ_A, mao_coeff_virt_A
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_munu, mat_dm_occ_local, &
+      TYPE(dbcsr_p_type)                                 :: mat_munu, mat_dm_occ_local, &
                                                             mat_dm_virt_local, mat_P_local, &
                                                             mat_P_global, mat_M
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
@@ -266,20 +246,18 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc_t, ends_array_mc_t
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_mao_for_occ, &
                                                             mat_3c_overl_int_mao_for_virt
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter
+      REAL(KIND=dp)                                      :: eps_filter
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(INOUT), OPTIONAL                         :: BIb_C_beta
-      INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT), &
-         OPTIONAL                                        :: Eigenval_beta
-      INTEGER, ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT), OPTIONAL                         :: ends_B_virtual_beta, &
+         OPTIONAL                                        :: BIb_C_beta
+      INTEGER, OPTIONAL                                  :: homo_beta
+      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: Eigenval_beta
+      INTEGER, ALLOCATABLE, DIMENSION(:), OPTIONAL       :: ends_B_virtual_beta, &
                                                             sizes_B_virtual_beta, &
                                                             starts_B_virtual_beta
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: mo_coeff_beta
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(INOUT), OPTIONAL                         :: BIb_C_gw_beta
-      INTEGER, INTENT(IN), OPTIONAL                      :: gw_corr_lev_occ_beta, &
+         OPTIONAL                                        :: BIb_C_gw_beta
+      INTEGER, OPTIONAL                                  :: gw_corr_lev_occ_beta, &
                                                             gw_corr_lev_virt_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rpa_ri_compute_en', &
@@ -513,13 +491,13 @@ CONTAINS
       pos_integ_group = MOD(color_sub, integ_group_size)
       color_rpa_group = color_sub/integ_group_size
 
+      ! reordering is not necessary for imaginary time
       IF (.NOT. do_im_time) THEN
          IF (my_open_shell) THEN
             my_homo_beta = homo_beta
          ELSE
             my_homo_beta = homo
          END IF
-
       END IF ! not imaginary time
 
       CALL timeset(routineN//"_reorder", handle2)
@@ -545,6 +523,7 @@ CONTAINS
          CALL calculate_BIb_C_2D(BIb_C_2D, BIb_C, para_env_sub, dimen_ia, homo, virtual, &
                                  sizes_B_virtual, starts_B_virtual, ends_B_virtual, &
                                  sub_proc_map, my_ia_size, my_ia_start, my_ia_end, my_group_L_size)
+
          DEALLOCATE (BIb_C)
          DEALLOCATE (starts_B_virtual)
          DEALLOCATE (ends_B_virtual)
@@ -769,7 +748,7 @@ CONTAINS
                              do_dbcsr_t, t_3c_M, t_3c_O, &
                              starts_array_mc_t, ends_array_mc_t, &
                              matrix_s, &
-                             mao_coeff_occ, mao_coeff_virt, eps_filter, &
+                             mao_coeff_occ, mao_coeff_virt, kpoints, eps_filter, &
                              starts_array, ends_array, sizes_array, color_sub, &
                              fm_mo_coeff_occ_beta=fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta=fm_mo_coeff_virt_beta, &
                              homo_beta=homo_beta, virtual_beta=virtual_beta, &
@@ -802,7 +781,7 @@ CONTAINS
                              do_dbcsr_t, t_3c_M, t_3c_O, &
                              starts_array_mc_t, ends_array_mc_t, &
                              matrix_s, &
-                             mao_coeff_occ, mao_coeff_virt, &
+                             mao_coeff_occ, mao_coeff_virt, kpoints, &
                              eps_filter, starts_array, ends_array, sizes_array, color_sub, &
                              do_ri_sos_laplace_mp2=do_ri_sos_laplace_mp2)
          END IF
@@ -1961,6 +1940,7 @@ CONTAINS
 !> \param matrix_s ...
 !> \param mao_coeff_occ ...
 !> \param mao_coeff_virt ...
+!> \param kpoints ...
 !> \param eps_filter ...
 !> \param starts_array ...
 !> \param ends_array ...
@@ -1995,7 +1975,7 @@ CONTAINS
                           mat_3c_overl_int_mao_for_virt, &
                           do_dbcsr_t, t_3c_M, t_3c_O, &
                           starts_array_mc_t, ends_array_mc_t, &
-                          matrix_s, mao_coeff_occ, mao_coeff_virt, &
+                          matrix_s, mao_coeff_occ, mao_coeff_virt, kpoints, &
                           eps_filter, starts_array, ends_array, sizes_array, color_sub, &
                           fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
                           homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta, &
@@ -2034,6 +2014,7 @@ CONTAINS
          INTENT(INOUT)                                   :: t_3c_O
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc_t, ends_array_mc_t
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mao_coeff_occ, mao_coeff_virt
+      TYPE(kpoint_type), POINTER                         :: kpoints
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array, ends_array, sizes_array
       INTEGER, INTENT(IN)                                :: color_sub
@@ -2051,22 +2032,21 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rpa_num_int', routineP = moduleN//':'//routineN
 
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
       INTEGER :: col_start_local, color_sub_col, color_sub_row, count_ev_sc_GW, crossing_search, &
-         cut_memory, cut_RI, group_size_P, gw_corr_lev_tot, handle, handle2, handle3, handle4, &
-         i_cell, i_cut_RI, i_dim, i_global, i_kp, i_mem, i_size, ierr, iiB, ikp, info_chol, iquad, &
-         isize, iter_ev_sc, j_cell, j_global, j_mem, j_size, jjB, jquad, jsize, ksize, LLL, &
-         m_global, m_global_beta, max_iter_bse, max_iter_fit, mm_style, my_group_L_size_im_time, &
-         my_num_dgemm_call, n_global, n_global_beta, n_group_col, n_group_row, n_level_gw, &
-         n_level_gw_ref, n_local_col, n_local_row, nblkrows_total, ncol_local
-      INTEGER :: ngroup_RI_orig, nkp, nm_global, nmo, nrow_local, num_3c_repl, num_cells_dm, &
-         num_fit_points, num_points_corr, num_points_per_magnitude, num_poles, num_Z_vectors, &
-         number_of_rec, number_of_rec_axk, number_of_rec_beta, number_of_send, number_of_send_axk, &
-         number_of_send_beta, row, row_start_local, size_P
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: map_rec_size, map_rec_size_axk, map_rec_size_beta, &
-         map_send_size, map_send_size_axk, map_send_size_beta, mepos_P_from_RI_row, &
-         my_group_L_sizes_im_time, my_group_L_starts_im_time, row_from_LLL, RPA_proc_map
+         cut_memory, cut_RI, first_ikp_local, group_size_P, gw_corr_lev_tot, handle, handle3, &
+         handle4, i_cell, i_cut_RI, i_dim, i_global, i_kp, i_mem, i_real_imag, i_size, ierr, iiB, &
+         ikp, info_chol, isize, iter_ev_sc, j_cell, j_global, j_mem, j_size, jjB, jquad, jsize, &
+         ksize, LLL, max_iter_bse, max_iter_fit, mm_style, my_group_L_size_im_time, &
+         my_num_dgemm_call, n_group_col, n_group_row, n_local_col, n_local_row, nblkrows_total, &
+         ncol_local, ngroup_RI_orig, nkp, nkp_self_energy, nmo, nrow_local, num_3c_repl
+      INTEGER :: num_cells_dm, num_fit_points, num_points_corr, num_points_per_magnitude, &
+         num_residues, num_Z_vectors, number_of_rec, number_of_rec_axk, number_of_rec_beta, &
+         number_of_send, number_of_send_axk, number_of_send_beta, row, row_start_local, size_P
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: ikp_local, map_rec_size, map_rec_size_axk, &
+         map_rec_size_beta, map_send_size, map_send_size_axk, map_send_size_beta, &
+         mepos_P_from_RI_row, my_group_L_sizes_im_time, my_group_L_starts_im_time, row_from_LLL, &
+         RPA_proc_map
       INTEGER, ALLOCATABLE, DIMENSION(:, :) :: ends_array_prim_col, ends_array_prim_fullcol, &
          ends_array_prim_fullrow, ends_array_prim_row, index_to_cell_3c, local_size_source, &
          local_size_source_axk, local_size_source_beta, sizes_array_prim_col, &
@@ -2074,43 +2054,47 @@ CONTAINS
          starts_array_prim_fullrow, starts_array_prim_row
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c, non_zero_blocks_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :, :)        :: non_zero_blocks_3c_cut_col
-      INTEGER, DIMENSION(3)                              :: cell_grid_dm
+      INTEGER, DIMENSION(3)                              :: cell_grid_dm, periodic
       INTEGER, DIMENSION(:), POINTER :: col_blk_size, col_indices, ends_array_cm, &
          ends_array_cm_mao_occ, ends_array_cm_mao_virt, prim_blk_sizes, RI_blk_sizes, &
          row_blk_offset, row_blk_size, row_indices, starts_array_cm, starts_array_cm_mao_occ, &
          starts_array_cm_mao_virt
       LOGICAL :: check_fit, do_apply_ic_corr_to_gw, do_gw_im_time, do_ic_model, &
-         do_ic_opt_homo_lumo, do_kpoints_cubic_RPA, do_periodic, do_ri_Sigma_x, first_cycle, &
-         first_cycle_periodic_correction, my_open_shell, remove_neg_virt_energies
+         do_ic_opt_homo_lumo, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_periodic, &
+         do_ri_Sigma_x, first_cycle, first_cycle_periodic_correction, my_open_shell, &
+         print_ic_values
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: do_GW_corr
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :)           :: cycle_due_to_sparse_dm, &
                                                             multiply_needed_occ, &
                                                             multiply_needed_virt
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :) :: needed_cutRI_mem_R1vec_R2vec_for_kp
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :)     :: has_mat_P_blocks
-      REAL(KIND=dp) :: a_scaling, alpha, delta_corr_nn, delta_corr_nn_beta, e_axk, e_axk_corr, &
-         e_fermi, e_fermi_beta, E_Range, Emax, Emax_beta, Emin, Emin_beta, eps_filter_im_time, &
-         eps_min_trans, ext_scaling, FComega, fermi_level_offset, max_error_min, my_flop_rate, &
-         omega, omega_i, omega_max_fit, omega_old, scaling, sign_occ_virt, stabilize_exp, &
-         stop_crit, tau, tau_old, trace_XX, weight
+      REAL(KIND=dp) :: a_scaling, alpha, e_axk, e_axk_corr, e_fermi, e_fermi_beta, E_Range, Emax, &
+         Emax_beta, Emin, Emin_beta, eps_filter_im_time, eps_min_trans, ext_scaling, FComega, &
+         fermi_level_offset, max_error_min, my_flop_rate, omega, omega_max_fit, omega_old, &
+         scaling, stabilize_exp, stop_crit, tau, tau_old, trace_XX
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:) :: delta_corr, Eigenval_last, Eigenval_last_beta, &
-         Eigenval_scf, Eigenval_scf_beta, m_value, m_value_beta, Q_log, tau_tj, tau_wj, tj, &
-         trace_Qomega, vec_gw_energ, vec_gw_energ_beta, vec_gw_energ_error_fit, &
-         vec_gw_energ_error_fit_beta, vec_omega_fit_gw, vec_omega_gw, vec_Sigma_x_gw, &
-         vec_Sigma_x_gw_beta, vec_W_gw, vec_W_gw_beta, wj, x_tw, z_value, z_value_beta
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: buffer_mat_M, weights_cos_tf_t_to_w, &
-                                                            weights_cos_tf_w_to_t, &
-                                                            weights_sin_tf_t_to_w
+         Eigenval_scf, Eigenval_scf_beta, m_value, m_value_beta, Q_log, tau_tj, tau_tj_dummy, &
+         tau_wj, tj, tj_dummy, trace_Qomega, vec_gw_energ, vec_gw_energ_beta, &
+         vec_gw_energ_error_fit, vec_gw_energ_error_fit_beta, vec_omega_fit_gw, vec_W_gw, &
+         vec_W_gw_beta, wj, x_tw, z_value, z_value_beta
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: buffer_mat_M, Eigenval_kp, Eigenval_scf_kp, &
+         vec_Sigma_x_gw, vec_Sigma_x_gw_beta, weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, &
+         weights_cos_tf_w_to_t_dummy, weights_sin_tf_t_to_w
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: B_abQ_bse_local, B_bar_iaQ_bse_local, &
                                                             B_bar_ijQ_bse_local, B_iaQ_bse_local
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list, ic_corr_list_beta
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list, ic_corr_list_beta, wkp_W
+      TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_mat_L
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_sub_kp
       TYPE(cp_fm_type), POINTER :: fm_mat_L_transposed, fm_mat_Q_static_bse, &
-         fm_mat_Q_static_bse_gemm, fm_mat_S_gw_work, fm_mat_S_gw_work_beta, fm_mat_work, &
-         fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled
+         fm_mat_Q_static_bse_gemm, fm_mat_RI_global_work, fm_mat_S_gw_work, fm_mat_S_gw_work_beta, &
+         fm_mat_work, fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fmdummy
+      TYPE(cp_para_env_type), POINTER                    :: para_env_sub_kp
       TYPE(dbcsr_p_type)                                 :: mat_dm, mat_L, mat_M_P_munu_occ, &
                                                             mat_M_P_munu_virt, mat_P_global_copy, &
                                                             mat_SinvVSinv
@@ -2120,7 +2104,7 @@ CONTAINS
          mat_greens_fct_virt, mat_greens_fct_virt_beta, mat_M_mu_Pnu_occ, mat_M_mu_Pnu_virt, &
          mat_W, matrix_berry_im_mo_mo, matrix_berry_re_mo_mo
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_beta, &
-                                                            mat_P_omega_im_part
+                                                            mat_P_omega_kp
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_dm_loc_occ_cut, mat_dm_loc_virt_cut
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut, &
          mat_3c_overl_int_mao_for_occ_cut, mat_3c_overl_int_mao_for_virt_cut
@@ -2133,7 +2117,6 @@ CONTAINS
          DIMENSION(:)                                    :: buffer_rec, buffer_rec_axk, &
                                                             buffer_rec_beta, buffer_send, &
                                                             buffer_send_axk, buffer_send_beta
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(two_dim_int_array), ALLOCATABLE, &
          DIMENSION(:, :)                                 :: offset_combi_block
 
@@ -2154,15 +2137,16 @@ CONTAINS
       do_ri_Sigma_x = mp2_env%ri_g0w0%do_ri_Sigma_x
       do_ic_model = mp2_env%ri_g0w0%do_ic_model
       do_ic_opt_homo_lumo = mp2_env%ri_g0w0%do_opt_homo_lumo
+      print_ic_values = mp2_env%ri_g0w0%print_ic_values
       do_periodic = mp2_env%ri_g0w0%do_periodic
       ic_corr_list => mp2_env%ri_g0w0%ic_corr_list
       ic_corr_list_beta => mp2_env%ri_g0w0%ic_corr_list_beta
       do_kpoints_cubic_RPA = mp2_env%ri_rpa_im_time%do_im_time_kpoints
+      do_kpoints_from_Gamma = SUM(mp2_env%ri_rpa_im_time%kp_grid) > 0
       mm_style = mp2_env%ri_rpa%mm_style
 
       IF (my_do_gw .OR. mp2_env%ri_rpa_im_time%do_gw_im_time) THEN
          ext_scaling = 0.2_dp
-         num_poles = mp2_env%ri_g0w0%num_poles
          omega_max_fit = mp2_env%ri_g0w0%omega_max_fit
          stop_crit = 1.0e-7_dp
          max_iter_fit = mp2_env%ri_g0w0%max_iter_fit
@@ -2204,7 +2188,7 @@ CONTAINS
 
          CALL timeset(routineN//"_im_t_alloc_mat", handle4)
 
-         ALLOCATE (tau_tj(num_integ_points))
+         ALLOCATE (tau_tj(0:num_integ_points))
          tau_tj = 0.0_dp
 
          ALLOCATE (weights_cos_tf_t_to_w(num_integ_points, num_integ_points))
@@ -2264,8 +2248,6 @@ CONTAINS
          ENDIF
 
          IF (do_kpoints_cubic_RPA) THEN
-            CALL get_qs_env(qs_env, &
-                            kpoints=kpoints)
             ! we always use an odd number of image cells
             ! CAUTION: also at another point, cell_grid_dm is defined, these definitions have to be identical
             DO i_dim = 1, 3
@@ -2280,16 +2262,24 @@ CONTAINS
                                        LBOUND(kpoints%cell_to_index, 3):UBOUND(kpoints%cell_to_index, 3)))
             cell_to_index_3c(:, :, :) = kpoints%cell_to_index(:, :, :)
 
-            NULLIFY (cfm_mat_Q)
-            CALL cp_cfm_create(cfm_mat_Q, fm_mat_Q%matrix_struct)
-            CALL cp_cfm_set_all(cfm_mat_Q, z_zero)
-
          ELSE
             ALLOCATE (index_to_cell_3c(3, 1))
             index_to_cell_3c(:, 1) = 0
             ALLOCATE (cell_to_index_3c(0:0, 0:0, 0:0))
             cell_to_index_3c(0, 0, 0) = 1
             num_cells_dm = 1
+         END IF
+
+         IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
+
+            CALL get_sub_para_kp(para_env_sub_kp, fm_struct_sub_kp, para_env, kpoints%nkp, &
+                                 dimen_RI, ikp_local, first_ikp_local, do_kpoints_cubic_RPA)
+
+            NULLIFY (cfm_mat_Q)
+            CALL cp_cfm_create(cfm_mat_Q, fm_struct_sub_kp)
+            CALL cp_cfm_set_all(cfm_mat_Q, z_zero)
+         ELSE
+            first_ikp_local = 1
          END IF
 
          IF (.NOT. do_dbcsr_t) THEN
@@ -2393,9 +2383,25 @@ CONTAINS
 
          ! if we do kpoints, mat_P has a kpoint and mat_P_omega has the inted
          ! mat_P(tau, kpoint)
-         IF (do_kpoints_cubic_RPA) THEN
+         IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
+
+            NULLIFY (cell)
+            CALL get_qs_env(qs_env, cell=cell)
+            CALL get_cell(cell=cell, periodic=periodic)
+
             CALL get_kpoint_info(kpoints, nkp=nkp)
+            ! compute k-point weights such that functions 1/k^2, 1/k and const function are
+            ! integrated correctly
+            CALL compute_wkp_W(wkp_W, kpoints, cell%hmat, cell%h_inv, &
+                               qs_env%mp2_env%ri_rpa_im_time%exp_kpoints, periodic)
+         ELSE
+            nkp = 1
+         END IF
+
+         IF (do_kpoints_cubic_RPA) THEN
             size_P = MAX(num_cells_dm/2+1, nkp)
+         ELSE IF (do_kpoints_from_Gamma) THEN
+            size_P = MAX(3**(periodic(1)+periodic(2)+periodic(3)), nkp)
          ELSE
             size_P = 1
          END IF
@@ -2424,16 +2430,16 @@ CONTAINS
             END DO
          END IF
 
-         IF (do_kpoints_cubic_RPA) THEN
+         IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
 
-            NULLIFY (mat_P_omega_im_part)
-            CALL dbcsr_allocate_matrix_set(mat_P_omega_im_part, num_integ_points, size_P)
-            DO jquad = 1, num_integ_points
+            NULLIFY (mat_P_omega_kp)
+            CALL dbcsr_allocate_matrix_set(mat_P_omega_kp, 2, size_P)
+            DO i_real_imag = 1, 2
                DO i_kp = 1, size_P
-                  ALLOCATE (mat_P_omega_im_part(jquad, i_kp)%matrix)
-                  CALL dbcsr_create(matrix=mat_P_omega_im_part(jquad, i_kp)%matrix, &
+                  ALLOCATE (mat_P_omega_kp(i_real_imag, i_kp)%matrix)
+                  CALL dbcsr_create(matrix=mat_P_omega_kp(i_real_imag, i_kp)%matrix, &
                                     template=mat_P_global%matrix)
-                  CALL dbcsr_set(mat_P_omega_im_part(jquad, i_kp)%matrix, 0.0_dp)
+                  CALL dbcsr_set(mat_P_omega_kp(i_real_imag, i_kp)%matrix, 0.0_dp)
                END DO
             END DO
 
@@ -2568,8 +2574,15 @@ CONTAINS
          ALLOCATE (fm_mat_L(SIZE(fm_matrix_L_RI_metric, 1), SIZE(fm_matrix_L_RI_metric, 2)))
          DO i_size = 1, SIZE(fm_matrix_L_RI_metric, 1)
             DO j_size = 1, SIZE(fm_matrix_L_RI_metric, 2)
-               CALL cp_fm_create(fm_mat_L(i_size, j_size)%matrix, fm_mat_Q%matrix_struct)
-               CALL cp_fm_set_all(fm_mat_L(i_size, j_size)%matrix, 0.0_dp)
+               IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
+                  IF (ANY(ikp_local(:) == i_size)) THEN
+                     CALL cp_fm_create(fm_mat_L(i_size, j_size)%matrix, fm_struct_sub_kp)
+                     CALL cp_fm_set_all(fm_mat_L(i_size, j_size)%matrix, 0.0_dp)
+                  END IF
+               ELSE
+                  CALL cp_fm_create(fm_mat_L(i_size, j_size)%matrix, fm_mat_Q%matrix_struct)
+                  CALL cp_fm_set_all(fm_mat_L(i_size, j_size)%matrix, 0.0_dp)
+               END IF
             END DO
          END DO
 
@@ -2609,6 +2622,8 @@ CONTAINS
 
          CALL timestop(handle4)
 
+         CALL timeset(routineN//"_im_t_alloc_mat_gw", handle4)
+
          IF (do_gw_im_time) THEN
 
             num_points_corr = mp2_env%ri_g0w0%num_omega_points
@@ -2621,144 +2636,25 @@ CONTAINS
 
             gw_corr_lev_tot = gw_corr_lev_occ+gw_corr_lev_virt
 
-            NULLIFY (mat_3c_overl_int_gw)
-            CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw, gw_corr_lev_tot)
+         END IF
 
-            IF (do_ic_model) THEN
+         IF (do_gw_im_time .AND. (.NOT. do_kpoints_cubic_RPA)) THEN
 
-               NULLIFY (mat_3c_overl_nnP_ic)
-               CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic, gw_corr_lev_tot)
-
-               NULLIFY (mat_3c_overl_nnP_ic_reflected)
-               CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic_reflected, gw_corr_lev_tot)
-
-            END IF
-
-            DO n_level_gw = 1, gw_corr_lev_tot
-
-               ALLOCATE (mat_3c_overl_int_gw(n_level_gw)%matrix)
-               CALL dbcsr_create(matrix=mat_3c_overl_int_gw(n_level_gw)%matrix, &
-                                 template=matrix_s(1)%matrix, &
-                                 matrix_type=dbcsr_type_no_symmetry, &
-                                 row_blk_size=RI_blk_sizes, &
-                                 col_blk_size=prim_blk_sizes)
-
-               IF (do_ic_model) THEN
-                  ALLOCATE (mat_3c_overl_nnP_ic(n_level_gw)%matrix)
-                  CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic(n_level_gw)%matrix, &
-                                    template=matrix_s(1)%matrix, &
-                                    matrix_type=dbcsr_type_no_symmetry, &
-                                    row_blk_size=RI_blk_sizes, &
-                                    col_blk_size=prim_blk_sizes)
-
-                  ALLOCATE (mat_3c_overl_nnP_ic_reflected(n_level_gw)%matrix)
-                  CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic_reflected(n_level_gw)%matrix, &
-                                    template=matrix_s(1)%matrix, &
-                                    matrix_type=dbcsr_type_no_symmetry, &
-                                    row_blk_size=RI_blk_sizes, &
-                                    col_blk_size=prim_blk_sizes)
-
-               END IF
-
-            END DO
-
-            CALL get_mat_3c_overl_int_gw(mat_3c_overl_int, mat_3c_overl_int_gw, mo_coeff, matrix_s, &
-                                         gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, mat_dm_virt_local, &
-                                         para_env, para_env_sub, cut_RI, row_from_LLL, &
-                                         my_group_L_starts_im_time, my_group_L_sizes_im_time, do_ic_model, &
-                                         do_ic_opt_homo_lumo, mat_3c_overl_nnP_ic, &
-                                         mat_3c_overl_nnP_ic_reflected, qs_env, unit_nr)
-
-            IF (my_open_shell) THEN
-
-               NULLIFY (mat_3c_overl_int_gw_beta)
-               CALL dbcsr_allocate_matrix_set(mat_3c_overl_int_gw_beta, gw_corr_lev_tot)
-
-               IF (do_ic_model) THEN
-
-                  NULLIFY (mat_3c_overl_nnP_ic_beta)
-                  CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic_beta, gw_corr_lev_tot)
-
-                  NULLIFY (mat_3c_overl_nnP_ic_reflected_beta)
-                  CALL dbcsr_allocate_matrix_set(mat_3c_overl_nnP_ic_reflected_beta, gw_corr_lev_tot)
-
-               END IF
-
-               DO n_level_gw = 1, gw_corr_lev_tot
-
-                  ALLOCATE (mat_3c_overl_int_gw_beta(n_level_gw)%matrix)
-                  CALL dbcsr_create(matrix=mat_3c_overl_int_gw_beta(n_level_gw)%matrix, &
-                                    template=matrix_s(1)%matrix, &
-                                    matrix_type=dbcsr_type_no_symmetry, &
-                                    row_blk_size=RI_blk_sizes, &
-                                    col_blk_size=prim_blk_sizes)
-
-                  IF (do_ic_model) THEN
-                     ALLOCATE (mat_3c_overl_nnP_ic_beta(n_level_gw)%matrix)
-                     CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic_beta(n_level_gw)%matrix, &
-                                       template=matrix_s(1)%matrix, &
-                                       matrix_type=dbcsr_type_no_symmetry, &
-                                       row_blk_size=RI_blk_sizes, &
-                                       col_blk_size=prim_blk_sizes)
-
-                     ALLOCATE (mat_3c_overl_nnP_ic_reflected_beta(n_level_gw)%matrix)
-                     CALL dbcsr_create(matrix=mat_3c_overl_nnP_ic_reflected_beta(n_level_gw)%matrix, &
-                                       template=matrix_s(1)%matrix, &
-                                       matrix_type=dbcsr_type_no_symmetry, &
-                                       row_blk_size=RI_blk_sizes, &
-                                       col_blk_size=prim_blk_sizes)
-                  END IF
-
-               END DO
-
-               CALL get_mat_3c_overl_int_gw(mat_3c_overl_int, mat_3c_overl_int_gw_beta, mo_coeff_beta, matrix_s, &
-                                            gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, nmo, mat_dm_virt_local, &
-                                            para_env, para_env_sub, cut_RI, row_from_LLL, &
-                                            my_group_L_starts_im_time, my_group_L_sizes_im_time, do_ic_model, &
-                                            do_ic_opt_homo_lumo, mat_3c_overl_nnP_ic_beta, &
-                                            mat_3c_overl_nnP_ic_reflected_beta, qs_env, unit_nr, do_beta=.TRUE.)
-
-            END IF
-
-            NULLIFY (fm_mat_W_tau)
-            ALLOCATE (fm_mat_W_tau(num_integ_points))
-
-            DO jquad = 1, num_integ_points
-
-               NULLIFY (fm_mat_W_tau(jquad)%matrix)
-               CALL cp_fm_create(fm_mat_W_tau(jquad)%matrix, fm_mat_Q%matrix_struct)
-               CALL cp_fm_to_fm(fm_mat_Q, fm_mat_W_tau(jquad)%matrix)
-               CALL cp_fm_set_all(fm_mat_W_tau(jquad)%matrix, 0.0_dp)
-
-            END DO
-
-            NULLIFY (mat_contr_gf_occ)
-            CALL dbcsr_init_p(mat_contr_gf_occ)
-            CALL dbcsr_create(matrix=mat_contr_gf_occ, &
-                              template=mat_3c_overl_int_gw(1)%matrix)
-
-            NULLIFY (mat_contr_gf_virt)
-            CALL dbcsr_init_p(mat_contr_gf_virt)
-            CALL dbcsr_create(matrix=mat_contr_gf_virt, &
-                              template=mat_3c_overl_int_gw(1)%matrix)
-
-            NULLIFY (mat_contr_W)
-            CALL dbcsr_init_p(mat_contr_W)
-            CALL dbcsr_create(matrix=mat_contr_W, &
-                              template=mat_3c_overl_int_gw(1)%matrix)
-
-            NULLIFY (mat_W)
-            ALLOCATE (mat_W(num_integ_points))
-            DO jquad = 1, num_integ_points
-               ALLOCATE (mat_W(jquad)%matrix)
-               CALL dbcsr_create(matrix=mat_W(jquad)%matrix, &
-                                 template=mat_3c_overl_int_gw(1)%matrix, &
-                                 matrix_type=dbcsr_type_no_symmetry, &
-                                 row_blk_size=RI_blk_sizes, &
-                                 col_blk_size=RI_blk_sizes)
-            END DO
+            CALL allocate_matrices_gw_im_time(cut_RI, gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_tot, &
+                                              gw_corr_lev_virt, gw_corr_lev_virt_beta, homo, homo_beta, nmo, &
+                                              num_integ_points, unit_nr, my_group_L_sizes_im_time, my_group_L_starts_im_time, &
+                                              row_from_LLL, prim_blk_sizes, RI_blk_sizes, do_ic_model, do_ic_opt_homo_lumo, &
+                                              my_open_shell, para_env, para_env_sub, fm_mat_W_tau, fm_mat_Q, &
+                                              mo_coeff, mo_coeff_beta, mat_dm_virt_local, mat_3c_overl_int_gw, &
+                                              mat_3c_overl_int_gw_beta, mat_3c_overl_nnP_ic, &
+                                              mat_3c_overl_nnP_ic_beta, mat_3c_overl_nnP_ic_reflected, &
+                                              mat_3c_overl_nnP_ic_reflected_beta, matrix_s, mat_W, &
+                                              mat_3c_overl_int, mat_contr_gf_occ, mat_contr_gf_virt, &
+                                              mat_contr_W, qs_env)
 
          END IF
+
+         CALL timestop(handle4)
 
          CALL timeset(routineN//"_im_t_alloc_mat_21", handle4)
 
@@ -2767,7 +2663,8 @@ CONTAINS
                                              starts_array_mc_t, ends_array_mc_t, eps_filter)
          ELSE
             CALL setup_mat_for_mem_cut_3c(mat_3c_overl_int_cut, mat_3c_overl_int, cut_memory, cut_RI, &
-                                          starts_array_cm, ends_array_cm, my_group_L_sizes_im_time, eps_filter)
+                                          starts_array_cm, ends_array_cm, my_group_L_sizes_im_time, eps_filter, &
+                                          do_kpoints_cubic_RPA, do_gw_im_time, num_3c_repl)
          ENDIF
 
          CALL timestop(handle4)
@@ -2779,10 +2676,12 @@ CONTAINS
             ! the mao 3c overlap integrals here
             CALL setup_mat_for_mem_cut_3c(mat_3c_overl_int_mao_for_occ_cut, mat_3c_overl_int_mao_for_occ, &
                                           cut_memory, cut_RI, starts_array_cm_mao_virt, ends_array_cm_mao_virt, &
-                                          my_group_L_sizes_im_time, eps_filter)
+                                          my_group_L_sizes_im_time, eps_filter, do_kpoints_cubic_RPA, do_gw_im_time, &
+                                          num_3c_repl)
             CALL setup_mat_for_mem_cut_3c(mat_3c_overl_int_mao_for_virt_cut, mat_3c_overl_int_mao_for_virt, &
                                           cut_memory, cut_RI, starts_array_cm_mao_occ, ends_array_cm_mao_occ, &
-                                          my_group_L_sizes_im_time, eps_filter)
+                                          my_group_L_sizes_im_time, eps_filter, do_kpoints_cubic_RPA, do_gw_im_time, &
+                                          num_3c_repl)
 
          ELSE
             IF (.NOT. do_dbcsr_t) THEN
@@ -2814,8 +2713,8 @@ CONTAINS
          CALL timeset(routineN//"_im_t_alloc_mat_23", handle4)
 
          NULLIFY (fm_mat_L_transposed)
-         CALL cp_fm_create(fm_mat_L_transposed, fm_mat_L(1, 1)%matrix%matrix_struct)
-         CALL cp_fm_to_fm(fm_mat_L(1, 1)%matrix, fm_mat_L_transposed)
+         CALL cp_fm_create(fm_mat_L_transposed, fm_mat_L(first_ikp_local, 1)%matrix%matrix_struct)
+         CALL cp_fm_to_fm(fm_mat_L(first_ikp_local, 1)%matrix, fm_mat_L_transposed)
          CALL cp_fm_set_all(matrix=fm_mat_L_transposed, alpha=0.0_dp)
 
          CALL timestop(handle4)
@@ -2827,15 +2726,28 @@ CONTAINS
          DO i_size = 1, SIZE(fm_matrix_L_RI_metric, 1)
          DO j_size = 1, SIZE(fm_matrix_L_RI_metric, 2)
 
-            CALL cp_fm_copy_general(fm_matrix_L_RI_metric(i_size, j_size)%matrix, fm_mat_L_transposed, blacs_env%para_env)
-            IF (do_kpoints_cubic_RPA) THEN
-               CALL cp_fm_to_fm(fm_mat_L_transposed, fm_mat_L(i_size, j_size)%matrix)
+            IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
+               IF (ANY(ikp_local(:) == i_size)) THEN
+                  CALL cp_fm_copy_general(fm_matrix_L_RI_metric(i_size, j_size)%matrix, fm_mat_L_transposed, para_env)
+                  CALL cp_fm_to_fm(fm_mat_L_transposed, fm_mat_L(i_size, j_size)%matrix)
+               ELSE
+                  NULLIFY (fmdummy)
+                  CALL cp_fm_copy_general(fm_matrix_L_RI_metric(i_size, j_size)%matrix, fmdummy, para_env)
+               END IF
             ELSE
+               CALL cp_fm_copy_general(fm_matrix_L_RI_metric(i_size, j_size)%matrix, fm_mat_L_transposed, blacs_env%para_env)
                CALL cp_fm_transpose(fm_mat_L_transposed, fm_mat_L(i_size, j_size)%matrix)
             END IF
 
          END DO
          END DO
+
+         IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
+            NULLIFY (fm_mat_RI_global_work)
+            CALL cp_fm_create(fm_mat_RI_global_work, fm_matrix_L_RI_metric(1, 1)%matrix%matrix_struct)
+            CALL cp_fm_to_fm(fm_matrix_L_RI_metric(1, 1)%matrix, fm_mat_RI_global_work)
+            CALL cp_fm_set_all(fm_mat_RI_global_work, 0.0_dp)
+         END IF
 
          DO i_size = 1, SIZE(fm_matrix_L_RI_metric, 1)
          DO j_size = 1, SIZE(fm_matrix_L_RI_metric, 2)
@@ -2856,9 +2768,12 @@ CONTAINS
          CALL timestop(handle4)
          CALL timeset(routineN//"_im_t_alloc_mat_26", handle4)
 
-         IF (.NOT. do_kpoints_cubic_RPA) THEN
+         IF (.NOT. (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma)) THEN
             CALL copy_fm_to_dbcsr(fm_mat_L(1, 1)%matrix, mat_L%matrix)
          END IF
+
+         CALL timestop(handle4)
+         CALL timeset(routineN//"_im_t_alloc_mat_laplace_beta", handle4)
 
          CALL timestop(handle4)
 
@@ -2870,10 +2785,16 @@ CONTAINS
             NULLIFY (mat_SinvVSinv%matrix)
             ALLOCATE (mat_SinvVSinv%matrix)
             CALL dbcsr_create(mat_SinvVSinv%matrix, template=mat_P_global%matrix)
+            CALL dbcsr_set(mat_SinvVSinv%matrix, 0.0_dp)
 
-            !  get the Coulomb matrix for Sigma_x = G*V
-            CALL dbcsr_multiply("T", "N", 1.0_dp, mat_L%matrix, mat_L%matrix, &
-                                0.0_dp, mat_SinvVSinv%matrix, filter_eps=eps_filter_im_time)
+            ! for kpoints we compute SinvVSinv later with kpoints
+            IF (.NOT. do_kpoints_from_Gamma) THEN
+
+               !  get the Coulomb matrix for Sigma_x = G*V
+               CALL dbcsr_multiply("T", "N", 1.0_dp, mat_L%matrix, mat_L%matrix, &
+                                   0.0_dp, mat_SinvVSinv%matrix, filter_eps=eps_filter_im_time)
+
+            END IF
 
          END IF
 
@@ -3035,8 +2956,8 @@ CONTAINS
          END IF
 
          ! for G0W0, we may set the scaling factor by hand
-         IF (my_do_gw) THEN
-            a_scaling = 0.2_dp
+         IF (my_do_gw .AND. ext_scaling > 0.0_dp) THEN
+            a_scaling = ext_scaling
          END IF
 
          IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T56,F25.5)') 'INTEG_INFO| Scaling parameter:', a_scaling
@@ -3073,247 +2994,21 @@ CONTAINS
 
       IF (my_do_gw .OR. do_gw_im_time) THEN
 
-         gw_corr_lev_tot = gw_corr_lev_occ+gw_corr_lev_virt
-
-         ! fill the omega_frequency vector
-         ALLOCATE (vec_omega_gw(num_integ_points))
-         vec_omega_gw = 0.0_dp
-
-         DO jquad = 1, num_integ_points
-            IF (do_minimax_quad) THEN
-               omega = tj(jquad)
-            ELSE
-               omega = a_scaling/TAN(tj(jquad))
-            END IF
-            vec_omega_gw(jquad) = omega
-         END DO
-
-         ! determine number of fit points in the interval [0,w_max] for virt, or [-w_max,0] for occ
-         num_fit_points = 0
-
-         DO jquad = 1, num_integ_points
-            IF (vec_omega_gw(jquad) < omega_max_fit) THEN
-               num_fit_points = num_fit_points+1
-            END IF
-         END DO
-
-         IF (mp2_env%ri_g0w0%analytic_continuation == gw_pade_approx) THEN
-            IF (mp2_env%ri_g0w0%nparam_pade > num_fit_points) THEN
-               IF (unit_nr > 0) &
-                  CPWARN("Pade approximation: more parameters than data points. Reset # of parameters.")
-               mp2_env%ri_g0w0%nparam_pade = num_fit_points
-               IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T74,I7)") &
-                  "Number of pade parameters:", mp2_env%ri_g0w0%nparam_pade
-            ENDIF
-         ENDIF
-
-         ! create new arrays containing omega values at which we calculate vec_Sigma_c_gw
-         ALLOCATE (vec_omega_fit_gw(num_fit_points))
-
-         ! fill the omega vector with frequencies, where we calculate the self-energy
-         iquad = 0
-         DO jquad = 1, num_integ_points
-            IF (vec_omega_gw(jquad) < omega_max_fit) THEN
-               iquad = iquad+1
-               vec_omega_fit_gw(iquad) = vec_omega_gw(jquad)
-            END IF
-         END DO
-
-         DEALLOCATE (vec_omega_gw)
-
-         ALLOCATE (vec_Sigma_c_gw(gw_corr_lev_tot, num_fit_points))
-         vec_Sigma_c_gw = (0.0_dp, 0.0_dp)
-
-         IF (my_open_shell) THEN
-            ALLOCATE (vec_Sigma_c_gw_beta(gw_corr_lev_tot, num_fit_points))
-            vec_Sigma_c_gw_beta = (0.0_dp, 0.0_dp)
-         END IF
-
-         ! arrays storing the correlation self-energy, stat. error and z-shot value
-         ALLOCATE (vec_gw_energ(gw_corr_lev_tot))
-         vec_gw_energ = 0.0_dp
-         ALLOCATE (vec_gw_energ_error_fit(gw_corr_lev_tot))
-         vec_gw_energ_error_fit = 0.0_dp
-         ALLOCATE (z_value(gw_corr_lev_tot))
-         z_value = 0.0_dp
-         ALLOCATE (m_value(gw_corr_lev_tot))
-         m_value = 0.0_dp
-
-         ! the same for beta
-         IF (my_open_shell) THEN
-            ALLOCATE (vec_gw_energ_beta(gw_corr_lev_tot))
-            vec_gw_energ_beta = 0.0_dp
-            ALLOCATE (vec_gw_energ_error_fit_beta(gw_corr_lev_tot))
-            vec_gw_energ_error_fit_beta = 0.0_dp
-            ALLOCATE (z_value_beta(gw_corr_lev_tot))
-            z_value_beta = 0.0_dp
-            ALLOCATE (m_value_beta(gw_corr_lev_tot))
-            m_value_beta = 0.0_dp
-         END IF
-
-         ALLOCATE (Eigenval_scf(nmo))
-         Eigenval_scf(:) = Eigenval(:)
-
-         ALLOCATE (Eigenval_last(nmo))
-         Eigenval_last(:) = Eigenval(:)
-
-         ! in the case of HF_diag approach of X. Blase (PRB 83, 115103 (2011), Sec. IV), we subtract the
-         ! XC potential and add exact exchange
-         IF (mp2_env%ri_g0w0%hf_like_ev_start) THEN
-            DO n_level_gw = 1, gw_corr_lev_tot
-               n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-               Eigenval(n_level_gw_ref) = Eigenval(n_level_gw_ref)+ &
-                                          mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(n_level_gw_ref, 1)
-            END DO
-         END IF
-
-         ! Eigenval for beta
-         IF (my_open_shell) THEN
-            ALLOCATE (Eigenval_scf_beta(nmo))
-            Eigenval_scf_beta(:) = Eigenval_beta(:)
-
-            ALLOCATE (Eigenval_last_beta(nmo))
-            Eigenval_last_beta(:) = Eigenval_beta(:)
-
-            ! in the case of HF_diag approach of X. Blase (PRB 83, 115103 (2011), Sec. IV), we subtract the
-            ! XC potential and add exact exchange
-            IF (mp2_env%ri_g0w0%hf_like_ev_start) THEN
-               DO n_level_gw = 1, gw_corr_lev_tot
-                  n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-                  Eigenval_beta(n_level_gw_ref) = Eigenval_beta(n_level_gw_ref)+ &
-                                                  mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(n_level_gw_ref, 2)
-               END DO
-            END IF
-         END IF
-
-         IF (do_periodic) THEN
-
-            ALLOCATE (delta_corr(1+homo-gw_corr_lev_occ:homo+gw_corr_lev_virt))
-            delta_corr(:) = 0.0_dp
-
-            first_cycle_periodic_correction = .TRUE.
-
-         END IF
-
-         ALLOCATE (do_GW_corr(1:gw_corr_lev_tot))
-         do_GW_corr(:) = .TRUE.
-
-         IF (do_ri_Sigma_x) THEN
-            ALLOCATE (vec_Sigma_x_gw(nmo))
-            vec_Sigma_x_gw = 0.0_dp
-
-            IF (my_open_shell) THEN
-               ALLOCATE (vec_Sigma_x_gw_beta(nmo))
-               vec_Sigma_x_gw_beta = 0.0_dp
-            END IF
-         END IF
-
-      END IF
-
-      IF (my_do_gw) THEN
-
-         ! minimax grids not implemented for O(N^4) GW
-         CPASSERT(.NOT. do_minimax_quad)
-
-         ! create temporary matrix to store B*([1+Q(iw')]^-1-1), has the same size as B
-         NULLIFY (fm_mat_S_gw_work)
-         CALL cp_fm_create(fm_mat_S_gw_work, fm_mat_S_gw%matrix_struct)
-         CALL cp_fm_set_all(matrix=fm_mat_S_gw_work, alpha=0.0_dp)
-
-         IF (my_open_shell) THEN
-            NULLIFY (fm_mat_S_gw_work_beta)
-            CALL cp_fm_create(fm_mat_S_gw_work_beta, fm_mat_S_gw%matrix_struct)
-            CALL cp_fm_set_all(matrix=fm_mat_S_gw_work_beta, alpha=0.0_dp)
-         END IF
-
-         ALLOCATE (vec_W_gw(dimen_nm_gw))
-         vec_W_gw = 0.0_dp
-
-         IF (my_open_shell) THEN
-            ALLOCATE (vec_W_gw_beta(dimen_nm_gw))
-            vec_W_gw_beta = 0.0_dp
-         END IF
-
-         im_unit = (0.0_dp, 1.0_dp)
-         re_unit = (1.0_dp, 0.0_dp)
-
-         ! in case we do RI for Sigma_x, we calculate Sigma_x right here
-         IF (do_ri_Sigma_x) THEN
-
-            CALL cp_fm_get_info(matrix=fm_mat_S_gw, &
-                                nrow_local=nrow_local, &
-                                ncol_local=ncol_local, &
-                                row_indices=row_indices)
-
-            CALL mp_sync(para_env%group)
-
-            ! loop over (nm) index
-            DO iiB = 1, nrow_local
-
-               ! this is needed for correct values within parallelization, see analogue
-               ! statement below
-               IF (MODULO(1, num_integ_group) /= color_rpa_group) CYCLE
-
-               nm_global = row_indices(iiB)
-
-               ! transform the index nm to n and m, formulae copied from Mauro's code
-               n_global = MAX(1, nm_global-1)/nmo+1
-               m_global = nm_global-(n_global-1)*nmo
-               n_global = n_global+homo-gw_corr_lev_occ
-
-               IF (my_open_shell) THEN
-                  n_global_beta = MAX(1, nm_global-1)/nmo+1
-                  m_global_beta = nm_global-(n_global_beta-1)*nmo
-                  n_global_beta = n_global_beta+homo_beta-gw_corr_lev_occ_beta
-               END IF
-
-               IF (m_global <= homo) THEN
-
-                  ! loop over auxiliary basis functions
-                  DO jjB = 1, ncol_local
-
-                     ! Sigma_x_n = -sum_m^occ sum_P (B_(nm)^P)^2
-                     vec_Sigma_x_gw(n_global) = &
-                        vec_Sigma_x_gw(n_global)- &
-                        fm_mat_S_gw%local_data(iiB, jjB)**2
-
-                  END DO
-
-               END IF
-
-               ! The same for beta
-               IF (my_open_shell) THEN
-                  IF (m_global_beta <= homo_beta) THEN
-                     ! loop over auxiliary basis functions
-                     DO jjB = 1, ncol_local
-
-                        ! Sigma_x_n = -sum_m^occ sum_P (B_(nm)^P)^2
-                        vec_Sigma_x_gw_beta(n_global_beta) = &
-                           vec_Sigma_x_gw_beta(n_global_beta)- &
-                           fm_mat_S_gw_beta%local_data(iiB, jjB)**2
-
-                     END DO
-                  END IF
-               END IF
-            END DO
-
-            CALL mp_sum(vec_Sigma_x_gw, para_env%group)
-
-            mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1) = &
-               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1)+ &
-               vec_Sigma_x_gw(:)
-
-            IF (my_open_shell) THEN
-
-               CALL mp_sum(vec_Sigma_x_gw_beta, para_env%group)
-
-               mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2) = &
-                  mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2)+ &
-                  vec_Sigma_x_gw_beta(:)
-
-            END IF
-
-         END IF
+         CALL allocate_matrices_gw(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, color_rpa_group, dimen_nm_gw, &
+                                   gw_corr_lev_occ, gw_corr_lev_occ_beta, gw_corr_lev_virt, homo, homo_beta, &
+                                   nmo, num_integ_points, num_integ_group, unit_nr, &
+                                   gw_corr_lev_tot, num_fit_points, omega_max_fit, &
+                                   do_minimax_quad, do_periodic, do_ri_Sigma_x, my_do_gw, my_open_shell, &
+                                   first_cycle_periodic_correction, do_GW_corr, &
+                                   a_scaling, Eigenval, Eigenval_beta, &
+                                   tj, vec_omega_fit_gw, vec_Sigma_x_gw, &
+                                   vec_Sigma_x_gw_beta, delta_corr, Eigenval_last, Eigenval_last_beta, &
+                                   Eigenval_scf, Eigenval_scf_beta, m_value, m_value_beta, &
+                                   vec_gw_energ, vec_gw_energ_beta, vec_gw_energ_error_fit, vec_gw_energ_error_fit_beta, &
+                                   vec_W_gw, vec_W_gw_beta, z_value, z_value_beta, &
+                                   fm_mat_S_gw, fm_mat_S_gw_work, fm_mat_S_gw_work_beta, &
+                                   fm_mat_S_gw_beta, para_env, mp2_env, kpoints, nkp, nkp_self_energy, &
+                                   do_kpoints_cubic_RPA, do_kpoints_from_Gamma)
 
          IF (do_bse) THEN
 
@@ -3345,11 +3040,6 @@ CONTAINS
       ELSE
          iter_ev_sc = 1
       END IF
-
-!      IF (do_gw_im_time) THEN
-!         ! for cubic-scaling GW, we only do G0W0 and no evGW
-!         CPASSERT(iter_ev_sc == 1)
-!      END IF
 
       DO count_ev_sc_GW = 1, iter_ev_sc
 
@@ -3403,7 +3093,7 @@ CONTAINS
             CALL zero_mat_P_omega(mat_P_omega, num_integ_points, size_P)
 
             ! compute the matrix Q(it) and Fourier transform it directly to mat_P_omega(iw)
-            CALL compute_mat_P_omega(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+            CALL compute_mat_P_omega(mat_P_omega, fm_scaled_dm_occ_tau, &
                                      fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                      mat_P_local, mat_P_global, mat_P_global_copy, &
@@ -3430,7 +3120,7 @@ CONTAINS
                                      non_zero_blocks_3c, non_zero_blocks_3c_cut_col, buffer_mat_M, &
                                      do_mao, stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                      needed_cutRI_mem_R1vec_R2vec_for_kp, &
-                                     has_mat_P_blocks, do_ri_sos_laplace_mp2)
+                                     has_mat_P_blocks, num_3c_repl, do_ri_sos_laplace_mp2)
 
             ! the same for open shell, use fm_mo_coeff_occ_beta and fm_mo_coeff_virt_beta
             IF (my_open_shell) THEN
@@ -3438,7 +3128,7 @@ CONTAINS
                IF (do_ri_sos_laplace_mp2) THEN
                   CALL zero_mat_P_omega(mat_P_omega_beta, num_integ_points, size_P)
 
-                  CALL compute_mat_P_omega(mat_P_omega_beta, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+                  CALL compute_mat_P_omega(mat_P_omega_beta, fm_scaled_dm_occ_tau, &
                                            fm_scaled_dm_virt_tau, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
                                            fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                            mat_P_local, mat_P_global, mat_P_global_copy, &
@@ -3465,9 +3155,9 @@ CONTAINS
                                            non_zero_blocks_3c, non_zero_blocks_3c_cut_col, buffer_mat_M, &
                                            do_mao, stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                            needed_cutRI_mem_R1vec_R2vec_for_kp, &
-                                           has_mat_P_blocks, do_ri_sos_laplace_mp2)
+                                           has_mat_P_blocks, num_3c_repl, do_ri_sos_laplace_mp2)
                ELSE
-                  CALL compute_mat_P_omega(mat_P_omega, mat_P_omega_im_part, fm_scaled_dm_occ_tau, &
+                  CALL compute_mat_P_omega(mat_P_omega, fm_scaled_dm_occ_tau, &
                                            fm_scaled_dm_virt_tau, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
                                            fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                            mat_P_local, mat_P_global, mat_P_global_copy, &
@@ -3494,12 +3184,14 @@ CONTAINS
                                            non_zero_blocks_3c, non_zero_blocks_3c_cut_col, buffer_mat_M, &
                                            do_mao, stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                            needed_cutRI_mem_R1vec_R2vec_for_kp, &
-                                           has_mat_P_blocks, do_ri_sos_laplace_mp2)
+                                           has_mat_P_blocks, num_3c_repl, do_ri_sos_laplace_mp2)
                END IF ! do_ri_sos_laplace_mp2
 
             END IF ! my_open_shell
 
          END IF ! do im time
+
+         num_residues = 0
 
          DO jquad = 1, num_integ_points
 
@@ -3508,19 +3200,17 @@ CONTAINS
             CALL timeset(routineN//"_RPA_matrix_operations", handle3)
 
             IF (.NOT. do_ri_sos_laplace_mp2) THEN
-
                IF (do_minimax_quad) THEN
                   omega = tj(jquad)
                ELSE
                   omega = a_scaling/TAN(tj(jquad))
                END IF
-
             END IF ! do_ri_sos_laplace_mp2
 
             IF (do_im_time) THEN
                ! in case we do imag time, we already calculated fm_mat_Q by a Fourier transform from im. time
 
-               IF (.NOT. do_kpoints_cubic_RPA) THEN
+               IF (.NOT. (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma)) THEN
 
                   ! multiplication with RI metric/Coulomb operator
                   CALL dbcsr_multiply("N", "T", 1.0_dp, mat_P_omega(jquad, 1)%matrix, mat_L%matrix, &
@@ -3592,14 +3282,15 @@ CONTAINS
             IF (do_ri_sos_laplace_mp2) THEN
                ! calculate the trace of the product Q*Q
                trace_XX = 0.0_dp
-               IF (my_open_shell) THEN
-                  DO jjB = 1, ncol_local
-                     trace_XX = trace_XX+DOT_PRODUCT(fm_mat_Q%local_data(:, jjB), fm_mat_Q_beta%local_data(:, jjB))
+               DO jjB = 1, ncol_local
+                  DO iiB = 1, nrow_local
+                     IF (my_open_shell) THEN
+                        trace_XX = trace_XX+fm_mat_Q%local_data(iiB, jjB)*fm_mat_Q_beta%local_data(iiB, jjB)
+                     ELSE
+                        trace_XX = trace_XX+fm_mat_Q%local_data(iiB, jjB)*fm_mat_Q%local_data(iiB, jjB)
+                     END IF
                   END DO
-               ELSE
-                  trace_XX = NORM2(fm_mat_Q%local_data)
-                  trace_XX = trace_XX*trace_XX
-               END IF
+               END DO
 
                Erpa = Erpa-trace_XX*tau_wj(jquad)
 
@@ -3620,7 +3311,7 @@ CONTAINS
                END DO
                CALL mp_sum(trace_Qomega, para_env_RPA%group)
 
-               IF (.NOT. do_kpoints_cubic_RPA) THEN
+               IF (.NOT. (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma)) THEN
 
                   ! calculate Trace(Log(Matrix)) as Log(DET(Matrix)) via cholesky decomposition
                   CALL cp_fm_cholesky_decompose(matrix=fm_mat_Q, n=dimen_RI, info_out=info_chol)
@@ -3658,19 +3349,32 @@ CONTAINS
 
                END IF
 
-               IF (do_kpoints_cubic_RPA) THEN
+               IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
 
-                  CALL get_kpoint_info(kpoints, nkp=nkp)
+                  IF (do_kpoints_cubic_RPA .AND. do_gw_im_time) THEN
+                     CALL allocate_Wc_kp_tau_GW(cfm_mat_W_kp_tau, cfm_mat_Q, num_integ_points, jquad, &
+                                                nkp, ikp_local)
+                  END IF
+
+                  IF (do_kpoints_from_Gamma) THEN
+                     CALL get_P_cell_T_from_P_gamma(mat_P_omega, qs_env, kpoints, jquad)
+                  END IF
+
+                  CALL transform_P_from_real_space_to_kpoints(mat_P_omega, mat_P_omega_kp, &
+                                                              kpoints, eps_filter_im_time, jquad)
 
                   DO ikp = 1, nkp
 
-                     ! 1. multiplication Q(iw,k) = K^T(k)P(iw,k)K(k)
-                     CALL compute_Q(cfm_mat_Q, &
-                                    mat_P_omega(jquad, ikp)%matrix, &
-                                    mat_P_omega_im_part(jquad, ikp)%matrix, &
-                                    fm_mat_L(ikp, 1)%matrix, &
-                                    fm_mat_L(ikp, 2)%matrix, &
-                                    dimen_RI)
+                     ! parallization
+                     IF (ikp_local(ikp) .NE. ikp) CYCLE
+
+                     ! 1. multiplication Q(iw,k) = K^H(k)P(iw,k)K(k)
+                     CALL compute_Q_kp_RPA(cfm_mat_Q, &
+                                           mat_P_omega_kp, &
+                                           fm_mat_L(ikp, 1)%matrix, &
+                                           fm_mat_L(ikp, 2)%matrix, &
+                                           fm_mat_RI_global_work, &
+                                           dimen_RI, ikp, nkp, ikp_local, para_env)
 
                      ! 2. Cholesky decomposition of Id + Q(iw,k)
                      CALL cholesky_decomp_Q(cfm_mat_Q, para_env_RPA, trace_Qomega, dimen_RI)
@@ -3678,6 +3382,51 @@ CONTAINS
                      ! 3. Computing E_c^RPA = E_c^RPA + a_w/N_k*sum_k ln[det(1+Q(iw,k))-Tr(Q(iw,k))]
                      CALL frequency_and_kpoint_integration(Erpa, cfm_mat_Q, para_env_RPA, trace_Qomega, &
                                                            dimen_RI, wj(jquad), kpoints%wkp(ikp))
+
+                     IF (do_gw_im_time) THEN
+
+                        ! compute S^-1*V*S^-1 for exchange part of the self-energy in real space as W in real space
+                        IF (do_ri_Sigma_x .AND. jquad == 1 .AND. count_ev_sc_GW == 1 &
+                            .AND. do_kpoints_from_Gamma) THEN
+
+                           CALL get_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
+
+                           CALL compute_Wc_real_space_tau_GW(fm_mat_W_tau, cfm_mat_Q, &
+                                                             fm_mat_L(ikp, 1)%matrix, &
+                                                             fm_mat_L(ikp, 2)%matrix, &
+                                                             dimen_RI, 1, 1, &
+                                                             ikp, tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy, &
+                                                             ikp_local, para_env, kpoints, qs_env, wkp_W, &
+                                                             mat_SinvVSinv, do_W_and_not_V=.FALSE.)
+
+                           CALL release_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
+
+                        END IF
+
+                        IF (do_kpoints_from_Gamma) THEN
+
+                           CALL compute_Wc_real_space_tau_GW(fm_mat_W_tau, cfm_mat_Q, &
+                                                             fm_mat_L(ikp, 1)%matrix, &
+                                                             fm_mat_L(ikp, 2)%matrix, &
+                                                             dimen_RI, num_integ_points, jquad, &
+                                                             ikp, tj, tau_tj, weights_cos_tf_w_to_t, &
+                                                             ikp_local, para_env, kpoints, qs_env, wkp_W, &
+                                                             mat_SinvVSinv, do_W_and_not_V=.TRUE.)
+
+                        END IF
+
+                        IF (do_kpoints_cubic_RPA) THEN
+
+                           CALL compute_Wc_kp_tau_GW(cfm_mat_W_kp_tau, cfm_mat_Q, &
+                                                     fm_mat_L(ikp, 1)%matrix, &
+                                                     fm_mat_L(ikp, 2)%matrix, &
+                                                     dimen_RI, num_integ_points, jquad, &
+                                                     ikp, tj, tau_tj, &
+                                                     weights_cos_tf_w_to_t)
+
+                        END IF
+
+                     END IF
 
                   END DO
 
@@ -3690,261 +3439,20 @@ CONTAINS
 
             CALL timestop(handle3)
 
-            ! the actual G0W0 calculation
-            IF (my_do_gw) THEN
-               CALL timeset(routineN//"_G0W0_matrix_operations", handle2)
-
-               IF (jquad <= num_integ_points) THEN
-
-                  ! calculate [1+Q(iw')]^-1
-                  CALL cp_fm_cholesky_invert(fm_mat_Q)
-                  ! symmetrize the result, fm_mat_R_gw is only temporary work matrix
-                  CALL cp_fm_upper_to_full(fm_mat_Q, fm_mat_R_gw)
-
-                  IF (do_bse .AND. jquad == 1) THEN
-                     CALL cp_fm_to_fm(fm_mat_Q, fm_mat_Q_static_bse)
-                  END IF
-
-               ELSE
-
-                  ! inverted matrix is written to fm_mat_R_gw
-                  CALL cp_fm_invert(fm_mat_Q, fm_mat_R_gw)
-
-                  CALL cp_fm_to_fm(source=fm_mat_R_gw, destination=fm_mat_Q)
-
-               END IF
-
-               ! periodic correction for GW
-               IF (do_periodic) THEN
-                  CALL calc_periodic_correction(delta_corr, qs_env, para_env, para_env_RPA, &
-                                                mp2_env%ri_g0w0%kp_grid, homo, nmo, gw_corr_lev_occ, &
-                                                gw_corr_lev_virt, omega, mo_coeff, Eigenval, &
-                                                matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                                first_cycle_periodic_correction, kpoints, &
-                                                mp2_env%ri_g0w0%do_mo_coeff_gamma, &
-                                                mp2_env%ri_g0w0%num_kp_grids, mp2_env%ri_g0w0%eps_kpoint, &
-                                                mp2_env%ri_g0w0%do_extra_kpoints, &
-                                                mp2_env%ri_g0w0%do_aux_bas_gw, mp2_env%ri_g0w0%frac_aux_mos)
-               END IF
-
-               ! subtract 1 from the diagonal to get rid of exchange self-energy
-!$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(jjB,iiB,i_global,j_global) &
-!$OMP                       SHARED(ncol_local,nrow_local,col_indices,row_indices,fm_mat_Q,dimen_RI)
-               DO jjB = 1, ncol_local
-                  j_global = col_indices(jjB)
-                  DO iiB = 1, nrow_local
-                     i_global = row_indices(iiB)
-                     IF (j_global == i_global .AND. i_global <= dimen_RI) THEN
-                        fm_mat_Q%local_data(iiB, jjB) = fm_mat_Q%local_data(iiB, jjB)-1.0_dp
-                     END IF
-                  END DO
-               END DO
-
-               ! S_work_(nm)Q = B_(nm)P * ([1+Q]^-1-1)_PQ
-               CALL timeset(routineN//"_mult_B_f(Pi)_gw", handle3)
-               CALL cp_gemm(transa="N", transb="N", m=dimen_nm_gw, n=dimen_RI, k=dimen_RI, alpha=1.0_dp, &
-                            matrix_a=fm_mat_S_gw, matrix_b=fm_mat_Q, beta=0.0_dp, &
-                            matrix_c=fm_mat_S_gw_work)
-               IF (my_open_shell) THEN
-                  CALL cp_gemm(transa="N", transb="N", m=dimen_nm_gw, n=dimen_RI, k=dimen_RI, alpha=1.0_dp, &
-                               matrix_a=fm_mat_S_gw_beta, matrix_b=fm_mat_Q, beta=0.0_dp, &
-                               matrix_c=fm_mat_S_gw_work_beta)
-               END IF
-
-               CALL timestop(handle3)
-
-               ! vector W_(nm) = S_work_(nm)Q * [B_(nm)Q]^T
-
-               CALL cp_fm_get_info(matrix=fm_mat_S_gw, &
-                                   nrow_local=nrow_local, &
-                                   ncol_local=ncol_local, &
-                                   row_indices=row_indices, &
-                                   col_indices=col_indices)
-
-               vec_W_gw = 0.0_dp
-               IF (my_open_shell) THEN
-                  vec_W_gw_beta = 0.0_dp
-               END IF
-
-               IF (jquad == 1) THEN
-
-                  DO iiB = 1, nrow_local
-
-                     nm_global = row_indices(iiB)
-                     n_global = MAX(1, nm_global-1)/nmo+1
-                     m_global = nm_global-(n_global-1)*nmo
-                     n_global = n_global+homo-gw_corr_lev_occ
-
-                  END DO
-
-               END IF
-
-               DO iiB = 1, nrow_local
-                  nm_global = row_indices(iiB)
-                  DO jjB = 1, ncol_local
-                     vec_W_gw(nm_global) = vec_W_gw(nm_global)+ &
-                                           fm_mat_S_gw_work%local_data(iiB, jjB)*fm_mat_S_gw%local_data(iiB, jjB)
-                     IF (my_open_shell) THEN
-                        vec_W_gw_beta(nm_global) = vec_W_gw_beta(nm_global)+ &
-                                                   fm_mat_S_gw_work_beta%local_data(iiB, jjB)*fm_mat_S_gw_beta%local_data(iiB, jjB)
-                     END IF
-                  END DO
-
-                  ! transform the index nm of vec_W_gw back to n and m, formulae copied from Mauro's code
-                  n_global = MAX(1, nm_global-1)/nmo+1
-                  m_global = nm_global-(n_global-1)*nmo
-                  n_global = n_global+homo-gw_corr_lev_occ
-
-                  IF (my_open_shell) THEN
-                     n_global_beta = MAX(1, nm_global-1)/nmo+1
-                     m_global_beta = nm_global-(n_global_beta-1)*nmo
-                     n_global_beta = n_global_beta+homo_beta-gw_corr_lev_occ_beta
-                  END IF
-
-                  ! compute self-energy for imaginary frequencies
-                  IF (jquad <= num_integ_points) THEN
-
-                     DO iquad = 1, num_fit_points
-
-                        ! for occ orbitals, we compute the self-energy for negative frequencies
-                        IF (n_global <= homo) THEN
-                           sign_occ_virt = -1.0_dp
-                        ELSE
-                           sign_occ_virt = 1.0_dp
-                        END IF
-
-                        omega_i = vec_omega_fit_gw(iquad)*sign_occ_virt
-
-                        ! set the Fermi energy for occ orbitals slightly above the HOMO and
-                        ! for virt orbitals slightly below the LUMO
-                        IF (n_global <= homo) THEN
-                           e_fermi = Eigenval(homo)+fermi_level_offset
-                        ELSE
-                           e_fermi = Eigenval(homo+1)-fermi_level_offset
-                        END IF
-
-                        ! add here the periodic correction
-                        IF (do_periodic .AND. col_indices(1) == 1 .AND. n_global == m_global) THEN
-                           delta_corr_nn = delta_corr(n_global)
-                        ELSE
-                           delta_corr_nn = 0.0_dp
-                        END IF
-
-                        ! update the self-energy (use that vec_W_gw(iw) is symmetric), divide the integration
-                        ! weight by 2, because the integration is from -infty to +infty and not just 0 to +infty
-                        ! as for RPA, also we need for virtual orbitals a complex conjugate
-                        vec_Sigma_c_gw(n_global-homo+gw_corr_lev_occ, iquad) = &
-                           vec_Sigma_c_gw(n_global-homo+gw_corr_lev_occ, iquad)- &
-                           0.5_dp/pi*wj(jquad)/2.0_dp*(vec_W_gw(nm_global)+delta_corr_nn)* &
-                           (1.0_dp/(im_unit*(omega+omega_i)+e_fermi-Eigenval(m_global))+ &
-                            1.0_dp/(im_unit*(-omega+omega_i)+e_fermi-Eigenval(m_global)))
-
-                        ! the same for beta
-                        IF (my_open_shell) THEN
-                           ! for occ orbitals, we compute the self-energy for negative frequencies
-                           IF (n_global_beta <= homo_beta) THEN
-                              sign_occ_virt = -1.0_dp
-                           ELSE
-                              sign_occ_virt = 1.0_dp
-                           END IF
-
-                           omega_i = vec_omega_fit_gw(iquad)*sign_occ_virt
-
-                           ! set the Fermi energy for occ orbitals slightly above the HOMO and
-                           ! for virt orbitals slightly below the LUMO
-                           IF (n_global_beta <= homo_beta) THEN
-                              e_fermi = Eigenval_beta(homo_beta)+fermi_level_offset
-                           ELSE
-                              e_fermi = Eigenval_beta(homo_beta+1)-fermi_level_offset
-                           END IF
-
-                           ! add here the periodic correction
-                           IF (do_periodic .AND. col_indices(1) == 1 .AND. n_global_beta == m_global) THEN
-                              delta_corr_nn_beta = delta_corr(n_global_beta)
-                           ELSE
-                              delta_corr_nn_beta = 0.0_dp
-                           END IF
-
-                           ! update the self-energy (use that vec_W_gw(iw) is symmetric), divide the integration
-                           ! weight by 2, because the integration is from -infty to +infty and not just 0 to +infty
-                           ! as for RPA, also we need for virtual orbitals a complex conjugate
-                           vec_Sigma_c_gw_beta(n_global_beta-homo_beta+gw_corr_lev_occ_beta, iquad) = &
-                              vec_Sigma_c_gw_beta(n_global_beta-homo_beta+gw_corr_lev_occ_beta, iquad)- &
-                              !                              0.5_dp/pi*wj(jquad)/2.0_dp*vec_W_gw_beta(nm_global)/ &
-                              !                              (im_unit*(omega+omega_i)+e_fermi-Eigenval_beta(m_global))- &
-                              !                              0.5_dp/pi*wj(jquad)/2.0_dp*vec_W_gw_beta(nm_global)/ &
-                              !                              (im_unit*(-omega+omega_i)+e_fermi-Eigenval_beta(m_global))
-                              0.5_dp/pi*wj(jquad)/2.0_dp*(vec_W_gw_beta(nm_global)+delta_corr_nn_beta)* &
-                              (1.0_dp/(im_unit*(omega+omega_i)+e_fermi-Eigenval_beta(m_global))+ &
-                               1.0_dp/(im_unit*(-omega+omega_i)+e_fermi-Eigenval_beta(m_global)))
-
-                        END IF
-                     END DO ! iquad
-                  END IF ! check imaginary frequency
-
-               END DO ! iiB
-
-               CALL timestop(handle2)
-
-            END IF ! GW
-
-            ! cubic scaling GW calculation
-            IF (do_gw_im_time) THEN
-
-               CALL timeset(routineN//"_cholesky_inv", handle3)
-
-               ! calculate [1+Q(iw')]^-1
-               CALL cp_fm_cholesky_invert(fm_mat_Q)
-
-               ! symmetrize the result
-               CALL cp_fm_upper_to_full(fm_mat_Q, fm_mat_work)
-
-               CALL timestop(handle3)
-
-               ! subtract 1 from the diagonal to get rid of exchange self-energy
-!$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(jjB,iiB,i_global,j_global) &
-!$OMP                       SHARED(ncol_local,nrow_local,col_indices,row_indices,fm_mat_Q,dimen_RI)
-               DO jjB = 1, ncol_local
-                  j_global = col_indices(jjB)
-                  DO iiB = 1, nrow_local
-                     i_global = row_indices(iiB)
-                     IF (j_global == i_global .AND. i_global <= dimen_RI) THEN
-                        fm_mat_Q%local_data(iiB, jjB) = fm_mat_Q%local_data(iiB, jjB)-1.0_dp
-                     END IF
-                  END DO
-               END DO
-
-               CALL timeset(routineN//"_multiply_L^TQL", handle3)
-
-               ! multiply with L from the left and the right to get the screened Coulomb interaction
-               CALL cp_gemm('T', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_mat_L(1, 1)%matrix, fm_mat_Q, &
-                            0.0_dp, fm_mat_work)
-               CALL cp_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_mat_work, fm_mat_L(1, 1)%matrix, &
-                            0.0_dp, fm_mat_Q)
-
-               CALL timestop(handle3)
-
-               CALL timeset(routineN//"_cos_tf_W", handle3)
-
-               ! Fourier transform from w to t
-               DO iquad = 1, num_integ_points
-
-                  omega = tj(jquad)
-                  tau = tau_tj(iquad)
-                  weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
-
-                  IF (jquad == 1) THEN
-
-                     CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad)%matrix, alpha=0.0_dp)
-
-                  END IF
-
-                  CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad)%matrix, beta=weight, matrix_b=fm_mat_Q)
-
-               END DO
-
-               CALL timestop(handle3)
-
+            IF (my_do_gw .OR. do_gw_im_time) THEN
+               CALL GW_matrix_operations(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, &
+                                         dimen_nm_gw, dimen_RI, gw_corr_lev_occ, &
+                                         gw_corr_lev_occ_beta, gw_corr_lev_virt, homo, homo_beta, jquad, &
+                                         nmo, num_fit_points, num_integ_points, ncol_local, nrow_local, &
+                                         col_indices, row_indices, do_bse, &
+                                         do_gw_im_time, do_periodic, my_do_gw, my_open_shell, &
+                                         first_cycle_periodic_correction, fermi_level_offset, &
+                                         omega, Eigenval, Eigenval_beta, delta_corr, tau_tj, tj, vec_omega_fit_gw, &
+                                         vec_W_gw, vec_W_gw_beta, wj, weights_cos_tf_w_to_t, fm_mat_W_tau, fm_mat_L, &
+                                         fm_mat_Q, fm_mat_Q_static_bse, fm_mat_R_gw, fm_mat_S_gw, fm_mat_S_gw_beta, &
+                                         fm_mat_S_gw_work, fm_mat_S_gw_work_beta, fm_mat_work, mo_coeff, para_env, &
+                                         para_env_RPA, matrix_berry_im_mo_mo, matrix_berry_re_mo_mo, &
+                                         kpoints, qs_env, mp2_env, do_kpoints_cubic_RPA, do_kpoints_from_Gamma)
             END IF
 
          END DO ! jquad
@@ -3954,6 +3462,8 @@ CONTAINS
          IF (.NOT. do_ri_sos_laplace_mp2) THEN
             Erpa = Erpa/(pi*2.0_dp)
             IF (do_minimax_quad) Erpa = Erpa/2.0_dp
+!         ELSE
+!            IF (my_open_shell) Erpa = Erpa/4.0_dp
          END IF
 
          IF (mp2_env%ri_rpa%do_ri_axk) THEN
@@ -3972,187 +3482,59 @@ CONTAINS
                "PERFORMANCE| PDGEMM flop rate (Gflops / MPI rank):", my_flop_rate
          END IF
 
-         ! postprocessing for cubic scaling GW calculation
-         IF (do_gw_im_time) THEN
+         ! postprocessing for cubic scaling GW calculation with kpoints
+         IF (do_gw_im_time .AND. do_kpoints_cubic_RPA) THEN
 
-            CALL compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ, mat_greens_fct_virt, &
-                                                matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                                fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                                fm_scaled_dm_virt_tau, Eigenval, eps_filter, e_fermi, fm_mat_W_tau, &
-                                                gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, count_ev_sc_GW, &
-                                                mat_3c_overl_int_gw, mat_contr_gf_occ, mat_contr_gf_virt, &
-                                                mat_contr_W, mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
-                                                weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, do_periodic, &
-                                                num_points_corr, ext_scaling, delta_corr, qs_env, para_env, para_env_RPA, &
-                                                mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                                first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
-                                                do_GW_corr, do_ri_Sigma_x, vec_Sigma_x_gw)
-
-            IF (my_open_shell) THEN
-
-               CALL compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, &
-                                                   mat_greens_fct_occ_beta, mat_greens_fct_virt_beta, &
-                                                   matrix_s, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, fm_mo_coeff_occ_scaled, &
-                                                   fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                                   fm_scaled_dm_virt_tau, Eigenval_beta, eps_filter, e_fermi_beta, fm_mat_W_tau, &
-                                                   gw_corr_lev_tot, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, &
-                                                   count_ev_sc_GW, mat_3c_overl_int_gw_beta, mat_contr_gf_occ, mat_contr_gf_virt, &
-                                                   mat_contr_W, mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
-                                                   weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw_beta, do_periodic, &
-                                                   num_points_corr, ext_scaling, delta_corr, qs_env, para_env, para_env_RPA, &
-                                                   mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                                   first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
-                                                   do_GW_corr, do_ri_Sigma_x, vec_Sigma_x_gw_beta, do_beta=.TRUE.)
-
-            END IF
+            CALL compute_self_energy_im_time_gw_kp(vec_Sigma_c_gw, vec_Sigma_x_gw, &
+                                                   mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, :), &
+                                                   mat_3c_overl_int, cell_to_index_3c, index_to_cell_3c, &
+                                                   num_cells_dm, kpoints, unit_nr, gw_corr_lev_tot, num_3c_repl, &
+                                                   nkp_self_energy, num_fit_points, &
+                                                   RI_blk_sizes, prim_blk_sizes, matrix_s, &
+                                                   para_env, para_env_sub, gw_corr_lev_occ, gw_corr_lev_virt, &
+                                                   dimen_RI, homo, nmo, cut_RI, &
+                                                   mat_dm_virt_local, row_from_LLL, my_group_L_starts_im_time, &
+                                                   my_group_L_sizes_im_time, cfm_mat_Q, cfm_mat_W_kp_tau, &
+                                                   qs_env, e_fermi, eps_filter, &
+                                                   tj, tau_tj, weights_sin_tf_t_to_w, weights_cos_tf_t_to_w, &
+                                                   num_integ_points, stabilize_exp, fm_mat_L, wkp_W)
 
          END IF
 
          ! G0W0 postprocessing: Fitting + correction of MO energies
          IF (my_do_gw .OR. do_gw_im_time) THEN
 
-            CALL timeset(routineN//"_G0W0_fit", handle3)
+            CALL GW_postprocessing(vec_Sigma_c_gw, vec_Sigma_c_gw_beta, count_ev_sc_GW, &
+                                   gw_corr_lev_occ, gw_corr_lev_occ_beta, &
+                                   gw_corr_lev_tot, gw_corr_lev_virt, gw_corr_lev_virt_beta, &
+                                   homo, homo_beta, &
+                                   nmo, num_fit_points, num_integ_points, &
+                                   num_points_corr, unit_nr, &
+                                   do_apply_ic_corr_to_gw, do_gw_im_time, &
+                                   do_periodic, do_ri_Sigma_x, &
+                                   first_cycle_periodic_correction, my_do_gw, my_open_shell, &
+                                   do_GW_corr, e_fermi, &
+                                   e_fermi_beta, eps_filter, &
+                                   fermi_level_offset, stabilize_exp, delta_corr, Eigenval, &
+                                   Eigenval_beta, Eigenval_last, Eigenval_last_beta, Eigenval_scf, &
+                                   Eigenval_scf_beta, m_value, m_value_beta, &
+                                   tau_tj, tj, vec_gw_energ, vec_gw_energ_beta, vec_gw_energ_error_fit, &
+                                   vec_gw_energ_error_fit_beta, vec_omega_fit_gw, &
+                                   vec_Sigma_x_gw, vec_Sigma_x_gw_beta, &
+                                   z_value, z_value_beta, ic_corr_list, ic_corr_list_beta, &
+                                   weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
+                                   fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
+                                   fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
+                                   fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, mo_coeff, fm_mat_W_tau, &
+                                   para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
+                                   mat_3c_overl_int_gw, mat_3c_overl_int_gw_beta, matrix_berry_im_mo_mo, &
+                                   matrix_berry_re_mo_mo, mat_greens_fct_occ, mat_greens_fct_occ_beta, &
+                                   mat_greens_fct_virt, mat_greens_fct_virt_beta, mat_W, matrix_s, &
+                                   mat_contr_gf_occ, mat_contr_gf_virt, mat_contr_W, kpoints, mp2_env, qs_env, &
+                                   nkp_self_energy, do_kpoints_cubic_RPA, Eigenval_kp, Eigenval_scf_kp, &
+                                   iter_ev_sc)
 
-            IF (my_do_gw) THEN
-
-               CALL mp_sum(vec_Sigma_c_gw, para_env%group)
-
-            END IF
-
-            IF (do_periodic .AND. mp2_env%ri_g0w0%do_average_deg_levels) THEN
-
-               CALL average_degenerate_levels(vec_Sigma_c_gw, Eigenval(1+homo-gw_corr_lev_occ:homo+gw_corr_lev_virt), &
-                                              mp2_env%ri_g0w0%eps_eigenval)
-               IF (my_open_shell) THEN
-                  CALL average_degenerate_levels(vec_Sigma_c_gw_beta, &
-                                                 Eigenval_beta(1+homo_beta-gw_corr_lev_occ_beta: &
-                                                               homo_beta+gw_corr_lev_virt_beta), &
-                                                 mp2_env%ri_g0w0%eps_eigenval)
-               END IF
-            END IF
-
-            IF (my_open_shell .AND. my_do_gw) THEN
-               CALL mp_sum(vec_Sigma_c_gw_beta, para_env%group)
-            END IF
-
-            CALL mp_sync(para_env%group)
-
-            ! fit the self-energy on imaginary frequency axis and evaluate the fit on the MO energy of the SCF
-            DO n_level_gw = 1, gw_corr_lev_tot
-               ! processes perform different fits
-               IF (MODULO(n_level_gw, para_env%num_pe) /= para_env%mepos) CYCLE
-
-               SELECT CASE (mp2_env%ri_g0w0%analytic_continuation)
-               CASE (gw_two_pole_model)
-                  CALL fit_and_continuation_2pole(vec_gw_energ, vec_gw_energ_error_fit, vec_omega_fit_gw, &
-                                                  z_value, m_value, vec_Sigma_c_gw, &
-                                                  mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), &
-                                                  Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, num_poles, &
-                                                  num_fit_points, max_iter_fit, crossing_search, homo, check_fit, &
-                                                  fermi_level_offset, do_gw_im_time)
-               CASE (gw_pade_approx)
-                  CALL continuation_pade(vec_gw_energ, vec_omega_fit_gw, &
-                                         z_value, m_value, vec_Sigma_c_gw, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), &
-                                         Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, mp2_env%ri_g0w0%nparam_pade, &
-                                         num_fit_points, crossing_search, homo, check_fit, &
-                                         fermi_level_offset, do_gw_im_time)
-
-               CASE DEFAULT
-                  CPABORT("Only two-model and Pade approximation are implemented.")
-               END SELECT
-
-               IF (my_open_shell) THEN
-                  SELECT CASE (mp2_env%ri_g0w0%analytic_continuation)
-                  CASE (gw_two_pole_model)
-                     CALL fit_and_continuation_2pole( &
-                        vec_gw_energ_beta, vec_gw_energ_error_fit_beta, vec_omega_fit_gw, &
-                        z_value_beta, m_value_beta, vec_Sigma_c_gw_beta, &
-                        mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2), &
-                        Eigenval_beta, Eigenval_scf_beta, n_level_gw, &
-                        gw_corr_lev_occ_beta, num_poles, &
-                        num_fit_points, max_iter_fit, crossing_search, homo_beta, check_fit, &
-                        fermi_level_offset, do_gw_im_time)
-                  CASE (gw_pade_approx)
-                     CALL continuation_pade(vec_gw_energ_beta, vec_omega_fit_gw, &
-                                            z_value_beta, m_value_beta, vec_Sigma_c_gw_beta, &
-                                            mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2), &
-                                            Eigenval_beta, Eigenval_scf_beta, n_level_gw, &
-                                            gw_corr_lev_occ_beta, mp2_env%ri_g0w0%nparam_pade, &
-                                            num_fit_points, crossing_search, homo_beta, check_fit, &
-                                            fermi_level_offset, do_gw_im_time)
-                  CASE DEFAULT
-                     CPABORT("Only two-model and Pade approximation are implemented.")
-                  END SELECT
-
-               END IF
-
-            END DO ! n_level_gw
-
-            CALL mp_sum(vec_gw_energ_error_fit, para_env%group)
-            CALL mp_sum(vec_gw_energ, para_env%group)
-            CALL mp_sum(z_value, para_env%group)
-            CALL mp_sum(m_value, para_env%group)
-
-            IF (my_open_shell) THEN
-               CALL mp_sum(vec_gw_energ_error_fit_beta, para_env%group)
-               CALL mp_sum(vec_gw_energ_beta, para_env%group)
-               CALL mp_sum(z_value_beta, para_env%group)
-               CALL mp_sum(m_value_beta, para_env%group)
-            END IF
-
-            remove_neg_virt_energies = mp2_env%ri_g0w0%remove_neg_virt_energies
-
-            ! print the quasiparticle energies and update Eigenval in case you do eigenvalue self-consistent GW
-            IF (my_open_shell) THEN
-
-               CALL print_and_update_for_ev_sc( &
-                  vec_gw_energ, vec_gw_energ_error_fit, &
-                  z_value, m_value, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), Eigenval, &
-                  Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                  count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
-                  remove_neg_virt_energies, do_alpha=.TRUE.)
-
-               CALL print_and_update_for_ev_sc( &
-                  vec_gw_energ_beta, vec_gw_energ_error_fit_beta, &
-                  z_value_beta, m_value_beta, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 2), Eigenval_beta, &
-                  Eigenval_last_beta, Eigenval_scf_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, gw_corr_lev_tot, &
-                  count_ev_sc_GW, crossing_search, homo_beta, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
-                  remove_neg_virt_energies, do_beta=.TRUE.)
-
-               IF (do_apply_ic_corr_to_gw .AND. count_ev_sc_GW == 1) THEN
-
-                  CALL apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
-                                     gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                                     homo, nmo, unit_nr, do_alpha=.TRUE.)
-
-                  CALL apply_ic_corr(Eigenval_beta, Eigenval_scf_beta, ic_corr_list_beta, &
-                                     gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, gw_corr_lev_tot, &
-                                     homo_beta, nmo, unit_nr, do_beta=.TRUE.)
-
-               END IF
-
-            ELSE
-
-               CALL print_and_update_for_ev_sc( &
-                  vec_gw_energ, vec_gw_energ_error_fit, &
-                  z_value, m_value, mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1), Eigenval, &
-                  Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                  count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, mp2_env%ri_g0w0%print_gw_details, &
-                  remove_neg_virt_energies)
-
-               IF (do_apply_ic_corr_to_gw .AND. count_ev_sc_GW == 1) THEN
-
-                  CALL apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
-                                     gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                                     homo, nmo, unit_nr)
-
-               END IF
-
-            END IF
-
-            CALL timestop(handle3)
-
-            ! if HOMO-LUMO gap differs by less then mp2_env%ri_g0w0%eps_ev_sc_iter, exit ev sc GW loop
+            ! if HOMO-LUMO gap differs by less than mp2_env%ri_g0w0%eps_ev_sc_iter, exit ev sc GW loop
             IF (ABS(Eigenval(homo)-Eigenval_last(homo)-Eigenval(homo+1)+Eigenval_last(homo+1)) &
                 < mp2_env%ri_g0w0%eps_ev_sc_iter) THEN
                EXIT
@@ -4168,19 +3550,19 @@ CONTAINS
 
             CALL calculate_ic_correction(Eigenval, mat_SinvVSinv, mat_3c_overl_nnP_ic, &
                                          mat_3c_overl_nnP_ic_reflected, mat_contr_gf_occ, matrix_s, gw_corr_lev_tot, &
-                                         gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, dimen_RI, unit_nr, &
+                                         gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, dimen_RI, unit_nr, print_ic_values, &
                                          do_ic_opt_homo_lumo, fm_mat_Q, para_env, mp2_env, do_alpha=.TRUE.)
 
             CALL calculate_ic_correction(Eigenval_beta, mat_SinvVSinv, mat_3c_overl_nnP_ic_beta, &
                                          mat_3c_overl_nnP_ic_reflected_beta, mat_contr_gf_occ, matrix_s, gw_corr_lev_tot, &
                                          gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, nmo, dimen_RI, unit_nr, &
-                                         do_ic_opt_homo_lumo, fm_mat_Q, para_env, mp2_env, do_beta=.TRUE.)
+                                         print_ic_values, do_ic_opt_homo_lumo, fm_mat_Q, para_env, mp2_env, do_beta=.TRUE.)
 
          ELSE
 
             CALL calculate_ic_correction(Eigenval, mat_SinvVSinv, mat_3c_overl_nnP_ic, &
                                          mat_3c_overl_nnP_ic_reflected, mat_contr_gf_occ, matrix_s, gw_corr_lev_tot, &
-                                         gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, dimen_RI, unit_nr, &
+                                         gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, dimen_RI, unit_nr, print_ic_values, &
                                          do_ic_opt_homo_lumo, fm_mat_Q, para_env, mp2_env)
 
          END IF
@@ -4240,12 +3622,6 @@ CONTAINS
             DEALLOCATE (Eigenval_last_beta)
             DEALLOCATE (Eigenval_scf_beta)
          END IF
-         IF (do_bse) THEN
-            CALL cp_fm_release(fm_mat_Q_static_bse)
-            CALL cp_fm_release(fm_mat_Q_static_bse_gemm)
-            DEALLOCATE (B_iaQ_bse_local, B_bar_iaQ_bse_local, &
-                        B_bar_ijQ_bse_local, B_abQ_bse_local)
-         END IF
       END IF
 
       IF (do_gw_im_time .OR. my_do_gw) THEN
@@ -4265,6 +3641,7 @@ CONTAINS
       END IF
 
       IF (do_im_time) THEN
+
          CALL cp_fm_release(fm_scaled_dm_occ_tau)
          CALL cp_fm_release(fm_scaled_dm_virt_tau)
          CALL cp_fm_release(fm_mo_coeff_occ)
@@ -4279,7 +3656,13 @@ CONTAINS
 
          DO i_size = 1, SIZE(fm_mat_L, 1)
             DO j_size = 1, SIZE(fm_mat_L, 2)
-               CALL cp_fm_release(fm_mat_L(i_size, j_size)%matrix)
+               IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
+                  IF (ANY(ikp_local(:) == i_size)) THEN
+                     CALL cp_fm_release(fm_mat_L(i_size, j_size)%matrix)
+                  END IF
+               ELSE
+                  CALL cp_fm_release(fm_mat_L(i_size, j_size)%matrix)
+               END IF
             END DO
          END DO
          DEALLOCATE (fm_mat_L)
@@ -4354,7 +3737,7 @@ CONTAINS
          ENDIF
          DEALLOCATE (has_mat_P_blocks)
 
-         IF (do_gw_im_time) THEN
+         IF (do_gw_im_time .AND. (.NOT. do_kpoints_cubic_RPA)) THEN
             CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int_gw)
 
             IF (.NOT. do_ic_model) THEN
@@ -4367,6 +3750,7 @@ CONTAINS
             DO jquad = 1, num_integ_points
                CALL cp_fm_release(fm_mat_W_tau(jquad)%matrix)
             END DO
+
             DEALLOCATE (fm_mat_W_tau)
             DEALLOCATE (vec_Sigma_c_gw)
             DEALLOCATE (vec_gw_energ)
@@ -4403,9 +3787,45 @@ CONTAINS
 
          END IF
 
-         IF (do_kpoints_cubic_RPA) THEN
-            CALL dbcsr_deallocate_matrix_set(mat_P_omega_im_part)
+         IF (do_kpoints_cubic_RPA .AND. do_gw_im_time) THEN
+            CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int)
+
+            DEALLOCATE (weights_cos_tf_w_to_t)
+            DEALLOCATE (weights_sin_tf_t_to_w)
+            DEALLOCATE (vec_Sigma_c_gw)
+            DEALLOCATE (vec_gw_energ)
+            DEALLOCATE (vec_gw_energ_error_fit)
+            DEALLOCATE (z_value)
+            DEALLOCATE (m_value)
+            DEALLOCATE (vec_omega_fit_gw)
+
+            IF (my_open_shell) THEN
+               DEALLOCATE (vec_Sigma_c_gw_beta)
+               DEALLOCATE (z_value_beta)
+               DEALLOCATE (m_value_beta)
+               DEALLOCATE (vec_gw_energ_beta)
+               DEALLOCATE (vec_gw_energ_error_fit_beta)
+            END IF
+
+            DO jquad = 1, num_integ_points
+               DO ikp = 1, nkp
+                  IF (.NOT. (ANY(ikp_local(:) == ikp))) CYCLE
+                  CALL cp_cfm_release(cfm_mat_W_kp_tau(ikp, jquad)%matrix)
+               END DO
+            END DO
+            DEALLOCATE (cfm_mat_W_kp_tau)
+
+            CALL dbcsr_deallocate_matrix_set(mat_3c_overl_int)
+
+         END IF
+
+         IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
             CALL cp_cfm_release(cfm_mat_Q)
+            CALL cp_fm_release(fm_mat_RI_global_work)
+            CALL dbcsr_deallocate_matrix_set(mat_P_omega_kp)
+            CALL cp_para_env_release(para_env_sub_kp)
+            CALL cp_fm_struct_release(fm_struct_sub_kp)
+            DEALLOCATE (wkp_W)
          END IF
 
       END IF
@@ -4592,25 +4012,35 @@ CONTAINS
                            map_send_size, map_rec_size, local_size_source, para_env_RPA)
 
       CALL timestop(handle)
+
    END SUBROUTINE matrix_operations_canonical
 
 ! **************************************************************************************************
 !> \brief ...
 !> \param cfm_mat_Q ...
-!> \param mat_P_omega_re ...
-!> \param mat_P_omega_im ...
+!> \param mat_P_omega_kp ...
 !> \param fm_mat_L_re ...
 !> \param fm_mat_L_im ...
+!> \param fm_mat_RI_global_work ...
 !> \param dimen_RI ...
+!> \param ikp ...
+!> \param nkp ...
+!> \param ikp_local ...
+!> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Q(cfm_mat_Q, mat_P_omega_re, mat_P_omega_im, fm_mat_L_re, fm_mat_L_im, dimen_RI)
+   SUBROUTINE compute_Q_kp_RPA(cfm_mat_Q, mat_P_omega_kp, fm_mat_L_re, fm_mat_L_im, &
+                               fm_mat_RI_global_work, dimen_RI, ikp, nkp, ikp_local, para_env)
 
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
-      TYPE(dbcsr_type), POINTER                          :: mat_P_omega_re, mat_P_omega_im
-      TYPE(cp_fm_type), POINTER                          :: fm_mat_L_re, fm_mat_L_im
-      INTEGER, INTENT(IN)                                :: dimen_RI
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
+      TYPE(cp_fm_type), POINTER                          :: fm_mat_L_re, fm_mat_L_im, &
+                                                            fm_mat_RI_global_work
+      INTEGER                                            :: dimen_RI, ikp, nkp
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+      TYPE(cp_para_env_type), POINTER                    :: para_env
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Q', routineP = moduleN//':'//routineN
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Q_kp_RPA', &
+         routineP = moduleN//':'//routineN
 
       INTEGER                                            :: handle
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_L, cfm_mat_work
@@ -4630,14 +4060,8 @@ CONTAINS
       CALL cp_fm_create(fm_mat_work, fm_mat_L_re%matrix_struct)
       CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
 
-      ! 1. Copy dbcsr matrices mat_P_omega_re and mat_P_omega_im to cfm_mat_Q
-      CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
-      CALL copy_dbcsr_to_fm(mat_P_omega_re, fm_mat_work)
-      CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_Q, z_one, fm_mat_work)
-
-      CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
-      CALL copy_dbcsr_to_fm(mat_P_omega_im, fm_mat_work)
-      CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_Q, gaussi, fm_mat_work)
+      CALL mat_P_to_subgroup(mat_P_omega_kp, fm_mat_RI_global_work, &
+                             fm_mat_work, cfm_mat_Q, ikp, nkp, ikp_local, para_env)
 
       ! 2. Copy fm_mat_L_re and fm_mat_L_re to cfm_mat_L
       CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_L, z_one, fm_mat_L_re)
@@ -4647,7 +4071,7 @@ CONTAINS
       CALL cp_cfm_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
                        z_zero, cfm_mat_work)
 
-      ! 4. Q(iw,k) = L^T(k)*work
+      ! 4. Q(iw,k) = L^H(k)*work
       CALL cp_cfm_gemm('C', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
                        z_zero, cfm_mat_Q)
 
@@ -4657,7 +4081,89 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE compute_Q
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_P_omega_kp ...
+!> \param fm_mat_RI_global_work ...
+!> \param fm_mat_work ...
+!> \param cfm_mat_Q ...
+!> \param ikp ...
+!> \param nkp ...
+!> \param ikp_local ...
+!> \param para_env ...
+! **************************************************************************************************
+   SUBROUTINE mat_P_to_subgroup(mat_P_omega_kp, fm_mat_RI_global_work, &
+                                fm_mat_work, cfm_mat_Q, ikp, nkp, ikp_local, para_env)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
+      TYPE(cp_fm_type), POINTER                          :: fm_mat_RI_global_work, fm_mat_work
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
+      INTEGER                                            :: ikp, nkp
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'mat_P_to_subgroup', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, jkp
+      TYPE(cp_fm_type), POINTER                          :: fm_dummy
+      TYPE(dbcsr_type), POINTER                          :: mat_P_omega_im, mat_P_omega_re
+
+      CALL timeset(routineN, handle)
+
+      IF (SUM(ikp_local) > nkp) THEN
+
+         mat_P_omega_re => mat_P_omega_kp(1, ikp)%matrix
+         CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+         CALL copy_dbcsr_to_fm(mat_P_omega_re, fm_mat_work)
+         CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_Q, z_one, fm_mat_work)
+
+         mat_P_omega_im => mat_P_omega_kp(2, ikp)%matrix
+         CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+         CALL copy_dbcsr_to_fm(mat_P_omega_im, fm_mat_work)
+         CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_Q, gaussi, fm_mat_work)
+
+      ELSE
+
+         DO jkp = 1, nkp
+
+            mat_P_omega_re => mat_P_omega_kp(1, jkp)%matrix
+
+            CALL cp_fm_set_all(fm_mat_RI_global_work, 0.0_dp)
+            CALL copy_dbcsr_to_fm(mat_P_omega_re, fm_mat_RI_global_work)
+
+            IF (ANY(ikp_local(:) == jkp)) THEN
+               CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+               CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_mat_work, para_env)
+               CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_Q, z_one, fm_mat_work)
+            ELSE
+               NULLIFY (fm_dummy)
+               CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_dummy, para_env)
+            END IF
+
+            mat_P_omega_im => mat_P_omega_kp(2, jkp)%matrix
+
+            CALL cp_fm_set_all(fm_mat_RI_global_work, 0.0_dp)
+            CALL copy_dbcsr_to_fm(mat_P_omega_im, fm_mat_RI_global_work)
+
+            IF (ANY(ikp_local(:) == jkp)) THEN
+               CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+               CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_mat_work, para_env)
+               CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_Q, gaussi, fm_mat_work)
+            ELSE
+               NULLIFY (fm_dummy)
+               CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_dummy, para_env)
+            END IF
+
+         END DO
+
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
 
 ! **************************************************************************************************
 !> \brief ...
@@ -4670,9 +4176,8 @@ CONTAINS
 
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
       TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: trace_Qomega
-      INTEGER, INTENT(IN)                                :: dimen_RI
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: trace_Qomega
+      INTEGER                                            :: dimen_RI
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cholesky_decomp_Q', &
          routineP = moduleN//':'//routineN
@@ -4726,13 +4231,12 @@ CONTAINS
    SUBROUTINE frequency_and_kpoint_integration(Erpa, cfm_mat_Q, para_env_RPA, trace_Qomega, &
                                                dimen_RI, freq_weight, kp_weight)
 
-      REAL(KIND=dp), INTENT(INOUT)                       :: Erpa
+      REAL(KIND=dp)                                      :: Erpa
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
       TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: trace_Qomega
-      INTEGER, INTENT(IN)                                :: dimen_RI
-      REAL(KIND=dp), INTENT(IN)                          :: freq_weight, kp_weight
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: trace_Qomega
+      INTEGER                                            :: dimen_RI
+      REAL(KIND=dp)                                      :: freq_weight, kp_weight
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'frequency_and_kpoint_integration', &
          routineP = moduleN//':'//routineN
@@ -4785,156 +4289,6 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param Eigenval ...
-!> \param Eigenval_scf ...
-!> \param ic_corr_list ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param gw_corr_lev_tot ...
-!> \param homo ...
-!> \param nmo ...
-!> \param unit_nr ...
-!> \param do_alpha ...
-!> \param do_beta ...
-! **************************************************************************************************
-   SUBROUTINE apply_ic_corr(Eigenval, Eigenval_scf, ic_corr_list, &
-                            gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                            homo, nmo, unit_nr, do_alpha, do_beta)
-
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval, Eigenval_scf, ic_corr_list
-      INTEGER                                            :: gw_corr_lev_occ, gw_corr_lev_virt, &
-                                                            gw_corr_lev_tot, homo, nmo, unit_nr
-      LOGICAL, OPTIONAL                                  :: do_alpha, do_beta
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_ic_corr', routineP = moduleN//':'//routineN
-
-      CHARACTER(4)                                       :: occ_virt
-      INTEGER                                            :: handle, n_level_gw, n_level_gw_ref
-      LOGICAL                                            :: do_closed_shell, my_do_alpha, my_do_beta
-      REAL(KIND=dp)                                      :: eigen_diff
-
-      CALL timeset(routineN, handle)
-
-      IF (PRESENT(do_alpha)) THEN
-         my_do_alpha = do_alpha
-      ELSE
-         my_do_alpha = .FALSE.
-      END IF
-
-      IF (PRESENT(do_beta)) THEN
-         my_do_beta = do_beta
-      ELSE
-         my_do_beta = .FALSE.
-      END IF
-
-      do_closed_shell = .NOT. (my_do_alpha .OR. my_do_beta)
-
-      ! check the number of input image charge corrected levels
-      CPASSERT(SIZE(ic_corr_list) == gw_corr_lev_tot)
-
-      IF (unit_nr > 0) THEN
-
-         WRITE (unit_nr, *) ' '
-
-         IF (do_closed_shell) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies with image charge (ic) correction'
-            WRITE (unit_nr, '(T3,A)') '-----------------------------------------------------------'
-         ELSE IF (my_do_alpha) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of alpha spins with image charge (ic) correction'
-            WRITE (unit_nr, '(T3,A)') '--------------------------------------------------------------------------'
-         ELSE IF (my_do_beta) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of beta spins with image charge (ic) correction'
-            WRITE (unit_nr, '(T3,A)') '-------------------------------------------------------------------------'
-         END IF
-
-         WRITE (unit_nr, *) ' '
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            IF (n_level_gw <= gw_corr_lev_occ) THEN
-               occ_virt = 'occ'
-            ELSE
-               occ_virt = 'vir'
-            END IF
-
-            WRITE (unit_nr, '(T4,I4,3A,3F21.3)') &
-               n_level_gw_ref, ' ( ', occ_virt, ')  ', &
-               Eigenval(n_level_gw_ref)*evolt, &
-               ic_corr_list(n_level_gw)*evolt, &
-               (Eigenval(n_level_gw_ref)+ic_corr_list(n_level_gw))*evolt
-
-         END DO
-
-         WRITE (unit_nr, *) ' '
-
-      END IF
-
-      Eigenval(homo-gw_corr_lev_occ+1:homo+gw_corr_lev_virt) = Eigenval(homo-gw_corr_lev_occ+1: &
-                                                                        homo+gw_corr_lev_virt) &
-                                                               +ic_corr_list(1:gw_corr_lev_tot)
-
-      Eigenval_scf(homo-gw_corr_lev_occ+1:homo+gw_corr_lev_virt) = Eigenval_scf(homo-gw_corr_lev_occ+1: &
-                                                                                homo+gw_corr_lev_virt) &
-                                                                   +ic_corr_list(1:gw_corr_lev_tot)
-
-      IF (unit_nr > 0) THEN
-
-         IF (do_closed_shell) THEN
-            WRITE (unit_nr, '(T3,A,F52.2)') 'G0W0 IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
-         ELSE IF (my_do_alpha) THEN
-            WRITE (unit_nr, '(T3,A,F46.2)') 'G0W0 Alpha IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
-         ELSE IF (my_do_beta) THEN
-            WRITE (unit_nr, '(T3,A,F47.2)') 'G0W0 Beta IC HOMO-LUMO gap (eV)', Eigenval(homo+1)-Eigenval(homo)
-         END IF
-
-         WRITE (unit_nr, *) ' '
-
-      END IF
-
-      ! for eigenvalue self-consistent GW, all eigenvalues have to be corrected
-      ! 1) the occupied; check if there are occupied MOs not being corrected by the IC model
-      IF (gw_corr_lev_occ < homo .AND. gw_corr_lev_occ > 0) THEN
-
-         ! calculate average IC contribution for occupied orbitals
-         eigen_diff = 0.0_dp
-
-         DO n_level_gw = 1, gw_corr_lev_occ
-            eigen_diff = eigen_diff+ic_corr_list(n_level_gw)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_occ
-
-         ! correct the eigenvalues of the occupied orbitals which have not been corrected by the IC model
-         DO n_level_gw = 1, homo-gw_corr_lev_occ
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-            Eigenval_scf(n_level_gw) = Eigenval_scf(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      ! 2) the virtual: check if there are virtual orbitals not being corrected by the IC model
-      IF (gw_corr_lev_virt < nmo-homo .AND. gw_corr_lev_virt > 0) THEN
-
-         ! calculate average IC correction for virtual orbitals
-         eigen_diff = 0.0_dp
-         DO n_level_gw = gw_corr_lev_occ+1, gw_corr_lev_tot
-            eigen_diff = eigen_diff+ic_corr_list(n_level_gw)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_virt
-
-         ! correct the eigenvalues of the virtual orbitals which have not been corrected by the IC model
-         DO n_level_gw = homo+gw_corr_lev_virt+1, nmo
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-            Eigenval_scf(n_level_gw) = Eigenval_scf(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE apply_ic_corr
-
-! **************************************************************************************************
-!> \brief ...
-!> \param Eigenval ...
 !> \param mat_SinvVSinv ...
 !> \param mat_3c_overl_nnP_ic ...
 !> \param mat_3c_overl_nnP_ic_reflected ...
@@ -4947,6 +4301,7 @@ CONTAINS
 !> \param nmo ...
 !> \param dimen_RI ...
 !> \param unit_nr ...
+!> \param print_ic_values ...
 !> \param do_ic_opt_homo_lumo ...
 !> \param fm_mat_Q ...
 !> \param para_env ...
@@ -4957,23 +4312,23 @@ CONTAINS
    SUBROUTINE calculate_ic_correction(Eigenval, mat_SinvVSinv, mat_3c_overl_nnP_ic, &
                                       mat_3c_overl_nnP_ic_reflected, mat_work, matrix_s, gw_corr_lev_tot, &
                                       gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, dimen_RI, unit_nr, &
-                                      do_ic_opt_homo_lumo, fm_mat_Q, para_env, mp2_env, &
+                                      print_ic_values, do_ic_opt_homo_lumo, fm_mat_Q, para_env, mp2_env, &
                                       do_alpha, do_beta)
 
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_SinvVSinv
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_nnP_ic, &
                                                             mat_3c_overl_nnP_ic_reflected
       TYPE(dbcsr_type), POINTER                          :: mat_work
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_tot, gw_corr_lev_occ, &
+      INTEGER                                            :: gw_corr_lev_tot, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, homo, nmo, dimen_RI, &
                                                             unit_nr
-      LOGICAL, INTENT(IN)                                :: do_ic_opt_homo_lumo
+      LOGICAL                                            :: print_ic_values, do_ic_opt_homo_lumo
       TYPE(cp_fm_type), POINTER                          :: fm_mat_Q
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mp2_type), POINTER                            :: mp2_env
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_alpha, do_beta
+      LOGICAL, OPTIONAL                                  :: do_alpha, do_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_ic_correction', &
          routineP = moduleN//':'//routineN
@@ -5095,7 +4450,7 @@ CONTAINS
                                                                               Delta_Sigma_Neaton(gw_corr_lev_occ))*evolt
             END IF
 
-            IF (mp2_env%ri_g0w0%print_ic_values) THEN
+            IF (print_ic_values) THEN
 
                WRITE (unit_nr, '(T3,A)') ' '
                WRITE (unit_nr, '(T3,A)') 'Horizontal list for copying the image charge corrections for use as input:'
@@ -5379,9 +4734,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE print_Neaton_value(fm_mat_M_occ, unit_nr, gw_corr_lev_occ, para_env, do_homo, do_lumo)
       TYPE(cp_fm_type), POINTER                          :: fm_mat_M_occ
-      INTEGER, INTENT(IN)                                :: unit_nr, gw_corr_lev_occ
+      INTEGER                                            :: unit_nr, gw_corr_lev_occ
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_homo, do_lumo
+      LOGICAL, OPTIONAL                                  :: do_homo, do_lumo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'print_Neaton_value', &
          routineP = moduleN//':'//routineN
@@ -5440,21 +4795,20 @@ CONTAINS
 !> \param do_lumo ...
 ! **************************************************************************************************
    SUBROUTINE update_coeff_homo(coeff_homo, fm_mat_U_occ, para_env, homo, gw_corr_lev_occ, do_lumo)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: coeff_homo
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: coeff_homo
       TYPE(cp_fm_type), POINTER                          :: fm_mat_U_occ
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_occ
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_lumo
+      INTEGER                                            :: homo, gw_corr_lev_occ
+      LOGICAL, OPTIONAL                                  :: do_lumo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'update_coeff_homo', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i_global, iiB, j_global, jjB, &
-                                                            ncol_local, nrow_local
+      INTEGER                                            :: handle, i_global, i_occ_level, iiB, &
+                                                            j_global, jjB, ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: my_do_homo
-      REAL(KIND=dp)                                      :: norm_coeff_homo
+      REAL(KIND=dp)                                      :: norm_coeff_homo, scalar_prod
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: coeff_homo_update, &
                                                             coeff_homo_update_orthog
 
@@ -5477,7 +4831,9 @@ CONTAINS
 
       ! take the eigenvector belongning to the largest eigenvalue
       DO iiB = 1, nrow_local
+
          i_global = row_indices(iiB)
+
          DO jjB = 1, ncol_local
 
             j_global = col_indices(jjB)
@@ -5485,18 +4841,41 @@ CONTAINS
             IF (j_global .NE. 1) CYCLE
 
             IF (my_do_homo) THEN
+
                coeff_homo_update(i_global+homo-gw_corr_lev_occ) = fm_mat_U_occ%local_data(iiB, jjB)
+
             ELSE
+
                coeff_homo_update(i_global) = fm_mat_U_occ%local_data(iiB, jjB)
+
             END IF
+
          END DO
+
       END DO
 
       CALL mp_sum(coeff_homo_update, para_env%group)
 
-      norm_coeff_homo = NORM2(coeff_homo_update)
+      scalar_prod = 0.0_dp
+      DO i_occ_level = 1, homo
 
-      coeff_homo(:) = coeff_homo_update(:)/norm_coeff_homo
+         scalar_prod = scalar_prod+coeff_homo(i_occ_level)*coeff_homo_update(i_occ_level)
+
+      END DO
+
+      norm_coeff_homo = 0.0_dp
+      DO i_occ_level = 1, homo
+
+!         coeff_homo(i_occ_level) = 0.8_dp*coeff_homo(i_occ_level) + &
+!                                   0.2_dp*(coeff_homo_update(i_occ_level) - scalar_prod*coeff_homo(i_occ_level))
+
+         coeff_homo(i_occ_level) = coeff_homo_update(i_occ_level)
+
+         norm_coeff_homo = norm_coeff_homo+(coeff_homo(i_occ_level))**2
+
+      END DO
+
+      coeff_homo = coeff_homo/SQRT(norm_coeff_homo)
 
       CALL timestop(handle)
 
@@ -5515,8 +4894,8 @@ CONTAINS
    SUBROUTINE fill_fm_mat_M_virt(fm_mat_M_virt, mat_N_virt_dbcsr, matrix_s, Eigenval, gw_corr_lev_virt, homo, para_env)
       TYPE(cp_fm_type), POINTER                          :: fm_mat_M_virt
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_N_virt_dbcsr, matrix_s
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_virt, homo
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      INTEGER                                            :: gw_corr_lev_virt, homo
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_fm_mat_M_virt', &
@@ -5561,13 +4940,18 @@ CONTAINS
       ALLOCATE (blk_from_indx(nfullrows_total))
 
       DO row_index = 1, nfullrows_total
+
          DO row_block = 1, nblkrows_total
+
             IF (row_index >= row_blk_offset(row_block) .AND. &
                 row_index <= row_blk_offset(row_block)+row_blk_sizes(row_block)-1) THEN
 
                blk_from_indx(row_index) = row_block
+
             END IF
+
          END DO
+
       END DO
 
       ALLOCATE (num_entries_send(0:para_env%num_pe-1))
@@ -5576,24 +4960,32 @@ CONTAINS
       num_entries_rec = 0
 
       DO n_level_gw = 1, gw_corr_lev_virt
+
          CALL dbcsr_iterator_start(iter, mat_N_virt_dbcsr(n_level_gw)%matrix)
          DO WHILE (dbcsr_iterator_blocks_left(iter))
+
             CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
                                            row_offset=row_offset, row_size=row_size)
 
             DO i_row = 1, row_size
+
                m_level_gw = row_offset-1+i_row-homo
 
                IF (m_level_gw < 1) CYCLE
+
                IF (m_level_gw > gw_corr_lev_virt) CYCLE
 
                CALL dbcsr_get_stored_coordinates(matrix_tmp, blk_from_indx(m_level_gw), &
                                                  blk_from_indx(n_level_gw), imepos)
 
                num_entries_send(imepos) = num_entries_send(imepos)+1
+
             END DO
+
          END DO
+
          CALL dbcsr_iterator_stop(iter)
+
       END DO
 
       CALL mp_alltoall(num_entries_send, num_entries_rec, 1, para_env%group)
@@ -5630,9 +5022,11 @@ CONTAINS
                                            row_offset=row_offset, row_size=row_size)
 
             DO i_row = 1, row_size
+
                m_level_gw = row_offset-1+i_row-homo
 
                IF (m_level_gw < 1) CYCLE
+
                IF (m_level_gw > gw_corr_lev_virt) CYCLE
 
                CALL dbcsr_get_stored_coordinates(matrix_tmp, blk_from_indx(m_level_gw), &
@@ -5645,9 +5039,13 @@ CONTAINS
                buffer_send(imepos)%indx(offset, 2) = n_level_gw
 
                entry_counter(imepos) = entry_counter(imepos)+1
+
             END DO
+
          END DO
+
          CALL dbcsr_iterator_stop(iter)
+
       END DO
 
       ALLOCATE (req_array(1:para_env%num_pe, 4))
@@ -5658,12 +5056,15 @@ CONTAINS
 
       CALL dbcsr_iterator_start(iter, matrix_tmp)
       DO WHILE (dbcsr_iterator_blocks_left(iter))
+
          CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
                                         row_offset=row_offset, row_size=row_size, &
                                         col_offset=col_offset, col_size=col_size)
 
          DO imepos = 0, para_env%num_pe-1
+
             DO i_index = 1, num_entries_rec(imepos)
+
                IF (buffer_rec(imepos)%indx(i_index, 1) >= row_offset .AND. &
                    buffer_rec(imepos)%indx(i_index, 1) <= row_offset+row_size-1 .AND. &
                    buffer_rec(imepos)%indx(i_index, 2) >= col_offset .AND. &
@@ -5673,9 +5074,13 @@ CONTAINS
                   i_col = buffer_rec(imepos)%indx(i_index, 2)-col_offset+1
 
                   data_block(i_row, i_col) = buffer_rec(imepos)%msg(i_index)
+
                END IF
+
             END DO
+
          END DO
+
       END DO
 
       CALL dbcsr_iterator_stop(iter)
@@ -5732,8 +5137,8 @@ CONTAINS
    SUBROUTINE fill_fm_mat_M_occ(fm_mat_M_occ, mat_N_occ_dbcsr, matrix_s, Eigenval, gw_corr_lev_occ, homo, para_env)
       TYPE(cp_fm_type), POINTER                          :: fm_mat_M_occ
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_N_occ_dbcsr, matrix_s
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, homo
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      INTEGER                                            :: gw_corr_lev_occ, homo
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_fm_mat_M_occ', &
@@ -5772,13 +5177,18 @@ CONTAINS
       ALLOCATE (blk_from_indx(nfullrows_total))
 
       DO row_index = 1, nfullrows_total
+
          DO row_block = 1, nblkrows_total
+
             IF (row_index >= row_blk_offset(row_block) .AND. &
                 row_index <= row_blk_offset(row_block)+row_blk_sizes(row_block)-1) THEN
 
                blk_from_indx(row_index) = row_block
+
             END IF
+
          END DO
+
       END DO
 
       ALLOCATE (num_entries_send(0:para_env%num_pe-1))
@@ -5795,7 +5205,9 @@ CONTAINS
                                            row_offset=row_offset, row_size=row_size)
 
             IF (row_offset+row_size-1 <= homo) THEN
+
                DO i_row = 1, row_size
+
                   m_level_gw = row_offset-1+i_row-(homo-gw_corr_lev_occ)
 
                   IF (m_level_gw < 1) CYCLE
@@ -5804,8 +5216,11 @@ CONTAINS
                                                     blk_from_indx(n_level_gw), imepos)
 
                   num_entries_send(imepos) = num_entries_send(imepos)+1
+
                END DO
+
             ELSE IF (row_offset <= homo) THEN
+
                DO m_level_gw = row_offset-(homo-gw_corr_lev_occ), gw_corr_lev_occ
 
                   IF (m_level_gw < 1) CYCLE
@@ -5814,10 +5229,15 @@ CONTAINS
                                                     blk_from_indx(n_level_gw), imepos)
 
                   num_entries_send(imepos) = num_entries_send(imepos)+1
+
                END DO
+
             END IF
+
          END DO
+
          CALL dbcsr_iterator_stop(iter)
+
       END DO
 
       CALL mp_alltoall(num_entries_send, num_entries_rec, 1, para_env%group)
@@ -5854,7 +5274,9 @@ CONTAINS
                                            row_offset=row_offset, row_size=row_size)
 
             IF (row_offset+row_size-1 <= homo) THEN
+
                DO i_row = 1, row_size
+
                   m_level_gw = row_offset-1+i_row-(homo-gw_corr_lev_occ)
 
                   IF (m_level_gw < 1) CYCLE
@@ -5869,8 +5291,11 @@ CONTAINS
                   buffer_send(imepos)%indx(offset, 2) = n_level_gw
 
                   entry_counter(imepos) = entry_counter(imepos)+1
+
                END DO
+
             ELSE IF (row_offset <= homo) THEN
+
                DO m_level_gw = row_offset-(homo-gw_corr_lev_occ), gw_corr_lev_occ
 
                   IF (m_level_gw < 1) CYCLE
@@ -5887,10 +5312,15 @@ CONTAINS
                   buffer_send(imepos)%indx(offset, 2) = n_level_gw
 
                   entry_counter(imepos) = entry_counter(imepos)+1
+
                END DO
+
             END IF
+
          END DO
+
          CALL dbcsr_iterator_stop(iter)
+
       END DO
 
       ALLOCATE (req_array(1:para_env%num_pe, 4))
@@ -5901,12 +5331,15 @@ CONTAINS
 
       CALL dbcsr_iterator_start(iter, matrix_tmp)
       DO WHILE (dbcsr_iterator_blocks_left(iter))
+
          CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
                                         row_offset=row_offset, row_size=row_size, &
                                         col_offset=col_offset, col_size=col_size)
 
          DO imepos = 0, para_env%num_pe-1
+
             DO i_index = 1, num_entries_rec(imepos)
+
                IF (buffer_rec(imepos)%indx(i_index, 1) >= row_offset .AND. &
                    buffer_rec(imepos)%indx(i_index, 1) <= row_offset+row_size-1 .AND. &
                    buffer_rec(imepos)%indx(i_index, 2) >= col_offset .AND. &
@@ -5916,9 +5349,13 @@ CONTAINS
                   i_col = buffer_rec(imepos)%indx(i_index, 2)-col_offset+1
 
                   data_block(i_row, i_col) = buffer_rec(imepos)%msg(i_index)
+
                END IF
+
             END DO
+
          END DO
+
       END DO
 
       CALL dbcsr_iterator_stop(iter)
@@ -5965,8 +5402,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fill_coeff_dbcsr_occ(coeff_dbcsr, coeff, homo)
       TYPE(dbcsr_type), POINTER                          :: coeff_dbcsr
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: coeff
-      INTEGER, INTENT(IN)                                :: homo
+      REAL(KIND=dp), DIMENSION(:)                        :: coeff
+      INTEGER                                            :: homo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_coeff_dbcsr_occ', &
          routineP = moduleN//':'//routineN
@@ -5985,12 +5422,17 @@ CONTAINS
                                         row_offset=row_offset, row_size=row_size)
 
          IF (row_offset+row_size-1 <= homo) THEN
+
             data_block(1:row_size, 1) = coeff(row_offset:row_offset+row_size-1)
+
          ELSE IF (row_offset <= homo) THEN
+
             end_data_block = homo-row_offset+1
 
             data_block(1:end_data_block, 1) = coeff(row_offset:row_offset+end_data_block-1)
+
          END IF
+
       END DO
 
       CALL dbcsr_iterator_stop(iter)
@@ -6007,8 +5449,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fill_coeff_dbcsr_virt(coeff_dbcsr, coeff, homo)
       TYPE(dbcsr_type), POINTER                          :: coeff_dbcsr
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: coeff
-      INTEGER, INTENT(IN)                                :: homo
+      REAL(KIND=dp), DIMENSION(:)                        :: coeff
+      INTEGER                                            :: homo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_coeff_dbcsr_virt', &
          routineP = moduleN//':'//routineN
@@ -6022,16 +5464,22 @@ CONTAINS
 
       CALL dbcsr_iterator_start(iter, coeff_dbcsr)
       DO WHILE (dbcsr_iterator_blocks_left(iter))
+
          CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
                                         row_offset=row_offset, row_size=row_size)
 
          IF (row_offset > homo) THEN
+
             data_block(1:row_size, 1) = coeff(row_offset-homo:row_offset+row_size-homo-1)
+
          ELSE IF (row_offset+row_size-1 > homo) THEN
+
             start_data_block = homo-row_offset+2
 
             data_block(start_data_block:row_size, 1) = coeff(1:row_offset+row_size-homo)
+
          END IF
+
       END DO
 
       CALL dbcsr_iterator_stop(iter)
@@ -6039,383 +5487,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE fill_coeff_dbcsr_virt
-
-! **************************************************************************************************
-!> \brief ...
-!> \param num_integ_points ...
-!> \param nmo ...
-!> \param tau_tj ...
-!> \param tj ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
-!> \param matrix_s ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
-!> \param Eigenval ...
-!> \param eps_filter ...
-!> \param e_fermi ...
-!> \param fm_mat_W_tau ...
-!> \param gw_corr_lev_tot ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param homo ...
-!> \param count_ev_sc_GW ...
-!> \param mat_3c_overl_int_gw ...
-!> \param mat_contr_gf_occ ...
-!> \param mat_contr_gf_virt ...
-!> \param mat_contr_W ...
-!> \param mat_W ...
-!> \param mat_SinvVSinv ...
-!> \param mat_dm ...
-!> \param stabilize_exp ...
-!> \param weights_cos_tf_t_to_w ...
-!> \param weights_sin_tf_t_to_w ...
-!> \param vec_Sigma_c_gw ...
-!> \param do_periodic ...
-!> \param num_points_corr ...
-!> \param ext_scaling ...
-!> \param delta_corr ...
-!> \param qs_env ...
-!> \param para_env ...
-!> \param para_env_RPA ...
-!> \param mp2_env ...
-!> \param matrix_berry_re_mo_mo ...
-!> \param matrix_berry_im_mo_mo ...
-!> \param first_cycle_periodic_correction ...
-!> \param kpoints ...
-!> \param num_fit_points ...
-!> \param mo_coeff ...
-!> \param do_GW_corr ...
-!> \param do_ri_Sigma_x ...
-!> \param vec_Sigma_x_gw ...
-!> \param do_beta ...
-! **************************************************************************************************
-   SUBROUTINE compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ, mat_greens_fct_virt, &
-                                             matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                             fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                             fm_scaled_dm_virt_tau, Eigenval, eps_filter, e_fermi, fm_mat_W_tau, &
-                                             gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, count_ev_sc_GW, &
-                                             mat_3c_overl_int_gw, mat_contr_gf_occ, mat_contr_gf_virt, &
-                                             mat_contr_W, mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
-                                             weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, do_periodic, &
-                                             num_points_corr, ext_scaling, delta_corr, qs_env, para_env, para_env_RPA, &
-                                             mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                             first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
-                                             do_GW_corr, do_ri_Sigma_x, vec_Sigma_x_gw, do_beta)
-
-      INTEGER                                            :: num_integ_points, nmo
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tj
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt, &
-                                                            matrix_s
-      TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-         fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      REAL(KIND=dp)                                      :: eps_filter, e_fermi
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
-      INTEGER                                            :: gw_corr_lev_tot, gw_corr_lev_occ, &
-                                                            gw_corr_lev_virt, homo, count_ev_sc_GW
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_int_gw
-      TYPE(dbcsr_type), POINTER                          :: mat_contr_gf_occ, mat_contr_gf_virt, &
-                                                            mat_contr_W
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_W
-      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv, mat_dm
-      REAL(KIND=dp)                                      :: stabilize_exp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w, &
-                                                            weights_sin_tf_t_to_w
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: vec_Sigma_c_gw
-      LOGICAL                                            :: do_periodic
-      INTEGER                                            :: num_points_corr
-      REAL(KIND=dp)                                      :: ext_scaling
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
-      TYPE(mp2_type), POINTER                            :: mp2_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
-                                                            matrix_berry_im_mo_mo
-      LOGICAL :: first_cycle_periodic_correction
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      INTEGER                                            :: num_fit_points
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
-      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: do_GW_corr
-      LOGICAL                                            :: do_ri_Sigma_x
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_Sigma_x_gw
-      LOGICAL, OPTIONAL                                  :: do_beta
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_self_energy_im_time_gw', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: delta_corr_omega
-      INTEGER                                            :: gw_lev_end, gw_lev_start, handle, &
-                                                            handle3, iquad, jquad, n_level_gw, &
-                                                            n_level_gw_ref
-      LOGICAL                                            :: my_do_beta
-      REAL(KIND=dp)                                      :: omega, omega_i, omega_sign, &
-                                                            sign_occ_virt, t_i_Clenshaw, tau, &
-                                                            weight_cos, weight_i, weight_sin
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_c_gw_cos_omega, &
-         vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
-         vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
-
-      CALL timeset(routineN, handle)
-
-      my_do_beta = .FALSE.
-      IF (PRESENT(do_beta)) my_do_beta = do_beta
-
-      im_unit = (0.0_dp, 1.0_dp)
-
-      ALLOCATE (vec_Sigma_c_gw_pos_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_pos_tau = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_neg_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_neg_tau = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_cos_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_cos_tau = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_sin_tau(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_sin_tau = 0.0_dp
-
-      ALLOCATE (vec_Sigma_c_gw_cos_omega(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_cos_omega = 0.0_dp
-      ALLOCATE (vec_Sigma_c_gw_sin_omega(gw_corr_lev_tot, num_integ_points))
-      vec_Sigma_c_gw_sin_omega = 0.0_dp
-
-      ALLOCATE (delta_corr_omega(1+homo-gw_corr_lev_occ:homo+gw_corr_lev_virt, num_integ_points))
-      delta_corr_omega(:, :) = (0.0_dp, 0.0_dp)
-
-      DO jquad = 1, num_integ_points
-
-         tau = tau_tj(jquad)
-
-         CALL compute_Greens_function(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                      fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, num_integ_points, nmo, &
-                                      eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
-
-         CALL copy_fm_to_dbcsr(fm_mat_W_tau(jquad)%matrix, mat_W(jquad)%matrix, keep_sparsity=.FALSE.)
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-
-            IF (.NOT. do_GW_corr(n_level_gw)) CYCLE
-
-            ! the following formulas are partially taken from Liu et al. PRB 94, 165109 (2016), Eq. (63) - (69)
-
-            CALL timeset(routineN//"_cubic_GW_operation_1", handle3)
-
-            ! the occ Gf has no minus, but already include the minus from Sigma = -GW
-            CALL dbcsr_multiply("N", "N", -1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, mat_greens_fct_occ(jquad)%matrix, &
-                                0.0_dp, mat_contr_gf_occ)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_2", handle3)
-
-            ! the virt Gf has a minus, but already include the minus from Sigma = -GW
-            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, mat_greens_fct_virt(jquad)%matrix, &
-                                0.0_dp, mat_contr_gf_virt)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_3", handle3)
-
-            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_W(jquad)%matrix, mat_3c_overl_int_gw(n_level_gw)%matrix, &
-                                0.0_dp, mat_contr_W)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_4", handle3)
-
-            CALL dbcsr_trace(mat_contr_gf_virt, &
-                             mat_contr_W, &
-                             vec_Sigma_c_gw_pos_tau(n_level_gw, jquad))
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_5", handle3)
-
-            CALL dbcsr_trace(mat_contr_gf_occ, &
-                             mat_contr_W, &
-                             vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_5", handle3)
-
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_cubic_GW_operation_7", handle3)
-
-            vec_Sigma_c_gw_cos_tau(n_level_gw, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(n_level_gw, jquad)+ &
-                                                                vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
-
-            vec_Sigma_c_gw_sin_tau(n_level_gw, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(n_level_gw, jquad)- &
-                                                                vec_Sigma_c_gw_neg_tau(n_level_gw, jquad))
-
-            CALL timestop(handle3)
-
-         END DO ! n_levl_gw
-
-         CALL dbcsr_set(mat_W(jquad)%matrix, 0.0_dp)
-
-         CALL dbcsr_filter(mat_W(jquad)%matrix, 1.0_dp)
-
-      END DO ! jquad (tau)
-
-      ! Fourier transform from time to frequency
-      DO jquad = 1, num_integ_points
-
-         DO iquad = 1, num_integ_points
-
-            omega = tj(jquad)
-            tau = tau_tj(iquad)
-            weight_cos = weights_cos_tf_t_to_w(jquad, iquad)*COS(omega*tau)
-            weight_sin = weights_sin_tf_t_to_w(jquad, iquad)*SIN(omega*tau)
-
-            vec_Sigma_c_gw_cos_omega(:, jquad) = vec_Sigma_c_gw_cos_omega(:, jquad)+ &
-                                                 weight_cos*vec_Sigma_c_gw_cos_tau(:, iquad)
-
-            vec_Sigma_c_gw_sin_omega(:, jquad) = vec_Sigma_c_gw_sin_omega(:, jquad)+ &
-                                                 weight_sin*vec_Sigma_c_gw_sin_tau(:, iquad)
-
-         END DO
-
-      END DO
-
-      ! for occupied levels, we need the correlation self-energy for negative omega. Therefore, weight_sin
-      ! should be computed with -omega, which results in an additional minus for vec_Sigma_c_gw_sin_omega:
-      vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :) = -vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :)
-
-      vec_Sigma_c_gw(:, 1:num_fit_points) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points)+ &
-                                            im_unit*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
-
-      IF (do_ri_Sigma_x .AND. count_ev_sc_GW == 1) THEN
-
-         CALL timeset(routineN//"_RI_HFX_operation_1", handle3)
-
-         ! get density matrix
-         CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
-                      matrix_a=fm_mo_coeff_occ, matrix_b=fm_mo_coeff_occ, beta=0.0_dp, &
-                      matrix_c=fm_scaled_dm_occ_tau)
-
-         CALL timestop(handle3)
-
-         CALL timeset(routineN//"_RI_HFX_operation_2", handle3)
-
-         CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
-                               mat_dm%matrix, &
-                               keep_sparsity=.FALSE.)
-
-         CALL timestop(handle3)
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-
-            IF (.NOT. do_GW_corr(n_level_gw)) CYCLE
-
-            CALL timeset(routineN//"_RI_HFX_operation_3", handle3)
-
-            ! the occ Gf has no minus, but already include the minus from Sigma = -GW
-            CALL dbcsr_multiply("N", "N", -1.0_dp, mat_3c_overl_int_gw(n_level_gw)%matrix, mat_dm%matrix, &
-                                0.0_dp, mat_contr_gf_occ)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_RI_HFX_operation_4", handle3)
-
-            CALL dbcsr_multiply("N", "N", 1.0_dp, mat_SinvVSinv%matrix, mat_3c_overl_int_gw(n_level_gw)%matrix, &
-                                0.0_dp, mat_contr_W)
-
-            CALL timestop(handle3)
-
-            CALL timeset(routineN//"_RI_HFX_operation_5", handle3)
-
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-            CALL dbcsr_trace(mat_contr_gf_occ, &
-                             mat_contr_W, &
-                             vec_Sigma_x_gw(n_level_gw_ref))
-
-            CALL timestop(handle3)
-
-         END DO
-
-      END IF
-
-      ! compute and add the periodic correction
-      IF (do_periodic) THEN
-
-         ! loop over omega' (integration)
-         DO iquad = 1, num_points_corr
-
-            ! use the Clenshaw-grid
-            t_i_Clenshaw = iquad*pi/(2.0_dp*num_points_corr)
-            omega_i = ext_scaling/TAN(t_i_Clenshaw)
-
-            IF (iquad < num_points_corr) THEN
-               weight_i = ext_scaling*pi/(num_points_corr*SIN(t_i_Clenshaw)**2)
-            ELSE
-               weight_i = ext_scaling*pi/(2.0_dp*num_points_corr*SIN(t_i_Clenshaw)**2)
-            END IF
-
-            CALL calc_periodic_correction(delta_corr, qs_env, para_env, para_env_RPA, &
-                                          mp2_env%ri_g0w0%kp_grid, homo, nmo, gw_corr_lev_occ, &
-                                          gw_corr_lev_virt, omega_i, mo_coeff, Eigenval, &
-                                          matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                          first_cycle_periodic_correction, kpoints, &
-                                          mp2_env%ri_g0w0%do_mo_coeff_gamma, &
-                                          mp2_env%ri_g0w0%num_kp_grids, mp2_env%ri_g0w0%eps_kpoint, &
-                                          mp2_env%ri_g0w0%do_extra_kpoints, &
-                                          mp2_env%ri_g0w0%do_aux_bas_gw, mp2_env%ri_g0w0%frac_aux_mos)
-
-            DO n_level_gw = 1, gw_corr_lev_tot
-
-               n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-               IF (n_level_gw <= gw_corr_lev_occ) THEN
-                  sign_occ_virt = -1.0_dp
-               ELSE
-                  sign_occ_virt = 1.0_dp
-               END IF
-
-               DO jquad = 1, num_integ_points
-
-                  omega_sign = tj(jquad)*sign_occ_virt
-
-                  delta_corr_omega(n_level_gw_ref, jquad) = &
-                     delta_corr_omega(n_level_gw_ref, jquad)- &
-                     0.5_dp/pi*weight_i/2.0_dp*delta_corr(n_level_gw_ref)* &
-                     (1.0_dp/(im_unit*(omega_i+omega_sign)+e_fermi-Eigenval(n_level_gw_ref))+ &
-                      1.0_dp/(im_unit*(-omega_i+omega_sign)+e_fermi-Eigenval(n_level_gw_ref)))
-
-               END DO
-
-            END DO
-
-         END DO
-
-         gw_lev_start = 1+homo-gw_corr_lev_occ
-         gw_lev_end = homo+gw_corr_lev_virt
-
-         ! add the periodic correction
-         vec_Sigma_c_gw(1:gw_corr_lev_tot, :) = vec_Sigma_c_gw(1:gw_corr_lev_tot, :)+ &
-                                                delta_corr_omega(gw_lev_start:gw_lev_end, 1:num_fit_points)
-
-      END IF
-
-      DEALLOCATE (vec_Sigma_c_gw_pos_tau)
-      DEALLOCATE (vec_Sigma_c_gw_neg_tau)
-      DEALLOCATE (vec_Sigma_c_gw_cos_tau)
-      DEALLOCATE (vec_Sigma_c_gw_sin_tau)
-      DEALLOCATE (vec_Sigma_c_gw_cos_omega)
-      DEALLOCATE (vec_Sigma_c_gw_sin_omega)
-      DEALLOCATE (delta_corr_omega)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE compute_self_energy_im_time_gw
 
 ! **************************************************************************************************
 !> \brief ...
@@ -6441,30 +5512,35 @@ CONTAINS
                                   num_integ_points, num_integ_group, color_rpa_group, &
                                   tj_ext, wj_ext, fm_mat_S, &
                                   homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
-      REAL(KIND=dp), INTENT(INOUT)                       :: a_scaling_ext
+      REAL(KIND=dp)                                      :: a_scaling_ext
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
-      INTEGER, INTENT(IN)                                :: homo, virtual
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: num_integ_points, num_integ_group, &
+      INTEGER                                            :: homo, virtual
+      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      INTEGER                                            :: num_integ_points, num_integ_group, &
                                                             color_rpa_group
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tj_ext, wj_ext
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj_ext, wj_ext
       TYPE(cp_fm_type), POINTER                          :: fm_mat_S
-      INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta, virtual_beta, dimen_ia_beta
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: Eigenval_beta
+      INTEGER, OPTIONAL                                  :: homo_beta, virtual_beta, dimen_ia_beta
+      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: Eigenval_beta
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: fm_mat_S_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_scaling_factor', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, icycle, jquad, nrow_local, &
-                                                            nrow_local_beta
+      INTEGER :: avirt, color_col, color_col_beta, color_row, color_row_beta, comm_col, &
+         comm_col_beta, comm_row, comm_row_beta, handle, i_global, icycle, iiB, iocc, jjB, jquad, &
+         ncol_local, ncol_local_beta, nrow_local, nrow_local_beta
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, col_indices_beta, &
+                                                            row_indices, row_indices_beta
       LOGICAL                                            :: my_open_shell
-      REAL(KIND=dp) :: a_high, a_low, a_scaling, conv_param, eps, first_deriv, left_term, &
-         right_term, right_term_ref, right_term_ref_beta, step
+      REAL(KIND=dp) :: a_high, a_low, a_scaling, conv_param, eigen_diff, eps, first_deriv, four, &
+         left_term, one, pig, right_term, right_term_ref, right_term_ref_beta, step, two, zero
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: cottj, D_ia, D_ia_beta, iaia_RI, &
-                                                            iaia_RI_beta, M_ia, M_ia_beta
-      TYPE(cp_para_env_type), POINTER                    :: para_env_row, para_env_row_beta
+                                                            iaia_RI_beta, iaia_RI_dp, &
+                                                            iaia_RI_dp_beta, M_ia, M_ia_beta, tj, &
+                                                            wj
+      TYPE(cp_para_env_type), POINTER                    :: para_env_col, para_env_col_beta, &
+                                                            para_env_row, para_env_row_beta
 
       CALL timeset(routineN, handle)
 
@@ -6475,142 +5551,25 @@ CONTAINS
           PRESENT(Eigenval_beta) .AND. &
           PRESENT(fm_mat_S_beta)) my_open_shell = .TRUE.
 
+      ZERO = 0.0_dp
+      ONE = 1.0_dp
+      TWO = 2.0_dp
+      FOUR = 4.0_dp
+      PIG = pi
       eps = 1.0E-10_dp
 
       ALLOCATE (cottj(num_integ_points))
 
+      ALLOCATE (tj(num_integ_points))
+
+      ALLOCATE (wj(num_integ_points))
+
       ! calculate the cotangent of the abscissa tj
       DO jquad = 1, num_integ_points
-         cottj(jquad) = 1.0_dp/TAN(tj_ext(jquad))
+         tj(jquad) = tj_ext(jquad)
+         wj(jquad) = wj_ext(jquad)
+         cottj(jquad) = ONE/TAN(tj(jquad))
       END DO
-
-      CALL calc_ia_ia_integrals(para_env_RPA, homo, virtual, nrow_local, right_term_ref, Eigenval, D_ia, iaia_RI, M_ia, fm_mat_S, &
-                                para_env_row)
-
-      ! In the open shell case do point 1-2-3 for the beta spin
-      IF (my_open_shell) THEN
-         CALL calc_ia_ia_integrals(para_env_RPA, homo_beta, virtual_beta, nrow_local_beta, right_term_ref_beta, Eigenval_beta, &
-                                   D_ia_beta, iaia_RI_beta, M_ia_beta, fm_mat_S_beta, para_env_row_beta)
-
-         right_term_ref = right_term_ref+right_term_ref_beta
-      END IF
-
-      ! bcast the result
-      IF (para_env%mepos == 0) THEN
-         CALL mp_bcast(right_term_ref, 0, para_env%group)
-      ELSE
-         right_term_ref = 0.0_dp
-         CALL mp_bcast(right_term_ref, 0, para_env%group)
-      END IF
-
-      ! 5) start iteration for solving the non-linear equation by bisection
-      ! find limit, here step=0.5 seems a good compromise
-      conv_param = 100.0_dp*EPSILON(right_term_ref)
-      step = 0.5_dp
-      a_low = 0.0_dp
-      a_high = step
-      right_term = -right_term_ref
-      DO icycle = 1, num_integ_points*2
-         a_scaling = a_high
-
-         CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
-                                M_ia, cottj, wj_ext, D_ia, D_ia_beta, M_ia_beta, &
-                                nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
-                                para_env, para_env_row, para_env_row_beta)
-         left_term = left_term/4.0_dp/pi*a_scaling
-
-         IF (ABS(left_term) > ABS(right_term) .OR. ABS(left_term+right_term) <= conv_param) EXIT
-         a_low = a_high
-         a_high = a_high+step
-
-      END DO
-
-      IF (ABS(left_term+right_term) >= conv_param) THEN
-         IF (a_scaling >= 2*num_integ_points*step) THEN
-            a_scaling = 1.0_dp
-         ELSE
-
-            DO icycle = 1, num_integ_points*2
-               a_scaling = (a_low+a_high)/2.0_dp
-
-               CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
-                                      M_ia, cottj, wj_ext, D_ia, D_ia_beta, M_ia_beta, &
-                                      nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
-                                      para_env, para_env_row, para_env_row_beta)
-               left_term = left_term/4.0_dp/pi*a_scaling
-
-               IF (ABS(left_term) > ABS(right_term)) THEN
-                  a_high = a_scaling
-               ELSE
-                  a_low = a_scaling
-               END IF
-
-               IF (ABS(a_high-a_low) < 1.0e-5_dp) EXIT
-
-            END DO
-
-         END IF
-      END IF
-
-      a_scaling_ext = a_scaling
-      CALL mp_bcast(a_scaling_ext, 0, para_env%group)
-
-      DEALLOCATE (cottj)
-      DEALLOCATE (iaia_RI)
-      DEALLOCATE (D_ia)
-      DEALLOCATE (M_ia)
-      CALL cp_para_env_release(para_env_row)
-
-      IF (my_open_shell) THEN
-         DEALLOCATE (iaia_RI_beta)
-         DEALLOCATE (D_ia_beta)
-         DEALLOCATE (M_ia_beta)
-         CALL cp_para_env_release(para_env_row_beta)
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE calc_scaling_factor
-
-! **************************************************************************************************
-!> \brief ...
-!> \param para_env_RPA ...
-!> \param homo ...
-!> \param virtual ...
-!> \param nrow_local ...
-!> \param right_term_ref ...
-!> \param Eigenval ...
-!> \param D_ia ...
-!> \param iaia_RI ...
-!> \param M_ia ...
-!> \param fm_mat_S ...
-!> \param para_env_row ...
-! **************************************************************************************************
-   SUBROUTINE calc_ia_ia_integrals(para_env_RPA, homo, virtual, nrow_local, right_term_ref, Eigenval, &
-                                   D_ia, iaia_RI, M_ia, fm_mat_S, para_env_row)
-
-      TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
-      INTEGER, INTENT(IN)                                :: homo, virtual
-      INTEGER, INTENT(OUT)                               :: nrow_local
-      REAL(KIND=dp), INTENT(OUT)                         :: right_term_ref
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: D_ia, iaia_RI, M_ia
-      TYPE(cp_fm_type), POINTER                          :: fm_mat_S
-      TYPE(cp_para_env_type), POINTER                    :: para_env_row
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_ia_ia_integrals', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: avirt, color_col, color_row, comm_col, &
-                                                            comm_row, handle, i_global, iiB, iocc, &
-                                                            jjB, ncol_local
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      REAL(KIND=dp)                                      :: eigen_diff
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: iaia_RI_dp
-      TYPE(cp_para_env_type), POINTER                    :: para_env_col
-
-      CALL timeset(routineN, handle)
 
       ! calculate the (ia|ia) RI integrals
       ! ----------------------------------
@@ -6681,14 +5640,15 @@ CONTAINS
       END DO
 
       DO iiB = 1, nrow_local
-         M_ia(iiB) = D_ia(iiB)*D_ia(iiB)+2.0_dp*D_ia(iiB)*iaia_RI(iiB)
+         M_ia(iiB) = D_ia(iiB)*D_ia(iiB)+TWO*D_ia(iiB)*iaia_RI(iiB)
       END DO
 
-      right_term_ref = 0.0_dp
+      right_term_ref = ZERO
       DO iiB = 1, nrow_local
          right_term_ref = right_term_ref+(SQRT(M_ia(iiB))-D_ia(iiB)-iaia_RI(iiB))
       END DO
-      right_term_ref = right_term_ref/2.0_dp
+      right_term_ref = right_term_ref/TWO
+      ! right_term_ref=accurate_sum((SQRT(M_ia)-D_ia-iaia_RI))/2.0_dp
 
       ! sum the result with the processes of the RPA_group having the same col
       color_col = fm_mat_S%matrix_struct%context%mepos(2)
@@ -6699,11 +5659,152 @@ CONTAINS
       ! allocate communication array for columns
       CALL mp_sum(right_term_ref, para_env_col%group)
 
+      ! In the open shell case do point 1-2-3 for the beta spin
+      IF (my_open_shell) THEN
+         !XXX CALL cp_fm_to_fm(source=fm_mat_S_beta,destination=fm_mat_G_beta)
+         CALL cp_fm_get_info(matrix=fm_mat_S_beta, &
+                             nrow_local=nrow_local_beta, &
+                             ncol_local=ncol_local_beta, &
+                             row_indices=row_indices_beta, &
+                             col_indices=col_indices_beta)
+
+         ALLOCATE (iaia_RI_dp_beta(nrow_local_beta))
+         iaia_RI_dp_beta = 0.0_dp
+
+         DO jjB = 1, ncol_local_beta
+            DO iiB = 1, nrow_local_beta
+               iaia_RI_dp_beta(iiB) = iaia_RI_dp_beta(iiB)+fm_mat_S_beta%local_data(iiB, jjB)*fm_mat_S_beta%local_data(iiB, jjB)
+            END DO
+         END DO
+
+         color_row_beta = fm_mat_S_beta%matrix_struct%context%mepos(1)
+         CALL mp_comm_split_direct(para_env_RPA%group, comm_row_beta, color_row_beta)
+         NULLIFY (para_env_row_beta)
+         CALL cp_para_env_create(para_env_row_beta, comm_row_beta)
+
+         CALL mp_sum(iaia_RI_dp_beta, para_env_row_beta%group)
+
+         ALLOCATE (iaia_RI_beta(nrow_local_beta))
+         DO iiB = 1, nrow_local_beta
+            iaia_RI_beta(iiB) = iaia_RI_dp_beta(iiB)
+         END DO
+         DEALLOCATE (iaia_RI_dp_beta)
+
+         ALLOCATE (D_ia_beta(nrow_local_beta))
+
+         ALLOCATE (M_ia_beta(nrow_local_beta))
+
+         DO iiB = 1, nrow_local_beta
+            i_global = row_indices_beta(iiB)
+
+            iocc = MAX(1, i_global-1)/virtual_beta+1
+            avirt = i_global-(iocc-1)*virtual_beta
+            eigen_diff = Eigenval_beta(avirt+homo_beta)-Eigenval_beta(iocc)
+
+            D_ia_beta(iiB) = eigen_diff
+         END DO
+
+         DO iiB = 1, nrow_local_beta
+            M_ia_beta(iiB) = D_ia_beta(iiB)*D_ia_beta(iiB)+TWO*D_ia_beta(iiB)*iaia_RI_beta(iiB)
+         END DO
+
+         right_term_ref_beta = ZERO
+         DO iiB = 1, nrow_local_beta
+            right_term_ref_beta = right_term_ref_beta+(SQRT(M_ia_beta(iiB))-D_ia_beta(iiB)-iaia_RI_beta(iiB))
+         END DO
+         right_term_ref_beta = right_term_ref_beta/TWO
+
+         ! sum the result with the processes of the RPA_group having the same col
+         color_col_beta = fm_mat_S_beta%matrix_struct%context%mepos(2)
+         CALL mp_comm_split_direct(para_env_RPA%group, comm_col_beta, color_col_beta)
+         NULLIFY (para_env_col_beta)
+         CALL cp_para_env_create(para_env_col_beta, comm_col_beta)
+
+         CALL mp_sum(right_term_ref_beta, para_env_col_beta%group)
+
+         right_term_ref = right_term_ref+right_term_ref_beta
+      END IF
+
+      ! bcast the result
+      IF (para_env%mepos == 0) THEN
+         CALL mp_bcast(right_term_ref, 0, para_env%group)
+      ELSE
+         right_term_ref = 0.0_dp
+         CALL mp_bcast(right_term_ref, 0, para_env%group)
+      END IF
+
+      ! 5) start iteration for solving the non-linear equation by bisection
+      ! find limit, here step=0.5 seems a good compromise
+      conv_param = 100.0_dp*EPSILON(right_term_ref)
+      step = 0.5_dp
+      a_low = 0.0_dp
+      a_high = step
+      right_term = -right_term_ref
+      DO icycle = 1, num_integ_points*2
+         a_scaling = a_high
+
+         CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
+                                ZERO, ONE, M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
+                                nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
+                                para_env, para_env_row, para_env_row_beta)
+         left_term = left_term/FOUR/PIG*a_scaling
+
+         IF (ABS(left_term) > ABS(right_term) .OR. ABS(left_term+right_term) <= conv_param) EXIT
+         a_low = a_high
+         a_high = a_high+step
+
+      END DO
+
+      IF (ABS(left_term+right_term) >= conv_param) THEN
+         IF (a_scaling >= 2*num_integ_points*step) THEN
+            a_scaling = 1.0_dp
+         ELSE
+
+            DO icycle = 1, num_integ_points*2
+               a_scaling = (a_low+a_high)/2.0_dp
+
+               CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
+                                      ZERO, ONE, M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
+                                      nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
+                                      para_env, para_env_row, para_env_row_beta)
+               left_term = left_term/FOUR/PIG*a_scaling
+
+               IF (ABS(left_term) > ABS(right_term)) THEN
+                  a_high = a_scaling
+               ELSE
+                  a_low = a_scaling
+               END IF
+
+               IF (ABS(a_high-a_low) < 1.0D-5) EXIT
+
+            END DO
+
+         END IF
+      END IF
+
+      a_scaling_ext = a_scaling
+      CALL mp_bcast(a_scaling_ext, 0, para_env%group)
+
+      DEALLOCATE (cottj)
+      DEALLOCATE (tj)
+      DEALLOCATE (wj)
+      DEALLOCATE (iaia_RI)
+      DEALLOCATE (D_ia)
+      DEALLOCATE (M_ia)
+      CALL cp_para_env_release(para_env_row)
       CALL cp_para_env_release(para_env_col)
+
+      IF (my_open_shell) THEN
+         DEALLOCATE (iaia_RI_beta)
+         DEALLOCATE (D_ia_beta)
+         DEALLOCATE (M_ia_beta)
+         CALL cp_para_env_release(para_env_row_beta)
+         CALL cp_para_env_release(para_env_col_beta)
+      END IF
 
       CALL timestop(handle)
 
-   END SUBROUTINE calc_ia_ia_integrals
+   END SUBROUTINE calc_scaling_factor
 
 ! **************************************************************************************************
 !> \brief ...
@@ -6712,6 +5813,8 @@ CONTAINS
 !> \param first_deriv ...
 !> \param num_integ_points ...
 !> \param my_open_shell ...
+!> \param ZERO ...
+!> \param ONE ...
 !> \param M_ia ...
 !> \param cottj ...
 !> \param wj ...
@@ -6727,27 +5830,26 @@ CONTAINS
 !> \param para_env_row_beta ...
 ! **************************************************************************************************
    SUBROUTINE calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
-                                M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
+                                ZERO, ONE, M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
                                 nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
                                 para_env, para_env_row, para_env_row_beta)
-      REAL(KIND=dp), INTENT(IN)                          :: a_scaling
-      REAL(KIND=dp), INTENT(INOUT)                       :: left_term, first_deriv
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      LOGICAL, INTENT(IN)                                :: my_open_shell
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: M_ia, cottj, wj, D_ia, D_ia_beta, &
+      REAL(KIND=dp)                                      :: a_scaling, left_term, first_deriv
+      INTEGER                                            :: num_integ_points
+      LOGICAL                                            :: my_open_shell
+      REAL(KIND=dp)                                      :: zero, one
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: M_ia, cottj, wj, D_ia, D_ia_beta, &
                                                             M_ia_beta
-      INTEGER, INTENT(IN)                                :: nrow_local, nrow_local_beta, &
+      INTEGER                                            :: nrow_local, nrow_local_beta, &
                                                             num_integ_group, color_rpa_group
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_row, para_env_row_beta
 
       INTEGER                                            :: iiB, jquad
       REAL(KIND=dp)                                      :: first_deriv_beta, left_term_beta, omega
 
-      left_term = 0.0_dp
-      first_deriv = 0.0_dp
-      left_term_beta = 0.0_dp
-      first_deriv_beta = 0.0_dp
+      left_term = ZERO
+      first_deriv = ZERO
+      left_term_beta = ZERO
+      first_deriv_beta = ZERO
       DO jquad = 1, num_integ_points
          ! parallelize over integration points
          IF (MODULO(jquad, num_integ_group) /= color_rpa_group) CYCLE
@@ -6758,7 +5860,7 @@ CONTAINS
             IF (MODULO(iiB, para_env_row%num_pe) /= para_env_row%mepos) CYCLE
             ! calculate left_term
             left_term = left_term+wj(jquad)* &
-                        (LOG(1.0_dp+(M_ia(iiB)-D_ia(iiB)**2)/(omega**2+D_ia(iiB)**2))- &
+                        (LOG(ONE+(M_ia(iiB)-D_ia(iiB)**2)/(omega**2+D_ia(iiB)**2))- &
                          (M_ia(iiB)-D_ia(iiB)**2)/(omega**2+D_ia(iiB)**2))
             first_deriv = first_deriv+wj(jquad)*cottj(jquad)**2* &
                           ((-M_ia(iiB)+D_ia(iiB)**2)**2/((omega**2+D_ia(iiB)**2)**2*(omega**2+M_ia(iiB))))
@@ -6770,7 +5872,7 @@ CONTAINS
                IF (MODULO(iiB, para_env_row_beta%num_pe) /= para_env_row_beta%mepos) CYCLE
                ! calculate left_term
                left_term_beta = left_term_beta+wj(jquad)* &
-                                (LOG(1.0_dp+(M_ia_beta(iiB)-D_ia_beta(iiB)**2)/(omega**2+D_ia_beta(iiB)**2))- &
+                                (LOG(ONE+(M_ia_beta(iiB)-D_ia_beta(iiB)**2)/(omega**2+D_ia_beta(iiB)**2))- &
                                  (M_ia_beta(iiB)-D_ia_beta(iiB)**2)/(omega**2+D_ia_beta(iiB)**2))
                first_deriv_beta = &
                   first_deriv_beta+wj(jquad)*cottj(jquad)**2* &
@@ -6808,16 +5910,12 @@ CONTAINS
    SUBROUTINE get_l_sq_wghts_cos_tf_t_to_w(num_integ_points, tau_tj, weights_cos_tf_t_to_w, omega_tj, &
                                            E_min, E_max, max_error, num_points_per_magnitude)
 
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: weights_cos_tf_t_to_w
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj
-      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
+      INTEGER                                            :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj
+      REAL(KIND=dp)                                      :: E_min, E_max, max_error
+      INTEGER                                            :: num_points_per_magnitude
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_cos_tf_t_to_w', &
          routineP = moduleN//':'//routineN
@@ -7066,145 +6164,6 @@ CONTAINS
    END SUBROUTINE get_l_sq_wghts_sin_tf_t_to_w
 
 ! **************************************************************************************************
-!> \brief Calculate the matrix mat_N_gw containing the second derivatives
-!>        with respect to the fitting parameters. The second derivatives are
-!>        calculated numerically by finite differences.
-!> \param N_ij matrix element
-!> \param Lambda fitting parameters
-!> \param Sigma_c ...
-!> \param vec_omega_fit_gw ...
-!> \param i ...
-!> \param j ...
-!> \param num_poles ...
-!> \param num_fit_points ...
-!> \param n_level_gw ...
-!> \param h  ...
-! **************************************************************************************************
-   SUBROUTINE calc_mat_N(N_ij, Lambda, Sigma_c, vec_omega_fit_gw, i, j, &
-                         num_poles, num_fit_points, n_level_gw, h)
-      REAL(KIND=dp)                                      :: N_ij
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: Sigma_c
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw
-      INTEGER                                            :: i, j, num_poles, num_fit_points, &
-                                                            n_level_gw
-      REAL(KIND=dp)                                      :: h
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_mat_N', routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda_tmp
-      INTEGER                                            :: handle, num_var
-      REAL(KIND=dp)                                      :: chi2, chi2_sum
-
-      CALL timeset(routineN, handle)
-
-      num_var = 2*num_poles+1
-      ALLOCATE (Lambda_tmp(num_var))
-      Lambda_tmp = (0.0_dp, 0.0_dp)
-      chi2_sum = 0.0_dp
-      re_unit = (1.0_dp, 0.0_dp)
-      im_unit = (0.0_dp, 1.0_dp)
-
-      !test
-      Lambda_tmp(:) = Lambda(:)
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-
-      ! Fitting parameters with offset h
-      Lambda_tmp(:) = Lambda(:)
-      IF (MODULO(i, 2) == 0) THEN
-         Lambda_tmp(i/2) = Lambda_tmp(i/2)+h*re_unit
-      ELSE
-         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)+h*im_unit
-      END IF
-      IF (MODULO(j, 2) == 0) THEN
-         Lambda_tmp(j/2) = Lambda_tmp(j/2)+h*re_unit
-      ELSE
-         Lambda_tmp((j+1)/2) = Lambda_tmp((j+1)/2)+h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum+chi2
-
-      IF (MODULO(i, 2) == 0) THEN
-         Lambda_tmp(i/2) = Lambda_tmp(i/2)-2.0_dp*h*re_unit
-      ELSE
-         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)-2.0_dp*h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum-chi2
-
-      IF (MODULO(j, 2) == 0) THEN
-         Lambda_tmp(j/2) = Lambda_tmp(j/2)-2.0_dp*h*re_unit
-      ELSE
-         Lambda_tmp((j+1)/2) = Lambda_tmp((j+1)/2)-2.0_dp*h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum+chi2
-
-      IF (MODULO(i, 2) == 0) THEN
-         Lambda_tmp(i/2) = Lambda_tmp(i/2)+2.0_dp*h*re_unit
-      ELSE
-         Lambda_tmp((i+1)/2) = Lambda_tmp((i+1)/2)+2.0_dp*h*im_unit
-      END IF
-      CALL calc_chi2(chi2, Lambda_tmp, Sigma_c, vec_omega_fit_gw, num_poles, &
-                     num_fit_points, n_level_gw)
-      chi2_sum = chi2_sum-chi2
-
-      ! Second derivative with symmetric difference quotient
-      N_ij = 1.0_dp/2.0_dp*chi2_sum/(4.0_dp*h*h)
-
-      DEALLOCATE (Lambda_tmp)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE calc_mat_N
-
-! **************************************************************************************************
-!> \brief Calculate chi2
-!> \param chi2 ...
-!> \param Lambda fitting parameters
-!> \param Sigma_c ...
-!> \param vec_omega_fit_gw ...
-!> \param num_poles ...
-!> \param num_fit_points ...
-!> \param n_level_gw ...
-! **************************************************************************************************
-   SUBROUTINE calc_chi2(chi2, Lambda, Sigma_c, vec_omega_fit_gw, num_poles, &
-                        num_fit_points, n_level_gw)
-      REAL(KIND=dp)                                      :: chi2
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: Lambda
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: Sigma_c
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw
-      INTEGER                                            :: num_poles, num_fit_points, n_level_gw
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_chi2', routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: func_val, im_unit
-      INTEGER                                            :: handle, iii, jjj, kkk
-
-      CALL timeset(routineN, handle)
-
-      im_unit = (0.0_dp, 1.0_dp)
-      chi2 = 0.0_dp
-      DO kkk = 1, num_fit_points
-         func_val = Lambda(1)
-         DO iii = 1, num_poles
-            jjj = iii*2
-            ! calculate value of the fit function
-            func_val = func_val+Lambda(jjj)/(im_unit*vec_omega_fit_gw(kkk)-Lambda(jjj+1))
-         END DO
-         chi2 = chi2+(ABS(Sigma_c(n_level_gw, kkk)-func_val))**2
-      END DO
-
-      CALL timestop(handle)
-
-   END SUBROUTINE calc_chi2
-
-! **************************************************************************************************
 !> \brief ...
 !> \param max_error ...
 !> \param omega ...
@@ -7215,20 +6174,20 @@ CONTAINS
 !> \param num_integ_points ...
 !> \param num_x_nodes ...
 ! **************************************************************************************************
-   PURE SUBROUTINE calc_max_error_fit_tau_grid_with_cosine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                           y_values, num_integ_points, num_x_nodes)
+   SUBROUTINE calc_max_error_fit_tau_grid_with_cosine(max_error, omega, tau_tj, tau_wj_work, x_values, &
+                                                      y_values, num_integ_points, num_x_nodes)
 
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work, x_values, y_values
-      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
+      REAL(KIND=dp)                                      :: max_error, omega
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work, x_values, y_values
+      INTEGER                                            :: num_integ_points, num_x_nodes
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_cosine', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: kkk
-      REAL(KIND=dp)                                      :: func_val, max_error_tmp
+      INTEGER                                            :: handle, kkk
+      REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
+
+      CALL timeset(routineN, handle)
 
       max_error_tmp = 0.0_dp
 
@@ -7240,6 +6199,7 @@ CONTAINS
 
          IF (ABS(y_values(kkk)-func_val) > max_error_tmp) THEN
             max_error_tmp = ABS(y_values(kkk)-func_val)
+            func_val_temp = func_val
          END IF
 
       END DO
@@ -7249,1079 +6209,10 @@ CONTAINS
          max_error = max_error_tmp
 
       END IF
+
+      CALL timestop(handle)
 
    END SUBROUTINE calc_max_error_fit_tau_grid_with_cosine
-
-! **************************************************************************************************
-!> \brief ...
-!> \param max_error ...
-!> \param omega ...
-!> \param tau_tj ...
-!> \param tau_wj_work ...
-!> \param x_values ...
-!> \param y_values ...
-!> \param num_integ_points ...
-!> \param num_x_nodes ...
-! **************************************************************************************************
-   PURE SUBROUTINE calc_max_error_fit_tau_grid_with_sine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                         y_values, num_integ_points, num_x_nodes)
-
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work, x_values, y_values
-      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_sine', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: kkk
-      REAL(KIND=dp)                                      :: func_val, max_error_tmp
-
-      max_error_tmp = 0.0_dp
-
-      DO kkk = 1, num_x_nodes
-
-         func_val = 0.0_dp
-
-         CALL eval_fit_func_tau_grid_sine(func_val, x_values(kkk), num_integ_points, tau_tj, tau_wj_work, omega)
-
-         IF (ABS(y_values(kkk)-func_val) > max_error_tmp) THEN
-            max_error_tmp = ABS(y_values(kkk)-func_val)
-         END IF
-
-      END DO
-
-      IF (max_error_tmp > max_error) THEN
-
-         max_error = max_error_tmp
-
-      END IF
-
-   END SUBROUTINE calc_max_error_fit_tau_grid_with_sine
-
-! **************************************************************************************************
-!> \brief Fits the complex self-energy of n_level_gw to a multi-pole model and evaluates the
-!>        fit at the energy eigenvalue of the SCF. Real part of the correlation self-energy
-!>        is written to vec_gw_energ. Also calculates the statistical error of the correlation
-!>        self-energy due to the fit
-!> \param vec_gw_energ ...
-!> \param vec_gw_energ_error_fit ...
-!> \param vec_omega_fit_gw ...
-!> \param z_value ...
-!> \param m_value ...
-!> \param vec_Sigma_c_gw ...
-!> \param vec_Sigma_x_minus_vxc_gw ...
-!> \param Eigenval ...
-!> \param Eigenval_scf ...
-!> \param n_level_gw ...
-!> \param gw_corr_lev_occ ...
-!> \param num_poles ...
-!> \param num_fit_points ...
-!> \param max_iter_fit ...
-!> \param crossing_search ...
-!> \param homo ...
-!> \param check_fit ...
-!> \param fermi_level_offset ...
-!> \param do_gw_im_time ...
-! **************************************************************************************************
-   SUBROUTINE fit_and_continuation_2pole(vec_gw_energ, vec_gw_energ_error_fit, vec_omega_fit_gw, &
-                                         z_value, m_value, vec_Sigma_c_gw, vec_Sigma_x_minus_vxc_gw, &
-                                         Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, num_poles, &
-                                         num_fit_points, max_iter_fit, crossing_search, homo, check_fit, &
-                                         fermi_level_offset, do_gw_im_time)
-
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: vec_gw_energ, vec_gw_energ_error_fit
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: vec_omega_fit_gw
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: z_value, m_value
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(IN)                                      :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
-                                                            Eigenval_scf
-      INTEGER, INTENT(IN)                                :: n_level_gw, gw_corr_lev_occ, num_poles, &
-                                                            num_fit_points, max_iter_fit, &
-                                                            crossing_search, homo
-      LOGICAL, INTENT(IN)                                :: check_fit
-      REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
-      LOGICAL, INTENT(IN)                                :: do_gw_im_time
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'fit_and_continuation_2pole', &
-         routineP = moduleN//':'//routineN
-
-      CHARACTER(5)                                       :: MO_number
-      COMPLEX(KIND=dp)                                   :: func_val, im_unit, one, re_unit, rho1, &
-                                                            zero
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: dLambda, dLambda_2, Lambda, &
-                                                            Lambda_without_offset, vec_b_gw, &
-                                                            vec_b_gw_copy
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: mat_A_gw, mat_B_gw
-      INTEGER                                            :: handle4, ierr, iii, iiter, info, &
-                                                            integ_range, jjj, jquad, kkk, &
-                                                            n_level_gw_ref, num_var, output_unit, &
-                                                            xpos
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ipiv
-      LOGICAL                                            :: could_exit
-      REAL(KIND=dp) :: chi2, chi2_old, delta, deriv_val_real, e_fermi, gw_energ, Ldown, &
-         level_energ_GW, Lup, range_step, ScalParam, sign_occ_virt, stat_error, stop_crit
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: Lambda_Im, Lambda_Re, stat_errors, &
-                                                            vec_N_gw, vec_omega_fit_gw_sign
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: mat_N_gw
-
-      output_unit = cp_logger_get_default_io_unit()
-
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
-
-      num_var = 2*num_poles+1
-      ALLOCATE (Lambda(num_var))
-      Lambda = (0.0_dp, 0.0_dp)
-      ALLOCATE (Lambda_without_offset(num_var))
-      Lambda_without_offset = (0.0_dp, 0.0_dp)
-      ALLOCATE (Lambda_Re(num_var))
-      Lambda_Re = 0.0_dp
-      ALLOCATE (Lambda_Im(num_var))
-      Lambda_Im = 0.0_dp
-
-      ALLOCATE (vec_omega_fit_gw_sign(num_fit_points))
-
-      IF (n_level_gw <= gw_corr_lev_occ) THEN
-         sign_occ_virt = -1.0_dp
-      ELSE
-         sign_occ_virt = 1.0_dp
-      END IF
-
-      DO jquad = 1, num_fit_points
-         vec_omega_fit_gw_sign(jquad) = ABS(vec_omega_fit_gw(jquad))*sign_occ_virt
-      END DO
-
-      ! initial guess
-      range_step = (vec_omega_fit_gw_sign(num_fit_points)-vec_omega_fit_gw_sign(1))/(num_poles-1)
-      DO iii = 1, num_poles
-         Lambda_Im(2*iii+1) = vec_omega_fit_gw_sign(1)+(iii-1)*range_step
-      END DO
-      range_step = (vec_omega_fit_gw_sign(num_fit_points)-vec_omega_fit_gw_sign(1))/num_poles
-      DO iii = 1, num_poles
-         Lambda_Re(2*iii+1) = ABS(vec_omega_fit_gw_sign(1)+(iii-0.5_dp)*range_step)
-      END DO
-
-      DO iii = 1, num_var
-         Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)
-      END DO
-
-      CALL calc_chi2(chi2_old, Lambda, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
-                     num_fit_points, n_level_gw)
-
-      ALLOCATE (mat_A_gw(num_poles+1, num_poles+1))
-      ALLOCATE (vec_b_gw(num_poles+1))
-      ALLOCATE (ipiv(num_poles+1))
-      mat_A_gw = (0.0_dp, 0.0_dp)
-      vec_b_gw = 0.0_dp
-
-      DO iii = 1, num_poles+1
-         mat_A_gw(iii, 1) = (1.0_dp, 0.0_dp)
-      END DO
-      integ_range = num_fit_points/num_poles
-      DO kkk = 1, num_poles+1
-         xpos = (kkk-1)*integ_range+1
-         xpos = MIN(xpos, num_fit_points)
-         ! calculate coefficient at this point
-         DO iii = 1, num_poles
-            jjj = iii*2
-            func_val = (1.0_dp, 0.0_dp)/(im_unit*vec_omega_fit_gw_sign(xpos)- &
-                                         CMPLX(Lambda_Re(jjj+1), Lambda_Im(jjj+1), KIND=dp))
-            mat_A_gw(kkk, iii+1) = func_val
-         END DO
-         vec_b_gw(kkk) = vec_Sigma_c_gw(n_level_gw, xpos)
-      END DO
-
-      ! Solve system of linear equations
-      CALL ZGETRF(num_poles+1, num_poles+1, mat_A_gw, num_poles+1, ipiv, info)
-
-      CALL ZGETRS('N', num_poles+1, 1, mat_A_gw, num_poles+1, ipiv, vec_b_gw, num_poles+1, info)
-
-      Lambda_Re(1) = REAL(vec_b_gw(1))
-      Lambda_Im(1) = AIMAG(vec_b_gw(1))
-      DO iii = 1, num_poles
-         jjj = iii*2
-         Lambda_Re(jjj) = REAL(vec_b_gw(iii+1))
-         Lambda_Im(jjj) = AIMAG(vec_b_gw(iii+1))
-      END DO
-
-      DEALLOCATE (mat_A_gw)
-      DEALLOCATE (vec_b_gw)
-      DEALLOCATE (ipiv)
-
-      ALLOCATE (mat_A_gw(num_var*2, num_var*2))
-      ALLOCATE (mat_B_gw(num_fit_points, num_var*2))
-      ALLOCATE (dLambda(num_fit_points))
-      ALLOCATE (dLambda_2(num_fit_points))
-      ALLOCATE (vec_b_gw(num_var*2))
-      ALLOCATE (vec_b_gw_copy(num_var*2))
-      ALLOCATE (ipiv(num_var*2))
-
-      ScalParam = 0.01_dp
-      Ldown = 1.5_dp
-      Lup = 10.0_dp
-      stop_crit = 1.0e-7_dp
-      could_exit = .FALSE.
-
-      ! iteration loop for fitting
-      DO iiter = 1, max_iter_fit
-
-         CALL timeset(routineN//"_fit_loop_1", handle4)
-
-         ! calc delta lambda
-         DO iii = 1, num_var
-            Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)
-         END DO
-         dLambda = (0.0_dp, 0.0_dp)
-
-         DO kkk = 1, num_fit_points
-            func_val = Lambda(1)
-            DO iii = 1, num_poles
-               jjj = iii*2
-               func_val = func_val+Lambda(jjj)/(vec_omega_fit_gw_sign(kkk)*im_unit-Lambda(jjj+1))
-            END DO
-            dLambda(kkk) = vec_Sigma_c_gw(n_level_gw, kkk)-func_val
-         END DO
-         rho1 = SUM(dLambda*dLambda)
-
-         ! fill matrix
-         mat_B_gw = (0.0_dp, 0.0_dp)
-         DO iii = 1, num_fit_points
-            mat_B_gw(iii, 1) = 1.0_dp
-            mat_B_gw(iii, num_var+1) = im_unit
-         END DO
-         DO iii = 1, num_poles
-            jjj = iii*2
-            DO kkk = 1, num_fit_points
-               mat_B_gw(kkk, jjj) = 1.0_dp/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
-               mat_B_gw(kkk, jjj+num_var) = im_unit/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
-               mat_B_gw(kkk, jjj+1) = Lambda(jjj)/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))**2
-               mat_B_gw(kkk, jjj+1+num_var) = (-Lambda_Im(jjj)+im_unit*Lambda_Re(jjj))/ &
-                                              (im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))**2
-            END DO
-         END DO
-
-         CALL timestop(handle4)
-
-         CALL timeset(routineN//"_fit_matmul_1", handle4)
-
-         one = (1.0_dp, 0.0_dp)
-         zero = (0.0_dp, 0.0_dp)
-         CALL zgemm('C', 'N', num_var*2, num_var*2, num_fit_points, one, mat_B_gw, num_fit_points, mat_B_gw, num_fit_points, &
-                    zero, mat_A_gw, num_var*2)
-         CALL timestop(handle4)
-
-         CALL timeset(routineN//"_fit_zgemv_1", handle4)
-         CALL zgemv('C', num_fit_points, num_var*2, one, mat_B_gw, num_fit_points, dLambda, 1, &
-                    zero, vec_b_gw, 1)
-
-         CALL timestop(handle4)
-
-         ! scale diagonal elements of a_mat
-         DO iii = 1, num_var*2
-            mat_A_gw(iii, iii) = mat_A_gw(iii, iii)+ScalParam*mat_A_gw(iii, iii)
-         END DO
-
-         ! solve linear system
-         ierr = 0
-         ipiv = 0
-
-         CALL timeset(routineN//"_fit_lin_eq_2", handle4)
-
-         CALL ZGETRF(2*num_var, 2*num_var, mat_A_gw, 2*num_var, ipiv, info)
-
-         CALL ZGETRS('N', 2*num_var, 1, mat_A_gw, 2*num_var, ipiv, vec_b_gw, 2*num_var, info)
-
-         CALL timestop(handle4)
-
-         DO iii = 1, num_var
-            Lambda(iii) = Lambda_Re(iii)+im_unit*Lambda_Im(iii)+vec_b_gw(iii)+vec_b_gw(iii+num_var)
-         END DO
-
-         ! calculate chi2
-         CALL calc_chi2(chi2, Lambda, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
-                        num_fit_points, n_level_gw)
-
-         IF (chi2 < chi2_old) THEN
-            ScalParam = MAX(ScalParam/Ldown, 1E-12_dp)
-            DO iii = 1, num_var
-               Lambda_Re(iii) = Lambda_Re(iii)+REAL(vec_b_gw(iii)+vec_b_gw(iii+num_var))
-               Lambda_Im(iii) = Lambda_Im(iii)+AIMAG(vec_b_gw(iii)+vec_b_gw(iii+num_var))
-            END DO
-            IF (chi2_old/chi2-1.0_dp < stop_crit) could_exit = .TRUE.
-            chi2_old = chi2
-         ELSE
-            ScalParam = ScalParam*Lup
-         END IF
-         IF (ScalParam > 100.0_dp .AND. could_exit) EXIT
-
-         IF (ScalParam > 1E+10_dp) ScalParam = 1E-4_dp
-
-         n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-         IF (iiter == max_iter_fit) THEN
-            WRITE (MO_number, "(I3)") n_level_gw_ref
-            CALL cp_warn(__LOCATION__, &
-                         "The fit for corrected level n ="//MO_number//" did not converge. "// &
-                         "For levels close to HOMO or LUMO, this is normally no issue. "// &
-                         "To avoid this warning, you can (1) increase the "// &
-                         "number of fit iterations MAX_ITER_FIT, or you can (2) increase the number "// &
-                         "of RPA integration points (then, Sigma_c(i*omega) is more accurate) "// &
-                         "or  you can (3) decrease "// &
-                         "the fit range by setting the keyword OMEGA_MAX_FIT (in Hartree). ")
-
-         END IF
-
-      END DO
-
-      IF (.NOT. do_gw_im_time) THEN
-
-         ! change a_0 [Lambda(1)], so that Sigma(i0) = Fit(i0)
-         ! do not do this for imaginary time since we do not have many fit points and the fit should be perfect
-         func_val = Lambda(1)
-         DO iii = 1, num_poles
-            jjj = iii*2
-            ! calculate value of the fit function
-            func_val = func_val+Lambda(jjj)/(-Lambda(jjj+1))
-         END DO
-
-         Lambda_Re(1) = Lambda_Re(1)-REAL(func_val)+REAL(vec_Sigma_c_gw(n_level_gw, num_fit_points))
-         Lambda_Im(1) = Lambda_Im(1)-AIMAG(func_val)+AIMAG(vec_Sigma_c_gw(n_level_gw, num_fit_points))
-
-      END IF
-
-      Lambda_without_offset(:) = Lambda(:)
-
-      DO iii = 1, num_var
-         Lambda(iii) = CMPLX(Lambda_Re(iii), Lambda_Im(iii), KIND=dp)
-      END DO
-
-      ! print self_energy and fit on the imaginary frequency axis if required
-      IF (check_fit) THEN
-
-         IF (output_unit > 0) THEN
-
-            WRITE (output_unit, *) ' '
-            WRITE (output_unit, '(T3,A,I5)') 'Check the GW fit for molecular orbital', n_level_gw_ref
-            WRITE (output_unit, '(T3,A)') '-------------------------------------------'
-            WRITE (output_unit, *)
-            WRITE (output_unit, '(T3,5A)') '  omega (i*eV)    ', 'Re(fit) (eV)    ', &
-               'Im(fit) (eV)  ', 'Re(Sig_c) (eV)  ', &
-               'Im(Sig_c) (eV)'
-
-         END IF
-
-         DO kkk = 1, num_fit_points
-            func_val = Lambda(1)
-            DO iii = 1, num_poles
-               jjj = iii*2
-               ! calculate value of the fit function
-               func_val = func_val+Lambda(jjj)/(im_unit*vec_omega_fit_gw_sign(kkk)-Lambda(jjj+1))
-            END DO
-            WRITE (output_unit, '(1F16.3,4F16.5)') vec_omega_fit_gw_sign(kkk)*evolt, REAL(func_val)*evolt, &
-               AIMAG(func_val)*evolt, REAL(vec_Sigma_c_gw(n_level_gw, kkk))*evolt, &
-               AIMAG(vec_Sigma_c_gw(n_level_gw, kkk))*evolt
-         END DO
-
-         WRITE (output_unit, *) ' '
-
-      END IF
-
-      IF (do_gw_im_time) THEN
-         ! for cubic-scaling GW, we have one Green's function for occ and virt states with the Fermi level
-         ! in the middle of homo and lumo
-         e_fermi = 0.5_dp*(Eigenval(homo)+Eigenval(homo+1))
-      ELSE
-         ! in case of O(N^4) GW, we have the Fermi level differently for occ and virt states, see
-         ! Fig. 1 in JCTC 12, 3623-3635 (2016)
-         IF (n_level_gw <= gw_corr_lev_occ) THEN
-            e_fermi = Eigenval(homo)+fermi_level_offset
-         ELSE
-            e_fermi = Eigenval(homo+1)-fermi_level_offset
-         END IF
-      END IF
-
-      ! either Z-shot or no crossing search for evaluating Sigma_c
-      IF (crossing_search == ri_rpa_g0w0_crossing_none) THEN
-
-         ! calculate func val on the real axis
-         ! gw_energ = only correlation part of the self energy
-         func_val = Lambda(1)
-         DO iii = 1, num_poles
-            jjj = iii*2
-            func_val = func_val+Lambda(jjj)/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))
-         END DO
-
-         gw_energ = REAL(func_val)
-         vec_gw_energ(n_level_gw) = gw_energ
-
-      ELSE IF (crossing_search == ri_rpa_g0w0_crossing_z_shot .OR. &
-               crossing_search == ri_rpa_g0w0_crossing_newton) THEN
-
-         ! calculate Sigma_c_fit(e_n) and Z
-         func_val = Lambda(1)
-         z_value(n_level_gw) = 1.0_dp
-         DO iii = 1, num_poles
-            jjj = iii*2
-            z_value(n_level_gw) = z_value(n_level_gw)+REAL(Lambda(jjj)/ &
-                                                           (Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))**2)
-            func_val = func_val+Lambda(jjj)/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(jjj+1))
-         END DO
-         ! m is the slope of the correl self-energy
-         m_value(n_level_gw) = 1.0_dp-z_value(n_level_gw)
-         z_value(n_level_gw) = 1.0_dp/z_value(n_level_gw)
-         gw_energ = REAL(func_val)
-         vec_gw_energ(n_level_gw) = gw_energ
-
-         ! in case one wants to do Newton-Raphson on top of the Z-shot
-         IF (crossing_search == ri_rpa_g0w0_crossing_newton) THEN
-
-            level_energ_GW = (Eigenval_scf(n_level_gw_ref)- &
-                              m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
-                              vec_gw_energ(n_level_gw)+ &
-                              vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
-                             z_value(n_level_gw)
-
-            ! Newton-Raphson iteration
-            DO kkk = 1, 1000
-
-               ! calculate the value of the fit function for level_energ_GW
-               func_val = Lambda(1)
-               z_value(n_level_gw) = 1.0_dp
-               DO iii = 1, num_poles
-                  jjj = iii*2
-                  func_val = func_val+Lambda(jjj)/(level_energ_GW-e_fermi-Lambda(jjj+1))
-               END DO
-
-               ! calculate the derivative of the fit function for level_energ_GW
-               deriv_val_real = -1.0_dp
-               DO iii = 1, num_poles
-                  jjj = iii*2
-                  deriv_val_real = deriv_val_real+REAL(Lambda(jjj))/((ABS(level_energ_GW-e_fermi-Lambda(jjj+1)))**2) &
-                                   -(REAL(Lambda(jjj))*(level_energ_GW-e_fermi)-REAL(Lambda(jjj)*CONJG(Lambda(jjj+1))))* &
-                                   2.0_dp*(level_energ_GW-e_fermi-REAL(Lambda(jjj+1)))/ &
-                                   ((ABS(level_energ_GW-e_fermi-Lambda(jjj+1)))**2)
-
-               END DO
-
-               delta = (Eigenval_scf(n_level_gw_ref)+vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)+REAL(func_val)-level_energ_GW)/ &
-                       deriv_val_real
-
-               level_energ_GW = level_energ_GW-delta
-
-               IF (ABS(delta) < 1.0E-08) EXIT
-
-            END DO
-
-            ! update the GW-energy by Newton-Raphson and set the Z-value to 1
-
-            vec_gw_energ(n_level_gw) = REAL(func_val)
-            z_value(n_level_gw) = 1.0_dp
-            m_value(n_level_gw) = 0.0_dp
-
-         END IF ! Newton-Raphson on top of Z-shot
-
-      ELSE
-         CPABORT("Only NONE, ZSHOT and NEWTON implemented for 2-pole model")
-      END IF ! decision crossing search none, Z-shot
-
-      !   --------------------------------------------
-      !  | calculate statistical error due to fitting |
-      !   --------------------------------------------
-
-      ! estimate the statistical error of the calculated Sigma_c(i*omega)
-      ! by sqrt(chi2/n), where n is the number of fit points
-
-      CALL calc_chi2(chi2, Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, num_poles, &
-                     num_fit_points, n_level_gw)
-
-      ! Estimate the statistical error of every fit point
-      stat_error = SQRT(chi2/num_fit_points)
-
-      ! allocate N array containing the second derivatives of chi^2
-      ALLOCATE (vec_N_gw(num_var*2))
-      vec_N_gw = 0.0_dp
-
-      ALLOCATE (mat_N_gw(num_var*2, num_var*2))
-      mat_N_gw = 0.0_dp
-
-      DO iii = 1, num_var*2
-         CALL calc_mat_N(vec_N_gw(iii), Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, &
-                         iii, iii, num_poles, num_fit_points, n_level_gw, 0.001_dp)
-      END DO
-
-      DO iii = 1, num_var*2
-         DO jjj = 1, num_var*2
-            CALL calc_mat_N(mat_N_gw(iii, jjj), Lambda_without_offset, vec_Sigma_c_gw, vec_omega_fit_gw_sign, &
-                            iii, jjj, num_poles, num_fit_points, n_level_gw, 0.001_dp)
-         END DO
-      END DO
-
-      CALL DGETRF(2*num_var, 2*num_var, mat_N_gw, 2*num_var, ipiv, info)
-
-      ! vec_b_gw is only working array
-      CALL DGETRI(2*num_var, mat_N_gw, 2*num_var, ipiv, vec_b_gw, 2*num_var, info)
-
-      ALLOCATE (stat_errors(2*num_var))
-      stat_errors = 0.0_dp
-
-      DO iii = 1, 2*num_var
-         stat_errors(iii) = SQRT(ABS(mat_N_gw(iii, iii)))*stat_error
-      END DO
-
-      ! Compute error of Sigma_c on real axis according to error propagation
-
-      vec_gw_energ_error_fit(n_level_gw) = 0.0_dp
-
-      DO kkk = 1, num_poles
-         vec_gw_energ_error_fit(n_level_gw) = vec_gw_energ_error_fit(n_level_gw)+ &
-                                              (stat_errors(4*kkk-1)+stat_errors(4*kkk))* &
-                                              ABS(1.0_dp/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(2*kkk+1))- &
-                                                  1.0_dp/(-Lambda(2*kkk+1)))+ &
-                                              (stat_errors(4*kkk+1)+stat_errors(4*kkk+2))*ABS(Lambda(2*kkk))* &
-                                              ABS(1.0_dp/(Eigenval(n_level_gw_ref)-e_fermi-Lambda(2*kkk+1))**2- &
-                                                  1.0_dp/(-Lambda(2*kkk+1))**2)
-      END DO
-
-      DEALLOCATE (mat_N_gw)
-      DEALLOCATE (vec_N_gw)
-      DEALLOCATE (mat_A_gw)
-      DEALLOCATE (mat_B_gw)
-      DEALLOCATE (stat_errors)
-      DEALLOCATE (dLambda)
-      DEALLOCATE (dLambda_2)
-      DEALLOCATE (vec_b_gw)
-      DEALLOCATE (vec_b_gw_copy)
-      DEALLOCATE (ipiv)
-      DEALLOCATE (vec_omega_fit_gw_sign)
-      DEALLOCATE (Lambda)
-      DEALLOCATE (Lambda_without_offset)
-      DEALLOCATE (Lambda_Re)
-      DEALLOCATE (Lambda_Im)
-
-   END SUBROUTINE fit_and_continuation_2pole
-
-! **************************************************************************************************
-!> \brief perform analytic continuation with pade approximation
-!> \param vec_gw_energ real Sigma_c
-!> \param vec_omega_fit_gw frequency points for Sigma_c(iomega)
-!> \param z_value 1/(1-dev)
-!> \param m_value derivative of real Sigma_c
-!> \param vec_Sigma_c_gw complex Sigma_c(iomega)
-!> \param vec_Sigma_x_minus_vxc_gw ...
-!> \param Eigenval quasiparticle energy during ev self-consistent GW
-!> \param Eigenval_scf KS/HF eigenvalue
-!> \param n_level_gw ...
-!> \param gw_corr_lev_occ ...
-!> \param nparam_pade number of pade parameters
-!> \param num_fit_points number of fit points for Sigma_c(iomega)
-!> \param crossing_search type ofr cross search to find quasiparticle energies
-!> \param homo ...
-!> \param check_fit ...
-!> \param fermi_level_offset ...
-!> \param do_gw_im_time ...
-! **************************************************************************************************
-   SUBROUTINE continuation_pade(vec_gw_energ, vec_omega_fit_gw, &
-                                z_value, m_value, vec_Sigma_c_gw, vec_Sigma_x_minus_vxc_gw, &
-                                Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, nparam_pade, &
-                                num_fit_points, crossing_search, homo, check_fit, &
-                                fermi_level_offset, do_gw_im_time)
-
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: vec_gw_energ
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_omega_fit_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: z_value, m_value
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw, Eigenval, &
-                                                            Eigenval_scf
-      INTEGER, INTENT(IN)                                :: n_level_gw, gw_corr_lev_occ, &
-                                                            nparam_pade, num_fit_points, &
-                                                            crossing_search, homo
-      LOGICAL, INTENT(IN)                                :: check_fit
-      REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
-      LOGICAL, INTENT(IN)                                :: do_gw_im_time
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'continuation_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit, sigma_c_pade
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: coeff_pade, omega_points_pade, &
-                                                            Sigma_c_gw_reorder
-      INTEGER                                            :: handle, jquad, n_level_gw_ref, &
-                                                            output_unit
-      REAL(KIND=dp)                                      :: e_fermi, energy_val, level_energ_GW, &
-                                                            sign_occ_virt
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: vec_omega_fit_gw_sign, &
-                                                            vec_omega_fit_gw_sign_reorder
-
-      CALL timeset(routineN, handle)
-
-      output_unit = cp_logger_get_default_io_unit()
-
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
-
-      ALLOCATE (vec_omega_fit_gw_sign(num_fit_points))
-
-      IF (n_level_gw <= gw_corr_lev_occ) THEN
-         sign_occ_virt = -1.0_dp
-      ELSE
-         sign_occ_virt = 1.0_dp
-      END IF
-
-      DO jquad = 1, num_fit_points
-         vec_omega_fit_gw_sign(jquad) = ABS(vec_omega_fit_gw(jquad))*sign_occ_virt
-      END DO
-
-      IF (do_gw_im_time) THEN
-         ! for cubic-scaling GW, we have one Green's function for occ and virt states with the Fermi level
-         ! in the middle of homo and lumo
-         e_fermi = 0.5_dp*(Eigenval(homo)+Eigenval(homo+1))
-      ELSE
-         ! in case of O(N^4) GW, we have the Fermi level differently for occ and virt states, see
-         ! Fig. 1 in JCTC 12, 3623-3635 (2016)
-         IF (n_level_gw <= gw_corr_lev_occ) THEN
-            e_fermi = Eigenval(homo)+fermi_level_offset
-         ELSE
-            e_fermi = Eigenval(homo+1)-fermi_level_offset
-         END IF
-      END IF
-
-      n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-      !*** reorder, such that omega=i*0 is first entry
-      ALLOCATE (Sigma_c_gw_reorder(num_fit_points))
-      ALLOCATE (vec_omega_fit_gw_sign_reorder(num_fit_points))
-      ! for cubic scaling GW fit points are ordered differently than in N^4 GW
-      IF (do_gw_im_time) THEN
-         DO jquad = 1, num_fit_points
-            Sigma_c_gw_reorder(jquad) = vec_Sigma_c_gw(n_level_gw, jquad)
-            vec_omega_fit_gw_sign_reorder(jquad) = vec_omega_fit_gw_sign(jquad)
-         ENDDO
-      ELSE
-         DO jquad = 1, num_fit_points
-            Sigma_c_gw_reorder(jquad) = vec_Sigma_c_gw(n_level_gw, num_fit_points-jquad+1)
-            vec_omega_fit_gw_sign_reorder(jquad) = vec_omega_fit_gw_sign(num_fit_points-jquad+1)
-         ENDDO
-      ENDIF
-
-      !*** evaluate parameters for pade approximation
-      ALLOCATE (coeff_pade(nparam_pade))
-      ALLOCATE (omega_points_pade(nparam_pade))
-      coeff_pade = 0.0_dp
-      CALL get_pade_parameters(Sigma_c_gw_reorder, vec_omega_fit_gw_sign_reorder, &
-                               num_fit_points, nparam_pade, omega_points_pade, coeff_pade)
-      IF (check_fit) THEN
-         CALL check_fit_pade(vec_omega_fit_gw_sign, vec_Sigma_c_gw(n_level_gw, :), &
-                             nparam_pade, omega_points_pade, coeff_pade, &
-                             num_fit_points, n_level_gw_ref, output_unit)
-      ENDIF
-
-      !*** calculate start_value for iterative cross-searching methods
-      IF ((crossing_search == ri_rpa_g0w0_crossing_bisection) .OR. &
-          (crossing_search == ri_rpa_g0w0_crossing_newton)) THEN
-         energy_val = Eigenval(n_level_gw_ref)-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c_pade)
-         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, z_value(n_level_gw), m_value(n_level_gw))
-         level_energ_GW = (Eigenval_scf(n_level_gw_ref)- &
-                           m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
-                           REAL(sigma_c_pade)+ &
-                           vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
-                          z_value(n_level_gw)
-      ENDIF
-
-      !*** perform crossing search
-      SELECT CASE (crossing_search)
-      CASE (ri_rpa_g0w0_crossing_none)
-         energy_val = Eigenval(n_level_gw_ref)-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c_pade)
-         vec_gw_energ(n_level_gw) = REAL(sigma_c_pade)
-
-      CASE (ri_rpa_g0w0_crossing_z_shot)
-         energy_val = Eigenval(n_level_gw_ref)-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c_pade)
-         vec_gw_energ(n_level_gw) = REAL(sigma_c_pade)
-
-         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, z_value(n_level_gw), m_value(n_level_gw))
-
-      CASE (ri_rpa_g0w0_crossing_bisection)
-         CALL get_sigma_c_bisection_pade(vec_gw_energ(n_level_gw), Eigenval_scf(n_level_gw_ref), &
-                                         vec_Sigma_x_minus_vxc_gw(n_level_gw_ref), e_fermi, &
-                                         nparam_pade, omega_points_pade, coeff_pade, &
-                                         start_val=level_energ_GW)
-         z_value(n_level_gw) = 1.0_dp
-         m_value(n_level_gw) = 0.0_dp
-
-      CASE (ri_rpa_g0w0_crossing_newton)
-         CALL get_sigma_c_newton_pade(vec_gw_energ(n_level_gw), Eigenval_scf(n_level_gw_ref), &
-                                      vec_Sigma_x_minus_vxc_gw(n_level_gw_ref), e_fermi, &
-                                      nparam_pade, omega_points_pade, coeff_pade, &
-                                      start_val=level_energ_GW)
-         z_value(n_level_gw) = 1.0_dp
-         m_value(n_level_gw) = 0.0_dp
-
-      CASE DEFAULT
-         CPABORT("Only NONE, Z_SHOT, NEWTON, and BISECTION crossing search implemented.")
-      END SELECT
-
-      DEALLOCATE (vec_omega_fit_gw_sign)
-      DEALLOCATE (Sigma_c_gw_reorder)
-      DEALLOCATE (vec_omega_fit_gw_sign_reorder)
-      DEALLOCATE (coeff_pade, omega_points_pade)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE continuation_pade
-
-! **************************************************************************************************
-!> \brief calculate pade parameter recursively as in  Eq. (A2) in J. Low Temp. Phys., Vol. 29,
-!>          1977, pp. 179
-!> \param y f(x), here: Sigma_c(iomega)
-!> \param x the frequency points omega
-!> \param num_fit_points ...
-!> \param nparam number of pade parameters
-!> \param xpoints set of points used in pade approximation, selection of x
-!> \param coeff pade coefficients
-! **************************************************************************************************
-   SUBROUTINE get_pade_parameters(y, x, num_fit_points, nparam, xpoints, coeff)
-
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: y
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: x
-      INTEGER, INTENT(IN)                                :: num_fit_points, nparam
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(INOUT)      :: xpoints, coeff
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_pade_parameters', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: ypoints
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: g_mat
-      INTEGER                                            :: handle, idat, iparam, nstep
-
-      CALL timeset(routineN, handle)
-
-      im_unit = (0.0_dp, 1.0_dp)
-
-      nstep = INT(num_fit_points/(nparam-1))
-      CPASSERT(LBOUND(x, 1) == 1)
-      CPASSERT(LBOUND(y, 1) == 1)
-
-      ALLOCATE (ypoints(nparam))
-      !omega=i0 is in element x(1)
-      idat = 1
-      DO iparam = 1, nparam-1
-         xpoints(iparam) = im_unit*x(idat)
-         ypoints(iparam) = y(idat)
-         idat = idat+nstep
-      ENDDO
-      xpoints(nparam) = im_unit*x(num_fit_points)
-      ypoints(nparam) = y(num_fit_points)
-
-      !*** generate parameters recursively
-
-      ALLOCATE (g_mat(nparam, nparam))
-      g_mat(:, 1) = ypoints(:)
-      DO iparam = 2, nparam
-         DO idat = iparam, nparam
-            g_mat(idat, iparam) = (g_mat(iparam-1, iparam-1)-g_mat(idat, iparam-1))/ &
-                                  ((xpoints(idat)-xpoints(iparam-1))*g_mat(idat, iparam-1))
-         ENDDO
-      ENDDO
-
-      DO iparam = 1, nparam
-         coeff(iparam) = g_mat(iparam, iparam)
-      ENDDO
-
-      DEALLOCATE (ypoints)
-      DEALLOCATE (g_mat)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_pade_parameters
-
-! **************************************************************************************************
-!> \brief evalute pade function for a real value x_val
-!> \param x_val real value
-!> \param nparam number of pade parameters
-!> \param xpoints selection of points of the original complex function, i.e. here of Sigma_c(iomega)
-!> \param coeff pade coefficients
-!> \param func_val function value
-! **************************************************************************************************
-   SUBROUTINE evaluate_pade_function(x_val, nparam, xpoints, coeff, func_val)
-
-      REAL(KIND=dp), INTENT(IN)                          :: x_val
-      INTEGER, INTENT(IN)                                :: nparam
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
-      COMPLEX(KIND=dp), INTENT(OUT)                      :: func_val
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'evaluate_pade_function', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: im_unit, re_unit
-      INTEGER                                            :: handle, iparam
-
-      CALL timeset(routineN, handle)
-
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
-
-      func_val = re_unit
-      DO iparam = nparam, 2, -1
-         func_val = re_unit+coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))/func_val
-      ENDDO
-
-      func_val = coeff(1)/func_val
-
-      CALL timestop(handle)
-
-   END SUBROUTINE evaluate_pade_function
-
-! **************************************************************************************************
-!> \brief get the z-value and the m-value (derivative) of the pade function
-!> \param x_val real value
-!> \param nparam number of pade parameters
-!> \param xpoints selection of points of the original complex function, i.e. here of Sigma_c(iomega)
-!> \param coeff pade coefficients
-!> \param z_value 1/(1-dev)
-!> \param m_value derivative
-! **************************************************************************************************
-   SUBROUTINE get_z_and_m_value_pade(x_val, nparam, xpoints, coeff, z_value, m_value)
-
-      REAL(KIND=dp), INTENT(IN)                          :: x_val
-      INTEGER, INTENT(IN)                                :: nparam
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: xpoints, coeff
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: z_value, m_value
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_z_and_m_value_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: denominator, dev_denominator, &
-                                                            dev_numerator, dev_val, func_val, &
-                                                            im_unit, numerator, re_unit
-      INTEGER                                            :: iparam
-
-      im_unit = (0.0_dp, 1.0_dp)
-      re_unit = (1.0_dp, 0.0_dp)
-
-      func_val = re_unit
-      dev_val = (0.0_dp, 0.0_dp)
-      DO iparam = nparam, 2, -1
-         numerator = coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))
-         dev_numerator = coeff(iparam)*re_unit
-         denominator = func_val
-         dev_denominator = dev_val
-         dev_val = dev_numerator/denominator-(numerator*dev_denominator)/(denominator**2)
-         func_val = re_unit+coeff(iparam)*(re_unit*x_val-xpoints(iparam-1))/func_val
-      ENDDO
-
-      dev_val = -1.0_dp*coeff(1)/(func_val**2)*dev_val
-      func_val = coeff(1)/func_val
-
-      IF (PRESENT(z_value)) THEN
-         z_value = 1.0_dp-REAL(dev_val)
-         z_value = 1.0_dp/z_value
-      ENDIF
-      IF (PRESENT(m_value)) m_value = REAL(dev_val)
-
-   END SUBROUTINE get_z_and_m_value_pade
-
-! **************************************************************************************************
-!> \brief crossing search using the bisection method to find the quasiparticle energy
-!> \param gw_energ real Sigma_c
-!> \param Eigenval_scf Eigenvalue from the SCF
-!> \param Sigma_x_minus_vxc_gw ...
-!> \param e_fermi fermi level
-!> \param nparam_pade number of pade parameters
-!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
-!> \param coeff_pade pade coefficients
-!> \param start_val start value for the quasiparticle iteration
-! **************************************************************************************************
-   SUBROUTINE get_sigma_c_bisection_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
-                                         nparam_pade, omega_points_pade, coeff_pade, start_val)
-
-      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
-      REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
-                                                            e_fermi
-      INTEGER, INTENT(IN)                                :: nparam_pade
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: start_val
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_sigma_c_bisection_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: sigma_c
-      INTEGER                                            :: handle, icount
-      REAL(KIND=dp)                                      :: delta, energy_val, my_start_val, &
-                                                            qp_energy, qp_energy_old, threshold
-
-      CALL timeset(routineN, handle)
-
-      threshold = 1.0E-7_dp
-
-      IF (PRESENT(start_val)) THEN
-         my_start_val = start_val
-      ELSE
-         my_start_val = Eigenval_scf
-      ENDIF
-
-      qp_energy = my_start_val
-      qp_energy_old = my_start_val
-      delta = 1.0E-3_dp
-
-      icount = 0
-      DO WHILE (ABS(delta) > threshold)
-         icount = icount+1
-         qp_energy = qp_energy_old+0.5_dp*delta
-         qp_energy_old = qp_energy
-         energy_val = qp_energy-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c)
-         qp_energy = Eigenval_scf+REAL(sigma_c)+Sigma_x_minus_vxc_gw
-         delta = qp_energy-qp_energy_old
-         IF (icount > 500) THEN
-            CPABORT("Self-consistent quasi-particle solution not found")
-            EXIT
-         ENDIF
-      ENDDO
-
-      gw_energ = REAL(sigma_c)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_sigma_c_bisection_pade
-
-! **************************************************************************************************
-!> \brief crossing search using the Newton method to find the quasiparticle energy
-!> \param gw_energ real Sigma_c
-!> \param Eigenval_scf Eigenvalue from the SCF
-!> \param Sigma_x_minus_vxc_gw ...
-!> \param e_fermi fermi level
-!> \param nparam_pade number of pade parameters
-!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
-!> \param coeff_pade pade coefficients
-!> \param start_val start value for the quasiparticle iteration
-! **************************************************************************************************
-   SUBROUTINE get_sigma_c_newton_pade(gw_energ, Eigenval_scf, Sigma_x_minus_vxc_gw, e_fermi, &
-                                      nparam_pade, omega_points_pade, coeff_pade, start_val)
-
-      REAL(KIND=dp), INTENT(OUT)                         :: gw_energ
-      REAL(KIND=dp), INTENT(IN)                          :: Eigenval_scf, Sigma_x_minus_vxc_gw, &
-                                                            e_fermi
-      INTEGER, INTENT(IN)                                :: nparam_pade
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: start_val
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_sigma_c_newton_pade', &
-         routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: sigma_c
-      INTEGER                                            :: handle, icount
-      REAL(KIND=dp)                                      :: delta, energy_val, m_value, &
-                                                            my_start_val, qp_energy, &
-                                                            qp_energy_old, threshold
-
-      CALL timeset(routineN, handle)
-
-      threshold = 1.0E-7_dp
-
-      IF (PRESENT(start_val)) THEN
-         my_start_val = start_val
-      ELSE
-         my_start_val = Eigenval_scf
-      ENDIF
-
-      qp_energy = my_start_val
-      qp_energy_old = my_start_val
-      delta = 1.0E-3_dp
-
-      icount = 0
-      DO WHILE (ABS(delta) > threshold)
-         icount = icount+1
-         energy_val = qp_energy-e_fermi
-         CALL evaluate_pade_function(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, sigma_c)
-         !get m_value --> derivative of function
-         CALL get_z_and_m_value_pade(energy_val, nparam_pade, omega_points_pade, &
-                                     coeff_pade, m_value=m_value)
-         qp_energy_old = qp_energy
-         qp_energy = qp_energy-(Eigenval_scf+Sigma_x_minus_vxc_gw+REAL(sigma_c)-qp_energy)/ &
-                     (m_value-1.0_dp)
-         delta = qp_energy-qp_energy_old
-         IF (icount > 500) THEN
-            CPABORT("Self-consistent quasi-particle solution not found")
-            EXIT
-         ENDIF
-      ENDDO
-
-      gw_energ = REAL(sigma_c)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_sigma_c_newton_pade
-
-! **************************************************************************************************
-!> \brief check "fit" for analytic continuation with pade approximation
-!> \param vec_omega_fit_gw_sign ...
-!> \param Sigma_c_gw complex Sigma_c(iomega) for n_level_gw
-!> \param nparam_pade number of pade parameters
-!> \param omega_points_pade selection of frequency points of Sigma_c(iomega)
-!> \param coeff_pade pade coefficients
-!> \param num_fit_points total number of frequency points for the complex Sigma_c
-!> \param n_level_gw_ref n_level_gw+homo-gw_corr_lev_occ
-!> \param output_unit ...
-! **************************************************************************************************
-   SUBROUTINE check_fit_pade(vec_omega_fit_gw_sign, Sigma_c_gw, &
-                             nparam_pade, omega_points_pade, coeff_pade, &
-                             num_fit_points, n_level_gw_ref, output_unit)
-
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_omega_fit_gw_sign
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: Sigma_c_gw
-      INTEGER, INTENT(IN)                                :: nparam_pade
-      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: omega_points_pade, coeff_pade
-      INTEGER, INTENT(IN)                                :: num_fit_points, n_level_gw_ref, &
-                                                            output_unit
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'check_fit_pade', routineP = moduleN//':'//routineN
-
-      COMPLEX(KIND=dp)                                   :: func_val, im_unit, re_unit
-      INTEGER                                            :: iparam, kkk
-
-      re_unit = (1.0_dp, 0.0_dp)
-      im_unit = (0.0_dp, 1.0_dp)
-
-      WRITE (output_unit, *) ' '
-      WRITE (output_unit, '(T3,A,I5)') 'Check the GW fit for molecular orbital', n_level_gw_ref
-      WRITE (output_unit, '(T3,A)') '-------------------------------------------'
-      WRITE (output_unit, *)
-      WRITE (output_unit, '(T3,5A)') '  omega (i*eV)    ', 'Re(fit) (eV)    ', &
-         'Im(fit) (eV)  ', 'Re(Sig_c) (eV)  ', &
-         'Im(Sig_c) (eV)'
-
-      DO kkk = 1, num_fit_points
-         func_val = re_unit
-         DO iparam = nparam_pade, 2, -1
-            func_val = re_unit+coeff_pade(iparam) &
-                       *(im_unit*vec_omega_fit_gw_sign(kkk)-omega_points_pade(iparam-1))/func_val
-         ENDDO
-
-         func_val = coeff_pade(1)/func_val
-
-         WRITE (output_unit, '(1F16.3,4F16.5)') vec_omega_fit_gw_sign(kkk)*evolt, REAL(func_val)*evolt, &
-            AIMAG(func_val)*evolt, REAL(Sigma_c_gw(kkk))*evolt, &
-            AIMAG(Sigma_c_gw(kkk))*evolt
-      END DO
-
-      WRITE (output_unit, *) ' '
-
-   END SUBROUTINE check_fit_pade
 
 ! **************************************************************************************************
 !> \brief Evaluate fit function when calculating tau grid for cosine transform
@@ -8332,14 +6223,12 @@ CONTAINS
 !> \param tau_wj_work ...
 !> \param omega ...
 ! **************************************************************************************************
-   PURE SUBROUTINE eval_fit_func_tau_grid_cosine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
+   SUBROUTINE eval_fit_func_tau_grid_cosine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: func_val
-      REAL(KIND=dp), INTENT(IN)                          :: x_value
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work
-      REAL(KIND=dp), INTENT(IN)                          :: omega
+      REAL(KIND=dp)                                      :: func_val, x_value
+      INTEGER                                            :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work
+      REAL(KIND=dp)                                      :: omega
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_tau_grid_cosine', &
          routineP = moduleN//':'//routineN
@@ -8366,14 +6255,12 @@ CONTAINS
 !> \param tau_wj_work ...
 !> \param omega ...
 ! **************************************************************************************************
-   PURE SUBROUTINE eval_fit_func_tau_grid_sine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
+   SUBROUTINE eval_fit_func_tau_grid_sine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: func_val
-      REAL(KIND=dp), INTENT(IN)                          :: x_value
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tau_wj_work
-      REAL(KIND=dp), INTENT(IN)                          :: omega
+      REAL(KIND=dp)                                      :: func_val, x_value
+      INTEGER                                            :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work
+      REAL(KIND=dp)                                      :: omega
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_tau_grid_sine', &
          routineP = moduleN//':'//routineN
@@ -8392,298 +6279,55 @@ CONTAINS
    END SUBROUTINE eval_fit_func_tau_grid_sine
 
 ! **************************************************************************************************
-!> \brief Prints the GW stuff to the output and optinally to an external file.
-!>        Also updates the eigenvalues for eigenvalue-self-consistent GW
-!> \param vec_gw_energ ...
-!> \param vec_gw_energ_error_fit ...
-!> \param z_value ...
-!> \param m_value ...
-!> \param vec_Sigma_x_minus_vxc_gw ...
-!> \param Eigenval ...
-!> \param Eigenval_last ...
-!> \param Eigenval_scf ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param gw_corr_lev_tot ...
-!> \param count_ev_sc_GW ...
-!> \param crossing_search ...
-!> \param homo ...
-!> \param nmo ...
-!> \param unit_nr ...
-!> \param print_gw_details ...
-!> \param remove_neg_virt_energies ...
-!> \param do_alpha ...
-!> \param do_beta ...
+!> \brief ...
+!> \param max_error ...
+!> \param omega ...
+!> \param tau_tj ...
+!> \param tau_wj_work ...
+!> \param x_values ...
+!> \param y_values ...
+!> \param num_integ_points ...
+!> \param num_x_nodes ...
 ! **************************************************************************************************
-   SUBROUTINE print_and_update_for_ev_sc(vec_gw_energ, vec_gw_energ_error_fit, &
-                                         z_value, m_value, vec_Sigma_x_minus_vxc_gw, Eigenval, &
-                                         Eigenval_last, Eigenval_scf, gw_corr_lev_occ, gw_corr_lev_virt, gw_corr_lev_tot, &
-                                         count_ev_sc_GW, crossing_search, homo, nmo, unit_nr, print_gw_details, &
-                                         remove_neg_virt_energies, do_alpha, do_beta)
+   SUBROUTINE calc_max_error_fit_tau_grid_with_sine(max_error, omega, tau_tj, tau_wj_work, x_values, &
+                                                    y_values, num_integ_points, num_x_nodes)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: vec_gw_energ, vec_gw_energ_error_fit, &
-                                                            z_value, m_value
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vec_Sigma_x_minus_vxc_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: Eigenval_last
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: Eigenval_scf
-      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, gw_corr_lev_virt, &
-                                                            gw_corr_lev_tot, count_ev_sc_GW, &
-                                                            crossing_search, homo, nmo, unit_nr
-      LOGICAL, INTENT(IN)                                :: print_gw_details, &
-                                                            remove_neg_virt_energies
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_alpha, do_beta
+      REAL(KIND=dp)                                      :: max_error, omega
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work, x_values, y_values
+      INTEGER                                            :: num_integ_points, num_x_nodes
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'print_and_update_for_ev_sc', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_sine', &
          routineP = moduleN//':'//routineN
 
-      CHARACTER(4)                                       :: occ_virt
-      INTEGER                                            :: handle, n_level_gw, n_level_gw_ref
-      LOGICAL                                            :: do_closed_shell, is_energy_okay, &
-                                                            my_do_alpha, my_do_beta
-      REAL(KIND=dp)                                      :: eigen_diff, new_energy
+      INTEGER                                            :: handle, kkk
+      REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
 
       CALL timeset(routineN, handle)
 
-      IF (PRESENT(do_alpha)) THEN
-         my_do_alpha = do_alpha
-      ELSE
-         my_do_alpha = .FALSE.
-      END IF
+      max_error_tmp = 0.0_dp
 
-      IF (PRESENT(do_beta)) THEN
-         my_do_beta = do_beta
-      ELSE
-         my_do_beta = .FALSE.
-      END IF
+      DO kkk = 1, num_x_nodes
 
-      do_closed_shell = .NOT. (my_do_alpha .OR. my_do_beta)
+         func_val = 0.0_dp
 
-      Eigenval_last(:) = Eigenval(:)
+         CALL eval_fit_func_tau_grid_sine(func_val, x_values(kkk), num_integ_points, tau_tj, tau_wj_work, omega)
 
-      IF (unit_nr > 0) THEN
-
-         WRITE (unit_nr, *) ' '
-
-         IF (do_closed_shell) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies'
-            WRITE (unit_nr, '(T3,A)') '-------------------------'
-         ELSE IF (my_do_alpha) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of alpha spins'
-            WRITE (unit_nr, '(T3,A)') '----------------------------------------'
-         ELSE IF (my_do_beta) THEN
-            WRITE (unit_nr, '(T3,A)') 'GW quasiparticle energies of beta spins'
-            WRITE (unit_nr, '(T3,A)') '---------------------------------------'
+         IF (ABS(y_values(kkk)-func_val) > max_error_tmp) THEN
+            max_error_tmp = ABS(y_values(kkk)-func_val)
+            func_val_temp = func_val
          END IF
 
-      END IF
+      END DO
 
-      IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
-         WRITE (unit_nr, *) ' '
-         WRITE (unit_nr, '(T5,A)') 'Molecular orbital        MO energy after SCF (eV)        G0W0 QP energy (eV)'
-      END IF
+      IF (max_error_tmp > max_error) THEN
 
-      IF (unit_nr > 0 .AND. print_gw_details) THEN
-         WRITE (unit_nr, '(T3,A)') ' '
-         WRITE (unit_nr, '(T3,A)') 'The GW quasiparticle energies are calculated according to: '
-      END IF
+         max_error = max_error_tmp
 
-      IF (crossing_search == ri_rpa_g0w0_crossing_none) THEN
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            new_energy = Eigenval_scf(n_level_gw_ref)+vec_gw_energ(n_level_gw)+ &
-                         vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)
-
-            is_energy_okay = .TRUE.
-
-            IF (remove_neg_virt_energies .AND. (n_level_gw_ref > homo .AND. new_energy < Eigenval(homo))) THEN
-               is_energy_okay = .FALSE.
-            END IF
-
-            IF (is_energy_okay) THEN
-               Eigenval(n_level_gw_ref) = new_energy
-            END IF
-         END DO
-
-         IF (unit_nr > 0 .AND. print_gw_details) THEN
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A)') 'E_GW = E_SCF +  Sigc(E_SCF) + Sigx - vxc'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A)') 'The energy unit of the following table is eV. Sigc_fit is a very conservative'
-            WRITE (unit_nr, '(T3,A)') 'estimate of the statistical error of the correlation self-energy caused by the'
-            WRITE (unit_nr, '(T3,A)') 'fitting.'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T14,2A)') 'MO        E_SCF         Sigc', &
-               '     Sigc_fit     Sigx-vxc         E_GW'
-         END IF
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            IF (n_level_gw <= gw_corr_lev_occ) THEN
-               occ_virt = 'occ'
-            ELSE
-               occ_virt = 'vir'
-            END IF
-
-            IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
-               WRITE (unit_nr, '(T5,I9,3A,2F27.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')     ', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-
-            IF (unit_nr > 0 .AND. print_gw_details) THEN
-               WRITE (unit_nr, '(T4,I4,3A,5F13.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  vec_gw_energ(n_level_gw)*evolt, &
-                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
-                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-         END DO
-
-         ! z-shot
-      ELSE
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-
-            new_energy = (Eigenval_scf(n_level_gw_ref)- &
-                          m_value(n_level_gw)*Eigenval(n_level_gw_ref)+ &
-                          vec_gw_energ(n_level_gw)+ &
-                          vec_Sigma_x_minus_vxc_gw(n_level_gw_ref))* &
-                         z_value(n_level_gw)
-
-            is_energy_okay = .TRUE.
-
-            IF (remove_neg_virt_energies .AND. (n_level_gw_ref > homo .AND. new_energy < Eigenval(homo))) THEN
-               is_energy_okay = .FALSE.
-            END IF
-
-            IF (is_energy_okay) THEN
-               Eigenval(n_level_gw_ref) = new_energy
-            END IF
-
-         END DO
-
-         IF (unit_nr > 0 .AND. print_gw_details) THEN
-            WRITE (unit_nr, '(T3,A)') 'E_GW = E_SCF + Z * ( Sigc(E_SCF) + Sigx - vxc )'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A)') 'The energy unit of the following table is eV.  Sigc_fit is a very conservative'
-            WRITE (unit_nr, '(T3,2A)') 'estimate of the statistical error of the fitting.'
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T13,2A)') 'MO      E_SCF       Sigc', &
-               '   Sigc_fit   Sigx-vxc          Z       E_GW'
-         END IF
-
-         DO n_level_gw = 1, gw_corr_lev_tot
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            IF (n_level_gw <= gw_corr_lev_occ) THEN
-               occ_virt = 'occ'
-            ELSE
-               occ_virt = 'vir'
-            END IF
-
-            IF (unit_nr > 0 .AND. (.NOT. print_gw_details)) THEN
-               WRITE (unit_nr, '(T5,I9,3A,2F27.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')     ', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-
-            IF (unit_nr > 0 .AND. print_gw_details .AND. MAXVAL(vec_gw_energ_error_fit) < 0.3_dp) THEN
-               WRITE (unit_nr, '(T3,I4,3A,6F11.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  vec_gw_energ(n_level_gw)*evolt, &
-                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
-                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
-                  z_value(n_level_gw), &
-                  Eigenval(n_level_gw_ref)*evolt
-            ELSE IF (unit_nr > 0 .AND. print_gw_details .AND. MAXVAL(vec_gw_energ_error_fit) .GE. 0.3_dp) THEN
-               WRITE (unit_nr, '(T3,I4,3A,2F11.3, ES11.1, 2F11.3)') &
-                  n_level_gw_ref, ' ( ', occ_virt, ')', &
-                  Eigenval_last(n_level_gw_ref)*evolt, &
-                  vec_gw_energ(n_level_gw)*evolt, &
-                  vec_gw_energ_error_fit(n_level_gw)*evolt, &
-                  vec_Sigma_x_minus_vxc_gw(n_level_gw_ref)*evolt, &
-                  z_value(n_level_gw), &
-                  Eigenval(n_level_gw_ref)*evolt
-            END IF
-         END DO
-
-         IF (unit_nr > 0) THEN
-            IF (do_closed_shell) THEN
-               WRITE (unit_nr, '(T3,A)') ' '
-               WRITE (unit_nr, '(T3,A,F57.2)') 'GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
-            ELSE IF (my_do_alpha) THEN
-               WRITE (unit_nr, '(T3,A)') ' '
-               WRITE (unit_nr, '(T3,A,F51.2)') 'Alpha GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
-            ELSE IF (my_do_beta) THEN
-               WRITE (unit_nr, '(T3,A)') ' '
-               WRITE (unit_nr, '(T3,A,F52.2)') 'Beta GW HOMO-LUMO gap (eV)', (Eigenval(homo+1)-Eigenval(homo))*evolt
-            END IF
-         END IF
-
-      END IF ! z-shot vs. no crossing
-
-      IF (unit_nr > 0) THEN
-         WRITE (unit_nr, *) ' '
-      END IF
-
-      ! for eigenvalue self-consistent GW, all eigenvalues have to be corrected
-      ! 1) the occupied; check if there are occupied MOs not being corrected by GW
-      IF (gw_corr_lev_occ < homo .AND. gw_corr_lev_occ > 0) THEN
-
-         ! calculate average GW correction for occupied orbitals
-         eigen_diff = 0.0_dp
-
-         DO n_level_gw = 1, gw_corr_lev_occ
-            n_level_gw_ref = n_level_gw+homo-gw_corr_lev_occ
-            eigen_diff = eigen_diff+Eigenval(n_level_gw_ref)-Eigenval_last(n_level_gw_ref)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_occ
-
-         ! correct the eigenvalues of the occupied orbitals which have not been corrected by GW
-         DO n_level_gw = 1, homo-gw_corr_lev_occ
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      ! 2) the virtual: check if there are virtual orbitals not being corrected by GW
-      IF (gw_corr_lev_virt < nmo-homo .AND. gw_corr_lev_virt > 0) THEN
-
-         ! calculate average GW correction for virtual orbitals
-         eigen_diff = 0.0_dp
-         DO n_level_gw = 1, gw_corr_lev_virt
-            n_level_gw_ref = n_level_gw+homo
-            eigen_diff = eigen_diff+Eigenval(n_level_gw_ref)-Eigenval_last(n_level_gw_ref)
-         END DO
-         eigen_diff = eigen_diff/gw_corr_lev_virt
-
-         ! correct the eigenvalues of the virtual orbitals which have not been corrected by GW
-         DO n_level_gw = homo+gw_corr_lev_virt+1, nmo
-            Eigenval(n_level_gw) = Eigenval(n_level_gw)+eigen_diff
-         END DO
-
-      END IF
-
-      IF ((gw_corr_lev_occ == 0 .OR. gw_corr_lev_virt == 0) .AND. count_ev_sc_GW > 1) THEN
-         CALL cp_warn(__LOCATION__, &
-                      "Please increase for eigenvalue-self-consistent GW, the number of "// &
-                      "corrected occupied and/or virtual orbitals above 0.")
       END IF
 
       CALL timestop(handle)
 
-   END SUBROUTINE print_and_update_for_ev_sc
+   END SUBROUTINE calc_max_error_fit_tau_grid_with_sine
 
 ! **************************************************************************************************
 !> \brief ...
@@ -8696,9 +6340,8 @@ CONTAINS
 
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
-      INTEGER, INTENT(IN)                                :: cut_RI
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(OUT)                                     :: non_zero_blocks_3c
+      INTEGER                                            :: cut_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: non_zero_blocks_3c
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_non_zero_blocks_3c', &
          routineP = moduleN//':'//routineN
@@ -8794,9 +6437,8 @@ CONTAINS
 
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut_col
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
-      INTEGER, INTENT(IN)                                :: cut_RI, cut_memory
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :, :), &
-         INTENT(OUT)                                     :: non_zero_blocks_3c_cut
+      INTEGER                                            :: cut_RI, cut_memory
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :, :)        :: non_zero_blocks_3c_cut
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_non_zero_blocks_3c_cut_col', &
          routineP = moduleN//':'//routineN
@@ -8944,12 +6586,11 @@ CONTAINS
                                            mat_3c_overl_int_cut, cut_RI, cut_memory, para_env_sub, &
                                            do_kpoints_cubic_RPA)
 
-      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :), INTENT(OUT) :: &
-         needed_cutRI_mem_R1vec_R2vec_for_kp
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :) :: needed_cutRI_mem_R1vec_R2vec_for_kp
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut
-      INTEGER, INTENT(IN)                                :: cut_RI, cut_memory
+      INTEGER                                            :: cut_RI, cut_memory
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
-      LOGICAL, INTENT(IN)                                :: do_kpoints_cubic_RPA
+      LOGICAL                                            :: do_kpoints_cubic_RPA
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'check_sparsity_arrays_for_kp', &
          routineP = moduleN//':'//routineN
@@ -9074,1629 +6715,6 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param delta_corr ...
-!> \param qs_env ...
-!> \param para_env ...
-!> \param para_env_RPA ...
-!> \param kp_grid ...
-!> \param homo ...
-!> \param nmo ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param omega ...
-!> \param fm_mo_coeff ...
-!> \param Eigenval ...
-!> \param matrix_berry_re_mo_mo ...
-!> \param matrix_berry_im_mo_mo ...
-!> \param first_cycle_periodic_correction ...
-!> \param kpoints ...
-!> \param do_mo_coeff_Gamma_only ...
-!> \param num_kp_grids ...
-!> \param eps_kpoint ...
-!> \param do_extra_kpoints ...
-!> \param do_aux_bas ...
-!> \param frac_aux_mos ...
-! **************************************************************************************************
-   SUBROUTINE calc_periodic_correction(delta_corr, qs_env, para_env, para_env_RPA, kp_grid, homo, nmo, &
-                                       gw_corr_lev_occ, gw_corr_lev_virt, omega, fm_mo_coeff, Eigenval, &
-                                       matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                       first_cycle_periodic_correction, kpoints, do_mo_coeff_Gamma_only, &
-                                       num_kp_grids, eps_kpoint, do_extra_kpoints, do_aux_bas, frac_aux_mos)
-
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: delta_corr
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
-      INTEGER, DIMENSION(:), POINTER                     :: kp_grid
-      INTEGER, INTENT(IN)                                :: homo, nmo, gw_corr_lev_occ, &
-                                                            gw_corr_lev_virt
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-      TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
-                                                            matrix_berry_im_mo_mo
-      LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only
-      INTEGER, INTENT(IN)                                :: num_kp_grids
-      REAL(KIND=dp), INTENT(IN)                          :: eps_kpoint
-      LOGICAL, INTENT(IN)                                :: do_extra_kpoints, do_aux_bas
-      REAL(KIND=dp), INTENT(IN)                          :: frac_aux_mos
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_periodic_correction', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eps_head, eps_inv_head
-      REAL(KIND=dp), DIMENSION(3, 3)                     :: h_inv
-
-      CALL timeset(routineN, handle)
-
-      IF (first_cycle_periodic_correction) THEN
-
-         CALL get_kpoints(qs_env, kpoints, kp_grid, num_kp_grids, para_env, h_inv, nmo, do_mo_coeff_Gamma_only, &
-                          do_extra_kpoints)
-
-         CALL get_berry_phase(qs_env, kpoints, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, fm_mo_coeff, &
-                              para_env, do_mo_coeff_Gamma_only, homo, nmo, gw_corr_lev_virt, eps_kpoint, do_aux_bas, &
-                              frac_aux_mos)
-
-      END IF
-
-      CALL compute_eps_head_Berry(eps_head, kpoints, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, para_env_RPA, &
-                                  qs_env, homo, Eigenval, omega)
-
-      CALL compute_eps_inv_head(eps_inv_head, eps_head, kpoints)
-
-      CALL kpoint_sum_for_eps_inv_head_Berry(delta_corr, eps_inv_head, kpoints, qs_env, &
-                                             matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                             homo, gw_corr_lev_occ, gw_corr_lev_virt, para_env_RPA, &
-                                             do_extra_kpoints)
-
-      DEALLOCATE (eps_head, eps_inv_head)
-
-      first_cycle_periodic_correction = .FALSE.
-
-      CALL timestop(handle)
-
-   END SUBROUTINE calc_periodic_correction
-
-! **************************************************************************************************
-!> \brief ...
-!> \param eps_head ...
-!> \param kpoints ...
-!> \param matrix_berry_re_mo_mo ...
-!> \param matrix_berry_im_mo_mo ...
-!> \param para_env_RPA ...
-!> \param qs_env ...
-!> \param homo ...
-!> \param Eigenval ...
-!> \param omega ...
-! **************************************************************************************************
-   SUBROUTINE compute_eps_head_Berry(eps_head, kpoints, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, para_env_RPA, &
-                                     qs_env, homo, Eigenval, omega)
-
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: eps_head
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
-                                                            matrix_berry_im_mo_mo
-      TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      INTEGER, INTENT(IN)                                :: homo
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      REAL(KIND=dp), INTENT(IN)                          :: omega
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_eps_head_Berry', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER :: col, col_end_in_block, col_offset, col_size, handle, i_col, i_row, ikp, nkp, row, &
-         row_offset, row_size, row_start_in_block
-      REAL(KIND=dp)                                      :: abs_k_square, cell_volume, &
-                                                            correct_kpoint(3), cos_square, &
-                                                            eigen_diff, relative_kpoint(3), &
-                                                            sin_square
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: P_head
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(dbcsr_iterator_type)                          :: iter
-
-      CALL timeset(routineN, handle)
-
-      CALL get_qs_env(qs_env=qs_env, cell=cell)
-      CALL get_cell(cell=cell, deth=cell_volume)
-
-      NULLIFY (data_block)
-
-      nkp = kpoints%nkp
-
-      ALLOCATE (P_head(nkp))
-      P_head(:) = 0.0_dp
-
-      ALLOCATE (eps_head(nkp))
-      eps_head(:) = 0.0_dp
-
-      DO ikp = 1, nkp
-
-         relative_kpoint(1:3) = MATMUL(cell%hmat, kpoints%xkp(1:3, ikp))
-
-         correct_kpoint(1:3) = twopi*kpoints%xkp(1:3, ikp)
-
-         abs_k_square = (correct_kpoint(1))**2+(correct_kpoint(2))**2+(correct_kpoint(3))**2
-
-         ! real part of the Berry phase
-         CALL dbcsr_iterator_start(iter, matrix_berry_re_mo_mo(ikp)%matrix)
-         DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-            CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                           row_size=row_size, col_size=col_size, &
-                                           row_offset=row_offset, col_offset=col_offset)
-
-            IF (row_offset+row_size <= homo .OR. col_offset > homo) CYCLE
-
-            IF (row_offset <= homo) THEN
-               row_start_in_block = homo-row_offset+2
-            ELSE
-               row_start_in_block = 1
-            END IF
-
-            IF (col_offset+col_size-1 > homo) THEN
-               col_end_in_block = homo-col_offset+1
-            ELSE
-               col_end_in_block = col_size
-            END IF
-
-            DO i_row = row_start_in_block, row_size
-
-               DO i_col = 1, col_end_in_block
-
-                  eigen_diff = Eigenval(i_col+col_offset-1)-Eigenval(i_row+row_offset-1)
-
-                  cos_square = (data_block(i_row, i_col))**2
-
-                  P_head(ikp) = P_head(ikp)+2.0_dp*eigen_diff/(omega**2+eigen_diff**2)*cos_square/abs_k_square
-
-               END DO
-
-            END DO
-
-         END DO
-
-         CALL dbcsr_iterator_stop(iter)
-
-         ! imaginary part of the Berry phase
-         CALL dbcsr_iterator_start(iter, matrix_berry_im_mo_mo(ikp)%matrix)
-         DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-            CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                           row_size=row_size, col_size=col_size, &
-                                           row_offset=row_offset, col_offset=col_offset)
-
-            IF (row_offset+row_size <= homo .OR. col_offset > homo) CYCLE
-
-            IF (row_offset <= homo) THEN
-               row_start_in_block = homo-row_offset+2
-            ELSE
-               row_start_in_block = 1
-            END IF
-
-            IF (col_offset+col_size-1 > homo) THEN
-               col_end_in_block = homo-col_offset+1
-            ELSE
-               col_end_in_block = col_size
-            END IF
-
-            DO i_row = row_start_in_block, row_size
-
-               DO i_col = 1, col_end_in_block
-
-                  eigen_diff = Eigenval(i_col+col_offset-1)-Eigenval(i_row+row_offset-1)
-
-                  sin_square = (data_block(i_row, i_col))**2
-
-                  P_head(ikp) = P_head(ikp)+2.0_dp*eigen_diff/(omega**2+eigen_diff**2)*sin_square/abs_k_square
-
-               END DO
-
-            END DO
-
-         END DO
-
-         CALL dbcsr_iterator_stop(iter)
-
-      END DO
-
-      CALL mp_sum(P_head, para_env_RPA%group)
-
-      ! normalize eps_head
-      ! 2.0_dp due to closed shell
-      eps_head(:) = 1.0_dp-2.0_dp*P_head(:)/cell_volume*fourpi
-
-      DEALLOCATE (P_head)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE compute_eps_head_Berry
-
-! **************************************************************************************************
-!> \brief ...
-!> \param qs_env ...
-!> \param kpoints ...
-!> \param matrix_berry_re_mo_mo ...
-!> \param matrix_berry_im_mo_mo ...
-!> \param fm_mo_coeff ...
-!> \param para_env ...
-!> \param do_mo_coeff_Gamma_only ...
-!> \param homo ...
-!> \param nmo ...
-!> \param gw_corr_lev_virt ...
-!> \param eps_kpoint ...
-!> \param do_aux_bas ...
-!> \param frac_aux_mos ...
-! **************************************************************************************************
-   SUBROUTINE get_berry_phase(qs_env, kpoints, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, fm_mo_coeff, para_env, &
-                              do_mo_coeff_Gamma_only, homo, nmo, gw_corr_lev_virt, eps_kpoint, do_aux_bas, &
-                              frac_aux_mos)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
-                                                            matrix_berry_im_mo_mo
-      TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff
-      TYPE(cp_para_env_type), POINTER                    :: para_env
-      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only
-      INTEGER, INTENT(IN)                                :: homo, nmo, gw_corr_lev_virt
-      REAL(KIND=dp), INTENT(IN)                          :: eps_kpoint
-      LOGICAL, INTENT(IN)                                :: do_aux_bas
-      REAL(KIND=dp), INTENT(IN)                          :: frac_aux_mos
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_berry_phase', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: col_index, handle, i_col_local, iab, &
-                                                            ikind, ikp, nao_aux, ncol_local, &
-                                                            nkind, nkp, nmo_for_aux_bas
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices
-      REAL(dp)                                           :: abs_kpoint, correct_kpoint(3), &
-                                                            scale_kpoint
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: evals_P, evals_P_sqrt_inv
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_aux_aux
-      TYPE(cp_fm_type), POINTER :: fm_mat_eigv_P, fm_mat_P, fm_mat_P_sqrt_inv, &
-         fm_mat_s_aux_aux_inv, fm_mat_scaled_eigv_P, fm_mat_work_aux_aux
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, matrix_s_aux_aux, &
-                                                            matrix_s_aux_orb
-      TYPE(dbcsr_type), POINTER :: cosmat, cosmat_desymm, mat_mo_coeff_aux, mat_mo_coeff_aux_2, &
-         mat_mo_coeff_Gamma_all, mat_mo_coeff_Gamma_occ_and_GW, mat_mo_coeff_im, mat_mo_coeff_re, &
-         mat_work_aux_orb, mat_work_aux_orb_2, matrix_P, matrix_P_sqrt, matrix_P_sqrt_inv, &
-         matrix_s_inv_aux_aux, sinmat, sinmat_desymm, tmp
-      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: gw_aux_basis_set_list, orb_basis_set_list
-      TYPE(gto_basis_set_type), POINTER                  :: basis_set_gw_aux
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_orb, sab_orb_mic, sgwgw_list, &
-                                                            sgworb_list
-      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(qs_kind_type), POINTER                        :: qs_kind
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
-
-      CALL timeset(routineN, handle)
-
-      nkp = kpoints%nkp
-
-      NULLIFY (matrix_berry_re_mo_mo, matrix_s, cell, matrix_berry_im_mo_mo, sinmat, cosmat, tmp, &
-               cosmat_desymm, sinmat_desymm, qs_kind_set, orb_basis_set_list, sab_orb_mic)
-
-      CALL get_qs_env(qs_env=qs_env, &
-                      cell=cell, &
-                      matrix_s=matrix_s, &
-                      qs_kind_set=qs_kind_set, &
-                      nkind=nkind, &
-                      ks_env=ks_env, &
-                      sab_orb=sab_orb)
-
-      ALLOCATE (orb_basis_set_list(nkind))
-      CALL basis_set_list_setup(orb_basis_set_list, "ORB", qs_kind_set)
-
-      CALL setup_neighbor_list(sab_orb_mic, orb_basis_set_list, qs_env=qs_env, mic=.FALSE.)
-
-      ! create dbcsr matrix of mo_coeff for multiplcation
-      NULLIFY (mat_mo_coeff_re)
-      CALL dbcsr_init_p(mat_mo_coeff_re)
-      CALL dbcsr_create(matrix=mat_mo_coeff_re, &
-                        template=matrix_s(1)%matrix, &
-                        matrix_type=dbcsr_type_no_symmetry)
-
-      NULLIFY (mat_mo_coeff_im)
-      CALL dbcsr_init_p(mat_mo_coeff_im)
-      CALL dbcsr_create(matrix=mat_mo_coeff_im, &
-                        template=matrix_s(1)%matrix, &
-                        matrix_type=dbcsr_type_no_symmetry)
-
-      NULLIFY (mat_mo_coeff_Gamma_all)
-      CALL dbcsr_init_p(mat_mo_coeff_Gamma_all)
-      CALL dbcsr_create(matrix=mat_mo_coeff_Gamma_all, &
-                        template=matrix_s(1)%matrix, &
-                        matrix_type=dbcsr_type_no_symmetry)
-
-      CALL copy_fm_to_dbcsr(fm_mo_coeff, mat_mo_coeff_Gamma_all, keep_sparsity=.FALSE.)
-
-      NULLIFY (mat_mo_coeff_Gamma_occ_and_GW)
-      CALL dbcsr_init_p(mat_mo_coeff_Gamma_occ_and_GW)
-      CALL dbcsr_create(matrix=mat_mo_coeff_Gamma_occ_and_GW, &
-                        template=matrix_s(1)%matrix, &
-                        matrix_type=dbcsr_type_no_symmetry)
-
-      CALL copy_fm_to_dbcsr(fm_mo_coeff, mat_mo_coeff_Gamma_occ_and_GW, keep_sparsity=.FALSE.)
-
-      IF (.NOT. do_aux_bas) THEN
-
-         ! allocate intermediate matrices
-         CALL dbcsr_init_p(cosmat)
-         CALL dbcsr_init_p(sinmat)
-         CALL dbcsr_init_p(tmp)
-         CALL dbcsr_init_p(cosmat_desymm)
-         CALL dbcsr_init_p(sinmat_desymm)
-         CALL dbcsr_create(matrix=cosmat, template=matrix_s(1)%matrix)
-         CALL dbcsr_create(matrix=sinmat, template=matrix_s(1)%matrix)
-         CALL dbcsr_create(matrix=tmp, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_create(matrix=cosmat_desymm, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_create(matrix=sinmat_desymm, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_copy(cosmat, matrix_s(1)%matrix)
-         CALL dbcsr_copy(sinmat, matrix_s(1)%matrix)
-         CALL dbcsr_set(cosmat, 0.0_dp)
-         CALL dbcsr_set(sinmat, 0.0_dp)
-
-         CALL dbcsr_allocate_matrix_set(matrix_berry_re_mo_mo, nkp)
-         CALL dbcsr_allocate_matrix_set(matrix_berry_im_mo_mo, nkp)
-
-      END IF
-
-      IF (do_aux_bas) THEN
-
-         NULLIFY (gw_aux_basis_set_list)
-         ALLOCATE (gw_aux_basis_set_list(nkind))
-
-         DO ikind = 1, nkind
-
-            NULLIFY (gw_aux_basis_set_list(ikind)%gto_basis_set)
-
-            NULLIFY (basis_set_gw_aux)
-
-            qs_kind => qs_kind_set(ikind)
-            CALL get_qs_kind(qs_kind=qs_kind, basis_set=basis_set_gw_aux, basis_type="AUX_GW")
-            CPASSERT(ASSOCIATED(basis_set_gw_aux))
-
-            basis_set_gw_aux%kind_radius = orb_basis_set_list(ikind)%gto_basis_set%kind_radius
-
-            gw_aux_basis_set_list(ikind)%gto_basis_set => basis_set_gw_aux
-
-         END DO
-
-         ! neighbor lists
-         NULLIFY (sgwgw_list, sgworb_list)
-         CALL setup_neighbor_list(sgwgw_list, gw_aux_basis_set_list, qs_env=qs_env)
-         CALL setup_neighbor_list(sgworb_list, gw_aux_basis_set_list, orb_basis_set_list, qs_env=qs_env)
-
-         NULLIFY (matrix_s_aux_aux, matrix_s_aux_orb)
-
-         ! build overlap matrix in gw aux basis and the mixed gw aux basis-orb basis
-         CALL build_overlap_matrix_simple(ks_env, matrix_s_aux_aux, &
-                                          gw_aux_basis_set_list, gw_aux_basis_set_list, sgwgw_list)
-
-         CALL build_overlap_matrix_simple(ks_env, matrix_s_aux_orb, &
-                                          gw_aux_basis_set_list, orb_basis_set_list, sgworb_list)
-
-         CALL dbcsr_get_info(matrix_s_aux_aux(1)%matrix, nfullrows_total=nao_aux)
-
-         nmo_for_aux_bas = FLOOR(frac_aux_mos*REAL(nao_aux, KIND=dp))
-
-         CALL cp_fm_struct_create(fm_struct_aux_aux, &
-                                  context=fm_mo_coeff%matrix_struct%context, &
-                                  nrow_global=nao_aux, &
-                                  ncol_global=nao_aux, &
-                                  para_env=para_env)
-
-         NULLIFY (mat_work_aux_orb)
-         CALL dbcsr_init_p(mat_work_aux_orb)
-         CALL dbcsr_create(matrix=mat_work_aux_orb, &
-                           template=matrix_s_aux_orb(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (mat_work_aux_orb_2)
-         CALL dbcsr_init_p(mat_work_aux_orb_2)
-         CALL dbcsr_create(matrix=mat_work_aux_orb_2, &
-                           template=matrix_s_aux_orb(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (mat_mo_coeff_aux)
-         CALL dbcsr_init_p(mat_mo_coeff_aux)
-         CALL dbcsr_create(matrix=mat_mo_coeff_aux, &
-                           template=matrix_s_aux_orb(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (mat_mo_coeff_aux_2)
-         CALL dbcsr_init_p(mat_mo_coeff_aux_2)
-         CALL dbcsr_create(matrix=mat_mo_coeff_aux_2, &
-                           template=matrix_s_aux_orb(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (matrix_s_inv_aux_aux)
-         CALL dbcsr_init_p(matrix_s_inv_aux_aux)
-         CALL dbcsr_create(matrix=matrix_s_inv_aux_aux, &
-                           template=matrix_s_aux_aux(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (matrix_P)
-         CALL dbcsr_init_p(matrix_P)
-         CALL dbcsr_create(matrix=matrix_P, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (matrix_P_sqrt)
-         CALL dbcsr_init_p(matrix_P_sqrt)
-         CALL dbcsr_create(matrix=matrix_P_sqrt, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (matrix_P_sqrt_inv)
-         CALL dbcsr_init_p(matrix_P_sqrt_inv)
-         CALL dbcsr_create(matrix=matrix_P_sqrt_inv, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (fm_mat_s_aux_aux_inv)
-         CALL cp_fm_create(fm_mat_s_aux_aux_inv, fm_struct_aux_aux, name="inverse overlap mat")
-
-         NULLIFY (fm_mat_work_aux_aux)
-         CALL cp_fm_create(fm_mat_work_aux_aux, fm_struct_aux_aux, name="work mat")
-
-         NULLIFY (fm_mat_P)
-         CALL cp_fm_create(fm_mat_P, fm_mo_coeff%matrix_struct)
-
-         NULLIFY (fm_mat_eigv_P)
-         CALL cp_fm_create(fm_mat_eigv_P, fm_mo_coeff%matrix_struct)
-
-         NULLIFY (fm_mat_scaled_eigv_P)
-         CALL cp_fm_create(fm_mat_scaled_eigv_P, fm_mo_coeff%matrix_struct)
-
-         NULLIFY (fm_mat_P_sqrt_inv)
-         CALL cp_fm_create(fm_mat_P_sqrt_inv, fm_mo_coeff%matrix_struct)
-
-         NULLIFY (evals_P)
-         ALLOCATE (evals_P(nmo))
-
-         NULLIFY (evals_P_sqrt_inv)
-         ALLOCATE (evals_P_sqrt_inv(nmo))
-
-         CALL copy_dbcsr_to_fm(matrix_s_aux_aux(1)%matrix, fm_mat_s_aux_aux_inv)
-         ! Calculate S_inverse
-         CALL cp_fm_cholesky_decompose(fm_mat_s_aux_aux_inv)
-         CALL cp_fm_cholesky_invert(fm_mat_s_aux_aux_inv)
-         ! Symmetrize the guy
-         CALL cp_fm_upper_to_full(fm_mat_s_aux_aux_inv, fm_mat_work_aux_aux)
-
-         CALL copy_fm_to_dbcsr(fm_mat_s_aux_aux_inv, matrix_s_inv_aux_aux, keep_sparsity=.FALSE.)
-
-         CALL dbcsr_multiply('N', 'N', 1.0_dp, matrix_s_inv_aux_aux, matrix_s_aux_orb(1)%matrix, 0.0_dp, mat_work_aux_orb, &
-                             filter_eps=1.0E-15_dp)
-
-         CALL dbcsr_multiply('N', 'N', 1.0_dp, mat_work_aux_orb, mat_mo_coeff_Gamma_all, 0.0_dp, mat_mo_coeff_aux_2, &
-                             last_column=nmo_for_aux_bas, filter_eps=1.0E-15_dp)
-
-         CALL dbcsr_multiply('N', 'N', 1.0_dp, matrix_s_aux_aux(1)%matrix, mat_mo_coeff_aux_2, 0.0_dp, mat_work_aux_orb, &
-                             filter_eps=1.0E-15_dp)
-
-         CALL dbcsr_multiply('T', 'N', 1.0_dp, mat_mo_coeff_aux_2, mat_work_aux_orb, 0.0_dp, matrix_P, &
-                             filter_eps=1.0E-15_dp)
-
-         CALL copy_dbcsr_to_fm(matrix_P, fm_mat_P)
-
-         CALL cp_fm_syevd(fm_mat_P, fm_mat_eigv_P, evals_P)
-
-         ! only invert the eigenvalues which correspond to the MOs used in the aux. basis
-         evals_P_sqrt_inv(1:nmo-nmo_for_aux_bas) = 0.0_dp
-         evals_P_sqrt_inv(nmo-nmo_for_aux_bas+1:nmo) = 1.0_dp/SQRT(evals_P(nmo-nmo_for_aux_bas+1:nmo))
-
-         CALL cp_fm_to_fm(fm_mat_eigv_P, fm_mat_scaled_eigv_P)
-
-         CALL cp_fm_get_info(matrix=fm_mat_scaled_eigv_P, &
-                             ncol_local=ncol_local, &
-                             col_indices=col_indices)
-
-         ! multiply eigenvectors with inverse sqrt of eigenvalues
-         DO i_col_local = 1, ncol_local
-
-            col_index = col_indices(i_col_local)
-
-            fm_mat_scaled_eigv_P%local_data(:, i_col_local) = &
-               fm_mat_scaled_eigv_P%local_data(:, i_col_local)*evals_P_sqrt_inv(col_index)
-
-         END DO
-
-         CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
-                      matrix_a=fm_mat_eigv_P, matrix_b=fm_mat_scaled_eigv_P, beta=0.0_dp, &
-                      matrix_c=fm_mat_P_sqrt_inv)
-
-         CALL copy_fm_to_dbcsr(fm_mat_P_sqrt_inv, matrix_P_sqrt_inv, keep_sparsity=.FALSE.)
-
-         CALL dbcsr_multiply('N', 'N', 1.0_dp, mat_mo_coeff_aux_2, matrix_P_sqrt_inv, 0.0_dp, mat_mo_coeff_aux, &
-                             filter_eps=1.0E-15_dp)
-
-         ! allocate intermediate matrices
-         CALL dbcsr_init_p(cosmat)
-         CALL dbcsr_init_p(sinmat)
-         CALL dbcsr_init_p(tmp)
-         CALL dbcsr_init_p(cosmat_desymm)
-         CALL dbcsr_init_p(sinmat_desymm)
-         CALL dbcsr_create(matrix=cosmat, template=matrix_s_aux_aux(1)%matrix)
-         CALL dbcsr_create(matrix=sinmat, template=matrix_s_aux_aux(1)%matrix)
-         CALL dbcsr_create(matrix=tmp, &
-                           template=matrix_s_aux_orb(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_create(matrix=cosmat_desymm, &
-                           template=matrix_s_aux_aux(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_create(matrix=sinmat_desymm, &
-                           template=matrix_s_aux_aux(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_copy(cosmat, matrix_s_aux_aux(1)%matrix)
-         CALL dbcsr_copy(sinmat, matrix_s_aux_aux(1)%matrix)
-         CALL dbcsr_set(cosmat, 0.0_dp)
-         CALL dbcsr_set(sinmat, 0.0_dp)
-
-         CALL dbcsr_allocate_matrix_set(matrix_berry_re_mo_mo, nkp)
-         CALL dbcsr_allocate_matrix_set(matrix_berry_im_mo_mo, nkp)
-
-         ! allocate the new MO coefficients in the aux basis
-         CALL dbcsr_release_p(mat_mo_coeff_Gamma_all)
-         CALL dbcsr_release_p(mat_mo_coeff_Gamma_occ_and_GW)
-
-         NULLIFY (mat_mo_coeff_Gamma_all)
-         CALL dbcsr_init_p(mat_mo_coeff_Gamma_all)
-         CALL dbcsr_create(matrix=mat_mo_coeff_Gamma_all, &
-                           template=matrix_s_aux_orb(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         CALL dbcsr_copy(mat_mo_coeff_Gamma_all, mat_mo_coeff_aux)
-
-         NULLIFY (mat_mo_coeff_Gamma_occ_and_GW)
-         CALL dbcsr_init_p(mat_mo_coeff_Gamma_occ_and_GW)
-         CALL dbcsr_create(matrix=mat_mo_coeff_Gamma_occ_and_GW, &
-                           template=matrix_s_aux_orb(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         CALL dbcsr_copy(mat_mo_coeff_Gamma_occ_and_GW, mat_mo_coeff_aux)
-
-         DEALLOCATE (evals_P, evals_P_sqrt_inv)
-
-      END IF
-
-      CALL remove_unnecessary_blocks(mat_mo_coeff_Gamma_occ_and_GW, homo, gw_corr_lev_virt)
-
-      DO ikp = 1, nkp
-
-         ALLOCATE (matrix_berry_re_mo_mo(ikp)%matrix)
-         CALL dbcsr_init_p(matrix_berry_re_mo_mo(ikp)%matrix)
-         CALL dbcsr_create(matrix_berry_re_mo_mo(ikp)%matrix, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, matrix_berry_re_mo_mo(ikp)%matrix)
-         CALL dbcsr_set(matrix_berry_re_mo_mo(ikp)%matrix, 0.0_dp)
-
-         ALLOCATE (matrix_berry_im_mo_mo(ikp)%matrix)
-         CALL dbcsr_init_p(matrix_berry_im_mo_mo(ikp)%matrix)
-         CALL dbcsr_create(matrix_berry_im_mo_mo(ikp)%matrix, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, matrix_berry_im_mo_mo(ikp)%matrix)
-         CALL dbcsr_set(matrix_berry_im_mo_mo(ikp)%matrix, 0.0_dp)
-
-         correct_kpoint(1:3) = -twopi*kpoints%xkp(1:3, ikp)
-
-         abs_kpoint = SQRT(correct_kpoint(1)**2+correct_kpoint(2)**2+correct_kpoint(3)**2)
-
-         IF (abs_kpoint < eps_kpoint) THEN
-
-            scale_kpoint = eps_kpoint/abs_kpoint
-            correct_kpoint(:) = correct_kpoint(:)*scale_kpoint
-
-         END IF
-
-         ! get the Berry phase
-         IF (do_aux_bas) THEN
-            CALL build_berry_moment_matrix(qs_env, cosmat, sinmat, correct_kpoint, sab_orb_external=sab_orb_mic, &
-                                           basis_type="AUX_GW")
-         ELSE
-            CALL build_berry_moment_matrix(qs_env, cosmat, sinmat, correct_kpoint, sab_orb_external=sab_orb_mic, &
-                                           basis_type="ORB")
-         END IF
-
-         IF (do_mo_coeff_Gamma_only) THEN
-
-            CALL dbcsr_desymmetrize(cosmat, cosmat_desymm)
-
-            CALL dbcsr_multiply('N', 'N', 1.0_dp, cosmat_desymm, mat_mo_coeff_Gamma_occ_and_GW, 0.0_dp, tmp, &
-                                filter_eps=1.0E-15_dp)
-
-            CALL dbcsr_multiply('T', 'N', 1.0_dp, mat_mo_coeff_Gamma_all, tmp, 0.0_dp, &
-                                matrix_berry_re_mo_mo(ikp)%matrix, filter_eps=1.0E-15_dp)
-
-            CALL dbcsr_desymmetrize(sinmat, sinmat_desymm)
-
-            CALL dbcsr_multiply('N', 'N', 1.0_dp, sinmat_desymm, mat_mo_coeff_Gamma_occ_and_GW, 0.0_dp, tmp, &
-                                filter_eps=1.0E-15_dp)
-
-            CALL dbcsr_multiply('T', 'N', 1.0_dp, mat_mo_coeff_Gamma_all, tmp, 0.0_dp, &
-                                matrix_berry_im_mo_mo(ikp)%matrix, filter_eps=1.0E-15_dp)
-
-         ELSE
-
-            ! get mo coeff at the ikp
-            CALL copy_fm_to_dbcsr(kpoints%kp_env(ikp)%kpoint_env%mos(1, 1)%mo_set%mo_coeff, &
-                                  mat_mo_coeff_re, keep_sparsity=.FALSE.)
-
-            CALL copy_fm_to_dbcsr(kpoints%kp_env(ikp)%kpoint_env%mos(2, 1)%mo_set%mo_coeff, &
-                                  mat_mo_coeff_im, keep_sparsity=.FALSE.)
-
-            CALL dbcsr_desymmetrize(cosmat, cosmat_desymm)
-
-            CALL dbcsr_desymmetrize(sinmat, sinmat_desymm)
-
-            ! I.
-            CALL dbcsr_multiply('N', 'N', 1.0_dp, cosmat_desymm, mat_mo_coeff_re, 0.0_dp, tmp)
-
-            ! I.1
-            CALL dbcsr_multiply('T', 'N', 1.0_dp, mat_mo_coeff_Gamma_all, tmp, 0.0_dp, &
-                                matrix_berry_re_mo_mo(ikp)%matrix)
-
-            ! II.
-            CALL dbcsr_multiply('N', 'N', 1.0_dp, sinmat_desymm, mat_mo_coeff_re, 0.0_dp, tmp)
-
-            ! II.5
-            CALL dbcsr_multiply('T', 'N', 1.0_dp, mat_mo_coeff_Gamma_all, tmp, 0.0_dp, &
-                                matrix_berry_im_mo_mo(ikp)%matrix)
-
-            ! III.
-            CALL dbcsr_multiply('N', 'N', 1.0_dp, cosmat_desymm, mat_mo_coeff_im, 0.0_dp, tmp)
-
-            ! III.7
-            CALL dbcsr_multiply('T', 'N', 1.0_dp, mat_mo_coeff_Gamma_all, tmp, 1.0_dp, &
-                                matrix_berry_im_mo_mo(ikp)%matrix)
-
-            ! IV.
-            CALL dbcsr_multiply('N', 'N', 1.0_dp, sinmat_desymm, mat_mo_coeff_im, 0.0_dp, tmp)
-
-            ! IV.3
-            CALL dbcsr_multiply('T', 'N', -1.0_dp, mat_mo_coeff_Gamma_all, tmp, 1.0_dp, &
-                                matrix_berry_re_mo_mo(ikp)%matrix)
-
-         END IF
-
-         IF (abs_kpoint < eps_kpoint) THEN
-
-            CALL dbcsr_scale(matrix_berry_im_mo_mo(ikp)%matrix, 1.0_dp/scale_kpoint)
-            CALL dbcsr_set(matrix_berry_re_mo_mo(ikp)%matrix, 0.0_dp)
-            CALL dbcsr_add_on_diag(matrix_berry_re_mo_mo(ikp)%matrix, 1.0_dp)
-
-         END IF
-
-      END DO
-
-      CALL dbcsr_release_p(cosmat)
-      CALL dbcsr_release_p(sinmat)
-      CALL dbcsr_release_p(mat_mo_coeff_re)
-      CALL dbcsr_release_p(mat_mo_coeff_im)
-      CALL dbcsr_release_p(mat_mo_coeff_Gamma_all)
-      CALL dbcsr_release_p(mat_mo_coeff_Gamma_occ_and_GW)
-      CALL dbcsr_release_p(tmp)
-      CALL dbcsr_release_p(cosmat_desymm)
-      CALL dbcsr_release_p(sinmat_desymm)
-      DEALLOCATE (orb_basis_set_list)
-
-      IF (ASSOCIATED(sab_orb_mic)) THEN
-         DO iab = 1, SIZE(sab_orb_mic)
-            CALL deallocate_neighbor_list_set(sab_orb_mic(iab)%neighbor_list_set)
-         END DO
-         DEALLOCATE (sab_orb_mic)
-      END IF
-
-      IF (do_aux_bas) THEN
-
-         DEALLOCATE (gw_aux_basis_set_list)
-         CALL dbcsr_deallocate_matrix_set(matrix_s_aux_aux)
-         CALL dbcsr_deallocate_matrix_set(matrix_s_aux_orb)
-         CALL dbcsr_release_p(mat_work_aux_orb)
-         CALL dbcsr_release_p(mat_work_aux_orb_2)
-         CALL dbcsr_release_p(mat_mo_coeff_aux)
-         CALL dbcsr_release_p(mat_mo_coeff_aux_2)
-         CALL dbcsr_release_p(matrix_s_inv_aux_aux)
-         CALL dbcsr_release_p(matrix_P)
-         CALL dbcsr_release_p(matrix_P_sqrt)
-         CALL dbcsr_release_p(matrix_P_sqrt_inv)
-
-         CALL cp_fm_struct_release(fm_struct_aux_aux)
-
-         CALL cp_fm_release(fm_mat_s_aux_aux_inv)
-         CALL cp_fm_release(fm_mat_work_aux_aux)
-         CALL cp_fm_release(fm_mat_P)
-         CALL cp_fm_release(fm_mat_eigv_P)
-         CALL cp_fm_release(fm_mat_scaled_eigv_P)
-         CALL cp_fm_release(fm_mat_P_sqrt_inv)
-
-         ! Deallocate the neighbor list structure
-         IF (ASSOCIATED(sgwgw_list)) THEN
-            DO iab = 1, SIZE(sgwgw_list)
-               CALL deallocate_neighbor_list_set(sgwgw_list(iab)%neighbor_list_set)
-            END DO
-            DEALLOCATE (sgwgw_list)
-         END IF
-
-         IF (ASSOCIATED(sgworb_list)) THEN
-            DO iab = 1, SIZE(sgworb_list)
-               CALL deallocate_neighbor_list_set(sgworb_list(iab)%neighbor_list_set)
-            END DO
-            DEALLOCATE (sgworb_list)
-         END IF
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_berry_phase
-
-! **************************************************************************************************
-!> \brief ...
-!> \param mat_mo_coeff_Gamma_occ_and_GW ...
-!> \param homo ...
-!> \param gw_corr_lev_virt ...
-! **************************************************************************************************
-   SUBROUTINE remove_unnecessary_blocks(mat_mo_coeff_Gamma_occ_and_GW, homo, gw_corr_lev_virt)
-
-      TYPE(dbcsr_type), POINTER                          :: mat_mo_coeff_Gamma_occ_and_GW
-      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_virt
-
-      INTEGER                                            :: col, col_offset, row
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
-      TYPE(dbcsr_iterator_type)                          :: iter
-
-      CALL dbcsr_iterator_start(iter, mat_mo_coeff_Gamma_occ_and_GW)
-
-      DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-         CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                        col_offset=col_offset)
-
-         IF (col_offset > homo+gw_corr_lev_virt) THEN
-
-            data_block = 0.0_dp
-
-         END IF
-
-      END DO
-
-      CALL dbcsr_iterator_stop(iter)
-
-      CALL dbcsr_filter(mat_mo_coeff_Gamma_occ_and_GW, 1.0E-15_dp)
-
-   END SUBROUTINE remove_unnecessary_blocks
-
-! **************************************************************************************************
-!> \brief ...
-!> \param Berry_nn_local ...
-!> \param matrix_berry_mo_mo ...
-!> \param para_env ...
-!> \param homo ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-! **************************************************************************************************
-   SUBROUTINE replicate_Berry_nn(Berry_nn_local, matrix_berry_mo_mo, para_env, homo, gw_corr_lev_occ, gw_corr_lev_virt)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: Berry_nn_local
-      TYPE(dbcsr_type), POINTER                          :: matrix_berry_mo_mo
-      TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_occ, gw_corr_lev_virt
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'replicate_Berry_nn', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: col, handle, i_row, n_level_gw, row, &
-                                                            row_offset, row_size
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
-      TYPE(dbcsr_iterator_type)                          :: iter
-
-      CALL timeset(routineN, handle)
-
-      Berry_nn_local = 0.0_dp
-
-      ! fill buffer_send
-      CALL dbcsr_iterator_start(iter, matrix_berry_mo_mo)
-      DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-         CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                        row_size=row_size, row_offset=row_offset)
-
-         IF (row .NE. col) CYCLE
-
-         DO i_row = 1, row_size
-
-            n_level_gw = i_row+row_offset-1
-
-            IF (n_level_gw < 1+homo-gw_corr_lev_occ .OR. n_level_gw > homo+gw_corr_lev_virt) CYCLE
-
-            Berry_nn_local(n_level_gw) = data_block(i_row, i_row)
-
-         END DO
-
-      END DO
-
-      CALL dbcsr_iterator_stop(iter)
-
-      CALL mp_sum(Berry_nn_local, para_env%group)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE replicate_Berry_nn
-
-! **************************************************************************************************
-!> \brief ...
-!> \param Berry_ia_local ...
-!> \param matrix_berry_mo_mo ...
-!> \param para_env ...
-!> \param homo ...
-! **************************************************************************************************
-   SUBROUTINE replicate_Berry_ia(Berry_ia_local, matrix_berry_mo_mo, para_env, homo)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: Berry_ia_local
-      TYPE(dbcsr_type), POINTER                          :: matrix_berry_mo_mo
-      TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: homo
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'replicate_Berry_ia', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER :: block_counter, block_size, col, col_offset, col_size, col_size_modified, &
-         col_start_loc_array, entry_counter, handle, iblk, imepos, msg_offset, num_blocks_send, &
-         num_entries_send, row, row_offset, row_offset_modified, row_size, row_size_modified, &
-         row_start_block, row_start_loc_array
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_rec, num_entries_rec, &
-                                                            sizes_rec, sizes_send
-      INTEGER, DIMENSION(:, :), POINTER                  :: req_array
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
-      TYPE(dbcsr_iterator_type)                          :: iter
-      TYPE(integ_mat_buffer_type), ALLOCATABLE, &
-         DIMENSION(:)                                    :: buffer_rec, buffer_send
-
-      CALL timeset(routineN, handle)
-
-      num_blocks_send = 0
-      num_entries_send = 0
-
-      NULLIFY (data_block)
-
-      CALL dbcsr_iterator_start(iter, matrix_berry_mo_mo)
-      DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-         CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                        row_size=row_size, col_size=col_size, &
-                                        row_offset=row_offset, col_offset=col_offset)
-
-         IF (row_offset+row_size <= homo .OR. col_offset > homo) CYCLE
-
-         IF (row_offset <= homo) THEN
-            row_size_modified = row_size+row_offset-homo-1
-         ELSE
-            row_size_modified = row_size
-         END IF
-
-         IF (col_offset+col_size-1 > homo) THEN
-            col_size_modified = homo-col_offset+1
-         ELSE
-            col_size_modified = col_size
-         END IF
-
-         num_blocks_send = num_blocks_send+1
-         num_entries_send = num_entries_send+row_size_modified*col_size_modified
-
-      END DO
-
-      CALL dbcsr_iterator_stop(iter)
-
-      ALLOCATE (buffer_rec(0:para_env%num_pe-1))
-      ALLOCATE (buffer_send(0:para_env%num_pe-1))
-
-      ALLOCATE (num_entries_rec(0:para_env%num_pe-1))
-      ALLOCATE (num_blocks_rec(0:para_env%num_pe-1))
-
-      IF (para_env%num_pe > 1) THEN
-
-         ALLOCATE (sizes_rec(0:2*para_env%num_pe-1))
-         ALLOCATE (sizes_send(0:2*para_env%num_pe-1))
-
-         DO imepos = 0, para_env%num_pe-1
-            sizes_send(2*imepos) = num_entries_send
-            sizes_send(2*imepos+1) = num_blocks_send
-         END DO
-
-         CALL mp_alltoall(sizes_send, sizes_rec, 2, para_env%group)
-
-         DO imepos = 0, para_env%num_pe-1
-            num_entries_rec(imepos) = sizes_rec(2*imepos)
-            num_blocks_rec(imepos) = sizes_rec(2*imepos+1)
-         END DO
-
-         DEALLOCATE (sizes_rec, sizes_send)
-
-      ELSE
-
-         num_entries_rec(0) = num_entries_send
-         num_blocks_rec(0) = num_blocks_send
-
-      END IF
-
-      ! allocate data message and corresponding indices
-      DO imepos = 0, para_env%num_pe-1
-
-         ALLOCATE (buffer_rec(imepos)%msg(num_entries_rec(imepos)))
-         buffer_rec(imepos)%msg = 0.0_dp
-
-         ALLOCATE (buffer_send(imepos)%msg(num_entries_send))
-         buffer_send(imepos)%msg = 0.0_dp
-
-         ALLOCATE (buffer_rec(imepos)%indx(num_blocks_rec(imepos), 5))
-         buffer_rec(imepos)%indx = 0
-
-         ALLOCATE (buffer_send(imepos)%indx(num_blocks_send, 5))
-         buffer_send(imepos)%indx = 0
-
-      END DO
-
-      entry_counter = 0
-      block_counter = 0
-
-      NULLIFY (data_block)
-
-      ! fill buffer_send
-      CALL dbcsr_iterator_start(iter, matrix_berry_mo_mo)
-      DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-         CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                        row_size=row_size, col_size=col_size, &
-                                        row_offset=row_offset, col_offset=col_offset)
-
-         IF (row_offset+row_size <= homo .OR. col_offset > homo) CYCLE
-
-         IF (row_offset <= homo) THEN
-            row_size_modified = row_size+row_offset-homo-1
-            row_start_block = row_size-row_size_modified+1
-            row_offset_modified = homo+1
-         ELSE
-            row_start_block = 1
-            row_size_modified = row_size
-            row_offset_modified = row_offset
-         END IF
-
-         IF (col_offset+col_size-1 > homo) THEN
-            col_size_modified = homo-col_offset+1
-         ELSE
-            col_size_modified = col_size
-         END IF
-
-         block_size = row_size_modified*col_size_modified
-
-         DO imepos = 0, para_env%num_pe-1
-
-            buffer_send(imepos)%msg(entry_counter+1:entry_counter+block_size) = &
-               RESHAPE(data_block(row_start_block:row_size, 1:col_size_modified), (/block_size/))
-
-            buffer_send(imepos)%indx(block_counter+1, 1) = row_offset_modified
-            buffer_send(imepos)%indx(block_counter+1, 2) = row_size_modified
-            buffer_send(imepos)%indx(block_counter+1, 3) = col_offset
-            buffer_send(imepos)%indx(block_counter+1, 4) = col_size_modified
-            buffer_send(imepos)%indx(block_counter+1, 5) = entry_counter
-
-         END DO
-
-         entry_counter = entry_counter+block_size
-
-         block_counter = block_counter+1
-
-      END DO
-
-      CALL dbcsr_iterator_stop(iter)
-
-      ALLOCATE (req_array(1:para_env%num_pe, 4))
-
-      ALLOCATE (sizes_rec(0:para_env%num_pe-1))
-      ALLOCATE (sizes_send(0:para_env%num_pe-1))
-
-      DO imepos = 0, para_env%num_pe-1
-
-         sizes_send(imepos) = num_entries_send
-         sizes_rec(imepos) = num_entries_rec(imepos)
-
-      END DO
-
-      CALL communicate_buffer(para_env, sizes_rec, sizes_send, buffer_rec, buffer_send, req_array)
-
-      DEALLOCATE (req_array, sizes_rec, sizes_send)
-
-      Berry_ia_local = 0.0_dp
-
-      ! fill Berry_ia_local
-      DO imepos = 0, para_env%num_pe-1
-
-         DO iblk = 1, num_blocks_rec(imepos)
-
-            row_start_loc_array = buffer_rec(imepos)%indx(iblk, 1)-homo
-            row_size = buffer_rec(imepos)%indx(iblk, 2)
-            col_start_loc_array = buffer_rec(imepos)%indx(iblk, 3)
-            col_size = buffer_rec(imepos)%indx(iblk, 4)
-            msg_offset = buffer_rec(imepos)%indx(iblk, 5)
-
-            Berry_ia_local(row_start_loc_array:row_start_loc_array+row_size-1, &
-                           col_start_loc_array:col_start_loc_array+col_size-1) = &
-               RESHAPE(buffer_rec(imepos)%msg(msg_offset+1:msg_offset+row_size*col_size), &
-                       (/row_size, col_size/))
-
-         END DO
-
-      END DO
-
-      ! deallocate data message and corresponding indices
-      DO imepos = 0, para_env%num_pe-1
-
-         DEALLOCATE (buffer_rec(imepos)%msg)
-         DEALLOCATE (buffer_send(imepos)%msg)
-         DEALLOCATE (buffer_rec(imepos)%indx)
-         DEALLOCATE (buffer_send(imepos)%indx)
-
-      END DO
-
-      CALL timestop(handle)
-
-   END SUBROUTINE replicate_Berry_ia
-
-! **************************************************************************************************
-! ...
-! **************************************************************************************************
-!> \brief ...
-!> \param delta_corr ...
-!> \param eps_inv_head ...
-!> \param kpoints ...
-!> \param qs_env ...
-!> \param matrix_berry_re_mo_mo ...
-!> \param matrix_berry_im_mo_mo ...
-!> \param homo ...
-!> \param gw_corr_lev_occ ...
-!> \param gw_corr_lev_virt ...
-!> \param para_env_RPA ...
-!> \param do_extra_kpoints ...
-! **************************************************************************************************
-   SUBROUTINE kpoint_sum_for_eps_inv_head_Berry(delta_corr, eps_inv_head, kpoints, qs_env, matrix_berry_re_mo_mo, &
-                                                matrix_berry_im_mo_mo, homo, gw_corr_lev_occ, gw_corr_lev_virt, &
-                                                para_env_RPA, do_extra_kpoints)
-
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: delta_corr
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: eps_inv_head
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_re_mo_mo, &
-                                                            matrix_berry_im_mo_mo
-      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_occ, gw_corr_lev_virt
-      TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env_RPA
-      LOGICAL, INTENT(IN)                                :: do_extra_kpoints
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_sum_for_eps_inv_head_Berry', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: col, col_offset, col_size, handle, &
-                                                            i_col, i_row, ikp, m_level, &
-                                                            n_level_gw, nkp, row, row_offset, &
-                                                            row_size
-      REAL(KIND=dp)                                      :: abs_k_square, cell_volume, &
-                                                            check_int_one_over_ksq, contribution, &
-                                                            weight
-      REAL(KIND=dp), DIMENSION(3)                        :: correct_kpoint
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: delta_corr_extra
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(dbcsr_iterator_type)                          :: iter, iter_new
-
-      CALL timeset(routineN, handle)
-
-      CALL get_qs_env(qs_env=qs_env, cell=cell)
-
-      CALL get_cell(cell=cell, deth=cell_volume)
-
-      nkp = kpoints%nkp
-
-      delta_corr = 0.0_dp
-
-      IF (do_extra_kpoints) THEN
-         NULLIFY (delta_corr_extra)
-         ALLOCATE (delta_corr_extra(1+homo-gw_corr_lev_occ:homo+gw_corr_lev_virt))
-         delta_corr_extra = 0.0_dp
-      END IF
-
-      check_int_one_over_ksq = 0.0_dp
-
-      DO ikp = 1, nkp
-
-         weight = kpoints%wkp(ikp)
-
-         correct_kpoint(1:3) = twopi*kpoints%xkp(1:3, ikp)
-
-         abs_k_square = (correct_kpoint(1))**2+(correct_kpoint(2))**2+(correct_kpoint(3))**2
-
-         ! cos part of the Berry phase
-         CALL dbcsr_iterator_start(iter, matrix_berry_re_mo_mo(ikp)%matrix)
-         DO WHILE (dbcsr_iterator_blocks_left(iter))
-
-            CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                           row_size=row_size, col_size=col_size, &
-                                           row_offset=row_offset, col_offset=col_offset)
-
-            DO i_col = 1, col_size
-
-               DO n_level_gw = 1+homo-gw_corr_lev_occ, homo+gw_corr_lev_virt
-
-                  IF (n_level_gw == i_col+col_offset-1) THEN
-
-                     DO i_row = 1, row_size
-
-                        contribution = weight*(eps_inv_head(ikp)-1.0_dp)/abs_k_square*(data_block(i_row, i_col))**2
-
-                        m_level = i_row+row_offset-1
-
-                        ! we only compute the correction for n=m
-                        IF (m_level .NE. n_level_gw) CYCLE
-
-                        IF (.NOT. do_extra_kpoints) THEN
-
-                           delta_corr(n_level_gw) = delta_corr(n_level_gw)+contribution
-
-                        ELSE
-
-                           IF (ikp <= nkp*8/9) THEN
-
-                              delta_corr(n_level_gw) = delta_corr(n_level_gw)+contribution
-
-                           ELSE
-
-                              delta_corr_extra(n_level_gw) = delta_corr_extra(n_level_gw)+contribution
-
-                           END IF
-
-                        END IF
-
-                     END DO
-
-                  END IF
-
-               END DO
-
-            END DO
-
-         END DO
-
-         CALL dbcsr_iterator_stop(iter)
-
-         ! the same for the im. part of the Berry phase
-         CALL dbcsr_iterator_start(iter_new, matrix_berry_im_mo_mo(ikp)%matrix)
-         DO WHILE (dbcsr_iterator_blocks_left(iter_new))
-
-            CALL dbcsr_iterator_next_block(iter_new, row, col, data_block, &
-                                           row_size=row_size, col_size=col_size, &
-                                           row_offset=row_offset, col_offset=col_offset)
-
-            DO i_col = 1, col_size
-
-               DO n_level_gw = 1+homo-gw_corr_lev_occ, homo+gw_corr_lev_virt
-
-                  IF (n_level_gw == i_col+col_offset-1) THEN
-
-                     DO i_row = 1, row_size
-
-                        m_level = i_row+row_offset-1
-
-                        contribution = weight*(eps_inv_head(ikp)-1.0_dp)/abs_k_square*(data_block(i_row, i_col))**2
-
-                        ! we only compute the correction for n=m
-                        IF (m_level .NE. n_level_gw) CYCLE
-
-                        IF (.NOT. do_extra_kpoints) THEN
-
-                           delta_corr(n_level_gw) = delta_corr(n_level_gw)+contribution
-
-                        ELSE
-
-                           IF (ikp <= nkp*8/9) THEN
-
-                              delta_corr(n_level_gw) = delta_corr(n_level_gw)+contribution
-
-                           ELSE
-
-                              delta_corr_extra(n_level_gw) = delta_corr_extra(n_level_gw)+contribution
-
-                           END IF
-
-                        END IF
-
-                     END DO
-
-                  END IF
-
-               END DO
-
-            END DO
-
-         END DO
-
-         CALL dbcsr_iterator_stop(iter_new)
-
-         check_int_one_over_ksq = check_int_one_over_ksq+weight/abs_k_square
-
-      END DO
-
-      ! normalize by the cell volume
-      delta_corr = delta_corr/cell_volume*fourpi
-
-      check_int_one_over_ksq = check_int_one_over_ksq/cell_volume
-
-      CALL mp_sum(delta_corr, para_env_RPA%group)
-
-      IF (do_extra_kpoints) THEN
-
-         delta_corr_extra = delta_corr_extra/cell_volume*fourpi
-
-         CALL mp_sum(delta_corr_extra, para_env_RPA%group)
-
-         delta_corr(:) = delta_corr(:)+(delta_corr(:)-delta_corr_extra(:))
-
-         DEALLOCATE (delta_corr_extra)
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE kpoint_sum_for_eps_inv_head_Berry
-
-! **************************************************************************************************
-! ...
-! **************************************************************************************************
-!> \brief ...
-!> \param eps_inv_head ...
-!> \param eps_head ...
-!> \param kpoints ...
-! **************************************************************************************************
-   PURE SUBROUTINE compute_eps_inv_head(eps_inv_head, eps_head, kpoints)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: eps_inv_head
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: eps_head
-      TYPE(kpoint_type), POINTER                         :: kpoints
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_eps_inv_head', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: ikp, nkp
-
-      nkp = kpoints%nkp
-
-      ALLOCATE (eps_inv_head(nkp))
-
-      DO ikp = 1, nkp
-
-         eps_inv_head(ikp) = 1.0_dp/eps_head(ikp)
-
-      END DO
-
-   END SUBROUTINE compute_eps_inv_head
-
-! **************************************************************************************************
-! ...
-! **************************************************************************************************
-!> \brief ...
-!> \param qs_env ...
-!> \param kpoints ...
-!> \param kp_grid ...
-!> \param num_kp_grids ...
-!> \param para_env ...
-!> \param h_inv ...
-!> \param nmo ...
-!> \param do_mo_coeff_Gamma_only ...
-!> \param do_extra_kpoints ...
-! **************************************************************************************************
-   SUBROUTINE get_kpoints(qs_env, kpoints, kp_grid, num_kp_grids, para_env, h_inv, nmo, &
-                          do_mo_coeff_Gamma_only, do_extra_kpoints)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      INTEGER, DIMENSION(:), POINTER                     :: kp_grid
-      INTEGER, INTENT(IN)                                :: num_kp_grids
-      TYPE(cp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT)      :: h_inv
-      INTEGER, INTENT(IN)                                :: nmo
-      LOGICAL, INTENT(IN)                                :: do_mo_coeff_Gamma_only, do_extra_kpoints
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_kpoints', routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: end_kp, handle, i, i_grid_level, ix, iy, &
-                                                            iz, nkp_inner_grid, nkp_outer_grid, &
-                                                            npoints, start_kp
-      INTEGER, DIMENSION(3)                              :: outer_kp_grid
-      REAL(KIND=dp)                                      :: kpoint_weight_left, single_weight
-      REAL(KIND=dp), DIMENSION(3)                        :: kpt_latt, reducing_factor
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      TYPE(qs_environment_type), POINTER                 :: qs_env_kp_Gamma_only
-
-      CALL timeset(routineN, handle)
-
-      NULLIFY (kpoints, cell, particle_set, qs_env_kp_Gamma_only)
-
-      ! check whether kp_grid includes the Gamma point. If so, abort.
-      CPASSERT(MOD(kp_grid(1)*kp_grid(2)*kp_grid(3), 2) == 0)
-      IF (do_extra_kpoints) THEN
-         CPASSERT(do_mo_coeff_Gamma_only)
-      END IF
-
-      IF (do_mo_coeff_Gamma_only) THEN
-
-         outer_kp_grid(1) = kp_grid(1)-1
-         outer_kp_grid(2) = kp_grid(2)-1
-         outer_kp_grid(3) = kp_grid(3)-1
-
-         CALL get_qs_env(qs_env=qs_env, cell=cell, particle_set=particle_set)
-
-         CALL get_cell(cell, h_inv=h_inv)
-
-         CALL kpoint_create(kpoints)
-
-         kpoints%kp_scheme = "GENERAL"
-         kpoints%symmetry = .FALSE.
-         kpoints%verbose = .FALSE.
-         kpoints%full_grid = .FALSE.
-         kpoints%use_real_wfn = .FALSE.
-         kpoints%eps_geo = 1.e-6_dp
-         npoints = kp_grid(1)*kp_grid(2)*kp_grid(3)/2+ &
-                   (num_kp_grids-1)*((outer_kp_grid(1)+1)/2*outer_kp_grid(2)*outer_kp_grid(3)-1)
-
-         IF (do_extra_kpoints) THEN
-
-            CPASSERT(num_kp_grids == 1)
-            CPASSERT(MOD(kp_grid(1), 4) == 0)
-            CPASSERT(MOD(kp_grid(2), 4) == 0)
-            CPASSERT(MOD(kp_grid(3), 4) == 0)
-
-         END IF
-
-         IF (do_extra_kpoints) THEN
-
-            npoints = kp_grid(1)*kp_grid(2)*kp_grid(3)/2+kp_grid(1)*kp_grid(2)*kp_grid(3)/2/8
-
-         END IF
-
-         kpoints%full_grid = .TRUE.
-         kpoints%nkp = npoints
-         ALLOCATE (kpoints%xkp(3, npoints), kpoints%wkp(npoints))
-         kpoints%xkp = 0.0_dp
-         kpoints%wkp = 0.0_dp
-
-         nkp_outer_grid = outer_kp_grid(1)*outer_kp_grid(2)*outer_kp_grid(3)
-         nkp_inner_grid = kp_grid(1)*kp_grid(2)*kp_grid(3)
-
-         i = 0
-         reducing_factor(:) = 1.0_dp
-         kpoint_weight_left = 1.0_dp
-
-         ! the outer grids
-         DO i_grid_level = 1, num_kp_grids-1
-
-            single_weight = kpoint_weight_left/REAL(nkp_outer_grid, KIND=dp)
-
-            start_kp = i+1
-
-            DO ix = 1, outer_kp_grid(1)
-               DO iy = 1, outer_kp_grid(2)
-                  DO iz = 1, outer_kp_grid(3)
-
-                     ! exclude Gamma
-                     IF (2*ix-outer_kp_grid(1)-1 == 0 .AND. 2*iy-outer_kp_grid(2)-1 == 0 .AND. &
-                         2*iz-outer_kp_grid(3)-1 == 0) CYCLE
-
-                     ! use time reversal symmetry k<->-k
-                     IF (2*ix-outer_kp_grid(1)-1 < 0) CYCLE
-
-                     i = i+1
-                     kpt_latt(1) = REAL(2*ix-outer_kp_grid(1)-1, KIND=dp)/(2._dp*REAL(outer_kp_grid(1), KIND=dp)) &
-                                   *reducing_factor(1)
-                     kpt_latt(2) = REAL(2*iy-outer_kp_grid(2)-1, KIND=dp)/(2._dp*REAL(outer_kp_grid(2), KIND=dp)) &
-                                   *reducing_factor(2)
-                     kpt_latt(3) = REAL(2*iz-outer_kp_grid(3)-1, KIND=dp)/(2._dp*REAL(outer_kp_grid(3), KIND=dp)) &
-                                   *reducing_factor(3)
-                     kpoints%xkp(1:3, i) = MATMUL(TRANSPOSE(h_inv), kpt_latt(:))
-
-                     IF (2*ix-outer_kp_grid(1)-1 == 0) THEN
-                        kpoints%wkp(i) = single_weight
-                     ELSE
-                        kpoints%wkp(i) = 2._dp*single_weight
-                     END IF
-
-                  END DO
-               END DO
-            END DO
-
-            end_kp = i
-
-            kpoint_weight_left = kpoint_weight_left-SUM(kpoints%wkp(start_kp:end_kp))
-
-            reducing_factor(1) = reducing_factor(1)/REAL(outer_kp_grid(1), KIND=dp)
-            reducing_factor(2) = reducing_factor(2)/REAL(outer_kp_grid(2), KIND=dp)
-            reducing_factor(3) = reducing_factor(3)/REAL(outer_kp_grid(3), KIND=dp)
-
-         END DO
-
-         single_weight = kpoint_weight_left/REAL(nkp_inner_grid, KIND=dp)
-
-         ! the inner grid
-         DO ix = 1, kp_grid(1)
-            DO iy = 1, kp_grid(2)
-               DO iz = 1, kp_grid(3)
-
-                  ! use time reversal symmetry k<->-k
-                  IF (2*ix-kp_grid(1)-1 < 0) CYCLE
-
-                  i = i+1
-                  kpt_latt(1) = REAL(2*ix-kp_grid(1)-1, KIND=dp)/(2._dp*REAL(kp_grid(1), KIND=dp))*reducing_factor(1)
-                  kpt_latt(2) = REAL(2*iy-kp_grid(2)-1, KIND=dp)/(2._dp*REAL(kp_grid(2), KIND=dp))*reducing_factor(2)
-                  kpt_latt(3) = REAL(2*iz-kp_grid(3)-1, KIND=dp)/(2._dp*REAL(kp_grid(3), KIND=dp))*reducing_factor(3)
-
-                  kpoints%xkp(1:3, i) = MATMUL(TRANSPOSE(h_inv), kpt_latt(:))
-
-                  kpoints%wkp(i) = 2._dp*single_weight
-
-               END DO
-            END DO
-         END DO
-
-         IF (do_extra_kpoints) THEN
-
-            single_weight = kpoint_weight_left/REAL(kp_grid(1)*kp_grid(2)*kp_grid(3)/8, KIND=dp)
-
-            DO ix = 1, kp_grid(1)/2
-               DO iy = 1, kp_grid(2)/2
-                  DO iz = 1, kp_grid(3)/2
-
-                     ! use time reversal symmetry k<->-k
-                     IF (2*ix-kp_grid(1)/2-1 < 0) CYCLE
-
-                     i = i+1
-                     kpt_latt(1) = REAL(2*ix-kp_grid(1)/2-1, KIND=dp)/(REAL(kp_grid(1), KIND=dp))
-                     kpt_latt(2) = REAL(2*iy-kp_grid(2)/2-1, KIND=dp)/(REAL(kp_grid(2), KIND=dp))
-                     kpt_latt(3) = REAL(2*iz-kp_grid(3)/2-1, KIND=dp)/(REAL(kp_grid(3), KIND=dp))
-
-                     kpoints%xkp(1:3, i) = MATMUL(TRANSPOSE(h_inv), kpt_latt(:))
-
-                     kpoints%wkp(i) = 2._dp*single_weight
-
-                  END DO
-               END DO
-            END DO
-
-         END IF
-
-         ! default: no symmetry settings
-         ALLOCATE (kpoints%kp_sym(kpoints%nkp))
-         DO i = 1, kpoints%nkp
-            NULLIFY (kpoints%kp_sym(i)%kpoint_sym)
-            CALL kpoint_sym_create(kpoints%kp_sym(i)%kpoint_sym)
-         END DO
-
-      ELSE
-
-         CALL create_kp_from_gamma(qs_env, qs_env_kp_Gamma_only)
-
-         CALL get_qs_env(qs_env=qs_env, cell=cell, particle_set=particle_set)
-
-         CALL calculate_kp_orbitals(qs_env_kp_Gamma_only, kpoints, "MONKHORST-PACK", nadd=nmo, mp_grid=kp_grid(1:3), &
-                                    group_size_ext=para_env%num_pe)
-
-         CALL qs_env_release(qs_env_kp_Gamma_only)
-
-      END IF
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_kpoints
-
-! **************************************************************************************************
-!> \brief ...
-!> \param vec_Sigma_c_gw ...
-!> \param Eigenval_DFT ...
-!> \param eps_eigenval ...
-! **************************************************************************************************
-   PURE SUBROUTINE average_degenerate_levels(vec_Sigma_c_gw, Eigenval_DFT, eps_eigenval)
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: vec_Sigma_c_gw
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval_DFT
-      REAL(KIND=dp), INTENT(IN)                          :: eps_eigenval
-
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: avg_self_energy
-      INTEGER :: degeneracy, first_degenerate_level, i_deg_level, i_level_gw, j_deg_level, jquad, &
-         num_deg_levels, num_integ_points, num_levels_gw
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: list_degenerate_levels
-
-      num_levels_gw = SIZE(vec_Sigma_c_gw, 1)
-
-      ALLOCATE (list_degenerate_levels(num_levels_gw))
-      list_degenerate_levels = 1
-
-      num_integ_points = SIZE(vec_Sigma_c_gw, 2)
-
-      ALLOCATE (avg_self_energy(num_integ_points))
-
-      DO i_level_gw = 2, num_levels_gw
-
-         IF (ABS(Eigenval_DFT(i_level_gw)-Eigenval_DFT(i_level_gw-1)) < eps_eigenval) THEN
-
-            list_degenerate_levels(i_level_gw) = list_degenerate_levels(i_level_gw-1)
-
-         ELSE
-
-            list_degenerate_levels(i_level_gw) = list_degenerate_levels(i_level_gw-1)+1
-
-         END IF
-
-      END DO
-
-      num_deg_levels = list_degenerate_levels(num_levels_gw)
-
-      DO i_deg_level = 1, num_deg_levels
-
-         degeneracy = 0
-
-         DO i_level_gw = 1, num_levels_gw
-
-            IF (degeneracy == 0 .AND. i_deg_level == list_degenerate_levels(i_level_gw)) THEN
-
-               first_degenerate_level = i_level_gw
-
-            END IF
-
-            IF (i_deg_level == list_degenerate_levels(i_level_gw)) THEN
-
-               degeneracy = degeneracy+1
-
-            END IF
-
-         END DO
-
-         DO jquad = 1, num_integ_points
-
-            avg_self_energy(jquad) = SUM(vec_Sigma_c_gw(first_degenerate_level:first_degenerate_level+degeneracy-1, jquad)) &
-                                     /REAL(degeneracy, KIND=dp)
-
-         END DO
-
-         DO j_deg_level = 0, degeneracy-1
-
-            vec_Sigma_c_gw(first_degenerate_level+j_deg_level, :) = avg_self_energy(:)
-
-         END DO
-
-      END DO
-
-   END SUBROUTINE average_degenerate_levels
-
-! **************************************************************************************************
-!> \brief ...
 !> \param num_integ_points ...
 !> \param tau_tj ...
 !> \param weights_cos_tf_w_to_t ...
@@ -10709,16 +6727,12 @@ CONTAINS
    SUBROUTINE get_l_sq_wghts_cos_tf_w_to_t(num_integ_points, tau_tj, weights_cos_tf_w_to_t, omega_tj, &
                                            E_min, E_max, max_error, num_points_per_magnitude)
 
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(INOUT)                                   :: weights_cos_tf_w_to_t
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj
-      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
-      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
-      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
+      INTEGER                                            :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj
+      REAL(KIND=dp)                                      :: E_min, E_max, max_error
+      INTEGER                                            :: num_points_per_magnitude
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_cos_tf_w_to_t', &
          routineP = moduleN//':'//routineN
@@ -10846,21 +6860,21 @@ CONTAINS
 !> \param num_integ_points ...
 !> \param num_x_nodes ...
 ! **************************************************************************************************
-   PURE SUBROUTINE calc_max_error_fit_omega_grid_with_cosine(max_error, tau, omega_tj, omega_wj_work, x_values, &
-                                                             y_values, num_integ_points, num_x_nodes)
+   SUBROUTINE calc_max_error_fit_omega_grid_with_cosine(max_error, tau, omega_tj, omega_wj_work, x_values, &
+                                                        y_values, num_integ_points, num_x_nodes)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: max_error
-      REAL(KIND=dp), INTENT(IN)                          :: tau
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj, omega_wj_work, x_values, &
+      REAL(KIND=dp)                                      :: max_error, tau
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj, omega_wj_work, x_values, &
                                                             y_values
-      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
+      INTEGER                                            :: num_integ_points, num_x_nodes
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_omega_grid_with_cosine', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: kkk
+      INTEGER                                            :: handle, kkk
       REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
+
+      CALL timeset(routineN, handle)
 
       max_error_tmp = 0.0_dp
 
@@ -10883,6 +6897,8 @@ CONTAINS
 
       END IF
 
+      CALL timestop(handle)
+
    END SUBROUTINE calc_max_error_fit_omega_grid_with_cosine
 
 ! **************************************************************************************************
@@ -10894,13 +6910,11 @@ CONTAINS
 !> \param omega_wj_work ...
 !> \param tau ...
 ! **************************************************************************************************
-   PURE SUBROUTINE eval_fit_func_omega_grid_cosine(func_val, x_value, num_integ_points, omega_tj, omega_wj_work, tau)
-      REAL(KIND=dp), INTENT(OUT)                         :: func_val
-      REAL(KIND=dp), INTENT(IN)                          :: x_value
-      INTEGER, INTENT(IN)                                :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: omega_tj, omega_wj_work
-      REAL(KIND=dp), INTENT(IN)                          :: tau
+   SUBROUTINE eval_fit_func_omega_grid_cosine(func_val, x_value, num_integ_points, omega_tj, omega_wj_work, tau)
+      REAL(KIND=dp)                                      :: func_val, x_value
+      INTEGER                                            :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj, omega_wj_work
+      REAL(KIND=dp)                                      :: tau
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_omega_grid_cosine', &
          routineP = moduleN//':'//routineN
@@ -10922,154 +6936,164 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
-!> \param matrix_s ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
-!> \param Eigenval ...
-!> \param jquad ...
-!> \param num_integ_points ...
-!> \param nmo ...
-!> \param eps_filter ...
-!> \param e_fermi ...
-!> \param stabilize_exp ...
-!> \param tau_tj ...
-!> \param count_ev_sc_GW ...
+!> \param para_env_sub_kp ...
+!> \param fm_struct_sub_kp ...
+!> \param para_env ...
+!> \param nkp ...
+!> \param dimen_RI ...
+!> \param ikp_local ...
+!> \param first_ikp_local ...
+!> \param do_kpoints_cubic_RPA ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Greens_function(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                      fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, num_integ_points, nmo, &
-                                      eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
+   SUBROUTINE get_sub_para_kp(para_env_sub_kp, fm_struct_sub_kp, para_env, nkp, dimen_RI, &
+                              ikp_local, first_ikp_local, do_kpoints_cubic_RPA)
+      TYPE(cp_para_env_type), POINTER                    :: para_env_sub_kp
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_sub_kp
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      INTEGER                                            :: nkp, dimen_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+      INTEGER                                            :: first_ikp_local
+      LOGICAL                                            :: do_kpoints_cubic_RPA
 
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt, &
-                                                            matrix_s
-      TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-         fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: jquad, num_integ_points, nmo
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, stabilize_exp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj
-      INTEGER, INTENT(IN)                                :: count_ev_sc_GW
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function', &
+      CHARACTER(len=*), PARAMETER :: routineN = 'get_sub_para_kp', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i_global, iiB, iquad, jjB, &
-                                                            ncol_local, nrow_local
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      REAL(KIND=dp)                                      :: tau
+      INTEGER                                            :: color_sub_kp, comm_sub_kp, handle, ikp, &
+                                                            num_proc_per_kp
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_sub_kp
 
       CALL timeset(routineN, handle)
 
-      ! release memory
-      IF (jquad > 1) THEN
-         CALL dbcsr_set(mat_greens_fct_occ(jquad-1)%matrix, 0.0_dp)
-         CALL dbcsr_set(mat_greens_fct_virt(jquad-1)%matrix, 0.0_dp)
-         CALL dbcsr_filter(mat_greens_fct_occ(jquad-1)%matrix, 0.0_dp)
-         CALL dbcsr_filter(mat_greens_fct_virt(jquad-1)%matrix, 0.0_dp)
+      IF (nkp > para_env%num_pe .OR. do_kpoints_cubic_RPA) THEN
+         ! we have all kpoints on every processpr
+         num_proc_per_kp = para_env%num_pe
+      ELSE
+         ! we have only one kpoint per group
+         num_proc_per_kp = para_env%num_pe/nkp
       END IF
 
-      tau = tau_tj(jquad)
+      color_sub_kp = MOD(para_env%mepos/num_proc_per_kp, nkp)
+      CALL mp_comm_split_direct(para_env%group, comm_sub_kp, color_sub_kp)
+      NULLIFY (para_env_sub_kp)
+      CALL cp_para_env_create(para_env_sub_kp, comm_sub_kp)
+      NULLIFY (blacs_env_sub_kp)
+      CALL cp_blacs_env_create(blacs_env=blacs_env_sub_kp, para_env=para_env_sub_kp)
 
-      ! get info of fm_mo_coeff_occ
-      CALL cp_fm_get_info(matrix=fm_mo_coeff_occ, &
-                          nrow_local=nrow_local, &
-                          ncol_local=ncol_local, &
-                          row_indices=row_indices, &
-                          col_indices=col_indices)
+      NULLIFY (fm_struct_sub_kp)
+      CALL cp_fm_struct_create(fm_struct_sub_kp, context=blacs_env_sub_kp, nrow_global=dimen_RI, &
+                               ncol_global=dimen_RI, para_env=para_env_sub_kp)
 
-      ! Multiply the occupied and the virtual MO coefficients with the factor exp((-e_i-e_F)*tau/2).
-      ! Then, we simply get the sum over all occ states and virt. states by a simple matrix-matrix
-      ! multiplication.
+      CALL cp_blacs_env_release(blacs_env_sub_kp)
 
-      ! first, the occ
-      DO jjB = 1, nrow_local
-         DO iiB = 1, ncol_local
-            i_global = col_indices(iiB)
-
-            IF (ABS(tau*0.5_dp*(Eigenval(i_global)-e_fermi)) < stabilize_exp) THEN
-               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = &
-                  fm_mo_coeff_occ%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global)-e_fermi))
-            ELSE
-               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = 0.0_dp
-            END IF
-
-         END DO
+      ALLOCATE (ikp_local(nkp))
+      ikp_local = 0
+      first_ikp_local = 1
+      DO ikp = 1, nkp
+         IF (nkp > para_env%num_pe .OR. do_kpoints_cubic_RPA .OR. ikp == color_sub_kp+1) THEN
+            ikp_local(ikp) = ikp
+            first_ikp_local = ikp
+         END IF
       END DO
-
-      ! the same for virt
-      DO jjB = 1, nrow_local
-         DO iiB = 1, ncol_local
-            i_global = col_indices(iiB)
-
-            IF (ABS(tau*0.5_dp*(Eigenval(i_global)-e_fermi)) < stabilize_exp) THEN
-               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = &
-                  fm_mo_coeff_virt%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global)-e_fermi))
-            ELSE
-               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = 0.0_dp
-            END IF
-
-         END DO
-      END DO
-
-      CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
-                   matrix_a=fm_mo_coeff_occ_scaled, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
-                   matrix_c=fm_scaled_dm_occ_tau)
-
-      CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
-                   matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
-                   matrix_c=fm_scaled_dm_virt_tau)
-
-      IF (jquad == 1 .AND. count_ev_sc_GW == 1) THEN
-
-         ! transfer occ greens function to dbcsr matrix
-         NULLIFY (mat_greens_fct_occ)
-         CALL dbcsr_allocate_matrix_set(mat_greens_fct_occ, num_integ_points)
-
-         DO iquad = 1, num_integ_points
-
-            ALLOCATE (mat_greens_fct_occ(iquad)%matrix)
-            CALL dbcsr_create(matrix=mat_greens_fct_occ(iquad)%matrix, &
-                              template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-
-         END DO
-
-         ! transfer virt greens function to dbcsr matrix
-         NULLIFY (mat_greens_fct_virt)
-         CALL dbcsr_allocate_matrix_set(mat_greens_fct_virt, num_integ_points)
-
-         DO iquad = 1, num_integ_points
-
-            ALLOCATE (mat_greens_fct_virt(iquad)%matrix)
-            CALL dbcsr_create(matrix=mat_greens_fct_virt(iquad)%matrix, &
-                              template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-
-         END DO
-
-      END IF
-
-      CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
-                            mat_greens_fct_occ(jquad)%matrix, &
-                            keep_sparsity=.FALSE.)
-
-      CALL dbcsr_filter(mat_greens_fct_occ(jquad)%matrix, eps_filter)
-
-      CALL copy_fm_to_dbcsr(fm_scaled_dm_virt_tau, &
-                            mat_greens_fct_virt(jquad)%matrix, &
-                            keep_sparsity=.FALSE.)
-
-      CALL dbcsr_filter(mat_greens_fct_virt(jquad)%matrix, eps_filter)
 
       CALL timestop(handle)
 
-   END SUBROUTINE compute_Greens_function
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param tj_dummy ...
+!> \param tau_tj_dummy ...
+!> \param weights_cos_tf_w_to_t_dummy ...
+! **************************************************************************************************
+   SUBROUTINE get_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
+
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj_dummy, tau_tj_dummy
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t_dummy
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_dummys', routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      ALLOCATE (weights_cos_tf_w_to_t_dummy(1, 1))
+      ALLOCATE (tj_dummy(1))
+      ALLOCATE (tau_tj_dummy(1))
+
+      tj_dummy(1) = 0.0_dp
+      tau_tj_dummy(1) = 0.0_dp
+      weights_cos_tf_w_to_t_dummy(1, 1) = 1.0_dp
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param tj_dummy ...
+!> \param tau_tj_dummy ...
+!> \param weights_cos_tf_w_to_t_dummy ...
+! **************************************************************************************************
+   SUBROUTINE release_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
+
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj_dummy, tau_tj_dummy
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t_dummy
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'release_dummys', routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      DEALLOCATE (weights_cos_tf_w_to_t_dummy)
+      DEALLOCATE (tj_dummy)
+      DEALLOCATE (tau_tj_dummy)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief ...
+!> \param cfm_mat_W_kp_tau ...
+!> \param cfm_mat_Q ...
+!> \param num_integ_points ...
+!> \param jquad ...
+!> \param nkp ...
+!> \param ikp_local ...
+! **************************************************************************************************
+   SUBROUTINE allocate_Wc_kp_tau_GW(cfm_mat_W_kp_tau, cfm_mat_Q, num_integ_points, jquad, &
+                                    nkp, ikp_local)
+
+      TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
+      TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
+      INTEGER                                            :: num_integ_points, jquad, nkp
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_Wc_kp_tau_GW', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, iquad, jkp
+
+      CALL timeset(routineN, handle)
+
+      ! Fourier transform from w to t; allocate only one (at first time point and also at
+      ! first kpoint in case we do not do
+      IF (jquad == 1) THEN
+         NULLIFY (cfm_mat_W_kp_tau)
+         ALLOCATE (cfm_mat_W_kp_tau(nkp, num_integ_points))
+         DO iquad = 1, num_integ_points
+            DO jkp = 1, nkp
+               NULLIFY (cfm_mat_W_kp_tau(jkp, iquad)%matrix)
+               IF (.NOT. (ANY(ikp_local(:) == jkp))) CYCLE
+               CALL cp_cfm_create(cfm_mat_W_kp_tau(jkp, iquad)%matrix, cfm_mat_Q%matrix_struct)
+               CALL cp_cfm_set_all(matrix=cfm_mat_W_kp_tau(jkp, iquad)%matrix, alpha=z_zero)
+            END DO
+         END DO
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
 
 END MODULE rpa_ri_gpw

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -3828,6 +3828,10 @@ CONTAINS
             DEALLOCATE (wkp_W)
          END IF
 
+         IF (do_kpoints_from_Gamma) THEN
+            CALL kpoint_release(kpoints)
+         END IF
+
       END IF
 
       DEALLOCATE (tj)

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -248,7 +248,7 @@ CONTAINS
                                                             mat_3c_overl_int_mao_for_virt
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(IN), OPTIONAL                            :: BIb_C_beta
+         INTENT(INout), OPTIONAL                         :: BIb_C_beta
       INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta
       REAL(KIND=dp), DIMENSION(:), INTENT(INout), &
          OPTIONAL                                        :: Eigenval_beta
@@ -6237,12 +6237,14 @@ CONTAINS
 !> \param tau_wj_work ...
 !> \param omega ...
 ! **************************************************************************************************
-   SUBROUTINE eval_fit_func_tau_grid_sine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
+   PURE SUBROUTINE eval_fit_func_tau_grid_sine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
 
-      REAL(KIND=dp)                                      :: func_val, x_value
-      INTEGER                                            :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work
-      REAL(KIND=dp)                                      :: omega
+      REAL(KIND=dp), INTENT(inOUT)                       :: func_val
+      REAL(KIND=dp), INTENT(IN)                          :: x_value
+      INTEGER, INTENT(in)                                :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj, tau_wj_work
+      REAL(KIND=dp), INTENT(IN)                          :: omega
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_tau_grid_sine', &
          routineP = moduleN//':'//routineN
@@ -6282,10 +6284,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_sine', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, kkk
+      INTEGER                                            :: kkk
       REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
-
-      CALL timeset(routineN, handle)
 
       max_error_tmp = 0.0_dp
 
@@ -6307,8 +6307,6 @@ CONTAINS
          max_error = max_error_tmp
 
       END IF
-
-      CALL timestop(handle)
 
    END SUBROUTINE calc_max_error_fit_tau_grid_with_sine
 

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -10,7 +10,7 @@
 !>      04.2015 GW routines added [Jan Wilhelm]
 !>      10.2015 Cubic-scaling RPA routines added [Jan Wilhelm]
 !>      10.2018 Cubic-scaling SOS-MP2 added [Frederick Stein]
-!>      03.2019 Refactoring [Frederick Stein, Jan Wilhelm]
+!>      03.2019 Refactoring [Frederick Stein]
 ! **************************************************************************************************
 MODULE rpa_ri_gpw
    USE bibliography,                    ONLY: Bates2013,&
@@ -219,7 +219,8 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       REAL(KIND=dp), INTENT(OUT)                         :: Erpa
       TYPE(mp2_type), INTENT(INOUT), POINTER             :: mp2_env
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: BIb_C, BIb_C_gw, BIb_C_bse_ij, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
+         INTENT(INOUT)                                   :: BIb_C, BIb_C_gw, BIb_C_bse_ij, &
                                                             BIb_C_bse_ab
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
       INTEGER, INTENT(INOUT)                             :: color_sub
@@ -231,7 +232,7 @@ CONTAINS
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_RI_metric
       TYPE(kpoint_type), POINTER                         :: kpoints
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
-      INTEGER                                            :: nmo, homo, dimen_RI, gw_corr_lev_occ, &
+      INTEGER, INTENT(IN)                                :: nmo, homo, dimen_RI, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, unit_nr
       LOGICAL, INTENT(IN)                                :: do_ri_sos_laplace_mp2, my_do_gw, &
                                                             do_im_time, do_mao, do_bse
@@ -4035,8 +4036,8 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
       TYPE(cp_fm_type), POINTER                          :: fm_mat_L_re, fm_mat_L_im, &
                                                             fm_mat_RI_global_work
-      INTEGER                                            :: dimen_RI, ikp, nkp
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+      INTEGER, INTENT(IN)                                :: dimen_RI, ikp, nkp
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: ikp_local
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Q_kp_RPA', &
@@ -4081,7 +4082,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE
+   END SUBROUTINE compute_Q_kp_RPA
 
 ! **************************************************************************************************
 !> \brief ...
@@ -4100,8 +4101,8 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
       TYPE(cp_fm_type), POINTER                          :: fm_mat_RI_global_work, fm_mat_work
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
-      INTEGER                                            :: ikp, nkp
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+      INTEGER, INTENT(IN)                                :: ikp, nkp
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: ikp_local
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mat_P_to_subgroup', &
@@ -4163,7 +4164,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE
+   END SUBROUTINE mat_P_to_subgroup
 
 ! **************************************************************************************************
 !> \brief ...
@@ -4176,8 +4177,9 @@ CONTAINS
 
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
       TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: trace_Qomega
-      INTEGER                                            :: dimen_RI
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: trace_Qomega
+      INTEGER, INTENT(IN)                                :: dimen_RI
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cholesky_decomp_Q', &
          routineP = moduleN//':'//routineN
@@ -4231,12 +4233,13 @@ CONTAINS
    SUBROUTINE frequency_and_kpoint_integration(Erpa, cfm_mat_Q, para_env_RPA, trace_Qomega, &
                                                dimen_RI, freq_weight, kp_weight)
 
-      REAL(KIND=dp)                                      :: Erpa
+      REAL(KIND=dp), INTENT(INOUT)                       :: Erpa
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
       TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: trace_Qomega
-      INTEGER                                            :: dimen_RI
-      REAL(KIND=dp)                                      :: freq_weight, kp_weight
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: trace_Qomega
+      INTEGER, INTENT(IN)                                :: dimen_RI
+      REAL(KIND=dp), INTENT(IN)                          :: freq_weight, kp_weight
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'frequency_and_kpoint_integration', &
          routineP = moduleN//':'//routineN
@@ -4315,20 +4318,20 @@ CONTAINS
                                       print_ic_values, do_ic_opt_homo_lumo, fm_mat_Q, para_env, mp2_env, &
                                       do_alpha, do_beta)
 
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
+      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_SinvVSinv
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_3c_overl_nnP_ic, &
                                                             mat_3c_overl_nnP_ic_reflected
       TYPE(dbcsr_type), POINTER                          :: mat_work
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
-      INTEGER                                            :: gw_corr_lev_tot, gw_corr_lev_occ, &
+      INTEGER, INTENT(IN)                                :: gw_corr_lev_tot, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, homo, nmo, dimen_RI, &
                                                             unit_nr
-      LOGICAL                                            :: print_ic_values, do_ic_opt_homo_lumo
+      LOGICAL, INTENT(IN)                                :: print_ic_values, do_ic_opt_homo_lumo
       TYPE(cp_fm_type), POINTER                          :: fm_mat_Q
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mp2_type), POINTER                            :: mp2_env
-      LOGICAL, OPTIONAL                                  :: do_alpha, do_beta
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_alpha, do_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_ic_correction', &
          routineP = moduleN//':'//routineN
@@ -4734,9 +4737,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE print_Neaton_value(fm_mat_M_occ, unit_nr, gw_corr_lev_occ, para_env, do_homo, do_lumo)
       TYPE(cp_fm_type), POINTER                          :: fm_mat_M_occ
-      INTEGER                                            :: unit_nr, gw_corr_lev_occ
+      INTEGER, INTENT(IN)                                :: unit_nr, gw_corr_lev_occ
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      LOGICAL, OPTIONAL                                  :: do_homo, do_lumo
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_homo, do_lumo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'print_Neaton_value', &
          routineP = moduleN//':'//routineN
@@ -5121,8 +5124,8 @@ CONTAINS
    SUBROUTINE fill_fm_mat_M_occ(fm_mat_M_occ, mat_N_occ_dbcsr, matrix_s, Eigenval, gw_corr_lev_occ, homo, para_env)
       TYPE(cp_fm_type), POINTER                          :: fm_mat_M_occ
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_N_occ_dbcsr, matrix_s
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      INTEGER                                            :: gw_corr_lev_occ, homo
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, homo
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_fm_mat_M_occ', &
@@ -5433,8 +5436,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fill_coeff_dbcsr_virt(coeff_dbcsr, coeff, homo)
       TYPE(dbcsr_type), POINTER                          :: coeff_dbcsr
-      REAL(KIND=dp), DIMENSION(:)                        :: coeff
-      INTEGER                                            :: homo
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: coeff
+      INTEGER, INTENT(IN)                                :: homo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_coeff_dbcsr_virt', &
          routineP = moduleN//':'//routineN
@@ -5505,7 +5508,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tj_ext, wj_ext
       TYPE(cp_fm_type), POINTER                          :: fm_mat_S
-      INTEGER, OPTIONAL                                  :: homo_beta, virtual_beta, dimen_ia_beta
+      INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta, virtual_beta, dimen_ia_beta
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: Eigenval_beta
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: fm_mat_S_beta
 
@@ -5818,13 +5821,15 @@ CONTAINS
                                 ZERO, ONE, M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
                                 nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
                                 para_env, para_env_row, para_env_row_beta)
-      REAL(KIND=dp)                                      :: a_scaling, left_term, first_deriv
-      INTEGER                                            :: num_integ_points
-      LOGICAL                                            :: my_open_shell
-      REAL(KIND=dp)                                      :: zero, one
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: M_ia, cottj, wj, D_ia, D_ia_beta, &
+      REAL(KIND=dp), INTENT(IN)                          :: a_scaling
+      REAL(KIND=dp), INTENT(INOUT)                       :: left_term, first_deriv
+      INTEGER, INTENT(IN)                                :: num_integ_points
+      LOGICAL, INTENT(IN)                                :: my_open_shell
+      REAL(KIND=dp), INTENT(IN)                          :: zero, one
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: M_ia, cottj, wj, D_ia, D_ia_beta, &
                                                             M_ia_beta
-      INTEGER                                            :: nrow_local, nrow_local_beta, &
+      INTEGER, INTENT(IN)                                :: nrow_local, nrow_local_beta, &
                                                             num_integ_group, color_rpa_group
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_row, para_env_row_beta
 
@@ -6032,12 +6037,16 @@ CONTAINS
    SUBROUTINE get_l_sq_wghts_sin_tf_t_to_w(num_integ_points, tau_tj, weights_sin_tf_t_to_w, omega_tj, &
                                            E_min, E_max, max_error, num_points_per_magnitude)
 
-      INTEGER                                            :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_sin_tf_t_to_w
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj
-      REAL(KIND=dp)                                      :: E_min, E_max, max_error
-      INTEGER                                            :: num_points_per_magnitude
+      INTEGER, INTENT(IN)                                :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: weights_sin_tf_t_to_w
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: omega_tj
+      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
+      REAL(KIND=dp), INTENT(OUT)                         :: max_error
+      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_sin_tf_t_to_w', &
          routineP = moduleN//':'//routineN
@@ -6245,7 +6254,7 @@ CONTAINS
 ! **************************************************************************************************
    PURE SUBROUTINE eval_fit_func_tau_grid_sine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
 
-      REAL(KIND=dp), INTENT(inOUT)                       :: func_val
+      REAL(KIND=dp), INTENT(INOUT)                       :: func_val
       REAL(KIND=dp), INTENT(IN)                          :: x_value
       INTEGER, INTENT(in)                                :: num_integ_points
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
@@ -6327,8 +6336,9 @@ CONTAINS
 
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
-      INTEGER                                            :: cut_RI
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: non_zero_blocks_3c
+      INTEGER, INTENT(IN)                                :: cut_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
+         INTENT(OUT)                                     :: non_zero_blocks_3c
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_non_zero_blocks_3c', &
          routineP = moduleN//':'//routineN
@@ -6424,8 +6434,9 @@ CONTAINS
 
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut_col
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
-      INTEGER                                            :: cut_RI, cut_memory
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :, :)        :: non_zero_blocks_3c_cut
+      INTEGER, INTENT(IN)                                :: cut_RI, cut_memory
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :, :), &
+         INTENT(OUT)                                     :: non_zero_blocks_3c_cut
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_non_zero_blocks_3c_cut_col', &
          routineP = moduleN//':'//routineN
@@ -6855,10 +6866,12 @@ CONTAINS
    SUBROUTINE calc_max_error_fit_omega_grid_with_cosine(max_error, tau, omega_tj, omega_wj_work, x_values, &
                                                         y_values, num_integ_points, num_x_nodes)
 
-      REAL(KIND=dp)                                      :: max_error, tau
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj, omega_wj_work, x_values, &
+      REAL(KIND=dp), INTENT(OUT)                         :: max_error
+      REAL(KIND=dp), INTENT(IN)                          :: tau
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: omega_tj, omega_wj_work, x_values, &
                                                             y_values
-      INTEGER                                            :: num_integ_points, num_x_nodes
+      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_omega_grid_with_cosine', &
          routineP = moduleN//':'//routineN
@@ -6944,10 +6957,10 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub_kp
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_sub_kp
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER                                            :: nkp, dimen_RI
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
-      INTEGER                                            :: first_ikp_local
-      LOGICAL                                            :: do_kpoints_cubic_RPA
+      INTEGER, INTENT(IN)                                :: nkp, dimen_RI
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: ikp_local
+      INTEGER, INTENT(OUT)                               :: first_ikp_local
+      LOGICAL, INTENT(IN)                                :: do_kpoints_cubic_RPA
 
       CHARACTER(len=*), PARAMETER :: routineN = 'get_sub_para_kp', &
          routineP = moduleN//':'//routineN
@@ -7001,8 +7014,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj_dummy, tau_tj_dummy
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t_dummy
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: tj_dummy, tau_tj_dummy
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: weights_cos_tf_w_to_t_dummy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_dummys', routineP = moduleN//':'//routineN
 
@@ -7030,8 +7045,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE release_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
 
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj_dummy, tau_tj_dummy
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t_dummy
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: tj_dummy, tau_tj_dummy
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: weights_cos_tf_w_to_t_dummy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'release_dummys', routineP = moduleN//':'//routineN
 
@@ -7061,8 +7078,8 @@ CONTAINS
 
       TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
-      INTEGER                                            :: num_integ_points, jquad, nkp
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
+      INTEGER, INTENT(IN)                                :: num_integ_points, jquad, nkp
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: ikp_local
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_Wc_kp_tau_GW', &
          routineP = moduleN//':'//routineN

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -216,23 +216,23 @@ CONTAINS
                                 mo_coeff_beta, BIb_C_gw_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(KIND=dp)                                      :: Erpa
-      TYPE(mp2_type), POINTER                            :: mp2_env
+      REAL(KIND=dp), INTENT(OUT)                         :: Erpa
+      TYPE(mp2_type), INTENT(INOUT), POINTER             :: mp2_env
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: BIb_C, BIb_C_gw, BIb_C_bse_ij, &
                                                             BIb_C_bse_ab
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
-      INTEGER                                            :: color_sub
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: ends_array, ends_B_virtual, ends_B_all, sizes_array, &
-         sizes_B_virtual, sizes_B_all, starts_array, starts_B_virtual, starts_B_all, &
+      INTEGER, INTENT(INOUT)                             :: color_sub
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(INOUT) :: ends_array, ends_B_virtual, ends_B_all, &
+         sizes_array, sizes_B_virtual, sizes_B_all, starts_array, starts_B_virtual, starts_B_all, &
          starts_B_occ_bse, sizes_B_occ_bse, ends_B_occ_bse, starts_B_virt_bse, sizes_B_virt_bse, &
          ends_B_virt_bse
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_RI_metric
       TYPE(kpoint_type), POINTER                         :: kpoints
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
       INTEGER                                            :: nmo, homo, dimen_RI, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, unit_nr
-      LOGICAL                                            :: do_ri_sos_laplace_mp2, my_do_gw, &
+      LOGICAL, INTENT(IN)                                :: do_ri_sos_laplace_mp2, my_do_gw, &
                                                             do_im_time, do_mao, do_bse
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mao_coeff_occ, mao_coeff_virt, &
                                                             mao_coeff_occ_A, mao_coeff_virt_A
@@ -246,18 +246,20 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc_t, ends_array_mc_t
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int_mao_for_occ, &
                                                             mat_3c_overl_int_mao_for_virt
-      REAL(KIND=dp)                                      :: eps_filter
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         OPTIONAL                                        :: BIb_C_beta
-      INTEGER, OPTIONAL                                  :: homo_beta
-      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: Eigenval_beta
-      INTEGER, ALLOCATABLE, DIMENSION(:), OPTIONAL       :: ends_B_virtual_beta, &
+         INTENT(IN), OPTIONAL                            :: BIb_C_beta
+      INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta
+      REAL(KIND=dp), DIMENSION(:), INTENT(INout), &
+         OPTIONAL                                        :: Eigenval_beta
+      INTEGER, ALLOCATABLE, DIMENSION(:), &
+         INTENT(INout), OPTIONAL                         :: ends_B_virtual_beta, &
                                                             sizes_B_virtual_beta, &
                                                             starts_B_virtual_beta
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: mo_coeff_beta
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         OPTIONAL                                        :: BIb_C_gw_beta
-      INTEGER, OPTIONAL                                  :: gw_corr_lev_occ_beta, &
+         INTENT(INout), OPTIONAL                         :: BIb_C_gw_beta
+      INTEGER, INTENT(IN), OPTIONAL                      :: gw_corr_lev_occ_beta, &
                                                             gw_corr_lev_virt_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rpa_ri_compute_en', &
@@ -2041,8 +2043,8 @@ CONTAINS
          my_num_dgemm_call, n_group_col, n_group_row, n_local_col, n_local_row, nblkrows_total, &
          ncol_local, ngroup_RI_orig, nkp, nkp_self_energy, nmo, nrow_local, num_3c_repl
       INTEGER :: num_cells_dm, num_fit_points, num_points_corr, num_points_per_magnitude, &
-         num_residues, num_Z_vectors, number_of_rec, number_of_rec_axk, number_of_rec_beta, &
-         number_of_send, number_of_send_axk, number_of_send_beta, row, row_start_local, size_P
+         num_Z_vectors, number_of_rec, number_of_rec_axk, number_of_rec_beta, number_of_send, &
+         number_of_send_axk, number_of_send_beta, row, row_start_local, size_P
       INTEGER, ALLOCATABLE, DIMENSION(:) :: ikp_local, map_rec_size, map_rec_size_axk, &
          map_rec_size_beta, map_send_size, map_send_size_axk, map_send_size_beta, &
          mepos_P_from_RI_row, my_group_L_sizes_im_time, my_group_L_starts_im_time, row_from_LLL, &
@@ -3191,8 +3193,6 @@ CONTAINS
 
          END IF ! do im time
 
-         num_residues = 0
-
          DO jquad = 1, num_integ_points
 
             IF (MODULO(jquad, num_integ_group) /= color_rpa_group) CYCLE
@@ -3282,15 +3282,14 @@ CONTAINS
             IF (do_ri_sos_laplace_mp2) THEN
                ! calculate the trace of the product Q*Q
                trace_XX = 0.0_dp
-               DO jjB = 1, ncol_local
-                  DO iiB = 1, nrow_local
-                     IF (my_open_shell) THEN
-                        trace_XX = trace_XX+fm_mat_Q%local_data(iiB, jjB)*fm_mat_Q_beta%local_data(iiB, jjB)
-                     ELSE
-                        trace_XX = trace_XX+fm_mat_Q%local_data(iiB, jjB)*fm_mat_Q%local_data(iiB, jjB)
-                     END IF
+               IF (my_open_shell) THEN
+                  DO jjB = 1, ncol_local
+                     trace_XX = trace_XX+DOT_PRODUCT(fm_mat_Q%local_data(:, jjB), fm_mat_Q_beta%local_data(:, jjB))
                   END DO
-               END DO
+               ELSE
+                  trace_XX = NORM2(fm_mat_Q%local_data)
+                  trace_XX = trace_XX*trace_XX
+               END IF
 
                Erpa = Erpa-trace_XX*tau_wj(jquad)
 
@@ -4804,11 +4803,11 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'update_coeff_homo', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i_global, i_occ_level, iiB, &
-                                                            j_global, jjB, ncol_local, nrow_local
+      INTEGER                                            :: handle, i_global, iiB, j_global, jjB, &
+                                                            ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: my_do_homo
-      REAL(KIND=dp)                                      :: norm_coeff_homo, scalar_prod
+      REAL(KIND=dp)                                      :: norm_coeff_homo
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: coeff_homo_update, &
                                                             coeff_homo_update_orthog
 
@@ -4856,26 +4855,9 @@ CONTAINS
 
       CALL mp_sum(coeff_homo_update, para_env%group)
 
-      scalar_prod = 0.0_dp
-      DO i_occ_level = 1, homo
+      norm_coeff_homo = NORM2(coeff_homo_update)
 
-         scalar_prod = scalar_prod+coeff_homo(i_occ_level)*coeff_homo_update(i_occ_level)
-
-      END DO
-
-      norm_coeff_homo = 0.0_dp
-      DO i_occ_level = 1, homo
-
-!         coeff_homo(i_occ_level) = 0.8_dp*coeff_homo(i_occ_level) + &
-!                                   0.2_dp*(coeff_homo_update(i_occ_level) - scalar_prod*coeff_homo(i_occ_level))
-
-         coeff_homo(i_occ_level) = coeff_homo_update(i_occ_level)
-
-         norm_coeff_homo = norm_coeff_homo+(coeff_homo(i_occ_level))**2
-
-      END DO
-
-      coeff_homo = coeff_homo/SQRT(norm_coeff_homo)
+      coeff_homo(:) = coeff_homo_update(:)/norm_coeff_homo
 
       CALL timestop(handle)
 
@@ -6289,12 +6271,13 @@ CONTAINS
 !> \param num_integ_points ...
 !> \param num_x_nodes ...
 ! **************************************************************************************************
-   SUBROUTINE calc_max_error_fit_tau_grid_with_sine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                    y_values, num_integ_points, num_x_nodes)
+   PURE SUBROUTINE calc_max_error_fit_tau_grid_with_sine(max_error, omega, tau_tj, tau_wj_work, x_values, &
+                                                         y_values, num_integ_points, num_x_nodes)
 
-      REAL(KIND=dp)                                      :: max_error, omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work, x_values, y_values
-      INTEGER                                            :: num_integ_points, num_x_nodes
+      REAL(KIND=dp), INTENT(INOUT)                       :: max_error, omega
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj, tau_wj_work, x_values, y_values
+      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_sine', &
          routineP = moduleN//':'//routineN

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -7015,9 +7015,9 @@ CONTAINS
    SUBROUTINE get_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
 
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: tj_dummy, tau_tj_dummy
+         INTENT(INOUT)                                   :: tj_dummy, tau_tj_dummy
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(OUT)                                     :: weights_cos_tf_w_to_t_dummy
+         INTENT(INOUT)                                   :: weights_cos_tf_w_to_t_dummy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_dummys', routineP = moduleN//':'//routineN
 
@@ -7046,9 +7046,9 @@ CONTAINS
    SUBROUTINE release_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
 
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: tj_dummy, tau_tj_dummy
+         INTENT(INOUT)                                   :: tj_dummy, tau_tj_dummy
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         INTENT(OUT)                                     :: weights_cos_tf_w_to_t_dummy
+         INTENT(INOUT)                                   :: weights_cos_tf_w_to_t_dummy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'release_dummys', routineP = moduleN//':'//routineN
 

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -4237,7 +4237,7 @@ CONTAINS
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
       TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: trace_Qomega
+         INTENT(IN)                                      :: trace_Qomega
       INTEGER, INTENT(IN)                                :: dimen_RI
       REAL(KIND=dp), INTENT(IN)                          :: freq_weight, kp_weight
 
@@ -5515,20 +5515,14 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_scaling_factor', &
          routineP = moduleN//':'//routineN
 
-      INTEGER :: avirt, color_col, color_col_beta, color_row, color_row_beta, comm_col, &
-         comm_col_beta, comm_row, comm_row_beta, handle, i_global, icycle, iiB, iocc, jjB, jquad, &
-         ncol_local, ncol_local_beta, nrow_local, nrow_local_beta
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices, col_indices_beta, &
-                                                            row_indices, row_indices_beta
+      INTEGER                                            :: handle, icycle, jquad, nrow_local, &
+                                                            nrow_local_beta
       LOGICAL                                            :: my_open_shell
-      REAL(KIND=dp) :: a_high, a_low, a_scaling, conv_param, eigen_diff, eps, first_deriv, four, &
-         left_term, one, pig, right_term, right_term_ref, right_term_ref_beta, step, two, zero
+      REAL(KIND=dp) :: a_high, a_low, a_scaling, conv_param, eps, first_deriv, left_term, &
+         right_term, right_term_ref, right_term_ref_beta, step
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: cottj, D_ia, D_ia_beta, iaia_RI, &
-                                                            iaia_RI_beta, iaia_RI_dp, &
-                                                            iaia_RI_dp_beta, M_ia, M_ia_beta, tj, &
-                                                            wj
-      TYPE(cp_para_env_type), POINTER                    :: para_env_col, para_env_col_beta, &
-                                                            para_env_row, para_env_row_beta
+                                                            iaia_RI_beta, M_ia, M_ia_beta
+      TYPE(cp_para_env_type), POINTER                    :: para_env_row, para_env_row_beta
 
       CALL timeset(routineN, handle)
 
@@ -5539,25 +5533,142 @@ CONTAINS
           PRESENT(Eigenval_beta) .AND. &
           PRESENT(fm_mat_S_beta)) my_open_shell = .TRUE.
 
-      ZERO = 0.0_dp
-      ONE = 1.0_dp
-      TWO = 2.0_dp
-      FOUR = 4.0_dp
-      PIG = pi
       eps = 1.0E-10_dp
 
       ALLOCATE (cottj(num_integ_points))
 
-      ALLOCATE (tj(num_integ_points))
-
-      ALLOCATE (wj(num_integ_points))
-
       ! calculate the cotangent of the abscissa tj
       DO jquad = 1, num_integ_points
-         tj(jquad) = tj_ext(jquad)
-         wj(jquad) = wj_ext(jquad)
-         cottj(jquad) = ONE/TAN(tj(jquad))
+         cottj(jquad) = 1.0_dp/TAN(tj_ext(jquad))
       END DO
+
+      CALL calc_ia_ia_integrals(para_env_RPA, homo, virtual, nrow_local, right_term_ref, Eigenval, D_ia, iaia_RI, M_ia, fm_mat_S, &
+                                para_env_row)
+
+      ! In the open shell case do point 1-2-3 for the beta spin
+      IF (my_open_shell) THEN
+         CALL calc_ia_ia_integrals(para_env_RPA, homo_beta, virtual_beta, nrow_local_beta, right_term_ref_beta, Eigenval_beta, &
+                                   D_ia_beta, iaia_RI_beta, M_ia_beta, fm_mat_S_beta, para_env_row_beta)
+
+         right_term_ref = right_term_ref+right_term_ref_beta
+      END IF
+
+      ! bcast the result
+      IF (para_env%mepos == 0) THEN
+         CALL mp_bcast(right_term_ref, 0, para_env%group)
+      ELSE
+         right_term_ref = 0.0_dp
+         CALL mp_bcast(right_term_ref, 0, para_env%group)
+      END IF
+
+      ! 5) start iteration for solving the non-linear equation by bisection
+      ! find limit, here step=0.5 seems a good compromise
+      conv_param = 100.0_dp*EPSILON(right_term_ref)
+      step = 0.5_dp
+      a_low = 0.0_dp
+      a_high = step
+      right_term = -right_term_ref
+      DO icycle = 1, num_integ_points*2
+         a_scaling = a_high
+
+         CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
+                                M_ia, cottj, wj_ext, D_ia, D_ia_beta, M_ia_beta, &
+                                nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
+                                para_env, para_env_row, para_env_row_beta)
+         left_term = left_term/4.0_dp/pi*a_scaling
+
+         IF (ABS(left_term) > ABS(right_term) .OR. ABS(left_term+right_term) <= conv_param) EXIT
+         a_low = a_high
+         a_high = a_high+step
+
+      END DO
+
+      IF (ABS(left_term+right_term) >= conv_param) THEN
+         IF (a_scaling >= 2*num_integ_points*step) THEN
+            a_scaling = 1.0_dp
+         ELSE
+
+            DO icycle = 1, num_integ_points*2
+               a_scaling = (a_low+a_high)/2.0_dp
+
+               CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
+                                      M_ia, cottj, wj_ext, D_ia, D_ia_beta, M_ia_beta, &
+                                      nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
+                                      para_env, para_env_row, para_env_row_beta)
+               left_term = left_term/4.0_dp/pi*a_scaling
+
+               IF (ABS(left_term) > ABS(right_term)) THEN
+                  a_high = a_scaling
+               ELSE
+                  a_low = a_scaling
+               END IF
+
+               IF (ABS(a_high-a_low) < 1.0e-5_dp) EXIT
+
+            END DO
+
+         END IF
+      END IF
+
+      a_scaling_ext = a_scaling
+      CALL mp_bcast(a_scaling_ext, 0, para_env%group)
+
+      DEALLOCATE (cottj)
+      DEALLOCATE (iaia_RI)
+      DEALLOCATE (D_ia)
+      DEALLOCATE (M_ia)
+      CALL cp_para_env_release(para_env_row)
+
+      IF (my_open_shell) THEN
+         DEALLOCATE (iaia_RI_beta)
+         DEALLOCATE (D_ia_beta)
+         DEALLOCATE (M_ia_beta)
+         CALL cp_para_env_release(para_env_row_beta)
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE calc_scaling_factor
+
+! **************************************************************************************************
+!> \brief ...
+!> \param para_env_RPA ...
+!> \param homo ...
+!> \param virtual ...
+!> \param nrow_local ...
+!> \param right_term_ref ...
+!> \param Eigenval ...
+!> \param D_ia ...
+!> \param iaia_RI ...
+!> \param M_ia ...
+!> \param fm_mat_S ...
+!> \param para_env_row ...
+! **************************************************************************************************
+   SUBROUTINE calc_ia_ia_integrals(para_env_RPA, homo, virtual, nrow_local, right_term_ref, Eigenval, &
+                                   D_ia, iaia_RI, M_ia, fm_mat_S, para_env_row)
+
+      TYPE(cp_para_env_type), POINTER                    :: para_env_RPA
+      INTEGER, INTENT(IN)                                :: homo, virtual
+      INTEGER, INTENT(OUT)                               :: nrow_local
+      REAL(KIND=dp), INTENT(OUT)                         :: right_term_ref
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: D_ia, iaia_RI, M_ia
+      TYPE(cp_fm_type), POINTER                          :: fm_mat_S
+      TYPE(cp_para_env_type), POINTER                    :: para_env_row
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_ia_ia_integrals', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: avirt, color_col, color_row, comm_col, &
+                                                            comm_row, handle, i_global, iiB, iocc, &
+                                                            jjB, ncol_local
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+      REAL(KIND=dp)                                      :: eigen_diff
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: iaia_RI_dp
+      TYPE(cp_para_env_type), POINTER                    :: para_env_col
+
+      CALL timeset(routineN, handle)
 
       ! calculate the (ia|ia) RI integrals
       ! ----------------------------------
@@ -5628,15 +5739,14 @@ CONTAINS
       END DO
 
       DO iiB = 1, nrow_local
-         M_ia(iiB) = D_ia(iiB)*D_ia(iiB)+TWO*D_ia(iiB)*iaia_RI(iiB)
+         M_ia(iiB) = D_ia(iiB)*D_ia(iiB)+2.0_dp*D_ia(iiB)*iaia_RI(iiB)
       END DO
 
-      right_term_ref = ZERO
+      right_term_ref = 0.0_dp
       DO iiB = 1, nrow_local
          right_term_ref = right_term_ref+(SQRT(M_ia(iiB))-D_ia(iiB)-iaia_RI(iiB))
       END DO
-      right_term_ref = right_term_ref/TWO
-      ! right_term_ref=accurate_sum((SQRT(M_ia)-D_ia-iaia_RI))/2.0_dp
+      right_term_ref = right_term_ref/2.0_dp
 
       ! sum the result with the processes of the RPA_group having the same col
       color_col = fm_mat_S%matrix_struct%context%mepos(2)
@@ -5647,152 +5757,11 @@ CONTAINS
       ! allocate communication array for columns
       CALL mp_sum(right_term_ref, para_env_col%group)
 
-      ! In the open shell case do point 1-2-3 for the beta spin
-      IF (my_open_shell) THEN
-         !XXX CALL cp_fm_to_fm(source=fm_mat_S_beta,destination=fm_mat_G_beta)
-         CALL cp_fm_get_info(matrix=fm_mat_S_beta, &
-                             nrow_local=nrow_local_beta, &
-                             ncol_local=ncol_local_beta, &
-                             row_indices=row_indices_beta, &
-                             col_indices=col_indices_beta)
-
-         ALLOCATE (iaia_RI_dp_beta(nrow_local_beta))
-         iaia_RI_dp_beta = 0.0_dp
-
-         DO jjB = 1, ncol_local_beta
-            DO iiB = 1, nrow_local_beta
-               iaia_RI_dp_beta(iiB) = iaia_RI_dp_beta(iiB)+fm_mat_S_beta%local_data(iiB, jjB)*fm_mat_S_beta%local_data(iiB, jjB)
-            END DO
-         END DO
-
-         color_row_beta = fm_mat_S_beta%matrix_struct%context%mepos(1)
-         CALL mp_comm_split_direct(para_env_RPA%group, comm_row_beta, color_row_beta)
-         NULLIFY (para_env_row_beta)
-         CALL cp_para_env_create(para_env_row_beta, comm_row_beta)
-
-         CALL mp_sum(iaia_RI_dp_beta, para_env_row_beta%group)
-
-         ALLOCATE (iaia_RI_beta(nrow_local_beta))
-         DO iiB = 1, nrow_local_beta
-            iaia_RI_beta(iiB) = iaia_RI_dp_beta(iiB)
-         END DO
-         DEALLOCATE (iaia_RI_dp_beta)
-
-         ALLOCATE (D_ia_beta(nrow_local_beta))
-
-         ALLOCATE (M_ia_beta(nrow_local_beta))
-
-         DO iiB = 1, nrow_local_beta
-            i_global = row_indices_beta(iiB)
-
-            iocc = MAX(1, i_global-1)/virtual_beta+1
-            avirt = i_global-(iocc-1)*virtual_beta
-            eigen_diff = Eigenval_beta(avirt+homo_beta)-Eigenval_beta(iocc)
-
-            D_ia_beta(iiB) = eigen_diff
-         END DO
-
-         DO iiB = 1, nrow_local_beta
-            M_ia_beta(iiB) = D_ia_beta(iiB)*D_ia_beta(iiB)+TWO*D_ia_beta(iiB)*iaia_RI_beta(iiB)
-         END DO
-
-         right_term_ref_beta = ZERO
-         DO iiB = 1, nrow_local_beta
-            right_term_ref_beta = right_term_ref_beta+(SQRT(M_ia_beta(iiB))-D_ia_beta(iiB)-iaia_RI_beta(iiB))
-         END DO
-         right_term_ref_beta = right_term_ref_beta/TWO
-
-         ! sum the result with the processes of the RPA_group having the same col
-         color_col_beta = fm_mat_S_beta%matrix_struct%context%mepos(2)
-         CALL mp_comm_split_direct(para_env_RPA%group, comm_col_beta, color_col_beta)
-         NULLIFY (para_env_col_beta)
-         CALL cp_para_env_create(para_env_col_beta, comm_col_beta)
-
-         CALL mp_sum(right_term_ref_beta, para_env_col_beta%group)
-
-         right_term_ref = right_term_ref+right_term_ref_beta
-      END IF
-
-      ! bcast the result
-      IF (para_env%mepos == 0) THEN
-         CALL mp_bcast(right_term_ref, 0, para_env%group)
-      ELSE
-         right_term_ref = 0.0_dp
-         CALL mp_bcast(right_term_ref, 0, para_env%group)
-      END IF
-
-      ! 5) start iteration for solving the non-linear equation by bisection
-      ! find limit, here step=0.5 seems a good compromise
-      conv_param = 100.0_dp*EPSILON(right_term_ref)
-      step = 0.5_dp
-      a_low = 0.0_dp
-      a_high = step
-      right_term = -right_term_ref
-      DO icycle = 1, num_integ_points*2
-         a_scaling = a_high
-
-         CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
-                                ZERO, ONE, M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
-                                nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
-                                para_env, para_env_row, para_env_row_beta)
-         left_term = left_term/FOUR/PIG*a_scaling
-
-         IF (ABS(left_term) > ABS(right_term) .OR. ABS(left_term+right_term) <= conv_param) EXIT
-         a_low = a_high
-         a_high = a_high+step
-
-      END DO
-
-      IF (ABS(left_term+right_term) >= conv_param) THEN
-         IF (a_scaling >= 2*num_integ_points*step) THEN
-            a_scaling = 1.0_dp
-         ELSE
-
-            DO icycle = 1, num_integ_points*2
-               a_scaling = (a_low+a_high)/2.0_dp
-
-               CALL calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
-                                      ZERO, ONE, M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
-                                      nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
-                                      para_env, para_env_row, para_env_row_beta)
-               left_term = left_term/FOUR/PIG*a_scaling
-
-               IF (ABS(left_term) > ABS(right_term)) THEN
-                  a_high = a_scaling
-               ELSE
-                  a_low = a_scaling
-               END IF
-
-               IF (ABS(a_high-a_low) < 1.0D-5) EXIT
-
-            END DO
-
-         END IF
-      END IF
-
-      a_scaling_ext = a_scaling
-      CALL mp_bcast(a_scaling_ext, 0, para_env%group)
-
-      DEALLOCATE (cottj)
-      DEALLOCATE (tj)
-      DEALLOCATE (wj)
-      DEALLOCATE (iaia_RI)
-      DEALLOCATE (D_ia)
-      DEALLOCATE (M_ia)
-      CALL cp_para_env_release(para_env_row)
       CALL cp_para_env_release(para_env_col)
-
-      IF (my_open_shell) THEN
-         DEALLOCATE (iaia_RI_beta)
-         DEALLOCATE (D_ia_beta)
-         DEALLOCATE (M_ia_beta)
-         CALL cp_para_env_release(para_env_row_beta)
-         CALL cp_para_env_release(para_env_col_beta)
-      END IF
 
       CALL timestop(handle)
 
-   END SUBROUTINE calc_scaling_factor
+   END SUBROUTINE calc_ia_ia_integrals
 
 ! **************************************************************************************************
 !> \brief ...
@@ -5801,8 +5770,6 @@ CONTAINS
 !> \param first_deriv ...
 !> \param num_integ_points ...
 !> \param my_open_shell ...
-!> \param ZERO ...
-!> \param ONE ...
 !> \param M_ia ...
 !> \param cottj ...
 !> \param wj ...
@@ -5818,14 +5785,13 @@ CONTAINS
 !> \param para_env_row_beta ...
 ! **************************************************************************************************
    SUBROUTINE calculate_objfunc(a_scaling, left_term, first_deriv, num_integ_points, my_open_shell, &
-                                ZERO, ONE, M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
+                                M_ia, cottj, wj, D_ia, D_ia_beta, M_ia_beta, &
                                 nrow_local, nrow_local_beta, num_integ_group, color_rpa_group, &
                                 para_env, para_env_row, para_env_row_beta)
       REAL(KIND=dp), INTENT(IN)                          :: a_scaling
       REAL(KIND=dp), INTENT(INOUT)                       :: left_term, first_deriv
       INTEGER, INTENT(IN)                                :: num_integ_points
       LOGICAL, INTENT(IN)                                :: my_open_shell
-      REAL(KIND=dp), INTENT(IN)                          :: zero, one
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: M_ia, cottj, wj, D_ia, D_ia_beta, &
                                                             M_ia_beta
@@ -5836,10 +5802,10 @@ CONTAINS
       INTEGER                                            :: iiB, jquad
       REAL(KIND=dp)                                      :: first_deriv_beta, left_term_beta, omega
 
-      left_term = ZERO
-      first_deriv = ZERO
-      left_term_beta = ZERO
-      first_deriv_beta = ZERO
+      left_term = 0.0_dp
+      first_deriv = 0.0_dp
+      left_term_beta = 0.0_dp
+      first_deriv_beta = 0.0_dp
       DO jquad = 1, num_integ_points
          ! parallelize over integration points
          IF (MODULO(jquad, num_integ_group) /= color_rpa_group) CYCLE
@@ -5850,7 +5816,7 @@ CONTAINS
             IF (MODULO(iiB, para_env_row%num_pe) /= para_env_row%mepos) CYCLE
             ! calculate left_term
             left_term = left_term+wj(jquad)* &
-                        (LOG(ONE+(M_ia(iiB)-D_ia(iiB)**2)/(omega**2+D_ia(iiB)**2))- &
+                        (LOG(1.0_dp+(M_ia(iiB)-D_ia(iiB)**2)/(omega**2+D_ia(iiB)**2))- &
                          (M_ia(iiB)-D_ia(iiB)**2)/(omega**2+D_ia(iiB)**2))
             first_deriv = first_deriv+wj(jquad)*cottj(jquad)**2* &
                           ((-M_ia(iiB)+D_ia(iiB)**2)**2/((omega**2+D_ia(iiB)**2)**2*(omega**2+M_ia(iiB))))
@@ -5862,7 +5828,7 @@ CONTAINS
                IF (MODULO(iiB, para_env_row_beta%num_pe) /= para_env_row_beta%mepos) CYCLE
                ! calculate left_term
                left_term_beta = left_term_beta+wj(jquad)* &
-                                (LOG(ONE+(M_ia_beta(iiB)-D_ia_beta(iiB)**2)/(omega**2+D_ia_beta(iiB)**2))- &
+                                (LOG(1.0_dp+(M_ia_beta(iiB)-D_ia_beta(iiB)**2)/(omega**2+D_ia_beta(iiB)**2))- &
                                  (M_ia_beta(iiB)-D_ia_beta(iiB)**2)/(omega**2+D_ia_beta(iiB)**2))
                first_deriv_beta = &
                   first_deriv_beta+wj(jquad)*cottj(jquad)**2* &

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -3828,10 +3828,6 @@ CONTAINS
             DEALLOCATE (wkp_W)
          END IF
 
-         IF (do_kpoints_from_Gamma) THEN
-            CALL kpoint_release(kpoints)
-         END IF
-
       END IF
 
       DEALLOCATE (tj)

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -10,6 +10,7 @@
 !>      04.2015 GW routines added [Jan Wilhelm]
 !>      10.2015 Cubic-scaling RPA routines added [Jan Wilhelm]
 !>      10.2018 Cubic-scaling SOS-MP2 added [Frederick Stein]
+!>      03.2019 Refactoring [Frederick Stein, Jan Wilhelm]
 ! **************************************************************************************************
 MODULE rpa_ri_gpw
    USE bibliography,                    ONLY: Bates2013,&
@@ -236,7 +237,7 @@ CONTAINS
                                                             do_im_time, do_mao, do_bse
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mao_coeff_occ, mao_coeff_virt, &
                                                             mao_coeff_occ_A, mao_coeff_virt_A
-      TYPE(dbcsr_p_type)                                 :: mat_munu, mat_dm_occ_local, &
+      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_munu, mat_dm_occ_local, &
                                                             mat_dm_virt_local, mat_P_local, &
                                                             mat_P_global, mat_M
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: mat_3c_overl_int
@@ -248,17 +249,17 @@ CONTAINS
                                                             mat_3c_overl_int_mao_for_virt
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(INout), OPTIONAL                         :: BIb_C_beta
+         INTENT(INOUT), OPTIONAL                         :: BIb_C_beta
       INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta
-      REAL(KIND=dp), DIMENSION(:), INTENT(INout), &
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT), &
          OPTIONAL                                        :: Eigenval_beta
       INTEGER, ALLOCATABLE, DIMENSION(:), &
-         INTENT(INout), OPTIONAL                         :: ends_B_virtual_beta, &
+         INTENT(INOUT), OPTIONAL                         :: ends_B_virtual_beta, &
                                                             sizes_B_virtual_beta, &
                                                             starts_B_virtual_beta
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: mo_coeff_beta
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(INout), OPTIONAL                         :: BIb_C_gw_beta
+         INTENT(INOUT), OPTIONAL                         :: BIb_C_gw_beta
       INTEGER, INTENT(IN), OPTIONAL                      :: gw_corr_lev_occ_beta, &
                                                             gw_corr_lev_virt_beta
 
@@ -4794,11 +4795,12 @@ CONTAINS
 !> \param do_lumo ...
 ! **************************************************************************************************
    SUBROUTINE update_coeff_homo(coeff_homo, fm_mat_U_occ, para_env, homo, gw_corr_lev_occ, do_lumo)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: coeff_homo
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: coeff_homo
       TYPE(cp_fm_type), POINTER                          :: fm_mat_U_occ
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER                                            :: homo, gw_corr_lev_occ
-      LOGICAL, OPTIONAL                                  :: do_lumo
+      INTEGER, INTENT(IN)                                :: homo, gw_corr_lev_occ
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_lumo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'update_coeff_homo', &
          routineP = moduleN//':'//routineN
@@ -4876,8 +4878,8 @@ CONTAINS
    SUBROUTINE fill_fm_mat_M_virt(fm_mat_M_virt, mat_N_virt_dbcsr, matrix_s, Eigenval, gw_corr_lev_virt, homo, para_env)
       TYPE(cp_fm_type), POINTER                          :: fm_mat_M_virt
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_N_virt_dbcsr, matrix_s
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      INTEGER                                            :: gw_corr_lev_virt, homo
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      INTEGER, INTENT(IN)                                :: gw_corr_lev_virt, homo
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_fm_mat_M_virt', &
@@ -5384,8 +5386,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fill_coeff_dbcsr_occ(coeff_dbcsr, coeff, homo)
       TYPE(dbcsr_type), POINTER                          :: coeff_dbcsr
-      REAL(KIND=dp), DIMENSION(:)                        :: coeff
-      INTEGER                                            :: homo
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: coeff
+      INTEGER, INTENT(IN)                                :: homo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fill_coeff_dbcsr_occ', &
          routineP = moduleN//':'//routineN
@@ -5494,16 +5496,17 @@ CONTAINS
                                   num_integ_points, num_integ_group, color_rpa_group, &
                                   tj_ext, wj_ext, fm_mat_S, &
                                   homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
-      REAL(KIND=dp)                                      :: a_scaling_ext
+      REAL(KIND=dp), INTENT(INOUT)                       :: a_scaling_ext
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
-      INTEGER                                            :: homo, virtual
-      REAL(KIND=dp), DIMENSION(:)                        :: Eigenval
-      INTEGER                                            :: num_integ_points, num_integ_group, &
+      INTEGER, INTENT(IN)                                :: homo, virtual
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      INTEGER, INTENT(IN)                                :: num_integ_points, num_integ_group, &
                                                             color_rpa_group
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tj_ext, wj_ext
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tj_ext, wj_ext
       TYPE(cp_fm_type), POINTER                          :: fm_mat_S
       INTEGER, OPTIONAL                                  :: homo_beta, virtual_beta, dimen_ia_beta
-      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: Eigenval_beta
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: Eigenval_beta
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: fm_mat_S_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_scaling_factor', &
@@ -5892,12 +5895,16 @@ CONTAINS
    SUBROUTINE get_l_sq_wghts_cos_tf_t_to_w(num_integ_points, tau_tj, weights_cos_tf_t_to_w, omega_tj, &
                                            E_min, E_max, max_error, num_points_per_magnitude)
 
-      INTEGER                                            :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_t_to_w
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj
-      REAL(KIND=dp)                                      :: E_min, E_max, max_error
-      INTEGER                                            :: num_points_per_magnitude
+      INTEGER, INTENT(IN)                                :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: weights_cos_tf_t_to_w
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: omega_tj
+      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
+      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
+      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_cos_tf_t_to_w', &
          routineP = moduleN//':'//routineN
@@ -6156,20 +6163,19 @@ CONTAINS
 !> \param num_integ_points ...
 !> \param num_x_nodes ...
 ! **************************************************************************************************
-   SUBROUTINE calc_max_error_fit_tau_grid_with_cosine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                      y_values, num_integ_points, num_x_nodes)
+   PURE SUBROUTINE calc_max_error_fit_tau_grid_with_cosine(max_error, omega, tau_tj, tau_wj_work, x_values, &
+                                                           y_values, num_integ_points, num_x_nodes)
 
-      REAL(KIND=dp)                                      :: max_error, omega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work, x_values, y_values
-      INTEGER                                            :: num_integ_points, num_x_nodes
+      REAL(KIND=dp), INTENT(INOUT)                       :: max_error, omega
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj, tau_wj_work, x_values, y_values
+      INTEGER, INTENT(IN)                                :: num_integ_points, num_x_nodes
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_max_error_fit_tau_grid_with_cosine', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, kkk
+      INTEGER                                            :: kkk
       REAL(KIND=dp)                                      :: func_val, func_val_temp, max_error_tmp
-
-      CALL timeset(routineN, handle)
 
       max_error_tmp = 0.0_dp
 
@@ -6192,8 +6198,6 @@ CONTAINS
 
       END IF
 
-      CALL timestop(handle)
-
    END SUBROUTINE calc_max_error_fit_tau_grid_with_cosine
 
 ! **************************************************************************************************
@@ -6205,12 +6209,14 @@ CONTAINS
 !> \param tau_wj_work ...
 !> \param omega ...
 ! **************************************************************************************************
-   SUBROUTINE eval_fit_func_tau_grid_cosine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
+   PURE SUBROUTINE eval_fit_func_tau_grid_cosine(func_val, x_value, num_integ_points, tau_tj, tau_wj_work, omega)
 
-      REAL(KIND=dp)                                      :: func_val, x_value
-      INTEGER                                            :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj, tau_wj_work
-      REAL(KIND=dp)                                      :: omega
+      REAL(KIND=dp), INTENT(OUT)                         :: func_val
+      REAL(KIND=dp), INTENT(IN)                          :: x_value
+      INTEGER, INTENT(IN)                                :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj, tau_wj_work
+      REAL(KIND=dp), INTENT(IN)                          :: omega
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_tau_grid_cosine', &
          routineP = moduleN//':'//routineN
@@ -6567,11 +6573,12 @@ CONTAINS
                                            mat_3c_overl_int_cut, cut_RI, cut_memory, para_env_sub, &
                                            do_kpoints_cubic_RPA)
 
-      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :) :: needed_cutRI_mem_R1vec_R2vec_for_kp
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :), INTENT(OUT) :: &
+         needed_cutRI_mem_R1vec_R2vec_for_kp
       TYPE(dbcsr_p_type), DIMENSION(:, :, :, :), POINTER :: mat_3c_overl_int_cut
-      INTEGER                                            :: cut_RI, cut_memory
+      INTEGER, INTENT(IN)                                :: cut_RI, cut_memory
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
-      LOGICAL                                            :: do_kpoints_cubic_RPA
+      LOGICAL, INTENT(IN)                                :: do_kpoints_cubic_RPA
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'check_sparsity_arrays_for_kp', &
          routineP = moduleN//':'//routineN
@@ -6708,12 +6715,16 @@ CONTAINS
    SUBROUTINE get_l_sq_wghts_cos_tf_w_to_t(num_integ_points, tau_tj, weights_cos_tf_w_to_t, omega_tj, &
                                            E_min, E_max, max_error, num_points_per_magnitude)
 
-      INTEGER                                            :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj
-      REAL(KIND=dp)                                      :: E_min, E_max, max_error
-      INTEGER                                            :: num_points_per_magnitude
+      INTEGER, INTENT(IN)                                :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: tau_tj
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: weights_cos_tf_w_to_t
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: omega_tj
+      REAL(KIND=dp), INTENT(IN)                          :: E_min, E_max
+      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
+      INTEGER, INTENT(IN)                                :: num_points_per_magnitude
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_l_sq_wghts_cos_tf_w_to_t', &
          routineP = moduleN//':'//routineN
@@ -6891,11 +6902,13 @@ CONTAINS
 !> \param omega_wj_work ...
 !> \param tau ...
 ! **************************************************************************************************
-   SUBROUTINE eval_fit_func_omega_grid_cosine(func_val, x_value, num_integ_points, omega_tj, omega_wj_work, tau)
-      REAL(KIND=dp)                                      :: func_val, x_value
-      INTEGER                                            :: num_integ_points
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: omega_tj, omega_wj_work
-      REAL(KIND=dp)                                      :: tau
+   PURE SUBROUTINE eval_fit_func_omega_grid_cosine(func_val, x_value, num_integ_points, omega_tj, omega_wj_work, tau)
+      REAL(KIND=dp), INTENT(OUT)                         :: func_val
+      REAL(KIND=dp), INTENT(IN)                          :: x_value
+      INTEGER, INTENT(IN)                                :: num_integ_points
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(IN)                                      :: omega_tj, omega_wj_work
+      REAL(KIND=dp), INTENT(IN)                          :: tau
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_fit_func_omega_grid_cosine', &
          routineP = moduleN//':'//routineN

--- a/tests/QS/regtest-gw-cubic/G0W0_kpoints_H2O.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_kpoints_H2O.inp
@@ -1,0 +1,105 @@
+&GLOBAL
+  PROJECT  RPA_H2O_kpoints
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+  &TIMINGS
+     THRESHOLD 0.01
+  &END
+&END GLOBAL
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME  HFX_BASIS
+    POTENTIAL_FILE_NAME  GTH_POTENTIALS
+    &MGRID
+      CUTOFF  100
+      REL_CUTOFF  20
+    &END MGRID
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-15
+      EPS_PGF_ORB 1.0E-15
+    &END QS
+    &SCF
+      SCF_GUESS RESTART
+      EPS_SCF 1.0E-5
+      MAX_SCF 100
+      &PRINT
+        &RESTART ON
+        &END
+      &END
+      ADDED_MOS 10000000
+    &END SCF
+    &KPOINTS
+       SCHEME  MONKHORST-PACK 1 1 4
+       SYMMETRY ON
+       EPS_GEO 1.e-8
+       FULL_GRID ON
+       VERBOSE F
+       PARALLEL_GROUP_SIZE  0
+    &END KPOINTS
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+      &WF_CORRELATION
+        METHOD  RI_RPA_GPW
+        RI OVERLAP
+        ERI_METHOD OS
+        &WFC_GPW
+          CUTOFF  100
+          REL_CUTOFF 20
+          EPS_GRID 1.0E-7
+          EPS_FILTER 1.0E-7
+          SIZE_LATTICE_SUM 5
+        &END
+        MEMORY  200.
+        NUMBER_PROC  1
+        IM_TIME
+        &IM_TIME
+          MEMORY_CUT 1
+          MEMORY_INFO
+          GROUP_SIZE_P  1
+          DO_KPOINTS
+          EPS_FILTER_IM_TIME 1.0E-7
+          DO_DBCSR_T FALSE
+          GW
+        &END IM_TIME
+        &RI_RPA
+          RPA_NUM_QUAD_POINTS  6
+          MINIMAX
+          &RI_G0W0
+           CORR_OCC   1
+           CORR_VIRT  1
+           CROSSING_SEARCH NEWTON
+           RI_SIGMA_X
+          &END RI_G0W0
+        &END RI_RPA
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom]  8.000   8.000  8.000
+      MULTIPLE_UNIT_CELL  1 1 1
+      PERIODIC Z
+    &END CELL
+    &KIND H
+      BASIS_SET        DZVP-GTH
+      RI_AUX_BASIS_SET RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET        DZVP-GTH
+      RI_AUX_BASIS_SET RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q6
+    &END KIND
+    &TOPOLOGY
+      MULTIPLE_UNIT_CELL  1 1 1
+    &END TOPOLOGY
+    &COORD
+      H  0.0 -0.5 -4.5
+      O  0.5  0.0  4.5
+      H  0.0  0.5 -4.5
+    &END COORD
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-gw-cubic/G0W0_kpoints_from_Gamma.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_kpoints_from_Gamma.inp
@@ -1,0 +1,97 @@
+&GLOBAL
+  PROJECT  RPA_H2O_kpoints
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+  &TIMINGS
+     THRESHOLD 0.01
+  &END
+&END GLOBAL
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME  HFX_BASIS
+    POTENTIAL_FILE_NAME  GTH_POTENTIALS
+    &MGRID
+      CUTOFF  100
+      REL_CUTOFF  20
+    &END MGRID
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-15
+      EPS_PGF_ORB 1.0E-15
+    &END QS
+    &SCF
+      SCF_GUESS RESTART
+      EPS_SCF 1.0E-5
+      MAX_SCF 100
+      &PRINT
+        &RESTART ON
+        &END
+      &END
+      ADDED_MOS 10000000
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+      &WF_CORRELATION
+        METHOD  RI_RPA_GPW
+        RI OVERLAP
+        ERI_METHOD OS
+        &WFC_GPW
+          CUTOFF  100
+          REL_CUTOFF 20
+          EPS_GRID 1.0E-7
+          EPS_FILTER 1.0E-7
+          SIZE_LATTICE_SUM 5
+        &END
+        MEMORY  200.
+        NUMBER_PROC  1
+        IM_TIME
+        &IM_TIME
+          MEMORY_CUT 1
+          MEMORY_INFO
+          GROUP_SIZE_P  1
+          KPOINTS 1 1 4
+          EPS_FILTER_IM_TIME 1.0E-7
+          DO_DBCSR_T FALSE
+          GW
+        &END IM_TIME
+        &RI_RPA
+          RPA_NUM_QUAD_POINTS  6
+          MINIMAX
+          &RI_G0W0
+           CORR_OCC   1
+           CORR_VIRT  1
+           CROSSING_SEARCH NEWTON
+           RI_SIGMA_X
+          &END RI_G0W0
+        &END RI_RPA
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom]  8.000   8.000  8.000
+      MULTIPLE_UNIT_CELL  1 1 1
+      PERIODIC Z
+    &END CELL
+    &KIND H
+      BASIS_SET        DZVP-GTH
+      RI_AUX_BASIS_SET RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET        DZVP-GTH
+      RI_AUX_BASIS_SET RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q6
+    &END KIND
+    &TOPOLOGY
+      MULTIPLE_UNIT_CELL  1 1 1
+    &END TOPOLOGY
+    &COORD
+      H  0.0 -0.5 -4.5
+      O  0.5  0.0  4.5
+      H  0.0  0.5 -4.5
+    &END COORD
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-gw-cubic/TEST_FILES
+++ b/tests/QS/regtest-gw-cubic/TEST_FILES
@@ -1,4 +1,6 @@
 G0W0_H2O_PBE0.inp                                     78      1e-05                          16.66
 G0W0_H2O_PBE_periodic.inp                             78      1e-05                          15.50
 G0W0_OH_PBE.inp                                       79      1e-05                          11.65
+G0W0_kpoints_H2O.inp                                  78      1e-05                          15.20
+G0W0_kpoints_from_Gamma.inp                           78      1e-05                          15.20
 #EOF

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_from_Gamma_H2O.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_from_Gamma_H2O.inp
@@ -1,0 +1,89 @@
+&GLOBAL
+  PROJECT  RPA_H2O_kpoints
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+  &TIMINGS
+     THRESHOLD 0.01
+  &END
+&END GLOBAL
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME  HFX_BASIS
+    POTENTIAL_FILE_NAME  GTH_POTENTIALS
+    &MGRID
+      CUTOFF  100
+      REL_CUTOFF  20
+    &END MGRID
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-15
+      EPS_PGF_ORB 1.0E-15
+    &END QS
+    &SCF
+      SCF_GUESS ATOMIC
+      EPS_SCF 1.0E-5
+      MAX_SCF 100
+      &PRINT
+        &RESTART OFF
+        &END
+      &END
+      ADDED_MOS 10000000
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+      &WF_CORRELATION
+        METHOD  RI_RPA_GPW
+        RI OVERLAP
+        ERI_METHOD OS
+        &WFC_GPW
+          CUTOFF  100
+          REL_CUTOFF 20
+          EPS_GRID 1.0E-6
+          EPS_FILTER 1.0E-6
+          SIZE_LATTICE_SUM 3
+        &END
+        MEMORY  200.
+        NUMBER_PROC  1
+        IM_TIME
+        &IM_TIME
+          MEMORY_CUT 1
+          MEMORY_INFO
+          GROUP_SIZE_P  1
+          KPOINTS 4 4 4
+          EPS_FILTER_IM_TIME 1.0E-6
+        &END IM_TIME
+        &RI_RPA
+          RPA_NUM_QUAD_POINTS  6
+          MINIMAX
+        &END RI_RPA
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom]  10.000   10.000  10.000
+      MULTIPLE_UNIT_CELL  1 1 1
+      PERIODIC XYZ
+    &END CELL
+    &KIND H
+      BASIS_SET        DZVP-GTH
+      RI_AUX_BASIS_SET RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET        DZVP-GTH
+      RI_AUX_BASIS_SET RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q6
+    &END KIND
+    &TOPOLOGY
+      MULTIPLE_UNIT_CELL  1 1 1
+    &END TOPOLOGY
+    &COORD
+      H  0.0 -0.5 -5.5
+      O  0.5  0.0  5.5
+      H  0.0  0.5 -5.5
+    &END COORD
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-ri-rpa/TEST_FILES
+++ b/tests/QS/regtest-ri-rpa/TEST_FILES
@@ -10,4 +10,5 @@ RI_RPA_H2O_PBE0_ADMM1.inp                             11      1e-08            -
 RI_RPA_H2O_Obara_Saika.inp                            11      1e-08            -17.160204463746162
 RPA_kpoints_H2O.inp                                   11      1e-08            -17.384611923474342
 RPA_kpoints_H2O_non_zero_group_sizes.inp              11      1e-08            -17.384611923474342
+RPA_kpoints_from_Gamma_H2O.inp                        11      1e-08            -17.384614981790069
 #EOF


### PR DESCRIPTION
- kpoints for low-scaling GW using recursions over neighboring cells (no GPW, calculations quite expensive, probably only routinely usable for 1d periodic systems because of few neighboring cells)
- kpoints for low-scaling RPA/GW from a Gamma-only DFT-calculation (computational effort of periodic calculation similar to non-periodic calculation, works for 1d, 2d and 3d periodicity)
- refactoring of rpa_ri_gpw.F and moving GW routines from rpa_ri_gpw.F to rpa_gw.F as proposed by Frederick
- todo 1: RI with attenuated Coulomb metric to accelerate convergence with RI basis set size which is necessary to generate reliable GW benchmark results for periodic systems, e.g. TiO2 pure/interface/surface, or graphene nanoribbons
- todo 2: would be desirable to completely replace old dbcsr tensors by Patrick's tensors to speed up the code and improve code quality