### PR TITLE
Toolchain: Remove ELPA from requirements of SIRIUS

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -745,7 +745,6 @@ if [ "$with_sirius" = "__INSTALL__" ] ; then
     [ "$with_hdf5" = "__DONTUSE__" ] && with_hdf5="__INSTALL__"
     [ "$with_libvdwxc" = "__DONTUSE__" ] && with_libvdwxc="__INSTALL__"
     [ "$with_cosma" = "__DONTUSE__" ] && with_cosma="__INSTALL__"
-    [ "$with_elpa" = "__DONTUSE__" ] && with_elpa="__INSTALL__"
 fi
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow up to #1220 to fix the [Cuda test](https://dashboard.cp2k.org/archive/cuda-pascal/index.html) which [explicitly disables](https://github.com/cp2k/cp2k/blob/master/tools/toolchain/Dockerfile.cuda_mkl#L42) ELPA.