### PR TITLE
RI HFX: Adjust threshold for H2O-hfx-identity.inp

### DIFF
--- a/tests/QS/regtest-hfx-ri/TEST_FILES
+++ b/tests/QS/regtest-hfx-ri/TEST_FILES
@@ -1,5 +1,5 @@
 H2O-hfx-coulomb.inp                                          1    1.0E-12             -75.93799524358548
-H2O-hfx-identity.inp                                         1    1.0E-12             -75.85187159469186
+H2O-hfx-identity.inp                                         1    1.0E-10             -75.85187159469186
 H2O-hfx-periodic-ri-truncated.inp                            1    1.0E-12             -66.83226303451153
 H2O-hybrid-b3lyp.inp                                         1    1.0E-12             -76.15358900494054
 CH-hfx-ri-mo.inp                                             1    1.0E-12             -37.91967383839648


### PR DESCRIPTION
this is justified by the observation that identity metric is much less
stable than (truncated) Coulomb metric