### PR TITLE
build system: set variable CXXOMPFLAGS needed by DBCSR

### DIFF
--- a/arch/CRAY-XC30-gfortran-cuda.psmp
+++ b/arch/CRAY-XC30-gfortran-cuda.psmp
@@ -13,6 +13,7 @@ GPUVER   = K20X
 
 CPPFLAGS =
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = -fopenmp
 DFLAGS   = -D__FFTW3 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn -D__ACC -D__DBCSR_ACC
 CFLAGS   = $(DFLAGS)
 FCFLAGS  = $(DFLAGS) -O3 -fopenmp -mavx -funroll-loops -ftree-vectorize \

--- a/arch/CRAY-XK7-gfortran-cuda.psmp
+++ b/arch/CRAY-XK7-gfortran-cuda.psmp
@@ -14,6 +14,7 @@ GPUVER   = K20X
 
 CPPFLAGS =
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = -fopenmp
 DFLAGS   = -D__GEMINI -D__FFTW3 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn -D__ACC -D__DBCSR_ACC
 CFLAGS   = $(DFLAGS)
 FCFLAGS  = $(DFLAGS) -O3 -fopenmp -march=bdver1 -funroll-loops -ftree-vectorize \

--- a/arch/Linux-x86-64-cuda-ma.psmp
+++ b/arch/Linux-x86-64-cuda-ma.psmp
@@ -19,6 +19,7 @@ GPUVER   = K20X
 
 CPPFLAGS =
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = -fopenmp
 DFLAGS   = -D__GFORTRAN  -D__parallel -D__SCALAPACK -D__BLACS -D__FFTSG -D__LIBINT -D__ACC -D__DBCSR_ACC -D__HAS_smm_dnn -D__HWLOC
 GFLAGS   = -g -fopenmp -O3 $(DFLAGS)
 FCFLAGS  = -ffree-form -fcray-pointer $(GFLAGS)

--- a/arch/Linux-x86-64-cuda.sopt
+++ b/arch/Linux-x86-64-cuda.sopt
@@ -26,6 +26,7 @@ DFLAGS   = -D__CUDAPW -D__FFTW3
 CFLAGS   =  -O2
 CPPFLAGS = -traditional -C $(DFLAGS) -P -I/opt/intel/mkl/10.0.1.014/include/fftw
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = -fopenmp
 NVFLAGS	 = $(DFLAGS) -Xcompiler='-fopenmp' --std=c++11
 FCFLAGS  = $(DFLAGS) -O2 -xW
 MKLPATH  = /opt/intel/mkl/10.0.1.014/lib/em64t/

--- a/arch/Linux-x86-64-cuda.sopt
+++ b/arch/Linux-x86-64-cuda.sopt
@@ -18,7 +18,7 @@ CXX      = CC
 CPP      = cpp
 NVCC	 = nvcc
 FC       = /opt/intel/fce/10.0.025/bin/ifort -FR
-LD       = /opt/intel/fce/10.0.025/bin/ifort -i-static -openmp
+LD       = /opt/intel/fce/10.0.025/bin/ifort -i-static
 AR       = ar -r
 GPUVER   = K20X
 
@@ -26,8 +26,7 @@ DFLAGS   = -D__CUDAPW -D__FFTW3
 CFLAGS   =  -O2
 CPPFLAGS = -traditional -C $(DFLAGS) -P -I/opt/intel/mkl/10.0.1.014/include/fftw
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
-CXXOMPFLAGS = -fopenmp
-NVFLAGS	 = $(DFLAGS) -Xcompiler='-fopenmp' --std=c++11
+NVFLAGS	 = $(DFLAGS) --std=c++11
 FCFLAGS  = $(DFLAGS) -O2 -xW
 MKLPATH  = /opt/intel/mkl/10.0.1.014/lib/em64t/
 CUDAPATH = /usr/local/cuda/lib/

--- a/arch/Linux-x86-64-cudadp.sopt
+++ b/arch/Linux-x86-64-cudadp.sopt
@@ -29,6 +29,7 @@ DFLAGSCU  = $(DFLAGSBASE) -Dcpu_d_gemm=dgemm -Dcpu_d_symm=dsymm
 CFLAGS   =  -O2
 CPPFLAGS = -traditional -C $(DFLAGS) -P -I/opt/intel/mkl/10.0.1.014/include/fftw
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = -fopenmp
 CPPFLAGSCU = -traditional -C $(DFLAGSCU) -P -I/opt/intel/mkl/10.0.1.014/include/fftw
 NVFLAGS	 = $(DFLAGS) -arch sm_13 -deviceemu -Xcompiler='-fopenmp' --std=c++11
 FCFLAGS  = $(DFLAGS) -O2 -xW

--- a/arch/Linux-x86-64-cudadp.sopt
+++ b/arch/Linux-x86-64-cudadp.sopt
@@ -18,7 +18,7 @@ CXX      = CC
 CPP      = cpp
 NVCC	 = /usr/local/cuda/bin/nvcc
 FC       = /opt/intel/fce/10.0.025/bin/ifort -FR
-LD       = /opt/intel/fce/10.0.025/bin/ifort -i-static -openmp
+LD       = /opt/intel/fce/10.0.025/bin/ifort -i-static
 AR       = ar -r
 GPUVER   = K20X
 
@@ -29,9 +29,8 @@ DFLAGSCU  = $(DFLAGSBASE) -Dcpu_d_gemm=dgemm -Dcpu_d_symm=dsymm
 CFLAGS   =  -O2
 CPPFLAGS = -traditional -C $(DFLAGS) -P -I/opt/intel/mkl/10.0.1.014/include/fftw
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
-CXXOMPFLAGS = -fopenmp
 CPPFLAGSCU = -traditional -C $(DFLAGSCU) -P -I/opt/intel/mkl/10.0.1.014/include/fftw
-NVFLAGS	 = $(DFLAGS) -arch sm_13 -deviceemu -Xcompiler='-fopenmp' --std=c++11
+NVFLAGS	 = $(DFLAGS) -arch sm_13 -deviceemu --std=c++11
 FCFLAGS  = $(DFLAGS) -O2 -xW
 FCFLAGSCU = $(DFLAGSCU) -O2 -xW
 MKLPATH  = /opt/intel/mkl/10.0.1.014/lib/em64t/

--- a/arch/Linux-x86-64-dbcsr-cuda.popt
+++ b/arch/Linux-x86-64-dbcsr-cuda.popt
@@ -11,11 +11,10 @@ GPUVER   = K20X
 
 CPPFLAGS =
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
-CXXOMPFLAGS = -fopenmp
 DFLAGS   = -D__parallel -D__SCALAPACK -D__ACC -D__DBCSR_ACC
 FCFLAGS  = -g -O3 -ffree-form $(DFLAGS) -I$(GFORTRAN_INC)
 LDFLAGS  = $(FCFLAGS)
-NVFLAGS  = $(DFLAGS) -g -O3 -arch sm_35 -Xcompiler='-fopenmp' --std=c++11
+NVFLAGS  = $(DFLAGS) -g -O3 -arch sm_35 --std=c++11
 
 CUDAPATH = /usr/local/cuda/lib/
 

--- a/arch/Linux-x86-64-dbcsr-cuda.popt
+++ b/arch/Linux-x86-64-dbcsr-cuda.popt
@@ -11,6 +11,7 @@ GPUVER   = K20X
 
 CPPFLAGS =
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = -fopenmp
 DFLAGS   = -D__parallel -D__SCALAPACK -D__ACC -D__DBCSR_ACC
 FCFLAGS  = -g -O3 -ffree-form $(DFLAGS) -I$(GFORTRAN_INC)
 LDFLAGS  = $(FCFLAGS)

--- a/arch/Linux-x86-64-gfortran.warn
+++ b/arch/Linux-x86-64-gfortran.warn
@@ -9,6 +9,7 @@ GPUVER   = K20X
 
 CPPFLAGS =
 CXXFLAGS = -O3 -I${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = -fopenmp
 
 #https://gcc.gnu.org/onlinedocs/gfortran/Error-and-Warning-Options.html
 

--- a/arch/test_tsan.sdbg
+++ b/arch/test_tsan.sdbg
@@ -4,15 +4,15 @@
 # needs tsan instrumented lib gomp (http://gcc.gnu.org/bugzilla/show_bug.cgi?id=55561#c15)
 #
 CC       = cc
-CPP      = 
+CPP      =
 FC       = gfortran
 LD       = gfortran
 
 AR       = ar -r
 
-CPPFLAGS = 
-DFLAGS   = -D__LIBINT 
-FCFLAGS  = -gdwarf-3 -fPIE -pie -fsanitize=thread -fno-omit-frame-pointer  -fopenmp -O0 -march=native -ffree-form $(DFLAGS)
-LDFLAGS  = $(FCFLAGS)  -L/data/vjoost/libint/sanitize/install/lib/ 
+CPPFLAGS =
+DFLAGS   = -D__LIBINT
+FCFLAGS  = -gdwarf-3 -fPIE -pie -fsanitize=thread -fno-omit-frame-pointer -O0 -march=native -ffree-form $(DFLAGS)
+LDFLAGS  = $(FCFLAGS)  -L/data/vjoost/libint/sanitize/install/lib/
 LIBS     = -llapack -lblas -lderiv -lint -lstdc++
 

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -159,6 +159,7 @@ gen_arch_file() {
 #
 CXX         = \${CC}
 CXXFLAGS    = \${CXXFLAGS} -I\\\${CUDA_PATH}/include -std=c++11
+CXXOMPFLAGS = IF_OMP(-fopenmp|)
 GPUVER      = \${GPUVER}
 NVCC        = \${NVCC} -D__GNUC__=4 -D__GNUC_MINOR__=9
 NVFLAGS     = \${NVFLAGS}


### PR DESCRIPTION
If omitted, DBCSR's C++ code gets compiled without OpenMP support, leading to race conditions (observed on OLCF's Summit). 

Add this variable to the toolchain as well as to the relevant arch files.

Fixes #338