### PR TITLE
Dashboard: Enable notifications for everything

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -2,7 +2,6 @@
 sortkey:     10
 name:        Formatting
 host:        GCP
-notify:      on
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_formatting_report.txt
 info_url:    http://www.cp2k.org/dev:formattingconventions
 
@@ -10,7 +9,6 @@ info_url:    http://www.cp2k.org/dev:formattingconventions
 sortkey:     20
 name:        Coding conventions
 host:        GCP
-notify:      on
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_conventions_report.txt
 info_url:    http://www.cp2k.org/dev:codingconventions
 
@@ -248,7 +246,6 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_python_report.txt
 sortkey:     630
 name:        Linux-x86-64-valgrind.sdbg
 host:        UZH, opt5
-notify:      on
 timeout:     48
 report_url:  http://www.cp2k.org/static/regtest/trunk/uzh-opt5/Linux-x86-64-valgrind.sdbg.out
 

--- a/tools/dashboard/generate_dashboard.py
+++ b/tools/dashboard/generate_dashboard.py
@@ -95,7 +95,7 @@ def gen_frontpage(config, log, status_fn, outdir):
         name        = config.get(s,"name")
         host        = config.get(s,"host")
         report_url  = config.get(s,"report_url")
-        do_notify   = config.getboolean(s,"notify") if(config.has_option(s,"notify")) else False
+        do_notify   = config.getboolean(s,"notify") if(config.has_option(s,"notify")) else True
         timeout     = config.getint(s,"timeout") if(config.has_option(s,"timeout")) else 24
 
         # find latest commit that should have been tested by now


### PR DESCRIPTION
With the CI in place people pay less attention to the dashboard. Hence, this PR enables email notifications for all tests.

@alazzaro, is this what you had in mind?