### PR TITLE
regtesting: always set the CP2K_DATA_DIR env variable

### DIFF
--- a/tools/regtesting/do_regtest
+++ b/tools/regtesting/do_regtest
@@ -241,6 +241,7 @@ else
 fi
 
 export OMP_NUM_THREADS=${numthreads}
+export CP2K_DATA_DIR=${cp2k_data_dir:-"${dir_base}/${cp2k_dir}/data"}
 
 #
 # these should not be needed


### PR DESCRIPTION
fixes #234 to ensure we always use the data provided in the running
copy of CP2K and not accidentally picking up already installed data
from an earlier copy OR not finding the data because the user set the
directory the baked-in directory to somewhere in the system (distros
for example)