### PR TITLE
benchmark/H2O-dft-ls: add a 1-node version of the benchmark

### DIFF
--- a/tests/QS/benchmark_DM_LS/H2O-dft-ls.smaller.inp
+++ b/tests/QS/benchmark_DM_LS/H2O-dft-ls.smaller.inp
@@ -1,6 +1,6 @@
 ! size can be tuned by setting NREP
 ! molecular clustering is an interesting parameter
-@SET NREP 6
+@SET NREP 2
 &FORCE_EVAL
   METHOD QS
   &DFT

--- a/tests/QS/benchmark_DM_LS/README.md
+++ b/tests/QS/benchmark_DM_LS/README.md
@@ -1,0 +1,10 @@
+
+# Benchmarks DM LS
+
+## Benchmarks
+
+- [H2O-dft-ls](H2O-dft-ls.inp): H20 density functional theory linear scaling
+- [H2O-dft-ls.smaller](H2O-dft-ls.smaller.inp): a smaller version of the H2O-dft-ls benchmark, meant to run on 1 nodes
+- [TiO2](TiO2.inp)
+- [amorph](amorph.inp)
+


### PR DESCRIPTION
- and add a corresponding README
- Fix #584