### PR TITLE
Improve CPUID hint for cases where CFLAGS are not in sync with FCFLAGS

### DIFF
--- a/src/base/machine.F
+++ b/src/base/machine.F
@@ -210,9 +210,9 @@ END FUNCTION m_cpuid
 ! **************************************************************************************************
 FUNCTION m_cpuid_name(cpuid)
       INTEGER                                            :: cpuid
-      CHARACTER, POINTER                                 :: m_cpuid_name(:)
+      CHARACTER(len=default_string_length), POINTER      :: m_cpuid_name
 
-      CHARACTER, DIMENSION(default_string_length), SAVE, TARGET :: name_generic = "generic", &
+      CHARACTER(len=default_string_length), SAVE, TARGET :: name_generic = "generic", &
          name_unknown = "unknown", name_x86_avx = "x86_avx", name_x86_avx2 = "x86_avx2", &
          name_x86_avx512 = "x86_avx512", name_x86_sse4 = "x86_sse4"
 

--- a/src/base/machine.F
+++ b/src/base/machine.F
@@ -56,10 +56,10 @@ MODULE machine
 
   PRIVATE
 
-  PUBLIC :: m_walltime, m_datum, m_flush, m_flush_internal,&
-            m_hostnm, m_getcwd, m_getlog, m_getpid, m_getarg, m_procrun,&
-            m_memory, m_iargc, m_abort, m_chdir, m_mov, m_memory_details,&
-            m_energy, m_memory_max, m_cpuinfo, m_cpuid_static, m_cpuid
+  PUBLIC :: m_walltime, m_datum, m_hostnm, m_flush, m_flush_internal,&
+            m_getcwd, m_getlog, m_getpid, m_getarg, m_iargc, m_procrun, m_abort,&
+            m_chdir, m_mov, m_memory, m_memory_details, m_memory_max, m_energy,&
+            m_cpuinfo, m_cpuid_static, m_cpuid, m_cpuid_name
 
   INTERFACE
     ! **********************************************************************************************
@@ -200,6 +200,37 @@ PURE FUNCTION m_cpuid() RESULT (cpuid)
     cpuid = m_cpuid_static()
 #endif
 END FUNCTION m_cpuid
+
+! **************************************************************************************************
+!> \brief Determine name of target architecture for a given CPUID.
+!> \param cpuid integer value (MACHINE_*)
+!> \return name or short name.
+!> \par History
+!>      06.2019 created [Hans Pabst]
+! **************************************************************************************************
+FUNCTION m_cpuid_name(cpuid)
+      INTEGER                                            :: cpuid
+      CHARACTER, POINTER                                 :: m_cpuid_name(:)
+
+      CHARACTER, DIMENSION(default_string_length), SAVE, TARGET :: name_generic = "generic", &
+         name_unknown = "unknown", name_x86_avx = "x86_avx", name_x86_avx2 = "x86_avx2", &
+         name_x86_avx512 = "x86_avx512", name_x86_sse4 = "x86_sse4"
+
+    SELECT CASE (cpuid)
+    CASE (MACHINE_CPU_GENERIC)
+       m_cpuid_name => name_generic
+    CASE (MACHINE_X86_SSE4)
+       m_cpuid_name => name_x86_sse4
+    CASE (MACHINE_X86_AVX)
+       m_cpuid_name => name_x86_avx
+    CASE (MACHINE_X86_AVX2)
+       m_cpuid_name => name_x86_avx2
+    CASE (MACHINE_X86_AVX512)
+       m_cpuid_name => name_x86_avx512
+    CASE DEFAULT
+       m_cpuid_name => name_unknown
+    END SELECT
+END FUNCTION m_cpuid_name
 
 ! **************************************************************************************************
 !> \brief returns the energy used since some time in the past.

--- a/src/environment.F
+++ b/src/environment.F
@@ -66,14 +66,9 @@ MODULE environment
                                               dp,&
                                               int_8,&
                                               print_kind_info
-   USE machine,                         ONLY: flush_should_flush,&
-                                              m_cpuid,&
-                                              m_cpuid_static,&
-                                              m_cpuinfo,&
-                                              m_energy,&
-                                              m_flush_internal,&
-                                              m_memory_details,&
-                                              m_procrun
+   USE machine,                         ONLY: &
+        MACHINE_CPU_GENERIC, flush_should_flush, m_cpuid, m_cpuid_static, m_cpuinfo, m_energy, &
+        m_flush_internal, m_memory_details, m_procrun
    USE message_passing,                 ONLY: add_mp_perf_env,&
                                               describe_mp_perf_env,&
                                               mp_collect_timings,&
@@ -800,10 +795,14 @@ CONTAINS
          CALL m_cpuinfo(model_name)
          WRITE (UNIT=output_unit, FMT="(T2,A)") &
             start_section_label//"| CPU model name : "//TRIM(model_name)
-         IF (m_cpuid_static() .LT. m_cpuid()) THEN
-            CALL cp_hint(__LOCATION__, &
-                         "The compiler target flags used to build this binary are insufficiently "// &
-                         "exploiting the extensions which are available for this CPU model.")
+         IF (MACHINE_CPU_GENERIC .NE. m_cpuid_static()) THEN
+            IF (m_cpuid_static() .LT. m_cpuid()) THEN
+               CALL cp_hint(__LOCATION__, &
+                            "The compiler target flags used to build this binary are insufficiently "// &
+                            "exploiting the extensions which are available for this CPU model.")
+            END IF
+         ELSE ! base/machine_cpuid.c relies on the (same) target flags as the Fortran code
+            CPHINT("Consider compiler target flags as part of FCFLAGS and CFLAGS (ARCH file).")
          END IF
 
          WRITE (UNIT=output_unit, FMT="()")

--- a/src/environment.F
+++ b/src/environment.F
@@ -798,10 +798,11 @@ CONTAINS
 
          IF (m_cpuid_static() .LT. m_cpuid()) THEN
             ! base/machine_cpuid.c relies on the (same) target flags as the Fortran code
-            CALL cp_hint(__LOCATION__, "The compiler target flags ("//m_cpuid_name(m_cpuid_static())// &
-                         ") used to build this binary cannot exploit all extensions of this CPU model ("// &
-                         m_cpuid_name(m_cpuid())//")."// &
-                         "Consider compiler target flags as part of FCFLAGS and CFLAGS (ARCH file).")
+            CALL cp_hint(__LOCATION__, "The compiler target flags ("// &
+                         TRIM(m_cpuid_name(m_cpuid_static()))//") used to build"//NEW_LINE("C")// &
+                         "   this binary cannot exploit all extensions of this CPU model ("// &
+                         TRIM(m_cpuid_name(m_cpuid()))//")."//NEW_LINE("C")// &
+                         "   Consider compiler target flags as part of FCFLAGS and CFLAGS (ARCH file).")
          END IF
 
          WRITE (UNIT=output_unit, FMT="()")

--- a/src/environment.F
+++ b/src/environment.F
@@ -66,14 +66,9 @@ MODULE environment
                                               dp,&
                                               int_8,&
                                               print_kind_info
-   USE machine,                         ONLY: flush_should_flush,&
-                                              m_cpuid,&
-                                              m_cpuid_static,&
-                                              m_cpuinfo,&
-                                              m_energy,&
-                                              m_flush_internal,&
-                                              m_memory_details,&
-                                              m_procrun
+   USE machine,                         ONLY: &
+        flush_should_flush, m_cpuid, m_cpuid_name, m_cpuid_static, m_cpuinfo, m_energy, &
+        m_flush_internal, m_memory_details, m_procrun
    USE message_passing,                 ONLY: add_mp_perf_env,&
                                               describe_mp_perf_env,&
                                               mp_collect_timings,&

--- a/src/environment.F
+++ b/src/environment.F
@@ -66,9 +66,14 @@ MODULE environment
                                               dp,&
                                               int_8,&
                                               print_kind_info
-   USE machine,                         ONLY: &
-        MACHINE_CPU_GENERIC, flush_should_flush, m_cpuid, m_cpuid_static, m_cpuinfo, m_energy, &
-        m_flush_internal, m_memory_details, m_procrun
+   USE machine,                         ONLY: flush_should_flush,&
+                                              m_cpuid,&
+                                              m_cpuid_static,&
+                                              m_cpuinfo,&
+                                              m_energy,&
+                                              m_flush_internal,&
+                                              m_memory_details,&
+                                              m_procrun
    USE message_passing,                 ONLY: add_mp_perf_env,&
                                               describe_mp_perf_env,&
                                               mp_collect_timings,&
@@ -795,14 +800,13 @@ CONTAINS
          CALL m_cpuinfo(model_name)
          WRITE (UNIT=output_unit, FMT="(T2,A)") &
             start_section_label//"| CPU model name : "//TRIM(model_name)
-         IF (MACHINE_CPU_GENERIC .NE. m_cpuid_static()) THEN
-            IF (m_cpuid_static() .LT. m_cpuid()) THEN
-               CALL cp_hint(__LOCATION__, &
-                            "The compiler target flags used to build this binary are insufficiently "// &
-                            "exploiting the extensions which are available for this CPU model.")
-            END IF
-         ELSE ! base/machine_cpuid.c relies on the (same) target flags as the Fortran code
-            CPHINT("Consider compiler target flags as part of FCFLAGS and CFLAGS (ARCH file).")
+
+         IF (m_cpuid_static() .LT. m_cpuid()) THEN
+            ! base/machine_cpuid.c relies on the (same) target flags as the Fortran code
+            CALL cp_hint(__LOCATION__, "The compiler target flags ("//m_cpuid_name(m_cpuid_static())// &
+                         ") used to build this binary cannot exploit all extensions of this CPU model ("// &
+                         m_cpuid_name(m_cpuid())//")."// &
+                         "Consider compiler target flags as part of FCFLAGS and CFLAGS (ARCH file).")
          END IF
 
          WRITE (UNIT=output_unit, FMT="()")


### PR DESCRIPTION
The translation unit base/machine_cpuid.c relies on the (same) target flags as the Fortran code, otherwise it is impossible (with the current implementation) to determine which target flags have been given at compile-time of CP2K.

If m_cpuid_static() returns MACHINE_CPU_GENERIC, then it is likely CFLAGS did not carry the same target flags as FCFLAGS. Instead of hinting "The compiler target flags used to build this binary are insufficiently exploiting the extensions which are available for this CPU model", the hint "Consider compiler target flags as part of FCFLAGS and CFLAGS (ARCH file)" is given.

Prettified the source code.