### PR TITLE
Density fit returns best possible values even if not converged.

### DIFF
--- a/src/atom_fit.F
+++ b/src/atom_fit.F
@@ -139,6 +139,7 @@ CONTAINS
 
       ostate%state = 8
       CALL powell_optimize(ostate%nvar, x, ostate)
+      CALL density_fit(density, atom, num_gto, x(1), x(2), co, ostate%f)
 
       CALL release_opgrid(density)
 


### PR DESCRIPTION
Is needed for Hirshfeld charges using density shape function.