### PR TITLE
Fix ADMM in combination with GW

### DIFF
--- a/src/mp2.F
+++ b/src/mp2.F
@@ -1378,6 +1378,7 @@ CONTAINS
          IF (do_kpoints_cubic_RPA) THEN
 
             CALL get_qs_env(qs_env, &
+                            admm_env=admm_env, &
                             matrix_ks_kp=matrix_ks_transl, &
                             rho=rho, &
                             input=input, &
@@ -1392,6 +1393,7 @@ CONTAINS
          ELSE
 
             CALL get_qs_env(qs_env, &
+                            admm_env=admm_env, &
                             matrix_ks=matrix_ks, &
                             rho=rho, &
                             input=input, &
@@ -1414,6 +1416,7 @@ CONTAINS
 
       ! If ADMM we should make the ks matrix up-to-date
       IF (dft_control%do_admm) THEN
+      CPASSERT(ASSOCIATED(admm_env))
       DO ispin = 1, SIZE(matrix_ks)
          CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks(ispin)%matrix)
       END DO

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -1416,10 +1416,10 @@ CONTAINS
 
       ! If ADMM we should make the ks matrix up-to-date
       IF (dft_control%do_admm) THEN
-      CPASSERT(ASSOCIATED(admm_env))
-      DO ispin = 1, SIZE(matrix_ks)
-         CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks(ispin)%matrix)
-      END DO
+         CPASSERT(ASSOCIATED(admm_env))
+         DO ispin = 1, SIZE(matrix_ks)
+            CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks(ispin)%matrix)
+         END DO
       END IF
 
       IF (do_kpoints_cubic_RPA) THEN

--- a/tests/QS/regtest-gw/G0W0_H2O_PBE0_ADMM.inp
+++ b/tests/QS/regtest-gw/G0W0_H2O_PBE0_ADMM.inp
@@ -1,0 +1,111 @@
+&GLOBAL
+  PROJECT G0W0_H2O_PBE0_ADMM
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+  &TIMINGS
+     THRESHOLD 0.01
+  &END
+&END GLOBAL
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME HFX_BASIS
+    BASIS_SET_FILE_NAME BASIS_ADMM
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &MGRID
+      CUTOFF  100
+      REL_CUTOFF  20
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      POISSON_SOLVER WAVELET
+    &END POISSON
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-15
+      EPS_PGF_ORB 1.0E-30
+    &END QS
+    &SCF
+      SCF_GUESS ATOMIC
+      EPS_SCF 1.0E-7
+      MAX_SCF 100
+      &PRINT
+        &RESTART OFF
+        &END
+      &END
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+        &PBE
+          SCALE_X 0.7500000
+          SCALE_C 1.0000000
+        &END
+      &END XC_FUNCTIONAL
+      &HF
+        FRACTION 0.2500000
+        &SCREENING
+          EPS_SCHWARZ 1.0E-6
+          SCREEN_ON_INITIAL_P FALSE
+        &END SCREENING
+      &END HF
+      &WF_CORRELATION
+        &INTEGRALS
+        &WFC_GPW
+          CUTOFF  100
+          REL_CUTOFF 20
+        &END WFC_GPW
+        &END INTEGRALS
+        &RI_RPA
+          &HF
+            FRACTION 1.0000000
+            &SCREENING
+              EPS_SCHWARZ 1.0E-6
+              SCREEN_ON_INITIAL_P FALSE
+            &END SCREENING
+          &END HF
+          RPA_NUM_QUAD_POINTS 10
+          &GW
+            CORR_MOS_OCC          10
+            CORR_MOS_VIRT         10
+            ANALYTIC_CONTINUATION TWO_POLE
+            NUMB_POLES            2
+            CROSSING_SEARCH       Z_SHOT 
+            FERMI_LEVEL_OFFSET    2.0E-2
+            EV_GW_ITER            1
+            UPDATE_XC_ENERGY
+          &END GW 
+        &END RI_RPA
+        MEMORY  200.
+        NUMBER_PROC  1
+      &END
+    &END XC
+    &AUXILIARY_DENSITY_MATRIX_METHOD
+      METHOD BASIS_PROJECTION
+      ADMM_PURIFICATION_METHOD NONE
+    &END AUXILIARY_DENSITY_MATRIX_METHOD
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom]  6.000   6.000  6.000
+      PERIODIC NONE
+    &END CELL
+    &KIND H
+      BASIS_SET DZVP-GTH
+      BASIS_SET RI_AUX RI_DZVP-GTH
+      BASIS_SET AUX_FIT cFIT3
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET DZVP-GTH
+      BASIS_SET RI_AUX RI_DZVP-GTH
+      BASIS_SET AUX_FIT cFIT3
+      POTENTIAL GTH-PBE-q6
+    &END KIND
+    &TOPOLOGY
+      COORD_FILE_NAME H2O_gas.xyz
+      COORD_FILE_FORMAT xyz
+      &CENTER_COORDINATES
+      &END
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-gw/TEST_FILES
+++ b/tests/QS/regtest-gw/TEST_FILES
@@ -1,4 +1,5 @@
 G0W0_H2O_PBE0.inp                                     11      1e-09            -17.092199812564395
+G0W0_H2O_PBE0_ADMM.inp                                11      1e-09            -17.094819020855002
 evGW_H2O_PBE.inp                                      11      1e-08            -17.052437673881482
 evGW_H2O_PBE_Fermi_level_offset.inp                   11      1e-08            -17.102203857645577
 evGW_OH_PBE.inp                                       11      1e-08            -16.414920515710477


### PR DESCRIPTION
We came across a segfault in a calculation that combines ADMM for the SCF (but not for HFX in RPA) and GW.

This led me to a pointer that was not associated with this combination of settings. This PR fixes the issue - the pointer `admm_env` is now assigned even in this case. I also added an assert and a regtest (based on `G0W0_H2O_PBE0.inp` with minimal changes) in case things change in the future.