### PR TITLE
Optimization of 3-center integrals contraction using LIBXSMM

### DIFF
--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -254,7 +254,7 @@ CONTAINS
       INTEGER                                            :: handle, i
 #if(__LIBXSMM)
       INTEGER(libxsmm_blasint_kind)                      :: m, n, k
-      TYPE(libxsmm_dmmfunction), DIMENSION(2)            :: xmm
+      TYPE(libxsmm_dmmfunction)                          :: xmm1, xmm2
 #endif
 
       CALL timeset(routineN, handle)
@@ -265,14 +265,14 @@ CONTAINS
 
       !pre-fetch the kernels
       m = nsgfa; n = ncob; k = ncoa
-      CALL libxsmm_dispatch(xmm(1), m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+      CALL libxsmm_dispatch(xmm1, m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
       m = nsgfa; n = nsgfb; k = ncob
-      CALL libxsmm_dispatch(xmm(2), m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+      CALL libxsmm_dispatch(xmm2, m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
 
       !contractions over a and b
       DO i = 1, ncoc
-         CALL libxsmm_dmmcall(xmm(1), tsphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
-         CALL libxsmm_dmmcall(xmm(2), cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
+         CALL libxsmm_dmmcall(xmm1, tsphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
+         CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
       END DO
 
 #else
@@ -289,7 +289,7 @@ CONTAINS
 
 #endif
 
-      !last contraciton, over c, as a larfer MM
+      !last contraciton, over c, as a larger MM
       CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, 1.0_dp, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
                  0.0_dp, abcint, nsgfa*nsgfb)
 

--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -14,8 +14,6 @@ MODULE ai_contraction_sphi
 
    USE kinds, ONLY: dp
 #if(__LIBXSMM)
-   USE ISO_C_BINDING, ONLY: C_F_POINTER, &
-                            C_LOC
    USE libxsmm, ONLY: LIBXSMM_PREFETCH_NONE, &
                       libxsmm_blasint_kind, &
                       libxsmm_dgemm, &
@@ -225,12 +223,12 @@ CONTAINS
 !> \brief 3-center contraction routine from primitive cartesain Gaussians to spherical Gaussian
 !>        functions. Exploits LIBXSMM for performance, falls back to BLAS if LIBXSMM not available.
 !>        Requires pre-allocation of work buffers and pre-transposition of the sphi_a array. Requires
-!>        the LIBXSMM libreary to be initialized somewhere before this routine is called.
+!>        the LIBXSMM library to be initialized somewhere before this routine is called.
 !> \param abcint contracted integrals
 !> \param sabc uncontracted integrals
-!> \param tsphi_a ...
-!> \param sphi_b ...
-!> \param sphi_c ...
+!> \param tsphi_a assumed to have dimensions nsgfa x ncoa
+!> \param sphi_b assumed to have dimensions ncob x nsgfb
+!> \param sphi_c assumed to have dimensions ncoc x nsgfc
 !> \param ncoa ...
 !> \param ncob ...
 !> \param ncoc ...
@@ -244,18 +242,17 @@ CONTAINS
    SUBROUTINE libxsmm_abc_contract(abcint, sabc, tsphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
                                    nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer)
 
-      REAL(dp), DIMENSION(*), TARGET                     :: abcint, sabc
+      REAL(dp), DIMENSION(*)                             :: abcint, sabc
       REAL(dp), DIMENSION(:, :)                          :: tsphi_a, sphi_b, sphi_c
       INTEGER, INTENT(IN)                                :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
       REAL(dp), DIMENSION(nsgfa*ncob)                    :: cpp_buffer
-      REAL(dp), DIMENSION(nsgfa*nsgfb*ncoc), TARGET      :: ccp_buffer
+      REAL(dp), DIMENSION(nsgfa*nsgfb*ncoc)              :: ccp_buffer
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'libxsmm_abc_contract', &
                                      routineP = moduleN//':'//routineN
 
       INTEGER                                            :: handle, i
 #if(__LIBXSMM)
-      REAL(dp), DIMENSION(:, :), POINTER                 :: abc, ccp
       INTEGER(libxsmm_blasint_kind)                      :: m, n, k
       TYPE(libxsmm_dmmfunction), DIMENSION(2)            :: xmm
 #endif
@@ -278,13 +275,6 @@ CONTAINS
          CALL libxsmm_dmmcall(xmm(2), cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
       END DO
 
-      !last contraction, over c, as a larger MM
-      !note: libxsmm_dgemm falls back to BLAS if matrix too large
-      CALL C_F_POINTER(C_LOC(ccp_buffer), ccp, [nsgfa*nsgfb, ncoc])
-      CALL C_F_POINTER(C_LOC(abcint), abc, [nsgfa*nsgfb, nsgfc])
-      m = nsgfa*nsgfb; n = nsgfc; k = ncoc
-      CALL libxsmm_dgemm(m=m, n=n, k=k, a=ccp, b=sphi_c, beta=0.0_dp, c=abc)
-
 #else
 
       !we follow the same flow as for libxsmm above, but use BLAS dgemm
@@ -297,11 +287,11 @@ CONTAINS
                     ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
       END DO
 
-      !contraciton over c
+#endif
+
+      !last contraciton, over c, as a larfer MM
       CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, 1.0_dp, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
                  0.0_dp, abcint, nsgfa*nsgfb)
-
-#endif
 
       CALL timestop(handle)
 

--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -7,12 +7,23 @@
 !> \brief Contraction of integrals over primitive Cartesian Gaussians based on the contraction
 !>        matrix sphi which is part of the gto_basis_set_type
 !> \par History
-!>      none
+!>      -added libxsmm_abc_contract routine, A. Bussy (04.2020)
 !> \author Dorothea Golze (05.2016)
 ! **************************************************************************************************
 MODULE ai_contraction_sphi
 
-   USE kinds,                           ONLY: dp
+   USE kinds, ONLY: dp
+#if(__LIBXSMM)
+   USE ISO_C_BINDING, ONLY: C_F_POINTER, &
+                            C_LOC
+   USE libxsmm, ONLY: LIBXSMM_PREFETCH_NONE, &
+                      libxsmm_blasint_kind, &
+                      libxsmm_dgemm, &
+                      libxsmm_dispatch, &
+                      libxsmm_dmmcall, &
+                      libxsmm_dmmfunction
+#endif
+
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -21,7 +32,7 @@ MODULE ai_contraction_sphi
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'ai_contraction_sphi'
 
-   PUBLIC :: ab_contract, abc_contract, abcd_contract
+   PUBLIC :: ab_contract, abc_contract, abcd_contract, libxsmm_abc_contract
 
 CONTAINS
 
@@ -209,5 +220,91 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE abcd_contract
+
+! **************************************************************************************************
+!> \brief 3-center contraction routine from primitive cartesain Gaussians to spherical Gaussian
+!>        functions. Exploits LIBXSMM for performance, falls back to BLAS if LIBXSMM not available.
+!>        Requires pre-allocation of work buffers and pre-transposition of the sphi_a array. Requires
+!>        the LIBXSMM libreary to be initialized somewhere before this routine is called.
+!> \param abcint contracted integrals
+!> \param sabc uncontracted integrals
+!> \param tsphi_a ...
+!> \param sphi_b ...
+!> \param sphi_c ...
+!> \param ncoa ...
+!> \param ncob ...
+!> \param ncoc ...
+!> \param nsgfa ...
+!> \param nsgfb ...
+!> \param nsgfc ...
+!> \param cpp_buffer ...
+!> \param ccp_buffer ...
+!> \note tested from version 1.9.0 of libxsmm
+! **************************************************************************************************
+   SUBROUTINE libxsmm_abc_contract(abcint, sabc, tsphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
+                                   nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer)
+
+      REAL(dp), DIMENSION(*), TARGET                     :: abcint, sabc
+      REAL(dp), DIMENSION(:, :)                          :: tsphi_a, sphi_b, sphi_c
+      INTEGER, INTENT(IN)                                :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
+      REAL(dp), DIMENSION(nsgfa*ncob)                    :: cpp_buffer
+      REAL(dp), DIMENSION(nsgfa*nsgfb*ncoc), TARGET      :: ccp_buffer
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'libxsmm_abc_contract', &
+                                     routineP = moduleN//':'//routineN
+
+      INTEGER                                            :: handle, i
+#if(__LIBXSMM)
+      REAL(dp), DIMENSION(:, :), POINTER                 :: abc, ccp
+      INTEGER(libxsmm_blasint_kind)                      :: m, n, k
+      TYPE(libxsmm_dmmfunction), DIMENSION(2)            :: xmm
+#endif
+
+      CALL timeset(routineN, handle)
+
+#if(__LIBXSMM)
+      !We make use of libxsmm code dispatching feature and call the same kernel multiple times
+      !We loop over the last index of the matrix and call libxsmm each time
+
+      !pre-fetch the kernels
+      m = nsgfa; n = ncob; k = ncoa
+      CALL libxsmm_dispatch(xmm(1), m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+      m = nsgfa; n = nsgfb; k = ncob
+      CALL libxsmm_dispatch(xmm(2), m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+
+      !contractions over a and b
+      DO i = 1, ncoc
+         CALL libxsmm_dmmcall(xmm(1), tsphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
+         CALL libxsmm_dmmcall(xmm(2), cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
+      END DO
+
+      !last contraction, over c, as a larger MM
+      !note: libxsmm_dgemm falls back to BLAS if matrix too large
+      CALL C_F_POINTER(C_LOC(ccp_buffer), ccp, [nsgfa*nsgfb, ncoc])
+      CALL C_F_POINTER(C_LOC(abcint), abc, [nsgfa*nsgfb, nsgfc])
+      m = nsgfa*nsgfb; n = nsgfc; k = ncoc
+      CALL libxsmm_dgemm(m=m, n=n, k=k, a=ccp, b=sphi_c, beta=0.0_dp, c=abc)
+
+#else
+
+      !we follow the same flow as for libxsmm above, but use BLAS dgemm
+
+      !contractions over a and b
+      DO i = 1, ncoc
+         CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, tsphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
+                    ncoa, 0.0_dp, cpp_buffer, nsgfa)
+         CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1.0_dp, cpp_buffer, nsgfa, sphi_b, ncob, 0.0_dp, &
+                    ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
+      END DO
+
+      !contraciton over c
+      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, 1.0_dp, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
+                 0.0_dp, abcint, nsgfa*nsgfb)
+
+#endif
+
+      CALL timestop(handle)
+
+   END SUBROUTINE libxsmm_abc_contract
 
 END MODULE ai_contraction_sphi

--- a/src/qs_tensors.F
+++ b/src/qs_tensors.F
@@ -9,14 +9,15 @@
 MODULE qs_tensors
    USE ai_contraction,                  ONLY: block_add
    USE ai_contraction_sphi,             ONLY: ab_contract,&
-                                              abc_contract
+                                              libxsmm_abc_contract
    USE ai_overlap,                      ONLY: overlap_ab
-   USE ai_overlap3,                     ONLY: overlap3
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
-                                              gto_basis_set_p_type
+                                              gto_basis_set_p_type,&
+                                              gto_basis_set_type
    USE block_p_types,                   ONLY: block_p_type
    USE cell_types,                      ONLY: cell_type
+   USE cp_array_utils,                  ONLY: cp_2d_r_p_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_files,                        ONLY: close_file,&
@@ -859,9 +860,10 @@ CONTAINS
          routineP = moduleN//':'//routineN
 
       INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
-         block_start_k, handle, handle2, i, iatom, ibasis, ikind, imax, iset, jatom, jcell, jkind, &
-         jset, katom, kcell, kkind, kset, m_max, maxli, maxlj, maxlk, natom, ncoi, ncoj, ncok, &
-         nimg, nseti, nsetj, nsetk, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
+         block_start_k, egfi, handle, handle2, i, iatom, ibasis, ikind, ilist, imax, iset, jatom, &
+         jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_nco, max_nset, max_nsgf, maxli, &
+         maxlj, maxlk, natom, nbasis, ncoi, ncoj, ncok, nimg, nseti, nsetj, nsetk, op_ij, op_jk, &
+         op_pos_prv, sgfi, sgfj, sgfk, unit_id
       INTEGER, DIMENSION(3)                              :: blk_size, cell_j, cell_k, &
                                                             kp_index_lbounds, kp_index_ubounds, sp
       INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmax_k, lmin_i, lmin_j, &
@@ -874,7 +876,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: dij, dik, djk, dr_ij, dr_ik, dr_jk, &
                                                             kind_radius_i, kind_radius_j, &
                                                             kind_radius_k, prefac, sijk_ext
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: max_contraction_i, max_contraction_j, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: ccp_buffer, cpp_buffer, &
+                                                            max_contraction_i, max_contraction_j, &
                                                             max_contraction_k
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: block_t, dummy_block_t, sijk, sijk_contr
       REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rik, rj, rjk, rk
@@ -882,10 +885,12 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgf_i, rpgf_j, rpgf_k, sphi_i, sphi_j, &
                                                             sphi_k, zeti, zetj, zetk
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cp_2d_r_p_type), DIMENSION(:, :), POINTER     :: spi, spj, spk, tspi, tspj
       TYPE(cp_libint_t)                                  :: lib
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_t_type)                                 :: t_3c_tmp
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_type), POINTER                  :: basis_set
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(neighbor_list_3c_iterator_type)               :: nl_3c_iter
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -957,23 +962,100 @@ CONTAINS
 
       CPASSERT(ALL(SHAPE(t3c) == [nimg, nimg]))
 
-      !Need the max l for each basis for libint
+      !Need the max l for each basis for libint and max nset, nco and nsgf for LIBXSMM contraction
+      nbasis = SIZE(basis_i)
+      max_nsgf = 0
+      max_nco = 0
+      max_nset = 0
       maxli = 0
-      DO ibasis = 1, SIZE(basis_i)
-         CALL get_gto_basis_set(gto_basis_set=basis_i(ibasis)%gto_basis_set, maxl=imax)
+      DO ibasis = 1, nbasis
+         CALL get_gto_basis_set(gto_basis_set=basis_i(ibasis)%gto_basis_set, maxl=imax, &
+                                nset=iset, nsgf_set=nsgfi, npgf=npgfi)
          maxli = MAX(maxli, imax)
+         max_nset = MAX(max_nset, iset)
+         max_nsgf = MAX(max_nsgf, MAXVAL(nsgfi))
+         max_nco = MAX(max_nco, MAXVAL(npgfi)*ncoset(maxli))
       END DO
       maxlj = 0
-      DO ibasis = 1, SIZE(basis_j)
-         CALL get_gto_basis_set(gto_basis_set=basis_j(ibasis)%gto_basis_set, maxl=imax)
+      DO ibasis = 1, nbasis
+         CALL get_gto_basis_set(gto_basis_set=basis_j(ibasis)%gto_basis_set, maxl=imax, &
+                                nset=jset, nsgf_set=nsgfj, npgf=npgfj)
          maxlj = MAX(maxlj, imax)
+         max_nset = MAX(max_nset, jset)
+         max_nsgf = MAX(max_nsgf, MAXVAL(nsgfj))
+         max_nco = MAX(max_nco, MAXVAL(npgfj)*ncoset(maxlj))
       END DO
       maxlk = 0
-      DO ibasis = 1, SIZE(basis_k)
-         CALL get_gto_basis_set(gto_basis_set=basis_k(ibasis)%gto_basis_set, maxl=imax)
+      DO ibasis = 1, nbasis
+         CALL get_gto_basis_set(gto_basis_set=basis_k(ibasis)%gto_basis_set, maxl=imax, &
+                                nset=kset, nsgf_set=nsgfk, npgf=npgfk)
          maxlk = MAX(maxlk, imax)
+         max_nset = MAX(max_nset, kset)
+         max_nsgf = MAX(max_nsgf, MAXVAL(nsgfk))
+         max_nco = MAX(max_nco, MAXVAL(npgfk)*ncoset(maxlk))
       END DO
       m_max = maxli + maxlj + maxlk
+
+      !To minimize expensive memory opsand generally optimize contraction, pre-allocate buffers and
+      !contiguous sphi arrays (and transposed in the cas of sphi_i)
+      ALLOCATE (cpp_buffer(max_nsgf*max_nco), ccp_buffer(max_nsgf*max_nsgf*max_nco))
+      NULLIFY (tspi, tspj, spi, spj, spk)
+
+      IF (op_ij /= do_potential_id) THEN
+         ALLOCATE (spi(max_nset, nbasis), tspj(max_nset, nbasis), spk(max_nset, nbasis))
+      ELSE
+         ALLOCATE (tspi(max_nset, nbasis), spj(max_nset, nbasis), spk(max_nset, nbasis))
+      END IF
+
+      DO ibasis = 1, nbasis
+         DO iset = 1, max_nset
+            IF (op_ij /= do_potential_id) THEN
+               NULLIFY (spi(iset, ibasis)%array)
+               NULLIFY (tspj(iset, ibasis)%array)
+            ELSE
+               NULLIFY (tspi(iset, ibasis)%array)
+               NULLIFY (spj(iset, ibasis)%array)
+            END IF
+            NULLIFY (spk(iset, ibasis)%array)
+         END DO
+      END DO
+
+      DO ilist = 1, 3
+         DO ibasis = 1, nbasis
+            IF (ilist == 1) basis_set => basis_i(ibasis)%gto_basis_set
+            IF (ilist == 2) basis_set => basis_j(ibasis)%gto_basis_set
+            IF (ilist == 3) basis_set => basis_k(ibasis)%gto_basis_set
+
+            DO iset = 1, basis_set%nset
+
+               ncoi = basis_set%npgf(iset)*ncoset(basis_set%lmax(iset))
+               sgfi = basis_set%first_sgf(1, iset)
+               egfi = sgfi + basis_set%nsgf_set(iset) - 1
+
+               IF (ilist == 1) THEN
+                  IF (op_ij /= do_potential_id) THEN
+                     ALLOCATE (spi(iset, ibasis)%array(ncoi, basis_set%nsgf_set(iset)))
+                     spi(iset, ibasis)%array(:, :) = basis_set%sphi(1:ncoi, sgfi:egfi)
+                  ELSE
+                     ALLOCATE (tspi(iset, ibasis)%array(basis_set%nsgf_set(iset), ncoi))
+                     tspi(iset, ibasis)%array(:, :) = TRANSPOSE(basis_set%sphi(1:ncoi, sgfi:egfi))
+                  END IF
+               ELSE IF (ilist == 2) THEN
+                  IF (op_ij /= do_potential_id) THEN
+                     ALLOCATE (tspj(iset, ibasis)%array(basis_set%nsgf_set(iset), ncoi))
+                     tspj(iset, ibasis)%array(:, :) = TRANSPOSE(basis_set%sphi(1:ncoi, sgfi:egfi))
+                  ELSE
+                     ALLOCATE (spj(iset, ibasis)%array(ncoi, basis_set%nsgf_set(iset)))
+                     spj(iset, ibasis)%array(:, :) = basis_set%sphi(1:ncoi, sgfi:egfi)
+                  END IF
+               ELSE
+                  ALLOCATE (spk(iset, ibasis)%array(ncoi, basis_set%nsgf_set(iset)))
+                  spk(iset, ibasis)%array(:, :) = basis_set%sphi(1:ncoi, sgfi:egfi)
+               END IF
+
+            END DO !iset
+         END DO !ibasis
+      END DO !ilist
 
       !Init the truncated Coulomb operator
       IF (op_ij == do_potential_truncated .OR. op_jk == do_potential_truncated) THEN
@@ -991,10 +1073,8 @@ CONTAINS
 
       CALL init_md_ftable(nmax=m_max)
 
-      IF (op_ij /= do_potential_id .OR. op_jk /= do_potential_id) THEN
-         CALL cp_libint_init_3eri(lib, MAX(maxli, maxlj, maxlk))
-         CALL cp_libint_set_contrdepth(lib, 1)
-      ENDIF
+      CALL cp_libint_init_3eri(lib, MAX(maxli, maxlj, maxlk))
+      CALL cp_libint_set_contrdepth(lib, 1)
 
       CALL neighbor_list_3c_iterator_create(nl_3c_iter, nl_3c)
       CALL nl_3c_iter_set_bounds(nl_3c_iter, bounds_i, bounds_j, bounds_k)
@@ -1114,29 +1194,10 @@ CONTAINS
 
                   IF (ncoj*ncok*ncoi > 0) THEN
 
-                     IF (op_ij == do_potential_id .AND. op_jk == do_potential_id) THEN ! cp2k overlap integrals
-                        ALLOCATE (sijk(ncoi, ncoj, ncok))
-                        sijk(:, :, :) = 0.0_dp
-                        CALL overlap3(lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), &
-                                      lmin_i(iset), &
-                                      lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), lmin_j(jset), &
-                                      lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), lmin_k(kset), &
-                                      rij, dij, rik, dik, rjk, djk, sijk, int_abc_ext=sijk_ext)
-                     ELSEIF (op_jk /= do_potential_id) THEN ! for everything else use libint
-                        ALLOCATE (sijk(ncoi, ncoj, ncok))
-                        sijk(:, :, :) = 0.0_dp
-                        !need positions for libint. Only relative positions are needed => set ri to 0.0
-                        ri = 0.0_dp
-                        rj = rij ! ri + rij
-                        rk = rik ! ri + rik
-                        CALL eri_3center(sijk, &
-                                         lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
-                                         lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
-                                         lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
-                                         dij, dik, djk, lib, potential_parameter, int_abc_ext=sijk_ext)
-                     ELSEIF (op_ij /= do_potential_id) THEN
+                     IF (op_ij /= do_potential_id) THEN
                         ALLOCATE (sijk(ncoj, ncok, ncoi))
                         sijk(:, :, :) = 0.0_dp
+                        !need positions for libint. Only relative positions are needed => set ri to 0.0
                         ri = 0.0_dp
                         rj = rij ! ri + rij
                         rk = rik ! ri + rik
@@ -1146,6 +1207,17 @@ CONTAINS
                                          lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
                                          djk, dij, dik, lib, potential_parameter, int_abc_ext=sijk_ext)
 
+                     ELSE
+                        ALLOCATE (sijk(ncoi, ncoj, ncok))
+                        sijk(:, :, :) = 0.0_dp
+                        ri = 0.0_dp
+                        rj = rij ! ri + rij
+                        rk = rik ! ri + rik
+                        CALL eri_3center(sijk, &
+                                         lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
+                                         lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
+                                         lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
+                                         dij, dik, djk, lib, potential_parameter, int_abc_ext=sijk_ext)
                      ENDIF
 
                      IF (PRESENT(int_eps)) THEN
@@ -1161,9 +1233,10 @@ CONTAINS
 
                      IF (op_ij /= do_potential_id) THEN
                         ALLOCATE (sijk_contr(nsgfj(jset), nsgfk(kset), nsgfi(iset)))
-                        CALL abc_contract(sijk_contr, sijk, &
-                                          sphi_j(:, sgfj:), sphi_k(:, sgfk:), sphi_i(:, sgfi:), &
-                                          ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), nsgfi(iset))
+                        CALL libxsmm_abc_contract(sijk_contr, sijk, tspj(jset, jkind)%array, &
+                                                  spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                                  ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                                  nsgfi(iset), cpp_buffer, ccp_buffer)
                         DEALLOCATE (sijk)
 
                         block_start_j = sgfj
@@ -1183,12 +1256,13 @@ CONTAINS
                         DEALLOCATE (sijk_contr)
                      ELSE
                         ALLOCATE (sijk_contr(nsgfi(iset), nsgfj(jset), nsgfk(kset)))
-
-                        CALL abc_contract(sijk_contr, sijk, &
-                                          sphi_i(:, sgfi:), sphi_j(:, sgfj:), sphi_k(:, sgfk:), &
-                                          ncoi, ncoj, ncok, nsgfi(iset), nsgfj(jset), nsgfk(kset))
+                        CALL libxsmm_abc_contract(sijk_contr, sijk, tspi(iset, ikind)%array, &
+                                                  spj(jset, jkind)%array, spk(kset, kkind)%array, &
+                                                  ncoi, ncoj, ncok, nsgfi(iset), nsgfj(jset), &
+                                                  nsgfk(kset), cpp_buffer, ccp_buffer)
 
                         DEALLOCATE (sijk)
+
                         block_start_j = sgfj
                         block_end_j = sgfj + nsgfj(jset) - 1
                         block_start_k = sgfk
@@ -1242,9 +1316,7 @@ CONTAINS
          DEALLOCATE (max_contraction_i, max_contraction_j, max_contraction_k)
       END DO
 
-      IF (op_ij /= do_potential_id .OR. op_jk /= do_potential_id) THEN
-         CALL cp_libint_cleanup_3eri(lib)
-      ENDIF
+      CALL cp_libint_cleanup_3eri(lib)
 
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
 
@@ -1284,6 +1356,25 @@ CONTAINS
       ELSE
          CPABORT("requested symmetric case not implemented")
       ENDIF
+
+      DO iset = 1, max_nset
+         DO ibasis = 1, nbasis
+            IF (op_ij /= do_potential_id) THEN
+               IF (ASSOCIATED(spi(iset, ibasis)%array)) DEALLOCATE (spi(iset, ibasis)%array)
+               IF (ASSOCIATED(tspj(iset, ibasis)%array)) DEALLOCATE (tspj(iset, ibasis)%array)
+            ELSE
+               IF (ASSOCIATED(tspi(iset, ibasis)%array)) DEALLOCATE (tspi(iset, ibasis)%array)
+               IF (ASSOCIATED(spj(iset, ibasis)%array)) DEALLOCATE (spj(iset, ibasis)%array)
+            END IF
+            IF (ASSOCIATED(spk(iset, ibasis)%array)) DEALLOCATE (spk(iset, ibasis)%array)
+         END DO
+      END DO
+
+      IF (op_ij /= do_potential_id) THEN
+         DEALLOCATE (spi, tspj, spk)
+      ELSE
+         DEALLOCATE (tspi, spj, spk)
+      END IF
 
       CALL timestop(handle)
    END SUBROUTINE

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -10,14 +10,15 @@
 
 MODULE xas_tdp_integrals
    USE ai_contraction_sphi,             ONLY: ab_contract,&
-                                              abc_contract
+                                              libxsmm_abc_contract
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                               gto_basis_set_p_type,&
                                               gto_basis_set_type
    USE cell_types,                      ONLY: cell_type
    USE constants_operator,              ONLY: operator_coulomb
-   USE cp_array_utils,                  ONLY: cp_1d_i_p_type
+   USE cp_array_utils,                  ONLY: cp_1d_i_p_type,&
+                                              cp_2d_r_p_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_dbcsr_operations,             ONLY: cp_dbcsr_dist2d_to_dist
    USE cp_eri_mme_interface,            ONLY: cp_eri_mme_param,&
@@ -278,8 +279,9 @@ CONTAINS
          routineP = moduleN//':'//routineN
 
       INTEGER :: egfa, egfb, egfc, handle, i, iatom, ibasis, ikind, ilist, imax, iset, jatom, &
-         jkind, jset, katom, kkind, kset, m_max, max_nset, maxli, maxlj, maxlk, mepos, nbasis, &
-         ncoa, ncob, ncoc, ni, nj, nk, nseta, nsetb, nsetc, nthread, sgfa, sgfb, sgfc, unit_id
+         jkind, jset, katom, kkind, kset, m_max, max_nco, max_nset, max_nsgf, maxli, maxlj, maxlk, &
+         mepos, nbasis, ncoa, ncob, ncoc, ni, nj, nk, nseta, nsetb, nsetc, nthread, sgfa, sgfb, &
+         sgfc, unit_id
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, lc_max, &
                                                             lc_min, npgfa, npgfb, npgfc, nsgfa, &
                                                             nsgfb, nsgfc
@@ -288,12 +290,14 @@ CONTAINS
       REAL(dp)                                           :: dij, dik, djk, my_eps_screen, ri(3), &
                                                             rij(3), rik(3), rj(3), rjk(3), rk(3), &
                                                             sabc_ext, screen_radius
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: ccp_buffer, cpp_buffer
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: max_contr, max_contra, max_contrb, &
                                                             max_contrc
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: iabc, sabc, work
       REAL(dp), DIMENSION(:), POINTER                    :: set_radius_a, set_radius_b, set_radius_c
       REAL(dp), DIMENSION(:, :), POINTER                 :: rpgf_a, rpgf_b, rpgf_c, sphi_a, sphi_b, &
                                                             sphi_c, zeta, zetb, zetc
+      TYPE(cp_2d_r_p_type), DIMENSION(:, :), POINTER     :: spb, spc, tspa
       TYPE(cp_libint_t)                                  :: lib
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_list
@@ -306,33 +310,41 @@ CONTAINS
       NULLIFY (lb_max, lb_min, lc_max, lc_min, npgfa, npgfb, npgfc, nsgfa, nsgfb, nsgfc)
       NULLIFY (first_sgfa, first_sgfb, first_sgfc, set_radius_a, set_radius_b, set_radius_c)
       NULLIFY (rpgf_a, rpgf_b, rpgf_c, sphi_a, sphi_b, sphi_c, zeta, zetb, zetc)
-      NULLIFY (basis_set_a, basis_set_b, basis_set_c)
+      NULLIFY (basis_set_a, basis_set_b, basis_set_c, tspa, spb, spc)
 
       CALL timeset(routineN, handle)
 
       !Need the max l for each basis for libint (and overall max #of sets for screening)
       nbasis = SIZE(basis_set_list_a)
+      max_nsgf = 0
+      max_nco = 0
       max_nset = 0
       maxli = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_set_list_a(ibasis)%gto_basis_set, &
-                                maxl=imax, nset=iset)
+                                maxl=imax, nset=iset, nsgf_set=nsgfa, npgf=npgfa)
          maxli = MAX(maxli, imax)
          max_nset = MAX(max_nset, iset)
+         max_nsgf = MAX(max_nsgf, MAXVAL(nsgfa))
+         max_nco = MAX(max_nco, MAXVAL(npgfa)*ncoset(maxli))
       END DO
       maxlj = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_set_list_b(ibasis)%gto_basis_set, &
-                                maxl=imax, nset=iset)
+                                maxl=imax, nset=iset, nsgf_set=nsgfb, npgf=npgfb)
          maxlj = MAX(maxlj, imax)
          max_nset = MAX(max_nset, iset)
+         max_nsgf = MAX(max_nsgf, MAXVAL(nsgfb))
+         max_nco = MAX(max_nco, MAXVAL(npgfb)*ncoset(maxlj))
       END DO
       maxlk = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_set_list_c(ibasis)%gto_basis_set, &
-                                maxl=imax, nset=iset)
+                                maxl=imax, nset=iset, nsgf_set=nsgfc, npgf=npgfc)
          maxlk = MAX(maxlk, imax)
          max_nset = MAX(max_nset, iset)
+         max_nsgf = MAX(max_nsgf, MAXVAL(nsgfc))
+         max_nco = MAX(max_nco, MAXVAL(npgfc)*ncoset(maxlk))
       END DO
       m_max = maxli + maxlj + maxlk
 
@@ -390,6 +402,47 @@ CONTAINS
          DEALLOCATE (max_contr)
       END IF !do_screen
 
+      !To minimize memory ops in contraction, we need to pre-allocate buffers, pre-tranpose sphi_a
+      !and also trim sphi in general to have contiguous arrays
+      ALLOCATE (tspa(max_nset, nbasis), spb(max_nset, nbasis), spc(max_nset, nbasis))
+      DO iset = 1, max_nset
+         DO ibasis = 1, nbasis
+            NULLIFY (tspa(iset, ibasis)%array)
+            NULLIFY (spb(iset, ibasis)%array)
+            NULLIFY (spc(iset, ibasis)%array)
+         END DO
+      END DO
+
+      DO ilist = 1, 3
+
+         IF (ilist == 1) basis_set_list => basis_set_list_a
+         IF (ilist == 2) basis_set_list => basis_set_list_b
+         IF (ilist == 3) basis_set_list => basis_set_list_c
+
+         DO ibasis = 1, nbasis
+            basis_set => basis_set_list(ibasis)%gto_basis_set
+
+            DO iset = 1, basis_set%nset
+
+               ncoa = basis_set%npgf(iset)*ncoset(basis_set%lmax(iset))
+               sgfa = basis_set%first_sgf(1, iset)
+               egfa = sgfa + basis_set%nsgf_set(iset) - 1
+
+               IF (ilist == 1) THEN
+                  ALLOCATE (tspa(iset, ibasis)%array(basis_set%nsgf_set(iset), ncoa))
+                  tspa(iset, ibasis)%array(:, :) = TRANSPOSE(basis_set%sphi(1:ncoa, sgfa:egfa))
+               ELSE IF (ilist == 2) THEN
+                  ALLOCATE (spb(iset, ibasis)%array(ncoa, basis_set%nsgf_set(iset)))
+                  spb(iset, ibasis)%array(:, :) = basis_set%sphi(1:ncoa, sgfa:egfa)
+               ELSE
+                  ALLOCATE (spc(iset, ibasis)%array(ncoa, basis_set%nsgf_set(iset)))
+                  spc(iset, ibasis)%array(:, :) = basis_set%sphi(1:ncoa, sgfa:egfa)
+               END IF
+
+            END DO !iset
+         END DO !ibasis
+      END DO !ilist
+
       my_sort_bc = .FALSE.
       IF (PRESENT(only_bc_same_center)) my_sort_bc = only_bc_same_center
 
@@ -424,19 +477,26 @@ CONTAINS
       CALL o3c_iterator_create(o3c, o3c_iterator, nthread=nthread)
 
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED (pq_X,do_screen,max_nset,basis_set_list_a,max_contra,max_contrb,max_contrc,&
-!$OMP         basis_set_list_b, basis_set_list_c,ncoset,screen_radius,potential_parameter,&
-!$OMP         my_eps_screen,maxli,maxlj,maxlk,my_sort_bc,nthread,o3c,o3c_iterator) &
+!$OMP SHARED (pq_X,do_screen,max_nset,basis_set_list_a,max_contra,max_contrb,max_contrc,max_nsgf,&
+!$OMP         basis_set_list_b, basis_set_list_c,ncoset,screen_radius,potential_parameter,max_nco,&
+!$OMP         my_eps_screen,maxli,maxlj,maxlk,my_sort_bc,nthread,o3c,o3c_iterator,tspa,spb,spc) &
 !$OMP PRIVATE (lib,i,mepos,work,iset,ncoa,sgfa,egfa,nseta,&
 !$OMP          iatom,ikind,jatom,jkind,katom,kkind,rij,rik,rjk,basis_set_a,nsetb,&
 !$OMP          la_max,la_min,lb_max,lb_min,lc_max,lc_min,npgfa,npgfb,npgfc,nsgfa,nsgfb,nsgfc,ri,rk,&
 !$OMP          first_sgfa,first_sgfb,first_sgfc,set_radius_a,set_radius_b,set_radius_c, nsetc,rj,&
 !$OMP          rpgf_a,rpgf_b,rpgf_c,sphi_a,sphi_b,sphi_c,zeta,zetb,zetc,basis_set_b,basis_set_c,&
-!$OMP          dij,dik,djk,ni,nj,nk,iabc,sabc,jset,kset,ncob,ncoc,sgfb,sgfc,egfb,egfc,&
-!$OMP          sabc_ext)
+!$OMP          dij,dik,djk,ni,nj,nk,iabc,sabc,jset,kset,ncob,ncoc,sgfb,sgfc,egfb,egfc, &
+!$OMP          sabc_ext,cpp_buffer,ccp_buffer)
 
       mepos = 0
 !$    mepos = omp_get_thread_num()
+
+      !pre-allocate work buffers for LIBXSMM contract in order to avoid memory ops
+      ALLOCATE (cpp_buffer(max_nsgf*max_nco))
+      ALLOCATE (ccp_buffer(max_nsgf*max_nsgf*max_nco))
+
+      !note: we do not initalize libxsmm here, because we assume that if the flag is there, then it
+      !      is done in dbcsr already
 
       !each thread need its own libint object (internals may change at different rates)
       CALL cp_libint_init_3eri(lib, MAX(maxli, maxlj, maxlk))
@@ -547,11 +607,10 @@ CONTAINS
                   END IF
 
                   ALLOCATE (work(nsgfa(iset), nsgfb(jset), nsgfc(kset)))
-                  !zeroing work is superfluous here (work = 0.0_dp)
 
-                  CALL abc_contract(work, sabc, &
-                                    sphi_a(:, sgfa:), sphi_b(:, sgfb:), sphi_c(:, sgfc:), &
-                                    ncoa, ncob, ncoc, nsgfa(iset), nsgfb(jset), nsgfc(kset))
+                  CALL libxsmm_abc_contract(work, sabc, tspa(iset, ikind)%array, spb(jset, jkind)%array, &
+                                            spc(kset, kkind)%array, ncoa, ncob, ncoc, nsgfa(iset), &
+                                            nsgfb(jset), nsgfc(kset), cpp_buffer, ccp_buffer)
 
                   iabc(sgfa:egfa, sgfb:egfb, sgfc:egfc) = work(:, :, :)
                   DEALLOCATE (sabc, work)
@@ -574,6 +633,15 @@ CONTAINS
       CALL o3c_iterator_release(o3c_iterator)
       CALL release_o3c_container(o3c)
       DEALLOCATE (o3c)
+
+      DO iset = 1, max_nset
+         DO ibasis = 1, nbasis
+            IF (ASSOCIATED(tspa(iset, ibasis)%array)) DEALLOCATE (tspa(iset, ibasis)%array)
+            IF (ASSOCIATED(spb(iset, ibasis)%array)) DEALLOCATE (spb(iset, ibasis)%array)
+            IF (ASSOCIATED(spc(iset, ibasis)%array)) DEALLOCATE (spc(iset, ibasis)%array)
+         END DO
+      END DO
+      DEALLOCATE (tspa, spb, spc)
 
       CALL timestop(handle)
 

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -295,8 +295,7 @@ CONTAINS
                                                             max_contrc
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: iabc, sabc, work
       REAL(dp), DIMENSION(:), POINTER                    :: set_radius_a, set_radius_b, set_radius_c
-      REAL(dp), DIMENSION(:, :), POINTER                 :: rpgf_a, rpgf_b, rpgf_c, sphi_a, sphi_b, &
-                                                            sphi_c, zeta, zetb, zetc
+      REAL(dp), DIMENSION(:, :), POINTER                 :: rpgf_a, rpgf_b, rpgf_c, zeta, zetb, zetc
       TYPE(cp_2d_r_p_type), DIMENSION(:, :), POINTER     :: spb, spc, tspa
       TYPE(cp_libint_t)                                  :: lib
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -309,7 +308,7 @@ CONTAINS
       NULLIFY (basis_set, basis_set_list, para_env, la_max, la_min)
       NULLIFY (lb_max, lb_min, lc_max, lc_min, npgfa, npgfb, npgfc, nsgfa, nsgfb, nsgfc)
       NULLIFY (first_sgfa, first_sgfb, first_sgfc, set_radius_a, set_radius_b, set_radius_c)
-      NULLIFY (rpgf_a, rpgf_b, rpgf_c, sphi_a, sphi_b, sphi_c, zeta, zetb, zetc)
+      NULLIFY (rpgf_a, rpgf_b, rpgf_c, zeta, zetb, zetc)
       NULLIFY (basis_set_a, basis_set_b, basis_set_c, tspa, spb, spc)
 
       CALL timeset(routineN, handle)
@@ -484,9 +483,8 @@ CONTAINS
 !$OMP          iatom,ikind,jatom,jkind,katom,kkind,rij,rik,rjk,basis_set_a,nsetb,&
 !$OMP          la_max,la_min,lb_max,lb_min,lc_max,lc_min,npgfa,npgfb,npgfc,nsgfa,nsgfb,nsgfc,ri,rk,&
 !$OMP          first_sgfa,first_sgfb,first_sgfc,set_radius_a,set_radius_b,set_radius_c, nsetc,rj,&
-!$OMP          rpgf_a,rpgf_b,rpgf_c,sphi_a,sphi_b,sphi_c,zeta,zetb,zetc,basis_set_b,basis_set_c,&
-!$OMP          dij,dik,djk,ni,nj,nk,iabc,sabc,jset,kset,ncob,ncoc,sgfb,sgfc,egfb,egfc, &
-!$OMP          sabc_ext,cpp_buffer,ccp_buffer)
+!$OMP          rpgf_a,rpgf_b,rpgf_c,zeta,zetb,zetc,basis_set_b,basis_set_c,dij,dik,djk,ni,nj,nk,&
+!$OMP          iabc,sabc,jset,kset,ncob,ncoc,sgfb,sgfc,egfb,egfc,sabc_ext,cpp_buffer,ccp_buffer)
 
       mepos = 0
 !$    mepos = omp_get_thread_num()
@@ -514,7 +512,6 @@ CONTAINS
          npgfa => basis_set_a%npgf
          nseta = basis_set_a%nset
          nsgfa => basis_set_a%nsgf_set
-         sphi_a => basis_set_a%sphi
          zeta => basis_set_a%zet
          rpgf_a => basis_set_a%pgf_radius
          set_radius_a => basis_set_a%set_radius
@@ -527,7 +524,6 @@ CONTAINS
          npgfb => basis_set_b%npgf
          nsetb = basis_set_b%nset
          nsgfb => basis_set_b%nsgf_set
-         sphi_b => basis_set_b%sphi
          zetb => basis_set_b%zet
          rpgf_b => basis_set_b%pgf_radius
          set_radius_b => basis_set_b%set_radius
@@ -540,7 +536,6 @@ CONTAINS
          npgfc => basis_set_c%npgf
          nsetc = basis_set_c%nset
          nsgfc => basis_set_c%nsgf_set
-         sphi_c => basis_set_c%sphi
          zetc => basis_set_c%zet
          rpgf_c => basis_set_c%pgf_radius
          set_radius_c => basis_set_c%set_radius

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -404,8 +404,8 @@ CONTAINS
       !To minimize memory ops in contraction, we need to pre-allocate buffers, pre-tranpose sphi_a
       !and also trim sphi in general to have contiguous arrays
       ALLOCATE (tspa(max_nset, nbasis), spb(max_nset, nbasis), spc(max_nset, nbasis))
-      DO iset = 1, max_nset
-         DO ibasis = 1, nbasis
+      DO ibasis = 1, nbasis
+         DO iset = 1, max_nset
             NULLIFY (tspa(iset, ibasis)%array)
             NULLIFY (spb(iset, ibasis)%array)
             NULLIFY (spc(iset, ibasis)%array)
@@ -414,12 +414,10 @@ CONTAINS
 
       DO ilist = 1, 3
 
-         IF (ilist == 1) basis_set_list => basis_set_list_a
-         IF (ilist == 2) basis_set_list => basis_set_list_b
-         IF (ilist == 3) basis_set_list => basis_set_list_c
-
          DO ibasis = 1, nbasis
-            basis_set => basis_set_list(ibasis)%gto_basis_set
+            IF (ilist == 1) basis_set => basis_set_list_a(ibasis)%gto_basis_set
+            IF (ilist == 2) basis_set => basis_set_list_b(ibasis)%gto_basis_set
+            IF (ilist == 3) basis_set => basis_set_list_c(ibasis)%gto_basis_set
 
             DO iset = 1, basis_set%nset
 


### PR DESCRIPTION
In this PR, LIBXSMM is used to accelerate the contraction of 3-center integrals from pgf to sgf. The present code together with #869 allows for a cost reduction of 30% to 50% on the 3-center integrals calculation in XAS_TDP (depending on the simulated system and machine used).

@pseewald If you think that this can be useful for your tensor code and/or other methods using 3-center integrals, let me know and I can make the changes there too.

@hfp I stopped short of writing a version dependent code and simply check for the -D__LIBXSMM flag with a fallback on BLAS. I tested the code with versions 1.9.0 and the current development branch, assuming everything in between would work.