### PR TITLE
Increase length of 'reference' array in xc_write

### DIFF
--- a/src/xc_write_output.F
+++ b/src/xc_write_output.F
@@ -45,9 +45,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xc_write', routineP = moduleN//':'//routineN
 
-      CHARACTER(LEN=20*default_string_length)            :: reference
       CHARACTER(LEN=2*default_string_length)             :: shortform
       CHARACTER(LEN=20)                                  :: tmpStr
+      CHARACTER(LEN=20*default_string_length)            :: reference
       INTEGER                                            :: i_rep, ifun, il, myfun, n_rep
       TYPE(section_vals_type), POINTER                   :: libxc_fun, xc_fun, xc_fun_section
 

--- a/src/xc_write_output.F
+++ b/src/xc_write_output.F
@@ -45,7 +45,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xc_write', routineP = moduleN//':'//routineN
 
-      CHARACTER(LEN=10*default_string_length)            :: reference
+      CHARACTER(LEN=20*default_string_length)            :: reference
       CHARACTER(LEN=2*default_string_length)             :: shortform
       CHARACTER(LEN=20)                                  :: tmpStr
       INTEGER                                            :: i_rep, ifun, il, myfun, n_rep


### PR DESCRIPTION
When using the HSE06 hybrid functional from LIBXC, CP2K crashes because the length assigned to `reference` in xc_write is not enough. As a fix, I simply doubled the size of the character array. The input file Ne.txt produces the mentioned error.
[Ne.txt](https://github.com/cp2k/cp2k/files/3345826/Ne.txt)

