### PR TITLE
Restore old `make pretty` as `make fpretty`, add pre-commit installation script and hook into Makefile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,16 +23,11 @@ repos:
     rev: master
     hooks:
     -   id: markdownlint
--   repo: git://github.com/doublify/pre-commit-clang-format
-    rev: master
+-   repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.1.1
     hooks:
-    -   id: clang-format
-        args: ['--style=llvm']
-        exclude: >-
-          (?x)^(
-            tools/manual/collapsibleList.js|
-            tools/manual/toggle_folding.js|
-          )$
+    -   id: shellcheck
+        files: '^tools/pre-commit-install.sh$'
 -   repo: local
     hooks:
     -   id: doxify
@@ -61,3 +56,16 @@ repos:
         language: system
         files: 'data/*'
         pass_filenames: false
+    -   id: clang-format
+        name: clang-format
+        description: Format files with ClangFormat.
+        entry: clang-format
+        language: python
+        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|textproto|vert)$
+        args: ['-i', '-fallback-style=none', '--style=llvm']
+        additional_dependencies: ['clang-format']
+        exclude: >-
+          (?x)^(
+            tools/manual/collapsibleList.js|
+            tools/manual/toggle_folding.js|
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-added-large-files
     -   id: check-ast
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: "19.10b0"
     hooks:
     -   id: black
         name: Reformat Python files with the black code formatter

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ endif
 .PHONY : $(VERSION) $(EXE_NAMES) \
          dirs makedep default_target all \
          toolversions extversions extclean libcp2k cp2k_shell exts python-bindings \
+         pre-commit pre-commit-clean \
          pretty precommit precommitclean doxygen/clean doxygen \
          fpretty fprettyclean \
          doxify doxifyclean \
@@ -425,6 +426,20 @@ TOOL_HELP += "precommit : Run precommit checks."
 precommitclean:
 	-rm -rf $(PRECOMMITDIR)
 TOOL_HELP += "precommitclean : Remove temporary files from precommit checks."
+
+# pre-commit script for manual execution ====================================
+
+pre-commit:
+	@$(TOOLSRC)/pre-commit-install.sh
+	@$(CP2KHOME)/.pre-commit-env/bin/pre-commit run -a
+
+TOOL_HELP += "pre-commit : Install pre-commit tools, register git hooks and run a full pre-commit check"
+
+pre-commit-clean:
+	-@$(CP2KHOME)/.pre-commit-env/bin/pre-commit uninstall
+	-@$(CP2KHOME)/.pre-commit-env/bin/pre-commit clean
+	-rm -rf $(CP2KHOME)/.pre-commit-env
+TOOL_HELP += "pre-commit-clean : Uninstall git hooks, drop the pre-commit tool cache and remove its environment"
 
 # data stuff ================================================================
 data: data/POTENTIAL

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ MAINLIBDIR   := $(CP2KHOME)/lib
 MAINOBJDIR   := $(CP2KHOME)/obj
 MAINTSTDIR   := $(CP2KHOME)/regtesting
 PRECOMMITDIR := $(CP2KHOME)/obj/precommit
+PRETTYOBJDIR := $(CP2KHOME)/obj/prettified
+DOXIFYOBJDIR := $(CP2KHOME)/obj/doxified
 TOOLSRC      := $(CP2KHOME)/tools
 SRCDIR       := $(CP2KHOME)/src
 EXEDIR       := $(MAINEXEDIR)/$(ARCH)
@@ -76,33 +78,37 @@ endif
          dirs makedep default_target all \
          toolversions extversions extclean libcp2k cp2k_shell exts python-bindings \
          pretty precommit precommitclean doxygen/clean doxygen \
+         fpretty fprettyclean \
+         doxify doxifyclean \
          install clean realclean distclean mrproper help \
          test testbg testclean testrealclean \
          data \
 	 $(EXTSPACKAGES)
 
 # Discover files and directories ============================================
-ALL_SRC_DIRS := $(shell find $(SRCDIR) -type d | awk '{printf("%s:",$$1)}')
-ALL_PKG_FILES  = $(shell find $(SRCDIR) -name "PACKAGE")
-OBJ_SRC_FILES  = $(shell cd $(SRCDIR); find . -name "*.F")
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . ! -path "*/python*" -name "*.c")
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -name "*.cpp")
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -name "*.cxx")
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -name "*.cc")
+ALL_SRC_DIRS := $(shell find $(SRCDIR) -type d ! -name preprettify | awk '{printf("%s:",$$1)}')
+ALL_PREPRETTY_DIRS = $(shell find $(SRCDIR) -type d -name preprettify)
+
+ALL_PKG_FILES  = $(shell find $(SRCDIR) ! -path "*/preprettify/*" -name "PACKAGE")
+OBJ_SRC_FILES  = $(shell cd $(SRCDIR); find . ! -path "*/preprettify/*" -name "*.F")
+OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . ! -path "*/preprettify/*" ! -path "*/python*" -name "*.c")
+OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . ! -path "*/preprettify/*" -name "*.cpp")
+OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . ! -path "*/preprettify/*" -name "*.cxx")
+OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . ! -path "*/preprettify/*" -name "*.cc")
 ifneq ($(NVCC),)
-OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . -name "*.cu")
+OBJ_SRC_FILES += $(shell cd $(SRCDIR); find . ! -path "*/preprettify/*" -name "*.cu")
 endif
 
 # Included files used by Fypp preprocessor and standard includes
-INCLUDED_SRC_FILES = $(filter-out base_uses.f90, $(notdir $(shell find $(SRCDIR) -name "*.f90")))
+INCLUDED_SRC_FILES = $(filter-out base_uses.f90, $(notdir $(shell find $(SRCDIR) ! -path "*/preprettify/*" -name "*.f90")))
 
 # Include also source files which won't compile into an object file
 ALL_SRC_FILES  = $(strip $(subst $(NULL) .,$(NULL) $(SRCDIR),$(NULL) $(OBJ_SRC_FILES)))
-ALL_SRC_FILES += $(filter-out base_uses.f90, $(shell find $(SRCDIR) -name "*.f90"))
-ALL_SRC_FILES += $(shell find $(SRCDIR) -name "*.h")
-ALL_SRC_FILES += $(shell find $(SRCDIR) -name "*.hpp")
-ALL_SRC_FILES += $(shell find $(SRCDIR) -name "*.hxx")
-ALL_SRC_FILES += $(shell find $(SRCDIR) -name "*.hcc")
+ALL_SRC_FILES += $(filter-out base_uses.f90, $(shell find $(SRCDIR) ! -path "*/preprettify/*" -name "*.f90"))
+ALL_SRC_FILES += $(shell find $(SRCDIR) ! -path "*/preprettify/*" -name "*.h")
+ALL_SRC_FILES += $(shell find $(SRCDIR) ! -path "*/preprettify/*" -name "*.hpp")
+ALL_SRC_FILES += $(shell find $(SRCDIR) ! -path "*/preprettify/*" -name "*.hxx")
+ALL_SRC_FILES += $(shell find $(SRCDIR) ! -path "*/preprettify/*" -name "*.hcc")
 
 ALL_OBJECTS        = $(addsuffix .o, $(basename $(notdir $(OBJ_SRC_FILES))))
 ALL_EXE_OBJECTS    = $(addsuffix .o, $(EXE_NAMES))
@@ -325,9 +331,67 @@ OTHER_HELP += "testrealclean : Remove all LAST-* and TEST-* files for given ARCH
 #
 # Remove all files from previous builds
 #
-distclean: precommitclean testrealclean
+distclean: precommitclean fprettyclean doxifyclean testrealclean
 	rm -rf $(DOXYGENDIR) $(MAINEXEDIR) $(MAINOBJDIR) $(MAINLIBDIR) $(MAINTSTDIR)
 OTHER_HELP += "distclean : Remove all files from previous builds"
+
+# Prettyfier stuff ==========================================================
+vpath %.pretty $(PRETTYOBJDIR)
+
+fpretty: $(addprefix $(PRETTYOBJDIR)/, $(ALL_OBJECTS:.o=.pretty)) $(addprefix $(PRETTYOBJDIR)/, $(INCLUDED_SRC_FILES:.f90=.pretty_included))
+TOOL_HELP += "fpretty : Reformat all Fortran source files in a pretty way."
+
+fprettyclean:
+	-rm -rf $(PRETTYOBJDIR) $(ALL_PREPRETTY_DIRS)
+TOOL_HELP += "fprettyclean : Remove prettify marker files and preprettify directories"
+
+$(PRETTYOBJDIR)/%.pretty: %.F $(DOXIFYOBJDIR)/%.doxified
+	@mkdir -p $(PRETTYOBJDIR)
+	cd $(dir $<); $(TOOLSRC)/prettify/prettify.py --do-backup --backup-dir=$(PRETTYOBJDIR) $(notdir $<)
+	@touch $@
+
+$(PRETTYOBJDIR)/%.pretty_included: %.f90 $(DOXIFYOBJDIR)/%.doxified_included
+	@mkdir -p $(PRETTYOBJDIR)
+	cd $(dir $<); $(TOOLSRC)/prettify/prettify.py --do-backup --backup-dir=$(PRETTYOBJDIR) $(notdir $<)
+	@touch $@
+
+$(PRETTYOBJDIR)/%.pretty: %.c $(DOXIFYOBJDIR)/%.doxified
+#   TODO: call indent here?
+	@mkdir -p $(PRETTYOBJDIR)
+	@touch $@
+
+$(PRETTYOBJDIR)/%.pretty: %.cpp $(DOXIFYOBJDIR)/%.doxified
+#   TODO: call indent here?
+	@mkdir -p $(PRETTYOBJDIR)
+	@touch $@
+
+# Doxyifier stuff ===========================================================
+vpath %.doxified $(DOXIFYOBJDIR)
+
+doxify: $(addprefix $(DOXIFYOBJDIR)/, $(ALL_OBJECTS:.o=.doxified)) $(addprefix $(DOXIFYOBJDIR)/, $(INCLUDED_SRC_FILES:.f90=.doxified_included))
+TOOL_HELP += "doxify : Autogenerate doxygen headers for subroutines"
+
+doxifyclean:
+	-rm -rf $(DOXIFYOBJDIR)
+TOOL_HELP += "doxifyclean : Remove doxify marker files"
+
+$(DOXIFYOBJDIR)/%.doxified: %.F
+	$(TOOLSRC)/doxify/doxify.sh $<
+	@mkdir -p $(DOXIFYOBJDIR)
+	@touch $@
+
+$(DOXIFYOBJDIR)/%.doxified_included: %.f90
+	$(TOOLSRC)/doxify/doxify.sh $<
+	@mkdir -p $(DOXIFYOBJDIR)
+	@touch $@
+
+$(DOXIFYOBJDIR)/%.doxified: %.c
+	@mkdir -p $(DOXIFYOBJDIR)
+	@touch $@
+
+$(DOXIFYOBJDIR)/%.doxified: %.cpp
+	@mkdir -p $(DOXIFYOBJDIR)
+	@touch $@
 
 # doxygen stuff =============================================================
 doxygen/clean:

--- a/tools/pre-commit-install.sh
+++ b/tools/pre-commit-install.sh
@@ -1,0 +1,88 @@
+#!/bin/sh -l
+# author: Tiziano Müller
+# SPDX-License-Identifier: MIT
+
+set -o errexit
+set -o nounset
+
+PYTHON=$(command -v python3 || true)
+
+if [ x"${PYTHON}" = "x" ] ; then
+    echo "ERROR: the python3 executable could not be found, but is required for the complete build process"
+    exit 1
+fi
+
+SCRIPTDIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+
+# here we assume that this script is located in the tools/ subfolder
+ENVDIR="${SCRIPTDIR}/../.pre-commit-env"
+
+if [ -f "${ENVDIR}/bootstrap_done" ] ; then
+    echo "The environment in <CP2K-SRC-DIR>/.pre-commit-env/ is ready to use..."
+    exit 0
+fi
+
+echo "Installing all required tools to run pre-commit in <CP2K-SRC-DIR>/.pre-commit-env/"
+
+echo "Creating the virtualenv for pre-commit..."
+if [ ! -d "${ENVDIR}" ] ; then
+    "${PYTHON}" -m venv "${ENVDIR}"
+fi
+
+# resolve the relative path now that we have it:
+ENVDIR=$(CDPATH='' cd -- "${ENVDIR}" && pwd)
+
+# shellcheck source=/dev/null
+. "${ENVDIR}/bin/activate"
+
+# change the command to the prefixed one for the rest of the script:
+PYTHON=$(command -v python)
+PIP=$(command -v pip || true)
+
+if [ x"${PIP}" = "x" ] ; then
+    echo "Bootstrapping the pip command inside the virtual environment..."
+
+    FETCHER="$(command -v curl || true)"
+    FETCHER_OPTS=""
+
+    if [ x"${FETCHER}" = "x" ] ; then
+        FETCHER="$(command -v wget || true)"
+        FETCHER_OPTS="-O-"
+    fi
+
+    if [ x"${FETCHER}" = "x" ] ; then
+        echo "ERROR: neither wget nor curl seem to be available, please download"
+        echo "    https://bootstrap.pypa.io/get-pip.py"
+        echo "manually and run:"
+        echo "    python3 get-pip.py"
+        echo "to install the pip command, then rerun this script."
+        rm -rf "${ENVDIR}"  # cleaning up to avoid picking up the unprefixed pip on the rerun
+        exit 1
+    fi
+
+    "${FETCHER}" ${FETCHER_OPTS} "https://bootstrap.pypa.io/get-pip.py" | "${PYTHON}"
+fi
+
+PIP=$(command -v pip)
+
+echo "Installing pre-commit..."
+"${PIP}" install pre-commit
+# this will also install things like shellcheck and a pre-built node if necessary
+
+PRE_COMMIT=$(command -v pre-commit)
+
+echo "Letting pre-commit setup the rest..."
+"${PRE_COMMIT}" install --install-hooks
+
+echo "successfully bootstrapped at $(date) by $0" > "${ENVDIR}/bootstrap_done"
+
+echo ""
+echo "All done: pre-commit will now run on each 'git commit' on the files you are committing!"
+
+echo ""
+echo "Should you need to run it manually, use"
+echo ""
+echo "    ${ENVDIR}/bin/pre-commit"
+echo ""
+echo "or add the directory ${ENVDIR}/bin to your \$PATH variable."
+echo "Happy hacking! :)"


### PR DESCRIPTION
This reverts parts of commit 1525887a18b79688d8ee2d66285ece64b699e213
due to regressions:

- the cloud-based replacement does not scale with the number of local
processors while the old (local) behavior did, meaning that it takes
some key devs 4-5 times longer now to run `make pretty`, depending on
the number of local cores
- since the tools run on the complete codebase (including Python and
C/C++ files), developers relying on the previous behavior of `make pretty`
now get possibly more unrelated changes, interrupting their workflow
further
- `make pretty` is used outside of a commit scenario, for example when
when developers are refactoring code to automatically remove unused
variables, sorting the declaration section, etc. hence pre-commit is not a drop-in replacement