### PR TITLE
Improved time/frequency treatment for low-scaling GW

### DIFF
--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -86,7 +86,8 @@ MODULE bibliography
                             Schuett2018, Holmberg2018, Togo2018, Staub2019, Grimme2013, Grimme2016, &
                             Grimme2017, Kondov2007, &
                             Ren2011, Ren2013, Cohen2000, Rogers2002, Filippetti2000, Paziani2006, &
-                            Toulouse2004, Limpanuparb2011, Martin2003, Yin2017, Goerigk2017
+                            Toulouse2004, Limpanuparb2011, Martin2003, Yin2017, Goerigk2017, &
+                            Wilhelm2016a, Wilhelm2016b, Wilhelm2017, Wilhelm2018
 
 CONTAINS
 
@@ -4344,6 +4345,82 @@ CONTAINS
                          "UR  - http://dx.doi.org/10.1039/C7CP04913G", &
                          "ER"), &
                          DOI="10.1039/C7CP04913G")
+
+      CALL add_reference(key=Wilhelm2016a, ISI_record=s2a( &
+                         "PT J", &
+                         "AU Wilhelm, J", &
+                         "   Del Ben, M", &
+                         "   Hutter, J", &
+                         "AF Wilhelm, Jan", &
+                         "   Del Ben, Mauro", &
+                         "   Hutter, Juerg", &
+                         "TI GW in the Gaussian and plane waves scheme with application to linear acenes", &
+                         "JO J. Chem. Theory Comput.", &
+                         "SP 3623", &
+                         "EP 3635", &
+                         "PY 2016", &
+                         "VL 12", &
+                         "DI 10.1021/acs.jctc.6b00380", &
+                         "ER"), &
+                         DOI="10.1021/acs.jctc.6b00380")
+
+      CALL add_reference(key=Wilhelm2016a, ISI_record=s2a( &
+                         "PT J", &
+                         "AU Wilhelm, J", &
+                         "   Seewald, P", &
+                         "   Del Ben, M", &
+                         "   Hutter, J", &
+                         "AF Wilhelm, Jan", &
+                         "   Seewald, Patrick", &
+                         "   Del Ben, Mauro", &
+                         "   Hutter, Juerg", &
+                         "TI Large-Scale Cubic-Scaling Random Phase Approximation Correlation", &
+                         "Energy Calculations Using a Gaussian Basis", &
+                         "JO J. Chem. Theory Comput.", &
+                         "SP 5851", &
+                         "EP 5859", &
+                         "PY 2016", &
+                         "VL 12", &
+                         "DI 10.1021/acs.jctc.6b00840", &
+                         "ER"), &
+                         DOI="10.1021/acs.jctc.6b00840")
+
+      CALL add_reference(key=Wilhelm2016a, ISI_record=s2a( &
+                         "PT J", &
+                         "AU Wilhelm, J", &
+                         "   Hutter, J", &
+                         "AF Wilhelm, Jan", &
+                         "   Hutter, Juerg", &
+                         "TI Periodic GW calculations in the Gaussian and plane-waves scheme", &
+                         "JO Phys. Rev. B", &
+                         "SP 235123", &
+                         "PY 2017", &
+                         "VL 95", &
+                         "DI 10.1103/PhysRevB.95.235123", &
+                         "ER"), &
+                         DOI="10.1103/PhysRevB.95.235123")
+
+      CALL add_reference(key=Wilhelm2016a, ISI_record=s2a( &
+                         "PT J", &
+                         "AU Wilhelm, J", &
+                         "   Golze, D", &
+                         "   Talirz, L", &
+                         "   Hutter, J", &
+                         "   Pignedoli, CA", &
+                         "AF Wilhelm, Jan", &
+                         "   Golze, Dorothea", &
+                         "   Talirz, Leopold", &
+                         "   Hutter, Juerg", &
+                         "   Pignedoli, Carlo A.", &
+                         "TI Toward GW calculations on thousands of atoms", &
+                         "JO J. Phys. Chem. Lett.", &
+                         "SP 306", &
+                         "EP 312", &
+                         "PY 2018", &
+                         "VL 9", &
+                         "DI 10.1021/acs.jpclett.7b02740", &
+                         "ER"), &
+                         DOI="10.1021/acs.jpclett.7b02740")
 
    END SUBROUTINE add_all_references
 

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -890,7 +890,7 @@ CONTAINS
                           enum_i_vals=(/gw_two_pole_model, gw_pade_approx/), &
                           enum_desc=s2a("Use 'two-pole' model.", &
                                         "Use Pade approximation."), &
-                          default_i_val=gw_two_pole_model)
+                          default_i_val=gw_pade_approx)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -911,6 +911,17 @@ CONTAINS
                           usage="GAMMA TRUE", &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="NUM_FREQ_POINTS_CLENSHAW_LOW_SCALING_GW", &
+                          description="If this number is larger than NUM_INTEG_POINTS, then use a Clenshaw-Curtis grid "// &
+                          "for the frequency dependency of G, W and Sigma "// &
+                          "in low-scaling (imag. time) GW calculations. Putting more Clenshaw-Curtis "// &
+                          "points than minimax points is computationally more expensive, but doesn't affect the "// &
+                          "scaling and does improve the accuracy. Putting this parameter in normal N^4-scaling GW "// &
+                          "calculation doesn't have any effect.", &
+                          usage="NUM_FREQ_POINTS_CLENSHAW_LOW_SCALING_GW 80", default_i_val=-1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -77,7 +77,7 @@ MODULE library_tests
                                               mp_sync,&
                                               mpi_perf_test
    USE minimax_exp,                     ONLY: validate_exp_minimax
-   USE mp2_weights,                     ONLY: test_least_square_ft
+   USE mp2_grids,                       ONLY: test_least_square_ft
    USE parallel_rng_types,              ONLY: UNIFORM,&
                                               rng_stream_type
    USE pw_grid_types,                   ONLY: FULLSPACE,&

--- a/src/mp2_grids.F
+++ b/src/mp2_grids.F
@@ -155,7 +155,7 @@ CONTAINS
       END IF
 
       IF (my_do_mixed_minimax_clenshaw) THEN
-         CALL compute_tj_from_clenshaw(tj, a_scaling)
+         tj(:) = a_scaling/TAN(tj(:))
       END IF
 
       IF (.NOT. do_ri_sos_laplace_mp2 .AND. (.NOT. my_do_mixed_minimax_clenshaw)) THEN
@@ -280,29 +280,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE get_minimax_grid
-
-! **************************************************************************************************
-!> \brief ...
-!> \param tj ...
-!> \param a_scaling ...
-! **************************************************************************************************
-   SUBROUTINE compute_tj_from_clenshaw(tj, a_scaling)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: tj
-      REAL(KIND=dp), INTENT(IN)                          :: a_scaling
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_tj_from_clenshaw', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
-
-      tj(:) = a_scaling/TAN(tj(:))
-
-      CALL timestop(handle)
-
-   END SUBROUTINE compute_tj_from_clenshaw
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/mp2_grids.F
+++ b/src/mp2_grids.F
@@ -4,11 +4,12 @@
 !--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
-!> \brief Routines to calculate weights for correlation methods
+!> \brief Routines to calculate frequency and time grids (integration points and weights)
+!>        for correlation methods
 !> \par History
 !>      05.2019 Refactored from rpa_ri_gpw [Frederick Stein]
 ! **************************************************************************************************
-MODULE mp2_weights
+MODULE mp2_grids
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
                                               cp_fm_type
    USE cp_para_env,                     ONLY: cp_para_env_create,&
@@ -36,9 +37,9 @@ MODULE mp2_weights
 
    PRIVATE
 
-   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'mp2_weights'
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'mp2_grids'
 
-   PUBLIC :: get_minimax_weights, get_clenshaw_weights, test_least_square_ft
+   PUBLIC :: get_minimax_grid, get_clenshaw_grid, test_least_square_ft
 
 CONTAINS
 
@@ -48,7 +49,8 @@ CONTAINS
 !> \param unit_nr ...
 !> \param homo ...
 !> \param Eigenval ...
-!> \param num_integ_points ...
+!> \param num_time_points ...
+!> \param num_freq_points ...
 !> \param do_im_time ...
 !> \param do_ri_sos_laplace_mp2 ...
 !> \param do_print ...
@@ -57,7 +59,6 @@ CONTAINS
 !> \param qs_env ...
 !> \param do_gw_im_time ...
 !> \param do_kpoints_cubic_RPA ...
-!> \param ext_scaling ...
 !> \param a_scaling ...
 !> \param e_fermi ...
 !> \param tj ...
@@ -69,27 +70,28 @@ CONTAINS
 !> \param homo_beta ...
 !> \param dimen_ia_beta ...
 !> \param Eigenval_beta ...
+!> \param do_mixed_minimax_clenshaw ...
 ! **************************************************************************************************
-   SUBROUTINE get_minimax_weights(para_env, unit_nr, homo, Eigenval, num_integ_points, &
-                                  do_im_time, do_ri_sos_laplace_mp2, do_print, tau_tj, tau_wj, qs_env, do_gw_im_time, &
-                                  do_kpoints_cubic_RPA, ext_scaling, a_scaling, e_fermi, tj, wj, mp2_env, weights_cos_tf_t_to_w, &
-                                  weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, &
-                                  homo_beta, dimen_ia_beta, Eigenval_beta)
+   SUBROUTINE get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_time_points, num_freq_points, &
+                               do_im_time, do_ri_sos_laplace_mp2, do_print, tau_tj, tau_wj, qs_env, do_gw_im_time, &
+                               do_kpoints_cubic_RPA, a_scaling, e_fermi, tj, wj, mp2_env, weights_cos_tf_t_to_w, &
+                               weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, &
+                               homo_beta, dimen_ia_beta, Eigenval_beta, do_mixed_minimax_clenshaw)
 
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: unit_nr, homo
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: num_integ_points
+      INTEGER, INTENT(IN)                                :: num_time_points, num_freq_points
       LOGICAL, INTENT(IN)                                :: do_im_time, do_ri_sos_laplace_mp2, &
                                                             do_print
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(OUT)                                     :: tau_tj, tau_wj
       TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_gw_im_time, do_kpoints_cubic_RPA
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: ext_scaling
-      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: a_scaling, e_fermi
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: a_scaling
+      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: e_fermi
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT), OPTIONAL                           :: tj, wj
+         INTENT(INOUT), OPTIONAL                         :: tj, wj
       TYPE(mp2_type), OPTIONAL, POINTER                  :: mp2_env
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(OUT), OPTIONAL                           :: weights_cos_tf_t_to_w, &
@@ -97,13 +99,16 @@ CONTAINS
                                                             weights_sin_tf_t_to_w
       INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta, dimen_ia_beta
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: Eigenval_beta
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_mixed_minimax_clenshaw
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_minimax_weights', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_minimax_grid', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, ierr, jquad, &
+      INTEGER                                            :: handle, ierr, jquad, num_integ_points, &
                                                             num_points_per_magnitude
-      LOGICAL                                            :: my_do_kpoints, my_open_shell
+      LOGICAL                                            :: my_do_kpoints, &
+                                                            my_do_mixed_minimax_clenshaw, &
+                                                            my_open_shell
       REAL(KIND=dp)                                      :: E_Range, Emax, Emax_beta, Emin, &
                                                             Emin_beta, max_error_min, scaling
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: x_tw
@@ -119,7 +124,7 @@ CONTAINS
       ! Test whether all necessary variables are available
       my_do_kpoints = .FALSE.
       IF (.NOT. do_ri_sos_laplace_mp2) THEN
-         IF (.NOT. (PRESENT(do_gw_im_time) .AND. PRESENT(do_kpoints_cubic_RPA) .AND. PRESENT(ext_scaling) .AND. PRESENT(a_scaling) &
+         IF (.NOT. (PRESENT(do_gw_im_time) .AND. PRESENT(do_kpoints_cubic_RPA) .AND. PRESENT(a_scaling) &
                     .AND. PRESENT(e_fermi) .AND. PRESENT(tj) .AND. PRESENT(wj) .AND. PRESENT(weights_cos_tf_t_to_w) .AND. &
                     PRESENT(weights_cos_tf_w_to_t) .AND. PRESENT(weights_sin_tf_t_to_w) .AND. PRESENT(mp2_env))) THEN
             CPABORT("Need more parameters without SOS-MP2")
@@ -127,14 +132,15 @@ CONTAINS
          my_do_kpoints = do_kpoints_cubic_RPA
       END IF
 
+      my_do_mixed_minimax_clenshaw = .FALSE.
+      IF (PRESENT(do_mixed_minimax_clenshaw)) THEN
+         my_do_mixed_minimax_clenshaw = do_mixed_minimax_clenshaw
+      END IF
+
       IF (my_do_kpoints) THEN
-
          CALL gap_and_max_eig_diff_kpoints(qs_env, para_env, Emin, Emax, e_fermi)
-
          E_Range = Emax/Emin
-
       ELSE
-
          Emin = Eigenval(homo + 1) - Eigenval(homo)
          Emax = MAXVAL(Eigenval) - MINVAL(Eigenval)
          IF (my_open_shell) THEN
@@ -146,24 +152,27 @@ CONTAINS
             END IF
          END IF
          E_Range = Emax/Emin
-
       END IF
 
-      IF (.NOT. do_ri_sos_laplace_mp2) THEN
-         ALLOCATE (x_tw(2*num_integ_points))
+      IF (my_do_mixed_minimax_clenshaw) THEN
+         CALL compute_tj_from_clenshaw(tj, a_scaling)
+      END IF
+
+      IF (.NOT. do_ri_sos_laplace_mp2 .AND. (.NOT. my_do_mixed_minimax_clenshaw)) THEN
+         ALLOCATE (x_tw(2*num_freq_points))
          x_tw = 0.0_dp
          ierr = 0
-         CALL get_rpa_minimax_coeff(num_integ_points, E_Range, x_tw, ierr)
+         CALL get_rpa_minimax_coeff(num_freq_points, E_Range, x_tw, ierr)
 
-         ALLOCATE (tj(num_integ_points))
+         ALLOCATE (tj(num_freq_points))
          tj = 0.0_dp
 
-         ALLOCATE (wj(num_integ_points))
+         ALLOCATE (wj(num_freq_points))
          wj = 0.0_dp
 
-         DO jquad = 1, num_integ_points
+         DO jquad = 1, num_freq_points
             tj(jquad) = x_tw(jquad)
-            wj(jquad) = x_tw(jquad + num_integ_points)
+            wj(jquad) = x_tw(jquad + num_freq_points)
          END DO
 
          DEALLOCATE (x_tw)
@@ -172,7 +181,7 @@ CONTAINS
             WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.4)") &
                "INTEG_INFO| Range for the minimax approximation:", E_Range
             WRITE (UNIT=unit_nr, FMT="(T3,A,T54,A,T72,A)") "INTEG_INFO| Minimax parameters:", "Weights", "Abscissas"
-            DO jquad = 1, num_integ_points
+            DO jquad = 1, num_freq_points
                WRITE (UNIT=unit_nr, FMT="(T41,F20.10,F20.10)") wj(jquad), tj(jquad)
             END DO
             CALL m_flush(unit_nr)
@@ -191,24 +200,24 @@ CONTAINS
       ! set up the minimax time grid
       IF (do_im_time .OR. do_ri_sos_laplace_mp2) THEN
 
-         ALLOCATE (x_tw(2*num_integ_points))
+         ALLOCATE (x_tw(2*num_time_points))
          x_tw = 0.0_dp
 
-         CALL get_exp_minimax_coeff(num_integ_points, E_Range, x_tw)
+         CALL get_exp_minimax_coeff(num_time_points, E_Range, x_tw)
 
          ! For RPA we include already a factor of two (see later steps)
          scaling = 2.0_dp
          IF (do_ri_sos_laplace_mp2) scaling = 1.0_dp
 
-         ALLOCATE (tau_tj(0:num_integ_points))
+         ALLOCATE (tau_tj(0:num_time_points))
          tau_tj = 0.0_dp
 
-         ALLOCATE (tau_wj(num_integ_points))
+         ALLOCATE (tau_wj(num_time_points))
          tau_wj = 0.0_dp
 
-         DO jquad = 1, num_integ_points
+         DO jquad = 1, num_time_points
             tau_tj(jquad) = x_tw(jquad)/scaling
-            tau_wj(jquad) = x_tw(jquad + num_integ_points)/scaling
+            tau_wj(jquad) = x_tw(jquad + num_time_points)/scaling
          END DO
 
          DEALLOCATE (x_tw)
@@ -221,7 +230,7 @@ CONTAINS
                "INTEG_INFO| Gap:", Emin
             WRITE (UNIT=unit_nr, FMT="(T3,A,T54,A,T72,A)") &
                "INTEG_INFO| Minimax parameters of the time grid:", "Weights", "Abscissas"
-            DO jquad = 1, num_integ_points
+            DO jquad = 1, num_time_points
                WRITE (UNIT=unit_nr, FMT="(T41,F20.10,F20.10)") tau_wj(jquad), tau_tj(jquad)
             END DO
             CALL m_flush(unit_nr)
@@ -232,14 +241,17 @@ CONTAINS
          tau_wj(:) = tau_wj(:)/Emin
 
          IF (.NOT. do_ri_sos_laplace_mp2) THEN
-            ALLOCATE (weights_cos_tf_t_to_w(num_integ_points, num_integ_points))
+            ALLOCATE (weights_cos_tf_t_to_w(num_freq_points, num_time_points))
             weights_cos_tf_t_to_w = 0.0_dp
 
             num_points_per_magnitude = mp2_env%ri_rpa_im_time%num_points_per_magnitude
-            CALL get_l_sq_wghts_cos_tf_t_to_w(num_integ_points, tau_tj, weights_cos_tf_t_to_w, tj, &
+            CALL get_l_sq_wghts_cos_tf_t_to_w(num_freq_points, num_time_points, tau_tj, weights_cos_tf_t_to_w, tj, &
                                               Emin, Emax, max_error_min, num_points_per_magnitude)
 
-            IF (do_gw_im_time) THEN
+            IF (do_gw_im_time .AND. (.NOT. my_do_mixed_minimax_clenshaw)) THEN
+
+               CPASSERT(num_freq_points == num_time_points)
+               num_integ_points = num_freq_points
 
                ! get the weights for the cosine transform W^c(iw) -> W^c(it)
                ALLOCATE (weights_cos_tf_w_to_t(num_integ_points, num_integ_points))
@@ -267,7 +279,30 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE get_minimax_weights
+   END SUBROUTINE get_minimax_grid
+
+! **************************************************************************************************
+!> \brief ...
+!> \param tj ...
+!> \param a_scaling ...
+! **************************************************************************************************
+   SUBROUTINE compute_tj_from_clenshaw(tj, a_scaling)
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(INOUT)                                   :: tj
+      REAL(KIND=dp), INTENT(IN)                          :: a_scaling
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_tj_from_clenshaw', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      tj(:) = a_scaling/TAN(tj(:))
+
+      CALL timestop(handle)
+
+   END SUBROUTINE compute_tj_from_clenshaw
 
 ! **************************************************************************************************
 !> \brief ...
@@ -292,10 +327,10 @@ CONTAINS
 !> \param Eigenval_beta ...
 !> \param fm_mat_S_beta ...
 ! **************************************************************************************************
-   SUBROUTINE get_clenshaw_weights(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points, &
-                                   num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, &
-                                   ext_scaling, a_scaling, tj, wj, &
-                                   homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
+   SUBROUTINE get_clenshaw_grid(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points, &
+                                num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, &
+                                ext_scaling, a_scaling, tj, wj, &
+                                homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
 
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
       INTEGER, INTENT(IN)                                :: unit_nr, homo, virtual
@@ -312,7 +347,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: Eigenval_beta
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: fm_mat_S_beta
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_clenshaw_weights', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_clenshaw_grid', &
          routineP = moduleN//':'//routineN
 
       INTEGER                                            :: handle, jquad
@@ -340,21 +375,20 @@ CONTAINS
       tj(num_integ_points) = pi/2.0_dp
       wj(num_integ_points) = pi/(2.0_dp*num_integ_points*SIN(tj(num_integ_points))**2)
 
-      a_scaling = 1.0_dp
-      IF (my_open_shell) THEN
-         CALL calc_scaling_factor(a_scaling, para_env, para_env_RPA, homo, virtual, Eigenval, &
-                                  num_integ_points, num_integ_group, color_rpa_group, &
-                                  tj, wj, fm_mat_S, &
-                                  homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
-      ELSE
-         CALL calc_scaling_factor(a_scaling, para_env, para_env_RPA, homo, virtual, Eigenval, &
-                                  num_integ_points, num_integ_group, color_rpa_group, &
-                                  tj, wj, fm_mat_S)
-      END IF
-
-      ! for G0W0, we may set the scaling factor by hand
       IF (my_do_gw .AND. ext_scaling > 0.0_dp) THEN
          a_scaling = ext_scaling
+      ELSE
+         a_scaling = 1.0_dp
+         IF (my_open_shell) THEN
+            CALL calc_scaling_factor(a_scaling, para_env, para_env_RPA, homo, virtual, Eigenval, &
+                                     num_integ_points, num_integ_group, color_rpa_group, &
+                                     tj, wj, fm_mat_S, &
+                                     homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
+         ELSE
+            CALL calc_scaling_factor(a_scaling, para_env, para_env_RPA, homo, virtual, Eigenval, &
+                                     num_integ_points, num_integ_group, color_rpa_group, &
+                                     tj, wj, fm_mat_S)
+         END IF
       END IF
 
       IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T56,F25.5)') 'INTEG_INFO| Scaling parameter:', a_scaling
@@ -363,7 +397,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE get_clenshaw_weights
+   END SUBROUTINE get_clenshaw_grid
 
 ! **************************************************************************************************
 !> \brief ...
@@ -744,7 +778,8 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Calculate integration weights for the tau grid (in dependency of the omega node)
-!> \param num_integ_points ...
+!> \param num_freq_points ...
+!> \param num_time_points ...
 !> \param tau_tj ...
 !> \param weights_cos_tf_t_to_w ...
 !> \param omega_tj ...
@@ -753,10 +788,10 @@ CONTAINS
 !> \param max_error ...
 !> \param num_points_per_magnitude ...
 ! **************************************************************************************************
-   SUBROUTINE get_l_sq_wghts_cos_tf_t_to_w(num_integ_points, tau_tj, weights_cos_tf_t_to_w, omega_tj, &
+   SUBROUTINE get_l_sq_wghts_cos_tf_t_to_w(num_freq_points, num_time_points, tau_tj, weights_cos_tf_t_to_w, omega_tj, &
                                            E_min, E_max, max_error, num_points_per_magnitude)
 
-      INTEGER, INTENT(IN)                                :: num_integ_points
+      INTEGER, INTENT(IN)                                :: num_freq_points, num_time_points
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tau_tj
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
@@ -773,9 +808,9 @@ CONTAINS
       INTEGER                                            :: handle, iii, info, jjj, jquad, lwork, &
                                                             num_x_nodes
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
-      REAL(KIND=dp)                                      :: chi2_min_jquad, multiplicator, omega
+      REAL(KIND=dp)                                      :: multiplicator, omega
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: sing_values, tau_wj_work, vec_UTy, work, &
-                                                            work_array, x_values, y_values
+                                                            x_values, y_values
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: mat_A, mat_SinvVSinvSigma, &
                                                             mat_SinvVSinvT, mat_U
 
@@ -786,32 +821,30 @@ CONTAINS
 
       ! take at least as many x points as integration points to have clear
       ! input for the singular value decomposition
-      num_x_nodes = MAX(num_x_nodes, num_integ_points)
+      num_x_nodes = MAX(num_x_nodes, num_freq_points)
 
       ALLOCATE (x_values(num_x_nodes))
       x_values = 0.0_dp
       ALLOCATE (y_values(num_x_nodes))
       y_values = 0.0_dp
-      ALLOCATE (mat_A(num_x_nodes, num_integ_points))
+      ALLOCATE (mat_A(num_x_nodes, num_time_points))
       mat_A = 0.0_dp
-      ALLOCATE (tau_wj_work(num_integ_points))
+      ALLOCATE (tau_wj_work(num_time_points))
       tau_wj_work = 0.0_dp
-      ALLOCATE (work_array(2*num_integ_points))
-      work_array = 0.0_dp
-      ALLOCATE (sing_values(num_integ_points))
+      ALLOCATE (sing_values(num_time_points))
       sing_values = 0.0_dp
       ALLOCATE (mat_U(num_x_nodes, num_x_nodes))
       mat_U = 0.0_dp
-      ALLOCATE (mat_SinvVSinvT(num_x_nodes, num_integ_points))
+      ALLOCATE (mat_SinvVSinvT(num_x_nodes, num_time_points))
 
       mat_SinvVSinvT = 0.0_dp
       ! double the value nessary for 'A' to achieve good performance
-      lwork = 8*num_integ_points*num_integ_points + 12*num_integ_points + 2*num_x_nodes
+      lwork = 8*num_time_points*num_time_points + 12*num_time_points + 2*num_x_nodes
       ALLOCATE (work(lwork))
       work = 0.0_dp
-      ALLOCATE (iwork(8*num_integ_points))
+      ALLOCATE (iwork(8*num_time_points))
       iwork = 0
-      ALLOCATE (mat_SinvVSinvSigma(num_integ_points, num_x_nodes))
+      ALLOCATE (mat_SinvVSinvSigma(num_time_points, num_x_nodes))
       mat_SinvVSinvSigma = 0.0_dp
       ALLOCATE (vec_UTy(num_x_nodes))
       vec_UTy = 0.0_dp
@@ -819,9 +852,7 @@ CONTAINS
       max_error = 0.0_dp
 
       ! loop over all omega frequency points
-      DO jquad = 1, num_integ_points
-
-         chi2_min_jquad = 100.0_dp
+      DO jquad = 1, num_freq_points
 
          ! set the x-values logarithmically in the interval [Emin,Emax]
          multiplicator = (E_max/E_min)**(1.0_dp/(REAL(num_x_nodes, KIND=dp) - 1.0_dp))
@@ -837,22 +868,22 @@ CONTAINS
          END DO
 
          ! calculate mat_A
-         DO jjj = 1, num_integ_points
+         DO jjj = 1, num_time_points
             DO iii = 1, num_x_nodes
                mat_A(iii, jjj) = COS(omega*tau_tj(jjj))*EXP(-x_values(iii)*tau_tj(jjj))
             END DO
          END DO
 
          ! Singular value decomposition of mat_A
-         CALL DGESDD('A', num_x_nodes, num_integ_points, mat_A, num_x_nodes, sing_values, mat_U, num_x_nodes, &
+         CALL DGESDD('A', num_x_nodes, num_time_points, mat_A, num_x_nodes, sing_values, mat_U, num_x_nodes, &
                      mat_SinvVSinvT, num_x_nodes, work, lwork, iwork, info)
 
          CPASSERT(info == 0)
 
          ! integration weights = V Sigma U^T y
          ! 1) V*Sigma
-         DO jjj = 1, num_integ_points
-            DO iii = 1, num_integ_points
+         DO jjj = 1, num_time_points
+            DO iii = 1, num_time_points
                mat_SinvVSinvSigma(iii, jjj) = mat_SinvVSinvT(jjj, iii)/sing_values(jjj)
             END DO
          END DO
@@ -862,17 +893,17 @@ CONTAINS
                     0.0_dp, vec_UTy, num_x_nodes)
 
          ! 3) (V*Sigma) * (U^T y)
-         CALL DGEMM('N', 'N', num_integ_points, 1, num_x_nodes, 1.0_dp, mat_SinvVSinvSigma, num_integ_points, vec_UTy, &
-                    num_x_nodes, 0.0_dp, tau_wj_work, num_integ_points)
+         CALL DGEMM('N', 'N', num_time_points, 1, num_x_nodes, 1.0_dp, mat_SinvVSinvSigma, num_time_points, vec_UTy, &
+                    num_x_nodes, 0.0_dp, tau_wj_work, num_time_points)
 
          weights_cos_tf_t_to_w(jquad, :) = tau_wj_work(:)
 
          CALL calc_max_error_fit_tau_grid_with_cosine(max_error, omega, tau_tj, tau_wj_work, x_values, &
-                                                      y_values, num_integ_points, num_x_nodes)
+                                                      y_values, num_time_points, num_x_nodes)
 
       END DO ! jquad
 
-      DEALLOCATE (x_values, y_values, mat_A, tau_wj_work, work_array, sing_values, mat_U, mat_SinvVSinvT, &
+      DEALLOCATE (x_values, y_values, mat_A, tau_wj_work, sing_values, mat_U, mat_SinvVSinvT, &
                   work, iwork, mat_SinvVSinvSigma, vec_UTy)
 
       CALL timestop(handle)
@@ -1235,8 +1266,8 @@ CONTAINS
                tau_wj(jquad) = x_tw(jquad + num_integ_points)/2.0_dp
             END DO
 
-            CALL get_l_sq_wghts_cos_tf_t_to_w(num_integ_points, tau_tj, weights_cos_tf_t_to_w, tj, &
-                                              1.0_dp, Rc, max_error, 200)
+            CALL get_l_sq_wghts_cos_tf_t_to_w(num_integ_points, num_integ_points, tau_tj, &
+                                              weights_cos_tf_t_to_w, tj, 1.0_dp, Rc, max_error, 200)
 
             IF (iw > 0) THEN
                WRITE (iw, '(T2, I3, F12.1, ES12.3)') num_integ_points, Rc, max_error
@@ -1569,4 +1600,4 @@ CONTAINS
 
    END SUBROUTINE
 
-END MODULE mp2_weights
+END MODULE mp2_grids

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -180,6 +180,9 @@ CONTAINS
                                 r_vals=mp2_env%ri_g0w0%ic_corr_list_beta)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%GAMMA_ONLY_SIGMA", &
                                 l_val=mp2_env%ri_g0w0%do_gamma_only_sigma)
+      CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%NUM_FREQ_POINTS_CLENSHAW_LOW_SCALING_GW", &
+                                i_val=mp2_env%ri_g0w0%num_integ_points_freq)
+
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%BSE", &
                                 l_val=mp2_env%ri_g0w0%do_bse)
       CALL section_vals_val_get(mp2_section, "RI_RPA%RI_G0W0%BSE%NUM_Z_VECTORS", &

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -156,8 +156,8 @@ MODULE mp2_types
       LOGICAL                  :: do_ic_model, print_ic_values
       REAL(KIND=dp)            :: eps_dist
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list, ic_corr_list_beta
-      INTEGER :: print_exx
-      LOGICAL :: do_gamma_only_sigma
+      INTEGER :: print_exx, num_integ_points_freq
+      LOGICAL :: do_gamma_only_sigma, do_gw_im_time_mix_minimax_clenshaw
    END TYPE
 
    TYPE ri_basis_opt

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -4904,10 +4904,10 @@ CONTAINS
          vec_Sigma_c_gw(:, 1:num_fit_points, 1) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points) + &
                                                   im_unit*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
 
-         CALL dbcsr_release_P(mat_greens_fct_occ)
-         CALL dbcsr_release_P(mat_greens_fct_virt)
-
       END IF
+
+      CALL dbcsr_release_P(mat_greens_fct_occ)
+      CALL dbcsr_release_P(mat_greens_fct_virt)
 
       IF (do_ri_Sigma_x .AND. count_ev_sc_GW == 1) THEN
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -4723,6 +4723,18 @@ CONTAINS
       ALLOCATE (delta_corr_omega(1 + homo - gw_corr_lev_occ:homo + gw_corr_lev_virt, num_integ_points))
       delta_corr_omega(:, :) = (0.0_dp, 0.0_dp)
 
+      NULLIFY (mat_greens_fct_occ)
+      CALL dbcsr_init_p(mat_greens_fct_occ)
+      CALL dbcsr_create(matrix=mat_greens_fct_occ, &
+                        template=matrix_s(1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+
+      NULLIFY (mat_greens_fct_virt)
+      CALL dbcsr_init_p(mat_greens_fct_virt)
+      CALL dbcsr_create(matrix=mat_greens_fct_virt, &
+                        template=matrix_s(1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+
       IF (do_gw_im_time_mix_minimax_clenshaw) THEN
 
          ! we perform an integration Sigma(iw) = int dw' G(i(w-w')) W(iw') here with jquad: omega' amd iquad: omega
@@ -4753,11 +4765,10 @@ CONTAINS
                   ! fm_scaled_dm_virt_tau. In the occ-matrix, we store the Gf with e_f = e_HOMO + fermi_level_offset,
                   ! in the virt-matrix, we store the Gf with e_f = e_LUMO - fermi_level_offset.
                   ! The Gf is imaginary, so we do a loop real_imaginary = 1, 2
-                  CALL compute_Greens_function_freq(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff, &
+                  CALL compute_Greens_function_freq(mat_greens_fct_occ, mat_greens_fct_virt, fm_mo_coeff, &
                                                     fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                                     fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, fermi_level_offset, &
-                                                    iquad*jquad, nmo, homo, eps_filter, omega_diff, count_ev_sc_GW, &
-                                                    real_imaginary)
+                                                    nmo, homo, eps_filter, omega_diff, real_imaginary)
 
                   DO i_occ_virt = 1, 2
 
@@ -4847,12 +4858,11 @@ CONTAINS
 
             tau = tau_tj(jquad)
 
-            CALL compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, &
+            CALL compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, &
                                               fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                               fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                               fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, &
-                                              jquad, nmo, &
-                                              eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
+                                              jquad, nmo, eps_filter, e_fermi, stabilize_exp, tau_tj)
 
             CALL dbcsr_set(mat_W, 0.0_dp)
             CALL copy_fm_to_dbcsr(fm_mat_W(jquad)%matrix, mat_W, keep_sparsity=.FALSE.)
@@ -5190,7 +5200,6 @@ CONTAINS
 !> \brief ...
 !> \param mat_greens_fct_occ ...
 !> \param mat_greens_fct_virt ...
-!> \param matrix_s ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
 !> \param fm_mo_coeff_occ_scaled ...
@@ -5204,15 +5213,13 @@ CONTAINS
 !> \param e_fermi ...
 !> \param stabilize_exp ...
 !> \param tau_tj ...
-!> \param count_ev_sc_GW ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+   SUBROUTINE compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                            fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, nmo, &
-                                           eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
+                                           eps_filter, e_fermi, stabilize_exp, tau_tj)
 
       TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
          fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
@@ -5220,7 +5227,6 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, stabilize_exp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tau_tj
-      INTEGER, INTENT(IN)                                :: count_ev_sc_GW
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function_time', &
          routineP = moduleN//':'//routineN
@@ -5283,22 +5289,6 @@ CONTAINS
                    matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
                    matrix_c=fm_scaled_dm_virt_tau)
 
-      IF (jquad == 1 .AND. count_ev_sc_GW == 1) THEN
-
-         NULLIFY (mat_greens_fct_occ)
-         CALL dbcsr_init_p(mat_greens_fct_occ)
-         CALL dbcsr_create(matrix=mat_greens_fct_occ, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (mat_greens_fct_virt)
-         CALL dbcsr_init_p(mat_greens_fct_virt)
-         CALL dbcsr_create(matrix=mat_greens_fct_virt, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-      END IF
-
       CALL dbcsr_set(mat_greens_fct_occ, 0.0_dp)
 
       CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
@@ -5323,7 +5313,6 @@ CONTAINS
 !> \brief ...
 !> \param mat_greens_fct_occ ...
 !> \param mat_greens_fct_virt ...
-!> \param matrix_s ...
 !> \param fm_mo_coeff ...
 !> \param fm_mo_coeff_occ_scaled ...
 !> \param fm_mo_coeff_virt_scaled ...
@@ -5331,28 +5320,25 @@ CONTAINS
 !> \param fm_scaled_dm_virt_tau ...
 !> \param Eigenval ...
 !> \param fermi_level_offset ...
-!> \param combined_quad ...
 !> \param nmo ...
 !> \param homo ...
 !> \param eps_filter ...
 !> \param omega ...
-!> \param count_ev_sc_GW ...
 !> \param real_imaginary ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Greens_function_freq(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff, &
+   SUBROUTINE compute_Greens_function_freq(mat_greens_fct_occ, mat_greens_fct_virt, fm_mo_coeff, &
                                            fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                           fm_scaled_dm_virt_tau, Eigenval, fermi_level_offset, combined_quad, nmo, &
-                                           homo, eps_filter, omega, count_ev_sc_GW, real_imaginary)
+                                           fm_scaled_dm_virt_tau, Eigenval, fermi_level_offset, nmo, &
+                                           homo, eps_filter, omega, real_imaginary)
 
       TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff, fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
          fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
       REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
-      INTEGER, INTENT(IN)                                :: combined_quad, nmo, homo
+      INTEGER, INTENT(IN)                                :: nmo, homo
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter, omega
-      INTEGER, INTENT(IN)                                :: count_ev_sc_GW, real_imaginary
+      INTEGER, INTENT(IN)                                :: real_imaginary
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function_freq', &
          routineP = moduleN//':'//routineN
@@ -5384,22 +5370,6 @@ CONTAINS
       CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
                    matrix_a=fm_mo_coeff, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
                    matrix_c=fm_scaled_dm_virt_tau)
-
-      IF (combined_quad == 1 .AND. count_ev_sc_GW == 1) THEN
-
-         NULLIFY (mat_greens_fct_occ)
-         CALL dbcsr_init_p(mat_greens_fct_occ)
-         CALL dbcsr_create(matrix=mat_greens_fct_occ, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-         NULLIFY (mat_greens_fct_virt)
-         CALL dbcsr_init_p(mat_greens_fct_virt)
-         CALL dbcsr_create(matrix=mat_greens_fct_virt, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
-
-      END IF
 
       CALL dbcsr_set(mat_greens_fct_occ, 0.0_dp)
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -94,7 +94,7 @@ MODULE rpa_gw
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'rpa_gw'
 
    PUBLIC :: allocate_matrices_gw_im_time, allocate_matrices_gw, GW_matrix_operations, GW_postprocessing, &
-             compute_self_energy_im_time_gw, deallocate_matrices_gw_im_time, deallocate_matrices_gw
+             deallocate_matrices_gw_im_time, deallocate_matrices_gw
 
 CONTAINS
 
@@ -104,12 +104,12 @@ CONTAINS
 !> \param gw_corr_lev_virt ...
 !> \param homo ...
 !> \param nmo ...
-!> \param num_integ_points ...
+!> \param num_integ_points_freq ...
 !> \param unit_nr ...
 !> \param RI_blk_sizes ...
 !> \param do_ic_model ...
 !> \param para_env ...
-!> \param fm_mat_W_tau ...
+!> \param fm_mat_W ...
 !> \param fm_mat_Q ...
 !> \param mo_coeff ...
 !> \param t_3c_overl_int_gw_RI ...
@@ -130,9 +130,9 @@ CONTAINS
 !> \param t_3c_overl_nnP_ic_reflected_beta ...
 ! **************************************************************************************************
    SUBROUTINE allocate_matrices_gw_im_time(gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, &
-                                           num_integ_points, unit_nr, &
+                                           num_integ_points_freq, unit_nr, &
                                            RI_blk_sizes, do_ic_model, &
-                                           para_env, fm_mat_W_tau, fm_mat_Q, &
+                                           para_env, fm_mat_W, fm_mat_Q, &
                                            mo_coeff, &
                                            t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
                                            t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, &
@@ -144,17 +144,18 @@ CONTAINS
                                            t_3c_overl_nnP_ic_beta, t_3c_overl_nnP_ic_reflected_beta)
 
       INTEGER, INTENT(IN)                                :: gw_corr_lev_occ, gw_corr_lev_virt, homo, &
-                                                            nmo, num_integ_points, unit_nr
+                                                            nmo, num_integ_points_freq, unit_nr
       INTEGER, DIMENSION(:), POINTER                     :: RI_blk_sizes
       LOGICAL, INTENT(IN)                                :: do_ic_model
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W
       TYPE(cp_fm_type), POINTER                          :: fm_mat_Q, mo_coeff
       TYPE(dbcsr_t_type)                                 :: t_3c_overl_int_gw_RI, &
                                                             t_3c_overl_int_gw_AO, &
                                                             t_3c_overl_nnP_ic, &
                                                             t_3c_overl_nnP_ic_reflected
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mat_W
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(dbcsr_type), POINTER                          :: mat_W
       TYPE(dbcsr_t_type), DIMENSION(:, :)                :: t_3c_overl_int
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN), OPTIONAL                      :: gw_corr_lev_occ_beta, &
@@ -202,28 +203,25 @@ CONTAINS
 
       END IF
 
-      NULLIFY (fm_mat_W_tau)
-      ALLOCATE (fm_mat_W_tau(num_integ_points))
+      NULLIFY (fm_mat_W)
+      ALLOCATE (fm_mat_W(num_integ_points_freq))
 
-      DO jquad = 1, num_integ_points
+      DO jquad = 1, num_integ_points_freq
 
-         NULLIFY (fm_mat_W_tau(jquad)%matrix)
-         CALL cp_fm_create(fm_mat_W_tau(jquad)%matrix, fm_mat_Q%matrix_struct)
-         CALL cp_fm_to_fm(fm_mat_Q, fm_mat_W_tau(jquad)%matrix)
-         CALL cp_fm_set_all(fm_mat_W_tau(jquad)%matrix, 0.0_dp)
+         NULLIFY (fm_mat_W(jquad)%matrix)
+         CALL cp_fm_create(fm_mat_W(jquad)%matrix, fm_mat_Q%matrix_struct)
+         CALL cp_fm_to_fm(fm_mat_Q, fm_mat_W(jquad)%matrix)
+         CALL cp_fm_set_all(fm_mat_W(jquad)%matrix, 0.0_dp)
 
       END DO
 
       NULLIFY (mat_W)
-      ALLOCATE (mat_W(num_integ_points))
-      DO jquad = 1, num_integ_points
-         ALLOCATE (mat_W(jquad)%matrix)
-         CALL dbcsr_create(matrix=mat_W(jquad)%matrix, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry, &
-                           row_blk_size=RI_blk_sizes, &
-                           col_blk_size=RI_blk_sizes)
-      END DO
+      CALL dbcsr_init_p(mat_W)
+      CALL dbcsr_create(matrix=mat_W, &
+                        template=matrix_s(1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry, &
+                        row_blk_size=RI_blk_sizes, &
+                        col_blk_size=RI_blk_sizes)
 
       CALL timestop(handle)
 
@@ -238,8 +236,8 @@ CONTAINS
 !> \param gw_corr_lev_virt ...
 !> \param homo ...
 !> \param nmo ...
-!> \param num_integ_points ...
 !> \param num_integ_group ...
+!> \param num_integ_points_freq ...
 !> \param unit_nr ...
 !> \param gw_corr_lev_tot ...
 !> \param num_fit_points ...
@@ -280,7 +278,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE allocate_matrices_gw(vec_Sigma_c_gw, color_rpa_group, dimen_nm_gw, &
                                    gw_corr_lev_occ, gw_corr_lev_virt, homo, &
-                                   nmo, num_integ_points, num_integ_group, unit_nr, &
+                                   nmo, num_integ_group, num_integ_points_freq, unit_nr, &
                                    gw_corr_lev_tot, num_fit_points, omega_max_fit, &
                                    do_minimax_quad, do_periodic, do_ri_Sigma_x, my_do_gw, &
                                    first_cycle_periodic_correction, &
@@ -296,7 +294,7 @@ CONTAINS
       COMPLEX(KIND=dp), ALLOCATABLE, &
          DIMENSION(:, :, :), INTENT(OUT)                 :: vec_Sigma_c_gw
       INTEGER, INTENT(IN) :: color_rpa_group, dimen_nm_gw, gw_corr_lev_occ, gw_corr_lev_virt, &
-         homo, nmo, num_integ_points, num_integ_group, unit_nr
+         homo, nmo, num_integ_group, num_integ_points_freq, unit_nr
       INTEGER, INTENT(INOUT)                             :: gw_corr_lev_tot, num_fit_points
       REAL(KIND=dp)                                      :: omega_max_fit
       LOGICAL, INTENT(IN)                                :: do_minimax_quad, do_periodic, &
@@ -354,10 +352,10 @@ CONTAINS
       gw_corr_lev_tot = gw_corr_lev_occ + gw_corr_lev_virt
 
       ! fill the omega_frequency vector
-      ALLOCATE (vec_omega_gw(num_integ_points))
+      ALLOCATE (vec_omega_gw(num_integ_points_freq))
       vec_omega_gw = 0.0_dp
 
-      DO jquad = 1, num_integ_points
+      DO jquad = 1, num_integ_points_freq
          IF (do_minimax_quad) THEN
             omega = tj(jquad)
          ELSE
@@ -369,7 +367,7 @@ CONTAINS
       ! determine number of fit points in the interval [0,w_max] for virt, or [-w_max,0] for occ
       num_fit_points = 0
 
-      DO jquad = 1, num_integ_points
+      DO jquad = 1, num_integ_points_freq
          IF (vec_omega_gw(jquad) < omega_max_fit) THEN
             num_fit_points = num_fit_points + 1
          END IF
@@ -390,7 +388,7 @@ CONTAINS
 
       ! fill the omega vector with frequencies, where we calculate the self-energy
       iquad = 0
-      DO jquad = 1, num_integ_points
+      DO jquad = 1, num_integ_points_freq
          IF (vec_omega_gw(jquad) < omega_max_fit) THEN
             iquad = iquad + 1
             vec_omega_fit_gw(iquad) = vec_omega_gw(jquad)
@@ -712,11 +710,9 @@ CONTAINS
 !> \param weights_sin_tf_t_to_w ...
 !> \param do_ic_model ...
 !> \param do_kpoints_cubic_RPA ...
-!> \param fm_mat_W_tau ...
+!> \param fm_mat_W ...
 !> \param t_3c_overl_int_gw_RI ...
 !> \param t_3c_overl_int_gw_AO ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
 !> \param t_3c_overl_nnP_ic ...
 !> \param t_3c_overl_nnP_ic_reflected ...
 !> \param mat_W ...
@@ -726,37 +722,28 @@ CONTAINS
 !> \param t_3c_overl_int_gw_AO_beta ...
 !> \param t_3c_overl_nnP_ic_beta ...
 !> \param t_3c_overl_nnP_ic_reflected_beta ...
-!> \param mat_greens_fct_occ_beta ...
-!> \param mat_greens_fct_virt_beta ...
 ! **************************************************************************************************
    SUBROUTINE deallocate_matrices_gw_im_time(weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, do_ic_model, do_kpoints_cubic_RPA, &
-                                             fm_mat_W_tau, t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                             mat_greens_fct_occ, mat_greens_fct_virt, &
-                                             t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, &
-                                             mat_W, &
+                                             fm_mat_W, t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
+                                             t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, mat_W, &
                                              ikp_local, cfm_mat_W_kp_tau, &
                                              t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta, &
-                                             t_3c_overl_nnP_ic_beta, t_3c_overl_nnP_ic_reflected_beta, &
-                                             mat_greens_fct_occ_beta, mat_greens_fct_virt_beta)
+                                             t_3c_overl_nnP_ic_beta, t_3c_overl_nnP_ic_reflected_beta)
 
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: weights_cos_tf_w_to_t, &
                                                             weights_sin_tf_t_to_w
       LOGICAL, INTENT(IN)                                :: do_ic_model, do_kpoints_cubic_RPA
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W
       TYPE(dbcsr_t_type)                                 :: t_3c_overl_int_gw_RI, &
-                                                            t_3c_overl_int_gw_AO
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt
-      TYPE(dbcsr_t_type)                                 :: t_3c_overl_nnP_ic, &
+                                                            t_3c_overl_int_gw_AO, &
+                                                            t_3c_overl_nnP_ic, &
                                                             t_3c_overl_nnP_ic_reflected
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_W
+      TYPE(dbcsr_type), POINTER                          :: mat_W
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: ikp_local
       TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
       TYPE(dbcsr_t_type), OPTIONAL :: t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta, &
          t_3c_overl_nnP_ic_beta, t_3c_overl_nnP_ic_reflected_beta
-      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mat_greens_fct_occ_beta, &
-                                                            mat_greens_fct_virt_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'deallocate_matrices_gw_im_time', &
          routineP = moduleN//':'//routineN
@@ -772,29 +759,18 @@ CONTAINS
          my_open_shell = .TRUE.
       END IF
 
-      DEALLOCATE (weights_cos_tf_w_to_t)
-      DEALLOCATE (weights_sin_tf_t_to_w)
+      IF (ALLOCATED(weights_cos_tf_w_to_t)) DEALLOCATE (weights_cos_tf_w_to_t)
+      IF (ALLOCATED(weights_sin_tf_t_to_w)) DEALLOCATE (weights_sin_tf_t_to_w)
 
       IF (.NOT. do_kpoints_cubic_RPA) THEN
 
-         IF (.NOT. do_ic_model) THEN
-            CALL dbcsr_deallocate_matrix_set(mat_greens_fct_occ)
-            CALL dbcsr_deallocate_matrix_set(mat_greens_fct_virt)
-         END IF
-
-         DO jquad = 1, SIZE(fm_mat_W_tau, 1)
-            CALL cp_fm_release(fm_mat_W_tau(jquad)%matrix)
+         DO jquad = 1, SIZE(fm_mat_W, 1)
+            CALL cp_fm_release(fm_mat_W(jquad)%matrix)
          END DO
 
-         DEALLOCATE (fm_mat_W_tau)
-         IF (my_open_shell) THEN
-            IF (.NOT. do_ic_model) THEN
-               CALL dbcsr_deallocate_matrix_set(mat_greens_fct_occ_beta)
-               CALL dbcsr_deallocate_matrix_set(mat_greens_fct_virt_beta)
-            END IF
-         END IF
+         DEALLOCATE (fm_mat_W)
 
-         CALL dbcsr_deallocate_matrix_set(mat_W)
+         CALL dbcsr_release_P(mat_W)
 
       ELSE
          DO jquad = 1, SIZE(cfm_mat_W_kp_tau, 2)
@@ -837,6 +813,7 @@ CONTAINS
 !> \param do_bse ...
 !> \param do_im_time ...
 !> \param do_periodic ...
+!> \param do_gw_im_time_mix_minimax_clenshaw ...
 !> \param first_cycle_periodic_correction ...
 !> \param fermi_level_offset ...
 !> \param omega ...
@@ -848,7 +825,7 @@ CONTAINS
 !> \param vec_W_gw ...
 !> \param wj ...
 !> \param weights_cos_tf_w_to_t ...
-!> \param fm_mat_W_tau ...
+!> \param fm_mat_W ...
 !> \param fm_mat_L ...
 !> \param fm_mat_Q ...
 !> \param fm_mat_Q_static_bse ...
@@ -876,10 +853,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE GW_matrix_operations(vec_Sigma_c_gw, dimen_nm_gw, dimen_RI, gw_corr_lev_occ, &
                                    gw_corr_lev_virt, homo, jquad, nmo, num_fit_points, num_integ_points, &
-                                   do_bse, do_im_time, do_periodic, &
+                                   do_bse, do_im_time, do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
                                    first_cycle_periodic_correction, fermi_level_offset, &
                                    omega, Eigenval, delta_corr, tau_tj, tj, vec_omega_fit_gw, &
-                                   vec_W_gw, wj, weights_cos_tf_w_to_t, fm_mat_W_tau, fm_mat_L, &
+                                   vec_W_gw, wj, weights_cos_tf_w_to_t, fm_mat_W, fm_mat_L, &
                                    fm_mat_Q, fm_mat_Q_static_bse, fm_mat_R_gw, fm_mat_S_gw, &
                                    fm_mat_S_gw_work, fm_mat_work, mo_coeff, para_env, &
                                    para_env_RPA, matrix_berry_im_mo_mo, matrix_berry_re_mo_mo, &
@@ -892,7 +869,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: dimen_nm_gw, dimen_RI, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, homo, jquad, nmo, &
                                                             num_fit_points, num_integ_points
-      LOGICAL, INTENT(IN)                                :: do_bse, do_im_time, do_periodic
+      LOGICAL, INTENT(IN) :: do_bse, do_im_time, do_periodic, do_gw_im_time_mix_minimax_clenshaw
       LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
       REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
       REAL(KIND=dp), INTENT(INOUT)                       :: omega
@@ -907,7 +884,7 @@ CONTAINS
          INTENT(IN)                                      :: wj
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(IN)                                      :: weights_cos_tf_w_to_t
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_mat_L
       TYPE(cp_fm_type), POINTER                          :: fm_mat_Q, fm_mat_Q_static_bse, &
                                                             fm_mat_R_gw, fm_mat_S_gw, &
@@ -1026,25 +1003,34 @@ CONTAINS
          ! multiply with L from the left and the right to get the screened Coulomb interaction
          CALL cp_gemm('T', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_mat_L(1, 1)%matrix, fm_mat_Q, &
                       0.0_dp, fm_mat_work)
+
          CALL cp_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_mat_work, fm_mat_L(1, 1)%matrix, &
                       0.0_dp, fm_mat_Q)
 
-         ! Fourier transform from w to t
-         DO iquad = 1, num_integ_points
+         IF (do_gw_im_time_mix_minimax_clenshaw) THEN
 
-            omega = tj(jquad)
-            tau = tau_tj(iquad)
-            weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
+            CALL cp_fm_to_fm(fm_mat_Q, fm_mat_W(jquad)%matrix)
 
-            IF (jquad == 1) THEN
+         ELSE
 
-               CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad)%matrix, alpha=0.0_dp)
+            ! Fourier transform from w to t
+            DO iquad = 1, num_integ_points
 
-            END IF
+               omega = tj(jquad)
+               tau = tau_tj(iquad)
+               weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
 
-            CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad)%matrix, beta=weight, matrix_b=fm_mat_Q)
+               IF (jquad == 1) THEN
 
-         END DO
+                  CALL cp_fm_set_all(matrix=fm_mat_W(iquad)%matrix, alpha=0.0_dp)
+
+               END IF
+
+               CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W(iquad)%matrix, beta=weight, matrix_b=fm_mat_Q)
+
+            END DO
+
+         END IF
 
       END IF
 
@@ -1184,11 +1170,13 @@ CONTAINS
 !> \param nmo ...
 !> \param num_fit_points ...
 !> \param num_integ_points ...
+!> \param num_integ_points_freq ...
 !> \param num_points_corr ...
 !> \param unit_nr ...
 !> \param do_apply_ic_corr_to_gw ...
 !> \param do_im_time ...
 !> \param do_periodic ...
+!> \param do_gw_im_time_mix_minimax_clenshaw ...
 !> \param do_ri_Sigma_x ...
 !> \param first_cycle_periodic_correction ...
 !> \param e_fermi ...
@@ -1201,6 +1189,7 @@ CONTAINS
 !> \param Eigenval_scf ...
 !> \param tau_tj ...
 !> \param tj ...
+!> \param wj ...
 !> \param vec_omega_fit_gw ...
 !> \param vec_Sigma_x_gw ...
 !> \param ic_corr_list ...
@@ -1213,7 +1202,7 @@ CONTAINS
 !> \param fm_scaled_dm_occ_tau ...
 !> \param fm_scaled_dm_virt_tau ...
 !> \param mo_coeff ...
-!> \param fm_mat_W_tau ...
+!> \param fm_mat_W ...
 !> \param para_env ...
 !> \param para_env_RPA ...
 !> \param mat_dm ...
@@ -1222,8 +1211,6 @@ CONTAINS
 !> \param t_3c_overl_int_gw_AO ...
 !> \param matrix_berry_im_mo_mo ...
 !> \param matrix_berry_re_mo_mo ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
 !> \param mat_W ...
 !> \param matrix_s ...
 !> \param kpoints ...
@@ -1248,40 +1235,37 @@ CONTAINS
 !> \param fm_mo_coeff_virt_beta ...
 !> \param t_3c_overl_int_gw_RI_beta ...
 !> \param t_3c_overl_int_gw_AO_beta ...
-!> \param mat_greens_fct_occ_beta ...
-!> \param mat_greens_fct_virt_beta ...
 ! **************************************************************************************************
    SUBROUTINE GW_postprocessing(vec_Sigma_c_gw, count_ev_sc_GW, gw_corr_lev_occ, &
                                 gw_corr_lev_tot, gw_corr_lev_virt, homo, &
-                                nmo, num_fit_points, num_integ_points, &
+                                nmo, num_fit_points, num_integ_points, num_integ_points_freq, &
                                 num_points_corr, unit_nr, do_apply_ic_corr_to_gw, do_im_time, &
-                                do_periodic, do_ri_Sigma_x, first_cycle_periodic_correction, &
-                                e_fermi, eps_filter, &
+                                do_periodic, do_gw_im_time_mix_minimax_clenshaw, do_ri_Sigma_x, &
+                                first_cycle_periodic_correction, e_fermi, eps_filter, &
                                 fermi_level_offset, stabilize_exp, delta_corr, Eigenval, &
-                                Eigenval_last, Eigenval_scf, tau_tj, tj, &
+                                Eigenval_last, Eigenval_scf, tau_tj, tj, wj, &
                                 vec_omega_fit_gw, vec_Sigma_x_gw, ic_corr_list, &
                                 weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
                                 fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
                                 fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                mo_coeff, fm_mat_W_tau, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
+                                mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
                                 t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, matrix_berry_im_mo_mo, &
-                                matrix_berry_re_mo_mo, mat_greens_fct_occ, mat_greens_fct_virt, mat_W, matrix_s, &
+                                matrix_berry_re_mo_mo, mat_W, matrix_s, &
                                 kpoints, mp2_env, qs_env, &
                                 nkp_self_energy, do_kpoints_cubic_RPA, Eigenval_kp, Eigenval_scf_kp, iter_ev_sc, &
                                 vec_Sigma_c_gw_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, &
                                 e_fermi_beta, Eigenval_beta, Eigenval_last_beta, Eigenval_scf_beta, &
                                 vec_Sigma_x_gw_beta, ic_corr_list_beta, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
-                                t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta, &
-                                mat_greens_fct_occ_beta, mat_greens_fct_virt_beta)
+                                t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta)
 
       COMPLEX(KIND=dp), ALLOCATABLE, &
          DIMENSION(:, :, :), INTENT(INOUT)               :: vec_Sigma_c_gw
       INTEGER, INTENT(IN) :: count_ev_sc_GW, gw_corr_lev_occ, gw_corr_lev_tot, gw_corr_lev_virt, &
-         homo, nmo, num_fit_points, num_integ_points
+         homo, nmo, num_fit_points, num_integ_points, num_integ_points_freq
       INTEGER                                            :: num_points_corr
       INTEGER, INTENT(IN)                                :: unit_nr
-      LOGICAL, INTENT(IN)                                :: do_apply_ic_corr_to_gw, do_im_time, &
-                                                            do_periodic, do_ri_Sigma_x
+      LOGICAL, INTENT(IN) :: do_apply_ic_corr_to_gw, do_im_time, do_periodic, &
+         do_gw_im_time_mix_minimax_clenshaw, do_ri_Sigma_x
       LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
       REAL(KIND=dp), INTENT(IN)                          :: e_fermi, eps_filter, fermi_level_offset, &
                                                             stabilize_exp
@@ -1290,7 +1274,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: Eigenval
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(INOUT)                                   :: Eigenval_last, Eigenval_scf, tau_tj, tj, &
-                                                            vec_omega_fit_gw
+                                                            wj, vec_omega_fit_gw
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: vec_Sigma_x_gw
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list
@@ -1299,15 +1283,15 @@ CONTAINS
                                                             weights_sin_tf_t_to_w
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
          fm_mo_coeff_occ, fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, mo_coeff
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
       TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_dm, mat_SinvVSinv
       TYPE(dbcsr_t_type)                                 :: t_3c_overl_int_gw_RI, &
                                                             t_3c_overl_int_gw_AO
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_im_mo_mo, &
-                                                            matrix_berry_re_mo_mo, &
-                                                            mat_greens_fct_occ, &
-                                                            mat_greens_fct_virt, mat_W, matrix_s
+                                                            matrix_berry_re_mo_mo
+      TYPE(dbcsr_type), POINTER                          :: mat_W
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -1332,9 +1316,6 @@ CONTAINS
                                                             fm_mo_coeff_virt_beta
       TYPE(dbcsr_t_type), OPTIONAL                       :: t_3c_overl_int_gw_RI_beta, &
                                                             t_3c_overl_int_gw_AO_beta
-      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mat_greens_fct_occ_beta, &
-                                                            mat_greens_fct_virt_beta
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'GW_postprocessing', &
          routineP = moduleN//':'//routineN
@@ -1355,8 +1336,7 @@ CONTAINS
           PRESENT(homo_beta) .AND. PRESENT(e_fermi_beta) .AND. PRESENT(Eigenval_beta) .AND. PRESENT(Eigenval_last_beta) &
           .AND. PRESENT(Eigenval_scf_beta) .AND. PRESENT(vec_Sigma_x_gw_beta) .AND. &
           PRESENT(ic_corr_list_beta) .AND. PRESENT(fm_mo_coeff_occ_beta) .AND. PRESENT(fm_mo_coeff_virt_beta) .AND. &
-          PRESENT(t_3c_overl_int_gw_RI_beta) .AND. PRESENT(t_3c_overl_int_gw_AO_beta) .AND. PRESENT(mat_greens_fct_occ_beta) &
-          .AND. PRESENT(mat_greens_fct_virt_beta)) THEN
+          PRESENT(t_3c_overl_int_gw_RI_beta) .AND. PRESENT(t_3c_overl_int_gw_AO_beta)) THEN
          my_open_shell = .TRUE. ! todo: this should be refactored (and any similar occurence of my_open_shell)
       END IF
 
@@ -1364,37 +1344,39 @@ CONTAINS
       IF (do_im_time .AND. .NOT. do_kpoints_cubic_RPA) THEN
          num_points_corr = mp2_env%ri_g0w0%num_omega_points
 
-         CALL compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ, &
-                                             mat_greens_fct_virt, &
-                                             matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                             fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                             fm_scaled_dm_virt_tau, Eigenval, eps_filter, e_fermi, fm_mat_W_tau, &
-                                             gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, &
-                                             count_ev_sc_GW, &
-                                             t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                             mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
-                                             weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, do_periodic, &
-                                             num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
-                                             mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                             first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
-                                             do_ri_Sigma_x, vec_Sigma_x_gw, unit_nr)
+         CALL compute_self_energy_cubic_gw(num_integ_points, num_integ_points_freq, nmo, tau_tj, tj, wj, &
+                                           matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
+                                           fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
+                                           fm_scaled_dm_virt_tau, Eigenval, vec_omega_fit_gw, eps_filter, &
+                                           e_fermi, fermi_level_offset, fm_mat_W, &
+                                           gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, &
+                                           count_ev_sc_GW, &
+                                           t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
+                                           mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
+                                           weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, &
+                                           do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
+                                           num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
+                                           mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
+                                           first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
+                                           do_ri_Sigma_x, vec_Sigma_x_gw, unit_nr)
 
          IF (my_open_shell) THEN
 
-            CALL compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ_beta, &
-                                                mat_greens_fct_virt_beta, &
-                                                matrix_s, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, fm_mo_coeff_occ_scaled, &
-                                                fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                                fm_scaled_dm_virt_tau, Eigenval_beta, eps_filter, e_fermi_beta, fm_mat_W_tau, &
-                                                gw_corr_lev_tot, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, &
-                                                count_ev_sc_GW, &
-                                                t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta, &
-                                                mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
-                                                weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw_beta, do_periodic, &
-                                                num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
-                                                mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                                first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
-                                                do_ri_Sigma_x, vec_Sigma_x_gw_beta, unit_nr, do_beta=.TRUE.)
+            CALL compute_self_energy_cubic_gw(num_integ_points, num_integ_points_freq, nmo, tau_tj, tj, wj, &
+                                              matrix_s, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, fm_mo_coeff_occ_scaled, &
+                                              fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
+                                              fm_scaled_dm_virt_tau, Eigenval_beta, vec_omega_fit_gw, eps_filter, &
+                                              e_fermi_beta, fermi_level_offset, fm_mat_W, &
+                                              gw_corr_lev_tot, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, &
+                                              count_ev_sc_GW, &
+                                              t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta, &
+                                              mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
+                                              weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw_beta, &
+                                              do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
+                                              num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
+                                              mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
+                                              first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
+                                              do_ri_Sigma_x, vec_Sigma_x_gw_beta, unit_nr, do_beta=.TRUE.)
 
          END IF
 
@@ -1478,14 +1460,17 @@ CONTAINS
                                                mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp), &
                                                Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, num_poles, &
                                                num_fit_points, max_iter_fit, crossing_search, homo, check_fit, stop_crit, &
-                                               fermi_level_offset, do_im_time)
+                                               fermi_level_offset, &
+                                               do_im_time .AND. (.NOT. do_gw_im_time_mix_minimax_clenshaw))
+
             CASE (gw_pade_approx)
                CALL continuation_pade(vec_gw_energ, vec_omega_fit_gw, &
                                       z_value, m_value, vec_Sigma_c_gw(:, :, ikp), &
                                       mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp), &
                                       Eigenval, Eigenval_scf, n_level_gw, gw_corr_lev_occ, mp2_env%ri_g0w0%nparam_pade, &
                                       num_fit_points, crossing_search, homo, check_fit, &
-                                      fermi_level_offset, do_im_time)
+                                      fermi_level_offset, &
+                                      do_im_time .AND. (.NOT. do_gw_im_time_mix_minimax_clenshaw))
 
             CASE DEFAULT
                CPABORT("Only two-model and Pade approximation are implemented.")
@@ -4580,11 +4565,11 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param num_integ_points ...
+!> \param num_integ_points_freq ...
 !> \param nmo ...
 !> \param tau_tj ...
 !> \param tj ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
+!> \param wj ...
 !> \param matrix_s ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
@@ -4593,9 +4578,11 @@ CONTAINS
 !> \param fm_scaled_dm_occ_tau ...
 !> \param fm_scaled_dm_virt_tau ...
 !> \param Eigenval ...
+!> \param vec_omega_fit_gw ...
 !> \param eps_filter ...
 !> \param e_fermi ...
-!> \param fm_mat_W_tau ...
+!> \param fermi_level_offset ...
+!> \param fm_mat_W ...
 !> \param gw_corr_lev_tot ...
 !> \param gw_corr_lev_occ ...
 !> \param gw_corr_lev_virt ...
@@ -4611,6 +4598,7 @@ CONTAINS
 !> \param weights_sin_tf_t_to_w ...
 !> \param vec_Sigma_c_gw ...
 !> \param do_periodic ...
+!> \param do_gw_im_time_mix_minimax_clenshaw ...
 !> \param num_points_corr ...
 !> \param delta_corr ...
 !> \param qs_env ...
@@ -4622,39 +4610,41 @@ CONTAINS
 !> \param first_cycle_periodic_correction ...
 !> \param kpoints ...
 !> \param num_fit_points ...
-!> \param mo_coeff ...
+!> \param fm_mo_coeff ...
 !> \param do_ri_Sigma_x ...
 !> \param vec_Sigma_x_gw ...
 !> \param unit_nr ...
 !> \param do_beta ...
 ! **************************************************************************************************
-   SUBROUTINE compute_self_energy_im_time_gw(num_integ_points, nmo, tau_tj, tj, mat_greens_fct_occ, mat_greens_fct_virt, &
-                                             matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                             fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                             fm_scaled_dm_virt_tau, Eigenval, eps_filter, e_fermi, fm_mat_W_tau, &
-                                             gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, count_ev_sc_GW, &
-                                             t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                             mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
-                                             weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, do_periodic, &
-                                             num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
-                                             mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
-                                             first_cycle_periodic_correction, kpoints, num_fit_points, mo_coeff, &
-                                             do_ri_Sigma_x, vec_Sigma_x_gw, unit_nr, do_beta)
-      INTEGER, INTENT(IN)                                :: num_integ_points, nmo
+   SUBROUTINE compute_self_energy_cubic_gw(num_integ_points, num_integ_points_freq, nmo, tau_tj, tj, wj, &
+                                           matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
+                                           fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
+                                           fm_scaled_dm_virt_tau, Eigenval, vec_omega_fit_gw, eps_filter, &
+                                           e_fermi, fermi_level_offset, fm_mat_W, &
+                                           gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, count_ev_sc_GW, &
+                                           t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
+                                           mat_W, mat_SinvVSinv, mat_dm, stabilize_exp, &
+                                           weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, &
+                                           do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
+                                           num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
+                                           mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
+                                           first_cycle_periodic_correction, kpoints, num_fit_points, fm_mo_coeff, &
+                                           do_ri_Sigma_x, vec_Sigma_x_gw, unit_nr, do_beta)
+      INTEGER, INTENT(IN)                                :: num_integ_points, num_integ_points_freq, &
+                                                            nmo
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                                      :: tau_tj, tj
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt, &
-                                                            matrix_s
+         INTENT(IN)                                      :: tau_tj, tj, wj
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
          fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval, vec_omega_fit_gw
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, fermi_level_offset
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W
       INTEGER, INTENT(IN)                                :: gw_corr_lev_tot, gw_corr_lev_occ, &
                                                             gw_corr_lev_virt, homo, count_ev_sc_GW
       TYPE(dbcsr_t_type)                                 :: t_3c_overl_int_gw_RI, &
                                                             t_3c_overl_int_gw_AO
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_W
+      TYPE(dbcsr_type), POINTER                          :: mat_W
       TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv, mat_dm
       REAL(KIND=dp), INTENT(IN)                          :: stabilize_exp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
@@ -4662,7 +4652,7 @@ CONTAINS
                                                             weights_sin_tf_t_to_w
       COMPLEX(KIND=dp), ALLOCATABLE, &
          DIMENSION(:, :, :), INTENT(INOUT)               :: vec_Sigma_c_gw
-      LOGICAL, INTENT(IN)                                :: do_periodic
+      LOGICAL, INTENT(IN) :: do_periodic, do_gw_im_time_mix_minimax_clenshaw
       INTEGER, INTENT(IN)                                :: num_points_corr
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(INOUT)                                   :: delta_corr
@@ -4674,30 +4664,29 @@ CONTAINS
       LOGICAL, INTENT(INOUT) :: first_cycle_periodic_correction
       TYPE(kpoint_type), POINTER                         :: kpoints
       INTEGER, INTENT(IN)                                :: num_fit_points
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
+      TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff
       LOGICAL, INTENT(IN)                                :: do_ri_Sigma_x
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: vec_Sigma_x_gw
       INTEGER, INTENT(IN)                                :: unit_nr
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_beta
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_self_energy_im_time_gw', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_self_energy_cubic_gw', &
          routineP = moduleN//':'//routineN
 
-      COMPLEX(KIND=dp)                                   :: im_unit
+      COMPLEX(KIND=dp)                                   :: im_unit, re_im
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: delta_corr_omega
-      INTEGER                                            :: gw_lev_end, gw_lev_start, handle, &
-                                                            handle3, iquad, jquad, mo_end, &
-                                                            mo_start, n_level_gw, n_level_gw_ref, &
-                                                            unit_nr_prv
-      LOGICAL                                            :: memory_info, my_do_beta
-      REAL(KIND=dp)                                      :: ext_scaling, omega, omega_i, omega_sign, &
-                                                            sign_occ_virt, t_i_Clenshaw, tau, &
-                                                            weight_cos, weight_i, weight_sin
+      INTEGER :: gw_lev_end, gw_lev_start, handle, handle3, i_occ_virt, iquad, jquad, mo_end, &
+         mo_start, n, n_level_gw, n_level_gw_ref, real_imaginary, unit_nr_prv
+      LOGICAL                                            :: do_occ, do_virt, memory_info, my_do_beta
+      REAL(KIND=dp) :: ext_scaling, omega, omega_diff, omega_i, omega_sign, sign_occ_virt, &
+         t_i_Clenshaw, tau, weight, weight_cos, weight_i, weight_sin
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: Sigma_c_gw_tmp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_c_gw_cos_omega, &
          vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
          vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
       TYPE(dbcsr_t_type)                                 :: t_3c_ctr_RI
+      TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
 
       CALL timeset(routineN, handle)
 
@@ -4734,67 +4723,191 @@ CONTAINS
       ALLOCATE (delta_corr_omega(1 + homo - gw_corr_lev_occ:homo + gw_corr_lev_virt, num_integ_points))
       delta_corr_omega(:, :) = (0.0_dp, 0.0_dp)
 
-      DO jquad = 1, num_integ_points
+      IF (do_gw_im_time_mix_minimax_clenshaw) THEN
 
-         tau = tau_tj(jquad)
+         ! we perform an integration Sigma(iw) = int dw' G(i(w-w')) W(iw') here with jquad: omega' amd iquad: omega
+         ! w' is stored in tj with entries > 0. Therefore, we split the integration in two parts for w' > 0 / w' = tj(jquad)
+         ! w' < 0 / w' = -tj(jquad)
+         DO jquad = 1, 2*num_integ_points_freq
 
-         CALL compute_Greens_function(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                      fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, num_integ_points, nmo, &
-                                      eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
+            CALL dbcsr_set(mat_W, 0.0_dp)
 
-         CALL copy_fm_to_dbcsr(fm_mat_W_tau(jquad)%matrix, mat_W(jquad)%matrix, keep_sparsity=.FALSE.)
+            ! W(iw') = W(-iw')
+            IF (jquad .LE. num_integ_points_freq) THEN
+               CALL copy_fm_to_dbcsr(fm_mat_W(jquad)%matrix, mat_W, keep_sparsity=.FALSE.)
+            ELSE
+               CALL copy_fm_to_dbcsr(fm_mat_W(jquad - num_integ_points_freq)%matrix, mat_W, keep_sparsity=.FALSE.)
+            END IF
 
-         CALL compute_sigma_gw(t_3c_overl_int_gw_AO, t_3c_overl_int_gw_RI, &
-                               mat_greens_fct_occ(jquad)%matrix, mat_W(jquad)%matrix, [1.0_dp, -1.0_dp], &
-                               vec_Sigma_c_gw_neg_tau(:, jquad), [mo_start, mo_end], para_env, unit_nr_prv, &
-                               t_3c_ctr_RI=t_3c_ctr_RI, t_3c_ctr_in=.FALSE.)
+            DO iquad = 1, num_fit_points
 
-         CALL compute_sigma_gw(t_3c_overl_int_gw_AO, t_3c_overl_int_gw_RI, &
-                               mat_greens_fct_virt(jquad)%matrix, mat_W(jquad)%matrix, [1.0_dp, 1.0_dp], &
-                               vec_Sigma_c_gw_pos_tau(:, jquad), [mo_start, mo_end], para_env, unit_nr_prv, &
-                               t_3c_ctr_RI=t_3c_ctr_RI, t_3c_ctr_in=.TRUE.)
+               IF (jquad .LE. num_integ_points_freq) THEN
+                  omega_diff = vec_omega_fit_gw(iquad) - tj(jquad)
+               ELSE
+                  omega_diff = vec_omega_fit_gw(iquad) + tj(jquad - num_integ_points_freq)
+               END IF
 
-         CALL dbcsr_t_destroy(t_3c_ctr_RI)
+               DO real_imaginary = 1, 2
 
-         vec_Sigma_c_gw_cos_tau(:, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(:, jquad) + &
-                                                    vec_Sigma_c_gw_neg_tau(:, jquad))
+                  ! compute Green's function G(i*(w-/+w')) and store it to fm_scaled_dm_occ_tau and
+                  ! fm_scaled_dm_virt_tau. In the occ-matrix, we store the Gf with e_f = e_HOMO + fermi_level_offset,
+                  ! in the virt-matrix, we store the Gf with e_f = e_LUMO - fermi_level_offset.
+                  ! The Gf is imaginary, so we do a loop real_imaginary = 1, 2
+                  CALL compute_Greens_function_freq(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff, &
+                                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                                    fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, fermi_level_offset, &
+                                                    iquad*jquad, nmo, homo, eps_filter, omega_diff, count_ev_sc_GW, &
+                                                    real_imaginary)
 
-         vec_Sigma_c_gw_sin_tau(:, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(:, jquad) - &
-                                                    vec_Sigma_c_gw_neg_tau(:, jquad))
+                  DO i_occ_virt = 1, 2
 
-         CALL dbcsr_set(mat_W(jquad)%matrix, 0.0_dp)
+                     do_occ = .FALSE.
+                     do_virt = .FALSE.
+                     IF (i_occ_virt == 1) do_occ = .TRUE.
+                     IF (i_occ_virt == 2) do_virt = .TRUE.
 
-         CALL dbcsr_filter(mat_W(jquad)%matrix, 1.0_dp)
+                     IF (do_occ) THEN
+                        mo_start = homo - gw_corr_lev_occ + 1
+                        mo_end = homo
+                        ALLOCATE (Sigma_c_gw_tmp(gw_corr_lev_occ))
+                     ELSE IF (do_virt) THEN
+                        mo_start = homo + 1
+                        mo_end = homo + gw_corr_lev_virt
+                        ALLOCATE (Sigma_c_gw_tmp(gw_corr_lev_virt))
+                     END IF
 
-      END DO ! jquad (tau)
+                     IF (real_imaginary == 1) re_im = (1.0_dp, 0.0_dp)
+                     IF (real_imaginary == 2) re_im = (0.0_dp, 1.0_dp)
 
-      ! Fourier transform from time to frequency
-      DO jquad = 1, num_fit_points
+                     Sigma_c_gw_tmp = 0.0_dp
 
-         DO iquad = 1, num_integ_points
+                     ! 3-center * W(iw')
+                     CALL compute_sigma_gw(t_3c_overl_int_gw_AO, t_3c_overl_int_gw_RI, &
+                                           mat_greens_fct_occ, mat_W, [1.0_dp, 0.0_dp], &
+                                           vec_Sigma_c_gw_neg_tau(:, 1), [mo_start, mo_end], para_env, unit_nr_prv, &
+                                           t_3c_ctr_RI=t_3c_ctr_RI, t_3c_ctr_in=.FALSE.)
 
-            omega = tj(jquad)
-            tau = tau_tj(iquad)
-            weight_cos = weights_cos_tf_t_to_w(jquad, iquad)*COS(omega*tau)
-            weight_sin = weights_sin_tf_t_to_w(jquad, iquad)*SIN(omega*tau)
+                     IF (do_occ) THEN
 
-            vec_Sigma_c_gw_cos_omega(:, jquad) = vec_Sigma_c_gw_cos_omega(:, jquad) + &
-                                                 weight_cos*vec_Sigma_c_gw_cos_tau(:, iquad)
+                        ! 3-center * G(i(w-w')) for an occupied level n (other Fermi level than virtuals)
+                        CALL compute_sigma_gw(t_3c_overl_int_gw_AO, t_3c_overl_int_gw_RI, &
+                                              mat_greens_fct_occ, mat_W, [1.0_dp, -1.0_dp], &
+                                              Sigma_c_gw_tmp, [mo_start, mo_end], para_env, unit_nr_prv, &
+                                              t_3c_ctr_RI=t_3c_ctr_RI, t_3c_ctr_in=.TRUE.)
 
-            vec_Sigma_c_gw_sin_omega(:, jquad) = vec_Sigma_c_gw_sin_omega(:, jquad) + &
-                                                 weight_sin*vec_Sigma_c_gw_sin_tau(:, iquad)
+                     END IF
+
+                     IF (do_virt) THEN
+                        ! 3-center * G(i(w-w')) for a virtual level n (other Fermi level than occupieds)
+                        CALL compute_sigma_gw(t_3c_overl_int_gw_AO, t_3c_overl_int_gw_RI, &
+                                              mat_greens_fct_virt, mat_W, [1.0_dp, 1.0_dp], &
+                                              Sigma_c_gw_tmp, [mo_start, mo_end], para_env, unit_nr_prv, &
+                                              t_3c_ctr_RI=t_3c_ctr_RI, t_3c_ctr_in=.TRUE.)
+                     END IF
+
+                     CALL dbcsr_t_destroy(t_3c_ctr_RI)
+
+                     ! divide the integration weight by 2, because the integration
+                     ! is from -infty to +infty and not just 0 to +infty as for RPA
+                     IF (jquad .LE. num_integ_points_freq) THEN
+                        weight = wj(jquad)/2.0_dp
+                     ELSE
+                        weight = wj(jquad - num_integ_points_freq)/2.0_dp
+                     END IF
+
+                     IF (do_occ) THEN
+                        vec_Sigma_c_gw(1:gw_corr_lev_occ, iquad, 1) = &
+                           vec_Sigma_c_gw(1:gw_corr_lev_occ, iquad, 1) - &
+                           weight/twopi*re_im*Sigma_c_gw_tmp(:)
+                     ELSE IF (do_virt) THEN
+                        vec_Sigma_c_gw(gw_corr_lev_occ + 1:gw_corr_lev_tot, iquad, 1) = &
+                           vec_Sigma_c_gw(gw_corr_lev_occ + 1:gw_corr_lev_tot, iquad, 1) - &
+                           weight/twopi*re_im*Sigma_c_gw_tmp(:)
+                     END IF
+
+                     DEALLOCATE (Sigma_c_gw_tmp)
+
+                  END DO
+
+               END DO
+
+            END DO
 
          END DO
 
-      END DO
+         ! empirically found that the sign of real part of self-energy for occupied levels
+         ! is wrong when comparing to N^4 code...
+         n = gw_corr_lev_occ
+         vec_Sigma_c_gw(1:n, :, :) = -REAL(vec_Sigma_c_gw(1:n, :, :))*(1.0_dp, 0.0_dp) &
+                                     + AIMAG(vec_Sigma_c_gw(1:n, :, :))*(0.0_dp, 1.0_dp)
 
-      ! for occupied levels, we need the correlation self-energy for negative omega. Therefore, weight_sin
-      ! should be computed with -omega, which results in an additional minus for vec_Sigma_c_gw_sin_omega:
-      vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :) = -vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :)
+      ELSE
 
-      vec_Sigma_c_gw(:, 1:num_fit_points, 1) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points) + &
-                                               im_unit*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
+         DO jquad = 1, num_integ_points
+
+            tau = tau_tj(jquad)
+
+            CALL compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, &
+                                              fm_mo_coeff_occ, fm_mo_coeff_virt, &
+                                              fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, &
+                                              jquad, nmo, &
+                                              eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
+
+            CALL dbcsr_set(mat_W, 0.0_dp)
+            CALL copy_fm_to_dbcsr(fm_mat_W(jquad)%matrix, mat_W, keep_sparsity=.FALSE.)
+
+            CALL compute_sigma_gw(t_3c_overl_int_gw_AO, t_3c_overl_int_gw_RI, &
+                                  mat_greens_fct_occ, mat_W, [1.0_dp, -1.0_dp], &
+                                  vec_Sigma_c_gw_neg_tau(:, jquad), [mo_start, mo_end], para_env, unit_nr_prv, &
+                                  t_3c_ctr_RI=t_3c_ctr_RI, t_3c_ctr_in=.FALSE.)
+
+            CALL compute_sigma_gw(t_3c_overl_int_gw_AO, t_3c_overl_int_gw_RI, &
+                                  mat_greens_fct_virt, mat_W, [1.0_dp, 1.0_dp], &
+                                  vec_Sigma_c_gw_pos_tau(:, jquad), [mo_start, mo_end], para_env, unit_nr_prv, &
+                                  t_3c_ctr_RI=t_3c_ctr_RI, t_3c_ctr_in=.TRUE.)
+
+            CALL dbcsr_t_destroy(t_3c_ctr_RI)
+
+            vec_Sigma_c_gw_cos_tau(:, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(:, jquad) + &
+                                                       vec_Sigma_c_gw_neg_tau(:, jquad))
+
+            vec_Sigma_c_gw_sin_tau(:, jquad) = 0.5_dp*(vec_Sigma_c_gw_pos_tau(:, jquad) - &
+                                                       vec_Sigma_c_gw_neg_tau(:, jquad))
+
+         END DO ! jquad (tau)
+
+         ! Fourier transform from time to frequency
+         DO jquad = 1, num_fit_points
+
+            DO iquad = 1, num_integ_points
+
+               omega = tj(jquad)
+               tau = tau_tj(iquad)
+               weight_cos = weights_cos_tf_t_to_w(jquad, iquad)*COS(omega*tau)
+               weight_sin = weights_sin_tf_t_to_w(jquad, iquad)*SIN(omega*tau)
+
+               vec_Sigma_c_gw_cos_omega(:, jquad) = vec_Sigma_c_gw_cos_omega(:, jquad) + &
+                                                    weight_cos*vec_Sigma_c_gw_cos_tau(:, iquad)
+
+               vec_Sigma_c_gw_sin_omega(:, jquad) = vec_Sigma_c_gw_sin_omega(:, jquad) + &
+                                                    weight_sin*vec_Sigma_c_gw_sin_tau(:, iquad)
+
+            END DO
+
+         END DO
+
+         ! for occupied levels, we need the correlation self-energy for negative omega. Therefore, weight_sin
+         ! should be computed with -omega, which results in an additional minus for vec_Sigma_c_gw_sin_omega:
+         vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :) = -vec_Sigma_c_gw_sin_omega(1:gw_corr_lev_occ, :)
+
+         vec_Sigma_c_gw(:, 1:num_fit_points, 1) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points) + &
+                                                  im_unit*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
+
+         CALL dbcsr_release_P(mat_greens_fct_occ)
+         CALL dbcsr_release_P(mat_greens_fct_virt)
+
+      END IF
 
       IF (do_ri_Sigma_x .AND. count_ev_sc_GW == 1) THEN
 
@@ -4855,7 +4968,7 @@ CONTAINS
 
             CALL calc_periodic_correction(delta_corr, qs_env, para_env, para_env_RPA, &
                                           mp2_env%ri_g0w0%kp_grid, homo, nmo, gw_corr_lev_occ, &
-                                          gw_corr_lev_virt, omega_i, mo_coeff, Eigenval, &
+                                          gw_corr_lev_virt, omega_i, fm_mo_coeff, Eigenval, &
                                           matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
                                           first_cycle_periodic_correction, kpoints, &
                                           mp2_env%ri_g0w0%do_mo_coeff_gamma, &
@@ -4908,7 +5021,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE compute_self_energy_im_time_gw
+   END SUBROUTINE compute_self_energy_cubic_gw
 
 ! **************************************************************************************************
 !> \brief ...
@@ -5086,7 +5199,6 @@ CONTAINS
 !> \param fm_scaled_dm_virt_tau ...
 !> \param Eigenval ...
 !> \param jquad ...
-!> \param num_integ_points ...
 !> \param nmo ...
 !> \param eps_filter ...
 !> \param e_fermi ...
@@ -5094,39 +5206,31 @@ CONTAINS
 !> \param tau_tj ...
 !> \param count_ev_sc_GW ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Greens_function(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                      fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, num_integ_points, nmo, &
-                                      eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
+   SUBROUTINE compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+                                           fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                           fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, jquad, nmo, &
+                                           eps_filter, e_fermi, stabilize_exp, tau_tj, count_ev_sc_GW)
 
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_greens_fct_occ, mat_greens_fct_virt, &
-                                                            matrix_s
+      TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(cp_fm_type), POINTER :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
          fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: jquad, num_integ_points, nmo
+      INTEGER, INTENT(IN)                                :: jquad, nmo
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, stabilize_exp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tau_tj
       INTEGER, INTENT(IN)                                :: count_ev_sc_GW
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function_time', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i_global, iiB, iquad, jjB, &
-                                                            ncol_local, nrow_local
+      INTEGER                                            :: handle, i_global, iiB, jjB, ncol_local, &
+                                                            nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: tau
 
       CALL timeset(routineN, handle)
-
-      ! release memory
-      IF (jquad > 1) THEN
-         CALL dbcsr_set(mat_greens_fct_occ(jquad - 1)%matrix, 0.0_dp)
-         CALL dbcsr_set(mat_greens_fct_virt(jquad - 1)%matrix, 0.0_dp)
-         CALL dbcsr_filter(mat_greens_fct_occ(jquad - 1)%matrix, 0.0_dp)
-         CALL dbcsr_filter(mat_greens_fct_virt(jquad - 1)%matrix, 0.0_dp)
-      END IF
 
       tau = tau_tj(jquad)
 
@@ -5181,49 +5285,190 @@ CONTAINS
 
       IF (jquad == 1 .AND. count_ev_sc_GW == 1) THEN
 
-         ! transfer occ greens function to dbcsr matrix
          NULLIFY (mat_greens_fct_occ)
-         CALL dbcsr_allocate_matrix_set(mat_greens_fct_occ, num_integ_points)
+         CALL dbcsr_init_p(mat_greens_fct_occ)
+         CALL dbcsr_create(matrix=mat_greens_fct_occ, &
+                           template=matrix_s(1)%matrix, &
+                           matrix_type=dbcsr_type_no_symmetry)
 
-         DO iquad = 1, num_integ_points
-
-            ALLOCATE (mat_greens_fct_occ(iquad)%matrix)
-            CALL dbcsr_create(matrix=mat_greens_fct_occ(iquad)%matrix, &
-                              template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-
-         END DO
-
-         ! transfer virt greens function to dbcsr matrix
          NULLIFY (mat_greens_fct_virt)
-         CALL dbcsr_allocate_matrix_set(mat_greens_fct_virt, num_integ_points)
-
-         DO iquad = 1, num_integ_points
-
-            ALLOCATE (mat_greens_fct_virt(iquad)%matrix)
-            CALL dbcsr_create(matrix=mat_greens_fct_virt(iquad)%matrix, &
-                              template=matrix_s(1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-
-         END DO
+         CALL dbcsr_init_p(mat_greens_fct_virt)
+         CALL dbcsr_create(matrix=mat_greens_fct_virt, &
+                           template=matrix_s(1)%matrix, &
+                           matrix_type=dbcsr_type_no_symmetry)
 
       END IF
 
+      CALL dbcsr_set(mat_greens_fct_occ, 0.0_dp)
+
       CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
-                            mat_greens_fct_occ(jquad)%matrix, &
+                            mat_greens_fct_occ, &
                             keep_sparsity=.FALSE.)
 
-      CALL dbcsr_filter(mat_greens_fct_occ(jquad)%matrix, eps_filter)
+      CALL dbcsr_filter(mat_greens_fct_occ, eps_filter)
+
+      CALL dbcsr_set(mat_greens_fct_virt, 0.0_dp)
 
       CALL copy_fm_to_dbcsr(fm_scaled_dm_virt_tau, &
-                            mat_greens_fct_virt(jquad)%matrix, &
+                            mat_greens_fct_virt, &
                             keep_sparsity=.FALSE.)
 
-      CALL dbcsr_filter(mat_greens_fct_virt(jquad)%matrix, eps_filter)
+      CALL dbcsr_filter(mat_greens_fct_virt, eps_filter)
 
       CALL timestop(handle)
 
-   END SUBROUTINE compute_Greens_function
+   END SUBROUTINE compute_Greens_function_time
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mat_greens_fct_occ ...
+!> \param mat_greens_fct_virt ...
+!> \param matrix_s ...
+!> \param fm_mo_coeff ...
+!> \param fm_mo_coeff_occ_scaled ...
+!> \param fm_mo_coeff_virt_scaled ...
+!> \param fm_scaled_dm_occ_tau ...
+!> \param fm_scaled_dm_virt_tau ...
+!> \param Eigenval ...
+!> \param fermi_level_offset ...
+!> \param combined_quad ...
+!> \param nmo ...
+!> \param homo ...
+!> \param eps_filter ...
+!> \param omega ...
+!> \param count_ev_sc_GW ...
+!> \param real_imaginary ...
+! **************************************************************************************************
+   SUBROUTINE compute_Greens_function_freq(mat_greens_fct_occ, mat_greens_fct_virt, matrix_s, fm_mo_coeff, &
+                                           fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
+                                           fm_scaled_dm_virt_tau, Eigenval, fermi_level_offset, combined_quad, nmo, &
+                                           homo, eps_filter, omega, count_ev_sc_GW, real_imaginary)
+
+      TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(cp_fm_type), POINTER :: fm_mo_coeff, fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+         fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      REAL(KIND=dp), INTENT(IN)                          :: fermi_level_offset
+      INTEGER, INTENT(IN)                                :: combined_quad, nmo, homo
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, omega
+      INTEGER, INTENT(IN)                                :: count_ev_sc_GW, real_imaginary
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function_freq', &
+         routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, ncol_local
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices
+      REAL(KIND=dp)                                      :: e_fermi
+
+      CALL timeset(routineN, handle)
+
+      ! get info of fm_mo_coeff
+      CALL cp_fm_get_info(matrix=fm_mo_coeff, &
+                          ncol_local=ncol_local, &
+                          col_indices=col_indices)
+
+      ! we have two different fermi levels for correcting occupied and virtual energy levels
+      e_fermi = Eigenval(homo) + fermi_level_offset
+      CALL scale_mo_coeff(fm_mo_coeff_occ_scaled, fm_mo_coeff, e_fermi, ncol_local, &
+                          Eigenval, omega, real_imaginary, col_indices)
+
+      e_fermi = Eigenval(homo + 1) - fermi_level_offset
+      CALL scale_mo_coeff(fm_mo_coeff_virt_scaled, fm_mo_coeff, e_fermi, ncol_local, &
+                          Eigenval, omega, real_imaginary, col_indices)
+
+      CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
+                   matrix_a=fm_mo_coeff, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
+                   matrix_c=fm_scaled_dm_occ_tau)
+
+      CALL cp_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
+                   matrix_a=fm_mo_coeff, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
+                   matrix_c=fm_scaled_dm_virt_tau)
+
+      IF (combined_quad == 1 .AND. count_ev_sc_GW == 1) THEN
+
+         NULLIFY (mat_greens_fct_occ)
+         CALL dbcsr_init_p(mat_greens_fct_occ)
+         CALL dbcsr_create(matrix=mat_greens_fct_occ, &
+                           template=matrix_s(1)%matrix, &
+                           matrix_type=dbcsr_type_no_symmetry)
+
+         NULLIFY (mat_greens_fct_virt)
+         CALL dbcsr_init_p(mat_greens_fct_virt)
+         CALL dbcsr_create(matrix=mat_greens_fct_virt, &
+                           template=matrix_s(1)%matrix, &
+                           matrix_type=dbcsr_type_no_symmetry)
+
+      END IF
+
+      CALL dbcsr_set(mat_greens_fct_occ, 0.0_dp)
+
+      CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
+                            mat_greens_fct_occ, &
+                            keep_sparsity=.FALSE.)
+
+      CALL dbcsr_filter(mat_greens_fct_occ, eps_filter)
+
+      CALL dbcsr_set(mat_greens_fct_virt, 0.0_dp)
+
+      CALL copy_fm_to_dbcsr(fm_scaled_dm_virt_tau, &
+                            mat_greens_fct_virt, &
+                            keep_sparsity=.FALSE.)
+
+      CALL dbcsr_filter(mat_greens_fct_virt, eps_filter)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE compute_Greens_function_freq
+
+! **************************************************************************************************
+!> \brief ...
+!> \param fm_mo_coeff_scaled ...
+!> \param fm_mo_coeff ...
+!> \param e_fermi ...
+!> \param ncol_local ...
+!> \param Eigenval ...
+!> \param omega ...
+!> \param real_imaginary ...
+!> \param col_indices ...
+! **************************************************************************************************
+   SUBROUTINE scale_mo_coeff(fm_mo_coeff_scaled, fm_mo_coeff, e_fermi, ncol_local, &
+                             Eigenval, omega, real_imaginary, col_indices)
+
+      TYPE(cp_fm_type), POINTER                          :: fm_mo_coeff_scaled, fm_mo_coeff
+      REAL(KIND=dp)                                      :: e_fermi
+      INTEGER, INTENT(IN)                                :: ncol_local
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      REAL(KIND=dp), INTENT(IN)                          :: omega
+      INTEGER, INTENT(IN)                                :: real_imaginary
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'scale_mo_coeff', routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i_global, iiB
+      REAL(KIND=dp)                                      :: energy_diff
+
+      CALL timeset(routineN, handle)
+
+      DO iiB = 1, ncol_local
+
+         i_global = col_indices(iiB)
+
+         energy_diff = e_fermi - Eigenval(i_global)
+
+         IF (real_imaginary == 1) THEN
+            fm_mo_coeff_scaled%local_data(:, iiB) = fm_mo_coeff%local_data(:, iiB)* &
+                                                    energy_diff/(omega**2 + energy_diff**2)
+         ELSE IF (real_imaginary == 2) THEN
+            fm_mo_coeff_scaled%local_data(:, iiB) = fm_mo_coeff%local_data(:, iiB)* &
+                                                    (-omega/(omega**2 + energy_diff**2))
+         END IF
+
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE scale_mo_coeff
 
 END MODULE rpa_gw
 

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -98,6 +98,7 @@ CONTAINS
 !> \param Eigenval ...
 !> \param nmo ...
 !> \param num_integ_points ...
+!> \param num_integ_points_freq ...
 !> \param cut_memory ...
 !> \param unit_nr ...
 !> \param mp2_env ...
@@ -120,7 +121,7 @@ CONTAINS
                                   weights_cos_tf_t_to_w, &
                                   tj, tau_tj, e_fermi, eps_filter, &
                                   alpha, eps_filter_im_time, Eigenval, nmo, &
-                                  num_integ_points, cut_memory, unit_nr, &
+                                  num_integ_points, num_integ_points_freq, cut_memory, unit_nr, &
                                   mp2_env, para_env, &
                                   stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                   has_mat_P_blocks, do_ri_sos_laplace_mp2)
@@ -142,7 +143,8 @@ CONTAINS
                                                             e_fermi
       REAL(KIND=dp), DIMENSION(0:num_integ_points), &
          INTENT(IN)                                      :: tau_tj
-      INTEGER, INTENT(IN)                                :: cut_memory, unit_nr
+      INTEGER, INTENT(IN)                                :: num_integ_points_freq, cut_memory, &
+                                                            unit_nr
       TYPE(mp2_type), POINTER                            :: mp2_env
       TYPE(cp_para_env_type), POINTER                    :: para_env
       REAL(KIND=dp), INTENT(IN)                          :: stabilize_exp
@@ -506,7 +508,7 @@ CONTAINS
 
                            tau = tau_tj(jquad)
 
-                           DO iquad = 1, num_integ_points
+                           DO iquad = 1, num_integ_points_freq
 
                               omega = tj(iquad)
                               weight = weights_cos_tf_t_to_w(iquad, jquad)
@@ -591,17 +593,14 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param mat_P_omega ...
-!> \param num_integ_points ...
-!> \param nkp ...
 ! **************************************************************************************************
-   SUBROUTINE zero_mat_P_omega(mat_P_omega, num_integ_points, nkp)
+   SUBROUTINE zero_mat_P_omega(mat_P_omega)
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega
-      INTEGER, INTENT(IN)                                :: num_integ_points, nkp
 
       INTEGER                                            :: i_kp, jquad
 
-      DO jquad = 1, num_integ_points
-         DO i_kp = 1, nkp
+      DO jquad = 1, SIZE(mat_P_omega, 1)
+         DO i_kp = 1, SIZE(mat_P_omega, 2)
 
             CALL dbcsr_set(mat_P_omega(jquad, i_kp)%matrix, 0.0_dp)
 

--- a/src/rpa_kpoints.F
+++ b/src/rpa_kpoints.F
@@ -88,14 +88,14 @@ CONTAINS
 !> \param eps_filter_im_time ...
 !> \param kpoints ...
 !> \param fm_mat_L ...
-!> \param fm_mat_W_tau ...
+!> \param fm_mat_W ...
 !> \param fm_mat_RI_global_work ...
 !> \param mat_SinvVSinv ...
 ! **************************************************************************************************
    SUBROUTINE RPA_postprocessing_kp(dimen_RI, num_integ_points, jquad, nkp, count_ev_sc_GW, para_env, para_env_RPA, &
                                     Erpa, tau_tj, tj, wj, weights_cos_tf_w_to_t, wkp_W, do_gw_im_time, do_ri_Sigma_x, &
                                     do_kpoints_from_Gamma, do_kpoints_cubic_RPA, cfm_mat_W_kp_tau, cfm_mat_Q, ikp_local, &
-                                    mat_P_omega, mat_P_omega_kp, qs_env, eps_filter_im_time, kpoints, fm_mat_L, fm_mat_W_tau, &
+                                    mat_P_omega, mat_P_omega_kp, qs_env, eps_filter_im_time, kpoints, fm_mat_L, fm_mat_W, &
                                     fm_mat_RI_global_work, mat_SinvVSinv)
 
       INTEGER, INTENT(IN)                                :: dimen_RI, num_integ_points, jquad, nkp, &
@@ -119,7 +119,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter_im_time
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_mat_L
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W
       TYPE(cp_fm_type), POINTER                          :: fm_mat_RI_global_work
       TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_SinvVSinv
 
@@ -174,7 +174,7 @@ CONTAINS
 
                CALL get_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
 
-               CALL compute_Wc_real_space_tau_GW(fm_mat_W_tau, cfm_mat_Q, &
+               CALL compute_Wc_real_space_tau_GW(fm_mat_W, cfm_mat_Q, &
                                                  fm_mat_L(ikp, 1)%matrix, &
                                                  fm_mat_L(ikp, 2)%matrix, &
                                                  dimen_RI, 1, 1, &
@@ -187,7 +187,7 @@ CONTAINS
             END IF
             IF (do_kpoints_from_Gamma) THEN
 
-               CALL compute_Wc_real_space_tau_GW(fm_mat_W_tau, cfm_mat_Q, &
+               CALL compute_Wc_real_space_tau_GW(fm_mat_W, cfm_mat_Q, &
                                                  fm_mat_L(ikp, 1)%matrix, &
                                                  fm_mat_L(ikp, 2)%matrix, &
                                                  dimen_RI, num_integ_points, jquad, &

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -238,12 +238,19 @@ CONTAINS
 
       IF (mp2_env%ri_rpa%do_ri_axk) THEN
          CALL cite_reference(Bates2013)
-
       ENDIF
       IF (mp2_env%ri_rpa%do_rse) THEN
          CALL cite_reference(Ren2011)
          CALL cite_reference(Ren2013)
       ENDIF
+      IF (my_do_gw) THEN
+         CALL cite_reference(Wilhelm2016a)
+         CALL cite_reference(Wilhelm2017)
+         CALL cite_reference(Wilhelm2018)
+      END IF
+      IF (do_im_time) THEN
+         CALL cite_reference(Wilhelm2016b)
+      END IF
 
       my_open_shell = .FALSE.
       IF (PRESENT(BIb_C_beta) .AND. &

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -62,12 +62,12 @@ MODULE rpa_main
                                               mp_sendrecv,&
                                               mp_sum
    USE minimax_exp,                     ONLY: check_exp_minimax_range
+   USE mp2_grids,                       ONLY: get_clenshaw_grid,&
+                                              get_minimax_grid
    USE mp2_laplace,                     ONLY: SOS_MP2_postprocessing
    USE mp2_ri_grad_util,                ONLY: array2fm
    USE mp2_types,                       ONLY: integ_mat_buffer_type,&
                                               mp2_type
-   USE mp2_weights,                     ONLY: get_clenshaw_weights,&
-                                              get_minimax_weights
    USE qs_environment_types,            ONLY: qs_environment_type
    USE rpa_axk,                         ONLY: compute_axk_ener
    USE rpa_communication,               ONLY: initialize_buffer,&
@@ -238,19 +238,12 @@ CONTAINS
 
       IF (mp2_env%ri_rpa%do_ri_axk) THEN
          CALL cite_reference(Bates2013)
+
       ENDIF
       IF (mp2_env%ri_rpa%do_rse) THEN
          CALL cite_reference(Ren2011)
          CALL cite_reference(Ren2013)
       ENDIF
-      IF (my_do_gw) THEN
-         CALL cite_reference(Wilhelm2016a)
-         CALL cite_reference(Wilhelm2017)
-         CALL cite_reference(Wilhelm2018)
-      END IF
-      IF (do_im_time) THEN
-         CALL cite_reference(Wilhelm2016b)
-      END IF
 
       my_open_shell = .FALSE.
       IF (PRESENT(BIb_C_beta) .AND. &
@@ -296,11 +289,24 @@ CONTAINS
          num_integ_points = mp2_env%ri_rpa%rpa_num_quad_points
          input_integ_group_size = mp2_env%ri_rpa%rpa_integ_group_size
          do_minimax_quad = mp2_env%ri_rpa%minimax_quad
+         mp2_env%ri_g0w0%do_gw_im_time_mix_minimax_clenshaw = mp2_env%ri_g0w0%num_integ_points_freq > num_integ_points
+
          IF (do_minimax_quad .AND. num_integ_points > 20) THEN
-            CALL cp_warn(__LOCATION__, &
-                         "The required number of quadrature point exceeds the maximum possible in the "// &
-                         "Minimax quadrature scheme. The number of quadrature point has been reset to 20.")
-            num_integ_points = 20
+            IF (mp2_env%ri_g0w0%do_gw_im_time_mix_minimax_clenshaw) THEN
+               ! we only do minimax for the time grid, where Braess & Hackbusch parameters are available
+               ! up to 53 time points.
+               IF (num_integ_points > 53) THEN
+                  CALL cp_warn(__LOCATION__, &
+                               "The required number of quadrature point exceeds the maximum possible in the "// &
+                               "Minimax quadrature scheme. The number of quadrature point has been reset to 53.")
+                  num_integ_points = 53
+               END IF
+            ELSE
+               CALL cp_warn(__LOCATION__, &
+                            "The required number of quadrature point exceeds the maximum possible in the "// &
+                            "Minimax quadrature scheme. The number of quadrature point has been reset to 20.")
+               num_integ_points = 20
+            END IF
          END IF
       END IF
       allowed_memory = mp2_env%mp2_memory
@@ -1296,9 +1302,9 @@ CONTAINS
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: vec_Sigma_c_gw, vec_Sigma_c_gw_beta
       INTEGER :: count_ev_sc_GW, cut_memory, group_size_P, gw_corr_lev_tot, handle, handle3, &
          iter_ev_sc, jquad, max_iter_bse, mm_style, my_num_dgemm_call, nkp, nkp_self_energy, nmo, &
-         num_3c_repl, num_cells_dm, num_fit_points, num_points_corr, num_Z_vectors, number_of_rec, &
-         number_of_rec_axk, number_of_rec_beta, number_of_send, number_of_send_axk, &
-         number_of_send_beta, size_P
+         num_3c_repl, num_cells_dm, num_fit_points, num_integ_points_freq, num_points_corr, &
+         num_Z_vectors, number_of_rec, number_of_rec_axk, number_of_rec_beta, number_of_send, &
+         number_of_send_axk, number_of_send_beta, size_P
       INTEGER, ALLOCATABLE, DIMENSION(:) :: ikp_local, map_rec_size, map_rec_size_axk, &
          map_rec_size_beta, map_send_size, map_send_size_axk, map_send_size_beta, RPA_proc_map
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_3c, local_size_source, &
@@ -1307,9 +1313,9 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, prim_blk_sizes, &
                                                             RI_blk_sizes
-      LOGICAL :: do_apply_ic_corr_to_gw, do_gw_im_time, do_ic_model, do_kpoints_cubic_RPA, &
-         do_kpoints_from_Gamma, do_periodic, do_ri_Sigma_x, first_cycle, &
-         first_cycle_periodic_correction, my_open_shell, print_ic_values
+      LOGICAL :: do_apply_ic_corr_to_gw, do_gw_im_time, do_gw_im_time_mix_minimax_clenshaw, &
+         do_ic_model, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_periodic, do_ri_Sigma_x, &
+         first_cycle, first_cycle_periodic_correction, my_open_shell, print_ic_values
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :)     :: has_mat_P_blocks
       REAL(KIND=dp) :: a_scaling, alpha, e_axk, e_axk_corr, e_fermi, e_fermi_beta, &
          eps_filter_im_time, eps_min_trans, ext_scaling, fermi_level_offset, my_flop_rate, omega, &
@@ -1324,7 +1330,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ic_corr_list, ic_corr_list_beta, wkp_W
       TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: cfm_mat_W_kp_tau
       TYPE(cp_cfm_type), POINTER                         :: cfm_mat_Q
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W_tau
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mat_W
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_mat_L
       TYPE(cp_fm_type), POINTER :: fm_mat_Q_static_bse, fm_mat_Q_static_bse_gemm, &
          fm_mat_RI_global_work, fm_mat_S_gw_work, fm_mat_S_gw_work_beta, fm_mat_work, &
@@ -1332,15 +1338,14 @@ CONTAINS
       TYPE(dbcsr_p_type)                                 :: mat_dm, mat_L, mat_M_P_munu_occ, &
                                                             mat_M_P_munu_virt, mat_P_global_copy, &
                                                             mat_SinvVSinv
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: mat_greens_fct_occ, mat_greens_fct_occ_beta, &
-         mat_greens_fct_virt, mat_greens_fct_virt_beta, mat_W, matrix_berry_im_mo_mo, &
-         matrix_berry_re_mo_mo
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_im_mo_mo, &
+                                                            matrix_berry_re_mo_mo
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega, mat_P_omega_beta, &
                                                             mat_P_omega_kp
       TYPE(dbcsr_t_type) :: t_3c_overl_int_gw_AO, t_3c_overl_int_gw_AO_beta, t_3c_overl_int_gw_RI, &
          t_3c_overl_int_gw_RI_beta, t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_beta, &
          t_3c_overl_nnP_ic_reflected, t_3c_overl_nnP_ic_reflected_beta
-      TYPE(dbcsr_type), POINTER                          :: mat_work
+      TYPE(dbcsr_type), POINTER                          :: mat_W, mat_work
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_rec_axk, &
                                                             buffer_rec_beta, buffer_send, &
@@ -1368,6 +1373,8 @@ CONTAINS
       ic_corr_list_beta => mp2_env%ri_g0w0%ic_corr_list_beta
       do_kpoints_cubic_RPA = mp2_env%ri_rpa_im_time%do_im_time_kpoints
       do_kpoints_from_Gamma = SUM(mp2_env%ri_rpa_im_time%kp_grid) > 0
+      do_gw_im_time_mix_minimax_clenshaw = mp2_env%ri_g0w0%do_gw_im_time_mix_minimax_clenshaw
+      num_integ_points_freq = MAX(mp2_env%ri_g0w0%num_integ_points_freq, num_integ_points)
 
       ! For SOS-MP2 only gemm is implemented
       mm_style = wfc_mm_style_gemm
@@ -1405,8 +1412,8 @@ CONTAINS
          eps_filter_im_time = mp2_env%ri_rpa_im_time%eps_filter_im_time
          stabilize_exp = mp2_env%ri_rpa_im_time%stabilize_exp
 
-         CALL alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, num_integ_points, &
-                            fm_mat_Q, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+         CALL alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, &
+                            num_integ_points_freq, fm_mat_Q, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                             fm_matrix_L_RI_metric, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
                             do_ri_sos_laplace_mp2, cut_memory, nkp, num_cells_dm, num_3c_repl, &
@@ -1438,9 +1445,9 @@ CONTAINS
             IF (.NOT. do_kpoints_cubic_RPA) THEN
                IF (my_open_shell) THEN
                   CALL allocate_matrices_gw_im_time(gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, &
-                                                    num_integ_points, unit_nr, &
+                                                    num_integ_points_freq, unit_nr, &
                                                     RI_blk_sizes, do_ic_model, &
-                                                    para_env, fm_mat_W_tau, fm_mat_Q, &
+                                                    para_env, fm_mat_W, fm_mat_Q, &
                                                     mo_coeff, &
                                                     t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
                                                     t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, &
@@ -1452,9 +1459,9 @@ CONTAINS
                                                     t_3c_overl_nnP_ic_beta, t_3c_overl_nnP_ic_reflected_beta)
                ELSE
                   CALL allocate_matrices_gw_im_time(gw_corr_lev_occ, gw_corr_lev_virt, homo, nmo, &
-                                                    num_integ_points, unit_nr, &
+                                                    num_integ_points_freq, unit_nr, &
                                                     RI_blk_sizes, do_ic_model, &
-                                                    para_env, fm_mat_W_tau, fm_mat_Q, &
+                                                    para_env, fm_mat_W, fm_mat_Q, &
                                                     mo_coeff, &
                                                     t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
                                                     t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, &
@@ -1467,29 +1474,37 @@ CONTAINS
 
       END IF
 
-      IF (do_minimax_quad .OR. do_ri_sos_laplace_mp2) THEN
+      IF (do_gw_im_time_mix_minimax_clenshaw) THEN
+         CALL get_clenshaw_grid(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points_freq, &
+                                num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, ext_scaling, a_scaling, tj, wj)
+         CALL get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_integ_points, num_integ_points_freq, do_im_time, &
+                               do_ri_sos_laplace_mp2,.NOT. do_ic_model, tau_tj, tau_wj, qs_env, do_gw_im_time, &
+                               do_kpoints_cubic_RPA, a_scaling, e_fermi, tj, wj, mp2_env, &
+                               weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, &
+                               do_mixed_minimax_clenshaw=.TRUE.)
+      ELSE IF (do_minimax_quad .OR. do_ri_sos_laplace_mp2) THEN
          IF (my_open_shell) THEN
-            CALL get_minimax_weights(para_env, unit_nr, homo, Eigenval, num_integ_points, &
-                                     do_im_time, do_ri_sos_laplace_mp2,.NOT. do_ic_model, tau_tj, tau_wj, qs_env, do_gw_im_time, &
-                                     do_kpoints_cubic_RPA, ext_scaling, a_scaling, e_fermi, tj, wj, mp2_env, &
-                                     weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, &
-                                     homo_beta, dimen_ia_beta, Eigenval_beta)
+            CALL get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_integ_points, num_integ_points, do_im_time, &
+                                  do_ri_sos_laplace_mp2,.NOT. do_ic_model, tau_tj, tau_wj, qs_env, do_gw_im_time, &
+                                  do_kpoints_cubic_RPA, a_scaling, e_fermi, tj, wj, mp2_env, &
+                                  weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, &
+                                  homo_beta, dimen_ia_beta, Eigenval_beta)
          ELSE
-            CALL get_minimax_weights(para_env, unit_nr, homo, Eigenval, num_integ_points, &
-                                     do_im_time, do_ri_sos_laplace_mp2,.NOT. do_ic_model, tau_tj, tau_wj, qs_env, do_gw_im_time, &
-                                     do_kpoints_cubic_RPA, ext_scaling, a_scaling, e_fermi, tj, wj, mp2_env, &
-                                     weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)
+            CALL get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_integ_points, num_integ_points, do_im_time, &
+                                  do_ri_sos_laplace_mp2,.NOT. do_ic_model, tau_tj, tau_wj, qs_env, do_gw_im_time, &
+                                  do_kpoints_cubic_RPA, a_scaling, e_fermi, tj, wj, mp2_env, &
+                                  weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)
          END IF
       ELSE
          IF (my_open_shell) THEN
-            CALL get_clenshaw_weights(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points, &
-                                      num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, &
-                                      ext_scaling, a_scaling, tj, wj, &
-                                      homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
+            CALL get_clenshaw_grid(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points, &
+                                   num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, &
+                                   ext_scaling, a_scaling, tj, wj, &
+                                   homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta)
          ELSE
-            CALL get_clenshaw_weights(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points, &
-                                      num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, &
-                                      ext_scaling, a_scaling, tj, wj)
+            CALL get_clenshaw_grid(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points, &
+                                   num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, &
+                                   ext_scaling, a_scaling, tj, wj)
          END IF
       END IF
 
@@ -1529,7 +1544,7 @@ CONTAINS
          IF (my_open_shell) THEN
             CALL allocate_matrices_gw(vec_Sigma_c_gw, color_rpa_group, dimen_nm_gw, &
                                       gw_corr_lev_occ, gw_corr_lev_virt, homo, &
-                                      nmo, num_integ_points, num_integ_group, unit_nr, &
+                                      nmo, num_integ_group, num_integ_points_freq, unit_nr, &
                                       gw_corr_lev_tot, num_fit_points, omega_max_fit, &
                                       do_minimax_quad, do_periodic, do_ri_Sigma_x,.NOT. do_im_time, &
                                       first_cycle_periodic_correction, &
@@ -1544,7 +1559,7 @@ CONTAINS
          ELSE
             CALL allocate_matrices_gw(vec_Sigma_c_gw, color_rpa_group, dimen_nm_gw, &
                                       gw_corr_lev_occ, gw_corr_lev_virt, homo, &
-                                      nmo, num_integ_points, num_integ_group, unit_nr, &
+                                      nmo, num_integ_group, num_integ_points_freq, unit_nr, &
                                       gw_corr_lev_tot, num_fit_points, omega_max_fit, &
                                       do_minimax_quad, do_periodic, do_ri_Sigma_x,.NOT. do_im_time, &
                                       first_cycle_periodic_correction, &
@@ -1629,7 +1644,7 @@ CONTAINS
                "SPARSITY_INFO| Second eps filter for imaginary time:", eps_filter_im_time
 
             ! for evGW, we have to ensure that mat_P_omega is zero
-            CALL zero_mat_P_omega(mat_P_omega, num_integ_points, size_P)
+            CALL zero_mat_P_omega(mat_P_omega)
 
             ! compute the matrix Q(it) and Fourier transform it directly to mat_P_omega(iw)
             CALL compute_mat_P_omega(mat_P_omega, fm_scaled_dm_occ_tau, &
@@ -1642,7 +1657,7 @@ CONTAINS
                                      starts_array_mc, ends_array_mc, &
                                      weights_cos_tf_t_to_w, tj, tau_tj, e_fermi, eps_filter, alpha, &
                                      eps_filter_im_time, Eigenval, nmo, &
-                                     num_integ_points, cut_memory, &
+                                     num_integ_points, num_integ_points_freq, cut_memory, &
                                      unit_nr, mp2_env, para_env, &
                                      stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                      has_mat_P_blocks, do_ri_sos_laplace_mp2)
@@ -1651,7 +1666,7 @@ CONTAINS
             IF (my_open_shell) THEN
                ! For SOS-MP2 we need the same calculation for alpha and beta spin independently, for RPA the sum of both
                IF (do_ri_sos_laplace_mp2) THEN
-                  CALL zero_mat_P_omega(mat_P_omega_beta, num_integ_points, size_P)
+                  CALL zero_mat_P_omega(mat_P_omega_beta)
 
                   CALL compute_mat_P_omega(mat_P_omega_beta, fm_scaled_dm_occ_tau, &
                                            fm_scaled_dm_virt_tau, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
@@ -1663,7 +1678,7 @@ CONTAINS
                                            starts_array_mc, ends_array_mc, &
                                            weights_cos_tf_t_to_w, tj, tau_tj, e_fermi_beta, eps_filter, alpha, &
                                            eps_filter_im_time, Eigenval_beta, nmo, &
-                                           num_integ_points, cut_memory, &
+                                           num_integ_points, num_integ_points_freq, cut_memory, &
                                            unit_nr, mp2_env, para_env, &
                                            stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                            has_mat_P_blocks, do_ri_sos_laplace_mp2)
@@ -1678,7 +1693,7 @@ CONTAINS
                                            starts_array_mc, ends_array_mc, &
                                            weights_cos_tf_t_to_w, tj, tau_tj, e_fermi_beta, eps_filter, alpha, &
                                            eps_filter_im_time, Eigenval_beta, nmo, &
-                                           num_integ_points, cut_memory, &
+                                           num_integ_points, num_integ_points_freq, cut_memory, &
                                            unit_nr, mp2_env, para_env, &
                                            stabilize_exp, qs_env, index_to_cell_3c, cell_to_index_3c, &
                                            has_mat_P_blocks, do_ri_sos_laplace_mp2)
@@ -1688,7 +1703,7 @@ CONTAINS
 
          END IF ! do im time
 
-         DO jquad = 1, num_integ_points
+         DO jquad = 1, num_integ_points_freq
 
             IF (MODULO(jquad, num_integ_group) /= color_rpa_group) CYCLE
 
@@ -1772,7 +1787,7 @@ CONTAINS
                                              para_env_RPA, Erpa, tau_tj, tj, wj, weights_cos_tf_w_to_t, wkp_W, do_gw_im_time, &
                                              do_ri_Sigma_x, do_kpoints_from_Gamma, do_kpoints_cubic_RPA, cfm_mat_W_kp_tau, &
                                              cfm_mat_Q, ikp_local, mat_P_omega, mat_P_omega_kp, qs_env, eps_filter_im_time, &
-                                             kpoints, fm_mat_L, fm_mat_W_tau, fm_mat_RI_global_work, mat_SinvVSinv)
+                                             kpoints, fm_mat_L, fm_mat_W, fm_mat_RI_global_work, mat_SinvVSinv)
                ELSE
                   CALL RPA_postprocessing_nokp(dimen_RI_red, trace_Qomega, fm_mat_Q, para_env_RPA, Erpa, wj(jquad))
                END IF
@@ -1788,10 +1803,10 @@ CONTAINS
                IF (my_open_shell) THEN
                   CALL GW_matrix_operations(vec_Sigma_c_gw, dimen_nm_gw, dimen_RI_red, gw_corr_lev_occ, &
                                             gw_corr_lev_virt, homo, jquad, nmo, num_fit_points, num_integ_points, &
-                                            do_bse, do_im_time, do_periodic, &
+                                            do_bse, do_im_time, do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
                                             first_cycle_periodic_correction, fermi_level_offset, &
                                             omega, Eigenval, delta_corr, tau_tj, tj, vec_omega_fit_gw, &
-                                            vec_W_gw, wj, weights_cos_tf_w_to_t, fm_mat_W_tau, fm_mat_L, &
+                                            vec_W_gw, wj, weights_cos_tf_w_to_t, fm_mat_W, fm_mat_L, &
                                             fm_mat_Q, fm_mat_Q_static_bse, fm_mat_R_gw, fm_mat_S_gw, &
                                             fm_mat_S_gw_work, fm_mat_work, mo_coeff, para_env, &
                                             para_env_RPA, matrix_berry_im_mo_mo, matrix_berry_re_mo_mo, &
@@ -1801,10 +1816,10 @@ CONTAINS
                ELSE
                   CALL GW_matrix_operations(vec_Sigma_c_gw, dimen_nm_gw, dimen_RI_red, gw_corr_lev_occ, &
                                             gw_corr_lev_virt, homo, jquad, nmo, num_fit_points, num_integ_points, &
-                                            do_bse, do_im_time, do_periodic, &
+                                            do_bse, do_im_time, do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
                                             first_cycle_periodic_correction, fermi_level_offset, &
                                             omega, Eigenval, delta_corr, tau_tj, tj, vec_omega_fit_gw, &
-                                            vec_W_gw, wj, weights_cos_tf_w_to_t, fm_mat_W_tau, fm_mat_L, &
+                                            vec_W_gw, wj, weights_cos_tf_w_to_t, fm_mat_W, fm_mat_L, &
                                             fm_mat_Q, fm_mat_Q_static_bse, fm_mat_R_gw, fm_mat_S_gw, &
                                             fm_mat_S_gw_work, fm_mat_work, mo_coeff, para_env, &
                                             para_env_RPA, matrix_berry_im_mo_mo, matrix_berry_re_mo_mo, &
@@ -1818,7 +1833,7 @@ CONTAINS
 
          IF (.NOT. do_ri_sos_laplace_mp2) THEN
             Erpa = Erpa/(pi*2.0_dp)
-            IF (do_minimax_quad) Erpa = Erpa/2.0_dp
+            IF (do_minimax_quad .AND. (.NOT. do_gw_im_time_mix_minimax_clenshaw)) Erpa = Erpa/2.0_dp
          END IF
 
          IF (mp2_env%ri_rpa%do_ri_axk) THEN
@@ -1842,43 +1857,43 @@ CONTAINS
             IF (my_open_shell) THEN
                CALL GW_postprocessing(vec_Sigma_c_gw, count_ev_sc_GW, gw_corr_lev_occ, &
                                       gw_corr_lev_tot, gw_corr_lev_virt, homo, &
-                                      nmo, num_fit_points, num_integ_points, &
+                                      nmo, num_fit_points, num_integ_points, num_integ_points_freq, &
                                       num_points_corr, unit_nr, do_apply_ic_corr_to_gw, do_im_time, &
-                                      do_periodic, do_ri_Sigma_x, first_cycle_periodic_correction, &
+                                      do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
+                                      do_ri_Sigma_x, first_cycle_periodic_correction, &
                                       e_fermi, eps_filter, &
                                       fermi_level_offset, stabilize_exp, delta_corr, Eigenval, &
-                                      Eigenval_last, Eigenval_scf, tau_tj, tj, &
+                                      Eigenval_last, Eigenval_scf, tau_tj, tj, wj, &
                                       vec_omega_fit_gw, vec_Sigma_x_gw, ic_corr_list, &
                                       weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
                                       fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
                                       fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                      mo_coeff, fm_mat_W_tau, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
+                                      mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
                                       t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                      matrix_berry_im_mo_mo, &
-                                      matrix_berry_re_mo_mo, mat_greens_fct_occ, mat_greens_fct_virt, mat_W, matrix_s, &
+                                      matrix_berry_im_mo_mo, matrix_berry_re_mo_mo, mat_W, matrix_s, &
                                       kpoints, mp2_env, qs_env, &
                                       nkp_self_energy, do_kpoints_cubic_RPA, Eigenval_kp, Eigenval_scf_kp, iter_ev_sc, &
                                       vec_Sigma_c_gw_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta, homo_beta, &
                                       e_fermi_beta, Eigenval_beta, Eigenval_last_beta, Eigenval_scf_beta, &
                                       vec_Sigma_x_gw_beta, ic_corr_list_beta, fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
-                                      t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta, &
-                                      mat_greens_fct_occ_beta, mat_greens_fct_virt_beta)
+                                      t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta)
             ELSE
                CALL GW_postprocessing(vec_Sigma_c_gw, count_ev_sc_GW, gw_corr_lev_occ, &
                                       gw_corr_lev_tot, gw_corr_lev_virt, homo, &
-                                      nmo, num_fit_points, num_integ_points, &
+                                      nmo, num_fit_points, num_integ_points, num_integ_points_freq, &
                                       num_points_corr, unit_nr, do_apply_ic_corr_to_gw, do_im_time, &
-                                      do_periodic, do_ri_Sigma_x, first_cycle_periodic_correction, &
+                                      do_periodic, do_gw_im_time_mix_minimax_clenshaw, &
+                                      do_ri_Sigma_x, first_cycle_periodic_correction, &
                                       e_fermi, eps_filter, &
                                       fermi_level_offset, stabilize_exp, delta_corr, Eigenval, &
-                                      Eigenval_last, Eigenval_scf, tau_tj, tj, &
+                                      Eigenval_last, Eigenval_scf, tau_tj, tj, wj, &
                                       vec_omega_fit_gw, vec_Sigma_x_gw, ic_corr_list, &
                                       weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
                                       fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
                                       fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                      mo_coeff, fm_mat_W_tau, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
+                                      mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
                                       t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, matrix_berry_im_mo_mo, &
-                                      matrix_berry_re_mo_mo, mat_greens_fct_occ, mat_greens_fct_virt, mat_W, matrix_s, &
+                                      matrix_berry_re_mo_mo, mat_W, matrix_s, &
                                       kpoints, mp2_env, qs_env, &
                                       nkp_self_energy, do_kpoints_cubic_RPA, Eigenval_kp, Eigenval_scf_kp, iter_ev_sc)
             END IF
@@ -1997,22 +2012,17 @@ CONTAINS
          IF (my_do_gw) THEN
             IF (my_open_shell) THEN
                CALL deallocate_matrices_gw_im_time(weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, do_ic_model, &
-                                                   do_kpoints_cubic_RPA, fm_mat_W_tau, &
+                                                   do_kpoints_cubic_RPA, fm_mat_W, &
                                                    t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                                   mat_greens_fct_occ, &
-                                                   mat_greens_fct_virt, &
                                                    t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, &
                                                    mat_W, &
                                                    ikp_local, cfm_mat_W_kp_tau, &
                                                    t_3c_overl_int_gw_RI_beta, t_3c_overl_int_gw_AO_beta, &
-                                                   t_3c_overl_nnP_ic_beta, t_3c_overl_nnP_ic_reflected_beta, &
-                                                   mat_greens_fct_occ_beta, mat_greens_fct_virt_beta)
+                                                   t_3c_overl_nnP_ic_beta, t_3c_overl_nnP_ic_reflected_beta)
             ELSE
                CALL deallocate_matrices_gw_im_time(weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, do_ic_model, &
-                                                   do_kpoints_cubic_RPA, fm_mat_W_tau, &
+                                                   do_kpoints_cubic_RPA, fm_mat_W, &
                                                    t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                                   mat_greens_fct_occ, &
-                                                   mat_greens_fct_virt, &
                                                    t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, &
                                                    mat_W, &
                                                    ikp_local, cfm_mat_W_kp_tau)

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -84,7 +84,7 @@ CONTAINS
 !> \param para_env ...
 !> \param dimen_RI ...
 !> \param dimen_RI_red ...
-!> \param num_integ_points ...
+!> \param num_integ_points_freq ...
 !> \param fm_mat_Q ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
@@ -128,7 +128,7 @@ CONTAINS
 !> \param mat_work ...
 !> \param mat_P_omega_beta ...
 ! **************************************************************************************************
-   SUBROUTINE alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, num_integ_points, &
+   SUBROUTINE alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, num_integ_points_freq, &
                             fm_mat_Q, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                             fm_matrix_L_RI_metric, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
@@ -148,7 +148,8 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: dimen_RI, dimen_RI_red, num_integ_points
+      INTEGER, INTENT(IN)                                :: dimen_RI, dimen_RI_red, &
+                                                            num_integ_points_freq
       TYPE(cp_fm_type), POINTER                          :: fm_mat_Q, fm_mo_coeff_occ, &
                                                             fm_mo_coeff_virt
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: fm_matrix_L_RI_metric
@@ -256,10 +257,10 @@ CONTAINS
          size_P = 1
       END IF
 
-      CALL alloc_mat_P_omega(mat_P_omega, num_integ_points, size_P, mat_P_global%matrix)
+      CALL alloc_mat_P_omega(mat_P_omega, num_integ_points_freq, size_P, mat_P_global%matrix)
 
       IF (my_open_shell .AND. do_ri_sos_laplace_mp2) THEN
-         CALL alloc_mat_P_omega(mat_P_omega_beta, num_integ_points, size_P, mat_P_global%matrix)
+         CALL alloc_mat_P_omega(mat_P_omega_beta, num_integ_points_freq, size_P, mat_P_global%matrix)
       END IF
 
       IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_trunc_Clenshaw.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_trunc_Clenshaw.inp
@@ -50,7 +50,8 @@
       &WF_CORRELATION
         METHOD  RI_RPA_GPW
         &RI_METRIC
-          POTENTIAL_TYPE IDENTITY
+          POTENTIAL_TYPE TRUNCATED
+          CUTOFF_RADIUS 3.0
         &END
         &WFC_GPW
           ! normally, this EPS_FILTER controls the accuracy and
@@ -68,13 +69,14 @@
               SCREEN_ON_INITIAL_P FALSE
             &END SCREENING
           &END HF
-          RPA_NUM_QUAD_POINTS 10
+          RPA_NUM_QUAD_POINTS 5
           MINIMAX
           GW
           &RI_G0W0
-            CORR_MOS_OCC          10
-            CORR_MOS_VIRT         10
+            CORR_MOS_OCC          1
+            CORR_MOS_VIRT         1
             ANALYTIC_CONTINUATION TWO_POLE
+            NUM_FREQ_POINTS_CLENSHAW_LOW_SCALING_GW     6
           &END RI_G0W0
         &END RI_RPA
         MEMORY  200.

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_trunc_Clenshaw_evGW.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_trunc_Clenshaw_evGW.inp
@@ -1,0 +1,110 @@
+&GLOBAL
+  PROJECT  G0W0_H2O_PBE0
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+  &TIMINGS
+     THRESHOLD 0.01
+  &END
+&END GLOBAL
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME  HFX_BASIS
+    POTENTIAL_FILE_NAME  GTH_POTENTIALS
+    &MGRID
+      CUTOFF  100
+      REL_CUTOFF  20
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      POISSON_SOLVER WAVELET
+    &END POISSON
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-15
+      EPS_PGF_ORB 1.0E-30
+    &END QS
+    &SCF
+      SCF_GUESS ATOMIC
+      EPS_SCF 1.0E-7
+      MAX_SCF 100
+      &PRINT
+        &RESTART OFF
+        &END
+      &END
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+        &PBE
+          SCALE_X 0.7500000
+          SCALE_C 1.0000000
+        &END
+      &END XC_FUNCTIONAL
+      &HF
+        FRACTION 0.2500000
+        &SCREENING
+          EPS_SCHWARZ 1.0E-8
+          SCREEN_ON_INITIAL_P FALSE
+        &END SCREENING
+      &END HF
+      &WF_CORRELATION
+        METHOD  RI_RPA_GPW
+        &RI_METRIC
+          POTENTIAL_TYPE TRUNCATED
+          CUTOFF_RADIUS 3.0
+        &END
+        &WFC_GPW
+          ! normally, this EPS_FILTER controls the accuracy and
+          ! the time for the cubic_scaling RPA calculation
+          EPS_FILTER  1.0E-7
+        &END
+        ERI_METHOD OS
+        &IM_TIME
+        &END
+        &RI_RPA
+          &HF
+            FRACTION 1.0000000
+            &SCREENING
+              EPS_SCHWARZ 1.0E-8
+              SCREEN_ON_INITIAL_P FALSE
+            &END SCREENING
+          &END HF
+          RPA_NUM_QUAD_POINTS 5
+          MINIMAX
+          GW
+          &RI_G0W0
+            EV_SC_ITER            3
+            CORR_MOS_OCC          1
+            CORR_MOS_VIRT         1
+            ANALYTIC_CONTINUATION TWO_POLE
+            NUM_FREQ_POINTS_CLENSHAW_LOW_SCALING_GW     6
+          &END RI_G0W0
+        &END RI_RPA
+        MEMORY  200.
+        NUMBER_PROC  1
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom]  8.000   8.000  8.000
+      PERIODIC NONE
+    &END CELL
+    &KIND H
+      BASIS_SET  DZVP-GTH
+      BASIS_SET RI_AUX  RI_DZVP-GTH
+      POTENTIAL  GTH-PBE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET  DZVP-GTH
+      BASIS_SET RI_AUX  RI_DZVP-GTH
+      POTENTIAL  GTH-PBE-q6
+    &END KIND
+    &TOPOLOGY
+      COORD_FILE_NAME  H2O_gas.xyz
+      COORD_FILE_FORMAT xyz
+      &CENTER_COORDINATES
+      &END
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE_periodic.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE_periodic.inp
@@ -67,6 +67,7 @@
           &RI_G0W0
             CORR_MOS_OCC          4
             CORR_MOS_VIRT         4
+            ANALYTIC_CONTINUATION TWO_POLE
             PRINT_GW_DETAILS
             PERIODIC
             &PERIODIC

--- a/tests/QS/regtest-gw-cubic/G0W0_OH_PBE.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_OH_PBE.inp
@@ -64,6 +64,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT

--- a/tests/QS/regtest-gw-cubic/G0W0_OH_PBE_svd.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_OH_PBE_svd.inp
@@ -64,6 +64,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT

--- a/tests/QS/regtest-gw-cubic/G0W0_kpoints_from_Gamma.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_kpoints_from_Gamma.inp
@@ -61,6 +61,7 @@
            CORR_OCC   1
            CORR_VIRT  1
            CROSSING_SEARCH NEWTON
+           ANALYTIC_CONTINUATION TWO_POLE
            RI_SIGMA_X
           &END RI_G0W0
         &END RI_RPA

--- a/tests/QS/regtest-gw-cubic/TEST_FILES
+++ b/tests/QS/regtest-gw-cubic/TEST_FILES
@@ -3,4 +3,5 @@ G0W0_H2O_PBE_periodic.inp                             78      1e-05             
 G0W0_OH_PBE.inp                                       79      1e-05                          11.65
 G0W0_kpoints_from_Gamma.inp                           78      1e-05                          15.20
 G0W0_OH_PBE_svd.inp                                   79      1e-05                          11.65
+G0W0_H2O_PBE0_trunc_Clenshaw.inp                      78      1e-05                          15.91
 #EOF

--- a/tests/QS/regtest-gw-cubic/TEST_FILES
+++ b/tests/QS/regtest-gw-cubic/TEST_FILES
@@ -1,4 +1,5 @@
 G0W0_H2O_PBE0.inp                                     78      1e-05                          16.66
+G0W0_H2O_PBE0_trunc_Clenshaw_evGW.inp                 11      1e-08            -17.033765982511991
 G0W0_H2O_PBE_periodic.inp                             78      1e-05                          16.42
 G0W0_OH_PBE.inp                                       79      1e-05                          11.65
 G0W0_kpoints_from_Gamma.inp                           78      1e-05                          15.20

--- a/tests/QS/regtest-gw/G0W0_H2O_PBE0.inp
+++ b/tests/QS/regtest-gw/G0W0_H2O_PBE0.inp
@@ -66,6 +66,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT 

--- a/tests/QS/regtest-gw/G0W0_H2O_PBE_ev_sc.inp
+++ b/tests/QS/regtest-gw/G0W0_H2O_PBE_ev_sc.inp
@@ -59,6 +59,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT 

--- a/tests/QS/regtest-gw/G0W0_H2O_PBE_ev_sc_RI_HFX.inp
+++ b/tests/QS/regtest-gw/G0W0_H2O_PBE_ev_sc_RI_HFX.inp
@@ -59,6 +59,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT 

--- a/tests/QS/regtest-gw/G0W0_H2O_PBE_ev_sc_RI_HFX_svd.inp
+++ b/tests/QS/regtest-gw/G0W0_H2O_PBE_ev_sc_RI_HFX_svd.inp
@@ -59,6 +59,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT 

--- a/tests/QS/regtest-gw/G0W0_H2O_PBE_periodic.inp
+++ b/tests/QS/regtest-gw/G0W0_H2O_PBE_periodic.inp
@@ -59,6 +59,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT 

--- a/tests/QS/regtest-gw/G0W0_OH_PBE_ev_sc.inp
+++ b/tests/QS/regtest-gw/G0W0_OH_PBE_ev_sc.inp
@@ -62,6 +62,7 @@
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
             NUMB_POLES            2
+            ANALYTIC_CONTINUATION TWO_POLE
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT 
             FERMI_LEVEL_OFFSET    2.0E-2

--- a/tests/QS/regtest-gw/G0W0_OH_PBE_ev_sc_svd.inp
+++ b/tests/QS/regtest-gw/G0W0_OH_PBE_ev_sc_svd.inp
@@ -61,6 +61,7 @@
           &RI_G0W0
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
             NUMB_POLES            2
             MAX_ITER_FIT          10000
             CROSSING_SEARCH       Z_SHOT 


### PR DESCRIPTION
The LUMOs computed with the low-scaling GW algorithm of all 100 molecules from the GW100 set deviate now on average 0.007 eV from the reference data. HOMO is slightly worse due to multiple GW solutions. HOMOs in practice are expected to be as well behaved as LUMOs in GW100 because in larger molecules and materials, the self-interaction is less severe than in small molecules as in GW100. High accuracy is also gained using RI with truncated Coulomb metric as implemented by Patrick Seewald. In the long term, high accuracy is especially important for applying and benchmarking the k-point low-scaling GW code for periodic systems.