### PR TITLE
Add missing cp2k copyright banners

### DIFF
--- a/src/common/fparser.F
+++ b/src/common/fparser.F
@@ -1,23 +1,20 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2020 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief This public domain function parser module is intended for applications
+!>        where a set of mathematical expressions is specified at runtime and is
+!>        then evaluated for a large number of variable values. This is done by
+!>        compiling the set of function strings into byte code, which is interpreted
+!>        very efficiently for the various variable values.
+!>
+!> \author Roland Schmehl <Roland.Schmehl@mach.uni-karlsruhe.de>
 ! **************************************************************************************************
 MODULE fparser
-   !------- -------- --------- --------- --------- --------- --------- --------- -------
-   ! Fortran 90 function parser v1.1
-   !------- -------- --------- --------- --------- --------- --------- --------- -------
-   !
-   ! This public domain function parser module is intended for applications
-   ! where a set of mathematical expressions is specified at runtime and is
-   ! then evaluated for a large number of variable values. This is done by
-   ! compiling the set of function strings into byte code, which is interpreted
-   ! very efficiently for the various variable values.
-   !
-   ! The source code is available from:
-   ! http://www.its.uni-karlsruhe.de/~schmehl/opensource/fparser-v1.1.tar.gz
-   !
-   ! Please send comments, corrections or questions to the author:
-   ! Roland Schmehl <Roland.Schmehl@mach.uni-karlsruhe.de>
-   !
-   !------- -------- --------- --------- --------- --------- --------- --------- -------
-
    USE kinds,                           ONLY: default_string_length,&
                                               rn => dp
 #include "../base/base_uses.f90"

--- a/src/common/t_c_g0.F
+++ b/src/common/t_c_g0.F
@@ -1,54 +1,59 @@
-!
-! * Copyright (c) 2008, 2009, Joost VandeVondele and Manuel Guidon
-! * All rights reserved.
-! *
-! * Redistribution and use in source and binary forms, with or without
-! * modification, are permitted provided that the following conditions are met:
-! *     * Redistributions of source code must retain the above copyright
-! *       notice, this list of conditions and the following disclaimer.
-! *     * Redistributions in binary form must reproduce the above copyright
-! *       notice, this list of conditions and the following disclaimer in the
-! *       documentation and/or other materials provided with the distribution.
-! *
-! * THIS SOFTWARE IS PROVIDED BY Joost VandeVondele and Manuel Guidon AS IS AND ANY
-! * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-! * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-! * DISCLAIMED. IN NO EVENT SHALL Joost VandeVondele or Manuel Guidon BE LIABLE FOR ANY
-! * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-! * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-! * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-! * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-! * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-! * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-!
-!
-!   This module computes the basic integrals for the
-!   truncated coulomb operator
-!
-!   res(1) =G_0(R,T)= ((2*erf(sqrt(t))+erf(R-sqrt(t))-erf(R+sqrt(t)))/sqrt(t))
-!
-!   and up to 21 derivatives with respect to T
-!
-!   res(n+1)=(-1)**n d^n/dT^n G_0(R,T)
-!
-!
-!   The function is only computed for values of R,T which fulfil
-!
-!   R**2 - 11.0_dp*R + 0.0_dp < T < R**2 + 11.0_dp*R + 50.0_dp
-!   where R>=0 T>=0
-!
-!   for T larger than the upper bound, 0 is returned
-!   (which is accurate at least up to 1.0E-16)
-!   while for T smaller than the lower bound, the caller is instructed
-!   to use the conventional gamma function instead
-!   (i.e. the limit of above expression for R to Infinity)
-!
-!   Joost VandeVondele and Manuel Guidon, Nov 2008.
-! instead of a module one could use: INTEGER, PARAMETER ::  dp=KIND(0.0D0)
-!
-! History: -05.2019 Added a get_maxl_init function to get current status of nderiv_init and moved
-!           the file to common (made it accessible from aobasis, same place as gamma.F) A. Bussy
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2020 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
 
+!--------------------------------------------------------------------------------------------------!
+!   Copyright (c) 2008, 2009, Joost VandeVondele and Manuel Guidon                                 !
+!   All rights reserved.                                                                           !
+!                                                                                                  !
+!   Redistribution and use in source and binary forms, with or without                             !
+!   modification, are permitted provided that the following conditions are met:                    !
+!       * Redistributions of source code must retain the above copyright                           !
+!         notice, this list of conditions and the following disclaimer.                            !
+!       * Redistributions in binary form must reproduce the above copyright                        !
+!         notice, this list of conditions and the following disclaimer in the                      !
+!         documentation and/or other materials provided with the distribution.                     !
+!                                                                                                  !
+!   THIS SOFTWARE IS PROVIDED BY Joost VandeVondele and Manuel Guidon AS IS AND ANY                !
+!   EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                      !
+!   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                         !
+!   DISCLAIMED. IN NO EVENT SHALL Joost VandeVondele or Manuel Guidon BE LIABLE FOR ANY            !
+!   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                     !
+!   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                   !
+!   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                    !
+!   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                     !
+!   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                  !
+!   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                   !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief This module computes the basic integrals for the truncated coulomb operator
+!>
+!>          res(1) =G_0(R,T)= ((2*erf(sqrt(t))+erf(R-sqrt(t))-erf(R+sqrt(t)))/sqrt(t))
+!>
+!>        and up to 21 derivatives with respect to T
+!>
+!>          res(n+1)=(-1)**n d^n/dT^n G_0(R,T)
+!>
+!>        The function is only computed for values of R,T which fulfil
+!>
+!>          R**2 - 11.0_dp*R + 0.0_dp < T < R**2 + 11.0_dp*R + 50.0_dp where R>=0 T>=0
+!>
+!>        for T larger than the upper bound, 0 is returned
+!>        (which is accurate at least up to 1.0E-16)
+!>        while for T smaller than the lower bound, the caller is instructed
+!>        to use the conventional gamma function instead
+!>        (i.e. the limit of above expression for R to Infinity)
+!>
+!> \author Joost VandeVondele and Manuel Guidon
+!> \par History
+!>      Nov 2008, 2009 Joost VandeVondele and Manuel Guidon
+!>      May 2019 A. Bussy: Added a get_maxl_init function to get current status of nderiv_init and
+!>                moved the file to common (made it accessible from aobasis, same place as gamma.F).
+! **************************************************************************************************
 MODULE t_c_g0
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_bcast
@@ -56,6 +61,7 @@ MODULE t_c_g0
 
    IMPLICIT NONE
    PRIVATE
+
    PUBLIC :: t_c_g0_n, init, free_C0, get_lmax_init
    REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE, SAVE :: C0
    INTEGER, PARAMETER :: degree = 13
@@ -63,7 +69,9 @@ MODULE t_c_g0
    INTEGER, PARAMETER :: nderiv_max = 21
    INTEGER, SAVE      :: nderiv_init = -1
    INTEGER, SAVE      :: patches = -1
+
 CONTAINS
+
 ! **************************************************************************************************
 !> \brief ...
 !> \param RES ...
@@ -1337,12 +1345,11 @@ CONTAINS
          ENDIF
       ENDIF
    END SUBROUTINE t_c_g0_n
-! iunit contains the data file to initialize the table
-! Nder is the number of derivatives that will actually be used
+
 ! **************************************************************************************************
 !> \brief ...
-!> \param Nder ...
-!> \param iunit ...
+!> \param Nder the number of derivatives that will actually be used
+!> \param iunit contains the data file to initialize the table
 !> \param mepos ...
 !> \param group ...
 ! **************************************************************************************************
@@ -1371,6 +1378,7 @@ CONTAINS
       CALL mp_bcast(C0, 0, group)
 
    END SUBROUTINE init
+
 ! **************************************************************************************************
 !> \brief ...
 ! **************************************************************************************************
@@ -1378,6 +1386,7 @@ CONTAINS
       IF (ALLOCATED(C0)) DEALLOCATE (C0)
       nderiv_init = -1
    END SUBROUTINE free_C0
+
 ! **************************************************************************************************
 !> \brief ...
 !> \param RES ...

--- a/src/common/t_sh_p_s_c.F
+++ b/src/common/t_sh_p_s_c.F
@@ -1,30 +1,41 @@
-!
-! * Copyright (c) 2008, Joost VandeVondele and Manuel Guidon
-! * All rights reserved.
-! *
-! * Redistribution and use in source and binary forms, with or without
-! * modification, are permitted provided that the following conditions are met:
-! *     * Redistributions of source code must retain the above copyright
-! *       notice, this list of conditions and the following disclaimer.
-! *     * Redistributions in binary form must reproduce the above copyright
-! *       notice, this list of conditions and the following disclaimer in the
-! *       documentation and/or other materials provided with the distribution.
-! *
-! * THIS SOFTWARE IS PROVIDED BY Joost VandeVondele and Manuel Guidon AS IS AND ANY
-! * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-! * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-! * DISCLAIMED. IN NO EVENT SHALL Joost VandeVondele or Manuel Guidon BE LIABLE FOR ANY
-! * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-! * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-! * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-! * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-! * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-! * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-!
-!
-!   Joost VandeVondele and Manuel Guidon, Nov 2008.
-!
-! History: -09.2019 Moved the file to common (together with gamma.F and t_c_g0.F) A.Bussy
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2020 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+!--------------------------------------------------------------------------------------------------!
+!   Copyright (c) 2008, Joost VandeVondele and Manuel Guidon                                       !
+!   All rights reserved.                                                                           !
+!                                                                                                  !
+!   Redistribution and use in source and binary forms, with or without                             !
+!   modification, are permitted provided that the following conditions are met:                    !
+!       * Redistributions of source code must retain the above copyright                           !
+!         notice, this list of conditions and the following disclaimer.                            !
+!       * Redistributions in binary form must reproduce the above copyright                        !
+!         notice, this list of conditions and the following disclaimer in the                      !
+!         documentation and/or other materials provided with the distribution.                     !
+!                                                                                                  !
+!   THIS SOFTWARE IS PROVIDED BY Joost VandeVondele and Manuel Guidon AS IS AND ANY                !
+!   EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED                      !
+!   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                         !
+!   DISCLAIMED. IN NO EVENT SHALL Joost VandeVondele or Manuel Guidon BE LIABLE FOR ANY            !
+!   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES                     !
+!   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                   !
+!   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND                    !
+!   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                     !
+!   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS                  !
+!   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                   !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief ...
+!> \author Joost VandeVondele and Manuel Guidon
+!> \par History
+!>      Nov 2008 Joost VandeVondele and Manuel Guidon
+!>      Sep 2019 A.Bussy: Moved the file to common (together with gamma.F and t_c_g0.F)
+! **************************************************************************************************
 MODULE t_sh_p_s_c
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_bcast
@@ -32,6 +43,7 @@ MODULE t_sh_p_s_c
 
    IMPLICIT NONE
    PRIVATE
+
    PUBLIC :: trunc_CS_poly_n20, init, free_C0
    REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE, SAVE :: C0
    INTEGER, PARAMETER :: degree = 15
@@ -39,7 +51,9 @@ MODULE t_sh_p_s_c
    INTEGER, PARAMETER :: nderiv_max = 21
    INTEGER, SAVE      :: nderiv_init = -1
    INTEGER, SAVE      :: patches = -1
+
 CONTAINS
+
 ! **************************************************************************************************
 !> \brief ...
 !> \param RES ...
@@ -1087,12 +1101,10 @@ CONTAINS
       END IF
    END SUBROUTINE trunc_CS_poly_n20
 
-! iunit contains the data file to initialize the table
-! Nder is the number of derivatives that will actually be used
 ! **************************************************************************************************
 !> \brief ...
-!> \param Nder ...
-!> \param iunit ...
+!> \param Nder the number of derivatives that will actually be used
+!> \param iunit contains the data file to initialize the table
 !> \param mepos ...
 !> \param group ...
 ! **************************************************************************************************
@@ -1128,6 +1140,7 @@ CONTAINS
       IF (ALLOCATED(C0)) DEALLOCATE (C0)
       nderiv_init = -1
    END SUBROUTINE free_C0
+
 ! **************************************************************************************************
 !> \brief ...
 !> \param RES ...
@@ -1198,4 +1211,5 @@ CONTAINS
          RES(K) = RES(K) + DOT_PRODUCT(T1(0:0), C0(136:136, K))*T2(15)
       ENDDO
    END SUBROUTINE PD2VAL
+
 END MODULE t_sh_p_s_c

--- a/src/metadyn_tools/graph.F
+++ b/src/metadyn_tools/graph.F
@@ -1,9 +1,9 @@
 !--------------------------------------------------------------------------------------------------!
-!   FES: a fast and general program to map metadynamics on grids                                   !
-!   Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010,2011,2012,2013                      !
-!                 2014                                                        !
-!                 Teodoro Laino                                               !
-!-----------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2020 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
 !> \brief   Program to Map on grid the hills spawned during a metadynamics run

--- a/src/metadyn_tools/graph_methods.F
+++ b/src/metadyn_tools/graph_methods.F
@@ -1,8 +1,9 @@
 !--------------------------------------------------------------------------------------------------!
-!   FES: a fast and general program to map metadynamics on grids                                   !
-!   Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010,2011,2012,2013                      !
-!                 Teodoro Laino                                               !
-!-----------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2020 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
 !> \brief   Program to Map on grid the hills spawned during a metadynamics run

--- a/src/metadyn_tools/graph_utils.F
+++ b/src/metadyn_tools/graph_utils.F
@@ -1,8 +1,9 @@
 !--------------------------------------------------------------------------------------------------!
-!   FES: a fast and general program to map metadynamics on grids                                   !
-!   Copyright (C) 2002,2003,2004,2005,2006,2007,2008,2009,2010,2011,2012,2013                      !
-!                 Teodoro Laino                                               !
-!-----------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2020 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
 !> \brief   Module containing utils for mapping FESs

--- a/src/sockets.c
+++ b/src/sockets.c
@@ -1,38 +1,41 @@
-/* A minimal wrapper for socket communication.
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2020 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
 
-Copyright (C) 2013, Joshua More and Michele Ceriotti
+/*----------------------------------------------------------------------------*/
+/*  Copyright (C) 2013, Joshua More and Michele Ceriotti                      */
+/*                                                                            */
+/*  Permission is hereby granted, free of charge, to any person obtaining     */
+/*  a copy of this software and associated documentation files (the           */
+/*  "Software"), to deal in the Software without restriction, including       */
+/*  without limitation the rights to use, copy, modify, merge, publish,       */
+/*  distribute, sublicense, and/or sell copies of the Software, and to        */
+/*  permit persons to whom the Software is furnished to do so, subject to     */
+/*  the following conditions:                                                 */
+/*                                                                            */
+/*  The above copyright notice and this permission notice shall be included   */
+/*  in all copies or substantial portions of the Software.                    */
+/*                                                                            */
+/*  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,           */
+/*  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF        */
+/*  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.    */
+/*  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY      */
+/*  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,      */
+/*  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE         */
+/*  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                    */
+/*----------------------------------------------------------------------------*/
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-Contains both the functions that transmit data to the socket and read the data
-back out again once finished, and the function which opens the socket initially.
-Can be linked to a FORTRAN code that does not support sockets natively.
-
-Functions:
-   error: Prints an error message and then exits.
-   open_socket_: Opens a socket with the required host server, socket type and
-      port number.
-   write_buffer_: Writes a string to the socket.
-   read_buffer_: Reads data from the socket.
-*/
+/*******************************************************************************
+ * \brief A minimal wrapper for socket communication.
+ *        Contains both the functions that transmit data to the socket and read
+ *        the data back out again once finished, and the function which opens
+ *        the socket initially. Can be linked to a FORTRAN code that does not
+ *        support sockets natively.
+ * \author Joshua More and Michele Ceriotti
+ ******************************************************************************/
 #ifndef __NO_IPI_DRIVER
 
 #define _XOPEN_SOURCE 700 /* Enable POSIX 2008/13 */
@@ -49,23 +52,19 @@ Functions:
 #include <time.h>
 #include <unistd.h>
 
-void open_socket(int *psockfd, int *inet, int *port, char *host)
-/* Opens a socket.
-
-Note that fortran passes an extra argument for the string length, but this is
-ignored here for C compatibility.
-
-Args:
-   psockfd: The id of the socket that will be created.
-   inet: An integer that determines whether the socket will be an inet or unix
-      domain socket. Gives unix if 0, inet otherwise.
-   port: The port number for the socket to be created. Low numbers are often
-      reserved for important channels, so use of numbers of 4 or more digits is
-      recommended.
-   host: The name of the host server.
-*/
-
-{
+/*******************************************************************************
+ * \brief Opens a socket.
+ * \param psockfd The id of the socket that will be created.
+ * \param inet    An integer that determines whether the socket will be an inet
+ *                or unix domain socket. Gives unix if 0, inet otherwise.
+ * \param port    The port number for the socket to be created. Low numbers are
+ *                often reserved for important channels, so use of numbers of 4
+ *                or more digits is recommended.
+ * \param host    The name of the host server.
+ * \note  Fortran passes an extra argument for the string length, but this is
+ *        ignored here for C compatibility.
+ ******************************************************************************/
+void open_socket(int *psockfd, int *inet, int *port, char *host) {
   int sockfd, ai_err;
 
   if (*inet > 0) { // creates an internet socket
@@ -122,16 +121,13 @@ Args:
   *psockfd = sockfd;
 }
 
-void writebuffer(int *psockfd, char *data, int *plen)
-/* Writes to a socket.
-
-Args:
-   psockfd: The id of the socket that will be written to.
-   data: The data to be written to the socket.
-   plen: The length of the data in bytes.
-*/
-
-{
+/*******************************************************************************
+ * \brief Writes to a socket.
+ * \param psockfd The id of the socket that will be written to.
+ * \param data    The data to be written to the socket.
+ * \param plen    The length of the data in bytes.
+ ******************************************************************************/
+void writebuffer(int *psockfd, char *data, int *plen) {
   int n;
   int sockfd = *psockfd;
   int len = *plen;
@@ -143,16 +139,13 @@ Args:
   }
 }
 
-void readbuffer(int *psockfd, char *data, int *plen)
-/* Reads from a socket.
-
-Args:
-   psockfd: The id of the socket that will be read from.
-   data: The storage array for data read from the socket.
-   plen: The length of the data in bytes.
-*/
-
-{
+/*******************************************************************************
+ * \brief Reads from a socket.
+ * \param psockfd The id of the socket that will be read from.
+ * \param data    The storage array for data read from the socket.
+ * \param plen    The length of the data in bytes.
+ ******************************************************************************/
+void readbuffer(int *psockfd, char *data, int *plen) {
   int n, nr;
   int sockfd = *psockfd;
   int len = *plen;
@@ -170,13 +163,11 @@ Args:
   }
 }
 
-void uwait(double *dsec)
-/* mini-wrapper to nanosleep
-
-   Args:
-     dsec:  number of seconds to wait (float values accepted)
-*/
-{
+/*******************************************************************************
+ * \brief Mini-wrapper to nanosleep
+ * \param dsec number of seconds to wait (float values accepted)
+ ******************************************************************************/
+void uwait(double *dsec) {
   struct timespec wt, rem;
   wt.tv_sec = floor(*dsec);
   wt.tv_nsec = (*dsec - wt.tv_sec) * 1000000000;

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -115,24 +115,18 @@ et_coupling_proj.F: Routine INFOG2L called with an implicit interface.
 extended_system_init.F: Found WRITE statement with hardcoded unit in "init_barostat_variables"
 farming_methods.F: Found CLOSE statement in procedure "farming_parse_input"
 farming_methods.F: Found OPEN statement in procedure "farming_parse_input"
-fparser.F: Copyright banner malformed
 fparser.F: Found WRITE statement with hardcoded unit in "parseerrmsg"
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_norm_sc"
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_norm_sc_low"
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_trend"
 glbopt_history.F: Found WRITE statement with hardcoded unit in "verify_history_lookup"
 glbopt_mincrawl.F: Found WRITE statement with hardcoded unit in "print_tempdist"
-glob_matching.F: Copyright banner malformed
-gopt_f77_methods.h: Copyright banner malformed
-graph.F: Copyright banner malformed
 graph.F: Found CALL RANDOM_SEED in procedure "graph"
 graph.F: Found WRITE statement with hardcoded unit in "graph"
-graph_methods.F: Copyright banner malformed
 graph_methods.F: Found OPEN statement in procedure "fes_cube_write"
 graph_methods.F: Found WRITE statement with hardcoded unit in "fes_cube_write"
 graph_methods.F: Found WRITE statement with hardcoded unit in "fes_min"
 graph_methods.F: Found WRITE statement with hardcoded unit in "fes_path"
-graph_utils.F: Copyright banner malformed
 graph_utils.F: Found WRITE statement with hardcoded unit in "get_val_res"
 graphcon.F: Found GOTO statement in procedure "all_permutations"
 graphcon.F: Found WRITE statement with hardcoded unit in "reorder_graph"
@@ -228,7 +222,6 @@ se_core_matrix.F: Found WRITE statement with hardcoded unit in "makes"
 se_fock_matrix_coulomb.F: Found WRITE statement with hardcoded unit in "build_fock_matrix_coulomb_lr"
 se_fock_matrix_dbg.F: Found WRITE statement with hardcoded unit in "dbg_energy_coulomb_lr"
 semi_empirical_int3_utils.F: Routine EVAL called with an implicit interface.
-semi_empirical_int_args.h: Copyright banner malformed
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_dcore_nucint_ana"
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_dcorecore_ana"
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_drotnuc_ana"
@@ -239,17 +232,13 @@ semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_value"
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "rot_2el_2c_first_debug"
 semi_empirical_int_debug.F: Routine CHECK_VALUE called with an implicit interface.
-semi_empirical_int_debug.h: Copyright banner malformed
 semi_empirical_int_utils.F: Routine EVAL called with an implicit interface.
 semi_empirical_mpole_methods.F: Found WRITE statement with hardcoded unit in "semi_empirical_mpole_p_setup"
-sockets.c: Copyright banner malformed
 spherical_harmonics.F: Found WRITE statement with hardcoded unit in "cgc"
 spherical_harmonics.F: Found WRITE statement with hardcoded unit in "get_factor"
 statistical_methods.F: Found WRITE statement with hardcoded unit in "tests"
 swarm_mpi.F: Found CLOSE statement in procedure "logger_init_master"
 swarm_mpi.F: Found OPEN statement in procedure "logger_finalize"
-t_c_g0.F: Copyright banner malformed
-t_sh_p_s_c.F: Copyright banner malformed
 task_list_methods.F: Found WRITE statement with hardcoded unit in "generate_qs_task_list"
 timings.F: Found WRITE statement with hardcoded unit in "timestop_handler"
 tmc_analysis.F: Found WRITE statement with hardcoded unit in "print_average_displacement"
@@ -274,7 +263,6 @@ xc.F: Found OPEN statement in procedure "xc_vxc_pw_create_debug"
 xc.F: Found OPEN statement in procedure "xc_vxc_pw_create_test_lsd"
 xc.F: Found WRITE statement with hardcoded unit in "xc_vxc_pw_create_debug"
 xc.F: Found WRITE statement with hardcoded unit in "xc_vxc_pw_create_test_lsd"
-xml_parser.F: Copyright banner malformed
 xml_parser.F: Found WRITE statement with hardcoded unit in "xml_put_element_"
 xml_parser.F: Found WRITE statement with hardcoded unit in "xml_report_details_int_"
 xml_parser.F: Found WRITE statement with hardcoded unit in "xml_report_details_string_"


### PR DESCRIPTION
After this PR all our files will have the same copyright banner.

I also discovered BSD licenses in [t_c_g0.F](https://github.com/cp2k/cp2k/blob/master/src/common/t_c_g0.F), [t_sh_p_s_c.F](https://github.com/cp2k/cp2k/blob/master/src/common/t_sh_p_s_c.F), and [sockets.c](https://github.com/cp2k/cp2k/blob/master/src/sockets.c). I'm actually not sure if the BSD license still applies to the entire file, because subsequent changes within the CP2K project are probably under GPL-2+. To resolve this confusing situation, I'd like to remove the BSD licenses with the permissions of the original authors.

So, @vondele and @ceriottm are you ok with removing these BSD license statements?