### PR TITLE
grid: Calculate virial only when needed

### DIFF
--- a/src/grid/grid_api.F
+++ b/src/grid/grid_api.F
@@ -1091,6 +1091,7 @@ CONTAINS
 !> \param task_list ...
 !> \param compute_tau ...
 !> \param calculate_forces ...
+!> \param calculate_virial ...
 !> \param pab_blocks ...
 !> \param rs_grids ...
 !> \param hab_blocks ...
@@ -1098,10 +1099,11 @@ CONTAINS
 !> \param virial ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE grid_integrate_task_list(task_list, compute_tau, calculate_forces, pab_blocks, &
-                                       rs_grids, hab_blocks, forces, virial)
+   SUBROUTINE grid_integrate_task_list(task_list, compute_tau, calculate_forces, calculate_virial, &
+                                       pab_blocks, rs_grids, hab_blocks, forces, virial)
       TYPE(grid_task_list_type), INTENT(IN)              :: task_list
-      LOGICAL, INTENT(IN)                                :: compute_tau, calculate_forces
+      LOGICAL, INTENT(IN)                                :: compute_tau, calculate_forces, &
+                                                            calculate_virial
       TYPE(grid_buffer_type), INTENT(IN)                 :: pab_blocks
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: rs_grids
       TYPE(grid_buffer_type), INTENT(INOUT)              :: hab_blocks
@@ -1119,11 +1121,12 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          TARGET                                          :: dh, dh_inv
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: grid
+      TYPE(C_PTR)                                        :: forces_c, virial_c
       TYPE(C_PTR), ALLOCATABLE, DIMENSION(:), TARGET     :: grid_pointers
       TYPE(realspace_grid_type), POINTER                 :: rsgrid
       INTERFACE
-         SUBROUTINE grid_integrate_task_list_c(task_list, orthorhombic, compute_tau, calculate_forces, &
-                                               natoms, nlevels, npts_global, npts_local, shift_local, &
+         SUBROUTINE grid_integrate_task_list_c(task_list, orthorhombic, compute_tau, natoms, &
+                                               nlevels, npts_global, npts_local, shift_local, &
                                                border_width, dh, dh_inv, &
                                                pab_blocks, grid, hab_blocks, forces, virial) &
             BIND(C, name="grid_integrate_task_list")
@@ -1131,7 +1134,6 @@ CONTAINS
             TYPE(C_PTR), VALUE                        :: task_list
             LOGICAL(KIND=C_BOOL), VALUE               :: orthorhombic
             LOGICAL(KIND=C_BOOL), VALUE               :: compute_tau
-            LOGICAL(KIND=C_BOOL), VALUE               :: calculate_forces
             INTEGER(KIND=C_INT), VALUE                :: natoms
             INTEGER(KIND=C_INT), VALUE                :: nlevels
             TYPE(C_PTR), VALUE                        :: npts_global
@@ -1172,6 +1174,18 @@ CONTAINS
          grid_pointers(ilevel) = C_LOC(grid(1, 1, 1))
       END DO
 
+      IF (calculate_forces) THEN
+         forces_c = C_LOC(forces(1, 1))
+      ELSE
+         forces_c = C_NULL_PTR
+      ENDIF
+
+      IF (calculate_virial) THEN
+         virial_c = C_LOC(virial(1, 1))
+      ELSE
+         virial_c = C_NULL_PTR
+      ENDIF
+
 #if __GNUC__ >= 9
       CPASSERT(IS_CONTIGUOUS(npts_global))
       CPASSERT(IS_CONTIGUOUS(npts_local))
@@ -1192,11 +1206,11 @@ CONTAINS
       CPASSERT(C_ASSOCIATED(task_list%c_ptr))
       CPASSERT(C_ASSOCIATED(hab_blocks%c_ptr))
       CPASSERT(C_ASSOCIATED(pab_blocks%c_ptr) .OR. .NOT. calculate_forces)
+      CPASSERT(C_ASSOCIATED(pab_blocks%c_ptr) .OR. .NOT. calculate_virial)
 
       CALL grid_integrate_task_list_c(task_list=task_list%c_ptr, &
                                       orthorhombic=orthorhombic, &
                                       compute_tau=LOGICAL(compute_tau, C_BOOL), &
-                                      calculate_forces=LOGICAL(calculate_forces, C_BOOL), &
                                       natoms=SIZE(forces, 2), &
                                       nlevels=nlevels, &
                                       npts_global=C_LOC(npts_global(1, 1)), &
@@ -1208,8 +1222,8 @@ CONTAINS
                                       pab_blocks=pab_blocks%c_ptr, &
                                       grid=C_LOC(grid_pointers(1)), &
                                       hab_blocks=hab_blocks%c_ptr, &
-                                      forces=C_LOC(forces(1, 1)), &
-                                      virial=C_LOC(virial(1, 1)))
+                                      forces=forces_c, &
+                                      virial=virial_c)
 
       CALL timestop(handle)
    END SUBROUTINE grid_integrate_task_list

--- a/src/grid/grid_task_list.c
+++ b/src/grid/grid_task_list.c
@@ -5,6 +5,7 @@
 /*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
 /*----------------------------------------------------------------------------*/
 
+#include <assert.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -221,40 +222,42 @@ void grid_collocate_task_list(
  ******************************************************************************/
 void grid_integrate_task_list(
     const grid_task_list *task_list, const bool orthorhombic,
-    const bool compute_tau, const bool calculate_forces, const int natoms,
-    const int nlevels, const int npts_global[nlevels][3],
-    const int npts_local[nlevels][3], const int shift_local[nlevels][3],
-    const int border_width[nlevels][3], const double dh[nlevels][3][3],
-    const double dh_inv[nlevels][3][3], const grid_buffer *pab_blocks,
-    const double *grid[nlevels], grid_buffer *hab_blocks,
-    double forces[natoms][3], double virial[3][3]) {
+    const bool compute_tau, const int natoms, const int nlevels,
+    const int npts_global[nlevels][3], const int npts_local[nlevels][3],
+    const int shift_local[nlevels][3], const int border_width[nlevels][3],
+    const double dh[nlevels][3][3], const double dh_inv[nlevels][3][3],
+    const grid_buffer *pab_blocks, const double *grid[nlevels],
+    grid_buffer *hab_blocks, double forces[natoms][3], double virial[3][3]) {
+
+  assert(forces == NULL || pab_blocks != NULL);
+  assert(virial == NULL || pab_blocks != NULL);
 
   switch (task_list->backend) {
 #ifdef __GRID_CUDA
   case GRID_BACKEND_GPU:
     // grid_gpu_integrate_task_list(
-    //     task_list->gpu, orthorhombic, compute_tau, calculate_forces, natoms,
+    //     task_list->gpu, orthorhombic, compute_tau, natoms,
     //     nlevels, npts_global, npts_local, shift_local, border_width, dh,
     //     dh_inv, pab_blocks, grid, hab_blocks, forces, virial);
     // break;
   case GRID_BACKEND_HYBRID:
     // grid_hybrid_integrate_task_list(
-    //     task_list->hybrid, orthorhombic, compute_tau, calculate_forces,
-    //     natoms, nlevels, npts_global, npts_local, shift_local, border_width,
+    //     task_list->hybrid, orthorhombic, compute_tau, natoms,
+    //     nlevels, npts_global, npts_local, shift_local, border_width,
     //     dh, dh_inv, pab_blocks, grid, hab_blocks, forces, virial);
     // break;
 #endif
   case GRID_BACKEND_CPU:
     // grid_cpu_integrate_task_list(
-    //     task_list->cpu, orthorhombic, compute_tau, calculate_forces, natoms,
-    //     nlevels, npts_global, npts_local, shift_local, border_width, dh,
-    //     dh_inv, pab_blocks, grid, hab_blocks, forces, virial);
+    //     task_list->hybrid, orthorhombic, compute_tau, natoms,
+    //     nlevels, npts_global, npts_local, shift_local, border_width,
+    //     dh, dh_inv, pab_blocks, grid, hab_blocks, forces, virial);
     // break;
   case GRID_BACKEND_REF:
-    grid_ref_integrate_task_list(
-        task_list->ref, orthorhombic, compute_tau, calculate_forces, natoms,
-        nlevels, npts_global, npts_local, shift_local, border_width, dh, dh_inv,
-        pab_blocks, grid, hab_blocks, forces, virial);
+    grid_ref_integrate_task_list(task_list->ref, orthorhombic, compute_tau,
+                                 natoms, nlevels, npts_global, npts_local,
+                                 shift_local, border_width, dh, dh_inv,
+                                 pab_blocks, grid, hab_blocks, forces, virial);
     break;
   default:
     printf("Error: Unknown grid backend: %i.\n", task_list->backend);

--- a/src/grid/grid_task_list.h
+++ b/src/grid/grid_task_list.h
@@ -116,7 +116,6 @@ void grid_collocate_task_list(
  * \param task_list        Task list to collocate.
  * \param orthorhombic     Whether simulation box is orthorhombic.
  * \param compute_tau      When true then <nabla a| V | nabla b> is computed.
- * \param calculate_forces When true then forces and virial are calculated.
  * \param natoms           Number of atoms.
  * \param nlevels          Number of grid levels.
  *
@@ -130,23 +129,22 @@ void grid_collocate_task_list(
  * \param dh_inv          Inverse incremental grid matrix.
  * \param grid            Grid array to integrate from.
  *
- * \param pab_blocks      Optional density blocks, needed for calculate_forces.
+ * \param pab_blocks      Optional density blocks, needed for forces and virial.
  *
  * \param hab_blocks      Output buffer with the Hamiltonian matrix blocks.
- * \param forces          Optional output forces, requires calculate_forces=T.
- * \param virial          Optional output virials, requires calculate_forces=T.
+ * \param forces          Optional output forces, requires pab_blocks.
+ * \param virial          Optional output virials, requires pab_blocks.
  *
  * \author Ole Schuett
  ******************************************************************************/
 void grid_integrate_task_list(
     const grid_task_list *task_list, const bool orthorhombic,
-    const bool compute_tau, const bool calculate_forces, const int natoms,
-    const int nlevels, const int npts_global[nlevels][3],
-    const int npts_local[nlevels][3], const int shift_local[nlevels][3],
-    const int border_width[nlevels][3], const double dh[nlevels][3][3],
-    const double dh_inv[nlevels][3][3], const grid_buffer *pab_blocks,
-    const double *grid[nlevels], grid_buffer *hab_blocks,
-    double forces[natoms][3], double virial[3][3]);
+    const bool compute_tau, const int natoms, const int nlevels,
+    const int npts_global[nlevels][3], const int npts_local[nlevels][3],
+    const int shift_local[nlevels][3], const int border_width[nlevels][3],
+    const double dh[nlevels][3][3], const double dh_inv[nlevels][3][3],
+    const grid_buffer *pab_blocks, const double *grid[nlevels],
+    grid_buffer *hab_blocks, double forces[natoms][3], double virial[3][3]);
 
 #endif
 

--- a/src/grid/ref/grid_ref_task_list.h
+++ b/src/grid/ref/grid_ref_task_list.h
@@ -93,13 +93,12 @@ void grid_ref_collocate_task_list(
  ******************************************************************************/
 void grid_ref_integrate_task_list(
     const grid_ref_task_list *task_list, const bool orthorhombic,
-    const bool compute_tau, const bool calculate_forces, const int natoms,
-    const int nlevels, const int npts_global[nlevels][3],
-    const int npts_local[nlevels][3], const int shift_local[nlevels][3],
-    const int border_width[nlevels][3], const double dh[nlevels][3][3],
-    const double dh_inv[nlevels][3][3], const grid_buffer *pab_blocks,
-    const double *grid[nlevels], grid_buffer *hab_blocks,
-    double forces[natoms][3], double virial[3][3]);
+    const bool compute_tau, const int natoms, const int nlevels,
+    const int npts_global[nlevels][3], const int npts_local[nlevels][3],
+    const int shift_local[nlevels][3], const int border_width[nlevels][3],
+    const double dh[nlevels][3][3], const double dh_inv[nlevels][3][3],
+    const grid_buffer *pab_blocks, const double *grid[nlevels],
+    grid_buffer *hab_blocks, double forces[natoms][3], double virial[3][3]);
 
 #endif
 

--- a/src/qs_integrate_potential_product.F
+++ b/src/qs_integrate_potential_product.F
@@ -139,9 +139,9 @@ CONTAINS
                                                             igrid_level, ikind, img, maxco, &
                                                             maxsgf_set, natoms, nimages, nkind
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, kind_of
-      LOGICAL                                            :: distributed_grids, do_kp, &
-                                                            my_compute_tau, my_force_adm, my_gapw, &
-                                                            pab_required, use_virial
+      LOGICAL                                            :: calculate_virial, distributed_grids, &
+                                                            do_kp, my_compute_tau, my_force_adm, &
+                                                            my_gapw, pab_required
       REAL(KIND=dp)                                      :: admm_scal_fac
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: forces_array
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_matrix
@@ -258,8 +258,7 @@ CONTAINS
          CPASSERT(do_kp)
       END IF
       nkind = SIZE(qs_kind_set)
-      use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
-
+      calculate_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer) .AND. calculate_forces
       pab_required = (PRESENT(pmat) .OR. PRESENT(pmat_kp)) .AND. calculate_forces
 
       CALL get_qs_kind_set(qs_kind_set=qs_kind_set, &
@@ -300,6 +299,7 @@ CONTAINS
       CALL grid_integrate_task_list(task_list=task_list%grid_task_list, &
                                     compute_tau=my_compute_tau, &
                                     calculate_forces=calculate_forces, &
+                                    calculate_virial=calculate_virial, &
                                     pab_blocks=task_list%pab_buffer, &
                                     rs_grids=rs_v, &
                                     hab_blocks=task_list%hab_buffer, &
@@ -320,7 +320,7 @@ CONTAINS
          DEALLOCATE (atom_of_kind, kind_of)
       END IF
 
-      IF (use_virial .AND. calculate_forces) THEN
+      IF (calculate_virial) THEN
          virial%pv_virial = virial%pv_virial + admm_scal_fac*virial_matrix
       END IF
 


### PR DESCRIPTION
Hopefully, this recovers the performance lost in 1db9737f56ec8fa53ebf24f5ca1218c6f49d9d56.