### PR TITLE
Toolchain: Disable runtime warning about temporary arrays.

### DIFF
--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -36,7 +36,7 @@ NOOPT_FLAGS="-O1"
 
 # those flags that do not influence code generation are used always, the others if debug
 FCDEB_FLAGS="-fbacktrace -ffree-form -fimplicit-none -std=f2008"
-FCDEB_FLAGS_DEBUG="-fsanitize=leak -fcheck=all -ffpe-trap=invalid,zero,overflow -finit-derived -finit-real=snan -finit-integer=-42 -Werror=realloc-lhs -finline-matmul-limit=0"
+FCDEB_FLAGS_DEBUG="-fsanitize=leak -fcheck=all,no-array-temps -ffpe-trap=invalid,zero,overflow -finit-derived -finit-real=snan -finit-integer=-42 -Werror=realloc-lhs -finline-matmul-limit=0"
 
 # code coverage generation flags
 COVERAGE_FLAGS="-O1 -coverage -fkeep-static-functions"


### PR DESCRIPTION
Usually these copies are unavoidable because we're calling into C or F77 code.

See also discussion at https://github.com/cp2k/cp2k/pull/861 and  https://github.com/cp2k/dbcsr/issues/325.