### PR TITLE
NDEBUG: grid/collocate sample/driver code

### DIFF
--- a/src/grid/grid_collocate_miniapp.c
+++ b/src/grid/grid_collocate_miniapp.c
@@ -15,11 +15,11 @@ int main(int argc, char *argv[]){
     }
 
     int cycles;
-    assert(sscanf(argv[1], "%i", &cycles) == 1);
-    assert(cycles > 0);
+    GRID_COLLOCATE_ASSERT(sscanf(argv[1], "%i", &cycles) == 1);
+    GRID_COLLOCATE_ASSERT(cycles > 0);
 
     const double max_diff = grid_collocate_replay(argv[2], cycles);
-    assert(max_diff < 1e-14 * cycles);
+    GRID_COLLOCATE_ASSERT(max_diff < 1e-14 * cycles);
     return 0;
 }
 

--- a/src/grid/grid_collocate_replay.c
+++ b/src/grid/grid_collocate_replay.c
@@ -123,153 +123,153 @@ double grid_collocate_replay(const char* filename, const int cycles){
 
     char line[100], key[100];
 
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(strcmp(line, "#Grid collocate task v8\n") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(strcmp(line, "#Grid collocate task v8\n") == 0);
 
     int orthorhombic_i;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &orthorhombic_i) == 2);
-    assert(strcmp(key, "orthorhombic") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &orthorhombic_i) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "orthorhombic") == 0);
     bool orthorhombic = orthorhombic_i;
 
     int use_subpatch_i;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &use_subpatch_i) == 2);
-    assert(strcmp(key, "use_subpatch") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &use_subpatch_i) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "use_subpatch") == 0);
     bool use_subpatch = use_subpatch_i;
 
     int subpatch;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &subpatch) == 2);
-    assert(strcmp(key, "subpatch") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &subpatch) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "subpatch") == 0);
 
     int border;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &border) == 2);
-    assert(strcmp(key, "border") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &border) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "border") == 0);
 
     int func;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &func) == 2);
-    assert(strcmp(key, "func") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &func) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "func") == 0);
 
     int la_max;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &la_max) == 2);
-    assert(strcmp(key, "la_max") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &la_max) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "la_max") == 0);
 
     int la_min;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &la_min) == 2);
-    assert(strcmp(key, "la_min") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &la_min) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "la_min") == 0);
 
     int lb_max;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &lb_max) == 2);
-    assert(strcmp(key, "lb_max") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &lb_max) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "lb_max") == 0);
 
     int lb_min;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &lb_min) == 2);
-    assert(strcmp(key, "lb_min") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &lb_min) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "lb_min") == 0);
 
     double zeta;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %le", key, &zeta) == 2);
-    assert(strcmp(key, "zeta") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %le", key, &zeta) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "zeta") == 0);
 
     double zetb;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %le", key, &zetb) == 2);
-    assert(strcmp(key, "zetb") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %le", key, &zetb) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "zetb") == 0);
 
     double rscale;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %le", key, &rscale) == 2);
-    assert(strcmp(key, "rscale") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %le", key, &rscale) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "rscale") == 0);
 
     double dh[3][3];
     for (int i=0; i<3; i++) {
         int j;
-        assert(fgets(line, sizeof(line), fp) != NULL);
-        assert(sscanf(line, "%99s %i %le %le %le", key, &j, &dh[i][0], &dh[i][1], &dh[i][2]) == 5);
-        assert(strcmp(key, "dh") == 0 && i == j);
+        GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+        GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i %le %le %le", key, &j, &dh[i][0], &dh[i][1], &dh[i][2]) == 5);
+        GRID_COLLOCATE_ASSERT(strcmp(key, "dh") == 0 && i == j);
     }
 
     double dh_inv[3][3];
     for (int i=0; i<3; i++) {
         int j;
-        assert(fgets(line, sizeof(line), fp) != NULL);
-        assert(sscanf(line, "%99s %i %le %le %le", key, &j, &dh_inv[i][0], &dh_inv[i][1], &dh_inv[i][2]) == 5);
-        assert(strcmp(key, "dh_inv") == 0 && i == j);
+        GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+        GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i %le %le %le", key, &j, &dh_inv[i][0], &dh_inv[i][1], &dh_inv[i][2]) == 5);
+        GRID_COLLOCATE_ASSERT(strcmp(key, "dh_inv") == 0 && i == j);
     }
 
     double ra[3];
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %le %le %le", key, &ra[0], &ra[1], &ra[2]) == 4);
-    assert(strcmp(key, "ra") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %le %le %le", key, &ra[0], &ra[1], &ra[2]) == 4);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "ra") == 0);
 
     double rab[3];
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %le %le %le", key, &rab[0], &rab[1], &rab[2]) == 4);
-    assert(strcmp(key, "rab") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %le %le %le", key, &rab[0], &rab[1], &rab[2]) == 4);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "rab") == 0);
 
     int npts_global[3];
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i %i %i", key, &npts_global[0], &npts_global[1], &npts_global[2]) == 4);
-    assert(strcmp(key, "npts_global") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i %i %i", key, &npts_global[0], &npts_global[1], &npts_global[2]) == 4);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "npts_global") == 0);
 
     int npts_local[3];
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i %i %i", key, &npts_local[0], &npts_local[1], &npts_local[2]) == 4);
-    assert(strcmp(key, "npts_local") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i %i %i", key, &npts_local[0], &npts_local[1], &npts_local[2]) == 4);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "npts_local") == 0);
 
     int shift_local[3];
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i %i %i", key, &shift_local[0], &shift_local[1], &shift_local[2]) == 4);
-    assert(strcmp(key, "shift_local") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i %i %i", key, &shift_local[0], &shift_local[1], &shift_local[2]) == 4);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "shift_local") == 0);
 
     double radius;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %le", key, &radius) == 2);
-    assert(strcmp(key, "radius") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %le", key, &radius) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "radius") == 0);
 
     int o1;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &o1) == 2);
-    assert(strcmp(key, "o1") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &o1) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "o1") == 0);
 
     int o2;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &o2) == 2);
-    assert(strcmp(key, "o2") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &o2) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "o2") == 0);
 
     int n1;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &n1) == 2);
-    assert(strcmp(key, "n1") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &n1) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "n1") == 0);
 
     int n2;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &n2) == 2);
-    assert(strcmp(key, "n2") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &n2) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "n2") == 0);
 
     double pab[n2][n1];
     for (int i=0; i<n2; i++) {
     for (int j=0; j<n1; j++) {
         int i2, j2;
         double value;
-        assert(fgets(line, sizeof(line), fp) != NULL);
-        assert(sscanf(line, "%99s %i %i %le", key, &i2, &j2, &value) == 4);
-        assert(strcmp(key, "pab") == 0 && i == i2 && j==j2);
+        GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+        GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i %i %le", key, &i2, &j2, &value) == 4);
+        GRID_COLLOCATE_ASSERT(strcmp(key, "pab") == 0 && i == i2 && j==j2);
         pab[i][j] = value;
     }
     }
 
     int ngrid_nonzero;
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(sscanf(line, "%99s %i", key, &ngrid_nonzero) == 2);
-    assert(strcmp(key, "ngrid_nonzero") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i", key, &ngrid_nonzero) == 2);
+    GRID_COLLOCATE_ASSERT(strcmp(key, "ngrid_nonzero") == 0);
 
     const int npts_local_total = npts_local[0] * npts_local[1] * npts_local[2];
     const size_t sizeof_grid = sizeof(double) * npts_local_total;
@@ -279,14 +279,14 @@ double grid_collocate_replay(const char* filename, const int cycles){
     for (int n=0; n < ngrid_nonzero; n++) {
         int i, j, k;
         double value;
-        assert(fgets(line, sizeof(line), fp) != NULL);
-        assert(sscanf(line, "%99s %i %i %i %le", key, &i, &j, &k, &value) == 5);
-        assert(strcmp(key, "grid") == 0);
+        GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+        GRID_COLLOCATE_ASSERT(sscanf(line, "%99s %i %i %i %le", key, &i, &j, &k, &value) == 5);
+        GRID_COLLOCATE_ASSERT(strcmp(key, "grid") == 0);
         grid_ref[k*npts_local[1]*npts_local[0] + j*npts_local[0] + i] = value;
     }
 
-    assert(fgets(line, sizeof(line), fp) != NULL);
-    assert(strcmp(line, "#THE_END\n") == 0);
+    GRID_COLLOCATE_ASSERT(fgets(line, sizeof(line), fp) != NULL);
+    GRID_COLLOCATE_ASSERT(strcmp(line, "#THE_END\n") == 0);
 
     double* grid_test = malloc(sizeof_grid);
     memset(grid_test, 0, sizeof_grid);

--- a/src/grid/grid_collocate_replay.h
+++ b/src/grid/grid_collocate_replay.h
@@ -8,6 +8,12 @@
 
 #include <stdbool.h>
 
+#if defined(NDEBUG)
+# define GRID_COLLOCATE_ASSERT(EXPR) (void)(EXPR)
+#else
+# define GRID_COLLOCATE_ASSERT(EXPR) assert(EXPR)
+#endif
+
 void grid_collocate_record(const bool orthorhombic,
                            const bool use_subpatch,
                            const int subpatch,

--- a/src/grid/grid_collocate_unittest.c
+++ b/src/grid/grid_collocate_unittest.c
@@ -12,14 +12,14 @@
 static int run_test(const char cp2k_root_dir[], const char task_file[]) {
     char filename[1024] = "";
 
-    assert(strlen(cp2k_root_dir) < 512);
-    assert(strcpy(filename, cp2k_root_dir) != NULL);
+    GRID_COLLOCATE_ASSERT(strlen(cp2k_root_dir) < 512);
+    GRID_COLLOCATE_ASSERT(strcpy(filename, cp2k_root_dir) != NULL);
     if (filename[strlen(filename) - 1] != '/') {
-        assert(strcat(filename, "/") != NULL);
+        GRID_COLLOCATE_ASSERT(strcat(filename, "/") != NULL);
     }
 
-    assert(strcat(filename, "src/grid/sample_tasks/") != NULL);
-    assert(strcat(filename, task_file) != NULL);
+    GRID_COLLOCATE_ASSERT(strcat(filename, "src/grid/sample_tasks/") != NULL);
+    GRID_COLLOCATE_ASSERT(strcat(filename, task_file) != NULL);
 
     const double max_diff = grid_collocate_replay(filename, 1);
     if (max_diff > 1e-12) {


### PR DESCRIPTION
Introduced GRID_COLLOCATE_ASSERT to substitute "assert" in order to avoid eliding side-effects (NDEBUG).