### PR TITLE
Fixed GAPW meta-GGA bug

### DIFF
--- a/src/qs_grid_atom.F
+++ b/src/qs_grid_atom.F
@@ -248,7 +248,6 @@ CONTAINS
                END IF
                grid_atom%cos_azi(ia) = COS(grid_atom%azi(ia))
                pol = ACOS(cosia)
-               IF (grid_atom%sin_pol(ia) < 0.0_dp) pol = -pol
                grid_atom%pol(ia) = pol
                grid_atom%sin_pol(ia) = SIN(grid_atom%pol(ia))
 

--- a/src/qs_harmonics_atom.F
+++ b/src/qs_harmonics_atom.F
@@ -19,8 +19,7 @@ MODULE qs_harmonics_atom
                                               nso,&
                                               nsoset
    USE orbital_transformation_matrices, ONLY: orbtramat
-   USE spherical_harmonics,             ONLY: dy_lm,&
-                                              y_lm
+   USE spherical_harmonics,             ONLY: y_lm
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -36,9 +35,9 @@ MODULE qs_harmonics_atom
                                                 damax_iso_not0, &
                                                 ngrid
       REAL(dp), DIMENSION(:, :), POINTER   :: a, slm
-      REAL(dp), DIMENSION(:, :, :), POINTER   :: dslm, dslm_dxyz
-      REAL(dp), DIMENSION(:, :, :), POINTER   :: my_CG, my_dCG
-      REAL(dp), DIMENSION(:, :, :, :), POINTER :: my_CG_dxyz
+      REAL(dp), DIMENSION(:, :, :), POINTER   :: dslm_dxyz
+      REAL(dp), DIMENSION(:, :, :), POINTER   :: my_CG
+      REAL(dp), DIMENSION(:, :, :, :), POINTER :: my_CG_dxyz, my_dCG, my_ddCG
       REAL(dp), DIMENSION(:, :, :, :), POINTER :: my_CG_dxyz_asym
       REAL(dp), DIMENSION(:), POINTER        :: slm_int
 
@@ -78,11 +77,11 @@ CONTAINS
       harmonics%ngrid = 0
 
       NULLIFY (harmonics%slm)
-      NULLIFY (harmonics%dslm)
       NULLIFY (harmonics%dslm_dxyz)
       NULLIFY (harmonics%slm_int)
       NULLIFY (harmonics%my_CG)
       NULLIFY (harmonics%my_dCG)
+      NULLIFY (harmonics%my_ddCG)
       NULLIFY (harmonics%my_CG_dxyz)
       NULLIFY (harmonics%my_CG_dxyz_asym)
       NULLIFY (harmonics%a)
@@ -104,10 +103,6 @@ CONTAINS
             DEALLOCATE (harmonics%slm)
          ENDIF
 
-         IF (ASSOCIATED(harmonics%dslm)) THEN
-            DEALLOCATE (harmonics%dslm)
-         ENDIF
-
          IF (ASSOCIATED(harmonics%dslm_dxyz)) THEN
             DEALLOCATE (harmonics%dslm_dxyz)
          ENDIF
@@ -122,6 +117,10 @@ CONTAINS
 
          IF (ASSOCIATED(harmonics%my_dCG)) THEN
             DEALLOCATE (harmonics%my_dCG)
+         ENDIF
+
+         IF (ASSOCIATED(harmonics%my_ddCG)) THEN
+            DEALLOCATE (harmonics%my_ddCG)
          ENDIF
 
          IF (ASSOCIATED(harmonics%my_CG_dxyz)) THEN
@@ -187,11 +186,13 @@ CONTAINS
       harmonics%llmax = llmax
       harmonics%ngrid = na
 
-      NULLIFY (harmonics%my_CG, harmonics%my_CG_dxyz, harmonics%my_CG_dxyz_asym, harmonics%my_dCG)
+      NULLIFY (harmonics%my_CG, harmonics%my_CG_dxyz, harmonics%my_CG_dxyz_asym, harmonics%my_dCG, &
+               harmonics%my_ddCG)
       CALL reallocate(harmonics%my_CG, 1, maxs, 1, maxs, 1, max_s_harm)
       CALL reallocate(harmonics%my_CG_dxyz, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
       CALL reallocate(harmonics%my_CG_dxyz_asym, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
-      CALL reallocate(harmonics%my_dCG, 1, maxs, 1, maxs, 1, max_s_harm)
+      CALL reallocate(harmonics%my_dCG, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
+      CALL reallocate(harmonics%my_ddCG, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
 
       DO i = 1, max_s_harm
          DO is1 = 1, maxs
@@ -201,9 +202,8 @@ CONTAINS
 
       ! allocate and calculate the spherical harmonics LM for this grid
       ! and their derivatives
-      NULLIFY (harmonics%slm, harmonics%dslm, harmonics%dslm_dxyz, harmonics%a, harmonics%slm_int)
+      NULLIFY (harmonics%slm, harmonics%dslm_dxyz, harmonics%a, harmonics%slm_int)
       CALL reallocate(harmonics%slm, 1, na, 1, max_s_harm)
-      CALL reallocate(harmonics%dslm, 1, 2, 1, na, 1, maxs)
       CALL reallocate(harmonics%dslm_dxyz, 1, 3, 1, na, 1, max_s_harm)
       CALL reallocate(harmonics%a, 1, 3, 1, na)
       CALL reallocate(harmonics%slm_int, 1, max_s_harm)
@@ -372,39 +372,56 @@ CONTAINS
       END DO ! iso1
 !$OMP END DO
 
-      ! Calculate the derivatives of the harmonics with respect of the 2 angles
-      ! the first angle (polar) is acos(lebedev_grid(ll)%r(3))
-      ! the second angle (azimutal) is atan(lebedev_grid(ll)%r(2)/lebedev_grid(ll)%r(1))
-!$OMP DO
-      DO iso = 1, maxs
-         l = indso(1, iso)
-         m = indso(2, iso)
-         DO ia = 1, na
-            cin(1) = pol(ia)
-            cin(2) = azi(ia)
-            CALL dy_lm(cin, dylm, l, m)
-            harmonics%dslm(:, ia, iso) = dylm(:)
+      ! CG coefficients for the tau functionals, namely dYl1m1/dx * dYl2m2/dx and Yl1m1 * dYl2m2/dx
+      ! named my_ddCG and my_dCG (derivative * derivative and normal * derivative)
+
+!$OMP DO COLLAPSE(3)
+      DO iso1 = 1, maxs
+         DO iso2 = 1, maxs
+
+            DO iso = 1, max_s_harm
+               rx = 0.0_dp
+               ry = 0.0_dp
+               rz = 0.0_dp
+
+               DO ia = 1, na
+                  rx = rx + wa(ia)*slm(ia, iso)*(dslm_dxyz(1, ia, iso1)*dslm_dxyz(1, ia, iso2))
+                  ry = ry + wa(ia)*slm(ia, iso)*(dslm_dxyz(2, ia, iso1)*dslm_dxyz(2, ia, iso2))
+                  rz = rz + wa(ia)*slm(ia, iso)*(dslm_dxyz(3, ia, iso1)*dslm_dxyz(3, ia, iso2))
+               END DO
+
+               harmonics%my_ddCG(1, iso1, iso2, iso) = rx
+
+               harmonics%my_ddCG(2, iso1, iso2, iso) = ry
+
+               harmonics%my_ddCG(3, iso1, iso2, iso) = rz
+
+            END DO
          END DO
       END DO
 !$OMP END DO
 
-      ! expansion coefficients of product of polar angle derivatives (dslm(1...)) in
-      ! spherical harmonics (used for tau functionals)
+!$OMP DO COLLAPSE(3)
+      DO iso1 = 1, maxs
+         DO iso2 = 1, maxs
 
-!$OMP DO
-      DO is1 = 1, maxs
-         l1 = indso(1, is1)
-         m1 = indso(2, is1)
-         DO is2 = 1, maxs
-            l2 = indso(1, is2)
-            m2 = indso(2, is2)
             DO iso = 1, max_s_harm
-               l = indso(1, iso)
-               m = indso(2, iso)
-               CALL y_lm(lebedev_grid(ll)%r, y, l, m)
+               rx = 0.0_dp
+               ry = 0.0_dp
+               rz = 0.0_dp
 
-               y(1:na) = y(1:na)*lebedev_grid(ll)%w(1:na)*harmonics%dslm(1, 1:na, is1)*harmonics%dslm(1, 1:na, is2)
-               harmonics%my_dCG(is1, is2, iso) = SUM(y(1:na))
+               DO ia = 1, na
+                  rx = rx + wa(ia)*slm(ia, iso)*(slm(ia, iso1)*dslm_dxyz(1, ia, iso2))
+                  ry = ry + wa(ia)*slm(ia, iso)*(slm(ia, iso1)*dslm_dxyz(2, ia, iso2))
+                  rz = rz + wa(ia)*slm(ia, iso)*(slm(ia, iso1)*dslm_dxyz(3, ia, iso2))
+               END DO
+
+               harmonics%my_dCG(1, iso1, iso2, iso) = rx
+
+               harmonics%my_dCG(2, iso1, iso2, iso) = ry
+
+               harmonics%my_dCG(3, iso1, iso2, iso) = rz
+
             END DO
          END DO
       END DO

--- a/src/qs_rho_atom_methods.F
+++ b/src/qs_rho_atom_methods.F
@@ -113,23 +113,25 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_rho_atom'
 
-      INTEGER :: damax_iso_not0_local, dbmax_iso_not0_local, dmax_iso_not0, handle, i, i1, i2, &
-         iat, iatom, icg, ipgf1, ipgf2, ir, iset1, iset2, iso, iso1, iso1_first, iso1_last, iso2, &
-         iso2_first, iso2_last, isom1, isom2, istat, j, l, l1, l2, l_iso, l_sub, l_sum, lmax12, &
-         lmax_expansion, lmin12, m1, m1s, m2, m2s, max_iso_not0, max_iso_not0_local, max_s_harm, &
-         maxl, maxso, mepos, n1s, n2s, nr, nset, num_pe, size1, size2
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dacg_n_list, dbcg_n_list
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dacg_list, dbcg_list
+      INTEGER :: damax_iso_not0_local, dbmax_iso_not0_local, dcmax_iso_not0_local, dir, &
+         dmax_iso_not0, handle, i, i1, i2, iat, iatom, icg, ipgf1, ipgf2, ir, iset1, iset2, iso, &
+         iso1, iso1_first, iso1_last, iso2, iso2_first, iso2_last, isom1, isom2, istat, j, l, l1, &
+         l2, l_iso, l_sub, l_sum, lmax12, lmax_expansion, lmin12, m1, m1s, m2, m2s, max_iso_not0, &
+         max_iso_not0_local, max_s_harm, maxl, maxso, mepos, n1s, n2s, nr, nset, num_pe, size1, &
+         size2
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dacg_n_list, dbcg_n_list, &
+                                                            dccg_n_list
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dacg_list, dbcg_list, dccg_list
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(:), POINTER                     :: lmax, lmin, npgf, o2nindex
       LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: done_vgg
       REAL(dp)                                           :: c1, c2, rho_h, rho_s, root_zet12, zet12
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: dd, erf_zet12, g1, g2, gg0, int1, int2
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: erf_zet12, g1, g2, gg0, int1, int2
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: CPCH_sphere, CPCS_sphere, dgg, gg, gg_lm1
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: vgg
       REAL(dp), DIMENSION(:, :), POINTER                 :: coeff, zet
-      REAL(dp), DIMENSION(:, :, :), POINTER              :: my_CG, my_dCG
-      REAL(dp), DIMENSION(:, :, :, :), POINTER           :: my_CG_dxyz
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: my_CG
+      REAL(dp), DIMENSION(:, :, :, :), POINTER           :: my_CG_dxyz, my_dCG, my_ddCG
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
@@ -137,9 +139,13 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
+      !Note on tau funtionals: need to take the Cartesian dot product of the gradient of 2 Gaussians
+      !     => we keep track of the direction (x,y,z) and separate the different cross terms
+      !        depending on their angular part dependencies. That is 3x3=9 terms in total
+
       NULLIFY (orb_basis)
       NULLIFY (harmonics, grid_atom)
-      NULLIFY (lmin, lmax, npgf, zet, my_CG, my_dCG, my_CG_dxyz, coeff)
+      NULLIFY (lmin, lmax, npgf, zet, my_CG, my_dCG, my_CG_dxyz, coeff, my_ddCG)
 
       CALL get_qs_kind(qs_kind, basis_set=orb_basis, grid_atom=grid_atom, &
                        paw_proj_set=paw_proj, harmonics=harmonics)
@@ -163,6 +169,7 @@ CONTAINS
 
       my_CG => harmonics%my_CG
       my_dCG => harmonics%my_dCG
+      my_ddCG => harmonics%my_ddCG
       my_CG_dxyz => harmonics%my_CG_dxyz
 
       ALLOCATE (CPCH_sphere(nsoset(maxl), nsoset(maxl)))
@@ -170,10 +177,11 @@ CONTAINS
       ALLOCATE (g1(nr), g2(nr), gg0(nr), gg(nr, 0:2*maxl), dgg(nr, 0:2*maxl), gg_lm1(nr, 0:2*maxl))
       ALLOCATE (erf_zet12(nr), vgg(nr, 0:2*maxl, 0:indso(1, max_iso_not0)))
       ALLOCATE (done_vgg(0:2*maxl, 0:indso(1, max_iso_not0)))
-      ALLOCATE (dd(nr), int1(nr), int2(nr))
+      ALLOCATE (int1(nr), int2(nr))
       ALLOCATE (cg_list(2, nsoset(maxl)**2, max_s_harm), cg_n_list(max_s_harm), &
                 dacg_list(2, nsoset(maxl)**2, max_s_harm), dacg_n_list(max_s_harm), &
                 dbcg_list(2, nsoset(maxl)**2, max_s_harm), dbcg_n_list(max_s_harm), &
+                dccg_list(2, nsoset(maxl)**2, max_s_harm), dccg_n_list(max_s_harm), &
                 STAT=istat)
       CPASSERT(istat == 0)
 
@@ -200,6 +208,8 @@ CONTAINS
                                    max_s_harm, lmax_expansion, dacg_list, dacg_n_list, damax_iso_not0_local)
             CALL get_none0_cg_list(my_dCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
                                    max_s_harm, lmax_expansion, dbcg_list, dbcg_n_list, dbmax_iso_not0_local)
+            CALL get_none0_cg_list(my_ddCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
+                                   max_s_harm, lmax_expansion, dccg_list, dccg_n_list, dcmax_iso_not0_local)
             n1s = nsoset(lmax(iset1))
 
             DO ipgf1 = 1, npgf(iset1)
@@ -258,12 +268,11 @@ CONTAINS
                      DO l = lmin12 + 1, lmax12
                         gg(1:nr, l) = grid_atom%rad(1:nr)*gg(1:nr, l - 1)
                         gg_lm1(1:nr, l) = gg(1:nr, l - 1)
-                        dgg(1:nr, l - 1) = dgg(1:nr, l - 1) - 2.0_dp*(zet(ipgf1, iset1) &
-                                                                      + zet(ipgf2, iset2))*gg(1:nr, l)
+                        dgg(1:nr, l - 1) = -2.0_dp*(zet(ipgf1, iset1) + zet(ipgf2, iset2))*gg(1:nr, l)
 
                      END DO
-                     dgg(1:nr, lmax12) = dgg(1:nr, lmax12) - 2.0_dp*(zet(ipgf1, iset1) &
-                                                                     + zet(ipgf2, iset2))*grid_atom%rad(1:nr)*gg(1:nr, lmax12)
+                     dgg(1:nr, lmax12) = -2.0_dp*(zet(ipgf1, iset1) + &
+                                                  zet(ipgf2, iset2))*grid_atom%rad(1:nr)*gg(1:nr, lmax12)
 
                      c2 = SQRT(pi*pi*pi/(zet12*zet12*zet12))
 
@@ -322,10 +331,6 @@ CONTAINS
                               isom1 = soset(l1, -m1)
                               isom2 = soset(l2, -m2)
 
-                              dd(1:nr) = REAL(l1*l2, dp)/grid_atom%rad2(1:nr) &
-                                         - 2._dp*REAL(l1, dp)*zet(ipgf2, iset2) &
-                                         - 2._dp*REAL(l2, dp)*zet(ipgf1, iset1) &
-                                         + 4._dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)*grid_atom%rad2(1:nr)
                               l = indso(1, iso1) + indso(1, iso2)
                               CPASSERT(l <= lmax_expansion)
 
@@ -353,23 +358,18 @@ CONTAINS
                                  rho_atom_set(iatom)%vrho_rad_s(i)%r_coef(1:nr, iso) + &
                                  vgg(1:nr, l, l_iso)*CPCS_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
 
-                              rho_atom_set(iatom)%trho_rad_h(1, i)%r_coef(1:nr, iso) = &
-                                 rho_atom_set(iatom)%trho_rad_h(1, i)%r_coef(1:nr, iso) + &
-                                 0.5_dp*gg(1:nr, l)*dd(1:nr)*CPCH_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
+                              !tau functionals, terms in Ylm*Ylm, to be multiplied by x^2 comp. of unit vector
+                              DO dir = 1, 3
+                                 rho_atom_set(iatom)%trho_rad_h(1, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_h(1, dir, i)%r_coef(1:nr, iso) + &
+                                    2.0_dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)*grid_atom%rad2(1:nr)* &
+                                    gg(1:nr, l)*CPCH_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
 
-                              rho_atom_set(iatom)%trho_rad_s(1, i)%r_coef(1:nr, iso) = &
-                                 rho_atom_set(iatom)%trho_rad_s(1, i)%r_coef(1:nr, iso) + &
-                                 0.5_dp*gg(1:nr, l)*dd(1:nr)*CPCS_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
-
-                              rho_atom_set(iatom)%trho_rad_h(3, i)%r_coef(1:nr, iso) = &
-                                 rho_atom_set(iatom)%trho_rad_h(3, i)%r_coef(1:nr, iso) + &
-                                 0.5_dp*REAL(m1*m2, dp)*gg(1:nr, l)*CPCH_sphere(iso1, iso2)* &
-                                 my_CG(isom1, isom2, iso)/grid_atom%rad2(1:nr)
-
-                              rho_atom_set(iatom)%trho_rad_s(3, i)%r_coef(1:nr, iso) = &
-                                 rho_atom_set(iatom)%trho_rad_s(3, i)%r_coef(1:nr, iso) + &
-                                 0.5_dp*REAL(m1*m2, dp)*gg(1:nr, l)*CPCS_sphere(iso1, iso2)* &
-                                 my_CG(isom1, isom2, iso)/grid_atom%rad2(1:nr)
+                                 rho_atom_set(iatom)%trho_rad_s(1, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_s(1, dir, i)%r_coef(1:nr, iso) + &
+                                    2.0_dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)*grid_atom%rad2(1:nr)* &
+                                    gg(1:nr, l)*CPCS_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
+                              END DO
 
                            ENDDO ! icg
 
@@ -395,28 +395,63 @@ CONTAINS
 
                         ENDDO ! iso
 
-                        !Expansion for tau functionals (polar angle term)
-                        !We ignore the contributions iso > max_iso_not0 (should be dmax_iso_not0)
-
-                        DO iso = 1, max_iso_not0 !dbmax_iso_not0_local
+                        !tau functionals, terms in Ylm * dYlm/dx, to be multiplied by x comp. of unit vector
+                        DO iso = 1, max_iso_not0
                            l_iso = indso(1, iso)
                            DO icg = 1, dbcg_n_list(iso)
                               iso1 = dbcg_list(1, icg, iso)
                               iso2 = dbcg_list(2, icg, iso)
 
                               l = indso(1, iso1) + indso(1, iso2)
-                              CPASSERT(l <= lmax_expansion)
-                              rho_atom_set(iatom)%trho_rad_h(2, i)%r_coef(1:nr, iso) = &
-                                 rho_atom_set(iatom)%trho_rad_h(2, i)%r_coef(1:nr, iso) + &
-                                 0.5_dp*gg(1:nr, l)*CPCH_sphere(iso1, iso2)* &
-                                 my_dCG(iso1, iso2, iso)/grid_atom%rad2(1:nr)
 
-                              rho_atom_set(iatom)%trho_rad_s(2, i)%r_coef(1:nr, iso) = &
-                                 rho_atom_set(iatom)%trho_rad_s(2, i)%r_coef(1:nr, iso) + &
-                                 0.5_dp*gg(1:nr, l)*CPCS_sphere(iso1, iso2)* &
-                                 my_dCG(iso1, iso2, iso)/grid_atom%rad2(1:nr)
-                           END DO ! icg
-                        ENDDO ! iso
+                              DO dir = 1, 3
+
+                                 !Yl1m1 * dYl2m2/dx
+                                 rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) - &
+                                    zet(ipgf1, iset1)*gg(1:nr, l)*CPCH_sphere(iso1, iso2)*my_dCG(dir, iso1, iso2, iso)
+
+                                 rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) - &
+                                    zet(ipgf1, iset1)*gg(1:nr, l)*CPCS_sphere(iso1, iso2)*my_dCG(dir, iso1, iso2, iso)
+
+                                 !dYl1m1/dx * Yl2m2
+                                 rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) - &
+                                    zet(ipgf2, iset2)*gg(1:nr, l)*CPCH_sphere(iso1, iso2)*my_dCG(dir, iso2, iso1, iso)
+
+                                 rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) - &
+                                    zet(ipgf2, iset2)*gg(1:nr, l)*CPCS_sphere(iso1, iso2)*my_dCG(dir, iso2, iso1, iso)
+
+                              ENDDO !dir
+                           ENDDO !icg
+                        ENDDO !iso
+
+                        !tau functionals, terms in dYlm/dx * dYlm/dx, to be multiplied by 1
+                        DO iso = 1, max_iso_not0
+                           l_iso = indso(1, iso)
+                           DO icg = 1, dccg_n_list(iso)
+                              iso1 = dccg_list(1, icg, iso)
+                              iso2 = dccg_list(2, icg, iso)
+
+                              l = indso(1, iso1) + indso(1, iso2)
+
+                              DO dir = 1, 3
+
+                                 rho_atom_set(iatom)%trho_rad_h(3, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_h(3, dir, i)%r_coef(1:nr, iso) + &
+                                    0.5_dp*gg(1:nr, l)/grid_atom%rad2(1:nr)* &
+                                    CPCH_sphere(iso1, iso2)*my_ddCG(dir, iso1, iso2, iso)
+
+                                 rho_atom_set(iatom)%trho_rad_s(3, dir, i)%r_coef(1:nr, iso) = &
+                                    rho_atom_set(iatom)%trho_rad_s(3, dir, i)%r_coef(1:nr, iso) + &
+                                    0.5_dp*gg(1:nr, l)/grid_atom%rad2(1:nr)* &
+                                    CPCS_sphere(iso1, iso2)*my_ddCG(dir, iso1, iso2, iso)
+
+                              ENDDO !dir
+                           ENDDO !icg
+                        ENDDO !iso
 
                      ENDDO ! i
                   ENDDO ! iat
@@ -450,7 +485,7 @@ CONTAINS
 
       DEALLOCATE (CPCH_sphere, CPCS_sphere)
       DEALLOCATE (g1, g2, gg0, gg, gg_lm1, dgg, vgg, done_vgg, erf_zet12, int1, int2)
-      DEALLOCATE (cg_list, cg_n_list, dacg_list, dacg_n_list, dbcg_list, dbcg_n_list)
+      DEALLOCATE (cg_list, cg_n_list, dacg_list, dacg_n_list, dbcg_list, dbcg_n_list, dccg_list, dccg_n_list)
 
       CALL timestop(handle)
 
@@ -996,9 +1031,10 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'allocate_rho_atom_internals'
 
-      INTEGER                                            :: bo(2), handle, iat, iatom, ikind, ispin, &
-                                                            istat, j, max_iso_not0, mepos, nat, &
-                                                            natom, nsatbas, nsotot, nspins, num_pe
+      INTEGER                                            :: bo(2), dir, handle, iat, iatom, ikind, &
+                                                            ispin, istat, j, max_iso_not0, mepos, &
+                                                            nat, natom, nsatbas, nsotot, nspins, &
+                                                            num_pe
       INTEGER, DIMENSION(:), POINTER                     :: atom_list
       LOGICAL                                            :: paw_atom
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
@@ -1053,8 +1089,8 @@ CONTAINS
                       rho_atom_set(iatom)%cpc_s(nspins), &
                       rho_atom_set(iatom)%drho_rad_h(nspins), &
                       rho_atom_set(iatom)%drho_rad_s(nspins), &
-                      rho_atom_set(iatom)%trho_rad_h(3, nspins), &
-                      rho_atom_set(iatom)%trho_rad_s(3, nspins), &
+                      rho_atom_set(iatom)%trho_rad_h(3, 3, nspins), &
+                      rho_atom_set(iatom)%trho_rad_s(3, 3, nspins), &
                       rho_atom_set(iatom)%rho_rad_h_d(3, nspins), &
                       rho_atom_set(iatom)%rho_rad_s_d(3, nspins), &
                       STAT=istat)
@@ -1063,13 +1099,15 @@ CONTAINS
             IF (paw_atom) THEN
                DO ispin = 1, nspins
                   NULLIFY (rho_atom_set(iatom)%drho_rad_h(ispin)%r_coef, &
-                           rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef, &
-                           rho_atom_set(iatom)%trho_rad_h(1, ispin)%r_coef, &
-                           rho_atom_set(iatom)%trho_rad_h(2, ispin)%r_coef, &
-                           rho_atom_set(iatom)%trho_rad_h(3, ispin)%r_coef, &
-                           rho_atom_set(iatom)%trho_rad_s(1, ispin)%r_coef, &
-                           rho_atom_set(iatom)%trho_rad_s(2, ispin)%r_coef, &
-                           rho_atom_set(iatom)%trho_rad_s(3, ispin)%r_coef)
+                           rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef)
+                  DO dir = 1, 3
+                     NULLIFY (rho_atom_set(iatom)%trho_rad_h(1, dir, ispin)%r_coef, &
+                              rho_atom_set(iatom)%trho_rad_h(2, dir, ispin)%r_coef, &
+                              rho_atom_set(iatom)%trho_rad_h(3, dir, ispin)%r_coef, &
+                              rho_atom_set(iatom)%trho_rad_s(1, dir, ispin)%r_coef, &
+                              rho_atom_set(iatom)%trho_rad_s(2, dir, ispin)%r_coef, &
+                              rho_atom_set(iatom)%trho_rad_s(3, dir, ispin)%r_coef)
+                  END DO
                   ALLOCATE (rho_atom_set(iatom)%cpc_h(ispin)%r_coef(1:nsatbas, 1:nsatbas), &
                             rho_atom_set(iatom)%cpc_s(ispin)%r_coef(1:nsatbas, 1:nsatbas), &
                             STAT=istat)
@@ -1087,8 +1125,10 @@ CONTAINS
                   NULLIFY (rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef)
 
                   DO j = 1, 3
-                     NULLIFY (rho_atom_set(iatom)%trho_rad_h(j, ispin)%r_coef)
-                     NULLIFY (rho_atom_set(iatom)%trho_rad_s(j, ispin)%r_coef)
+                     DO dir = 1, 3
+                        NULLIFY (rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef)
+                        NULLIFY (rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef)
+                     END DO
                      NULLIFY (rho_atom_set(iatom)%rho_rad_h_d(j, ispin)%r_coef)
                      NULLIFY (rho_atom_set(iatom)%rho_rad_s_d(j, ispin)%r_coef)
                   END DO
@@ -1149,7 +1189,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'allocate_rho_atom_rad'
 
-      INTEGER                                            :: handle, istat, j
+      INTEGER                                            :: dir, handle, istat, j
 
       CALL timeset(routineN, handle)
 
@@ -1172,13 +1212,15 @@ CONTAINS
       rho_atom_set(iatom)%drho_rad_h(ispin)%r_coef = 0.0_dp
       rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef = 0.0_dp
 
-      DO j = 1, 3
-         ALLOCATE (rho_atom_set(iatom)%trho_rad_h(j, ispin)%r_coef(nr, max_iso_not0), &
-                   rho_atom_set(iatom)%trho_rad_s(j, ispin)%r_coef(nr, max_iso_not0), &
-                   STAT=istat)
-         CPASSERT(istat == 0)
-         rho_atom_set(iatom)%trho_rad_h(j, ispin)%r_coef = 0.0_dp
-         rho_atom_set(iatom)%trho_rad_s(j, ispin)%r_coef = 0.0_dp
+      DO dir = 1, 3
+         DO j = 1, 3
+            ALLOCATE (rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef(nr, max_iso_not0), &
+                      rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef(nr, max_iso_not0), &
+                      STAT=istat)
+            CPASSERT(istat == 0)
+            rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef = 0.0_dp
+            rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef = 0.0_dp
+         END DO
       END DO
 
       DO j = 1, 3
@@ -1207,7 +1249,7 @@ CONTAINS
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set
       INTEGER, INTENT(IN)                                :: iatom, ispin
 
-      INTEGER                                            :: j
+      INTEGER                                            :: dir, j
 
       rho_atom_set(iatom)%rho_rad_h(ispin)%r_coef = 0.0_dp
       rho_atom_set(iatom)%rho_rad_s(ispin)%r_coef = 0.0_dp
@@ -1218,11 +1260,13 @@ CONTAINS
       rho_atom_set(iatom)%drho_rad_h(ispin)%r_coef = 0.0_dp
       rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef = 0.0_dp
 
-      DO j = 1, 3
-         rho_atom_set(iatom)%trho_rad_h(j, ispin)%r_coef = 0.0_dp
-         rho_atom_set(iatom)%trho_rad_s(j, ispin)%r_coef = 0.0_dp
-         rho_atom_set(iatom)%rho_rad_h_d(j, ispin)%r_coef = 0.0_dp
-         rho_atom_set(iatom)%rho_rad_s_d(j, ispin)%r_coef = 0.0_dp
+      DO dir = 1, 3
+         DO j = 1, 3
+            rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef = 0.0_dp
+            rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef = 0.0_dp
+            rho_atom_set(iatom)%rho_rad_h_d(j, ispin)%r_coef = 0.0_dp
+            rho_atom_set(iatom)%rho_rad_s_d(j, ispin)%r_coef = 0.0_dp
+         END DO
       END DO
 
    END SUBROUTINE set2zero_rho_atom_rad

--- a/src/qs_rho_atom_types.F
+++ b/src/qs_rho_atom_types.F
@@ -34,7 +34,7 @@ MODULE qs_rho_atom_types
       TYPE(rho_atom_coeff), DIMENSION(:, :), &
          POINTER  :: rho_rad_h_d, &
                      rho_rad_s_d
-      TYPE(rho_atom_coeff), DIMENSION(:, :), &
+      TYPE(rho_atom_coeff), DIMENSION(:, :, :), &
          POINTER  :: trho_rad_h, &
                      trho_rad_s
 
@@ -105,7 +105,7 @@ CONTAINS
 
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set
 
-      INTEGER                                            :: i, iat, j, n, natom
+      INTEGER                                            :: dir, i, iat, j, n, natom
 
       IF (ASSOCIATED(rho_atom_set)) THEN
 
@@ -194,24 +194,28 @@ CONTAINS
             ENDIF
 
             IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_h)) THEN
-               IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_h(1, 1)%r_coef)) THEN
-                  n = SIZE(rho_atom_set(iat)%trho_rad_h, 2)
+               IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_h(1, 1, 1)%r_coef)) THEN
+                  n = SIZE(rho_atom_set(iat)%trho_rad_h, 3)
                   DO i = 1, n
-                     DEALLOCATE (rho_atom_set(iat)%trho_rad_h(1, i)%r_coef)
-                     DEALLOCATE (rho_atom_set(iat)%trho_rad_h(2, i)%r_coef)
-                     DEALLOCATE (rho_atom_set(iat)%trho_rad_h(3, i)%r_coef)
+                     DO dir = 1, 3
+                        DEALLOCATE (rho_atom_set(iat)%trho_rad_h(1, dir, i)%r_coef)
+                        DEALLOCATE (rho_atom_set(iat)%trho_rad_h(2, dir, i)%r_coef)
+                        DEALLOCATE (rho_atom_set(iat)%trho_rad_h(3, dir, i)%r_coef)
+                     ENDDO
                   ENDDO
                ENDIF
                DEALLOCATE (rho_atom_set(iat)%trho_rad_h)
             ENDIF
 
             IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_s)) THEN
-               IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_s(1, 1)%r_coef)) THEN
-                  n = SIZE(rho_atom_set(iat)%trho_rad_s, 2)
+               IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_s(1, 1, 1)%r_coef)) THEN
+                  n = SIZE(rho_atom_set(iat)%trho_rad_s, 3)
                   DO i = 1, n
-                     DEALLOCATE (rho_atom_set(iat)%trho_rad_s(1, i)%r_coef)
-                     DEALLOCATE (rho_atom_set(iat)%trho_rad_s(2, i)%r_coef)
-                     DEALLOCATE (rho_atom_set(iat)%trho_rad_s(3, i)%r_coef)
+                     DO dir = 1, 3
+                        DEALLOCATE (rho_atom_set(iat)%trho_rad_s(1, dir, i)%r_coef)
+                        DEALLOCATE (rho_atom_set(iat)%trho_rad_s(2, dir, i)%r_coef)
+                        DEALLOCATE (rho_atom_set(iat)%trho_rad_s(3, dir, i)%r_coef)
+                     ENDDO
                   ENDDO
                ENDIF
                DEALLOCATE (rho_atom_set(iat)%trho_rad_s)
@@ -260,8 +264,9 @@ CONTAINS
                                                             drho_rad_h, drho_rad_s, vrho_rad_h, &
                                                             vrho_rad_s
       TYPE(rho_atom_coeff), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: rho_rad_h_d, rho_rad_s_d, trho_rad_h, &
-                                                            trho_rad_s
+         POINTER                                         :: rho_rad_h_d, rho_rad_s_d
+      TYPE(rho_atom_coeff), DIMENSION(:, :, :), &
+         OPTIONAL, POINTER                               :: trho_rad_h, trho_rad_s
       TYPE(rho_atom_coeff), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: ga_Vlocal_gb_h, ga_Vlocal_gb_s
 

--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -121,7 +121,8 @@ CONTAINS
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: my_kind_set
       TYPE(qs_kind_type), POINTER                        :: qs_kind
       TYPE(rho_atom_coeff), DIMENSION(:), POINTER        :: dr_h, dr_s, r_h, r_s
-      TYPE(rho_atom_coeff), DIMENSION(:, :), POINTER     :: r_h_d, r_s_d, trho_h, trho_s
+      TYPE(rho_atom_coeff), DIMENSION(:, :), POINTER     :: r_h_d, r_s_d
+      TYPE(rho_atom_coeff), DIMENSION(:, :, :), POINTER  :: trho_h, trho_s
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: my_rho_atom_set
       TYPE(rho_atom_type), POINTER                       :: rho_atom
       TYPE(section_vals_type), POINTER                   :: input, my_xc_section, xc_fun_section
@@ -864,10 +865,10 @@ CONTAINS
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
       INTEGER, INTENT(IN)                                :: nspins, ir
-      TYPE(rho_atom_coeff), DIMENSION(:, :), POINTER     :: trho_h, trho_s
+      TYPE(rho_atom_coeff), DIMENSION(:, :, :), POINTER  :: trho_h, trho_s
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: tau_h, tau_s
 
-      INTEGER                                            :: ia, iso, ispin, na
+      INTEGER                                            :: dir, ia, iso, ispin, na
 
       CPASSERT(ASSOCIATED(trho_h))
       CPASSERT(ASSOCIATED(trho_s))
@@ -878,28 +879,38 @@ CONTAINS
       tau_h = 0.0_dp
       tau_s = 0.0_dp
 
+      !Here we multiply the different radial parts of tau by the angular parts (x^2, x or 1)
+      !and we take the cartesian dot product
+
       DO ispin = 1, nspins
          DO iso = 1, harmonics%max_iso_not0
             DO ia = 1, na
-               tau_h(ia, ispin) = tau_h(ia, ispin) + &
-                                  trho_h(1, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
-               tau_h(ia, ispin) = tau_h(ia, ispin) + &
-                                  trho_h(3, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
-               tau_s(ia, ispin) = tau_s(ia, ispin) + &
-                                  trho_s(1, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
-               tau_s(ia, ispin) = tau_s(ia, ispin) + &
-                                  trho_s(3, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
-            END DO ! ia
-         END DO ! iso
-         DO iso = 1, harmonics%max_iso_not0
-            DO ia = 1, na
-               tau_h(ia, ispin) = tau_h(ia, ispin) + &
-                                  trho_h(2, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*grid_atom%usin_azi(ia)**2
-               tau_s(ia, ispin) = tau_s(ia, ispin) + &
-                                  trho_s(2, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*grid_atom%usin_azi(ia)**2
-            END DO ! ia
-         END DO ! iso
-      END DO ! ispin
+
+               DO dir = 1, 3
+
+                  !part to be multiplied by x^2
+                  tau_h(ia, ispin) = tau_h(ia, ispin) + &
+                                     trho_h(1, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)**2
+                  tau_s(ia, ispin) = tau_s(ia, ispin) + &
+                                     trho_s(1, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)**2
+
+                  !part to be multiplied by x
+                  tau_h(ia, ispin) = tau_h(ia, ispin) + &
+                                     trho_h(2, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)
+                  tau_s(ia, ispin) = tau_s(ia, ispin) + &
+                                     trho_s(2, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)
+
+                  !part to be multiplied by 1
+                  tau_h(ia, ispin) = tau_h(ia, ispin) + &
+                                     trho_h(3, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
+                  tau_s(ia, ispin) = tau_s(ia, ispin) + &
+                                     trho_s(3, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
+
+               END DO !dir
+
+            END DO !ia
+         END DO !iso
+      END DO !ispin
 
    END SUBROUTINE calc_tau_angular
 ! **************************************************************************************************
@@ -1436,19 +1447,19 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'dgaVtaudgb'
 
-      INTEGER :: dmax_iso_not0_local, handle, ic, icg, ipgf1, ipgf2, iset1, iset2, iso, iso1, &
-         iso2, isom1, isom2, ispin, l1, l2, lmax12, lmax_expansion, lmin12, m1, m2, max_iso_not0, &
-         max_iso_not0_local, max_s_harm, maxiso, maxl, maxso, mm1, mm2, n1, n2, na, ngau1, ngau2, &
-         nngau1, nr, nset, size1
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dcg_n_list
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dcg_list
+      INTEGER :: ddmax_iso_not0_local, dir, dmax_iso_not0_local, handle, ic, icg, ipgf1, ipgf2, &
+         iset1, iset2, iso, iso1, iso2, isom1, isom2, ispin, l1, l2, lmax12, lmax_expansion, &
+         lmin12, m1, m2, max_iso_not0, max_iso_not0_local, max_s_harm, maxiso, maxl, maxso, mm1, &
+         mm2, n1, n2, na, ngau1, ngau2, nngau1, nr, nset, size1
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dcg_n_list, ddcg_n_list
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dcg_list, ddcg_list
       INTEGER, DIMENSION(:), POINTER                     :: lmax, lmin, npgf
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: dd, g1, g2, gg, gr, ww
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: dgr, dvth, dvts, matso_h, matso_s, vth, &
-                                                            vts
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: fgr
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: g1, g2, gr, ww
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: matso_h, matso_s
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: ddvth, ddvts, dvth, dvts, gg, vth, vts
       REAL(dp), DIMENSION(:, :), POINTER                 :: zet
-      REAL(dp), DIMENSION(:, :, :), POINTER              :: my_CG, my_dCG
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: my_CG
+      REAL(dp), DIMENSION(:, :, :, :), POINTER           :: my_dCG, my_ddCG
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
@@ -1469,17 +1480,19 @@ CONTAINS
 
       my_CG => harmonics%my_CG
       my_dCG => harmonics%my_dCG
+      my_ddCG => harmonics%my_ddCG
       max_iso_not0 = harmonics%max_iso_not0
       lmax_expansion = indso(1, max_iso_not0)
       max_s_harm = harmonics%max_s_harm
 
       nr = grid_atom%nr
       na = grid_atom%ng_sphere
-      ALLOCATE (g1(nr), g2(nr), gg(nr), dd(nr), gr(nr), ww(na))
-      ALLOCATE (fgr(nr, 0:maxl, 0:maxl), dgr(nr, 0:lmax_expansion))
+      ALLOCATE (g1(nr), g2(nr), ww(na), gr(nr))
+      ALLOCATE (gg(nr, 0:maxl, 0:maxl))
 
       ALLOCATE (cg_list(2, nsoset(maxl)**2, max_s_harm), cg_n_list(max_s_harm), &
-                dcg_list(2, nsoset(maxl)**2, max_s_harm), dcg_n_list(max_s_harm))
+                dcg_list(2, nsoset(maxl)**2, max_s_harm), dcg_n_list(max_s_harm), &
+                ddcg_list(2, nsoset(maxl)**2, max_s_harm), ddcg_n_list(max_s_harm))
 
       ALLOCATE (matso_h(nsoset(maxl), nsoset(maxl)), &
                 matso_s(nsoset(maxl), nsoset(maxl)))
@@ -1492,15 +1505,26 @@ CONTAINS
 
       DO ispin = 1, nspins
          maxiso = SIZE(harmonics%slm, 2)
-         ALLOCATE (vth(nr, maxiso), vts(nr, maxiso))
-         ALLOCATE (dvth(nr, maxiso), dvts(nr, maxiso))
+         ALLOCATE (vth(nr, 3, maxiso), vts(nr, 3, maxiso))
+         ALLOCATE (dvth(nr, 3, maxiso), dvts(nr, 3, maxiso))
+         ALLOCATE (ddvth(nr, 3, maxiso), ddvts(nr, 3, maxiso))
          DO iso = 1, maxiso
-            ww(1:na) = harmonics%slm(1:na, iso)
-            vth(1:nr, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
-            vts(1:nr, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
-            ww(1:na) = harmonics%slm(1:na, iso)*grid_atom%usin_azi(1:na)**2
-            dvth(1:nr, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
-            dvts(1:nr, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
+            DO dir = 1, 3
+               !term in Ylm*Ylm, to be multiplied by x^2
+               ww(1:na) = harmonics%slm(1:na, iso)*harmonics%a(dir, 1:na)**2
+               vth(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
+               vts(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
+
+               !term in Ylm * dYlm/dx, to be multiplied by x
+               ww(1:na) = harmonics%slm(1:na, iso)*harmonics%a(dir, 1:na)
+               dvth(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
+               dvts(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
+
+               !term in dYlm/dx * dYlm/dx, to be multiplied by 1
+               ww(1:na) = harmonics%slm(1:na, iso)
+               ddvth(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
+               ddvts(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
+            END DO
          END DO
          m1 = 0
          DO iset1 = 1, nset
@@ -1512,6 +1536,8 @@ CONTAINS
                CPASSERT(max_iso_not0_local .LE. max_iso_not0)
                CALL get_none0_cg_list(my_dCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
                                       max_s_harm, lmax_expansion, dcg_list, dcg_n_list, dmax_iso_not0_local)
+               CALL get_none0_cg_list(my_ddCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
+                                      max_s_harm, lmax_expansion, ddcg_list, ddcg_n_list, ddmax_iso_not0_local)
 
                n2 = nsoset(lmax(iset2))
                DO ipgf1 = 1, npgf(iset1)
@@ -1526,22 +1552,15 @@ CONTAINS
                      lmax12 = lmax(iset1) + lmax(iset2)
 
                      IF (lmin12 .LE. lmax_expansion) THEN
-                        fgr = 0._dp
-                        dgr = 0._dp
+                        gg = 0.0_dp
                         DO l1 = 0, maxl
                            DO l2 = 0, maxl
                               IF (l1 + l2 > lmax_expansion) CYCLE
                               IF (l1 + l2 > 0) THEN
-                                 gg(1:nr) = g1(1:nr)*g2(1:nr)*grid_atom%rad2l(1:nr, l1 + l2)
+                                 gg(1:nr, l1, l2) = g1(1:nr)*g2(1:nr)*grid_atom%rad2l(1:nr, l1 + l2)
                               ELSE
-                                 gg(1:nr) = g1(1:nr)*g2(1:nr)
+                                 gg(1:nr, l1, l2) = g1(1:nr)*g2(1:nr)
                               END IF
-                              dd(1:nr) = REAL(l1*l2, dp)/grid_atom%rad2(1:nr) - &
-                                         2._dp*REAL(l1, dp)*zet(ipgf2, iset2) - &
-                                         2._dp*REAL(l2, dp)*zet(ipgf1, iset1) + &
-                                         4._dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)*grid_atom%rad2(1:nr)
-                              fgr(1:nr, l1, l2) = dd(1:nr)*gg(1:nr)
-                              dgr(1:nr, l1 + l2) = gg(1:nr)/grid_atom%rad2(1:nr)
                            END DO
                         END DO
                      END IF
@@ -1563,19 +1582,21 @@ CONTAINS
 
                               IF (l1 + l2 > lmax_expansion) CYCLE
 
-                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_CG(iso1, iso2, iso)* &
-                                                    DOT_PRODUCT(vth(1:nr, ispin), fgr(1:nr, l1, l2))
-                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_CG(iso1, iso2, iso)* &
-                                                    DOT_PRODUCT(vts(1:nr, ispin), fgr(1:nr, l1, l2))
-                              ! d azimuthal
-                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + REAL(mm1*mm2, dp)*my_CG(isom1, isom2, iso)* &
-                                                    DOT_PRODUCT(vth(1:nr, ispin), dgr(1:nr, l1 + l2))
-                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + REAL(mm1*mm2, dp)*my_CG(isom1, isom2, iso)* &
-                                                    DOT_PRODUCT(vts(1:nr, ispin), dgr(1:nr, l1 + l2))
+                              !The term in Ylm*Ylm
+                              gr(1:nr) = 4.0_dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)* &
+                                         gg(1:nr, l1, l2)*grid_atom%rad2(1:nr)
+
+                              DO dir = 1, 3
+                                 matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_CG(iso1, iso2, iso)* &
+                                                       DOT_PRODUCT(vth(1:nr, dir, iso), gr(1:nr))
+                                 matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_CG(iso1, iso2, iso)* &
+                                                       DOT_PRODUCT(vts(1:nr, dir, iso), gr(1:nr))
+                              END DO
+
                            END DO
                         END DO
                      END IF
-                     ! d polar
+
                      DO iso = 1, dmax_iso_not0_local
                         DO icg = 1, dcg_n_list(iso)
                            iso1 = dcg_list(1, icg, iso)
@@ -1583,10 +1604,45 @@ CONTAINS
 
                            l1 = indso(1, iso1)
                            l2 = indso(1, iso2)
-                           matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_dCG(iso1, iso2, iso)* &
-                                                 DOT_PRODUCT(dvth(1:nr, ispin), dgr(1:nr, l1 + l2))
-                           matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_dCG(iso1, iso2, iso)* &
-                                                 DOT_PRODUCT(dvts(1:nr, ispin), dgr(1:nr, l1 + l2))
+
+                           !The term in Yl1m1 * dYl2m2/dx
+                           gr(1:nr) = -2.0_dp*zet(ipgf1, iset1)*gg(1:nr, l1, l2)
+                           DO dir = 1, 3
+                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_dCG(dir, iso1, iso2, iso)* &
+                                                    DOT_PRODUCT(dvth(1:nr, dir, iso), gr(1:nr))
+                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_dCG(dir, iso1, iso2, iso)* &
+                                                    DOT_PRODUCT(dvts(1:nr, dir, iso), gr(1:nr))
+                           END DO
+
+                           !The term in dYl1m1/dx * Yl2m2
+                           gr(1:nr) = -2.0_dp*zet(ipgf2, iset2)*gg(1:nr, l1, l2)
+                           DO dir = 1, 3
+                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_dCG(dir, iso2, iso1, iso)* &
+                                                    DOT_PRODUCT(dvth(1:nr, dir, iso), gr(1:nr))
+                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_dCG(dir, iso2, iso1, iso)* &
+                                                    DOT_PRODUCT(dvts(1:nr, dir, iso), gr(1:nr))
+                           END DO
+
+                        END DO
+                     END DO
+
+                     DO iso = 1, ddmax_iso_not0_local
+                        DO icg = 1, ddcg_n_list(iso)
+                           iso1 = ddcg_list(1, icg, iso)
+                           iso2 = ddcg_list(2, icg, iso)
+
+                           l1 = indso(1, iso1)
+                           l2 = indso(1, iso2)
+
+                           !The term in dYlm/dx * dYlm/dx
+                           gr(1:nr) = gg(1:nr, l1, l2)/grid_atom%rad2(1:nr)
+                           DO dir = 1, 3
+                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_ddCG(dir, iso1, iso2, iso)* &
+                                                    DOT_PRODUCT(ddvth(1:nr, dir, iso), gr(1:nr))
+                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_ddCG(dir, iso1, iso2, iso)* &
+                                                    DOT_PRODUCT(ddvts(1:nr, dir, iso), gr(1:nr))
+                           END DO
+
                         END DO
                      END DO
 
@@ -1604,12 +1660,11 @@ CONTAINS
             END DO ! iset2
             m1 = m1 + maxso
          END DO ! iset1
-         DEALLOCATE (vth, vts, dvth, dvts)
+         DEALLOCATE (vth, vts, dvth, dvts, ddvth, ddvts)
       END DO ! ispin
 
       DEALLOCATE (matso_h, matso_s)
-      DEALLOCATE (g1, g2, gg, dd, gr, ww)
-      DEALLOCATE (fgr, dgr)
+      DEALLOCATE (g1, g2, gg, gr, ww)
       DEALLOCATE (cg_list, cg_n_list, dcg_list, dcg_n_list)
 
       vtau_h = 2._dp*vtau_h

--- a/src/xc/xc_atom.F
+++ b/src/xc/xc_atom.F
@@ -291,16 +291,23 @@ CONTAINS
             END IF ! lsd
 !  Derivative with respect to tau
             IF (lsd) THEN
-               deriv_att => xc_dset_get_derivative(deriv_set, "(taua)")
+               deriv_att => xc_dset_get_derivative(deriv_set, "(tau_a)")
                IF (ASSOCIATED(deriv_att)) THEN
                   CALL xc_derivative_get(deriv_att, deriv_data=deriv_data)
                   vtau(:, :, 1) = deriv_data(:, :, 1)*w(:, :)*my_adiabatic_rescale_factor
                   NULLIFY (deriv_data)
                END IF
-               deriv_att => xc_dset_get_derivative(deriv_set, "(taub)")
+               deriv_att => xc_dset_get_derivative(deriv_set, "(tau_b)")
                IF (ASSOCIATED(deriv_att)) THEN
                   CALL xc_derivative_get(deriv_att, deriv_data=deriv_data)
                   vtau(:, :, 2) = deriv_data(:, :, 1)*w(:, :)*my_adiabatic_rescale_factor
+                  NULLIFY (deriv_data)
+               END IF
+               deriv_att => xc_dset_get_derivative(deriv_set, "(tau)")
+               IF (ASSOCIATED(deriv_att)) THEN
+                  CALL xc_derivative_get(deriv_att, deriv_data=deriv_data)
+                  vtau(:, :, 1) = vtau(:, :, 1) + deriv_data(:, :, 1)*w(:, :)*my_adiabatic_rescale_factor
+                  vtau(:, :, 2) = vtau(:, :, 2) + deriv_data(:, :, 1)*w(:, :)*my_adiabatic_rescale_factor
                   NULLIFY (deriv_data)
                END IF
             ELSE

--- a/tests/QS/regtest-gapw/TEST_FILES
+++ b/tests/QS/regtest-gapw/TEST_FILES
@@ -38,6 +38,6 @@ H2S-gapw-ot.inp                                        1      1e-12             
 H2S-gapw-gop-ot.inp                                    1      3e-13             -11.25777225805304
 # XRD total density output to file
 xrd.inp                                                0
-# TEST GAPW meta functional (was buggy, now corrected)
-HF_gapw_TPSS.inp                                       1      1e-10            -100.48458714808403
+# TEST GAPW meta functional (was buggy, now corrected. Edit: was wrongly corrected, now OK)
+HF_gapw_TPSS.inp                                       1      1e-10            -100.48682767842233
 #EOF

--- a/tests/QS/regtest-libxc/TEST_FILES
+++ b/tests/QS/regtest-libxc/TEST_FILES
@@ -8,7 +8,7 @@ H2O_pbe_libxc_tddfpt-s.inp                             1      6e-14             
 H2O_lda_libxc_tddfpt-s.inp                             1      2e-14             -17.13289833455457
 H2O_pbe_libxc_tddfpt-t_uks.inp                         1      2e-14             -17.23116251474715
 H2O-hybrid-b3lyp_libxc.inp                             1      3e-14             -76.41035426581175
-H2O-hybrid-tpssh_libxc.inp                             1      3e-14             -76.40464600997517
+H2O-hybrid-tpssh_libxc.inp                             1      3e-14             -76.40913833393611
 H2O_lda_libxc_tddfpt-t_uks.inp                         1    1.0E-14             -17.13289833455847
 H2O-tpssx_libxc.inp                                    1      3e-13             -33.88300963208589
 diamond_br89_libxc_uks.inp                             1      7e-14             -11.06581614908332


### PR DESCRIPTION
An issue concerning GAPW with meta-GGA functionals was raised (#1116). Energies obtained with this combination were slightly different than those of different programs and DEBUG runs would fail due to wrong analytical forces.

meta-GGA functionals require the computation of the dot product of the gradients of Gaussian functions on the grid. The way it was done was wrong for atomic grids. The gradients were computed in spherical coordinates, but the dot product was made as in cartesian coordinates, leading to inconsistencies and wrong results. 

The fix involves computing the gradients in cartesian coordinates instead, such that the dot product can easily be computed.  This choice of coordinate is also more consistent with the rest of the program, where cartesian coordinates are always preferred for spherical harmonics expansions.

DEBUG runs for all-electron calculations now yield sub 1% errors on the forces (tested with water, 6-31G* and TPSS/M06 for both spin restricted and unrestricted cases). Two regtests files had to be modified.