### PR TITLE
toolchain: collection of small fixes

### DIFF
--- a/tools/toolchain/scripts/install_cosma.sh
+++ b/tools/toolchain/scripts/install_cosma.sh
@@ -117,7 +117,6 @@ case "$with_cosma" in
         echo "==================== Linking cosma to user paths ===================="
         pkg_install_dir="$with_cosma"
         check_dir "$pkg_install_dir/lib"
-        check_dir "$pkg_install_dir/lib64"
         check_dir "$pkg_install_dir/include"
 
 

--- a/tools/toolchain/scripts/install_gsl.sh
+++ b/tools/toolchain/scripts/install_gsl.sh
@@ -58,7 +58,6 @@ case "$with_gsl" in
         echo "==================== Linking gsl to user paths ===================="
         pkg_install_dir="$with_gsl"
         check_dir "$pkg_install_dir/lib"
-        check_dir "$pkg_install_dir/lib64"
         check_dir "$pkg_install_dir/include"
         GSL_CFLAGS="-I'${pkg_install_dir}/include'"
         GSL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"

--- a/tools/toolchain/scripts/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/install_libvdwxc.sh
@@ -101,7 +101,6 @@ case "$with_libvdwxc" in
         echo "==================== Linking libvdwxc to user paths ===================="
         pkg_install_dir="$with_libvdwxc"
         check_dir "$pkg_install_dir/lib"
-        check_dir "$pkg_install_dir/lib64"
         check_dir "$pkg_install_dir/include"
         LIBVDWXC_CFLAGS="-I'${pkg_install_dir}/include'"
         LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"

--- a/tools/toolchain/scripts/install_openblas.sh
+++ b/tools/toolchain/scripts/install_openblas.sh
@@ -83,11 +83,16 @@ case "$with_openblas" in
         OPENBLAS_CFLAGS="-I'${pkg_install_dir}/include'"
         OPENBLAS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
         OPENBLASROOT='${pkg_install_dir}'
+        OPENBLAS_LIBS="-lopenblas"
   ;;
     __SYSTEM__)
         echo "==================== Finding LAPACK from system paths ===================="
         # assume that system openblas is threaded
         check_lib -lopenblas "OpenBLAS"
+        OPENBLAS_LIBS="-lopenblas"
+        # detect separate omp builds
+        check_lib -lopenblas_openmp 2>/dev/null && OPENBLAS_LIBS="-lopenblas_openmp"
+        check_lib -lopenblas_omp 2>/dev/null && OPENBLAS_LIBS="-lopenblas_omp"
         add_include_from_paths OPENBLAS_CFLAGS "openblas_config.h" $INCLUDE_PATHS
         add_lib_from_paths OPENBLAS_LDFLAGS "libopenblas.*" $LIB_PATHS
         ;;
@@ -100,10 +105,15 @@ case "$with_openblas" in
         check_dir "${pkg_install_dir}/lib"
         OPENBLAS_CFLAGS="-I'${pkg_install_dir}/include'"
         OPENBLAS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+        OPENBLAS_LIBS="-lopenblas"
+        # detect separate omp builds
+        (__libdir="${pkg_install_dir}/lib" LIB_PATHS="__libdir" check_lib -lopenblas_openmp 2>/dev/null) && \
+            OPENBLAS_LIBS="-lopenblas_openmp"
+        (__libdir="${pkg_install_dir}/lib" LIB_PATHS="__libdir" check_lib -lopenblas_omp 2>/dev/null) && \
+            OPENBLAS_LIBS="-lopenblas_omp"
         ;;
 esac
 if [ "$with_openblas" != "__DONTUSE__" ] ; then
-    OPENBLAS_LIBS="-lopenblas"
     if [ "$with_openblas" != "__SYSTEM__" ] ; then
         cat <<EOF > "${BUILDDIR}/setup_openblas"
 prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"

--- a/tools/toolchain/scripts/install_spfft.sh
+++ b/tools/toolchain/scripts/install_spfft.sh
@@ -75,7 +75,6 @@ case "$with_spfft" in
         echo "==================== Linking psfft to user paths ===================="
         pkg_install_dir="$with_spfft"
         check_dir "$pkg_install_dir/lib"
-        check_dir "$pkg_install_dir/lib64"
         check_dir "$pkg_install_dir/include"
         SPFFT_CFLAGS="-I'${pkg_install_dir}/include'"
         SPFFT_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"

--- a/tools/toolchain/scripts/install_spglib.sh
+++ b/tools/toolchain/scripts/install_spglib.sh
@@ -62,7 +62,6 @@ case "$with_spglib" in
         echo "==================== Linking spglib to user paths ===================="
         pkg_install_dir="$with_spglib"
         check_dir "$pkg_install_dir/lib"
-        check_dir "$pkg_install_dir/lib64"
         check_dir "$pkg_install_dir/include"
         SPGLIB_CFLAGS="-I'${pkg_install_dir}/include'"
         SPGLIB_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"


### PR DESCRIPTION
* openblas: Detect if there is a separate openblas_omp library instead of guessing. This change is for example required when linking against a system installation of openblas which provides only libopenblas.so.
* Remove checks for lib64 where lib64 is not strictly required. Many installation do not contain a separate lib64 folder but still provide everything required (observed for example with easybuild). Unless lib64 is really required, we should not check for its existence.