### PR TITLE
grid: Remove FE_INVALID check to avoid false positives from fast-math

### DIFF
--- a/src/grid/grid_collocate_replay.c
+++ b/src/grid/grid_collocate_replay.c
@@ -455,10 +455,6 @@ double grid_collocate_replay(const char *filename, const int cycles,
   free(grid_test);
 
   // Check floating point exceptions.
-  if (fetestexcept(FE_INVALID) != 0) {
-    fprintf(stderr, "Error: Floating point exception FE_INVALID.\n");
-    exit(1);
-  }
   if (fetestexcept(FE_DIVBYZERO) != 0) {
     fprintf(stderr, "Error: Floating point exception FE_DIVBYZERO.\n");
     exit(1);


### PR DESCRIPTION
Fixes #1104