### PR TITLE
[RFC] OO Implementation of SCF Inner Loop/Diagonalization

### DIFF
--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -50,8 +50,7 @@ MODULE qs_scf
    USE cp_files,                        ONLY: close_file
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_release,&
-                                              cp_fm_to_fm,&
-                                              cp_fm_type
+                                              cp_fm_to_fm
    USE cp_log_handling,                 ONLY: cp_add_default_logger,&
                                               cp_get_default_logger,&
                                               cp_logger_release,&
@@ -73,15 +72,12 @@ MODULE qs_scf
                                               dbcsr_get_info,&
                                               dbcsr_init_p,&
                                               dbcsr_p_type,&
-                                              dbcsr_set,&
-                                              dbcsr_type
+                                              dbcsr_set
    USE input_constants,                 ONLY: &
         broyden_type_1, broyden_type_1_explicit, broyden_type_1_explicit_ls, broyden_type_1_ls, &
         broyden_type_2, broyden_type_2_explicit, broyden_type_2_explicit_ls, broyden_type_2_ls, &
-        cdft2ot, history_guess, ot2cdft, ot_precond_full_all, ot_precond_full_single, &
-        ot_precond_full_single_inverse, ot_precond_none, ot_precond_s_inverse, &
-        outer_scf_becke_constraint, outer_scf_hirshfeld_constraint, outer_scf_optimizer_broyden, &
-        outer_scf_optimizer_newton_ls
+        cdft2ot, history_guess, ot2cdft, outer_scf_becke_constraint, &
+        outer_scf_hirshfeld_constraint, outer_scf_optimizer_broyden, outer_scf_optimizer_newton_ls
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type
    USE kinds,                           ONLY: default_path_length,&
@@ -94,8 +90,6 @@ MODULE qs_scf
    USE mathlib,                         ONLY: invert_matrix
    USE message_passing,                 ONLY: mp_send
    USE particle_types,                  ONLY: particle_type
-   USE preconditioner,                  ONLY: prepare_preconditioner,&
-                                              restart_preconditioner
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
@@ -122,17 +116,12 @@ MODULE qs_scf
    USE qs_ks_types,                     ONLY: qs_ks_did_change,&
                                               qs_ks_env_type
    USE qs_mo_io,                        ONLY: write_mo_set
-   USE qs_mo_methods,                   ONLY: calculate_density_matrix,&
-                                              make_basis_simple,&
-                                              make_basis_sm
+   USE qs_mo_methods,                   ONLY: calculate_density_matrix
    USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: deallocate_mo_set,&
                                               duplicate_mo_set,&
                                               get_mo_set,&
                                               mo_set_p_type
-   USE qs_ot,                           ONLY: qs_ot_new_preconditioner
-   USE qs_ot_scf,                       ONLY: ot_scf_init,&
-                                              ot_scf_read_input
    USE qs_outer_scf,                    ONLY: outer_loop_gradient,&
                                               outer_loop_optimize,&
                                               outer_loop_purge_history,&
@@ -141,15 +130,16 @@ MODULE qs_scf
    USE qs_rho_methods,                  ONLY: qs_rho_update_rho
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
    USE qs_scf_initialization,           ONLY: qs_scf_env_initialize
    USE qs_scf_loop_utils,               ONLY: qs_scf_check_inner_exit,&
                                               qs_scf_check_outer_exit,&
                                               qs_scf_density_mixing,&
                                               qs_scf_inner_finalize,&
-                                              qs_scf_new_mos,&
-                                              qs_scf_new_mos_kp,&
                                               qs_scf_rho_update,&
                                               qs_scf_set_loop_flags
+   USE qs_scf_mo_calc_ot,               ONLY: MOCalcOT
+   USE qs_scf_mo_calc_ot_diag,          ONLY: MOCalcOTDiag
    USE qs_scf_output,                   ONLY: qs_scf_cdft_info,&
                                               qs_scf_cdft_initial_info,&
                                               qs_scf_loop_info,&
@@ -164,8 +154,6 @@ MODULE qs_scf
    USE qs_wf_history_methods,           ONLY: wfi_purge_history,&
                                               wfi_update
    USE scf_control_types,               ONLY: scf_control_type
-   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
-   USE qs_scf_mo_calc_ot_diag,          ONLY: MOCalcOTDiag
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -343,6 +331,7 @@ CONTAINS
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: dft_section, input, scf_section
+
       CLASS(AbstractMOCalc), POINTER                     :: mo_calc
 
       CALL timeset(routineN, handle)
@@ -421,20 +410,21 @@ CONTAINS
       energy%tot_old = 0.0_dp
 
       SELECT CASE (scf_env%method)
-         CASE DEFAULT
-            ! ignore
-         CASE (ot_diag_method_nr)
-            ALLOCATE(MOCalcOTDiag :: mo_calc)
-            call mo_calc%init(qs_env, scf_env, scf_section)
+      CASE DEFAULT
+         CPABORT("specified MO calc method not implemented")
+      CASE (ot_diag_method_nr)
+         ALLOCATE (MOCalcOTDiag :: mo_calc)
+         CALL mo_calc%init(qs_env, scf_env, scf_section)
+      CASE (ot_method_nr)
+         ALLOCATE (MOCalcOT :: mo_calc)
+         CALL mo_calc%init(qs_env, scf_env, scf_section)
       END SELECT
 
       scf_outer_loop: DO
 
-         CALL init_scf_loop(scf_env=scf_env, qs_env=qs_env, &
-                            scf_section=scf_section)
+         CALL init_scf_loop(scf_env=scf_env, qs_env=qs_env)
 
-         ! if new OO model, call the preconditioner
-         IF (ASSOCIATED(mo_calc)) call mo_calc%pre()
+         CALL mo_calc%pre()
 
          CALL qs_scf_set_loop_flags(scf_env, diis_step, &
                                     energy_only, just_energy, exit_inner_loop)
@@ -458,16 +448,16 @@ CONTAINS
             ! print 'heavy weight' or relatively expensive quantities
             CALL qs_scf_loop_print(qs_env, scf_env, para_env)
 
-            ! if new OO model, call the MO calculation routine
-            IF (ASSOCIATED(mo_calc)) call mo_calc%run(diis_step)
+            ! call the MO calculation routine
+            CALL mo_calc%run(diis_step, energy_only)
 
-            IF (do_kpoints) THEN
-               ! kpoints
-               CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
-            ELSE
-               ! Gamma points only
-               CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, energy_only)
-            END IF
+            ! IF (do_kpoints) THEN
+            !    ! kpoints
+            !    CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
+            ! ELSE
+            !    ! Gamma points only
+            !    CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step)
+            ! END IF
 
             ! another heavy weight print object, print controlled by dft_section
             CALL qs_scf_write_mos(mos, atomic_kind_set, qs_kind_set, particle_set, dft_section)
@@ -554,7 +544,7 @@ CONTAINS
       converged = inner_loop_converged .AND. outer_loop_converged
 
       ! if new OO model is used, deallocate the object
-      IF (ASSOCIATED(mo_calc)) DEALLOCATE(mo_calc)
+      DEALLOCATE (mo_calc)
 
       IF (dft_control%qs_control%cdft) &
          dft_control%qs_control%cdft_control%total_steps = &
@@ -592,26 +582,21 @@ CONTAINS
 !> \par History
 !>      03.2006 created [Joost VandeVondele]
 ! **************************************************************************************************
-   SUBROUTINE init_scf_loop(scf_env, qs_env, scf_section)
+   SUBROUTINE init_scf_loop(scf_env, qs_env)
 
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(section_vals_type), POINTER                   :: scf_section
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'init_scf_loop', routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, ispin, nmo, number_of_OT_envs
-      LOGICAL                                            :: do_rotation, has_unit_metric, is_full_all
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
-      TYPE(dbcsr_type), POINTER                          :: orthogonality_metric
+      INTEGER                                            :: handle, ispin
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(scf_control_type), POINTER                    :: scf_control
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (scf_control, matrix_s, matrix_ks, dft_control, mos, mo_coeff)
+      NULLIFY (scf_control, dft_control, mos)
 
       CPASSERT(ASSOCIATED(scf_env))
       CPASSERT(scf_env%ref_count > 0)
@@ -665,129 +650,12 @@ CONTAINS
       CASE (block_davidson_diag_method_nr)
          ! Preconditioner initialized within the loop, when required
       CASE (ot_method_nr)
-         CALL get_qs_env(qs_env, &
-                         has_unit_metric=has_unit_metric, &
-                         matrix_s=matrix_s, &
-                         matrix_ks=matrix_ks)
-
-         ! reortho the wavefunctions if we are having an outer scf and
-         ! this is not the first iteration
-         ! this is useful to avoid the build-up of numerical noise
-         ! however, we can not play this trick if restricted (don't mix non-equivalent orbs)
-         IF (scf_control%do_outer_scf_reortho) THEN
-            IF (scf_control%outer_scf%have_scf .AND. .NOT. dft_control%restricted) THEN
-               IF (scf_env%outer_scf%iter_count > 0) THEN
-                  DO ispin = 1, dft_control%nspins
-                     CALL get_mo_set(mo_set=mos(ispin)%mo_set, mo_coeff=mo_coeff, nmo=nmo)
-                     IF (has_unit_metric) THEN
-                        CALL make_basis_simple(mo_coeff, nmo)
-                     ELSE
-                        CALL make_basis_sm(mo_coeff, nmo, matrix_s(1)%matrix)
-                     ENDIF
-                  ENDDO
-               ENDIF
-            ENDIF
-         ELSE
-            ! dont need any dirty trick for the numerically stable irac algorithm.
-         ENDIF
-
-         IF (.NOT. ASSOCIATED(scf_env%qs_ot_env)) THEN
-
-            ! restricted calculations require just one set of OT orbitals
-            number_of_OT_envs = dft_control%nspins
-            IF (dft_control%restricted) number_of_OT_envs = 1
-
-            ALLOCATE (scf_env%qs_ot_env(number_of_OT_envs))
-
-            ! XXX Joost XXX should disentangle reading input from this part
-            CALL ot_scf_read_input(scf_env%qs_ot_env, scf_section)
-
-            ! keep a note that we are restricted
-            IF (dft_control%restricted) THEN
-               scf_env%qs_ot_env(1)%restricted = .TRUE.
-               ! requires rotation
-               IF (.NOT. scf_env%qs_ot_env(1)%settings%do_rotation) &
-                  CALL cp_abort(__LOCATION__, &
-                                "Restricted calculation with OT requires orbital rotation. Please "// &
-                                "activate the OT%ROTATION keyword!")
-            ELSE
-               scf_env%qs_ot_env(:)%restricted = .FALSE.
-            ENDIF
-
-            ! might need the KS matrix to init properly
-            CALL qs_ks_update_qs_env(qs_env, just_energy=.FALSE., &
-                                     calculate_forces=.FALSE.)
-
-            ! if an old preconditioner is still around (i.e. outer SCF is active),
-            ! remove it if this could be worthwhile
-            IF (.NOT. reuse_precond) &
-               CALL restart_preconditioner(qs_env, scf_env%ot_preconditioner, &
-                                           scf_env%qs_ot_env(1)%settings%preconditioner_type, &
-                                           dft_control%nspins)
-
-            !
-            ! preconditioning still needs to be done correctly with has_unit_metric
-            ! notice that a big part of the preconditioning (S^-1) is fine anyhow
-            !
-            IF (has_unit_metric) THEN
-               NULLIFY (orthogonality_metric)
-            ELSE
-               orthogonality_metric => matrix_s(1)%matrix
-            ENDIF
-
-            IF (.NOT. reuse_precond) &
-               CALL prepare_preconditioner(qs_env, mos, matrix_ks, matrix_s, scf_env%ot_preconditioner, &
-                                           scf_env%qs_ot_env(1)%settings%preconditioner_type, &
-                                           scf_env%qs_ot_env(1)%settings%precond_solver_type, &
-                                           scf_env%qs_ot_env(1)%settings%energy_gap, dft_control%nspins, &
-                                           has_unit_metric=has_unit_metric, &
-                                           chol_type=scf_env%qs_ot_env(1)%settings%cholesky_type)
-            IF (reuse_precond) reuse_precond = .FALSE.
-
-            CALL ot_scf_init(mo_array=mos, matrix_s=orthogonality_metric, &
-                             broyden_adaptive_sigma=qs_env%broyden_adaptive_sigma, &
-                             qs_ot_env=scf_env%qs_ot_env, matrix_ks=matrix_ks(1)%matrix)
-
-            SELECT CASE (scf_env%qs_ot_env (1)%settings%preconditioner_type)
-            CASE (ot_precond_none)
-            CASE (ot_precond_full_all, ot_precond_full_single_inverse)
-               ! this will rotate the MOs to be eigen states, which is not compatible with rotation
-               ! e.g. mo_derivs here do not yet include potentially different occupations numbers
-               do_rotation = scf_env%qs_ot_env(1)%settings%do_rotation
-               ! only full all needs rotation
-               is_full_all = scf_env%qs_ot_env(1)%settings%preconditioner_type == ot_precond_full_all
-               CPASSERT(.NOT. (do_rotation .AND. is_full_all))
-               DO ispin = 1, SIZE(scf_env%qs_ot_env)
-                  CALL qs_ot_new_preconditioner(scf_env%qs_ot_env(ispin), &
-                                                scf_env%ot_preconditioner(ispin)%preconditioner)
-               ENDDO
-            CASE (ot_precond_s_inverse, ot_precond_full_single)
-               DO ispin = 1, SIZE(scf_env%qs_ot_env)
-                  CALL qs_ot_new_preconditioner(scf_env%qs_ot_env(ispin), &
-                                                scf_env%ot_preconditioner(1)%preconditioner)
-               ENDDO
-            CASE DEFAULT
-               DO ispin = 1, SIZE(scf_env%qs_ot_env)
-                  CALL qs_ot_new_preconditioner(scf_env%qs_ot_env(ispin), &
-                                                scf_env%ot_preconditioner(1)%preconditioner)
-               ENDDO
-            END SELECT
-         ENDIF
-
-         ! if we have non-uniform occupations we should be using rotation
-         do_rotation = scf_env%qs_ot_env(1)%settings%do_rotation
-         DO ispin = 1, SIZE(mos)
-            IF (.NOT. mos(ispin)%mo_set%uniform_occupation) THEN
-               CPASSERT(do_rotation)
-            ENDIF
-         ENDDO
+         ! Initialization is part of the new OO model
       END SELECT
 
       ! another safety check
       IF (dft_control%low_spin_roks) THEN
          CPASSERT(scf_env%method == ot_method_nr)
-         do_rotation = scf_env%qs_ot_env(1)%settings%do_rotation
-         CPASSERT(do_rotation)
       ENDIF
 
       CALL timestop(handle)

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -94,7 +94,6 @@ MODULE qs_scf
                                               pw_env_type
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE qs_block_davidson_types,         ONLY: block_davidson_deallocate
    USE qs_cdft_scf_utils,               ONLY: build_diagonal_jacobian,&
                                               create_tmp_logger,&
                                               initialize_inverse_jacobian,&
@@ -104,8 +103,6 @@ MODULE qs_scf
    USE qs_cdft_types,                   ONLY: cdft_control_type
    USE qs_charges_types,                ONLY: qs_charges_type
    USE qs_density_mixing_types,         ONLY: gspace_mixing_nr
-   USE qs_diis,                         ONLY: qs_diis_b_clear,&
-                                              qs_diis_b_create
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
@@ -136,10 +133,16 @@ MODULE qs_scf
                                               qs_scf_check_outer_exit,&
                                               qs_scf_density_mixing,&
                                               qs_scf_inner_finalize,&
+                                              qs_scf_new_mos_kp,&
                                               qs_scf_rho_update,&
                                               qs_scf_set_loop_flags
+   USE qs_scf_mo_calc_block_davidson,   ONLY: MOCalcBlockDavidson
+   USE qs_scf_mo_calc_block_krylov,     ONLY: MOCalcBlockKrylov
+   USE qs_scf_mo_calc_filter_matrix,    ONLY: MOCalcFilterMatrix
+   USE qs_scf_mo_calc_general_diag,     ONLY: MOCalcGeneralDiag
    USE qs_scf_mo_calc_ot,               ONLY: MOCalcOT
    USE qs_scf_mo_calc_ot_diag,          ONLY: MOCalcOTDiag
+   USE qs_scf_mo_calc_special_diag,     ONLY: MOCalcSpecialDiag
    USE qs_scf_output,                   ONLY: qs_scf_cdft_info,&
                                               qs_scf_cdft_initial_info,&
                                               qs_scf_loop_info,&
@@ -418,6 +421,21 @@ CONTAINS
       CASE (ot_method_nr)
          ALLOCATE (MOCalcOT :: mo_calc)
          CALL mo_calc%init(qs_env, scf_env, scf_section)
+      CASE (filter_matrix_diag_method_nr)
+         ALLOCATE (MOCalcFilterMatrix :: mo_calc)
+         CALL mo_calc%init(qs_env, scf_env, scf_section)
+      CASE (block_krylov_diag_method_nr)
+         ALLOCATE (MOCalcBlockKrylov :: mo_calc)
+         CALL mo_calc%init(qs_env, scf_env, scf_section)
+      CASE (block_davidson_diag_method_nr)
+         ALLOCATE (MOCalcBlockDavidson :: mo_calc)
+         CALL mo_calc%init(qs_env, scf_env, scf_section)
+      CASE (general_diag_method_nr)
+         ALLOCATE (MOCalcGeneralDiag :: mo_calc)
+         CALL mo_calc%init(qs_env, scf_env, scf_section)
+      CASE (special_diag_method_nr)
+         ALLOCATE (MOCalcSpecialDiag :: mo_calc)
+         CALL mo_calc%init(qs_env, scf_env, scf_section)
       END SELECT
 
       scf_outer_loop: DO
@@ -448,16 +466,24 @@ CONTAINS
             ! print 'heavy weight' or relatively expensive quantities
             CALL qs_scf_loop_print(qs_env, scf_env, para_env)
 
-            ! call the MO calculation routine
-            CALL mo_calc%run(diis_step, energy_only)
+            IF (do_kpoints) THEN
+               ! kpoints
+               CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
+            ELSE
+               ! Gamma points only
+               scf_env%iter_param = 0.0_dp ! where should this one go?
 
-            ! IF (do_kpoints) THEN
-            !    ! kpoints
-            !    CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
-            ! ELSE
-            !    ! Gamma points only
-            !    CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step)
-            ! END IF
+               ! call the MO calculation routine
+               CALL mo_calc%run(diis_step, energy_only)
+
+               energy%kTS = 0.0_dp
+               energy%efermi = 0.0_dp
+               DO ispin = 1, SIZE(mos)
+                  energy%kTS = energy%kTS+mos(ispin)%mo_set%kTS
+                  energy%efermi = energy%efermi+mos(ispin)%mo_set%mu
+               ENDDO
+               energy%efermi = energy%efermi/REAL(SIZE(mos), KIND=dp)
+            END IF
 
             ! another heavy weight print object, print controlled by dft_section
             CALL qs_scf_write_mos(mos, atomic_kind_set, qs_kind_set, particle_set, dft_section)
@@ -623,36 +649,6 @@ CONTAINS
                                    smear=scf_control%smear)
       ENDDO
 
-      SELECT CASE (scf_env%method)
-      CASE DEFAULT
-
-         CPABORT("unknown scf method method:"//cp_to_string(scf_env%method))
-
-      CASE (filter_matrix_diag_method_nr)
-
-         IF (.NOT. scf_env%skip_diis) THEN
-            IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
-               CALL qs_diis_b_create(scf_env%scf_diis_buffer, nbuffer=scf_control%max_diis)
-            END IF
-            CALL qs_diis_b_clear(scf_env%scf_diis_buffer)
-         END IF
-
-      CASE (general_diag_method_nr, special_diag_method_nr, block_krylov_diag_method_nr)
-         IF (.NOT. scf_env%skip_diis) THEN
-            IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
-               CALL qs_diis_b_create(scf_env%scf_diis_buffer, nbuffer=scf_control%max_diis)
-            END IF
-            CALL qs_diis_b_clear(scf_env%scf_diis_buffer)
-         END IF
-
-      CASE (ot_diag_method_nr)
-         ! Initialization is part of the new OO model
-      CASE (block_davidson_diag_method_nr)
-         ! Preconditioner initialized within the loop, when required
-      CASE (ot_method_nr)
-         ! Initialization is part of the new OO model
-      END SELECT
-
       ! another safety check
       IF (dft_control%low_spin_roks) THEN
          CPASSERT(scf_env%method == ot_method_nr)
@@ -712,25 +708,6 @@ CONTAINS
       IF (ASSOCIATED(scf_env%p_delta)) THEN
          CALL dbcsr_deallocate_matrix_set(scf_env%p_delta)
       END IF
-
-! *** method dependent cleanup
-      SELECT CASE (scf_env%method)
-      CASE (ot_method_nr)
-         !
-      CASE (ot_diag_method_nr)
-         !
-      CASE (general_diag_method_nr)
-         !
-      CASE (special_diag_method_nr)
-         !
-      CASE (block_krylov_diag_method_nr)
-      CASE (block_davidson_diag_method_nr)
-         CALL block_davidson_deallocate(scf_env%block_davidson_env)
-      CASE (filter_matrix_diag_method_nr)
-         !
-      CASE DEFAULT
-         CPABORT("unknown scf method method:"//cp_to_string(scf_env%method))
-      END SELECT
 
       IF (ASSOCIATED(scf_env%outer_scf%variables)) THEN
          DEALLOCATE (scf_env%outer_scf%variables)

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -164,6 +164,8 @@ MODULE qs_scf
    USE qs_wf_history_methods,           ONLY: wfi_purge_history,&
                                               wfi_update
    USE scf_control_types,               ONLY: scf_control_type
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_mo_calc_ot_diag,          ONLY: MOCalcOTDiag
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -341,13 +343,15 @@ CONTAINS
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: dft_section, input, scf_section
+      CLASS(AbstractMOCalc), POINTER                     :: mo_calc
 
       CALL timeset(routineN, handle)
 
       NULLIFY (dft_control, rho, energy, &
                logger, qs_charges, ks_env, mos, atomic_kind_set, qs_kind_set, &
                particle_set, dft_section, input, &
-               scf_section, para_env, results, kpoints, pw_env, rho_ao_kp)
+               scf_section, para_env, results, kpoints, pw_env, rho_ao_kp, &
+               mo_calc)
 
       CPASSERT(ASSOCIATED(scf_env))
       CPASSERT(scf_env%ref_count > 0)
@@ -416,10 +420,21 @@ CONTAINS
       total_steps = 0
       energy%tot_old = 0.0_dp
 
+      SELECT CASE (scf_env%method)
+         CASE DEFAULT
+            ! ignore
+         CASE (ot_diag_method_nr)
+            ALLOCATE(MOCalcOTDiag :: mo_calc)
+            call mo_calc%init(qs_env, scf_env, scf_section)
+      END SELECT
+
       scf_outer_loop: DO
 
          CALL init_scf_loop(scf_env=scf_env, qs_env=qs_env, &
                             scf_section=scf_section)
+
+         ! if new OO model, call the preconditioner
+         IF (ASSOCIATED(mo_calc)) call mo_calc%pre()
 
          CALL qs_scf_set_loop_flags(scf_env, diis_step, &
                                     energy_only, just_energy, exit_inner_loop)
@@ -442,6 +457,9 @@ CONTAINS
 
             ! print 'heavy weight' or relatively expensive quantities
             CALL qs_scf_loop_print(qs_env, scf_env, para_env)
+
+            ! if new OO model, call the MO calculation routine
+            IF (ASSOCIATED(mo_calc)) call mo_calc%run(diis_step)
 
             IF (do_kpoints) THEN
                ! kpoints
@@ -534,6 +552,9 @@ CONTAINS
       END DO scf_outer_loop
 
       converged = inner_loop_converged .AND. outer_loop_converged
+
+      ! if new OO model is used, deallocate the object
+      IF (ASSOCIATED(mo_calc)) DEALLOCATE(mo_calc)
 
       IF (dft_control%qs_control%cdft) &
          dft_control%qs_control%cdft_control%total_steps = &
@@ -640,33 +661,7 @@ CONTAINS
          END IF
 
       CASE (ot_diag_method_nr)
-         CALL get_qs_env(qs_env, matrix_ks=matrix_ks, matrix_s=matrix_s)
-
-         IF (.NOT. scf_env%skip_diis) THEN
-            IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
-               CALL qs_diis_b_create(scf_env%scf_diis_buffer, nbuffer=scf_control%max_diis)
-            END IF
-            CALL qs_diis_b_clear(scf_env%scf_diis_buffer)
-         END IF
-
-         ! disable DFTB and SE for now
-         IF (dft_control%qs_control%dftb .OR. &
-             dft_control%qs_control%xtb .OR. &
-             dft_control%qs_control%semi_empirical) THEN
-            CPABORT("DFTB and SE not available with OT/DIAG")
-         END IF
-
-         ! if an old preconditioner is still around (i.e. outer SCF is active),
-         ! remove it if this could be worthwhile
-         CALL restart_preconditioner(qs_env, scf_env%ot_preconditioner, &
-                                     scf_control%diagonalization%ot_settings%preconditioner_type, &
-                                     dft_control%nspins)
-
-         CALL prepare_preconditioner(qs_env, mos, matrix_ks, matrix_s, scf_env%ot_preconditioner, &
-                                     scf_control%diagonalization%ot_settings%preconditioner_type, &
-                                     scf_control%diagonalization%ot_settings%precond_solver_type, &
-                                     scf_control%diagonalization%ot_settings%energy_gap, dft_control%nspins)
-
+         ! Initialization is part of the new OO model
       CASE (block_davidson_diag_method_nr)
          ! Preconditioner initialized within the loop, when required
       CASE (ot_method_nr)

--- a/src/qs_scf_abstract_mo_calc.F
+++ b/src/qs_scf_abstract_mo_calc.F
@@ -1,0 +1,46 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_abstract_mo_calc
+   USE input_section_types,             ONLY: section_vals_type
+   USE qs_environment_types,            ONLY: qs_environment_type
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+
+   IMPLICIT NONE
+
+   TYPE, ABSTRACT :: AbstractMOCalc
+   CONTAINS
+      PROCEDURE(abstract_mo_calc_init), deferred, pass(self) :: init
+      PROCEDURE(abstract_mo_calc_pre), deferred, pass(self)  :: pre
+      PROCEDURE(abstract_mo_calc_run), deferred, pass(self)  :: run
+   END TYPE
+
+   INTERFACE
+      SUBROUTINE abstract_mo_calc_init(self, qs_env, scf_env, scf_section)
+         IMPORT AbstractMOCalc, qs_environment_type, qs_scf_env_type, section_vals_type
+
+         CLASS(AbstractMOCalc), INTENT(INOUT)              :: self
+         TYPE(qs_environment_type), POINTER, INTENT(IN)    :: qs_env
+         TYPE(qs_scf_env_type), POINTER, INTENT(IN)        :: scf_env
+         TYPE(section_vals_type), POINTER, INTENT(IN)      :: scf_section
+      END SUBROUTINE abstract_mo_calc_init
+   END INTERFACE
+
+   INTERFACE
+      SUBROUTINE abstract_mo_calc_pre(self)
+         IMPORT AbstractMOCalc
+         CLASS(AbstractMOCalc), INTENT(INOUT) :: self
+      END SUBROUTINE abstract_mo_calc_pre
+   END INTERFACE
+
+   INTERFACE
+      SUBROUTINE abstract_mo_calc_run(self, diis_step, energy_only)
+         IMPORT AbstractMOCalc
+         CLASS(AbstractMOCalc), INTENT(INOUT) :: self
+         LOGICAL, INTENT(INOUT)               :: diis_step
+         LOGICAL, INTENT(INOUT)               :: energy_only
+      END SUBROUTINE abstract_mo_calc_run
+   END INTERFACE
+END MODULE qs_scf_abstract_mo_calc

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -22,7 +22,6 @@ MODULE qs_scf_diagonalization
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
-                                              copy_fm_to_dbcsr,&
                                               cp_dbcsr_sm_fm_multiply,&
                                               dbcsr_allocate_matrix_set
    USE cp_fm_basic_linalg,              ONLY: cp_fm_symm,&
@@ -84,13 +83,11 @@ MODULE qs_scf_diagonalization
                                               mixing_allocate,&
                                               mixing_init,&
                                               self_consistency_check
-   USE qs_mo_methods,                   ONLY: calculate_density_matrix,&
-                                              calculate_subspace_eigenvalues
+   USE qs_mo_methods,                   ONLY: calculate_density_matrix
    USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_p_type
    USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
-   USE qs_ot_eigensolver,               ONLY: ot_eigensolver
    USE qs_rho_atom_types,               ONLY: rho_atom_type
    USE qs_rho_methods,                  ONLY: qs_rho_update_rho
    USE qs_rho_types,                    ONLY: qs_rho_get,&
@@ -117,7 +114,7 @@ MODULE qs_scf_diagonalization
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_scf_diagonalization'
 
    PUBLIC :: do_general_diag, do_general_diag_kp, do_roks_diag, &
-             do_special_diag, do_ot_diag, do_block_davidson_diag, &
+             do_special_diag, do_block_davidson_diag, &
              do_block_krylov_diag, do_scf_diag_subspace, diag_subspace_allocate, general_eigenproblem
 
 CONTAINS
@@ -965,110 +962,6 @@ CONTAINS
       END DO
 
    END SUBROUTINE do_special_diag
-
-! **************************************************************************************************
-!> \brief the inner loop of scf, specific to iterative diagonalization using OT
-!>        with S matrix; basically, in goes the ks matrix out goes a new p matrix
-!> \param scf_env ...
-!> \param mos ...
-!> \param matrix_ks ...
-!> \param matrix_s ...
-!> \param scf_control ...
-!> \param scf_section ...
-!> \param diis_step ...
-!> \par History
-!>      10.2008 created [JGH]
-! **************************************************************************************************
-   SUBROUTINE do_ot_diag(scf_env, mos, matrix_ks, matrix_s, &
-                         scf_control, scf_section, diis_step)
-
-      TYPE(qs_scf_env_type), POINTER                     :: scf_env
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
-      TYPE(scf_control_type), POINTER                    :: scf_control
-      TYPE(section_vals_type), POINTER                   :: scf_section
-      LOGICAL, INTENT(INOUT)                             :: diis_step
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'do_ot_diag', routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: homo, ispin, nmo, nspin
-      REAL(KIND=dp)                                      :: diis_error, eps_iter
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
-
-      NULLIFY (eigenvalues)
-
-      nspin = SIZE(matrix_ks)
-
-      DO ispin = 1, nspin
-         CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, &
-                               scf_env%scf_work1(ispin)%matrix)
-      END DO
-
-      IF ((scf_env%iter_count > 1) .AND. (.NOT. scf_env%skip_diis)) THEN
-         CALL qs_diis_b_step(scf_env%scf_diis_buffer, mos, scf_env%scf_work1, &
-                             scf_env%scf_work2, scf_env%iter_delta, diis_error, diis_step, &
-                             scf_control%eps_diis, scf_control%nmixing, &
-                             s_matrix=matrix_s, &
-                             scf_section=scf_section)
-      ELSE
-         diis_step = .FALSE.
-      END IF
-
-      eps_iter = scf_control%diagonalization%eps_iter
-      IF (diis_step) THEN
-         scf_env%iter_param = diis_error
-         scf_env%iter_method = "DIIS/OTdiag"
-         DO ispin = 1, nspin
-            CALL copy_fm_to_dbcsr(scf_env%scf_work1(ispin)%matrix, &
-                                  matrix_ks(ispin)%matrix, keep_sparsity=.TRUE.)
-         END DO
-         eps_iter = MAX(eps_iter, scf_control%diagonalization%eps_adapt*diis_error)
-      ELSE
-         IF (scf_env%mixing_method == 1) THEN
-            scf_env%iter_param = scf_env%p_mix_alpha
-            scf_env%iter_method = "P_Mix/OTdiag."
-         ELSEIF (scf_env%mixing_method > 1) THEN
-            scf_env%iter_param = scf_env%mixing_store%alpha
-            scf_env%iter_method = TRIM(scf_env%mixing_store%iter_method)//"/OTdiag."
-         END IF
-      END IF
-
-      scf_env%iter_delta = 0.0_dp
-
-      DO ispin = 1, nspin
-         CALL get_mo_set(mos(ispin)%mo_set, &
-                         mo_coeff=mo_coeff, &
-                         eigenvalues=eigenvalues, &
-                         nmo=nmo, &
-                         homo=homo)
-         CALL ot_eigensolver(matrix_h=matrix_ks(ispin)%matrix, &
-                             matrix_s=matrix_s(1)%matrix, &
-                             matrix_c_fm=mo_coeff, &
-                             preconditioner=scf_env%ot_preconditioner(1)%preconditioner, &
-                             eps_gradient=eps_iter, &
-                             iter_max=scf_control%diagonalization%max_iter, &
-                             silent=.TRUE., &
-                             ot_settings=scf_control%diagonalization%ot_settings)
-         CALL calculate_subspace_eigenvalues(mo_coeff, matrix_ks(ispin)%matrix, &
-                                             evals_arg=eigenvalues, &
-                                             do_rotation=.TRUE.)
-         !MK WRITE(*,*) routinen//' copy_dbcsr_to_fm'
-         CALL copy_fm_to_dbcsr(mos(ispin)%mo_set%mo_coeff, &
-                               mos(ispin)%mo_set%mo_coeff_b)
-         !fm->dbcsr
-      END DO
-
-      CALL set_mo_occupation(mo_array=mos, &
-                             smear=scf_control%smear)
-
-      DO ispin = 1, nspin
-         ! does not yet handle k-points
-         CALL calculate_density_matrix(mos(ispin)%mo_set, &
-                                       scf_env%p_mix_new(ispin, 1)%matrix)
-      END DO
-
-   END SUBROUTINE do_ot_diag
 
 ! **************************************************************************************************
 !> \brief Solve a set restricted open Kohn-Sham (ROKS) equations based on the

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -13,7 +13,6 @@ MODULE qs_scf_loop_utils
    USE dbcsr_api,                       ONLY: dbcsr_copy,&
                                               dbcsr_get_info,&
                                               dbcsr_p_type
-   USE input_section_types,             ONLY: section_vals_type
    USE kinds,                           ONLY: default_string_length,&
                                               dp
    USE kpoint_types,                    ONLY: kpoint_type
@@ -27,29 +26,20 @@ MODULE qs_scf_loop_utils
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
-   USE qs_fb_env_methods,               ONLY: fb_env_do_diag
    USE qs_gspace_mixing,                ONLY: gspace_mixing
    USE qs_ks_types,                     ONLY: qs_ks_did_change,&
                                               qs_ks_env_type
    USE qs_mixing_utils,                 ONLY: self_consistency_check
    USE qs_mo_types,                     ONLY: mo_set_p_type
-   USE qs_mom_methods,                  ONLY: do_mom_diag
    USE qs_outer_scf,                    ONLY: outer_loop_gradient
    USE qs_rho_methods,                  ONLY: qs_rho_update_rho
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
-   USE qs_scf_diagonalization,          ONLY: do_block_davidson_diag,&
-                                              do_block_krylov_diag,&
-                                              do_general_diag,&
-                                              do_general_diag_kp,&
-                                              do_roks_diag,&
-                                              do_scf_diag_subspace,&
-                                              do_special_diag
+   USE qs_scf_diagonalization,          ONLY: do_general_diag_kp
    USE qs_scf_methods,                  ONLY: scf_env_density_mixing
    USE qs_scf_output,                   ONLY: qs_scf_print_summary
    USE qs_scf_types,                    ONLY: block_davidson_diag_method_nr,&
                                               block_krylov_diag_method_nr,&
-                                              filter_matrix_diag_method_nr,&
                                               general_diag_method_nr,&
                                               ot_diag_method_nr,&
                                               ot_method_nr,&
@@ -65,7 +55,7 @@ MODULE qs_scf_loop_utils
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_scf_loop_utils'
 
    PUBLIC :: qs_scf_set_loop_flags, &
-             qs_scf_new_mos, qs_scf_new_mos_kp, &
+             qs_scf_new_mos_kp, &
              qs_scf_density_mixing, qs_scf_check_inner_exit, &
              qs_scf_check_outer_exit, qs_scf_inner_finalize, qs_scf_rho_update
 
@@ -102,136 +92,6 @@ CONTAINS
       exit_inner_loop = .FALSE.
 
    END SUBROUTINE qs_scf_set_loop_flags
-
-! **************************************************************************************************
-!> \brief takes known energy and derivatives and produces new wfns
-!>        and or density matrix
-!> \param qs_env ...
-!> \param scf_env ...
-!> \param scf_control ...
-!> \param scf_section ...
-!> \param diis_step ...
-! **************************************************************************************************
-   SUBROUTINE qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(qs_scf_env_type), POINTER                     :: scf_env
-      TYPE(scf_control_type), POINTER                    :: scf_control
-      TYPE(section_vals_type), POINTER                   :: scf_section
-      LOGICAL                                            :: diis_step
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'qs_scf_new_mos', routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, ispin
-      LOGICAL                                            :: has_unit_metric, skip_diag_sub
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
-      TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
-      TYPE(qs_energy_type), POINTER                      :: energy
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
-      TYPE(qs_rho_type), POINTER                         :: rho
-
-      CALL timeset(routineN, handle)
-
-      NULLIFY (energy, ks_env, matrix_ks, matrix_s, rho, mos, dft_control)
-
-      CALL get_qs_env(qs_env=qs_env, &
-                      matrix_s=matrix_s, energy=energy, &
-                      ks_env=ks_env, &
-                      matrix_ks=matrix_ks, rho=rho, mos=mos, &
-                      dft_control=dft_control, &
-                      has_unit_metric=has_unit_metric)
-      scf_env%iter_param = 0.0_dp
-
-      SELECT CASE (scf_env%method)
-      CASE DEFAULT
-         CALL cp_abort(__LOCATION__, &
-                       "unknown scf method: "// &
-                       cp_to_string(scf_env%method))
-
-         ! *************************************************************************
-         ! Filter matrix diagonalisation: ugly implementation at this point of time
-         ! *************************************************************************
-      CASE (filter_matrix_diag_method_nr)
-
-         CALL fb_env_do_diag(scf_env%filter_matrix_env, qs_env, &
-                             matrix_ks, matrix_s, scf_section, diis_step)
-
-         ! Diagonlization in non orthonormal case
-      CASE (general_diag_method_nr)
-         IF (dft_control%roks) THEN
-            CALL do_roks_diag(scf_env, mos, matrix_ks, matrix_s, &
-                              scf_control, scf_section, diis_step, &
-                              has_unit_metric)
-         ELSE
-            IF (scf_control%diagonalization%mom) THEN
-               CALL do_mom_diag(scf_env, mos, matrix_ks, &
-                                matrix_s, scf_control, scf_section, &
-                                diis_step)
-            ELSE
-               CALL do_general_diag(scf_env, mos, matrix_ks, &
-                                    matrix_s, scf_control, scf_section, &
-                                    diis_step)
-            END IF
-            IF (scf_control%do_diag_sub) THEN
-               skip_diag_sub = (scf_env%subspace_env%eps_diag_sub > 0.0_dp) .AND. &
-                               (scf_env%iter_count == 1 .OR. scf_env%iter_delta > scf_env%subspace_env%eps_diag_sub)
-               IF (.NOT. skip_diag_sub) THEN
-                  CALL do_scf_diag_subspace(qs_env, scf_env, scf_env%subspace_env, mos, rho, &
-                                            ks_env, scf_section, scf_control)
-               END IF
-            END IF
-         END IF
-         ! Diagonlization in orthonormal case
-      CASE (special_diag_method_nr)
-         IF (dft_control%roks) THEN
-            CALL do_roks_diag(scf_env, mos, matrix_ks, matrix_s, &
-                              scf_control, scf_section, diis_step, &
-                              has_unit_metric)
-         ELSE
-            CALL do_special_diag(scf_env, mos, matrix_ks, &
-                                 scf_control, scf_section, &
-                                 diis_step)
-         END IF
-         ! Block Krylov diagonlization
-      CASE (block_krylov_diag_method_nr)
-         IF ((scf_env%krylov_space%eps_std_diag > 0.0_dp) .AND. &
-             (scf_env%iter_count == 1 .OR. scf_env%iter_delta > scf_env%krylov_space%eps_std_diag)) THEN
-            IF (scf_env%krylov_space%always_check_conv) THEN
-               CALL do_block_krylov_diag(scf_env, mos, matrix_ks, &
-                                         scf_control, scf_section, check_moconv_only=.TRUE.)
-            END IF
-            CALL do_general_diag(scf_env, mos, matrix_ks, &
-                                 matrix_s, scf_control, scf_section, diis_step)
-         ELSE
-            CALL do_block_krylov_diag(scf_env, mos, matrix_ks, &
-                                      scf_control, scf_section)
-         END IF
-         IF (scf_control%do_diag_sub) THEN
-            skip_diag_sub = (scf_env%subspace_env%eps_diag_sub > 0.0_dp) .AND. &
-                            (scf_env%iter_count == 1 .OR. scf_env%iter_delta > scf_env%subspace_env%eps_diag_sub)
-            IF (.NOT. skip_diag_sub) THEN
-               CALL do_scf_diag_subspace(qs_env, scf_env, scf_env%subspace_env, mos, rho, &
-                                         ks_env, scf_section, scf_control)
-            END IF
-         END IF
-         ! Block Davidson diagonlization
-      CASE (block_davidson_diag_method_nr)
-         CALL do_block_davidson_diag(qs_env, scf_env, mos, matrix_ks, matrix_s, scf_control, &
-                                     scf_section, .FALSE.)
-      END SELECT
-
-      energy%kTS = 0.0_dp
-      energy%efermi = 0.0_dp
-      CALL get_qs_env(qs_env, mos=mos)
-      DO ispin = 1, SIZE(mos)
-         energy%kTS = energy%kTS+mos(ispin)%mo_set%kTS
-         energy%efermi = energy%efermi+mos(ispin)%mo_set%mu
-      ENDDO
-      energy%efermi = energy%efermi/REAL(SIZE(mos), KIND=dp)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE qs_scf_new_mos
 
 ! **************************************************************************************************
 !> \brief Updates MOs and density matrix using diagonalization

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -47,7 +47,6 @@ MODULE qs_scf_loop_utils
                                               do_block_krylov_diag,&
                                               do_general_diag,&
                                               do_general_diag_kp,&
-                                              do_ot_diag,&
                                               do_roks_diag,&
                                               do_scf_diag_subspace,&
                                               do_special_diag
@@ -201,10 +200,8 @@ CONTAINS
                                  scf_control, scf_section, &
                                  diis_step)
          END IF
-         ! OT diagonlization
+         ! OT diagonalization, ignored since this is part of the OO-model now
       CASE (ot_diag_method_nr)
-         CALL do_ot_diag(scf_env, mos, matrix_ks, matrix_s, &
-                         scf_control, scf_section, diis_step)
          ! Block Krylov diagonlization
       CASE (block_krylov_diag_method_nr)
          IF ((scf_env%krylov_space%eps_std_diag > 0.0_dp) .AND. &

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -12,8 +12,7 @@ MODULE qs_scf_loop_utils
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: dbcsr_copy,&
                                               dbcsr_get_info,&
-                                              dbcsr_p_type,&
-                                              dbcsr_type
+                                              dbcsr_p_type
    USE input_section_types,             ONLY: section_vals_type
    USE kinds,                           ONLY: default_string_length,&
                                               dp
@@ -33,12 +32,8 @@ MODULE qs_scf_loop_utils
    USE qs_ks_types,                     ONLY: qs_ks_did_change,&
                                               qs_ks_env_type
    USE qs_mixing_utils,                 ONLY: self_consistency_check
-   USE qs_mo_methods,                   ONLY: calculate_density_matrix
-   USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: mo_set_p_type
    USE qs_mom_methods,                  ONLY: do_mom_diag
-   USE qs_ot_scf,                       ONLY: ot_scf_destroy,&
-                                              ot_scf_mini
    USE qs_outer_scf,                    ONLY: outer_loop_gradient
    USE qs_rho_methods,                  ONLY: qs_rho_update_rho
    USE qs_rho_types,                    ONLY: qs_rho_get,&
@@ -60,8 +55,7 @@ MODULE qs_scf_loop_utils
                                               ot_method_nr,&
                                               qs_scf_env_type,&
                                               special_diag_method_nr
-   USE scf_control_types,               ONLY: scf_control_type,&
-                                              smear_type
+   USE scf_control_types,               ONLY: scf_control_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -117,15 +111,13 @@ CONTAINS
 !> \param scf_control ...
 !> \param scf_section ...
 !> \param diis_step ...
-!> \param energy_only ...
 ! **************************************************************************************************
-   SUBROUTINE qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, &
-                             energy_only)
+   SUBROUTINE qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(scf_control_type), POINTER                    :: scf_control
       TYPE(section_vals_type), POINTER                   :: scf_section
-      LOGICAL                                            :: diis_step, energy_only
+      LOGICAL                                            :: diis_step
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'qs_scf_new_mos', routineP = moduleN//':'//routineN
 
@@ -200,8 +192,6 @@ CONTAINS
                                  scf_control, scf_section, &
                                  diis_step)
          END IF
-         ! OT diagonalization, ignored since this is part of the OO-model now
-      CASE (ot_diag_method_nr)
          ! Block Krylov diagonlization
       CASE (block_krylov_diag_method_nr)
          IF ((scf_env%krylov_space%eps_std_diag > 0.0_dp) .AND. &
@@ -228,11 +218,6 @@ CONTAINS
       CASE (block_davidson_diag_method_nr)
          CALL do_block_davidson_diag(qs_env, scf_env, mos, matrix_ks, matrix_s, scf_control, &
                                      scf_section, .FALSE.)
-         ! OT without diagonlization. Needs special treatment for SCP runs
-      CASE (ot_method_nr)
-         CALL qs_scf_loop_do_ot(qs_env, scf_env, scf_control%smear, mos, rho, &
-                                qs_env%mo_derivs, energy%total, &
-                                matrix_s, energy_only=energy_only, has_unit_metric=has_unit_metric)
       END SELECT
 
       energy%kTS = 0.0_dp
@@ -331,81 +316,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE qs_scf_new_mos_kp
-
-! **************************************************************************************************
-!> \brief the inner loop of scf, specific to using to the orbital transformation method
-!>       basically, in goes the ks matrix out goes a new p matrix
-!> \param qs_env ...
-!> \param scf_env ...
-!> \param smear ...
-!> \param mos ...
-!> \param rho ...
-!> \param mo_derivs ...
-!> \param total_energy ...
-!> \param matrix_s ...
-!> \param energy_only ...
-!> \param has_unit_metric ...
-!> \par History
-!>      03.2006 created [Joost VandeVondele]
-!>      2013    moved from qs_scf [Florian Schiffmann]
-! **************************************************************************************************
-   SUBROUTINE qs_scf_loop_do_ot(qs_env, scf_env, smear, mos, rho, mo_derivs, total_energy, &
-                                matrix_s, energy_only, has_unit_metric)
-
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(qs_scf_env_type), POINTER                     :: scf_env
-      TYPE(smear_type), POINTER                          :: smear
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
-      TYPE(qs_rho_type), POINTER                         :: rho
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mo_derivs
-      REAL(KIND=dp), INTENT(IN)                          :: total_energy
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
-      LOGICAL, INTENT(INOUT)                             :: energy_only
-      LOGICAL, INTENT(IN)                                :: has_unit_metric
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'qs_scf_loop_do_ot', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, ispin
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
-      TYPE(dbcsr_type), POINTER                          :: orthogonality_metric
-
-      CALL timeset(routineN, handle)
-      NULLIFY (rho_ao)
-
-      CALL qs_rho_get(rho, rho_ao=rho_ao)
-
-      IF (has_unit_metric) THEN
-         NULLIFY (orthogonality_metric)
-      ELSE
-         orthogonality_metric => matrix_s(1)%matrix
-      END IF
-
-      ! in case of LSD the first spin qs_ot_env will drive the minimization
-      ! in the case of a restricted calculation, it will make sure the spin orbitals are equal
-
-      CALL ot_scf_mini(mos, mo_derivs, smear, orthogonality_metric, &
-                       total_energy, energy_only, scf_env%iter_delta, &
-                       scf_env%qs_ot_env, qs_env%input)
-
-      DO ispin = 1, SIZE(mos)
-         CALL set_mo_occupation(mo_set=mos(ispin)%mo_set, &
-                                smear=smear)
-      ENDDO
-
-      DO ispin = 1, SIZE(mos)
-         CALL calculate_density_matrix(mos(ispin)%mo_set, &
-                                       rho_ao(ispin)%matrix, &
-                                       use_dbcsr=.TRUE.)
-      END DO
-
-      scf_env%iter_method = scf_env%qs_ot_env(1)%OT_METHOD_FULL
-      scf_env%iter_param = scf_env%qs_ot_env(1)%ds_min
-      qs_env%broyden_adaptive_sigma = scf_env%qs_ot_env(1)%broyden_adaptive_sigma
-
-      CALL timestop(handle)
-
-   END SUBROUTINE qs_scf_loop_do_ot
 
 ! **************************************************************************************************
 !> \brief Performs the requested density mixing if any needed
@@ -634,20 +544,18 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'qs_scf_inner_finalize', &
          routineP = moduleN//':'//routineN
 
-      LOGICAL                                            :: do_kpoints
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
 
-      NULLIFY (energy, rho, dft_control, ks_env)
+      NULLIFY (rho, dft_control, ks_env)
 
-      CALL get_qs_env(qs_env=qs_env, energy=energy, ks_env=ks_env, &
-                      rho=rho, dft_control=dft_control, para_env=para_env, &
-                      do_kpoints=do_kpoints)
+      CALL get_qs_env(qs_env=qs_env, ks_env=ks_env, &
+                      rho=rho, dft_control=dft_control, para_env=para_env)
 
-      CALL cleanup_scf_loop(scf_env)
+      CPASSERT(ASSOCIATED(scf_env))
+      CPASSERT(scf_env%ref_count > 0)
 
       ! now, print out energies and charges corresponding to the obtained wfn
       ! (this actually is not 100% consistent at this point)!
@@ -661,50 +569,5 @@ CONTAINS
       CALL qs_scf_rho_update(rho, qs_env, scf_env, ks_env, mix_rho=.FALSE.)
 
    END SUBROUTINE qs_scf_inner_finalize
-
-! **************************************************************************************************
-!> \brief perform cleanup operations at the end of an scf loop
-!> \param scf_env ...
-!> \par History
-!>      03.2006 created [Joost VandeVondele]
-! **************************************************************************************************
-   SUBROUTINE cleanup_scf_loop(scf_env)
-      TYPE(qs_scf_env_type), POINTER                     :: scf_env
-
-      CHARACTER(len=*), PARAMETER :: routineN = 'cleanup_scf_loop', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, ispin
-
-      CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(scf_env))
-      CPASSERT(scf_env%ref_count > 0)
-! *** method dependent cleanup
-      SELECT CASE (scf_env%method)
-      CASE (ot_method_nr)
-         DO ispin = 1, SIZE(scf_env%qs_ot_env)
-            CALL ot_scf_destroy(scf_env%qs_ot_env(ispin))
-         ENDDO
-         DEALLOCATE (scf_env%qs_ot_env)
-      CASE (ot_diag_method_nr)
-         !
-      CASE (general_diag_method_nr)
-         !
-      CASE (special_diag_method_nr)
-         !
-      CASE (block_krylov_diag_method_nr, block_davidson_diag_method_nr)
-         !
-      CASE (filter_matrix_diag_method_nr)
-         !
-      CASE DEFAULT
-         CALL cp_abort(__LOCATION__, &
-                       "unknown scf method method:"// &
-                       cp_to_string(scf_env%method))
-      END SELECT
-
-      CALL timestop(handle)
-
-   END SUBROUTINE cleanup_scf_loop
 
 END MODULE qs_scf_loop_utils

--- a/src/qs_scf_mo_calc_block_davidson.F
+++ b/src/qs_scf_mo_calc_block_davidson.F
@@ -1,0 +1,86 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_mo_calc_block_davidson
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_section_types,             ONLY: section_vals_type
+   USE qs_block_davidson_types,         ONLY: block_davidson_deallocate
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_mo_types,                     ONLY: mo_set_p_type
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_diagonalization,          ONLY: do_block_davidson_diag
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE scf_control_types,               ONLY: scf_control_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   ! CASE (block_davidson_diag_method_nr, general_diag_method_nr, special_diag_method_nr, block_krylov_diag_method_nr)
+
+   TYPE, PUBLIC, EXTENDS(AbstractMOCalc) :: MOCalcBlockDavidson
+   PRIVATE
+
+   TYPE(qs_environment_type), POINTER         :: qs_env => null()
+   TYPE(qs_scf_env_type), POINTER             :: scf_env => null()
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER  :: matrix_ks => null(), matrix_s => null()
+   TYPE(mo_set_p_type), DIMENSION(:), POINTER :: mos => null()
+   TYPE(section_vals_type), POINTER           :: scf_section => null()
+   TYPE(scf_control_type), POINTER            :: scf_control => null()
+
+CONTAINS
+   PROCEDURE, PUBLIC, PASS(self) :: init => block_davidson_init
+   PROCEDURE, PUBLIC, PASS(self) :: pre => block_davidson_pre
+   PROCEDURE, PUBLIC, PASS(self) :: run => block_davidson_run
+   FINAL :: block_davidson_finalize
+END TYPE
+
+CONTAINS
+SUBROUTINE block_davidson_init(self, qs_env, scf_env, scf_section)
+   CLASS(MOCalcBlockDavidson), INTENT(INOUT)             :: self
+   TYPE(qs_environment_type), POINTER, INTENT(IN) :: qs_env
+   TYPE(qs_scf_env_type), POINTER, INTENT(IN)     :: scf_env
+   TYPE(section_vals_type), POINTER, INTENT(IN)   :: scf_section
+
+   self%qs_env => qs_env
+   self%scf_env => scf_env
+   self%scf_section => scf_section
+
+   CALL get_qs_env(qs_env, &
+                   scf_control=self%scf_control, &
+                   mos=self%mos, &
+                   matrix_ks=self%matrix_ks, &
+                   matrix_s=self%matrix_s)
+END SUBROUTINE block_davidson_init
+
+SUBROUTINE block_davidson_pre(self)
+   CLASS(MOCalcBlockDavidson), INTENT(INOUT) :: self
+
+   MARK_USED(self)
+
+END SUBROUTINE block_davidson_pre
+
+SUBROUTINE block_davidson_run(self, diis_step, energy_only)
+   !! the inner loop of scf, specific to iterative diagonalization using OT
+   !! with S matrix; basically, in goes the ks matrix out goes a new p matrix
+   CLASS(MOCalcBlockDavidson), INTENT(INOUT)   :: self
+   LOGICAL, INTENT(INOUT)               :: diis_step
+   LOGICAL, INTENT(INOUT)               :: energy_only
+
+   MARK_USED(diis_step)
+   MARK_USED(energy_only)
+
+   CALL do_block_davidson_diag(self%qs_env, self%scf_env, self%mos, self%matrix_ks, self%matrix_s, self%scf_control, &
+                               self%scf_section, .FALSE.)
+END SUBROUTINE block_davidson_run
+
+SUBROUTINE block_davidson_finalize(self)
+      TYPE(MOCalcBlockDavidson), INTENT(INOUT)           :: self
+
+   CALL block_davidson_deallocate(self%scf_env%block_davidson_env)
+END SUBROUTINE
+
+END MODULE qs_scf_mo_calc_block_davidson

--- a/src/qs_scf_mo_calc_block_krylov.F
+++ b/src/qs_scf_mo_calc_block_krylov.F
@@ -1,0 +1,115 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_mo_calc_block_krylov
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_section_types,             ONLY: section_vals_type
+   USE kinds,                           ONLY: dp
+   USE qs_diis,                         ONLY: qs_diis_b_clear,&
+                                              qs_diis_b_create
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_ks_types,                     ONLY: qs_ks_env_type
+   USE qs_mo_types,                     ONLY: mo_set_p_type
+   USE qs_rho_types,                    ONLY: qs_rho_type
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_diagonalization,          ONLY: do_block_krylov_diag,&
+                                              do_general_diag,&
+                                              do_scf_diag_subspace
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE scf_control_types,               ONLY: scf_control_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   ! CASE (block_krylov_diag_method_nr, general_diag_method_nr, special_diag_method_nr, block_krylov_diag_method_nr)
+
+   TYPE, PUBLIC, EXTENDS(AbstractMOCalc) :: MOCalcBlockKrylov
+   PRIVATE
+
+   TYPE(qs_environment_type), POINTER         :: qs_env => null()
+   TYPE(qs_scf_env_type), POINTER             :: scf_env => null()
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER  :: matrix_ks => null(), matrix_s => null()
+   TYPE(section_vals_type), POINTER           :: scf_section => null()
+   TYPE(scf_control_type), POINTER            :: scf_control => null()
+   TYPE(qs_ks_env_type), POINTER              :: ks_env => null()
+   TYPE(mo_set_p_type), DIMENSION(:), POINTER :: mos => null()
+   TYPE(qs_rho_type), POINTER                 :: rho => null()
+
+CONTAINS
+   PROCEDURE, PUBLIC, PASS(self) :: init => block_krylov_init
+   PROCEDURE, PUBLIC, PASS(self) :: pre => block_krylov_pre
+   PROCEDURE, PUBLIC, PASS(self) :: run => block_krylov_run
+END TYPE
+
+CONTAINS
+SUBROUTINE block_krylov_init(self, qs_env, scf_env, scf_section)
+   CLASS(MOCalcBlockKrylov), INTENT(INOUT)             :: self
+   TYPE(qs_environment_type), POINTER, INTENT(IN) :: qs_env
+   TYPE(qs_scf_env_type), POINTER, INTENT(IN)     :: scf_env
+   TYPE(section_vals_type), POINTER, INTENT(IN)   :: scf_section
+
+   self%qs_env => qs_env
+   self%scf_env => scf_env
+   self%scf_section => scf_section
+
+   CALL get_qs_env(qs_env, &
+                   scf_control=self%scf_control, &
+                   matrix_ks=self%matrix_ks, &
+                   matrix_s=self%matrix_s, &
+                   ks_env=self%ks_env, &
+                   rho=self%rho, &
+                   mos=self%mos)
+
+   IF (.NOT. scf_env%skip_diis) THEN
+      IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
+         CALL qs_diis_b_create(scf_env%scf_diis_buffer, nbuffer=self%scf_control%max_diis)
+      END IF
+   END IF
+END SUBROUTINE block_krylov_init
+
+SUBROUTINE block_krylov_pre(self)
+   CLASS(MOCalcBlockKrylov), INTENT(INOUT) :: self
+
+   CALL qs_diis_b_clear(self%scf_env%scf_diis_buffer)
+END SUBROUTINE block_krylov_pre
+
+SUBROUTINE block_krylov_run(self, diis_step, energy_only)
+   !! the inner loop of scf, specific to iterative diagonalization using OT
+   !! with S matrix; basically, in goes the ks matrix out goes a new p matrix
+   CLASS(MOCalcBlockKrylov), INTENT(INOUT)   :: self
+   LOGICAL, INTENT(INOUT)               :: diis_step
+   LOGICAL, INTENT(INOUT)               :: energy_only
+   LOGICAL :: skip_diag_sub
+
+   MARK_USED(energy_only)
+
+   ASSOCIATE (scf_env=>self%scf_env)
+      IF ((scf_env%krylov_space%eps_std_diag > 0.0_dp) .AND. &
+          (scf_env%iter_count == 1 .OR. scf_env%iter_delta > scf_env%krylov_space%eps_std_diag)) THEN
+         IF (scf_env%krylov_space%always_check_conv) THEN
+            ! something is fishy with do_block_krylov_diag (missing dummy argument specs?!)
+            CALL do_block_krylov_diag(self%scf_env, self%mos, self%matrix_ks, &
+                                      self%scf_control, self%scf_section, check_moconv_only=.TRUE.)
+         END IF
+         CALL do_general_diag(self%scf_env, self%mos, self%matrix_ks, &
+                              self%matrix_s, self%scf_control, self%scf_section, diis_step)
+      ELSE
+         CALL do_block_krylov_diag(self%scf_env, self%mos, self%matrix_ks, &
+                                   self%scf_control, self%scf_section)
+      END IF
+      IF (self%scf_control%do_diag_sub) THEN
+         skip_diag_sub = (scf_env%subspace_env%eps_diag_sub > 0.0_dp) .AND. &
+                         (scf_env%iter_count == 1 .OR. scf_env%iter_delta > scf_env%subspace_env%eps_diag_sub)
+         IF (.NOT. skip_diag_sub) THEN
+            CALL do_scf_diag_subspace(self%qs_env, self%scf_env, scf_env%subspace_env, self%mos, self%rho, &
+                                      self%ks_env, self%scf_section, self%scf_control)
+         END IF
+      END IF
+   END ASSOCIATE
+END SUBROUTINE block_krylov_run
+
+END MODULE qs_scf_mo_calc_block_krylov

--- a/src/qs_scf_mo_calc_filter_matrix.F
+++ b/src/qs_scf_mo_calc_filter_matrix.F
@@ -1,0 +1,81 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_mo_calc_filter_matrix
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_section_types,             ONLY: section_vals_type
+   USE qs_diis,                         ONLY: qs_diis_b_clear,&
+                                              qs_diis_b_create
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_fb_env_methods,               ONLY: fb_env_do_diag
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE scf_control_types,               ONLY: scf_control_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   ! CASE (filter_matrix_diag_method_nr, general_diag_method_nr, special_diag_method_nr, block_krylov_diag_method_nr)
+
+   TYPE, PUBLIC, EXTENDS(AbstractMOCalc) :: MOCalcFilterMatrix
+   PRIVATE
+
+   TYPE(qs_environment_type), POINTER         :: qs_env => null()
+   TYPE(qs_scf_env_type), POINTER             :: scf_env => null()
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER  :: matrix_ks => null(), matrix_s => null()
+   TYPE(section_vals_type), POINTER           :: scf_section
+
+CONTAINS
+   PROCEDURE, PUBLIC, PASS(self) :: init => filter_matrix_init
+   PROCEDURE, PUBLIC, PASS(self) :: pre => filter_matrix_pre
+   PROCEDURE, PUBLIC, PASS(self) :: run => filter_matrix_run
+END TYPE
+
+CONTAINS
+SUBROUTINE filter_matrix_init(self, qs_env, scf_env, scf_section)
+   CLASS(MOCalcFilterMatrix), INTENT(INOUT)             :: self
+   TYPE(qs_environment_type), POINTER, INTENT(IN) :: qs_env
+   TYPE(qs_scf_env_type), POINTER, INTENT(IN)     :: scf_env
+   TYPE(section_vals_type), POINTER, INTENT(IN)   :: scf_section
+   TYPE(scf_control_type), POINTER            :: scf_control => null()
+
+   self%qs_env => qs_env
+   self%scf_env => scf_env
+   self%scf_section => scf_section
+
+   CALL get_qs_env(qs_env, &
+                   scf_control=scf_control, &
+                   matrix_ks=self%matrix_ks, &
+                   matrix_s=self%matrix_s)
+
+   IF (.NOT. scf_env%skip_diis) THEN
+      IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
+         CALL qs_diis_b_create(scf_env%scf_diis_buffer, nbuffer=scf_control%max_diis)
+      END IF
+   END IF
+END SUBROUTINE filter_matrix_init
+
+SUBROUTINE filter_matrix_pre(self)
+   CLASS(MOCalcFilterMatrix), INTENT(INOUT) :: self
+
+   CALL qs_diis_b_clear(self%scf_env%scf_diis_buffer)
+END SUBROUTINE filter_matrix_pre
+
+SUBROUTINE filter_matrix_run(self, diis_step, energy_only)
+   !! the inner loop of scf, specific to iterative diagonalization using OT
+   !! with S matrix; basically, in goes the ks matrix out goes a new p matrix
+   CLASS(MOCalcFilterMatrix), INTENT(INOUT)   :: self
+   LOGICAL, INTENT(INOUT)               :: diis_step
+   LOGICAL, INTENT(INOUT)               :: energy_only
+
+   MARK_USED(energy_only)
+
+   CALL fb_env_do_diag(self%scf_env%filter_matrix_env, self%qs_env, &
+                       self%matrix_ks, self%matrix_s, self%scf_section, diis_step)
+END SUBROUTINE filter_matrix_run
+
+END MODULE qs_scf_mo_calc_filter_matrix

--- a/src/qs_scf_mo_calc_general_diag.F
+++ b/src/qs_scf_mo_calc_general_diag.F
@@ -1,0 +1,125 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_mo_calc_general_diag
+   USE cp_control_types,                ONLY: dft_control_type
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_section_types,             ONLY: section_vals_type
+   USE kinds,                           ONLY: dp
+   USE qs_diis,                         ONLY: qs_diis_b_clear,&
+                                              qs_diis_b_create
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_ks_types,                     ONLY: qs_ks_env_type
+   USE qs_mo_types,                     ONLY: mo_set_p_type
+   USE qs_mom_methods,                  ONLY: do_mom_diag
+   USE qs_rho_types,                    ONLY: qs_rho_type
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_diagonalization,          ONLY: do_general_diag,&
+                                              do_roks_diag,&
+                                              do_scf_diag_subspace
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE scf_control_types,               ONLY: scf_control_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   TYPE, PUBLIC, EXTENDS(AbstractMOCalc) :: MOCalcGeneralDiag
+   PRIVATE
+
+   TYPE(qs_environment_type), POINTER         :: qs_env => null()
+   TYPE(dft_control_type), POINTER            :: dft_control => null()
+   TYPE(qs_scf_env_type), POINTER             :: scf_env => null()
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER  :: matrix_ks => null(), matrix_s => null()
+   TYPE(section_vals_type), POINTER           :: scf_section
+   TYPE(mo_set_p_type), DIMENSION(:), POINTER :: mos => null()
+   TYPE(qs_rho_type), POINTER                 :: rho => null()
+   TYPE(qs_ks_env_type), POINTER              :: ks_env => null()
+   TYPE(scf_control_type), POINTER            :: scf_control => null()
+   LOGICAL :: has_unit_metric
+
+CONTAINS
+   PROCEDURE, PUBLIC, PASS(self) :: init => general_diag_init
+   PROCEDURE, PUBLIC, PASS(self) :: pre => general_diag_pre
+   PROCEDURE, PUBLIC, PASS(self) :: run => general_diag_run
+END TYPE
+
+CONTAINS
+SUBROUTINE general_diag_init(self, qs_env, scf_env, scf_section)
+   CLASS(MOCalcGeneralDiag), INTENT(INOUT)             :: self
+   TYPE(qs_environment_type), POINTER, INTENT(IN) :: qs_env
+   TYPE(qs_scf_env_type), POINTER, INTENT(IN)     :: scf_env
+   TYPE(section_vals_type), POINTER, INTENT(IN)   :: scf_section
+
+   self%qs_env => qs_env
+   self%scf_env => scf_env
+   self%scf_section => scf_section
+
+   CALL get_qs_env(qs_env, &
+                   scf_control=self%scf_control, &
+                   dft_control=self%dft_control, &
+                   mos=self%mos, &
+                   matrix_ks=self%matrix_ks, &
+                   matrix_s=self%matrix_s, &
+                   ks_env=self%ks_env, &
+                   rho=self%rho, &
+                   has_unit_metric=self%has_unit_metric)
+
+   IF (.NOT. scf_env%skip_diis) THEN
+      IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
+         CALL qs_diis_b_create(scf_env%scf_diis_buffer, nbuffer=self%scf_control%max_diis)
+      END IF
+   END IF
+END SUBROUTINE general_diag_init
+
+SUBROUTINE general_diag_pre(self)
+   CLASS(MOCalcGeneralDiag), INTENT(INOUT) :: self
+
+   CALL qs_diis_b_clear(self%scf_env%scf_diis_buffer)
+END SUBROUTINE general_diag_pre
+
+SUBROUTINE general_diag_run(self, diis_step, energy_only)
+   CLASS(MOCalcGeneralDiag), INTENT(INOUT)   :: self
+   LOGICAL, INTENT(INOUT)               :: diis_step
+   LOGICAL, INTENT(INOUT)               :: energy_only
+   LOGICAL :: skip_diag_sub
+
+   MARK_USED(energy_only)
+
+   ASSOCIATE (scf_env=>self%scf_env, &
+              scf_control=>self%scf_control, &
+              scf_section=>self%scf_section, &
+              matrix_s=>self%matrix_s, &
+              matrix_ks=>self%matrix_ks, &
+              mos=>self%mos)
+
+      IF (self%dft_control%roks) THEN
+         CALL do_roks_diag(self%scf_env, self%mos, self%matrix_ks, self%matrix_s, &
+                           self%scf_control, self%scf_section, diis_step, &
+                           self%has_unit_metric)
+      ELSE
+         IF (self%scf_control%diagonalization%mom) THEN
+            CALL do_mom_diag(self%scf_env, self%mos, self%matrix_ks, &
+                             self%matrix_s, self%scf_control, self%scf_section, &
+                             diis_step)
+         ELSE
+            CALL do_general_diag(self%scf_env, self%mos, self%matrix_ks, &
+                                 self%matrix_s, self%scf_control, self%scf_section, &
+                                 diis_step)
+         END IF
+         IF (self%scf_control%do_diag_sub) THEN
+            skip_diag_sub = (scf_env%subspace_env%eps_diag_sub > 0.0_dp) .AND. &
+                            (scf_env%iter_count == 1 .OR. scf_env%iter_delta > scf_env%subspace_env%eps_diag_sub)
+            IF (.NOT. skip_diag_sub) THEN
+               CALL do_scf_diag_subspace(self%qs_env, self%scf_env, scf_env%subspace_env, self%mos, self%rho, &
+                                         self%ks_env, self%scf_section, self%scf_control)
+            END IF
+         END IF
+      END IF
+   END ASSOCIATE
+END SUBROUTINE general_diag_run
+
+END MODULE qs_scf_mo_calc_general_diag

--- a/src/qs_scf_mo_calc_ot.F
+++ b/src/qs_scf_mo_calc_ot.F
@@ -1,0 +1,287 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) CP2K developers group                                                            !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_mo_calc_ot
+   USE cp_control_types,                ONLY: dft_control_type
+   USE cp_fm_types,                     ONLY: cp_fm_type
+   USE dbcsr_api,                       ONLY: dbcsr_p_type,&
+                                              dbcsr_type
+   USE input_constants,                 ONLY: ot_precond_full_all,&
+                                              ot_precond_full_single,&
+                                              ot_precond_full_single_inverse,&
+                                              ot_precond_none,&
+                                              ot_precond_s_inverse
+   USE input_section_types,             ONLY: section_vals_type
+   USE preconditioner,                  ONLY: prepare_preconditioner,&
+                                              restart_preconditioner
+   USE qs_energy_types,                 ONLY: qs_energy_type
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_ks_methods,                   ONLY: qs_ks_update_qs_env
+   USE qs_mo_methods,                   ONLY: calculate_density_matrix,&
+                                              make_basis_simple,&
+                                              make_basis_sm
+   USE qs_mo_occupation,                ONLY: set_mo_occupation
+   USE qs_mo_types,                     ONLY: get_mo_set,&
+                                              mo_set_p_type
+   USE qs_ot,                           ONLY: qs_ot_new_preconditioner
+   USE qs_ot_scf,                       ONLY: ot_scf_destroy,&
+                                              ot_scf_init,&
+                                              ot_scf_mini,&
+                                              ot_scf_read_input
+   USE qs_rho_types,                    ONLY: qs_rho_get,&
+                                              qs_rho_type
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE scf_control_types,               ONLY: scf_control_type,&
+                                              smear_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   TYPE, PUBLIC, EXTENDS(AbstractMOCalc) :: MOCalcOT
+   PRIVATE
+
+   TYPE(qs_environment_type), POINTER         :: qs_env => null()
+   TYPE(dft_control_type), POINTER            :: dft_control => null()
+   TYPE(mo_set_p_type), DIMENSION(:), POINTER :: mos => null()
+   TYPE(scf_control_type), POINTER            :: scf_control => null()
+   TYPE(qs_scf_env_type), POINTER             :: scf_env => null()
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER  :: matrix_ks => null(), matrix_s => null()
+   TYPE(section_vals_type), POINTER           :: scf_section
+
+CONTAINS
+   PROCEDURE, PUBLIC, PASS(self) :: init => ot_init
+   PROCEDURE, PUBLIC, PASS(self) :: pre => ot_pre
+   PROCEDURE, PUBLIC, PASS(self) :: run => ot_run
+   FINAL :: ot_finalize
+END TYPE
+
+CONTAINS
+SUBROUTINE ot_init(self, qs_env, scf_env, scf_section)
+   CLASS(MOCalcOT), INTENT(INOUT)                 :: self
+   TYPE(qs_environment_type), POINTER, INTENT(IN) :: qs_env
+   TYPE(qs_scf_env_type), POINTER, INTENT(IN)     :: scf_env
+   TYPE(section_vals_type), POINTER, INTENT(IN)   :: scf_section
+   LOGICAL                                        :: has_unit_metric
+   INTEGER                                        :: ispin, nmo, number_of_OT_envs
+   TYPE(cp_fm_type), POINTER                      :: mo_coeff
+
+   self%qs_env => qs_env
+   self%scf_env => scf_env
+   self%scf_section => scf_section
+
+   CALL get_qs_env(qs_env, &
+                   scf_control=self%scf_control, &
+                   dft_control=self%dft_control, &
+                   mos=self%mos, &
+                   matrix_s=self%matrix_s, &
+                   matrix_ks=self%matrix_ks, &
+                   has_unit_metric=has_unit_metric)
+
+   ASSOCIATE (scf_control=>self%scf_control, &
+              dft_control=>self%dft_control)
+
+      ! reortho the wavefunctions if we are having an outer scf and
+      ! this is not the first iteration
+      ! this is useful to avoid the build-up of numerical noise
+      ! however, we can not play this trick if restricted (don't mix non-equivalent orbs)
+      IF (scf_control%do_outer_scf_reortho) THEN
+         IF (scf_control%outer_scf%have_scf .AND. .NOT. dft_control%restricted) THEN
+            IF (scf_env%outer_scf%iter_count > 0) THEN
+               DO ispin = 1, dft_control%nspins
+                  CALL get_mo_set(mo_set=self%mos(ispin)%mo_set, mo_coeff=mo_coeff, nmo=nmo)
+                  IF (has_unit_metric) THEN
+                     CALL make_basis_simple(mo_coeff, nmo)
+                  ELSE
+                     CALL make_basis_sm(mo_coeff, nmo, self%matrix_s(1)%matrix)
+                  ENDIF
+               ENDDO
+            ENDIF
+         ENDIF
+      ELSE
+         ! dont need any dirty trick for the numerically stable irac algorithm.
+      ENDIF
+
+      ! restricted calculations require just one set of OT orbitals
+      number_of_OT_envs = dft_control%nspins
+      IF (dft_control%restricted) number_of_OT_envs = 1
+
+      ALLOCATE (scf_env%qs_ot_env(number_of_OT_envs))
+
+      ! XXX Joost XXX should disentangle reading input from this part
+      CALL ot_scf_read_input(scf_env%qs_ot_env, scf_section)
+
+      ! keep a note that we are restricted
+      IF (dft_control%restricted) THEN
+         scf_env%qs_ot_env(1)%restricted = .TRUE.
+         ! requires rotation
+         IF (.NOT. scf_env%qs_ot_env(1)%settings%do_rotation) &
+            CALL cp_abort(__LOCATION__, &
+                          "Restricted calculation with OT requires orbital rotation. Please "// &
+                          "activate the OT%ROTATION keyword!")
+      ELSE
+         scf_env%qs_ot_env(:)%restricted = .FALSE.
+      ENDIF
+
+      ! might need the KS matrix to init properly
+      CALL qs_ks_update_qs_env(qs_env, just_energy=.FALSE., &
+                               calculate_forces=.FALSE.)
+
+   END ASSOCIATE
+END SUBROUTINE ot_init
+
+SUBROUTINE ot_pre(self)
+   CLASS(MOCalcOT), INTENT(INOUT) :: self
+
+   TYPE(dbcsr_type), POINTER                      :: orthogonality_metric
+   LOGICAL                                        :: do_rotation, has_unit_metric, is_full_all
+   INTEGER                                        :: ispin
+
+   CALL get_qs_env(self%qs_env, &
+                   has_unit_metric=has_unit_metric)
+
+   ASSOCIATE (scf_control=>self%scf_control, &
+              dft_control=>self%dft_control, &
+              scf_env=>self%scf_env)
+
+      do_rotation = scf_env%qs_ot_env(1)%settings%do_rotation
+
+      ! another safety check
+      IF (dft_control%low_spin_roks) THEN
+         CPASSERT(do_rotation)
+      ENDIF
+
+      ! if an old preconditioner is still around (i.e. outer SCF is active),
+      ! remove it if this could be worthwhile
+      CALL restart_preconditioner(self%qs_env, self%scf_env%ot_preconditioner, &
+                                  self%scf_env%qs_ot_env(1)%settings%preconditioner_type, &
+                                  dft_control%nspins)
+
+      !
+      ! preconditioning still needs to be done correctly with has_unit_metric
+      ! notice that a big part of the preconditioning (S^-1) is fine anyhow
+      !
+      IF (has_unit_metric) THEN
+         NULLIFY (orthogonality_metric)
+      ELSE
+         orthogonality_metric => self%matrix_s(1)%matrix
+      ENDIF
+
+      CALL prepare_preconditioner(self%qs_env, self%mos, self%matrix_ks, self%matrix_s, scf_env%ot_preconditioner, &
+                                  scf_env%qs_ot_env(1)%settings%preconditioner_type, &
+                                  scf_env%qs_ot_env(1)%settings%precond_solver_type, &
+                                  scf_env%qs_ot_env(1)%settings%energy_gap, dft_control%nspins, &
+                                  has_unit_metric=has_unit_metric, &
+                                  chol_type=scf_env%qs_ot_env(1)%settings%cholesky_type)
+
+      CALL ot_scf_init(mo_array=self%mos, matrix_s=orthogonality_metric, &
+                       broyden_adaptive_sigma=self%qs_env%broyden_adaptive_sigma, &
+                       qs_ot_env=scf_env%qs_ot_env, matrix_ks=self%matrix_ks(1)%matrix)
+
+      SELECT CASE (scf_env%qs_ot_env (1)%settings%preconditioner_type)
+      CASE (ot_precond_none)
+      CASE (ot_precond_full_all, ot_precond_full_single_inverse)
+         ! this will rotate the MOs to be eigen states, which is not compatible with rotation
+         ! e.g. mo_derivs here do not yet include potentially different occupations numbers
+         ! only full all needs rotation
+         is_full_all = scf_env%qs_ot_env(1)%settings%preconditioner_type == ot_precond_full_all
+         CPASSERT(.NOT. (do_rotation .AND. is_full_all))
+         DO ispin = 1, SIZE(scf_env%qs_ot_env)
+            CALL qs_ot_new_preconditioner(scf_env%qs_ot_env(ispin), &
+                                          scf_env%ot_preconditioner(ispin)%preconditioner)
+         ENDDO
+      CASE (ot_precond_s_inverse, ot_precond_full_single)
+         DO ispin = 1, SIZE(scf_env%qs_ot_env)
+            CALL qs_ot_new_preconditioner(scf_env%qs_ot_env(ispin), &
+                                          scf_env%ot_preconditioner(1)%preconditioner)
+         ENDDO
+      CASE DEFAULT
+         DO ispin = 1, SIZE(scf_env%qs_ot_env)
+            CALL qs_ot_new_preconditioner(scf_env%qs_ot_env(ispin), &
+                                          scf_env%ot_preconditioner(1)%preconditioner)
+         ENDDO
+      END SELECT
+
+      ! if we have non-uniform occupations we should be using rotation
+      do_rotation = scf_env%qs_ot_env(1)%settings%do_rotation
+      DO ispin = 1, SIZE(self%mos)
+         IF (.NOT. self%mos(ispin)%mo_set%uniform_occupation) THEN
+            CPASSERT(do_rotation)
+         ENDIF
+      ENDDO
+
+   END ASSOCIATE
+END SUBROUTINE ot_pre
+
+SUBROUTINE ot_finalize(self)
+      TYPE(MOCalcOT)                                     :: self
+
+      INTEGER                                            :: ispin
+
+   DO ispin = 1, SIZE(self%scf_env%qs_ot_env)
+      CALL ot_scf_destroy(self%scf_env%qs_ot_env(ispin))
+   ENDDO
+
+   DEALLOCATE (self%scf_env%qs_ot_env)
+END SUBROUTINE
+
+SUBROUTINE ot_run(self, diis_step, energy_only)
+   !! The inner loop of scf, specific to using to the orbital transformation method
+   !! basically, in goes the ks matrix out goes a new p matrix
+   CLASS(MOCalcOT), INTENT(INOUT) :: self
+   LOGICAL, INTENT(INOUT)         :: diis_step
+   LOGICAL, INTENT(INOUT)                             :: energy_only
+
+   TYPE(smear_type), POINTER                          :: smear
+   TYPE(qs_rho_type), POINTER                         :: rho
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mo_derivs
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+   LOGICAL                                            :: has_unit_metric
+   INTEGER                                            :: ispin
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
+   TYPE(dbcsr_type), POINTER                          :: orthogonality_metric
+   TYPE(qs_energy_type), POINTER                      :: energy
+   NULLIFY (rho_ao)
+
+   MARK_USED(diis_step) ! should diis_step be removed?!
+
+   CALL qs_rho_get(rho, rho_ao=rho_ao)
+   CALL get_qs_env(self%qs_env, &
+                   energy=energy, &
+                   has_unit_metric=has_unit_metric) ! store this as a member variable?!
+
+   IF (has_unit_metric) THEN
+      NULLIFY (orthogonality_metric)
+   ELSE
+      orthogonality_metric => matrix_s(1)%matrix
+   END IF
+
+   ! in case of LSD the first spin qs_ot_env will drive the minimization
+   ! in the case of a restricted calculation, it will make sure the spin orbitals are equal
+
+   CALL ot_scf_mini(self%mos, mo_derivs, smear, orthogonality_metric, &
+                    energy%total, energy_only, self%scf_env%iter_delta, &
+                    self%scf_env%qs_ot_env, self%qs_env%input)
+
+   DO ispin = 1, SIZE(self%mos)
+      CALL set_mo_occupation(mo_set=self%mos(ispin)%mo_set, &
+                             smear=smear)
+   ENDDO
+
+   DO ispin = 1, SIZE(self%mos)
+      CALL calculate_density_matrix(self%mos(ispin)%mo_set, &
+                                    rho_ao(ispin)%matrix, &
+                                    use_dbcsr=.TRUE.)
+   END DO
+
+   self%scf_env%iter_method = self%scf_env%qs_ot_env(1)%OT_METHOD_FULL
+   self%scf_env%iter_param = self%scf_env%qs_ot_env(1)%ds_min
+   self%qs_env%broyden_adaptive_sigma = self%scf_env%qs_ot_env(1)%broyden_adaptive_sigma
+
+END SUBROUTINE ot_run
+
+END MODULE qs_scf_mo_calc_ot

--- a/src/qs_scf_mo_calc_ot_diag.F
+++ b/src/qs_scf_mo_calc_ot_diag.F
@@ -1,0 +1,201 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_mo_calc_ot_diag
+   USE cp_control_types,                ONLY: dft_control_type
+   USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
+                                              copy_fm_to_dbcsr
+   USE cp_fm_types,                     ONLY: cp_fm_type
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_section_types,             ONLY: section_vals_type
+   USE kinds,                           ONLY: dp
+   USE preconditioner,                  ONLY: prepare_preconditioner,&
+                                              restart_preconditioner
+   USE qs_diis,                         ONLY: qs_diis_b_clear,&
+                                              qs_diis_b_create,&
+                                              qs_diis_b_step
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_mo_methods,                   ONLY: calculate_density_matrix,&
+                                              calculate_subspace_eigenvalues
+   USE qs_mo_occupation,                ONLY: set_mo_occupation
+   USE qs_mo_types,                     ONLY: get_mo_set,&
+                                              mo_set_p_type
+   USE qs_ot_eigensolver,               ONLY: ot_eigensolver
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE scf_control_types,               ONLY: scf_control_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   TYPE, PUBLIC, EXTENDS(AbstractMOCalc) :: MOCalcOTDiag
+   PRIVATE
+
+   TYPE(qs_environment_type), POINTER         :: qs_env => null()
+   TYPE(dft_control_type), POINTER            :: dft_control => null()
+   TYPE(mo_set_p_type), DIMENSION(:), POINTER :: mos => null()
+   TYPE(scf_control_type), POINTER            :: scf_control => null()
+   TYPE(qs_scf_env_type), POINTER             :: scf_env => null()
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER  :: matrix_ks => null(), matrix_s => null()
+   TYPE(section_vals_type), POINTER           :: scf_section
+
+CONTAINS
+   PROCEDURE, PUBLIC, PASS(self) :: init => ot_diag_init
+   PROCEDURE, PUBLIC, PASS(self) :: pre => ot_diag_pre
+   PROCEDURE, PUBLIC, PASS(self) :: run => ot_diag_run
+END TYPE
+
+CONTAINS
+SUBROUTINE ot_diag_init(self, qs_env, scf_env, scf_section)
+   CLASS(MOCalcOTDiag), INTENT(INOUT)             :: self
+   TYPE(qs_environment_type), POINTER, INTENT(IN) :: qs_env
+   TYPE(qs_scf_env_type), POINTER, INTENT(IN)     :: scf_env
+   TYPE(section_vals_type), POINTER, INTENT(IN)   :: scf_section
+
+   self%qs_env => qs_env
+   self%scf_env => scf_env
+   self%scf_section => scf_section
+
+   CALL get_qs_env(qs_env, &
+                   scf_control=self%scf_control, &
+                   dft_control=self%dft_control, &
+                   mos=self%mos, &
+                   matrix_ks=self%matrix_ks, &
+                   matrix_s=self%matrix_s)
+
+   ! disable DFTB, SE, xTB for now
+   IF (self%dft_control%qs_control%dftb .OR. &
+       self%dft_control%qs_control%xtb .OR. &
+       self%dft_control%qs_control%semi_empirical) THEN
+      CPABORT("DFTB and SE not available with OT/DIAG")
+   END IF
+END SUBROUTINE ot_diag_init
+
+SUBROUTINE ot_diag_pre(self)
+   CLASS(MOCalcOTDiag), INTENT(INOUT) :: self
+
+   IF (.NOT. self%scf_env%skip_diis) THEN
+      IF (.NOT. ASSOCIATED(self%scf_env%scf_diis_buffer)) THEN
+         CALL qs_diis_b_create(self%scf_env%scf_diis_buffer, nbuffer=self%scf_control%max_diis)
+      END IF
+      CALL qs_diis_b_clear(self%scf_env%scf_diis_buffer)
+   END IF
+
+   ASSOCIATE (settings=>self%scf_control%diagonalization%ot_settings)
+
+      ! if an old preconditioner is still around (i.e. outer SCF is active),
+      ! remove it if this could be worthwhile
+      CALL restart_preconditioner(self%qs_env, self%scf_env%ot_preconditioner, &
+                                  settings%preconditioner_type, &
+                                  self%dft_control%nspins)
+
+      CALL prepare_preconditioner(self%qs_env, self%mos, self%matrix_ks, self%matrix_s, &
+                                  self%scf_env%ot_preconditioner, &
+                                  settings%preconditioner_type, &
+                                  settings%precond_solver_type, &
+                                  settings%energy_gap, &
+                                  self%dft_control%nspins)
+
+   END ASSOCIATE
+END SUBROUTINE ot_diag_pre
+
+SUBROUTINE ot_diag_run(self, diis_step, energy_only)
+   !! the inner loop of scf, specific to iterative diagonalization using OT
+   !! with S matrix; basically, in goes the ks matrix out goes a new p matrix
+   CLASS(MOCalcOTDiag), INTENT(INOUT)   :: self
+   LOGICAL, INTENT(INOUT)               :: diis_step
+   LOGICAL, INTENT(INOUT)               :: energy_only
+   INTEGER                              :: homo, ispin, nmo, nspin
+   REAL(KIND=dp)                        :: diis_error, eps_iter
+   REAL(KIND=dp), DIMENSION(:), POINTER :: eigenvalues
+   TYPE(cp_fm_type), POINTER            :: mo_coeff
+
+   NULLIFY (eigenvalues)
+   MARK_USED(energy_only)
+
+   ! note: associate'd pointers get the TARGET attribute, making it impossible
+   !       to pass them to our functions without changing the function definition.
+   !       we can therefore only alias members we are not passing along directly.
+   ASSOCIATE (scf_env=>self%scf_env, &
+              scf_control=>self%scf_control, &
+              scf_section=>self%scf_section, &
+              matrix_ks=>self%matrix_ks)
+
+      nspin = SIZE(matrix_ks)
+
+      DO ispin = 1, nspin
+         CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, &
+                               scf_env%scf_work1(ispin)%matrix)
+      END DO
+
+      IF ((scf_env%iter_count > 1) .AND. (.NOT. self%scf_env%skip_diis)) THEN
+         CALL qs_diis_b_step(scf_env%scf_diis_buffer, self%mos, scf_env%scf_work1, &
+                             scf_env%scf_work2, scf_env%iter_delta, diis_error, diis_step, &
+                             scf_control%eps_diis, scf_control%nmixing, &
+                             s_matrix=self%matrix_s, &
+                             scf_section=self%scf_section)
+      ELSE
+         diis_step = .FALSE.
+      END IF
+
+      eps_iter = scf_control%diagonalization%eps_iter
+
+      IF (diis_step) THEN
+         scf_env%iter_param = diis_error
+         scf_env%iter_method = "DIIS/OTdiag"
+         DO ispin = 1, nspin
+            CALL copy_fm_to_dbcsr(scf_env%scf_work1(ispin)%matrix, &
+                                  matrix_ks(ispin)%matrix, keep_sparsity=.TRUE.)
+         END DO
+         eps_iter = MAX(eps_iter, scf_control%diagonalization%eps_adapt*diis_error)
+      ELSE
+         IF (scf_env%mixing_method == 1) THEN
+            scf_env%iter_param = scf_env%p_mix_alpha
+            scf_env%iter_method = "P_Mix/OTdiag."
+         ELSEIF (scf_env%mixing_method > 1) THEN
+            scf_env%iter_param = scf_env%mixing_store%alpha
+            scf_env%iter_method = TRIM(scf_env%mixing_store%iter_method)//"/OTdiag."
+         END IF
+      END IF
+
+      scf_env%iter_delta = 0.0_dp
+
+      DO ispin = 1, nspin
+         CALL get_mo_set(self%mos(ispin)%mo_set, &
+                         mo_coeff=mo_coeff, &
+                         eigenvalues=eigenvalues, &
+                         nmo=nmo, &
+                         homo=homo)
+         CALL ot_eigensolver(matrix_h=matrix_ks(ispin)%matrix, &
+                             matrix_s=self%matrix_s(1)%matrix, &
+                             matrix_c_fm=mo_coeff, &
+                             preconditioner=scf_env%ot_preconditioner(1)%preconditioner, &
+                             eps_gradient=eps_iter, &
+                             iter_max=scf_control%diagonalization%max_iter, &
+                             silent=.TRUE., &
+                             ot_settings=scf_control%diagonalization%ot_settings)
+         CALL calculate_subspace_eigenvalues(mo_coeff, matrix_ks(ispin)%matrix, &
+                                             evals_arg=eigenvalues, &
+                                             do_rotation=.TRUE.)
+         !MK WRITE(*,*) routinen//' copy_dbcsr_to_fm'
+         CALL copy_fm_to_dbcsr(self%mos(ispin)%mo_set%mo_coeff, &
+                               self%mos(ispin)%mo_set%mo_coeff_b)
+         !fm->dbcsr
+      END DO
+
+      CALL set_mo_occupation(mo_array=self%mos, smear=self%scf_control%smear)
+
+      DO ispin = 1, nspin
+         ! does not yet handle k-points
+         CALL calculate_density_matrix(self%mos(ispin)%mo_set, &
+                                       scf_env%p_mix_new(ispin, 1)%matrix)
+      END DO
+
+   END ASSOCIATE
+END SUBROUTINE ot_diag_run
+
+END MODULE qs_scf_mo_calc_ot_diag

--- a/src/qs_scf_mo_calc_special_diag.F
+++ b/src/qs_scf_mo_calc_special_diag.F
@@ -1,0 +1,97 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE qs_scf_mo_calc_special_diag
+   USE cp_control_types,                ONLY: dft_control_type
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_section_types,             ONLY: section_vals_type
+   USE qs_diis,                         ONLY: qs_diis_b_clear,&
+                                              qs_diis_b_create
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_mo_types,                     ONLY: mo_set_p_type
+   USE qs_scf_abstract_mo_calc,         ONLY: AbstractMOCalc
+   USE qs_scf_diagonalization,          ONLY: do_roks_diag,&
+                                              do_special_diag
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE scf_control_types,               ONLY: scf_control_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   ! CASE (special_diag_diag_method_nr, general_diag_method_nr, special_diag_method_nr, block_krylov_diag_method_nr)
+
+   TYPE, PUBLIC, EXTENDS(AbstractMOCalc) :: MOCalcSpecialDiag
+   PRIVATE
+
+   TYPE(qs_environment_type), POINTER         :: qs_env => null()
+   TYPE(qs_scf_env_type), POINTER             :: scf_env => null()
+   TYPE(dbcsr_p_type), DIMENSION(:), POINTER  :: matrix_ks => null(), matrix_s => null()
+   TYPE(section_vals_type), POINTER           :: scf_section => null()
+   TYPE(scf_control_type), POINTER            :: scf_control => null()
+   TYPE(dft_control_type), POINTER            :: dft_control => null()
+   TYPE(mo_set_p_type), DIMENSION(:), POINTER :: mos => null()
+   LOGICAL :: has_unit_metric
+
+CONTAINS
+   PROCEDURE, PUBLIC, PASS(self) :: init => special_diag_init
+   PROCEDURE, PUBLIC, PASS(self) :: pre => special_diag_pre
+   PROCEDURE, PUBLIC, PASS(self) :: run => special_diag_run
+END TYPE
+
+CONTAINS
+SUBROUTINE special_diag_init(self, qs_env, scf_env, scf_section)
+   CLASS(MOCalcSpecialDiag), INTENT(INOUT)             :: self
+   TYPE(qs_environment_type), POINTER, INTENT(IN) :: qs_env
+   TYPE(qs_scf_env_type), POINTER, INTENT(IN)     :: scf_env
+   TYPE(section_vals_type), POINTER, INTENT(IN)   :: scf_section
+
+   self%qs_env => qs_env
+   self%scf_env => scf_env
+   self%scf_section => scf_section
+
+   CALL get_qs_env(qs_env, &
+                   scf_control=self%scf_control, &
+                   dft_control=self%dft_control, &
+                   mos=self%mos, &
+                   matrix_ks=self%matrix_ks, &
+                   matrix_s=self%matrix_s, &
+                   has_unit_metric=self%has_unit_metric)
+
+   IF (.NOT. scf_env%skip_diis) THEN
+      IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
+         CALL qs_diis_b_create(scf_env%scf_diis_buffer, nbuffer=self%scf_control%max_diis)
+      END IF
+   END IF
+END SUBROUTINE special_diag_init
+
+SUBROUTINE special_diag_pre(self)
+   CLASS(MOCalcSpecialDiag), INTENT(INOUT) :: self
+
+   CALL qs_diis_b_clear(self%scf_env%scf_diis_buffer)
+END SUBROUTINE special_diag_pre
+
+SUBROUTINE special_diag_run(self, diis_step, energy_only)
+   !! the inner loop of scf, specific to iterative diagonalization using OT
+   !! with S matrix; basically, in goes the ks matrix out goes a new p matrix
+   CLASS(MOCalcSpecialDiag), INTENT(INOUT)   :: self
+   LOGICAL, INTENT(INOUT)               :: diis_step
+   LOGICAL, INTENT(INOUT)               :: energy_only
+
+   MARK_USED(energy_only)
+
+   IF (self%dft_control%roks) THEN
+      CALL do_roks_diag(self%scf_env, self%mos, self%matrix_ks, self%matrix_s, &
+                        self%scf_control, self%scf_section, diis_step, &
+                        self%has_unit_metric)
+   ELSE
+      CALL do_special_diag(self%scf_env, self%mos, self%matrix_ks, &
+                           self%scf_control, self%scf_section, &
+                           diis_step)
+   END IF
+END SUBROUTINE special_diag_run
+
+END MODULE qs_scf_mo_calc_special_diag


### PR DESCRIPTION
This is a Request for Comments and while it compiles it likely contains bugs and subtle changes.

The idea here is to try an Object-oriented approach to structure part of the SCF Inner Loop with the goal to increase cohesion of code, meaning that everything related to a diagonalization method (or concretely the `new_mos` routine) is isolated in a single class, rather than distributed between multiple functions (resulting in a single `CASE`-switch before entering the SCF cycle).

In principle a `new_mos` class has to bring the following:

* a `init` routine, which is currently called before entering the outer SCF
* a `pre` routine which gets called at the beginning of each inner SCF and can be used to (re-)generate the preconditioner (hence `pre`)
* a `run` routine which does the actual diagonalization