### PR TITLE
XAS_TDP| scaled down regtest

### DIFF
--- a/tests/QS/regtest-xastdp/He-LDA-extRI_XAS.inp
+++ b/tests/QS/regtest-xastdp/He-LDA-extRI_XAS.inp
@@ -1,5 +1,5 @@
 &GLOBAL
-  PROJECT Ne-LDA-extRI_XAS
+  PROJECT He-LDA-extRI_XAS
   PRINT_LEVEL LOW
   RUN_TYPE ENERGY
 &END GLOBAL
@@ -32,7 +32,7 @@
       &END DONOR_STATES
 
       TAMM_DANCOFF 
-      GRID Ne 250 250
+      GRID He 150 250
       N_EXCITED 10
 
       &KERNEL
@@ -52,9 +52,9 @@
       PERIODIC NONE
     &END CELL
     &COORD
-      Ne 2.5 2.5 2.5
+      He 2.5 2.5 2.5
     &END COORD
-    &KIND Ne
+    &KIND He
       BASIS_SET def2-QZVP
       BASIS_SET RI_XAS RI-5Z
       POTENTIAL ALL

--- a/tests/QS/regtest-xastdp/TEST_FILES
+++ b/tests/QS/regtest-xastdp/TEST_FILES
@@ -1,6 +1,6 @@
 #Testing the XAS_TDP method and the keyword combinations it involves
 #Checking that the user can spefify his own RI_XAS basis set + simple LDA
-Ne-LDA-extRI_XAS.inp                                   88      1e-08           833.277232
+He-LDA-extRI_XAS.inp                                   88      1e-07            25.875010
 #Checking that the searched excitation energies can be defined by a range
 Ne-LDA-e_range.inp                                     88      1e-08           829.640328
 #Checking full TDDFT and simple hybrid functional


### PR DESCRIPTION
Switched from Neon to Helium for external RI_XAS basis regtest. It seems that the large Ne def2-QZVP RI basis lead to OMP stack overflow on some dashboard systems + should be faster in general