### PR TITLE
grid: use posix_memalign instead of deprecated memalign

### DIFF
--- a/src/grid/cpu/coefficients.c
+++ b/src/grid/cpu/coefficients.c
@@ -6,7 +6,6 @@
 /*----------------------------------------------------------------------------*/
 
 #include <assert.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/grid/cpu/collocation_integration.c
+++ b/src/grid/cpu/collocation_integration.c
@@ -7,7 +7,9 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #ifdef __GRID_CUDA
 #include <cublas_v2.h>
@@ -41,7 +43,8 @@ struct collocation_integration_ *collocate_create_handle() {
   handle->coef_alloc_size = realloc_tensor(&handle->coef);
   handle->pol_alloc_size = realloc_tensor(&handle->pol);
 
-  handle->scratch = memalign(4096, sizeof(double) * 32768);
+  handle->scratch =
+      aligned_alloc(sysconf(_SC_PAGESIZE), sizeof(double) * 32768);
   handle->scratch_alloc_size = 32768;
   handle->T_alloc_size = 8192;
   handle->W_alloc_size = 2048;
@@ -106,7 +109,7 @@ void initialize_W_and_T(collocation_integration *const handler,
     if (handler->scratch)
       free(handler->scratch);
     handler->scratch =
-        memalign(64, sizeof(double) * handler->scratch_alloc_size);
+        aligned_alloc(64, sizeof(double) * handler->scratch_alloc_size);
     if (handler->scratch == NULL)
       abort();
   }
@@ -137,7 +140,7 @@ void initialize_W_and_T_integrate(collocation_integration *const handler,
     if (handler->scratch)
       free(handler->scratch);
     handler->scratch =
-        memalign(64, sizeof(double) * handler->scratch_alloc_size);
+        aligned_alloc(64, sizeof(double) * handler->scratch_alloc_size);
     if (handler->scratch == NULL)
       abort();
   }

--- a/src/grid/cpu/grid_integrate_dgemm.c
+++ b/src/grid/cpu/grid_integrate_dgemm.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <omp.h>
 
@@ -1068,9 +1069,9 @@ void grid_cpu_integrate_task_list(
 
   const int max_threads = omp_get_max_threads();
 
-  if (ctx->scratch == NULL) {
-    ctx->scratch = memalign(4096, hab_blocks->size * max_threads);
-  }
+  if (ctx->scratch == NULL)
+    ctx->scratch =
+        aligned_alloc(sysconf(_SC_PAGESIZE), hab_blocks->size * max_threads);
 
   ctx->orthorhombic = orthorhombic;
 

--- a/src/grid/cpu/non_orthorombic_corrections.c
+++ b/src/grid/cpu/non_orthorombic_corrections.c
@@ -7,9 +7,9 @@
 
 #include "non_orthorombic_corrections.h"
 
-#include <malloc.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../common/grid_common.h"
@@ -119,8 +119,8 @@ void calculate_non_orthorombic_corrections_tensor(
   initialize_tensor_3(Exp, 3, max_elem, max_elem);
   realloc_tensor(Exp);
 
-  x1 = memalign(64, sizeof(double) * max_elem);
-  x2 = memalign(64, sizeof(double) * max_elem);
+  x1 = aligned_alloc(64, sizeof(double) * max_elem);
+  x2 = aligned_alloc(64, sizeof(double) * max_elem);
   initialize_tensor_2(&exp_tmp, Exp->size[1], Exp->size[2]);
 
   memset(&idx3(Exp[0], 0, 0, 0), 0, sizeof(double) * Exp->alloc_size_);
@@ -198,8 +198,8 @@ void calculate_non_orthorombic_corrections_tensor_blocked(
                                 block_size[2]};
 
   const int max_elem = imax(imax(cube_size[0], cube_size[1]), cube_size[2]);
-  x1 = memalign(64, sizeof(double) * max_elem);
-  x2 = memalign(64, sizeof(double) * max_elem);
+  x1 = aligned_alloc(64, sizeof(double) * max_elem);
+  x2 = aligned_alloc(64, sizeof(double) * max_elem);
 
   initialize_tensor_4(Exp, 3,
                       imax(upper_corner[0] - lower_corner[0],

--- a/src/grid/cpu/tensor_local.c
+++ b/src/grid/cpu/tensor_local.c
@@ -28,7 +28,8 @@ size_t realloc_tensor(tensor *t) {
   t->data = NULL;
 
   if (t->data == NULL) {
-    t->data = memalign(4096, sizeof(double) * t->alloc_size_);
+    t->data =
+        aligned_alloc(sysconf(_SC_PAGESIZE), sizeof(double) * t->alloc_size_);
     if (!t->data)
       abort();
     t->old_alloc_size_ = t->alloc_size_;
@@ -42,7 +43,8 @@ void alloc_tensor(tensor *t) {
     abort();
   }
 
-  t->data = memalign(4096, sizeof(double) * t->alloc_size_);
+  t->data =
+      aligned_alloc(sysconf(_SC_PAGESIZE), sizeof(double) * t->alloc_size_);
   if (!t->data)
     abort();
   t->old_alloc_size_ = t->alloc_size_;

--- a/src/grid/cpu/tensor_local.h
+++ b/src/grid/cpu/tensor_local.h
@@ -8,11 +8,11 @@
 #ifndef TENSOR_LOCAL_H
 #define TENSOR_LOCAL_H
 
-#include <malloc.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 typedef struct tensor_ {
   int dim_;
@@ -115,7 +115,7 @@ static inline tensor *create_tensor(const int dim, const int *sizes) {
     abort();
 
   initialize_tensor(a, dim, sizes);
-  a->data = (double *)memalign(64, sizeof(double) * a->alloc_size_);
+  a->data = aligned_alloc(64, sizeof(double) * a->alloc_size_);
   if (a->data == NULL)
     abort();
   a->old_alloc_size_ = a->alloc_size_;

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -90,7 +90,7 @@ G_CFLAGS="$G_CFLAGS $CP_CFLAGS"
 # FCFLAGS, for gfortran
 FCFLAGS="$G_CFLAGS \$(FCDEBFLAGS) \$(WFLAGS) \$(DFLAGS)"
 # CFLAGS, special flags for gcc
-CFLAGS="$G_CFLAGS -std=c99 -Wall -Wextra -Werror \$(DFLAGS)"
+CFLAGS="$G_CFLAGS -std=c11 -Wall -Wextra -Werror \$(DFLAGS)"
 
 # Linker flags
 LDFLAGS="\$(FCFLAGS) ${CP_LDFLAGS}"


### PR DESCRIPTION
"modern" systems like macOS BigSur do not provide malloc.h anymore,
this is required for CP2K to build on macOS

This could potentially break the build on older systems and may require
additional #ifdef logic.

Besides, it seems there are some hardcoded alignments to 4096 which should
probably be replaced by `sysconf(_SC_PAGESIZE)` or `4*sysconf(_SC_PAGESIZE)`.
As an alternative one could use `aligned_alloc` (from C11), but that has
additional restrictions on the size.
