### PR TITLE
Docker: Abort AiiDA test after 30 minutes

### DIFF
--- a/tools/docker/scripts/test_aiida.sh
+++ b/tools/docker/scripts/test_aiida.sh
@@ -92,6 +92,7 @@ cd  /opt/aiida-cp2k/
 set +e # disable error trapping for remainder of script
 (
 set -e # abort on error
+ulimit -t 1800  # abort after 30 minutes
 $AS_UBUNTU_USER py.test
 )
 


### PR DESCRIPTION
Prevent CI resource drain due to https://github.com/aiidateam/aiida-cp2k/issues/71.