### PR TITLE
Fix CELL_OPT ignoring CONSTRAINT for convergence criterion

### DIFF
--- a/src/motion/cell_opt_types.F
+++ b/src/motion/cell_opt_types.F
@@ -60,7 +60,7 @@ MODULE cell_opt_types
       INTEGER                                    :: constraint_id, id_nr, ref_count
       LOGICAL                                    :: keep_angles, &
                                                     keep_symmetry
-      REAL(KIND=dp)                              :: pres_ext, pres_int, pres_tol
+      REAL(KIND=dp)                              :: pres_ext, pres_int, pres_tol, pres_constr
       REAL(KIND=dp), DIMENSION(3, 3)             :: mtrx
       REAL(KIND=dp), DIMENSION(3, 3)             :: rot_matrix
       TYPE(cell_type), POINTER                   :: ref_cell

--- a/src/motion/cell_opt_utils.F
+++ b/src/motion/cell_opt_utils.F
@@ -255,11 +255,12 @@ CONTAINS
 !> \param keep_angles ...
 !> \param keep_symmetry ...
 !> \param pres_int ...
+!> \param pres_constr ...
 !> \param constraint_id ...
 !> \author Teodoro Laino [tlaino] - University of Zurich - 03.2008
 ! **************************************************************************************************
    SUBROUTINE get_dg_dh(gradient, av_ptens, pres_ext, cell, mtrx, keep_angles, &
-                        keep_symmetry, pres_int, constraint_id)
+                        keep_symmetry, pres_int, pres_constr, constraint_id)
 
       REAL(KIND=dp), DIMENSION(:), POINTER               :: gradient
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: av_ptens
@@ -267,12 +268,12 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: mtrx
       LOGICAL, INTENT(IN), OPTIONAL                      :: keep_angles, keep_symmetry
-      REAL(KIND=dp), INTENT(OUT)                         :: pres_int
+      REAL(KIND=dp), INTENT(OUT)                         :: pres_int, pres_constr
       INTEGER, INTENT(IN), OPTIONAL                      :: constraint_id
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_dg_dh', routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: my_constraint_id
+      INTEGER                                            :: i, my_constraint_id
       LOGICAL                                            :: my_keep_angles, my_keep_symmetry
       REAL(KIND=dp), DIMENSION(3, 3)                     :: correction, pten_hinv_old, ptens
 
@@ -292,23 +293,29 @@ CONTAINS
       ptens = av_ptens
 
       ! Evaluating the internal pressure
+      pres_int = 0.0_dp
+      DO i = 1, 3
+         pres_int = pres_int + ptens(i, i)
+      ENDDO
+      pres_int = pres_int/3.0_dp
+
       SELECT CASE (my_constraint_id)
       CASE (fix_x)
-         pres_int = ptens(2, 2) + ptens(3, 3)
+         pres_constr = ptens(2, 2) + ptens(3, 3)
       CASE (fix_y)
-         pres_int = ptens(1, 1) + ptens(3, 3)
+         pres_constr = ptens(1, 1) + ptens(3, 3)
       CASE (fix_z)
-         pres_int = ptens(1, 1) + ptens(2, 2)
+         pres_constr = ptens(1, 1) + ptens(2, 2)
       CASE (fix_xy)
-         pres_int = ptens(3, 3)
+         pres_constr = ptens(3, 3)
       CASE (fix_xz)
-         pres_int = ptens(2, 2)
+         pres_constr = ptens(2, 2)
       CASE (fix_yz)
-         pres_int = ptens(1, 1)
+         pres_constr = ptens(1, 1)
       CASE (fix_none)
-         pres_int = ptens(1, 1) + ptens(2, 2) + ptens(3, 3)
+         pres_constr = ptens(1, 1) + ptens(2, 2) + ptens(3, 3)
       END SELECT
-      pres_int = pres_int/3.0_dp
+      pres_constr = pres_constr/3.0_dp
 
       ptens(1, 1) = av_ptens(1, 1) - pres_ext
       ptens(2, 2) = av_ptens(2, 2) - pres_ext

--- a/src/motion/cell_opt_utils.F
+++ b/src/motion/cell_opt_utils.F
@@ -272,7 +272,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_dg_dh', routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: i, my_constraint_id
+      INTEGER                                            :: my_constraint_id
       LOGICAL                                            :: my_keep_angles, my_keep_symmetry
       REAL(KIND=dp), DIMENSION(3, 3)                     :: correction, pten_hinv_old, ptens
 
@@ -292,10 +292,22 @@ CONTAINS
       ptens = av_ptens
 
       ! Evaluating the internal pressure
-      pres_int = 0.0_dp
-      DO i = 1, 3
-         pres_int = pres_int + ptens(i, i)
-      ENDDO
+      SELECT CASE (my_constraint_id)
+      CASE (fix_x)
+         pres_int = ptens(2, 2) + ptens(3, 3)
+      CASE (fix_y)
+         pres_int = ptens(1, 1) + ptens(3, 3)
+      CASE (fix_z)
+         pres_int = ptens(1, 1) + ptens(2, 2)
+      CASE (fix_xy)
+         pres_int = ptens(3, 3)
+      CASE (fix_xz)
+         pres_int = ptens(2, 2)
+      CASE (fix_yz)
+         pres_int = ptens(1, 1)
+      CASE (fix_none)
+         pres_int = ptens(1, 1) + ptens(2, 2) + ptens(3, 3)
+      END SELECT
       pres_int = pres_int/3.0_dp
 
       ptens(1, 1) = av_ptens(1, 1) - pres_ext

--- a/src/motion/gopt_f77_methods.F
+++ b/src/motion/gopt_f77_methods.F
@@ -54,7 +54,8 @@ RECURSIVE SUBROUTINE cp_eval_at(gopt_env, x, f, gradient, master, &
                               nvt_ensemble, &
                               mol_dyn_run, &
                               geo_opt_run, &
-                              cell_opt_run
+                              cell_opt_run, &
+                              fix_none
    USE input_section_types, ONLY: section_vals_get, &
                                   section_vals_get_subs_vals, &
                                   section_vals_type, &
@@ -208,11 +209,14 @@ RECURSIVE SUBROUTINE cp_eval_at(gopt_env, x, f, gradient, master, &
                               keep_angles=gopt_env%cell_env%keep_angles, &
                               keep_symmetry=gopt_env%cell_env%keep_symmetry, &
                               pres_int=gopt_env%cell_env%pres_int, &
+                              pres_constr=gopt_env%cell_env%pres_constr, &
                               constraint_id=gopt_env%cell_env%constraint_id)
             END IF
             ! some callers expect pres_int to be available on all ranks. Also, here master is not necessarily a single rank.
             ! Assume at least master==0
             CALL mp_bcast(gopt_env%cell_env%pres_int, 0, para_env%group)
+            IF (gopt_env%cell_env%constraint_id /= fix_none) &
+               CALL mp_bcast(gopt_env%cell_env%pres_constr, 0, para_env%group)
          END IF
          CALL virial_release(virial_avg)
       CASE (default_cell_geo_opt_id, default_cell_md_id)
@@ -291,11 +295,14 @@ RECURSIVE SUBROUTINE cp_eval_at(gopt_env, x, f, gradient, master, &
                               keep_angles=gopt_env%cell_env%keep_angles, &
                               keep_symmetry=gopt_env%cell_env%keep_symmetry, &
                               pres_int=gopt_env%cell_env%pres_int, &
+                              pres_constr=gopt_env%cell_env%pres_constr, &
                               constraint_id=gopt_env%cell_env%constraint_id)
             END IF
             ! some callers expect pres_int to be available on all ranks. Also, here master is not necessarily a single rank.
             ! Assume at least master==0
             CALL mp_bcast(gopt_env%cell_env%pres_int, 0, para_env%group)
+            IF (gopt_env%cell_env%constraint_id /= fix_none) &
+               CALL mp_bcast(gopt_env%cell_env%pres_constr, 0, para_env%group)
          END IF
          CALL virial_release(virial_avg)
       CASE DEFAULT

--- a/src/motion/gopt_f_methods.F
+++ b/src/motion/gopt_f_methods.F
@@ -44,7 +44,8 @@ MODULE gopt_f_methods
                                               default_cell_method_id,&
                                               default_minimization_method_id,&
                                               default_shellcore_method_id,&
-                                              default_ts_method_id
+                                              default_ts_method_id,&
+                                              fix_none
    USE input_cp2k_restarts,             ONLY: write_restart
    USE input_section_types,             ONLY: section_vals_type
    USE kinds,                           ONLY: default_string_length,&
@@ -257,7 +258,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'gopt_f_io', routineP = moduleN//':'//routineN
 
-      REAL(KIND=dp)                                      :: pres_diff, pres_int, pres_tol
+      REAL(KIND=dp)                                      :: pres_diff, pres_diff_constr, pres_int, &
+                                                            pres_tol
 
       SELECT CASE (gopt_env%type_id)
       CASE (default_ts_method_id, default_minimization_method_id)
@@ -300,7 +302,12 @@ CONTAINS
             CPASSERT(PRESENT(ndf))
             CPASSERT(PRESENT(dx))
             CPASSERT(PRESENT(xi))
-            CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, pres_diff, pres_tol)
+            IF (gopt_env%cell_env%constraint_id == fix_none) THEN
+               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, pres_diff, pres_tol)
+            ELSE
+               pres_diff_constr = gopt_env%cell_env%pres_constr - gopt_env%cell_env%pres_ext
+               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, pres_diff, pres_tol, pres_diff_constr)
+            END IF
          END IF
       CASE (default_shellcore_method_id)
          CALL write_cycle_infos(output_unit, its, etot=opt_energy, ediff=opt_energy - eold, &
@@ -498,15 +505,17 @@ CONTAINS
 !> \param gopt_param ...
 !> \param pres_diff ...
 !> \param pres_tol ...
+!> \param pres_diff_constr ...
 ! **************************************************************************************************
-   SUBROUTINE check_converg(ndf, dr, g, output_unit, conv, gopt_param, pres_diff, pres_tol)
+   SUBROUTINE check_converg(ndf, dr, g, output_unit, conv, gopt_param, pres_diff, &
+                            pres_tol, pres_diff_constr)
 
       INTEGER, INTENT(IN)                                :: ndf
       REAL(KIND=dp), INTENT(IN)                          :: dr(ndf), g(ndf)
       INTEGER, INTENT(IN)                                :: output_unit
       LOGICAL, INTENT(OUT)                               :: conv
       TYPE(gopt_param_type), POINTER                     :: gopt_param
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pres_diff, pres_tol
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pres_diff, pres_tol, pres_diff_constr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'check_converg', routineP = moduleN//':'//routineN
 
@@ -550,7 +559,11 @@ CONTAINS
       IF (dumm > (rmsgcon*rmsgcon*ndf)) conv_rg = .FALSE.
       maxdum(4) = SQRT(dumm/ndf)
 
-      IF (PRESENT(pres_diff) .AND. PRESENT(pres_tol)) conv_p = ABS(pres_diff) < ABS(pres_tol)
+      IF (PRESENT(pres_diff_constr) .AND. PRESENT(pres_tol)) THEN
+         conv_p = ABS(pres_diff_constr) < ABS(pres_tol)
+      ELSEIF (PRESENT(pres_diff) .AND. PRESENT(pres_tol)) THEN
+         conv_p = ABS(pres_diff) < ABS(pres_tol)
+      END IF
 
       IF (output_unit > 0) THEN
          WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
@@ -610,8 +623,18 @@ CONTAINS
          END IF
          IF (PRESENT(pres_diff) .AND. PRESENT(pres_tol)) THEN
             tmp_r1 = cp_unit_from_cp2k(pres_diff, "bar")
-            WRITE (UNIT=output_unit, FMT="(T2,A,F20.10)") &
-               " Pressure Deviation [bar]   = ", tmp_r1
+            IF (PRESENT(pres_diff_constr)) THEN
+               WRITE (UNIT=output_unit, FMT="(T2,A,F20.10)") &
+                  " Pressure Deviation [bar]   = ", tmp_r1, &
+                  " (without constraint)"
+               tmp_r1 = cp_unit_from_cp2k(pres_diff_constr, "bar")
+               WRITE (UNIT=output_unit, FMT="(T2,A,F20.10)") &
+                  " Pressure Deviation [bar]   = ", tmp_r1, &
+                  " (with constraint)"
+            ELSE
+               WRITE (UNIT=output_unit, FMT="(T2,A,F20.10)") &
+                  " Pressure Deviation [bar]   = ", tmp_r1
+            END IF
             tmp_r1 = cp_unit_from_cp2k(pres_tol, "bar")
             WRITE (UNIT=output_unit, FMT="(T2,A,F20.10)") &
                " Pressure Tolerance [bar]   = ", tmp_r1

--- a/tests/Fist/regtest-opt/cell_opt_constraint_xy.inp
+++ b/tests/Fist/regtest-opt/cell_opt_constraint_xy.inp
@@ -26,7 +26,7 @@
   MAX_FORCE 0.0001
   MAX_ITER 200
   OPTIMIZER LBFGS
-  PRESSURE_TOLERANCE [bar] 1.0E6 # Disable this convergence check
+  PRESSURE_TOLERANCE [bar] 1.0E1 # Disable this convergence check
   RMS_DR 0.0003
   RMS_FORCE 0.00003
   TYPE direct_cell_opt

--- a/tests/Fist/regtest-opt/cell_opt_constraint_z.inp
+++ b/tests/Fist/regtest-opt/cell_opt_constraint_z.inp
@@ -26,7 +26,7 @@
   MAX_FORCE 0.0001
   MAX_ITER 200
   OPTIMIZER LBFGS
-  PRESSURE_TOLERANCE [bar] 1.0E6 # Disable this convergence check
+  PRESSURE_TOLERANCE [bar] 1.0E1 # Disable this convergence check
   RMS_DR 0.0003
   RMS_FORCE 0.00003
   TYPE direct_cell_opt


### PR DESCRIPTION
The internal pressure is calculated including dimensions fixed
with the CELL_OPT%CONSTRAINT keyword. This can result in
CELL_OPT simulations that never converge because the 
direction with remaining stress is not allowed to change. With
this patch only directions that are not constrained contribute
to the internal pressure when checking for convergence.