### PR TITLE
Fpga interface for pw fft computations

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,6 +183,18 @@ SIRIUS is a domain specific library for electronic structure calculations.
   * Furthermore, SIRIUS depends on JSON-Fortran.
   * See https://electronic-structure.github.io/SIRIUS/ for more information.
 
+### 2s. FPGA (optional, plane wave FFT calculations)
+  * Use `-D__PW_FPGA` to enable FPGA support for PW (fft) calculations. Currently tested only for Intel Stratix 10 and Arria 10 GX1150 FPGAs.
+  * Supports single precision and double precision fft calculations with the use of dedicated APIs.
+  * Double precision is the default API chosen when set using the `-D__PW_FPGA` flag.
+  * Single precision can be set using an additional `-D__PW_FPGA_SP` flag along with the `-D__PW_FPGA` flag.
+  * Kernel code has to be synthesized separately and copied to a specific location. 
+  * See https://github.com/pc2/fft3d-fpga for the kernel code and instructions for synthesis.
+  * Read `src/pw/fpga/README.md` for information on the specific location to copy the binaries to. 
+  * Currently supported FFT3d sizes - 16^3, 32^3, 64^3.
+  * Include aocl compile flags and `-D__PW_FPGA -D__PW_FPGA_SP` to `CFLAGS`, aocl linker flags to `LDFLAGS` and aocl libs to `LIBS`.
+  * CUDA and FPGA are mutually exclusive. Building with both `__PW_CUDA` and  `__PW_FPGA` will throw a compilation error.
+  
 ## 3. Compile
 
 ### 3a. ARCH files

--- a/src/common/PACKAGE
+++ b/src/common/PACKAGE
@@ -1,4 +1,4 @@
 {
 "description": "Basic routines which are conceptually independent from CP2K and its input",
-"requires": ["../mpiwrap", "../base" ]
+"requires": ["../mpiwrap", "../base"]
 }

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -136,6 +136,12 @@ CONTAINS
 #if defined(__PW_CUDA)
       flags = TRIM(flags)//" pw_cuda"
 #endif
+#if defined(__PW_FPGA)
+      flags = TRIM(flags)//" pw_fpga"
+#endif
+#if defined(__PW_FPGA_SP)
+      flags = TRIM(flags)//" pw_fpga_sp"
+#endif
 #if defined(__HAS_PATCHED_CUFFT_70)
       flags = TRIM(flags)//" patched_cufft_70"
 #endif

--- a/src/pw/PACKAGE
+++ b/src/pw/PACKAGE
@@ -1,4 +1,4 @@
 {
 "description": "Real-Space and Plane-Wave Grids",
-"requires": ["fft", "../common", "cuda", "../base", "../mpiwrap"],
+"requires": [ "fpga", "fft", "../common", "cuda", "../base", "../mpiwrap"],
 }

--- a/src/pw/fpga/PACKAGE
+++ b/src/pw/fpga/PACKAGE
@@ -1,0 +1,4 @@
+{
+"description": " FPGA FFT3d implementation",
+"requires": [],
+}

--- a/src/pw/fpga/README.md
+++ b/src/pw/fpga/README.md
@@ -1,0 +1,16 @@
+# FPGA
+
+## Finding the kernel code
+ - See https://github.com/pc2/fft3d-fpga for the kernel code and instructions on synthesizing them for INTEL FPGAs.
+
+### Copy the bitstream generated to a particular path
+ - The bitstream generated on synthesis can be found as the `.aocx` file. 
+ - Copy this file to the following locations:
+    - If single precision: `~/cp2k/fpgabitstream/fft3d/synthesis_sp/syn??/*. `
+    - If double precision: `~/cp2k/fpgabitstream/fft3d/synthesis_dp/syn??/*.` 
+    - where `syn??` is dependent on the size of the FFT3d
+    - Therefore, a 16^3 FFT3d file should be copied to `syn16` folder.
+    - The sizes supported are 16^3, 32^3, 64^3.
+ - If the required FFT size is different from the default options:
+    - modify the switch case in the `fft_fpga.c` to include the required size
+      and the path to the location of the bitstream.

--- a/src/pw/fpga/fft_fpga.c
+++ b/src/pw/fpga/fft_fpga.c
@@ -1,0 +1,353 @@
+/*****************************************************************************
+ *  CP2K: A general program to perform molecular dynamics simulations        *
+ *  Copyright (C) 2000 - 2019  CP2K developers group                         *
+ *****************************************************************************/
+
+/******************************************************************************
+ *  Author: Arjun Ramaswami
+ *****************************************************************************/
+
+#if defined ( __PW_FPGA )
+
+// global dependencies
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+// common dependencies
+#include "CL/opencl.h"
+
+// local dependencies
+#include "fft_fpga.h"
+#include "opencl_utils.h"
+
+// host variables
+static cl_platform_id platform = NULL;
+static cl_device_id device = NULL;
+static cl_context context = NULL;
+static cl_program program = NULL;
+
+static cl_command_queue queue1 = NULL, queue2 = NULL, queue3 = NULL;
+static cl_command_queue queue4 = NULL, queue5 = NULL, queue6 = NULL;
+
+static cl_kernel fft_kernel = NULL, fft_kernel_2 = NULL;
+static cl_kernel fetch_kernel = NULL, transpose_kernel = NULL, transpose_kernel_2 = NULL;
+
+// Device memory buffers
+cl_mem d_inData, d_outData;
+
+// Global Variables
+static cl_int status = 0;
+static int fft_size[3] = {0,0,0};
+bool fft_size_changed = true;
+
+// Function prototypes
+bool init();
+void cleanup();
+void init_program(char *data_path);
+void queue_setup();
+void queue_cleanup();
+void fftfpga_run_3d(bool inverse, cmplx *c_in);
+
+// --- CODE -------------------------------------------------------------------
+
+int pw_fpga_initialize_(){
+   status = init();
+   return status;
+}
+
+void pw_fpga_final_(){
+   cleanup();
+}
+
+/******************************************************************************
+ * \brief  check whether FFT3d can be computed on the FPGA or not. This depends 
+ *         on the availability of bitstreams whose sizes are for now listed here 
+ *         The var fft_size_changed indicates whether a new binary needs to be 
+ *         loaded before execution. 
+ * \param  N - integer pointer to the size of the FFT3d
+ * \retval true if fft3d size supported
+ *****************************************************************************/
+bool pw_fpga_check_bitstream_(int N[3]){
+    // check the supported sizes
+    if( (N[0] == 16 && N[1] == 16 && N[2] == 16) ||
+        (N[0] == 32 && N[1] == 32 && N[2] == 32) ||
+        (N[0] == 64 && N[1] == 64 && N[2] == 64)  ){
+
+        // if previously used binary needs to be executed again, otherwise set
+        // the new size and load new binary
+        if( fft_size[0] == N[0] && fft_size[1] == N[1] && fft_size[2] == N[2] ){
+            fft_size_changed = false;
+        }
+        else{
+            fft_size[0] = N[0];
+            fft_size[1] = N[1];
+            fft_size[2] = N[2];
+            fft_size_changed = true;
+        }
+        return 1;
+    }
+    else{
+        return 0;
+    }
+}
+
+/******************************************************************************
+ * \brief   compute an in-place single precision complex 3D-FFT on the FPGA
+ * \param   data_path_len - length of the path to the data directory
+ * \param   data_path - path to the data directory 
+ * \param   direction : direction - 1/forward, otherwise/backward FFT3d
+ * \param   N   : integer pointer to size of FFT3d  
+ * \param   din : complex input/output single precision data pointer 
+ *****************************************************************************/
+void pw_fpga_fft3d_sp_(int data_path_len, char *data_path, int direction, int N[3], cmplx *din) {
+
+  data_path[data_path_len] = '\0';
+
+  queue_setup();
+
+  // If fft size changes, need to rebuild program using another binary
+  if(fft_size_changed == true){
+    init_program(data_path);
+  }
+
+  // setup device specific constructs 
+  if(direction == 1){
+    fftfpga_run_3d(0, din);
+  }
+  else{
+    fftfpga_run_3d(1, din);
+  }
+
+  queue_cleanup();
+}
+
+/******************************************************************************
+ * \brief   compute an in-place double precision complex 3D-FFT on the FPGA
+ * \param   data_path_len - length of the path to the data directory
+ * \param   data_path - path to the data directory 
+ * \param   direction : direction - 1/forward, otherwise/backward FFT3d
+ * \param   N   : integer pointer to size of FFT3d  
+ * \param   din : complex input/output single precision data pointer 
+ *****************************************************************************/
+void pw_fpga_fft3d_dp_(int data_path_len, char *data_path, int direction, int N[3], cmplx *din) {
+
+  data_path[data_path_len] = '\0';
+
+  queue_setup();
+
+  // If fft size changes, need to rebuild program using another binary
+  if(fft_size_changed == true){
+    init_program(data_path);
+  }
+
+  // setup device specific constructs 
+  if(direction == 1){
+    fftfpga_run_3d(0, din);
+  }
+  else{
+    fftfpga_run_3d(1, din);
+  }
+
+  queue_cleanup();
+}
+
+/******************************************************************************
+ * \brief   Execute a single precision complex FFT3d
+ * \param   inverse : boolean
+ * \param   N       : integer pointer to size of FFT3d  
+ * \param   din     : complex input/output single precision data pointer 
+ *****************************************************************************/
+void fftfpga_run_3d(bool inverse, cmplx *c_in) {
+
+  int inverse_int = inverse;
+  cmplx *h_inData = (cmplx *)alignedMalloc(sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2]);
+  cmplx *h_outData = (cmplx *)alignedMalloc(sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2]);
+
+  memcpy(h_inData, c_in, sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2]);
+
+  // Copy data from host to device
+  status = clEnqueueWriteBuffer(queue6, d_inData, CL_TRUE, 0, sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2], h_inData, 0, NULL, NULL);
+  checkError(status, "Failed to copy data to device");
+
+  status = clFinish(queue6);
+  checkError(status, "failed to finish");
+
+  status = clSetKernelArg(fetch_kernel, 0, sizeof(cl_mem), (void *)&d_inData);
+  checkError(status, "Failed to set kernel arg 0");
+  status = clSetKernelArg(fft_kernel, 0, sizeof(cl_int), (void*)&inverse_int);
+  checkError(status, "Failed to set kernel arg 1");
+  status = clSetKernelArg(transpose_kernel, 0, sizeof(cl_mem), (void *)&d_outData);
+  checkError(status, "Failed to set kernel arg 2");
+  status = clSetKernelArg(fft_kernel_2, 0, sizeof(cl_int), (void*)&inverse_int);
+  checkError(status, "Failed to set kernel arg 3");
+
+  status = clEnqueueTask(queue1, fetch_kernel, 0, NULL, NULL);
+  checkError(status, "Failed to launch fetch kernel");
+
+  // Launch the fft kernel - we launch a single work item hence enqueue a task
+  status = clEnqueueTask(queue2, fft_kernel, 0, NULL, NULL);
+  checkError(status, "Failed to launch fft kernel");
+
+  status = clEnqueueTask(queue3, transpose_kernel, 0, NULL, NULL);
+  checkError(status, "Failed to launch transpose kernel");
+
+  status = clEnqueueTask(queue4, fft_kernel_2, 0, NULL, NULL);
+  checkError(status, "Failed to launch second fft kernel");
+
+  status = clEnqueueTask(queue5, transpose_kernel_2, 0, NULL, NULL);
+  checkError(status, "Failed to launch second transpose kernel");
+
+  // Wait for all command queues to complete pending events
+  status = clFinish(queue1);
+  checkError(status, "failed to finish");
+  status = clFinish(queue2);
+  checkError(status, "failed to finish");
+  status = clFinish(queue3);
+  checkError(status, "failed to finish");
+  status = clFinish(queue4);
+  checkError(status, "failed to finish");
+  status = clFinish(queue5);
+  checkError(status, "failed to finish");
+
+  // Copy results from device to host
+  status = clEnqueueReadBuffer(queue3, d_outData, CL_TRUE, 0, sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2], h_outData, 0, NULL, NULL);
+  checkError(status, "Failed to read data from device");
+
+  memcpy(c_in, h_outData, sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2] );
+
+  if (h_outData)
+	  free(h_outData);
+  if (h_inData)
+	  free(h_inData);
+}
+
+/******************************************************************************
+ * \brief   Initialize the OpenCL FPGA environment
+ * \retval  true if error in initialization
+ *****************************************************************************/
+bool init() {
+
+  // Get the OpenCL platform.
+  platform = findPlatform("Intel(R) FPGA");
+  if(platform == NULL) {
+    printf("ERROR: Unable to find Intel(R) FPGA OpenCL platform\n");
+    return true;
+  }
+
+  // Query the available OpenCL devices.
+  cl_uint num_devices;
+  cl_device_id *devices = getTestDevices(platform, CL_DEVICE_TYPE_ALL, &num_devices);
+
+  // use the first device.
+  device = devices[0];
+
+  // Create the context.
+  context = clCreateContext(NULL, 1, &device, &openCLContextCallBackFxn, NULL, &status);
+  checkError(status, "Failed to create context");
+
+  free(devices);
+  return false;
+}
+
+/******************************************************************************
+ * \brief   Initialize the program and its kernels
+ *****************************************************************************/
+void init_program(char *data_path){
+
+  // Create the program.
+  program = getProgramWithBinary(context, &device, 1, fft_size, data_path);
+  if(program == NULL) {
+    printf("Failed to create program");
+    exit(0);
+  }
+  // Build the program that was just created.
+  status = clBuildProgram(program, 0, NULL, "", NULL, NULL);
+  checkError(status, "Failed to build program");
+
+  // Create the kernel - name passed in here must match kernel name in the
+  // original CL file, that was compiled into an AOCX file using the AOC tool
+  fft_kernel = clCreateKernel(program, "fft3da", &status);
+  checkError(status, "Failed to create fft3da kernel");
+  fft_kernel_2 = clCreateKernel(program, "fft3db", &status);
+  checkError(status, "Failed to create fft3db kernel");
+  fetch_kernel = clCreateKernel(program, "fetch", &status);
+  checkError(status, "Failed to create fetch kernel");
+  transpose_kernel = clCreateKernel(program, "transpose", &status);
+  checkError(status, "Failed to create transpose kernel");
+  transpose_kernel_2 = clCreateKernel(program, "transpose3d", &status);
+  checkError(status, "Failed to create transpose3d kernel");
+
+  d_inData = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2], NULL, &status);
+  checkError(status, "Failed to allocate input device buffer\n");
+  d_outData = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cmplx) * fft_size[0] * fft_size[1] * fft_size[2], NULL, &status);
+  checkError(status, "Failed to allocate output device buffer\n");
+}
+
+/******************************************************************************
+ * \brief   Create a command queue for each kernel
+ *****************************************************************************/
+void queue_setup(){
+  // Create one command queue for each kernel.
+  queue1 = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+  checkError(status, "Failed to create command queue1");
+  queue2 = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+  checkError(status, "Failed to create command queue2");
+  queue3 = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+  checkError(status, "Failed to create command queue3");
+  queue4 = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+  checkError(status, "Failed to create command queue4");
+  queue5 = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+  checkError(status, "Failed to create command queue5");
+  queue6 = clCreateCommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &status);
+  checkError(status, "Failed to create command queue6");
+}
+
+/******************************************************************************
+ * \brief   Free resources allocated during initialization
+ *****************************************************************************/
+void cleanup(){
+
+  if(context)
+    clReleaseContext(context);
+  if(program) 
+    clReleaseProgram(program);
+
+  if(fft_kernel) 
+    clReleaseKernel(fft_kernel);  
+  if(fft_kernel_2) 
+    clReleaseKernel(fft_kernel_2);  
+  if(fetch_kernel) 
+    clReleaseKernel(fetch_kernel);  
+  if(transpose_kernel) 
+    clReleaseKernel(transpose_kernel);  
+  if(transpose_kernel_2) 
+    clReleaseKernel(transpose_kernel_2);  
+
+  if (d_inData)
+	clReleaseMemObject(d_inData);
+  if (d_outData) 
+	clReleaseMemObject(d_outData);
+}
+
+/******************************************************************************
+ * \brief   Release all command queues
+ *****************************************************************************/
+void queue_cleanup() {
+  if(queue1) 
+    clReleaseCommandQueue(queue1);
+  if(queue2) 
+    clReleaseCommandQueue(queue2);
+  if(queue3) 
+    clReleaseCommandQueue(queue3);
+  if(queue4) 
+    clReleaseCommandQueue(queue4);
+  if(queue5) 
+    clReleaseCommandQueue(queue5);
+  if(queue6) 
+    clReleaseCommandQueue(queue6);
+}
+
+#endif

--- a/src/pw/fpga/fft_fpga.c
+++ b/src/pw/fpga/fft_fpga.c
@@ -40,14 +40,12 @@ void pw_fpga_final_(){
  * \brief  check whether FFT3d can be computed on the FPGA or not. This depends 
  *         on the availability of bitstreams whose sizes are for now listed here 
  *         If the fft sizes are found and the FPGA is not setup before, it is done
- * \param  data_path_len - length of the path to the data directory
  * \param  data_path - path to the data directory
  * \param  N - integer pointer to the size of the FFT3d
  * \retval true if fft3d size supported
  *****************************************************************************/
-int pw_fpga_check_bitstream_(int data_path_len, char *data_path, int N[3]){
+int pw_fpga_check_bitstream_(char *data_path, int N[3]){
     static int fft_size[3] = { 0, 0, 0};
-    data_path[data_path_len] = '\0';
 
     // check the supported sizes
     if( (N[0] == 16 && N[1] == 16 && N[2] == 16) ||
@@ -123,7 +121,15 @@ void fftfpga_run_3d(int inverse, int N[3], cmplx *c_in) {
   cl_int status = 0;
   int inverse_int = inverse;
   cmplx *h_inData = (cmplx *)alignedMalloc(sizeof(cmplx) * N[0] * N[1] * N[2]);
+  if (h_inData == NULL){
+    printf("Unable to allocate host memory\n");
+    exit(1);
+  }
   cmplx *h_outData = (cmplx *)alignedMalloc(sizeof(cmplx) * N[0] * N[1] * N[2]);
+  if (h_outData == NULL){
+    printf("Unable to allocate host memory\n");
+    exit(1);
+  }
 
   memcpy(h_inData, c_in, sizeof(cmplx) * N[0] * N[1] * N[2]);
 
@@ -220,7 +226,7 @@ void init_program(int N[3], char *data_path){
   program = getProgramWithBinary(context, &device, 1, N, data_path);
   if(program == NULL) {
     printf("Failed to create program");
-    exit(0);
+    exit(1);
   }
   // Build the program that was just created.
   status = clBuildProgram(program, 0, NULL, "", NULL, NULL);

--- a/src/pw/fpga/fft_fpga.h
+++ b/src/pw/fpga/fft_fpga.h
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ *  CP2K: A general program to perform molecular dynamics simulations        *
+ *  Copyright (C) 2000 - 2019  CP2K developers group                         *
+ *****************************************************************************/
+
+#ifndef FFT_FPGA_H
+#define FFT_FPGA_H
+/******************************************************************************
+ *  Authors: Arjun Ramaswami
+ *****************************************************************************/
+#if defined ( __PW_FPGA )
+
+typedef struct {
+  double x;
+  double y;
+} double2;
+
+typedef struct {
+  float x;
+  float y;
+} float2;
+
+#ifdef __PW_FPGA_SP
+    typedef float2 cmplx;
+#else
+    typedef double2 cmplx;
+#endif
+
+// Initialize FPGA
+int pw_fpga_initialize_();
+
+// Finalize FPGA
+void pw_fpga_final_();
+
+// Single precision FFT3d procedure
+void pw_fpga_fft3d_sp_(int data_path_len, char *data_path, int direction, int N[3], cmplx *din);
+
+// Double precision FFT3d procedure
+void pw_fpga_fft3d_dp_(int data_path_len, char *data_path, int direction, int N[3], cmplx *din);
+
+// Check fpga bitstream present in directory
+bool pw_fpga_check_bitstream_(int N[3]);
+
+#endif
+#endif

--- a/src/pw/fpga/fft_fpga.h
+++ b/src/pw/fpga/fft_fpga.h
@@ -39,7 +39,7 @@ void pw_fpga_fft3d_sp_(int direction, int N[3], cmplx *din);
 void pw_fpga_fft3d_dp_(int direction, int N[3], cmplx *din);
 
 // Check fpga bitstream present in directory
-int pw_fpga_check_bitstream_(int data_path_len, char *data_path, int N[3]);
+int pw_fpga_check_bitstream_(char *data_path, int N[3]);
 
 // host variables
 static cl_platform_id platform = NULL;

--- a/src/pw/fpga/fft_fpga.h
+++ b/src/pw/fpga/fft_fpga.h
@@ -33,13 +33,28 @@ int pw_fpga_initialize_();
 void pw_fpga_final_();
 
 // Single precision FFT3d procedure
-void pw_fpga_fft3d_sp_(int data_path_len, char *data_path, int direction, int N[3], cmplx *din);
+void pw_fpga_fft3d_sp_(int direction, int N[3], cmplx *din);
 
 // Double precision FFT3d procedure
-void pw_fpga_fft3d_dp_(int data_path_len, char *data_path, int direction, int N[3], cmplx *din);
+void pw_fpga_fft3d_dp_(int direction, int N[3], cmplx *din);
 
 // Check fpga bitstream present in directory
-bool pw_fpga_check_bitstream_(int N[3]);
+int pw_fpga_check_bitstream_(int data_path_len, char *data_path, int N[3]);
+
+// host variables
+static cl_platform_id platform = NULL;
+static cl_device_id device = NULL;
+static cl_context context = NULL;
+static cl_program program = NULL;
+
+static cl_command_queue queue1 = NULL, queue2 = NULL, queue3 = NULL;
+static cl_command_queue queue4 = NULL, queue5 = NULL, queue6 = NULL;
+
+static cl_kernel fft_kernel = NULL, fft_kernel_2 = NULL;
+static cl_kernel fetch_kernel = NULL, transpose_kernel = NULL, transpose_kernel_2 = NULL;
+
+// Device memory buffers
+static cl_mem d_inData, d_outData;
 
 #endif
 #endif

--- a/src/pw/fpga/fft_fpga.h
+++ b/src/pw/fpga/fft_fpga.h
@@ -43,18 +43,13 @@ int pw_fpga_check_bitstream_(char *data_path, int N[3]);
 
 // host variables
 static cl_platform_id platform = NULL;
+static cl_device_id *devices;
 static cl_device_id device = NULL;
 static cl_context context = NULL;
 static cl_program program = NULL;
 
 static cl_command_queue queue1 = NULL, queue2 = NULL, queue3 = NULL;
 static cl_command_queue queue4 = NULL, queue5 = NULL, queue6 = NULL;
-
-static cl_kernel fft_kernel = NULL, fft_kernel_2 = NULL;
-static cl_kernel fetch_kernel = NULL, transpose_kernel = NULL, transpose_kernel_2 = NULL;
-
-// Device memory buffers
-static cl_mem d_inData, d_outData;
 
 #endif
 #endif

--- a/src/pw/fpga/opencl_utils.c
+++ b/src/pw/fpga/opencl_utils.c
@@ -53,6 +53,7 @@ cl_platform_id findPlatform(char *platform_name){
   status = clGetPlatformIDs(num_platforms, pids, NULL);
   if (status != CL_SUCCESS){
     printf("Query for platform ids failed\n");
+    free(pids);
     exit(1);
   }
 
@@ -101,7 +102,7 @@ cl_platform_id findPlatform(char *platform_name){
  * \param   total number of devices found for the given platform
  * \retval  array of device ids
  *****************************************************************************/
-cl_device_id* getTestDevices(cl_platform_id pid, cl_device_type device_type, cl_uint *num_devices) {
+cl_device_id* getDevices(cl_platform_id pid, cl_device_type device_type, cl_uint *num_devices) {
   cl_int status;
 
   // Query for number of devices

--- a/src/pw/fpga/opencl_utils.c
+++ b/src/pw/fpga/opencl_utils.c
@@ -1,0 +1,370 @@
+/*****************************************************************************
+ *  CP2K: A general program to perform molecular dynamics simulations        *
+ *  Copyright (C) 2000 - 2019  CP2K developers group                         *
+ *****************************************************************************/
+
+/******************************************************************************
+ *  Author: Arjun Ramaswami
+ *****************************************************************************/
+
+#if defined ( __PW_FPGA )
+
+// global dependencies
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#define _USE_MATH_DEFINES
+#include <string.h>
+#include <sys/time.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <unistd.h> // access in fileExists()
+#include "ctype.h"
+
+// common dependencies
+#include "CL/opencl.h"
+
+// function prototype
+static void tolowercase(char *p, char *q);
+static bool getBinaryPath(char *path, int N[3]);
+static char* loadBinary(char *binary_path, size_t *bin_size);
+
+// --- CODE -------------------------------------------------------------------
+
+/******************************************************************************
+ * \brief   return the first platform id with the name passed as argument
+ * \param   platform_name : search string
+ * \retval  din : platform id
+ *****************************************************************************/
+cl_platform_id findPlatform(char *platform_name){
+  unsigned int i;
+  cl_uint status;
+
+  // Check if there are any platforms available
+  cl_uint num_platforms;
+  status = clGetPlatformIDs(0, NULL, &num_platforms);
+  if (status != CL_SUCCESS){
+    printf("Query for number of platforms failed\n");
+    exit(0);
+  }
+
+  // Get ids of platforms available
+  cl_platform_id *pids = (cl_platform_id*) malloc(sizeof(cl_platform_id) * num_platforms);
+  status = clGetPlatformIDs(num_platforms, pids, NULL);
+  if (status != CL_SUCCESS){
+    printf("Query for platform ids failed\n");
+    exit(0);
+  }
+
+  // Convert argument string to lowercase compare platform names
+  size_t pl_len = strlen(platform_name);
+  char name_search[pl_len + 1];
+  tolowercase(platform_name, name_search);
+
+  // Search the platforms for the platform name passed as argument
+  size_t sz;
+  for(i=0; i<num_platforms; i++){
+    // Get the size of the platform name referred to by the id
+		status = clGetPlatformInfo(pids[i], CL_PLATFORM_NAME, 0, NULL, &sz);
+    if (status != CL_SUCCESS){
+      printf("Query for platform info failed\n");
+      free(pids);
+      exit(0);
+    }
+
+    char pl_name[sz];
+    char plat_name[sz];
+
+    // Store the name of string size
+	  status = clGetPlatformInfo(pids[i], CL_PLATFORM_NAME, sz, pl_name, NULL);
+    if (status != CL_SUCCESS){
+      printf("Query for platform info failed\n");
+      free(pids);
+      exit(0);
+    }
+
+    tolowercase(pl_name, plat_name);
+    if( strstr(plat_name, name_search)){
+      cl_platform_id pid = pids[i];
+      free(pids);
+      return pid;
+    }
+  }
+  free(pids);
+  return NULL;
+}
+
+/******************************************************************************
+ * \brief   returns the list of all devices for the specfic platform
+ * \param   platform id to search for devices 
+ * \param   specific type of device to search for
+ * \param   total number of devices found for the given platform
+ * \retval  array of device ids
+ *****************************************************************************/
+cl_device_id* getTestDevices(cl_platform_id pid, cl_device_type device_type, cl_uint *num_devices) {
+  cl_int status;
+
+  // Query for number of devices
+  status = clGetDeviceIDs(pid, device_type, 0, NULL, num_devices);
+  if(status != CL_SUCCESS){
+    printf("Query for number of devices failed\n");
+    exit(0);
+  }
+
+  //  Based on the number of devices get their device ids
+  cl_device_id *dev_ids = (cl_device_id*) malloc(sizeof(cl_device_id) * (*num_devices));
+  status = clGetDeviceIDs(pid, device_type, *num_devices, dev_ids, NULL);
+  if(status != CL_SUCCESS){
+    printf("Query for device ids failed\n");
+    free(dev_ids);
+    exit(0);
+  }
+  return dev_ids;
+}
+
+/******************************************************************************
+ * \brief   returns the list of all devices for the specfic platform
+ * \param   context created using device
+ * \param   array of devices
+ * \param   number of devices found
+ * \param   size of FFT3d
+ * \retval  created program
+ *****************************************************************************/
+cl_program getProgramWithBinary(cl_context context, const cl_device_id *devices, unsigned num_device, int N[3], char *data_path){
+  char bin_path[500];
+  char *binary;
+  char *binaries[num_device];
+
+  size_t bin_size;
+  cl_int bin_status, status;
+
+  strcpy(bin_path, data_path);
+
+  // Get the full path of the binary
+  if( !getBinaryPath(bin_path, N) ){
+    printf("No paths to the binary found\n");
+    return NULL;
+  }
+
+  // Load binary to character array
+  binary = loadBinary(bin_path, &bin_size);
+  if(binary == NULL){
+    printf("Could not load binary\n");
+    free(binary);
+    return NULL;
+  }
+
+  binaries[0] = binary;
+
+  // Create the program.
+  cl_program program = clCreateProgramWithBinary(context, 1, devices, &bin_size, (const unsigned char **) binaries, &bin_status, &status);
+  if (status != CL_SUCCESS){
+    printf("Query to create program with binary failed\n");
+    free(binary);
+    return NULL;
+  }
+  free(binary);
+  return program;
+}
+
+static bool fileTestExists(char* filename){
+  if( access( filename, R_OK ) != -1 ) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static bool getBinaryPath(char *path, int N[3]){
+
+#ifdef __PW_FPGA_SP
+  char *subpath = "/../fpgabitstream/fft3d/synthesis_sp/";
+#else
+  char *subpath = "/../fpgabitstream/fft3d/synthesis_dp/";
+#endif
+  
+  switch(N[0]){
+    case 16 : 
+      strcat(path, subpath);
+      strcat(path, "syn16/");
+      break;
+
+    case 32 : 
+      strcat(path, subpath);
+      strcat(path, "syn32/");
+      break;
+
+    case 64 : 
+      strcat(path, subpath);
+      strcat(path, "syn64/");
+      break;
+
+    default:
+      printf("Path not found for the size (%d,%d,%d)", N[0], N[1], N[2]);
+      exit(0);
+      break;
+  }
+  // strcat(full_path, specific_path); // transfer specific path to filename 
+  strcat(path, "fft3d");      // Append filename
+  strcat(path, ".aocx");      // Append extension
+  strcat(path, "\0");         // Append extension
+
+  if (!fileTestExists(path)){
+    printf("File not found \n");
+    return false;
+  }
+
+  return true;
+}
+
+static char* loadBinary(char *binary_path, size_t *bin_size){
+
+  FILE *fp;
+
+  // Open file and check if it exists
+  fp = fopen(binary_path, "rb");
+  if(fp == 0){
+    return NULL;
+  }
+
+  // Find the size of the file
+  fseek(fp, 0L, SEEK_END);
+  *bin_size = ftell(fp);
+
+  char *binary = (char *)malloc(*bin_size);
+  rewind(fp);
+
+  if(fread( (void *)binary, *bin_size, 1, fp) == 0) {
+    free(binary);
+    fclose(fp);
+    return NULL;
+  }
+
+  fclose(fp);
+  return binary;
+}
+
+// Minimum alignment requirement to use DMA
+const unsigned OPENCL_ALIGNMENT = 64;
+void* alignedMalloc(size_t size){
+
+  void *memptr = NULL;
+  int ret = posix_memalign(&memptr, OPENCL_ALIGNMENT, size);
+  return memptr;
+}
+
+void openCLContextCallBackFxn(const char *errinfo, const void *private_info, size_t cb, void *user_data) {
+  printf("Context Callback - %s\n", errinfo);
+}
+
+void printError(cl_int error) {
+
+  switch(error)
+  {
+    case CL_INVALID_PLATFORM:
+      printf("CL_PLATFORM NOT FOUND OR INVALID ");
+      break;
+    case CL_INVALID_DEVICE:
+      printf("CL_DEVICE NOT FOUND OR INVALID OR DOESN'T MATCH THE PLATFORM ");
+      break;
+    case CL_INVALID_CONTEXT:
+      printf("CL_CONTEXT INVALID ");
+      break;
+    case CL_OUT_OF_HOST_MEMORY:
+      printf("FAILURE TO ALLOCATE RESOURCES BY OPENCL");
+      break;
+    case CL_DEVICE_NOT_AVAILABLE:
+      printf("CL_DEVICE NOT AVAILABLE ALTHOUGH FOUND");
+      break;
+    case CL_INVALID_QUEUE_PROPERTIES:
+      printf("CL_QUEUE PROPERTIES INVALID");
+      break;
+    case CL_INVALID_PROGRAM:
+      printf("CL_PROGRAM INVALID");
+      break;
+    case CL_INVALID_BINARY:
+      printf("CL_BINARY INVALID");
+      break;
+    case CL_INVALID_KERNEL_NAME:
+      printf("CL_KERNEL_NAME INVALID");
+      break;
+    case CL_INVALID_KERNEL_DEFINITION:
+      printf("CL_KERNEL_DEFN INVALID");
+      break;
+    case CL_INVALID_VALUE:
+      printf("CL_VALUE INVALID");
+      break;
+    case CL_INVALID_BUFFER_SIZE:
+      printf("CL_BUFFER_SIZE INVALID");
+      break;
+    case CL_INVALID_HOST_PTR:
+      printf("CL_HOST_PTR INVALID");
+      break;
+    case CL_INVALID_COMMAND_QUEUE:
+      printf("CL_COMMAND_QUEUE INVALID");
+      break;
+    case CL_INVALID_MEM_OBJECT:
+      printf("CL_MEM_OBJECT INVALID");
+      break;
+    case CL_MEM_OBJECT_ALLOCATION_FAILURE:
+      printf("CL_MEM_OBJECT_ALLOCATION INVALID");
+      break;
+    case CL_INVALID_ARG_INDEX:
+      printf("CL_ARG_INDEX INVALID");
+      break;
+    case CL_INVALID_ARG_VALUE:
+      printf("CL_ARG_VALUE INVALID");
+      break;
+    case CL_INVALID_ARG_SIZE:
+      printf("CL_ARG_SIZE INVALID");
+      break;
+    case CL_INVALID_PROGRAM_EXECUTABLE:
+      printf("CL_PROGRAM_EXEC INVALID");
+      break;
+    case CL_INVALID_KERNEL:
+      printf("CL_KERNEL INVALID");
+      break;
+    case CL_INVALID_KERNEL_ARGS:
+      printf("CL_KERNEL_ARG INVALID");
+      break;
+    case CL_INVALID_WORK_GROUP_SIZE:
+      printf("CL_WORK_GROUP_SIZE INVALID");
+      break;
+
+    default:
+      printf("UNKNOWN ERROR %d\n", error);
+  }
+
+}
+
+void _checkError(const char *file, int line, const char *func, cl_int err, const char *msg, ...){
+
+  if(err != CL_SUCCESS){
+    printf("ERROR: ");
+    printError(err);
+    printf("\nError Location: %s:%d:%s\n", file, line, func);
+
+    // custom message 
+    va_list vl;
+    va_start(vl, msg);
+    vprintf(msg, vl);
+    printf("\n");
+    va_end(vl);
+
+    queue_cleanup();
+    cleanup();
+    exit(err);
+  }
+}
+
+static void tolowercase(char *p, char *q){
+  int i;
+  char a;
+  for(i=0; i<strlen(p);i++){
+    a = tolower(p[i]);
+    q[i] = a;
+  }
+  q[strlen(p)] = '\0';
+}
+
+#endif

--- a/src/pw/fpga/opencl_utils.h
+++ b/src/pw/fpga/opencl_utils.h
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ *  CP2K: A general program to perform molecular dynamics simulations        *
+ *  Copyright (C) 2000 - 2019  CP2K developers group                         *
+ *****************************************************************************/
+
+/******************************************************************************
+ *  Author: Arjun Ramaswami
+ *****************************************************************************/
+
+#ifndef OPENCL_UTILS_H
+#define OPENCL_UTILS_H
+
+#if defined ( __PW_FPGA )
+
+extern void queue_cleanup();
+extern void cleanup();
+// Search for a platform that contains the search string
+// Returns platform id if found
+// Return NULL if none found
+cl_platform_id findPlatform(char *platform_name);
+
+// Search for a device based on the platform
+// Return array of device ids
+cl_device_id* getTestDevices(cl_platform_id pid, cl_device_type device_type, cl_uint *num_devices);
+
+// OpenCL program created for all the devices of the context with the same binary
+cl_program getProgramWithBinary(cl_context context, const cl_device_id *devices, unsigned num_devices, int N[3], char *data_path);
+
+void openCLContextCallBackFxn(const char *errinfo, const void *private_info, size_t cb, void *user_data);
+
+void* alignedMalloc(size_t size);
+
+void printError(cl_int error);
+
+void _checkError(const char *file, int line, const char *func, cl_int err, const char *msg, ...);
+
+#define checkError(status, ...) _checkError(__FILE__, __LINE__, __FUNCTION__, status, __VA_ARGS__)
+
+#endif
+
+#endif // OPENCL_UTILS_H

--- a/src/pw/fpga/opencl_utils.h
+++ b/src/pw/fpga/opencl_utils.h
@@ -21,7 +21,7 @@ cl_platform_id findPlatform(char *platform_name);
 
 // Search for a device based on the platform
 // Return array of device ids
-cl_device_id* getTestDevices(cl_platform_id pid, cl_device_type device_type, cl_uint *num_devices);
+cl_device_id* getDevices(cl_platform_id pid, cl_device_type device_type, cl_uint *num_devices);
 
 // OpenCL program created for all the devices of the context with the same binary
 cl_program getProgramWithBinary(cl_context context, const cl_device_id *devices, unsigned num_devices, int N[3], char *data_path);

--- a/src/pw/pw_fpga.F
+++ b/src/pw/pw_fpga.F
@@ -16,7 +16,8 @@ MODULE pw_fpga
    USE ISO_C_BINDING,                   ONLY: C_CHAR,&
                                               C_DOUBLE_COMPLEX,&
                                               C_FLOAT_COMPLEX,&
-                                              C_INT
+                                              C_INT,&
+                                              C_NULL_CHAR
    USE cp_files,                        ONLY: get_data_dir
    USE kinds,                           ONLY: dp,&
                                               sp
@@ -54,19 +55,16 @@ MODULE pw_fpga
    INTERFACE
 ! **************************************************************************************************
 !> \brief Check whether an fpga bitstream for the given FFT3d size is present & load binary if needed
-!> \param data_path_len - length of the path to the data directory
 !> \param data_path - path to the data directory
 !> \param npts - fft3d size
 !> \return res - true if fft3d size supported
 ! **************************************************************************************************
-      FUNCTION pw_fpga_check_bitstream(data_path_len, data_path, n) RESULT(res) &
+      FUNCTION pw_fpga_check_bitstream(data_path, n) RESULT(res) &
          BIND(C, name="pw_fpga_check_bitstream_")
          IMPORT
-         INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: data_path_len
-         CHARACTER(len=1, kind=C_CHAR), TARGET    :: data_path(data_path_len)
-         INTEGER(KIND=C_INT), DIMENSION(*), &
-            INTENT(IN)                            :: n
-         INTEGER(KIND=C_INT)                     :: res
+         CHARACTER(KIND=C_CHAR)        :: data_path(*)
+         INTEGER(KIND=C_INT)           :: n(3)
+         INTEGER(KIND=C_INT)           :: res
       END FUNCTION pw_fpga_check_bitstream
 
    END INTERFACE
@@ -81,9 +79,8 @@ MODULE pw_fpga
       SUBROUTINE pw_fpga_fft3d_sp(dir, n, c_in_sp) &
          BIND(C, name="pw_fpga_fft3d_sp_")
          IMPORT
-         INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: dir
-         INTEGER(KIND=C_INT), DIMENSION(*), &
-            INTENT(IN)                            :: n
+         INTEGER(KIND=C_INT), VALUE              :: dir
+         INTEGER(KIND=C_INT)                     :: n(3)
          COMPLEX(KIND=C_FLOAT_COMPLEX)           :: c_in_sp(n(1), n(2), n(3))
       END SUBROUTINE pw_fpga_fft3d_sp
    END INTERFACE
@@ -98,10 +95,9 @@ MODULE pw_fpga
       SUBROUTINE pw_fpga_fft3d_dp(dir, n, c_in_dp) &
          BIND(C, name="pw_fpga_fft3d_dp_")
          IMPORT
-         INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: dir
-         INTEGER(KIND=C_INT), DIMENSION(*), &
-            INTENT(IN)                            :: n
-         COMPLEX(KIND=C_DOUBLE_COMPLEX)           :: c_in_dp(n(1), n(2), n(3))
+         INTEGER(KIND=C_INT), VALUE              :: dir
+         INTEGER(KIND=C_INT)                     :: n(3)
+         COMPLEX(KIND=C_DOUBLE_COMPLEX)          :: c_in_dp(n(1), n(2), n(3))
       END SUBROUTINE pw_fpga_fft3d_dp
    END INTERFACE
 
@@ -273,10 +269,10 @@ CONTAINS
       CHARACTER(len=100)                               :: data_path
       INTEGER                                          :: data_path_len
 
-      data_path = TRIM(get_data_dir())
+      data_path = TRIM(get_data_dir())//C_NULL_CHAR
       data_path_len = LEN_TRIM(data_path)
 
-      res = pw_fpga_check_bitstream(data_path_len, data_path, n)
+      res = pw_fpga_check_bitstream(data_path, n)
 #endif
    END FUNCTION
 

--- a/src/pw/pw_fpga.F
+++ b/src/pw/pw_fpga.F
@@ -13,8 +13,7 @@
 ! **************************************************************************************************
 
 MODULE pw_fpga
-   USE ISO_C_BINDING,                   ONLY: C_BOOL,&
-                                              C_CHAR,&
+   USE ISO_C_BINDING,                   ONLY: C_CHAR,&
                                               C_DOUBLE_COMPLEX,&
                                               C_FLOAT_COMPLEX,&
                                               C_INT
@@ -28,7 +27,7 @@ MODULE pw_fpga
    PRIVATE
 
    PUBLIC :: pw_fpga_init, pw_fpga_finalize
-   PUBLIC :: pw_fpga_check_bitstream
+   PUBLIC :: pw_fpga_init_bitstream
    PUBLIC :: pw_fpga_r3dc1d_3d_sp, pw_fpga_c1dr3d_3d_sp
    PUBLIC :: pw_fpga_r3dc1d_3d_dp, pw_fpga_c1dr3d_3d_dp
 
@@ -54,17 +53,20 @@ MODULE pw_fpga
 
    INTERFACE
 ! **************************************************************************************************
-!> \brief Check whether an fpga bitstream for the given FFT3d size is present
-!> \param npts ...
-!> \return res ...
+!> \brief Check whether an fpga bitstream for the given FFT3d size is present & load binary if needed
+!> \param data_path_len - length of the path to the data directory
+!> \param data_path - path to the data directory
+!> \param npts - fft3d size
+!> \return res - true if fft3d size supported
 ! **************************************************************************************************
-      FUNCTION pw_fpga_check_bitstream(n) RESULT(res) &
+      FUNCTION pw_fpga_check_bitstream(data_path_len, data_path, n) RESULT(res) &
          BIND(C, name="pw_fpga_check_bitstream_")
          IMPORT
+         INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: data_path_len
+         CHARACTER(len=1, kind=C_CHAR), TARGET    :: data_path(data_path_len)
          INTEGER(KIND=C_INT), DIMENSION(*), &
             INTENT(IN)                            :: n
-         LOGICAL(KIND=C_BOOL)                     :: res
-
+         INTEGER(KIND=C_INT)                     :: res
       END FUNCTION pw_fpga_check_bitstream
 
    END INTERFACE
@@ -72,17 +74,13 @@ MODULE pw_fpga
    INTERFACE
 ! **************************************************************************************************
 !> \brief single precision FFT3d using FPGA
-!> \param data_path_len - length of the path to the data directory
-!> \param data_path - path to the data directory
 !> \param dir - direction of FFT3d
 !> \param npts - dimensions of FFT3d
 !> \param single precision c_in...
 ! **************************************************************************************************
-      SUBROUTINE pw_fpga_fft3d_sp(data_path_len, data_path, dir, n, c_in_sp) &
+      SUBROUTINE pw_fpga_fft3d_sp(dir, n, c_in_sp) &
          BIND(C, name="pw_fpga_fft3d_sp_")
          IMPORT
-         INTEGER(KIND=C_INT), VALUE, INTENT(IN)  :: data_path_len
-         CHARACTER(len=1, kind=C_CHAR), TARGET    :: data_path(data_path_len)
          INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: dir
          INTEGER(KIND=C_INT), DIMENSION(*), &
             INTENT(IN)                            :: n
@@ -93,17 +91,13 @@ MODULE pw_fpga
    INTERFACE
 ! **************************************************************************************************
 !> \brief double precision FFT3d using FPGA
-!> \param data_path_len - length of the path to the data directory
-!> \param data_path - path to the data directory
 !> \param dir - direction of FFT3d
 !> \param npts - dimensions of FFT3d
 !> \param double precision c_in...
 ! **************************************************************************************************
-      SUBROUTINE pw_fpga_fft3d_dp(data_path_len, data_path, dir, n, c_in_dp) &
+      SUBROUTINE pw_fpga_fft3d_dp(dir, n, c_in_dp) &
          BIND(C, name="pw_fpga_fft3d_dp_")
          IMPORT
-         INTEGER(KIND=C_INT), VALUE, INTENT(IN)  :: data_path_len
-         CHARACTER(len=1, kind=C_CHAR), TARGET    :: data_path(data_path_len)
          INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: dir
          INTEGER(KIND=C_INT), DIMENSION(*), &
             INTENT(IN)                            :: n
@@ -122,12 +116,18 @@ CONTAINS
 
 #if defined (__PW_CUDA)
 #error "CUDA and FPGA cannot be configured concurrently!"
+      CPABORT("CUDA and FPGA cannot be configured concurrently!")
 #endif
-
       stat = pw_fpga_initialize()
       IF (stat /= 0) &
          CPABORT("pw_fpga_init: failed")
 #endif
+
+#if (__PW_FPGA_SP && !(__PW_FPGA))
+#error "Define both __PW_FPGA_SP and __PW_FPGA"
+      CPABORT("Define both __PW_FPGA_SP and __PW_FPGA")
+#endif
+
    END SUBROUTINE pw_fpga_init
 
 ! **************************************************************************************************
@@ -153,16 +153,11 @@ CONTAINS
       MARK_USED(n)
 #else
       INTEGER                                     :: handle3
-      CHARACTER(len=100)                          :: data_path
-      INTEGER                                     :: data_path_len
 
       CHARACTER(len=*), PARAMETER :: routineX = 'fw_fft_fpga_r3dc1d_dp'
 
-      data_path = TRIM(get_data_dir())
-      data_path_len = LEN_TRIM(data_path)
-
       CALL timeset(routineX, handle3)
-      CALL pw_fpga_fft3d_dp(data_path_len, data_path, +1, n, c_out)
+      CALL pw_fpga_fft3d_dp(+1, n, c_out)
       CALL timestop(handle3)
 
 #endif
@@ -182,16 +177,11 @@ CONTAINS
       MARK_USED(n)
 #else
       INTEGER                                          :: handle3
-      CHARACTER(len=100)                               :: data_path
-      INTEGER                                          :: data_path_len
 
       CHARACTER(len=*), PARAMETER :: routineX = 'bw_fft_fpga_c1dr3d_dp'
 
-      data_path = TRIM(get_data_dir())
-      data_path_len = LEN_TRIM(data_path)
-
       CALL timeset(routineX, handle3)
-      CALL pw_fpga_fft3d_dp(data_path_len, data_path, -1, n, c_out)
+      CALL pw_fpga_fft3d_dp(-1, n, c_out)
       CALL timestop(handle3)
 
 #endif
@@ -212,20 +202,15 @@ CONTAINS
 #else
       COMPLEX, DIMENSION(:, :, :), POINTER             :: c_in_sp
       INTEGER                                          :: handle3
-      CHARACTER(len=100)                               :: data_path
-      INTEGER                                          :: data_path_len
 
       CHARACTER(len=*), PARAMETER :: routineX = 'fw_fft_fpga_r3dc1d_sp'
-
-      data_path = TRIM(get_data_dir())
-      data_path_len = LEN_TRIM(data_path)
 
       ALLOCATE (c_in_sp(n(1), n(2), n(3)))
       ! pointer to single precision complex array
       c_in_sp = CMPLX(c_out, KIND=sp)
 
       CALL timeset(routineX, handle3)
-      CALL pw_fpga_fft3d_sp(data_path_len, data_path, +1, n, c_in_sp)
+      CALL pw_fpga_fft3d_sp(+1, n, c_in_sp)
       CALL timestop(handle3)
 
       ! typecast sp back to dp
@@ -252,20 +237,15 @@ CONTAINS
 #else
       COMPLEX, DIMENSION(:, :, :), POINTER             :: c_in_sp
       INTEGER                                          :: handle3
-      CHARACTER(len=100)                               :: data_path
-      INTEGER                                          :: data_path_len
 
       CHARACTER(len=*), PARAMETER :: routineX = 'bw_fft_fpga_c1dr3d_sp'
-
-      data_path = TRIM(get_data_dir())
-      data_path_len = LEN_TRIM(data_path)
 
       ALLOCATE (c_in_sp(n(1), n(2), n(3)))
       ! pointer to single precision complex array
       c_in_sp = CMPLX(c_out, KIND=sp)
 
       CALL timeset(routineX, handle3)
-      CALL pw_fpga_fft3d_sp(data_path_len, data_path, -1, n, c_in_sp)
+      CALL pw_fpga_fft3d_sp(-1, n, c_in_sp)
       CALL timestop(handle3)
 
       ! typecast sp back to dp
@@ -274,6 +254,31 @@ CONTAINS
       DEALLOCATE (c_in_sp)
 #endif
    END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief  Invoke the pw_fpga_check_bitstream C function passing the path to the data dir
+!> \param  n   - fft3d size
+!> \return ...
+!> \retval res - true if fft size found and initialized else false
+! **************************************************************************************************
+   FUNCTION pw_fpga_init_bitstream(n) RESULT(res)
+      INTEGER, DIMENSION(:), INTENT(IN)                 :: n
+      INTEGER                                           :: res
+
+#if ! defined (__PW_FPGA)
+      res = 0
+      MARK_USED(n)
+      MARK_USED(res)
+#else
+      CHARACTER(len=100)                               :: data_path
+      INTEGER                                          :: data_path_len
+
+      data_path = TRIM(get_data_dir())
+      data_path_len = LEN_TRIM(data_path)
+
+      res = pw_fpga_check_bitstream(data_path_len, data_path, n)
+#endif
+   END FUNCTION
 
 END MODULE pw_fpga
 

--- a/src/pw/pw_fpga.F
+++ b/src/pw/pw_fpga.F
@@ -1,0 +1,279 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright (C) 2000 - 2019  CP2K developers group                                               !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \note
+!> This module contains routines necessary to operate on plane waves on INTEL
+!> FPGAs using OpenCL. It depends at execution time on the board support
+!> packages of the specific FPGA
+!> \author Arjun Ramaswami
+!> \author Robert Schade
+! **************************************************************************************************
+
+MODULE pw_fpga
+   USE ISO_C_BINDING,                   ONLY: C_BOOL,&
+                                              C_CHAR,&
+                                              C_DOUBLE_COMPLEX,&
+                                              C_FLOAT_COMPLEX,&
+                                              C_INT
+   USE cp_files,                        ONLY: get_data_dir
+   USE kinds,                           ONLY: dp,&
+                                              sp
+#include "../base/base_uses.f90"
+
+   IMPLICIT NONE
+
+   PRIVATE
+
+   PUBLIC :: pw_fpga_init, pw_fpga_finalize
+   PUBLIC :: pw_fpga_check_bitstream
+   PUBLIC :: pw_fpga_r3dc1d_3d_sp, pw_fpga_c1dr3d_3d_sp
+   PUBLIC :: pw_fpga_r3dc1d_3d_dp, pw_fpga_c1dr3d_3d_dp
+
+   INTERFACE
+! **************************************************************************************************
+!> \brief Initialize FPGA
+!> \retval status if the routine failed or not
+! **************************************************************************************************
+      FUNCTION pw_fpga_initialize() RESULT(stat) &
+         BIND(C, name="pw_fpga_initialize_")
+         IMPORT
+         INTEGER(KIND=C_INT)                    :: stat
+      END FUNCTION pw_fpga_initialize
+
+! **************************************************************************************************
+!> \brief Destroy FPGA
+! **************************************************************************************************
+      SUBROUTINE pw_fpga_final() &
+         BIND(C, name="pw_fpga_final_")
+      END SUBROUTINE pw_fpga_final
+
+   END INTERFACE
+
+   INTERFACE
+! **************************************************************************************************
+!> \brief Check whether an fpga bitstream for the given FFT3d size is present
+!> \param npts ...
+!> \return res ...
+! **************************************************************************************************
+      FUNCTION pw_fpga_check_bitstream(n) RESULT(res) &
+         BIND(C, name="pw_fpga_check_bitstream_")
+         IMPORT
+         INTEGER(KIND=C_INT), DIMENSION(*), &
+            INTENT(IN)                            :: n
+         LOGICAL(KIND=C_BOOL)                     :: res
+
+      END FUNCTION pw_fpga_check_bitstream
+
+   END INTERFACE
+
+   INTERFACE
+! **************************************************************************************************
+!> \brief single precision FFT3d using FPGA
+!> \param data_path_len - length of the path to the data directory
+!> \param data_path - path to the data directory
+!> \param dir - direction of FFT3d
+!> \param npts - dimensions of FFT3d
+!> \param single precision c_in...
+! **************************************************************************************************
+      SUBROUTINE pw_fpga_fft3d_sp(data_path_len, data_path, dir, n, c_in_sp) &
+         BIND(C, name="pw_fpga_fft3d_sp_")
+         IMPORT
+         INTEGER(KIND=C_INT), VALUE, INTENT(IN)  :: data_path_len
+         CHARACTER(len=1, kind=C_CHAR), TARGET    :: data_path(data_path_len)
+         INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: dir
+         INTEGER(KIND=C_INT), DIMENSION(*), &
+            INTENT(IN)                            :: n
+         COMPLEX(KIND=C_FLOAT_COMPLEX)           :: c_in_sp(n(1), n(2), n(3))
+      END SUBROUTINE pw_fpga_fft3d_sp
+   END INTERFACE
+
+   INTERFACE
+! **************************************************************************************************
+!> \brief double precision FFT3d using FPGA
+!> \param data_path_len - length of the path to the data directory
+!> \param data_path - path to the data directory
+!> \param dir - direction of FFT3d
+!> \param npts - dimensions of FFT3d
+!> \param double precision c_in...
+! **************************************************************************************************
+      SUBROUTINE pw_fpga_fft3d_dp(data_path_len, data_path, dir, n, c_in_dp) &
+         BIND(C, name="pw_fpga_fft3d_dp_")
+         IMPORT
+         INTEGER(KIND=C_INT), VALUE, INTENT(IN)  :: data_path_len
+         CHARACTER(len=1, kind=C_CHAR), TARGET    :: data_path(data_path_len)
+         INTEGER(KIND=C_INT), VALUE, INTENT(IN)   :: dir
+         INTEGER(KIND=C_INT), DIMENSION(*), &
+            INTENT(IN)                            :: n
+         COMPLEX(KIND=C_DOUBLE_COMPLEX)           :: c_in_dp(n(1), n(2), n(3))
+      END SUBROUTINE pw_fpga_fft3d_dp
+   END INTERFACE
+
+CONTAINS
+
+! **************************************************************************************************
+!> \brief Allocates resources on the fpga device
+! **************************************************************************************************
+   SUBROUTINE pw_fpga_init()
+#if defined (__PW_FPGA)
+      INTEGER :: stat
+
+#if defined (__PW_CUDA)
+#error "CUDA and FPGA cannot be configured concurrently!"
+#endif
+
+      stat = pw_fpga_initialize()
+      IF (stat /= 0) &
+         CPABORT("pw_fpga_init: failed")
+#endif
+   END SUBROUTINE pw_fpga_init
+
+! **************************************************************************************************
+!> \brief Releases resources on the fpga device
+! **************************************************************************************************
+   SUBROUTINE pw_fpga_finalize()
+#if defined (__PW_FPGA)
+      CALL pw_fpga_final()
+#endif
+   END SUBROUTINE pw_fpga_finalize
+
+! **************************************************************************************************
+!> \brief perform an in-place double precision fft3d on the FPGA
+!> \param n ...
+!> \param c_out  ...
+! **************************************************************************************************
+   SUBROUTINE pw_fpga_r3dc1d_3d_dp(n, c_out)
+      INTEGER, DIMENSION(:), INTENT(IN)          :: n
+      COMPLEX(KIND=dp), INTENT(INOUT)            :: c_out(n(1), n(2), n(3))
+
+#if ! defined (__PW_FPGA)
+      MARK_USED(c_out)
+      MARK_USED(n)
+#else
+      INTEGER                                     :: handle3
+      CHARACTER(len=100)                          :: data_path
+      INTEGER                                     :: data_path_len
+
+      CHARACTER(len=*), PARAMETER :: routineX = 'fw_fft_fpga_r3dc1d_dp'
+
+      data_path = TRIM(get_data_dir())
+      data_path_len = LEN_TRIM(data_path)
+
+      CALL timeset(routineX, handle3)
+      CALL pw_fpga_fft3d_dp(data_path_len, data_path, +1, n, c_out)
+      CALL timestop(handle3)
+
+#endif
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief perform an in-place double precision inverse fft3d on the FPGA
+!> \param n ...
+!> \param c_out  ...
+! **************************************************************************************************
+   SUBROUTINE pw_fpga_c1dr3d_3d_dp(n, c_out)
+      INTEGER, DIMENSION(:), INTENT(IN)                 :: n
+      COMPLEX(KIND=dp), INTENT(INOUT)    :: c_out(n(1), n(2), n(3))
+
+#if ! defined (__PW_FPGA)
+      MARK_USED(c_out)
+      MARK_USED(n)
+#else
+      INTEGER                                          :: handle3
+      CHARACTER(len=100)                               :: data_path
+      INTEGER                                          :: data_path_len
+
+      CHARACTER(len=*), PARAMETER :: routineX = 'bw_fft_fpga_c1dr3d_dp'
+
+      data_path = TRIM(get_data_dir())
+      data_path_len = LEN_TRIM(data_path)
+
+      CALL timeset(routineX, handle3)
+      CALL pw_fpga_fft3d_dp(data_path_len, data_path, -1, n, c_out)
+      CALL timestop(handle3)
+
+#endif
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief perform an in-place single precision fft3d on the FPGA
+!> \param n ...
+!> \param c_out  ...
+! **************************************************************************************************
+   SUBROUTINE pw_fpga_r3dc1d_3d_sp(n, c_out)
+      INTEGER, DIMENSION(:), INTENT(IN)                 :: n
+      COMPLEX(KIND=dp), INTENT(INOUT)             :: c_out(n(1), n(2), n(3))
+
+#if ! defined (__PW_FPGA)
+      MARK_USED(c_out)
+      MARK_USED(n)
+#else
+      COMPLEX, DIMENSION(:, :, :), POINTER             :: c_in_sp
+      INTEGER                                          :: handle3
+      CHARACTER(len=100)                               :: data_path
+      INTEGER                                          :: data_path_len
+
+      CHARACTER(len=*), PARAMETER :: routineX = 'fw_fft_fpga_r3dc1d_sp'
+
+      data_path = TRIM(get_data_dir())
+      data_path_len = LEN_TRIM(data_path)
+
+      ALLOCATE (c_in_sp(n(1), n(2), n(3)))
+      ! pointer to single precision complex array
+      c_in_sp = CMPLX(c_out, KIND=sp)
+
+      CALL timeset(routineX, handle3)
+      CALL pw_fpga_fft3d_sp(data_path_len, data_path, +1, n, c_in_sp)
+      CALL timestop(handle3)
+
+      ! typecast sp back to dp
+      !c_out = CMPLX(real(c_in_sp), 0.0_dp, KIND=dp)
+      c_out = CMPLX(c_in_sp, KIND=dp)
+
+      DEALLOCATE (c_in_sp)
+#endif
+   END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief perform an in-place single precision inverse fft3d on the FPGA
+!> \param n ...
+!> \param c_out  ...
+! **************************************************************************************************
+   SUBROUTINE pw_fpga_c1dr3d_3d_sp(n, c_out)
+      INTEGER, DIMENSION(:), INTENT(IN)                 :: n
+      COMPLEX(KIND=dp), INTENT(INOUT)             :: c_out(n(1), n(2), n(3))
+
+#if ! defined (__PW_FPGA)
+      MARK_USED(c_out)
+      MARK_USED(n)
+
+#else
+      COMPLEX, DIMENSION(:, :, :), POINTER             :: c_in_sp
+      INTEGER                                          :: handle3
+      CHARACTER(len=100)                               :: data_path
+      INTEGER                                          :: data_path_len
+
+      CHARACTER(len=*), PARAMETER :: routineX = 'bw_fft_fpga_c1dr3d_sp'
+
+      data_path = TRIM(get_data_dir())
+      data_path_len = LEN_TRIM(data_path)
+
+      ALLOCATE (c_in_sp(n(1), n(2), n(3)))
+      ! pointer to single precision complex array
+      c_in_sp = CMPLX(c_out, KIND=sp)
+
+      CALL timeset(routineX, handle3)
+      CALL pw_fpga_fft3d_sp(data_path_len, data_path, -1, n, c_in_sp)
+      CALL timestop(handle3)
+
+      ! typecast sp back to dp
+      c_out = CMPLX(c_in_sp, KIND=dp)
+
+      DEALLOCATE (c_in_sp)
+#endif
+   END SUBROUTINE
+
+END MODULE pw_fpga
+

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -36,6 +36,11 @@ MODULE pw_methods
                                               pw_cuda_c1dr3d_3d_ps,&
                                               pw_cuda_r3dc1d_3d,&
                                               pw_cuda_r3dc1d_3d_ps
+   USE pw_fpga,                         ONLY: pw_fpga_c1dr3d_3d_dp,&
+                                              pw_fpga_c1dr3d_3d_sp,&
+                                              pw_fpga_check_bitstream,&
+                                              pw_fpga_r3dc1d_3d_dp,&
+                                              pw_fpga_r3dc1d_3d_sp
    USE pw_grid_types,                   ONLY: HALFSPACE,&
                                               PW_MODE_DISTRIBUTED,&
                                               PW_MODE_LOCAL,&
@@ -1376,6 +1381,30 @@ CONTAINS
          CASE ("FW_R3DC1D")
 #if defined (__PW_CUDA)
             CALL pw_cuda_r3dc1d_3d(pw1, pw2, scale=norm)
+#elif defined (__PW_FPGA)
+            ! check if bitstream for the fft size is present
+            ! if not, perform fft3d in CPU
+            IF (pw_fpga_check_bitstream(n) .EQV. .TRUE.) THEN
+               ALLOCATE (c_out(n(1), n(2), n(3)))
+
+               CALL copy_rc(pw1%cr3d, c_out)
+#if defined (__PW_FPGA_SP)
+               CALL pw_fpga_r3dc1d_3d_sp(n, c_out)
+#else
+               CALL pw_fpga_r3dc1d_3d_dp(n, c_out)
+#endif
+               CALL zdscal(n(1)*n(2)*n(3), norm, c_out, 1)
+
+               CALL pw_gather(pw2, c_out)
+
+               DEALLOCATE (c_out)
+            ELSE
+               ALLOCATE (c_out(n(1), n(2), n(3)))
+               CALL copy_rc(pw1%cr3d, c_out)
+               CALL fft3d(dir, n, c_out, scale=norm, debug=test)
+               CALL pw_gather(pw2, c_out)
+               DEALLOCATE (c_out)
+            ENDIF
 #else
             ALLOCATE (c_out(n(1), n(2), n(3)))
             CALL copy_rc(pw1%cr3d, c_out)
@@ -1403,6 +1432,35 @@ CONTAINS
          CASE ("BW_C1DR3D")
 #if defined (__PW_CUDA)
             CALL pw_cuda_c1dr3d_3d(pw1, pw2, scale=norm)
+#elif defined (__PW_FPGA)
+            ! check if bitstream for the fft size is present
+            ! if not, perform fft3d in CPU
+            IF (pw_fpga_check_bitstream(n) .EQV. .TRUE.) THEN
+               ALLOCATE (c_out(n(1), n(2), n(3)))
+
+               CALL pw_scatter(pw1, c_out)
+               ! transform using FPGA
+#if defined (__PW_FPGA_SP)
+               CALL pw_fpga_c1dr3d_3d_sp(n, c_out)
+#else
+               CALL pw_fpga_c1dr3d_3d_dp(n, c_out)
+#endif
+               CALL zdscal(n(1)*n(2)*n(3), norm, c_out, 1)
+               ! use real part only
+               CALL copy_cr(c_out, pw2%cr3d)
+
+               DEALLOCATE (c_out)
+            ELSE
+               ALLOCATE (c_out(n(1), n(2), n(3)))
+               IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_SCATTER : 3d -> 1d "
+               CALL pw_scatter(pw1, c_out)
+               ! transform
+               CALL fft3d(dir, n, c_out, scale=norm, debug=test)
+               ! use real part only
+               IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  REAL part "
+               CALL copy_cr(c_out, pw2%cr3d)
+               DEALLOCATE (c_out)
+            END IF
 #else
             ALLOCATE (c_out(n(1), n(2), n(3)))
             IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_SCATTER : 3d -> 1d "

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -38,7 +38,7 @@ MODULE pw_methods
                                               pw_cuda_r3dc1d_3d_ps
    USE pw_fpga,                         ONLY: pw_fpga_c1dr3d_3d_dp,&
                                               pw_fpga_c1dr3d_3d_sp,&
-                                              pw_fpga_check_bitstream,&
+                                              pw_fpga_init_bitstream,&
                                               pw_fpga_r3dc1d_3d_dp,&
                                               pw_fpga_r3dc1d_3d_sp
    USE pw_grid_types,                   ONLY: HALFSPACE,&
@@ -1382,29 +1382,24 @@ CONTAINS
 #if defined (__PW_CUDA)
             CALL pw_cuda_r3dc1d_3d(pw1, pw2, scale=norm)
 #elif defined (__PW_FPGA)
+            ALLOCATE (c_out(n(1), n(2), n(3)))
             ! check if bitstream for the fft size is present
             ! if not, perform fft3d in CPU
-            IF (pw_fpga_check_bitstream(n) .EQV. .TRUE.) THEN
-               ALLOCATE (c_out(n(1), n(2), n(3)))
-
+            IF (pw_fpga_init_bitstream(n) == 1) THEN
                CALL copy_rc(pw1%cr3d, c_out)
-#if defined (__PW_FPGA_SP)
+#if (__PW_FPGA_SP && __PW_FPGA)
                CALL pw_fpga_r3dc1d_3d_sp(n, c_out)
 #else
                CALL pw_fpga_r3dc1d_3d_dp(n, c_out)
 #endif
                CALL zdscal(n(1)*n(2)*n(3), norm, c_out, 1)
-
                CALL pw_gather(pw2, c_out)
-
-               DEALLOCATE (c_out)
             ELSE
-               ALLOCATE (c_out(n(1), n(2), n(3)))
                CALL copy_rc(pw1%cr3d, c_out)
                CALL fft3d(dir, n, c_out, scale=norm, debug=test)
                CALL pw_gather(pw2, c_out)
-               DEALLOCATE (c_out)
             ENDIF
+            DEALLOCATE (c_out)
 #else
             ALLOCATE (c_out(n(1), n(2), n(3)))
             CALL copy_rc(pw1%cr3d, c_out)
@@ -1433,14 +1428,13 @@ CONTAINS
 #if defined (__PW_CUDA)
             CALL pw_cuda_c1dr3d_3d(pw1, pw2, scale=norm)
 #elif defined (__PW_FPGA)
+            ALLOCATE (c_out(n(1), n(2), n(3)))
             ! check if bitstream for the fft size is present
             ! if not, perform fft3d in CPU
-            IF (pw_fpga_check_bitstream(n) .EQV. .TRUE.) THEN
-               ALLOCATE (c_out(n(1), n(2), n(3)))
-
+            IF (pw_fpga_init_bitstream(n) == 1) THEN
                CALL pw_scatter(pw1, c_out)
                ! transform using FPGA
-#if defined (__PW_FPGA_SP)
+#if (__PW_FPGA_SP && __PW_FPGA)
                CALL pw_fpga_c1dr3d_3d_sp(n, c_out)
 #else
                CALL pw_fpga_c1dr3d_3d_dp(n, c_out)
@@ -1448,10 +1442,7 @@ CONTAINS
                CALL zdscal(n(1)*n(2)*n(3), norm, c_out, 1)
                ! use real part only
                CALL copy_cr(c_out, pw2%cr3d)
-
-               DEALLOCATE (c_out)
             ELSE
-               ALLOCATE (c_out(n(1), n(2), n(3)))
                IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_SCATTER : 3d -> 1d "
                CALL pw_scatter(pw1, c_out)
                ! transform
@@ -1459,8 +1450,8 @@ CONTAINS
                ! use real part only
                IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  REAL part "
                CALL copy_cr(c_out, pw2%cr3d)
-               DEALLOCATE (c_out)
             END IF
+            DEALLOCATE (c_out)
 #else
             ALLOCATE (c_out(n(1), n(2), n(3)))
             IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_SCATTER : 3d -> 1d "

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -121,6 +121,8 @@ MODULE cp2k_runs
    USE pint_methods,                    ONLY: do_pint_run
    USE pw_cuda,                         ONLY: pw_cuda_finalize,&
                                               pw_cuda_init
+   USE pw_fpga,                         ONLY: pw_fpga_init, &
+                                              pw_fpga_finalize
    USE qs_environment_types,            ONLY: get_qs_env
    USE qs_linres_module,                ONLY: linres_calculation
    USE qs_tddfpt_module,                ONLY: tddfpt_calculation
@@ -202,6 +204,8 @@ CONTAINS
 
       CALL pw_cuda_init()
 
+      CALL pw_fpga_init()
+
       CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
 
       CALL cp_sirius_init()
@@ -266,10 +270,12 @@ CONTAINS
          CALL dbcsr_finalize_lib()
          CALL cp_sirius_finalize()
          CALL pw_cuda_finalize()
+         CALL pw_fpga_finalize()
          CALL farming_run(input_declaration, root_section, para_env)
          CALL cp_sirius_init()
          CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
          CALL pw_cuda_init()
+         CALL pw_fpga_init()
       CASE (do_opt_basis)
          CALL run_optimize_basis(input_declaration, root_section, para_env)
          globenv%run_type_id = none_run
@@ -393,6 +399,9 @@ CONTAINS
       CALL cp_sirius_finalize()
 
       CALL pw_cuda_finalize()
+
+      CALL pw_fpga_finalize()
+
       CALL dbcsr_print_statistics()
       CALL dbcsr_finalize_lib()
 


### PR DESCRIPTION
Added APIs for computing single and double precision forward and backward fft3d
with intel fpgas set using -D__PW_FPGA and -D__PW_FPGA_SP flags. Tested for
FW_R3DC1D and BW_C1DR3D calculations for sizes 16^3, 32^3, 64^3 fft3d. If sizes
not found, falls back to CPU FFT computations.
Included host and kernel code that work with uniform fft3d sizes.

- included OpenCL Utils Library replacing Intel's
- opencl kernel files moved to external repo
- cuda and fpga are mutually exclusive