### PR TITLE
Making XAS_TDP regtests compatible for libint compiled with maxl=4

### DIFF
--- a/tests/QS/regtest-xastdp/Ne-LDA-extRI_XAS.inp
+++ b/tests/QS/regtest-xastdp/Ne-LDA-extRI_XAS.inp
@@ -1,7 +1,6 @@
 &GLOBAL
-  PROJECT Ne-HF-extRI_XAS
+  PROJECT Ne-LDA-extRI_XAS
   PRINT_LEVEL LOW
-  RUN_TYPE ENERGY
 &END GLOBAL
 &FORCE_EVAL
   METHOD Quickstep
@@ -19,10 +18,8 @@
     &END
 
     &XC
-      &XC_FUNCTIONAL NONE
+      &XC_FUNCTIONAL PADE
       &END XC_FUNCTIONAL
-      &HF
-      &END HF
     &END XC
 
     &XAS_TDP
@@ -34,11 +31,14 @@
       &END DONOR_STATES
 
       TAMM_DANCOFF 
+      GRID Ne 250 250
 
       &KERNEL
-         &EXACT_EXCHANGE
-            OPERATOR COULOMB
-         &END EXACT_EXCHANGE
+         &XC_FUNCTIONAL
+            &LIBXC
+               FUNCTIONAL LDA_XC_TETER93
+            &END LIBXC
+         &END XC_FUNCTIONAL
       &END KERNEL
 
       &DIAGONALIZATION

--- a/tests/QS/regtest-xastdp/TEST_FILES
+++ b/tests/QS/regtest-xastdp/TEST_FILES
@@ -1,6 +1,6 @@
 #Testing the XAS_TDP method and the keyword combinations it involves
-#Checking that the user can spefify his own RI_XAS basis set + simple CIS
-Ne-HF-extRI_XAS.inp                                    88      1e-06           890.898285
+#Checking that the user can spefify his own RI_XAS basis set + simple LDA
+Ne-LDA-extRI_XAS.inp                                   88      1e-06           833.277232
 #Checking that the searched excitation energies can be defined by a range
 Ne-LDA-e_range.inp                                     88      1e-06           829.640328
 #Checking full TDDFT and simple hybrid functional


### PR DESCRIPTION
XAS_TDP regtests and more specifilcally `Ne-HF-extRI_XAS.inp` are causing some  failures in the case where libint is compiled with maxl=4. The issue arises in the initialization of the `HFX` environment which also sets up libint for derivatives.

To solve that problem without asking everyone to recompile libint with maxl=5, I switched from a HF  to a LDA calculation. The regtest still fulfills its purpose of including an external RI basis set while avoiding the problematic routine call. 