### PR TITLE
Revert "toolchain: remove elpa parallel build issue workaround"

### DIFF
--- a/tools/toolchain/scripts/install_elpa.sh
+++ b/tools/toolchain/scripts/install_elpa.sh
@@ -15,7 +15,8 @@ source "${INSTALLDIR}"/toolchain.env
 ELPA_CFLAGS=''
 ELPA_LDFLAGS=''
 ELPA_LIBS=''
-ELPA_MAKEOPTS=''
+# ELPA 2019.05.001 has a parallel build issue, restricting to -j1
+ELPA_MAKEOPTS='-j1'
 
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"


### PR DESCRIPTION
Parallel build is still broken for ELPA, even with version 2020.05.001.

make.log of the failed build attempt is attached (unfortunately with German locales...). The build fails because test_check_correctness.mod cannot be found when compiling test/Fortran/test_skewsymmetric.F90. Reverting to non-parallel build fixed this issue for me.

This reverts commit 1bfbee43f079e74953c0272c2857024b6c29ea07 (#1022).

[make.log](https://github.com/cp2k/cp2k/files/5076625/make.log)

