### PR TITLE
grid: Introduce generic buffer type

### DIFF
--- a/src/grid/Makefile
+++ b/src/grid/Makefile
@@ -5,25 +5,38 @@ all: grid_collocate_miniapp.x grid_collocate_unittest.x
 clean:
 	rm -fv grid_*.o */grid_*.o grid_*.x
 
-CFLAGS := -fopenmp -g -O3 -std=c99 -march=native -Wall -Wextra -Wpedantic -I${CUDA_PATH}/include -D__GRID_CUDA
+CFLAGS := -fopenmp -g -O3 -std=c99 -march=native -Wall -Wextra -I${CUDA_PATH}/include -D__GRID_CUDA
 NVFLAGS := -g -O3 -arch sm_50 -Wno-deprecated-gpu-targets -Xcompiler "-fopenmp -Wall -Wextra" -D__GRID_CUDA
 
-LIBS := -lm -lblas -lcudart -lcuda -L${CUDA_PATH}/lib64
+LIBS := -lm -lblas -lcudart -lcuda -lcublas -L${CUDA_PATH}/lib64
 
 ALL_HEADERS := $(shell find . -name "*.h")
 
 ALL_OBJECTS := grid_collocate_replay.o \
                grid_task_list.o \
                common/grid_library.o \
+               common/grid_buffer.o \
                common/grid_basis_set.o \
                common/grid_sphere_cache.o \
-               cpu/grid_cpu_task_list.o \
                ref/grid_ref_task_list.o \
                ref/grid_ref_collocate.o \
                ref/grid_ref_integrate.o \
                ref/grid_ref_prepare_pab.o \
                gpu/grid_gpu_task_list.o \
-               gpu/grid_gpu_collocate.o
+               gpu/grid_gpu_collocate.o \
+               hybrid/grid_collocate_hybrid_cuda.o \
+               hybrid/grid_collocate_hybrid.o \
+               cpu/grid_context_cpu.o \
+               cpu/coefficients.o \
+               cpu/grid_collocate_dgemm.o \
+               cpu/grid_integrate_dgemm.o \
+               cpu/non_orthorombic_corrections.o \
+               cpu/utils.o \
+               cpu/collocation_integration.o \
+               cpu/grid_context_cpu.o \
+               cpu/grid_prepare_pab_dgemm.o \
+               cpu/tensor_local.o
+
 
 %.o: %.c $(ALL_HEADERS)
 	cd $(dir $<); $(CC) -c $(CFLAGS) $(notdir $<)

--- a/src/grid/common/grid_buffer.c
+++ b/src/grid/common/grid_buffer.c
@@ -1,0 +1,88 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2020 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "grid_buffer.h"
+
+#ifdef __GRID_CUDA
+#include <cuda_runtime.h>
+
+/*******************************************************************************
+ * \brief Check given Cuda status and upon failure abort with a nice message.
+ * \author Ole Schuett
+ ******************************************************************************/
+#define CHECK(status)                                                          \
+  if (status != cudaSuccess) {                                                 \
+    fprintf(stderr, "ERROR: %s %s %d\n", cudaGetErrorString(status), __FILE__, \
+            __LINE__);                                                         \
+    abort();                                                                   \
+  }
+
+#endif // __GRID_CUDA
+
+/*******************************************************************************
+ * \brief Allocates a buffer of given length, ie. number of elements.
+ * \author Ole Schuett
+ ******************************************************************************/
+void grid_create_buffer(const int length, grid_buffer **buffer) {
+
+  const size_t requested_size = length * sizeof(double);
+
+  if (*buffer != NULL) {
+    if ((*buffer)->size >= requested_size) {
+      return; // reuse existing buffer
+    } else {
+      grid_free_buffer(*buffer);
+    }
+  }
+
+  (*buffer) = malloc(sizeof(grid_buffer));
+  (*buffer)->size = requested_size;
+
+#ifdef __GRID_CUDA
+  // With size 0 cudaMallocHost doesn't null the pointer and cudaFreeHost fails.
+  (*buffer)->host_buffer = NULL;
+  CHECK(cudaMallocHost((void **)&(*buffer)->host_buffer, requested_size));
+  CHECK(cudaMalloc((void **)&(*buffer)->device_buffer, requested_size));
+#else
+  (*buffer)->host_buffer = malloc(requested_size);
+  (*buffer)->device_buffer = NULL;
+#endif
+}
+
+/*******************************************************************************
+ * \brief Deallocate given buffer.
+ * \author Ole Schuett
+ ******************************************************************************/
+void grid_free_buffer(grid_buffer *buffer) {
+
+  if (buffer == NULL)
+    return;
+
+#ifdef __GRID_CUDA
+  CHECK(cudaFreeHost(buffer->host_buffer));
+  CHECK(cudaFree(buffer->device_buffer));
+#else
+  free(buffer->host_buffer);
+#endif
+
+  free(buffer);
+}
+
+/*******************************************************************************
+ * \brief Returns a pointer to the host buffer.
+ * \author Ole Schuett
+ ******************************************************************************/
+double *grid_buffer_get_host_pointer(grid_buffer *buffer) {
+  assert(buffer != NULL);
+  return buffer->host_buffer;
+}
+
+// EOF

--- a/src/grid/common/grid_buffer.h
+++ b/src/grid/common/grid_buffer.h
@@ -1,0 +1,42 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2020 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+#ifndef GRID_BUFFER_H
+#define GRID_BUFFER_H
+
+#include <stddef.h>
+
+/*******************************************************************************
+ * \brief Internal representation of a buffer.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  size_t size;
+  double *host_buffer;
+  double *device_buffer;
+} grid_buffer;
+
+/*******************************************************************************
+ * \brief Allocates a buffer of given length, ie. number of elements.
+ * \author Ole Schuett
+ ******************************************************************************/
+void grid_create_buffer(const int length, grid_buffer **buffer);
+
+/*******************************************************************************
+ * \brief Deallocate given buffer.
+ * \author Ole Schuett
+ ******************************************************************************/
+void grid_free_buffer(grid_buffer *buffer);
+
+/*******************************************************************************
+ * \brief Returns a pointer to the host buffer.
+ * \author Ole Schuett
+ ******************************************************************************/
+double *grid_buffer_get_host_pointer(grid_buffer *buffer);
+
+#endif
+
+// EOF

--- a/src/grid/cpu/grid_context_cpu.h
+++ b/src/grid/cpu/grid_context_cpu.h
@@ -9,21 +9,21 @@
 #define GRID_CONTEXT_CPU_H
 
 #include "../common/grid_basis_set.h"
+#include "../common/grid_buffer.h"
 void *create_grid_context_cpu(
     const int ntasks, const int nlevels, const int natoms, const int nkinds,
-    const int nblocks, const int buffer_size, const int *block_offsets,
+    const int nblocks, const int *block_offsets,
     const double atom_positions[natoms][3], const int *const atom_kinds,
     const grid_basis_set **const basis_sets, const int *const level_list,
     const int *const iatom_list, const int *jatom_list,
     const int *const iset_list, const int *const jset_list,
     const int *const ipgf_list, const int *const jpgf_list,
     const int *const border_mask_list, const int *block_num_list,
-    const double *const radius_list, const double rab_list[ntasks][3],
-    double **blocks_buffer);
+    const double *const radius_list, const double rab_list[ntasks][3]);
 
 void update_grid_context_cpu(
     const int ntasks, const int nlevels, const int natoms, const int nkinds,
-    const int nblocks, const int buffer_size, const int *block_offsets,
+    const int nblocks, const int *block_offsets,
     const double atom_positions[natoms][3], const int *const atom_kinds,
     const grid_basis_set **const basis_sets, const int *const level_list,
     const int *const iatom_list, const int *jatom_list,
@@ -31,7 +31,7 @@ void update_grid_context_cpu(
     const int *const ipgf_list, const int *const jpgf_list,
     const int *const border_mask_list, const int *block_num_list,
     const double *const radius_list, const double rab_list[ntasks][3],
-    double **blocks_buffer, void *ptr);
+    void *ptr);
 
 void initialize_grid_context_on_gpu(void *ptr, const int number_of_devices,
                                     const int *device_id);
@@ -40,9 +40,6 @@ void destroy_grid_context_cpu(void *ptr);
 
 void apply_cutoff(void *ptr);
 
-void extract_grid_context_block_buffer(const void *const ptr,
-                                       void *block_buffer);
-
 void update_queue_length(void *const ptr, const int queue_length);
 
 void grid_collocate_task_list_cpu(
@@ -50,5 +47,5 @@ void grid_collocate_task_list_cpu(
     const int npts_global[nlevels][3], const int npts_local[nlevels][3],
     const int shift_local[nlevels][3], const int border_width[nlevels][3],
     const double dh[nlevels][3][3], const double dh_inv[nlevels][3][3],
-    double *grid[nlevels]);
+    const grid_buffer *pab_blocks, double *grid[nlevels]);
 #endif

--- a/src/grid/cpu/private_header.h
+++ b/src/grid/cpu/private_header.h
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 /* everything here is specific to the cpu and gpu backends*/
 #include "../common/grid_basis_set.h"
+#include "../common/grid_buffer.h"
 #include "../common/grid_common.h"
 
 enum checksum_ { task_checksum = 0x2384989, ctx_checksum = 0x2356734 };
@@ -46,10 +47,6 @@ typedef struct {
   int nkinds_total;
   int nlevels_total;
   int ntasks_total;
-
-  double *blocks_buffer;
-  size_t block_buffer_size;
-  size_t block_buffer_size_alloc;
   int *block_offsets;
   double *atom_positions;
   int *atom_kinds;
@@ -145,7 +142,8 @@ extern void set_grid_parameters(
 
 extern void collocate_one_grid_level_dgemm(grid_context *const ctx,
                                            const int *const, const int *const,
-                                           const int func, const int level);
+                                           const int func, const int level,
+                                           const grid_buffer *pab_blocks);
 
 extern double compute_coefficients(grid_context *const ctx,
                                    struct collocation_integration_ *handler,
@@ -153,5 +151,5 @@ extern double compute_coefficients(grid_context *const ctx,
                                    tensor *const work, tensor *const pab_prep,
                                    int *const prev_block_num,
                                    int *const prev_iset, int *const prev_jset,
-                                   double *rp);
+                                   const grid_buffer *pab_blocks, double *rp);
 #endif

--- a/src/grid/gpu/grid_gpu_collocate.h
+++ b/src/grid/gpu/grid_gpu_collocate.h
@@ -25,7 +25,7 @@ void grid_gpu_collocate_one_grid_level(
     const int last_task, const bool orthorhombic, const enum grid_func func,
     const int npts_global[3], const int npts_local[3], const int shift_local[3],
     const int border_width[3], const double dh[3][3], const double dh_inv[3][3],
-    const cudaStream_t stream, double *grid_dev);
+    const cudaStream_t stream, const double *pab_blocks_dev, double *grid_dev);
 
 #ifdef __cplusplus
 }

--- a/src/grid/gpu/grid_gpu_task_list.h
+++ b/src/grid/gpu/grid_gpu_task_list.h
@@ -14,6 +14,7 @@ extern "C" {
 #endif
 
 #include "../common/grid_basis_set.h"
+#include "../common/grid_buffer.h"
 #include "../common/grid_constants.h"
 #include <cuda_runtime.h>
 #include <stdbool.h>
@@ -49,10 +50,7 @@ typedef struct {
   int *tasks_per_level;
   cudaStream_t *streams;
   int lmax;
-  int buffer_length;
-  double *blocks_buffer_host;
   // device pointers
-  double *blocks_buffer_dev;
   int *block_offsets_dev;
   double *atom_positions_dev;
   int *atom_kinds_dev;
@@ -69,14 +67,14 @@ typedef struct {
  ******************************************************************************/
 void grid_gpu_create_task_list(
     const int ntasks, const int nlevels, const int natoms, const int nkinds,
-    const int nblocks, const int buffer_length, const int block_offsets[],
+    const int nblocks, const int block_offsets[],
     const double atom_positions[][3], const int atom_kinds[],
     const grid_basis_set *basis_sets[], const int level_list[],
     const int iatom_list[], const int jatom_list[], const int iset_list[],
     const int jset_list[], const int ipgf_list[], const int jpgf_list[],
     const int border_mask_list[], const int block_num_list[],
     const double radius_list[], const double rab_list[][3],
-    double **blocks_buffer, grid_gpu_task_list **task_list_out);
+    grid_gpu_task_list **task_list_out);
 
 /*******************************************************************************
  * \brief Deallocates given task list, basis_sets have to be freed separately.
@@ -94,7 +92,7 @@ void grid_gpu_collocate_task_list(
     const enum grid_func func, const int nlevels, const int npts_global[][3],
     const int npts_local[][3], const int shift_local[][3],
     const int border_width[][3], const double dh[][3][3],
-    const double dh_inv[][3][3], double *grid[]);
+    const double dh_inv[][3][3], const grid_buffer *pab_blocks, double *grid[]);
 
 #ifdef __cplusplus
 }

--- a/src/grid/grid_api.F
+++ b/src/grid/grid_api.F
@@ -63,9 +63,15 @@ MODULE grid_api
    PUBLIC :: grid_library_init, grid_library_finalize
    PUBLIC :: grid_library_set_config, grid_library_print_stats
    PUBLIC :: collocate_pgf_product, integrate_pgf_product
+   PUBLIC :: grid_buffer_type, grid_create_buffer, grid_free_buffer
    PUBLIC :: grid_basis_set_type, grid_create_basis_set, grid_free_basis_set
    PUBLIC :: grid_task_list_type, grid_create_task_list, grid_free_task_list
    PUBLIC :: grid_collocate_task_list
+
+   TYPE grid_buffer_type
+      REAL(KIND=dp), DIMENSION(:), POINTER :: host_buffer => Null()
+      TYPE(C_PTR), PRIVATE :: c_ptr = C_NULL_PTR
+   END TYPE grid_buffer_type
 
    TYPE grid_basis_set_type
       PRIVATE
@@ -543,6 +549,82 @@ CONTAINS
    END SUBROUTINE get_rsgrid_properties
 
 ! **************************************************************************************************
+!> \brief Allocates a buffer of given length, ie. number of elements.
+!> \param length ...
+!> \param buffer ...
+!> \author Ole Schuett
+! **************************************************************************************************
+   SUBROUTINE grid_create_buffer(length, buffer)
+      INTEGER, INTENT(IN)                                :: length
+      TYPE(grid_buffer_type), INTENT(INOUT)              :: buffer
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'grid_create_buffer'
+
+      INTEGER                                            :: handle
+      TYPE(C_PTR)                                        :: host_buffer_c
+      INTERFACE
+         SUBROUTINE grid_create_buffer_c(length, buffer) &
+            BIND(C, name="grid_create_buffer")
+            IMPORT :: C_PTR, C_INT
+            INTEGER(KIND=C_INT), VALUE                :: length
+            TYPE(C_PTR)                               :: buffer
+         END SUBROUTINE grid_create_buffer_c
+      END INTERFACE
+      INTERFACE
+
+         FUNCTION grid_buffer_get_host_pointer_c(buffer) &
+            BIND(C, name="grid_buffer_get_host_pointer")
+            IMPORT :: C_PTR
+            TYPE(C_PTR), VALUE                        :: buffer
+            TYPE(C_PTR)                               :: grid_buffer_get_host_pointer_c
+         END FUNCTION grid_buffer_get_host_pointer_c
+      END INTERFACE
+
+      CALL timeset(routineN, handle)
+
+      CALL grid_create_buffer_C(length=length, buffer=buffer%c_ptr)
+      CPASSERT(C_ASSOCIATED(buffer%c_ptr))
+
+      IF (length > 0) THEN
+         host_buffer_c = grid_buffer_get_host_pointer_c(buffer%c_ptr)
+         CPASSERT(C_ASSOCIATED(host_buffer_c))
+         CALL C_F_POINTER(host_buffer_c, buffer%host_buffer, shape=(/length/))
+      ENDIF
+
+      CALL timestop(handle)
+   END SUBROUTINE grid_create_buffer
+
+! **************************************************************************************************
+!> \brief Deallocates given buffer.
+!> \param buffer ...
+!> \author Ole Schuett
+! **************************************************************************************************
+   SUBROUTINE grid_free_buffer(buffer)
+      TYPE(grid_buffer_type), INTENT(INOUT)              :: buffer
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'grid_free_buffer'
+
+      INTEGER                                            :: handle
+      INTERFACE
+         SUBROUTINE grid_free_buffer_c(buffer) &
+            BIND(C, name="grid_free_buffer")
+            IMPORT :: C_PTR
+            TYPE(C_PTR), VALUE                        :: buffer
+         END SUBROUTINE grid_free_buffer_c
+      END INTERFACE
+
+      CALL timeset(routineN, handle)
+
+      CPASSERT(C_ASSOCIATED(buffer%c_ptr))
+
+      CALL grid_free_buffer_c(buffer%c_ptr)
+
+      buffer%c_ptr = C_NULL_PTR
+
+      CALL timestop(handle)
+   END SUBROUTINE grid_free_buffer
+
+! **************************************************************************************************
 !> \brief Allocates a basis set which can be passed to grid_create_task_list.
 !> \param nset ...
 !> \param nsgf ...
@@ -696,7 +778,6 @@ CONTAINS
 !> \param natoms ...
 !> \param nkinds ...
 !> \param nblocks ...
-!> \param buffer_size ...
 !> \param block_offsets ...
 !> \param atom_positions ...
 !> \param atom_kinds ...
@@ -712,19 +793,17 @@ CONTAINS
 !> \param block_num_list ...
 !> \param radius_list ...
 !> \param rab_list ...
-!> \param blocks_buffer ...
 !> \param task_list ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE grid_create_task_list(ntasks, nlevels, natoms, nkinds, nblocks, buffer_size, &
+   SUBROUTINE grid_create_task_list(ntasks, nlevels, natoms, nkinds, nblocks, &
                                     block_offsets, atom_positions, atom_kinds, basis_sets, &
                                     level_list, iatom_list, jatom_list, &
                                     iset_list, jset_list, ipgf_list, jpgf_list, &
                                     border_mask_list, block_num_list, &
-                                    radius_list, rab_list, blocks_buffer, task_list)
+                                    radius_list, rab_list, task_list)
 
-      INTEGER, INTENT(IN)                                :: ntasks, nlevels, natoms, nkinds, &
-                                                            nblocks, buffer_size
+      INTEGER, INTENT(IN)                                :: ntasks, nlevels, natoms, nkinds, nblocks
       INTEGER, DIMENSION(:), INTENT(IN), TARGET          :: block_offsets
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), TARGET :: atom_positions
       INTEGER, DIMENSION(:), INTENT(IN), TARGET          :: atom_kinds
@@ -736,21 +815,19 @@ CONTAINS
                                                             block_num_list
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), TARGET    :: radius_list
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), TARGET :: rab_list
-      REAL(KIND=dp), DIMENSION(:), INTENT(OUT), POINTER  :: blocks_buffer
       TYPE(grid_task_list_type), INTENT(INOUT)           :: task_list
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'grid_create_task_list'
 
       INTEGER                                            :: handle, ikind
-      TYPE(C_PTR)                                        :: blocks_buffer_c
       TYPE(C_PTR), ALLOCATABLE, DIMENSION(:), TARGET     :: basis_sets_c
       INTERFACE
-         SUBROUTINE grid_create_task_list_c(ntasks, nlevels, natoms, nkinds, nblocks, buffer_size, &
+         SUBROUTINE grid_create_task_list_c(ntasks, nlevels, natoms, nkinds, nblocks, &
                                             block_offsets, atom_positions, atom_kinds, basis_sets, &
                                             level_list, iatom_list, jatom_list, &
                                             iset_list, jset_list, ipgf_list, jpgf_list, &
                                             border_mask_list, block_num_list, &
-                                            radius_list, rab_list, blocks_buffer, task_list) &
+                                            radius_list, rab_list, task_list) &
             BIND(C, name="grid_create_task_list")
             IMPORT :: C_PTR, C_INT
             INTEGER(KIND=C_INT), VALUE                :: ntasks
@@ -758,7 +835,6 @@ CONTAINS
             INTEGER(KIND=C_INT), VALUE                :: natoms
             INTEGER(KIND=C_INT), VALUE                :: nkinds
             INTEGER(KIND=C_INT), VALUE                :: nblocks
-            INTEGER(KIND=C_INT), VALUE                :: buffer_size
             TYPE(C_PTR), VALUE                        :: block_offsets
             TYPE(C_PTR), VALUE                        :: atom_positions
             TYPE(C_PTR), VALUE                        :: atom_kinds
@@ -774,7 +850,6 @@ CONTAINS
             TYPE(C_PTR), VALUE                        :: block_num_list
             TYPE(C_PTR), VALUE                        :: radius_list
             TYPE(C_PTR), VALUE                        :: rab_list
-            TYPE(C_PTR)                               :: blocks_buffer
             TYPE(C_PTR)                               :: task_list
          END SUBROUTINE grid_create_task_list_c
       END INTERFACE
@@ -821,13 +896,11 @@ CONTAINS
 #endif
 
       !If task_list%c_ptr is already allocated, then its memory will be reused or freed.
-      blocks_buffer_c = C_NULL_PTR
       IF (ntasks == 0) THEN
-         CALL grid_create_task_list_c(0, nlevels, 0, 0, 0, 0, C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, &
+         CALL grid_create_task_list_c(0, nlevels, 0, 0, 0, C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, &
                                       C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, &
                                       C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, C_NULL_PTR, &
                                       C_NULL_PTR, C_NULL_PTR, &
-                                      blocks_buffer=blocks_buffer_c, &
                                       task_list=task_list%c_ptr)
       ELSE
          CALL grid_create_task_list_c(ntasks=ntasks, &
@@ -835,7 +908,6 @@ CONTAINS
                                       natoms=natoms, &
                                       nkinds=nkinds, &
                                       nblocks=nblocks, &
-                                      buffer_size=buffer_size, &
                                       block_offsets=C_LOC(block_offsets(1)), &
                                       atom_positions=C_LOC(atom_positions(1, 1)), &
                                       atom_kinds=C_LOC(atom_kinds(1)), &
@@ -851,13 +923,10 @@ CONTAINS
                                       block_num_list=C_LOC(block_num_list(1)), &
                                       radius_list=C_LOC(radius_list(1)), &
                                       rab_list=C_LOC(rab_list(1, 1)), &
-                                      blocks_buffer=blocks_buffer_c, &
                                       task_list=task_list%c_ptr)
-         CPASSERT(C_ASSOCIATED(blocks_buffer_c))
       ENDIF
 
       CPASSERT(C_ASSOCIATED(task_list%c_ptr))
-      CALL C_F_POINTER(blocks_buffer_c, blocks_buffer, shape=(/buffer_size/))
 
       CALL timestop(handle)
    END SUBROUTINE grid_create_task_list
@@ -896,12 +965,14 @@ CONTAINS
 !> \brief Collocate all tasks of in given list onto given grids.
 !> \param task_list ...
 !> \param ga_gb_function ...
+!> \param pab_blocks ...
 !> \param rs_grids ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE grid_collocate_task_list(task_list, ga_gb_function, rs_grids)
+   SUBROUTINE grid_collocate_task_list(task_list, ga_gb_function, pab_blocks, rs_grids)
       TYPE(grid_task_list_type), INTENT(IN)              :: task_list
       INTEGER, INTENT(IN)                                :: ga_gb_function
+      TYPE(grid_buffer_type), INTENT(IN)                 :: pab_blocks
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: rs_grids
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'grid_collocate_task_list'
@@ -918,7 +989,7 @@ CONTAINS
       INTERFACE
          SUBROUTINE grid_collocate_task_list_c(task_list, orthorhombic, func, nlevels, &
                                                npts_global, npts_local, shift_local, &
-                                               border_width, dh, dh_inv, grid) &
+                                               border_width, dh, dh_inv, pab_blocks, grid) &
             BIND(C, name="grid_collocate_task_list")
             IMPORT :: C_PTR, C_INT, C_BOOL
             TYPE(C_PTR), VALUE                        :: task_list
@@ -931,6 +1002,7 @@ CONTAINS
             TYPE(C_PTR), VALUE                        :: border_width
             TYPE(C_PTR), VALUE                        :: dh
             TYPE(C_PTR), VALUE                        :: dh_inv
+            TYPE(C_PTR), VALUE                        :: pab_blocks
             TYPE(C_PTR), VALUE                        :: grid
          END SUBROUTINE grid_collocate_task_list_c
       END INTERFACE
@@ -985,6 +1057,7 @@ CONTAINS
                                       border_width=C_LOC(border_width(1, 1)), &
                                       dh=C_LOC(dh(1, 1, 1)), &
                                       dh_inv=C_LOC(dh_inv(1, 1, 1)), &
+                                      pab_blocks=pab_blocks%c_ptr, &
                                       grid=C_LOC(grid_pointers(1)))
 
       CALL timestop(handle)

--- a/src/grid/grid_task_list.h
+++ b/src/grid/grid_task_list.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 
 #include "common/grid_basis_set.h"
+#include "common/grid_buffer.h"
 #include "gpu/grid_gpu_task_list.h"
 #include "ref/grid_ref_task_list.h"
 
@@ -37,7 +38,6 @@ typedef struct {
  * \param natoms           Number of atoms.
  * \param nkinds           Number of atomic kinds.
  * \param nblocks          Number of local matrix blocks.
- * \param buffer_size      Required buffer size to store all local matrix blocks
  * \param block_offsets    Offset of each block within the buffer (zero based).
  * \param atom_positions   Position of the atoms.
  * \param atom_kinds       Mapping from atom to atomic kind (one based).
@@ -57,14 +57,13 @@ typedef struct {
  * \param radius_list      Radius where Gaussian becomes smaller than threshold.
  * \param rab_list         Vector between atoms, encodes the virtual image.
  *
- * \param blocks_buffer    Allocate buffer ready to be filled with blocks.
  * \param task_list        Handle to the created task list.
  *
  * \author Ole Schuett
  ******************************************************************************/
 void grid_create_task_list(
     const int ntasks, const int nlevels, const int natoms, const int nkinds,
-    const int nblocks, const int buffer_size, const int block_offsets[nblocks],
+    const int nblocks, const int block_offsets[nblocks],
     const double atom_positions[natoms][3], const int atom_kinds[natoms],
     const grid_basis_set *basis_sets[nkinds], const int level_list[ntasks],
     const int iatom_list[ntasks], const int jatom_list[ntasks],
@@ -72,7 +71,7 @@ void grid_create_task_list(
     const int ipgf_list[ntasks], const int jpgf_list[ntasks],
     const int border_mask_list[ntasks], const int block_num_list[ntasks],
     const double radius_list[ntasks], const double rab_list[ntasks][3],
-    double **blocks_buffer, grid_task_list **task_list);
+    grid_task_list **task_list);
 
 /*******************************************************************************
  * \brief Deallocates given task list, basis_sets have to be freed separately.
@@ -96,6 +95,7 @@ void grid_free_task_list(grid_task_list *task_list);
  * \param border_width    Width of halo region in grid points in each direction.
  * \param dh              Incremental grid matrix.
  * \param dh_inv          Inverse incremental grid matrix.
+ * \param pab_blocks      Buffer that contains the density matrix blocks.
  * \param grid            The output grid array to collocate into.
  *
  * \author Ole Schuett
@@ -106,7 +106,7 @@ void grid_collocate_task_list(
     const int npts_global[nlevels][3], const int npts_local[nlevels][3],
     const int shift_local[nlevels][3], const int border_width[nlevels][3],
     const double dh[nlevels][3][3], const double dh_inv[nlevels][3][3],
-    double *grid[nlevels]);
+    const grid_buffer *pab_blocks, double *grid[nlevels]);
 
 #endif
 

--- a/src/grid/hybrid/grid_collocate_hybrid.h
+++ b/src/grid/hybrid/grid_collocate_hybrid.h
@@ -8,10 +8,12 @@
 #ifndef GRID_COLLOCATE_HYBRID_H
 #define GRID_COLLOCATE_HYBRID_H
 
+#include "../common/grid_buffer.h"
+
 void grid_collocate_task_list_hybrid(
     void *const ptr, const bool orthorhombic, const int func, const int nlevels,
     const int npts_global[nlevels][3], const int npts_local[nlevels][3],
     const int shift_local[nlevels][3], const int border_width[nlevels][3],
     const double dh[nlevels][3][3], const double dh_inv[nlevels][3][3],
-    double *grid[nlevels]);
+    const grid_buffer *pab_blocks, double *grid[nlevels]);
 #endif

--- a/src/grid/ref/grid_ref_task_list.h
+++ b/src/grid/ref/grid_ref_task_list.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 
 #include "../common/grid_basis_set.h"
+#include "../common/grid_buffer.h"
 #include "../common/grid_constants.h"
 
 /*******************************************************************************
@@ -40,8 +41,6 @@ typedef struct {
   int natoms;
   int nkinds;
   int nblocks;
-  int buffer_size;
-  double *blocks_buffer;
   int *block_offsets;
   double *atom_positions;
   int *atom_kinds;
@@ -58,7 +57,7 @@ typedef struct {
  ******************************************************************************/
 void grid_ref_create_task_list(
     const int ntasks, const int nlevels, const int natoms, const int nkinds,
-    const int nblocks, const int buffer_size, const int block_offsets[nblocks],
+    const int nblocks, const int block_offsets[nblocks],
     const double atom_positions[natoms][3], const int atom_kinds[natoms],
     const grid_basis_set *basis_sets[nkinds], const int level_list[ntasks],
     const int iatom_list[ntasks], const int jatom_list[ntasks],
@@ -66,7 +65,7 @@ void grid_ref_create_task_list(
     const int ipgf_list[ntasks], const int jpgf_list[ntasks],
     const int border_mask_list[ntasks], const int block_num_list[ntasks],
     const double radius_list[ntasks], const double rab_list[ntasks][3],
-    double **blocks_buffer, grid_ref_task_list **task_list);
+    grid_ref_task_list **task_list);
 
 /*******************************************************************************
  * \brief Deallocates given task list, basis_sets have to be freed separately.
@@ -85,7 +84,7 @@ void grid_ref_collocate_task_list(
     const int npts_global[nlevels][3], const int npts_local[nlevels][3],
     const int shift_local[nlevels][3], const int border_width[nlevels][3],
     const double dh[nlevels][3][3], const double dh_inv[nlevels][3][3],
-    double *grid[nlevels]);
+    const grid_buffer *pab_blocks, double *grid[nlevels]);
 
 #endif
 

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -1546,6 +1546,7 @@ CONTAINS
       ! Map all tasks onto the grids
       CALL grid_collocate_task_list(task_list=task_list%grid_task_list, &
                                     ga_gb_function=ga_gb_function, &
+                                    pab_blocks=task_list%buffer_recv, &
                                     rs_grids=rs_rho)
 
       ! Merge realspace multi-grids into single planewave grid.

--- a/src/task_list_methods.F
+++ b/src/task_list_methods.F
@@ -13,7 +13,7 @@
 ! **************************************************************************************************
 MODULE task_list_methods
    USE grid_api, ONLY: &
-      grid_create_basis_set, grid_create_task_list
+      grid_create_basis_set, grid_create_task_list, grid_create_buffer
    USE ao_util, ONLY: exp_radius_very_extended
    USE basis_set_types, ONLY: get_gto_basis_set, &
                               gto_basis_set_p_type, &
@@ -603,7 +603,6 @@ CONTAINS
                                  natoms=natoms, &
                                  nkinds=nkinds, &
                                  nblocks=SIZE(task_list%pair_offsets_recv), &
-                                 buffer_size=task_list%buffer_size_recv, &
                                  block_offsets=task_list%pair_offsets_recv, &
                                  atom_positions=atom_positions, &
                                  atom_kinds=atom_kinds, &
@@ -619,8 +618,9 @@ CONTAINS
                                  block_num_list=block_num_list, &
                                  radius_list=radius_list, &
                                  rab_list=rab_list, &
-                                 blocks_buffer=task_list%buffer_recv, &
                                  task_list=task_list%grid_task_list)
+
+      CALL grid_create_buffer(task_list%buffer_size_recv, task_list%buffer_recv)
 
    END SUBROUTINE create_grid_task_list
 
@@ -2540,7 +2540,7 @@ CONTAINS
 
       ! mpi all-to-all communication, receiving directly into blocks_recv%buffer.
       CALL mp_alltoall(buffer_send, task_list%rank_sizes_send, task_list%rank_offsets_send, &
-                       task_list%buffer_recv, task_list%rank_sizes_recv, task_list%rank_offsets_recv, &
+                       task_list%buffer_recv%host_buffer, task_list%rank_sizes_recv, task_list%rank_offsets_recv, &
                        group)
 
       DEALLOCATE (buffer_send)
@@ -2559,7 +2559,7 @@ CONTAINS
       CALL rs_pack_matrix(pmats, &
                           atom_pair=task_list%atom_pair_recv, &
                           pair_offsets=task_list%pair_offsets_recv, &
-                          buffer=task_list%buffer_recv)
+                          buffer=task_list%buffer_recv%host_buffer)
 
    END SUBROUTINE rs_copy_matrix
 

--- a/src/task_list_types.F
+++ b/src/task_list_types.F
@@ -14,7 +14,9 @@
 MODULE task_list_types
 
    USE grid_api,                        ONLY: grid_basis_set_type,&
+                                              grid_buffer_type,&
                                               grid_free_basis_set,&
+                                              grid_free_buffer,&
                                               grid_free_task_list,&
                                               grid_task_list_type
    USE kinds,                           ONLY: dp,&
@@ -72,10 +74,9 @@ MODULE task_list_types
       INTEGER, DIMENSION(:), POINTER                :: rank_sizes_recv => Null()
       INTEGER                                       :: buffer_size_recv = 0
 
-      REAL(KIND=dp), DIMENSION(:), POINTER          :: buffer_recv => Null()
-
       TYPE(grid_basis_set_type), DIMENSION(:), POINTER :: grid_basis_sets => Null()
       TYPE(grid_task_list_type)                     :: grid_task_list
+      TYPE(grid_buffer_type)                        :: buffer_recv
    END TYPE task_list_type
 
    INTEGER, PARAMETER                               :: task_size_in_int8 = 17
@@ -183,8 +184,8 @@ CONTAINS
       IF (ASSOCIATED(task_list%rank_sizes_recv)) THEN
          DEALLOCATE (task_list%rank_sizes_recv)
       ENDIF
-      CALL grid_free_task_list(task_list%grid_task_list)  ! also frees task_list%buffer_recv
-      NULLIFY (task_list%buffer_recv)
+      CALL grid_free_task_list(task_list%grid_task_list)
+      CALL grid_free_buffer(task_list%buffer_recv)
       IF (ASSOCIATED(task_list%grid_basis_sets)) THEN
          DO i = 1, SIZE(task_list%grid_basis_sets)
             CALL grid_free_basis_set(task_list%grid_basis_sets(i))


### PR DESCRIPTION
This is a preparation for migrating integrate_v_rspace, which requires multiple block buffers.