### PR TITLE
toolchain: fix PLUMED installation

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -146,7 +146,7 @@ The --with-PKG options follow the rules:
   --with-gcc              The GCC compiler to use to compile CP2K
                           Default = system
   --with-cmake            Cmake utilities
-                          Default = no
+                          Default = install
   --with-valgrind         Valgrind memory debugging tool, only used for
                           debugging purposes.
                           Default = no
@@ -212,7 +212,7 @@ The --with-PKG options follow the rules:
   --with-sirius           Enable interface to the plane wave SIRIUS library.
                           This package requires: gsl, libspg, elpa, scalapack, hdf5 and libxc.
                           Default = install
-  --with-gsl              Enable the gnu scientific library
+  --with-gsl              Enable the gnu scientific library (required for PLUMED and SIRIUS)
                           Default = install
   --with-libvdwxc         Enable support of Van der Waals interactions in SIRIUS. Support provided by libvdwxc
                           Default = install
@@ -750,6 +750,10 @@ if [ "$with_sirius" = "__INSTALL__" ] ; then
     [ "$with_cosma" = "__DONTUSE__" ] && with_cosma="__INSTALL__"
 fi
 
+if [ "$with_plumed" = "__INSTALL__" ] ; then
+    [ "$with_gsl" = "__DONTUSE__" ] && with_gsl="__INSTALL__"
+    [ "$with_fftw" = "__DONTUSE__" ] && with_fftw="__INSTALL__"
+fi
 # ------------------------------------------------------------------------
 # Preliminaries
 # ------------------------------------------------------------------------

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -925,8 +925,8 @@ else
     ./scripts/install_superlu.sh
     ./scripts/install_pexsi.sh
     ./scripts/install_quip.sh
-    ./scripts/install_plumed.sh
     ./scripts/install_gsl.sh
+    ./scripts/install_plumed.sh
     ./scripts/install_hdf5.sh
     ./scripts/install_libvdwxc.sh
     ./scripts/install_spglib.sh

--- a/tools/toolchain/scripts/install_plumed.sh
+++ b/tools/toolchain/scripts/install_plumed.sh
@@ -43,7 +43,17 @@ case "$with_plumed" in
             # disable generating debugging infos for now to work around an issue in gcc-10.2:
             # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96354
             # note: some MPI wrappers carry a -g forward, thus stripping is not enough
-            ./configure CXX="${MPICXX}" CXXFLAGS="${CXXFLAGS//-g/-g0}" --prefix=${pkg_install_dir} --libdir="${pkg_install_dir}/lib" > configure.log 2>&1
+
+            libs=""
+            [ -n "${MKL_LIBS}" ] && libs+="${MKL_LIBS}"
+
+            ./configure \
+                CXX="${MPICXX}" \
+                CXXFLAGS="${CXXFLAGS//-g/-g0} ${GSL_CFLAGS}" \
+                LDFLAGS="${LDFLAGS} ${GSL_LDFLAGS}" \
+                LIBS="${libs}" \
+                --prefix=${pkg_install_dir} \
+                --libdir="${pkg_install_dir}/lib" > configure.log 2>&1
             make VERBOSE=1 -j $NPROCS > make.log 2>&1
             make install > install.log 2>&1
             write_checksums "${install_lock_file}" "${SCRIPT_DIR}/$(basename ${SCRIPT_NAME})"


### PR DESCRIPTION
... this way PLUMED picked up MKL, and GSL from the toolchain.
Still to do:

* use our OpenBLAS (will still pick up an external `libblas.so` or use an internal one)
* use fftw from MKL (but that does not seem to be supported anyway with the current toolchain)