### PR TITLE
Enable OpenMP for debug builds.

### DIFF
--- a/src/atom_upf.F
+++ b/src/atom_upf.F
@@ -117,7 +117,10 @@ CONTAINS
 
       ! Ignore json potentials as SIRIUS will parse those on its own.
       l = LEN_TRIM(pot%filename)
-      IF (pot%filename(l - 4:l) == '.json') RETURN
+      IF (pot%filename(l - 4:l) == '.json') THEN
+         pot%zion = 0.0
+         RETURN
+      ENDIF
 
       CALL atom_read_upf_v2(pot, upf_filename, readall)
 

--- a/src/input_cp2k_pwdft.F
+++ b/src/input_cp2k_pwdft.F
@@ -65,7 +65,6 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'create_pwdft_section', &
          routineP = moduleN//':'//routineN
 
-      CHARACTER(len=32)                                  :: section_name
       TYPE(section_type), POINTER                        :: subsection
 
 !     ------------------------------------------------------------------------
@@ -81,27 +80,19 @@ CONTAINS
                           "supported by libxc and Van der Waals corrections (libvdwxc).")
 
       NULLIFY (subsection)
-      section_name = ''
-      section_name = 'control'
-      CALL create_sirius_section(subsection, section_name)
+      CALL create_sirius_section(subsection, 'control')
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
-      section_name = ''
-      section_name = 'parameters'
-      CALL create_sirius_section(subsection, section_name)
+      CALL create_sirius_section(subsection, 'parameters')
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
-      section_name = ''
-      section_name = 'mixer'
-      CALL create_sirius_section(subsection, section_name)
+      CALL create_sirius_section(subsection, 'mixer')
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
-      section_name = ''
-      section_name = 'iterative_solver'
-      CALL create_sirius_section(subsection, section_name)
+      CALL create_sirius_section(subsection, 'iterative_solver')
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
@@ -119,7 +110,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE create_sirius_section(section, section_name)
       TYPE(section_type), POINTER                        :: section
-      CHARACTER(len=32), INTENT(in)                      :: section_name
+      CHARACTER(len=*), INTENT(in)                       :: section_name
 
       CHARACTER(len=*), PARAMETER :: routineN = 'create_sirius_section', &
          routineP = moduleN//':'//routineN
@@ -128,6 +119,7 @@ CONTAINS
 
       CPASSERT(.NOT. ASSOCIATED(section))
       CALL sirius_option_get_length(TRIM(ADJUSTL(section_name))//CHAR(0), length)
+
       CALL section_create(section, __LOCATION__, &
                           name=TRIM(ADJUSTL(section_name)), &
                           description=TRIM(section_name)//" section", &
@@ -145,7 +137,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fill_in_section(section, section_name)
       TYPE(section_type), POINTER                        :: section
-      CHARACTER(len=32), INTENT(in)                      :: section_name
+      CHARACTER(len=*), INTENT(in)                       :: section_name
 
       CHARACTER(len=*), PARAMETER :: routineN = 'fill_in_section', &
          routineP = moduleN//':'//routineN

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -602,12 +602,8 @@ CONTAINS
       CALL timeset(routineN, handle)
       nqs = dispersion_env%nqs
 
-      IF (PRESENT(virial)) THEN
-         use_virial = .TRUE.
-         virial_thread(:, :) = 0.0_dp
-      ELSE
-         use_virial = .FALSE.
-      END IF
+      use_virial = PRESENT(virial)
+      virial_thread(:, :) = 0.0_dp ! always initialize to avoid floating point exceptions in OMP REDUCTION
 
       vdW_xc_energy = 0._dp
       grid => thetas_g(1)%pw%pw_grid
@@ -769,15 +765,11 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      IF (PRESENT(virial)) THEN
-         use_virial = .TRUE.
-         virial_thread(:, :) = 0.0_dp
-         CPASSERT(PRESENT(drho))
-         CPASSERT(PRESENT(dvol))
-      ELSE
-         use_virial = .FALSE.
-      END IF
+      use_virial = PRESENT(virial)
+      CPASSERT(.NOT. use_virial .OR. PRESENT(drho))
+      CPASSERT(.NOT. use_virial .OR. PRESENT(dvol))
 
+      virial_thread(:, :) = 0.0_dp ! always initialize to avoid floating point exceptions in OMP REDUCTION
       b_value = dispersion_env%b_value
       const = 1.0_dp/(3.0_dp*b_value**(3.0_dp/2.0_dp)*pi**(5.0_dp/4.0_dp))
       potential = 0.0_dp

--- a/src/qs_kind_types.F
+++ b/src/qs_kind_types.F
@@ -270,6 +270,7 @@ CONTAINS
             ENDIF
             IF (ASSOCIATED(qs_kind_set(ikind)%upf_potential)) THEN
                CALL atom_release_upf(qs_kind_set(ikind)%upf_potential)
+               DEALLOCATE (qs_kind_set(ikind)%upf_potential)
             ENDIF
             IF (ASSOCIATED(qs_kind_set(ikind)%se_parameter)) THEN
                CALL semi_empirical_release(qs_kind_set(ikind)%se_parameter)

--- a/src/qs_ks_atom.F
+++ b/src/qs_ks_atom.F
@@ -213,10 +213,11 @@ CONTAINS
          CALL get_atomic_kind_set(atomic_kind_set, atom_of_kind=atom_of_kind)
          ldCPC = max_gau
          use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
-         IF (use_virial) pv_virial_thread(:, :) = 0.0_dp
       ELSE
          use_virial = .FALSE.
       END IF
+
+      pv_virial_thread(:, :) = 0.0_dp ! always initialize to avoid floating point exceptions in OMP REDUCTION
 
       nkind = SIZE(my_kind_set, 1)
       ! Collect the local potential contributions from all the processors

--- a/src/sirius_interface.F
+++ b/src/sirius_interface.F
@@ -35,8 +35,7 @@ MODULE sirius_interface
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE external_potential_types,        ONLY: gth_potential_type
    USE input_constants,                 ONLY: do_gapw_log
-   USE input_section_types,             ONLY: section_vals_duplicate,&
-                                              section_vals_get,&
+   USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_get_subs_vals2,&
                                               section_vals_type,&
@@ -154,8 +153,8 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_subsys_type), POINTER                      :: qs_subsys
-      TYPE(section_vals_type), POINTER                   :: libxc_fun, pwdft_section, &
-                                                            pwdft_sub_section, xc_fun, xc_section
+      TYPE(section_vals_type), POINTER                   :: pwdft_section, pwdft_sub_section, &
+                                                            xc_fun, xc_section
 
       CPASSERT(ASSOCIATED(pwdft_env))
 ! create context of simulation
@@ -181,9 +180,7 @@ CONTAINS
             IF (TRIM(xc_fun%section%name) == "LIBXC") THEN
                CALL section_vals_get(xc_fun, n_repetition=n)
                DO i = 1, n
-                  NULLIFY (libxc_fun)
-                  CALL section_vals_duplicate(xc_fun, libxc_fun, i_rep_start=i, i_rep_end=i)
-                  CALL section_vals_val_get(libxc_fun, "FUNCTIONAL", c_val=section_name)
+                  CALL section_vals_val_get(xc_fun, "FUNCTIONAL", i_rep_section=i, c_val=section_name)
                   CALL sirius_option_add_string_to(sctx, string('parameters'), string('xc_functionals'), string(section_name))
                END DO
             ENDIF

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -188,13 +188,13 @@ EOF
 rm -f ${INSTALLDIR}/arch/local*
 # normal production arch files
     { gen_arch_file "local.sopt" ;          arch_vers="sopt"; }
-    { gen_arch_file "local.sdbg" DEBUG;     arch_vers="${arch_vers} sdbg"; }
+    { gen_arch_file "local.sdbg" OMP DEBUG; arch_vers="${arch_vers} sdbg"; }
 [ "$ENABLE_OMP" = __TRUE__ ] && \
     { gen_arch_file "local.ssmp" OMP;       arch_vers="${arch_vers} ssmp"; }
 [ "$MPI_MODE" != no ] && \
     { gen_arch_file "local.popt" MPI;       arch_vers="${arch_vers} popt"; }
 [ "$MPI_MODE" != no ] && \
-    { gen_arch_file "local.pdbg" MPI DEBUG; arch_vers="${arch_vers} pdbg"; }
+    { gen_arch_file "local.pdbg" MPI OMP DEBUG; arch_vers="${arch_vers} pdbg"; }
 [ "$MPI_MODE" != no ] && \
 [ "$ENABLE_OMP" = __TRUE__ ] && \
     { gen_arch_file "local.psmp" MPI OMP;   arch_vers="${arch_vers} psmp"; }

--- a/tools/toolchain/scripts/install_sirius.sh
+++ b/tools/toolchain/scripts/install_sirius.sh
@@ -247,6 +247,16 @@ export CP_LIBS="IF_MPI(IF_OMP("\${SIRIUS_LIBS}"|)|) \${CP_LIBS}"
 EOF
 fi
 
+# ----------------------------------------------------------------------
+# Suppress reporting of known leaks
+# ----------------------------------------------------------------------
+cat <<EOF >> ${INSTALLDIR}/lsan.supp
+# Leaks in SIRIUS
+leak:sddk::Communicator::cart_sub
+leak:sddk::Communicator::split
+leak:sddk::Communicator::cart_create
+EOF
+
 # update toolchain environment
 load "${BUILDDIR}/setup_sirius"
 export -p > "${INSTALLDIR}/toolchain.env"

--- a/tools/toolchain/scripts/install_spfft.sh
+++ b/tools/toolchain/scripts/install_spfft.sh
@@ -107,6 +107,14 @@ EOF
     cat "${BUILDDIR}/setup_spfft" >> $SETUPFILE
 fi
 
+# ----------------------------------------------------------------------
+# Suppress reporting of known leaks
+# ----------------------------------------------------------------------
+cat <<EOF >> ${INSTALLDIR}/lsan.supp
+# Leaks in SpFFT
+leak:spfft::MPICommunicatorHandle::MPICommunicatorHandle
+EOF
+
 # update toolchain environment
 load "${BUILDDIR}/setup_spfft"
 export -p > "${INSTALLDIR}/toolchain.env"


### PR DESCRIPTION
This is will improve detection of lhs-reallocs (see #726) and is also a step towards #729.