### PR TITLE
Rollback to DBCSR 2.0.1

### DIFF
--- a/src/rpa_gw_im_time_util.F
+++ b/src/rpa_gw_im_time_util.F
@@ -401,12 +401,10 @@ CONTAINS
       ALLOCATE (sizes_MO(nmo))
       sizes_MO = 1
 
-      CALL dbcsr_t_pgrid_create(para_env%group, pdims, pgrid, &
-                                tensor_dims=[SIZE(sizes_RI_split), SIZE(sizes_AO_split), SIZE(sizes_MO)])
+      CALL dbcsr_t_pgrid_create(para_env%group, pdims, pgrid)
 
       pdims_2d = 0
-      CALL dbcsr_t_pgrid_create(para_env%group, pdims_2d, pgrid_2d, &
-                                tensor_dims=[SIZE(sizes_AO), SIZE(sizes_MO)])
+      CALL dbcsr_t_pgrid_create(para_env%group, pdims_2d, pgrid_2d)
 
       CALL create_3c_tensor(t_3c_overl_int_ao_ao, dist1, dist2, dist3, pgrid, &
                             sizes_RI_split, sizes_AO_split, sizes_AO, [1, 2], [3], "(RI AO | AO)")
@@ -450,8 +448,7 @@ CONTAINS
 
       IF (do_ic_model) THEN
          pdims = 0
-         CALL dbcsr_t_pgrid_create(para_env%group, pdims, pgrid_ic, &
-                                   tensor_dims=[SIZE(sizes_RI_split), SIZE(sizes_MO), SIZE(sizes_MO)])
+         CALL dbcsr_t_pgrid_create(para_env%group, pdims, pgrid_ic)
 
          CALL create_3c_tensor(t_3c_overl_int_mo_ao, dist1, dist2, dist3, pgrid_ic, &
                                sizes_RI_split, sizes_MO, sizes_AO, [1, 2], [3], "(RI MO | AO)")


### PR DESCRIPTION
This partially reverts 2824b54caf63b9adad79685dd3db4f417b4ac058

This pr should be merged as a preparation for a new CP2K release in case DBCSR 2.1.0 is not released by then.