### PR TITLE
Fix cce warnings

### DIFF
--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -33,6 +33,8 @@ MODULE almo_scf_optimizer
                                               cp_dbcsr_cholesky_invert,&
                                               cp_dbcsr_cholesky_restore
    USE cp_external_control,             ONLY: external_control
+   USE cp_files,                        ONLY: close_file,&
+                                              open_file
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_unit_nr,&
                                               cp_logger_type
@@ -5246,7 +5248,6 @@ CONTAINS
          routineP = moduleN//':'//routineN
 
       CHARACTER(LEN=20)                                  :: formatstr, Scols
-      CHARACTER(LEN=200)                                 :: logfile
       INTEGER                                            :: col, fiunit, handle, hori_offset, jj, &
                                                             nblkcols_tot, nblkrows_tot, Ncols, &
                                                             ncores, Nrows, row, unit_nr, &
@@ -5322,14 +5323,13 @@ CONTAINS
       CALL dbcsr_release(matrix_asym)
 
       IF (unit_nr > 0) THEN
-         logfile = TRIM(ADJUSTL(filename))
-         OPEN (fiunit, file=logfile, status='REPLACE')
+         CALL open_file(filename, unit_number=fiunit, file_status='REPLACE')
          WRITE (Scols, "(I10)") Ncols
          formatstr = "("//TRIM(Scols)//"E27.17)"
          DO jj = 1, Nrows
             WRITE (fiunit, formatstr) H(jj, :)
          ENDDO
-         CLOSE (fiunit)
+         CALL close_file(fiunit)
       ENDIF
 
       DEALLOCATE (mo_block_sizes)

--- a/src/iterate_matrix.F
+++ b/src/iterate_matrix.F
@@ -72,7 +72,7 @@ CONTAINS
 
       INTEGER                                            :: handle, i, max_iter_lanczos, nsize, &
                                                             order_lanczos, sign_iter, unit_nr
-      INTEGER(KIND=int_8)                                :: flop1, flop2
+      INTEGER(KIND=int_8)                                :: flop1
       INTEGER, SAVE                                      :: recursion_depth = 0
       REAL(KIND=dp)                                      :: det0, eps_lanczos, frobnorm, maxnorm, &
                                                             occ_matrix, t1, t2, trace
@@ -206,7 +206,7 @@ CONTAINS
                WRITE (unit_nr, '(T6,A,1X,I3,1X,F7.5,F16.10,F10.3,F11.3)') &
                   "Determinant iter", i, occ_matrix, &
                   det, t2-t1, &
-                  (flop1+flop2)/(1.0E6_dp*MAX(0.001_dp, t2-t1))
+                  flop1/(1.0E6_dp*MAX(0.001_dp, t2-t1))
                CALL m_flush(unit_nr)
             ENDIF
 

--- a/src/rpa_ri_gpw.F
+++ b/src/rpa_ri_gpw.F
@@ -6882,7 +6882,7 @@ CONTAINS
    SUBROUTINE calc_max_error_fit_omega_grid_with_cosine(max_error, tau, omega_tj, omega_wj_work, x_values, &
                                                         y_values, num_integ_points, num_x_nodes)
 
-      REAL(KIND=dp), INTENT(OUT)                         :: max_error
+      REAL(KIND=dp), INTENT(INOUT)                       :: max_error
       REAL(KIND=dp), INTENT(IN)                          :: tau
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: omega_tj, omega_wj_work, x_values, &

--- a/tests/QS/regtest-mp2-grad/TEST_FILES
+++ b/tests/QS/regtest-mp2-grad/TEST_FILES
@@ -3,7 +3,7 @@ H2O_grad_gpw.inp                                      11      7e-11            -
 H2_H2_no_freeHFX.inp                                  11      3e-14             -2.307711033963856
 O2_dyn.inp                                            11      2e-11            -31.653804574525605
 O2_dyn_mme.inp                                        72       1e-8                     0.62545275
-CH3_dyn_screen.inp                                    11      6e-05             -7.038310776774322
+CH3_dyn_screen.inp                                    11      2e-04             -7.038310776774322
 MOM_MP2_geoopt.inp                                    11      2e-06            -16.803428288626989
 H2O_MD_mme.inp                                        11      1e-10            -17.056807611430269
 #EOF


### PR DESCRIPTION
This PR fixes some warnings raised by the Cray compiler (see #360 ). The other two should be fixed by their respective owners.