### PR TITLE
PINT: Fix conserved quantity in PINT-RPMD restart

### DIFF
--- a/src/motion/input_cp2k_restarts.F
+++ b/src/motion/input_cp2k_restarts.F
@@ -1009,6 +1009,9 @@ CONTAINS
          CALL string_to_ascii(rng_record, ascii(:, 1))
          CALL section_rng_val_set(rng_section=tmpsec, nsize=1, &
                                   ascii=ascii)
+         tmpsec => section_vals_get_subs_vals(pint_section, "PILE")
+         CALL section_vals_val_set(tmpsec, "THERMOSTAT_ENERGY", &
+                                   r_val=pint_env%e_pile)
       ELSE IF (pint_env%pimd_thermostat == thermostat_qtb) THEN
          tmpsec => section_vals_get_subs_vals(pint_section, &
                                               "QTB%RNG_INIT")
@@ -1016,6 +1019,9 @@ CONTAINS
                               ascii(:, 1))
          CALL section_rng_val_set(rng_section=tmpsec, nsize=1, &
                                   ascii=ascii)
+         tmpsec => section_vals_get_subs_vals(pint_section, "QTB")
+         CALL section_vals_val_set(tmpsec, "THERMOSTAT_ENERGY", &
+                                   r_val=pint_env%e_qtb)
       ELSE IF (pint_env%pimd_thermostat == thermostat_piglet) THEN
          tmpsec => section_vals_get_subs_vals(pint_section, &
                                               "PIGLET%RNG_INIT")
@@ -1023,6 +1029,9 @@ CONTAINS
          CALL string_to_ascii(rng_record, ascii(:, 1))
          CALL section_rng_val_set(rng_section=tmpsec, nsize=1, &
                                   ascii=ascii)
+         tmpsec => section_vals_get_subs_vals(pint_section, "PIGLET")
+         CALL section_vals_val_set(tmpsec, "THERMOSTAT_ENERGY", &
+                                   r_val=pint_env%e_piglet)
          ! update thermostat velocities in the global input structure
          NULLIFY (r_vals)
          ALLOCATE (r_vals((pint_env%piglet_therm%nsp1 - 1)* &

--- a/src/motion/pint_piglet.F
+++ b/src/motion/pint_piglet.F
@@ -175,6 +175,7 @@ CONTAINS
       p = piglet_therm%p
       pint_env%e_piglet = 0.0_dp
       pint_env%piglet_therm%thermostat_energy = 0.0_dp
+      CALL section_vals_val_get(section, "THERMOSTAT_ENERGY", r_val=piglet_therm%thermostat_energy)
       CALL section_vals_val_get(section, "SMATRIX_INIT", i_val=matrix_init)
       !Read the matices
 

--- a/src/motion/pint_pile.F
+++ b/src/motion/pint_pile.F
@@ -71,6 +71,7 @@ CONTAINS
       !Get input parameter
       CALL section_vals_val_get(section, "TAU", r_val=pile_therm%tau)
       CALL section_vals_val_get(section, "LAMBDA", r_val=pile_therm%lamb)
+      CALL section_vals_val_get(section, "THERMOSTAT_ENERGY", r_val=pile_therm%thermostat_energy)
 
       p = pint_env%p
       dti2 = 0.5_dp*pint_env%dt

--- a/src/motion/pint_qtb.F
+++ b/src/motion/pint_qtb.F
@@ -97,6 +97,7 @@ CONTAINS
       CALL section_vals_val_get(section, "LAMBCUT", r_val=qtb_therm%lambcut)
       CALL section_vals_val_get(section, "FP", i_val=qtb_therm%fp)
       CALL section_vals_val_get(section, "NF", i_val=qtb_therm%nf)
+      CALL section_vals_val_get(section, "THERMOSTAT_ENERGY", r_val=qtb_therm%thermostat_energy)
 
       p = pint_env%p
       dti2 = 0.5_dp*pint_env%dt

--- a/src/start/input_cp2k_motion.F
+++ b/src/start/input_cp2k_motion.F
@@ -1780,7 +1780,7 @@ CONTAINS
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="THERMOSTAT_ENERGY", &
-                          description="Thermostat energy for conserved quantity."// &
+                          description="Thermostat energy for conserved quantity. "// &
                           "Only useful in restart files.", &
                           usage="THERMOSTAT_ENERGY {real}", type_of_var=real_t, &
                           n_var=1, default_r_val=0.0_dp)
@@ -1830,7 +1830,7 @@ CONTAINS
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="THERMOSTAT_ENERGY", &
-                          description="Thermostat energy for conserved quantity."// &
+                          description="Thermostat energy for conserved quantity. "// &
                           "Only useful in restart files.", &
                           usage="THERMOSTAT_ENERGY {real}", type_of_var=real_t, &
                           n_var=1, default_r_val=0.0_dp)
@@ -1886,7 +1886,7 @@ CONTAINS
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="THERMOSTAT_ENERGY", &
-                          description="Thermostat energy for conserved quantity."// &
+                          description="Thermostat energy for conserved quantity. "// &
                           "Only useful in restart files.", &
                           usage="THERMOSTAT_ENERGY {real}", type_of_var=real_t, &
                           n_var=1, default_r_val=0.0_dp)

--- a/src/start/input_cp2k_motion.F
+++ b/src/start/input_cp2k_motion.F
@@ -1761,7 +1761,7 @@ CONTAINS
                           " May lead to unphysical motions if constraint e.g. FIXED_ATOMS, is applied."// &
                           " RESTART_HELIUM section has to be .FALSE. when restarting the PIGLET job.", &
                           citations=(/Ceriotti2010/), &
-                          n_keywords=2, n_subsections=1, &
+                          n_keywords=3, n_subsections=1, &
                           repeats=.FALSE.)
       CALL create_rng_section(subsubsection)
       CALL section_add_subsection(subsection, subsubsection)
@@ -1779,6 +1779,13 @@ CONTAINS
                           n_var=1, default_r_val=0.5_dp)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="THERMOSTAT_ENERGY", &
+                          description="Thermostat energy for conserved quantity."// &
+                          "Only useful in restart files.", &
+                          usage="THERMOSTAT_ENERGY {real}", type_of_var=real_t, &
+                          n_var=1, default_r_val=0.0_dp)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
@@ -1786,7 +1793,7 @@ CONTAINS
                           description="Controls the PI Generalized Langevin Equation thermostat."// &
                           " Needs the exact harmonic integrator", &
                           citations=(/Ceriotti2012/), &
-                          n_keywords=3, n_subsections=2, &
+                          n_keywords=4, n_subsections=2, &
                           repeats=.FALSE.)
       CALL create_rng_section(subsubsection)
       CALL section_add_subsection(subsection, subsubsection)
@@ -1822,6 +1829,13 @@ CONTAINS
                           enum_i_vals=(/matrix_init_cholesky, matrix_init_diagonal/))
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="THERMOSTAT_ENERGY", &
+                          description="Thermostat energy for conserved quantity."// &
+                          "Only useful in restart files.", &
+                          usage="THERMOSTAT_ENERGY {real}", type_of_var=real_t, &
+                          n_var=1, default_r_val=0.0_dp)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
@@ -1829,7 +1843,7 @@ CONTAINS
                           description="Controls the QTB-PILE thermostat."// &
                           " Needs the exact harmonic integrator", &
                           citations=(/Brieuc2016/), &
-                          n_keywords=6, n_subsections=1, &
+                          n_keywords=7, n_subsections=1, &
                           repeats=.FALSE.)
       CALL create_rng_section(subsubsection)
       CALL section_add_subsection(subsection, subsubsection)
@@ -1869,6 +1883,13 @@ CONTAINS
                           description="Number of points used for the convolution product.", &
                           usage="NF {integer}", type_of_var=integer_t, &
                           n_var=1, default_i_val=128)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="THERMOSTAT_ENERGY", &
+                          description="Thermostat energy for conserved quantity."// &
+                          "Only useful in restart files.", &
+                          usage="THERMOSTAT_ENERGY {real}", type_of_var=real_t, &
+                          n_var=1, default_r_val=0.0_dp)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(section, subsection)

--- a/tests/Pimd/regtest-2/TEST_FILES
+++ b/tests/Pimd/regtest-2/TEST_FILES
@@ -9,7 +9,7 @@ w512_pint_pile.inp                                     9      3e-12             
 w512_pint_piglet.inp                                   9      1e-11             218.99114652708764
 w512_pint_qtb_fp0.inp                                  9      3e-12             3.1097152626523572
 w512_pint_qtb_fp1.inp                                  9      3e-11             3.1102704018032394
-w512_pint_qtb_fp1-1.restart                            9      4e-10             8.5170440538048666
+w512_pint_qtb_fp1-1.restart                            9      4e-10             3.1548759203858978
 centroid_velocity_init.inp                             9    1.0E-14            0.32999751991202331
 he32_density.inp                                      40      2e-14       -2.1415575929544138E-005
 he32_only_worm.inp                                    40      1e-11        3.2848032583585659E-004


### PR DESCRIPTION
Fix conserved quantity in restart of Path Integral (PINT) runs with the RPMD propagator.