### PR TITLE
Enable odd number of electrons in S-ALMO

### DIFF
--- a/src/almo_scf.F
+++ b/src/almo_scf.F
@@ -287,26 +287,31 @@ CONTAINS
             multip = almo_scf_env%multiplicity_of_domain(idomain)
             nelec_a = (nelec + multip - 1)/2
             nelec_b = nelec - nelec_a
-            almo_scf_env%nocc_of_domain(idomain, 1) = nelec_a
-            IF (nelec_a .NE. nelec_b) THEN
-               IF (nspins .EQ. 1) THEN
-                  WRITE (*, *) "Domain ", idomain, " out of ", ndomains, ". Electrons = ", nelec
-                  CPABORT("odd e- -- use unrestricted methods")
-               ENDIF
-               almo_scf_env%nocc_of_domain(idomain, 2) = nelec_b
-               ! RZK-warning: open-shell procedures have not been tested yet
-               ! Stop the program now
-               CPABORT("Unrestricted ALMO methods are NYI")
-            ENDIF
             !! Initializing an occupation-rescaling trick if smearing is on
             IF (almo_scf_env%smear) THEN
+               IF (multip .GT. 1) THEN
+                  CPWARN("BEWARE: Non singlet state detected, treating it as closed-shell")
+               ENDIF
                !! Save real number of electrons of each spin, as it is required for Fermi-dirac smearing
-               almo_scf_env%real_ne_of_domain(idomain, :) = REAL(almo_scf_env%nocc_of_domain(idomain, :), KIND=dp)
+               !! BEWARE : Non singlet states are allowed but treated as closed-shell
+               almo_scf_env%real_ne_of_domain(idomain, :) = REAL(nelec, KIND=dp)/2.0_dp
                !! Add a number of added_mos equal to the number of atoms in domain
                !! (since fragments were computed this way with smearing)
-               almo_scf_env%nocc_of_domain(idomain, :) = almo_scf_env%nocc_of_domain(idomain, :) &
+               almo_scf_env%nocc_of_domain(idomain, :) = CEILING(almo_scf_env%real_ne_of_domain(idomain, :)) &
                                                          + (almo_scf_env%last_atom_of_domain(idomain) &
                                                             - almo_scf_env%first_atom_of_domain(idomain) + 1)
+            ELSE
+               almo_scf_env%nocc_of_domain(idomain, 1) = nelec_a
+               IF (nelec_a .NE. nelec_b) THEN
+                  IF (nspins .EQ. 1) THEN
+                     WRITE (*, *) "Domain ", idomain, " out of ", ndomains, ". Electrons = ", nelec
+                     CPABORT("odd e- -- use unrestricted methods")
+                  ENDIF
+                  almo_scf_env%nocc_of_domain(idomain, 2) = nelec_b
+                  ! RZK-warning: open-shell procedures have not been tested yet
+                  ! Stop the program now
+                  CPABORT("Unrestricted ALMO methods are NYI")
+               ENDIF
             END IF
          ENDDO
          DO ispin = 1, nspins

--- a/tests/QS/regtest-almo-2/TEST_FILES
+++ b/tests/QS/regtest-almo-2/TEST_FILES
@@ -1,6 +1,7 @@
 almo-fullx.inp                                        11      1e-11           -137.653869649992146
 almo-no-deloc.inp                                     11      9e-12           -137.557304848837759
 s-almo-no-deloc.inp                                   11       2e-5           -376.101195076451177
+s-almo-no-deloc-odd-ne.inp                            11       2e-5           -115.255611348790495
 FH-chain.inp                                          11      3e-10            -98.108319997143496
 ion-pair.inp                                          11      1e-13           -115.006279649267199
 LiF.inp                                               11      3e-12           -127.539319485641016

--- a/tests/QS/regtest-almo-2/s-almo-no-deloc-odd-ne.inp
+++ b/tests/QS/regtest-almo-2/s-almo-no-deloc-odd-ne.inp
@@ -1,0 +1,94 @@
+&GLOBAL
+  PROJECT S-ALMO_odd_ne_regtest
+  PRINT_LEVEL LOW
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD QS
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT 
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    CHARGE 0
+    &MGRID
+      CUTOFF 50
+      NGRIDS 5
+    &END MGRID
+    &QS
+      ALMO_SCF T
+      EPS_DEFAULT 1.0E-8
+    &END QS
+
+    &ALMO_SCF
+      EPS_FILTER                 1.0E-8
+      ALMO_ALGORITHM             DIAG
+      ALMO_SCF_GUESS             MOLECULAR
+
+      &ALMO_OPTIMIZER_DIIS
+        MAX_ITER                 30
+        EPS_ERROR                5.0E-3
+        N_DIIS                   5
+      &END ALMO_OPTIMIZER_DIIS
+
+      DELOCALIZE_METHOD          NONE      
+    &END ALMO_SCF
+
+    &SCF
+      SCF_GUESS ATOMIC
+      EPS_SCF 5.0E-3
+      CHOLESKY INVERSE
+      ADDED_MOS 6 !! Must be same number as total number of atoms 
+      &DIAGONALIZATION
+         ALGORITHM STANDARD
+         EPS_ADAPT 0.01
+      &END DIAGONALIZATION
+      &SMEAR ON
+        METHOD FERMI_DIRAC
+        ELECTRONIC_TEMPERATURE [K] 300
+      &END SMEAR
+      &MIXING
+          METHOD BROYDEN_MIXING
+          ALPHA   0.1
+          BETA    1.5
+          NBROYDEN  8
+      &END
+    &END SCF
+
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL 
+    &END XC
+  &END DFT
+
+  &SUBSYS
+    &CELL
+      A [angstrom] 5.62    0.00    0.00 
+      B [angstrom] 2.80    4.86    0.00
+      C [angstrom] 0.00    0.00    7.00
+      PERIODIC XYZ
+    &END CELL
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-SR-GTH
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+
+    &KIND O
+      BASIS_SET DZVP-MOLOPT-SR-GTH
+      POTENTIAL GTH-PBE-q6
+    &END KIND
+
+    &KIND Au
+      BASIS_SET DZVP-MOLOPT-SR-GTH 
+      POTENTIAL GTH-PBE-q11
+    &END KIND
+
+    &COORD
+      Au  4.21  2.43  0.00  Au3
+      Au  1.40  2.43  0.00  Au3
+      Au  0.00  0.00  0.00  Au3
+      O   1.22  2.43  2.34  H2O
+      H   1.22  3.24  2.90  H2O
+      H   1.22  1.63  2.90  H2O
+    &END COORD
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
This patch allows systems with odd number of electrons to be
treated as closed-shell within the S-ALMO formalism. This is of
critical importance for non spin-polarized metallic slabs with an
odd number of electrons (e.g. p(3x3) Au(111) with 3 layers).