### PR TITLE
toolchain: avoid use of arch in install scripts

### DIFF
--- a/tools/toolchain/scripts/install_sirius.sh
+++ b/tools/toolchain/scripts/install_sirius.sh
@@ -67,7 +67,7 @@ case "$with_sirius" in
         require_env SPFFT_CFLAGS
         require_env SPFFT_LDFLAGS
         require_env SPFFT_LIBS
-        ARCH=`arch`
+        ARCH=`uname -m`
         SIRIUS_OPT="-O3 -DNDEBUG -mtune=native -ftree-loop-vectorize ${MATH_CFLAGS}"
         if [ "$ARCH" = "ppc64le" ]; then
             SIRIUS_OPT="-O3 -DNDEBUG -mcpu=power8 -mtune=power8 -funroll-loops -ftree-vectorize  -mvsx  -maltivec  -mpopcntd  -mveclibabi=mass -fvect-cost-model -fpeel-loops -mcmodel=medium ${MATH_CFLAGS}"


### PR DESCRIPTION
`arch` is basically an alias for `uname -m` but it is not available on all systems. Use `uname -m` instead. See: https://www.gnu.org/software/coreutils/manual/html_node/arch-invocation.html

This change was required for me to build the toolchain on Arch Linux.