### PR TITLE
Makefile: re-use REVISION to allow override, warn user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ doxygen: doxygen/clean
 	@echo "<html><body>Sorry, the Doxygen documentation is currently being updated. Please try again in a few minutes.</body></html>" > $(DOXYGENDIR)/html/index.html
 	cp $(ALL_SRC_FILES) $(DOXYGENDIR)
 	@for i in $(DOXYGENDIR)/*.F ; do mv $${i}  $${i%%.*}.f90; done ;
-	@cat $(TOOLSRC)/doxify/Doxyfile.template | sed "s/#revision#/`$(TOOLSRC)/build_utils/get_revision_number $(CP2KHOME)`/"  >$(DOXYGENDIR)/Doxyfile
+	@sed -e "s/#revision#/$(REVISION)/" $(TOOLSRC)/doxify/Doxyfile.template >$(DOXYGENDIR)/Doxyfile
 	cd $(DOXYGENDIR); doxygen ./Doxyfile 2>&1 | tee ./html/doxygen.out
 TOOL_HELP += "doxygen : Generate the doxygen documentation"
 
@@ -442,7 +442,7 @@ GIT_REF := ${MAINOBJDIR}/git-ref
 # use a force (fake) target to always rebuild this file but have Make consider this updated
 # iff it was actually rewritten (a .PHONY target is always considered new)
 $(GIT_REF): FORCE
-	@$(CP2KHOME)/tools/build_utils/get_revision_number $(SRCDIR) > "$@.tmp"
+	echo $(REVISION) > "$@.tmp"
 	@cmp "$@.tmp" "$@" || mv -f "$@.tmp" "$@"
 
 FORCE: ;

--- a/tools/build_utils/get_revision_number
+++ b/tools/build_utils/get_revision_number
@@ -16,6 +16,7 @@ GIT_HEAD="${GIT_DIR}/HEAD"
 
 if [ ! -s "${GIT_HEAD}" ] ; then
   echo "<unknown revision>"
+  >&2 echo "WARNING: $0 failed to determine the Git commit and no REVISION file available"
   exit 1
 fi
 


### PR DESCRIPTION
fixes #694 by warning the user via stderr and by allowing to override
the revision by setting REVISION explicitly as a `make` argument (the
warnings will still be shown since GNU make seems to execute the shell
commands prior to determining whether it is needed at all, but that is
somewhat intentional)