### PR TITLE
Fix segfault when using QM/MM added charges

### DIFF
--- a/src/qmmm_gpw_energy.F
+++ b/src/qmmm_gpw_energy.F
@@ -294,7 +294,7 @@ CONTAINS
                                           cube_info, para_env, eps_mm_rspace, qmmm_env%added_charges%pgfs, auxbas_grid, &
                                           coarser_grid, qmmm_env%added_charges%potentials, &
                                           mm_cell=mm_cell, dOmmOqm=qmmm_env%dOmmOqm, periodic=qmmm_env%periodic, &
-                                          per_potentials=qmmm_env%per_potentials, par_scheme=qmmm_env%par_scheme, &
+                                          per_potentials=qmmm_env%added_charges%per_potentials, par_scheme=qmmm_env%par_scheme, &
                                           qmmm_spherical_cutoff=qmmm_env%spherical_cutoff, shells=shells)
       END IF
       IF (qmmm_env%added_shells%num_mm_atoms .GT. 0) THEN

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -540,7 +540,7 @@ CONTAINS
                                            qmmm_env%added_charges%mm_atom_index, qmmm_env%added_charges%num_mm_atoms, &
                                        cube_info, para_env, eps_mm_rspace, auxbas_grid, coarser_grid, qmmm_env%added_charges%pgfs, &
                                            qmmm_env%added_charges%potentials, Forces_added_charges, aug_pools, mm_cell, &
-                                           qmmm_env%dOmmOqm, qmmm_env%periodic, qmmm_env%added_charges%per_potentials, iw, qmmm_env%par_scheme, &
+                              qmmm_env%dOmmOqm, qmmm_env%periodic, qmmm_env%added_charges%per_potentials, iw, qmmm_env%par_scheme, &
                                            qmmm_env%spherical_cutoff, shells)
       END IF
 

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -540,7 +540,7 @@ CONTAINS
                                            qmmm_env%added_charges%mm_atom_index, qmmm_env%added_charges%num_mm_atoms, &
                                        cube_info, para_env, eps_mm_rspace, auxbas_grid, coarser_grid, qmmm_env%added_charges%pgfs, &
                                            qmmm_env%added_charges%potentials, Forces_added_charges, aug_pools, mm_cell, &
-                                           qmmm_env%dOmmOqm, qmmm_env%periodic, qmmm_env%per_potentials, iw, qmmm_env%par_scheme, &
+                                           qmmm_env%dOmmOqm, qmmm_env%periodic, qmmm_env%added_charges%per_potentials, iw, qmmm_env%par_scheme, &
                                            qmmm_env%spherical_cutoff, shells)
       END IF
 


### PR DESCRIPTION
Added-charge only periodic potential data should be used instead of whole MM-part data
in corresponding parts of QM/MM code. Fixes #985.