### PR TITLE
GAPW meta-GGA bug fixing

### DIFF
--- a/src/qs_harmonics_atom.F
+++ b/src/qs_harmonics_atom.F
@@ -19,7 +19,8 @@ MODULE qs_harmonics_atom
                                               nso,&
                                               nsoset
    USE orbital_transformation_matrices, ONLY: orbtramat
-   USE spherical_harmonics,             ONLY: y_lm
+   USE spherical_harmonics,             ONLY: dy_lm,&
+                                              y_lm
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -35,9 +36,9 @@ MODULE qs_harmonics_atom
                                                 damax_iso_not0, &
                                                 ngrid
       REAL(dp), DIMENSION(:, :), POINTER   :: a, slm
-      REAL(dp), DIMENSION(:, :, :), POINTER   :: dslm_dxyz
+      REAL(dp), DIMENSION(:, :, :), POINTER   :: dslm, dslm_dxyz
       REAL(dp), DIMENSION(:, :, :), POINTER   :: my_CG
-      REAL(dp), DIMENSION(:, :, :, :), POINTER :: my_CG_dxyz, my_dCG, my_ddCG
+      REAL(dp), DIMENSION(:, :, :, :), POINTER :: my_CG_dxyz
       REAL(dp), DIMENSION(:, :, :, :), POINTER :: my_CG_dxyz_asym
       REAL(dp), DIMENSION(:), POINTER        :: slm_int
 
@@ -77,11 +78,10 @@ CONTAINS
       harmonics%ngrid = 0
 
       NULLIFY (harmonics%slm)
+      NULLIFY (harmonics%dslm)
       NULLIFY (harmonics%dslm_dxyz)
       NULLIFY (harmonics%slm_int)
       NULLIFY (harmonics%my_CG)
-      NULLIFY (harmonics%my_dCG)
-      NULLIFY (harmonics%my_ddCG)
       NULLIFY (harmonics%my_CG_dxyz)
       NULLIFY (harmonics%my_CG_dxyz_asym)
       NULLIFY (harmonics%a)
@@ -103,6 +103,10 @@ CONTAINS
             DEALLOCATE (harmonics%slm)
          ENDIF
 
+         IF (ASSOCIATED(harmonics%dslm)) THEN
+            DEALLOCATE (harmonics%dslm)
+         ENDIF
+
          IF (ASSOCIATED(harmonics%dslm_dxyz)) THEN
             DEALLOCATE (harmonics%dslm_dxyz)
          ENDIF
@@ -113,14 +117,6 @@ CONTAINS
 
          IF (ASSOCIATED(harmonics%my_CG)) THEN
             DEALLOCATE (harmonics%my_CG)
-         ENDIF
-
-         IF (ASSOCIATED(harmonics%my_dCG)) THEN
-            DEALLOCATE (harmonics%my_dCG)
-         ENDIF
-
-         IF (ASSOCIATED(harmonics%my_ddCG)) THEN
-            DEALLOCATE (harmonics%my_ddCG)
          ENDIF
 
          IF (ASSOCIATED(harmonics%my_CG_dxyz)) THEN
@@ -186,13 +182,10 @@ CONTAINS
       harmonics%llmax = llmax
       harmonics%ngrid = na
 
-      NULLIFY (harmonics%my_CG, harmonics%my_CG_dxyz, harmonics%my_CG_dxyz_asym, harmonics%my_dCG, &
-               harmonics%my_ddCG)
+      NULLIFY (harmonics%my_CG, harmonics%my_CG_dxyz, harmonics%my_CG_dxyz_asym)
       CALL reallocate(harmonics%my_CG, 1, maxs, 1, maxs, 1, max_s_harm)
       CALL reallocate(harmonics%my_CG_dxyz, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
       CALL reallocate(harmonics%my_CG_dxyz_asym, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
-      CALL reallocate(harmonics%my_dCG, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
-      CALL reallocate(harmonics%my_ddCG, 1, 3, 1, maxs, 1, maxs, 1, max_s_harm)
 
       DO i = 1, max_s_harm
          DO is1 = 1, maxs
@@ -202,8 +195,9 @@ CONTAINS
 
       ! allocate and calculate the spherical harmonics LM for this grid
       ! and their derivatives
-      NULLIFY (harmonics%slm, harmonics%dslm_dxyz, harmonics%a, harmonics%slm_int)
+      NULLIFY (harmonics%slm, harmonics%dslm, harmonics%dslm_dxyz, harmonics%a, harmonics%slm_int)
       CALL reallocate(harmonics%slm, 1, na, 1, max_s_harm)
+      CALL reallocate(harmonics%dslm, 1, 2, 1, na, 1, maxs)
       CALL reallocate(harmonics%dslm_dxyz, 1, 3, 1, na, 1, max_s_harm)
       CALL reallocate(harmonics%a, 1, 3, 1, na)
       CALL reallocate(harmonics%slm_int, 1, max_s_harm)
@@ -372,60 +366,25 @@ CONTAINS
       END DO ! iso1
 !$OMP END DO
 
-      ! CG coefficients for the tau functionals, namely dYl1m1/dx * dYl2m2/dx and Yl1m1 * dYl2m2/dx
-      ! named my_ddCG and my_dCG (derivative * derivative and normal * derivative)
-
-!$OMP DO COLLAPSE(3)
-      DO iso1 = 1, maxs
-         DO iso2 = 1, maxs
-
-            DO iso = 1, max_s_harm
-               rx = 0.0_dp
-               ry = 0.0_dp
-               rz = 0.0_dp
-
-               DO ia = 1, na
-                  rx = rx + wa(ia)*slm(ia, iso)*(dslm_dxyz(1, ia, iso1)*dslm_dxyz(1, ia, iso2))
-                  ry = ry + wa(ia)*slm(ia, iso)*(dslm_dxyz(2, ia, iso1)*dslm_dxyz(2, ia, iso2))
-                  rz = rz + wa(ia)*slm(ia, iso)*(dslm_dxyz(3, ia, iso1)*dslm_dxyz(3, ia, iso2))
-               END DO
-
-               harmonics%my_ddCG(1, iso1, iso2, iso) = rx
-
-               harmonics%my_ddCG(2, iso1, iso2, iso) = ry
-
-               harmonics%my_ddCG(3, iso1, iso2, iso) = rz
-
-            END DO
+      ! Calculate the derivatives of the harmonics with respect of the 2 angles
+      ! the first angle (polar) is acos(lebedev_grid(ll)%r(3))
+      ! the second angle (azimutal) is atan(lebedev_grid(ll)%r(2)/lebedev_grid(ll)%r(1))
+!$OMP DO
+      DO iso = 1, maxs
+         l = indso(1, iso)
+         m = indso(2, iso)
+         DO ia = 1, na
+            cin(1) = pol(ia)
+            cin(2) = azi(ia)
+            CALL dy_lm(cin, dylm, l, m)
+            harmonics%dslm(:, ia, iso) = dylm(:)
          END DO
       END DO
 !$OMP END DO
 
-!$OMP DO COLLAPSE(3)
-      DO iso1 = 1, maxs
-         DO iso2 = 1, maxs
+      ! expansion coefficients of product of polar angle derivatives (dslm(1...)) in
+      ! spherical harmonics (used for tau functionals)
 
-            DO iso = 1, max_s_harm
-               rx = 0.0_dp
-               ry = 0.0_dp
-               rz = 0.0_dp
-
-               DO ia = 1, na
-                  rx = rx + wa(ia)*slm(ia, iso)*(slm(ia, iso1)*dslm_dxyz(1, ia, iso2))
-                  ry = ry + wa(ia)*slm(ia, iso)*(slm(ia, iso1)*dslm_dxyz(2, ia, iso2))
-                  rz = rz + wa(ia)*slm(ia, iso)*(slm(ia, iso1)*dslm_dxyz(3, ia, iso2))
-               END DO
-
-               harmonics%my_dCG(1, iso1, iso2, iso) = rx
-
-               harmonics%my_dCG(2, iso1, iso2, iso) = ry
-
-               harmonics%my_dCG(3, iso1, iso2, iso) = rz
-
-            END DO
-         END DO
-      END DO
-!$OMP END DO
       DEALLOCATE (y, dc)
 !$OMP END PARALLEL
 
@@ -468,7 +427,7 @@ CONTAINS
                                    lmin(is1), lmax(is1), lmin(is2), lmax(is2), &
                                    max_s_harm, llmax, max_iso_not0=itmp)
             max_iso_not0 = MAX(max_iso_not0, itmp)
-            CALL get_none0_cg_list(harmonics%my_dCG, &
+            CALL get_none0_cg_list(harmonics%my_CG_dxyz, &
                                    lmin(is1), lmax(is1), lmin(is2), lmax(is2), &
                                    max_s_harm, llmax, max_iso_not0=itmp)
             dmax_iso_not0 = MAX(dmax_iso_not0, itmp)

--- a/src/qs_rho_atom_methods.F
+++ b/src/qs_rho_atom_methods.F
@@ -29,8 +29,7 @@ MODULE qs_rho_atom_methods
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_sum
    USE orbital_pointers,                ONLY: indso,&
-                                              nsoset,&
-                                              soset
+                                              nsoset
    USE paw_proj_set_types,              ONLY: get_paw_proj_set,&
                                               paw_proj_set_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -113,15 +112,13 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_rho_atom'
 
-      INTEGER :: damax_iso_not0_local, dbmax_iso_not0_local, dcmax_iso_not0_local, dir, &
-         dmax_iso_not0, handle, i, i1, i2, iat, iatom, icg, ipgf1, ipgf2, ir, iset1, iset2, iso, &
-         iso1, iso1_first, iso1_last, iso2, iso2_first, iso2_last, isom1, isom2, istat, j, l, l1, &
-         l2, l_iso, l_sub, l_sum, lmax12, lmax_expansion, lmin12, m1, m1s, m2, m2s, max_iso_not0, &
+      INTEGER :: damax_iso_not0_local, handle, i, i1, i2, iat, iatom, icg, ipgf1, ipgf2, ir, &
+         iset1, iset2, iso, iso1, iso1_first, iso1_last, iso2, iso2_first, iso2_last, istat, j, l, &
+         l1, l2, l_iso, l_sub, l_sum, lmax12, lmax_expansion, lmin12, m1s, m2s, max_iso_not0, &
          max_iso_not0_local, max_s_harm, maxl, maxso, mepos, n1s, n2s, nr, nset, num_pe, size1, &
          size2
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dacg_n_list, dbcg_n_list, &
-                                                            dccg_n_list
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dacg_list, dbcg_list, dccg_list
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dacg_n_list
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dacg_list
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(:), POINTER                     :: lmax, lmin, npgf, o2nindex
       LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: done_vgg
@@ -131,7 +128,7 @@ CONTAINS
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: vgg
       REAL(dp), DIMENSION(:, :), POINTER                 :: coeff, zet
       REAL(dp), DIMENSION(:, :, :), POINTER              :: my_CG
-      REAL(dp), DIMENSION(:, :, :, :), POINTER           :: my_CG_dxyz, my_dCG, my_ddCG
+      REAL(dp), DIMENSION(:, :, :, :), POINTER           :: my_CG_dxyz
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
@@ -139,13 +136,11 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      !Note on tau funtionals: need to take the Cartesian dot product of the gradient of 2 Gaussians
-      !     => we keep track of the direction (x,y,z) and separate the different cross terms
-      !        depending on their angular part dependencies. That is 3x3=9 terms in total
+      !Note: tau is taken care of separately in qs_vxc_atom.F
 
       NULLIFY (orb_basis)
       NULLIFY (harmonics, grid_atom)
-      NULLIFY (lmin, lmax, npgf, zet, my_CG, my_dCG, my_CG_dxyz, coeff, my_ddCG)
+      NULLIFY (lmin, lmax, npgf, zet, my_CG, my_CG_dxyz, coeff)
 
       CALL get_qs_kind(qs_kind, basis_set=orb_basis, grid_atom=grid_atom, &
                        paw_proj_set=paw_proj, harmonics=harmonics)
@@ -157,7 +152,6 @@ CONTAINS
       CALL get_paw_proj_set(paw_proj_set=paw_proj, o2nindex=o2nindex)
 
       max_iso_not0 = harmonics%max_iso_not0
-      dmax_iso_not0 = harmonics%dmax_iso_not0
       max_s_harm = harmonics%max_s_harm
 
       nr = grid_atom%nr
@@ -168,8 +162,6 @@ CONTAINS
       bo = get_limit(natom, num_pe, mepos)
 
       my_CG => harmonics%my_CG
-      my_dCG => harmonics%my_dCG
-      my_ddCG => harmonics%my_ddCG
       my_CG_dxyz => harmonics%my_CG_dxyz
 
       ALLOCATE (CPCH_sphere(nsoset(maxl), nsoset(maxl)))
@@ -180,8 +172,6 @@ CONTAINS
       ALLOCATE (int1(nr), int2(nr))
       ALLOCATE (cg_list(2, nsoset(maxl)**2, max_s_harm), cg_n_list(max_s_harm), &
                 dacg_list(2, nsoset(maxl)**2, max_s_harm), dacg_n_list(max_s_harm), &
-                dbcg_list(2, nsoset(maxl)**2, max_s_harm), dbcg_n_list(max_s_harm), &
-                dccg_list(2, nsoset(maxl)**2, max_s_harm), dccg_n_list(max_s_harm), &
                 STAT=istat)
       CPASSERT(istat == 0)
 
@@ -206,10 +196,6 @@ CONTAINS
             CPASSERT(max_iso_not0_local .LE. max_iso_not0)
             CALL get_none0_cg_list(my_CG_dxyz, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
                                    max_s_harm, lmax_expansion, dacg_list, dacg_n_list, damax_iso_not0_local)
-            CALL get_none0_cg_list(my_dCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
-                                   max_s_harm, lmax_expansion, dbcg_list, dbcg_n_list, dbmax_iso_not0_local)
-            CALL get_none0_cg_list(my_ddCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
-                                   max_s_harm, lmax_expansion, dccg_list, dccg_n_list, dcmax_iso_not0_local)
             n1s = nsoset(lmax(iset1))
 
             DO ipgf1 = 1, npgf(iset1)
@@ -326,10 +312,6 @@ CONTAINS
 
                               l1 = indso(1, iso1)
                               l2 = indso(1, iso2)
-                              m1 = indso(2, iso1)
-                              m2 = indso(2, iso2)
-                              isom1 = soset(l1, -m1)
-                              isom2 = soset(l2, -m2)
 
                               l = indso(1, iso1) + indso(1, iso2)
                               CPASSERT(l <= lmax_expansion)
@@ -358,19 +340,6 @@ CONTAINS
                                  rho_atom_set(iatom)%vrho_rad_s(i)%r_coef(1:nr, iso) + &
                                  vgg(1:nr, l, l_iso)*CPCS_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
 
-                              !tau functionals, terms in Ylm*Ylm, to be multiplied by x^2 comp. of unit vector
-                              DO dir = 1, 3
-                                 rho_atom_set(iatom)%trho_rad_h(1, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_h(1, dir, i)%r_coef(1:nr, iso) + &
-                                    2.0_dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)*grid_atom%rad2(1:nr)* &
-                                    gg(1:nr, l)*CPCH_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
-
-                                 rho_atom_set(iatom)%trho_rad_s(1, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_s(1, dir, i)%r_coef(1:nr, iso) + &
-                                    2.0_dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)*grid_atom%rad2(1:nr)* &
-                                    gg(1:nr, l)*CPCS_sphere(iso1, iso2)*my_CG(iso1, iso2, iso)
-                              END DO
-
                            ENDDO ! icg
 
                         ENDDO ! iso
@@ -394,64 +363,6 @@ CONTAINS
                            END DO ! icg
 
                         ENDDO ! iso
-
-                        !tau functionals, terms in Ylm * dYlm/dx, to be multiplied by x comp. of unit vector
-                        DO iso = 1, max_iso_not0
-                           l_iso = indso(1, iso)
-                           DO icg = 1, dbcg_n_list(iso)
-                              iso1 = dbcg_list(1, icg, iso)
-                              iso2 = dbcg_list(2, icg, iso)
-
-                              l = indso(1, iso1) + indso(1, iso2)
-
-                              DO dir = 1, 3
-
-                                 !Yl1m1 * dYl2m2/dx
-                                 rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) - &
-                                    zet(ipgf1, iset1)*gg(1:nr, l)*CPCH_sphere(iso1, iso2)*my_dCG(dir, iso1, iso2, iso)
-
-                                 rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) - &
-                                    zet(ipgf1, iset1)*gg(1:nr, l)*CPCS_sphere(iso1, iso2)*my_dCG(dir, iso1, iso2, iso)
-
-                                 !dYl1m1/dx * Yl2m2
-                                 rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_h(2, dir, i)%r_coef(1:nr, iso) - &
-                                    zet(ipgf2, iset2)*gg(1:nr, l)*CPCH_sphere(iso1, iso2)*my_dCG(dir, iso2, iso1, iso)
-
-                                 rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_s(2, dir, i)%r_coef(1:nr, iso) - &
-                                    zet(ipgf2, iset2)*gg(1:nr, l)*CPCS_sphere(iso1, iso2)*my_dCG(dir, iso2, iso1, iso)
-
-                              ENDDO !dir
-                           ENDDO !icg
-                        ENDDO !iso
-
-                        !tau functionals, terms in dYlm/dx * dYlm/dx, to be multiplied by 1
-                        DO iso = 1, max_iso_not0
-                           l_iso = indso(1, iso)
-                           DO icg = 1, dccg_n_list(iso)
-                              iso1 = dccg_list(1, icg, iso)
-                              iso2 = dccg_list(2, icg, iso)
-
-                              l = indso(1, iso1) + indso(1, iso2)
-
-                              DO dir = 1, 3
-
-                                 rho_atom_set(iatom)%trho_rad_h(3, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_h(3, dir, i)%r_coef(1:nr, iso) + &
-                                    0.5_dp*gg(1:nr, l)/grid_atom%rad2(1:nr)* &
-                                    CPCH_sphere(iso1, iso2)*my_ddCG(dir, iso1, iso2, iso)
-
-                                 rho_atom_set(iatom)%trho_rad_s(3, dir, i)%r_coef(1:nr, iso) = &
-                                    rho_atom_set(iatom)%trho_rad_s(3, dir, i)%r_coef(1:nr, iso) + &
-                                    0.5_dp*gg(1:nr, l)/grid_atom%rad2(1:nr)* &
-                                    CPCS_sphere(iso1, iso2)*my_ddCG(dir, iso1, iso2, iso)
-
-                              ENDDO !dir
-                           ENDDO !icg
-                        ENDDO !iso
 
                      ENDDO ! i
                   ENDDO ! iat
@@ -485,7 +396,7 @@ CONTAINS
 
       DEALLOCATE (CPCH_sphere, CPCS_sphere)
       DEALLOCATE (g1, g2, gg0, gg, gg_lm1, dgg, vgg, done_vgg, erf_zet12, int1, int2)
-      DEALLOCATE (cg_list, cg_n_list, dacg_list, dacg_n_list, dbcg_list, dbcg_n_list, dccg_list, dccg_n_list)
+      DEALLOCATE (cg_list, cg_n_list, dacg_list, dacg_n_list)
 
       CALL timestop(handle)
 
@@ -1031,10 +942,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'allocate_rho_atom_internals'
 
-      INTEGER                                            :: bo(2), dir, handle, iat, iatom, ikind, &
-                                                            ispin, istat, j, max_iso_not0, mepos, &
-                                                            nat, natom, nsatbas, nsotot, nspins, &
-                                                            num_pe
+      INTEGER                                            :: bo(2), handle, iat, iatom, ikind, ispin, &
+                                                            istat, j, max_iso_not0, mepos, nat, &
+                                                            natom, nsatbas, nsotot, nspins, num_pe
       INTEGER, DIMENSION(:), POINTER                     :: atom_list
       LOGICAL                                            :: paw_atom
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
@@ -1089,8 +999,6 @@ CONTAINS
                       rho_atom_set(iatom)%cpc_s(nspins), &
                       rho_atom_set(iatom)%drho_rad_h(nspins), &
                       rho_atom_set(iatom)%drho_rad_s(nspins), &
-                      rho_atom_set(iatom)%trho_rad_h(3, 3, nspins), &
-                      rho_atom_set(iatom)%trho_rad_s(3, 3, nspins), &
                       rho_atom_set(iatom)%rho_rad_h_d(3, nspins), &
                       rho_atom_set(iatom)%rho_rad_s_d(3, nspins), &
                       STAT=istat)
@@ -1100,14 +1008,7 @@ CONTAINS
                DO ispin = 1, nspins
                   NULLIFY (rho_atom_set(iatom)%drho_rad_h(ispin)%r_coef, &
                            rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef)
-                  DO dir = 1, 3
-                     NULLIFY (rho_atom_set(iatom)%trho_rad_h(1, dir, ispin)%r_coef, &
-                              rho_atom_set(iatom)%trho_rad_h(2, dir, ispin)%r_coef, &
-                              rho_atom_set(iatom)%trho_rad_h(3, dir, ispin)%r_coef, &
-                              rho_atom_set(iatom)%trho_rad_s(1, dir, ispin)%r_coef, &
-                              rho_atom_set(iatom)%trho_rad_s(2, dir, ispin)%r_coef, &
-                              rho_atom_set(iatom)%trho_rad_s(3, dir, ispin)%r_coef)
-                  END DO
+
                   ALLOCATE (rho_atom_set(iatom)%cpc_h(ispin)%r_coef(1:nsatbas, 1:nsatbas), &
                             rho_atom_set(iatom)%cpc_s(ispin)%r_coef(1:nsatbas, 1:nsatbas), &
                             STAT=istat)
@@ -1125,10 +1026,6 @@ CONTAINS
                   NULLIFY (rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef)
 
                   DO j = 1, 3
-                     DO dir = 1, 3
-                        NULLIFY (rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef)
-                        NULLIFY (rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef)
-                     END DO
                      NULLIFY (rho_atom_set(iatom)%rho_rad_h_d(j, ispin)%r_coef)
                      NULLIFY (rho_atom_set(iatom)%rho_rad_s_d(j, ispin)%r_coef)
                   END DO
@@ -1189,7 +1086,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'allocate_rho_atom_rad'
 
-      INTEGER                                            :: dir, handle, istat, j
+      INTEGER                                            :: handle, istat, j
 
       CALL timeset(routineN, handle)
 
@@ -1211,17 +1108,6 @@ CONTAINS
       CPASSERT(istat == 0)
       rho_atom_set(iatom)%drho_rad_h(ispin)%r_coef = 0.0_dp
       rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef = 0.0_dp
-
-      DO dir = 1, 3
-         DO j = 1, 3
-            ALLOCATE (rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef(nr, max_iso_not0), &
-                      rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef(nr, max_iso_not0), &
-                      STAT=istat)
-            CPASSERT(istat == 0)
-            rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef = 0.0_dp
-            rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef = 0.0_dp
-         END DO
-      END DO
 
       DO j = 1, 3
          NULLIFY (rho_atom_set(iatom)%rho_rad_h_d(j, ispin)%r_coef, &
@@ -1249,7 +1135,7 @@ CONTAINS
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set
       INTEGER, INTENT(IN)                                :: iatom, ispin
 
-      INTEGER                                            :: dir, j
+      INTEGER                                            :: j
 
       rho_atom_set(iatom)%rho_rad_h(ispin)%r_coef = 0.0_dp
       rho_atom_set(iatom)%rho_rad_s(ispin)%r_coef = 0.0_dp
@@ -1260,13 +1146,9 @@ CONTAINS
       rho_atom_set(iatom)%drho_rad_h(ispin)%r_coef = 0.0_dp
       rho_atom_set(iatom)%drho_rad_s(ispin)%r_coef = 0.0_dp
 
-      DO dir = 1, 3
-         DO j = 1, 3
-            rho_atom_set(iatom)%trho_rad_h(j, dir, ispin)%r_coef = 0.0_dp
-            rho_atom_set(iatom)%trho_rad_s(j, dir, ispin)%r_coef = 0.0_dp
-            rho_atom_set(iatom)%rho_rad_h_d(j, ispin)%r_coef = 0.0_dp
-            rho_atom_set(iatom)%rho_rad_s_d(j, ispin)%r_coef = 0.0_dp
-         END DO
+      DO j = 1, 3
+         rho_atom_set(iatom)%rho_rad_h_d(j, ispin)%r_coef = 0.0_dp
+         rho_atom_set(iatom)%rho_rad_s_d(j, ispin)%r_coef = 0.0_dp
       END DO
 
    END SUBROUTINE set2zero_rho_atom_rad

--- a/src/qs_rho_atom_types.F
+++ b/src/qs_rho_atom_types.F
@@ -34,9 +34,6 @@ MODULE qs_rho_atom_types
       TYPE(rho_atom_coeff), DIMENSION(:, :), &
          POINTER  :: rho_rad_h_d, &
                      rho_rad_s_d
-      TYPE(rho_atom_coeff), DIMENSION(:, :, :), &
-         POINTER  :: trho_rad_h, &
-                     trho_rad_s
 
       INTEGER                             :: rhoa_of_atom
       REAL(dp)                            :: exc_h, &
@@ -88,8 +85,6 @@ CONTAINS
          NULLIFY (rho_atom_set(iat)%rho_rad_s_d)
          NULLIFY (rho_atom_set(iat)%vrho_rad_h)
          NULLIFY (rho_atom_set(iat)%vrho_rad_s)
-         NULLIFY (rho_atom_set(iat)%trho_rad_h)
-         NULLIFY (rho_atom_set(iat)%trho_rad_s)
          NULLIFY (rho_atom_set(iat)%ga_Vlocal_gb_h)
          NULLIFY (rho_atom_set(iat)%ga_Vlocal_gb_s)
 
@@ -105,7 +100,7 @@ CONTAINS
 
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set
 
-      INTEGER                                            :: dir, i, iat, j, n, natom
+      INTEGER                                            :: i, iat, j, n, natom
 
       IF (ASSOCIATED(rho_atom_set)) THEN
 
@@ -193,34 +188,6 @@ CONTAINS
                DEALLOCATE (rho_atom_set(iat)%vrho_rad_s)
             ENDIF
 
-            IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_h)) THEN
-               IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_h(1, 1, 1)%r_coef)) THEN
-                  n = SIZE(rho_atom_set(iat)%trho_rad_h, 3)
-                  DO i = 1, n
-                     DO dir = 1, 3
-                        DEALLOCATE (rho_atom_set(iat)%trho_rad_h(1, dir, i)%r_coef)
-                        DEALLOCATE (rho_atom_set(iat)%trho_rad_h(2, dir, i)%r_coef)
-                        DEALLOCATE (rho_atom_set(iat)%trho_rad_h(3, dir, i)%r_coef)
-                     ENDDO
-                  ENDDO
-               ENDIF
-               DEALLOCATE (rho_atom_set(iat)%trho_rad_h)
-            ENDIF
-
-            IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_s)) THEN
-               IF (ASSOCIATED(rho_atom_set(iat)%trho_rad_s(1, 1, 1)%r_coef)) THEN
-                  n = SIZE(rho_atom_set(iat)%trho_rad_s, 3)
-                  DO i = 1, n
-                     DO dir = 1, 3
-                        DEALLOCATE (rho_atom_set(iat)%trho_rad_s(1, dir, i)%r_coef)
-                        DEALLOCATE (rho_atom_set(iat)%trho_rad_s(2, dir, i)%r_coef)
-                        DEALLOCATE (rho_atom_set(iat)%trho_rad_s(3, dir, i)%r_coef)
-                     ENDDO
-                  ENDDO
-               ENDIF
-               DEALLOCATE (rho_atom_set(iat)%trho_rad_s)
-            ENDIF
-
          ENDDO
 
          DEALLOCATE (rho_atom_set)
@@ -248,15 +215,12 @@ CONTAINS
 !> \param vrho_rad_s ...
 !> \param rho_rad_h_d ...
 !> \param rho_rad_s_d ...
-!> \param trho_rad_h ...
-!> \param trho_rad_s ...
 !> \param ga_Vlocal_gb_h ...
 !> \param ga_Vlocal_gb_s ...
 ! **************************************************************************************************
    SUBROUTINE get_rho_atom(rho_atom, cpc_h, cpc_s, rho_rad_h, rho_rad_s, &
                            drho_rad_h, drho_rad_s, vrho_rad_h, vrho_rad_s, &
-                           rho_rad_h_d, rho_rad_s_d, trho_rad_h, trho_rad_s, &
-                           ga_Vlocal_gb_h, ga_Vlocal_gb_s)
+                           rho_rad_h_d, rho_rad_s_d, ga_Vlocal_gb_h, ga_Vlocal_gb_s)
 
       TYPE(rho_atom_type), INTENT(IN), POINTER           :: rho_atom
       TYPE(rho_atom_coeff), DIMENSION(:), OPTIONAL, &
@@ -265,8 +229,6 @@ CONTAINS
                                                             vrho_rad_s
       TYPE(rho_atom_coeff), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: rho_rad_h_d, rho_rad_s_d
-      TYPE(rho_atom_coeff), DIMENSION(:, :, :), &
-         OPTIONAL, POINTER                               :: trho_rad_h, trho_rad_s
       TYPE(rho_atom_coeff), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: ga_Vlocal_gb_h, ga_Vlocal_gb_s
 
@@ -281,8 +243,6 @@ CONTAINS
          IF (PRESENT(rho_rad_s_d)) rho_rad_s_d => rho_atom%rho_rad_s_d
          IF (PRESENT(vrho_rad_h)) vrho_rad_h => rho_atom%vrho_rad_h
          IF (PRESENT(vrho_rad_s)) vrho_rad_s => rho_atom%vrho_rad_s
-         IF (PRESENT(trho_rad_h)) trho_rad_h => rho_atom%trho_rad_h
-         IF (PRESENT(trho_rad_s)) trho_rad_s => rho_atom%trho_rad_s
          IF (PRESENT(ga_Vlocal_gb_h)) ga_Vlocal_gb_h => rho_atom%ga_Vlocal_gb_h
          IF (PRESENT(ga_Vlocal_gb_s)) ga_Vlocal_gb_s => rho_atom%ga_Vlocal_gb_s
       ELSE

--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -26,8 +26,9 @@ MODULE qs_vxc_atom
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_sum
    USE orbital_pointers,                ONLY: indso,&
-                                              nsoset,&
-                                              soset
+                                              nsoset
+   USE paw_proj_set_types,              ONLY: get_paw_proj_set,&
+                                              paw_proj_set_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -109,9 +110,9 @@ CONTAINS
                                                             paw_atom, tau_f
       REAL(dp)                                           :: density_cut, exc_h, exc_s, gradient_cut, &
                                                             my_adiabatic_rescale_factor, tau_cut
-      REAL(dp), DIMENSION(:, :), POINTER                 :: rho_h, rho_nlcc, rho_s, tau_h, tau_s, &
-                                                            weight
-      REAL(dp), DIMENSION(:, :, :), POINTER              :: vtau_h, vtau_s, vxc_h, vxc_s
+      REAL(dp), DIMENSION(:, :), POINTER                 :: rho_h, rho_nlcc, rho_s, weight
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: tau_h, tau_s, vtau_h, vtau_s, vxc_h, &
+                                                            vxc_s
       REAL(dp), DIMENSION(:, :, :, :), POINTER           :: drho_h, drho_s, vxg_h, vxg_s
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -122,7 +123,6 @@ CONTAINS
       TYPE(qs_kind_type), POINTER                        :: qs_kind
       TYPE(rho_atom_coeff), DIMENSION(:), POINTER        :: dr_h, dr_s, r_h, r_s
       TYPE(rho_atom_coeff), DIMENSION(:, :), POINTER     :: r_h_d, r_s_d
-      TYPE(rho_atom_coeff), DIMENSION(:, :, :), POINTER  :: trho_h, trho_s
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: my_rho_atom_set
       TYPE(rho_atom_type), POINTER                       :: rho_atom
       TYPE(section_vals_type), POINTER                   :: input, my_xc_section, xc_fun_section
@@ -133,8 +133,6 @@ CONTAINS
 ! -------------------------------------------------------------------------
 
       CALL timeset(routineN, handle)
-
-      !TODO: make sure we use the right xc_section
 
       NULLIFY (atom_list)
       NULLIFY (my_kind_set)
@@ -267,8 +265,8 @@ CONTAINS
             END IF
 
             IF (tau_f) THEN
-               CALL reallocate(tau_h, 1, na, 1, nspins)
-               CALL reallocate(tau_s, 1, na, 1, nspins)
+               CALL reallocate(tau_h, 1, na, 1, nr, 1, nspins)
+               CALL reallocate(tau_s, 1, na, 1, nr, 1, nspins)
                CALL reallocate(vtau_h, 1, na, 1, nr, 1, nspins)
                CALL reallocate(vtau_s, 1, na, 1, nr, 1, nspins)
             END IF
@@ -307,24 +305,20 @@ CONTAINS
                   CALL get_rho_atom(rho_atom=rho_atom, rho_rad_h=r_h, rho_rad_s=r_s)
                END IF
                IF (tau_f) THEN
-                  NULLIFY (trho_h, trho_s)
-                  CALL get_rho_atom(rho_atom=rho_atom, trho_rad_h=trho_h, trho_rad_s=trho_s)
+                  !compute tau on the grid all at once
+                  CALL calc_tau_atom(tau_h, tau_s, rho_atom, my_kind_set(ikind), nspins)
                END IF
 
                DO ir = 1, nr
                   CALL calc_rho_angular(grid_atom, harmonics, nspins, gradient_f, &
                                         ir, r_h, r_s, rho_h, rho_s, dr_h, dr_s, &
                                         r_h_d, r_s_d, drho_h, drho_s)
-                  IF (tau_f) THEN
-                     CALL calc_tau_angular(grid_atom, harmonics, nspins, ir, &
-                                           trho_h, trho_s, tau_h, tau_s)
-                  END IF
                   IF (donlcc) THEN
                      CALL calc_rho_nlcc(grid_atom, nspins, gradient_f, &
                                         ir, rho_nlcc(:, 1), rho_h, rho_s, rho_nlcc(:, 2), drho_h, drho_s)
                   END IF
-                  CALL fill_rho_set(rho_set_h, lsd, nspins, needs, rho_h, drho_h, tau_h, na, ir)
-                  CALL fill_rho_set(rho_set_s, lsd, nspins, needs, rho_s, drho_s, tau_s, na, ir)
+                  CALL fill_rho_set(rho_set_h, lsd, nspins, needs, rho_h, drho_h, tau_h(:, ir, :), na, ir)
+                  CALL fill_rho_set(rho_set_s, lsd, nspins, needs, rho_s, drho_s, tau_s(:, ir, :), na, ir)
                END DO
 
                !-------------------!
@@ -848,71 +842,227 @@ CONTAINS
       END IF
 
    END SUBROUTINE calc_rho_angular
+
 ! **************************************************************************************************
-!> \brief ...
-!> \param grid_atom ...
-!> \param harmonics ...
+!> \brief Computes tau hard and soft on the atomic grids for meta-GGA calculations
+!> \param tau_h the hard part of tau
+!> \param tau_s the soft part of tau
+!> \param rho_atom ...
+!> \param qs_kind ...
 !> \param nspins ...
-!> \param ir ...
-!> \param trho_h ...
-!> \param trho_s ...
-!> \param tau_h ...
-!> \param tau_s ...
+!> \note This is a rewrite to correct a meta-GGA GAPW bug. This is more brute force than the original,
+!>       which was done along in qs_rho_atom_methods.F, but makes sure that no corner is cut in
+!>       terms of accuracy (A. Bussy)
 ! **************************************************************************************************
-   SUBROUTINE calc_tau_angular(grid_atom, harmonics, nspins, ir, &
-                               trho_h, trho_s, tau_h, tau_s)
+   SUBROUTINE calc_tau_atom(tau_h, tau_s, rho_atom, qs_kind, nspins)
 
+      REAL(dp), DIMENSION(:, :, :), INTENT(INOUT)        :: tau_h, tau_s
+      TYPE(rho_atom_type), POINTER                       :: rho_atom
+      TYPE(qs_kind_type), INTENT(IN)                     :: qs_kind
+      INTEGER, INTENT(IN)                                :: nspins
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'calc_tau_atom'
+
+      INTEGER                                            :: dir, handle, ia, ip, ipgf, ir, iset, &
+                                                            iso, ispin, jp, jpgf, jset, jso, l, &
+                                                            maxso, na, nr, nset, starti, startj
+      INTEGER, DIMENSION(:), POINTER                     :: lmax, lmin, npgf, o2nindex
+      REAL(dp)                                           :: cpc_h, cpc_s
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: fga, fgr, r1, r2
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: a1, a2
+      REAL(dp), DIMENSION(:, :), POINTER                 :: slm, zet
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: dslm_dxyz
       TYPE(grid_atom_type), POINTER                      :: grid_atom
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
-      INTEGER, INTENT(IN)                                :: nspins, ir
-      TYPE(rho_atom_coeff), DIMENSION(:, :, :), POINTER  :: trho_h, trho_s
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: tau_h, tau_s
+      TYPE(paw_proj_set_type), POINTER                   :: paw_proj
 
-      INTEGER                                            :: dir, ia, iso, ispin, na
+      NULLIFY (harmonics, grid_atom, orb_basis, lmax, lmin, npgf, zet, slm, dslm_dxyz, o2nindex, paw_proj)
 
-      CPASSERT(ASSOCIATED(trho_h))
-      CPASSERT(ASSOCIATED(trho_s))
-      CPASSERT(ASSOCIATED(tau_h))
-      CPASSERT(ASSOCIATED(tau_s))
+      CALL timeset(routineN, handle)
 
+      !We need to put 0.5* grad_g1 dot grad_gw on the grid
+      !For this we need grid info, basis info, and projector info
+      CALL get_qs_kind(qs_kind, basis_set=orb_basis, grid_atom=grid_atom, &
+                       harmonics=harmonics, paw_proj_set=paw_proj)
+
+      nr = grid_atom%nr
       na = grid_atom%ng_sphere
+
+      slm => harmonics%slm
+      dslm_dxyz => harmonics%dslm_dxyz
+
+      CALL get_paw_proj_set(paw_proj_set=paw_proj, o2nindex=o2nindex)
+
+      !zeroing tau, assuming it is already allocated
       tau_h = 0.0_dp
       tau_s = 0.0_dp
 
-      !Here we multiply the different radial parts of tau by the angular parts (x^2, x or 1)
-      !and we take the cartesian dot product
+      CALL get_gto_basis_set(gto_basis_set=orb_basis, lmax=lmax, lmin=lmin, npgf=npgf, &
+                             nset=nset, zet=zet, maxso=maxso)
 
-      DO ispin = 1, nspins
-         DO iso = 1, harmonics%max_iso_not0
-            DO ia = 1, na
+      !Separate the functions into purely r and purely angular parts, precompute them all
+      ALLOCATE (a1(na, nset*maxso, 3), a2(na, nset*maxso, 3))
+      ALLOCATE (r1(nr, nset*maxso), r2(nr, nset*maxso))
+      a1 = 0.0_dp; a2 = 0.0_dp
+      r1 = 0.0_dp; r2 = 0.0_dp
+
+      DO iset = 1, nset
+         DO ipgf = 1, npgf(iset)
+            starti = (iset - 1)*maxso + (ipgf - 1)*nsoset(lmax(iset))
+            DO iso = nsoset(lmin(iset) - 1) + 1, nsoset(lmax(iset))
+               l = indso(1, iso)
+
+               ! The x derivative of the spherical orbital, divided in angular and radial parts
+               ! Two of each are needed because d/dx(r^l Y_lm) * exp(-al*r^2) + r^l Y_lm * ! d/dx(exp-al*r^2)
+
+               ! the purely radial part of d/dx(r^l Y_lm) * exp(-al*r^2) (same for y, z)
+               r1(1:nr, starti + iso) = grid_atom%rad(1:nr)**(l - 1)*EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
+
+               ! the purely radial part of r^l Y_lm * d/dx(exp-al*r^2) (same for y, z)
+               r2(1:nr, starti + iso) = -2.0_dp*zet(ipgf, iset)*grid_atom%rad(1:nr)**(l + 1) &
+                                        *EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
 
                DO dir = 1, 3
+                  ! the purely angular part of d/dx(r^l Y_lm) * exp(-al*r^2)
+                  a1(1:na, starti + iso, dir) = dslm_dxyz(dir, 1:na, iso)
 
-                  !part to be multiplied by x^2
-                  tau_h(ia, ispin) = tau_h(ia, ispin) + &
-                                     trho_h(1, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)**2
-                  tau_s(ia, ispin) = tau_s(ia, ispin) + &
-                                     trho_s(1, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)**2
+                  ! the purely angular part of r^l Y_lm * d/dx(exp-al*r^2)
+                  a2(1:na, starti + iso, dir) = harmonics%a(dir, 1:na)*slm(1:na, iso)
+               END DO
 
-                  !part to be multiplied by x
-                  tau_h(ia, ispin) = tau_h(ia, ispin) + &
-                                     trho_h(2, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)
-                  tau_s(ia, ispin) = tau_s(ia, ispin) + &
-                                     trho_s(2, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)*harmonics%a(dir, ia)
+            END DO !iso
+         END DO !ipgf
+      END DO !iset
 
-                  !part to be multiplied by 1
-                  tau_h(ia, ispin) = tau_h(ia, ispin) + &
-                                     trho_h(3, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
-                  tau_s(ia, ispin) = tau_s(ia, ispin) + &
-                                     trho_s(3, dir, ispin)%r_coef(ir, iso)*harmonics%slm(ia, iso)
+      !Compute the matrix products
+      ALLOCATE (fga(na, 1))
+      ALLOCATE (fgr(nr, 1))
+      fga = 0.0_dp; fgr = 0.0_dp
 
-               END DO !dir
+      DO iset = 1, nset
+         DO jset = 1, nset
+            DO ipgf = 1, npgf(iset)
+               starti = (iset - 1)*maxso + (ipgf - 1)*nsoset(lmax(iset))
+               DO jpgf = 1, npgf(jset)
+                  startj = (jset - 1)*maxso + (jpgf - 1)*nsoset(lmax(jset))
 
-            END DO !ia
-         END DO !iso
-      END DO !ispin
+                  DO iso = nsoset(lmin(iset) - 1) + 1, nsoset(lmax(iset))
+                     DO jso = nsoset(lmin(jset) - 1) + 1, nsoset(lmax(jset))
 
-   END SUBROUTINE calc_tau_angular
+                        ip = o2nindex(starti + iso)
+                        jp = o2nindex(startj + jso)
+
+                        !Two component per function => 4 terms in total
+
+                        ! take r1*a1(dir) *  r1*a1(dir)
+                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r1(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              !get the projectors
+                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
+                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
+
+                              !compute contribution to tau
+                              DO ir = 1, nr
+                                 DO ia = 1, na
+                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+
+                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+                                 END DO
+                              END DO
+
+                           END DO !ispin
+                        END DO !dir
+
+                        ! add r1*a1(dir) * r2*a2(dir)
+                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r2(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              !get the projectors
+                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
+                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
+
+                              !compute contribution to tau
+                              DO ir = 1, nr
+                                 DO ia = 1, na
+                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+
+                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+                                 END DO
+                              END DO
+
+                           END DO !ispin
+                        END DO !dir
+
+                        ! add r2*a2(dir) * V * r1*a1(dir)
+                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r1(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              !get the projectors
+                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
+                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
+
+                              !compute contribution to tau
+                              DO ir = 1, nr
+                                 DO ia = 1, na
+                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+
+                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+                                 END DO
+                              END DO
+
+                           END DO !ispin
+                        END DO !dir
+
+                        ! add the last term: r2*a2(dir) * r2*a2(dir)
+                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r2(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              !get the projectors
+                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
+                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
+
+                              !compute contribution to tau
+                              DO ir = 1, nr
+                                 DO ia = 1, na
+                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+
+                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
+                                                           fgr(ir, 1)*fga(ia, 1)
+                                 END DO
+                              END DO
+
+                           END DO !ispin
+                        END DO !dir
+
+                     END DO !jso
+                  END DO !iso
+
+               END DO !jpgf
+            END DO !ipgf
+         END DO !jset
+      END DO !iset
+
+      CALL timestop(handle)
+
+   END SUBROUTINE calc_tau_atom
+
 ! **************************************************************************************************
 !> \brief ...
 !> \param grid_atom ...
@@ -1185,8 +1335,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'gaVxcgb_GC'
 
-      INTEGER :: dmax_iso_not0, dmax_iso_not0_local, handle, ia, ic, icg, ipgf1, ipgf2, ir, iset1, &
-         iset2, iso, iso1, iso2, ispin, l, lmax12, lmax_expansion, lmin12, m1, m2, max_iso_not0, &
+      INTEGER :: dmax_iso_not0_local, handle, ia, ic, icg, ipgf1, ipgf2, ir, iset1, iset2, iso, &
+         iso1, iso2, ispin, l, lmax12, lmax_expansion, lmin12, m1, m2, max_iso_not0, &
          max_iso_not0_local, max_s_harm, maxl, maxso, n1, n2, na, ngau1, ngau2, nngau1, nr, nset, &
          size1
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dcg_n_list
@@ -1223,7 +1373,6 @@ CONTAINS
       my_CG => harmonics%my_CG
       my_CG_dxyz => harmonics%my_CG_dxyz
       max_iso_not0 = harmonics%max_iso_not0
-      dmax_iso_not0 = harmonics%dmax_iso_not0
       lmax_expansion = indso(1, max_iso_not0)
       max_s_harm = harmonics%max_s_harm
 
@@ -1254,7 +1403,6 @@ CONTAINS
                CPASSERT(max_iso_not0_local .LE. max_iso_not0)
                CALL get_none0_cg_list(my_CG_dxyz, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
                                       max_s_harm, lmax_expansion, dcg_list, dcg_n_list, dmax_iso_not0_local)
-               !CPASSERT(dmax_iso_not0_local.LE.dmax_iso_not0)
 
                n2 = nsoset(lmax(iset2))
                DO ipgf1 = 1, npgf(iset1)
@@ -1431,12 +1579,14 @@ CONTAINS
    END SUBROUTINE gaVxcgb_GC
 
 ! **************************************************************************************************
-!> \brief ...
-!> \param vtau_h ...
-!> \param vtau_s ...
+!> \brief Integrates 0.5 * grad_ga .dot. (V_tau * grad_gb) on the atomic grid for meta-GGA
+!> \param vtau_h the har tau potential
+!> \param vtau_s the soft tau potential
 !> \param qs_kind ...
 !> \param rho_atom ...
 !> \param nspins ...
+!> \note This is a rewrite to correct meat-GGA GAPW bug. This is more brute force than the original
+!>       but makes sure that no corner is cut in terms of accuracy (A. Bussy)
 ! **************************************************************************************************
    SUBROUTINE dgaVtaudgb(vtau_h, vtau_s, qs_kind, rho_atom, nspins)
 
@@ -1447,228 +1597,179 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'dgaVtaudgb'
 
-      INTEGER :: ddmax_iso_not0_local, dir, dmax_iso_not0_local, handle, ic, icg, ipgf1, ipgf2, &
-         iset1, iset2, iso, iso1, iso2, isom1, isom2, ispin, l1, l2, lmax12, lmax_expansion, &
-         lmin12, m1, m2, max_iso_not0, max_iso_not0_local, max_s_harm, maxiso, maxl, maxso, mm1, &
-         mm2, n1, n2, na, ngau1, ngau2, nngau1, nr, nset, size1
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dcg_n_list, ddcg_n_list
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dcg_list, ddcg_list
+      INTEGER                                            :: dir, handle, ipgf, iset, iso, ispin, &
+                                                            jpgf, jset, jso, l, maxso, na, nr, &
+                                                            nset, starti, startj
       INTEGER, DIMENSION(:), POINTER                     :: lmax, lmin, npgf
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: g1, g2, gr, ww
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: matso_h, matso_s
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: ddvth, ddvts, dvth, dvts, gg, vth, vts
-      REAL(dp), DIMENSION(:, :), POINTER                 :: zet
-      REAL(dp), DIMENSION(:, :, :), POINTER              :: my_CG
-      REAL(dp), DIMENSION(:, :, :, :), POINTER           :: my_dCG, my_ddCG
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: fga, fgr, r1, r2, work
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: a1, a2, intso_h, intso_s
+      REAL(dp), DIMENSION(:, :), POINTER                 :: slm, zet
+      REAL(dp), DIMENSION(:, :, :), POINTER              :: dslm_dxyz
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
       TYPE(rho_atom_coeff), DIMENSION(:), POINTER        :: int_hh, int_ss
 
-! -------------------------------------------------------------------------
+      NULLIFY (zet, slm, dslm_dxyz, harmonics, grid_atom, orb_basis, lmax, lmin, npgf, int_hh, int_ss)
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (harmonics, grid_atom)
       CALL get_qs_kind(qs_kind, basis_set=orb_basis, &
                        harmonics=harmonics, grid_atom=grid_atom)
 
-      NULLIFY (lmin, lmax, npgf, zet)
       CALL get_gto_basis_set(gto_basis_set=orb_basis, lmax=lmax, lmin=lmin, &
-                             maxso=maxso, maxl=maxl, npgf=npgf, &
-                             nset=nset, zet=zet)
+                             maxso=maxso, npgf=npgf, nset=nset, zet=zet)
 
-      my_CG => harmonics%my_CG
-      my_dCG => harmonics%my_dCG
-      my_ddCG => harmonics%my_ddCG
-      max_iso_not0 = harmonics%max_iso_not0
-      lmax_expansion = indso(1, max_iso_not0)
-      max_s_harm = harmonics%max_s_harm
-
-      nr = grid_atom%nr
       na = grid_atom%ng_sphere
-      ALLOCATE (g1(nr), g2(nr), ww(na), gr(nr))
-      ALLOCATE (gg(nr, 0:maxl, 0:maxl))
+      nr = grid_atom%nr
 
-      ALLOCATE (cg_list(2, nsoset(maxl)**2, max_s_harm), cg_n_list(max_s_harm), &
-                dcg_list(2, nsoset(maxl)**2, max_s_harm), dcg_n_list(max_s_harm), &
-                ddcg_list(2, nsoset(maxl)**2, max_s_harm), ddcg_n_list(max_s_harm))
+      slm => harmonics%slm
+      dslm_dxyz => harmonics%dslm_dxyz
 
-      ALLOCATE (matso_h(nsoset(maxl), nsoset(maxl)), &
-                matso_s(nsoset(maxl), nsoset(maxl)))
+      ! Separate the functions into purely r and purely angular parts and precompute them all
+      ! Not meory intensive since 1D arrays
+      ALLOCATE (a1(na, nset*maxso, 3), a2(na, nset*maxso, 3))
+      ALLOCATE (r1(nr, nset*maxso), r2(nr, nset*maxso))
+      a1 = 0.0_dp; a2 = 0.0_dp
+      r1 = 0.0_dp; r2 = 0.0_dp
 
+      DO iset = 1, nset
+         DO ipgf = 1, npgf(iset)
+            starti = (iset - 1)*maxso + (ipgf - 1)*nsoset(lmax(iset))
+            DO iso = nsoset(lmin(iset) - 1) + 1, nsoset(lmax(iset))
+               l = indso(1, iso)
+
+               ! The x derivative of the spherical orbital, divided in angular and radial parts
+               ! Two of each are needed because d/dx(r^l Y_lm) * exp(-al*r^2) + r^l Y_lm *  d/dx(exp-al*r^2)
+
+               ! the purely radial part of d/dx(r^l Y_lm) * exp(-al*r^2) (same for y,z)
+               r1(1:nr, starti + iso) = grid_atom%rad(1:nr)**(l - 1)*EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
+
+               ! the purely radial part of r^l Y_lm * d/dx(exp-al*r^2) (same for y,z)
+               r2(1:nr, starti + iso) = -2.0_dp*zet(ipgf, iset)*grid_atom%rad(1:nr)**(l + 1) &
+                                        *EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
+
+               DO dir = 1, 3
+                  ! the purely angular part of d/dx(r^l Y_lm) * exp(-al*r^2)
+                  a1(1:na, starti + iso, dir) = dslm_dxyz(dir, 1:na, iso)
+
+                  ! the purely angular part of r^l Y_lm * d/dx(exp-al*r^2)
+                  a2(1:na, starti + iso, dir) = harmonics%a(dir, 1:na)*slm(1:na, iso)
+               END DO
+
+            END DO !iso
+         END DO !ipgf
+      END DO !iset
+
+      !Do the integration in terms of matrix-matrix multiplications
+      ALLOCATE (intso_h(nset*maxso, nset*maxso, nspins))
+      ALLOCATE (intso_s(nset*maxso, nset*maxso, nspins))
+      intso_h = 0.0_dp; intso_s = 0.0_dp
+
+      ALLOCATE (fga(na, 1))
+      ALLOCATE (fgr(nr, 1))
+      ALLOCATE (work(na, 1))
+      fga = 0.0_dp; fgr = 0.0_dp; work = 0.0_dp
+
+      DO iset = 1, nset
+         DO jset = 1, nset
+            DO ipgf = 1, npgf(iset)
+               starti = (iset - 1)*maxso + (ipgf - 1)*nsoset(lmax(iset))
+               DO jpgf = 1, npgf(jset)
+                  startj = (jset - 1)*maxso + (jpgf - 1)*nsoset(lmax(jset))
+
+                  DO iso = nsoset(lmin(iset) - 1) + 1, nsoset(lmax(iset))
+                     DO jso = nsoset(lmin(jset) - 1) + 1, nsoset(lmax(jset))
+
+                        !Two component per function => 4 terms in total
+
+                        ! take 0.5*r1*a1(dir) * V * r1*a1(dir)
+                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r1(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_h(starti + iso:, startj + jso, ispin), 1)
+
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_s(starti + iso:, startj + jso, ispin), 1)
+                           END DO
+                        END DO !dir
+
+                        ! add 0.5*r1*a1(dir) * V * r2*a2(dir)
+                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r2(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_h(starti + iso:, startj + jso, ispin), 1)
+
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_s(starti + iso:, startj + jso, ispin), 1)
+                           END DO
+                        END DO !dir
+
+                        ! add 0.5*r2*a2(dir) * V * r1*a1(dir)
+                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r1(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_h(starti + iso:, startj + jso, ispin), 1)
+
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_s(starti + iso:, startj + jso, ispin), 1)
+                           END DO
+                        END DO !dir
+
+                        ! add the last term: 0.5*r2*a2(dir) * V * r2*a2(dir)
+                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r2(1:nr, startj + jso)
+                        DO dir = 1, 3
+                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
+
+                           DO ispin = 1, nspins
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_h(starti + iso:, startj + jso, ispin), 1)
+
+                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
+                                         nr, 0.0_dp, work, na)
+                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
+                                         intso_s(starti + iso:, startj + jso, ispin), 1)
+                           END DO
+                        END DO !dir
+
+                     END DO !jso
+                  END DO !iso
+
+               END DO !jpgf
+            END DO !ipgf
+         END DO !jset
+      END DO !iset
+
+      ! Put the integrals in the rho_atom data structure
       NULLIFY (int_hh, int_ss)
       CALL get_rho_atom(rho_atom=rho_atom, ga_Vlocal_gb_h=int_hh, ga_Vlocal_gb_s=int_ss)
-
-      vtau_h = 0.5_dp*vtau_h
-      vtau_s = 0.5_dp*vtau_s
-
       DO ispin = 1, nspins
-         maxiso = SIZE(harmonics%slm, 2)
-         ALLOCATE (vth(nr, 3, maxiso), vts(nr, 3, maxiso))
-         ALLOCATE (dvth(nr, 3, maxiso), dvts(nr, 3, maxiso))
-         ALLOCATE (ddvth(nr, 3, maxiso), ddvts(nr, 3, maxiso))
-         DO iso = 1, maxiso
-            DO dir = 1, 3
-               !term in Ylm*Ylm, to be multiplied by x^2
-               ww(1:na) = harmonics%slm(1:na, iso)*harmonics%a(dir, 1:na)**2
-               vth(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
-               vts(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
-
-               !term in Ylm * dYlm/dx, to be multiplied by x
-               ww(1:na) = harmonics%slm(1:na, iso)*harmonics%a(dir, 1:na)
-               dvth(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
-               dvts(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
-
-               !term in dYlm/dx * dYlm/dx, to be multiplied by 1
-               ww(1:na) = harmonics%slm(1:na, iso)
-               ddvth(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_h(1:na, 1:nr, ispin))
-               ddvts(1:nr, dir, iso) = MATMUL(ww(1:na), vtau_s(1:na, 1:nr, ispin))
-            END DO
-         END DO
-         m1 = 0
-         DO iset1 = 1, nset
-            n1 = nsoset(lmax(iset1))
-            m2 = 0
-            DO iset2 = 1, nset
-               CALL get_none0_cg_list(my_CG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
-                                      max_s_harm, lmax_expansion, cg_list, cg_n_list, max_iso_not0_local)
-               CPASSERT(max_iso_not0_local .LE. max_iso_not0)
-               CALL get_none0_cg_list(my_dCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
-                                      max_s_harm, lmax_expansion, dcg_list, dcg_n_list, dmax_iso_not0_local)
-               CALL get_none0_cg_list(my_ddCG, lmin(iset1), lmax(iset1), lmin(iset2), lmax(iset2), &
-                                      max_s_harm, lmax_expansion, ddcg_list, ddcg_n_list, ddmax_iso_not0_local)
-
-               n2 = nsoset(lmax(iset2))
-               DO ipgf1 = 1, npgf(iset1)
-                  ngau1 = n1*(ipgf1 - 1) + m1
-                  size1 = nsoset(lmax(iset1)) - nsoset(lmin(iset1) - 1)
-                  nngau1 = nsoset(lmin(iset1) - 1) + ngau1
-                  g1(1:nr) = EXP(-zet(ipgf1, iset1)*grid_atom%rad2(1:nr))
-                  DO ipgf2 = 1, npgf(iset2)
-                     ngau2 = n2*(ipgf2 - 1) + m2
-                     g2(1:nr) = EXP(-zet(ipgf2, iset2)*grid_atom%rad2(1:nr))
-                     lmin12 = lmin(iset1) + lmin(iset2)
-                     lmax12 = lmax(iset1) + lmax(iset2)
-
-                     IF (lmin12 .LE. lmax_expansion) THEN
-                        gg = 0.0_dp
-                        DO l1 = 0, maxl
-                           DO l2 = 0, maxl
-                              IF (l1 + l2 > lmax_expansion) CYCLE
-                              IF (l1 + l2 > 0) THEN
-                                 gg(1:nr, l1, l2) = g1(1:nr)*g2(1:nr)*grid_atom%rad2l(1:nr, l1 + l2)
-                              ELSE
-                                 gg(1:nr, l1, l2) = g1(1:nr)*g2(1:nr)
-                              END IF
-                           END DO
-                        END DO
-                     END IF
-
-                     matso_h = 0.0_dp
-                     matso_s = 0.0_dp
-                     IF (lmin12 .LE. lmax_expansion) THEN
-                        DO iso = 1, max_iso_not0_local
-                           DO icg = 1, cg_n_list(iso)
-                              iso1 = cg_list(1, icg, iso)
-                              iso2 = cg_list(2, icg, iso)
-
-                              l1 = indso(1, iso1)
-                              l2 = indso(1, iso2)
-                              mm1 = indso(2, iso1)
-                              mm2 = indso(2, iso2)
-                              isom1 = soset(l1, -mm1)
-                              isom2 = soset(l2, -mm2)
-
-                              IF (l1 + l2 > lmax_expansion) CYCLE
-
-                              !The term in Ylm*Ylm
-                              gr(1:nr) = 4.0_dp*zet(ipgf1, iset1)*zet(ipgf2, iset2)* &
-                                         gg(1:nr, l1, l2)*grid_atom%rad2(1:nr)
-
-                              DO dir = 1, 3
-                                 matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_CG(iso1, iso2, iso)* &
-                                                       DOT_PRODUCT(vth(1:nr, dir, iso), gr(1:nr))
-                                 matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_CG(iso1, iso2, iso)* &
-                                                       DOT_PRODUCT(vts(1:nr, dir, iso), gr(1:nr))
-                              END DO
-
-                           END DO
-                        END DO
-                     END IF
-
-                     DO iso = 1, dmax_iso_not0_local
-                        DO icg = 1, dcg_n_list(iso)
-                           iso1 = dcg_list(1, icg, iso)
-                           iso2 = dcg_list(2, icg, iso)
-
-                           l1 = indso(1, iso1)
-                           l2 = indso(1, iso2)
-
-                           !The term in Yl1m1 * dYl2m2/dx
-                           gr(1:nr) = -2.0_dp*zet(ipgf1, iset1)*gg(1:nr, l1, l2)
-                           DO dir = 1, 3
-                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_dCG(dir, iso1, iso2, iso)* &
-                                                    DOT_PRODUCT(dvth(1:nr, dir, iso), gr(1:nr))
-                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_dCG(dir, iso1, iso2, iso)* &
-                                                    DOT_PRODUCT(dvts(1:nr, dir, iso), gr(1:nr))
-                           END DO
-
-                           !The term in dYl1m1/dx * Yl2m2
-                           gr(1:nr) = -2.0_dp*zet(ipgf2, iset2)*gg(1:nr, l1, l2)
-                           DO dir = 1, 3
-                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_dCG(dir, iso2, iso1, iso)* &
-                                                    DOT_PRODUCT(dvth(1:nr, dir, iso), gr(1:nr))
-                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_dCG(dir, iso2, iso1, iso)* &
-                                                    DOT_PRODUCT(dvts(1:nr, dir, iso), gr(1:nr))
-                           END DO
-
-                        END DO
-                     END DO
-
-                     DO iso = 1, ddmax_iso_not0_local
-                        DO icg = 1, ddcg_n_list(iso)
-                           iso1 = ddcg_list(1, icg, iso)
-                           iso2 = ddcg_list(2, icg, iso)
-
-                           l1 = indso(1, iso1)
-                           l2 = indso(1, iso2)
-
-                           !The term in dYlm/dx * dYlm/dx
-                           gr(1:nr) = gg(1:nr, l1, l2)/grid_atom%rad2(1:nr)
-                           DO dir = 1, 3
-                              matso_h(iso1, iso2) = matso_h(iso1, iso2) + my_ddCG(dir, iso1, iso2, iso)* &
-                                                    DOT_PRODUCT(ddvth(1:nr, dir, iso), gr(1:nr))
-                              matso_s(iso1, iso2) = matso_s(iso1, iso2) + my_ddCG(dir, iso1, iso2, iso)* &
-                                                    DOT_PRODUCT(ddvts(1:nr, dir, iso), gr(1:nr))
-                           END DO
-
-                        END DO
-                     END DO
-
-                     ! Write in the global matrix
-                     DO ic = nsoset(lmin(iset2) - 1) + 1, nsoset(lmax(iset2))
-                        iso1 = nsoset(lmin(iset1) - 1) + 1
-                        iso2 = ngau2 + ic
-                        CALL daxpy(size1, 1.0_dp, matso_h(iso1, ic), 1, int_hh(ispin)%r_coef(nngau1 + 1, iso2), 1)
-                        CALL daxpy(size1, 1.0_dp, matso_s(iso1, ic), 1, int_ss(ispin)%r_coef(nngau1 + 1, iso2), 1)
-                     END DO
-
-                  END DO ! ipfg2
-               END DO ! ipfg1
-               m2 = m2 + maxso
-            END DO ! iset2
-            m1 = m1 + maxso
-         END DO ! iset1
-         DEALLOCATE (vth, vts, dvth, dvts, ddvth, ddvts)
-      END DO ! ispin
-
-      DEALLOCATE (matso_h, matso_s)
-      DEALLOCATE (g1, g2, gg, gr, ww)
-      DEALLOCATE (cg_list, cg_n_list, dcg_list, dcg_n_list)
-
-      vtau_h = 2._dp*vtau_h
-      vtau_s = 2._dp*vtau_s
+         int_hh(ispin)%r_coef(:, :) = int_hh(ispin)%r_coef(:, :) + intso_h(:, :, ispin)
+         int_ss(ispin)%r_coef(:, :) = int_ss(ispin)%r_coef(:, :) + intso_s(:, :, ispin)
+      END DO
 
       CALL timestop(handle)
 

--- a/src/xc/xc_atom.F
+++ b/src/xc/xc_atom.F
@@ -594,10 +594,10 @@ CONTAINS
       TYPE(xc_rho_set_type), POINTER                     :: rho_set
       LOGICAL, INTENT(IN)                                :: lsd
       INTEGER, INTENT(IN)                                :: nspins
-      TYPE(xc_rho_cflags_type), INTENT(in)               :: needs
-      REAL(dp), DIMENSION(:, :), POINTER                 :: rho
-      REAL(dp), DIMENSION(:, :, :, :), POINTER           :: drho
-      REAL(dp), DIMENSION(:, :), POINTER                 :: tau
+      TYPE(xc_rho_cflags_type), INTENT(IN)               :: needs
+      REAL(dp), DIMENSION(:, :), INTENT(IN)              :: rho
+      REAL(dp), DIMENSION(:, :, :, :), INTENT(IN)        :: drho
+      REAL(dp), DIMENSION(:, :), INTENT(IN)              :: tau
       INTEGER, INTENT(IN)                                :: na, ir
 
       REAL(KIND=dp), PARAMETER                           :: f13 = (1.0_dp/3.0_dp)
@@ -831,7 +831,6 @@ CONTAINS
 
       ! tau part
       IF (needs%tau .OR. needs%tau_spin) THEN
-         CPASSERT(ASSOCIATED(tau))
          CPASSERT(SIZE(tau, 2) == my_nspins)
       END IF
       IF (needs%tau) THEN

--- a/tests/QS/regtest-gapw/TEST_FILES
+++ b/tests/QS/regtest-gapw/TEST_FILES
@@ -39,5 +39,5 @@ H2S-gapw-gop-ot.inp                                    1      3e-13             
 # XRD total density output to file
 xrd.inp                                                0
 # TEST GAPW meta functional (was buggy, now corrected. Edit: was wrongly corrected, now OK)
-HF_gapw_TPSS.inp                                       1      1e-10            -100.48682767842233
+HF_gapw_TPSS.inp                                       1      1e-10            -100.48684877581044
 #EOF

--- a/tests/QS/regtest-libxc/TEST_FILES
+++ b/tests/QS/regtest-libxc/TEST_FILES
@@ -8,7 +8,7 @@ H2O_pbe_libxc_tddfpt-s.inp                             1      6e-14             
 H2O_lda_libxc_tddfpt-s.inp                             1      2e-14             -17.13289833455457
 H2O_pbe_libxc_tddfpt-t_uks.inp                         1      2e-14             -17.23116251474715
 H2O-hybrid-b3lyp_libxc.inp                             1      3e-14             -76.41035426581175
-H2O-hybrid-tpssh_libxc.inp                             1      3e-14             -76.40913833393611
+H2O-hybrid-tpssh_libxc.inp                             1      3e-14             -76.40918264715233
 H2O_lda_libxc_tddfpt-t_uks.inp                         1    1.0E-14             -17.13289833455847
 H2O-tpssx_libxc.inp                                    1      3e-13             -33.88300963208589
 diamond_br89_libxc_uks.inp                             1      7e-14             -11.06581614908332


### PR DESCRIPTION
This PR is an answer to issue #1116 and a follow-up to PR #1140, which respectively reported and tried to address a bug in GAPW with meta-GGA functionals. I was not able to find the exact issue in the code. Instead, I rewrote from scratch the 2 main steps involved, namely evaluating tau on the atomic grids and integrating the derived potential. The new code is slightly more brute force, as everything is explicitly put on the grid and no corner is cut.

Testing involved debug runs for the forces, on all combination of 6-311G** and def2-DZVP basis sets, TPSS and M06_L functionals and H2O, CO and C2H4 molecules. Most errors are at 0.01% or less (max error at 0.07%). Moreover, the OT method was used in combination with the CG minimzer and 3PNT LINESEARCH and the total energy was systematically decreasing at each CG step of the SCF procedure, which is sound behaviour.

