### PR TITLE
toolchain/fftw: set PKG_CONFIG_PATH/FFTW_ROOT properly and export them

### DIFF
--- a/tools/toolchain/scripts/install_fftw.sh
+++ b/tools/toolchain/scripts/install_fftw.sh
@@ -83,7 +83,6 @@ prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CPATH "$pkg_install_dir/include"
 EOF
-        cat "${BUILDDIR}/setup_fftw" >> $SETUPFILE
     fi
     # we may also want to cover FFT_SG
     cat <<EOF >> "${BUILDDIR}/setup_fftw"
@@ -95,9 +94,11 @@ export CP_DFLAGS="\${CP_DFLAGS} -D__FFTW3 IF_COVERAGE(IF_MPI(|-U__FFTW3)|)"
 export CP_CFLAGS="\${CP_CFLAGS} ${FFTW_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${FFTW_LDFLAGS}"
 export CP_LIBS="IF_MPI(-lfftw3_mpi|) ${FFTW_LIBS} IF_OMP(${FFTW_LIBS_OMP}|) \${CP_LIBS}"
-prepend_path PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$pkg_install_dir/lib/pkgconfig"
-export FFTWROOT="$pkg_install_dir"
+prepend_path PKG_CONFIG_PATH="$pkg_install_dir/lib/pkgconfig"
+export FFTW_ROOT="$pkg_install_dir"
 EOF
+
+    cat "${BUILDDIR}/setup_fftw" >> $SETUPFILE
 fi
 cd "${ROOTDIR}"
 


### PR DESCRIPTION
the variable should be `FFTW_ROOT` and not `FFTWROOT`, fix call to
`prepend_path` and make sure all the variables actually end up in
`install/setup`