### PR TITLE
Feature/cleanup library support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,7 +126,7 @@ Library ELPA for the solution of the eigenvalue problem
   * A version of ELPA can to be downloaded from http://elpa.rzg.mpg.de/software.
   * During the installation the libelpa.a (or libelpa_mt.a if omp active) is created.
   * Add `-D__ELPA=YYYYMM` to DFLAGS, where `YYYYMM` denotes the release date of the library.
-  * Currently supported versions are: `201112`, `201308`, `201311`, `201406`, `201502`, `201505`, `201511`, `201605`, and `201611`.
+  * Currently supported versions are: `201611`, `201705` and `201711`.
   * Add `-I$(ELPA_INCLUDE_DIR)/modules` to FCFLAGS
   * Add `-I$(ELPA_INCLUDE_DIR)/elpa` to FCFLAGS
   * Add `-L$(ELPA_DIR)` to `LDFLAGS`

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -128,9 +128,6 @@ CONTAINS
 #if defined(__SCALAPACK)
       flags = TRIM(flags)//" scalapack"
 #endif
-#if defined(__SCALAPACK2)
-      flags = TRIM(flags)//" scalapack2"
-#endif
 
 #if defined(__QUIP)
       flags = TRIM(flags)//" quip"

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -113,9 +113,6 @@ CONTAINS
 #if defined(__ELPA)
       CALL integer_to_string(__ELPA, tmp_str)
       flags = TRIM(flags)//" elpa="//TRIM(tmp_str)
-#if (__ELPA==201502) || (__ELPA==201505) || (__ELPA==201511) || (__ELPA==201605) || (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
-      flags = TRIM(flags)//" elpa_qr"
-#endif
 #endif
 #if defined(__parallel)
       flags = TRIM(flags)//" parallel"

--- a/src/environment.F
+++ b/src/environment.F
@@ -49,8 +49,8 @@ MODULE environment
    USE header,                          ONLY: cp2k_footer,&
                                               cp2k_header
    USE input_constants,                 ONLY: &
-        callgraph_all, callgraph_none, do_cp2k, do_diag_elpa, do_diag_sl, do_diag_sl2, do_eip, &
-        do_farming, do_fft_fftw3, do_fft_sg, do_fist, do_qs, do_sirius, do_test, energy_run, &
+        callgraph_all, callgraph_none, do_cp2k, do_diag_elpa, do_diag_sl, do_eip, do_farming, &
+        do_fft_fftw3, do_fft_sg, do_fist, do_qs, do_sirius, do_test, energy_run, &
         id_development_version, mol_dyn_run, none_run
    USE input_cp2k_global,               ONLY: create_global_section
    USE input_enumeration_types,         ONLY: enum_i2c,&
@@ -584,8 +584,6 @@ CONTAINS
       SELECT CASE (i_diag)
       CASE (do_diag_sl)
          globenv%diag_library = "SL"
-      CASE (do_diag_sl2)
-         globenv%diag_library = "SL2"
       CASE (do_diag_elpa)
          globenv%diag_library = "ELPA"
          CALL cite_reference(Marek2014)
@@ -969,20 +967,18 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'diag_setup_library', &
          routineP = moduleN//':'//routineN
 
-      LOGICAL                                            :: switched
+      LOGICAL                                            :: fallback_applied
 
-      switched = .FALSE.
-
-      CALL diag_init(diag_lib=TRIM(globenv%diag_library), switched=switched, k_elpa=globenv%k_elpa, &
+      CALL diag_init(diag_lib=TRIM(globenv%diag_library), fallback_applied=fallback_applied, k_elpa=globenv%k_elpa, &
                      elpa_qr=globenv%elpa_qr, elpa_print=globenv%elpa_print, &
                      elpa_qr_unsafe=globenv%elpa_qr_unsafe)
 
-      IF (switched) THEN
+      IF (fallback_applied) THEN
 
          IF (output_unit > 0) THEN
             WRITE (output_unit, '(A,A,T55,A)') &
                " WARNING : DIAGONALIZATION library "//TRIM(globenv%diag_library)// &
-               " is not available ", " Trying SCALAPACK"
+               " is not available, fallback to SCALAPACK"
          ENDIF
 
       END IF

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -71,6 +71,11 @@ MODULE cp_fm_diag
    ! these saved variables are DIAGONALIZATION global
    INTEGER, SAVE :: diag_type = 0
 
+   ! constants for the diag_type above
+   INTEGER, PARAMETER :: &
+      DIAG_TYPE_SCALAPACK = 1, &
+      DIAG_TYPE_ELPA = 2
+
    ! Public subroutines
 
    PUBLIC :: choose_eigv_solver, &
@@ -86,10 +91,9 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Setup the diagonalization library to be used
-!>         Check of availability not yet fully implemented
-!>         It should change library to Scalapack if others are not available
 !> \param diag_lib diag_library flag from GLOBAL section in input
-!> \param switched ...
+!> \param fallback_applied .TRUE. if support for the requested library was not compiled-in and fallback
+!>                         to SCALAPACK was applied, .FALSE. otherwise.
 !> \param k_elpa integer that determines which ELPA kernel to use for diagonalization
 !> \param elpa_qr logical that determines if ELPA should try to use QR to accelerate the
 !>                diagonalization procedure of suitably sized matrices
@@ -98,58 +102,37 @@ CONTAINS
 !> \param elpa_qr_unsafe logical that enables potentially unsafe ELPA options
 !> \author  MI 11.2013
 ! **************************************************************************************************
-   SUBROUTINE diag_init(diag_lib, switched, k_elpa, elpa_qr, elpa_print, elpa_qr_unsafe)
+   SUBROUTINE diag_init(diag_lib, fallback_applied, k_elpa, elpa_qr, elpa_print, elpa_qr_unsafe)
       CHARACTER(LEN=*), INTENT(IN)                       :: diag_lib
-      LOGICAL, INTENT(INOUT)                             :: switched
+      LOGICAL, INTENT(OUT)                               :: fallback_applied
       INTEGER, INTENT(IN)                                :: k_elpa
       LOGICAL, INTENT(IN)                                :: elpa_qr, elpa_print, elpa_qr_unsafe
 
       CHARACTER(len=*), PARAMETER :: routineN = 'diag_init', routineP = moduleN//':'//routineN
 
-      LOGICAL                                            :: try_library
+      fallback_applied = .FALSE.
 
-      ! scalapack is the default and always linked
       IF (diag_lib .EQ. "SL") THEN
-         try_library = .FALSE.
-         diag_type = 1
-      ELSE
-         try_library = .TRUE.
-      END IF
-
-      IF (try_library) THEN
-         IF (diag_lib .EQ. "ELPA") THEN
-
+         diag_type = DIAG_TYPE_SCALAPACK
+      ELSE IF (diag_lib .EQ. "ELPA") THEN
 #if defined (__ELPA)
-            diag_type = 3
-            MARK_USED(switched)
+         ! ELPA is requested and available
+         diag_type = DIAG_TYPE_ELPA
 #else
-            ! ELPA library not linked, switch to SL
-            diag_type = 1
-            switched = .TRUE.
+         ! ELPA library reqested but not linked, switch back to SL
+         diag_type = DIAG_TYPE_SCALAPACK
+         fallback_applied = .TRUE.
 #endif
-         ELSE IF (diag_lib .EQ. "SL2") THEN
-
-#if defined (__SCALAPACK2)
-            diag_type = 2
-            MARK_USED(switched)
-#else
-            ! SL2 library not linked, switch to SL
-            diag_type = 1
-            switched = .TRUE.
-#endif
-         END IF
+      ELSE
+         CPABORT("Initialization of unknown diagonalization library requested")
       END IF
 
-      CALL set_elpa_kernel(k_elpa)
-      CALL set_elpa_qr(elpa_qr, elpa_qr_unsafe)
-      CALL set_elpa_print(elpa_print)
-
-      ! Check that one of the diagonalization type is set
-      IF (diag_type < 1) THEN
-         ! something wrong
-         CPABORT("Unknown DIAG type")
+      ! Initialization of requested diagonalization library:
+      IF (diag_type == DIAG_TYPE_ELPA) THEN
+         CALL set_elpa_kernel(k_elpa)
+         CALL set_elpa_qr(elpa_qr, elpa_qr_unsafe)
+         CALL set_elpa_print(elpa_print)
       END IF
-
    END SUBROUTINE diag_init
 
 ! **************************************************************************************************
@@ -174,12 +157,11 @@ CONTAINS
 
       INTEGER                                            :: myinfo, nmo
 #if defined(__CHECK_DIAG)
-      CHARACTER(LEN=5), DIMENSION(3), PARAMETER          :: diag_driver = (/"SYEVD", &
-                                                                            "SYEVR", &
+      CHARACTER(LEN=5), DIMENSION(2), PARAMETER          :: diag_driver = (/"SYEVD", &
                                                                             "ELPA "/)
       REAL(KIND=dp), PARAMETER                           :: eps = 1.0E-12_dp
       INTEGER                                            :: i, j, n
-#if (defined(__SCALAPACK) || defined(__SCALAPACK2))
+#if defined(__SCALAPACK)
       TYPE(cp_blacs_env_type), POINTER                   :: context
       INTEGER                                            :: il, jl, ipcol, iprow, &
                                                             mypcol, myprow, npcol, nprow
@@ -194,24 +176,22 @@ CONTAINS
       !sample peak memory
       CALL m_memory()
 
-      IF (diag_type == 3) THEN
+      IF (diag_type == DIAG_TYPE_ELPA) THEN
          CALL cp_fm_diag_elpa(matrix, eigenvectors, eigenvalues)
-      ELSE IF (diag_type == 2) THEN
-         CALL cp_fm_syevr(matrix, eigenvectors, eigenvalues, 1, nmo)
-      ELSE IF (diag_type == 1) THEN
+      ELSE IF (diag_type == DIAG_TYPE_SCALAPACK) THEN
          IF (PRESENT(info)) THEN
             CALL cp_fm_syevd(matrix, eigenvectors, eigenvalues, info=myinfo)
          ELSE
             CALL cp_fm_syevd(matrix, eigenvectors, eigenvalues)
          END IF
       ELSE
-         CPABORT("Unknown DIAG type")
+         CPABORT("Invalid diagonalization type encountered")
       END IF
 
       IF (PRESENT(info)) info = myinfo
 
 #if defined(__CHECK_DIAG)
-#if (defined(__SCALAPACK) || defined(__SCALAPACK2))
+#if defined(__SCALAPACK)
       n = eigenvectors%matrix_struct%nrow_global
       CALL cp_fm_gemm("T", "N", nmo, nmo, n, 1.0_dp, eigenvectors, eigenvectors, 0.0_dp, matrix)
       context => matrix%matrix_struct%context
@@ -720,195 +700,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE cp_fm_syevx
-
-! **************************************************************************************************
-!> \brief  computes selected eigenvalues and, optionally, eigenvectors of
-!>        a real symmetric matrix A distributed in 2D blockcyclic format by
-!>       calling the recommended sequence of ScaLAPACK routines.
-!>
-!> \param matrix ...
-!> \param eigenvectors ...
-!> \param eigenvalues ...
-!> \param ilow ...
-!> \param iup ...
-!> \par     matrix is supposed to be in upper triangular form, and overwritten by this routine
-!>          subsets of eigenvalues/vectors can be selected by
-!>          specifying a range of values or a range of indices for the desired eigenvalues.
-! **************************************************************************************************
-   SUBROUTINE cp_fm_syevr(matrix, eigenvectors, eigenvalues, ilow, iup)
-
-      TYPE(cp_fm_type), POINTER                  :: matrix
-      TYPE(cp_fm_type), POINTER, OPTIONAL        :: eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)   :: eigenvalues
-      INTEGER, INTENT(IN), OPTIONAL              :: ilow, iup
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = "cp_fm_syevr", &
-                                     routineP = moduleN//":"//routineN
-
-      CHARACTER(LEN=1)                           :: job_type
-      INTEGER                                    :: handle, ilow_local, &
-                                                    iup_local, n, neig, &
-                                                    mypcol, myprow
-      LOGICAL                                    :: ionode, needs_evecs
-
-      TYPE(cp_blacs_env_type), POINTER           :: context
-      TYPE(cp_logger_type), POINTER              :: logger
-
-      REAL(KIND=dp), EXTERNAL :: dlamch
-
-#if (defined(__SCALAPACK) || defined(__SCALAPACK2))
-      REAL(KIND=dp), PARAMETER  :: vl = 0.0_dp, &
-                                   vu = 0.0_dp
-      REAL(KIND=dp), DIMENSION(:, :), POINTER    :: a, z
-      REAL(KIND=dp), DIMENSION(:), ALLOCATABLE   :: w, work
-      INTEGER, DIMENSION(:), ALLOCATABLE         :: iwork
-      INTEGER                                    :: info, liwork, lwork
-#if defined(__SCALAPACK2)
-      INTEGER, DIMENSION(9)                      :: desca, descz
-      INTEGER                                    :: m, nz
-#elif defined(__SCALAPACK)
-      INTEGER                                    :: m, nb
-      REAL(dp)                                   :: abstol
-      INTEGER, DIMENSION(:), ALLOCATABLE         :: ifail
-      INTEGER, EXTERNAL                          :: ilaenv
-#endif
-#endif
-
-      ! by default all
-      n = matrix%matrix_struct%nrow_global
-      neig = n
-      iup_local = n
-      ilow_local = 1
-      IF (PRESENT(ilow) .AND. PRESENT(iup)) THEN
-         neig = iup-ilow+1
-         iup_local = iup
-         ilow_local = ilow
-      END IF
-      IF (neig <= 0) RETURN
-
-      CALL timeset(routineN, handle)
-
-      needs_evecs = PRESENT(eigenvectors)
-
-      logger => cp_get_default_logger()
-      ionode = logger%para_env%mepos == logger%para_env%source
-      n = matrix%matrix_struct%nrow_global
-
-      ! set scalapack job type
-      IF (needs_evecs) THEN
-         job_type = "V"
-      ELSE
-         job_type = "N"
-      ENDIF
-
-      context => matrix%matrix_struct%context
-      myprow = context%mepos(1)
-      mypcol = context%mepos(2)
-
-      eigenvalues(:) = 0.0_dp
-
-#if defined(__SCALAPACK2)
-
-      IF (matrix%matrix_struct%nrow_block /= matrix%matrix_struct%ncol_block) THEN
-         CPABORT("")
-      END IF
-
-      a => matrix%local_data
-      desca(:) = matrix%matrix_struct%descriptor(:)
-
-      IF (needs_evecs) THEN
-         z => eigenvectors%local_data
-         descz(:) = eigenvectors%matrix_struct%descriptor(:)
-      ELSE
-         ! z will not be referenced
-         z => matrix%local_data
-         descz = desca
-      ENDIF
-
-      ! First Call: Determine the needed work_space
-      lwork = -1
-      ALLOCATE (w(n))
-      ALLOCATE (work(5*n))
-      ALLOCATE (iwork(6*n))
-      CALL pdsyevr(job_type, 'I', 'U', n, a, 1, 1, desca, vl, vu, ilow_local, iup_local, m, nz, w(1), &
-                   z, 1, 1, descz, work, lwork, iwork, liwork, info)
-      lwork = INT(work(1))
-      lwork = NINT(work(1)+300000)
-      liwork = iwork(1)
-      IF (lwork > SIZE(work, 1)) THEN
-         DEALLOCATE (work)
-         ALLOCATE (work(lwork))
-      END IF
-      IF (liwork > SIZE(iwork, 1)) THEN
-         DEALLOCATE (iwork)
-         ALLOCATE (iwork(liwork))
-      END IF
-
-      !Second call: solve the eigenvalue problem
-      info = 0
-      CALL pdsyevr(job_type, 'I', 'U', n, a, 1, 1, desca, vl, vu, ilow_local, iup_local, m, nz, w(1), &
-                   z, 1, 1, descz, work, lwork, iwork, liwork, info)
-
-      IF (info > 0) THEN
-         WRITE (*, *) 'Processor ', myprow, mypcol, ': Error! INFO code = ', INFO
-      END IF
-      CPASSERT(info == 0)
-
-      ! Release work storage
-      DEALLOCATE (iwork)
-      DEALLOCATE (work)
-
-      eigenvalues(ilow_local:iup_local) = w(ilow_local:iup_local)
-      DEALLOCATE (w)
-
-#elif defined(__SCALAPACK)
-
-      a => matrix%local_data
-      IF (needs_evecs) THEN
-         z => eigenvectors%local_data
-      ELSE
-         ! z will not be referenced
-         z => matrix%local_data
-      ENDIF
-
-      ! Get the optimal work storage size
-
-      nb = MAX(ilaenv(1, "DSYTRD", "U", n, -1, -1, -1), &
-               ilaenv(1, "DORMTR", "U", n, -1, -1, -1))
-
-      lwork = MAX((nb+3)*n, 8*n)+n ! sun bug fix
-      liwork = 5*n
-
-      ALLOCATE (ifail(n))
-      ifail = 0
-
-      ALLOCATE (w(n))
-      ALLOCATE (iwork(liwork))
-      ALLOCATE (work(lwork))
-
-      ! target the most accurate calculation of the eigenvalues
-      abstol = 2.0_dp*dlamch("S")
-
-      info = 0
-      CALL dsyevx(job_type, "I", "U", n, a(1, 1), n, vl, vu, ilow_local, iup_local, abstol, m, w, z(1, 1), n, work(1), lwork, &
-                  iwork(1), ifail(1), info)
-
-      ! Error handling
-      CPASSERT(info == 0)
-
-      ! Release work storage
-      DEALLOCATE (iwork)
-      DEALLOCATE (work)
-
-      eigenvalues(ilow_local:iup_local) = w(ilow_local:iup_local)
-      DEALLOCATE (w)
-#else
-      CPABORT("Scalapack is required but missing!")
-#endif
-
-      CALL timestop(handle)
-
-   END SUBROUTINE cp_fm_syevr
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/fm/cp_fm_elpa.F
+++ b/src/fm/cp_fm_elpa.F
@@ -29,10 +29,7 @@ MODULE cp_fm_elpa
 #include "../base/base_uses.f90"
 
 #if defined (__ELPA)
-# if (__ELPA < 201611)
-#  include "elpa_kernel_constants.h"
-   USE elpa2,                           ONLY: solve_evp_real_2stage
-# elif (__ELPA < 201705)
+# if (__ELPA < 201705)
 #  include "elpa_kernel_constants.h"
    USE elpa2,                           ONLY: elpa_solve_evp_real_2stage_double
 # else
@@ -232,16 +229,7 @@ $: "#endif"
       LOGICAL, INTENT(IN)                                :: use_qr, use_qr_unsafe
 
 #if defined(__ELPA)
-#if (__ELPA==201112) || (__ELPA==201308) || (__ELPA==201311) || (__ELPA==201406)
-      MARK_USED(use_qr)
-      MARK_USED(use_qr_unsafe)
-      elpa_qr = .FALSE.
-      elpa_qr_unsafe = .FALSE.
-#elif (__ELPA==201502) || (__ELPA==201505) || (__ELPA==201511)
-      MARK_USED(use_qr_unsafe)
-      elpa_qr = use_qr
-      elpa_qr_unsafe = .FALSE.
-#elif (__ELPA==201605) || (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
+#if (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
       elpa_qr = use_qr
       elpa_qr_unsafe = use_qr_unsafe
 #else
@@ -390,12 +378,7 @@ $: "#endif"
       !     - Proper matrix order:  src/elpa2.F90 (src/elpa2_template.X90 in git version)
       !     - Proper block size:    test/Fortran/test_real2_qr.F90
       ! Note that the names of these files might change in different ELPA versions
-#if (__ELPA==201112) || (__ELPA==201308) || (__ELPA==201311) || (__ELPA==201406)
-      use_qr = .FALSE.
-#elif (__ELPA==201502) || (__ELPA==201505) || (__ELPA==201511)
-      ! Matrix order must be an integer multiple of the block size
-      use_qr = elpa_qr .AND. MOD(n, nblk).EQ.0
-#elif (__ELPA==201605) || (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
+#if (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
       ! Matrix order must be even
       use_qr = elpa_qr .AND. MOD(n, 2).EQ.0
       ! Matrix order and block size must be greater than or equal to 64
@@ -438,19 +421,13 @@ $: "#endif"
             WRITE(io_unit, '(A,L14)') "ELPA| Use potentially unsafe QR: ", elpa_qr_unsafe
             WRITE(io_unit, '(A,L14)') "ELPA| Matrix is suitable for QR: ", use_qr
             IF (.NOT. use_qr) THEN
-#if (__ELPA==201502) || (__ELPA==201505) || (__ELPA==201511)
-               WRITE(io_unit, '(A)') "ELPA| Matrix order is NOT divisible by block size"
-#elif (__ELPA==201605) || (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
                IF (MOD(n, 2).NE.0 ) &
                   WRITE(io_unit, '(A)') "ELPA| Matrix order is NOT even"
                IF (nblk .LT. 64 .AND. .NOT. elpa_qr_unsafe) &
                   WRITE(io_unit, '(A)') "ELPA| Matrix block size is NOT 64 or greater"
-#endif
             ELSE
-#if (__ELPA==201605) || (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
                IF (nblk .LT. 64 .AND. elpa_qr_unsafe) &
                   WRITE(io_unit, '(A,L14)') "ELPA| Matrix block size check was bypassed"
-#endif
             END IF
          END IF
       END IF
@@ -464,51 +441,7 @@ $: "#endif"
 
       ! Make actual call to ELPA to calculate eigenvalues/eigenvectors
 
-!---------------------------------------------------------------------------------------------------
-#if (__ELPA==201112) || (__ELPA==201308) || (__ELPA==201311)
-      IF (elpa_kernel /= -1) CPABORT("The only available ELPA kernel is AUTO.")
-      CALL solve_evp_real_2stage(n, neig, m, n_rows, eval, v, n_rows, nblk, comm_row, comm_col, group)
-      success = .TRUE.
-
-!---------------------------------------------------------------------------------------------------
-#elif (__ELPA==201406) || (__ELPA==201502) || (__ELPA==201505)
-      IF (elpa_kernel == -1) THEN ! auto
-         success = solve_evp_real_2stage(n, neig, m, n_rows, eval, v, n_rows, nblk, &
-                                         comm_row, comm_col, group, &
-                                         useQR=use_qr)
-      ELSE
-         success = solve_evp_real_2stage(n, neig, m, n_rows, eval, v, n_rows, nblk, &
-                                         comm_row, comm_col, group, &
-                                         elpa_kernel, &
-                                         useQR=use_qr)
-      END IF
-
-!---------------------------------------------------------------------------------------------------
-#elif (__ELPA==201511) || (__ELPA==201605)
-      IF (elpa_kernel == -1) THEN ! auto
-         success = solve_evp_real_2stage(n, neig, m, n_rows, eval, v, n_rows, nblk, n_cols, &
-                                         comm_row, comm_col, group, &
-                                         useQR=use_qr)
-         IF (check_eigenvalues) THEN
-            success_noqr = solve_evp_real_2stage(n, neig, m_noqr, n_rows, eval_noqr, v_noqr, n_rows, nblk, n_cols, &
-                                                 comm_row, comm_col, group, &
-                                                 useQR=.FALSE.)
-         END IF
-      ELSE
-         success = solve_evp_real_2stage(n, neig, m, n_rows, eval, v, n_rows, nblk, n_cols, &
-                                         comm_row, comm_col, group, &
-                                         elpa_kernel, &
-                                         useQR=use_qr)
-         IF (check_eigenvalues) THEN
-            success_noqr = solve_evp_real_2stage(n, neig, m_noqr, n_rows, eval_noqr, v_noqr, n_rows, nblk, n_cols, &
-                                                 comm_row, comm_col, group, &
-                                                 elpa_kernel, &
-                                                 useQR=.FALSE.)
-         END IF
-      END IF
-
-!---------------------------------------------------------------------------------------------------
-#elif (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
+#if (__ELPA==201611) || (__ELPA==201705) || (__ELPA==201711)
       IF (elpa_kernel == -1) THEN ! auto
          success = elpa_solve_evp_real_2stage_double(n, neig, m, n_rows, eval, v, n_rows, nblk, n_cols, &
                                                      comm_row, comm_col, group, &
@@ -531,11 +464,9 @@ $: "#endif"
          END IF
       END IF
 
-!---------------------------------------------------------------------------------------------------
 #else
    Error: Unknown ELPA version, please specify library release date via __ELPA=YYYYMM
 #endif
-!---------------------------------------------------------------------------------------------------
 
       IF (.NOT. success) &
          CPABORT("ELPA failed to diagonalize a matrix")

--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -818,8 +818,7 @@ MODULE input_constants
 
    ! DIAGONALIZATION library
    INTEGER, PARAMETER, PUBLIC               :: do_diag_sl = 1, &
-                                               do_diag_sl2 = 2, &
-                                               do_diag_elpa = 3
+                                               do_diag_elpa = 2
    ! FFT library
    ! these might need sync with fft_lib.F
    INTEGER, PARAMETER, PUBLIC               :: do_fft_sg = 1, &

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -32,9 +32,9 @@ MODULE input_cp2k_global
                                               silent_print_level
    USE input_constants,                 ONLY: &
         bsse_run, callgraph_all, callgraph_master, callgraph_none, cell_opt_run, debug_run, &
-        do_atom, do_band, do_cp2k, do_dbcsr, do_diag_elpa, do_diag_sl, do_diag_sl2, do_farming, &
-        do_fft_fftw3, do_fft_sg, do_opt_basis, do_optimize_input, do_pdgemm, do_swarm, do_tamc, &
-        do_test, do_tree_mc, do_tree_mc_ana, driver_run, ehrenfest, electronic_spectra_run, &
+        do_atom, do_band, do_cp2k, do_dbcsr, do_diag_elpa, do_diag_sl, do_farming, do_fft_fftw3, &
+        do_fft_sg, do_opt_basis, do_optimize_input, do_pdgemm, do_swarm, do_tamc, do_test, &
+        do_tree_mc, do_tree_mc_ana, driver_run, ehrenfest, electronic_spectra_run, &
         energy_force_run, energy_run, fftw_plan_estimate, fftw_plan_exhaustive, fftw_plan_measure, &
         fftw_plan_patient, gaussian, geo_opt_run, linear_response_run, mol_dyn_run, mon_car_run, &
         negf_run, none_run, pint_run, real_time_propagation, tree_mc_run, vib_anal
@@ -110,9 +110,9 @@ CONTAINS
          description="Specifies the DIAGONALIZATION library to be used. If not availabe, the standard scalapack is used", &
          usage="PREFERRED_DIAG_LIBRARY ELPA", &
          default_i_val=do_diag_sl, &
-         enum_i_vals=(/do_diag_sl, do_diag_sl2, do_diag_elpa/), &
-         enum_c_vals=s2a("SL", "SL2", "ELPA"), &
-         enum_desc=s2a("Standard scalapack: syevd", "Scalapack 2.0: syevr", "ELPA"), &
+         enum_i_vals=(/do_diag_sl, do_diag_elpa/), &
+         enum_c_vals=s2a("SL", "ELPA"), &
+         enum_desc=s2a("Standard (Sca)LAPACK: syevd", "ELPA"), &
          citations=(/Marek2014/))
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -30,7 +30,6 @@ Flag __PILAENV_BLOCKSIZE not mentioned in cp2k_flags()
 Flag __PW_CUDA_NO_HOSTALLOC not mentioned in INSTALL.md
 Flag __RELEASE_VERSION not mentioned in INSTALL.md
 Flag __RELEASE_VERSION not mentioned in cp2k_flags()
-Flag __SCALAPACK2 not mentioned in INSTALL.md
 al_system_dynamics.F: Found WRITE statement with hardcoded unit in "dump_vel"
 almo_scf.F: Found WRITE statement with hardcoded unit in "almo_scf_init"
 almo_scf_optimizer.F: Found CLOSE statement in procedure "print_mathematica_matrix"


### PR DESCRIPTION
Given that we gain more options over time (and the combinatorial complexity they introduce) I think it is crucial to cut-down on old library support and make sure that what we provide is also tested.

As an alternative to removing the `dsyervx` implementation of `cp_fm_syevr`, we could also keep it as an implementation for `cp_fm_syevr` if `__SCALAPACK` is not set.