### PR TITLE
Toolchain: Update GCC to version 9.3.0

### DIFF
--- a/tools/toolchain/scripts/install_gcc.sh
+++ b/tools/toolchain/scripts/install_gcc.sh
@@ -2,8 +2,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")" && pwd -P)"
 
-gcc_ver="9.2.0"
-gcc_sha256="a931a750d6feadacbeecb321d73925cd5ebb6dfa7eff0802984af3aef63759f4"
+gcc_ver="9.3.0"
+gcc_sha256="5258a9b6afe9463c2e56b9e8355b1a4bee125ca828b8078f910303bc2ef91fa6"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh


### PR DESCRIPTION
This is needed for building the toolchain with Ubuntu 20.04.