### PR TITLE
Remove unused arrays for clusters. This complements CP2K/DBCSR #34

### DIFF
--- a/src/almo_scf_qs.F
+++ b/src/almo_scf_qs.F
@@ -126,9 +126,8 @@ CONTAINS
       INTEGER                                            :: dimen, handle, hold, iatom, iblock_col, &
                                                             iblock_row, imol, mynode, natoms, &
                                                             nblkrows_tot, nlength, nmols, row
-      INTEGER, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, cluster_distr, &
-         cluster_distr_new, col_cluster_new, col_distr_new, col_sizes_new, distr_new_array, &
-         row_cluster_new, row_distr_new, row_sizes_new
+      INTEGER, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, col_distr_new, &
+         col_sizes_new, distr_new_array, row_distr_new, row_sizes_new
       LOGICAL                                            :: active, one_dim_is_mo, tr
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: p_new_block
       TYPE(dbcsr_distribution_type)                      :: dist_new, dist_qs
@@ -140,7 +139,7 @@ CONTAINS
 ! symmetry type: dbcsr_type_no_symmetry, dbcsr_type_symmetric,
 !  dbcsr_type_antisymmetric, dbcsr_type_hermitian, dbcsr_type_antihermitian
 !  (see dbcsr_lib/dbcsr_types.F for other values)
-! spin_key: either 1 or 2 (0 is allowed for matrics in the AO basis)
+! spin_key: either 1 or 2 (0 is allowed for matrices in the AO basis)
 !    TYPE(dbcsr_iterator_type)                  :: iter
 !    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:) :: allones
 !-----------------------------------------------------------------------
@@ -149,7 +148,7 @@ CONTAINS
 
       ! RZK-warning The structure of the matrices can be optimized:
       ! 1. Diagonal matrices must be distributed evenly over the processes.
-      !    This can be achived by distributing cpus: 012012-rows and 001122-cols
+      !    This can be achieved by distributing cpus: 012012-rows and 001122-cols
       !    block_diagonal_flag is introduced but not used
       ! 2. Multiplication of diagonally dominant matrices will be faster
       !    if the diagonal blocks are local to the same processes.
@@ -167,12 +166,10 @@ CONTAINS
 
          ! distribution pattern is the same for all matrix types (ao, occ, virt)
          IF (dimen == 1) THEN !rows
-            CALL dbcsr_distribution_get(dist_qs, row_dist=blk_distr, row_cluster=cluster_distr)
+            CALL dbcsr_distribution_get(dist_qs, row_dist=blk_distr)
          ELSE !columns
-            CALL dbcsr_distribution_get(dist_qs, col_dist=blk_distr, col_cluster=cluster_distr)
+            CALL dbcsr_distribution_get(dist_qs, col_dist=blk_distr)
          ENDIF
-
-         NULLIFY (cluster_distr_new)
 
          IF (size_keys(dimen) == almo_mat_dim_aobasis) THEN ! this dimension is AO
 
@@ -184,10 +181,6 @@ CONTAINS
                ALLOCATE (block_sizes_new(natoms), distr_new_array(natoms))
                block_sizes_new(:) = blk_sizes(:)
                distr_new_array(:) = blk_distr(:)
-               IF (ASSOCIATED(cluster_distr)) THEN
-                  ALLOCATE (cluster_distr_new(natoms))
-                  cluster_distr_new(:) = cluster_distr(:)
-               END IF
                ! molecular clustering of AOs
             ELSE IF (almo_scf_env%mat_distr_aos == almo_mat_distr_molecular) THEN
                ALLOCATE (block_sizes_new(nmols), distr_new_array(nmols))
@@ -201,13 +194,6 @@ CONTAINS
                   distr_new_array(imol) = &
                      blk_distr(almo_scf_env%first_atom_of_domain(imol))
                ENDDO
-               IF (ASSOCIATED(cluster_distr)) THEN
-                  ALLOCATE (cluster_distr_new(nmols))
-                  DO imol = 1, nmols
-                     cluster_distr_new(imol) = &
-                        cluster_distr(almo_scf_env%first_atom_of_domain(imol))
-                  ENDDO
-               END IF
             ELSE
                CPABORT("Illegal distribution")
             ENDIF
@@ -259,27 +245,15 @@ CONTAINS
 
             ! distribution for MOs is copied from AOs
             ALLOCATE (distr_new_array(nlength))
-            IF (ASSOCIATED(cluster_distr)) THEN
-               ALLOCATE (cluster_distr_new(nlength))
-            END IF
             ! atomic clustering
             IF (almo_scf_env%mat_distr_mos == almo_mat_distr_atomic) THEN
                distr_new_array(:) = blk_distr(:)
-               IF (ASSOCIATED(cluster_distr)) THEN
-                  cluster_distr_new(:) = cluster_distr(:)
-               ENDIF
                ! molecular clustering
             ELSE IF (almo_scf_env%mat_distr_mos == almo_mat_distr_molecular) THEN
                DO imol = 1, nmols
                   distr_new_array(imol) = &
                      blk_distr(almo_scf_env%first_atom_of_domain(imol))
                ENDDO
-               IF (ASSOCIATED(cluster_distr)) THEN
-                  DO imol = 1, nmols
-                     cluster_distr_new(imol) = &
-                        cluster_distr(almo_scf_env%first_atom_of_domain(imol))
-                  ENDDO
-               END IF
             ENDIF
          ENDIF ! end choosing dimension size (AOs vs .NOT.AOs)
 
@@ -287,18 +261,15 @@ CONTAINS
          IF (dimen == 1) THEN !rows
             row_sizes_new => block_sizes_new
             row_distr_new => distr_new_array
-            row_cluster_new => cluster_distr_new
          ELSE !columns
             col_sizes_new => block_sizes_new
             col_distr_new => distr_new_array
-            col_cluster_new => cluster_distr_new
          ENDIF
       ENDDO ! both rows and columns are done
 
       ! Create the distribution
       CALL dbcsr_distribution_new(dist_new, template=dist_qs, &
                                   row_dist=row_distr_new, col_dist=col_distr_new, &
-                                  row_cluster=row_cluster_new, col_cluster=col_cluster_new, &
                                   reuse_arrays=.TRUE.)
 
       ! Create the matrix
@@ -307,7 +278,7 @@ CONTAINS
                         row_sizes_new, col_sizes_new, reuse_arrays=.TRUE.)
       CALL dbcsr_distribution_release(dist_new)
 
-      ! fill out reqired blocks with 1.0_dp to tell the dbcsr library
+      ! fill out required blocks with 1.0_dp to tell the dbcsr library
       ! which blocks to keep
       IF (init_domains) THEN
 
@@ -330,7 +301,7 @@ CONTAINS
          !QQQ
          !QQQ         ! RZK-warning replace with a function which says if this
          !QQQ         ! distribution block is active or not
-         !QQQ         ! Translate indeces of distribution blocks to domain blocks
+         !QQQ         ! Translate indices of distribution blocks to domain blocks
          !QQQ         if (size_keys(1)==almo_mat_dim_aobasis) then
          !QQQ           domain_row=almo_scf_env%domain_index_of_ao_block(iblock_row)
          !QQQ         else if (size_keys(2)==almo_mat_dim_occ .OR. &
@@ -426,7 +397,7 @@ CONTAINS
 
             ENDIF ! mynode
          ENDDO
-         ! end lnear-scaling replacement
+         ! end linear-scaling replacement
 
       ENDIF ! init_domains
 
@@ -1478,7 +1449,7 @@ CONTAINS
             ! check boundaries
             IF (domain_grid(grid1, 0) .GT. max_neig) THEN
                ! this neighbor will overstep the boundaries
-               ! stop the trial and increase the max number of neigbors
+               ! stop the trial and increase the max number of neighbors
                DEALLOCATE (domain_grid)
                max_neig = max_neig*2
                CYCLE max_neig_loop

--- a/src/cp_dbcsr_operations.F
+++ b/src/cp_dbcsr_operations.F
@@ -424,8 +424,7 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(distribution_2d_type), POINTER                :: dist2d_p
-      INTEGER, DIMENSION(:),             POINTER         :: row_dist, col_dist, &
-                                                            row_cluster, col_cluster
+      INTEGER, DIMENSION(:),             POINTER         :: row_dist, col_dist
 
 
       dist2d_p => dist2d
@@ -438,15 +437,11 @@ CONTAINS
       ! map to 1D arrays
       row_dist => row_dist_data(:, 1)
       col_dist => col_dist_data(:, 1)
-      row_cluster => row_dist_data(:, 2)
-      col_cluster => col_dist_data(:, 2)
 
       CALL dbcsr_distribution_new(dist, &
                                   group=para_env%group, pgrid=pgrid, &
                                   row_dist=row_dist, &
-                                  col_dist=col_dist, &
-                                  row_cluster=row_cluster, &
-                                  col_cluster=col_cluster)
+                                  col_dist=col_dist)
 
    END SUBROUTINE cp_dbcsr_dist2d_to_dist
 
@@ -569,7 +564,6 @@ CONTAINS
                                                             a_ncol, a_nrow,  b_ncol, b_nrow, c_ncol, c_nrow
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_size_right_in, &
                                                             col_blk_size_right_out, row_blk_size,&
-                                                            row_cluster, col_cluster,&
                                                             row_dist, col_dist
       TYPE(dbcsr_type)                                   :: in, out
       REAL(dp)                                           :: my_alpha, my_beta
@@ -606,11 +600,10 @@ CONTAINS
          CALL dbcsr_create(in, "D", dist_right_in, dbcsr_type_no_symmetry, &
                               row_blk_size, col_blk_size_right_in, nze=0)
 
-         CALL dbcsr_distribution_get(dist, row_dist=row_dist, row_cluster=row_cluster)
-         CALL dbcsr_distribution_get(dist_right_in, col_dist=col_dist, col_cluster=col_cluster)
+         CALL dbcsr_distribution_get(dist, row_dist=row_dist)
+         CALL dbcsr_distribution_get(dist_right_in, col_dist=col_dist)
          CALL dbcsr_distribution_new(product_dist, template=dist, &
-                                     row_dist=row_dist, col_dist=col_dist, &
-                                     row_cluster=row_cluster, col_cluster=col_cluster)
+                                     row_dist=row_dist, col_dist=col_dist)
          ALLOCATE (col_blk_size_right_out(SIZE(col_blk_size_right_in)))
          col_blk_size_right_out = col_blk_size_right_in
          CALL match_col_sizes(col_blk_size_right_out, col_blk_size_right_in, k_out)
@@ -707,8 +700,8 @@ CONTAINS
          routineP = moduleN//':'//routineN
 
       INTEGER                                            :: npcols, k, nao, timing_handle, data_type
-      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size_left, col_cluster, &
-                                                            col_dist_left, row_blk_size, row_dist, row_cluster
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size_left, col_dist_left, &
+                                                            row_blk_size, row_dist
       LOGICAL                                            :: check_product, my_keep_sparsity
       REAL(KIND=dp)                                      :: my_alpha, norm
       TYPE(dbcsr_type)                                :: mat_g, mat_v, sparse_matrix2, &
@@ -733,12 +726,10 @@ CONTAINS
          CALL cp_fm_get_info(matrix_v, ncol_global=k)
          !WRITE(*,*)routineN//'truncated mult k, ncol',k,ncol,' PRESENT (matrix_g)',PRESENT (matrix_g)
          CALL dbcsr_get_info(sparse_matrix, distribution=sparse_dist)
-         CALL dbcsr_distribution_get(sparse_dist, npcols=npcols, row_dist=row_dist, row_cluster=row_cluster)
+         CALL dbcsr_distribution_get(sparse_dist, npcols=npcols, row_dist=row_dist)
          CALL create_bl_distribution(col_dist_left, col_blk_size_left, k, npcols)
-         NULLIFY (col_cluster)
          CALL dbcsr_distribution_new(dist_left, template=sparse_dist, &
-                                     row_dist=row_dist, col_dist=col_dist_left, &
-                                     row_cluster=row_cluster, col_cluster=col_cluster)
+                                     row_dist=row_dist, col_dist=col_dist_left)
          DEALLOCATE (col_dist_left)
          CALL dbcsr_get_info(sparse_matrix, row_blk_size=row_blk_size, data_type=data_type)
          CALL dbcsr_create(mat_v, "DBCSR matrix_v", dist_left, dbcsr_type_no_symmetry, &
@@ -891,9 +882,8 @@ CONTAINS
 
       CHARACTER                                          :: mysym
       INTEGER                                            :: my_data_type, nprows, npcols
-      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_cluster, &
-                                                            col_dist, row_blk_size, &
-                                                            row_cluster, row_dist
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, &
+                                                            row_blk_size, row_dist
       TYPE(dbcsr_distribution_type)                       :: tmpl_dist, dist_m_n
 
       CALL dbcsr_get_info(template, &
@@ -906,14 +896,12 @@ CONTAINS
 
       NULLIFY (row_dist, col_dist)
       NULLIFY (row_blk_size, col_blk_size)
-      NULLIFY (row_cluster, col_cluster)
 
       CALL dbcsr_distribution_get(tmpl_dist, nprows=nprows, npcols=npcols)
       CALL create_bl_distribution(row_dist, row_blk_size, m, nprows)
       CALL create_bl_distribution(col_dist, col_blk_size, n, npcols)
       CALL dbcsr_distribution_new(dist_m_n, template=tmpl_dist, &
                                   row_dist=row_dist, col_dist=col_dist, &
-                                  row_cluster=row_cluster, col_cluster=col_cluster, &
                                   reuse_arrays=.TRUE.)
 
       CALL dbcsr_create(matrix, "m_n_template", dist_m_n, mysym, &
@@ -945,8 +933,8 @@ CONTAINS
 
       CHARACTER                                          :: mysym
       INTEGER                                            :: my_data_type, npcols
-      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_cluster, col_dist, row_blk_size, &
-                                                            row_cluster, row_dist
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, &
+                                                            row_blk_size, row_dist
       TYPE(dbcsr_distribution_type)                       :: dist_m_n, tmpl_dist
 
       mysym = dbcsr_get_matrix_type(template)
@@ -957,15 +945,12 @@ CONTAINS
       CALL dbcsr_get_info(template, distribution=tmpl_dist)
       CALL dbcsr_distribution_get(tmpl_dist, &
                                   npcols=npcols, &
-                                  row_dist=row_dist, &
-                                  row_cluster=row_cluster)
+                                  row_dist=row_dist)
 
       NULLIFY (col_dist, col_blk_size)
       CALL create_bl_distribution(col_dist, col_blk_size, n, npcols)
-      NULLIFY (col_cluster)
       CALL dbcsr_distribution_new(dist_m_n, template=tmpl_dist, &
-                                  row_dist=row_dist, col_dist=col_dist, &
-                                  row_cluster=row_cluster, col_cluster=col_cluster)
+                                  row_dist=row_dist, col_dist=col_dist)
 
       CALL dbcsr_get_info(template, row_blk_size=row_blk_size)
       CALL dbcsr_create(matrix, "m_n_template", dist_m_n, mysym, &
@@ -1119,8 +1104,6 @@ CONTAINS
                                  template=dist_left,&
                                  row_dist=right_row_dist,&
                                  col_dist=right_col_dist,&
-                                 row_cluster=dummy,&
-                                 col_cluster=dummy,&
                                  reuse_arrays=.TRUE.)
     DEALLOCATE(tmp_images)
   END SUBROUTINE dbcsr_create_dist_r_unrot

--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -107,11 +107,9 @@ CONTAINS
       INTEGER                                            :: handle, iatom, imol, jatom, &
                                                             ls_data_type, natom, nmol
       INTEGER, ALLOCATABLE, DIMENSION(:), TARGET         :: atom_to_cluster, atom_to_cluster_primus, &
-                                                            clustered_blk_sizes, primus_of_mol
-      INTEGER, DIMENSION(:), POINTER :: clustered_col_clusters, clustered_col_dist, &
-         clustered_row_clusters, clustered_row_dist, ls_blk_sizes, ls_col_cluster, ls_col_dist, &
-         ls_row_cluster, ls_row_dist
-      LOGICAL                                            :: ls_has_col_clusters, ls_has_row_clusters
+                                                            primus_of_mol
+      INTEGER, DIMENSION(:), POINTER                     :: clustered_col_dist, clustered_row_dist, &
+                                                            ls_blk_sizes, ls_col_dist, ls_row_dist
       TYPE(dbcsr_distribution_type)                      :: ls_dist, ls_dist_clustered
 
       CALL timeset(routineN, handle)
@@ -119,13 +117,7 @@ CONTAINS
       ! Defaults -----------------------------------------------------------------------------------
       CALL dbcsr_get_info(matrix_qs, col_blk_size=ls_blk_sizes, distribution=ls_dist)
       CALL dbcsr_distribution_hold(ls_dist)
-      CALL dbcsr_distribution_get(ls_dist, &
-                                  row_dist=ls_row_dist, &
-                                  col_dist=ls_col_dist, &
-                                  row_cluster=ls_row_cluster, &
-                                  col_cluster=ls_col_cluster, &
-                                  has_col_clusters=ls_has_col_clusters, &
-                                  has_row_clusters=ls_has_row_clusters)
+      CALL dbcsr_distribution_get(ls_dist, row_dist=ls_row_dist, col_dist=ls_col_dist)
       ls_data_type = dbcsr_type_real_8
       IF (ls_mstruct%single_precision) ls_data_type = dbcsr_type_real_4
 
@@ -165,42 +157,18 @@ CONTAINS
          DO imol = 1, nmol
             clustered_row_dist(imol) = ls_row_dist(primus_of_mol(imol))
          ENDDO
-         NULLIFY (clustered_row_clusters)
-         IF (ls_has_row_clusters) THEN
-            ALLOCATE (clustered_row_clusters(nmol))
-            DO imol = 1, nmol
-               clustered_row_clusters(imol) = ls_row_cluster(primus_of_mol(imol))
-            ENDDO
-         ENDIF
 
          ! col
          ALLOCATE (clustered_col_dist(nmol))
          DO imol = 1, nmol
             clustered_col_dist(imol) = ls_col_dist(primus_of_mol(imol))
          ENDDO
-         NULLIFY (clustered_col_clusters)
-         IF (ls_has_col_clusters) THEN
-            ALLOCATE (clustered_col_clusters(nmol))
-            DO imol = 1, nmol
-               clustered_col_clusters(imol) = ls_col_cluster(primus_of_mol(imol))
-            ENDDO
-         ENDIF
-
-         ALLOCATE (clustered_blk_sizes(nmol))
-         clustered_blk_sizes = 0
-         DO iatom = 1, natom
-            clustered_blk_sizes(atom_to_cluster(iatom)) = clustered_blk_sizes(atom_to_cluster(iatom))+ &
-                                                          ls_blk_sizes(iatom)
-         ENDDO
-         ls_blk_sizes => clustered_blk_sizes ! redirect pointer
 
          ! create new distribution
          CALL dbcsr_distribution_new(ls_dist_clustered, &
                                      template=ls_dist, &
                                      row_dist=clustered_row_dist, &
                                      col_dist=clustered_col_dist, &
-                                     row_cluster=clustered_row_clusters, &
-                                     col_cluster=clustered_col_clusters, &
                                      reuse_arrays=.TRUE.)
          CALL dbcsr_distribution_release(ls_dist)
          ls_dist = ls_dist_clustered

--- a/src/mscfg_types.F
+++ b/src/mscfg_types.F
@@ -209,9 +209,8 @@ CONTAINS
                                                             iblock_row, iblock_size, nblocks, &
                                                             nblocks_new, start_index, trailing_size
       INTEGER, DIMENSION(2)                              :: add_blocks_before
-      INTEGER, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, cluster_distr, &
-         cluster_distr_new, col_cluster_new, col_distr_new, col_sizes_new, distr_new_array, &
-         row_cluster_new, row_distr_new, row_sizes_new
+      INTEGER, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, col_distr_new, &
+         col_sizes_new, distr_new_array, row_distr_new, row_sizes_new
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_p, p_new_block
       TYPE(dbcsr_distribution_type)                      :: dist_new, dist_qs
       TYPE(dbcsr_iterator_type)                          :: iter
@@ -235,13 +234,11 @@ CONTAINS
             add_blocks_after = add_blocks_after+1
          ENDIF
 
-         NULLIFY (cluster_distr_new)
-
          IF (dimen == 1) THEN !rows
-            CALL dbcsr_distribution_get(dist_qs, row_dist=blk_distr, row_cluster=cluster_distr)
+            CALL dbcsr_distribution_get(dist_qs, row_dist=blk_distr)
             CALL dbcsr_get_info(submatrix_in, row_blk_size=blk_sizes)
          ELSE !columns
-            CALL dbcsr_distribution_get(dist_qs, col_dist=blk_distr, col_cluster=cluster_distr)
+            CALL dbcsr_distribution_get(dist_qs, col_dist=blk_distr)
             CALL dbcsr_get_info(submatrix_in, col_blk_size=blk_sizes)
          ENDIF
          nblocks = SIZE(blk_sizes) ! number of blocks in the small matrix
@@ -249,45 +246,30 @@ CONTAINS
          nblocks_new = nblocks+add_blocks_before(dimen)+add_blocks_after
          ALLOCATE (block_sizes_new(nblocks_new))
          ALLOCATE (distr_new_array(nblocks_new))
-         IF (ASSOCIATED(cluster_distr)) THEN
-            ALLOCATE (cluster_distr_new(nblocks_new))
-         END IF
          IF (add_blocks_before(dimen) .GT. 0) THEN
             block_sizes_new(1) = offset(dimen)
             distr_new_array(1) = 0
-            IF (ASSOCIATED(cluster_distr)) THEN
-               cluster_distr_new(1) = 0
-            END IF
          ENDIF
          block_sizes_new(start_index:nblocks+start_index-1) = blk_sizes(1:nblocks)
          distr_new_array(start_index:nblocks+start_index-1) = blk_distr(1:nblocks)
-         IF (ASSOCIATED(cluster_distr)) THEN
-            cluster_distr_new(start_index:nblocks+start_index-1) = cluster_distr(1:nblocks)
-         END IF
          IF (add_blocks_after .GT. 0) THEN
             block_sizes_new(nblocks_new) = trailing_size
             distr_new_array(nblocks_new) = 0
-            IF (ASSOCIATED(cluster_distr)) THEN
-               cluster_distr_new(nblocks_new) = 0
-            END IF
          ENDIF
 
          ! create final arrays
          IF (dimen == 1) THEN !rows
             row_sizes_new => block_sizes_new
             row_distr_new => distr_new_array
-            row_cluster_new => cluster_distr_new
          ELSE !columns
             col_sizes_new => block_sizes_new
             col_distr_new => distr_new_array
-            col_cluster_new => cluster_distr_new
          ENDIF
       ENDDO ! both rows and columns are done
 
       ! Create the distribution
       CALL dbcsr_distribution_new(dist_new, template=dist_qs, &
                                   row_dist=row_distr_new, col_dist=col_distr_new, &
-                                  row_cluster=row_cluster_new, col_cluster=col_cluster_new, &
                                   reuse_arrays=.TRUE.)
 
       ! Create big the matrix


### PR DESCRIPTION
This PR is to share what I have on this subject, but anyone else can take over. In particular the change should be reviewed by an expert. This PR should be perhaps **not merged** without updating DBCSR to the HEAD revision as of today.