### PR TITLE
Doc: Specify that RESTART.wfn is not created if FORCE_EVAL/DFT/QS/LS_SCF is true

### DIFF
--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -3209,7 +3209,8 @@ CONTAINS
 
       ! Logicals
       CALL keyword_create(keyword, __LOCATION__, name="LS_SCF", &
-                          description="Perform a linear scaling SCF", &
+                          description="Perform a linear scaling SCF; "// &
+                          "If true, RESTART file is not created", &
                           usage="LS_SCF", lone_keyword_l_val=.TRUE., &
                           default_l_val=.FALSE.)
       CALL section_add_keyword(section, keyword)


### PR DESCRIPTION
I'm not sure whether this is a feature or trivial, but RESTART.wfn is not created if FORCE_EVAL/DFT/QS/LS_SCF is true.

Steps to Reproduce:

1. Copy [benchmarks/QS_mp2_rpa/32-H2O](https://github.com/cp2k/cp2k/tree/40eef542d9bf427234f9f7592abc829d2a48b275/benchmarks/QS_mp2_rpa/32-H2O) to working directory
2. Add `LS_SCF` to H2O-32-PBE-TZ.inp:
```diff
@@ -9,6 +9,7 @@
     &END MGRID
     &QS
       EPS_DEFAULT 1.0E-12
+      LS_SCF T
     &END QS
     &SCF
       SCF_GUESS  ATOMIC
```
3. Run `mpiexec cp2k.pdbg H2O-32-PBE-TZ.inp` (CP2K v7.1)
4. `H2O-32-PBE-TZ-RESTART.wfn` is not created