### PR TITLE
Make cp2k + sirius cuda 11-compatible

### DIFF
--- a/tools/toolchain/Dockerfile.cuda_mkl
+++ b/tools/toolchain/Dockerfile.cuda_mkl
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+FROM nvidia/cuda:11.0-devel-ubuntu20.04
 ARG GPU_VERSION
 ARG LIBINT_LMAX=5
 

--- a/tools/toolchain/scripts/install_sirius.sh
+++ b/tools/toolchain/scripts/install_sirius.sh
@@ -2,8 +2,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")" && pwd -P)"
 
-sirius_ver="6.5.4"
-sirius_sha256="5f731926b882a567d117afa5e0ed33291f1db887fce52f371ba51f014209b85d"
+sirius_ver="6.5.5"
+sirius_sha256="0b23d3a8512682eea67aec57271031c65f465b61853a165015b38f7477651dd1"
 
 
 source "${SCRIPT_DIR}"/common_vars.sh

--- a/tools/toolchain/scripts/install_spfft.sh
+++ b/tools/toolchain/scripts/install_spfft.sh
@@ -2,8 +2,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")" && pwd -P)"
 
-spfft_ver="0.9.11"
-spfft_sha256="880aeddb6e88b4ce2ff88e78c6cac349359af10de0f4e909f305908852693593"
+spfft_ver="0.9.12"
+spfft_sha256="4bf879c6b3914bf5e462ef04a43656be559a8402755180301d99a080834d8fb3"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh


### PR DESCRIPTION
This is required for cuda 11 + cusolver support, but might still not be sufficient.

There seems to be an issue where SIRIUS is creating too many cuda streams. Locally I can make the tests pass with `TESTOPTS="-maxtasks 8"`

Ping @oschuett, you might want to give this a spin