### PR TITLE
avoid array temporaries

### DIFF
--- a/src/atom_operators.F
+++ b/src/atom_operators.F
@@ -74,7 +74,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vmat
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          TARGET                                          :: omat
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: amat, bmat, eri
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: mat, eri
 
       CALL timeset(routineN, handle)
 
@@ -311,15 +311,13 @@ CONTAINS
                END DO
                integrals%nne(l) = ii
                IF (ii > 0) THEN
-                  amat(1:ii, 1:ii) => omat
-                  amat = MATMUL(TRANSPOSE(integrals%utrans(1:n, 1:ii, l)), integrals%utrans(1:n, 1:ii, l))
+                  mat(1:ii, 1:ii) => omat
+                  mat = MATMUL(TRANSPOSE(integrals%utrans(1:n, 1:ii, l)), integrals%utrans(1:n, 1:ii, l))
 
-                  bmat => integrals%uptrans(:, :, l)
                   DO i = 1, ii
-                     bmat(i, i) = 1._dp
+                     integrals%uptrans(i, i, l) = 1._dp
                   ENDDO
-
-                  CALL lapack_sgesv(ii, ii, amat, ii, ipiv, bmat, ii, info)
+                  CALL lapack_sgesv(ii, ii, mat, ii, ipiv, integrals%uptrans(1:ii, 1:ii, l), ii, info)
                   CPASSERT(info == 0)
                END IF
             END IF

--- a/src/atom_operators.F
+++ b/src/atom_operators.F
@@ -74,7 +74,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vmat
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          TARGET                                          :: omat
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: mat, eri
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: eri, mat
 
       CALL timeset(routineN, handle)
 

--- a/src/atom_operators.F
+++ b/src/atom_operators.F
@@ -71,8 +71,10 @@ CONTAINS
                                                             n1, n2, nn1, nn2, nu, nx
       REAL(KIND=dp)                                      :: om, rc, ron, sc, x
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: cpot, w, work
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: omat, vmat
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: eri
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vmat
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         TARGET                                          :: omat
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: amat, bmat, eri
 
       CALL timeset(routineN, handle)
 
@@ -293,7 +295,7 @@ CONTAINS
          integrals%uptrans = 0._dp
          integrals%nne = integrals%n
          lwork = 10*n
-         ALLOCATE (omat(n, n), w(n), vmat(n, n), work(lwork))
+         ALLOCATE (omat(n, n), vmat(n, n), w(n), work(lwork))
          DO l = 0, lmat
             n = integrals%n(l)
             IF (n > 0) THEN
@@ -309,17 +311,20 @@ CONTAINS
                END DO
                integrals%nne(l) = ii
                IF (ii > 0) THEN
-                  omat(1:ii, 1:ii) = MATMUL(TRANSPOSE(integrals%utrans(1:n, 1:ii, l)), integrals%utrans(1:n, 1:ii, l))
+                  amat(1:ii, 1:ii) => omat
+                  amat = MATMUL(TRANSPOSE(integrals%utrans(1:n, 1:ii, l)), integrals%utrans(1:n, 1:ii, l))
+
+                  bmat => integrals%uptrans(:, :, l)
                   DO i = 1, ii
-                     integrals%uptrans(i, i, l) = 1._dp
+                     bmat(i, i) = 1._dp
                   ENDDO
-                  CALL lapack_sgesv(ii, ii, omat(1:ii, 1:ii), ii, ipiv, integrals%uptrans(1:ii, 1:ii, l), ii, info)
+
+                  CALL lapack_sgesv(ii, ii, amat, ii, ipiv, bmat, ii, info)
                   CPASSERT(info == 0)
                END IF
             END IF
          END DO
          DEALLOCATE (omat, vmat, w, work)
-
       END IF
 
       CALL timestop(handle)

--- a/src/base/base_uses.f90
+++ b/src/base/base_uses.f90
@@ -31,13 +31,16 @@
 # define CPASSERT(cond) IF(.NOT.(cond))CALL cp__a(__SHORT_FILE__,__LINE__)
 #endif
 
-! The MARK_USED macro can be used to mark an argument/variable as used.
-! It is intended to make it possible to switch on -Werror=unused-dummy-argument,
-! but deal elegantly with e.g. library wrapper routines that take arguments only used if the library is linked in. 
+! The MARK_USED macro can be used to mark an argument/variable as used. It is intended to make
+! it possible to switch on -Werror=unused-dummy-argument, but deal elegantly with, e.g.,
+! library wrapper routines that take arguments only used if the library is linked in.
 ! This code should be valid for any Fortran variable, is always standard conforming,
 ! and will be optimized away completely by the compiler
 #define MARK_USED(foo) IF(.FALSE.)THEN; DO ; IF(SIZE(SHAPE(foo))==-1) EXIT ;  END DO ; ENDIF
 
-! Calculate version number from 3-components. Can be used for comparison e.g.,
-! CPVERSION(4, 9, 0) <= CPVERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
-#define CPVERSION(MAJOR, MINOR, UPDATE) ((MAJOR) * 10000 + (MINOR) * 100 + (UPDATE))
+! Calculate version number from 2 or 3 components. Can be used for comparison, e.g.,
+! CPVERSION3(4, 9, 0) <= CPVERSION3(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+! CPVERSION(8, 0) <= CPVERSION(__GNUC__, __GNUC_MINOR__)
+#define CPVERSION2(MAJOR, MINOR) ((MAJOR) * 10000 + (MINOR) * 100)
+#define CPVERSION3(MAJOR, MINOR, UPDATE) (CPVERSION2(MAJOR, MINOR) + (UPDATE))
+#define CPVERSION CPVERSION2

--- a/src/eri_mme/eri_mme_error_control.F
+++ b/src/eri_mme/eri_mme_error_control.F
@@ -295,7 +295,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: h_inv
       REAL(KIND=dp), INTENT(IN)                          :: G_min, zet_max
       INTEGER, INTENT(IN)                                :: l_max_zet, n_minimax
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: minimax_aw
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: minimax_aw
       REAL(KIND=dp), INTENT(OUT)                         :: err_ctff, C_mm
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
 

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -297,7 +297,7 @@ CONTAINS
          mp2_env%mp2_num_proc = para_env%num_pe
       ENDIF
       IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T76,I5)') 'Used number of processes per group:', mp2_env%mp2_num_proc
-      IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'Maximum allowed memory usage per MPI processes:', &
+      IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'Maximum allowed memory usage per MPI process:', &
          mp2_env%mp2_memory, ' MiB'
 
       IF ((mp2_env%method .NE. mp2_method_gpw) .AND. &

--- a/tools/Fun2D/Makefile
+++ b/tools/Fun2D/Makefile
@@ -9,7 +9,7 @@
 YUKAWA   = -D__YUKAWA
 T_C_G0   = -D__T_C_G0
 DFLAGS   = $(T_C_G0)
-CPP      = cpp 
+CPP      = cpp
 CPPFLAGS = -C -traditional $(DFLAGS)
 FC       = gfortran-4.3 -ffree-line-length-512 -g -fopenmp -ffree-form $(DFLAGS)
 # mpfr needs to be thread safe if used with OMP
@@ -18,7 +18,7 @@ LIBS     = -lmpfr -lgmp
 # but should only be used to compile the tester program, compilation is otherwise way too slow
 FFLAGS   = -O3 -march=native -funroll-loops
 
-.SUFFIXES: .f90 .x .o 
+.SUFFIXES: .f90 .x .o
 
 %.o: %.f90
 ifneq ($(CPP),)
@@ -28,18 +28,18 @@ else
 	$(FC) -c $<
 endif
 
-drvrec_mpfr.o : drvrec_mpfr.f90 mpfr.o mpfr.o functions.o padua2_mpfr.o 
-evalf.o : evalf.f90 mpfr_cutoff_gamma.o 
-functions.o : functions.f90 function_types.o mpfr_yukawa.o mpfr_cutoff_gamma.o mpfr.o mpfr.o 
-function_types.o : function_types.f90 
-kinds.o : kinds.f90 
-mpfr_cutoff_gamma.o : mpfr_cutoff_gamma.f90 mpfr.o mpfr.o 
-mpfr.o : mpfr.f90 
-mpfr_yukawa.o : mpfr_yukawa.f90 mpfr.o mpfr.o 
-padua2_mpfr.o : padua2_mpfr.f90 mpfr.o mpfr.o 
-recurse.o : recurse.f90 function_types.o 
-t_c_g0.o : t_c_g0.f90 kinds.o 
-yukawa.o : yukawa.f90 kinds.o 
+drvrec_mpfr.o : drvrec_mpfr.f90 mpfr.o mpfr.o functions.o padua2_mpfr.o
+evalf.o : evalf.f90 mpfr_cutoff_gamma.o
+functions.o : functions.f90 function_types.o mpfr_yukawa.o mpfr_cutoff_gamma.o mpfr.o mpfr.o
+function_types.o : function_types.f90
+kinds.o : kinds.f90
+mpfr_cutoff_gamma.o : mpfr_cutoff_gamma.f90 mpfr.o mpfr.o
+mpfr.o : mpfr.f90
+mpfr_yukawa.o : mpfr_yukawa.f90 mpfr.o mpfr.o
+padua2_mpfr.o : padua2_mpfr.f90 mpfr.o mpfr.o
+recurse.o : recurse.f90 function_types.o
+t_c_g0.o : t_c_g0.f90 kinds.o
+yukawa.o : yukawa.f90 kinds.o
 
 .PHONY: recurse tester test
 recurse: recurse.x
@@ -86,8 +86,8 @@ yukawa.f90: recurse.x drvrec_mpfr.x
 test: tester.x
 	./tester.x
 
-clean: 
+clean:
 	rm -f *.o *.x *.mod *.MOD *.f
 
-realclean: clean 
+realclean: clean
 	rm -f *.dat *.in *.out t_c_g0.f90 fort.* yukawa.f90

--- a/tools/autotune_grid/xyz_to_vab/Makefile
+++ b/tools/autotune_grid/xyz_to_vab/Makefile
@@ -16,5 +16,5 @@ xyz_to_vab.o: kinds.mod
 
 
 
-clean: 
+clean:
 	rm xyz_to_vab_optimised.mod xyz_to_vab_optimised.o kinds.o kinds.mod

--- a/tools/cubecruncher/Makefile
+++ b/tools/cubecruncher/Makefile
@@ -4,22 +4,22 @@
 #
 
 ##FC=xlf90
-##FCFLAGS=-O2 -qsuffix=f=f90 -qmaxmem=128000 -bmaxdata:1000000000 -bmaxstack:128000000 
+##FCFLAGS=-O2 -qsuffix=f=f90 -qmaxmem=128000 -bmaxdata:1000000000 -bmaxstack:128000000
 
 ##FC=ifc
-##FCFLAGS=-O2 -Vaxlib 
+##FCFLAGS=-O2 -Vaxlib
 
 ##FC=ifort
-##FCFLAGS=-O2 
+##FCFLAGS=-O2
 
 ##FC=pgf90
-##FCFLAGS=-O2 
+##FCFLAGS=-O2
 
 ##FC=g95
-##FCFLAGS=-O2 
+##FCFLAGS=-O2
 
 FC=gfortran-mp-5
-FCFLAGS=-O2 
+FCFLAGS=-O2
 
 EXE=-o cubecruncher.x
 


### PR DESCRIPTION
Among resolving some array temporaries when calling the Lapack wrapper, this PR includes various (minor/unrelated) changes.