### PR TITLE
Sync input for CUTOFF and MULTIGRID_CUTOFF

### DIFF
--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -543,8 +543,9 @@ CONTAINS
 
          CALL section_vals_val_get(mgrid_section, "MULTIGRID_CUTOFF", r_vals=cutofflist)
          IF (ASSOCIATED(cutofflist)) THEN
-            IF (SIZE(cutofflist, 1) /= ngrid_level) &
+            IF (SIZE(cutofflist, 1) /= ngrid_level) THEN
                CPABORT("Number of multi-grids (NGRIDS) requested and number of cutoff values do not match")
+            END IF
             DO igrid_level = 1, ngrid_level
                qs_control%e_cutoff(igrid_level) = cutofflist(igrid_level)
             END DO

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -544,7 +544,7 @@ CONTAINS
          CALL section_vals_val_get(mgrid_section, "MULTIGRID_CUTOFF", r_vals=cutofflist)
          IF (ASSOCIATED(cutofflist)) THEN
             IF (SIZE(cutofflist, 1) /= ngrid_level) THEN
-               CPABORT("Number of multi-grids (NGRIDS) requested and number of cutoff values do not match")
+               CPABORT("Number of multi-grids requested and number of cutoff values do not match")
             END IF
             DO igrid_level = 1, ngrid_level
                qs_control%e_cutoff(igrid_level) = cutofflist(igrid_level)

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -544,10 +544,10 @@ CONTAINS
          CALL section_vals_val_get(mgrid_section, "MULTIGRID_CUTOFF", r_vals=cutofflist)
          IF (ASSOCIATED(cutofflist)) THEN
             IF (SIZE(cutofflist, 1) /= ngrid_level) &
-               CPABORT("Inconsistent values for number of multi grids")
+               CPABORT("Number of multi-grids (NGRIDS) requested and number of cutoff values do not match")
             DO igrid_level = 1, ngrid_level
-               qs_control%e_cutoff(igrid_level) = cutofflist(igrid_level)*0.5_dp
-            ENDDO
+               qs_control%e_cutoff(igrid_level) = cutofflist(igrid_level)
+            END DO
          END IF
          ! set cutoff to smallest value in multgrid available with >= cutoff
          DO igrid_level = ngrid_level, 1, -1
@@ -564,15 +564,16 @@ CONTAINS
          IF (qs_control%commensurate_mgrids) qs_control%progression_factor = 4.0_dp
          qs_control%e_cutoff(1) = qs_control%cutoff
          DO igrid_level = 2, ngrid_level
-            qs_control%e_cutoff(igrid_level) = qs_control%e_cutoff(igrid_level - 1) &
-                                               /qs_control%progression_factor
+            qs_control%e_cutoff(igrid_level) = qs_control%e_cutoff(igrid_level - 1)/ &
+                                               qs_control%progression_factor
          END DO
       END IF
       ! check that multigrids are ordered
       DO igrid_level = 2, ngrid_level
-         IF (qs_control%e_cutoff(igrid_level) > &
-             qs_control%e_cutoff(igrid_level - 1)) THEN
-            CPABORT("Multi-grids not ordered")
+         IF (qs_control%e_cutoff(igrid_level) > qs_control%e_cutoff(igrid_level - 1)) THEN
+            CPABORT("The cutoff values for the multi-grids are not ordered from large to small")
+         ELSE IF (qs_control%e_cutoff(igrid_level) == qs_control%e_cutoff(igrid_level - 1)) THEN
+            CPABORT("The same cutoff value was specified for two multi-grids")
          END IF
       END DO
       CALL timestop(handle)

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -6450,7 +6450,10 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MULTIGRID_CUTOFF", &
                           variants=(/"CUTOFF_LIST"/), &
                           description="List of cutoff values to set up multigrids manually", &
-                          usage="MULTIGRID_CUTOFF 200.0 100.0 ", n_var=-1, type_of_var=real_t)
+                          usage="MULTIGRID_CUTOFF 200.0 100.0 ", &
+                          n_var=-1, &
+                          type_of_var=real_t, &
+                          unit_str="Ry")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 


### PR DESCRIPTION
- Allow units for the keyword MULTIGRID_CUTOFF in accordance with CUTOFF
- Abort CP2K if the same multi-grid cutoff is specified twice
- Improve error messages