### PR TITLE
separate internal filter for low-scaling methods; adapt GW regtest

### DIFF
--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -4355,8 +4355,9 @@ CONTAINS
                          "   Del Ben, Mauro", &
                          "   Hutter, Juerg", &
                          "TI GW in the Gaussian and plane waves scheme with application to linear acenes", &
-                         "JO J. Chem. Theory Comput.", &
-                         "SP 3623", &
+                         "SO JOURNAL OF CHEMICAL THEORY AND COMPUTATION", &
+                         "PD FEB", &
+                         "BP 3623", &
                          "EP 3635", &
                          "PY 2016", &
                          "VL 12", &
@@ -4364,7 +4365,7 @@ CONTAINS
                          "ER"), &
                          DOI="10.1021/acs.jctc.6b00380")
 
-      CALL add_reference(key=Wilhelm2016a, ISI_record=s2a( &
+      CALL add_reference(key=Wilhelm2016b, ISI_record=s2a( &
                          "PT J", &
                          "AU Wilhelm, J", &
                          "   Seewald, P", &
@@ -4376,8 +4377,9 @@ CONTAINS
                          "   Hutter, Juerg", &
                          "TI Large-Scale Cubic-Scaling Random Phase Approximation Correlation", &
                          "Energy Calculations Using a Gaussian Basis", &
-                         "JO J. Chem. Theory Comput.", &
-                         "SP 5851", &
+                         "SO JOURNAL OF CHEMICAL THEORY AND COMPUTATION", &
+                         "PD FEB", &
+                         "BP 5851", &
                          "EP 5859", &
                          "PY 2016", &
                          "VL 12", &
@@ -4385,22 +4387,23 @@ CONTAINS
                          "ER"), &
                          DOI="10.1021/acs.jctc.6b00840")
 
-      CALL add_reference(key=Wilhelm2016a, ISI_record=s2a( &
+      CALL add_reference(key=Wilhelm2017, ISI_record=s2a( &
                          "PT J", &
                          "AU Wilhelm, J", &
                          "   Hutter, J", &
                          "AF Wilhelm, Jan", &
                          "   Hutter, Juerg", &
                          "TI Periodic GW calculations in the Gaussian and plane-waves scheme", &
-                         "JO Phys. Rev. B", &
-                         "SP 235123", &
+                         "SO PHYSICAL REVIEW B", &
+                         "PD FEB", &
+                         "BP 235123", &
                          "PY 2017", &
                          "VL 95", &
                          "DI 10.1103/PhysRevB.95.235123", &
                          "ER"), &
                          DOI="10.1103/PhysRevB.95.235123")
 
-      CALL add_reference(key=Wilhelm2016a, ISI_record=s2a( &
+      CALL add_reference(key=Wilhelm2018, ISI_record=s2a( &
                          "PT J", &
                          "AU Wilhelm, J", &
                          "   Golze, D", &
@@ -4413,8 +4416,9 @@ CONTAINS
                          "   Hutter, Juerg", &
                          "   Pignedoli, Carlo A.", &
                          "TI Toward GW calculations on thousands of atoms", &
-                         "JO J. Phys. Chem. Lett.", &
-                         "SP 306", &
+                         "SO JOURNAL OF PHYSICAL CHEMISTRY LETTERS", &
+                         "PD FEB", &
+                         "BP 306", &
                          "EP 312", &
                          "PY 2018", &
                          "VL 9", &

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -10,12 +10,9 @@
 !> \author MDB
 ! **************************************************************************************************
 MODULE input_cp2k_mp2
-   USE bibliography,                    ONLY: Bates2013,&
-                                              DelBen2012,&
-                                              DelBen2013,&
-                                              DelBen2015,&
-                                              DelBen2015b,&
-                                              Rybkin2016
+   USE bibliography,                    ONLY: &
+        Bates2013, DelBen2012, DelBen2013, DelBen2015, DelBen2015b, Rybkin2016, Wilhelm2016a, &
+        Wilhelm2016b, Wilhelm2017, Wilhelm2018
    USE cp_eri_mme_interface,            ONLY: create_eri_mme_section
    USE cp_output_handling,              ONLY: add_last_numeric,&
                                               cp_print_key_section_create,&
@@ -76,7 +73,8 @@ CONTAINS
                           description="Sets up the wavefunction-based correlation methods as MP2, "// &
                           "RI-MP2, RI-SOS-MP2, RI-RPA and GW (inside RI-RPA). ", &
                           n_keywords=4, n_subsections=7, repeats=.TRUE., &
-                          citations=(/DelBen2012, DelBen2013, DelBen2015, DelBen2015b, Rybkin2016/))
+                          citations=(/DelBen2012, DelBen2013, DelBen2015, DelBen2015b, Rybkin2016, &
+                                      Wilhelm2016a, Wilhelm2016b, Wilhelm2017, Wilhelm2018/))
 
       NULLIFY (keyword, subsection)
 

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -553,7 +553,7 @@ CONTAINS
                                    t_3c_M, t_3c_O, &
                                    starts_array_mc, ends_array_mc, &
                                    starts_array_mc_block, ends_array_mc_block, &
-                                   mp2_env%mp2_gpw%eps_filter, BIb_C_beta, homo_beta, Eigenval_beta, &
+                                   BIb_C_beta, homo_beta, Eigenval_beta, &
                                    gd_B_virtual_beta, &
                                    mo_coeff_beta, BIb_C_gw_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta)
 
@@ -572,8 +572,7 @@ CONTAINS
                                    mat_P_global, &
                                    t_3c_M, t_3c_O, &
                                    starts_array_mc, ends_array_mc, &
-                                   starts_array_mc_block, ends_array_mc_block, &
-                                   mp2_env%mp2_gpw%eps_filter)
+                                   starts_array_mc_block, ends_array_mc_block)
 
             IF (mp2_env%ri_rpa%do_rse) &
                CALL rse_energy(qs_env, mp2_env, para_env, dft_control, &

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -495,7 +495,7 @@ CONTAINS
 
       CALL mp_sync(para_env%group) ! sync to see memory output
 
-      ! in case we do imaginary time, we need the overlap matrix (alpha beta P)
+      ! in case we do imaginary time, we need the overlap tensor (alpha beta P) or trunc. Coulomb tensor
       IF (.NOT. do_im_time) THEN
 
          ALLOCATE (sub_proc_map(-para_env_sub%num_pe:2*para_env_sub%num_pe - 1))
@@ -722,6 +722,7 @@ CONTAINS
 
          DEALLOCATE (sub_proc_map)
 
+         ! imag. time = low-scaling SOS-MP2, RPA, GW
       ELSE
 
          impose_split = .NOT. qs_env%mp2_env%ri_rpa_im_time%group_size_internal
@@ -854,7 +855,7 @@ CONTAINS
 
          DO cm = 1, cut_memory
             CALL build_3c_integrals(t_3c_overl_int, &
-                                    qs_env%mp2_env%mp2_gpw%eps_filter/2, &
+                                    qs_env%mp2_env%ri_rpa_im_time%eps_filter/2, &
                                     qs_env, &
                                     nl_3c, &
                                     basis_i=basis_set_ri_aux, &
@@ -870,7 +871,7 @@ CONTAINS
                   CALL dbcsr_t_copy(t_3c_overl_int(i, j), t_3c_O(i, j), order=[1, 3, 2], &
                                     summation=.TRUE., move_data=.TRUE.)
                   CALL dbcsr_t_clear(t_3c_overl_int(i, j))
-                  CALL dbcsr_t_filter(t_3c_O(i, j), qs_env%mp2_env%mp2_gpw%eps_filter/2)
+                  CALL dbcsr_t_filter(t_3c_O(i, j), qs_env%mp2_env%ri_rpa_im_time%eps_filter/2)
                ENDDO
             ENDDO
 
@@ -891,14 +892,14 @@ CONTAINS
             DO kcell = 1, jcell
                CALL dbcsr_t_copy(t_3c_O(jcell, kcell), t_3c_tmp)
                CALL dbcsr_t_copy(t_3c_tmp, t_3c_O(kcell, jcell), order=[1, 3, 2], summation=.TRUE., move_data=.TRUE.)
-               CALL dbcsr_t_filter(t_3c_O(kcell, jcell), qs_env%mp2_env%mp2_gpw%eps_filter)
+               CALL dbcsr_t_filter(t_3c_O(kcell, jcell), qs_env%mp2_env%ri_rpa_im_time%eps_filter)
             ENDDO
          ENDDO
          DO jcell = 1, nimg
             DO kcell = jcell + 1, nimg
                CALL dbcsr_t_copy(t_3c_O(jcell, kcell), t_3c_tmp)
                CALL dbcsr_t_copy(t_3c_tmp, t_3c_O(kcell, jcell), order=[1, 3, 2], summation=.FALSE., move_data=.TRUE.)
-               CALL dbcsr_t_filter(t_3c_O(kcell, jcell), qs_env%mp2_env%mp2_gpw%eps_filter)
+               CALL dbcsr_t_filter(t_3c_O(kcell, jcell), qs_env%mp2_env%ri_rpa_im_time%eps_filter)
             ENDDO
          ENDDO
          CALL dbcsr_t_destroy(t_3c_tmp)

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -187,15 +187,10 @@ CONTAINS
       CALL section_vals_val_get(low_scaling_section, "_SECTION_PARAMETERS_", &
                                 l_val=mp2_env%do_im_time)
 
-      CALL section_vals_val_get(low_scaling_section, "MEMORY_CUT", &
-                                i_val=mp2_env%ri_rpa_im_time%cut_memory)
-      CALL section_vals_val_get(low_scaling_section, "MEMORY_INFO", &
-                                l_val=mp2_env%ri_rpa_im_time%memory_info)
-      IF (mp2_env%do_im_time) CALL section_vals_val_get(low_scaling_section, "EPS_FILTER", &
-                                                        r_val=mp2_env%mp2_gpw%eps_filter)
-      CALL section_vals_val_get(low_scaling_section, "EPS_FILTER_FACTOR", &
-                                r_val=eps_filter_factor)
-      mp2_env%ri_rpa_im_time%eps_filter_im_time = eps_filter_factor*mp2_env%mp2_gpw%eps_filter
+      CALL section_vals_val_get(low_scaling_section, "MEMORY_CUT", i_val=mp2_env%ri_rpa_im_time%cut_memory)
+      CALL section_vals_val_get(low_scaling_section, "MEMORY_INFO", l_val=mp2_env%ri_rpa_im_time%memory_info)
+      CALL section_vals_val_get(low_scaling_section, "EPS_FILTER", r_val=mp2_env%ri_rpa_im_time%eps_filter)
+      CALL section_vals_val_get(low_scaling_section, "EPS_FILTER_FACTOR", r_val=mp2_env%ri_rpa_im_time%eps_filter_factor)
 
       CALL section_vals_val_get(low_scaling_section, "DO_KPOINTS", &
                                 l_val=mp2_env%ri_rpa_im_time%do_im_time_kpoints)

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -61,7 +61,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: tmplist
       LOGICAL                                            :: do_mp2, do_opt_ri_basis, do_ri_mp2, &
                                                             do_ri_sos_mp2, do_rpa
-      REAL(dp)                                           :: eps_filter_factor, rc_ang
+      REAL(dp)                                           :: rc_ang
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: eri_mme_section, gw_section, &
                                                             im_time_test_section, &

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -109,8 +109,8 @@ MODULE mp2_types
    TYPE ri_rpa_im_time_type
       INTEGER                  :: cut_memory
       LOGICAL                  :: memory_info
-      REAL(KIND=dp)            :: eps_filter_im_time, cutoff, &
-                                  exp_kpoints
+      REAL(KIND=dp)            :: eps_filter, cutoff, &
+                                  exp_kpoints, eps_filter_factor
       INTEGER                  :: group_size_P, group_size_3c
       INTEGER, DIMENSION(:), POINTER     :: kp_grid
       LOGICAL                  :: do_im_time_kpoints

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -13,12 +13,9 @@
 !>      03.2019 Refactoring [Frederick Stein]
 ! **************************************************************************************************
 MODULE rpa_main
-   USE bibliography,                    ONLY: Bates2013,&
-                                              DelBen2013,&
-                                              DelBen2015,&
-                                              Ren2011,&
-                                              Ren2013,&
-                                              cite_reference
+   USE bibliography,                    ONLY: &
+        Bates2013, DelBen2013, DelBen2015, Ren2011, Ren2013, Wilhelm2016a, Wilhelm2016b, &
+        Wilhelm2017, Wilhelm2018, cite_reference
    USE bse,                             ONLY: do_subspace_iterations,&
                                               mult_B_with_W_and_fill_local_3c_arrays
    USE cp_blacs_env,                    ONLY: cp_blacs_env_create,&
@@ -142,7 +139,6 @@ CONTAINS
 !> \param ends_array_mc ...
 !> \param starts_array_mc_block ...
 !> \param ends_array_mc_block ...
-!> \param eps_filter ...
 !> \param BIb_C_beta ...
 !> \param homo_beta ...
 !> \param Eigenval_beta ...
@@ -163,7 +159,7 @@ CONTAINS
                                 t_3c_M, t_3c_O, &
                                 starts_array_mc, ends_array_mc, &
                                 starts_array_mc_block, ends_array_mc_block, &
-                                eps_filter, BIb_C_beta, homo_beta, Eigenval_beta, &
+                                BIb_C_beta, homo_beta, Eigenval_beta, &
                                 gd_B_virtual_beta, &
                                 mo_coeff_beta, BIb_C_gw_beta, gw_corr_lev_occ_beta, gw_corr_lev_virt_beta)
 
@@ -194,7 +190,6 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(INOUT), OPTIONAL                         :: BIb_C_beta
       INTEGER, INTENT(IN), OPTIONAL                      :: homo_beta
@@ -247,6 +242,16 @@ CONTAINS
          CALL cite_reference(Ren2011)
          CALL cite_reference(Ren2013)
       ENDIF
+
+      IF (my_do_gw) THEN
+         CALL cite_reference(Wilhelm2016a)
+         CALL cite_reference(Wilhelm2017)
+         CALL cite_reference(Wilhelm2018)
+      END IF
+
+      IF (do_im_time) THEN
+         CALL cite_reference(Wilhelm2016b)
+      END IF
 
       my_open_shell = .FALSE.
       IF (PRESENT(BIb_C_beta) .AND. &
@@ -308,6 +313,13 @@ CONTAINS
                                "The required number of quadrature point exceeds the maximum possible in the "// &
                                "Minimax quadrature scheme. The number of quadrature point has been reset to 30.")
                num_integ_points = 30
+            END IF
+            IF (num_integ_points > 20 .AND. E_Range < 100.0_dp) THEN
+               IF (unit_nr > 0) &
+                  CALL cp_warn(__LOCATION__, &
+                             "You requested a large minimax grid for a small minimax range (< 100). That may lead to numerical "// &
+                               "instabilities when computing minimax grid weights. You can prevent small ranges by choosing "// &
+                               "a larger basis set with higher angular momenta or alternatively using all-electron calculations.")
             END IF
          ELSE
             IF (do_minimax_quad .AND. num_integ_points > 20) THEN
@@ -670,7 +682,7 @@ CONTAINS
                           starts_array_mc, ends_array_mc, &
                           starts_array_mc_block, ends_array_mc_block, &
                           matrix_s, &
-                          kpoints, eps_filter, &
+                          kpoints, &
                           gd_array, color_sub, &
                           fm_mo_coeff_occ_beta=fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta=fm_mo_coeff_virt_beta, &
                           homo_beta=homo_beta, virtual_beta=virtual_beta, &
@@ -695,7 +707,7 @@ CONTAINS
                           starts_array_mc_block, ends_array_mc_block, &
                           matrix_s, &
                           kpoints, &
-                          eps_filter, gd_array, color_sub, &
+                          gd_array, color_sub, &
                           do_ri_sos_laplace_mp2=do_ri_sos_laplace_mp2)
       END IF
 
@@ -1229,7 +1241,6 @@ CONTAINS
 !> \param ends_array_mc_block ...
 !> \param matrix_s ...
 !> \param kpoints ...
-!> \param eps_filter ...
 !> \param gd_array ...
 !> \param color_sub ...
 !> \param fm_mo_coeff_occ_beta ...
@@ -1261,7 +1272,7 @@ CONTAINS
                           starts_array_mc, ends_array_mc, &
                           starts_array_mc_block, ends_array_mc_block, &
                           matrix_s, kpoints, &
-                          eps_filter, gd_array, color_sub, &
+                          gd_array, color_sub, &
                           fm_mo_coeff_occ_beta, fm_mo_coeff_virt_beta, &
                           homo_beta, virtual_beta, dimen_ia_beta, Eigenval_beta, fm_mat_S_beta, &
                           fm_mat_Q_gemm_beta, fm_mat_Q_beta, fm_mat_S_gw_beta, &
@@ -1297,7 +1308,6 @@ CONTAINS
                                                             ends_array_mc_block
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(kpoint_type), POINTER                         :: kpoints
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array
       INTEGER, INTENT(IN)                                :: color_sub
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: fm_mo_coeff_occ_beta, &
@@ -1334,7 +1344,7 @@ CONTAINS
          first_cycle_periodic_correction, my_open_shell, print_ic_values
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :)     :: has_mat_P_blocks
       REAL(dp)                                           :: dbcsr_time
-      REAL(KIND=dp) :: a_scaling, alpha, e_axk, e_axk_corr, e_fermi, e_fermi_beta, &
+      REAL(KIND=dp) :: a_scaling, alpha, e_axk, e_axk_corr, e_fermi, e_fermi_beta, eps_filter, &
          eps_filter_im_time, eps_min_trans, ext_scaling, fermi_level_offset, &
          fermi_level_offset_input, my_flop_rate, omega, omega_max_fit, omega_old, tau, tau_old
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:) :: delta_corr, Eigenval_last, Eigenval_last_beta, &
@@ -1433,7 +1443,10 @@ CONTAINS
 
          group_size_P = mp2_env%ri_rpa_im_time%group_size_P
          cut_memory = mp2_env%ri_rpa_im_time%cut_memory
-         eps_filter_im_time = mp2_env%ri_rpa_im_time%eps_filter_im_time
+         eps_filter = mp2_env%ri_rpa_im_time%eps_filter
+         eps_filter_im_time = mp2_env%ri_rpa_im_time%eps_filter* &
+                              mp2_env%ri_rpa_im_time%eps_filter_factor
+
          min_bsize = mp2_env%ri_rpa_im_time%min_bsize
 
          CALL alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, &

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_30_pts.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_30_pts.inp
@@ -36,25 +36,10 @@
     &END SCF
     &XC
       &XC_FUNCTIONAL PBE
-        &PBE
-          SCALE_X 0.7500000
-          SCALE_C 1.0000000
-        &END
       &END XC_FUNCTIONAL
-      &HF
-        FRACTION 0.2500000
-        &SCREENING
-          EPS_SCHWARZ 1.0E-8
-          SCREEN_ON_INITIAL_P FALSE
-        &END SCREENING
-      &END HF
       &WF_CORRELATION
-        &RI
-          &RI_METRIC
-            POTENTIAL_TYPE IDENTITY
-          &END
-        &END
         &LOW_SCALING
+          EPS_FILTER 0.0
           MEMORY_CUT 1
         &END
         &RI_RPA
@@ -69,12 +54,8 @@
           &GW
             CORR_MOS_OCC          10
             CORR_MOS_VIRT         10
-            CROSSING_SEARCH       Z_SHOT
-            ANALYTIC_CONTINUATION TWO_POLE
           &END GW
         &END RI_RPA
-        MEMORY  200.
-        NUMBER_PROC  1
       &END
     &END XC
   &END DFT
@@ -84,12 +65,12 @@
       PERIODIC NONE
     &END CELL
     &KIND H
-      BASIS_SET  DZVP-GTH
+      BASIS_SET  cc-TZV2P-GTH
       BASIS_SET RI_AUX  RI_DZVP-GTH
       POTENTIAL  GTH-PBE-q1
     &END KIND
     &KIND O
-      BASIS_SET  DZVP-GTH
+      BASIS_SET  cc-TZV2P-GTH
       BASIS_SET RI_AUX  RI_DZVP-GTH
       POTENTIAL  GTH-PBE-q6
     &END KIND

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_30_pts.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE0_30_pts.inp
@@ -50,6 +50,7 @@
               SCREEN_ON_INITIAL_P FALSE
             &END SCREENING
           &END HF
+          ! this test specifically tests a large minimax grid
           RPA_NUM_QUAD_POINTS 30
           &GW
             CORR_MOS_OCC          10
@@ -65,11 +66,13 @@
       PERIODIC NONE
     &END CELL
     &KIND H
+      ! this test specifically tests a large basis
       BASIS_SET  cc-TZV2P-GTH
       BASIS_SET RI_AUX  RI_DZVP-GTH
       POTENTIAL  GTH-PBE-q1
     &END KIND
     &KIND O
+      ! this test specifically tests a large basis
       BASIS_SET  cc-TZV2P-GTH
       BASIS_SET RI_AUX  RI_DZVP-GTH
       POTENTIAL  GTH-PBE-q6

--- a/tests/QS/regtest-gw-cubic/TEST_FILES
+++ b/tests/QS/regtest-gw-cubic/TEST_FILES
@@ -2,7 +2,7 @@ scGW0_H2O_PBE_default_values.inp                      78      1e-05             
 evGW_H2O_PBE_default_values.inp                       78      1e-05                          17.47
 G0W0_H2O_PBE_GAPW.inp                                 78      1e-05                          16.70
 G0W0_H2O_PBE0.inp                                     78      1e-05                          16.66
-G0W0_H2O_PBE0_30_pts.inp                              78      1e-05                          16.67
+G0W0_H2O_PBE0_30_pts.inp                              78      1e-05                          15.61
 scGW0_and_evGW_H2O_PBE0_trunc_minimax.inp             11      1e-08            -17.108489005370274
 G0W0_H2O_PBE_periodic.inp                             78      1e-05                          16.42
 G0W0_OH_PBE.inp                                       79      1e-05                          11.65


### PR DESCRIPTION
separate internal filter for low-scaling methods; increase basis set of GW regtest with 30 minimax points to have a larger minimax range and print warning in case minimax range is small (with all-electron GAPW calculations and large basis sets, the minimax range is large)