### PR TITLE
grid: collection of minor code changes

### DIFF
--- a/src/grid/common/grid_common.h
+++ b/src/grid/common/grid_common.h
@@ -40,18 +40,18 @@ static const double fac[] = {
     0.26525285981219105864E+33};
 
 //******************************************************************************
-// \brief Macros for integer minimum and maximum (missing from the C standard)
+// \brief Minimum and maximum for integers (missing from the C standard)
 // \author Ole Schuett
 //******************************************************************************
-#define LIBGRID_MIN(x, y) (((x) < (y)) ? x : y)
-#define LIBGRID_MAX(x, y) (((x) > (y)) ? x : y)
+inline int imin(int x, int y) { return (x < y ? x : y); }
+inline int imax(int x, int y) { return (x > y ? x : y); }
 
 //******************************************************************************
 // \brief Equivalent of Fortran's MODULO, which always return a positive number.
 //        https://gcc.gnu.org/onlinedocs/gfortran/MODULO.html
 // \author Ole Schuett
 //******************************************************************************
-#define LIBGRID_MOD(a, m) (((a) % (m) + (m)) % (m))
+inline int modulo(int a, int m) { return ((a % m + m) % m); }
 
 #endif // GRID_COMMON_H
 

--- a/src/grid/common/grid_common.h
+++ b/src/grid/common/grid_common.h
@@ -40,18 +40,18 @@ static const double fac[] = {
     0.26525285981219105864E+33};
 
 //******************************************************************************
-// \brief Macros for minimum and maximum as they are missing from the C standard
+// \brief Macros for integer minimum and maximum (missing from the C standard)
 // \author Ole Schuett
 //******************************************************************************
-#define min(x, y) (((x) < (y)) ? x : y)
-#define max(x, y) (((x) > (y)) ? x : y)
+#define LIBGRID_MIN(x, y) (((x) < (y)) ? x : y)
+#define LIBGRID_MAX(x, y) (((x) > (y)) ? x : y)
 
 //******************************************************************************
 // \brief Equivalent of Fortran's MODULO, which always return a positive number.
 //        https://gcc.gnu.org/onlinedocs/gfortran/MODULO.html
 // \author Ole Schuett
 //******************************************************************************
-#define modulo(a, m) (((a) % (m) + (m)) % (m))
+#define LIBGRID_MOD(a, m) (((a) % (m) + (m)) % (m))
 
 #endif // GRID_COMMON_H
 

--- a/src/grid/grid_collocate_miniapp.c
+++ b/src/grid/grid_collocate_miniapp.c
@@ -18,7 +18,7 @@ void mpi_sum_func(long *number, int mpi_comm) {
 }
 
 void print_func(char *message, int output_unit) {
-  output_unit += 0; // Pretent argument is used.
+  output_unit += 0; // Pretend argument is used.
   printf("%s", message);
 }
 
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 
   // All optional args have been parsed.
   if (argc - iarg != nrequired_args) {
-    fprintf(stderr, "Usage: grid_base_ref_miniapp.x [--batch "
+    fprintf(stderr, "Usage: grid_collocate_miniapp.x [--batch "
                     "<cycles-per-block>] <cycles> <task-file>\n");
     return 1;
   }

--- a/src/grid/grid_collocate_unittest.c
+++ b/src/grid/grid_collocate_unittest.c
@@ -18,7 +18,7 @@ void mpi_sum_func(long *number, int mpi_comm) {
 }
 
 void print_func(char *message, int output_unit) {
-  output_unit += 0; // Pretent argument is used.
+  output_unit += 0; // Pretend argument is used.
   printf("%s", message);
 }
 
@@ -54,7 +54,7 @@ static int run_test(const char cp2k_root_dir[], const char task_file[]) {
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {
-    printf("Usage: grid_base_ref_unittest.x <cp2k-root-dir>\n");
+    printf("Usage: grid_collocate_unittest.x <cp2k-root-dir>\n");
     return 1;
   }
 

--- a/src/grid/grid_task_list.c
+++ b/src/grid/grid_task_list.c
@@ -165,7 +165,7 @@ void grid_collocate_task_list(
                             j * npts_local[level][0] + i;
             const double ref_value = grid_ref[level][idx];
             const double diff = fabs(grid[level][idx] - ref_value);
-            const double rel_diff = diff / max(1.0, fabs(ref_value));
+            const double rel_diff = diff / fmax(1.0, fabs(ref_value));
             if (rel_diff > tolerance) {
               printf("Error: Grid validation failure\n");
               printf("   diff:     %le\n", diff);

--- a/src/grid/ref/grid_ref_collocate.c
+++ b/src/grid/ref/grid_ref_collocate.c
@@ -92,8 +92,8 @@ static void prepare_coef(const int la_max, const int la_min, const int lb_max,
           for (int i = 0; i <= lxpm; i++) {
             coef_xtt[i] = 0.0;
           }
-          for (int lxb = LIBGRID_MAX(lb_min - lzb - lyb, 0); lxb <= lb_max - lzb - lyb;
-               lxb++) {
+          for (int lxb = LIBGRID_MAX(lb_min - lzb - lyb, 0);
+               lxb <= lb_max - lzb - lyb; lxb++) {
             for (int lxa = LIBGRID_MAX(la_min - lza - lya, 0);
                  lxa <= la_max - lza - lya; lxa++) {
               const int ico = coset(lxa, lya, lza);
@@ -233,21 +233,24 @@ static void collocate_core_simple(
   const int kgmin = ceil(-1e-8 - disr_radius * dh_inv[2][2]);
   for (int kg = kgmin; kg <= 1 - kgmin; kg++) {
     const int ka = cubecenter[2] + kg - shift_local[2];
-    const int k = LIBGRID_MOD(ka, npts_global[2]); // target location on the grid
-    const int kd = (2 * kg - 1) / 2; // distance from center in grid points
-    const double kr = kd * dh[2][2]; // distance from center in a.u.
+    const int k =
+        LIBGRID_MOD(ka, npts_global[2]); // target location on the grid
+    const int kd = (2 * kg - 1) / 2;     // distance from center in grid points
+    const double kr = kd * dh[2][2];     // distance from center in a.u.
     const double kremain = disr_radius * disr_radius - kr * kr;
     const int jgmin = ceil(-1e-8 - sqrt(fmax(0.0, kremain)) * dh_inv[1][1]);
     for (int jg = jgmin; jg <= 1 - jgmin; jg++) {
       const int ja = cubecenter[1] + jg - shift_local[1];
-      const int j = LIBGRID_MOD(ja, npts_global[1]); // target location on the grid
+      const int j =
+          LIBGRID_MOD(ja, npts_global[1]); // target location on the grid
       const int jd = (2 * jg - 1) / 2; // distance from center in grid points
       const double jr = jd * dh[1][1]; // distance from center in a.u.
       const double jremain = kremain - jr * jr;
       const int igmin = ceil(-1e-8 - sqrt(fmax(0.0, jremain)) * dh_inv[0][0]);
       for (int ig = igmin; ig <= 1 - igmin; ig++) {
         const int ia = cubecenter[0] + ig - shift_local[0];
-        const int i = LIBGRID_MOD(ia, npts_global[0]); // target location on the grid
+        const int i =
+            LIBGRID_MOD(ia, npts_global[0]); // target location on the grid
         const int grid_index =
             k * npts_local[1] * npts_local[0] + j * npts_local[0] + i;
         const int cube_index = (kg - lb_cube[2]) * ny * nx +
@@ -418,7 +421,8 @@ static void collocate_ortho(const int lp, const double zetp,
     // If grid is not period check that cube fits without wrapping.
     if (npts_global[i] != npts_local[i]) {
       const int offset =
-          LIBGRID_MOD(cubecenter[i] + lb_cube[i] - shift_local[i], npts_global[i]) -
+          LIBGRID_MOD(cubecenter[i] + lb_cube[i] - shift_local[i],
+                      npts_global[i]) -
           lb_cube[i];
       assert(offset + ub_cube[i] < npts_local[i]);
       assert(offset + lb_cube[i] >= 0);

--- a/src/grid/ref/grid_ref_collocate.c
+++ b/src/grid/ref/grid_ref_collocate.c
@@ -92,9 +92,9 @@ static void prepare_coef(const int la_max, const int la_min, const int lb_max,
           for (int i = 0; i <= lxpm; i++) {
             coef_xtt[i] = 0.0;
           }
-          for (int lxb = LIBGRID_MAX(lb_min - lzb - lyb, 0);
-               lxb <= lb_max - lzb - lyb; lxb++) {
-            for (int lxa = LIBGRID_MAX(la_min - lza - lya, 0);
+          for (int lxb = imax(lb_min - lzb - lyb, 0); lxb <= lb_max - lzb - lyb;
+               lxb++) {
+            for (int lxa = imax(la_min - lza - lya, 0);
                  lxa <= la_max - lza - lya; lxa++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -137,7 +137,7 @@ static void fill_map(const int lb_cube, const int ub_cube, const int cubecenter,
   }
 
   for (int ig = lb_cube; ig <= ub_cube; ig++) {
-    map[ig + cmax] = LIBGRID_MOD(cubecenter + ig - shift_local, npts_global);
+    map[ig + cmax] = modulo(cubecenter + ig - shift_local, npts_global);
   }
 }
 
@@ -233,24 +233,21 @@ static void collocate_core_simple(
   const int kgmin = ceil(-1e-8 - disr_radius * dh_inv[2][2]);
   for (int kg = kgmin; kg <= 1 - kgmin; kg++) {
     const int ka = cubecenter[2] + kg - shift_local[2];
-    const int k =
-        LIBGRID_MOD(ka, npts_global[2]); // target location on the grid
-    const int kd = (2 * kg - 1) / 2;     // distance from center in grid points
-    const double kr = kd * dh[2][2];     // distance from center in a.u.
+    const int k = modulo(ka, npts_global[2]); // target location on the grid
+    const int kd = (2 * kg - 1) / 2; // distance from center in grid points
+    const double kr = kd * dh[2][2]; // distance from center in a.u.
     const double kremain = disr_radius * disr_radius - kr * kr;
     const int jgmin = ceil(-1e-8 - sqrt(fmax(0.0, kremain)) * dh_inv[1][1]);
     for (int jg = jgmin; jg <= 1 - jgmin; jg++) {
       const int ja = cubecenter[1] + jg - shift_local[1];
-      const int j =
-          LIBGRID_MOD(ja, npts_global[1]); // target location on the grid
+      const int j = modulo(ja, npts_global[1]); // target location on the grid
       const int jd = (2 * jg - 1) / 2; // distance from center in grid points
       const double jr = jd * dh[1][1]; // distance from center in a.u.
       const double jremain = kremain - jr * jr;
       const int igmin = ceil(-1e-8 - sqrt(fmax(0.0, jremain)) * dh_inv[0][0]);
       for (int ig = igmin; ig <= 1 - igmin; ig++) {
         const int ia = cubecenter[0] + ig - shift_local[0];
-        const int i =
-            LIBGRID_MOD(ia, npts_global[0]); // target location on the grid
+        const int i = modulo(ia, npts_global[0]); // target location on the grid
         const int grid_index =
             k * npts_local[1] * npts_local[0] + j * npts_local[0] + i;
         const int cube_index = (kg - lb_cube[2]) * ny * nx +
@@ -421,8 +418,7 @@ static void collocate_ortho(const int lp, const double zetp,
     // If grid is not period check that cube fits without wrapping.
     if (npts_global[i] != npts_local[i]) {
       const int offset =
-          LIBGRID_MOD(cubecenter[i] + lb_cube[i] - shift_local[i],
-                      npts_global[i]) -
+          modulo(cubecenter[i] + lb_cube[i] - shift_local[i], npts_global[i]) -
           lb_cube[i];
       assert(offset + ub_cube[i] < npts_local[i]);
       assert(offset + lb_cube[i] >= 0);
@@ -432,7 +428,7 @@ static void collocate_ortho(const int lp, const double zetp,
   // cmax = MAXVAL(ub_cube)
   int cmax = INT_MIN;
   for (int i = 0; i < 3; i++) {
-    cmax = LIBGRID_MAX(cmax, ub_cube[i]);
+    cmax = imax(cmax, ub_cube[i]);
   }
 
   double pol_mutable[3][lp + 1][2 * cmax + 1];
@@ -603,8 +599,8 @@ static void collocate_general(const int border_mask, const int lp,
         for (int idir = 0; idir < 3; idir++) {
           const double resc =
               dh_inv[0][idir] * x + dh_inv[1][idir] * y + dh_inv[2][idir] * z;
-          index_min[idir] = LIBGRID_MIN(index_min[idir], floor(resc));
-          index_max[idir] = LIBGRID_MAX(index_max[idir], ceil(resc));
+          index_min[idir] = imin(index_min[idir], floor(resc));
+          index_max[idir] = imax(index_max[idir], ceil(resc));
         }
       }
     }
@@ -612,7 +608,7 @@ static void collocate_general(const int border_mask, const int lp,
 
   // go over the grid, but cycle if the point is not within the radius
   for (int k = index_min[2]; k <= index_max[2]; k++) {
-    const int k_index = LIBGRID_MOD(k - shift_local[2], npts_global[2]);
+    const int k_index = modulo(k - shift_local[2], npts_global[2]);
     if (k_index < bounds[2][0] || bounds[2][1] < k_index) {
       continue;
     }
@@ -639,7 +635,7 @@ static void collocate_general(const int border_mask, const int lp,
     }
 
     for (int j = index_min[1]; j <= index_max[1]; j++) {
-      const int j_index = LIBGRID_MOD(j - shift_local[1], npts_global[1]);
+      const int j_index = modulo(j - shift_local[1], npts_global[1]);
       if (j_index < bounds[1][0] || bounds[1][1] < j_index) {
         continue;
       }
@@ -694,7 +690,7 @@ static void collocate_general(const int border_mask, const int lp,
       const int ismax = floor((-b + sqrt_d) / (2.0 * a));
 
       for (int i = ismin; i <= ismax; i++) {
-        const int i_index = LIBGRID_MOD(i - shift_local[0], npts_global[0]);
+        const int i_index = modulo(i - shift_local[0], npts_global[0]);
         if (i_index < bounds[0][0] || bounds[0][1] < i_index) {
           continue;
         }
@@ -756,8 +752,8 @@ void grid_ref_collocate_pgf_product(
   grid_ref_prepare_get_ldiffs(func, &la_min_diff, &la_max_diff, &lb_min_diff,
                               &lb_max_diff);
 
-  const int la_min_prep = LIBGRID_MAX(la_min + la_min_diff, 0);
-  const int lb_min_prep = LIBGRID_MAX(lb_min + lb_min_diff, 0);
+  const int la_min_prep = imax(la_min + la_min_diff, 0);
+  const int lb_min_prep = imax(lb_min + lb_min_diff, 0);
   const int la_max_prep = la_max + la_max_diff;
   const int lb_max_prep = lb_max + lb_max_diff;
   const int lp = la_max_prep + lb_max_prep;

--- a/src/grid/ref/grid_ref_prepare_pab.c
+++ b/src/grid/ref/grid_ref_prepare_pab.c
@@ -40,8 +40,8 @@ static void prepare_pab_AB(const int o1, const int o2, const int la_max,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
@@ -76,8 +76,8 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
@@ -172,8 +172,8 @@ static void prepare_pab_ADBmDAB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
@@ -257,8 +257,8 @@ static void prepare_pab_ARDBmDARB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
@@ -416,8 +416,8 @@ static void prepare_pab_DABpADB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
@@ -501,8 +501,8 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
@@ -644,8 +644,8 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
@@ -658,7 +658,8 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
 
               if ((ider1 == 1 && ider2 == 2) || (ider1 == 2 && ider2 == 1)) {
                 // xy
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), LIBGRID_MAX(lya - 1, 0),
+                              lza);
                 func_a = lxa * lya * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -677,7 +678,8 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
               } else if ((ider1 == 2 && ider2 == 3) ||
                          (ider1 == 3 && ider2 == 2)) {
                 // yz
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0),
+                              LIBGRID_MAX(lza - 1, 0));
                 func_a = lya * lza * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -696,7 +698,8 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
               } else if ((ider1 == 3 && ider2 == 1) ||
                          (ider1 == 1 && ider2 == 3)) {
                 // zx
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya,
+                              LIBGRID_MAX(lza - 1, 0));
                 func_a = lza * lxa * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -784,8 +787,8 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
-               lza++) {
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
+               lza <= la_max - lxa - lya; lza++) {
             for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);

--- a/src/grid/ref/grid_ref_prepare_pab.c
+++ b/src/grid/ref/grid_ref_prepare_pab.c
@@ -40,9 +40,9 @@ static void prepare_pab_AB(const int o1, const int o2, const int la_max,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -76,9 +76,9 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -87,16 +87,16 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
               // x  (all safe if lxa = 0, as the spurious added terms have zero
               // prefactor)
 
-              ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
-              jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
+              ico_l = coset(imax(lxa - 1, 0), lya, lza);
+              jco_l = coset(imax(lxb - 1, 0), lyb, lzb);
               pab_prep[jco_l][ico_l] +=
                   0.5 * lxa * lxb * pab[o2 + jco][o1 + ico];
-              ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+              ico_l = coset(imax(lxa - 1, 0), lya, lza);
               jco_l = coset((lxb + 1), lyb, lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * lxa * zetb * pab[o2 + jco][o1 + ico];
               ico_l = coset((lxa + 1), lya, lza);
-              jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
+              jco_l = coset(imax(lxb - 1, 0), lyb, lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * zeta * lxb * pab[o2 + jco][o1 + ico];
               ico_l = coset((lxa + 1), lya, lza);
@@ -106,16 +106,16 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
 
               // y
 
-              ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
-              jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
+              ico_l = coset(lxa, imax(lya - 1, 0), lza);
+              jco_l = coset(lxb, imax(lyb - 1, 0), lzb);
               pab_prep[jco_l][ico_l] +=
                   0.5 * lya * lyb * pab[o2 + jco][o1 + ico];
-              ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+              ico_l = coset(lxa, imax(lya - 1, 0), lza);
               jco_l = coset(lxb, (lyb + 1), lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * lya * zetb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, (lya + 1), lza);
-              jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
+              jco_l = coset(lxb, imax(lyb - 1, 0), lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * zeta * lyb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, (lya + 1), lza);
@@ -125,16 +125,16 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
 
               // z
 
-              ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
-              jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
+              ico_l = coset(lxa, lya, imax(lza - 1, 0));
+              jco_l = coset(lxb, lyb, imax(lzb - 1, 0));
               pab_prep[jco_l][ico_l] +=
                   0.5 * lza * lzb * pab[o2 + jco][o1 + ico];
-              ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+              ico_l = coset(lxa, lya, imax(lza - 1, 0));
               jco_l = coset(lxb, lyb, (lzb + 1));
               pab_prep[jco_l][ico_l] +=
                   -1.0 * lza * zetb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, lya, (lza + 1));
-              jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
+              jco_l = coset(lxb, lyb, imax(lzb - 1, 0));
               pab_prep[jco_l][ico_l] +=
                   -1.0 * zeta * lzb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, lya, (lza + 1));
@@ -172,9 +172,9 @@ static void prepare_pab_ADBmDAB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -185,12 +185,12 @@ static void prepare_pab_ADBmDAB(
 
               if (idir == 1) { // x
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
+                jco_l = coset(imax(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -198,12 +198,12 @@ static void prepare_pab_ADBmDAB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2) { // y
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
+                jco_l = coset(lxb, imax(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -211,12 +211,12 @@ static void prepare_pab_ADBmDAB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else { // z
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
+                jco_l = coset(lxb, lyb, imax(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, lya, imax(lza - 1, 0));
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -257,9 +257,9 @@ static void prepare_pab_ARDBmDARB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -275,7 +275,7 @@ static void prepare_pab_ARDBmDARB(
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 2), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -283,12 +283,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 1 && ir == 2) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), (lyb + 1), lzb);
+                jco_l = coset(imax(lxb - 1, 0), (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -296,12 +296,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 1 && ir == 3) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, (lzb + 1));
+                jco_l = coset(imax(lxb - 1, 0), lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -309,12 +309,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2 && ir == 1) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset((lxb + 1), LIBGRID_MAX(lyb - 1, 0), lzb);
+                jco_l = coset((lxb + 1), imax(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -327,7 +327,7 @@ static void prepare_pab_ARDBmDARB(
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 2), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -335,12 +335,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2 && ir == 3) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), (lzb + 1));
+                jco_l = coset(lxb, imax(lyb - 1, 0), (lzb + 1));
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -348,12 +348,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 3 && ir == 1) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset((lxb + 1), lyb, LIBGRID_MAX(lzb - 1, 0));
+                jco_l = coset((lxb + 1), lyb, imax(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, lya, imax(lza - 1, 0));
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -361,12 +361,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 3 && ir == 2) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, (lyb + 1), LIBGRID_MAX(lzb - 1, 0));
+                jco_l = coset(lxb, (lyb + 1), imax(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, lya, imax(lza - 1, 0));
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -379,7 +379,7 @@ static void prepare_pab_ARDBmDARB(
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 2));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, lya, imax(lza - 1, 0));
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -416,9 +416,9 @@ static void prepare_pab_DABpADB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -429,12 +429,12 @@ static void prepare_pab_DABpADB(
 
               if (idir == 1) { // x
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
+                jco_l = coset(imax(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -442,12 +442,12 @@ static void prepare_pab_DABpADB(
                 pab_prep[jco_l][ico_l] += -2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2) { // y
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
+                jco_l = coset(lxb, imax(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -455,12 +455,12 @@ static void prepare_pab_DABpADB(
                 pab_prep[jco_l][ico_l] += -2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else { // z
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
+                jco_l = coset(lxb, lyb, imax(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, lya, imax(lza - 1, 0));
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -501,9 +501,9 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -514,15 +514,15 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
               if (ider == 1) {
                 // x  (all safe if lxa = 0, as the spurious added terms have
                 // zero prefactor)
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
-                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza);
+                jco_l = coset(imax(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxa * lxb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * lxa * zetb * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
-                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
+                jco_l = coset(imax(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * zeta * lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -531,15 +531,15 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
                     +4.0 * zeta * zetb * pab[o2 + jco][o1 + ico];
               } else if (ider == 2) {
                 // y
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
-                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza);
+                jco_l = coset(lxb, imax(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lya * lyb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * lya * zetb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
-                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
+                jco_l = coset(lxb, imax(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * zeta * lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -548,15 +548,15 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
                     +4.0 * zeta * zetb * pab[o2 + jco][o1 + ico];
               } else if (ider == 3) {
                 // z
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
-                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
+                ico_l = coset(lxa, lya, imax(lza - 1, 0));
+                jco_l = coset(lxb, lyb, imax(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lza * lzb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, lya, imax(lza - 1, 0));
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * lza * zetb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
-                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
+                jco_l = coset(lxb, lyb, imax(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * zeta * lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -589,33 +589,33 @@ static void oneterm_dijdij(const int idir, const double func_a, const int ico_l,
   if (idir == 1) {
     const int l1 = lx;
     const int l2 = ly;
-    jco_l = coset(LIBGRID_MAX(lx - 1, 0), LIBGRID_MAX(ly - 1, 0), lz);
+    jco_l = coset(imax(lx - 1, 0), imax(ly - 1, 0), lz);
     pab_prep[jco_l][ico_l] += +l1 * l2 * func_a;
-    jco_l = coset(lx + 1, LIBGRID_MAX(ly - 1, 0), lz);
+    jco_l = coset(lx + 1, imax(ly - 1, 0), lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l2 * func_a;
-    jco_l = coset(LIBGRID_MAX(lx - 1, 0), ly + 1, lz);
+    jco_l = coset(imax(lx - 1, 0), ly + 1, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l1 * func_a;
     jco_l = coset(lx + 1, ly + 1, lz);
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 2) {
     const int l1 = ly;
     const int l2 = lz;
-    jco_l = coset(lx, LIBGRID_MAX(ly - 1, 0), LIBGRID_MAX(lz - 1, 0));
+    jco_l = coset(lx, imax(ly - 1, 0), imax(lz - 1, 0));
     pab_prep[jco_l][ico_l] += +l1 * l2 * func_a;
-    jco_l = coset(lx, ly + 1, LIBGRID_MAX(lz - 1, 0));
+    jco_l = coset(lx, ly + 1, imax(lz - 1, 0));
     pab_prep[jco_l][ico_l] += -2.0 * zet * l2 * func_a;
-    jco_l = coset(lx, LIBGRID_MAX(ly - 1, 0), lz + 1);
+    jco_l = coset(lx, imax(ly - 1, 0), lz + 1);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l1 * func_a;
     jco_l = coset(lx, ly + 1, lz + 1);
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 3) {
     const int l1 = lz;
     const int l2 = lx;
-    jco_l = coset(LIBGRID_MAX(lx - 1, 0), ly, LIBGRID_MAX(lz - 1, 0));
+    jco_l = coset(imax(lx - 1, 0), ly, imax(lz - 1, 0));
     pab_prep[jco_l][ico_l] += +l1 * l2 * func_a;
-    jco_l = coset(LIBGRID_MAX(lx - 1, 0), ly, lz + 1);
+    jco_l = coset(imax(lx - 1, 0), ly, lz + 1);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l2 * func_a;
-    jco_l = coset(lx + 1, ly, LIBGRID_MAX(lz - 1, 0));
+    jco_l = coset(lx + 1, ly, imax(lz - 1, 0));
     pab_prep[jco_l][ico_l] += -2.0 * zet * l1 * func_a;
     jco_l = coset(lx + 1, ly, lz + 1);
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
@@ -644,9 +644,9 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -658,16 +658,15 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
 
               if ((ider1 == 1 && ider2 == 2) || (ider1 == 2 && ider2 == 1)) {
                 // xy
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), LIBGRID_MAX(lya - 1, 0),
-                              lza);
+                ico_l = coset(imax(lxa - 1, 0), imax(lya - 1, 0), lza);
                 func_a = lxa * lya * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa + 1, LIBGRID_MAX(lya - 1, 0), lza);
+                ico_l = coset(lxa + 1, imax(lya - 1, 0), lza);
                 func_a = -2.0 * zeta * lya * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya + 1, lza);
+                ico_l = coset(imax(lxa - 1, 0), lya + 1, lza);
                 func_a = -2.0 * zeta * lxa * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -678,16 +677,15 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
               } else if ((ider1 == 2 && ider2 == 3) ||
                          (ider1 == 3 && ider2 == 2)) {
                 // yz
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0),
-                              LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, imax(lya - 1, 0), imax(lza - 1, 0));
                 func_a = lya * lza * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa, lya + 1, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa, lya + 1, imax(lza - 1, 0));
                 func_a = -2.0 * zeta * lza * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza + 1);
+                ico_l = coset(lxa, imax(lya - 1, 0), lza + 1);
                 func_a = -2.0 * zeta * lya * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -698,16 +696,15 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
               } else if ((ider1 == 3 && ider2 == 1) ||
                          (ider1 == 1 && ider2 == 3)) {
                 // zx
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya,
-                              LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(imax(lxa - 1, 0), lya, imax(lza - 1, 0));
                 func_a = lza * lxa * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza + 1);
+                ico_l = coset(imax(lxa - 1, 0), lya, lza + 1);
                 func_a = -2.0 * zeta * lxa * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa + 1, lya, LIBGRID_MAX(lza - 1, 0));
+                ico_l = coset(lxa + 1, lya, imax(lza - 1, 0));
                 func_a = -2.0 * zeta * lza * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -740,7 +737,7 @@ static void oneterm_diidii(const int idir, const double func_a, const int ico_l,
 
   if (idir == 1) {
     const int l1 = lx;
-    jco_l = coset(LIBGRID_MAX(lx - 2, 0), ly, lz);
+    jco_l = coset(imax(lx - 2, 0), ly, lz);
     pab_prep[jco_l][ico_l] += +l1 * (l1 - 1) * func_a;
     jco_l = coset(lx, ly, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * (2 * l1 + 1) * func_a;
@@ -748,7 +745,7 @@ static void oneterm_diidii(const int idir, const double func_a, const int ico_l,
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 2) {
     const int l1 = ly;
-    jco_l = coset(lx, LIBGRID_MAX(ly - 2, 0), lz);
+    jco_l = coset(lx, imax(ly - 2, 0), lz);
     pab_prep[jco_l][ico_l] += +l1 * (l1 - 1) * func_a;
     jco_l = coset(lx, ly, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * (2 * l1 + 1) * func_a;
@@ -756,7 +753,7 @@ static void oneterm_diidii(const int idir, const double func_a, const int ico_l,
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 3) {
     const int l1 = lz;
-    jco_l = coset(lx, ly, LIBGRID_MAX(lz - 2, 0));
+    jco_l = coset(lx, ly, imax(lz - 2, 0));
     pab_prep[jco_l][ico_l] += +l1 * (l1 - 1) * func_a;
     jco_l = coset(lx, ly, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * (2 * l1 + 1) * func_a;
@@ -787,9 +784,9 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0);
-               lza <= la_max - lxa - lya; lza++) {
-            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
+          for (int lza = imax(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+               lza++) {
+            for (int lzb = imax(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -801,7 +798,7 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
 
               if (ider == 1) {
                 // x
-                ico_l = coset(LIBGRID_MAX(lxa - 2, 0), lya, lza);
+                ico_l = coset(imax(lxa - 2, 0), lya, lza);
                 func_a = lxa * (lxa - 1) * pab[o2 + jco][o1 + ico];
                 oneterm_diidii(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -815,7 +812,7 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
                                n2_prep, pab_prep);
               } else if (ider == 2) {
                 // y
-                ico_l = coset(lxa, LIBGRID_MAX(lya - 2, 0), lza);
+                ico_l = coset(lxa, imax(lya - 2, 0), lza);
                 func_a = lya * (lya - 1) * pab[o2 + jco][o1 + ico];
                 oneterm_diidii(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -829,7 +826,7 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
                                n2_prep, pab_prep);
               } else if (ider == 3) {
                 // z
-                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 2, 0));
+                ico_l = coset(lxa, lya, imax(lza - 2, 0));
                 func_a = lza * (lza - 1) * pab[o2 + jco][o1 + ico];
                 oneterm_diidii(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);

--- a/src/grid/ref/grid_ref_prepare_pab.c
+++ b/src/grid/ref/grid_ref_prepare_pab.c
@@ -40,9 +40,9 @@ static void prepare_pab_AB(const int o1, const int o2, const int la_max,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -76,9 +76,9 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -87,16 +87,16 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
               // x  (all safe if lxa = 0, as the spurious added terms have zero
               // prefactor)
 
-              ico_l = coset(max(lxa - 1, 0), lya, lza);
-              jco_l = coset(max(lxb - 1, 0), lyb, lzb);
+              ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+              jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
               pab_prep[jco_l][ico_l] +=
                   0.5 * lxa * lxb * pab[o2 + jco][o1 + ico];
-              ico_l = coset(max(lxa - 1, 0), lya, lza);
+              ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
               jco_l = coset((lxb + 1), lyb, lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * lxa * zetb * pab[o2 + jco][o1 + ico];
               ico_l = coset((lxa + 1), lya, lza);
-              jco_l = coset(max(lxb - 1, 0), lyb, lzb);
+              jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * zeta * lxb * pab[o2 + jco][o1 + ico];
               ico_l = coset((lxa + 1), lya, lza);
@@ -106,16 +106,16 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
 
               // y
 
-              ico_l = coset(lxa, max(lya - 1, 0), lza);
-              jco_l = coset(lxb, max(lyb - 1, 0), lzb);
+              ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+              jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
               pab_prep[jco_l][ico_l] +=
                   0.5 * lya * lyb * pab[o2 + jco][o1 + ico];
-              ico_l = coset(lxa, max(lya - 1, 0), lza);
+              ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
               jco_l = coset(lxb, (lyb + 1), lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * lya * zetb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, (lya + 1), lza);
-              jco_l = coset(lxb, max(lyb - 1, 0), lzb);
+              jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
               pab_prep[jco_l][ico_l] +=
                   -1.0 * zeta * lyb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, (lya + 1), lza);
@@ -125,16 +125,16 @@ static void prepare_pab_DADB(const int o1, const int o2, const int la_max,
 
               // z
 
-              ico_l = coset(lxa, lya, max(lza - 1, 0));
-              jco_l = coset(lxb, lyb, max(lzb - 1, 0));
+              ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+              jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
               pab_prep[jco_l][ico_l] +=
                   0.5 * lza * lzb * pab[o2 + jco][o1 + ico];
-              ico_l = coset(lxa, lya, max(lza - 1, 0));
+              ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
               jco_l = coset(lxb, lyb, (lzb + 1));
               pab_prep[jco_l][ico_l] +=
                   -1.0 * lza * zetb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, lya, (lza + 1));
-              jco_l = coset(lxb, lyb, max(lzb - 1, 0));
+              jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
               pab_prep[jco_l][ico_l] +=
                   -1.0 * zeta * lzb * pab[o2 + jco][o1 + ico];
               ico_l = coset(lxa, lya, (lza + 1));
@@ -172,9 +172,9 @@ static void prepare_pab_ADBmDAB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -185,12 +185,12 @@ static void prepare_pab_ADBmDAB(
 
               if (idir == 1) { // x
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(max(lxb - 1, 0), lyb, lzb);
+                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(max(lxa - 1, 0), lya, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -198,12 +198,12 @@ static void prepare_pab_ADBmDAB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2) { // y
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, max(lyb - 1, 0), lzb);
+                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, max(lya - 1, 0), lza);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -211,12 +211,12 @@ static void prepare_pab_ADBmDAB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else { // z
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, lyb, max(lzb - 1, 0));
+                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, max(lza - 1, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -257,9 +257,9 @@ static void prepare_pab_ARDBmDARB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -275,7 +275,7 @@ static void prepare_pab_ARDBmDARB(
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 2), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(max(lxa - 1, 0), lya, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -283,12 +283,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 1 && ir == 2) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(max(lxb - 1, 0), (lyb + 1), lzb);
+                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(max(lxa - 1, 0), lya, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -296,12 +296,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 1 && ir == 3) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(max(lxb - 1, 0), lyb, (lzb + 1));
+                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(max(lxa - 1, 0), lya, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -309,12 +309,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2 && ir == 1) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset((lxb + 1), max(lyb - 1, 0), lzb);
+                jco_l = coset((lxb + 1), LIBGRID_MAX(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, max(lya - 1, 0), lza);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -327,7 +327,7 @@ static void prepare_pab_ARDBmDARB(
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 2), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, max(lya - 1, 0), lza);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -335,12 +335,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2 && ir == 3) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, max(lyb - 1, 0), (lzb + 1));
+                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), (lzb + 1));
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, max(lya - 1, 0), lza);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -348,12 +348,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 3 && ir == 1) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset((lxb + 1), lyb, max(lzb - 1, 0));
+                jco_l = coset((lxb + 1), lyb, LIBGRID_MAX(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, max(lza - 1, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -361,12 +361,12 @@ static void prepare_pab_ARDBmDARB(
                 pab_prep[jco_l][ico_l] += +2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 3 && ir == 2) {
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, (lyb + 1), max(lzb - 1, 0));
+                jco_l = coset(lxb, (lyb + 1), LIBGRID_MAX(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, max(lza - 1, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -379,7 +379,7 @@ static void prepare_pab_ARDBmDARB(
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 2));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, max(lza - 1, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -416,9 +416,9 @@ static void prepare_pab_DABpADB(
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -429,12 +429,12 @@ static void prepare_pab_DABpADB(
 
               if (idir == 1) { // x
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(max(lxb - 1, 0), lyb, lzb);
+                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(max(lxa - 1, 0), lya, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxa * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -442,12 +442,12 @@ static void prepare_pab_DABpADB(
                 pab_prep[jco_l][ico_l] += -2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else if (idir == 2) { // y
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, max(lyb - 1, 0), lzb);
+                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, max(lya - 1, 0), lza);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lya * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -455,12 +455,12 @@ static void prepare_pab_DABpADB(
                 pab_prep[jco_l][ico_l] += -2.0 * zeta * pab[o2 + jco][o1 + ico];
               } else { // z
                 ico_l = coset(lxa, lya, lza);
-                jco_l = coset(lxb, lyb, max(lzb - 1, 0));
+                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, lza);
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] += -2.0 * zetb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, max(lza - 1, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
                 jco_l = coset(lxb, lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lza * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -501,9 +501,9 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -514,15 +514,15 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
               if (ider == 1) {
                 // x  (all safe if lxa = 0, as the spurious added terms have
                 // zero prefactor)
-                ico_l = coset(max(lxa - 1, 0), lya, lza);
-                jco_l = coset(max(lxb - 1, 0), lyb, lzb);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
+                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] += +lxa * lxb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(max(lxa - 1, 0), lya, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza);
                 jco_l = coset((lxb + 1), lyb, lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * lxa * zetb * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
-                jco_l = coset(max(lxb - 1, 0), lyb, lzb);
+                jco_l = coset(LIBGRID_MAX(lxb - 1, 0), lyb, lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * zeta * lxb * pab[o2 + jco][o1 + ico];
                 ico_l = coset((lxa + 1), lya, lza);
@@ -531,15 +531,15 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
                     +4.0 * zeta * zetb * pab[o2 + jco][o1 + ico];
               } else if (ider == 2) {
                 // y
-                ico_l = coset(lxa, max(lya - 1, 0), lza);
-                jco_l = coset(lxb, max(lyb - 1, 0), lzb);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
+                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] += +lya * lyb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, max(lya - 1, 0), lza);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza);
                 jco_l = coset(lxb, (lyb + 1), lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * lya * zetb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
-                jco_l = coset(lxb, max(lyb - 1, 0), lzb);
+                jco_l = coset(lxb, LIBGRID_MAX(lyb - 1, 0), lzb);
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * zeta * lyb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, (lya + 1), lza);
@@ -548,15 +548,15 @@ static void prepare_pab_Di(const int ider, const int o1, const int o2,
                     +4.0 * zeta * zetb * pab[o2 + jco][o1 + ico];
               } else if (ider == 3) {
                 // z
-                ico_l = coset(lxa, lya, max(lza - 1, 0));
-                jco_l = coset(lxb, lyb, max(lzb - 1, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
+                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] += +lza * lzb * pab[o2 + jco][o1 + ico];
-                ico_l = coset(lxa, lya, max(lza - 1, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 1, 0));
                 jco_l = coset(lxb, lyb, (lzb + 1));
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * lza * zetb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
-                jco_l = coset(lxb, lyb, max(lzb - 1, 0));
+                jco_l = coset(lxb, lyb, LIBGRID_MAX(lzb - 1, 0));
                 pab_prep[jco_l][ico_l] +=
                     -2.0 * zeta * lzb * pab[o2 + jco][o1 + ico];
                 ico_l = coset(lxa, lya, (lza + 1));
@@ -589,33 +589,33 @@ static void oneterm_dijdij(const int idir, const double func_a, const int ico_l,
   if (idir == 1) {
     const int l1 = lx;
     const int l2 = ly;
-    jco_l = coset(max(lx - 1, 0), max(ly - 1, 0), lz);
+    jco_l = coset(LIBGRID_MAX(lx - 1, 0), LIBGRID_MAX(ly - 1, 0), lz);
     pab_prep[jco_l][ico_l] += +l1 * l2 * func_a;
-    jco_l = coset(lx + 1, max(ly - 1, 0), lz);
+    jco_l = coset(lx + 1, LIBGRID_MAX(ly - 1, 0), lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l2 * func_a;
-    jco_l = coset(max(lx - 1, 0), ly + 1, lz);
+    jco_l = coset(LIBGRID_MAX(lx - 1, 0), ly + 1, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l1 * func_a;
     jco_l = coset(lx + 1, ly + 1, lz);
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 2) {
     const int l1 = ly;
     const int l2 = lz;
-    jco_l = coset(lx, max(ly - 1, 0), max(lz - 1, 0));
+    jco_l = coset(lx, LIBGRID_MAX(ly - 1, 0), LIBGRID_MAX(lz - 1, 0));
     pab_prep[jco_l][ico_l] += +l1 * l2 * func_a;
-    jco_l = coset(lx, ly + 1, max(lz - 1, 0));
+    jco_l = coset(lx, ly + 1, LIBGRID_MAX(lz - 1, 0));
     pab_prep[jco_l][ico_l] += -2.0 * zet * l2 * func_a;
-    jco_l = coset(lx, max(ly - 1, 0), lz + 1);
+    jco_l = coset(lx, LIBGRID_MAX(ly - 1, 0), lz + 1);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l1 * func_a;
     jco_l = coset(lx, ly + 1, lz + 1);
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 3) {
     const int l1 = lz;
     const int l2 = lx;
-    jco_l = coset(max(lx - 1, 0), ly, max(lz - 1, 0));
+    jco_l = coset(LIBGRID_MAX(lx - 1, 0), ly, LIBGRID_MAX(lz - 1, 0));
     pab_prep[jco_l][ico_l] += +l1 * l2 * func_a;
-    jco_l = coset(max(lx - 1, 0), ly, lz + 1);
+    jco_l = coset(LIBGRID_MAX(lx - 1, 0), ly, lz + 1);
     pab_prep[jco_l][ico_l] += -2.0 * zet * l2 * func_a;
-    jco_l = coset(lx + 1, ly, max(lz - 1, 0));
+    jco_l = coset(lx + 1, ly, LIBGRID_MAX(lz - 1, 0));
     pab_prep[jco_l][ico_l] += -2.0 * zet * l1 * func_a;
     jco_l = coset(lx + 1, ly, lz + 1);
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
@@ -644,9 +644,9 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -658,15 +658,15 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
 
               if ((ider1 == 1 && ider2 == 2) || (ider1 == 2 && ider2 == 1)) {
                 // xy
-                ico_l = coset(max(lxa - 1, 0), max(lya - 1, 0), lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), LIBGRID_MAX(lya - 1, 0), lza);
                 func_a = lxa * lya * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa + 1, max(lya - 1, 0), lza);
+                ico_l = coset(lxa + 1, LIBGRID_MAX(lya - 1, 0), lza);
                 func_a = -2.0 * zeta * lya * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(max(lxa - 1, 0), lya + 1, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya + 1, lza);
                 func_a = -2.0 * zeta * lxa * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -677,15 +677,15 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
               } else if ((ider1 == 2 && ider2 == 3) ||
                          (ider1 == 3 && ider2 == 2)) {
                 // yz
-                ico_l = coset(lxa, max(lya - 1, 0), max(lza - 1, 0));
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), LIBGRID_MAX(lza - 1, 0));
                 func_a = lya * lza * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa, lya + 1, max(lza - 1, 0));
+                ico_l = coset(lxa, lya + 1, LIBGRID_MAX(lza - 1, 0));
                 func_a = -2.0 * zeta * lza * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa, max(lya - 1, 0), lza + 1);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 1, 0), lza + 1);
                 func_a = -2.0 * zeta * lya * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -696,15 +696,15 @@ static void prepare_pab_DiDj(const int ider1, const int ider2, const int o1,
               } else if ((ider1 == 3 && ider2 == 1) ||
                          (ider1 == 1 && ider2 == 3)) {
                 // zx
-                ico_l = coset(max(lxa - 1, 0), lya, max(lza - 1, 0));
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, LIBGRID_MAX(lza - 1, 0));
                 func_a = lza * lxa * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(max(lxa - 1, 0), lya, lza + 1);
+                ico_l = coset(LIBGRID_MAX(lxa - 1, 0), lya, lza + 1);
                 func_a = -2.0 * zeta * lxa * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
-                ico_l = coset(lxa + 1, lya, max(lza - 1, 0));
+                ico_l = coset(lxa + 1, lya, LIBGRID_MAX(lza - 1, 0));
                 func_a = -2.0 * zeta * lza * pab[o2 + jco][o1 + ico];
                 oneterm_dijdij(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -737,7 +737,7 @@ static void oneterm_diidii(const int idir, const double func_a, const int ico_l,
 
   if (idir == 1) {
     const int l1 = lx;
-    jco_l = coset(max(lx - 2, 0), ly, lz);
+    jco_l = coset(LIBGRID_MAX(lx - 2, 0), ly, lz);
     pab_prep[jco_l][ico_l] += +l1 * (l1 - 1) * func_a;
     jco_l = coset(lx, ly, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * (2 * l1 + 1) * func_a;
@@ -745,7 +745,7 @@ static void oneterm_diidii(const int idir, const double func_a, const int ico_l,
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 2) {
     const int l1 = ly;
-    jco_l = coset(lx, max(ly - 2, 0), lz);
+    jco_l = coset(lx, LIBGRID_MAX(ly - 2, 0), lz);
     pab_prep[jco_l][ico_l] += +l1 * (l1 - 1) * func_a;
     jco_l = coset(lx, ly, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * (2 * l1 + 1) * func_a;
@@ -753,7 +753,7 @@ static void oneterm_diidii(const int idir, const double func_a, const int ico_l,
     pab_prep[jco_l][ico_l] += +4.0 * zet * zet * func_a;
   } else if (idir == 3) {
     const int l1 = lz;
-    jco_l = coset(lx, ly, max(lz - 2, 0));
+    jco_l = coset(lx, ly, LIBGRID_MAX(lz - 2, 0));
     pab_prep[jco_l][ico_l] += +l1 * (l1 - 1) * func_a;
     jco_l = coset(lx, ly, lz);
     pab_prep[jco_l][ico_l] += -2.0 * zet * (2 * l1 + 1) * func_a;
@@ -784,9 +784,9 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
     for (int lxb = 0; lxb <= lb_max; lxb++) {
       for (int lya = 0; lya <= la_max - lxa; lya++) {
         for (int lyb = 0; lyb <= lb_max - lxb; lyb++) {
-          for (int lza = max(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
+          for (int lza = LIBGRID_MAX(la_min - lxa - lya, 0); lza <= la_max - lxa - lya;
                lza++) {
-            for (int lzb = max(lb_min - lxb - lyb, 0);
+            for (int lzb = LIBGRID_MAX(lb_min - lxb - lyb, 0);
                  lzb <= lb_max - lxb - lyb; lzb++) {
               const int ico = coset(lxa, lya, lza);
               const int jco = coset(lxb, lyb, lzb);
@@ -798,7 +798,7 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
 
               if (ider == 1) {
                 // x
-                ico_l = coset(max(lxa - 2, 0), lya, lza);
+                ico_l = coset(LIBGRID_MAX(lxa - 2, 0), lya, lza);
                 func_a = lxa * (lxa - 1) * pab[o2 + jco][o1 + ico];
                 oneterm_diidii(1, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -812,7 +812,7 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
                                n2_prep, pab_prep);
               } else if (ider == 2) {
                 // y
-                ico_l = coset(lxa, max(lya - 2, 0), lza);
+                ico_l = coset(lxa, LIBGRID_MAX(lya - 2, 0), lza);
                 func_a = lya * (lya - 1) * pab[o2 + jco][o1 + ico];
                 oneterm_diidii(2, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);
@@ -826,7 +826,7 @@ static void prepare_pab_Di2(const int ider, const int o1, const int o2,
                                n2_prep, pab_prep);
               } else if (ider == 3) {
                 // z
-                ico_l = coset(lxa, lya, max(lza - 2, 0));
+                ico_l = coset(lxa, lya, LIBGRID_MAX(lza - 2, 0));
                 func_a = lza * (lza - 1) * pab[o2 + jco][o1 + ico];
                 oneterm_diidii(3, func_a, ico_l, lxb, lyb, lzb, zetb, n1_prep,
                                n2_prep, pab_prep);

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -94,7 +94,8 @@ void grid_ref_create_task_list(
   // Find largest Cartesian subblock size.
   task_list->maxco = 0;
   for (int i = 0; i < nkinds; i++) {
-    task_list->maxco = LIBGRID_MAX(task_list->maxco, task_list->basis_sets[i]->maxco);
+    task_list->maxco =
+        LIBGRID_MAX(task_list->maxco, task_list->basis_sets[i]->maxco);
   }
 
   *blocks_buffer = task_list->blocks_buffer;

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -94,8 +94,7 @@ void grid_ref_create_task_list(
   // Find largest Cartesian subblock size.
   task_list->maxco = 0;
   for (int i = 0; i < nkinds; i++) {
-    task_list->maxco =
-        LIBGRID_MAX(task_list->maxco, task_list->basis_sets[i]->maxco);
+    task_list->maxco = imax(task_list->maxco, task_list->basis_sets[i]->maxco);
   }
 
   *blocks_buffer = task_list->blocks_buffer;

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -94,7 +94,7 @@ void grid_ref_create_task_list(
   // Find largest Cartesian subblock size.
   task_list->maxco = 0;
   for (int i = 0; i < nkinds; i++) {
-    task_list->maxco = max(task_list->maxco, task_list->basis_sets[i]->maxco);
+    task_list->maxco = LIBGRID_MAX(task_list->maxco, task_list->basis_sets[i]->maxco);
   }
 
   *blocks_buffer = task_list->blocks_buffer;


### PR DESCRIPTION
Capitalized and prefixed macro names (highly recommended), which significantly reduces risk of name-clash for instance with arbitrary variable names (even from common/standard/other headers). Replaced `ceill` with `ceil` (long double is not required; prevents micro-coded instruction flow). Rely on `fmin` and `fmax` when appropriate. Updated help message of driver programs. Fixed some spelling.