### PR TITLE
Adjust tolerance in QS/regtest-rel/h2o-1.inp

### DIFF
--- a/tests/QS/regtest-rel/TEST_FILES
+++ b/tests/QS/regtest-rel/TEST_FILES
@@ -1,7 +1,7 @@
 # runs are executed in the same order as in this file
 # the second field tells which test should be run in order to compare with the last available output
 # see regtest/TEST_FILES
-h2o-1.inp                                              1      3e-13             -75.93975427735262
+h2o-1.inp                                              1      1e-12             -75.93975427735262
 h2o-2.inp                                              1      1E-12             -75.93978939364264
 h2o-3.inp                                              1      7e-11             -75.94409355435376
 h2o-4.inp                                              1      3e-11             -75.95928403905509


### PR DESCRIPTION
The single failed test in my previous PR (38a7112) is not caused by my routines. The reason for the failure is an overly tight in ERROR threshold in TEST_FILES