### PR TITLE
Rely on CONTIGUOUS keyword in MPI wrapper

### DIFF
--- a/src/mpiwrap/message_passing.f90
+++ b/src/mpiwrap/message_passing.f90
@@ -584,7 +584,7 @@
 
 ! *****************************************************************************
 !> \brief Send one datum to another process
-!> \param[in] msg             Dum to send
+!> \param[in] msg             Scalar to send
 !> \param[in] dest            Destination process
 !> \param[in] tag             Transfer identifier
 !> \param[in] gid             Message passing environment identifier
@@ -658,7 +658,7 @@
 ! *****************************************************************************
 !> \brief Receive one datum from another process
 !> \param[in,out] msg         Place received data into this variable
-!> \param[in,out] source      Process to receieve from
+!> \param[in,out] source      Process to receive from
 !> \param[in,out] tag         Transfer identifier
 !> \param[in] gid             Message passing environment identifier
 !> \par MPI mapping
@@ -702,7 +702,7 @@
 
 ! *****************************************************************************
 !> \brief Receive rank-1 data from another process
-!> \param[in,out] msg         Place receieved data into this rank-1 array
+!> \param[in,out] msg         Place received data into this rank-1 array
 !> \param source ...
 !> \param tag ...
 !> \param gid ...
@@ -1115,7 +1115,7 @@
 !> \note see mp_sum_${nametype1}$
 ! *****************************************************************************
   SUBROUTINE mp_sum_${nametype1}$m3(msg,gid)
-    ${type1}$, INTENT(INOUT)                   :: msg( :, :, : )
+    ${type1}$, INTENT(INOUT), CONTIGUOUS     :: msg( :, :, : )
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$m3', &
@@ -1413,7 +1413,7 @@
 !> \note see mp_min_${nametype1}$
 ! *****************************************************************************
   SUBROUTINE mp_min_${nametype1}$v(msg,gid)
-    ${type1}$, INTENT(INOUT)                   :: msg( : )
+    ${type1}$, INTENT(INOUT), CONTIGUOUS     :: msg( : )
     INTEGER, INTENT(IN)                      :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_min_${nametype1}$v', &
@@ -1439,7 +1439,7 @@
 !> \brief Multiplies a set of numbers scattered across a number of processes,
 !>        then replicates the result.
 !> \param[in,out] msg         a number to multiply (input) and result (output)
-!> \param[in] gid             mssage passing environment identifier
+!> \param[in] gid             message passing environment identifier
 !> \par MPI mapping
 !>      mpi_allreduce
 ! *****************************************************************************
@@ -2826,7 +2826,7 @@
   END SUBROUTINE mp_sendrecv_${nametype1}$m4
 
 ! *****************************************************************************
-!> \brief Non-blocking send and receieve of a scalar
+!> \brief Non-blocking send and receive of a scalar
 !> \param[in] msgin           Scalar data to send
 !> \param[in] dest            Which process to send to
 !> \param[out] msgout         Receive data into this pointer
@@ -2886,7 +2886,7 @@
   END SUBROUTINE mp_isendrecv_${nametype1}$
 
 ! *****************************************************************************
-!> \brief Non-blocking send and receieve of a vector
+!> \brief Non-blocking send and receive of a vector
 !> \param[in] msgin           Vector data to send
 !> \param[in] dest            Which process to send to
 !> \param[out] msgout         Receive data into this pointer
@@ -3714,7 +3714,7 @@
 !>        (serial) Unformatted stream write
 !> \param[in] fh     file handle (file storage unit)
 !> \param[in] offset file offset (position)
-!> \param[in] msg    data to be writen to the file
+!> \param[in] msg    data to be written to the file
 !> \param msglen ...
 !> \par MPI-I/O mapping   mpi_file_write_at
 !> \par STREAM-I/O mapping   WRITE

--- a/src/mpiwrap/message_passing.f90
+++ b/src/mpiwrap/message_passing.f90
@@ -1275,9 +1275,9 @@
 !> \param[in] gid          Message passing environment identifier
 ! *****************************************************************************
   SUBROUTINE mp_sum_partial_${nametype1}$m(msg,res,gid)
-    ${type1}$, INTENT(IN)         :: msg( :, : )
-    ${type1}$, INTENT(OUT)        :: res( :, : )
-    INTEGER, INTENT(IN)         :: gid
+    ${type1}$, CONTIGUOUS, INTENT(IN)   :: msg( :, : )
+    ${type1}$, CONTIGUOUS, INTENT(OUT)  :: res( :, : )
+    INTEGER, INTENT(IN)                 :: gid
 
     CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_partial_${nametype1}$m'   &
                                  , routineP = moduleN//':'//routineN


### PR DESCRIPTION
Since CP2K moved to F08, the CONTIGUOUS keyword can be used. MPI requires contiguous buffers hence the wrapper can safely make that statement. In fact, this fixes occurrences of "created temporary array" (unveiled with related GNU Fortran flags). This change can be taken further by additing more uses of the CONTIGUOUS even in the MPI wrapper module.