### PR TITLE
Cubic scaling RPA: group sizes no longer needed in input

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "exts/dbcsr"]
 	path = exts/dbcsr
 	url = https://github.com/cp2k/dbcsr
-	branch = master
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "exts/dbcsr"]
 	path = exts/dbcsr
 	url = https://github.com/cp2k/dbcsr
-	branch = develop
+	branch = master

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -1241,7 +1241,8 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="GROUP_SIZE_3c", &
-                          description="Group size used for cutting the RI index P in (alpha beta P) and for "// &
+                          description="This keyword is not needed if DO_DBCSR_T enabled. "// &
+                          "Group size used for cutting the RI index P in (alpha beta P) and for "// &
                           "the multiplication M^occ/virt(it)=(alpha beta P)*D^occ/virt. Has to be increased "// &
                           "for larger systems, at least linearly with system size, at most quadratically in  "// &
                           "system size.", &
@@ -1251,7 +1252,8 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="GROUP_SIZE_P", &
-                          description="Group size used for the calculation of P(it)=(Mocc(it))^T*Mvirt(it). "// &
+                          description="This keyword is not needed if DO_DBCSR_T enabled. "// &
+                          "Group size used for the calculation of P(it)=(Mocc(it))^T*Mvirt(it). "// &
                           "Default is to use a single process. A larger group size (for example the node size), "// &
                           "could be recommended for larger systems, since the P matrix is replicated in every group. ", &
                           usage="GROUP_SIZE_P 8", &
@@ -1304,6 +1306,16 @@ CONTAINS
          usage="DO_DBCSR_T", &
          default_l_val=.TRUE., &
          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
+         name="GROUP_SIZE_INTERNAL", &
+         description="If DO_DBCSR_T and this keyword set to .TRUE., group sizes are automatic and keywords GROUP_SIZE_3C "// &
+         "& GROUP_SIZE_P are ignored. This should be set to .FALSE. for testing purposes only.", &
+         usage="GROUP_SIZE_INTERNAL F", &
+         default_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -115,6 +115,8 @@ MODULE mp2_integrals
                                               pw_p_type
    USE qs_3c_tensors,                   ONLY: build_3c_integrals,&
                                               build_3c_neighbor_lists,&
+                                              contiguous_tensor_dist,&
+                                              cyclic_tensor_dist,&
                                               distribution_3d_create,&
                                               neighbor_list_3c_destroy
    USE qs_3c_tensors_types,             ONLY: distribution_3d_type,&
@@ -326,9 +328,9 @@ CONTAINS
          sizes_RI_split, sub_proc_map
       INTEGER, ALLOCATABLE, DIMENSION(:, :) :: local_col_row_info, local_col_row_info_beta, &
          local_col_row_info_gw, local_col_row_info_occ_bse, local_col_row_info_virt_bse
-      INTEGER, DIMENSION(3)                              :: periodic
+      INTEGER, DIMENSION(3)                              :: pdims_t3c, periodic
       LOGICAL                                            :: do_alpha_beta, do_kpoints_from_Gamma, &
-                                                            memory_info
+                                                            impose_split, memory_info
       REAL(KIND=dp)                                      :: cond_num, mem_for_iaK, wfn_size
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: my_Lrows
       TYPE(cp_eri_mme_param), POINTER                    :: eri_param
@@ -763,6 +765,7 @@ CONTAINS
 
          ngroup_im_time = para_env%num_pe/qs_env%mp2_env%ri_rpa_im_time%group_size_3c
          ngroup_im_time_P = para_env%num_pe/qs_env%mp2_env%ri_rpa_im_time%group_size_p
+         impose_split = .NOT. qs_env%mp2_env%ri_rpa_im_time%group_size_internal
 
          color_sub_3c = para_env%mepos/qs_env%mp2_env%ri_rpa_im_time%group_size_3c
 
@@ -782,7 +785,12 @@ CONTAINS
 
             CALL get_qs_env(qs_env, natom=natom, nkind=nkind)
 
-            pgrid_t3c_overl = create_tensor_pgrid(para_env, ngroup_im_time, map1_2d=[1, 2], map2_2d=[3])
+            IF (.NOT. impose_split) THEN
+               pdims_t3c = 0
+               CALL dbcsr_t_pgrid_create(para_env%group, pdims_t3c, pgrid_t3c_overl, map1_2d=[1, 2], map2_2d=[3])
+            ELSE
+               pgrid_t3c_overl = get_pgrid_from_ngroup(para_env, ngroup_im_time, map1_2d=[1, 2], map2_2d=[3])
+            ENDIF
 
             ! set up basis
             ALLOCATE (sizes_RI(natom), sizes_AO(natom))
@@ -796,7 +804,7 @@ CONTAINS
             nimg = dft_control%nimages
             ALLOCATE (t_3c_overl_int(nimg, nimg))
 
-            CALL create_tensor_O_3c(t_3c_overl_int(1, 1), pgrid_t3c_overl, ngroup_im_time, &
+            CALL create_tensor_O_3c(t_3c_overl_int(1, 1), pgrid_t3c_overl, &
                                     sizes_AO, sizes_AO, sizes_RI, &
                                     nl_3c=nl_3c, qs_env=qs_env, &
                                     basis_ao_1=basis_set_ao, basis_ao_2=basis_set_ao, basis_RI=basis_set_ri_aux, &
@@ -823,16 +831,21 @@ CONTAINS
             CALL split_block_sizes(sizes_AO, sizes_AO_split, sqrt_max_bsize)
             CALL split_block_sizes(sizes_RI, sizes_RI_split, sqrt_max_bsize)
 
-            pgrid_t3c_M = create_tensor_pgrid(para_env, ngroup_im_time_P, map1_2d=[1], map2_2d=[2, 3])
+            IF (.NOT. impose_split) THEN
+               pdims_t3c = 0
+               CALL dbcsr_t_pgrid_create(para_env%group, pdims_t3c, pgrid_t3c_M, map1_2d=[1], map2_2d=[2, 3])
+            ELSE
+               pgrid_t3c_M = get_pgrid_from_ngroup(para_env, ngroup_im_time_P, map1_2d=[1], map2_2d=[2, 3])
+            ENDIF
 
             CALL create_tensor_M_3c(t_3c_M, pgrid_t3c_M, &
-                                    cut_memory, ngroup_im_time_P, &
+                                    cut_memory, &
                                     sizes_AO_split, sizes_RI, starts_array_mc_t, ends_array_mc_t)
 
             CALL dbcsr_t_pgrid_destroy(pgrid_t3c_M)
 
             ALLOCATE (t_3c_O(SIZE(t_3c_overl_int, 1), SIZE(t_3c_overl_int, 2)))
-            CALL create_tensor_O_3c(t_3c_O(1, 1), pgrid_t3c_overl, ngroup_im_time, sizes_AO_split, &
+            CALL create_tensor_O_3c(t_3c_O(1, 1), pgrid_t3c_overl, sizes_AO_split, &
                                     sizes_AO, sizes_RI_split)
 
             CALL dbcsr_t_pgrid_destroy(pgrid_t3c_overl)
@@ -975,13 +988,13 @@ CONTAINS
 !> \param map2_2d mapping of 3d grid to 2 dimensions (see dbcsr_t_pgrid_create)
 !> \return process grid object compatible with DBCSR tensors
 ! **************************************************************************************************
-   FUNCTION create_tensor_pgrid(para_env, ngroup, map1_2d, map2_2d) RESULT(pgrid)
+   FUNCTION get_pgrid_from_ngroup(para_env, ngroup, map1_2d, map2_2d) RESULT(pgrid)
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER, INTENT(IN)                                :: ngroup
       INTEGER, DIMENSION(:), INTENT(IN)                  :: map1_2d, map2_2d
       TYPE(dbcsr_t_pgrid_type)                           :: pgrid
 
-      INTEGER                                            :: nproc_sub
+      INTEGER                                            :: dimsplit, nproc_sub
       INTEGER, DIMENSION(2)                              :: pdims_2_2d, pdims_sub_2d
       INTEGER, DIMENSION(3)                              :: pdims_t3c
 
@@ -991,15 +1004,18 @@ CONTAINS
       pdims_2_2d = 0
       CALL mp_dims_create(pdims_sub_2d(2)*ngroup, pdims_2_2d)
       IF (SIZE(map1_2d) == 1) THEN
+         dimsplit = 2
          pdims_t3c(map1_2d(1)) = pdims_sub_2d(1)
          pdims_t3c(map2_2d) = pdims_2_2d
       ELSEIF (SIZE(map2_2d) == 1) THEN
+         dimsplit = 1
          pdims_t3c(map2_2d(1)) = pdims_sub_2d(1)
          pdims_t3c(map1_2d) = pdims_2_2d
       ELSE
          CPABORT("map1_2d and map2_2d not compatible with a 3d grid")
       ENDIF
-      CALL dbcsr_t_pgrid_create(para_env%group, pdims_t3c, pgrid, map1_2d=map1_2d, map2_2d=map2_2d)
+      CALL dbcsr_t_pgrid_create(para_env%group, pdims_t3c, pgrid, map1_2d=map1_2d, map2_2d=map2_2d, &
+                                nsplit=ngroup, dimsplit=dimsplit)
    END FUNCTION
 
 ! **************************************************************************************************
@@ -1042,17 +1058,16 @@ CONTAINS
 !> \param t_3c_M ...
 !> \param pgrid_t3c_M ...
 !> \param mem_cut ...
-!> \param ngroup ...
 !> \param sizes_AO ...
 !> \param sizes_RI ...
 !> \param starts_array_mc ...
 !> \param ends_array_mc ...
 ! **************************************************************************************************
-   SUBROUTINE create_tensor_M_3c(t_3c_M, pgrid_t3c_M, mem_cut, ngroup, sizes_AO, sizes_RI, &
+   SUBROUTINE create_tensor_M_3c(t_3c_M, pgrid_t3c_M, mem_cut, sizes_AO, sizes_RI, &
                                  starts_array_mc, ends_array_mc)
       TYPE(dbcsr_t_type), INTENT(OUT)                    :: t_3c_M
       TYPE(dbcsr_t_pgrid_type), INTENT(IN)               :: pgrid_t3c_M
-      INTEGER, INTENT(IN)                                :: mem_cut, ngroup
+      INTEGER, INTENT(IN)                                :: mem_cut
       INTEGER, DIMENSION(:), INTENT(IN)                  :: sizes_AO, sizes_RI
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: starts_array_mc, ends_array_mc
 
@@ -1069,7 +1084,7 @@ CONTAINS
       size_AO = SIZE(sizes_AO)
 
       ALLOCATE (dist_RI(size_RI))
-      CALL cyclic_dist(size_RI, pdims(1), sizes_RI, dist_RI)
+      CALL cyclic_tensor_dist(size_RI, pdims(1), sizes_RI, dist_RI)
 
       ALLOCATE (starts_array_mc(mem_cut))
       ALLOCATE (ends_array_mc(mem_cut))
@@ -1080,7 +1095,7 @@ CONTAINS
          CPABORT("Use smaller MEMORY_CUT")
       ENDIF
 
-      CALL contiguous_dist(size_AO, mem_cut, sizes_AO, limits_start=starts_array_mc_block, limits_end=ends_array_mc_block)
+      CALL contiguous_tensor_dist(size_AO, mem_cut, sizes_AO, limits_start=starts_array_mc_block, limits_end=ends_array_mc_block)
 
       bsum = 0
       DO imem = 1, mem_cut
@@ -1096,16 +1111,15 @@ CONTAINS
          size_AO_cut = ends_array_mc_block(imem)-starts_array_mc_block(imem)+1
 
          IF (size_AO_cut < MIN(pdims(2), pdims(3))) THEN
-            CPABORT("Increment GROUP_SIZE_P, use smaller MEMORY_CUT or use less MPI ranks")
+            CPABORT("use smaller MEMORY_CUT or use less MPI ranks")
          ENDIF
-         CALL cyclic_dist(size_AO_cut, pdims(2), sizes_AO(starts_array_mc_block(imem):ends_array_mc_block(imem)), &
-                          dist=dist_ao_1(starts_array_mc_block(imem):ends_array_mc_block(imem)))
-         CALL cyclic_dist(size_AO_cut, pdims(3), sizes_AO(starts_array_mc_block(imem):ends_array_mc_block(imem)), &
-                          dist=dist_ao_2(starts_array_mc_block(imem):ends_array_mc_block(imem)))
+         CALL cyclic_tensor_dist(size_AO_cut, pdims(2), sizes_AO(starts_array_mc_block(imem):ends_array_mc_block(imem)), &
+                                 dist=dist_ao_1(starts_array_mc_block(imem):ends_array_mc_block(imem)))
+         CALL cyclic_tensor_dist(size_AO_cut, pdims(3), sizes_AO(starts_array_mc_block(imem):ends_array_mc_block(imem)), &
+                                 dist=dist_ao_2(starts_array_mc_block(imem):ends_array_mc_block(imem)))
       ENDDO
 
-      CALL dbcsr_t_distribution_new(dist, pgrid_t3c_M, [1], [2, 3], dist_RI, dist_ao_1, dist_ao_2, &
-                                    ngroup=ngroup, dimsplit=2)
+      CALL dbcsr_t_distribution_new(dist, pgrid_t3c_M, [1], [2, 3], dist_RI, dist_ao_1, dist_ao_2)
       CALL dbcsr_t_create(t_3c_M, "M (RI | AO AO)", dist, [1], [2, 3], dbcsr_type_real_8, sizes_RI, &
                           sizes_AO, sizes_AO)
       CALL dbcsr_t_distribution_destroy(dist)
@@ -1117,7 +1131,6 @@ CONTAINS
 !> \param t_3c_O Create tensor with overlap integrals, optionally create 3c neighbor list matching tensor
 !>        distribution
 !> \param mp_comm_t3c ...
-!> \param ngroup number of process subgroups
 !> \param ao_sizes_1 block sizes of first AO index
 !> \param ao_sizes_2 block sizes of second AO index
 !> \param sizes_RI block sizes of RI index
@@ -1128,12 +1141,11 @@ CONTAINS
 !> \param basis_RI needed for nl_3c
 !> \param do_kpoints ...
 ! **************************************************************************************************
-   SUBROUTINE create_tensor_O_3c(t_3c_O, mp_comm_t3c, ngroup, ao_sizes_1, ao_sizes_2, sizes_RI, &
+   SUBROUTINE create_tensor_O_3c(t_3c_O, mp_comm_t3c, ao_sizes_1, ao_sizes_2, sizes_RI, &
                                  nl_3c, qs_env, basis_ao_1, basis_ao_2, basis_RI, &
                                  do_kpoints)
       TYPE(dbcsr_t_type), INTENT(OUT)                    :: t_3c_O
       TYPE(dbcsr_t_pgrid_type), INTENT(IN)               :: mp_comm_t3c
-      INTEGER, INTENT(IN)                                :: ngroup
       INTEGER, DIMENSION(:), INTENT(IN)                  :: ao_sizes_1, ao_sizes_2, sizes_RI
       TYPE(neighbor_list_3c_type), INTENT(OUT), OPTIONAL :: nl_3c
       TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
@@ -1166,9 +1178,9 @@ CONTAINS
       ALLOCATE (dist_ao_1(size_AO_1))
       ALLOCATE (dist_ao_2(size_AO_2))
 
-      CALL cyclic_dist(size_RI, pdims(1), sizes_RI, dist_RI)
-      CALL cyclic_dist(size_AO_1, pdims(2), ao_sizes_1, dist_ao_1)
-      CALL cyclic_dist(size_AO_2, pdims(3), ao_sizes_2, dist_ao_2)
+      CALL cyclic_tensor_dist(size_RI, pdims(1), sizes_RI, dist_RI)
+      CALL cyclic_tensor_dist(size_AO_1, pdims(2), ao_sizes_1, dist_ao_1)
+      CALL cyclic_tensor_dist(size_AO_2, pdims(3), ao_sizes_2, dist_ao_2)
 
       IF (PRESENT(nl_3c)) THEN
          CPASSERT(PRESENT(qs_env))
@@ -1187,91 +1199,12 @@ CONTAINS
                                       sym_jk=.NOT. kp, own_dist=.TRUE.)
       ENDIF
 
-      CALL dbcsr_t_distribution_new(dist, mp_comm_t3c, [1, 2], [3], dist_RI, dist_ao_1, dist_ao_2, &
-                                    ngroup=ngroup, dimsplit=1)
+      CALL dbcsr_t_distribution_new(dist, mp_comm_t3c, [1, 2], [3], dist_RI, dist_ao_1, dist_ao_2)
       CALL dbcsr_t_create(t_3c_O, "O (RI AO | AO)", dist, [1, 2], [3], dbcsr_type_real_8, sizes_RI, &
                           ao_sizes_1, ao_sizes_2)
       CALL dbcsr_t_distribution_destroy(dist)
 
    END SUBROUTINE create_tensor_O_3c
-
-! **************************************************************************************************
-!> \brief contiguous distribution of weighted elements
-!> \param nel ...
-!> \param nbin ...
-!> \param weights ...
-!> \param limits_start ...
-!> \param limits_end ...
-!> \param dist ...
-! **************************************************************************************************
-   SUBROUTINE contiguous_dist(nel, nbin, weights, limits_start, limits_end, dist)
-      INTEGER, INTENT(IN)                                :: nel, nbin
-      INTEGER, DIMENSION(nel), INTENT(IN)                :: weights
-      INTEGER, DIMENSION(nbin), INTENT(OUT), OPTIONAL    :: limits_start, limits_end
-      INTEGER, DIMENSION(nel), INTENT(OUT), OPTIONAL     :: dist
-
-      INTEGER                                            :: el_end, el_start, end_weight, ibin, &
-                                                            nel_div, nel_rem, nel_split, nel_w, &
-                                                            w_partialsum
-
-      nel_w = SUM(weights)
-      nel_div = nel_w/nbin
-      nel_rem = MOD(nel_w, nbin)
-
-      w_partialsum = 0
-      el_end = 0
-      end_weight = 0
-      DO ibin = 1, nbin
-         nel_split = nel_div
-         IF (ibin <= nel_rem) THEN
-            nel_split = nel_split+1
-         ENDIF
-         el_start = el_end+1
-         el_end = el_start
-         w_partialsum = w_partialsum+weights(el_end)
-         end_weight = end_weight+nel_split
-         DO WHILE (w_partialsum < end_weight)
-            !IF (ABS(w_partialsum + weights(el_end) - end_weight) > ABS(w_partialsum - end_weight)) EXIT
-            el_end = el_end+1
-            w_partialsum = w_partialsum+weights(el_end)
-         ENDDO
-         IF (PRESENT(dist)) dist(el_start:el_end) = ibin-1
-         IF (PRESENT(limits_start)) limits_start(ibin) = el_start
-         IF (PRESENT(limits_end)) limits_end(ibin) = el_end
-      ENDDO
-
-   END SUBROUTINE contiguous_dist
-
-! **************************************************************************************************
-!> \brief cyclic distribution of weighted elements
-!> \param nel ...
-!> \param nbin ...
-!> \param weights ...
-!> \param dist ...
-! **************************************************************************************************
-   SUBROUTINE cyclic_dist(nel, nbin, weights, dist)
-      INTEGER, INTENT(IN)                                :: nel, nbin
-      INTEGER, DIMENSION(nel), INTENT(IN)                :: weights
-      INTEGER, DIMENSION(nel), INTENT(OUT)               :: dist
-
-      INTEGER                                            :: ibin, iel, niter
-      INTEGER, DIMENSION(nbin)                           :: occup
-
-      occup(:) = 0
-      ibin = 0
-      DO iel = 1, nel
-         niter = 0
-         ibin = MOD(ibin+1, nbin)
-         DO WHILE (occup(ibin+1)+weights(iel) .GE. MAXVAL(occup))
-            IF (MINLOC(occup, DIM=1) == ibin+1) EXIT
-            ibin = MOD(ibin+1, nbin)
-            niter = niter+1
-         ENDDO
-         dist(iel) = ibin
-         occup(ibin+1) = occup(ibin+1)+weights(iel)
-      ENDDO
-
-   END SUBROUTINE cyclic_dist
 
 ! **************************************************************************************************
 !> \brief Contract (P|ai) = (R|P) x (R|ai)

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -310,6 +310,8 @@ CONTAINS
                                 l_val=mp2_env%ri_rpa_im_time%do_dbcsr_t)
       CALL section_vals_val_get(mp2_section, "IM_TIME%MAX_BLOCK_SIZE_SQRT", &
                                 i_val=mp2_env%ri_rpa_im_time%max_bsize_sqrt)
+      CALL section_vals_val_get(mp2_section, "IM_TIME%GROUP_SIZE_INTERNAL", &
+                                l_val=mp2_env%ri_rpa_im_time%group_size_internal)
 
       CALL section_vals_val_get(mp2_section, "RI_LAPLACE%QUADRATURE_POINTS", &
                                 i_val=mp2_env%ri_laplace%n_quadrature)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -152,7 +152,7 @@ MODULE mp2_types
       INTEGER, DIMENSION(:), POINTER     :: nmao_occ, nmao_virt, kp_grid
       LOGICAL                  :: do_im_time_kpoints
       REAL(KIND=dp)            :: stabilize_exp
-      LOGICAL  :: do_dbcsr_t
+      LOGICAL  :: do_dbcsr_t, group_size_internal
       INTEGER  :: max_bsize_sqrt
    END TYPE
 

--- a/src/qs_3c_tensors.F
+++ b/src/qs_3c_tensors.F
@@ -77,7 +77,8 @@ MODULE qs_3c_tensors
 
    PUBLIC :: distribution_3d_create, distribution_3d_destroy, build_3c_neighbor_lists, &
              neighbor_list_3c_destroy, neighbor_list_3c_iterate, neighbor_list_3c_iterator_create, &
-             neighbor_list_3c_iterator_destroy, get_3c_iterator_info, build_3c_integrals
+             neighbor_list_3c_iterator_destroy, get_3c_iterator_info, build_3c_integrals, &
+             contiguous_tensor_dist, cyclic_tensor_dist
 
    TYPE one_dim_int_array
       INTEGER, DIMENSION(:), ALLOCATABLE    :: array
@@ -1124,5 +1125,83 @@ CONTAINS
 
       CALL timestop(handle)
    END SUBROUTINE
+
+! **************************************************************************************************
+!> \brief contiguous distribution of weighted elements
+!> \param nel ...
+!> \param nbin ...
+!> \param weights ...
+!> \param limits_start ...
+!> \param limits_end ...
+!> \param dist ...
+! **************************************************************************************************
+   SUBROUTINE contiguous_tensor_dist(nel, nbin, weights, limits_start, limits_end, dist)
+      INTEGER, INTENT(IN)                                :: nel, nbin
+      INTEGER, DIMENSION(nel), INTENT(IN)                :: weights
+      INTEGER, DIMENSION(nbin), INTENT(OUT), OPTIONAL    :: limits_start, limits_end
+      INTEGER, DIMENSION(nel), INTENT(OUT), OPTIONAL     :: dist
+
+      INTEGER                                            :: el_end, el_start, end_weight, ibin, &
+                                                            nel_div, nel_rem, nel_split, nel_w, &
+                                                            w_partialsum
+
+      nel_w = SUM(weights)
+      nel_div = nel_w/nbin
+      nel_rem = MOD(nel_w, nbin)
+
+      w_partialsum = 0
+      el_end = 0
+      end_weight = 0
+      DO ibin = 1, nbin
+         nel_split = nel_div
+         IF (ibin <= nel_rem) THEN
+            nel_split = nel_split+1
+         ENDIF
+         el_start = el_end+1
+         el_end = el_start
+         w_partialsum = w_partialsum+weights(el_end)
+         end_weight = end_weight+nel_split
+         DO WHILE (w_partialsum < end_weight)
+            !IF (ABS(w_partialsum + weights(el_end) - end_weight) > ABS(w_partialsum - end_weight)) EXIT
+            el_end = el_end+1
+            w_partialsum = w_partialsum+weights(el_end)
+         ENDDO
+         IF (PRESENT(dist)) dist(el_start:el_end) = ibin-1
+         IF (PRESENT(limits_start)) limits_start(ibin) = el_start
+         IF (PRESENT(limits_end)) limits_end(ibin) = el_end
+      ENDDO
+
+   END SUBROUTINE contiguous_tensor_dist
+
+! **************************************************************************************************
+!> \brief cyclic distribution of weighted elements
+!> \param nel ...
+!> \param nbin ...
+!> \param weights ...
+!> \param dist ...
+! **************************************************************************************************
+   SUBROUTINE cyclic_tensor_dist(nel, nbin, weights, dist)
+      INTEGER, INTENT(IN)                                :: nel, nbin
+      INTEGER, DIMENSION(nel), INTENT(IN)                :: weights
+      INTEGER, DIMENSION(nel), INTENT(OUT)               :: dist
+
+      INTEGER                                            :: ibin, iel, niter
+      INTEGER, DIMENSION(nbin)                           :: occup
+
+      occup(:) = 0
+      ibin = 0
+      DO iel = 1, nel
+         niter = 0
+         ibin = MOD(ibin+1, nbin)
+         DO WHILE (occup(ibin+1)+weights(iel) .GE. MAXVAL(occup))
+            IF (MINLOC(occup, DIM=1) == ibin+1) EXIT
+            ibin = MOD(ibin+1, nbin)
+            niter = niter+1
+         ENDDO
+         dist(iel) = ibin
+         occup(ibin+1) = occup(ibin+1)+weights(iel)
+      ENDDO
+
+   END SUBROUTINE cyclic_tensor_dist
 
 END MODULE

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -32,16 +32,21 @@ MODULE rpa_im_time
         dbcsr_init_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
         dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_p_type, dbcsr_release_p, &
         dbcsr_reserve_all_blocks, dbcsr_reserve_blocks, dbcsr_scalar, dbcsr_scale, dbcsr_set, &
-        dbcsr_type, dbcsr_type_no_symmetry
+        dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_real_8
    USE dbcsr_tensor_api,                ONLY: &
         dbcsr_t_clear, dbcsr_t_contract, dbcsr_t_copy, dbcsr_t_copy_matrix_to_tensor, &
-        dbcsr_t_copy_tensor_to_matrix, dbcsr_t_create, dbcsr_t_destroy, dbcsr_t_filter, &
-        dbcsr_t_get_info, dbcsr_t_need_contract, dbcsr_t_type
-   USE kinds,                           ONLY: dp,&
+        dbcsr_t_copy_tensor_to_matrix, dbcsr_t_create, dbcsr_t_destroy, &
+        dbcsr_t_distribution_destroy, dbcsr_t_distribution_new, dbcsr_t_distribution_type, &
+        dbcsr_t_filter, dbcsr_t_get_info, dbcsr_t_get_mapping_info, dbcsr_t_mp_environ_pgrid, &
+        dbcsr_t_need_contract, dbcsr_t_pgrid_destroy, dbcsr_t_pgrid_type, dbcsr_t_type, &
+        dbcsr_t_write_split_info
+   USE kinds,                           ONLY: default_string_length,&
+                                              dp,&
                                               int_8
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_env_type,&
                                               kpoint_type
+   USE machine,                         ONLY: m_walltime
    USE mathconstants,                   ONLY: twopi
    USE message_passing,                 ONLY: mp_alltoall,&
                                               mp_irecv,&
@@ -52,6 +57,7 @@ MODULE rpa_im_time
    USE mp2_types,                       ONLY: integ_mat_buffer_type,&
                                               mp2_type,&
                                               two_dim_int_array
+   USE qs_3c_tensors,                   ONLY: cyclic_tensor_dist
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
@@ -161,32 +167,78 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_P_omega_t', &
          routineP = moduleN//':'//routineN
 
-      INTEGER :: handle, handle4, handle5, handle6, i_cell, i_cell_R_1, i_cell_R_1_minus_S, &
+      INTEGER :: handle, handle5, handle6, i, i_cell, i_cell_R_1, i_cell_R_1_minus_S, &
          i_cell_R_1_minus_T, i_cell_R_2, i_cell_R_2_minus_S_minus_T, i_cell_S, i_cell_T, i_mem, &
-         iquad, j_mem, jquad, num_3c_repl, num_cells_dm, unit_nr_prv
-      INTEGER(KIND=int_8)                                :: num_flops_mat_P
+         iquad, j, j_mem, jquad, num_3c_repl, num_cells_dm, unit_nr_prv
+      INTEGER(KIND=int_8)                                :: flops_1_max_occ, flops_1_max_virt, &
+                                                            flops_1_occ, flops_1_virt, flops_2, &
+                                                            flops_2_max
       INTEGER, DIMENSION(2, 1)                           :: ibounds_2, jbounds_2
       INTEGER, DIMENSION(2, 2)                           :: ibounds_1, jbounds_1
-      INTEGER, DIMENSION(3)                              :: bounds_3c
+      INTEGER, DIMENSION(3)                              :: bounds_3c, pdims
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
-      LOGICAL :: do_Gamma_RPA, do_kpoints_cubic_RPA, first_cycle_im_time, first_cycle_omega_loop, &
-         memory_info, R_1_minus_S_needed, R_1_minus_T_needed, R_2_minus_S_minus_T_needed
+      LOGICAL :: do_Gamma_RPA, do_kpoints_cubic_RPA, do_opt_pgrid, first_cycle_im_time, &
+         first_cycle_omega_loop, memory_info, pgrid_1_init_occ, pgrid_1_init_virt, pgrid_2_init, &
+         R_1_minus_S_needed, R_1_minus_T_needed, R_2_minus_S_minus_T_needed
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: does_mat_P_T_tau_have_blocks
-      REAL(KIND=dp)                                      :: omega, omega_old, tau, weight, weight_old
+      REAL(KIND=dp)                                      :: omega, omega_old, t1, t2, tau, weight, &
+                                                            weight_old
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
-      TYPE(dbcsr_t_type)                                 :: t_3c_M_occ, t_3c_M_tmp, t_3c_M_virt, t_P
+      TYPE(dbcsr_t_pgrid_type)                           :: pgrid_1_use_occ, pgrid_1_use_virt, &
+                                                            pgrid_2_use
+      TYPE(dbcsr_t_pgrid_type), POINTER                  :: pgrid_1_opt_occ, pgrid_1_opt_virt, &
+                                                            pgrid_2_opt
+      TYPE(dbcsr_t_type)                                 :: t_3c_M_occ, t_3c_M_occ_tmp, t_3c_M_virt, &
+                                                            t_3c_M_virt_tmp, t_P
       TYPE(dbcsr_t_type), ALLOCATABLE, DIMENSION(:)      :: t_dm_occ, t_dm_virt
+      TYPE(dbcsr_t_type), &
+         DIMENSION(SIZE(t_3c_O, 1), SIZE(t_3c_O, 2))     :: t_3c_O_occ, t_3c_O_virt
+
+      NULLIFY (pgrid_1_opt_occ, pgrid_1_opt_virt, pgrid_2_opt)
 
       memory_info = mp2_env%ri_rpa_im_time%memory_info
       do_kpoints_cubic_RPA = qs_env%mp2_env%ri_rpa_im_time%do_im_time_kpoints
       do_Gamma_RPA = .NOT. do_kpoints_cubic_RPA
       num_3c_repl = MAXVAL(cell_to_index_3c)
+      do_opt_pgrid = qs_env%mp2_env%ri_rpa_im_time%group_size_internal
 
       CALL timeset(routineN, handle)
 
       first_cycle_im_time = .TRUE.
+      DO i = 1, SIZE(t_3c_O, 1)
+         DO j = 1, SIZE(t_3c_O, 2)
+            CALL dbcsr_t_create(t_3c_O(i, j), t_3c_O_occ(i, j))
+            CALL dbcsr_t_copy(t_3c_O(i, j), t_3c_O_occ(i, j))
+            CALL dbcsr_t_create(t_3c_O(i, j), t_3c_O_virt(i, j))
+            CALL dbcsr_t_copy(t_3c_O(i, j), t_3c_O_virt(i, j))
+            CALL dbcsr_t_clear(t_3c_O(i, j))
+         ENDDO
+      ENDDO
 
+      pgrid_1_init_occ = .FALSE.; pgrid_1_init_virt = .FALSE.; pgrid_2_init = .FALSE.
       DO jquad = 1, num_integ_points
+
+         flops_1_max_virt = 0; flops_1_max_occ = 0; flops_2_max = 0
+
+         IF (jquad .GT. 1 .AND. do_opt_pgrid) THEN
+            DO i = 1, SIZE(t_3c_O, 1)
+               DO j = 1, SIZE(t_3c_O, 2)
+                  CALL tensor_change_pgrid(t_3c_O_occ(i, j), pgrid_1_use_occ)
+                  CALL tensor_change_pgrid(t_3c_O_virt(i, j), pgrid_1_use_virt)
+               ENDDO
+            ENDDO
+            CALL tensor_change_pgrid(t_3c_M, pgrid_2_use, nodata=.TRUE.)
+         ENDIF
+
+         ! loop over T for chi^T(it)
+         IF (memory_info) THEN
+            unit_nr_prv = unit_nr
+         ELSE
+            unit_nr_prv = 0
+         ENDIF
+
+         CALL mp_sync(para_env%group)
+         t1 = m_walltime()
 
          CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, nmo, &
                                     fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
@@ -198,17 +250,27 @@ CONTAINS
                                     num_cells_dm, index_to_cell_dm, &
                                     does_mat_P_T_tau_have_blocks)
 
-         CALL timeset(routineN//"_im_time_repl_subgr", handle4)
+         IF (memory_info .AND. jquad .GT. 1 .AND. do_opt_pgrid) THEN
+            CALL dbcsr_t_get_info(t_3c_O_occ(1, 1), pdims=pdims)
+            IF (unit_nr_prv > 0) THEN
+               WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO M = O x D_occ"
+               WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+            ENDIF
+            CALL dbcsr_t_write_split_info(pgrid_1_use_occ, unit_nr_prv)
 
-         CALL mp_sync(para_env%group)
+            CALL dbcsr_t_get_info(t_3c_O_virt(1, 1), pdims=pdims)
+            IF (unit_nr_prv > 0) THEN
+               WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO M = O x D_virt"
+               WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+            ENDIF
+            CALL dbcsr_t_write_split_info(pgrid_1_use_virt, unit_nr_prv)
 
-         CALL timestop(handle4)
-
-         ! loop over T for chi^T(it)
-         IF (memory_info .AND. first_cycle_im_time) THEN
-            unit_nr_prv = unit_nr
-         ELSE
-            unit_nr_prv = 0
+            CALL dbcsr_t_get_info(t_3c_M, pdims=pdims)
+            IF (unit_nr_prv > 0) THEN
+               WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO P = M x M"
+               WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+            ENDIF
+            CALL dbcsr_t_write_split_info(pgrid_2_use, unit_nr_prv)
          ENDIF
 
          CALL timeset(routineN//"_dbcsr_t", handle6)
@@ -223,7 +285,8 @@ CONTAINS
             CALL dbcsr_t_copy_matrix_to_tensor(mat_dm_occ_global(jquad, i_cell)%matrix, t_dm_occ(i_cell))
             CALL dbcsr_clear(mat_dm_occ_global(jquad, i_cell)%matrix)
          ENDDO
-         CALL dbcsr_t_create(t_3c_O(1, 1), t_3c_M_tmp, name="M (RI AO | AO)")
+         CALL dbcsr_t_create(t_3c_O_occ(1, 1), t_3c_M_occ_tmp, name="M (RI AO | AO)")
+         CALL dbcsr_t_create(t_3c_O_virt(1, 1), t_3c_M_virt_tmp, name="M (RI AO | AO)")
          CALL dbcsr_t_create(t_3c_M, t_3c_M_occ, name="M occ (RI | AO AO)")
          CALL dbcsr_t_create(t_3c_M, t_3c_M_virt, name="M virt (RI | AO AO)")
 
@@ -233,7 +296,7 @@ CONTAINS
 
             DO j_mem = 1, cut_memory
 
-               CALL dbcsr_t_get_info(t_3c_O(1, 1), nfull_total=bounds_3c)
+               CALL dbcsr_t_get_info(t_3c_O_occ(1, 1), nfull_total=bounds_3c)
 
                jbounds_1(:, 1) = [1, bounds_3c(1)]
                jbounds_1(:, 2) = [starts_array_mc_t(j_mem), ends_array_mc_t(j_mem)]
@@ -251,12 +314,12 @@ CONTAINS
                      "RPA_IM_TIME_INFO| Memory Cut iteration", i_mem, j_mem
 
                   IF (do_Gamma_RPA) THEN
-                     IF (.NOT. dbcsr_t_need_contract(t_3c_O(1, 1), &
+                     IF (.NOT. dbcsr_t_need_contract(t_3c_O_occ(1, 1), &
                                                      t_dm_occ(1), &
                                                      contract_1=[3], notcontract_1=[1, 2], &
                                                      contract_2=[2], notcontract_2=[1], &
                                                      bounds_2=jbounds_1, bounds_3=ibounds_2)) CYCLE
-                     IF (.NOT. dbcsr_t_need_contract(t_3c_O(1, 1), &
+                     IF (.NOT. dbcsr_t_need_contract(t_3c_O_occ(1, 1), &
                                                      t_dm_virt(1), &
                                                      contract_1=[3], notcontract_1=[1, 2], &
                                                      contract_2=[2], notcontract_2=[1], &
@@ -277,25 +340,41 @@ CONTAINS
                                                   cell_to_index_3c, index_to_cell_dm, R_1_minus_S_needed, &
                                                   do_kpoints_cubic_RPA)
                            IF (R_1_minus_S_needed) THEN
-                           IF (dbcsr_t_need_contract(t_3c_O(i_cell_R_1_minus_S, i_cell_R_2), &
+                           IF (dbcsr_t_need_contract(t_3c_O_occ(i_cell_R_1_minus_S, i_cell_R_2), &
                                                      t_dm_occ(i_cell_S), &
                                                      contract_1=[3], notcontract_1=[1, 2], &
                                                      contract_2=[2], notcontract_2=[1], &
                                                      bounds_2=jbounds_1, bounds_3=ibounds_2)) THEN
 
-                              CALL timeset(routineN//"_calc_M_t", handle5)
+                              CALL timeset(routineN//"_calc_M_occ_t", handle5)
+
                               CALL dbcsr_t_contract(alpha=dbcsr_scalar(1.0_dp), &
-                                                    tensor_1=t_3c_O(i_cell_R_1_minus_S, i_cell_R_2), &
+                                                    tensor_1=t_3c_O_occ(i_cell_R_1_minus_S, i_cell_R_2), &
                                                     tensor_2=t_dm_occ(i_cell_S), &
                                                     beta=dbcsr_scalar(1.0_dp), &
-                                                    tensor_3=t_3c_M_tmp, &
+                                                    tensor_3=t_3c_M_occ_tmp, &
                                                     contract_1=[3], notcontract_1=[1, 2], &
                                                     contract_2=[2], notcontract_2=[1], &
                                                     map_1=[1, 2], map_2=[3], &
                                                     bounds_2=jbounds_1, bounds_3=ibounds_2, &
-                                                    filter_eps=eps_filter, unit_nr=unit_nr_prv)
-                              CALL timestop(handle5)
+                                                    pgrid_opt_1=pgrid_1_opt_occ, &
+                                                    filter_eps=eps_filter, unit_nr=unit_nr_prv, &
+                                                    flop=flops_1_occ)
 
+                              CALL timestop(handle5)
+                              IF (do_opt_pgrid) THEN
+                                 CPASSERT(ASSOCIATED(pgrid_1_opt_occ))
+                                 IF (flops_1_occ .GT. flops_1_max_occ) THEN
+                                    IF (pgrid_1_init_occ) CALL dbcsr_t_pgrid_destroy(pgrid_1_use_occ)
+                                    pgrid_1_use_occ = pgrid_1_opt_occ
+                                    DEALLOCATE (pgrid_1_opt_occ)
+                                    pgrid_1_init_occ = .TRUE.
+                                    flops_1_max_occ = flops_1_occ
+                                 ELSE
+                                    CALL dbcsr_t_pgrid_destroy(pgrid_1_opt_occ)
+                                    DEALLOCATE (pgrid_1_opt_occ)
+                                 ENDIF
+                              ENDIF
                            ENDIF
                            ENDIF
                         ENDDO
@@ -305,9 +384,9 @@ CONTAINS
                         ! copy matrix to optimal contraction layout - copy is done manually in order
                         ! to better control memory allocations (we can release data of previous
                         ! representation)
-                        CALL dbcsr_t_copy(t_3c_M_tmp, t_3c_M_occ, order=[1, 3, 2], move_data=.TRUE.)
+                        CALL dbcsr_t_copy(t_3c_M_occ_tmp, t_3c_M_occ, order=[1, 3, 2], move_data=.TRUE.)
+                        CALL dbcsr_t_clear(t_3c_M_occ_tmp)
                         CALL dbcsr_t_filter(t_3c_M_occ, eps_filter)
-                        CALL dbcsr_t_clear(t_3c_M_tmp)
                         CALL timestop(handle5)
 
                         DO i_cell_S = 1, num_cells_dm
@@ -317,36 +396,51 @@ CONTAINS
 
                            IF (R_1_minus_T_needed .AND. R_2_minus_S_minus_T_needed) THEN
 
-                              IF (dbcsr_t_need_contract(t_3c_O(i_cell_R_2_minus_S_minus_T, i_cell_R_1_minus_T), &
+                              IF (dbcsr_t_need_contract(t_3c_O_virt(i_cell_R_2_minus_S_minus_T, i_cell_R_1_minus_T), &
                                                         t_dm_virt(i_cell_S), &
                                                         contract_1=[3], notcontract_1=[1, 2], &
                                                         contract_2=[2], notcontract_2=[1], &
                                                         bounds_2=ibounds_1, bounds_3=jbounds_2)) THEN
 
-                                 CALL timeset(routineN//"_calc_M_t", handle5)
+                                 CALL timeset(routineN//"_calc_M_virt_t", handle5)
                                  CALL dbcsr_t_contract(alpha=dbcsr_scalar(alpha/2.0_dp), &
-                                                       tensor_1=t_3c_O( &
+                                                       tensor_1=t_3c_O_virt( &
                                                        i_cell_R_2_minus_S_minus_T, i_cell_R_1_minus_T), &
                                                        tensor_2=t_dm_virt(i_cell_S), &
                                                        beta=dbcsr_scalar(1.0_dp), &
-                                                       tensor_3=t_3c_M_tmp, &
+                                                       tensor_3=t_3c_M_virt_tmp, &
                                                        contract_1=[3], notcontract_1=[1, 2], &
                                                        contract_2=[2], notcontract_2=[1], &
                                                        map_1=[1, 2], map_2=[3], &
                                                        bounds_2=ibounds_1, bounds_3=jbounds_2, &
-                                                       filter_eps=eps_filter, unit_nr=unit_nr_prv)
+                                                       pgrid_opt_1=pgrid_1_opt_virt, &
+                                                       filter_eps=eps_filter, unit_nr=unit_nr_prv, &
+                                                       flop=flops_1_virt)
                                  CALL timestop(handle5)
+                                 IF (do_opt_pgrid) THEN
+                                    CPASSERT(ASSOCIATED(pgrid_1_opt_virt))
+                                    IF (flops_1_virt .GT. flops_1_max_virt) THEN
+                                       IF (pgrid_1_init_virt) CALL dbcsr_t_pgrid_destroy(pgrid_1_use_virt)
+                                       pgrid_1_use_virt = pgrid_1_opt_virt
+                                       DEALLOCATE (pgrid_1_opt_virt)
+                                       pgrid_1_init_virt = .TRUE.
+                                       flops_1_max_virt = flops_1_virt
+                                    ELSE
+                                       CALL dbcsr_t_pgrid_destroy(pgrid_1_opt_virt)
+                                       DEALLOCATE (pgrid_1_opt_virt)
+                                    ENDIF
+                                 ENDIF
                               ENDIF
                            ENDIF
                         ENDDO
 
                         CALL timeset(routineN//"_copy_M_virt_t", handle5)
-                        CALL dbcsr_t_copy(t_3c_M_tmp, t_3c_M_virt, order=[1, 2, 3], move_data=.TRUE.)
+                        CALL dbcsr_t_copy(t_3c_M_virt_tmp, t_3c_M_virt, order=[1, 2, 3], move_data=.TRUE.)
+                        CALL dbcsr_t_clear(t_3c_M_virt_tmp)
                         CALL dbcsr_t_filter(t_3c_M_virt, eps_filter)
-                        CALL dbcsr_t_clear(t_3c_M_tmp)
                         CALL timestop(handle5)
 
-                        num_flops_mat_P = 0
+                        flops_2 = 0
                         IF (dbcsr_t_need_contract(t_3c_M_occ, t_3c_M_virt, &
                                                   contract_1=[2, 3], notcontract_1=[1], &
                                                   contract_2=[2, 3], notcontract_2=[1])) THEN
@@ -360,14 +454,29 @@ CONTAINS
                                                  contract_1=[2, 3], notcontract_1=[1], &
                                                  contract_2=[2, 3], notcontract_2=[1], &
                                                  map_1=[1], map_2=[2], &
+                                                 pgrid_opt_2=pgrid_2_opt, &
                                                  filter_eps=eps_filter_im_time/REAL(cut_memory**2, KIND=dp), &
-                                                 flop=num_flops_mat_P, &
+                                                 flop=flops_2, &
                                                  move_data=.TRUE., &
                                                  unit_nr=unit_nr_prv)
 
                            CALL dbcsr_t_copy_tensor_to_matrix(t_P, mat_P_global%matrix)
 
                            CALL timestop(handle5)
+
+                           IF (do_opt_pgrid) THEN
+                              CPASSERT(ASSOCIATED(pgrid_2_opt))
+                              IF (flops_2 .GT. flops_2_max) THEN
+                                 IF (pgrid_2_init) CALL dbcsr_t_pgrid_destroy(pgrid_2_use)
+                                 pgrid_2_use = pgrid_2_opt
+                                 DEALLOCATE (pgrid_2_opt)
+                                 pgrid_2_init = .TRUE.
+                                 flops_2_max = flops_2
+                              ELSE
+                                 CALL dbcsr_t_pgrid_destroy(pgrid_2_opt)
+                                 DEALLOCATE (pgrid_2_opt)
+                              ENDIF
+                           ENDIF
                         ENDIF
 
                         CALL dbcsr_t_clear(t_3c_M_occ)
@@ -415,7 +524,7 @@ CONTAINS
 
                            CALL check_if_mat_P_T_tau_has_blocks(does_mat_P_T_tau_have_blocks, mat_P_global, i_cell_T, &
                                                                 jquad, i_mem, j_mem, i_cell_R_1, i_cell_R_2, &
-                                                                para_env, has_mat_P_blocks, num_flops_mat_P)
+                                                                para_env, has_mat_P_blocks, flops_2)
 
                         END IF ! do_ri_sos_laplace_mp2
 
@@ -434,7 +543,9 @@ CONTAINS
             CALL dbcsr_t_destroy(t_dm_virt(i_cell))
             CALL dbcsr_t_destroy(t_dm_occ(i_cell))
          ENDDO
-         CALL dbcsr_t_destroy(t_3c_M_tmp)
+
+         CALL dbcsr_t_destroy(t_3c_M_occ_tmp)
+         CALL dbcsr_t_destroy(t_3c_M_virt_tmp)
          CALL dbcsr_t_destroy(t_3c_M_occ)
          CALL dbcsr_t_destroy(t_3c_M_virt)
          DEALLOCATE (t_dm_virt)
@@ -442,7 +553,24 @@ CONTAINS
 
          CALL timestop(handle6)
 
+         CALL mp_sync(para_env%group)
+         t2 = m_walltime()
+
+         IF (unit_nr_prv > 0) WRITE (unit_nr_prv, '(T3,A,1X,I3,A,11X,F25.6)') &
+            'RPA_IM_TIME_INFO| Time for time point', jquad, ':', t2-t1
+
       END DO ! time points
+
+      DO i = 1, SIZE(t_3c_O, 1)
+         DO j = 1, SIZE(t_3c_O, 2)
+            CALL dbcsr_t_destroy(t_3c_O_occ(i, j))
+            CALL dbcsr_t_destroy(t_3c_O_virt(i, j))
+         ENDDO
+      ENDDO
+
+      IF (pgrid_1_init_virt) CALL dbcsr_t_pgrid_destroy(pgrid_1_use_virt)
+      IF (pgrid_1_init_occ) CALL dbcsr_t_pgrid_destroy(pgrid_1_use_occ)
+      IF (pgrid_2_init) CALL dbcsr_t_pgrid_destroy(pgrid_2_use)
 
       CALL clean_up(mat_dm_occ_global, mat_dm_virt_global, does_mat_P_T_tau_have_blocks)
 
@@ -4059,5 +4187,50 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE get_diff_diff_index_3c
+
+! **************************************************************************************************
+!> \brief ...
+!> \param t_3c ...
+!> \param pgrid ...
+!> \param nodata ...
+! **************************************************************************************************
+   SUBROUTINE tensor_change_pgrid(t_3c, pgrid, nodata)
+      TYPE(dbcsr_t_type), INTENT(INOUT)                  :: t_3c
+      TYPE(dbcsr_t_pgrid_type), INTENT(IN)               :: pgrid
+      LOGICAL, INTENT(IN), OPTIONAL                      :: nodata
+
+      CHARACTER(default_string_length)                   :: name
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bs1, bs2, bs3, dist1, dist2, dist3, &
+                                                            map1, map2
+      INTEGER, DIMENSION(3)                              :: pcoord, pdims, tdims
+      TYPE(dbcsr_t_distribution_type)                    :: dist
+      TYPE(dbcsr_t_type)                                 :: t_tmp
+
+      CALL dbcsr_t_mp_environ_pgrid(pgrid, pdims, pcoord)
+      CALL dbcsr_t_get_info(t_3c, nblks_total=tdims, blk_size_1=bs1, blk_size_2=bs2, blk_size_3=bs3, &
+                            name=name)
+
+      ALLOCATE (dist1(tdims(1)))
+      ALLOCATE (dist2(tdims(2)))
+      ALLOCATE (dist3(tdims(3)))
+
+      CALL cyclic_tensor_dist(tdims(1), pdims(1), bs1, dist1)
+      CALL cyclic_tensor_dist(tdims(2), pdims(2), bs2, dist2)
+      CALL cyclic_tensor_dist(tdims(3), pdims(3), bs3, dist3)
+
+      CALL dbcsr_t_get_mapping_info(t_3c%nd_index_blk, map1_2d=map1, map2_2d=map2)
+      CALL dbcsr_t_distribution_new(dist, pgrid, map1, map2, dist1, dist2, dist3)
+      CALL dbcsr_t_create(t_tmp, name, dist, map1, map2, dbcsr_type_real_8, bs1, bs2, bs3)
+      CALL dbcsr_t_distribution_destroy(dist)
+
+      IF (PRESENT(nodata)) THEN
+         IF (.NOT. nodata) CALL dbcsr_t_copy(t_3c, t_tmp, move_data=.TRUE.)
+      ELSE
+         CALL dbcsr_t_copy(t_3c, t_tmp, move_data=.TRUE.)
+      ENDIF
+
+      CALL dbcsr_t_destroy(t_3c)
+      t_3c = t_tmp
+   END SUBROUTINE
 
 END MODULE rpa_im_time

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -211,7 +211,7 @@ CONTAINS
             CALL dbcsr_t_copy(t_3c_O(i, j), t_3c_O_occ(i, j))
             CALL dbcsr_t_create(t_3c_O(i, j), t_3c_O_virt(i, j))
             CALL dbcsr_t_copy(t_3c_O(i, j), t_3c_O_virt(i, j))
-            CALL dbcsr_t_clear(t_3c_O(i, j))
+            !CALL dbcsr_t_clear(t_3c_O(i, j)) ! clearing t_3c_O is not safe because it may be used later
          ENDDO
       ENDDO
 
@@ -220,13 +220,23 @@ CONTAINS
 
          flops_1_max_virt = 0; flops_1_max_occ = 0; flops_2_max = 0
 
-         IF (jquad .GT. 1 .AND. do_opt_pgrid) THEN
+         IF (pgrid_1_init_occ) THEN
             DO i = 1, SIZE(t_3c_O, 1)
                DO j = 1, SIZE(t_3c_O, 2)
                   CALL tensor_change_pgrid(t_3c_O_occ(i, j), pgrid_1_use_occ)
+               ENDDO
+            ENDDO
+         ENDIF
+
+         IF (pgrid_1_init_virt) THEN
+            DO i = 1, SIZE(t_3c_O, 1)
+               DO j = 1, SIZE(t_3c_O, 2)
                   CALL tensor_change_pgrid(t_3c_O_virt(i, j), pgrid_1_use_virt)
                ENDDO
             ENDDO
+         ENDIF
+
+         IF (pgrid_2_init) THEN
             CALL tensor_change_pgrid(t_3c_M, pgrid_2_use, nodata=.TRUE.)
          ENDIF
 
@@ -250,27 +260,33 @@ CONTAINS
                                     num_cells_dm, index_to_cell_dm, &
                                     does_mat_P_T_tau_have_blocks)
 
-         IF (memory_info .AND. jquad .GT. 1 .AND. do_opt_pgrid) THEN
-            CALL dbcsr_t_get_info(t_3c_O_occ(1, 1), pdims=pdims)
-            IF (unit_nr_prv > 0) THEN
-               WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO M = O x D_occ"
-               WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+         IF (memory_info) THEN
+            IF (pgrid_1_init_occ) THEN
+               CALL dbcsr_t_get_info(t_3c_O_occ(1, 1), pdims=pdims)
+               IF (unit_nr_prv > 0) THEN
+                  WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO M = O x D_occ"
+                  WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+               ENDIF
+               CALL dbcsr_t_write_split_info(pgrid_1_use_occ, unit_nr_prv)
             ENDIF
-            CALL dbcsr_t_write_split_info(pgrid_1_use_occ, unit_nr_prv)
 
-            CALL dbcsr_t_get_info(t_3c_O_virt(1, 1), pdims=pdims)
-            IF (unit_nr_prv > 0) THEN
-               WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO M = O x D_virt"
-               WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+            IF (pgrid_1_init_virt) THEN
+               CALL dbcsr_t_get_info(t_3c_O_virt(1, 1), pdims=pdims)
+               IF (unit_nr_prv > 0) THEN
+                  WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO M = O x D_virt"
+                  WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+               ENDIF
+               CALL dbcsr_t_write_split_info(pgrid_1_use_virt, unit_nr_prv)
             ENDIF
-            CALL dbcsr_t_write_split_info(pgrid_1_use_virt, unit_nr_prv)
 
-            CALL dbcsr_t_get_info(t_3c_M, pdims=pdims)
-            IF (unit_nr_prv > 0) THEN
-               WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO P = M x M"
-               WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+            IF (pgrid_2_init) THEN
+               CALL dbcsr_t_get_info(t_3c_M, pdims=pdims)
+               IF (unit_nr_prv > 0) THEN
+                  WRITE (unit_nr_prv, "(T2,A)") "OPTIMIZED PGRID INFO P = M x M"
+                  WRITE (unit_nr_prv, "(T4,A,1X,3I6)") "process grid dimensions:", pdims
+               ENDIF
+               IF (pgrid_2_init) CALL dbcsr_t_write_split_info(pgrid_2_use, unit_nr_prv)
             ENDIF
-            CALL dbcsr_t_write_split_info(pgrid_2_use, unit_nr_prv)
          ENDIF
 
          CALL timeset(routineN//"_dbcsr_t", handle6)

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -1791,10 +1791,12 @@ CONTAINS
 
             IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,i15)") &
                "MEMORY_INFO| Memory cut:", cut_memory
-            IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,i15)") &
-               "MEMORY_INFO| Im. time group size for RI functions:", mp2_env%ri_rpa_im_time%group_size_3c
-            IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,i15)") &
-               "MEMORY_INFO| Im. time group size for local P matrix:", group_size_P
+            IF (.NOT. mp2_env%ri_rpa_im_time%group_size_internal .OR. .NOT. mp2_env%ri_rpa_im_time%do_dbcsr_t) THEN
+               IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,i15)") &
+                  "MEMORY_INFO| Im. time group size for RI functions:", mp2_env%ri_rpa_im_time%group_size_3c
+               IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,i15)") &
+                  "MEMORY_INFO| Im. time group size for local P matrix:", group_size_P
+            ENDIF
             IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,ES15.2)") &
                "SPARSITY_INFO| Eps pgf orb for imaginary time:", mp2_env%mp2_gpw%eps_grid
             IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,ES15.2)") &

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O.inp
@@ -57,7 +57,7 @@
         IM_TIME
         &IM_TIME
           MEMORY_CUT 1
-          MEMORY_INFO
+          !MEMORY_INFO
           GROUP_SIZE_P  1
           DO_KPOINTS
           EPS_FILTER_IM_TIME 1.0E-6

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O_non_zero_group_sizes.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_H2O_non_zero_group_sizes.inp
@@ -56,9 +56,10 @@
         NUMBER_PROC  1
         IM_TIME
         &IM_TIME
+          GROUP_SIZE_INTERNAL .FALSE.
           MEMORY_CUT 2
           GROUP_SIZE_3C 2
-          MEMORY_INFO
+          !MEMORY_INFO
           GROUP_SIZE_P 2
           DO_KPOINTS
           EPS_FILTER_IM_TIME 1.0E-6

--- a/tests/QS/regtest-ri-rpa/RPA_kpoints_from_Gamma_H2O.inp
+++ b/tests/QS/regtest-ri-rpa/RPA_kpoints_from_Gamma_H2O.inp
@@ -49,7 +49,7 @@
         IM_TIME
         &IM_TIME
           MEMORY_CUT 1
-          MEMORY_INFO
+          !MEMORY_INFO
           GROUP_SIZE_P  1
           KPOINTS 4 4 4
           EPS_FILTER_IM_TIME 1.0E-6

--- a/tests/QS/regtest-rpa-cubic-scaling/Cubic_RPA_H2O_check_group_sizes.inp
+++ b/tests/QS/regtest-rpa-cubic-scaling/Cubic_RPA_H2O_check_group_sizes.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O_minimax
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -40,13 +40,15 @@
         METHOD  RI_RPA_GPW
         RI OVERLAP
         &WFC_GPW
-          ! normally, this EPS_FILTER controls the accuracy and 
+          ! normally, this EPS_FILTER controls the accuracy and
           ! the time for the cubic_scaling RPA calculation
           EPS_FILTER  1.0E-6
         &END
         ERI_METHOD MME
         IM_TIME
         &IM_TIME
+          GROUP_SIZE_INTERNAL .FALSE.
+          !MEMORY_INFO
           ! normally, increase MEMORY_CUT for large systems
           ! not to run out of memory
           MEMORY_CUT 2

--- a/tests/QS/regtest-rpa-cubic-scaling/Cubic_RPA_H2O_standard.inp
+++ b/tests/QS/regtest-rpa-cubic-scaling/Cubic_RPA_H2O_standard.inp
@@ -1,4 +1,4 @@
-&GLOBAL                                                                                           
+&GLOBAL
   PROJECT  RI_RPA_H2O_minimax
   PRINT_LEVEL MEDIUM
   RUN_TYPE ENERGY
@@ -40,7 +40,7 @@
         METHOD  RI_RPA_GPW
         RI OVERLAP
         &WFC_GPW
-          ! normally, this EPS_FILTER controls the accuracy and 
+          ! normally, this EPS_FILTER controls the accuracy and
           ! the time for the cubic_scaling RPA calculation
           EPS_FILTER  1.0E-6
         &END


### PR DESCRIPTION
* group sizes now internally optimized in DBCSR
* keywords GROUP_SIZE_3C and GROUP_SIZE_P only needed for testing
  and for old implementation of cubic scaling RPA