### PR TITLE
Fix AD_LANGEVIN for REGION other than MASSIVE

### DIFF
--- a/src/motion/thermostat/al_system_dynamics.F
+++ b/src/motion/thermostat/al_system_dynamics.F
@@ -147,7 +147,8 @@ CONTAINS
                IF (PRESENT(vel)) THEN
                   WRITE (unit=*, fmt='("VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), ipart, vel(:, ipart)
                ELSE
-                  WRITE (unit=*, fmt='("PARTICLE_SET%VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), ipart, particle_set(ipart)%v(:)
+                  WRITE (unit=*, fmt='("PARTICLE_SET%VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), &
+                      ipart, particle_set(ipart)%v(:)
                ENDIF
             END DO
          END DO

--- a/src/motion/thermostat/al_system_dynamics.F
+++ b/src/motion/thermostat/al_system_dynamics.F
@@ -147,7 +147,7 @@ CONTAINS
                IF (PRESENT(vel)) THEN
                   WRITE (unit=*, fmt='("VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), ipart, vel(:, ipart)
                ELSE
-                  WRITE (unit=*, fmt='("VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), ipart, particle_set(ipart)%v(:)
+                  WRITE (unit=*, fmt='("PARTICLE_SET%VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), ipart, particle_set(ipart)%v(:)
                ENDIF
             END DO
          END DO
@@ -181,7 +181,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'al_OU_step', routineP = moduleN//':'//routineN
 
-      INTEGER :: first_atom, i, ii, ikind, imap, imol, imol_local, ipart, iparticle_kind, &
+      INTEGER :: first_atom, i, ii, jj, ikind, imap, imol, imol_local, ipart, iparticle_kind, &
          iparticle_local, last_atom, nmol_local, nparticle, nparticle_kind, nparticle_local
       LOGICAL                                            :: check, present_vel
       REAL(KIND=dp)                                      :: mass
@@ -239,11 +239,15 @@ CONTAINS
                atomic_kind => particle_set(ipart)%atomic_kind
                CALL get_atomic_kind(atomic_kind=atomic_kind, mass=mass)
                IF (present_vel) THEN
-                  vel(:, ipart) = vel(:, ipart)*map_info%v_scale(ii) + &
-                                  map_info%s_kin(ii)/SQRT(mass)*w(:, ipart)
+                  DO jj=1, 3
+                     vel(jj, ipart) = vel(jj, ipart)*map_info%p_scale(jj,ii)%point + &
+                                     map_info%p_kin(jj,ii)%point/SQRT(mass)*w(jj, ipart)
+                  END DO
                ELSE
-                  particle_set(ipart)%v(:) = particle_set(ipart)%v(:)*map_info%v_scale(ii) + &
-                                             map_info%s_kin(ii)/SQRT(mass)*w(:, ipart)
+                  DO jj=1, 3
+                     particle_set(ipart)%v(jj) = particle_set(ipart)%v(jj)*map_info%p_scale(jj,ii)%point + &
+                                                map_info%p_kin(jj,ii)%point/SQRT(mass)*w(jj, ipart)
+                  END DO
                ENDIF
             END DO
          END DO

--- a/src/motion/thermostat/al_system_dynamics.F
+++ b/src/motion/thermostat/al_system_dynamics.F
@@ -148,7 +148,7 @@ CONTAINS
                   WRITE (unit=*, fmt='("VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), ipart, vel(:, ipart)
                ELSE
                   WRITE (unit=*, fmt='("PARTICLE_SET%VEL ",A20," IPART ",I6," V ",3F20.10)') TRIM(label), &
-                      ipart, particle_set(ipart)%v(:)
+                     ipart, particle_set(ipart)%v(:)
                ENDIF
             END DO
          END DO
@@ -182,8 +182,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'al_OU_step', routineP = moduleN//':'//routineN
 
-      INTEGER :: first_atom, i, ii, jj, ikind, imap, imol, imol_local, ipart, iparticle_kind, &
-         iparticle_local, last_atom, nmol_local, nparticle, nparticle_kind, nparticle_local
+      INTEGER :: first_atom, i, ii, ikind, imap, imol, imol_local, ipart, iparticle_kind, &
+         iparticle_local, jj, last_atom, nmol_local, nparticle, nparticle_kind, nparticle_local
       LOGICAL                                            :: check, present_vel
       REAL(KIND=dp)                                      :: mass
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: w(:, :)
@@ -240,14 +240,14 @@ CONTAINS
                atomic_kind => particle_set(ipart)%atomic_kind
                CALL get_atomic_kind(atomic_kind=atomic_kind, mass=mass)
                IF (present_vel) THEN
-                  DO jj=1, 3
-                     vel(jj, ipart) = vel(jj, ipart)*map_info%p_scale(jj,ii)%point + &
-                                     map_info%p_kin(jj,ii)%point/SQRT(mass)*w(jj, ipart)
+                  DO jj = 1, 3
+                     vel(jj, ipart) = vel(jj, ipart)*map_info%p_scale(jj, ii)%point + &
+                                      map_info%p_kin(jj, ii)%point/SQRT(mass)*w(jj, ipart)
                   END DO
                ELSE
-                  DO jj=1, 3
-                     particle_set(ipart)%v(jj) = particle_set(ipart)%v(jj)*map_info%p_scale(jj,ii)%point + &
-                                                map_info%p_kin(jj,ii)%point/SQRT(mass)*w(jj, ipart)
+                  DO jj = 1, 3
+                     particle_set(ipart)%v(jj) = particle_set(ipart)%v(jj)*map_info%p_scale(jj, ii)%point + &
+                                                 map_info%p_kin(jj, ii)%point/SQRT(mass)*w(jj, ipart)
                   END DO
                ENDIF
             END DO


### PR DESCRIPTION
As Mayank Dodia noticed, thermostat AD_LANGEVIN fails with any REGION except MASSIVE, because the code tried to index per-thermostat quantities with per-atom array indices.  It accidentally worked for REGION MASSIVE because there was exactly one thermostat per atom, so indices were equivalent.  This fixes it for regions with more than 1 atom.