### PR TITLE
RTP velocity representation

### DIFF
--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -14,6 +14,7 @@ MODULE commutator_rpnl
    USE ai_overlap,                      ONLY: overlap
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
                                               gto_basis_set_type
+   USE block_p_types,                   ONLY: block_p_type
    USE dbcsr_api,                       ONLY: dbcsr_get_block_p,&
                                               dbcsr_p_type
    USE external_potential_types,        ONLY: gth_potential_p_type,&
@@ -50,7 +51,7 @@ MODULE commutator_rpnl
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'commutator_rpnl'
 
-   PUBLIC :: build_com_rpnl
+   PUBLIC :: build_com_rpnl, build_com_mom_nl
 
 CONTAINS
 
@@ -397,5 +398,458 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE build_com_rpnl
+
+! **************************************************************************************************
+!> \brief ...
+!> \param matrix_rv ...
+!> \param qs_kind_set ...
+!> \param sab_all ...
+!> \param sap_ppnl ...
+!> \param eps_ppnl ...
+!> \param matrix_rxrv ...
+!> \param matrix_rrv ...
+!> \param ref_point ...
+! **************************************************************************************************
+   SUBROUTINE build_com_mom_nl(matrix_rv, qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv, matrix_rrv, ref_point)
+
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_rv
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_all, sap_ppnl
+      REAL(KIND=dp), INTENT(IN)                          :: eps_ppnl
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_rxrv, matrix_rrv
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: ref_point
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_com_mom_nl', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: handle, i, iab, iac, iatom, ibc, icol, ikind, ilist, ind, inode, irow, iset, &
+         jatom, jkind, jneighbor, kac, katom, kbc, kkind, l, lc_max, lc_min, ldai, ldsab, lppnl, &
+         maxco, maxder, maxl, maxlgto, maxlppnl, maxppnl, maxsgf, mepos, na, nb, ncoa, ncoc, &
+         nkind, nlist, nneighbor, nnode, np, nppnl, nprjc, nseta, nsgfa, nthread, order, prjc, sgfa
+      INTEGER, DIMENSION(3)                              :: cell_b, cell_c
+      INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nprj_ppnl, &
+                                                            nsgf_seta
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
+      LOGICAL                                            :: asso_rrv, asso_rv, asso_rxrv, found, go, &
+                                                            gpot, ppnl_present, spot
+      REAL(KIND=dp)                                      :: dac, ppnl_radius
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ai_work, sab, work
+      REAL(KIND=dp), DIMENSION(1)                        :: rprjc, zetc
+      REAL(KIND=dp), DIMENSION(3)                        :: rab, rac, rcc
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: alpha_ppnl, set_radius_a
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cprj, rpgfa, sphi_a, vprj_ppnl, zeta
+      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: achint, acint, bchint, bcint
+      TYPE(alist_type), POINTER                          :: alist_ac, alist_bc
+      TYPE(block_p_type), DIMENSION(:), POINTER          :: blocks_rrv, blocks_rv, blocks_rxrv
+      TYPE(clist_type), POINTER                          :: clist
+      TYPE(gth_potential_p_type), DIMENSION(:), POINTER  :: gpotential
+      TYPE(gth_potential_type), POINTER                  :: gth_potential
+      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(sap_int_type), DIMENSION(:), POINTER          :: sap_int
+      TYPE(sgp_potential_p_type), DIMENSION(:), POINTER  :: spotential
+      TYPE(sgp_potential_type), POINTER                  :: sgp_potential
+
+      CALL timeset(routineN, handle)
+
+      ppnl_present = ASSOCIATED(sap_ppnl)
+
+      IF (ppnl_present) THEN
+
+         nkind = SIZE(qs_kind_set)
+
+         CALL get_qs_kind_set(qs_kind_set, &
+                              maxco=maxco, &
+                              maxlgto=maxlgto, &
+                              maxsgf=maxsgf, &
+                              maxlppnl=maxlppnl, &
+                              maxppnl=maxppnl)
+
+         maxl = MAX(maxlgto, maxlppnl)
+         CALL init_orbital_pointers(maxl + 1)
+
+         ldsab = MAX(maxco, ncoset(maxlppnl), maxsgf, maxppnl)
+         ldai = ncoset(maxl + 1)
+
+         !sap_int needs to be shared as multiple threads need to access this
+         ALLOCATE (sap_int(nkind*nkind))
+         DO i = 1, nkind*nkind
+            NULLIFY (sap_int(i)%alist, sap_int(i)%asort, sap_int(i)%aindex)
+            sap_int(i)%nalist = 0
+         END DO
+
+         !set up direct access to basis and potential
+         ALLOCATE (basis_set(nkind), gpotential(nkind), spotential(nkind))
+         DO ikind = 1, nkind
+            CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
+            IF (ASSOCIATED(orb_basis_set)) THEN
+               basis_set(ikind)%gto_basis_set => orb_basis_set
+            ELSE
+               NULLIFY (basis_set(ikind)%gto_basis_set)
+            END IF
+            CALL get_qs_kind(qs_kind_set(ikind), gth_potential=gth_potential, &
+                             sgp_potential=sgp_potential)
+            IF (ASSOCIATED(gth_potential)) THEN
+               gpotential(ikind)%gth_potential => gth_potential
+               NULLIFY (spotential(ikind)%sgp_potential)
+            ELSE IF (ASSOCIATED(sgp_potential)) THEN
+               spotential(ikind)%sgp_potential => sgp_potential
+               NULLIFY (gpotential(ikind)%gth_potential)
+            ELSE
+               NULLIFY (gpotential(ikind)%gth_potential)
+               NULLIFY (spotential(ikind)%sgp_potential)
+            END IF
+         END DO
+
+         IF (PRESENT(matrix_rxrv) .OR. PRESENT(matrix_rrv)) THEN
+            maxder = 10
+            order = 2
+            CPASSERT(PRESENT(ref_point))
+         ELSE
+            maxder = 4
+            order = 1
+         ENDIF
+
+         IF (PRESENT(ref_point)) THEN
+            rcc = ref_point
+         ENDIF
+
+         nthread = 1
+!$       nthread = omp_get_max_threads()
+
+         !calculate the overlap integrals <a|p>
+         CALL neighbor_list_iterator_create(nl_iterator, sap_ppnl, nthread=nthread)
+!$OMP PARALLEL &
+!$OMP DEFAULT (NONE) &
+!$OMP SHARED  (nl_iterator, basis_set, spotential, gpotential, maxder, ncoset, &
+!$OMP          sap_int, nkind, ldsab,  ldai, nco, order) &
+!$OMP PRIVATE (mepos, ikind, kkind, iatom, katom, nlist, ilist, nneighbor, jneighbor, &
+!$OMP          cell_c, rac, iac, first_sgfa, la_max, la_min, npgfa, nseta, nsgfa, nsgf_seta, &
+!$OMP          sphi_a, zeta, cprj, lppnl, nppnl, nprj_ppnl, &
+!$OMP          clist, iset, ncoa, sgfa, prjc, work, sab, ai_work, nprjc,  ppnl_radius, &
+!$OMP          ncoc, rpgfa, vprj_ppnl, i, l, gpot, spot, &
+!$OMP          set_radius_a, rprjc, dac, lc_max, lc_min, zetc, alpha_ppnl)
+         mepos = 0
+!$       mepos = omp_get_thread_num()
+
+         ALLOCATE (sab(ldsab, ldsab, maxder), work(ldsab, ldsab, maxder))
+         sab = 0.0_dp
+         ALLOCATE (ai_work(ldai, ldai, 1))
+         ai_work = 0.0_dp
+
+         DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+            CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=kkind, iatom=iatom, &
+                                   jatom=katom, nlist=nlist, ilist=ilist, nnode=nneighbor, inode=jneighbor, cell=cell_c, r=rac)
+            iac = ikind + nkind*(kkind - 1)
+            IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
+            gpot = ASSOCIATED(gpotential(kkind)%gth_potential)
+            spot = ASSOCIATED(spotential(kkind)%sgp_potential)
+            IF ((.NOT. gpot) .AND. (.NOT. spot)) CYCLE
+            ! get definition of basis set
+            first_sgfa => basis_set(ikind)%gto_basis_set%first_sgf
+            la_max => basis_set(ikind)%gto_basis_set%lmax
+            la_min => basis_set(ikind)%gto_basis_set%lmin
+            npgfa => basis_set(ikind)%gto_basis_set%npgf
+            nseta = basis_set(ikind)%gto_basis_set%nset
+            nsgfa = basis_set(ikind)%gto_basis_set%nsgf
+            nsgf_seta => basis_set(ikind)%gto_basis_set%nsgf_set
+            rpgfa => basis_set(ikind)%gto_basis_set%pgf_radius
+            set_radius_a => basis_set(ikind)%gto_basis_set%set_radius
+            sphi_a => basis_set(ikind)%gto_basis_set%sphi
+            zeta => basis_set(ikind)%gto_basis_set%zet
+            ! get definition of PP projectors
+            IF (gpot) THEN
+               alpha_ppnl => gpotential(kkind)%gth_potential%alpha_ppnl
+               cprj => gpotential(kkind)%gth_potential%cprj
+               lppnl = gpotential(kkind)%gth_potential%lppnl
+               nppnl = gpotential(kkind)%gth_potential%nppnl
+               nprj_ppnl => gpotential(kkind)%gth_potential%nprj_ppnl
+               ppnl_radius = gpotential(kkind)%gth_potential%ppnl_radius
+               vprj_ppnl => gpotential(kkind)%gth_potential%vprj_ppnl
+            ELSEIF (spot) THEN
+               CPABORT('SGP not implemented')
+            ELSE
+               CPABORT('PPNL unknown')
+            END IF
+!$OMP CRITICAL(sap_int_critical)
+            IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) THEN
+               sap_int(iac)%a_kind = ikind
+               sap_int(iac)%p_kind = kkind
+               sap_int(iac)%nalist = nlist
+               ALLOCATE (sap_int(iac)%alist(nlist))
+               DO i = 1, nlist
+                  NULLIFY (sap_int(iac)%alist(i)%clist)
+                  sap_int(iac)%alist(i)%aatom = 0
+                  sap_int(iac)%alist(i)%nclist = 0
+               END DO
+            END IF
+            IF (.NOT. ASSOCIATED(sap_int(iac)%alist(ilist)%clist)) THEN
+               sap_int(iac)%alist(ilist)%aatom = iatom
+               sap_int(iac)%alist(ilist)%nclist = nneighbor
+               ALLOCATE (sap_int(iac)%alist(ilist)%clist(nneighbor))
+               DO i = 1, nneighbor
+                  sap_int(iac)%alist(ilist)%clist(i)%catom = 0
+               END DO
+            END IF
+!$OMP END CRITICAL(sap_int_critical)
+            dac = SQRT(SUM(rac*rac))
+            clist => sap_int(iac)%alist(ilist)%clist(jneighbor)
+            clist%catom = katom
+            clist%cell = cell_c
+            clist%rac = rac
+            ALLOCATE (clist%acint(nsgfa, nppnl, maxder), &
+                      clist%achint(nsgfa, nppnl, maxder))
+            clist%acint = 0._dp
+            clist%achint = 0._dp
+            clist%nsgf_cnt = 0
+            NULLIFY (clist%sgf_list)
+            DO iset = 1, nseta
+               ncoa = npgfa(iset)*ncoset(la_max(iset))
+               sgfa = first_sgfa(1, iset)
+               work = 0._dp
+               prjc = 1
+               DO l = 0, lppnl
+                  nprjc = nprj_ppnl(l)*nco(l)
+                  IF (nprjc == 0) CYCLE
+                  rprjc(1) = ppnl_radius
+                  IF (set_radius_a(iset) + rprjc(1) < dac) CYCLE
+                  lc_max = l + 2*(nprj_ppnl(l) - 1)
+                  lc_min = l
+                  zetc(1) = alpha_ppnl(l)
+                  ncoc = ncoset(lc_max)
+                  ! Calculate the primitive overlap and dipole moment integrals
+                  CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
+                               lc_max, lc_min, 1, rprjc, zetc, rac, dac, sab(:, :, 1), 0, .FALSE., ai_work, ldai)
+                  CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                              lc_max, 1, zetc, rprjc, order, rac, (/0._dp, 0._dp, 0._dp/), sab(:, :, 2:maxder))
+                  ! *** Transformation step projector functions (cartesian->spherical) ***
+                  DO i = 1, maxder
+                     CALL dgemm("N", "N", ncoa, nprjc, ncoc, 1.0_dp, sab(1, 1, i), ldsab, &
+                                cprj(1, prjc), SIZE(cprj, 1), 0.0_dp, work(1, prjc, i), ldsab)
+                  END DO
+                  prjc = prjc + nprjc
+               END DO
+               DO i = 1, maxder
+                  ! Contraction step (basis functions)
+                  CALL dgemm("T", "N", nsgf_seta(iset), nppnl, ncoa, 1.0_dp, sphi_a(1, sgfa), SIZE(sphi_a, 1), &
+                             work(1, 1, i), ldsab, 0.0_dp, clist%acint(sgfa, 1, i), nsgfa)
+                  ! Multiply with interaction matrix(h)
+                  CALL dgemm("N", "N", nsgf_seta(iset), nppnl, nppnl, 1.0_dp, clist%acint(sgfa, 1, i), nsgfa, &
+                             vprj_ppnl(1, 1), SIZE(vprj_ppnl, 1), 0.0_dp, clist%achint(sgfa, 1, i), nsgfa)
+               END DO
+            END DO
+            clist%maxac = MAXVAL(ABS(clist%acint(:, :, 1)))
+            clist%maxach = MAXVAL(ABS(clist%achint(:, :, 1)))
+         END DO
+
+         DEALLOCATE (sab, ai_work, work)
+!$OMP END PARALLEL
+         CALL neighbor_list_iterator_release(nl_iterator)
+
+         ! *** Set up a sorting index
+         CALL sap_sort(sap_int)
+         ! *** All integrals needed have been calculated and stored in sap_int
+         ! *** We now calculate the Hamiltonian matrix elements
+         CALL neighbor_list_iterator_create(nl_iterator, sab_all, nthread=nthread)
+
+!$OMP PARALLEL &
+!$OMP DEFAULT (NONE) &
+!$OMP SHARED  (nl_iterator, basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
+!$OMP          sap_int, nkind, eps_ppnl ) &
+!$OMP PRIVATE (mepos, ikind, jkind, iatom, jatom, nlist, ilist, nnode, inode, cell_b, rab, &
+!$OMP          iab, irow, icol, blocks_rv, blocks_rxrv, blocks_rrv, &
+!$OMP          found, iac, ibc, alist_ac, alist_bc, acint, bcint, &
+!$OMP          achint, bchint, na, np, nb, katom, rac, kkind, kac, kbc, i, &
+!$OMP          go, asso_rv, asso_rxrv, asso_rrv)
+
+         mepos = 0
+!$       mepos = omp_get_thread_num()
+
+         NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
+         ALLOCATE (blocks_rv(3))
+
+         IF (PRESENT(matrix_rxrv)) THEN
+            ALLOCATE (blocks_rxrv(3))
+         ENDIF
+         IF (PRESENT(matrix_rxrv)) THEN
+            ALLOCATE (blocks_rrv(6))
+         ENDIF
+
+         DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+            CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, iatom=iatom, &
+                                   jatom=jatom, nlist=nlist, ilist=ilist, nnode=nnode, inode=inode, cell=cell_b, r=rab)
+            IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
+            IF (.NOT. ASSOCIATED(basis_set(jkind)%gto_basis_set)) CYCLE
+            iab = ikind + nkind*(jkind - 1)
+
+            ! *** Create matrix blocks for a new matrix block column ***
+            irow = iatom
+            icol = jatom
+
+            DO ind = 1, 3
+               CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
+            ENDDO
+
+            IF (PRESENT(matrix_rxrv)) THEN
+               DO ind = 1, 3
+                  CALL dbcsr_get_block_p(matrix_rxrv(ind)%matrix, irow, icol, blocks_rxrv(ind)%block, found)
+               ENDDO
+            ENDIF
+
+            IF (PRESENT(matrix_rrv)) THEN
+               DO ind = 1, 3
+                  CALL dbcsr_get_block_p(matrix_rrv(ind)%matrix, irow, icol, blocks_rrv(ind)%block, found)
+               ENDDO
+            ENDIF
+
+            ! check whether all blocks are associated
+            asso_rv = (ASSOCIATED(blocks_rv(1)%block) .AND. ASSOCIATED(blocks_rv(2)%block) .AND. &
+                       ASSOCIATED(blocks_rv(3)%block))
+            go = asso_rv
+
+            IF (PRESENT(matrix_rxrv)) THEN
+               asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
+                            ASSOCIATED(blocks_rxrv(1)%block))
+               go = go .AND. asso_rxrv
+            ENDIF
+
+            IF (PRESENT(matrix_rxrv)) THEN
+               asso_rrv = (ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
+                           ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
+                           ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block))
+               go = go .AND. asso_rrv
+            ENDIF
+            ! loop over all kinds for projector atom
+            IF (go) THEN
+               DO kkind = 1, nkind
+                  iac = ikind + nkind*(kkind - 1)
+                  ibc = jkind + nkind*(kkind - 1)
+                  IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) CYCLE
+                  IF (.NOT. ASSOCIATED(sap_int(ibc)%alist)) CYCLE
+                  CALL get_alist(sap_int(iac), alist_ac, iatom)
+                  CALL get_alist(sap_int(ibc), alist_bc, jatom)
+                  IF (.NOT. ASSOCIATED(alist_ac)) CYCLE
+                  IF (.NOT. ASSOCIATED(alist_bc)) CYCLE
+                  DO kac = 1, alist_ac%nclist
+                     DO kbc = 1, alist_bc%nclist
+                        IF (alist_ac%clist(kac)%catom /= alist_bc%clist(kbc)%catom) CYCLE
+                        IF (ALL(cell_b + alist_bc%clist(kbc)%cell - alist_ac%clist(kac)%cell == 0)) THEN
+                           IF (alist_ac%clist(kac)%maxac*alist_bc%clist(kbc)%maxach < eps_ppnl) CYCLE
+                           acint => alist_ac%clist(kac)%acint
+                           bcint => alist_bc%clist(kbc)%acint
+                           achint => alist_ac%clist(kac)%achint
+                           bchint => alist_bc%clist(kbc)%achint
+                           na = SIZE(acint, 1)
+                           np = SIZE(acint, 2)
+                           nb = SIZE(bcint, 1)
+!$OMP CRITICAL(h_block_critical)
+                           ! r*Vnl
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
+
+                           ! -Vnl r
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
+
+                           IF (PRESENT(matrix_rxrv)) THEN
+                              ! x-component (y [z,Vnl] - z [y, Vnl])
+                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
+                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 3), na, &
+                                         bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -yVz
+                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 9), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -zyV
+                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
+                                         bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
+
+                              ! y-component (z [x,Vnl] - x [z, Vnl])
+                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 7), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! zxV
+                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 4), na, &
+                                         bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -zVx
+                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 7), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -xzV
+                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
+                                         bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
+
+                              ! z-component (x [y,Vnl] - y [x, Vnl])
+                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 6), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! xyV
+                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 2), na, &
+                                         bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -xVy
+                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 6), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -yxV
+                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
+                                         bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
+                           ENDIF
+
+                           IF (PRESENT(matrix_rrv)) THEN
+                              ! r_alpha * r_beta * Vnl
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 6), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! xyV
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 7), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! xzV
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 8), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! yyV
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 9), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! yzV
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
+
+                              ! - Vnl * r_alpha * r_beta
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 5), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! Vxx
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 6), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! Vxy
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 7), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! Vxz
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 8), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! Vyy
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 9), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! Vyz
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
+                           ENDIF
+!$OMP END CRITICAL(h_block_critical)
+                           EXIT ! We have found a match and there can be only one single match
+                        END IF
+                     END DO
+                  END DO
+               END DO
+            ENDIF
+         END DO
+         DEALLOCATE (blocks_rv)
+         IF (PRESENT(matrix_rxrv)) THEN
+            DEALLOCATE (blocks_rxrv)
+         ENDIF
+         IF (PRESENT(matrix_rxrv)) THEN
+            DEALLOCATE (blocks_rrv)
+         ENDIF
+!$OMP END PARALLEL
+         CALL neighbor_list_iterator_release(nl_iterator)
+
+         CALL release_sap_int(sap_int)
+
+         DEALLOCATE (basis_set, gpotential, spotential)
+
+      END IF !ppnl_present
+
+      CALL timestop(handle)
+
+   END SUBROUTINE build_com_mom_nl
 
 END MODULE commutator_rpnl

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -404,27 +404,26 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param matrix_rv ...
 !> \param qs_kind_set ...
 !> \param sab_all ...
 !> \param sap_ppnl ...
 !> \param eps_ppnl ...
+!> \param matrix_rv ...
 !> \param matrix_rxrv ...
 !> \param matrix_rrv ...
 !> \param ref_point ...
 !> \param particle_set ...
 !> \param cell ...
 ! **************************************************************************************************
-   SUBROUTINE build_com_mom_nl(matrix_rv, qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv, matrix_rrv, ref_point, &
+   SUBROUTINE build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv, matrix_rxrv, matrix_rrv, ref_point, &
                                particle_set, cell)
 
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_rv
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_all, sap_ppnl
       REAL(KIND=dp), INTENT(IN)                          :: eps_ppnl
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: matrix_rxrv, matrix_rrv
+         POINTER                                         :: matrix_rv, matrix_rxrv, matrix_rrv
       REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: ref_point
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: particle_set
@@ -442,7 +441,7 @@ CONTAINS
                                                             nsgf_seta
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
       LOGICAL                                            :: asso_rrv, asso_rv, asso_rxrv, found, go, &
-                                                            gpot, my_ref, my_rrv, my_rxrv, &
+                                                            gpot, my_ref, my_rrv, my_rv, my_rxrv, &
                                                             ppnl_present, spot
       REAL(KIND=dp)                                      :: dac, ppnl_radius
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ai_work, sab, work
@@ -465,6 +464,14 @@ CONTAINS
       TYPE(sgp_potential_type), POINTER                  :: sgp_potential
 
       CALL timeset(routineN, handle)
+
+      my_rxrv = .FALSE.
+      my_rrv = .FALSE.
+      my_rv = .FALSE.
+      IF (PRESENT(matrix_rxrv)) my_rxrv = .TRUE.
+      IF (PRESENT(matrix_rrv)) my_rrv = .TRUE.
+      IF (PRESENT(matrix_rv)) my_rv = .TRUE.
+      IF (.NOT. (my_rv .OR. my_rxrv .OR. my_rrv)) RETURN
 
       ppnl_present = ASSOCIATED(sap_ppnl)
 
@@ -514,11 +521,6 @@ CONTAINS
                NULLIFY (spotential(ikind)%sgp_potential)
             END IF
          END DO
-
-         my_rxrv = .FALSE.
-         my_rrv = .FALSE.
-         IF (PRESENT(matrix_rxrv)) my_rxrv = .TRUE.
-         IF (PRESENT(matrix_rrv)) my_rrv = .TRUE.
 
          IF (my_rxrv .OR. my_rrv) THEN
             maxder = 10
@@ -692,7 +694,7 @@ CONTAINS
 !$OMP PARALLEL &
 !$OMP DEFAULT (NONE) &
 !$OMP SHARED  (nl_iterator, basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
-!$OMP          sap_int, nkind, eps_ppnl, my_rxrv, my_rrv ) &
+!$OMP          sap_int, nkind, eps_ppnl, my_rv, my_rxrv, my_rrv ) &
 !$OMP PRIVATE (mepos, ikind, jkind, iatom, jatom, nlist, ilist, nnode, inode, cell_b, rab, &
 !$OMP          iab, irow, icol, blocks_rv, blocks_rxrv, blocks_rrv, &
 !$OMP          found, iac, ibc, alist_ac, alist_bc, acint, bcint, &
@@ -703,12 +705,14 @@ CONTAINS
 !$       mepos = omp_get_thread_num()
 
          NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
-         ALLOCATE (blocks_rv(3))
+         IF (my_rv) THEN
+            ALLOCATE (blocks_rv(3))
+         ENDIF
 
          IF (my_rxrv) THEN
             ALLOCATE (blocks_rxrv(3))
          ENDIF
-         IF (my_rxrv) THEN
+         IF (my_rrv) THEN
             ALLOCATE (blocks_rrv(6))
          ENDIF
 
@@ -723,9 +727,11 @@ CONTAINS
             irow = iatom
             icol = jatom
 
-            DO ind = 1, 3
-               CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
-            ENDDO
+            IF (my_rv) THEN
+               DO ind = 1, 3
+                  CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
+               ENDDO
+            ENDIF
 
             IF (my_rxrv) THEN
                DO ind = 1, 3
@@ -734,26 +740,29 @@ CONTAINS
             ENDIF
 
             IF (my_rrv) THEN
-               DO ind = 1, 3
+               DO ind = 1, 6
                   CALL dbcsr_get_block_p(matrix_rrv(ind)%matrix, irow, icol, blocks_rrv(ind)%block, found)
                ENDDO
             ENDIF
 
             ! check whether all blocks are associated
-            asso_rv = (ASSOCIATED(blocks_rv(1)%block) .AND. ASSOCIATED(blocks_rv(2)%block) .AND. &
-                       ASSOCIATED(blocks_rv(3)%block))
-            go = asso_rv
-
-            IF (my_rxrv) THEN
-               asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
-                            ASSOCIATED(blocks_rxrv(1)%block))
-               go = go .AND. asso_rxrv
+            go = .TRUE.
+            IF (my_rv) THEN
+               asso_rv = (ASSOCIATED(blocks_rv(1)%block) .AND. ASSOCIATED(blocks_rv(2)%block) .AND. &
+                          ASSOCIATED(blocks_rv(3)%block))
+               go = go .AND. asso_rv
             ENDIF
 
             IF (my_rxrv) THEN
+               asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
+                            ASSOCIATED(blocks_rxrv(3)%block))
+               go = go .AND. asso_rxrv
+            ENDIF
+
+            IF (my_rrv) THEN
                asso_rrv = (ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
-                           ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
-                           ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block))
+                           ASSOCIATED(blocks_rrv(3)%block) .AND. ASSOCIATED(blocks_rrv(4)%block) .AND. &
+                           ASSOCIATED(blocks_rrv(5)%block) .AND. ASSOCIATED(blocks_rrv(6)%block))
                go = go .AND. asso_rrv
             ENDIF
             ! loop over all kinds for projector atom
@@ -781,21 +790,23 @@ CONTAINS
                            nb = SIZE(bcint, 1)
 !$OMP CRITICAL(h_block_critical)
                            ! r*Vnl
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
+                           IF (my_rv) THEN
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
+                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
+                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
 
-                           ! -Vnl r
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
+                              ! -Vnl r
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
+                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                         bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
 
+                           ENDIF
                            IF (my_rxrv) THEN
                               ! x-component (y [z,Vnl] - z [y, Vnl])
                               CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
@@ -865,10 +876,12 @@ CONTAINS
                END DO
             ENDIF
          END DO
-         DO ind = 1, 3
-            NULLIFY (blocks_rv(ind)%block)
-         ENDDO
-         DEALLOCATE (blocks_rv)
+         IF (my_rv) THEN
+            DO ind = 1, 3
+               NULLIFY (blocks_rv(ind)%block)
+            ENDDO
+            DEALLOCATE (blocks_rv)
+         ENDIF
          IF (my_rxrv) THEN
             DO ind = 1, 3
                NULLIFY (blocks_rxrv(ind)%block)

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -15,6 +15,8 @@ MODULE commutator_rpnl
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
                                               gto_basis_set_type
    USE block_p_types,                   ONLY: block_p_type
+   USE cell_types,                      ONLY: cell_type,&
+                                              pbc
    USE dbcsr_api,                       ONLY: dbcsr_get_block_p,&
                                               dbcsr_p_type
    USE external_potential_types,        ONLY: gth_potential_p_type,&
@@ -25,6 +27,7 @@ MODULE commutator_rpnl
    USE orbital_pointers,                ONLY: init_orbital_pointers,&
                                               nco,&
                                               ncoset
+   USE particle_types,                  ONLY: particle_type
    USE qs_kind_types,                   ONLY: get_qs_kind,&
                                               get_qs_kind_set,&
                                               qs_kind_type
@@ -409,8 +412,11 @@ CONTAINS
 !> \param matrix_rxrv ...
 !> \param matrix_rrv ...
 !> \param ref_point ...
+!> \param particle_set ...
+!> \param cell ...
 ! **************************************************************************************************
-   SUBROUTINE build_com_mom_nl(matrix_rv, qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv, matrix_rrv, ref_point)
+   SUBROUTINE build_com_mom_nl(matrix_rv, qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv, matrix_rrv, ref_point, &
+                               particle_set, cell)
 
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_rv
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -420,6 +426,9 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_rxrv, matrix_rrv
       REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: ref_point
+      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: particle_set
+      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_com_mom_nl', &
          routineP = moduleN//':'//routineN
@@ -433,11 +442,12 @@ CONTAINS
                                                             nsgf_seta
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
       LOGICAL                                            :: asso_rrv, asso_rv, asso_rxrv, found, go, &
-                                                            gpot, ppnl_present, spot
+                                                            gpot, my_ref, my_rrv, my_rxrv, &
+                                                            ppnl_present, spot
       REAL(KIND=dp)                                      :: dac, ppnl_radius
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ai_work, sab, work
       REAL(KIND=dp), DIMENSION(1)                        :: rprjc, zetc
-      REAL(KIND=dp), DIMENSION(3)                        :: rab, rac, rcc
+      REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rac, raf, rc, rcf, rf
       REAL(KIND=dp), DIMENSION(:), POINTER               :: alpha_ppnl, set_radius_a
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cprj, rpgfa, sphi_a, vprj_ppnl, zeta
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: achint, acint, bchint, bcint
@@ -505,7 +515,12 @@ CONTAINS
             END IF
          END DO
 
-         IF (PRESENT(matrix_rxrv) .OR. PRESENT(matrix_rrv)) THEN
+         my_rxrv = .FALSE.
+         my_rrv = .FALSE.
+         IF (PRESENT(matrix_rxrv)) my_rxrv = .TRUE.
+         IF (PRESENT(matrix_rrv)) my_rrv = .TRUE.
+
+         IF (my_rxrv .OR. my_rrv) THEN
             maxder = 10
             order = 2
             CPASSERT(PRESENT(ref_point))
@@ -514,8 +529,13 @@ CONTAINS
             order = 1
          ENDIF
 
+         my_ref = .FALSE.
          IF (PRESENT(ref_point)) THEN
-            rcc = ref_point
+            CPASSERT((PRESENT(cell) .AND. PRESENT(particle_set)))
+            rf = ref_point
+            my_ref = .TRUE.
+         ELSE
+            rf(:) = 0._dp
          ENDIF
 
          nthread = 1
@@ -526,12 +546,12 @@ CONTAINS
 !$OMP PARALLEL &
 !$OMP DEFAULT (NONE) &
 !$OMP SHARED  (nl_iterator, basis_set, spotential, gpotential, maxder, ncoset, &
-!$OMP          sap_int, nkind, ldsab,  ldai, nco, order) &
+!$OMP          sap_int, nkind, ldsab,  ldai, nco, cell, particle_set, order, rf, my_ref) &
 !$OMP PRIVATE (mepos, ikind, kkind, iatom, katom, nlist, ilist, nneighbor, jneighbor, &
 !$OMP          cell_c, rac, iac, first_sgfa, la_max, la_min, npgfa, nseta, nsgfa, nsgf_seta, &
 !$OMP          sphi_a, zeta, cprj, lppnl, nppnl, nprj_ppnl, &
 !$OMP          clist, iset, ncoa, sgfa, prjc, work, sab, ai_work, nprjc,  ppnl_radius, &
-!$OMP          ncoc, rpgfa, vprj_ppnl, i, l, gpot, spot, &
+!$OMP          ncoc, rpgfa, vprj_ppnl, i, l, gpot, spot, raf, rcf, ra, rc, &
 !$OMP          set_radius_a, rprjc, dac, lc_max, lc_min, zetc, alpha_ppnl)
          mepos = 0
 !$       mepos = omp_get_thread_num()
@@ -607,6 +627,14 @@ CONTAINS
             clist%achint = 0._dp
             clist%nsgf_cnt = 0
             NULLIFY (clist%sgf_list)
+
+            IF (my_ref) THEN
+               ra(:) = pbc(particle_set(iatom)%r(:) - rf, cell) + rf
+               rc(:) = pbc(particle_set(katom)%r(:) - rf, cell) + rf
+               raf(:) = ra(:) - rf(:)
+               rcf(:) = rc(:) - rf(:)
+            ENDIF
+
             DO iset = 1, nseta
                ncoa = npgfa(iset)*ncoset(la_max(iset))
                sgfa = first_sgfa(1, iset)
@@ -624,8 +652,13 @@ CONTAINS
                   ! Calculate the primitive overlap and dipole moment integrals
                   CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
                                lc_max, lc_min, 1, rprjc, zetc, rac, dac, sab(:, :, 1), 0, .FALSE., ai_work, ldai)
-                  CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
-                              lc_max, 1, zetc, rprjc, order, rac, (/0._dp, 0._dp, 0._dp/), sab(:, :, 2:maxder))
+                  IF (.NOT. my_ref) THEN
+                     CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                                 lc_max, 1, zetc, rprjc, order, -rac, (/0._dp, 0._dp, 0._dp/), sab(:, :, 2:maxder))
+                  ELSE
+                     CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                                 lc_max, 1, zetc, rprjc, order, raf, rcf, sab(:, :, 2:maxder))
+                  ENDIF
                   ! *** Transformation step projector functions (cartesian->spherical) ***
                   DO i = 1, maxder
                      CALL dgemm("N", "N", ncoa, nprjc, ncoc, 1.0_dp, sab(1, 1, i), ldsab, &
@@ -659,7 +692,7 @@ CONTAINS
 !$OMP PARALLEL &
 !$OMP DEFAULT (NONE) &
 !$OMP SHARED  (nl_iterator, basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
-!$OMP          sap_int, nkind, eps_ppnl ) &
+!$OMP          sap_int, nkind, eps_ppnl, my_rxrv, my_rrv ) &
 !$OMP PRIVATE (mepos, ikind, jkind, iatom, jatom, nlist, ilist, nnode, inode, cell_b, rab, &
 !$OMP          iab, irow, icol, blocks_rv, blocks_rxrv, blocks_rrv, &
 !$OMP          found, iac, ibc, alist_ac, alist_bc, acint, bcint, &
@@ -672,10 +705,10 @@ CONTAINS
          NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
          ALLOCATE (blocks_rv(3))
 
-         IF (PRESENT(matrix_rxrv)) THEN
+         IF (my_rxrv) THEN
             ALLOCATE (blocks_rxrv(3))
          ENDIF
-         IF (PRESENT(matrix_rxrv)) THEN
+         IF (my_rxrv) THEN
             ALLOCATE (blocks_rrv(6))
          ENDIF
 
@@ -694,13 +727,13 @@ CONTAINS
                CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
             ENDDO
 
-            IF (PRESENT(matrix_rxrv)) THEN
+            IF (my_rxrv) THEN
                DO ind = 1, 3
                   CALL dbcsr_get_block_p(matrix_rxrv(ind)%matrix, irow, icol, blocks_rxrv(ind)%block, found)
                ENDDO
             ENDIF
 
-            IF (PRESENT(matrix_rrv)) THEN
+            IF (my_rrv) THEN
                DO ind = 1, 3
                   CALL dbcsr_get_block_p(matrix_rrv(ind)%matrix, irow, icol, blocks_rrv(ind)%block, found)
                ENDDO
@@ -711,13 +744,13 @@ CONTAINS
                        ASSOCIATED(blocks_rv(3)%block))
             go = asso_rv
 
-            IF (PRESENT(matrix_rxrv)) THEN
+            IF (my_rxrv) THEN
                asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
                             ASSOCIATED(blocks_rxrv(1)%block))
                go = go .AND. asso_rxrv
             ENDIF
 
-            IF (PRESENT(matrix_rxrv)) THEN
+            IF (my_rxrv) THEN
                asso_rrv = (ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
                            ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
                            ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block))
@@ -763,7 +796,7 @@ CONTAINS
                            CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
                                       bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
 
-                           IF (PRESENT(matrix_rxrv)) THEN
+                           IF (my_rxrv) THEN
                               ! x-component (y [z,Vnl] - z [y, Vnl])
                               CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
                                          bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
@@ -795,7 +828,7 @@ CONTAINS
                                          bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
                            ENDIF
 
-                           IF (PRESENT(matrix_rrv)) THEN
+                           IF (my_rrv) THEN
                               ! r_alpha * r_beta * Vnl
                               CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
                                          bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
@@ -832,11 +865,20 @@ CONTAINS
                END DO
             ENDIF
          END DO
+         DO ind = 1, 3
+            NULLIFY (blocks_rv(ind)%block)
+         ENDDO
          DEALLOCATE (blocks_rv)
-         IF (PRESENT(matrix_rxrv)) THEN
+         IF (my_rxrv) THEN
+            DO ind = 1, 3
+               NULLIFY (blocks_rxrv(ind)%block)
+            ENDDO
             DEALLOCATE (blocks_rxrv)
          ENDIF
-         IF (PRESENT(matrix_rxrv)) THEN
+         IF (my_rrv) THEN
+            DO ind = 1, 6
+               NULLIFY (blocks_rrv(ind)%block)
+            ENDDO
             DEALLOCATE (blocks_rrv)
          ENDIF
 !$OMP END PARALLEL

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -15,8 +15,7 @@ MODULE commutator_rpnl
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
                                               gto_basis_set_type
    USE block_p_types,                   ONLY: block_p_type
-   USE cell_types,                      ONLY: cell_type,&
-                                              pbc
+   USE cell_types,                      ONLY: cell_type
    USE dbcsr_api,                       ONLY: dbcsr_get_block_p,&
                                               dbcsr_p_type
    USE external_potential_types,        ONLY: gth_potential_p_type,&
@@ -46,6 +45,9 @@ MODULE commutator_rpnl
                                               sap_sort
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
+!$ USE OMP_LIB, ONLY: omp_lock_kind, &
+!$                    omp_init_lock, omp_set_lock, &
+!$                    omp_unset_lock, omp_destroy_lock
 
 #include "./base/base_uses.f90"
 
@@ -55,7 +57,7 @@ MODULE commutator_rpnl
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'commutator_rpnl'
 
-   PUBLIC :: build_com_rpnl, build_com_mom_nl, build_com_mom_nl_2
+   PUBLIC :: build_com_rpnl, build_com_mom_nl
 
 CONTAINS
 
@@ -410,537 +412,34 @@ CONTAINS
 !> \param sab_all ...
 !> \param sap_ppnl ...
 !> \param eps_ppnl ...
+!> \param particle_set ...
 !> \param matrix_rv ...
 !> \param matrix_rxrv ...
 !> \param matrix_rrv ...
 !> \param ref_point ...
-!> \param particle_set ...
 !> \param cell ...
 ! **************************************************************************************************
-   SUBROUTINE build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv, matrix_rxrv, matrix_rrv, ref_point, &
-                               particle_set, cell)
+   SUBROUTINE build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv, matrix_rxrv, &
+                               matrix_rrv, ref_point, cell)
 
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          INTENT(IN), POINTER                             :: sab_all, sap_ppnl
       REAL(KIND=dp), INTENT(IN)                          :: eps_ppnl
+      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
+         POINTER                                         :: particle_set
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
          OPTIONAL, POINTER                               :: matrix_rv, matrix_rxrv, matrix_rrv
       REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: ref_point
-      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
-         OPTIONAL, POINTER                               :: particle_set
       TYPE(cell_type), INTENT(IN), OPTIONAL, POINTER     :: cell
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_com_mom_nl', &
          routineP = moduleN//':'//routineN
 
-      INTEGER :: handle, i, iab, iac, iatom, ibc, icol, ikind, ilist, ind, inode, irow, iset, &
-         jatom, jkind, jneighbor, kac, katom, kbc, kkind, l, lc_max, lc_min, ldai, ldsab, lppnl, &
-         maxco, maxder, maxl, maxlgto, maxlppnl, maxppnl, maxsgf, mepos, na, nb, ncoa, ncoc, &
-         nkind, nlist, nneighbor, nnode, np, nppnl, nprjc, nseta, nsgfa, nthread, order, prjc, sgfa
-      INTEGER, DIMENSION(3)                              :: cell_b, cell_c
-      INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nprj_ppnl, &
-                                                            nsgf_seta
-      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
-      LOGICAL                                            :: asso_rrv, asso_rv, asso_rxrv, found, go, &
-                                                            gpot, my_ref, my_rrv, my_rv, my_rxrv, &
-                                                            ppnl_present, spot
-      REAL(KIND=dp)                                      :: dac, ppnl_radius
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ai_work, sab, work
-      REAL(KIND=dp), DIMENSION(1)                        :: rprjc, zetc
-      REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rac, raf, rc, rcf, rf
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: alpha_ppnl, set_radius_a
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cprj, rpgfa, sphi_a, vprj_ppnl, zeta
-      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: achint, acint, bchint, bcint
-      TYPE(alist_type), POINTER                          :: alist_ac, alist_bc
-      TYPE(block_p_type), DIMENSION(:), POINTER          :: blocks_rrv, blocks_rv, blocks_rxrv
-      TYPE(clist_type), POINTER                          :: clist
-      TYPE(gth_potential_p_type), DIMENSION(:), POINTER  :: gpotential
-      TYPE(gth_potential_type), POINTER                  :: gth_potential
-      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set
-      TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
-      TYPE(neighbor_list_iterator_p_type), &
-         DIMENSION(:), POINTER                           :: nl_iterator
-      TYPE(sap_int_type), DIMENSION(:), POINTER          :: sap_int
-      TYPE(sgp_potential_p_type), DIMENSION(:), POINTER  :: spotential
-      TYPE(sgp_potential_type), POINTER                  :: sgp_potential
-
-      ppnl_present = ASSOCIATED(sap_ppnl)
-      IF (.NOT. ppnl_present) RETURN
-
-      CALL timeset(routineN, handle)
-
-      my_rxrv = .FALSE.
-      my_rrv = .FALSE.
-      my_rv = .FALSE.
-      IF (PRESENT(matrix_rxrv)) my_rxrv = .TRUE.
-      IF (PRESENT(matrix_rrv)) my_rrv = .TRUE.
-      IF (PRESENT(matrix_rv)) my_rv = .TRUE.
-      IF (.NOT. (my_rv .OR. my_rxrv .OR. my_rrv)) THEN
-         CPABORT('No dbcsr matrix provided for commutator calculation!')
-      ENDIF
-
-      IF (my_rxrv .OR. my_rrv) THEN
-         maxder = 10
-         order = 2
-         CPASSERT(PRESENT(ref_point)) ! need reference point for r x [r,Vnl] and [rr,Vnl]
-      ELSE
-         maxder = 4
-         order = 1
-      ENDIF
-
-      my_ref = .FALSE.
-      IF (PRESENT(ref_point)) THEN
-         CPASSERT((PRESENT(cell) .AND. PRESENT(particle_set))) ! need these as well if refpoint is provided
-         rf = ref_point
-         my_ref = .TRUE.
-      ELSE
-         rf(:) = 0._dp
-      ENDIF
-
-      nkind = SIZE(qs_kind_set)
-
-      CALL get_qs_kind_set(qs_kind_set, &
-                           maxco=maxco, &
-                           maxlgto=maxlgto, &
-                           maxsgf=maxsgf, &
-                           maxlppnl=maxlppnl, &
-                           maxppnl=maxppnl)
-
-      maxl = MAX(maxlgto, maxlppnl)
-      CALL init_orbital_pointers(maxl + 1)
-
-      ldsab = MAX(maxco, ncoset(maxlppnl), maxsgf, maxppnl)
-      ldai = ncoset(maxl + 1)
-
-      !sap_int needs to be shared as multiple threads need to access this
-      ALLOCATE (sap_int(nkind*nkind))
-      DO i = 1, nkind*nkind
-         NULLIFY (sap_int(i)%alist, sap_int(i)%asort, sap_int(i)%aindex)
-         sap_int(i)%nalist = 0
-      END DO
-
-      !set up direct access to basis and potential
-      ALLOCATE (basis_set(nkind), gpotential(nkind), spotential(nkind))
-      DO ikind = 1, nkind
-         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
-         IF (ASSOCIATED(orb_basis_set)) THEN
-            basis_set(ikind)%gto_basis_set => orb_basis_set
-         ELSE
-            NULLIFY (basis_set(ikind)%gto_basis_set)
-         END IF
-         CALL get_qs_kind(qs_kind_set(ikind), gth_potential=gth_potential, &
-                          sgp_potential=sgp_potential)
-         IF (ASSOCIATED(gth_potential)) THEN
-            gpotential(ikind)%gth_potential => gth_potential
-            NULLIFY (spotential(ikind)%sgp_potential)
-         ELSE IF (ASSOCIATED(sgp_potential)) THEN
-            spotential(ikind)%sgp_potential => sgp_potential
-            NULLIFY (gpotential(ikind)%gth_potential)
-         ELSE
-            NULLIFY (gpotential(ikind)%gth_potential)
-            NULLIFY (spotential(ikind)%sgp_potential)
-         END IF
-      END DO
-
-      nthread = 1
-!$    nthread = omp_get_max_threads()
-
-      !calculate the overlap integrals <a|p>
-      CALL neighbor_list_iterator_create(nl_iterator, sap_ppnl, nthread=nthread)
-!$OMP PARALLEL &
-!$OMP DEFAULT (NONE) &
-!$OMP SHARED  (nl_iterator, basis_set, spotential, gpotential, maxder, ncoset, &
-!$OMP          sap_int, nkind, ldsab,  ldai, nco, cell, particle_set, order, rf, my_ref) &
-!$OMP PRIVATE (mepos, ikind, kkind, iatom, katom, nlist, ilist, nneighbor, jneighbor, &
-!$OMP          cell_c, rac, iac, first_sgfa, la_max, la_min, npgfa, nseta, nsgfa, nsgf_seta, &
-!$OMP          sphi_a, zeta, cprj, lppnl, nppnl, nprj_ppnl, &
-!$OMP          clist, iset, ncoa, sgfa, prjc, work, sab, ai_work, nprjc,  ppnl_radius, &
-!$OMP          ncoc, rpgfa, vprj_ppnl, i, l, gpot, spot, raf, rcf, ra, rc, &
-!$OMP          set_radius_a, rprjc, dac, lc_max, lc_min, zetc, alpha_ppnl)
-      mepos = 0
-!$    mepos = omp_get_thread_num()
-
-      ALLOCATE (sab(ldsab, ldsab, maxder), work(ldsab, ldsab, maxder))
-      sab = 0.0_dp
-      ALLOCATE (ai_work(ldai, ldai, 1))
-      ai_work = 0.0_dp
-
-      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
-         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=kkind, iatom=iatom, &
-                                jatom=katom, nlist=nlist, ilist=ilist, nnode=nneighbor, inode=jneighbor, cell=cell_c, r=rac)
-         iac = ikind + nkind*(kkind - 1)
-         IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
-         gpot = ASSOCIATED(gpotential(kkind)%gth_potential)
-         spot = ASSOCIATED(spotential(kkind)%sgp_potential)
-         IF ((.NOT. gpot) .AND. (.NOT. spot)) CYCLE
-         ! get definition of basis set
-         first_sgfa => basis_set(ikind)%gto_basis_set%first_sgf
-         la_max => basis_set(ikind)%gto_basis_set%lmax
-         la_min => basis_set(ikind)%gto_basis_set%lmin
-         npgfa => basis_set(ikind)%gto_basis_set%npgf
-         nseta = basis_set(ikind)%gto_basis_set%nset
-         nsgfa = basis_set(ikind)%gto_basis_set%nsgf
-         nsgf_seta => basis_set(ikind)%gto_basis_set%nsgf_set
-         rpgfa => basis_set(ikind)%gto_basis_set%pgf_radius
-         set_radius_a => basis_set(ikind)%gto_basis_set%set_radius
-         sphi_a => basis_set(ikind)%gto_basis_set%sphi
-         zeta => basis_set(ikind)%gto_basis_set%zet
-         ! get definition of PP projectors
-         IF (gpot) THEN
-            alpha_ppnl => gpotential(kkind)%gth_potential%alpha_ppnl
-            cprj => gpotential(kkind)%gth_potential%cprj
-            lppnl = gpotential(kkind)%gth_potential%lppnl
-            nppnl = gpotential(kkind)%gth_potential%nppnl
-            nprj_ppnl => gpotential(kkind)%gth_potential%nprj_ppnl
-            ppnl_radius = gpotential(kkind)%gth_potential%ppnl_radius
-            vprj_ppnl => gpotential(kkind)%gth_potential%vprj_ppnl
-         ELSEIF (spot) THEN
-            CPABORT('SGP not implemented')
-         ELSE
-            CPABORT('PPNL unknown')
-         END IF
-!$OMP CRITICAL(sap_int_critical)
-         IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) THEN
-            sap_int(iac)%a_kind = ikind
-            sap_int(iac)%p_kind = kkind
-            sap_int(iac)%nalist = nlist
-            ALLOCATE (sap_int(iac)%alist(nlist))
-            DO i = 1, nlist
-               NULLIFY (sap_int(iac)%alist(i)%clist)
-               sap_int(iac)%alist(i)%aatom = 0
-               sap_int(iac)%alist(i)%nclist = 0
-            END DO
-         END IF
-         IF (.NOT. ASSOCIATED(sap_int(iac)%alist(ilist)%clist)) THEN
-            sap_int(iac)%alist(ilist)%aatom = iatom
-            sap_int(iac)%alist(ilist)%nclist = nneighbor
-            ALLOCATE (sap_int(iac)%alist(ilist)%clist(nneighbor))
-            DO i = 1, nneighbor
-               sap_int(iac)%alist(ilist)%clist(i)%catom = 0
-            END DO
-         END IF
-!$OMP END CRITICAL(sap_int_critical)
-         dac = SQRT(SUM(rac*rac))
-         clist => sap_int(iac)%alist(ilist)%clist(jneighbor)
-         clist%catom = katom
-         clist%cell = cell_c
-         clist%rac = rac
-         ALLOCATE (clist%acint(nsgfa, nppnl, maxder), &
-                   clist%achint(nsgfa, nppnl, maxder))
-         clist%acint = 0._dp
-         clist%achint = 0._dp
-         clist%nsgf_cnt = 0
-         NULLIFY (clist%sgf_list)
-
-         IF (my_ref) THEN
-            ra(:) = pbc(particle_set(iatom)%r(:) - rf, cell) + rf
-            rc(:) = pbc(particle_set(katom)%r(:) - rf, cell) + rf
-            raf(:) = ra(:) - rf(:)
-            rcf(:) = rc(:) - rf(:)
-         ENDIF
-
-         DO iset = 1, nseta
-            ncoa = npgfa(iset)*ncoset(la_max(iset))
-            sgfa = first_sgfa(1, iset)
-            work = 0._dp
-            prjc = 1
-            DO l = 0, lppnl
-               nprjc = nprj_ppnl(l)*nco(l)
-               IF (nprjc == 0) CYCLE
-               rprjc(1) = ppnl_radius
-               IF (set_radius_a(iset) + rprjc(1) < dac) CYCLE
-               lc_max = l + 2*(nprj_ppnl(l) - 1)
-               lc_min = l
-               zetc(1) = alpha_ppnl(l)
-               ncoc = ncoset(lc_max)
-               ! Calculate the primitive overlap and dipole moment integrals
-               CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
-                            lc_max, lc_min, 1, rprjc, zetc, rac, dac, sab(:, :, 1), 0, .FALSE., ai_work, ldai)
-               IF (.NOT. my_ref) THEN
-                  CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
-                              lc_max, 1, zetc, rprjc, order, -rac, (/0._dp, 0._dp, 0._dp/), sab(:, :, 2:maxder))
-               ELSE
-                  CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
-                              lc_max, 1, zetc, rprjc, order, raf, rcf, sab(:, :, 2:maxder))
-               ENDIF
-               ! *** Transformation step projector functions (cartesian->spherical) ***
-               DO i = 1, maxder
-                  CALL dgemm("N", "N", ncoa, nprjc, ncoc, 1.0_dp, sab(1, 1, i), ldsab, &
-                             cprj(1, prjc), SIZE(cprj, 1), 0.0_dp, work(1, prjc, i), ldsab)
-               END DO
-               prjc = prjc + nprjc
-            END DO
-            DO i = 1, maxder
-               ! Contraction step (basis functions)
-               CALL dgemm("T", "N", nsgf_seta(iset), nppnl, ncoa, 1.0_dp, sphi_a(1, sgfa), SIZE(sphi_a, 1), &
-                          work(1, 1, i), ldsab, 0.0_dp, clist%acint(sgfa, 1, i), nsgfa)
-               ! Multiply with interaction matrix(h)
-               CALL dgemm("N", "N", nsgf_seta(iset), nppnl, nppnl, 1.0_dp, clist%acint(sgfa, 1, i), nsgfa, &
-                          vprj_ppnl(1, 1), SIZE(vprj_ppnl, 1), 0.0_dp, clist%achint(sgfa, 1, i), nsgfa)
-            END DO
-         END DO
-         clist%maxac = MAXVAL(ABS(clist%acint(:, :, 1)))
-         clist%maxach = MAXVAL(ABS(clist%achint(:, :, 1)))
-      END DO
-
-      DEALLOCATE (sab, ai_work, work)
-!$OMP END PARALLEL
-      CALL neighbor_list_iterator_release(nl_iterator)
-
-      ! *** Set up a sorting index
-      CALL sap_sort(sap_int)
-      ! *** All integrals needed have been calculated and stored in sap_int
-      ! *** We now calculate the Hamiltonian matrix elements
-      CALL neighbor_list_iterator_create(nl_iterator, sab_all, nthread=nthread)
-
-!$OMP PARALLEL &
-!$OMP DEFAULT (NONE) &
-!$OMP SHARED  (nl_iterator, basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
-!$OMP          sap_int, nkind, eps_ppnl, my_rv, my_rxrv, my_rrv ) &
-!$OMP PRIVATE (mepos, ikind, jkind, iatom, jatom, nlist, ilist, nnode, inode, cell_b, rab, &
-!$OMP          iab, irow, icol, blocks_rv, blocks_rxrv, blocks_rrv, &
-!$OMP          found, iac, ibc, alist_ac, alist_bc, acint, bcint, &
-!$OMP          achint, bchint, na, np, nb, katom, rac, kkind, kac, kbc, i, &
-!$OMP          go, asso_rv, asso_rxrv, asso_rrv)
-
-      mepos = 0
-!$    mepos = omp_get_thread_num()
-
-      NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
-      IF (my_rv) THEN
-         ALLOCATE (blocks_rv(3))
-      ENDIF
-
-      IF (my_rxrv) THEN
-         ALLOCATE (blocks_rxrv(3))
-      ENDIF
-      IF (my_rrv) THEN
-         ALLOCATE (blocks_rrv(6))
-      ENDIF
-
-      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
-         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, iatom=iatom, &
-                                jatom=jatom, nlist=nlist, ilist=ilist, nnode=nnode, inode=inode, cell=cell_b, r=rab)
-         IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
-         IF (.NOT. ASSOCIATED(basis_set(jkind)%gto_basis_set)) CYCLE
-         iab = ikind + nkind*(jkind - 1)
-
-         ! *** Create matrix blocks for a new matrix block column ***
-         irow = iatom
-         icol = jatom
-
-         IF (my_rv) THEN
-            DO ind = 1, 3
-               CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
-            ENDDO
-         ENDIF
-
-         IF (my_rxrv) THEN
-            DO ind = 1, 3
-               CALL dbcsr_get_block_p(matrix_rxrv(ind)%matrix, irow, icol, blocks_rxrv(ind)%block, found)
-            ENDDO
-         ENDIF
-
-         IF (my_rrv) THEN
-            DO ind = 1, 6
-               CALL dbcsr_get_block_p(matrix_rrv(ind)%matrix, irow, icol, blocks_rrv(ind)%block, found)
-            ENDDO
-         ENDIF
-
-         ! check whether all blocks are associated
-         go = .TRUE.
-         IF (my_rv) THEN
-            asso_rv = (ASSOCIATED(blocks_rv(1)%block) .AND. ASSOCIATED(blocks_rv(2)%block) .AND. &
-                       ASSOCIATED(blocks_rv(3)%block))
-            go = go .AND. asso_rv
-         ENDIF
-
-         IF (my_rxrv) THEN
-            asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
-                         ASSOCIATED(blocks_rxrv(3)%block))
-            go = go .AND. asso_rxrv
-         ENDIF
-
-         IF (my_rrv) THEN
-            asso_rrv = (ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
-                        ASSOCIATED(blocks_rrv(3)%block) .AND. ASSOCIATED(blocks_rrv(4)%block) .AND. &
-                        ASSOCIATED(blocks_rrv(5)%block) .AND. ASSOCIATED(blocks_rrv(6)%block))
-            go = go .AND. asso_rrv
-         ENDIF
-         ! loop over all kinds for projector atom
-         IF (go) THEN
-            DO kkind = 1, nkind
-               iac = ikind + nkind*(kkind - 1)
-               ibc = jkind + nkind*(kkind - 1)
-               IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) CYCLE
-               IF (.NOT. ASSOCIATED(sap_int(ibc)%alist)) CYCLE
-               CALL get_alist(sap_int(iac), alist_ac, iatom)
-               CALL get_alist(sap_int(ibc), alist_bc, jatom)
-               IF (.NOT. ASSOCIATED(alist_ac)) CYCLE
-               IF (.NOT. ASSOCIATED(alist_bc)) CYCLE
-               DO kac = 1, alist_ac%nclist
-                  DO kbc = 1, alist_bc%nclist
-                     IF (alist_ac%clist(kac)%catom /= alist_bc%clist(kbc)%catom) CYCLE
-                     IF (ALL(cell_b + alist_bc%clist(kbc)%cell - alist_ac%clist(kac)%cell == 0)) THEN
-                        IF (alist_ac%clist(kac)%maxac*alist_bc%clist(kbc)%maxach < eps_ppnl) CYCLE
-                        acint => alist_ac%clist(kac)%acint
-                        bcint => alist_bc%clist(kbc)%acint
-                        achint => alist_ac%clist(kac)%achint
-                        bchint => alist_bc%clist(kbc)%achint
-                        na = SIZE(acint, 1)
-                        np = SIZE(acint, 2)
-                        nb = SIZE(bcint, 1)
-!$OMP CRITICAL(h_block_critical)
-                        IF (my_rv) THEN
-                           ! r*Vnl
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
-
-                           ! -Vnl r
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
-                        ENDIF
-
-                        IF (my_rxrv) THEN
-                           ! x-component (y [z,Vnl] - z [y, Vnl])
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 3), na, &
-                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -yVz
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 9), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -zyV
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
-                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
-
-                           ! y-component (z [x,Vnl] - x [z, Vnl])
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 7), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! zxV
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 4), na, &
-                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -zVx
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 7), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -xzV
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
-                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
-
-                           ! z-component (x [y,Vnl] - y [x, Vnl])
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 6), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! xyV
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 2), na, &
-                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -xVy
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 6), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -yxV
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
-                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
-                        ENDIF
-
-                        IF (my_rrv) THEN
-                           ! r_alpha * r_beta * Vnl
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 6), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! xyV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 7), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! xzV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 8), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! yyV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 9), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! yzV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
-
-                           ! - Vnl * r_alpha * r_beta
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 5), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! Vxx
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 6), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! Vxy
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 7), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! Vxz
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 8), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! Vyy
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 9), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! Vyz
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
-                        ENDIF
-!$OMP END CRITICAL(h_block_critical)
-                        EXIT ! We have found a match and there can be only one single match
-                     END IF
-                  END DO
-               END DO
-            END DO
-         ENDIF
-      END DO
-      IF (my_rv) THEN
-         DO ind = 1, 3
-            NULLIFY (blocks_rv(ind)%block)
-         ENDDO
-         DEALLOCATE (blocks_rv)
-      ENDIF
-      IF (my_rxrv) THEN
-         DO ind = 1, 3
-            NULLIFY (blocks_rxrv(ind)%block)
-         ENDDO
-         DEALLOCATE (blocks_rxrv)
-      ENDIF
-      IF (my_rrv) THEN
-         DO ind = 1, 6
-            NULLIFY (blocks_rrv(ind)%block)
-         ENDDO
-         DEALLOCATE (blocks_rrv)
-      ENDIF
-!$OMP END PARALLEL
-      CALL neighbor_list_iterator_release(nl_iterator)
-
-      CALL release_sap_int(sap_int)
-
-      DEALLOCATE (basis_set, gpotential, spotential)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE build_com_mom_nl
-
-! **************************************************************************************************
-!> \brief Calculate [r,Vnl], r x [r,Vnl] or [rr,Vnl] in AO basis
-!>        reference point is required for the two latter options
-!> \param qs_kind_set ...
-!> \param sab_all ...
-!> \param sap_ppnl ...
-!> \param eps_ppnl ...
-!> \param matrix_rv ...
-!> \param matrix_rxrv ...
-!> \param matrix_rrv ...
-!> \param ref_point ...
-!> \param particle_set ...
-!> \param cell ...
-! **************************************************************************************************
-   SUBROUTINE build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv, matrix_rxrv, matrix_rrv, ref_point, &
-                                 particle_set, cell)
-
-      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         INTENT(IN), POINTER                             :: sab_all, sap_ppnl
-      REAL(KIND=dp), INTENT(IN)                          :: eps_ppnl
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
-         OPTIONAL, POINTER                               :: matrix_rv, matrix_rxrv, matrix_rrv
-      REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: ref_point
-      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
-         OPTIONAL, POINTER                               :: particle_set
-      TYPE(cell_type), INTENT(IN), OPTIONAL, POINTER     :: cell
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_com_mom_nl_2', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER :: handle, i, iab, iac, iatom, ibc, icol, ikind, ilist, ind, inode, irow, jatom, &
-         jkind, kac, kbc, kkind, maxder, mepos, na, nb, nkind, nlist, nnode, np, nthread, order
+      INTEGER                                            :: handle, i, iab, iac, iatom, ibc, icol, &
+                                                            ikind, ind, irow, jatom, jkind, kac, &
+                                                            kbc, kkind, na, natom, nb, nkind, np, &
+                                                            nthread, order, slot
       INTEGER, DIMENSION(3)                              :: cell_b
       LOGICAL                                            :: asso_rrv, asso_rv, asso_rxrv, found, go, &
                                                             my_ref, my_rrv, my_rv, my_rxrv, &
@@ -951,9 +450,12 @@ CONTAINS
       TYPE(block_p_type), DIMENSION(:), POINTER          :: blocks_rrv, blocks_rv, blocks_rxrv
       TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
-      TYPE(neighbor_list_iterator_p_type), &
-         DIMENSION(:), POINTER                           :: nl_iterator
       TYPE(sap_int_type), DIMENSION(:), POINTER          :: sap_int
+
+!$    INTEGER(kind=omp_lock_kind), &
+!$       ALLOCATABLE, DIMENSION(:) :: locks
+!$    INTEGER                                            :: lock_num, hash
+!$    INTEGER, PARAMETER                                 :: nlock = 501
 
       ppnl_present = ASSOCIATED(sap_ppnl)
       IF (.NOT. ppnl_present) RETURN
@@ -970,22 +472,20 @@ CONTAINS
          CPABORT('No dbcsr matrix provided for commutator calculation!')
       ENDIF
 
+      natom = SIZE(particle_set)
+
       IF (my_rxrv .OR. my_rrv) THEN
-         maxder = 10
          order = 2
          CPASSERT(PRESENT(ref_point)) ! need reference point for r x [r,Vnl] and [rr,Vnl]
       ELSE
-         maxder = 4
          order = 1
       ENDIF
 
       my_ref = .FALSE.
       IF (PRESENT(ref_point)) THEN
-         CPASSERT((PRESENT(cell) .AND. PRESENT(particle_set))) ! need these as well if refpoint is provided
+         CPASSERT(PRESENT(cell)) ! need cell as well if refpoint is provided
          rf = ref_point
          my_ref = .TRUE.
-      ELSE
-         rf(:) = 0._dp
       ENDIF
 
       nkind = SIZE(qs_kind_set)
@@ -997,12 +497,13 @@ CONTAINS
          sap_int(i)%nalist = 0
       END DO
 
-      ! calculate integrals <a|x^n|p>
-      CALL build_sap_ints(sap_int, sap_ppnl, qs_kind_set, order, moment_mode=.TRUE., refpoint=rf, &
-                          particle_set=particle_set, cell=cell)
-
-      nthread = 1
-!$    nthread = omp_get_max_threads()
+      IF (my_ref) THEN
+         ! calculate integrals <a|x^n|p>
+         CALL build_sap_ints(sap_int, sap_ppnl, qs_kind_set, order, moment_mode=.TRUE., refpoint=rf, &
+                             particle_set=particle_set, cell=cell)
+      ELSE
+         CALL build_sap_ints(sap_int, sap_ppnl, qs_kind_set, order, moment_mode=.TRUE.)
+      ENDIF
 
       ! *** Set up a sorting index
       CALL sap_sort(sap_int)
@@ -1016,46 +517,64 @@ CONTAINS
             NULLIFY (basis_set(ikind)%gto_basis_set)
          END IF
       ENDDO
+
+      nthread = 1
+!$    nthread = omp_get_max_threads()
+
       ! *** All integrals needed have been calculated and stored in sap_int
-      ! *** We now calculate the Hamiltonian matrix elements
-      CALL neighbor_list_iterator_create(nl_iterator, sab_all, nthread=nthread)
+      ! *** We now calculate the commutator matrix elements
 
 !$OMP PARALLEL &
 !$OMP DEFAULT (NONE) &
-!$OMP SHARED  (nl_iterator, basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
-!$OMP          sap_int, nkind, eps_ppnl, my_rv, my_rxrv, my_rrv ) &
-!$OMP PRIVATE (mepos, ikind, jkind, iatom, jatom, nlist, ilist, nnode, inode, cell_b, rab, &
+!$OMP SHARED  (basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
+!$OMP          sap_int, nkind, eps_ppnl, my_rv, my_rxrv, my_rrv, locks, sab_all) &
+!$OMP PRIVATE (ikind, jkind, iatom, jatom, cell_b, rab, &
 !$OMP          iab, irow, icol, blocks_rv, blocks_rxrv, blocks_rrv, &
 !$OMP          found, iac, ibc, alist_ac, alist_bc, acint, bcint, &
 !$OMP          achint, bchint, na, np, nb, kkind, kac, kbc, i, &
-!$OMP          go, asso_rv, asso_rxrv, asso_rrv)
+!$OMP          go, asso_rv, asso_rxrv, asso_rrv, hash, natom)
 
-      mepos = 0
-!$    mepos = omp_get_thread_num()
+!$OMP SINGLE
+!$    ALLOCATE (locks(nlock))
+!$OMP END SINGLE
 
-      NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
-      IF (my_rv) THEN
-         ALLOCATE (blocks_rv(3))
-      ENDIF
+!$OMP DO
+!$    DO lock_num = 1, nlock
+!$       call omp_init_lock(locks(lock_num))
+!$    END DO
+!$OMP END DO
 
-      IF (my_rxrv) THEN
-         ALLOCATE (blocks_rxrv(3))
-      ENDIF
-      IF (my_rrv) THEN
-         ALLOCATE (blocks_rrv(6))
-      ENDIF
+!$OMP DO SCHEDULE(GUIDED)
 
-      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
-         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, iatom=iatom, &
-                                jatom=jatom, nlist=nlist, ilist=ilist, nnode=nnode, inode=inode, cell=cell_b, r=rab)
+      DO slot = 1, sab_all(1)%nl_size
+
+         ikind = sab_all(1)%nlist_task(slot)%ikind
+         jkind = sab_all(1)%nlist_task(slot)%jkind
+         iatom = sab_all(1)%nlist_task(slot)%iatom
+         jatom = sab_all(1)%nlist_task(slot)%jatom
+         cell_b(:) = sab_all(1)%nlist_task(slot)%cell(:)
+         rab(1:3) = sab_all(1)%nlist_task(slot)%r(1:3)
+
          IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
          IF (.NOT. ASSOCIATED(basis_set(jkind)%gto_basis_set)) CYCLE
          iab = ikind + nkind*(jkind - 1)
 
-         ! *** Create matrix blocks for a new matrix block column ***
          irow = iatom
          icol = jatom
 
+         ! allocate blocks
+         NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
+         IF (my_rv) THEN
+            ALLOCATE (blocks_rv(3))
+         ENDIF
+         IF (my_rxrv) THEN
+            ALLOCATE (blocks_rxrv(3))
+         ENDIF
+         IF (my_rrv) THEN
+            ALLOCATE (blocks_rrv(6))
+         ENDIF
+
+         ! get blocks
          IF (my_rv) THEN
             DO ind = 1, 3
                CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
@@ -1094,6 +613,7 @@ CONTAINS
                         ASSOCIATED(blocks_rrv(5)%block) .AND. ASSOCIATED(blocks_rrv(6)%block))
             go = go .AND. asso_rrv
          ENDIF
+
          ! loop over all kinds for projector atom
          IF (go) THEN
             DO kkind = 1, nkind
@@ -1117,114 +637,199 @@ CONTAINS
                         na = SIZE(acint, 1)
                         np = SIZE(acint, 2)
                         nb = SIZE(bcint, 1)
-!$OMP CRITICAL(h_block_critical)
+!$                      hash = MOD((iatom - 1)*natom + jatom, nlock) + 1
+!$                      CALL omp_set_lock(locks(hash))
                         IF (my_rv) THEN
                            ! r*Vnl
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
+                           ! with LAPACK
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
+                           ! with MATMUL
+                           blocks_rv(1)%block(1:na, 1:nb) = blocks_rv(1)%block(1:na, 1:nb) + &
+                                                            MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! xV
+                           blocks_rv(2)%block(1:na, 1:nb) = blocks_rv(2)%block(1:na, 1:nb) + &
+                                                            MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! yV
+                           blocks_rv(3)%block(1:na, 1:nb) = blocks_rv(3)%block(1:na, 1:nb) + &
+                                                            MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! zV
 
                            ! -Vnl r
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
+                           ! with LAPACK
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
+                           ! with MATMUL
+                           blocks_rv(1)%block(1:na, 1:nb) = blocks_rv(1)%block(1:na, 1:nb) - &
+                                                            MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 2))) ! -Vx
+                           blocks_rv(2)%block(1:na, 1:nb) = blocks_rv(2)%block(1:na, 1:nb) - &
+                                                            MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 3))) ! -Vy
+                           blocks_rv(3)%block(1:na, 1:nb) = blocks_rv(3)%block(1:na, 1:nb) - &
+                                                            MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 4))) ! -Vz
                         ENDIF
 
                         IF (my_rxrv) THEN
                            ! x-component (y [z,Vnl] - z [y, Vnl])
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 3), na, &
-                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -yVz
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 9), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -zyV
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
-                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
+                           ! with LAPACK
+                           ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
+                           ! CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 3), na, &
+                           !            bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -yVz
+                           ! CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 9), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -zyV
+                           ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
+                           !            bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
+                           ! with MATMUL
+                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) + &
+                                                              MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! yzV
+                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) - &
+                                                              MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 4)))    ! -yVz
+                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) - &
+                                                              MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -zyV
+                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) + &
+                                                              MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 3)))    ! zVy
 
                            ! y-component (z [x,Vnl] - x [z, Vnl])
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 7), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! zxV
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 4), na, &
-                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -zVx
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 7), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -xzV
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
-                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
+                           ! with LAPACK
+                           ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 7), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! zxV
+                           ! CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 4), na, &
+                           !            bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -zVx
+                           ! CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 7), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -xzV
+                           ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
+                           !            bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
+                           ! with MATMUL
+                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) + &
+                                                              MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! zxV
+                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) - &
+                                                              MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 2)))    ! -zVx
+                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) - &
+                                                              MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -xzV
+                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) + &
+                                                              MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 4)))    ! xVz
 
                            ! z-component (x [y,Vnl] - y [x, Vnl])
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 6), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! xyV
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 2), na, &
-                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -xVy
-                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 6), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -yxV
-                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
-                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
+                           ! with LAPACK
+                           ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 6), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! xyV
+                           ! CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 2), na, &
+                           !            bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -xVy
+                           ! CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 6), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -yxV
+                           ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
+                           !            bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
+                           ! with MATMUL
+                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) + &
+                                                              MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! xyV
+                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) - &
+                                                              MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 3)))    ! -xVy
+                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) - &
+                                                              MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -yxV
+                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) + &
+                                                              MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 2)))    ! zVx
                         ENDIF
 
                         IF (my_rrv) THEN
                            ! r_alpha * r_beta * Vnl
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 6), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! xyV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 7), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! xzV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 8), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! yyV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 9), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! yzV
-                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
-                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
+                           ! with LAPACK
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 6), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! xyV
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 7), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! xzV
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 8), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! yyV
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 9), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! yzV
+                           ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
+                           !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
+                           ! with MATMUL
+                           blocks_rrv(1)%block(1:na, 1:nb) = blocks_rrv(1)%block(1:na, 1:nb) + &
+                                                             MATMUL(achint(1:na, 1:np, 5), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xxV
+                           blocks_rrv(2)%block(1:na, 1:nb) = blocks_rrv(2)%block(1:na, 1:nb) + &
+                                                             MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xyV
+                           blocks_rrv(3)%block(1:na, 1:nb) = blocks_rrv(3)%block(1:na, 1:nb) + &
+                                                             MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xzV
+                           blocks_rrv(4)%block(1:na, 1:nb) = blocks_rrv(4)%block(1:na, 1:nb) + &
+                                                             MATMUL(achint(1:na, 1:np, 8), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! yyV
+                           blocks_rrv(5)%block(1:na, 1:nb) = blocks_rrv(5)%block(1:na, 1:nb) + &
+                                                             MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! yzV
+                           blocks_rrv(6)%block(1:na, 1:nb) = blocks_rrv(6)%block(1:na, 1:nb) + &
+                                                             MATMUL(achint(1:na, 1:np, 10), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! zzV
 
                            ! - Vnl * r_alpha * r_beta
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 5), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! Vxx
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 6), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! Vxy
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 7), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! Vxz
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 8), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! Vyy
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 9), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! Vyz
-                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                      bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
+                           ! with LAPACK
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 5), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! Vxx
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 6), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! Vxy
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 7), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! Vxz
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 8), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! Vyy
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 9), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! Vyz
+                           ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                           !            bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
+                           ! with MATMUL
+                           blocks_rrv(1)%block(1:na, 1:nb) = blocks_rrv(1)%block(1:na, 1:nb) - &
+                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 5)))   ! -Vxx
+                           blocks_rrv(2)%block(1:na, 1:nb) = blocks_rrv(2)%block(1:na, 1:nb) - &
+                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 6)))   ! -Vxy
+                           blocks_rrv(3)%block(1:na, 1:nb) = blocks_rrv(3)%block(1:na, 1:nb) - &
+                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 7)))   ! -Vxz
+                           blocks_rrv(4)%block(1:na, 1:nb) = blocks_rrv(4)%block(1:na, 1:nb) - &
+                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 8)))   ! -Vyy
+                           blocks_rrv(5)%block(1:na, 1:nb) = blocks_rrv(5)%block(1:na, 1:nb) - &
+                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 9)))   ! -Vyz
+                           blocks_rrv(6)%block(1:na, 1:nb) = blocks_rrv(6)%block(1:na, 1:nb) - &
+                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 10)))   ! -Vzz
                         ENDIF
-!$OMP END CRITICAL(h_block_critical)
+!$                      CALL omp_unset_lock(locks(hash))
                         EXIT ! We have found a match and there can be only one single match
                      END IF
                   END DO
                END DO
             END DO
          ENDIF
+         IF (my_rv) THEN
+            DO ind = 1, 3
+               NULLIFY (blocks_rv(ind)%block)
+            ENDDO
+            DEALLOCATE (blocks_rv)
+         ENDIF
+         IF (my_rxrv) THEN
+            DO ind = 1, 3
+               NULLIFY (blocks_rxrv(ind)%block)
+            ENDDO
+            DEALLOCATE (blocks_rxrv)
+         ENDIF
+         IF (my_rrv) THEN
+            DO ind = 1, 6
+               NULLIFY (blocks_rrv(ind)%block)
+            ENDDO
+            DEALLOCATE (blocks_rrv)
+         ENDIF
       END DO
-      IF (my_rv) THEN
-         DO ind = 1, 3
-            NULLIFY (blocks_rv(ind)%block)
-         ENDDO
-         DEALLOCATE (blocks_rv)
-      ENDIF
-      IF (my_rxrv) THEN
-         DO ind = 1, 3
-            NULLIFY (blocks_rxrv(ind)%block)
-         ENDDO
-         DEALLOCATE (blocks_rxrv)
-      ENDIF
-      IF (my_rrv) THEN
-         DO ind = 1, 6
-            NULLIFY (blocks_rrv(ind)%block)
-         ENDDO
-         DEALLOCATE (blocks_rrv)
-      ENDIF
+
+!$OMP DO
+!$    DO lock_num = 1, nlock
+!$       call omp_destroy_lock(locks(lock_num))
+!$    END DO
+!$OMP END DO
+
+!$OMP SINGLE
+!$    DEALLOCATE (locks)
+!$OMP END SINGLE NOWAIT
+
 !$OMP END PARALLEL
-      CALL neighbor_list_iterator_release(nl_iterator)
 
       CALL release_sap_int(sap_int)
 
@@ -1232,5 +837,5 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE build_com_mom_nl_2
+   END SUBROUTINE build_com_mom_nl
 END MODULE commutator_rpnl

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -440,7 +440,7 @@ CONTAINS
       INTEGER                                            :: handle, i, iab, iac, iatom, ibc, icol, &
                                                             ikind, ind, irow, jatom, jkind, kac, &
                                                             kbc, kkind, na, natom, nb, nkind, np, &
-                                                            nthread, order, slot
+                                                            order, slot
       INTEGER, DIMENSION(3)                              :: cell_b
       LOGICAL                                            :: asso_rrv, asso_rv, asso_rxrv, found, go, &
                                                             my_ref, my_rrv, my_rv, my_rxrv, &
@@ -520,9 +520,6 @@ CONTAINS
             NULLIFY (basis_set(ikind)%gto_basis_set)
          END IF
       ENDDO
-
-      nthread = 1
-!$    nthread = omp_get_max_threads()
 
       ! *** All integrals needed have been calculated and stored in sap_int
       ! *** We now calculate the commutator matrix elements

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -789,8 +789,8 @@ CONTAINS
                            np = SIZE(acint, 2)
                            nb = SIZE(bcint, 1)
 !$OMP CRITICAL(h_block_critical)
-                           ! r*Vnl
                            IF (my_rv) THEN
+                              ! r*Vnl
                               CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
                                          bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
                               CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
@@ -805,8 +805,8 @@ CONTAINS
                                          bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
                               CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
                                          bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
-
                            ENDIF
+
                            IF (my_rxrv) THEN
                               ! x-component (y [z,Vnl] - z [y, Vnl])
                               CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -422,7 +422,8 @@ CONTAINS
    SUBROUTINE build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv, matrix_rxrv, &
                                matrix_rrv, ref_point, cell)
 
-      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(qs_kind_type), DIMENSION(:), INTENT(IN), &
+         POINTER                                         :: qs_kind_set
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          INTENT(IN), POINTER                             :: sab_all, sap_ppnl
       REAL(KIND=dp), INTENT(IN)                          :: eps_ppnl
@@ -447,8 +448,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: rab, rf
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: achint, acint, bchint, bcint
       TYPE(alist_type), POINTER                          :: alist_ac, alist_bc
-      TYPE(block_p_type), DIMENSION(:), POINTER          :: blocks_rrv, blocks_rv, blocks_rxrv
-      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set
+      TYPE(block_p_type), ALLOCATABLE, DIMENSION(:)      :: blocks_rrv, blocks_rv, blocks_rxrv
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:)                                    :: basis_set
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
       TYPE(sap_int_type), DIMENSION(:), POINTER          :: sap_int
 
@@ -491,6 +493,7 @@ CONTAINS
       nkind = SIZE(qs_kind_set)
 
       !sap_int needs to be shared as multiple threads need to access this
+      NULLIFY (sap_int)
       ALLOCATE (sap_int(nkind*nkind))
       DO i = 1, nkind*nkind
          NULLIFY (sap_int(i)%alist, sap_int(i)%asort, sap_int(i)%aindex)
@@ -568,7 +571,6 @@ CONTAINS
          END IF
 
          ! allocate blocks
-         NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
          IF (my_rv) THEN
             ALLOCATE (blocks_rv(3))
          ENDIF

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -38,6 +38,7 @@ MODULE commutator_rpnl
                                               neighbor_list_iterator_release,&
                                               neighbor_list_set_p_type
    USE sap_kind_types,                  ONLY: alist_type,&
+                                              build_sap_ints,&
                                               clist_type,&
                                               get_alist,&
                                               release_sap_int,&
@@ -54,7 +55,7 @@ MODULE commutator_rpnl
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'commutator_rpnl'
 
-   PUBLIC :: build_com_rpnl, build_com_mom_nl
+   PUBLIC :: build_com_rpnl, build_com_mom_nl, build_com_mom_nl_2
 
 CONTAINS
 
@@ -907,4 +908,329 @@ CONTAINS
 
    END SUBROUTINE build_com_mom_nl
 
+! **************************************************************************************************
+!> \brief Calculate [r,Vnl], r x [r,Vnl] or [rr,Vnl] in AO basis
+!>        reference point is required for the two latter options
+!> \param qs_kind_set ...
+!> \param sab_all ...
+!> \param sap_ppnl ...
+!> \param eps_ppnl ...
+!> \param matrix_rv ...
+!> \param matrix_rxrv ...
+!> \param matrix_rrv ...
+!> \param ref_point ...
+!> \param particle_set ...
+!> \param cell ...
+! **************************************************************************************************
+   SUBROUTINE build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv, matrix_rxrv, matrix_rrv, ref_point, &
+                                 particle_set, cell)
+
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         INTENT(IN), POINTER                             :: sab_all, sap_ppnl
+      REAL(KIND=dp), INTENT(IN)                          :: eps_ppnl
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
+         OPTIONAL, POINTER                               :: matrix_rv, matrix_rxrv, matrix_rrv
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: ref_point
+      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
+         OPTIONAL, POINTER                               :: particle_set
+      TYPE(cell_type), INTENT(IN), OPTIONAL, POINTER     :: cell
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_com_mom_nl_2', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER :: handle, i, iab, iac, iatom, ibc, icol, ikind, ilist, ind, inode, irow, jatom, &
+         jkind, kac, kbc, kkind, maxder, mepos, na, nb, nkind, nlist, nnode, np, nthread, order
+      INTEGER, DIMENSION(3)                              :: cell_b
+      LOGICAL                                            :: asso_rrv, asso_rv, asso_rxrv, found, go, &
+                                                            my_ref, my_rrv, my_rv, my_rxrv, &
+                                                            ppnl_present
+      REAL(KIND=dp), DIMENSION(3)                        :: rab, rf
+      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: achint, acint, bchint, bcint
+      TYPE(alist_type), POINTER                          :: alist_ac, alist_bc
+      TYPE(block_p_type), DIMENSION(:), POINTER          :: blocks_rrv, blocks_rv, blocks_rxrv
+      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(sap_int_type), DIMENSION(:), POINTER          :: sap_int
+
+      ppnl_present = ASSOCIATED(sap_ppnl)
+      IF (.NOT. ppnl_present) RETURN
+
+      CALL timeset(routineN, handle)
+
+      my_rxrv = .FALSE.
+      my_rrv = .FALSE.
+      my_rv = .FALSE.
+      IF (PRESENT(matrix_rxrv)) my_rxrv = .TRUE.
+      IF (PRESENT(matrix_rrv)) my_rrv = .TRUE.
+      IF (PRESENT(matrix_rv)) my_rv = .TRUE.
+      IF (.NOT. (my_rv .OR. my_rxrv .OR. my_rrv)) THEN
+         CPABORT('No dbcsr matrix provided for commutator calculation!')
+      ENDIF
+
+      IF (my_rxrv .OR. my_rrv) THEN
+         maxder = 10
+         order = 2
+         CPASSERT(PRESENT(ref_point)) ! need reference point for r x [r,Vnl] and [rr,Vnl]
+      ELSE
+         maxder = 4
+         order = 1
+      ENDIF
+
+      my_ref = .FALSE.
+      IF (PRESENT(ref_point)) THEN
+         CPASSERT((PRESENT(cell) .AND. PRESENT(particle_set))) ! need these as well if refpoint is provided
+         rf = ref_point
+         my_ref = .TRUE.
+      ELSE
+         rf(:) = 0._dp
+      ENDIF
+
+      nkind = SIZE(qs_kind_set)
+
+      !sap_int needs to be shared as multiple threads need to access this
+      ALLOCATE (sap_int(nkind*nkind))
+      DO i = 1, nkind*nkind
+         NULLIFY (sap_int(i)%alist, sap_int(i)%asort, sap_int(i)%aindex)
+         sap_int(i)%nalist = 0
+      END DO
+
+      ! calculate integrals <a|x^n|p>
+      CALL build_sap_ints(sap_int, sap_ppnl, qs_kind_set, order, moment_mode=.TRUE., refpoint=rf, &
+                          particle_set=particle_set, cell=cell)
+
+      nthread = 1
+!$    nthread = omp_get_max_threads()
+
+      ! *** Set up a sorting index
+      CALL sap_sort(sap_int)
+
+      ALLOCATE (basis_set(nkind))
+      DO ikind = 1, nkind
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
+         IF (ASSOCIATED(orb_basis_set)) THEN
+            basis_set(ikind)%gto_basis_set => orb_basis_set
+         ELSE
+            NULLIFY (basis_set(ikind)%gto_basis_set)
+         END IF
+      ENDDO
+      ! *** All integrals needed have been calculated and stored in sap_int
+      ! *** We now calculate the Hamiltonian matrix elements
+      CALL neighbor_list_iterator_create(nl_iterator, sab_all, nthread=nthread)
+
+!$OMP PARALLEL &
+!$OMP DEFAULT (NONE) &
+!$OMP SHARED  (nl_iterator, basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
+!$OMP          sap_int, nkind, eps_ppnl, my_rv, my_rxrv, my_rrv ) &
+!$OMP PRIVATE (mepos, ikind, jkind, iatom, jatom, nlist, ilist, nnode, inode, cell_b, rab, &
+!$OMP          iab, irow, icol, blocks_rv, blocks_rxrv, blocks_rrv, &
+!$OMP          found, iac, ibc, alist_ac, alist_bc, acint, bcint, &
+!$OMP          achint, bchint, na, np, nb, kkind, kac, kbc, i, &
+!$OMP          go, asso_rv, asso_rxrv, asso_rrv)
+
+      mepos = 0
+!$    mepos = omp_get_thread_num()
+
+      NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
+      IF (my_rv) THEN
+         ALLOCATE (blocks_rv(3))
+      ENDIF
+
+      IF (my_rxrv) THEN
+         ALLOCATE (blocks_rxrv(3))
+      ENDIF
+      IF (my_rrv) THEN
+         ALLOCATE (blocks_rrv(6))
+      ENDIF
+
+      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, iatom=iatom, &
+                                jatom=jatom, nlist=nlist, ilist=ilist, nnode=nnode, inode=inode, cell=cell_b, r=rab)
+         IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
+         IF (.NOT. ASSOCIATED(basis_set(jkind)%gto_basis_set)) CYCLE
+         iab = ikind + nkind*(jkind - 1)
+
+         ! *** Create matrix blocks for a new matrix block column ***
+         irow = iatom
+         icol = jatom
+
+         IF (my_rv) THEN
+            DO ind = 1, 3
+               CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
+            ENDDO
+         ENDIF
+
+         IF (my_rxrv) THEN
+            DO ind = 1, 3
+               CALL dbcsr_get_block_p(matrix_rxrv(ind)%matrix, irow, icol, blocks_rxrv(ind)%block, found)
+            ENDDO
+         ENDIF
+
+         IF (my_rrv) THEN
+            DO ind = 1, 6
+               CALL dbcsr_get_block_p(matrix_rrv(ind)%matrix, irow, icol, blocks_rrv(ind)%block, found)
+            ENDDO
+         ENDIF
+
+         ! check whether all blocks are associated
+         go = .TRUE.
+         IF (my_rv) THEN
+            asso_rv = (ASSOCIATED(blocks_rv(1)%block) .AND. ASSOCIATED(blocks_rv(2)%block) .AND. &
+                       ASSOCIATED(blocks_rv(3)%block))
+            go = go .AND. asso_rv
+         ENDIF
+
+         IF (my_rxrv) THEN
+            asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
+                         ASSOCIATED(blocks_rxrv(3)%block))
+            go = go .AND. asso_rxrv
+         ENDIF
+
+         IF (my_rrv) THEN
+            asso_rrv = (ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
+                        ASSOCIATED(blocks_rrv(3)%block) .AND. ASSOCIATED(blocks_rrv(4)%block) .AND. &
+                        ASSOCIATED(blocks_rrv(5)%block) .AND. ASSOCIATED(blocks_rrv(6)%block))
+            go = go .AND. asso_rrv
+         ENDIF
+         ! loop over all kinds for projector atom
+         IF (go) THEN
+            DO kkind = 1, nkind
+               iac = ikind + nkind*(kkind - 1)
+               ibc = jkind + nkind*(kkind - 1)
+               IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) CYCLE
+               IF (.NOT. ASSOCIATED(sap_int(ibc)%alist)) CYCLE
+               CALL get_alist(sap_int(iac), alist_ac, iatom)
+               CALL get_alist(sap_int(ibc), alist_bc, jatom)
+               IF (.NOT. ASSOCIATED(alist_ac)) CYCLE
+               IF (.NOT. ASSOCIATED(alist_bc)) CYCLE
+               DO kac = 1, alist_ac%nclist
+                  DO kbc = 1, alist_bc%nclist
+                     IF (alist_ac%clist(kac)%catom /= alist_bc%clist(kbc)%catom) CYCLE
+                     IF (ALL(cell_b + alist_bc%clist(kbc)%cell - alist_ac%clist(kac)%cell == 0)) THEN
+                        IF (alist_ac%clist(kac)%maxac*alist_bc%clist(kbc)%maxach < eps_ppnl) CYCLE
+                        acint => alist_ac%clist(kac)%acint
+                        bcint => alist_bc%clist(kbc)%acint
+                        achint => alist_ac%clist(kac)%achint
+                        bchint => alist_bc%clist(kbc)%achint
+                        na = SIZE(acint, 1)
+                        np = SIZE(acint, 2)
+                        nb = SIZE(bcint, 1)
+!$OMP CRITICAL(h_block_critical)
+                        IF (my_rv) THEN
+                           ! r*Vnl
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
+
+                           ! -Vnl r
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
+                        ENDIF
+
+                        IF (my_rxrv) THEN
+                           ! x-component (y [z,Vnl] - z [y, Vnl])
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 3), na, &
+                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -yVz
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 9), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -zyV
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
+                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
+
+                           ! y-component (z [x,Vnl] - x [z, Vnl])
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 7), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! zxV
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 4), na, &
+                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -zVx
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 7), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -xzV
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
+                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
+
+                           ! z-component (x [y,Vnl] - y [x, Vnl])
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 6), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! xyV
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 2), na, &
+                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -xVy
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 6), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -yxV
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
+                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
+                        ENDIF
+
+                        IF (my_rrv) THEN
+                           ! r_alpha * r_beta * Vnl
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 6), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! xyV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 7), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! xzV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 8), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! yyV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 9), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! yzV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
+
+                           ! - Vnl * r_alpha * r_beta
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 5), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! Vxx
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 6), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! Vxy
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 7), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! Vxz
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 8), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! Vyy
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 9), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! Vyz
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
+                        ENDIF
+!$OMP END CRITICAL(h_block_critical)
+                        EXIT ! We have found a match and there can be only one single match
+                     END IF
+                  END DO
+               END DO
+            END DO
+         ENDIF
+      END DO
+      IF (my_rv) THEN
+         DO ind = 1, 3
+            NULLIFY (blocks_rv(ind)%block)
+         ENDDO
+         DEALLOCATE (blocks_rv)
+      ENDIF
+      IF (my_rxrv) THEN
+         DO ind = 1, 3
+            NULLIFY (blocks_rxrv(ind)%block)
+         ENDDO
+         DEALLOCATE (blocks_rxrv)
+      ENDIF
+      IF (my_rrv) THEN
+         DO ind = 1, 6
+            NULLIFY (blocks_rrv(ind)%block)
+         ENDDO
+         DEALLOCATE (blocks_rrv)
+      ENDIF
+!$OMP END PARALLEL
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+      CALL release_sap_int(sap_int)
+
+      DEALLOCATE (basis_set)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE build_com_mom_nl_2
 END MODULE commutator_rpnl

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -559,8 +559,13 @@ CONTAINS
          IF (.NOT. ASSOCIATED(basis_set(jkind)%gto_basis_set)) CYCLE
          iab = ikind + nkind*(jkind - 1)
 
-         irow = iatom
-         icol = jatom
+         IF (iatom <= jatom) THEN
+            irow = iatom
+            icol = jatom
+         ELSE
+            irow = jatom
+            icol = iatom
+         END IF
 
          ! allocate blocks
          NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
@@ -648,14 +653,22 @@ CONTAINS
                            !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
                            ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
                            !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
-                           ! with MATMUL
-                           blocks_rv(1)%block(1:na, 1:nb) = blocks_rv(1)%block(1:na, 1:nb) + &
-                                                            MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! xV
-                           blocks_rv(2)%block(1:na, 1:nb) = blocks_rv(2)%block(1:na, 1:nb) + &
-                                                            MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! yV
-                           blocks_rv(3)%block(1:na, 1:nb) = blocks_rv(3)%block(1:na, 1:nb) + &
-                                                            MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! zV
-
+                           IF (iatom <= jatom) THEN
+                              ! with MATMUL
+                              blocks_rv(1)%block(1:na, 1:nb) = blocks_rv(1)%block(1:na, 1:nb) + &
+                                                               MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! xV
+                              blocks_rv(2)%block(1:na, 1:nb) = blocks_rv(2)%block(1:na, 1:nb) + &
+                                                               MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! yV
+                              blocks_rv(3)%block(1:na, 1:nb) = blocks_rv(3)%block(1:na, 1:nb) + &
+                                                               MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 1))) ! zV
+                           ELSE
+                              blocks_rv(1)%block(1:nb, 1:na) = blocks_rv(1)%block(1:nb, 1:na) + &
+                                                               MATMUL(bchint(1:nb, 1:np, 2), TRANSPOSE(acint(1:na, 1:np, 1)))
+                              blocks_rv(2)%block(1:nb, 1:na) = blocks_rv(2)%block(1:nb, 1:na) + &
+                                                               MATMUL(bchint(1:nb, 1:np, 3), TRANSPOSE(acint(1:na, 1:np, 1)))
+                              blocks_rv(3)%block(1:nb, 1:na) = blocks_rv(3)%block(1:nb, 1:na) + &
+                                                               MATMUL(bchint(1:nb, 1:np, 4), TRANSPOSE(acint(1:na, 1:np, 1)))
+                           ENDIF
                            ! -Vnl r
                            ! with LAPACK
                            ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
@@ -665,12 +678,22 @@ CONTAINS
                            ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
                            !            bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
                            ! with MATMUL
-                           blocks_rv(1)%block(1:na, 1:nb) = blocks_rv(1)%block(1:na, 1:nb) - &
-                                                            MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 2))) ! -Vx
-                           blocks_rv(2)%block(1:na, 1:nb) = blocks_rv(2)%block(1:na, 1:nb) - &
-                                                            MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 3))) ! -Vy
-                           blocks_rv(3)%block(1:na, 1:nb) = blocks_rv(3)%block(1:na, 1:nb) - &
-                                                            MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 4))) ! -Vz
+                           IF (iatom <= jatom) THEN
+                              blocks_rv(1)%block(1:na, 1:nb) = blocks_rv(1)%block(1:na, 1:nb) - &
+                                                               MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 2))) ! -Vx
+                              blocks_rv(2)%block(1:na, 1:nb) = blocks_rv(2)%block(1:na, 1:nb) - &
+                                                               MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 3))) ! -Vy
+                              blocks_rv(3)%block(1:na, 1:nb) = blocks_rv(3)%block(1:na, 1:nb) - &
+                                                               MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 4))) ! -Vz
+                           ELSE
+                              blocks_rv(1)%block(1:nb, 1:na) = blocks_rv(1)%block(1:nb, 1:na) - &
+                                                               MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 2)))
+                              blocks_rv(2)%block(1:nb, 1:na) = blocks_rv(2)%block(1:nb, 1:na) - &
+                                                               MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 3)))
+                              blocks_rv(3)%block(1:nb, 1:na) = blocks_rv(3)%block(1:nb, 1:na) - &
+                                                               MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 4)))
+                           ENDIF
+
                         ENDIF
 
                         IF (my_rxrv) THEN
@@ -685,14 +708,25 @@ CONTAINS
                            ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
                            !            bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
                            ! with MATMUL
-                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) + &
-                                                              MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! yzV
-                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) - &
-                                                              MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 4)))    ! -yVz
-                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) - &
-                                                              MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -zyV
-                           blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) + &
-                                                              MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 3)))    ! zVy
+                           IF (iatom <= jatom) THEN
+                              blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) + &
+                                                                 MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! yzV
+                              blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) - &
+                                                                 MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 4)))    ! -yVz
+                              blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) - &
+                                                                 MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -zyV
+                              blocks_rxrv(1)%block(1:na, 1:nb) = blocks_rxrv(1)%block(1:na, 1:nb) + &
+                                                                 MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 3)))    ! zVy
+                           ELSE
+                              blocks_rxrv(1)%block(1:nb, 1:na) = blocks_rxrv(1)%block(1:nb, 1:na) + &
+                                                                 MATMUL(bchint(1:nb, 1:np, 9), TRANSPOSE(acint(1:na, 1:np, 1)))    ! yzV
+                              blocks_rxrv(1)%block(1:nb, 1:na) = blocks_rxrv(1)%block(1:nb, 1:na) - &
+                                                                 MATMUL(bchint(1:nb, 1:np, 3), TRANSPOSE(acint(1:na, 1:np, 4)))    ! -yVz
+                              blocks_rxrv(1)%block(1:nb, 1:na) = blocks_rxrv(1)%block(1:nb, 1:na) - &
+                                                                 MATMUL(bchint(1:nb, 1:np, 9), TRANSPOSE(acint(1:na, 1:np, 1)))    ! -zyV
+                              blocks_rxrv(1)%block(1:nb, 1:na) = blocks_rxrv(1)%block(1:nb, 1:na) + &
+                                                                 MATMUL(bchint(1:nb, 1:np, 4), TRANSPOSE(acint(1:na, 1:np, 3)))    ! zVy
+                           ENDIF
 
                            ! y-component (z [x,Vnl] - x [z, Vnl])
                            ! with LAPACK
@@ -705,14 +739,25 @@ CONTAINS
                            ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
                            !            bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
                            ! with MATMUL
-                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) + &
-                                                              MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! zxV
-                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) - &
-                                                              MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 2)))    ! -zVx
-                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) - &
-                                                              MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -xzV
-                           blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) + &
-                                                              MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 4)))    ! xVz
+                           IF (iatom <= jatom) THEN
+                              blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) + &
+                                                                 MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! zxV
+                              blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) - &
+                                                                 MATMUL(achint(1:na, 1:np, 4), TRANSPOSE(bcint(1:nb, 1:np, 2)))    ! -zVx
+                              blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) - &
+                                                                 MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -xzV
+                              blocks_rxrv(2)%block(1:na, 1:nb) = blocks_rxrv(2)%block(1:na, 1:nb) + &
+                                                                 MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 4)))    ! xVz
+                           ELSE
+                              blocks_rxrv(2)%block(1:nb, 1:na) = blocks_rxrv(2)%block(1:nb, 1:na) + &
+                                                                 MATMUL(bchint(1:nb, 1:np, 7), TRANSPOSE(acint(1:na, 1:np, 1)))    ! zxV
+                              blocks_rxrv(2)%block(1:nb, 1:na) = blocks_rxrv(2)%block(1:nb, 1:na) - &
+                                                                 MATMUL(bchint(1:nb, 1:np, 4), TRANSPOSE(acint(1:na, 1:np, 2)))    ! -zVx
+                              blocks_rxrv(2)%block(1:nb, 1:na) = blocks_rxrv(2)%block(1:nb, 1:na) - &
+                                                                 MATMUL(bchint(1:nb, 1:np, 7), TRANSPOSE(acint(1:na, 1:np, 1)))    ! -xzV
+                              blocks_rxrv(2)%block(1:nb, 1:na) = blocks_rxrv(2)%block(1:nb, 1:na) + &
+                                                                 MATMUL(bchint(1:nb, 1:np, 2), TRANSPOSE(acint(1:na, 1:np, 4)))    ! xVz
+                           ENDIF
 
                            ! z-component (x [y,Vnl] - y [x, Vnl])
                            ! with LAPACK
@@ -725,14 +770,25 @@ CONTAINS
                            ! CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
                            !            bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
                            ! with MATMUL
-                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) + &
-                                                              MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! xyV
-                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) - &
-                                                              MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 3)))    ! -xVy
-                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) - &
-                                                              MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -yxV
-                           blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) + &
-                                                              MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 2)))    ! zVx
+                           IF (iatom <= jatom) THEN
+                              blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) + &
+                                                                 MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! xyV
+                              blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) - &
+                                                                 MATMUL(achint(1:na, 1:np, 2), TRANSPOSE(bcint(1:nb, 1:np, 3)))    ! -xVy
+                              blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) - &
+                                                                 MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))    ! -yxV
+                              blocks_rxrv(3)%block(1:na, 1:nb) = blocks_rxrv(3)%block(1:na, 1:nb) + &
+                                                                 MATMUL(achint(1:na, 1:np, 3), TRANSPOSE(bcint(1:nb, 1:np, 2)))    ! zVx
+                           ELSE
+                              blocks_rxrv(3)%block(1:nb, 1:na) = blocks_rxrv(3)%block(1:nb, 1:na) + &
+                                                                 MATMUL(bchint(1:nb, 1:np, 6), TRANSPOSE(acint(1:na, 1:np, 1)))    ! xyV
+                              blocks_rxrv(3)%block(1:nb, 1:na) = blocks_rxrv(3)%block(1:nb, 1:na) - &
+                                                                 MATMUL(bchint(1:nb, 1:np, 2), TRANSPOSE(acint(1:na, 1:np, 3)))    ! -xVy
+                              blocks_rxrv(3)%block(1:nb, 1:na) = blocks_rxrv(3)%block(1:nb, 1:na) - &
+                                                                 MATMUL(bchint(1:nb, 1:np, 6), TRANSPOSE(acint(1:na, 1:np, 1)))    ! -yxV
+                              blocks_rxrv(3)%block(1:nb, 1:na) = blocks_rxrv(3)%block(1:nb, 1:na) + &
+                                                                 MATMUL(bchint(1:nb, 1:np, 3), TRANSPOSE(acint(1:na, 1:np, 2)))    ! zVx
+                           ENDIF
                         ENDIF
 
                         IF (my_rrv) THEN
@@ -751,18 +807,33 @@ CONTAINS
                            ! CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
                            !            bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
                            ! with MATMUL
-                           blocks_rrv(1)%block(1:na, 1:nb) = blocks_rrv(1)%block(1:na, 1:nb) + &
-                                                             MATMUL(achint(1:na, 1:np, 5), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xxV
-                           blocks_rrv(2)%block(1:na, 1:nb) = blocks_rrv(2)%block(1:na, 1:nb) + &
-                                                             MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xyV
-                           blocks_rrv(3)%block(1:na, 1:nb) = blocks_rrv(3)%block(1:na, 1:nb) + &
-                                                             MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xzV
-                           blocks_rrv(4)%block(1:na, 1:nb) = blocks_rrv(4)%block(1:na, 1:nb) + &
-                                                             MATMUL(achint(1:na, 1:np, 8), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! yyV
-                           blocks_rrv(5)%block(1:na, 1:nb) = blocks_rrv(5)%block(1:na, 1:nb) + &
-                                                             MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! yzV
-                           blocks_rrv(6)%block(1:na, 1:nb) = blocks_rrv(6)%block(1:na, 1:nb) + &
-                                                             MATMUL(achint(1:na, 1:np, 10), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! zzV
+                           IF (iatom <= jatom) THEN
+                              blocks_rrv(1)%block(1:na, 1:nb) = blocks_rrv(1)%block(1:na, 1:nb) + &
+                                                                MATMUL(achint(1:na, 1:np, 5), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xxV
+                              blocks_rrv(2)%block(1:na, 1:nb) = blocks_rrv(2)%block(1:na, 1:nb) + &
+                                                                MATMUL(achint(1:na, 1:np, 6), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xyV
+                              blocks_rrv(3)%block(1:na, 1:nb) = blocks_rrv(3)%block(1:na, 1:nb) + &
+                                                                MATMUL(achint(1:na, 1:np, 7), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! xzV
+                              blocks_rrv(4)%block(1:na, 1:nb) = blocks_rrv(4)%block(1:na, 1:nb) + &
+                                                                MATMUL(achint(1:na, 1:np, 8), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! yyV
+                              blocks_rrv(5)%block(1:na, 1:nb) = blocks_rrv(5)%block(1:na, 1:nb) + &
+                                                                MATMUL(achint(1:na, 1:np, 9), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! yzV
+                              blocks_rrv(6)%block(1:na, 1:nb) = blocks_rrv(6)%block(1:na, 1:nb) + &
+                                                                MATMUL(achint(1:na, 1:np, 10), TRANSPOSE(bcint(1:nb, 1:np, 1)))   ! zzV
+                           ELSE
+                              blocks_rrv(1)%block(1:nb, 1:na) = blocks_rrv(1)%block(1:nb, 1:na) + &
+                                                                MATMUL(bchint(1:nb, 1:np, 5), TRANSPOSE(acint(1:na, 1:np, 1)))   ! xxV
+                              blocks_rrv(2)%block(1:nb, 1:na) = blocks_rrv(2)%block(1:nb, 1:na) + &
+                                                                MATMUL(bchint(1:nb, 1:np, 6), TRANSPOSE(acint(1:na, 1:np, 1)))   ! xyV
+                              blocks_rrv(3)%block(1:nb, 1:na) = blocks_rrv(3)%block(1:nb, 1:na) + &
+                                                                MATMUL(bchint(1:nb, 1:np, 7), TRANSPOSE(acint(1:na, 1:np, 1)))   ! xzV
+                              blocks_rrv(4)%block(1:nb, 1:na) = blocks_rrv(4)%block(1:nb, 1:na) + &
+                                                                MATMUL(bchint(1:nb, 1:np, 8), TRANSPOSE(acint(1:na, 1:np, 1)))   ! yyV
+                              blocks_rrv(5)%block(1:nb, 1:na) = blocks_rrv(5)%block(1:nb, 1:na) + &
+                                                                MATMUL(bchint(1:nb, 1:np, 9), TRANSPOSE(acint(1:na, 1:np, 1)))   ! yzV
+                              blocks_rrv(6)%block(1:nb, 1:na) = blocks_rrv(6)%block(1:nb, 1:na) + &
+                                                                MATMUL(bchint(1:nb, 1:np, 10), TRANSPOSE(acint(1:na, 1:np, 1)))   ! zzV
+                           ENDIF
 
                            ! - Vnl * r_alpha * r_beta
                            ! with LAPACK
@@ -779,18 +850,33 @@ CONTAINS
                            ! CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
                            !            bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
                            ! with MATMUL
-                           blocks_rrv(1)%block(1:na, 1:nb) = blocks_rrv(1)%block(1:na, 1:nb) - &
-                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 5)))   ! -Vxx
-                           blocks_rrv(2)%block(1:na, 1:nb) = blocks_rrv(2)%block(1:na, 1:nb) - &
-                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 6)))   ! -Vxy
-                           blocks_rrv(3)%block(1:na, 1:nb) = blocks_rrv(3)%block(1:na, 1:nb) - &
-                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 7)))   ! -Vxz
-                           blocks_rrv(4)%block(1:na, 1:nb) = blocks_rrv(4)%block(1:na, 1:nb) - &
-                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 8)))   ! -Vyy
-                           blocks_rrv(5)%block(1:na, 1:nb) = blocks_rrv(5)%block(1:na, 1:nb) - &
-                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 9)))   ! -Vyz
-                           blocks_rrv(6)%block(1:na, 1:nb) = blocks_rrv(6)%block(1:na, 1:nb) - &
-                                                             MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 10)))   ! -Vzz
+                           IF (iatom <= jatom) THEN
+                              blocks_rrv(1)%block(1:na, 1:nb) = blocks_rrv(1)%block(1:na, 1:nb) - &
+                                                                MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 5)))   ! -Vxx
+                              blocks_rrv(2)%block(1:na, 1:nb) = blocks_rrv(2)%block(1:na, 1:nb) - &
+                                                                MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 6)))   ! -Vxy
+                              blocks_rrv(3)%block(1:na, 1:nb) = blocks_rrv(3)%block(1:na, 1:nb) - &
+                                                                MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 7)))   ! -Vxz
+                              blocks_rrv(4)%block(1:na, 1:nb) = blocks_rrv(4)%block(1:na, 1:nb) - &
+                                                                MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 8)))   ! -Vyy
+                              blocks_rrv(5)%block(1:na, 1:nb) = blocks_rrv(5)%block(1:na, 1:nb) - &
+                                                                MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 9)))   ! -Vyz
+                              blocks_rrv(6)%block(1:na, 1:nb) = blocks_rrv(6)%block(1:na, 1:nb) - &
+                                                                MATMUL(achint(1:na, 1:np, 1), TRANSPOSE(bcint(1:nb, 1:np, 10)))   ! -Vzz
+                           ELSE
+                              blocks_rrv(1)%block(1:nb, 1:na) = blocks_rrv(1)%block(1:nb, 1:na) - &
+                                                                MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 5)))   ! -Vxx
+                              blocks_rrv(2)%block(1:nb, 1:na) = blocks_rrv(2)%block(1:nb, 1:na) - &
+                                                                MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 6)))   ! -Vxy
+                              blocks_rrv(3)%block(1:nb, 1:na) = blocks_rrv(3)%block(1:nb, 1:na) - &
+                                                                MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 7)))   ! -Vxz
+                              blocks_rrv(4)%block(1:nb, 1:na) = blocks_rrv(4)%block(1:nb, 1:na) - &
+                                                                MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 8)))   ! -Vyy
+                              blocks_rrv(5)%block(1:nb, 1:na) = blocks_rrv(5)%block(1:nb, 1:na) - &
+                                                                MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 9)))   ! -Vyz
+                              blocks_rrv(6)%block(1:nb, 1:na) = blocks_rrv(6)%block(1:nb, 1:na) - &
+                                                                MATMUL(bchint(1:nb, 1:np, 1), TRANSPOSE(acint(1:na, 1:np, 10)))   ! -Vzz
+                           ENDIF
                         ENDIF
 !$                      CALL omp_unset_lock(locks(hash))
                         EXIT ! We have found a match and there can be only one single match

--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -403,7 +403,8 @@ CONTAINS
    END SUBROUTINE build_com_rpnl
 
 ! **************************************************************************************************
-!> \brief ...
+!> \brief Calculate [r,Vnl], r x [r,Vnl] or [rr,Vnl] in AO basis
+!>        reference point is required for the two latter options
 !> \param qs_kind_set ...
 !> \param sab_all ...
 !> \param sap_ppnl ...
@@ -420,14 +421,14 @@ CONTAINS
 
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_all, sap_ppnl
+         INTENT(IN), POINTER                             :: sab_all, sap_ppnl
       REAL(KIND=dp), INTENT(IN)                          :: eps_ppnl
-      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: matrix_rv, matrix_rxrv, matrix_rrv
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
+         OPTIONAL, POINTER                               :: matrix_rv, matrix_rxrv, matrix_rrv
       REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: ref_point
-      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: particle_set
-      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
+      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
+         OPTIONAL, POINTER                               :: particle_set
+      TYPE(cell_type), INTENT(IN), OPTIONAL, POINTER     :: cell
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_com_mom_nl', &
          routineP = moduleN//':'//routineN
@@ -463,6 +464,9 @@ CONTAINS
       TYPE(sgp_potential_p_type), DIMENSION(:), POINTER  :: spotential
       TYPE(sgp_potential_type), POINTER                  :: sgp_potential
 
+      ppnl_present = ASSOCIATED(sap_ppnl)
+      IF (.NOT. ppnl_present) RETURN
+
       CALL timeset(routineN, handle)
 
       my_rxrv = .FALSE.
@@ -471,80 +475,78 @@ CONTAINS
       IF (PRESENT(matrix_rxrv)) my_rxrv = .TRUE.
       IF (PRESENT(matrix_rrv)) my_rrv = .TRUE.
       IF (PRESENT(matrix_rv)) my_rv = .TRUE.
-      IF (.NOT. (my_rv .OR. my_rxrv .OR. my_rrv)) RETURN
+      IF (.NOT. (my_rv .OR. my_rxrv .OR. my_rrv)) THEN
+         CPABORT('No dbcsr matrix provided for commutator calculation!')
+      ENDIF
 
-      ppnl_present = ASSOCIATED(sap_ppnl)
+      IF (my_rxrv .OR. my_rrv) THEN
+         maxder = 10
+         order = 2
+         CPASSERT(PRESENT(ref_point)) ! need reference point for r x [r,Vnl] and [rr,Vnl]
+      ELSE
+         maxder = 4
+         order = 1
+      ENDIF
 
-      IF (ppnl_present) THEN
+      my_ref = .FALSE.
+      IF (PRESENT(ref_point)) THEN
+         CPASSERT((PRESENT(cell) .AND. PRESENT(particle_set))) ! need these as well if refpoint is provided
+         rf = ref_point
+         my_ref = .TRUE.
+      ELSE
+         rf(:) = 0._dp
+      ENDIF
 
-         nkind = SIZE(qs_kind_set)
+      nkind = SIZE(qs_kind_set)
 
-         CALL get_qs_kind_set(qs_kind_set, &
-                              maxco=maxco, &
-                              maxlgto=maxlgto, &
-                              maxsgf=maxsgf, &
-                              maxlppnl=maxlppnl, &
-                              maxppnl=maxppnl)
+      CALL get_qs_kind_set(qs_kind_set, &
+                           maxco=maxco, &
+                           maxlgto=maxlgto, &
+                           maxsgf=maxsgf, &
+                           maxlppnl=maxlppnl, &
+                           maxppnl=maxppnl)
 
-         maxl = MAX(maxlgto, maxlppnl)
-         CALL init_orbital_pointers(maxl + 1)
+      maxl = MAX(maxlgto, maxlppnl)
+      CALL init_orbital_pointers(maxl + 1)
 
-         ldsab = MAX(maxco, ncoset(maxlppnl), maxsgf, maxppnl)
-         ldai = ncoset(maxl + 1)
+      ldsab = MAX(maxco, ncoset(maxlppnl), maxsgf, maxppnl)
+      ldai = ncoset(maxl + 1)
 
-         !sap_int needs to be shared as multiple threads need to access this
-         ALLOCATE (sap_int(nkind*nkind))
-         DO i = 1, nkind*nkind
-            NULLIFY (sap_int(i)%alist, sap_int(i)%asort, sap_int(i)%aindex)
-            sap_int(i)%nalist = 0
-         END DO
+      !sap_int needs to be shared as multiple threads need to access this
+      ALLOCATE (sap_int(nkind*nkind))
+      DO i = 1, nkind*nkind
+         NULLIFY (sap_int(i)%alist, sap_int(i)%asort, sap_int(i)%aindex)
+         sap_int(i)%nalist = 0
+      END DO
 
-         !set up direct access to basis and potential
-         ALLOCATE (basis_set(nkind), gpotential(nkind), spotential(nkind))
-         DO ikind = 1, nkind
-            CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
-            IF (ASSOCIATED(orb_basis_set)) THEN
-               basis_set(ikind)%gto_basis_set => orb_basis_set
-            ELSE
-               NULLIFY (basis_set(ikind)%gto_basis_set)
-            END IF
-            CALL get_qs_kind(qs_kind_set(ikind), gth_potential=gth_potential, &
-                             sgp_potential=sgp_potential)
-            IF (ASSOCIATED(gth_potential)) THEN
-               gpotential(ikind)%gth_potential => gth_potential
-               NULLIFY (spotential(ikind)%sgp_potential)
-            ELSE IF (ASSOCIATED(sgp_potential)) THEN
-               spotential(ikind)%sgp_potential => sgp_potential
-               NULLIFY (gpotential(ikind)%gth_potential)
-            ELSE
-               NULLIFY (gpotential(ikind)%gth_potential)
-               NULLIFY (spotential(ikind)%sgp_potential)
-            END IF
-         END DO
-
-         IF (my_rxrv .OR. my_rrv) THEN
-            maxder = 10
-            order = 2
-            CPASSERT(PRESENT(ref_point))
+      !set up direct access to basis and potential
+      ALLOCATE (basis_set(nkind), gpotential(nkind), spotential(nkind))
+      DO ikind = 1, nkind
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
+         IF (ASSOCIATED(orb_basis_set)) THEN
+            basis_set(ikind)%gto_basis_set => orb_basis_set
          ELSE
-            maxder = 4
-            order = 1
-         ENDIF
-
-         my_ref = .FALSE.
-         IF (PRESENT(ref_point)) THEN
-            CPASSERT((PRESENT(cell) .AND. PRESENT(particle_set)))
-            rf = ref_point
-            my_ref = .TRUE.
+            NULLIFY (basis_set(ikind)%gto_basis_set)
+         END IF
+         CALL get_qs_kind(qs_kind_set(ikind), gth_potential=gth_potential, &
+                          sgp_potential=sgp_potential)
+         IF (ASSOCIATED(gth_potential)) THEN
+            gpotential(ikind)%gth_potential => gth_potential
+            NULLIFY (spotential(ikind)%sgp_potential)
+         ELSE IF (ASSOCIATED(sgp_potential)) THEN
+            spotential(ikind)%sgp_potential => sgp_potential
+            NULLIFY (gpotential(ikind)%gth_potential)
          ELSE
-            rf(:) = 0._dp
-         ENDIF
+            NULLIFY (gpotential(ikind)%gth_potential)
+            NULLIFY (spotential(ikind)%sgp_potential)
+         END IF
+      END DO
 
-         nthread = 1
-!$       nthread = omp_get_max_threads()
+      nthread = 1
+!$    nthread = omp_get_max_threads()
 
-         !calculate the overlap integrals <a|p>
-         CALL neighbor_list_iterator_create(nl_iterator, sap_ppnl, nthread=nthread)
+      !calculate the overlap integrals <a|p>
+      CALL neighbor_list_iterator_create(nl_iterator, sap_ppnl, nthread=nthread)
 !$OMP PARALLEL &
 !$OMP DEFAULT (NONE) &
 !$OMP SHARED  (nl_iterator, basis_set, spotential, gpotential, maxder, ncoset, &
@@ -555,141 +557,141 @@ CONTAINS
 !$OMP          clist, iset, ncoa, sgfa, prjc, work, sab, ai_work, nprjc,  ppnl_radius, &
 !$OMP          ncoc, rpgfa, vprj_ppnl, i, l, gpot, spot, raf, rcf, ra, rc, &
 !$OMP          set_radius_a, rprjc, dac, lc_max, lc_min, zetc, alpha_ppnl)
-         mepos = 0
-!$       mepos = omp_get_thread_num()
+      mepos = 0
+!$    mepos = omp_get_thread_num()
 
-         ALLOCATE (sab(ldsab, ldsab, maxder), work(ldsab, ldsab, maxder))
-         sab = 0.0_dp
-         ALLOCATE (ai_work(ldai, ldai, 1))
-         ai_work = 0.0_dp
+      ALLOCATE (sab(ldsab, ldsab, maxder), work(ldsab, ldsab, maxder))
+      sab = 0.0_dp
+      ALLOCATE (ai_work(ldai, ldai, 1))
+      ai_work = 0.0_dp
 
-         DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
-            CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=kkind, iatom=iatom, &
-                                   jatom=katom, nlist=nlist, ilist=ilist, nnode=nneighbor, inode=jneighbor, cell=cell_c, r=rac)
-            iac = ikind + nkind*(kkind - 1)
-            IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
-            gpot = ASSOCIATED(gpotential(kkind)%gth_potential)
-            spot = ASSOCIATED(spotential(kkind)%sgp_potential)
-            IF ((.NOT. gpot) .AND. (.NOT. spot)) CYCLE
-            ! get definition of basis set
-            first_sgfa => basis_set(ikind)%gto_basis_set%first_sgf
-            la_max => basis_set(ikind)%gto_basis_set%lmax
-            la_min => basis_set(ikind)%gto_basis_set%lmin
-            npgfa => basis_set(ikind)%gto_basis_set%npgf
-            nseta = basis_set(ikind)%gto_basis_set%nset
-            nsgfa = basis_set(ikind)%gto_basis_set%nsgf
-            nsgf_seta => basis_set(ikind)%gto_basis_set%nsgf_set
-            rpgfa => basis_set(ikind)%gto_basis_set%pgf_radius
-            set_radius_a => basis_set(ikind)%gto_basis_set%set_radius
-            sphi_a => basis_set(ikind)%gto_basis_set%sphi
-            zeta => basis_set(ikind)%gto_basis_set%zet
-            ! get definition of PP projectors
-            IF (gpot) THEN
-               alpha_ppnl => gpotential(kkind)%gth_potential%alpha_ppnl
-               cprj => gpotential(kkind)%gth_potential%cprj
-               lppnl = gpotential(kkind)%gth_potential%lppnl
-               nppnl = gpotential(kkind)%gth_potential%nppnl
-               nprj_ppnl => gpotential(kkind)%gth_potential%nprj_ppnl
-               ppnl_radius = gpotential(kkind)%gth_potential%ppnl_radius
-               vprj_ppnl => gpotential(kkind)%gth_potential%vprj_ppnl
-            ELSEIF (spot) THEN
-               CPABORT('SGP not implemented')
-            ELSE
-               CPABORT('PPNL unknown')
-            END IF
+      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=kkind, iatom=iatom, &
+                                jatom=katom, nlist=nlist, ilist=ilist, nnode=nneighbor, inode=jneighbor, cell=cell_c, r=rac)
+         iac = ikind + nkind*(kkind - 1)
+         IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
+         gpot = ASSOCIATED(gpotential(kkind)%gth_potential)
+         spot = ASSOCIATED(spotential(kkind)%sgp_potential)
+         IF ((.NOT. gpot) .AND. (.NOT. spot)) CYCLE
+         ! get definition of basis set
+         first_sgfa => basis_set(ikind)%gto_basis_set%first_sgf
+         la_max => basis_set(ikind)%gto_basis_set%lmax
+         la_min => basis_set(ikind)%gto_basis_set%lmin
+         npgfa => basis_set(ikind)%gto_basis_set%npgf
+         nseta = basis_set(ikind)%gto_basis_set%nset
+         nsgfa = basis_set(ikind)%gto_basis_set%nsgf
+         nsgf_seta => basis_set(ikind)%gto_basis_set%nsgf_set
+         rpgfa => basis_set(ikind)%gto_basis_set%pgf_radius
+         set_radius_a => basis_set(ikind)%gto_basis_set%set_radius
+         sphi_a => basis_set(ikind)%gto_basis_set%sphi
+         zeta => basis_set(ikind)%gto_basis_set%zet
+         ! get definition of PP projectors
+         IF (gpot) THEN
+            alpha_ppnl => gpotential(kkind)%gth_potential%alpha_ppnl
+            cprj => gpotential(kkind)%gth_potential%cprj
+            lppnl = gpotential(kkind)%gth_potential%lppnl
+            nppnl = gpotential(kkind)%gth_potential%nppnl
+            nprj_ppnl => gpotential(kkind)%gth_potential%nprj_ppnl
+            ppnl_radius = gpotential(kkind)%gth_potential%ppnl_radius
+            vprj_ppnl => gpotential(kkind)%gth_potential%vprj_ppnl
+         ELSEIF (spot) THEN
+            CPABORT('SGP not implemented')
+         ELSE
+            CPABORT('PPNL unknown')
+         END IF
 !$OMP CRITICAL(sap_int_critical)
-            IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) THEN
-               sap_int(iac)%a_kind = ikind
-               sap_int(iac)%p_kind = kkind
-               sap_int(iac)%nalist = nlist
-               ALLOCATE (sap_int(iac)%alist(nlist))
-               DO i = 1, nlist
-                  NULLIFY (sap_int(iac)%alist(i)%clist)
-                  sap_int(iac)%alist(i)%aatom = 0
-                  sap_int(iac)%alist(i)%nclist = 0
-               END DO
-            END IF
-            IF (.NOT. ASSOCIATED(sap_int(iac)%alist(ilist)%clist)) THEN
-               sap_int(iac)%alist(ilist)%aatom = iatom
-               sap_int(iac)%alist(ilist)%nclist = nneighbor
-               ALLOCATE (sap_int(iac)%alist(ilist)%clist(nneighbor))
-               DO i = 1, nneighbor
-                  sap_int(iac)%alist(ilist)%clist(i)%catom = 0
-               END DO
-            END IF
-!$OMP END CRITICAL(sap_int_critical)
-            dac = SQRT(SUM(rac*rac))
-            clist => sap_int(iac)%alist(ilist)%clist(jneighbor)
-            clist%catom = katom
-            clist%cell = cell_c
-            clist%rac = rac
-            ALLOCATE (clist%acint(nsgfa, nppnl, maxder), &
-                      clist%achint(nsgfa, nppnl, maxder))
-            clist%acint = 0._dp
-            clist%achint = 0._dp
-            clist%nsgf_cnt = 0
-            NULLIFY (clist%sgf_list)
-
-            IF (my_ref) THEN
-               ra(:) = pbc(particle_set(iatom)%r(:) - rf, cell) + rf
-               rc(:) = pbc(particle_set(katom)%r(:) - rf, cell) + rf
-               raf(:) = ra(:) - rf(:)
-               rcf(:) = rc(:) - rf(:)
-            ENDIF
-
-            DO iset = 1, nseta
-               ncoa = npgfa(iset)*ncoset(la_max(iset))
-               sgfa = first_sgfa(1, iset)
-               work = 0._dp
-               prjc = 1
-               DO l = 0, lppnl
-                  nprjc = nprj_ppnl(l)*nco(l)
-                  IF (nprjc == 0) CYCLE
-                  rprjc(1) = ppnl_radius
-                  IF (set_radius_a(iset) + rprjc(1) < dac) CYCLE
-                  lc_max = l + 2*(nprj_ppnl(l) - 1)
-                  lc_min = l
-                  zetc(1) = alpha_ppnl(l)
-                  ncoc = ncoset(lc_max)
-                  ! Calculate the primitive overlap and dipole moment integrals
-                  CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
-                               lc_max, lc_min, 1, rprjc, zetc, rac, dac, sab(:, :, 1), 0, .FALSE., ai_work, ldai)
-                  IF (.NOT. my_ref) THEN
-                     CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
-                                 lc_max, 1, zetc, rprjc, order, -rac, (/0._dp, 0._dp, 0._dp/), sab(:, :, 2:maxder))
-                  ELSE
-                     CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
-                                 lc_max, 1, zetc, rprjc, order, raf, rcf, sab(:, :, 2:maxder))
-                  ENDIF
-                  ! *** Transformation step projector functions (cartesian->spherical) ***
-                  DO i = 1, maxder
-                     CALL dgemm("N", "N", ncoa, nprjc, ncoc, 1.0_dp, sab(1, 1, i), ldsab, &
-                                cprj(1, prjc), SIZE(cprj, 1), 0.0_dp, work(1, prjc, i), ldsab)
-                  END DO
-                  prjc = prjc + nprjc
-               END DO
-               DO i = 1, maxder
-                  ! Contraction step (basis functions)
-                  CALL dgemm("T", "N", nsgf_seta(iset), nppnl, ncoa, 1.0_dp, sphi_a(1, sgfa), SIZE(sphi_a, 1), &
-                             work(1, 1, i), ldsab, 0.0_dp, clist%acint(sgfa, 1, i), nsgfa)
-                  ! Multiply with interaction matrix(h)
-                  CALL dgemm("N", "N", nsgf_seta(iset), nppnl, nppnl, 1.0_dp, clist%acint(sgfa, 1, i), nsgfa, &
-                             vprj_ppnl(1, 1), SIZE(vprj_ppnl, 1), 0.0_dp, clist%achint(sgfa, 1, i), nsgfa)
-               END DO
+         IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) THEN
+            sap_int(iac)%a_kind = ikind
+            sap_int(iac)%p_kind = kkind
+            sap_int(iac)%nalist = nlist
+            ALLOCATE (sap_int(iac)%alist(nlist))
+            DO i = 1, nlist
+               NULLIFY (sap_int(iac)%alist(i)%clist)
+               sap_int(iac)%alist(i)%aatom = 0
+               sap_int(iac)%alist(i)%nclist = 0
             END DO
-            clist%maxac = MAXVAL(ABS(clist%acint(:, :, 1)))
-            clist%maxach = MAXVAL(ABS(clist%achint(:, :, 1)))
+         END IF
+         IF (.NOT. ASSOCIATED(sap_int(iac)%alist(ilist)%clist)) THEN
+            sap_int(iac)%alist(ilist)%aatom = iatom
+            sap_int(iac)%alist(ilist)%nclist = nneighbor
+            ALLOCATE (sap_int(iac)%alist(ilist)%clist(nneighbor))
+            DO i = 1, nneighbor
+               sap_int(iac)%alist(ilist)%clist(i)%catom = 0
+            END DO
+         END IF
+!$OMP END CRITICAL(sap_int_critical)
+         dac = SQRT(SUM(rac*rac))
+         clist => sap_int(iac)%alist(ilist)%clist(jneighbor)
+         clist%catom = katom
+         clist%cell = cell_c
+         clist%rac = rac
+         ALLOCATE (clist%acint(nsgfa, nppnl, maxder), &
+                   clist%achint(nsgfa, nppnl, maxder))
+         clist%acint = 0._dp
+         clist%achint = 0._dp
+         clist%nsgf_cnt = 0
+         NULLIFY (clist%sgf_list)
+
+         IF (my_ref) THEN
+            ra(:) = pbc(particle_set(iatom)%r(:) - rf, cell) + rf
+            rc(:) = pbc(particle_set(katom)%r(:) - rf, cell) + rf
+            raf(:) = ra(:) - rf(:)
+            rcf(:) = rc(:) - rf(:)
+         ENDIF
+
+         DO iset = 1, nseta
+            ncoa = npgfa(iset)*ncoset(la_max(iset))
+            sgfa = first_sgfa(1, iset)
+            work = 0._dp
+            prjc = 1
+            DO l = 0, lppnl
+               nprjc = nprj_ppnl(l)*nco(l)
+               IF (nprjc == 0) CYCLE
+               rprjc(1) = ppnl_radius
+               IF (set_radius_a(iset) + rprjc(1) < dac) CYCLE
+               lc_max = l + 2*(nprj_ppnl(l) - 1)
+               lc_min = l
+               zetc(1) = alpha_ppnl(l)
+               ncoc = ncoset(lc_max)
+               ! Calculate the primitive overlap and dipole moment integrals
+               CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
+                            lc_max, lc_min, 1, rprjc, zetc, rac, dac, sab(:, :, 1), 0, .FALSE., ai_work, ldai)
+               IF (.NOT. my_ref) THEN
+                  CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                              lc_max, 1, zetc, rprjc, order, -rac, (/0._dp, 0._dp, 0._dp/), sab(:, :, 2:maxder))
+               ELSE
+                  CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                              lc_max, 1, zetc, rprjc, order, raf, rcf, sab(:, :, 2:maxder))
+               ENDIF
+               ! *** Transformation step projector functions (cartesian->spherical) ***
+               DO i = 1, maxder
+                  CALL dgemm("N", "N", ncoa, nprjc, ncoc, 1.0_dp, sab(1, 1, i), ldsab, &
+                             cprj(1, prjc), SIZE(cprj, 1), 0.0_dp, work(1, prjc, i), ldsab)
+               END DO
+               prjc = prjc + nprjc
+            END DO
+            DO i = 1, maxder
+               ! Contraction step (basis functions)
+               CALL dgemm("T", "N", nsgf_seta(iset), nppnl, ncoa, 1.0_dp, sphi_a(1, sgfa), SIZE(sphi_a, 1), &
+                          work(1, 1, i), ldsab, 0.0_dp, clist%acint(sgfa, 1, i), nsgfa)
+               ! Multiply with interaction matrix(h)
+               CALL dgemm("N", "N", nsgf_seta(iset), nppnl, nppnl, 1.0_dp, clist%acint(sgfa, 1, i), nsgfa, &
+                          vprj_ppnl(1, 1), SIZE(vprj_ppnl, 1), 0.0_dp, clist%achint(sgfa, 1, i), nsgfa)
+            END DO
          END DO
+         clist%maxac = MAXVAL(ABS(clist%acint(:, :, 1)))
+         clist%maxach = MAXVAL(ABS(clist%achint(:, :, 1)))
+      END DO
 
-         DEALLOCATE (sab, ai_work, work)
+      DEALLOCATE (sab, ai_work, work)
 !$OMP END PARALLEL
-         CALL neighbor_list_iterator_release(nl_iterator)
+      CALL neighbor_list_iterator_release(nl_iterator)
 
-         ! *** Set up a sorting index
-         CALL sap_sort(sap_int)
-         ! *** All integrals needed have been calculated and stored in sap_int
-         ! *** We now calculate the Hamiltonian matrix elements
-         CALL neighbor_list_iterator_create(nl_iterator, sab_all, nthread=nthread)
+      ! *** Set up a sorting index
+      CALL sap_sort(sap_int)
+      ! *** All integrals needed have been calculated and stored in sap_int
+      ! *** We now calculate the Hamiltonian matrix elements
+      CALL neighbor_list_iterator_create(nl_iterator, sab_all, nthread=nthread)
 
 !$OMP PARALLEL &
 !$OMP DEFAULT (NONE) &
@@ -701,207 +703,205 @@ CONTAINS
 !$OMP          achint, bchint, na, np, nb, katom, rac, kkind, kac, kbc, i, &
 !$OMP          go, asso_rv, asso_rxrv, asso_rrv)
 
-         mepos = 0
-!$       mepos = omp_get_thread_num()
+      mepos = 0
+!$    mepos = omp_get_thread_num()
 
-         NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
+      NULLIFY (blocks_rv, blocks_rxrv, blocks_rrv)
+      IF (my_rv) THEN
+         ALLOCATE (blocks_rv(3))
+      ENDIF
+
+      IF (my_rxrv) THEN
+         ALLOCATE (blocks_rxrv(3))
+      ENDIF
+      IF (my_rrv) THEN
+         ALLOCATE (blocks_rrv(6))
+      ENDIF
+
+      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, iatom=iatom, &
+                                jatom=jatom, nlist=nlist, ilist=ilist, nnode=nnode, inode=inode, cell=cell_b, r=rab)
+         IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
+         IF (.NOT. ASSOCIATED(basis_set(jkind)%gto_basis_set)) CYCLE
+         iab = ikind + nkind*(jkind - 1)
+
+         ! *** Create matrix blocks for a new matrix block column ***
+         irow = iatom
+         icol = jatom
+
          IF (my_rv) THEN
-            ALLOCATE (blocks_rv(3))
+            DO ind = 1, 3
+               CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
+            ENDDO
          ENDIF
 
          IF (my_rxrv) THEN
-            ALLOCATE (blocks_rxrv(3))
-         ENDIF
-         IF (my_rrv) THEN
-            ALLOCATE (blocks_rrv(6))
-         ENDIF
-
-         DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
-            CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, iatom=iatom, &
-                                   jatom=jatom, nlist=nlist, ilist=ilist, nnode=nnode, inode=inode, cell=cell_b, r=rab)
-            IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
-            IF (.NOT. ASSOCIATED(basis_set(jkind)%gto_basis_set)) CYCLE
-            iab = ikind + nkind*(jkind - 1)
-
-            ! *** Create matrix blocks for a new matrix block column ***
-            irow = iatom
-            icol = jatom
-
-            IF (my_rv) THEN
-               DO ind = 1, 3
-                  CALL dbcsr_get_block_p(matrix_rv(ind)%matrix, irow, icol, blocks_rv(ind)%block, found)
-               ENDDO
-            ENDIF
-
-            IF (my_rxrv) THEN
-               DO ind = 1, 3
-                  CALL dbcsr_get_block_p(matrix_rxrv(ind)%matrix, irow, icol, blocks_rxrv(ind)%block, found)
-               ENDDO
-            ENDIF
-
-            IF (my_rrv) THEN
-               DO ind = 1, 6
-                  CALL dbcsr_get_block_p(matrix_rrv(ind)%matrix, irow, icol, blocks_rrv(ind)%block, found)
-               ENDDO
-            ENDIF
-
-            ! check whether all blocks are associated
-            go = .TRUE.
-            IF (my_rv) THEN
-               asso_rv = (ASSOCIATED(blocks_rv(1)%block) .AND. ASSOCIATED(blocks_rv(2)%block) .AND. &
-                          ASSOCIATED(blocks_rv(3)%block))
-               go = go .AND. asso_rv
-            ENDIF
-
-            IF (my_rxrv) THEN
-               asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
-                            ASSOCIATED(blocks_rxrv(3)%block))
-               go = go .AND. asso_rxrv
-            ENDIF
-
-            IF (my_rrv) THEN
-               asso_rrv = (ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
-                           ASSOCIATED(blocks_rrv(3)%block) .AND. ASSOCIATED(blocks_rrv(4)%block) .AND. &
-                           ASSOCIATED(blocks_rrv(5)%block) .AND. ASSOCIATED(blocks_rrv(6)%block))
-               go = go .AND. asso_rrv
-            ENDIF
-            ! loop over all kinds for projector atom
-            IF (go) THEN
-               DO kkind = 1, nkind
-                  iac = ikind + nkind*(kkind - 1)
-                  ibc = jkind + nkind*(kkind - 1)
-                  IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) CYCLE
-                  IF (.NOT. ASSOCIATED(sap_int(ibc)%alist)) CYCLE
-                  CALL get_alist(sap_int(iac), alist_ac, iatom)
-                  CALL get_alist(sap_int(ibc), alist_bc, jatom)
-                  IF (.NOT. ASSOCIATED(alist_ac)) CYCLE
-                  IF (.NOT. ASSOCIATED(alist_bc)) CYCLE
-                  DO kac = 1, alist_ac%nclist
-                     DO kbc = 1, alist_bc%nclist
-                        IF (alist_ac%clist(kac)%catom /= alist_bc%clist(kbc)%catom) CYCLE
-                        IF (ALL(cell_b + alist_bc%clist(kbc)%cell - alist_ac%clist(kac)%cell == 0)) THEN
-                           IF (alist_ac%clist(kac)%maxac*alist_bc%clist(kbc)%maxach < eps_ppnl) CYCLE
-                           acint => alist_ac%clist(kac)%acint
-                           bcint => alist_bc%clist(kbc)%acint
-                           achint => alist_ac%clist(kac)%achint
-                           bchint => alist_bc%clist(kbc)%achint
-                           na = SIZE(acint, 1)
-                           np = SIZE(acint, 2)
-                           nb = SIZE(bcint, 1)
-!$OMP CRITICAL(h_block_critical)
-                           IF (my_rv) THEN
-                              ! r*Vnl
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
-
-                              ! -Vnl r
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
-                           ENDIF
-
-                           IF (my_rxrv) THEN
-                              ! x-component (y [z,Vnl] - z [y, Vnl])
-                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
-                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 3), na, &
-                                         bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -yVz
-                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 9), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -zyV
-                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
-                                         bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
-
-                              ! y-component (z [x,Vnl] - x [z, Vnl])
-                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 7), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! zxV
-                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 4), na, &
-                                         bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -zVx
-                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 7), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -xzV
-                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
-                                         bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
-
-                              ! z-component (x [y,Vnl] - y [x, Vnl])
-                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 6), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! xyV
-                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 2), na, &
-                                         bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -xVy
-                              CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 6), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -yxV
-                              CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
-                                         bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
-                           ENDIF
-
-                           IF (my_rrv) THEN
-                              ! r_alpha * r_beta * Vnl
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 6), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! xyV
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 7), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! xzV
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 8), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! yyV
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 9), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! yzV
-                              CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
-                                         bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
-
-                              ! - Vnl * r_alpha * r_beta
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 5), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! Vxx
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 6), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! Vxy
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 7), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! Vxz
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 8), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! Vyy
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 9), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! Vyz
-                              CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
-                                         bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
-                           ENDIF
-!$OMP END CRITICAL(h_block_critical)
-                           EXIT ! We have found a match and there can be only one single match
-                        END IF
-                     END DO
-                  END DO
-               END DO
-            ENDIF
-         END DO
-         IF (my_rv) THEN
             DO ind = 1, 3
-               NULLIFY (blocks_rv(ind)%block)
+               CALL dbcsr_get_block_p(matrix_rxrv(ind)%matrix, irow, icol, blocks_rxrv(ind)%block, found)
             ENDDO
-            DEALLOCATE (blocks_rv)
          ENDIF
-         IF (my_rxrv) THEN
-            DO ind = 1, 3
-               NULLIFY (blocks_rxrv(ind)%block)
-            ENDDO
-            DEALLOCATE (blocks_rxrv)
-         ENDIF
+
          IF (my_rrv) THEN
             DO ind = 1, 6
-               NULLIFY (blocks_rrv(ind)%block)
+               CALL dbcsr_get_block_p(matrix_rrv(ind)%matrix, irow, icol, blocks_rrv(ind)%block, found)
             ENDDO
-            DEALLOCATE (blocks_rrv)
          ENDIF
+
+         ! check whether all blocks are associated
+         go = .TRUE.
+         IF (my_rv) THEN
+            asso_rv = (ASSOCIATED(blocks_rv(1)%block) .AND. ASSOCIATED(blocks_rv(2)%block) .AND. &
+                       ASSOCIATED(blocks_rv(3)%block))
+            go = go .AND. asso_rv
+         ENDIF
+
+         IF (my_rxrv) THEN
+            asso_rxrv = (ASSOCIATED(blocks_rxrv(1)%block) .AND. ASSOCIATED(blocks_rxrv(2)%block) .AND. &
+                         ASSOCIATED(blocks_rxrv(3)%block))
+            go = go .AND. asso_rxrv
+         ENDIF
+
+         IF (my_rrv) THEN
+            asso_rrv = (ASSOCIATED(blocks_rrv(1)%block) .AND. ASSOCIATED(blocks_rrv(2)%block) .AND. &
+                        ASSOCIATED(blocks_rrv(3)%block) .AND. ASSOCIATED(blocks_rrv(4)%block) .AND. &
+                        ASSOCIATED(blocks_rrv(5)%block) .AND. ASSOCIATED(blocks_rrv(6)%block))
+            go = go .AND. asso_rrv
+         ENDIF
+         ! loop over all kinds for projector atom
+         IF (go) THEN
+            DO kkind = 1, nkind
+               iac = ikind + nkind*(kkind - 1)
+               ibc = jkind + nkind*(kkind - 1)
+               IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) CYCLE
+               IF (.NOT. ASSOCIATED(sap_int(ibc)%alist)) CYCLE
+               CALL get_alist(sap_int(iac), alist_ac, iatom)
+               CALL get_alist(sap_int(ibc), alist_bc, jatom)
+               IF (.NOT. ASSOCIATED(alist_ac)) CYCLE
+               IF (.NOT. ASSOCIATED(alist_bc)) CYCLE
+               DO kac = 1, alist_ac%nclist
+                  DO kbc = 1, alist_bc%nclist
+                     IF (alist_ac%clist(kac)%catom /= alist_bc%clist(kbc)%catom) CYCLE
+                     IF (ALL(cell_b + alist_bc%clist(kbc)%cell - alist_ac%clist(kac)%cell == 0)) THEN
+                        IF (alist_ac%clist(kac)%maxac*alist_bc%clist(kbc)%maxach < eps_ppnl) CYCLE
+                        acint => alist_ac%clist(kac)%acint
+                        bcint => alist_bc%clist(kbc)%acint
+                        achint => alist_ac%clist(kac)%achint
+                        bchint => alist_bc%clist(kbc)%achint
+                        na = SIZE(acint, 1)
+                        np = SIZE(acint, 2)
+                        nb = SIZE(bcint, 1)
+!$OMP CRITICAL(h_block_critical)
+                        IF (my_rv) THEN
+                           ! r*Vnl
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 2), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! xV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 3), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! yV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 4), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! zV
+
+                           ! -Vnl r
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rv(1)%block, SIZE(blocks_rv(1)%block, 1)) ! -Vx
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rv(2)%block, SIZE(blocks_rv(2)%block, 1)) ! -Vy
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rv(3)%block, SIZE(blocks_rv(3)%block, 1)) ! -Vz
+                        ENDIF
+
+                        IF (my_rxrv) THEN
+                           ! x-component (y [z,Vnl] - z [y, Vnl])
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 9), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! yzV
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 3), na, &
+                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -yVz
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 9), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! -zyV
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 4), na, &
+                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(1)%block, SIZE(blocks_rxrv(1)%block, 1)) ! zVy
+
+                           ! y-component (z [x,Vnl] - x [z, Vnl])
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 7), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! zxV
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 4), na, &
+                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -zVx
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 7), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! -xzV
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 2), na, &
+                                      bcint(1, 1, 4), nb, 1.0_dp, blocks_rxrv(2)%block, SIZE(blocks_rxrv(2)%block, 1)) ! xVz
+
+                           ! z-component (x [y,Vnl] - y [x, Vnl])
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 6), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! xyV
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 2), na, &
+                                      bcint(1, 1, 3), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -xVy
+                           CALL dgemm("N", "T", na, nb, np, -1.0_dp, achint(1, 1, 6), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! -yxV
+                           CALL dgemm("N", "T", na, nb, np, 1.0_dp, achint(1, 1, 3), na, &
+                                      bcint(1, 1, 2), nb, 1.0_dp, blocks_rxrv(3)%block, SIZE(blocks_rxrv(3)%block, 1)) ! yVx
+                        ENDIF
+
+                        IF (my_rrv) THEN
+                           ! r_alpha * r_beta * Vnl
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 5), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! xxV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 6), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! xyV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 7), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! xzV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 8), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! yyV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 9), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! yzV
+                           CALL dgemm("N", "T", na, nb, np, 1._dp, achint(1, 1, 10), na, &
+                                      bcint(1, 1, 1), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! zzV
+
+                           ! - Vnl * r_alpha * r_beta
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 5), nb, 1.0_dp, blocks_rrv(1)%block, SIZE(blocks_rrv(1)%block, 1)) ! Vxx
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 6), nb, 1.0_dp, blocks_rrv(2)%block, SIZE(blocks_rrv(2)%block, 1)) ! Vxy
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 7), nb, 1.0_dp, blocks_rrv(3)%block, SIZE(blocks_rrv(3)%block, 1)) ! Vxz
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 8), nb, 1.0_dp, blocks_rrv(4)%block, SIZE(blocks_rrv(4)%block, 1)) ! Vyy
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 9), nb, 1.0_dp, blocks_rrv(5)%block, SIZE(blocks_rrv(5)%block, 1)) ! Vyz
+                           CALL dgemm("N", "T", na, nb, np, -1._dp, achint(1, 1, 1), na, &
+                                      bcint(1, 1, 10), nb, 1.0_dp, blocks_rrv(6)%block, SIZE(blocks_rrv(6)%block, 1)) ! Vzz
+                        ENDIF
+!$OMP END CRITICAL(h_block_critical)
+                        EXIT ! We have found a match and there can be only one single match
+                     END IF
+                  END DO
+               END DO
+            END DO
+         ENDIF
+      END DO
+      IF (my_rv) THEN
+         DO ind = 1, 3
+            NULLIFY (blocks_rv(ind)%block)
+         ENDDO
+         DEALLOCATE (blocks_rv)
+      ENDIF
+      IF (my_rxrv) THEN
+         DO ind = 1, 3
+            NULLIFY (blocks_rxrv(ind)%block)
+         ENDDO
+         DEALLOCATE (blocks_rxrv)
+      ENDIF
+      IF (my_rrv) THEN
+         DO ind = 1, 6
+            NULLIFY (blocks_rrv(ind)%block)
+         ENDDO
+         DEALLOCATE (blocks_rrv)
+      ENDIF
 !$OMP END PARALLEL
-         CALL neighbor_list_iterator_release(nl_iterator)
+      CALL neighbor_list_iterator_release(nl_iterator)
 
-         CALL release_sap_int(sap_int)
+      CALL release_sap_int(sap_int)
 
-         DEALLOCATE (basis_set, gpotential, spotential)
-
-      END IF !ppnl_present
+      DEALLOCATE (basis_set, gpotential, spotential)
 
       CALL timestop(handle)
 

--- a/src/emd/rt_delta_pulse.F
+++ b/src/emd/rt_delta_pulse.F
@@ -44,7 +44,7 @@ MODULE rt_delta_pulse
    USE cp_gemm_interface,               ONLY: cp_gemm
    USE dbcsr_api,                       ONLY: &
         dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_filter, dbcsr_init_p, &
-        dbcsr_p_type, dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry
+        dbcsr_p_type, dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric
    USE input_section_types,             ONLY: section_get_lval,&
                                               section_vals_type
    USE kinds,                           ONLY: dp
@@ -108,7 +108,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_all, sap_ppnl
+         POINTER                                         :: sab_orb, sap_ppnl
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(rt_prop_type), POINTER                        :: rtp
@@ -143,10 +143,10 @@ CONTAINS
 
       ! calculate non-local commutator
       IF (com_nl) THEN
-         NULLIFY (qs_kind_set, sab_all, sap_ppnl)
+         NULLIFY (qs_kind_set, sab_orb, sap_ppnl)
          CALL get_qs_env(qs_env, &
                          sap_ppnl=sap_ppnl, &
-                         sab_all=sab_all, &
+                         sab_orb=sab_orb, &
                          qs_kind_set=qs_kind_set)
          eps_ppnl = dft_control%qs_control%eps_ppnl
 
@@ -155,11 +155,11 @@ CONTAINS
          DO idir = 1, 3
             CALL dbcsr_init_p(matrix_rv(idir)%matrix)
             CALL dbcsr_create(matrix_rv(idir)%matrix, template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(idir)%matrix, sab_all)
+                              matrix_type=dbcsr_type_antisymmetric)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(idir)%matrix, sab_orb)
             CALL dbcsr_set(matrix_rv(idir)%matrix, 0._dp)
          ENDDO
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv)
+         CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv)
       ENDIF
 
       DO ispin = 1, SIZE(matrix_ks)

--- a/src/emd/rt_delta_pulse.F
+++ b/src/emd/rt_delta_pulse.F
@@ -49,6 +49,7 @@ MODULE rt_delta_pulse
                                               section_vals_type
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: twopi
+   USE particle_types,                  ONLY: particle_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_kind_types,                   ONLY: qs_kind_type
@@ -108,13 +109,14 @@ CONTAINS
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_all, sap_ppnl
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(rt_prop_type), POINTER                        :: rtp
       TYPE(section_vals_type), POINTER                   :: input
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (cell, mos, rtp, matrix_s, matrix_ks, input, dft_control)
+      NULLIFY (cell, mos, rtp, matrix_s, matrix_ks, input, dft_control, particle_set)
       ! we need the overlap and ks matrix for a full diagionalization
       CALL get_qs_env(qs_env, &
                       cell=cell, &
@@ -123,7 +125,8 @@ CONTAINS
                       matrix_s=matrix_s, &
                       matrix_ks=matrix_ks, &
                       dft_control=dft_control, &
-                      input=input)
+                      input=input, &
+                      particle_set=particle_set)
       com_nl = section_get_lval(section_vals=input, keyword_name="DFT%REAL_TIME_PROPAGATION%COM_NL")
       CALL get_rtp(rtp=rtp, S_inv=S_inv)
       CALL cp_fm_create(S_chol, matrix_struct=rtp%ao_ao_fmstruct, name="S_chol")
@@ -156,7 +159,7 @@ CONTAINS
             CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(idir)%matrix, sab_all)
             CALL dbcsr_set(matrix_rv(idir)%matrix, 0._dp)
          ENDDO
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv)
       ENDIF
 
       DO ispin = 1, SIZE(matrix_ks)

--- a/src/emd/rt_delta_pulse.F
+++ b/src/emd/rt_delta_pulse.F
@@ -9,6 +9,7 @@
 
 MODULE rt_delta_pulse
    USE cell_types,                      ONLY: cell_type
+   USE commutator_rpnl,                 ONLY: build_com_mom_nl
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_column_scale,&
                                               cp_cfm_gemm
    USE cp_cfm_diag,                     ONLY: cp_cfm_heevd
@@ -17,9 +18,12 @@ MODULE rt_delta_pulse
                                               cp_cfm_to_cfm,&
                                               cp_cfm_type
    USE cp_control_types,                ONLY: dft_control_type
+   USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               copy_fm_to_dbcsr,&
-                                              cp_dbcsr_sm_fm_multiply
+                                              cp_dbcsr_sm_fm_multiply,&
+                                              dbcsr_allocate_matrix_set,&
+                                              dbcsr_deallocate_matrix_set
    USE cp_fm_basic_linalg,              ONLY: cp_fm_scale_and_add,&
                                               cp_fm_upper_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
@@ -38,18 +42,20 @@ MODULE rt_delta_pulse
                                               cp_fm_to_fm,&
                                               cp_fm_type
    USE cp_gemm_interface,               ONLY: cp_gemm
-   USE dbcsr_api,                       ONLY: dbcsr_copy,&
-                                              dbcsr_deallocate_matrix,&
-                                              dbcsr_filter,&
-                                              dbcsr_p_type,&
-                                              dbcsr_type
+   USE dbcsr_api,                       ONLY: &
+        dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_filter, dbcsr_init_p, &
+        dbcsr_p_type, dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry
+   USE input_section_types,             ONLY: section_get_lval,&
+                                              section_vals_type
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: twopi
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
+   USE qs_kind_types,                   ONLY: qs_kind_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_p_type
    USE qs_moments,                      ONLY: build_berry_moment_matrix
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE rt_propagation_types,            ONLY: get_rtp,&
                                               rt_prop_type
 #include "../base/base_uses.f90"
@@ -85,7 +91,8 @@ CONTAINS
                                                             ncol_local, nmo, nrow_global, &
                                                             nrow_local, nvirt
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      REAL(KIND=dp)                                      :: factor
+      LOGICAL                                            :: com_nl
+      REAL(KIND=dp)                                      :: eps_ppnl, factor
       REAL(KIND=dp), DIMENSION(3)                        :: kvec
       REAL(kind=dp), DIMENSION(:), POINTER               :: eigenvalues
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
@@ -95,15 +102,19 @@ CONTAINS
       TYPE(cp_fm_type), POINTER                          :: eigenvectors, mat_ks, mat_tmp, momentum, &
                                                             oo_1, oo_2, S_chol, S_inv_fm, tmpS, &
                                                             virtuals
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_rv, matrix_s
       TYPE(dbcsr_type), POINTER                          :: S_inv
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_all, sap_ppnl
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(rt_prop_type), POINTER                        :: rtp
+      TYPE(section_vals_type), POINTER                   :: input
 
-      NULLIFY (dft_control)
       CALL timeset(routineN, handle)
 
+      NULLIFY (cell, mos, rtp, matrix_s, matrix_ks, input, dft_control)
       ! we need the overlap and ks matrix for a full diagionalization
       CALL get_qs_env(qs_env, &
                       cell=cell, &
@@ -111,7 +122,9 @@ CONTAINS
                       rtp=rtp, &
                       matrix_s=matrix_s, &
                       matrix_ks=matrix_ks, &
-                      dft_control=dft_control)
+                      dft_control=dft_control, &
+                      input=input)
+      com_nl = section_get_lval(section_vals=input, keyword_name="DFT%REAL_TIME_PROPAGATION%COM_NL")
       CALL get_rtp(rtp=rtp, S_inv=S_inv)
       CALL cp_fm_create(S_chol, matrix_struct=rtp%ao_ao_fmstruct, name="S_chol")
       CALL cp_fm_create(S_inv_fm, matrix_struct=rtp%ao_ao_fmstruct, name="S_inv_fm")
@@ -124,6 +137,27 @@ CONTAINS
       NULLIFY (mat_ks, eigenvectors, mat_tmp)
       CALL cp_fm_create(mat_ks, matrix_struct=S_inv_fm%matrix_struct, name="mat_ks")
       CALL cp_fm_create(eigenvectors, matrix_struct=S_inv_fm%matrix_struct, name="eigenvectors")
+
+      ! calculate non-local commutator
+      IF (com_nl) THEN
+         NULLIFY (qs_kind_set, sab_all, sap_ppnl)
+         CALL get_qs_env(qs_env, &
+                         sap_ppnl=sap_ppnl, &
+                         sab_all=sab_all, &
+                         qs_kind_set=qs_kind_set)
+         eps_ppnl = dft_control%qs_control%eps_ppnl
+
+         NULLIFY (matrix_rv)
+         CALL dbcsr_allocate_matrix_set(matrix_rv, 3)
+         DO idir = 1, 3
+            CALL dbcsr_init_p(matrix_rv(idir)%matrix)
+            CALL dbcsr_create(matrix_rv(idir)%matrix, template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(idir)%matrix, sab_all)
+            CALL dbcsr_set(matrix_rv(idir)%matrix, 0._dp)
+         ENDDO
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
+      ENDIF
 
       DO ispin = 1, SIZE(matrix_ks)
          ALLOCATE (eigenvalues(nrow_global))
@@ -166,6 +200,12 @@ CONTAINS
                CALL cp_dbcsr_sm_fm_multiply(matrix_s(idir + 1)%matrix, mos_old(2*ispin - 1)%matrix, &
                                             mos_old(2*ispin)%matrix, ncol=nmo)
                CALL cp_fm_scale_and_add(1.0_dp, mos_new(2*ispin - 1)%matrix, factor, mos_old(2*ispin)%matrix)
+               IF (com_nl) THEN
+                  CALL cp_fm_set_all(mos_old(2*ispin)%matrix, 0.0_dp)
+                  CALL cp_dbcsr_sm_fm_multiply(matrix_rv(idir)%matrix, mos_old(2*ispin - 1)%matrix, &
+                                               mos_old(2*ispin)%matrix, ncol=nmo)
+                  CALL cp_fm_scale_and_add(1.0_dp, mos_new(2*ispin - 1)%matrix, factor, mos_old(2*ispin)%matrix)
+               ENDIF
             ENDIF
          ENDDO
 
@@ -251,6 +291,8 @@ CONTAINS
       CALL cp_fm_release(S_chol)
       CALL cp_fm_release(mat_ks)
       CALL cp_fm_release(eigenvectors)
+
+      IF (com_nl) CALL dbcsr_deallocate_matrix_set(matrix_rv)
 
 !***************************************************************
 !remove later

--- a/src/emd/rt_propagation_utils.F
+++ b/src/emd/rt_propagation_utils.F
@@ -396,7 +396,7 @@ CONTAINS
       END DO
       CALL qs_rho_update_rho(rho, qs_env)
 
-      IF (rtp%do_hfx .OR. rtp%magnetic) THEN
+      IF (rtp%do_hfx .OR. rtp%track_imag_density) THEN
          CALL qs_rho_get(rho_struct=rho, rho_ao_im=rho_ao_im)
          CALL calculate_P_imaginary(qs_env, rtp, rho_ao_im, keep_sparsity=.TRUE.)
          CALL qs_rho_set(rho, rho_ao_im=rho_ao_im)
@@ -440,11 +440,13 @@ CONTAINS
       rtp_control => dft_control%rtp_control
       CALL get_rtp(rtp=rtp, rho_new=rho_new)
       CALL qs_rho_get(rho_struct=rho, rho_ao=rho_ao)
-      IF (rtp%do_hfx .OR. rtp%magnetic) CALL qs_rho_get(rho_struct=rho, rho_ao_im=rho_ao_im)
+      IF (rtp%do_hfx .OR. rtp%track_imag_density) CALL qs_rho_get(rho_struct=rho, rho_ao_im=rho_ao_im)
       DO ispin = 1, SIZE(rho_ao)
          CALL dbcsr_set(rho_ao(ispin)%matrix, zero)
          CALL dbcsr_copy_into_existing(rho_ao(ispin)%matrix, rho_new(ispin*2 - 1)%matrix)
-         IF (rtp%do_hfx .OR. rtp%magnetic) CALL dbcsr_copy_into_existing(rho_ao_im(ispin)%matrix, rho_new(ispin*2)%matrix)
+         IF (rtp%do_hfx .OR. rtp%track_imag_density) THEN
+            CALL dbcsr_copy_into_existing(rho_ao_im(ispin)%matrix, rho_new(ispin*2)%matrix)
+         ENDIF
       END DO
 
       CALL qs_rho_update_rho(rho, qs_env)

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -8709,6 +8709,13 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="COM_NL", &
+                          description="Include non local commutator for periodic delta pulse.", &
+                          usage="COM_NL", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
       CALL keyword_create(keyword, __LOCATION__, name="PERIODIC", &
                           description="Apply a delta-kick that is compatible with periodic boundary conditions"// &
                           " for any value of DELTA_PULSE_SCALE. Uses perturbation theory for the preparation of"// &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -1660,6 +1660,17 @@ CONTAINS
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, &
+                          name="VEL_REPRS", &
+                          description="Calculate expectation values the el. multipole moments in their velocity"// &
+                          "representation during RTP. Implemented up to el. quadrupole moment", &
+                          usage="VEL_REPS yes", &
+                          repeats=.FALSE., &
+                          n_var=1, &
+                          default_l_val=.FALSE., &
+                          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
       CALL section_add_subsection(section, print_key)
       CALL section_release(print_key)
 

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -1663,8 +1663,19 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, &
                           name="VEL_REPRS", &
                           description="Calculate expectation values the el. multipole moments in their velocity"// &
-                          "representation during RTP. Implemented up to el. quadrupole moment", &
+                          "representation during RTP. Implemented up to el. quadrupole moment.", &
                           usage="VEL_REPS yes", &
+                          repeats=.FALSE., &
+                          n_var=1, &
+                          default_l_val=.FALSE., &
+                          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, &
+                          name="COM_NL", &
+                          description="Include non local commutator for velocity representations."// &
+                          "Necessary for origin independent results.", &
+                          usage="COM_NL yes", &
                           repeats=.FALSE., &
                           n_var=1, &
                           default_l_val=.FALSE., &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -1663,7 +1663,7 @@ CONTAINS
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, &
                           name="VEL_REPRS", &
-                          description="Calculate expectation values the el. multipole moments in their velocity"// &
+                          description="Calculate expectation values of the el. multipole moments in their velocity"// &
                           "representation during RTP. Implemented up to el. quadrupole moment.", &
                           usage="VEL_REPS yes", &
                           repeats=.FALSE., &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -87,15 +87,16 @@ MODULE input_cp2k_dft
         sic_list_all, sic_list_unpaired, sic_mauri_spz, sic_mauri_us, sic_none, slater, &
         smear_energy_window, smear_fermi_dirac, smear_list, sparse_guess, tddfpt_davidson, &
         tddfpt_excitations, tddfpt_lanczos, tddfpt_singlet, tddfpt_spin_cons, tddfpt_spin_flip, &
-        tddfpt_triplet, use_coulomb, use_diff, use_no, use_restart_wfn, use_rt_restart, &
-        use_scf_wfn, wannier_projection, weight_type_mass, weight_type_unit, wfi_aspc_nr, &
-        wfi_frozen_method_nr, wfi_linear_p_method_nr, wfi_linear_ps_method_nr, &
-        wfi_linear_wf_method_nr, wfi_ps_method_nr, wfi_use_guess_method_nr, &
-        wfi_use_prev_p_method_nr, wfi_use_prev_rho_r_method_nr, wfi_use_prev_wf_method_nr, &
-        xas_1s_type, xas_2p_type, xas_2s_type, xas_3d_type, xas_3p_type, xas_3s_type, xas_4d_type, &
-        xas_4f_type, xas_4p_type, xas_4s_type, xas_dip_len, xas_dip_vel, xas_dscf, xas_none, &
-        xas_not_excited, xas_tdp_by_index, xas_tdp_by_kind, xas_tp_fh, xas_tp_flex, xas_tp_hh, &
-        xas_tp_xfh, xas_tp_xhh, xes_tp_val
+        tddfpt_triplet, use_coulomb, use_diff, use_mom_ref_coac, use_mom_ref_com, &
+        use_mom_ref_user, use_mom_ref_zero, use_no, use_restart_wfn, use_rt_restart, use_scf_wfn, &
+        wannier_projection, weight_type_mass, weight_type_unit, wfi_aspc_nr, wfi_frozen_method_nr, &
+        wfi_linear_p_method_nr, wfi_linear_ps_method_nr, wfi_linear_wf_method_nr, &
+        wfi_ps_method_nr, wfi_use_guess_method_nr, wfi_use_prev_p_method_nr, &
+        wfi_use_prev_rho_r_method_nr, wfi_use_prev_wf_method_nr, xas_1s_type, xas_2p_type, &
+        xas_2s_type, xas_3d_type, xas_3p_type, xas_3s_type, xas_4d_type, xas_4f_type, xas_4p_type, &
+        xas_4s_type, xas_dip_len, xas_dip_vel, xas_dscf, xas_none, xas_not_excited, &
+        xas_tdp_by_index, xas_tdp_by_kind, xas_tp_fh, xas_tp_flex, xas_tp_hh, xas_tp_xfh, &
+        xas_tp_xhh, xes_tp_val
    USE input_cp2k_almo,                 ONLY: create_almo_scf_section
    USE input_cp2k_distribution,         ONLY: create_distribution_section
    USE input_cp2k_ec,                   ONLY: create_ec_section
@@ -1680,6 +1681,42 @@ CONTAINS
                           n_var=1, &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, &
+                          name="SECOND_REFERENCE_POINT", &
+                          description="Use second reference point", &
+                          usage="SECOND_REFERENCE_POINT .TRUE.", &
+                          repeats=.FALSE., &
+                          n_var=1, &
+                          default_l_val=.FALSE., &
+                          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="REFERENCE_2", &
+                          variants=s2a("REF_2"), &
+                          description="Define a second reference point for the calculation of the electrostatic moment.", &
+                          usage="REFERENCE_2 COM", &
+                          enum_c_vals=s2a("COM", "COAC", "USER_DEFINED", "ZERO"), &
+                          enum_desc=s2a("Use Center of Mass", &
+                                        "Use Center of Atomic Charges", &
+                                        "Use User Defined Point (Keyword:REF_POINT)", &
+                                        "Use Origin of Coordinate System"), &
+                          enum_i_vals=(/use_mom_ref_com, &
+                                        use_mom_ref_coac, &
+                                        use_mom_ref_user, &
+                                        use_mom_ref_zero/), &
+                          default_i_val=use_mom_ref_zero)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="REFERENCE_POINT_2", &
+                          variants=s2a("REF_POINT_2"), &
+                          description="Fixed second reference point for the calculations of the electrostatic moment.", &
+                          usage="REFERENCE_POINT_2 x y z", &
+                          repeats=.FALSE., &
+                          n_var=3, default_r_vals=(/0._dp, 0._dp, 0._dp/), &
+                          type_of_var=real_t, &
+                          unit_str='bohr')
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(section, print_key)

--- a/src/motion/rt_propagation.F
+++ b/src/motion/rt_propagation.F
@@ -99,6 +99,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'rt_prop_setup', routineP = moduleN//':'//routineN
 
       INTEGER                                            :: aspc_order
+      LOGICAL                                            :: magnetic, vel_reprs
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(global_environment_type), POINTER             :: globenv
       TYPE(qs_energy_type), POINTER                      :: energy
@@ -145,11 +146,12 @@ CONTAINS
       CALL section_vals_val_get(ls_scf_section, "MAX_ITER_LANCZOS", i_val=rtp%lanzcos_max_iter)
       CALL section_vals_val_get(ls_scf_section, "SIGN_SQRT_ORDER", i_val=rtp%newton_schulz_order)
       CALL section_vals_get(hfx_sections, explicit=rtp%do_hfx)
-      CALL section_vals_val_get(print_moments_section, "MAGNETIC", l_val=rtp%magnetic)
-
+      CALL section_vals_val_get(print_moments_section, "MAGNETIC", l_val=magnetic)
+      CALL section_vals_val_get(print_moments_section, "VEL_REPRS", l_val=vel_reprs)
+      rtp%track_imag_density = magnetic .OR. vel_reprs
       ! Hmm, not really like to initialize with the structure of S but I reckon it is
       ! done everywhere like this
-      IF (rtp%do_hfx .OR. rtp%magnetic) &
+      IF (rtp%do_hfx .OR. rtp%track_imag_density) &
          CALL rtp_hfx_rebuild(qs_env)
 
       CALL init_propagation_run(qs_env)

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -132,7 +132,7 @@ CONTAINS
                                                             nsgfa, nsgfb
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
       LOGICAL                                            :: found
-      REAL(KIND=dp)                                      :: dab, rab2
+      REAL(KIND=dp)                                      :: dab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: work
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: mab
       REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rac, rb, rbc, rc
@@ -265,8 +265,7 @@ CONTAINS
          rab(:) = ra(:) - rb(:)
          rac(:) = ra(:) - rc(:)
          rbc(:) = rb(:) - rc(:)
-         rab2 = rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3)
-         dab = SQRT(rab2)
+         dab = NORM2(rab)
 
          DO iset = 1, nseta
 
@@ -361,7 +360,7 @@ CONTAINS
                                                             npgfb, nsgfa, nsgfb
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
       LOGICAL                                            :: found
-      REAL(KIND=dp)                                      :: dab, rab2
+      REAL(KIND=dp)                                      :: dab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: work
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: difmab
       REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rac, rb, rbc, rc
@@ -486,8 +485,7 @@ CONTAINS
          rab(:) = ra(:) - rb(:)
          rac(:) = ra(:) - rc(:)
          rbc(:) = rb(:) - rc(:)
-         rab2 = rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3)
-         dab = SQRT(rab2)
+         dab = NORM2(rab)
 
          ! get blocks
          IF (inode == 1) last_jatom = 0
@@ -649,7 +647,7 @@ CONTAINS
                                                             nsgfa, nsgfb
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
       LOGICAL                                            :: found
-      REAL(KIND=dp)                                      :: dab, rab2
+      REAL(KIND=dp)                                      :: dab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: work
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: mab
       REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rac, rb, rbc, rc
@@ -788,8 +786,7 @@ CONTAINS
          rab(:) = ra(:) - rb(:)
          rac(:) = ra(:) - rc(:)
          rbc(:) = rb(:) - rc(:)
-         rab2 = rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3)
-         dab = SQRT(rab2)
+         dab = NORM2(rab)
 
          DO iset = 1, nseta
 
@@ -2092,7 +2089,7 @@ CONTAINS
 
       IF (my_com_nl) THEN
          IF (magnetic) THEN
-            mmom = mmom + nlcom_rxrv
+            mmom(:) = mmom(:) + nlcom_rxrv(:)
          ENDIF
          IF (my_velreprs .AND. (nmom >= 1)) THEN
             rmom_vel(1:3) = rmom_vel(1:3) + nlcom_rv
@@ -2443,53 +2440,14 @@ CONTAINS
       CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
 
       IF (calc_rv) THEN
-         ! trace = 0._dp
-         ! DO ind = 1, SIZE(matrix_rv)
-         !    strace = 0._dp
-         !    DO ispin = 1, dft_control%nspins
-         !       CALL dbcsr_set(tmp_ao, 0.0_dp)
-         !       CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rv(ind)%matrix, &
-         !                           0.0_dp, tmp_ao)
-         !       CALL dbcsr_trace(tmp_ao, trace)
-         !       strace = strace + trace
-         !    END DO
-         !    nlcom_rv(ind) = nlcom_rv(ind) + strace
-         ! ENDDO
-         ! WRITE (*, *) nlcom_rv
          nlcom_rv(:) = 0._dp
       ENDIF
 
       IF (calc_rrv) THEN
-         ! trace = 0._dp
-         ! DO ind = 1, SIZE(matrix_rrv)
-         !    strace = 0._dp
-         !    DO ispin = 1, dft_control%nspins
-         !       CALL dbcsr_set(tmp_ao, 0.0_dp)
-         !       CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rrv(ind)%matrix, &
-         !                           0.0_dp, tmp_ao)
-         !       CALL dbcsr_trace(tmp_ao, trace)
-         !       strace = strace + trace
-         !    END DO
-         !    nlcom_rrv(ind) = nlcom_rrv(ind) + strace
-         ! ENDDO
-         ! ! WRITE (*, *) nlcom_rrv
          nlcom_rrv(:) = 0._dp
       ENDIF
 
       IF (calc_rxrv) THEN
-         ! trace = 0._dp
-         ! DO ind = 1, SIZE(matrix_rxrv)
-         !    strace = 0._dp
-         !    DO ispin = 1, dft_control%nspins
-         !       CALL dbcsr_set(tmp_ao, 0.0_dp)
-         !       CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rxrv(ind)%matrix, &
-         !                           0.0_dp, tmp_ao)
-         !       CALL dbcsr_trace(tmp_ao, trace)
-         !       strace = strace + trace
-         !    END DO
-         !    nlcom_rxrv(ind) = nlcom_rxrv(ind) + strace
-         ! ENDDO
-         ! ! WRITE (*, *) nlcom_rxrv
          nlcom_rxrv(:) = 0._dp
       ENDIF
 

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -330,6 +330,196 @@ CONTAINS
    END SUBROUTINE build_local_moment_matrix
 
 ! **************************************************************************************************
+!> \brief Calculate derivatives of multipole moments assuming the moments are already calculated
+!>        Note that the multipole moments are symmetric while their derivatives are anti-symmetric
+!> \param qs_env ...
+!> \param moments contains the multipole moments, already calculated
+!> \param moments_der will contain the derivatives of the multipole moments
+!> \param nmoments order of the multipole moments
+!> \param ref_point ...
+! **************************************************************************************************
+   SUBROUTINE build_local_moments_der_matrix(qs_env, moments, moments_der, nmoments, ref_point)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: moments
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: moments_der
+      INTEGER, INTENT(IN)                                :: nmoments
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: ref_point
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_local_moments_der_matrix', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i, iatom, icol, idir, ikind, &
+                                                            inode, irow, jatom, jkind, last_jatom, &
+                                                            M_dim, maxco, maxsgf, nkind, nm, &
+                                                            nseta, nsetb
+      INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, npgfa, &
+                                                            npgfb, nsgfa, nsgfb
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
+      LOGICAL                                            :: found
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: work
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: difmab
+      REAL(KIND=dp), DIMENSION(3)                        :: rab, rc
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a, set_radius_b
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgfa, rpgfb, sphi_a, sphi_b, zeta, zetb
+      TYPE(block_p_type), ALLOCATABLE, DIMENSION(:)      :: mom_block
+      TYPE(block_p_type), ALLOCATABLE, DIMENSION(:, :)   :: mom_block_der
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_list
+      TYPE(gto_basis_set_type), POINTER                  :: basis_set_a, basis_set_b
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(qs_kind_type), POINTER                        :: qs_kind
+
+      CALL timeset(routineN, handle)
+
+      IF (nmoments < 1) RETURN
+
+      nm = (6 + 11*nmoments + 6*nmoments**2 + nmoments**3)/6 - 1
+      CPASSERT(SIZE(moments) >= nm)
+
+      NULLIFY (qs_kind_set, particle_set, sab_orb, cell)
+      CALL get_qs_env(qs_env=qs_env, &
+                      qs_kind_set=qs_kind_set, &
+                      particle_set=particle_set, &
+                      cell=cell, &
+                      sab_orb=sab_orb)
+
+      nkind = SIZE(qs_kind_set)
+
+      ! Work storage
+      CALL get_qs_kind_set(qs_kind_set=qs_kind_set, &
+                           maxco=maxco, maxsgf=maxsgf)
+
+      M_dim = ncoset(nmoments) - 1
+      CPASSERT(M_dim <= SIZE(moments, 1))
+      ALLOCATE (difmab(maxco, maxco, M_dim, 3))
+      difmab(:, :, :, :) = 0.0_dp
+
+      ALLOCATE (work(maxco, maxsgf))
+      work(:, :) = 0.0_dp
+
+      ALLOCATE (mom_block(nm))
+      ALLOCATE (mom_block_der(M_dim, 3))
+      DO i = 1, nm
+         NULLIFY (mom_block(i)%block)
+         DO idir = 1, 3
+            NULLIFY (mom_block_der(i, idir)%block)
+         ENDDO
+      END DO
+
+      NULLIFY (basis_set_a, basis_set_b, basis_set_list)
+      NULLIFY (qs_kind)
+      ALLOCATE (basis_set_list(nkind))
+      DO ikind = 1, nkind
+         qs_kind => qs_kind_set(ikind)
+         CALL get_qs_kind(qs_kind=qs_kind, basis_set=basis_set_a)
+         IF (ASSOCIATED(basis_set_a)) THEN
+            basis_set_list(ikind)%gto_basis_set => basis_set_a
+         ELSE
+            NULLIFY (basis_set_list(ikind)%gto_basis_set)
+         END IF
+      END DO
+
+      ! Calculate derivatives looping over neighbour list
+      NULLIFY (first_sgfa, la_max, la_min, npgfa, nsgfa, set_radius_a, sphi_a, zeta)
+      NULLIFY (first_sgfb, lb_max, lb_min, npgfb, nsgfb, set_radius_b, sphi_b, zetb)
+      NULLIFY (nl_iterator)
+      CALL neighbor_list_iterator_create(nl_iterator, sab_orb)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+         CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, inode=inode, &
+                                iatom=iatom, jatom=jatom, r=rab)
+         basis_set_a => basis_set_list(ikind)%gto_basis_set
+         IF (.NOT. ASSOCIATED(basis_set_a)) CYCLE
+         basis_set_b => basis_set_list(jkind)%gto_basis_set
+         IF (.NOT. ASSOCIATED(basis_set_b)) CYCLE
+         ! basis ikind
+         first_sgfa => basis_set_a%first_sgf
+         la_max => basis_set_a%lmax
+         la_min => basis_set_a%lmin
+         npgfa => basis_set_a%npgf
+         nseta = basis_set_a%nset
+         nsgfa => basis_set_a%nsgf_set
+         rpgfa => basis_set_a%pgf_radius
+         set_radius_a => basis_set_a%set_radius
+         sphi_a => basis_set_a%sphi
+         zeta => basis_set_a%zet
+         ! basis jkind
+         first_sgfb => basis_set_b%first_sgf
+         lb_max => basis_set_b%lmax
+         lb_min => basis_set_b%lmin
+         npgfb => basis_set_b%npgf
+         nsetb = basis_set_b%nset
+         nsgfb => basis_set_b%nsgf_set
+         rpgfb => basis_set_b%pgf_radius
+         set_radius_b => basis_set_b%set_radius
+         sphi_b => basis_set_b%sphi
+         zetb => basis_set_b%zet
+
+         ! reference point
+         IF (PRESENT(ref_point)) THEN
+            rc(:) = ref_point(:)
+         ELSE
+            rc(:) = 0._dp
+         ENDIF
+
+         ! get blocks
+         IF (inode == 1) last_jatom = 0
+
+         IF (jatom == last_jatom) THEN
+            CYCLE
+         END IF
+
+         last_jatom = jatom
+
+         IF (iatom <= jatom) THEN
+            irow = iatom
+            icol = jatom
+         ELSE
+            irow = jatom
+            icol = iatom
+         END IF
+
+         DO i = 1, 3
+            NULLIFY (mom_block(i)%block)
+            ! get block from pre calculated overlap matrix
+            CALL dbcsr_get_block_p(matrix=moments(i)%matrix, &
+                                   row=irow, col=icol, BLOCK=mom_block(i)%block, found=found)
+            CPASSERT(found .AND. ASSOCIATED(mom_block(i)%block))
+            DO idir = 1, 3
+               NULLIFY (mom_block_der(i, idir)%block)
+               CALL dbcsr_get_block_p(matrix=moments_der(i, idir)%matrix, &
+                                      row=irow, col=icol, &
+                                      block=mom_block_der(i, idir)%block, &
+                                      found=found)
+               CPASSERT(found .AND. ASSOCIATED(mom_block_der(i, idir)%block))
+               mom_block_der(i, idir)%block = 0._dp
+            ENDDO
+         END DO
+
+      ENDDO
+
+      ! deallocations
+      DEALLOCATE (basis_set_list)
+      DEALLOCATE (difmab)
+      DEALLOCATE (work)
+      DO i = 1, nm
+         NULLIFY (mom_block(i)%block)
+         DO idir = 1, 3
+            NULLIFY (mom_block_der(i, idir)%block)
+         ENDDO
+      END DO
+      DEALLOCATE (mom_block)
+      DEALLOCATE (mom_block_der)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE build_local_moments_der_matrix
+
+! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
 !> \param magmom ...
@@ -1479,8 +1669,9 @@ CONTAINS
 
       CHARACTER(LEN=8), ALLOCATABLE, DIMENSION(:)        :: rlab
       CHARACTER(LEN=default_string_length)               :: description
-      INTEGER                                            :: akind, handle, i, ia, iatom, ikind, &
-                                                            ispin, ix, iy, iz, l, nm, nmm, nmom
+      INTEGER                                            :: akind, handle, i, ia, iatom, idir, &
+                                                            ikind, ispin, ix, iy, iz, l, nm, nmm, &
+                                                            nmom, order
       LOGICAL                                            :: my_velreprs
       REAL(dp)                                           :: charge, dd, strace, trace
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, rmom_vel
@@ -1490,11 +1681,14 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(cp_result_type), POINTER                      :: results
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: magmom, matrix_s, moments, moments_vel, &
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: magmom, matrix_s, moments, momentum, &
                                                             rho_ao
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: moments_vel
       TYPE(dbcsr_type), POINTER                          :: rho_magmom_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_1d_type), POINTER                :: local_particles
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -1557,8 +1751,6 @@ CONTAINS
          END DO
          rmom(i + 1, 1) = strace
       END DO
-
-      CALL dbcsr_deallocate_matrix_set(moments)
 
       ! nuclear contribution
       CALL get_qs_env(qs_env=qs_env, &
@@ -1627,19 +1819,50 @@ CONTAINS
          CALL dbcsr_deallocate_matrix(rho_magmom_ao)
       END IF
 
+      ! velocity representations
       IF (my_velreprs) THEN
          ALLOCATE (rmom_vel(nm))
          rmom_vel = 0.0_dp
-         NULLIFY (moments_vel)
-         CALL dbcsr_allocate_matrix_set(moments_vel, nm)
-         DO i = 1, nm
-            CALL dbcsr_init_p(moments_vel(i)%matrix)
-            CALL dbcsr_create(moments_vel(i)%matrix, template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_antisymmetric)
-            CALL dbcsr_set(moments_vel(i)%matrix, 0.0_dp)
-         END DO
-         CALL dbcsr_deallocate_matrix_set(moments_vel)
+         NULLIFY (sab_orb)
+         CALL get_qs_env(qs_env, sab_orb=sab_orb)
+
+         DO order = 1, nmom
+            SELECT CASE (order)
+            CASE (1)
+               NULLIFY (momentum)
+               CALL dbcsr_allocate_matrix_set(momentum, 3)
+               DO i = 1, 3
+                  CALL dbcsr_init_p(momentum(i)%matrix)
+                  CALL dbcsr_create(momentum(i)%matrix, template=matrix_s(1)%matrix, &
+                                    matrix_type=dbcsr_type_antisymmetric)
+                  CALL cp_dbcsr_alloc_block_from_nbl(momentum(i)%matrix, sab_orb)
+                  CALL dbcsr_set(momentum(i)%matrix, 0.0_dp)
+               ENDDO
+
+               CALL dbcsr_deallocate_matrix_set(momentum)
+            CASE (2)
+               NULLIFY (moments_vel)
+               CALL dbcsr_allocate_matrix_set(moments_vel, 3, 3)
+               DO i = 1, 3 ! x, y, z
+                  DO idir = 1, 3 ! d/dx, d/dy, d/dz
+                     CALL dbcsr_init_p(moments_vel(i, idir)%matrix)
+                     CALL dbcsr_create(moments_vel(i, idir)%matrix, template=matrix_s(1)%matrix, &
+                                       matrix_type=dbcsr_type_antisymmetric)
+                     CALL cp_dbcsr_alloc_block_from_nbl(moments_vel(i, idir)%matrix, sab_orb)
+                     CALL dbcsr_set(moments_vel(i, idir)%matrix, 0.0_dp)
+                  ENDDO
+               END DO
+
+               ! CALL build_local_moments_der_matrix(qs_env, moments, moments_vel, nmom, rcc)
+
+               CALL dbcsr_deallocate_matrix_set(moments_vel)
+            CASE DEFAULT
+            END SELECT
+         ENDDO
+
       ENDIF
+
+      CALL dbcsr_deallocate_matrix_set(moments)
 
       description = "[DIPOLE]"
       CALL cp_results_erase(results=results, description=description)

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -13,6 +13,7 @@ MODULE qs_moments
    USE ai_angmom,                       ONLY: angmom
    USE ai_moments,                      ONLY: contract_cossin,&
                                               cossin,&
+                                              diff_momop,&
                                               moment
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind
@@ -50,7 +51,7 @@ MODULE qs_moments
         dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_desymmetrize, &
         dbcsr_distribution_type, dbcsr_dot, dbcsr_get_block_p, dbcsr_init_p, dbcsr_multiply, &
         dbcsr_p_type, dbcsr_set, dbcsr_trace, dbcsr_type, dbcsr_type_antisymmetric, &
-        dbcsr_type_symmetric
+        dbcsr_type_no_symmetry, dbcsr_type_symmetric
    USE distribution_1d_types,           ONLY: distribution_1d_type
    USE kinds,                           ONLY: default_string_length,&
                                               dp
@@ -348,19 +349,19 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_local_moments_der_matrix', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i, iatom, icol, idir, ikind, &
-                                                            inode, irow, jatom, jkind, last_jatom, &
-                                                            M_dim, maxco, maxsgf, nkind, nm, &
-                                                            nseta, nsetb
+      INTEGER :: handle, i, iatom, icol, idir, ikind, inode, irow, iset, jatom, jkind, jset, &
+         last_jatom, M_dim, maxco, maxsgf, ncoa, ncob, nkind, nm, nseta, nsetb, sgfa, sgfb
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, npgfa, &
                                                             npgfb, nsgfa, nsgfb
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
       LOGICAL                                            :: found
+      REAL(KIND=dp)                                      :: dab, rab2
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: work
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: difmab
-      REAL(KIND=dp), DIMENSION(3)                        :: rab, rc
+      REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rac, rb, rbc, rc
       REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a, set_radius_b
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgfa, rpgfb, sphi_a, sphi_b, zeta, zetb
+      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: mab
       TYPE(block_p_type), ALLOCATABLE, DIMENSION(:)      :: mom_block
       TYPE(block_p_type), ALLOCATABLE, DIMENSION(:, :)   :: mom_block_der
       TYPE(cell_type), POINTER                           :: cell
@@ -369,7 +370,7 @@ CONTAINS
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: nl_iterator
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_orb
+         POINTER                                         :: sab_all
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_kind_type), POINTER                        :: qs_kind
@@ -381,18 +382,22 @@ CONTAINS
       nm = (6 + 11*nmoments + 6*nmoments**2 + nmoments**3)/6 - 1
       CPASSERT(SIZE(moments) >= nm)
 
-      NULLIFY (qs_kind_set, particle_set, sab_orb, cell)
+      NULLIFY (qs_kind_set, particle_set, sab_all, cell)
       CALL get_qs_env(qs_env=qs_env, &
                       qs_kind_set=qs_kind_set, &
                       particle_set=particle_set, &
                       cell=cell, &
-                      sab_orb=sab_orb)
+                      sab_all=sab_all)
 
       nkind = SIZE(qs_kind_set)
 
       ! Work storage
       CALL get_qs_kind_set(qs_kind_set=qs_kind_set, &
                            maxco=maxco, maxsgf=maxsgf)
+
+      NULLIFY (mab)
+      ALLOCATE (mab(maxco, maxco, nm))
+      mab(:, :, :) = 0.0_dp
 
       M_dim = ncoset(nmoments) - 1
       CPASSERT(M_dim <= SIZE(moments, 1))
@@ -428,7 +433,7 @@ CONTAINS
       NULLIFY (first_sgfa, la_max, la_min, npgfa, nsgfa, set_radius_a, sphi_a, zeta)
       NULLIFY (first_sgfb, lb_max, lb_min, npgfb, nsgfb, set_radius_b, sphi_b, zetb)
       NULLIFY (nl_iterator)
-      CALL neighbor_list_iterator_create(nl_iterator, sab_orb)
+      CALL neighbor_list_iterator_create(nl_iterator, sab_all)
       DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
          CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, inode=inode, &
                                 iatom=iatom, jatom=jatom, r=rab)
@@ -465,6 +470,16 @@ CONTAINS
          ELSE
             rc(:) = 0._dp
          ENDIF
+         ! using PBC here might screw a molecule that fits the box (but e.g. hasn't been shifted by center_molecule)
+         ! by folding around the center, such screwing can be avoided for a proper choice of center.
+         ra(:) = pbc(particle_set(iatom)%r(:) - rc, cell) + rc
+         rb(:) = pbc(particle_set(jatom)%r(:) - rc, cell) + rc
+         ! we dont use PBC at this point
+         rab(:) = ra(:) - rb(:)
+         rac(:) = ra(:) - rc(:)
+         rbc(:) = rb(:) - rc(:)
+         rab2 = rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3)
+         dab = SQRT(rab2)
 
          ! get blocks
          IF (inode == 1) last_jatom = 0
@@ -475,13 +490,8 @@ CONTAINS
 
          last_jatom = jatom
 
-         IF (iatom <= jatom) THEN
-            irow = iatom
-            icol = jatom
-         ELSE
-            irow = jatom
-            icol = iatom
-         END IF
+         irow = iatom
+         icol = jatom
 
          DO i = 1, 3
             NULLIFY (mom_block(i)%block)
@@ -489,6 +499,7 @@ CONTAINS
             CALL dbcsr_get_block_p(matrix=moments(i)%matrix, &
                                    row=irow, col=icol, BLOCK=mom_block(i)%block, found=found)
             CPASSERT(found .AND. ASSOCIATED(mom_block(i)%block))
+            mom_block(i)%block = 0._dp
             DO idir = 1, 3
                NULLIFY (mom_block_der(i, idir)%block)
                CALL dbcsr_get_block_p(matrix=moments_der(i, idir)%matrix, &
@@ -500,10 +511,69 @@ CONTAINS
             ENDDO
          END DO
 
+         DO iset = 1, nseta
+
+            ncoa = npgfa(iset)*ncoset(la_max(iset))
+            sgfa = first_sgfa(1, iset)
+
+            DO jset = 1, nsetb
+
+               IF (set_radius_a(iset) + set_radius_b(jset) < dab) CYCLE
+
+               ncob = npgfb(jset)*ncoset(lb_max(jset))
+               sgfb = first_sgfb(1, jset)
+
+               ! Calculate the primitive integrals
+               CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), &
+                           rpgfa(:, iset), la_min(iset), &
+                           lb_max(jset), npgfb(jset), zetb(:, jset), &
+                           rpgfb(:, jset), nmoments, rac, rbc, mab)
+
+               CALL diff_momop(la_max(iset), npgfa(iset), zeta(:, iset), &
+                               rpgfa(:, iset), la_min(iset), &
+                               lb_max(jset), npgfb(jset), zetb(:, jset), &
+                               rpgfb(:, jset), lb_min(jset), &
+                               nmoments, rac, rbc, difmab, mab_ext=mab)
+
+               ! Contraction step
+               DO i = 1, 3
+
+                  CALL dgemm("N", "N", ncoa, nsgfb(jset), ncob, &
+                             1.0_dp, mab(1, 1, i), SIZE(mab, 1), &
+                             sphi_b(1, sgfb), SIZE(sphi_b, 1), &
+                             0.0_dp, work(1, 1), SIZE(work, 1))
+
+                  CALL dgemm("T", "N", nsgfa(iset), nsgfb(jset), ncoa, &
+                             1.0_dp, sphi_a(1, sgfa), SIZE(sphi_a, 1), &
+                             work(1, 1), SIZE(work, 1), &
+                             1.0_dp, mom_block(i)%block(sgfa, sgfb), &
+                             SIZE(mom_block(i)%block, 1))
+
+                  DO idir = 1, 3
+                     CALL dgemm("N", "N", ncoa, nsgfb(jset), ncob, &
+                                1.0_dp, difmab(1, 1, i, idir), SIZE(difmab, 1), &
+                                sphi_b(1, sgfb), SIZE(sphi_b, 1), &
+                                0._dp, work(1, 1), SIZE(work, 1))
+
+                     CALL dgemm("T", "N", nsgfa(iset), nsgfb(jset), ncoa, &
+                                1.0_dp, sphi_a(1, sgfa), SIZE(sphi_a, 1), &
+                                work(1, 1), SIZE(work, 1), &
+                                1._dp, mom_block_der(i, idir)%block(sgfa, sgfb), &
+                                SIZE(mom_block_der(i, idir)%block, 1))
+
+                  ENDDO
+
+               END DO
+
+            END DO
+         END DO
+
       ENDDO
+      CALL neighbor_list_iterator_release(nl_iterator)
 
       ! deallocations
       DEALLOCATE (basis_set_list)
+      DEALLOCATE (mab)
       DEALLOCATE (difmab)
       DEALLOCATE (work)
       DO i = 1, nm
@@ -1752,6 +1822,8 @@ CONTAINS
          rmom(i + 1, 1) = strace
       END DO
 
+      CALL dbcsr_deallocate_matrix_set(moments)
+
       ! nuclear contribution
       CALL get_qs_env(qs_env=qs_env, &
                       local_particles=local_particles)
@@ -1823,12 +1895,12 @@ CONTAINS
       IF (my_velreprs) THEN
          ALLOCATE (rmom_vel(nm))
          rmom_vel = 0.0_dp
-         NULLIFY (sab_orb)
-         CALL get_qs_env(qs_env, sab_orb=sab_orb)
 
          DO order = 1, nmom
             SELECT CASE (order)
-            CASE (1)
+            CASE (1) ! expectation value of momentum
+               NULLIFY (sab_orb)
+               CALL get_qs_env(qs_env, sab_orb=sab_orb)
                NULLIFY (momentum)
                CALL dbcsr_allocate_matrix_set(momentum, 3)
                DO i = 1, 3
@@ -1840,29 +1912,37 @@ CONTAINS
                ENDDO
 
                CALL dbcsr_deallocate_matrix_set(momentum)
-            CASE (2)
-               NULLIFY (moments_vel)
+            CASE (2) ! expectation value of quadrupole moment in vel. reprs.
+               NULLIFY (sab_orb)
+               CALL get_qs_env(qs_env, sab_all=sab_orb)
+               NULLIFY (moments, moments_vel)
+               CALL dbcsr_allocate_matrix_set(moments, 3)
                CALL dbcsr_allocate_matrix_set(moments_vel, 3, 3)
                DO i = 1, 3 ! x, y, z
+                  CALL dbcsr_init_p(moments(i)%matrix)
+                  CALL dbcsr_create(moments(i)%matrix, template=matrix_s(1)%matrix, &
+                                    matrix_type=dbcsr_type_no_symmetry)
+                  CALL cp_dbcsr_alloc_block_from_nbl(moments(i)%matrix, sab_orb)
+                  CALL dbcsr_set(moments(i)%matrix, 0.0_dp)
+
                   DO idir = 1, 3 ! d/dx, d/dy, d/dz
                      CALL dbcsr_init_p(moments_vel(i, idir)%matrix)
                      CALL dbcsr_create(moments_vel(i, idir)%matrix, template=matrix_s(1)%matrix, &
-                                       matrix_type=dbcsr_type_antisymmetric)
+                                       matrix_type=dbcsr_type_no_symmetry)
                      CALL cp_dbcsr_alloc_block_from_nbl(moments_vel(i, idir)%matrix, sab_orb)
                      CALL dbcsr_set(moments_vel(i, idir)%matrix, 0.0_dp)
                   ENDDO
                END DO
 
-               ! CALL build_local_moments_der_matrix(qs_env, moments, moments_vel, nmom, rcc)
+               CALL build_local_moments_der_matrix(qs_env, moments, moments_vel, 1, rcc)
 
+               CALL dbcsr_deallocate_matrix_set(moments)
                CALL dbcsr_deallocate_matrix_set(moments_vel)
             CASE DEFAULT
             END SELECT
          ENDDO
 
       ENDIF
-
-      CALL dbcsr_deallocate_matrix_set(moments)
 
       description = "[DIPOLE]"
       CALL cp_results_erase(results=results, description=description)

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -1755,15 +1755,16 @@ CONTAINS
 !> \param ref_point ...
 !> \param unit_number ...
 !> \param vel_reprs ...
+!> \param com_nl ...
 ! **************************************************************************************************
-   SUBROUTINE qs_moment_locop(qs_env, magnetic, nmoments, reference, ref_point, unit_number, vel_reprs)
+   SUBROUTINE qs_moment_locop(qs_env, magnetic, nmoments, reference, ref_point, unit_number, vel_reprs, com_nl)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN)                                :: magnetic
       INTEGER, INTENT(IN)                                :: nmoments, reference
       REAL(dp), DIMENSION(:), POINTER                    :: ref_point
       INTEGER, INTENT(IN)                                :: unit_number
-      LOGICAL, INTENT(IN), OPTIONAL                      :: vel_reprs
+      LOGICAL, INTENT(IN), OPTIONAL                      :: vel_reprs, com_nl
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'qs_moment_locop', &
          routineP = moduleN//':'//routineN
@@ -1773,7 +1774,7 @@ CONTAINS
       INTEGER                                            :: akind, handle, i, ia, iatom, idir, &
                                                             ikind, ispin, ix, iy, iz, l, nm, nmm, &
                                                             nmom, order
-      LOGICAL                                            :: my_velreprs
+      LOGICAL                                            :: my_com_nl, my_velreprs
       REAL(dp)                                           :: charge, dd, strace, trace
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, qupole_der, rmom_vel
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: rmom
@@ -1800,6 +1801,7 @@ CONTAINS
 
       my_velreprs = .FALSE.
       IF (PRESENT(vel_reprs)) my_velreprs = vel_reprs
+      IF (PRESENT(com_nl)) my_com_nl = com_nl
 
       ! reference point
       CALL get_reference_point(rcc, qs_env=qs_env, reference=reference, ref_point=ref_point)

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -1760,7 +1760,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN)                                :: magnetic
       INTEGER, INTENT(IN)                                :: nmoments, reference
-      REAL(dp), DIMENSION(:), POINTER                    :: ref_point
+      REAL(dp), DIMENSION(:), INTENT(IN), POINTER        :: ref_point
       INTEGER, INTENT(IN)                                :: unit_number
       LOGICAL, INTENT(IN), OPTIONAL                      :: vel_reprs, com_nl
 
@@ -2237,7 +2237,7 @@ CONTAINS
          IF (PRESENT(mmom)) THEN
             IF (nmom >= 1) THEN
                dd = SQRT(SUM(mmom(1:3)**2))
-               WRITE (unit_number, "(T3,A)") "Magnetic Dipole Moment (only orbital contrib.) [a.u.]"
+               WRITE (unit_number, "(T3,A)") "Orbital angular momentum [a. u.]"
                WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
                   (TRIM(rlab(i + 1)), "=", mmom(i), i=1, 3), "Total=", dd
             END IF
@@ -2284,7 +2284,7 @@ CONTAINS
          IF (PRESENT(mmom)) THEN
             IF (nmom >= 1) THEN
                dd = SQRT(SUM(mmom(1:3)**2))
-               WRITE (unit_number, "(T3,A)") "Orbital angular momentum [a.u.] incl. com_nl"
+               WRITE (unit_number, "(T3,A)") "Orbital angular momentum incl. com_nl [a. u.]"
                WRITE (unit_number, "(T5,3(A,A,D14.8,1X),T60,A,T67,F14.8)") &
                   (TRIM(rlab(i + 1)), "=", mmom(i), i=1, 3), "Total=", dd
             END IF
@@ -2294,11 +2294,11 @@ CONTAINS
                SELECT CASE (l)
                CASE (1)
                   dd = SQRT(SUM(rmom_vel(1:3)**2))
-                  WRITE (unit_number, "(T3,A)") "Expectation value of momentum operator [a. u.] incl. com_nl"
+                  WRITE (unit_number, "(T3,A)") "Expectation value of momentum operator incl. com_nl [a. u.]"
                   WRITE (unit_number, "(T5,3(A,A,D14.8,1X),T60,A,T67,F14.8)") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=1, 3), "Total=", dd
                CASE (2)
-                  WRITE (unit_number, "(T3,A)") "Expectation value of quadrupole operator in vel. repr. [a. u.] incl. com_nl"
+                  WRITE (unit_number, "(T3,A)") "Expectation value of quadrupole operator in vel. repr. incl. com_nl [a. u.]"
                   WRITE (unit_number, "(T17,3(A,A,D14.8,9X))") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=4, 6)
                   WRITE (unit_number, "(T17,3(A,A,D14.8,9X))") &

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -1462,14 +1462,16 @@ CONTAINS
 !> \param reference ...
 !> \param ref_point ...
 !> \param unit_number ...
+!> \param vel_reprs ...
 ! **************************************************************************************************
-   SUBROUTINE qs_moment_locop(qs_env, magnetic, nmoments, reference, ref_point, unit_number)
+   SUBROUTINE qs_moment_locop(qs_env, magnetic, nmoments, reference, ref_point, unit_number, vel_reprs)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN)                                :: magnetic
       INTEGER, INTENT(IN)                                :: nmoments, reference
       REAL(dp), DIMENSION(:), POINTER                    :: ref_point
       INTEGER, INTENT(IN)                                :: unit_number
+      LOGICAL, INTENT(IN), OPTIONAL                      :: vel_reprs
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'qs_moment_locop', &
          routineP = moduleN//':'//routineN
@@ -1477,9 +1479,9 @@ CONTAINS
       CHARACTER(LEN=8), ALLOCATABLE, DIMENSION(:)        :: rlab
       CHARACTER(LEN=default_string_length)               :: description
       INTEGER                                            :: akind, handle, i, ia, iatom, ikind, &
-                                                            ispin, ix, iy, iz, l, nm, nmom
+                                                            ispin, ix, iy, iz, l, nm, nmm, nmom
       REAL(dp)                                           :: charge, dd, strace, trace
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, rmom_vel
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: rmom
       REAL(dp), DIMENSION(3)                             :: rcc, ria
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
@@ -1586,8 +1588,8 @@ CONTAINS
       IF (magnetic) THEN
          NULLIFY (magmom)
          CALL build_local_magmom_matrix(qs_env, magmom, nmom, ref_point=rcc)
-         nm = SIZE(magmom)
-         ALLOCATE (mmom(nm))
+         nmm = SIZE(magmom)
+         ALLOCATE (mmom(nmm))
 
          ! Allocate matrices to store the matrix product to be traced (dbcsr_dot only works for products of
          ! symmetric matrices)
@@ -1618,6 +1620,14 @@ CONTAINS
          CALL dbcsr_deallocate_matrix_set(magmom)
          CALL dbcsr_deallocate_matrix(rho_magmom_ao)
       END IF
+
+      IF (PRESENT(vel_reprs)) THEN
+         IF (vel_reprs) THEN
+            ALLOCATE (rmom_vel(nm))
+            rmom_vel = 0.0_dp
+
+         ENDIF
+      ENDIF
 
       description = "[DIPOLE]"
       CALL cp_results_erase(results=results, description=description)
@@ -1759,4 +1769,3 @@ CONTAINS
    END SUBROUTINE print_moments
 
 END MODULE qs_moments
-

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -22,6 +22,7 @@ MODULE qs_moments
    USE block_p_types,                   ONLY: block_p_type
    USE cell_types,                      ONLY: cell_type,&
                                               pbc
+   USE commutator_rpnl,                 ONLY: build_com_mom_nl
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_lu_decompose
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
@@ -1776,7 +1777,8 @@ CONTAINS
                                                             nmom, order
       LOGICAL                                            :: my_com_nl, my_velreprs
       REAL(dp)                                           :: charge, dd, strace, trace
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, qupole_der, rmom_vel
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, nlcom_rrv, nlcom_rv, nlcom_rxrv, &
+                                                            qupole_der, rmom_vel
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: rmom
       REAL(dp), DIMENSION(3)                             :: rcc, ria
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
@@ -1821,6 +1823,23 @@ CONTAINS
                       matrix_s=matrix_s, &
                       sab_all=sab_orb)
 
+      IF (my_com_nl) THEN
+         IF ((nmom >= 1) .AND. my_velreprs) THEN
+            ALLOCATE (nlcom_rv(3))
+            nlcom_rv(:) = 0._dp
+         ENDIF
+         IF ((nmom >= 2) .AND. my_velreprs) THEN
+            ALLOCATE (nlcom_rrv(6))
+            nlcom_rrv(:) = 0._dp
+         ENDIF
+         IF (magnetic) THEN
+            ALLOCATE (nlcom_rxrv(3))
+            nlcom_rxrv = 0._dp
+         ENDIF
+         ! Calculate non local correction terms
+         CALL calculate_commutator_nl_terms(qs_env, nlcom_rv, nlcom_rxrv, nlcom_rrv, rcc)
+      ENDIF
+
       NULLIFY (moments)
       nm = (6 + 11*nmom + 6*nmom**2 + nmom**3)/6 - 1
       CALL dbcsr_allocate_matrix_set(moments, nm)
@@ -1861,7 +1880,7 @@ CONTAINS
       rmom = 0.0_dp
       rlab = ""
 
-      IF ((my_velreprs .AND. (nmoments >= 2)) .OR. magnetic) THEN
+      IF ((my_velreprs .AND. (nmoments >= 1)) .OR. magnetic) THEN
          ! Allocate matrix to store the matrix product to be traced (dbcsr_dot only works for products of
          ! symmetric matrices)
          NULLIFY (tmp_ao)
@@ -2049,7 +2068,7 @@ CONTAINS
          ENDDO
       ENDIF
 
-      IF ((my_velreprs .AND. (nmoments >= 2)) .OR. magnetic) THEN
+      IF ((my_velreprs .AND. (nmoments >= 1)) .OR. magnetic) THEN
          CALL dbcsr_deallocate_matrix(tmp_ao)
       ENDIF
       IF (my_velreprs .AND. (nmoments >= 2)) THEN
@@ -2070,6 +2089,32 @@ CONTAINS
       ELSE
          CALL print_moments(unit_number, nmom, rmom, rlab, rcc, cell, periodic=.FALSE.)
       END IF
+
+      IF (my_com_nl) THEN
+         IF (magnetic) THEN
+            mmom = mmom + nlcom_rxrv
+         ENDIF
+         IF (my_velreprs .AND. (nmom >= 1)) THEN
+            rmom_vel(1:3) = rmom_vel(1:3) + nlcom_rv
+         ENDIF
+         IF (my_velreprs .AND. (nmom >= 2)) THEN
+            rmom_vel(4:9) = rmom_vel(4:9) + nlcom_rrv
+         ENDIF
+         IF (magnetic .AND. .NOT. my_velreprs) THEN
+            CALL print_moments_nl(unit_number, nmom, rlab, mmom)
+         ELSE IF (my_velreprs .AND. .NOT. magnetic) THEN
+            CALL print_moments_nl(unit_number, nmom, rlab, rmom_vel)
+         ELSE IF (my_velreprs .AND. magnetic) THEN
+            CALL print_moments_nl(unit_number, nmom, rlab, mmom, rmom_vel)
+         ENDIF
+
+      ENDIF
+
+      IF (my_com_nl) THEN
+         IF (nmom >= 1 .AND. my_velreprs) DEALLOCATE (nlcom_rv)
+         IF (nmom >= 2 .AND. my_velreprs) DEALLOCATE (nlcom_rrv)
+         IF (magnetic) DEALLOCATE (nlcom_rxrv)
+      ENDIF
 
       DEALLOCATE (rmom)
       DEALLOCATE (rlab)
@@ -2221,5 +2266,287 @@ CONTAINS
       END IF
 
    END SUBROUTINE print_moments
+
+! **************************************************************************************************
+!> \brief ...
+!> \param unit_number ...
+!> \param nmom ...
+!> \param rlab ...
+!> \param mmom ...
+!> \param rmom_vel ...
+! **************************************************************************************************
+   SUBROUTINE print_moments_nl(unit_number, nmom, rlab, mmom, rmom_vel)
+      INTEGER, INTENT(IN)                                :: unit_number, nmom
+      CHARACTER(LEN=8), DIMENSION(:)                     :: rlab
+      REAL(dp), DIMENSION(:), INTENT(IN), OPTIONAL       :: mmom, rmom_vel
+
+      INTEGER                                            :: i, l
+      REAL(dp)                                           :: dd
+
+      IF (unit_number > 0) THEN
+         IF (PRESENT(mmom)) THEN
+            IF (nmom >= 1) THEN
+               dd = SQRT(SUM(mmom(1:3)**2))
+               WRITE (unit_number, "(T3,A)") "Magnetic Dipole Moment (only orbital contrib.) [a.u.] incl. com_nl"
+               WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
+                  (TRIM(rlab(i + 1)), "=", mmom(i), i=1, 3), "Total=", dd
+            END IF
+         END IF
+         IF (PRESENT(rmom_vel)) THEN
+            DO l = 1, nmom
+               SELECT CASE (l)
+               CASE (1)
+                  dd = SQRT(SUM(rmom_vel(1:3)**2))
+                  WRITE (unit_number, "(T3,A)") "Expectation value of momentum operator [a. u.] incl. com_nl"
+                  WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
+                     (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=1, 3), "Total=", dd
+               CASE (2)
+                  WRITE (unit_number, "(T3,A)") "Expectation value of quadrupole operator in vel. repr. [a. u.] incl. com_nl"
+                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                     (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=4, 6)
+                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                     (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=7, 9)
+               CASE DEFAULT
+               END SELECT
+            ENDDO
+         ENDIF
+      END IF
+
+   END SUBROUTINE print_moments_nl
+
+! **************************************************************************************************
+!> \brief ...
+!> \param qs_env ...
+!> \param nlcom_rv ...
+!> \param nlcom_rxrv ...
+!> \param nlcom_rrv ...
+!> \param ref_point ...
+! **************************************************************************************************
+   SUBROUTINE calculate_commutator_nl_terms(qs_env, nlcom_rv, nlcom_rxrv, nlcom_rrv, ref_point)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(dp), ALLOCATABLE, DIMENSION(:), OPTIONAL      :: nlcom_rv, nlcom_rxrv, nlcom_rrv
+      REAL(dp), DIMENSION(3)                             :: ref_point
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_commutator_nl_terms', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, ind, ispin
+      LOGICAL                                            :: calc_rrv, calc_rv, calc_rxrv
+      REAL(dp)                                           :: eps_ppnl, strace, trace
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_rrv, matrix_rv, matrix_rxrv, &
+                                                            matrix_s, rho_ao
+      TYPE(dbcsr_type), POINTER                          :: tmp_ao
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_all, sap_ppnl
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(qs_rho_type), POINTER                         :: rho
+
+      CALL timeset(routineN, handle)
+
+      calc_rv = .FALSE.
+      calc_rxrv = .FALSE.
+      calc_rrv = .FALSE.
+
+      IF (ALLOCATED(nlcom_rv)) calc_rv = .TRUE.
+      IF (ALLOCATED(nlcom_rrv)) calc_rrv = .TRUE.
+      IF (ALLOCATED(nlcom_rxrv)) calc_rxrv = .TRUE.
+
+      ! WRITE (*, *) calc_rv, calc_rrv, calc_rxrv
+
+      IF (.NOT. (calc_rv .OR. calc_rrv .OR. calc_rxrv)) RETURN
+
+      NULLIFY (cell, matrix_s, particle_set, qs_kind_set, rho, sab_all, sap_ppnl)
+      CALL get_qs_env(qs_env, &
+                      cell=cell, &
+                      dft_control=dft_control, &
+                      matrix_s=matrix_s, &
+                      particle_set=particle_set, &
+                      qs_kind_set=qs_kind_set, &
+                      rho=rho, &
+                      sab_all=sab_all, &
+                      sap_ppnl=sap_ppnl)
+
+      eps_ppnl = dft_control%qs_control%eps_ppnl
+
+      ! Allocate storage
+      NULLIFY (matrix_rv, matrix_rrv, matrix_rxrv)
+      IF (calc_rv) THEN
+         CALL dbcsr_allocate_matrix_set(matrix_rv, 3)
+         DO ind = 1, 3
+            CALL dbcsr_init_p(matrix_rv(ind)%matrix)
+            CALL dbcsr_create(matrix_rv(ind)%matrix, template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(ind)%matrix, sab_all)
+            CALL dbcsr_set(matrix_rv(ind)%matrix, 0._dp)
+         ENDDO
+      ENDIF
+
+      IF (calc_rrv) THEN
+         CALL dbcsr_allocate_matrix_set(matrix_rrv, 6)
+         DO ind = 1, 6
+            CALL dbcsr_init_p(matrix_rrv(ind)%matrix)
+            CALL dbcsr_create(matrix_rrv(ind)%matrix, template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rrv(ind)%matrix, sab_all)
+            CALL dbcsr_set(matrix_rrv(ind)%matrix, 0._dp)
+         ENDDO
+      ENDIF
+
+      IF (calc_rxrv) THEN
+         CALL dbcsr_allocate_matrix_set(matrix_rxrv, 3)
+         DO ind = 1, 3
+            CALL dbcsr_init_p(matrix_rxrv(ind)%matrix)
+            CALL dbcsr_create(matrix_rxrv(ind)%matrix, template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rxrv(ind)%matrix, sab_all)
+            CALL dbcsr_set(matrix_rxrv(ind)%matrix, 0._dp)
+         ENDDO
+      ENDIF
+
+      ! calculate commutators in AO basis
+      IF (calc_rv .AND. calc_rrv .AND. .NOT. calc_rxrv) THEN
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rrv=matrix_rrv, &
+                               ref_point=ref_point, particle_set=particle_set, cell=cell)
+      ELSE IF (calc_rv .AND. calc_rxrv .AND. .NOT. calc_rrv) THEN
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
+                               ref_point=ref_point, particle_set=particle_set, cell=cell)
+      ELSE IF (calc_rrv .AND. calc_rxrv .AND. .NOT. calc_rv) THEN
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, &
+                               ref_point=ref_point, particle_set=particle_set, cell=cell)
+      ELSE IF (calc_rv .AND. calc_rxrv .AND. calc_rrv) THEN
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
+                               matrix_rrv=matrix_rrv, ref_point=ref_point, particle_set=particle_set, cell=cell)
+      ELSE IF (calc_rv .AND. .NOT. calc_rrv .AND. .NOT. calc_rxrv) THEN
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
+      ELSE IF (calc_rrv .AND. .NOT. calc_rv .AND. .NOT. calc_rxrv) THEN
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rrv=matrix_rrv, &
+                               ref_point=ref_point, particle_set=particle_set, cell=cell)
+      ELSE IF (calc_rxrv .AND. .NOT. calc_rv .AND. .NOT. calc_rrv) THEN
+         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, &
+                               ref_point=ref_point, particle_set=particle_set, cell=cell)
+      ENDIF
+
+      ! calculate expectation values
+      ! real part
+      NULLIFY (rho_ao)
+      CALL qs_rho_get(rho, rho_ao=rho_ao)
+
+      NULLIFY (tmp_ao)
+      ALLOCATE (tmp_ao)
+      CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
+
+      IF (calc_rv) THEN
+         trace = 0._dp
+         DO ind = 1, SIZE(matrix_rv)
+            strace = 0._dp
+            DO ispin = 1, dft_control%nspins
+               CALL dbcsr_set(tmp_ao, 0.0_dp)
+               CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rv(ind)%matrix, &
+                                   0.0_dp, tmp_ao)
+               CALL dbcsr_trace(tmp_ao, trace)
+               strace = strace + trace
+            END DO
+            nlcom_rv(ind) = nlcom_rv(ind) + strace
+         ENDDO
+         ! WRITE (*, *) nlcom_rv
+      ENDIF
+
+      IF (calc_rrv) THEN
+         trace = 0._dp
+         DO ind = 1, SIZE(matrix_rrv)
+            strace = 0._dp
+            DO ispin = 1, dft_control%nspins
+               CALL dbcsr_set(tmp_ao, 0.0_dp)
+               CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rrv(ind)%matrix, &
+                                   0.0_dp, tmp_ao)
+               CALL dbcsr_trace(tmp_ao, trace)
+               strace = strace + trace
+            END DO
+            nlcom_rrv(ind) = nlcom_rrv(ind) + strace
+         ENDDO
+         ! WRITE (*, *) nlcom_rrv
+      ENDIF
+
+      IF (calc_rxrv) THEN
+         trace = 0._dp
+         DO ind = 1, SIZE(matrix_rxrv)
+            strace = 0._dp
+            DO ispin = 1, dft_control%nspins
+               CALL dbcsr_set(tmp_ao, 0.0_dp)
+               CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rxrv(ind)%matrix, &
+                                   0.0_dp, tmp_ao)
+               CALL dbcsr_trace(tmp_ao, trace)
+               strace = strace + trace
+            END DO
+            nlcom_rxrv(ind) = nlcom_rxrv(ind) + strace
+         ENDDO
+         ! WRITE (*, *) nlcom_rxrv
+      ENDIF
+
+      ! imaginary part
+      IF (qs_env%run_rtp) THEN
+         NULLIFY (rho_ao)
+         CALL qs_rho_get(rho, rho_ao_im=rho_ao)
+
+         IF (calc_rv) THEN
+            trace = 0._dp
+            DO ind = 1, SIZE(matrix_rv)
+               strace = 0._dp
+               DO ispin = 1, dft_control%nspins
+                  CALL dbcsr_set(tmp_ao, 0.0_dp)
+                  CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rv(ind)%matrix, &
+                                      0.0_dp, tmp_ao)
+                  CALL dbcsr_trace(tmp_ao, trace)
+                  strace = strace + trace
+               END DO
+               nlcom_rv(ind) = nlcom_rv(ind) + strace
+            ENDDO
+            ! WRITE (*, *) nlcom_rv
+         ENDIF
+
+         IF (calc_rrv) THEN
+            trace = 0._dp
+            DO ind = 1, SIZE(matrix_rrv)
+               strace = 0._dp
+               DO ispin = 1, dft_control%nspins
+                  CALL dbcsr_set(tmp_ao, 0.0_dp)
+                  CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rrv(ind)%matrix, &
+                                      0.0_dp, tmp_ao)
+                  CALL dbcsr_trace(tmp_ao, trace)
+                  strace = strace + trace
+               END DO
+               nlcom_rrv(ind) = nlcom_rrv(ind) + strace
+            ENDDO
+            ! WRITE (*, *) nlcom_rrv
+         ENDIF
+
+         IF (calc_rxrv) THEN
+            trace = 0._dp
+            DO ind = 1, SIZE(matrix_rxrv)
+               strace = 0._dp
+               DO ispin = 1, dft_control%nspins
+                  CALL dbcsr_set(tmp_ao, 0.0_dp)
+                  CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rxrv(ind)%matrix, &
+                                      0.0_dp, tmp_ao)
+                  CALL dbcsr_trace(tmp_ao, trace)
+                  strace = strace + trace
+               END DO
+               nlcom_rxrv(ind) = nlcom_rxrv(ind) + strace
+            ENDDO
+            ! WRITE (*, *) nlcom_rxrv
+         ENDIF
+      ENDIF ! qs_env%run_rtp
+
+      CALL dbcsr_deallocate_matrix(tmp_ao)
+      IF (calc_rv) CALL dbcsr_deallocate_matrix_set(matrix_rv)
+      IF (calc_rrv) CALL dbcsr_deallocate_matrix_set(matrix_rrv)
+      IF (calc_rxrv) CALL dbcsr_deallocate_matrix_set(matrix_rxrv)
+
+      CALL timestop(handle)
+   END SUBROUTINE calculate_commutator_nl_terms
 
 END MODULE qs_moments

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -48,8 +48,9 @@ MODULE qs_moments
    USE cp_result_types,                 ONLY: cp_result_type
    USE dbcsr_api,                       ONLY: &
         dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_desymmetrize, &
-        dbcsr_distribution_type, dbcsr_dot, dbcsr_get_block_p, dbcsr_multiply, dbcsr_p_type, &
-        dbcsr_set, dbcsr_trace, dbcsr_type, dbcsr_type_symmetric
+        dbcsr_distribution_type, dbcsr_dot, dbcsr_get_block_p, dbcsr_init_p, dbcsr_multiply, &
+        dbcsr_p_type, dbcsr_set, dbcsr_trace, dbcsr_type, dbcsr_type_antisymmetric, &
+        dbcsr_type_symmetric
    USE distribution_1d_types,           ONLY: distribution_1d_type
    USE kinds,                           ONLY: default_string_length,&
                                               dp
@@ -1480,6 +1481,7 @@ CONTAINS
       CHARACTER(LEN=default_string_length)               :: description
       INTEGER                                            :: akind, handle, i, ia, iatom, ikind, &
                                                             ispin, ix, iy, iz, l, nm, nmm, nmom
+      LOGICAL                                            :: my_velreprs
       REAL(dp)                                           :: charge, dd, strace, trace
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, rmom_vel
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: rmom
@@ -1488,7 +1490,8 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(cp_result_type), POINTER                      :: results
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: magmom, matrix_s, moments, rho_ao
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: magmom, matrix_s, moments, moments_vel, &
+                                                            rho_ao
       TYPE(dbcsr_type), POINTER                          :: rho_magmom_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_1d_type), POINTER                :: local_particles
@@ -1499,6 +1502,9 @@ CONTAINS
       CPASSERT(ASSOCIATED(qs_env))
 
       CALL timeset(routineN, handle)
+
+      my_velreprs = .FALSE.
+      IF (PRESENT(vel_reprs)) my_velreprs = vel_reprs
 
       ! reference point
       CALL get_reference_point(rcc, qs_env=qs_env, reference=reference, ref_point=ref_point)
@@ -1621,20 +1627,31 @@ CONTAINS
          CALL dbcsr_deallocate_matrix(rho_magmom_ao)
       END IF
 
-      IF (PRESENT(vel_reprs)) THEN
-         IF (vel_reprs) THEN
-            ALLOCATE (rmom_vel(nm))
-            rmom_vel = 0.0_dp
-
-         ENDIF
+      IF (my_velreprs) THEN
+         ALLOCATE (rmom_vel(nm))
+         rmom_vel = 0.0_dp
+         NULLIFY (moments_vel)
+         CALL dbcsr_allocate_matrix_set(moments_vel, nm)
+         DO i = 1, nm
+            CALL dbcsr_init_p(moments_vel(i)%matrix)
+            CALL dbcsr_create(moments_vel(i)%matrix, template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_antisymmetric)
+            CALL dbcsr_set(moments_vel(i)%matrix, 0.0_dp)
+         END DO
+         CALL dbcsr_deallocate_matrix_set(moments_vel)
       ENDIF
 
       description = "[DIPOLE]"
       CALL cp_results_erase(results=results, description=description)
       CALL put_results(results=results, description=description, &
                        values=rmom(2:4, 3))
-      IF (magnetic) THEN
+
+      IF (magnetic .AND. my_velreprs) THEN
+         CALL print_moments(unit_number, nmom, rmom, rlab, rcc, cell, periodic=.FALSE., mmom=mmom, rmom_vel=rmom_vel)
+      ELSE IF (magnetic .AND. .NOT. my_velreprs) THEN
          CALL print_moments(unit_number, nmom, rmom, rlab, rcc, cell, periodic=.FALSE., mmom=mmom)
+      ELSE IF (my_velreprs .AND. .NOT. magnetic) THEN
+         CALL print_moments(unit_number, nmom, rmom, rlab, rcc, cell, periodic=.FALSE., rmom_vel=rmom_vel)
       ELSE
          CALL print_moments(unit_number, nmom, rmom, rlab, rcc, cell, periodic=.FALSE.)
       END IF
@@ -1644,6 +1661,9 @@ CONTAINS
       IF (magnetic) THEN
          DEALLOCATE (mmom)
       END IF
+      IF (my_velreprs) THEN
+         DEALLOCATE (rmom_vel)
+      ENDIF
 
       CALL timestop(handle)
 
@@ -1685,15 +1705,16 @@ CONTAINS
 !> \param cell ...
 !> \param periodic ...
 !> \param mmom ...
+!> \param rmom_vel ...
 ! **************************************************************************************************
-   SUBROUTINE print_moments(unit_number, nmom, rmom, rlab, rcc, cell, periodic, mmom)
+   SUBROUTINE print_moments(unit_number, nmom, rmom, rlab, rcc, cell, periodic, mmom, rmom_vel)
       INTEGER, INTENT(IN)                                :: unit_number, nmom
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: rmom
       CHARACTER(LEN=8), DIMENSION(:)                     :: rlab
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: rcc
       TYPE(cell_type), POINTER                           :: cell
       LOGICAL                                            :: periodic
-      REAL(dp), DIMENSION(:), INTENT(IN), OPTIONAL       :: mmom
+      REAL(dp), DIMENSION(:), INTENT(IN), OPTIONAL       :: mmom, rmom_vel
 
       INTEGER                                            :: i, i0, i1, j, l
       REAL(dp)                                           :: dd
@@ -1764,6 +1785,24 @@ CONTAINS
                   (TRIM(rlab(i + 1)), "=", mmom(i), i=1, 3), "Total=", dd
             END IF
          END IF
+         IF (PRESENT(rmom_vel)) THEN
+            DO l = 1, nmom
+               SELECT CASE (l)
+               CASE (1)
+                  dd = SQRT(SUM(rmom_vel(1:3)**2))
+                  WRITE (unit_number, "(T3,A)") "Expectation value of momentum operator [a. u.]"
+                  WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
+                     (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=1, 3), "Total=", dd
+               CASE (2)
+                  WRITE (unit_number, "(T3,A)") "Expectation value of quadrupole operator in vel. repr. [a. u.]"
+                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                     (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=4, 6)
+                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                     (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=7, 9)
+               CASE DEFAULT
+               END SELECT
+            ENDDO
+         ENDIF
       END IF
 
    END SUBROUTINE print_moments

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -22,7 +22,7 @@ MODULE qs_moments
    USE block_p_types,                   ONLY: block_p_type
    USE cell_types,                      ONLY: cell_type,&
                                               pbc
-   USE commutator_rpnl,                 ONLY: build_com_mom_nl
+   USE commutator_rpnl,                 ONLY: build_com_mom_nl_2
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_lu_decompose
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
@@ -2406,25 +2406,25 @@ CONTAINS
 
          ! calculate commutators in AO basis
          IF (calc_rv .AND. calc_rrv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rrv=matrix_rrv, &
-                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rrv=matrix_rrv, &
+                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
          ELSE IF (calc_rv .AND. calc_rxrv .AND. .NOT. calc_rrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
-                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
+                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
          ELSE IF (calc_rrv .AND. calc_rxrv .AND. .NOT. calc_rv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, &
-                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, &
+                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
          ELSE IF (calc_rv .AND. calc_rxrv .AND. calc_rrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
-                                  matrix_rrv=matrix_rrv, ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
+                                    matrix_rrv=matrix_rrv, ref_point=ref_point, particle_set=particle_set, cell=cell)
          ELSE IF (calc_rv .AND. .NOT. calc_rrv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
+            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
          ELSE IF (calc_rrv .AND. .NOT. calc_rv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rrv=matrix_rrv, &
-                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rrv=matrix_rrv, &
+                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
          ELSE IF (calc_rxrv .AND. .NOT. calc_rv .AND. .NOT. calc_rrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, &
-                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, &
+                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
          ENDIF
       ENDIF
 

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -2101,11 +2101,11 @@ CONTAINS
             rmom_vel(4:9) = rmom_vel(4:9) + nlcom_rrv
          ENDIF
          IF (magnetic .AND. .NOT. my_velreprs) THEN
-            CALL print_moments_nl(unit_number, nmom, rlab, mmom)
+            CALL print_moments_nl(unit_number, nmom, rlab, mmom=mmom)
          ELSE IF (my_velreprs .AND. .NOT. magnetic) THEN
-            CALL print_moments_nl(unit_number, nmom, rlab, rmom_vel)
+            CALL print_moments_nl(unit_number, nmom, rlab, rmom_vel=rmom_vel)
          ELSE IF (my_velreprs .AND. magnetic) THEN
-            CALL print_moments_nl(unit_number, nmom, rlab, mmom, rmom_vel)
+            CALL print_moments_nl(unit_number, nmom, rlab, mmom=mmom, rmom_vel=rmom_vel)
          ENDIF
 
       ENDIF
@@ -2251,13 +2251,13 @@ CONTAINS
                CASE (1)
                   dd = SQRT(SUM(rmom_vel(1:3)**2))
                   WRITE (unit_number, "(T3,A)") "Expectation value of momentum operator [a. u.]"
-                  WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
+                  WRITE (unit_number, "(T5,3(A,A,D14.8,1X),T60,A,T67,F14.8)") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=1, 3), "Total=", dd
                CASE (2)
                   WRITE (unit_number, "(T3,A)") "Expectation value of quadrupole operator in vel. repr. [a. u.]"
-                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                  WRITE (unit_number, "(T17,3(A,A,D14.8,9X))") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=4, 6)
-                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                  WRITE (unit_number, "(T17,3(A,A,D14.8,9X))") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=7, 9)
                CASE DEFAULT
                END SELECT
@@ -2288,7 +2288,7 @@ CONTAINS
             IF (nmom >= 1) THEN
                dd = SQRT(SUM(mmom(1:3)**2))
                WRITE (unit_number, "(T3,A)") "Orbital angular momentum [a.u.] incl. com_nl"
-               WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
+               WRITE (unit_number, "(T5,3(A,A,D14.8,1X),T60,A,T67,F14.8)") &
                   (TRIM(rlab(i + 1)), "=", mmom(i), i=1, 3), "Total=", dd
             END IF
          END IF
@@ -2298,13 +2298,13 @@ CONTAINS
                CASE (1)
                   dd = SQRT(SUM(rmom_vel(1:3)**2))
                   WRITE (unit_number, "(T3,A)") "Expectation value of momentum operator [a. u.] incl. com_nl"
-                  WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
+                  WRITE (unit_number, "(T5,3(A,A,D14.8,1X),T60,A,T67,F14.8)") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=1, 3), "Total=", dd
                CASE (2)
                   WRITE (unit_number, "(T3,A)") "Expectation value of quadrupole operator in vel. repr. [a. u.] incl. com_nl"
-                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                  WRITE (unit_number, "(T17,3(A,A,D14.8,9X))") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=4, 6)
-                  WRITE (unit_number, "(T17,3(A,A,F14.8,9X))") &
+                  WRITE (unit_number, "(T17,3(A,A,D14.8,9X))") &
                      (TRIM(rlab(i + 1)), "=", rmom_vel(i), i=7, 9)
                CASE DEFAULT
                END SELECT
@@ -2355,8 +2355,6 @@ CONTAINS
       IF (ALLOCATED(nlcom_rrv)) calc_rrv = .TRUE.
       IF (ALLOCATED(nlcom_rxrv)) calc_rxrv = .TRUE.
 
-      ! WRITE (*, *) calc_rv, calc_rrv, calc_rxrv
-
       IF (.NOT. (calc_rv .OR. calc_rrv .OR. calc_rxrv)) RETURN
 
       NULLIFY (cell, matrix_s, particle_set, qs_kind_set, rho, sab_all, sap_ppnl)
@@ -2372,66 +2370,71 @@ CONTAINS
 
       eps_ppnl = dft_control%qs_control%eps_ppnl
 
-      ! Allocate storage
-      NULLIFY (matrix_rv, matrix_rrv, matrix_rxrv)
-      IF (calc_rv) THEN
-         CALL dbcsr_allocate_matrix_set(matrix_rv, 3)
-         DO ind = 1, 3
-            CALL dbcsr_init_p(matrix_rv(ind)%matrix)
-            CALL dbcsr_create(matrix_rv(ind)%matrix, template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(ind)%matrix, sab_all)
-            CALL dbcsr_set(matrix_rv(ind)%matrix, 0._dp)
-         ENDDO
-      ENDIF
+      ! Calculate commutators, only needed of there is an imaginary part of the density matrix
+      IF (qs_env%run_rtp) THEN
+         ! Allocate storage
+         NULLIFY (matrix_rv, matrix_rrv, matrix_rxrv)
+         IF (calc_rv) THEN
+            CALL dbcsr_allocate_matrix_set(matrix_rv, 3)
+            DO ind = 1, 3
+               CALL dbcsr_init_p(matrix_rv(ind)%matrix)
+               CALL dbcsr_create(matrix_rv(ind)%matrix, template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry)
+               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(ind)%matrix, sab_all)
+               CALL dbcsr_set(matrix_rv(ind)%matrix, 0._dp)
+            ENDDO
+         ENDIF
 
-      IF (calc_rrv) THEN
-         CALL dbcsr_allocate_matrix_set(matrix_rrv, 6)
-         DO ind = 1, 6
-            CALL dbcsr_init_p(matrix_rrv(ind)%matrix)
-            CALL dbcsr_create(matrix_rrv(ind)%matrix, template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rrv(ind)%matrix, sab_all)
-            CALL dbcsr_set(matrix_rrv(ind)%matrix, 0._dp)
-         ENDDO
-      ENDIF
+         IF (calc_rrv) THEN
+            CALL dbcsr_allocate_matrix_set(matrix_rrv, 6)
+            DO ind = 1, 6
+               CALL dbcsr_init_p(matrix_rrv(ind)%matrix)
+               CALL dbcsr_create(matrix_rrv(ind)%matrix, template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry)
+               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rrv(ind)%matrix, sab_all)
+               CALL dbcsr_set(matrix_rrv(ind)%matrix, 0._dp)
+            ENDDO
+         ENDIF
 
-      IF (calc_rxrv) THEN
-         CALL dbcsr_allocate_matrix_set(matrix_rxrv, 3)
-         DO ind = 1, 3
-            CALL dbcsr_init_p(matrix_rxrv(ind)%matrix)
-            CALL dbcsr_create(matrix_rxrv(ind)%matrix, template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-            CALL cp_dbcsr_alloc_block_from_nbl(matrix_rxrv(ind)%matrix, sab_all)
-            CALL dbcsr_set(matrix_rxrv(ind)%matrix, 0._dp)
-         ENDDO
-      ENDIF
+         IF (calc_rxrv) THEN
+            CALL dbcsr_allocate_matrix_set(matrix_rxrv, 3)
+            DO ind = 1, 3
+               CALL dbcsr_init_p(matrix_rxrv(ind)%matrix)
+               CALL dbcsr_create(matrix_rxrv(ind)%matrix, template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry)
+               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rxrv(ind)%matrix, sab_all)
+               CALL dbcsr_set(matrix_rxrv(ind)%matrix, 0._dp)
+            ENDDO
+         ENDIF
 
-      ! calculate commutators in AO basis
-      IF (calc_rv .AND. calc_rrv .AND. .NOT. calc_rxrv) THEN
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rrv=matrix_rrv, &
-                               ref_point=ref_point, particle_set=particle_set, cell=cell)
-      ELSE IF (calc_rv .AND. calc_rxrv .AND. .NOT. calc_rrv) THEN
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
-                               ref_point=ref_point, particle_set=particle_set, cell=cell)
-      ELSE IF (calc_rrv .AND. calc_rxrv .AND. .NOT. calc_rv) THEN
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, &
-                               ref_point=ref_point, particle_set=particle_set, cell=cell)
-      ELSE IF (calc_rv .AND. calc_rxrv .AND. calc_rrv) THEN
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
-                               matrix_rrv=matrix_rrv, ref_point=ref_point, particle_set=particle_set, cell=cell)
-      ELSE IF (calc_rv .AND. .NOT. calc_rrv .AND. .NOT. calc_rxrv) THEN
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
-      ELSE IF (calc_rrv .AND. .NOT. calc_rv .AND. .NOT. calc_rxrv) THEN
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rrv=matrix_rrv, &
-                               ref_point=ref_point, particle_set=particle_set, cell=cell)
-      ELSE IF (calc_rxrv .AND. .NOT. calc_rv .AND. .NOT. calc_rrv) THEN
-         CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, &
-                               ref_point=ref_point, particle_set=particle_set, cell=cell)
+         ! calculate commutators in AO basis
+         IF (calc_rv .AND. calc_rrv .AND. .NOT. calc_rxrv) THEN
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rrv=matrix_rrv, &
+                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+         ELSE IF (calc_rv .AND. calc_rxrv .AND. .NOT. calc_rrv) THEN
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
+                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+         ELSE IF (calc_rrv .AND. calc_rxrv .AND. .NOT. calc_rv) THEN
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, &
+                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+         ELSE IF (calc_rv .AND. calc_rxrv .AND. calc_rrv) THEN
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
+                                  matrix_rrv=matrix_rrv, ref_point=ref_point, particle_set=particle_set, cell=cell)
+         ELSE IF (calc_rv .AND. .NOT. calc_rrv .AND. .NOT. calc_rxrv) THEN
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
+         ELSE IF (calc_rrv .AND. .NOT. calc_rv .AND. .NOT. calc_rxrv) THEN
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rrv=matrix_rrv, &
+                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+         ELSE IF (calc_rxrv .AND. .NOT. calc_rv .AND. .NOT. calc_rrv) THEN
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, &
+                                  ref_point=ref_point, particle_set=particle_set, cell=cell)
+         ENDIF
       ENDIF
 
       ! calculate expectation values
       ! real part
+      ! This evaluates to zero, because all commutator matrices are anti-symmetric while
+      ! the real part of the density matrix rho_ao is symmetric. Tr[A*S] = 0
       NULLIFY (rho_ao)
       CALL qs_rho_get(rho, rho_ao=rho_ao)
 
@@ -2440,51 +2443,54 @@ CONTAINS
       CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
 
       IF (calc_rv) THEN
-         trace = 0._dp
-         DO ind = 1, SIZE(matrix_rv)
-            strace = 0._dp
-            DO ispin = 1, dft_control%nspins
-               CALL dbcsr_set(tmp_ao, 0.0_dp)
-               CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rv(ind)%matrix, &
-                                   0.0_dp, tmp_ao)
-               CALL dbcsr_trace(tmp_ao, trace)
-               strace = strace + trace
-            END DO
-            nlcom_rv(ind) = nlcom_rv(ind) + strace
-         ENDDO
+         ! trace = 0._dp
+         ! DO ind = 1, SIZE(matrix_rv)
+         !    strace = 0._dp
+         !    DO ispin = 1, dft_control%nspins
+         !       CALL dbcsr_set(tmp_ao, 0.0_dp)
+         !       CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rv(ind)%matrix, &
+         !                           0.0_dp, tmp_ao)
+         !       CALL dbcsr_trace(tmp_ao, trace)
+         !       strace = strace + trace
+         !    END DO
+         !    nlcom_rv(ind) = nlcom_rv(ind) + strace
+         ! ENDDO
          ! WRITE (*, *) nlcom_rv
+         nlcom_rv(:) = 0._dp
       ENDIF
 
       IF (calc_rrv) THEN
-         trace = 0._dp
-         DO ind = 1, SIZE(matrix_rrv)
-            strace = 0._dp
-            DO ispin = 1, dft_control%nspins
-               CALL dbcsr_set(tmp_ao, 0.0_dp)
-               CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rrv(ind)%matrix, &
-                                   0.0_dp, tmp_ao)
-               CALL dbcsr_trace(tmp_ao, trace)
-               strace = strace + trace
-            END DO
-            nlcom_rrv(ind) = nlcom_rrv(ind) + strace
-         ENDDO
-         ! WRITE (*, *) nlcom_rrv
+         ! trace = 0._dp
+         ! DO ind = 1, SIZE(matrix_rrv)
+         !    strace = 0._dp
+         !    DO ispin = 1, dft_control%nspins
+         !       CALL dbcsr_set(tmp_ao, 0.0_dp)
+         !       CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rrv(ind)%matrix, &
+         !                           0.0_dp, tmp_ao)
+         !       CALL dbcsr_trace(tmp_ao, trace)
+         !       strace = strace + trace
+         !    END DO
+         !    nlcom_rrv(ind) = nlcom_rrv(ind) + strace
+         ! ENDDO
+         ! ! WRITE (*, *) nlcom_rrv
+         nlcom_rrv(:) = 0._dp
       ENDIF
 
       IF (calc_rxrv) THEN
-         trace = 0._dp
-         DO ind = 1, SIZE(matrix_rxrv)
-            strace = 0._dp
-            DO ispin = 1, dft_control%nspins
-               CALL dbcsr_set(tmp_ao, 0.0_dp)
-               CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rxrv(ind)%matrix, &
-                                   0.0_dp, tmp_ao)
-               CALL dbcsr_trace(tmp_ao, trace)
-               strace = strace + trace
-            END DO
-            nlcom_rxrv(ind) = nlcom_rxrv(ind) + strace
-         ENDDO
-         ! WRITE (*, *) nlcom_rxrv
+         ! trace = 0._dp
+         ! DO ind = 1, SIZE(matrix_rxrv)
+         !    strace = 0._dp
+         !    DO ispin = 1, dft_control%nspins
+         !       CALL dbcsr_set(tmp_ao, 0.0_dp)
+         !       CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, matrix_rxrv(ind)%matrix, &
+         !                           0.0_dp, tmp_ao)
+         !       CALL dbcsr_trace(tmp_ao, trace)
+         !       strace = strace + trace
+         !    END DO
+         !    nlcom_rxrv(ind) = nlcom_rxrv(ind) + strace
+         ! ENDDO
+         ! ! WRITE (*, *) nlcom_rxrv
+         nlcom_rxrv(:) = 0._dp
       ENDIF
 
       ! imaginary part
@@ -2539,12 +2545,11 @@ CONTAINS
             ENDDO
             ! WRITE (*, *) nlcom_rxrv
          ENDIF
+         CALL dbcsr_deallocate_matrix(tmp_ao)
+         IF (calc_rv) CALL dbcsr_deallocate_matrix_set(matrix_rv)
+         IF (calc_rrv) CALL dbcsr_deallocate_matrix_set(matrix_rrv)
+         IF (calc_rxrv) CALL dbcsr_deallocate_matrix_set(matrix_rxrv)
       ENDIF ! qs_env%run_rtp
-
-      CALL dbcsr_deallocate_matrix(tmp_ao)
-      IF (calc_rv) CALL dbcsr_deallocate_matrix_set(matrix_rv)
-      IF (calc_rrv) CALL dbcsr_deallocate_matrix_set(matrix_rrv)
-      IF (calc_rxrv) CALL dbcsr_deallocate_matrix_set(matrix_rxrv)
 
       CALL timestop(handle)
    END SUBROUTINE calculate_commutator_nl_terms

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -2058,7 +2058,7 @@ CONTAINS
                rmom_vel(4) = -2*qupole_der(1) - rmom(1, 1)
                rmom_vel(5) = -qupole_der(2) - qupole_der(4)
                rmom_vel(6) = -qupole_der(3) - qupole_der(7)
-               rmom_vel(7) = -2*(qupole_der(5)) - rmom(1, 1)
+               rmom_vel(7) = -2*qupole_der(5) - rmom(1, 1)
                rmom_vel(8) = -qupole_der(6) - qupole_der(8)
                rmom_vel(9) = -2*qupole_der(9) - rmom(1, 1)
 
@@ -2287,7 +2287,7 @@ CONTAINS
          IF (PRESENT(mmom)) THEN
             IF (nmom >= 1) THEN
                dd = SQRT(SUM(mmom(1:3)**2))
-               WRITE (unit_number, "(T3,A)") "Magnetic Dipole Moment (only orbital contrib.) [a.u.] incl. com_nl"
+               WRITE (unit_number, "(T3,A)") "Orbital angular momentum [a.u.] incl. com_nl"
                WRITE (unit_number, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
                   (TRIM(rlab(i + 1)), "=", mmom(i), i=1, 3), "Total=", dd
             END IF

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -2354,21 +2354,37 @@ CONTAINS
 
       IF (.NOT. (calc_rv .OR. calc_rrv .OR. calc_rxrv)) RETURN
 
-      NULLIFY (cell, matrix_s, particle_set, qs_kind_set, rho, sab_orb, sap_ppnl)
-      CALL get_qs_env(qs_env, &
-                      cell=cell, &
-                      dft_control=dft_control, &
-                      matrix_s=matrix_s, &
-                      particle_set=particle_set, &
-                      qs_kind_set=qs_kind_set, &
-                      rho=rho, &
-                      sab_orb=sab_orb, &
-                      sap_ppnl=sap_ppnl)
+      ! calculate expectation values
+      ! real part
+      ! This evaluates to zero, because all commutator matrices are anti-symmetric while
+      ! the real part of the density matrix rho_ao is symmetric. Tr[A*S] = 0
+      IF (calc_rv) THEN
+         nlcom_rv(:) = 0._dp
+      ENDIF
 
-      eps_ppnl = dft_control%qs_control%eps_ppnl
+      IF (calc_rrv) THEN
+         nlcom_rrv(:) = 0._dp
+      ENDIF
 
-      ! Calculate commutators, only needed of there is an imaginary part of the density matrix
+      IF (calc_rxrv) THEN
+         nlcom_rxrv(:) = 0._dp
+      ENDIF
+
+      ! imagninary part of the density matrix
       IF (qs_env%run_rtp) THEN
+         NULLIFY (cell, matrix_s, particle_set, qs_kind_set, rho, sab_orb, sap_ppnl)
+         CALL get_qs_env(qs_env, &
+                         cell=cell, &
+                         dft_control=dft_control, &
+                         matrix_s=matrix_s, &
+                         particle_set=particle_set, &
+                         qs_kind_set=qs_kind_set, &
+                         rho=rho, &
+                         sab_orb=sab_orb, &
+                         sap_ppnl=sap_ppnl)
+
+         eps_ppnl = dft_control%qs_control%eps_ppnl
+         ! Calculate commutators, only needed of there is an imaginary part of the density matrix
          ! Allocate storage
          NULLIFY (matrix_rv, matrix_rrv, matrix_rxrv)
          IF (calc_rv) THEN
@@ -2427,35 +2443,13 @@ CONTAINS
             CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rxrv=matrix_rxrv, &
                                   ref_point=ref_point, cell=cell)
          ENDIF
-      ENDIF
 
-      ! calculate expectation values
-      ! real part
-      ! This evaluates to zero, because all commutator matrices are anti-symmetric while
-      ! the real part of the density matrix rho_ao is symmetric. Tr[A*S] = 0
-      NULLIFY (rho_ao)
-      CALL qs_rho_get(rho, rho_ao=rho_ao)
-
-      NULLIFY (tmp_ao)
-      ALLOCATE (tmp_ao)
-      CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
-
-      IF (calc_rv) THEN
-         nlcom_rv(:) = 0._dp
-      ENDIF
-
-      IF (calc_rrv) THEN
-         nlcom_rrv(:) = 0._dp
-      ENDIF
-
-      IF (calc_rxrv) THEN
-         nlcom_rxrv(:) = 0._dp
-      ENDIF
-
-      ! imaginary part
-      IF (qs_env%run_rtp) THEN
          NULLIFY (rho_ao)
          CALL qs_rho_get(rho, rho_ao_im=rho_ao)
+
+         NULLIFY (tmp_ao)
+         ALLOCATE (tmp_ao)
+         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
 
          IF (calc_rv) THEN
             trace = 0._dp
@@ -2470,7 +2464,6 @@ CONTAINS
                END DO
                nlcom_rv(ind) = nlcom_rv(ind) + strace
             ENDDO
-            ! WRITE (*, *) nlcom_rv
          ENDIF
 
          IF (calc_rrv) THEN
@@ -2486,7 +2479,6 @@ CONTAINS
                END DO
                nlcom_rrv(ind) = nlcom_rrv(ind) + strace
             ENDDO
-            ! WRITE (*, *) nlcom_rrv
          ENDIF
 
          IF (calc_rxrv) THEN
@@ -2502,7 +2494,6 @@ CONTAINS
                END DO
                nlcom_rxrv(ind) = nlcom_rxrv(ind) + strace
             ENDDO
-            ! WRITE (*, *) nlcom_rxrv
          ENDIF
          CALL dbcsr_deallocate_matrix(tmp_ao)
          IF (calc_rv) CALL dbcsr_deallocate_matrix_set(matrix_rv)

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -2337,7 +2337,7 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: tmp_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_all, sap_ppnl
+         POINTER                                         :: sab_orb, sap_ppnl
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -2354,7 +2354,7 @@ CONTAINS
 
       IF (.NOT. (calc_rv .OR. calc_rrv .OR. calc_rxrv)) RETURN
 
-      NULLIFY (cell, matrix_s, particle_set, qs_kind_set, rho, sab_all, sap_ppnl)
+      NULLIFY (cell, matrix_s, particle_set, qs_kind_set, rho, sab_orb, sap_ppnl)
       CALL get_qs_env(qs_env, &
                       cell=cell, &
                       dft_control=dft_control, &
@@ -2362,7 +2362,7 @@ CONTAINS
                       particle_set=particle_set, &
                       qs_kind_set=qs_kind_set, &
                       rho=rho, &
-                      sab_all=sab_all, &
+                      sab_orb=sab_orb, &
                       sap_ppnl=sap_ppnl)
 
       eps_ppnl = dft_control%qs_control%eps_ppnl
@@ -2376,8 +2376,8 @@ CONTAINS
             DO ind = 1, 3
                CALL dbcsr_init_p(matrix_rv(ind)%matrix)
                CALL dbcsr_create(matrix_rv(ind)%matrix, template=matrix_s(1)%matrix, &
-                                 matrix_type=dbcsr_type_no_symmetry)
-               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(ind)%matrix, sab_all)
+                                 matrix_type=dbcsr_type_antisymmetric)
+               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rv(ind)%matrix, sab_orb)
                CALL dbcsr_set(matrix_rv(ind)%matrix, 0._dp)
             ENDDO
          ENDIF
@@ -2387,8 +2387,8 @@ CONTAINS
             DO ind = 1, 6
                CALL dbcsr_init_p(matrix_rrv(ind)%matrix)
                CALL dbcsr_create(matrix_rrv(ind)%matrix, template=matrix_s(1)%matrix, &
-                                 matrix_type=dbcsr_type_no_symmetry)
-               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rrv(ind)%matrix, sab_all)
+                                 matrix_type=dbcsr_type_antisymmetric)
+               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rrv(ind)%matrix, sab_orb)
                CALL dbcsr_set(matrix_rrv(ind)%matrix, 0._dp)
             ENDDO
          ENDIF
@@ -2398,33 +2398,33 @@ CONTAINS
             DO ind = 1, 3
                CALL dbcsr_init_p(matrix_rxrv(ind)%matrix)
                CALL dbcsr_create(matrix_rxrv(ind)%matrix, template=matrix_s(1)%matrix, &
-                                 matrix_type=dbcsr_type_no_symmetry)
-               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rxrv(ind)%matrix, sab_all)
+                                 matrix_type=dbcsr_type_antisymmetric)
+               CALL cp_dbcsr_alloc_block_from_nbl(matrix_rxrv(ind)%matrix, sab_orb)
                CALL dbcsr_set(matrix_rxrv(ind)%matrix, 0._dp)
             ENDDO
          ENDIF
 
          ! calculate commutators in AO basis
          IF (calc_rv .AND. calc_rrv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+            CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
                                   matrix_rrv=matrix_rrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rv .AND. calc_rxrv .AND. .NOT. calc_rrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+            CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
                                   matrix_rxrv=matrix_rxrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rrv .AND. calc_rxrv .AND. .NOT. calc_rv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rxrv=matrix_rxrv, &
+            CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rxrv=matrix_rxrv, &
                                   matrix_rrv=matrix_rrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rv .AND. calc_rxrv .AND. calc_rrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+            CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
                                   matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rv .AND. .NOT. calc_rrv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+            CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
                                   ref_point=ref_point, cell=cell)
          ELSE IF (calc_rrv .AND. .NOT. calc_rv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rrv=matrix_rrv, &
+            CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rrv=matrix_rrv, &
                                   ref_point=ref_point, cell=cell)
          ELSE IF (calc_rxrv .AND. .NOT. calc_rv .AND. .NOT. calc_rrv) THEN
-            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rxrv=matrix_rxrv, &
+            CALL build_com_mom_nl(qs_kind_set, sab_orb, sap_ppnl, eps_ppnl, particle_set, matrix_rxrv=matrix_rxrv, &
                                   ref_point=ref_point, cell=cell)
          ENDIF
       ENDIF

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -83,6 +83,7 @@ MODULE qs_moments
                                               neighbor_list_iterator_p_type,&
                                               neighbor_list_iterator_release,&
                                               neighbor_list_set_p_type
+   USE qs_operators_ao,                 ONLY: build_lin_mom_matrix
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
    USE rt_propagation_types,            ONLY: get_rtp,&
@@ -337,13 +338,14 @@ CONTAINS
 !> \param moments contains the multipole moments, already calculated
 !> \param moments_der will contain the derivatives of the multipole moments
 !> \param nmoments order of the multipole moments
+!> \param nders ...
 !> \param ref_point ...
 ! **************************************************************************************************
-   SUBROUTINE build_local_moments_der_matrix(qs_env, moments, moments_der, nmoments, ref_point)
+   SUBROUTINE build_local_moments_der_matrix(qs_env, moments, moments_der, nmoments, nders, ref_point)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: moments
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: moments_der
-      INTEGER, INTENT(IN)                                :: nmoments
+      INTEGER, INTENT(IN)                                :: nmoments, nders
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: ref_point
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_local_moments_der_matrix', &
@@ -399,8 +401,8 @@ CONTAINS
       ALLOCATE (mab(maxco, maxco, nm))
       mab(:, :, :) = 0.0_dp
 
-      M_dim = ncoset(nmoments) - 1
-      CPASSERT(M_dim <= SIZE(moments, 1))
+      M_dim = ncoset(nders) - 1
+      ! CPASSERT(M_dim <= SIZE(moments, 1))
       ALLOCATE (difmab(maxco, maxco, M_dim, 3))
       difmab(:, :, :, :) = 0.0_dp
 
@@ -411,6 +413,8 @@ CONTAINS
       ALLOCATE (mom_block_der(M_dim, 3))
       DO i = 1, nm
          NULLIFY (mom_block(i)%block)
+      ENDDO
+      DO i = 1, M_dim
          DO idir = 1, 3
             NULLIFY (mom_block_der(i, idir)%block)
          ENDDO
@@ -493,13 +497,15 @@ CONTAINS
          irow = iatom
          icol = jatom
 
-         DO i = 1, 3
+         DO i = 1, nm
             NULLIFY (mom_block(i)%block)
             ! get block from pre calculated overlap matrix
             CALL dbcsr_get_block_p(matrix=moments(i)%matrix, &
                                    row=irow, col=icol, BLOCK=mom_block(i)%block, found=found)
             CPASSERT(found .AND. ASSOCIATED(mom_block(i)%block))
             mom_block(i)%block = 0._dp
+         ENDDO
+         DO i = 1, M_dim
             DO idir = 1, 3
                NULLIFY (mom_block_der(i, idir)%block)
                CALL dbcsr_get_block_p(matrix=moments_der(i, idir)%matrix, &
@@ -533,10 +539,10 @@ CONTAINS
                                rpgfa(:, iset), la_min(iset), &
                                lb_max(jset), npgfb(jset), zetb(:, jset), &
                                rpgfb(:, jset), lb_min(jset), &
-                               nmoments, rac, rbc, difmab, mab_ext=mab)
+                               nders, rac, rbc, difmab) !, mab_ext=mab
 
                ! Contraction step
-               DO i = 1, 3
+               DO i = 1, nm
 
                   CALL dgemm("N", "N", ncoa, nsgfb(jset), ncob, &
                              1.0_dp, mab(1, 1, i), SIZE(mab, 1), &
@@ -548,7 +554,8 @@ CONTAINS
                              work(1, 1), SIZE(work, 1), &
                              1.0_dp, mom_block(i)%block(sgfa, sgfb), &
                              SIZE(mom_block(i)%block, 1))
-
+               ENDDO
+               DO i = 1, M_dim
                   DO idir = 1, 3
                      CALL dgemm("N", "N", ncoa, nsgfb(jset), ncob, &
                                 1.0_dp, difmab(1, 1, i, idir), SIZE(difmab, 1), &
@@ -1743,8 +1750,8 @@ CONTAINS
                                                             ikind, ispin, ix, iy, iz, l, nm, nmm, &
                                                             nmom, order
       LOGICAL                                            :: my_velreprs
-      REAL(dp)                                           :: charge, dd, strace, trace
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, rmom_vel
+      REAL(dp)                                           :: charge, dd, exp_s, strace, trace
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, qupole_der, rmom_vel
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: rmom
       REAL(dp), DIMENSION(3)                             :: rcc, ria
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
@@ -1753,8 +1760,8 @@ CONTAINS
       TYPE(cp_result_type), POINTER                      :: results
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: magmom, matrix_s, moments, momentum, &
                                                             rho_ao
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: moments_vel
-      TYPE(dbcsr_type), POINTER                          :: rho_magmom_ao
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: moments_der
+      TYPE(dbcsr_type), POINTER                          :: tmp_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_1d_type), POINTER                :: local_particles
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
@@ -1863,9 +1870,9 @@ CONTAINS
 
          ! Allocate matrices to store the matrix product to be traced (dbcsr_dot only works for products of
          ! symmetric matrices)
-         NULLIFY (rho_magmom_ao)
-         ALLOCATE (rho_magmom_ao)
-         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, rho_magmom_ao)
+         NULLIFY (tmp_ao)
+         ALLOCATE (tmp_ao)
+         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
 
          IF (qs_env%run_rtp) THEN
             ! get imaginary part of the density in rho_ao (the real part is not needed since the trace of the product
@@ -1878,17 +1885,17 @@ CONTAINS
          DO i = 1, SIZE(magmom)
             strace = 0._dp
             DO ispin = 1, dft_control%nspins
-               CALL dbcsr_set(rho_magmom_ao, 0.0_dp)
+               CALL dbcsr_set(tmp_ao, 0.0_dp)
                CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, magmom(i)%matrix, &
-                                   0.0_dp, rho_magmom_ao)
-               CALL dbcsr_trace(rho_magmom_ao, trace)
+                                   0.0_dp, tmp_ao)
+               CALL dbcsr_trace(tmp_ao, trace)
                strace = strace + trace
             END DO
             mmom(i) = strace
          END DO
 
          CALL dbcsr_deallocate_matrix_set(magmom)
-         CALL dbcsr_deallocate_matrix(rho_magmom_ao)
+         CALL dbcsr_deallocate_matrix(tmp_ao)
       END IF
 
       ! velocity representations
@@ -1896,8 +1903,13 @@ CONTAINS
          ALLOCATE (rmom_vel(nm))
          rmom_vel = 0.0_dp
 
+         NULLIFY (tmp_ao)
+         ALLOCATE (tmp_ao)
+         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
+
          DO order = 1, nmom
             SELECT CASE (order)
+
             CASE (1) ! expectation value of momentum
                NULLIFY (sab_orb)
                CALL get_qs_env(qs_env, sab_orb=sab_orb)
@@ -1910,37 +1922,122 @@ CONTAINS
                   CALL cp_dbcsr_alloc_block_from_nbl(momentum(i)%matrix, sab_orb)
                   CALL dbcsr_set(momentum(i)%matrix, 0.0_dp)
                ENDDO
+               CALL build_lin_mom_matrix(qs_env, momentum)
+
+               ! imaginary part of the density for RTP, real part gives 0 since momentum is antisymmetric
+               IF (qs_env%run_rtp) THEN
+                  NULLIFY (rho_ao)
+                  CALL qs_rho_get(rho, rho_ao_im=rho_ao)
+                  DO idir = 1, SIZE(momentum)
+                     strace = 0._dp
+                     DO ispin = 1, dft_control%nspins
+                        CALL dbcsr_set(tmp_ao, 0.0_dp)
+                        CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, momentum(idir)%matrix, &
+                                            0.0_dp, tmp_ao)
+                        CALL dbcsr_trace(tmp_ao, trace)
+                        strace = strace + trace
+                     END DO
+                     rmom_vel(idir) = rmom_vel(idir) + strace
+                  ENDDO
+               ENDIF
 
                CALL dbcsr_deallocate_matrix_set(momentum)
+
             CASE (2) ! expectation value of quadrupole moment in vel. reprs.
                NULLIFY (sab_orb)
                CALL get_qs_env(qs_env, sab_all=sab_orb)
-               NULLIFY (moments, moments_vel)
-               CALL dbcsr_allocate_matrix_set(moments, 3)
-               CALL dbcsr_allocate_matrix_set(moments_vel, 3, 3)
-               DO i = 1, 3 ! x, y, z
+
+               ! Allocate matrices
+               NULLIFY (moments, moments_der)
+               CALL dbcsr_allocate_matrix_set(moments, nm)
+               CALL dbcsr_allocate_matrix_set(moments_der, 3, 3)
+               DO i = 1, nm
                   CALL dbcsr_init_p(moments(i)%matrix)
                   CALL dbcsr_create(moments(i)%matrix, template=matrix_s(1)%matrix, &
                                     matrix_type=dbcsr_type_no_symmetry)
                   CALL cp_dbcsr_alloc_block_from_nbl(moments(i)%matrix, sab_orb)
                   CALL dbcsr_set(moments(i)%matrix, 0.0_dp)
-
+               ENDDO
+               DO i = 1, 3 ! x, y, z
                   DO idir = 1, 3 ! d/dx, d/dy, d/dz
-                     CALL dbcsr_init_p(moments_vel(i, idir)%matrix)
-                     CALL dbcsr_create(moments_vel(i, idir)%matrix, template=matrix_s(1)%matrix, &
+                     CALL dbcsr_init_p(moments_der(i, idir)%matrix)
+                     CALL dbcsr_create(moments_der(i, idir)%matrix, template=matrix_s(1)%matrix, &
                                        matrix_type=dbcsr_type_no_symmetry)
-                     CALL cp_dbcsr_alloc_block_from_nbl(moments_vel(i, idir)%matrix, sab_orb)
-                     CALL dbcsr_set(moments_vel(i, idir)%matrix, 0.0_dp)
+                     CALL cp_dbcsr_alloc_block_from_nbl(moments_der(i, idir)%matrix, sab_orb)
+                     CALL dbcsr_set(moments_der(i, idir)%matrix, 0.0_dp)
                   ENDDO
                END DO
 
-               CALL build_local_moments_der_matrix(qs_env, moments, moments_vel, 1, rcc)
+               ! get derivatives, e. g. x d/dy in ao basis
+               CALL build_local_moments_der_matrix(qs_env, moments, moments_der, 2, 1, rcc)
 
+               ! Expectation value of overlap matrix (identity operator) should give number of electrons
+               NULLIFY (rho_ao)
+               CALL qs_rho_get(rho, rho_ao=rho_ao)
+               exp_s = 0._dp
+               trace = 0.0_dp
+               DO ispin = 1, dft_control%nspins
+                  CALL dbcsr_dot(rho_ao(ispin)%matrix, matrix_s(1)%matrix, trace)
+                  exp_s = exp_s + trace
+               END DO
+
+               ALLOCATE (qupole_der(9)) ! will contain the expectation values of r_\alpha * d/d r_\beta
+               qupole_der = 0._dp
+
+               NULLIFY (rho_ao)
+               CALL qs_rho_get(rho, rho_ao=rho_ao)
+
+               ! Calculate expectation value over real part
+               trace = 0._dp
+               DO i = 1, 3
+                  DO idir = 1, 3
+                     strace = 0._dp
+                     DO ispin = 1, dft_control%nspins
+                        CALL dbcsr_set(tmp_ao, 0._dp)
+                        CALL dbcsr_multiply("T", "N", 1._dp, rho_ao(ispin)%matrix, moments_der(i, idir)%matrix, 0._dp, tmp_ao)
+                        CALL dbcsr_trace(tmp_ao, trace)
+                        strace = strace + trace
+                     ENDDO
+                     qupole_der((i - 1)*3 + idir) = qupole_der((i - 1)*3 + idir) + strace
+                  ENDDO
+               ENDDO
+
+               IF (qs_env%run_rtp) THEN
+                  NULLIFY (rho_ao)
+                  CALL qs_rho_get(rho, rho_ao_im=rho_ao)
+
+                  ! Calculate expectation value over imaginary part
+                  trace = 0._dp
+                  DO i = 1, 3
+                     DO idir = 1, 3
+                        strace = 0._dp
+                        DO ispin = 1, dft_control%nspins
+                           CALL dbcsr_set(tmp_ao, 0._dp)
+                           CALL dbcsr_multiply("T", "N", 1._dp, rho_ao(ispin)%matrix, moments_der(i, idir)%matrix, 0._dp, tmp_ao)
+                           CALL dbcsr_trace(tmp_ao, trace)
+                           strace = strace + trace
+                        ENDDO
+                        qupole_der((i - 1)*3 + idir) = qupole_der((i - 1)*3 + idir) + strace
+                     ENDDO
+                  ENDDO
+               ENDIF
+
+               ! calculate vel. reprs. of quadrupole moment from derivatives
+               rmom_vel(4) = -2*qupole_der(1) + exp_s
+               rmom_vel(5) = -qupole_der(2) - qupole_der(4)
+               rmom_vel(6) = -qupole_der(3) - qupole_der(7)
+               rmom_vel(7) = -2*(qupole_der(5)) + exp_s
+               rmom_vel(8) = -qupole_der(6) - qupole_der(8)
+               rmom_vel(9) = -2*qupole_der(9) + exp_s
+
+               DEALLOCATE (qupole_der)
                CALL dbcsr_deallocate_matrix_set(moments)
-               CALL dbcsr_deallocate_matrix_set(moments_vel)
+               CALL dbcsr_deallocate_matrix_set(moments_der)
             CASE DEFAULT
             END SELECT
          ENDDO
+
+         CALL dbcsr_deallocate_matrix(tmp_ao)
 
       ENDIF
 

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -22,7 +22,7 @@ MODULE qs_moments
    USE block_p_types,                   ONLY: block_p_type
    USE cell_types,                      ONLY: cell_type,&
                                               pbc
-   USE commutator_rpnl,                 ONLY: build_com_mom_nl_2
+   USE commutator_rpnl,                 ONLY: build_com_mom_nl
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_lu_decompose
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
@@ -2406,25 +2406,26 @@ CONTAINS
 
          ! calculate commutators in AO basis
          IF (calc_rv .AND. calc_rrv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rrv=matrix_rrv, &
-                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+                                  matrix_rrv=matrix_rrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rv .AND. calc_rxrv .AND. .NOT. calc_rrv) THEN
-            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
-                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+                                  matrix_rxrv=matrix_rxrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rrv .AND. calc_rxrv .AND. .NOT. calc_rv) THEN
-            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, &
-                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rxrv=matrix_rxrv, &
+                                  matrix_rrv=matrix_rrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rv .AND. calc_rxrv .AND. calc_rrv) THEN
-            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv, matrix_rxrv=matrix_rxrv, &
-                                    matrix_rrv=matrix_rrv, ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+                                  matrix_rxrv=matrix_rxrv, matrix_rrv=matrix_rrv, ref_point=ref_point, cell=cell)
          ELSE IF (calc_rv .AND. .NOT. calc_rrv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rv=matrix_rv)
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rv=matrix_rv, &
+                                  ref_point=ref_point, cell=cell)
          ELSE IF (calc_rrv .AND. .NOT. calc_rv .AND. .NOT. calc_rxrv) THEN
-            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rrv=matrix_rrv, &
-                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rrv=matrix_rrv, &
+                                  ref_point=ref_point, cell=cell)
          ELSE IF (calc_rxrv .AND. .NOT. calc_rv .AND. .NOT. calc_rrv) THEN
-            CALL build_com_mom_nl_2(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, matrix_rxrv=matrix_rxrv, &
-                                    ref_point=ref_point, particle_set=particle_set, cell=cell)
+            CALL build_com_mom_nl(qs_kind_set, sab_all, sap_ppnl, eps_ppnl, particle_set, matrix_rxrv=matrix_rxrv, &
+                                  ref_point=ref_point, cell=cell)
          ENDIF
       ENDIF
 

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -340,6 +340,8 @@ CONTAINS
 !> \param nmoments order of the multipole moments
 !> \param nders ...
 !> \param ref_point ...
+!> \note
+!>        Adapted from rRc_xyz_der_ao in qs_operators_ao
 ! **************************************************************************************************
    SUBROUTINE build_local_moments_der_matrix(qs_env, moments, moments_der, nmoments, nders, ref_point)
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -351,8 +353,9 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_local_moments_der_matrix', &
          routineP = moduleN//':'//routineN
 
-      INTEGER :: handle, i, iatom, icol, idir, ikind, inode, irow, iset, jatom, jkind, jset, &
-         last_jatom, M_dim, maxco, maxsgf, ncoa, ncob, nkind, nm, nseta, nsetb, sgfa, sgfb
+      INTEGER :: handle, i, iatom, icol, idir, ii, ikind, inode, ipgf, irow, iset, j, jatom, &
+         jkind, jpgf, jset, last_jatom, M_dim, maxco, maxsgf, na, nb, ncoa, ncob, nda, ndb, nkind, &
+         nm, nseta, nsetb, sgfa, sgfb
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, npgfa, &
                                                             npgfb, nsgfa, nsgfb
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
@@ -363,7 +366,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rac, rb, rbc, rc
       REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a, set_radius_b
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgfa, rpgfb, sphi_a, sphi_b, zeta, zetb
-      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: mab
+      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: mab, mab_tmp
       TYPE(block_p_type), ALLOCATABLE, DIMENSION(:)      :: mom_block
       TYPE(block_p_type), ALLOCATABLE, DIMENSION(:, :)   :: mom_block_der
       TYPE(cell_type), POINTER                           :: cell
@@ -383,7 +386,7 @@ CONTAINS
 
       nm = (6 + 11*nmoments + 6*nmoments**2 + nmoments**3)/6 - 1
       CPASSERT(SIZE(moments) >= nm)
-
+      CPASSERT(nmoments >= nders)
       NULLIFY (qs_kind_set, particle_set, sab_all, cell)
       CALL get_qs_env(qs_env=qs_env, &
                       qs_kind_set=qs_kind_set, &
@@ -529,18 +532,42 @@ CONTAINS
                ncob = npgfb(jset)*ncoset(lb_max(jset))
                sgfb = first_sgfb(1, jset)
 
-               ! Calculate the primitive integrals
-               CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), &
+               ALLOCATE (mab_tmp(npgfa(iset)*ncoset(la_max(iset) + 1), &
+                                 npgfb(jset)*ncoset(lb_max(jset) + 1), ncoset(nmoments) - 1))
+
+               ! Calculate the primitive integrals (need l+1 for derivatives)
+               CALL moment(la_max(iset) + 1, npgfa(iset), zeta(:, iset), &
                            rpgfa(:, iset), la_min(iset), &
-                           lb_max(jset), npgfb(jset), zetb(:, jset), &
-                           rpgfb(:, jset), nmoments, rac, rbc, mab)
+                           lb_max(jset) + 1, npgfb(jset), zetb(:, jset), &
+                           rpgfb(:, jset), nmoments, rac, rbc, mab_tmp)
 
                CALL diff_momop(la_max(iset), npgfa(iset), zeta(:, iset), &
                                rpgfa(:, iset), la_min(iset), &
                                lb_max(jset), npgfb(jset), zetb(:, jset), &
                                rpgfb(:, jset), lb_min(jset), &
-                               nders, rac, rbc, difmab) !, mab_ext=mab
+                               nders, rac, rbc, difmab, mab_ext=mab_tmp)
+               ! copy subset of mab_tmp (l+1) to mab (l)
+               mab = 0.0_dp
+               DO ii = 1, nm
+                  na = 0
+                  nda = 0
+                  DO ipgf = 1, npgfa(iset)
+                     nb = 0
+                     ndb = 0
+                     DO jpgf = 1, npgfb(jset)
+                        DO j = 1, ncoset(lb_max(jset))
+                           DO i = 1, ncoset(la_max(iset))
+                              mab(i + na, j + nb, ii) = mab_tmp(i + nda, j + ndb, ii)
+                           END DO ! i
+                        END DO ! j
+                        nb = nb + ncoset(lb_max(jset))
+                        ndb = ndb + ncoset(lb_max(jset) + 1)
+                     END DO ! jpgf
+                     na = na + ncoset(la_max(iset))
+                     nda = nda + ncoset(la_max(iset) + 1)
+                  END DO ! ipgf
 
+               ENDDO
                ! Contraction step
                DO i = 1, nm
 
@@ -567,14 +594,11 @@ CONTAINS
                                 work(1, 1), SIZE(work, 1), &
                                 1._dp, mom_block_der(i, idir)%block(sgfa, sgfb), &
                                 SIZE(mom_block_der(i, idir)%block, 1))
-
                   ENDDO
-
                END DO
-
+               DEALLOCATE (mab_tmp)
             END DO
          END DO
-
       ENDDO
       CALL neighbor_list_iterator_release(nl_iterator)
 
@@ -1750,7 +1774,7 @@ CONTAINS
                                                             ikind, ispin, ix, iy, iz, l, nm, nmm, &
                                                             nmom, order
       LOGICAL                                            :: my_velreprs
-      REAL(dp)                                           :: charge, dd, exp_s, strace, trace
+      REAL(dp)                                           :: charge, dd, strace, trace
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: mmom, qupole_der, rmom_vel
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: rmom
       REAL(dp), DIMENSION(3)                             :: rcc, ria
@@ -1783,19 +1807,7 @@ CONTAINS
       ! only allow for moments up to maxl set by basis
       nmom = MIN(nmoments, current_maxl)
       ! electronic contribution
-      NULLIFY (moments, matrix_s)
-      CALL get_qs_env(qs_env=qs_env, matrix_s=matrix_s)
-      nm = (6 + 11*nmom + 6*nmom**2 + nmom**3)/6 - 1
-      CALL dbcsr_allocate_matrix_set(moments, nm)
-      DO i = 1, nm
-         ALLOCATE (moments(i)%matrix)
-         CALL dbcsr_copy(moments(i)%matrix, matrix_s(1)%matrix, "Moments")
-         CALL dbcsr_set(moments(i)%matrix, 0.0_dp)
-      END DO
-
-      CALL build_local_moment_matrix(qs_env, moments, nmom, ref_point=rcc)
-
-      NULLIFY (dft_control, rho, cell, particle_set, qs_kind_set, results, para_env, matrix_s, rho_ao)
+      NULLIFY (dft_control, rho, cell, particle_set, qs_kind_set, results, para_env, matrix_s, rho_ao, sab_orb)
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
                       rho=rho, &
@@ -1804,15 +1816,56 @@ CONTAINS
                       particle_set=particle_set, &
                       qs_kind_set=qs_kind_set, &
                       para_env=para_env, &
-                      matrix_s=matrix_s)
+                      matrix_s=matrix_s, &
+                      sab_all=sab_orb)
+
+      NULLIFY (moments)
+      nm = (6 + 11*nmom + 6*nmom**2 + nmom**3)/6 - 1
+      CALL dbcsr_allocate_matrix_set(moments, nm)
+      DO i = 1, nm
+         ALLOCATE (moments(i)%matrix)
+         IF (my_velreprs .AND. (nmom >= 2)) THEN
+            CALL dbcsr_create(moments(i)%matrix, template=matrix_s(1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(moments(i)%matrix, sab_orb)
+         ELSE
+            CALL dbcsr_copy(moments(i)%matrix, matrix_s(1)%matrix, "Moments")
+         ENDIF
+         CALL dbcsr_set(moments(i)%matrix, 0.0_dp)
+      END DO
+
+      ! calculate derivatives if quadrupole in vel. reprs. is requested
+      IF (my_velreprs .AND. (nmom >= 2)) THEN
+         NULLIFY (moments_der)
+         CALL dbcsr_allocate_matrix_set(moments_der, 3, 3)
+         DO i = 1, 3 ! x, y, z
+            DO idir = 1, 3 ! d/dx, d/dy, d/dz
+               CALL dbcsr_init_p(moments_der(i, idir)%matrix)
+               CALL dbcsr_create(moments_der(i, idir)%matrix, template=matrix_s(1)%matrix, &
+                                 matrix_type=dbcsr_type_no_symmetry)
+               CALL cp_dbcsr_alloc_block_from_nbl(moments_der(i, idir)%matrix, sab_orb)
+               CALL dbcsr_set(moments_der(i, idir)%matrix, 0.0_dp)
+            ENDDO
+         END DO
+         CALL build_local_moments_der_matrix(qs_env, moments, moments_der, 2, 1, rcc)
+      ELSE
+         CALL build_local_moment_matrix(qs_env, moments, nmom, ref_point=rcc)
+      ENDIF
 
       CALL qs_rho_get(rho, rho_ao=rho_ao)
 
-      nm = SIZE(moments)
       ALLOCATE (rmom(nm + 1, 3))
       ALLOCATE (rlab(nm + 1))
       rmom = 0.0_dp
       rlab = ""
+
+      IF ((my_velreprs .AND. (nmoments >= 2)) .OR. magnetic) THEN
+         ! Allocate matrix to store the matrix product to be traced (dbcsr_dot only works for products of
+         ! symmetric matrices)
+         NULLIFY (tmp_ao)
+         ALLOCATE (tmp_ao)
+         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
+      ENDIF
 
       trace = 0.0_dp
       DO ispin = 1, dft_control%nspins
@@ -1823,7 +1876,13 @@ CONTAINS
       DO i = 1, SIZE(moments)
          strace = 0._dp
          DO ispin = 1, dft_control%nspins
-            CALL dbcsr_dot(rho_ao(ispin)%matrix, moments(i)%matrix, trace)
+            IF (my_velreprs .AND. nmoments >= 2) THEN
+               CALL dbcsr_multiply("T", "N", 1.0_dp, rho_ao(ispin)%matrix, moments(i)%matrix, &
+                                   0.0_dp, tmp_ao)
+               CALL dbcsr_trace(tmp_ao, trace)
+            ELSE
+               CALL dbcsr_dot(rho_ao(ispin)%matrix, moments(i)%matrix, trace)
+            ENDIF
             strace = strace + trace
          END DO
          rmom(i + 1, 1) = strace
@@ -1868,12 +1927,6 @@ CONTAINS
          nmm = SIZE(magmom)
          ALLOCATE (mmom(nmm))
 
-         ! Allocate matrices to store the matrix product to be traced (dbcsr_dot only works for products of
-         ! symmetric matrices)
-         NULLIFY (tmp_ao)
-         ALLOCATE (tmp_ao)
-         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
-
          IF (qs_env%run_rtp) THEN
             ! get imaginary part of the density in rho_ao (the real part is not needed since the trace of the product
             ! of a symmetric (REAL(rho_ao)) and an anti-symmetric (L_AO) matrix is zero)
@@ -1895,17 +1948,12 @@ CONTAINS
          END DO
 
          CALL dbcsr_deallocate_matrix_set(magmom)
-         CALL dbcsr_deallocate_matrix(tmp_ao)
       END IF
 
       ! velocity representations
       IF (my_velreprs) THEN
          ALLOCATE (rmom_vel(nm))
          rmom_vel = 0.0_dp
-
-         NULLIFY (tmp_ao)
-         ALLOCATE (tmp_ao)
-         CALL dbcsr_desymmetrize(matrix_s(1)%matrix, tmp_ao)
 
          DO order = 1, nmom
             SELECT CASE (order)
@@ -1944,43 +1992,6 @@ CONTAINS
                CALL dbcsr_deallocate_matrix_set(momentum)
 
             CASE (2) ! expectation value of quadrupole moment in vel. reprs.
-               NULLIFY (sab_orb)
-               CALL get_qs_env(qs_env, sab_all=sab_orb)
-
-               ! Allocate matrices
-               NULLIFY (moments, moments_der)
-               CALL dbcsr_allocate_matrix_set(moments, nm)
-               CALL dbcsr_allocate_matrix_set(moments_der, 3, 3)
-               DO i = 1, nm
-                  CALL dbcsr_init_p(moments(i)%matrix)
-                  CALL dbcsr_create(moments(i)%matrix, template=matrix_s(1)%matrix, &
-                                    matrix_type=dbcsr_type_no_symmetry)
-                  CALL cp_dbcsr_alloc_block_from_nbl(moments(i)%matrix, sab_orb)
-                  CALL dbcsr_set(moments(i)%matrix, 0.0_dp)
-               ENDDO
-               DO i = 1, 3 ! x, y, z
-                  DO idir = 1, 3 ! d/dx, d/dy, d/dz
-                     CALL dbcsr_init_p(moments_der(i, idir)%matrix)
-                     CALL dbcsr_create(moments_der(i, idir)%matrix, template=matrix_s(1)%matrix, &
-                                       matrix_type=dbcsr_type_no_symmetry)
-                     CALL cp_dbcsr_alloc_block_from_nbl(moments_der(i, idir)%matrix, sab_orb)
-                     CALL dbcsr_set(moments_der(i, idir)%matrix, 0.0_dp)
-                  ENDDO
-               END DO
-
-               ! get derivatives, e. g. x d/dy in ao basis
-               CALL build_local_moments_der_matrix(qs_env, moments, moments_der, 2, 1, rcc)
-
-               ! Expectation value of overlap matrix (identity operator) should give number of electrons
-               NULLIFY (rho_ao)
-               CALL qs_rho_get(rho, rho_ao=rho_ao)
-               exp_s = 0._dp
-               trace = 0.0_dp
-               DO ispin = 1, dft_control%nspins
-                  CALL dbcsr_dot(rho_ao(ispin)%matrix, matrix_s(1)%matrix, trace)
-                  exp_s = exp_s + trace
-               END DO
-
                ALLOCATE (qupole_der(9)) ! will contain the expectation values of r_\alpha * d/d r_\beta
                qupole_der = 0._dp
 
@@ -2023,22 +2034,24 @@ CONTAINS
                ENDIF
 
                ! calculate vel. reprs. of quadrupole moment from derivatives
-               rmom_vel(4) = -2*qupole_der(1) + exp_s
+               rmom_vel(4) = -2*qupole_der(1) - rmom(1, 1)
                rmom_vel(5) = -qupole_der(2) - qupole_der(4)
                rmom_vel(6) = -qupole_der(3) - qupole_der(7)
-               rmom_vel(7) = -2*(qupole_der(5)) + exp_s
+               rmom_vel(7) = -2*(qupole_der(5)) - rmom(1, 1)
                rmom_vel(8) = -qupole_der(6) - qupole_der(8)
-               rmom_vel(9) = -2*qupole_der(9) + exp_s
+               rmom_vel(9) = -2*qupole_der(9) - rmom(1, 1)
 
                DEALLOCATE (qupole_der)
-               CALL dbcsr_deallocate_matrix_set(moments)
-               CALL dbcsr_deallocate_matrix_set(moments_der)
             CASE DEFAULT
             END SELECT
          ENDDO
+      ENDIF
 
+      IF ((my_velreprs .AND. (nmoments >= 2)) .OR. magnetic) THEN
          CALL dbcsr_deallocate_matrix(tmp_ao)
-
+      ENDIF
+      IF (my_velreprs .AND. (nmoments >= 2)) THEN
+         CALL dbcsr_deallocate_matrix_set(moments_der)
       ENDIF
 
       description = "[DIPOLE]"

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1103,7 +1103,7 @@ CONTAINS
 
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: handle, maxmom, reference, unit_nr
-      LOGICAL                                            :: do_kpoints, magnetic, periodic
+      LOGICAL                                            :: do_kpoints, magnetic, periodic, vel_reprs
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ref_point
       TYPE(section_vals_type), POINTER                   :: print_key
 
@@ -1122,6 +1122,8 @@ CONTAINS
                                       keyword_name="DFT%PRINT%MOMENTS%REFERENCE")
          magnetic = section_get_lval(section_vals=input, &
                                      keyword_name="DFT%PRINT%MOMENTS%MAGNETIC")
+         vel_reprs = section_get_lval(section_vals=input, &
+                                      keyword_name="DFT%PRINT%MOMENTS%VEL_REPRS")
          NULLIFY (ref_point)
          CALL section_vals_val_get(input, "DFT%PRINT%MOMENTS%REF_POINT", r_vals=ref_point)
          unit_nr = cp_print_key_unit_nr(logger=logger, basis_section=input, &
@@ -1147,7 +1149,7 @@ CONTAINS
             IF (periodic) THEN
                CALL qs_moment_berry_phase(qs_env, magnetic, maxmom, reference, ref_point, unit_nr)
             ELSE
-               CALL qs_moment_locop(qs_env, magnetic, maxmom, reference, ref_point, unit_nr)
+               CALL qs_moment_locop(qs_env, magnetic, maxmom, reference, ref_point, unit_nr, vel_reprs)
             END IF
          END IF
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1104,7 +1104,7 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: handle, maxmom, reference, unit_nr
       LOGICAL                                            :: com_nl, do_kpoints, magnetic, periodic, &
-                                                            vel_reprs
+                                                            second_ref_point, vel_reprs
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ref_point
       TYPE(section_vals_type), POINTER                   :: print_key
 
@@ -1127,6 +1127,8 @@ CONTAINS
                                       keyword_name="DFT%PRINT%MOMENTS%VEL_REPRS")
          com_nl = section_get_lval(section_vals=input, &
                                    keyword_name="DFT%PRINT%MOMENTS%COM_NL")
+         second_ref_point = section_get_lval(section_vals=input, &
+                                             keyword_name="DFT%PRINT%MOMENTS%SECOND_REFERENCE_POINT")
 
          NULLIFY (ref_point)
          CALL section_vals_val_get(input, "DFT%PRINT%MOMENTS%REF_POINT", r_vals=ref_point)
@@ -1159,6 +1161,40 @@ CONTAINS
 
          CALL cp_print_key_finished_output(unit_nr=unit_nr, logger=logger, &
                                            basis_section=input, print_key_path="DFT%PRINT%MOMENTS")
+
+         IF (second_ref_point) THEN
+            reference = section_get_ival(section_vals=input, &
+                                         keyword_name="DFT%PRINT%MOMENTS%REFERENCE_2")
+
+            NULLIFY (ref_point)
+            CALL section_vals_val_get(input, "DFT%PRINT%MOMENTS%REF_POINT_2", r_vals=ref_point)
+            unit_nr = cp_print_key_unit_nr(logger=logger, basis_section=input, &
+                                           print_key_path="DFT%PRINT%MOMENTS", extension=".dat", &
+                                           middle_name="moments_refpoint_2", log_filename=.FALSE.)
+
+            IF (output_unit > 0) THEN
+               IF (unit_nr /= output_unit) THEN
+                  INQUIRE (UNIT=unit_nr, NAME=filename)
+                  WRITE (UNIT=output_unit, FMT="(/,T2,A,2(/,T3,A),/)") &
+                     "MOMENTS", "The electric/magnetic moments for the second reference point are written to file:", &
+                     TRIM(filename)
+               ELSE
+                  WRITE (UNIT=output_unit, FMT="(/,T2,A)") "ELECTRIC/MAGNETIC MOMENTS"
+               END IF
+            END IF
+            IF (do_kpoints) THEN
+               CPWARN("Moments not implemented for k-point calculations!")
+            ELSE
+               IF (periodic) THEN
+                  CALL qs_moment_berry_phase(qs_env, magnetic, maxmom, reference, ref_point, unit_nr)
+               ELSE
+                  CALL qs_moment_locop(qs_env, magnetic, maxmom, reference, ref_point, unit_nr, vel_reprs, com_nl)
+               END IF
+            END IF
+            CALL cp_print_key_finished_output(unit_nr=unit_nr, logger=logger, &
+                                              basis_section=input, print_key_path="DFT%PRINT%MOMENTS")
+         ENDIF
+
       END IF
 
       CALL timestop(handle)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1103,7 +1103,8 @@ CONTAINS
 
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: handle, maxmom, reference, unit_nr
-      LOGICAL                                            :: do_kpoints, magnetic, periodic, vel_reprs
+      LOGICAL                                            :: com_nl, do_kpoints, magnetic, periodic, &
+                                                            vel_reprs
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ref_point
       TYPE(section_vals_type), POINTER                   :: print_key
 
@@ -1124,6 +1125,9 @@ CONTAINS
                                      keyword_name="DFT%PRINT%MOMENTS%MAGNETIC")
          vel_reprs = section_get_lval(section_vals=input, &
                                       keyword_name="DFT%PRINT%MOMENTS%VEL_REPRS")
+         com_nl = section_get_lval(section_vals=input, &
+                                   keyword_name="DFT%PRINT%MOMENTS%COM_NL")
+
          NULLIFY (ref_point)
          CALL section_vals_val_get(input, "DFT%PRINT%MOMENTS%REF_POINT", r_vals=ref_point)
          unit_nr = cp_print_key_unit_nr(logger=logger, basis_section=input, &
@@ -1149,7 +1153,7 @@ CONTAINS
             IF (periodic) THEN
                CALL qs_moment_berry_phase(qs_env, magnetic, maxmom, reference, ref_point, unit_nr)
             ELSE
-               CALL qs_moment_locop(qs_env, magnetic, maxmom, reference, ref_point, unit_nr, vel_reprs)
+               CALL qs_moment_locop(qs_env, magnetic, maxmom, reference, ref_point, unit_nr, vel_reprs, com_nl)
             END IF
          END IF
 

--- a/src/rt_propagation_types.F
+++ b/src/rt_propagation_types.F
@@ -97,7 +97,7 @@ MODULE rt_propagation_types
       REAL(KIND=dp)                               :: mixing_factor
       LOGICAL                                     :: mixing
       LOGICAL                                     :: do_hfx
-      LOGICAL                                     :: magnetic
+      LOGICAL                                     :: track_imag_density
       INTEGER, DIMENSION(:, :), ALLOCATABLE          :: orders
       INTEGER                                     :: nsteps, istep, i_start, max_steps
       INTEGER                                     :: iter
@@ -283,7 +283,7 @@ CONTAINS
       rtp%istep = 0
       rtp%iter = 0
       rtp%do_hfx = .FALSE.
-      rtp%magnetic = .FALSE.
+      rtp%track_imag_density = .FALSE.
 
    END SUBROUTINE rt_prop_create
 

--- a/src/sap_kind_types.F
+++ b/src/sap_kind_types.F
@@ -9,7 +9,25 @@
 ! **************************************************************************************************
 MODULE sap_kind_types
 
+   USE ai_moments,                      ONLY: moment
+   USE ai_overlap,                      ONLY: overlap
+   USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
+                                              gto_basis_set_type
+   USE cell_types,                      ONLY: cell_type,&
+                                              pbc
+   USE external_potential_types,        ONLY: gth_potential_p_type,&
+                                              gth_potential_type,&
+                                              sgp_potential_p_type,&
+                                              sgp_potential_type
    USE kinds,                           ONLY: dp
+   USE orbital_pointers,                ONLY: init_orbital_pointers,&
+                                              nco,&
+                                              ncoset
+   USE particle_types,                  ONLY: particle_type
+   USE qs_kind_types,                   ONLY: get_qs_kind,&
+                                              get_qs_kind_set,&
+                                              qs_kind_type
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE util,                            ONLY: locate,&
                                               sort
 #include "./base/base_uses.f90"
@@ -46,7 +64,7 @@ MODULE sap_kind_types
 
    PUBLIC :: sap_int_type, clist_type, alist_type, &
              release_sap_int, get_alist, alist_pre_align_blk, &
-             alist_post_align_blk, sap_sort
+             alist_post_align_blk, sap_sort, build_sap_ints
 
 CONTAINS
 
@@ -238,5 +256,367 @@ CONTAINS
    END SUBROUTINE sap_sort
 
 !==========================================================================================================
+
+! **************************************************************************************************
+!> \brief Calculate overlap and optionally momenta <a|x^n|p> between GTOs and nl. pseudo potential projectors
+!>        adapted from core_ppnl.F::build_core_ppnl
+!> \param sap_int allocated in parent routine (nkind*nkind)
+!> \param sap_ppnl ...
+!> \param qs_kind_set ...
+!> \param nder Either number of derivatives or order of moments
+!> \param moment_mode if present and true, moments are calculated instead of derivatives
+!> \param refpoint optionally the reference point for moment calculation
+!> \param particle_set needed if refpoint is present
+!> \param cell needed if refpoint is present
+! **************************************************************************************************
+   SUBROUTINE build_sap_ints(sap_int, sap_ppnl, qs_kind_set, nder, moment_mode, refpoint, particle_set, cell)
+      TYPE(sap_int_type), DIMENSION(:), INTENT(INOUT), &
+         POINTER                                         :: sap_int
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         INTENT(IN), POINTER                             :: sap_ppnl
+      TYPE(qs_kind_type), DIMENSION(:), INTENT(IN), &
+         POINTER                                         :: qs_kind_set
+      INTEGER, INTENT(IN)                                :: nder
+      LOGICAL, INTENT(IN), OPTIONAL                      :: moment_mode
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN), OPTIONAL  :: refpoint
+      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
+         OPTIONAL, POINTER                               :: particle_set
+      TYPE(cell_type), INTENT(IN), OPTIONAL, POINTER     :: cell
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_sap_ints', routineP = moduleN//':'//routineN
+
+      INTEGER :: first_col, handle, i, iac, iatom, ikind, ilist, iset, j, jneighbor, katom, kkind, &
+         l, lc_max, lc_min, ldai, ldsab, lppnl, maxco, maxder, maxl, maxlgto, maxlppnl, maxppnl, &
+         maxsgf, na, nb, ncoa, ncoc, nkind, nlist, nneighbor, nnl, np, nppnl, nprjc, nseta, nsgfa, &
+         prjc, sgfa, slot
+      INTEGER, DIMENSION(3)                              :: cell_c
+      INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nprj_ppnl, &
+                                                            nsgf_seta
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
+      LOGICAL                                            :: dogth, my_momentmode, my_ref
+      LOGICAL, DIMENSION(0:9)                            :: is_nonlocal
+      REAL(KIND=dp)                                      :: dac, ppnl_radius
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: radp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: sab, work
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ai_work
+      REAL(KIND=dp), DIMENSION(1)                        :: rprjc, zetc
+      REAL(KIND=dp), DIMENSION(3)                        :: ra, rac, raf, rc, rcf, rf
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: a_nl, alpha_ppnl, hprj, set_radius_a
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cprj, h_nl, rpgfa, sphi_a, vprj_ppnl, &
+                                                            zeta
+      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: c_nl
+      TYPE(clist_type), POINTER                          :: clist
+      TYPE(gth_potential_p_type), DIMENSION(:), POINTER  :: gpotential
+      TYPE(gth_potential_type), POINTER                  :: gth_potential
+      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(sgp_potential_p_type), DIMENSION(:), POINTER  :: spotential
+      TYPE(sgp_potential_type), POINTER                  :: sgp_potential
+
+      CALL timeset(routineN, handle)
+
+      nkind = SIZE(qs_kind_set)
+      maxder = ncoset(nder)
+
+      ! determine whether moments or derivatives should be calculated
+      my_momentmode = .FALSE.
+      IF (PRESENT(moment_mode)) THEN
+         my_momentmode = moment_mode
+      ENDIF
+
+      my_ref = .FALSE.
+      IF (PRESENT(refpoint)) THEN
+         CPASSERT((PRESENT(cell) .AND. PRESENT(particle_set))) ! need these as well if refpoint is provided
+         rf = refpoint
+         my_ref = .TRUE.
+      ENDIF
+
+      CALL get_qs_kind_set(qs_kind_set, &
+                           maxco=maxco, &
+                           maxlgto=maxlgto, &
+                           maxsgf=maxsgf, &
+                           maxlppnl=maxlppnl, &
+                           maxppnl=maxppnl)
+
+      maxl = MAX(maxlgto, maxlppnl)
+      CALL init_orbital_pointers(maxl + nder + 1)
+
+      ldsab = MAX(maxco, ncoset(maxlppnl), maxsgf, maxppnl)
+      ldai = ncoset(maxl + nder + 1)
+
+      !set up direct access to basis and potential
+      ALLOCATE (basis_set(nkind), gpotential(nkind), spotential(nkind))
+      DO ikind = 1, nkind
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
+         IF (ASSOCIATED(orb_basis_set)) THEN
+            basis_set(ikind)%gto_basis_set => orb_basis_set
+         ELSE
+            NULLIFY (basis_set(ikind)%gto_basis_set)
+         END IF
+         CALL get_qs_kind(qs_kind_set(ikind), gth_potential=gth_potential, sgp_potential=sgp_potential)
+         NULLIFY (gpotential(ikind)%gth_potential)
+         NULLIFY (spotential(ikind)%sgp_potential)
+         IF (ASSOCIATED(gth_potential)) THEN
+            gpotential(ikind)%gth_potential => gth_potential
+         ELSE IF (ASSOCIATED(sgp_potential)) THEN
+            spotential(ikind)%sgp_potential => sgp_potential
+         END IF
+      END DO
+
+      !allocate sap int
+      DO slot = 1, sap_ppnl(1)%nl_size
+
+         ikind = sap_ppnl(1)%nlist_task(slot)%ikind
+         kkind = sap_ppnl(1)%nlist_task(slot)%jkind
+         iatom = sap_ppnl(1)%nlist_task(slot)%iatom
+         katom = sap_ppnl(1)%nlist_task(slot)%jatom
+         nlist = sap_ppnl(1)%nlist_task(slot)%nlist
+         ilist = sap_ppnl(1)%nlist_task(slot)%ilist
+         nneighbor = sap_ppnl(1)%nlist_task(slot)%nnode
+
+         iac = ikind + nkind*(kkind - 1)
+         IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
+         IF (.NOT. ASSOCIATED(gpotential(kkind)%gth_potential) .AND. &
+             .NOT. ASSOCIATED(spotential(kkind)%sgp_potential)) CYCLE
+         IF (.NOT. ASSOCIATED(sap_int(iac)%alist)) THEN
+            sap_int(iac)%a_kind = ikind
+            sap_int(iac)%p_kind = kkind
+            sap_int(iac)%nalist = nlist
+            ALLOCATE (sap_int(iac)%alist(nlist))
+            DO i = 1, nlist
+               NULLIFY (sap_int(iac)%alist(i)%clist)
+               sap_int(iac)%alist(i)%aatom = 0
+               sap_int(iac)%alist(i)%nclist = 0
+            END DO
+         END IF
+         IF (.NOT. ASSOCIATED(sap_int(iac)%alist(ilist)%clist)) THEN
+            sap_int(iac)%alist(ilist)%aatom = iatom
+            sap_int(iac)%alist(ilist)%nclist = nneighbor
+            ALLOCATE (sap_int(iac)%alist(ilist)%clist(nneighbor))
+            DO i = 1, nneighbor
+               sap_int(iac)%alist(ilist)%clist(i)%catom = 0
+            END DO
+         END IF
+      END DO
+
+      !calculate the overlap integrals <a|pp>
+!$OMP PARALLEL &
+!$OMP DEFAULT (NONE) &
+!$OMP SHARED  (basis_set, gpotential, spotential, maxder, ncoset, my_momentmode, &
+!$OMP          sap_ppnl, sap_int, nkind, ldsab, ldai, nder, nco, my_ref, cell, particle_set, rf) &
+!$OMP PRIVATE (ikind, kkind, iatom, katom, nlist, ilist, nneighbor, jneighbor, &
+!$OMP          cell_c, rac, iac, first_sgfa, la_max, la_min, npgfa, nseta, nsgfa, nsgf_seta, &
+!$OMP          slot, sphi_a, zeta, cprj, hprj, lppnl, nppnl, nprj_ppnl, &
+!$OMP          clist, iset, ncoa, sgfa, prjc, work, sab, ai_work, nprjc,  ppnl_radius, &
+!$OMP          ncoc, rpgfa, first_col, vprj_ppnl, i, j, l, dogth, &
+!$OMP          set_radius_a, rprjc, dac, lc_max, lc_min, zetc, alpha_ppnl, &
+!$OMP          na, nb, np, nnl, is_nonlocal, a_nl, h_nl, c_nl, radp, raf, rcf, ra, rc)
+
+      ! allocate work storage
+      ALLOCATE (sab(ldsab, ldsab*maxder), work(ldsab, ldsab*maxder))
+      sab = 0.0_dp
+      ALLOCATE (ai_work(ldai, ldai, ncoset(nder + 1)))
+      ai_work = 0.0_dp
+
+!$OMP DO SCHEDULE(GUIDED)
+      ! loop over neighbourlist
+      DO slot = 1, sap_ppnl(1)%nl_size
+         ikind = sap_ppnl(1)%nlist_task(slot)%ikind
+         kkind = sap_ppnl(1)%nlist_task(slot)%jkind
+         iatom = sap_ppnl(1)%nlist_task(slot)%iatom
+         katom = sap_ppnl(1)%nlist_task(slot)%jatom
+         nlist = sap_ppnl(1)%nlist_task(slot)%nlist
+         ilist = sap_ppnl(1)%nlist_task(slot)%ilist
+         nneighbor = sap_ppnl(1)%nlist_task(slot)%nnode
+         jneighbor = sap_ppnl(1)%nlist_task(slot)%inode
+         cell_c(:) = sap_ppnl(1)%nlist_task(slot)%cell(:)
+         rac(1:3) = sap_ppnl(1)%nlist_task(slot)%r(1:3)
+
+         iac = ikind + nkind*(kkind - 1)
+         IF (.NOT. ASSOCIATED(basis_set(ikind)%gto_basis_set)) CYCLE
+         ! get definition of basis set
+         first_sgfa => basis_set(ikind)%gto_basis_set%first_sgf
+         la_max => basis_set(ikind)%gto_basis_set%lmax
+         la_min => basis_set(ikind)%gto_basis_set%lmin
+         npgfa => basis_set(ikind)%gto_basis_set%npgf
+         nseta = basis_set(ikind)%gto_basis_set%nset
+         nsgfa = basis_set(ikind)%gto_basis_set%nsgf
+         nsgf_seta => basis_set(ikind)%gto_basis_set%nsgf_set
+         rpgfa => basis_set(ikind)%gto_basis_set%pgf_radius
+         set_radius_a => basis_set(ikind)%gto_basis_set%set_radius
+         sphi_a => basis_set(ikind)%gto_basis_set%sphi
+         zeta => basis_set(ikind)%gto_basis_set%zet
+         ! get definition of PP projectors
+         IF (ASSOCIATED(gpotential(kkind)%gth_potential)) THEN
+            ! GTH potential
+            dogth = .TRUE.
+            alpha_ppnl => gpotential(kkind)%gth_potential%alpha_ppnl
+            cprj => gpotential(kkind)%gth_potential%cprj
+            lppnl = gpotential(kkind)%gth_potential%lppnl
+            nppnl = gpotential(kkind)%gth_potential%nppnl
+            nprj_ppnl => gpotential(kkind)%gth_potential%nprj_ppnl
+            ppnl_radius = gpotential(kkind)%gth_potential%ppnl_radius
+            vprj_ppnl => gpotential(kkind)%gth_potential%vprj_ppnl
+         ELSE IF (ASSOCIATED(spotential(kkind)%sgp_potential)) THEN
+            ! SGP potential
+            dogth = .FALSE.
+            nprjc = spotential(kkind)%sgp_potential%nppnl
+            IF (nprjc == 0) CYCLE
+            nnl = spotential(kkind)%sgp_potential%n_nonlocal
+            lppnl = spotential(kkind)%sgp_potential%lmax
+            is_nonlocal = .FALSE.
+            is_nonlocal(0:lppnl) = spotential(kkind)%sgp_potential%is_nonlocal(0:lppnl)
+            a_nl => spotential(kkind)%sgp_potential%a_nonlocal
+            h_nl => spotential(kkind)%sgp_potential%h_nonlocal
+            c_nl => spotential(kkind)%sgp_potential%c_nonlocal
+            ppnl_radius = spotential(kkind)%sgp_potential%ppnl_radius
+            ALLOCATE (radp(nnl))
+            radp(:) = ppnl_radius
+            cprj => spotential(kkind)%sgp_potential%cprj_ppnl
+            hprj => spotential(kkind)%sgp_potential%vprj_ppnl
+            nppnl = SIZE(cprj, 2)
+         ELSE
+            CYCLE
+         END IF
+
+         IF (my_ref) THEN
+            ra(:) = pbc(particle_set(iatom)%r(:) - rf, cell) + rf
+            rc(:) = pbc(particle_set(katom)%r(:) - rf, cell) + rf
+            raf(:) = ra(:) - rf(:)
+            rcf(:) = rc(:) - rf(:)
+         ELSE
+            raf(:) = -rac
+            rcf(:) = (/0._dp, 0._dp, 0._dp/)
+         ENDIF
+
+         dac = NORM2(rac)
+         clist => sap_int(iac)%alist(ilist)%clist(jneighbor)
+         clist%catom = katom
+         clist%cell = cell_c
+         clist%rac = rac
+         ALLOCATE (clist%acint(nsgfa, nppnl, maxder), &
+                   clist%achint(nsgfa, nppnl, maxder))
+         clist%acint = 0._dp
+         clist%achint = 0._dp
+         clist%nsgf_cnt = 0
+         NULLIFY (clist%sgf_list)
+
+         DO iset = 1, nseta
+            ncoa = npgfa(iset)*ncoset(la_max(iset))
+            sgfa = first_sgfa(1, iset)
+            IF (dogth) THEN
+               ! GTH potential
+               prjc = 1
+               work = 0._dp
+               DO l = 0, lppnl
+                  nprjc = nprj_ppnl(l)*nco(l)
+                  IF (nprjc == 0) CYCLE
+                  rprjc(1) = ppnl_radius
+                  IF (set_radius_a(iset) + rprjc(1) < dac) CYCLE
+                  lc_max = l + 2*(nprj_ppnl(l) - 1)
+                  lc_min = l
+                  zetc(1) = alpha_ppnl(l)
+                  ncoc = ncoset(lc_max)
+
+                  ! *** Calculate the primitive overlap integrals ***
+                  IF (my_momentmode) THEN
+                     CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
+                                  lc_max, lc_min, 1, rprjc, zetc, rac, dac, sab, 0, .FALSE., ai_work, ldai)
+                  ELSE
+                     CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
+                                  lc_max, lc_min, 1, rprjc, zetc, rac, dac, sab, nder, .TRUE., ai_work, ldai)
+                  ENDIF
+                  IF (my_momentmode .AND. nder >= 1) THEN
+                     CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                                 lc_max, 1, zetc, rprjc, nder, raf, rcf, ai_work)
+                     ! reduce ai_work to sab
+                     na = ncoa
+                     np = ncoc
+                     DO i = 1, maxder - 1
+                        first_col = i*ldsab
+                        sab(1:na, first_col + 1:first_col + np) = ai_work(1:na, 1:np, i)
+                     ENDDO
+                  ENDIF
+
+                  ! *** Transformation step projector functions (cartesian->spherical) ***
+                  na = ncoa
+                  nb = nprjc
+                  np = ncoc
+                  DO i = 1, maxder
+                     first_col = (i - 1)*ldsab
+                     work(1:na, first_col + prjc:first_col + prjc + nb - 1) = &
+                        MATMUL(sab(1:na, first_col + 1:first_col + np), cprj(1:np, prjc:prjc + nb - 1))
+                  END DO
+                  prjc = prjc + nprjc
+               END DO
+
+               na = nsgf_seta(iset)
+               nb = nppnl
+               np = ncoa
+               DO i = 1, maxder
+                  first_col = (i - 1)*ldsab + 1
+
+                  ! *** Contraction step (basis functions) ***
+                  clist%acint(sgfa:sgfa + na - 1, 1:nb, i) = &
+                     MATMUL(TRANSPOSE(sphi_a(1:np, sgfa:sgfa + na - 1)), work(1:np, first_col:first_col + nb - 1))
+
+                  ! *** Multiply with interaction matrix(h) ***
+                  clist%achint(sgfa:sgfa + na - 1, 1:nb, i) = &
+                     MATMUL(clist%acint(sgfa:sgfa + na - 1, 1:nb, i), vprj_ppnl(1:nb, 1:nb))
+               END DO
+            ELSE
+               ! SGP potential
+               ! *** Calculate the primitive overlap integrals ***
+               IF (my_momentmode) THEN
+                  CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
+                               lppnl, 0, nnl, radp, a_nl, rac, dac, sab, 0, .FALSE., ai_work, ldai)
+               ELSE
+                  CALL overlap(la_max(iset), la_min(iset), npgfa(iset), rpgfa(:, iset), zeta(:, iset), &
+                               lppnl, 0, nnl, radp, a_nl, rac, dac, sab, nder, .TRUE., ai_work, ldai)
+               ENDIF
+               IF (my_momentmode .AND. nder >= 1) THEN
+                  CALL moment(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
+                              lppnl, nnl, a_nl, radp, nder, raf, rcf, ai_work)
+                  ! reduce ai_work to sab
+                  na = ncoa
+                  DO i = 1, maxder - 1
+                     first_col = i*ldsab
+                     sab(1:na, first_col:first_col + nprjc - 1) = ai_work(1:na, 1:nprjc, i)
+                  ENDDO
+               ENDIF
+
+               na = nsgf_seta(iset)
+               nb = nppnl
+               np = ncoa
+               DO i = 1, maxder
+                  first_col = (i - 1)*ldsab + 1
+                  ! *** Transformation step projector functions (cartesian->spherical) ***
+                  work(1:np, 1:nb) = MATMUL(sab(1:np, first_col:first_col + nprjc - 1), cprj(1:nprjc, 1:nb))
+
+                  ! *** Contraction step (basis functions) ***
+                  clist%acint(sgfa:sgfa + na - 1, 1:nb, i) = &
+                     MATMUL(TRANSPOSE(sphi_a(1:np, sgfa:sgfa + na - 1)), work(1:np, 1:nb))
+
+                  ! *** Multiply with interaction matrix(h) ***
+                  ncoc = sgfa + nsgf_seta(iset) - 1
+                  DO j = 1, nppnl
+                     clist%achint(sgfa:ncoc, j, i) = clist%acint(sgfa:ncoc, j, i)*hprj(j)
+                  END DO
+               END DO
+            END IF
+         END DO
+         clist%maxac = MAXVAL(ABS(clist%acint(:, :, 1)))
+         clist%maxach = MAXVAL(ABS(clist%achint(:, :, 1)))
+         IF (.NOT. dogth) DEALLOCATE (radp)
+
+      ENDDO
+
+      DEALLOCATE (sab, ai_work, work)
+
+!$OMP END PARALLEL
+
+      CALL timestop(handle)
+
+   END SUBROUTINE build_sap_ints
 
 END MODULE sap_kind_types

--- a/src/sap_kind_types.F
+++ b/src/sap_kind_types.F
@@ -617,7 +617,7 @@ CONTAINS
 
 !$OMP END PARALLEL
 
-      DEALLOCATE (basis_set)
+      DEALLOCATE (basis_set, gpotential, spotential)
 
       CALL timestop(handle)
 

--- a/src/sap_kind_types.F
+++ b/src/sap_kind_types.F
@@ -308,7 +308,8 @@ CONTAINS
       TYPE(clist_type), POINTER                          :: clist
       TYPE(gth_potential_p_type), DIMENSION(:), POINTER  :: gpotential
       TYPE(gth_potential_type), POINTER                  :: gth_potential
-      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:)                                    :: basis_set
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
       TYPE(sgp_potential_p_type), DIMENSION(:), POINTER  :: spotential
       TYPE(sgp_potential_type), POINTER                  :: sgp_potential
@@ -345,6 +346,7 @@ CONTAINS
       ldai = ncoset(maxl + nder + 1)
 
       !set up direct access to basis and potential
+      NULLIFY (gpotential, spotential)
       ALLOCATE (basis_set(nkind), gpotential(nkind), spotential(nkind))
       DO ikind = 1, nkind
          CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
@@ -614,6 +616,8 @@ CONTAINS
       DEALLOCATE (sab, ai_work, work)
 
 !$OMP END PARALLEL
+
+      DEALLOCATE (basis_set)
 
       CALL timestop(handle)
 


### PR DESCRIPTION
Include expectation value calculation of
- electric dipole moment
- electric quadrupole moment
in their velocity representation for RTP.

In the presence of pseudo potentials additional commutator terms are included for
- the velocity representation of the electric dipole moment
- the velocity representation of the electric quadrupole moment
- the magnetic dipole moment.

The input includes in DFT%PRINT%MOMENTS new keywords
- VEL_REPRS to switch on velocity representations
- COM_NL to include the commutator terms

additionally a second reference point can be included via the keywords
- SECOND_REFERENCE_POINT (logical)
- REF_2 (COM, COAC, ZERO, USER_DEFINED)
- REF_POINT_2 (x y z)

In DFT%REAL_TIME_PROPAGATION the new keyword
- COM_NL to include the commutator term for a delta pulse in the velocity representation
was added.

