### PR TITLE
Fix ScaLAPACK settings for MPICH & MKL

### DIFF
--- a/tools/toolchain/scripts/install_elpa.sh
+++ b/tools/toolchain/scripts/install_elpa.sh
@@ -42,7 +42,7 @@ case "$with_elpa" in
                 echo "elpa-${elpa_ver}.tar.gz is found"
             else
                 download_pkg ${DOWNLOADER_FLAGS} ${elpa_sha256} \
-                             https://elpa.mpcdf.mpg.de/html/Releases/${elpa_ver}/elpa-${elpa_ver}.tar.gz
+                             https://www.cp2k.org/static/downloads/elpa-${elpa_ver}.tar.gz
             fi
             [ -d elpa-${elpa_ver} ] && rm -rf elpa-${elpa_ver}
             echo "Installing from scratch into ${pkg_install_dir}"

--- a/tools/toolchain/scripts/install_mkl.sh
+++ b/tools/toolchain/scripts/install_mkl.sh
@@ -73,17 +73,16 @@ if [ "$with_mkl" != "__DONTUSE__" ] ; then
         mkl_optional_libs="libmkl_scalapack_lp64.a"
         case $MPI_MODE in
             mpich)
-                mkl_optional_libs="$mkl_optional_libs libmkl_blacs_intelmpi_lp64.a"
-                mkl_blacs_lib="libmkl_blacs_lp64.a"
+                mkl_blacs_lib="libmkl_blacs_intelmpi_lp64.a"
                 ;;
             openmpi)
-                mkl_optional_libs="$mkl_optional_libs libmkl_blacs_openmpi_lp64.a"
                 mkl_blacs_lib="libmkl_blacs_openmpi_lp64.a"
                 ;;
             *)
                 enable_mkl_scalapack="__FALSE__"
                 ;;
         esac
+        mkl_optional_libs="$mkl_optional_libs $mkl_blacs_lib"
         for ii in $mkl_optional_libs ; do
             if ! [ -f "${mkl_lib_dir}/${ii}" ] ; then
                 enable_mkl_scalapack="__FALSE__"

--- a/tools/toolchain/scripts/install_mkl.sh
+++ b/tools/toolchain/scripts/install_mkl.sh
@@ -73,7 +73,7 @@ if [ "$with_mkl" != "__DONTUSE__" ] ; then
         mkl_optional_libs="libmkl_scalapack_lp64.a"
         case $MPI_MODE in
             mpich)
-                mkl_optional_libs="$mkl_optional_libs libmkl_blacs_lp64.a"
+                mkl_optional_libs="$mkl_optional_libs libmkl_blacs_intelmpi_lp64.a"
                 mkl_blacs_lib="libmkl_blacs_lp64.a"
                 ;;
             openmpi)
@@ -94,6 +94,7 @@ if [ "$with_mkl" != "__DONTUSE__" ] ; then
             MKL_LIBS="${mkl_lib_dir}/libmkl_scalapack_lp64.a ${MKL_LIBS} ${mkl_lib_dir}/${mkl_blacs_lib}"
         fi
     else
+        echo "Not using MKL provided ScaLAPACK and BLACS"
         enable_mkl_scalapack="__FALSE__"
     fi
     MKL_LIBS="${MKL_LIBS} -Wl,--end-group -lpthread -lm -ldl"

--- a/tools/toolchain/scripts/install_mpich.sh
+++ b/tools/toolchain/scripts/install_mpich.sh
@@ -97,7 +97,7 @@ EOF
         mpi2_dflags=''
     fi
     cat <<EOF >> "${BUILDDIR}/setup_mpich"
-export MPI_MODE="__MPICH__"
+export MPI_MODE="${MPI_MODE}"
 export MPICH_CFLAGS="${MPICH_CFLAGS}"
 export MPICH_LDFLAGS="${MPICH_LDFLAGS}"
 export MPICH_LIBS="${MPICH_LIBS}"


### PR DESCRIPTION
These changes allow `install_mkl.sh` to find the required libraries and enable ScaLAPACK from MKL. Something is still not quite right, though, as the script still builds Netlib ScaLAPACK, unless I give ` --with-scalapack=no`.

I don't know if there are MKL versions that actually provide `libmkl_blacs_lp64.a`, but I checked the MKL link advisor and it suggests `libmkl_blacs_intelmpi_lp64.a` for MPICH, at least for MKL versions 2017-2019.