### PR TITLE
small fix to make valgrind happy

### DIFF
--- a/src/iterate_matrix.F
+++ b/src/iterate_matrix.F
@@ -771,7 +771,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'matrix_sign_proot', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i, unit_nr
+      INTEGER                                            :: handle, unit_nr
       INTEGER(KIND=int_8)                                :: flop0, flop1, flop2
       LOGICAL                                            :: converged, symmetrize
       REAL(KIND=dp)                                      :: frob_matrix, frob_matrix_base, occ_matrix
@@ -823,7 +823,7 @@ CONTAINS
       frob_matrix = dbcsr_frobenius_norm(tmp1)
       occ_matrix = dbcsr_get_occupation(matrix_sign)
       IF (unit_nr > 0) THEN
-         WRITE (unit_nr, '(T6,A,1X,I3,1X,F10.8,E12.3)') "Final proot sign iter", i, occ_matrix, &
+         WRITE (unit_nr, '(T6,A,F10.8,E12.3)') "Final proot sign iter", occ_matrix, &
             frob_matrix/frob_matrix_base
          WRITE (unit_nr, '()')
          CALL m_flush(unit_nr)


### PR DESCRIPTION
This (hopefully) fixes:
==46886== 
==46886== Conditional jump or move depends on uninitialised value(s)
==46886==    at 0x6060777: calculate_sign.isra.0 (write_float.def:41)
==46886==    by 0x6063DBF: write_decimal (write.c:693)
==46886==    by 0x6063DBF: _gfortrani_write_i (write.c:1039)
==46886==    by 0x605B37C: formatted_transfer_scalar_write (transfer.c:1775)
==46886==    by 0x605B37C: formatted_transfer (transfer.c:2004)
==46886==    by 0x9C7735: __iterate_matrix_MOD_matrix_sign_proot (iterate_matrix.F:826)
==46886==    by 0xD9DB51: __dm_ls_scf_methods_MOD_density_matrix_sign_fixed_mu (dm_ls_scf_methods.F:495)
==46886==    by 0xD9DD85: __dm_ls_scf_methods_MOD_density_matrix_sign (dm_ls_scf_methods.F:417)
==46886==    by 0xCC8B8B: __dm_ls_scf_MOD_ls_scf_main (dm_ls_scf.F:641)
==46886==    by 0xCD03AF: __dm_ls_scf_MOD_ls_scf (dm_ls_scf.F:120)
==46886==    by 0xB013BF: __qs_energy_MOD_qs_energies (qs_energy.F:82)
==46886==    by 0x169348B: __qs_force_MOD_qs_calc_energy_force (qs_force.F:116)
==46886==    by 0xC5EA4A: __force_env_methods_MOD_force_env_calc_energy_force (force_env_methods.F:258)
==46886==    by 0x43056E: __cp2k_runs_MOD_cp2k_run (cp2k_runs.F:329)
EXIT CODE:  42  MEANING:  RUNTIME FAIL


Please Note:
I could not reproduce the the error message of valgrind on my local system (sdbg, gcc-8.2.0, valgrind 3.14). So I can't be sure if my change fixes the problem but I am pretty certain.
The problem definitely did not affect any functionality since the variable i was simply superfluous.
