### PR TITLE
NEGF: add new print options

### DIFF
--- a/src/input_cp2k_negf.F
+++ b/src/input_cp2k_negf.F
@@ -13,7 +13,11 @@ MODULE input_cp2k_negf
    USE bibliography,                    ONLY: Bailey2006,&
                                               Papior2017
    USE cp_output_handling,              ONLY: cp_print_key_section_create,&
-                                              high_print_level
+                                              debug_print_level,&
+                                              high_print_level,&
+                                              low_print_level,&
+                                              medium_print_level,&
+                                              silent_print_level
    USE input_constants,                 ONLY: negfint_method_cc,&
                                               negfint_method_simpson
    USE input_keyword_types,             ONLY: keyword_create,&
@@ -206,14 +210,18 @@ CONTAINS
       CALL keyword_release(keyword)
 
       ! PRINT subsection
-      CALL section_create(subsection, __LOCATION__, "PRINT", "Print properties for the scattering region.", &
+      CALL section_create(subsection, __LOCATION__, "PRINT", "Printing of information during the NEGF.", &
                           repeats=.FALSE.)
 
-      CALL create_print_dos_section(print_key, "DOS", "the Density of States (DOS)")
+      CALL create_print_program_run_info_section(print_key)
       CALL section_add_subsection(subsection, print_key)
       CALL section_release(print_key)
 
-      CALL create_print_dos_section(print_key, "TRANSMISSION", "the Transmission Coefficient")
+      CALL create_print_dos_section(print_key, "DOS", "the Density of States (DOS) in the scattering region")
+      CALL section_add_subsection(subsection, print_key)
+      CALL section_release(print_key)
+
+      CALL create_print_dos_section(print_key, "TRANSMISSION", "the transmission coefficient")
       CALL section_add_subsection(subsection, print_key)
       CALL section_release(print_key)
 
@@ -346,6 +354,52 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
    END SUBROUTINE create_atomlist_section
+
+! **************************************************************************************************
+!> \brief Create the PROGRAM_RUN_INFO print section.
+!> \param section              section to create
+!> \par History
+!>    * 11.2020 created [Dmitry Ryndyk]
+! **************************************************************************************************
+   SUBROUTINE create_print_program_run_info_section(section)
+
+      TYPE(section_type), POINTER                        :: section
+
+      TYPE(keyword_type), POINTER                        :: keyword
+
+      CALL cp_print_key_section_create(section, __LOCATION__, "PROGRAM_RUN_INFO", &
+                                       description="Controls the printing of basic information during the NEGF.", &
+                                       print_level=low_print_level, filename="__STD_OUT__")
+      NULLIFY (keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="_SECTION_PARAMETERS_", &
+                          description="Level starting at which this property is printed", &
+                          usage="_SECTION_PARAMETERS_", &
+                          default_i_val=low_print_level, lone_keyword_i_val=low_print_level, &
+                          enum_c_vals=s2a("on", "off", "silent", "low", "medium", "high", "debug"), &
+                          enum_i_vals=(/silent_print_level - 1, debug_print_level + 1, &
+                                        silent_print_level, low_print_level, &
+                                        medium_print_level, high_print_level, debug_print_level/))
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="PRINT_LEVEL", &
+                          variants=(/"IOLEVEL"/), &
+                          description="Determines the verbose level for this section "// &
+                          "additionally to GLOBAL%PRINT_LEVEL and SECTION_PARAMETERS, "// &
+                          "which switch on printing.", &
+                          usage="PRINT_LEVEL HIGH", &
+                          default_i_val=low_print_level, enum_c_vals= &
+                          s2a("SILENT", "LOW", "MEDIUM", "HIGH", "DEBUG"), &
+                          enum_desc=s2a("No output", &
+                                        "Little output", "Quite some output", "Lots of output", &
+                                        "Everything is written out, useful for debugging purposes only"), &
+                          enum_i_vals=(/silent_print_level, low_print_level, medium_print_level, &
+                                        high_print_level, debug_print_level/))
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+   END SUBROUTINE create_print_program_run_info_section
 
 ! **************************************************************************************************
 !> \brief Create the DOS print section.

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -216,7 +216,7 @@ CONTAINS
       CALL negf_sub_env_create(sub_env, negf_control, blacs_env, global_env%blacs_grid_layout, global_env%blacs_repeatable)
       CALL negf_env_create(negf_env, sub_env, negf_control, force_env, negf_mixing_section, log_unit)
 
-      IF (log_unit > 0 .AND. print2) THEN
+      IF (log_unit > 0 .AND. verbose_output) THEN
          DO icontact = 1, SIZE(negf_control%contacts)
             WRITE (log_unit, "(/,' NEGF| Atoms in the contact region',I2,':',I4)") &
                icontact, SIZE(negf_control%contacts(icontact)%atomlist_bulk)

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -37,10 +37,12 @@ MODULE negf_methods
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type
-   USE cp_output_handling,              ONLY: &
-        cp_p_file, cp_print_key_finished_output, cp_print_key_should_output, cp_print_key_unit_nr, &
-        debug_print_level, high_print_level, low_print_level, medium_print_level, &
-        silent_print_level
+   USE cp_output_handling,              ONLY: cp_p_file,&
+                                              cp_print_key_finished_output,&
+                                              cp_print_key_should_output,&
+                                              cp_print_key_unit_nr,&
+                                              debug_print_level,&
+                                              high_print_level
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE cp_subsys_types,                 ONLY: cp_subsys_type
    USE dbcsr_api,                       ONLY: dbcsr_copy,&

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -37,10 +37,10 @@ MODULE negf_methods
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type
-   USE cp_output_handling,              ONLY: cp_p_file,&
-                                              cp_print_key_finished_output,&
-                                              cp_print_key_should_output,&
-                                              cp_print_key_unit_nr
+   USE cp_output_handling,              ONLY: &
+        cp_p_file, cp_print_key_finished_output, cp_print_key_should_output, cp_print_key_unit_nr, &
+        debug_print_level, high_print_level, low_print_level, medium_print_level, &
+        silent_print_level
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE cp_subsys_types,                 ONLY: cp_subsys_type
    USE dbcsr_api,                       ONLY: dbcsr_copy,&
@@ -155,8 +155,9 @@ CONTAINS
 
       CHARACTER(len=default_string_length)               :: contact_id_str
       INTEGER                                            :: handle, icontact, ispin, log_unit, &
-                                                            ncontacts, npoints, nspins, print_unit
-      LOGICAL                                            :: should_output
+                                                            ncontacts, npoints, nspins, &
+                                                            print_level, print_unit
+      LOGICAL                                            :: print1, print2, should_output
       REAL(kind=dp)                                      :: energy_max, energy_min
       REAL(kind=dp), DIMENSION(2)                        :: current
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
@@ -194,8 +195,50 @@ CONTAINS
       CALL negf_control_create(negf_control)
       CALL read_negf_control(negf_control, root_section, cp_subsys)
 
+      ! print unit, if log_unit > 0, otherwise no output
+      log_unit = cp_print_key_unit_nr(logger, negf_section, "PRINT%PROGRAM_RUN_INFO", extension=".Log")
+
+      ! print levels, are used if log_unit > 0
+      IF (log_unit > 0) THEN
+         CALL section_vals_val_get(negf_section, "PRINT%PROGRAM_RUN_INFO%PRINT_LEVEL", i_val=print_level)
+         SELECT CASE (print_level)
+         CASE (silent_print_level)
+            print1 = .FALSE.
+            print2 = .FALSE.
+         CASE (low_print_level)
+            print1 = .FALSE.
+            print2 = .FALSE.
+         CASE (medium_print_level)
+            print1 = .TRUE.
+            print2 = .FALSE.
+         CASE (high_print_level)
+            print1 = .TRUE.
+            print2 = .TRUE.
+         CASE (debug_print_level)
+            print1 = .TRUE.
+            print2 = .TRUE.
+         CASE DEFAULT
+            !do nothing
+         END SELECT
+      END IF
+
+      IF (log_unit > 0) THEN
+         WRITE (log_unit, '(/,T2,A,T62)') "COMPUTE THE RELEVANT HAMILTONIAN MATRICES"
+      END IF
+
       CALL negf_sub_env_create(sub_env, negf_control, blacs_env, global_env%blacs_grid_layout, global_env%blacs_repeatable)
       CALL negf_env_create(negf_env, sub_env, negf_control, force_env, negf_mixing_section, log_unit)
+
+      IF (log_unit > 0 .AND. print2) THEN
+         DO icontact = 1, SIZE(negf_control%contacts)
+            WRITE (log_unit, "(/,' NEGF| Atoms in the contact region',I2,':',I4)") &
+               icontact, SIZE(negf_control%contacts(icontact)%atomlist_bulk)
+            WRITE (log_unit, "(16I5)") negf_control%contacts(icontact)%atomlist_bulk
+         END DO
+         WRITE (log_unit, "(/,' NEGF| Atoms in the full scattering region:',I4)") SIZE(negf_control%atomlist_S_screening)
+         WRITE (log_unit, "(16I5)") negf_control%atomlist_S_screening
+         WRITE (log_unit, *)
+      END IF
 
       ! compute contact Fermi level as well as requested properties
       ncontacts = SIZE(negf_control%contacts)

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -202,23 +202,10 @@ CONTAINS
       IF (log_unit > 0) THEN
          CALL section_vals_val_get(negf_section, "PRINT%PROGRAM_RUN_INFO%PRINT_LEVEL", i_val=print_level)
          SELECT CASE (print_level)
-         CASE (silent_print_level)
-            print1 = .FALSE.
-            print2 = .FALSE.
-         CASE (low_print_level)
-            print1 = .FALSE.
-            print2 = .FALSE.
-         CASE (medium_print_level)
-            print1 = .TRUE.
-            print2 = .FALSE.
-         CASE (high_print_level)
-            print1 = .TRUE.
-            print2 = .TRUE.
-         CASE (debug_print_level)
-            print1 = .TRUE.
-            print2 = .TRUE.
+         CASE (high_print_level, debug_print_level)
+            verbose_output = .TRUE.
          CASE DEFAULT
-            !do nothing
+            verbose_output = .FALSE.
          END SELECT
       END IF
 

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -157,7 +157,7 @@ CONTAINS
       INTEGER                                            :: handle, icontact, ispin, log_unit, &
                                                             ncontacts, npoints, nspins, &
                                                             print_level, print_unit
-      LOGICAL                                            :: print1, print2, should_output
+      LOGICAL                                            :: should_output, verbose_output
       REAL(kind=dp)                                      :: energy_max, energy_min
       REAL(kind=dp), DIMENSION(2)                        :: current
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -1344,7 +1344,7 @@ CONTAINS
       DO ispin = 1, dft_control%nspins
          CALL get_mo_set(mo_set=mos(ispin)%mo_set, maxocc=occ, uniform_occupation=uniform)
          IF (.NOT. uniform) THEN
-            CPABORT("Berry phase moments for non uniform MOs' occupation numbers not implemented")
+            CPWARN("Berry phase moments for non uniform MOs' occupation numbers not implemented")
          END IF
       END DO
 


### PR DESCRIPTION
New sections
NEGF%PRINT%PROGRAM_RUN_INFO
NEGF%PRINT%PROGRAM_RUN_DETAILS
for control of printing levels.
Now "silent" is silent, etc.

CPABORT => CPWARN in src/qs_moments.F:1347,
it blocked print level HIGH for some structures.