### PR TITLE
eri_3center optional extreme value and improved pgf_sum_2c_gspace_1d_deltal

### DIFF
--- a/src/eri_mme/eri_mme_lattice_summation.F
+++ b/src/eri_mme/eri_mme_lattice_summation.F
@@ -669,26 +669,40 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'pgf_sum_2c_gspace_1d_deltal', &
                                      routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: k, l, l_max
+      INTEGER                                            :: k, k0, k1, l, l_max
       REAL(KIND=dp)                                      :: dG, exp_tot, G, prefac
 
       prefac = prefactor*inv_lgth
-      dG = inv_lgth*twopi
+      dG = inv_lgth*twopi ! positive
       l_max = UBOUND(S_G, 1)
 
       S_G(:) = 0.0_dp
-      DO k = G_min, G_c
-         IF (k .NE. 0) THEN
-            G = k*dG
-            exp_tot = EXP(-alpha*G**2)*prefac
+      IF (0 .LT. G_min) THEN
+         k0 = G_min; k1 = 0
+      ELSE IF (G_c .LT. 0) THEN
+         k0 = 0; k1 = G_c
+      ELSE ! Gmin <= 0 /\ 0 <= Gc
+         S_G(0) = prefac
+         k0 = 1; k1 = -1
+      ENDIF
+      ! positive range
+      IF (0 .LT. k0) THEN
+         DO k = k0, G_c
+            G = k*dG; exp_tot = EXP(-alpha*G**2)*prefac
+            DO l = 0, l_max
+               S_G(l) = S_G(l) + G**(l - delta_l)*exp_tot
+            ENDDO
+         ENDDO
+      ENDIF
+      ! negative range
+      IF (k1 .LT. 0) THEN
+         DO k = G_min, k1
+            G = k*dG; exp_tot = EXP(-alpha*G**2)*prefac
             DO l = 0, l_max
                S_G(l) = S_G(l) + ABS(G)**(l - delta_l)*exp_tot
             ENDDO
-         ELSE
-            S_G(0) = S_G(0) + prefac
-         ENDIF
-      ENDDO
-
+         ENDDO
+      ENDIF
    END SUBROUTINE pgf_sum_2c_gspace_1d_deltal
 
 ! **************************************************************************************************

--- a/src/libint_2c_3c.F
+++ b/src/libint_2c_3c.F
@@ -92,6 +92,7 @@ CONTAINS
 !> \param dbc ...
 !> \param lib the libint_t object for evaluation (assume that it is initialized outside)
 !> \param potential_parameter the info about the potential
+!> \param int_abc_ext the extremal value of int_abc, i.e., MAXVAL(ABS(int_abc))
 !> \note Prior to calling this routine, the cp_libint_t type passed as argument must be initialized,
 !>       the libint library must be static initialized, and in case of truncated Coulomb operator,
 !>       the latter must be initialized too
@@ -99,7 +100,8 @@ CONTAINS
    SUBROUTINE eri_3center(int_abc, la_min, la_max, npgfa, zeta, rpgfa, ra, &
                           lb_min, lb_max, npgfb, zetb, rpgfb, rb, &
                           lc_min, lc_max, npgfc, zetc, rpgfc, rc, &
-                          dab, dac, dbc, lib, potential_parameter)
+                          dab, dac, dbc, lib, potential_parameter, &
+                          int_abc_ext)
 
       REAL(dp), DIMENSION(:, :, :), INTENT(INOUT)        :: int_abc
       INTEGER, INTENT(IN)                                :: la_min, la_max, npgfa
@@ -114,6 +116,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: dab, dac, dbc
       TYPE(cp_libint_t), INTENT(INOUT)                   :: lib
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
+      REAL(dp), INTENT(OUT), OPTIONAL                    :: int_abc_ext
 
       CHARACTER(len=*), PARAMETER :: routineN = 'eri_3center', routineP = moduleN//':'//routineN
 
@@ -138,6 +141,10 @@ CONTAINS
       ELSEIF (op == do_potential_coulomb) THEN
          dr_bc = 1000000.0_dp
          dr_ac = 1000000.0_dp
+      ENDIF
+
+      IF (PRESENT(int_abc_ext)) THEN
+         int_abc_ext = 0.0_dp
       ENDIF
 
       !Note: we want to compute all possible integrals based on the 3-centers (ab|c) before
@@ -191,6 +198,9 @@ CONTAINS
                                  p3 = p2 + i
                                  int_abc(a_offset + i, b_offset + j, c_offset + k) = p_work(p3)
                               END DO
+                              IF (PRESENT(int_abc_ext)) THEN
+                                 int_abc_ext = MAX(int_abc_ext, MAXVAL(ABS(p_work(p3:p3 + ncoa))))
+                              ENDIF
                            END DO
                         END DO
 
@@ -222,6 +232,9 @@ CONTAINS
                                  p3 = p2 + j
                                  int_abc(a_offset + i, b_offset + j, c_offset + k) = p_work(p3)
                               END DO
+                              IF (PRESENT(int_abc_ext)) THEN
+                                 int_abc_ext = MAX(int_abc_ext, MAXVAL(ABS(p_work(p3:p3 + ncob))))
+                              ENDIF
                            END DO
                         END DO
 


### PR DESCRIPTION
* libint_2c_3c.F: introduced calculating the extreme value as part of eri_3center, which avoids revisiting the cube of integrals again once it is out of cache. The extreme value is calculated as part of eri_3center's flow in a cache-friendly and chunk-wise fashion. The extreme value is regularly used to prune integrals (screening).

* eri_mme_lattice_summation.F: removed inner condition from loop (routine yields ~10% faster code with GNU Fortran).

The optional extreme value for eri_3center makes subsequent code (screening) much faster. However, the latter is a separate PR.