### PR TITLE
Remove POINTER spec from dummy arguments where possible

### DIFF
--- a/src/force_env_types.F
+++ b/src/force_env_types.F
@@ -310,7 +310,7 @@ CONTAINS
                                       kinetic_energy, harmonic_shell, kinetic_shell, cell, sub_force_env, &
                                       qmmm_env, qmmmx_env, eip_env, pwdft_env, globenv, input, force_env_section, &
                                       method_name_id, root_section, mixed_env, nnp_env, embed_env)
-      TYPE(force_env_type), POINTER                      :: force_env
+      TYPE(force_env_type), INTENT(IN)                   :: force_env
       INTEGER, INTENT(out), OPTIONAL                     :: in_use
       TYPE(fist_environment_type), OPTIONAL, POINTER     :: fist_env
       TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
@@ -345,7 +345,6 @@ CONTAINS
 
       NULLIFY (subsys_tmp)
 
-      CPASSERT(ASSOCIATED(force_env))
       CPASSERT(force_env%ref_count > 0)
 
       SELECT CASE (force_env%in_use)
@@ -496,7 +495,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION force_env_get_natom(force_env) RESULT(n_atom)
 
-      TYPE(force_env_type), POINTER                      :: force_env
+      TYPE(force_env_type), INTENT(IN)                   :: force_env
       INTEGER                                            :: n_atom
 
       TYPE(cp_subsys_type), POINTER                      :: subsys
@@ -517,7 +516,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION force_env_get_nparticle(force_env) RESULT(n_particle)
 
-      TYPE(force_env_type), POINTER                      :: force_env
+      TYPE(force_env_type), INTENT(IN)                   :: force_env
       INTEGER                                            :: n_particle
 
       TYPE(cp_subsys_type), POINTER                      :: subsys
@@ -539,7 +538,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE force_env_get_frc(force_env, frc, n)
 
-      TYPE(force_env_type), POINTER                      :: force_env
+      TYPE(force_env_type), INTENT(IN)                   :: force_env
       REAL(KIND=dp), DIMENSION(*), INTENT(OUT)           :: frc
       INTEGER, INTENT(IN)                                :: n
 
@@ -549,7 +548,6 @@ CONTAINS
       TYPE(cp_subsys_type), POINTER                      :: subsys
 
       CALL timeset(routineN, handle)
-      CPASSERT(ASSOCIATED(force_env))
       CPASSERT(force_env%ref_count > 0)
       CALL force_env_get(force_env, subsys=subsys)
       CALL pack_subsys_particles(subsys=subsys, f=frc(1:n))
@@ -567,7 +565,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE force_env_get_pos(force_env, pos, n)
 
-      TYPE(force_env_type), POINTER                      :: force_env
+      TYPE(force_env_type), INTENT(IN)                   :: force_env
       REAL(kind=dp), DIMENSION(*), INTENT(OUT)           :: pos
       INTEGER, INTENT(IN)                                :: n
 
@@ -577,7 +575,6 @@ CONTAINS
       TYPE(cp_subsys_type), POINTER                      :: subsys
 
       CALL timeset(routineN, handle)
-      CPASSERT(ASSOCIATED(force_env))
       CPASSERT(force_env%ref_count > 0)
       CALL force_env_get(force_env, subsys=subsys)
       CALL pack_subsys_particles(subsys=subsys, r=pos(1:n))
@@ -595,7 +592,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE force_env_get_vel(force_env, vel, n)
 
-      TYPE(force_env_type), POINTER                      :: force_env
+      TYPE(force_env_type), INTENT(IN)                   :: force_env
       REAL(KIND=dp), DIMENSION(*), INTENT(OUT)           :: vel
       INTEGER, INTENT(IN)                                :: n
 
@@ -605,7 +602,6 @@ CONTAINS
       TYPE(cp_subsys_type), POINTER                      :: subsys
 
       CALL timeset(routineN, handle)
-      CPASSERT(ASSOCIATED(force_env))
       CPASSERT(force_env%ref_count > 0)
       CALL force_env_get(force_env, subsys=subsys)
       CALL pack_subsys_particles(subsys=subsys, v=vel(1:n))
@@ -628,14 +624,13 @@ CONTAINS
    SUBROUTINE force_env_set(force_env, meta_env, fp_env, force_env_section, &
                             method_name_id, additional_potential)
 
-      TYPE(force_env_type), POINTER                      :: force_env
+      TYPE(force_env_type), INTENT(INOUT)                :: force_env
       TYPE(meta_env_type), OPTIONAL, POINTER             :: meta_env
       TYPE(fp_type), OPTIONAL, POINTER                   :: fp_env
       TYPE(section_vals_type), OPTIONAL, POINTER         :: force_env_section
       INTEGER, OPTIONAL                                  :: method_name_id
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: additional_potential
 
-      CPASSERT(ASSOCIATED(force_env))
       CPASSERT(force_env%ref_count > 0)
       IF (PRESENT(meta_env)) THEN
          IF (ASSOCIATED(meta_env)) THEN
@@ -675,7 +670,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE multiple_fe_list(force_env_sections, root_section, i_force_eval, nforce_eval)
 
-      TYPE(section_vals_type), POINTER                   :: force_env_sections, root_section
+      TYPE(section_vals_type), INTENT(IN)                :: force_env_sections, root_section
       INTEGER, DIMENSION(:), POINTER                     :: i_force_eval
       INTEGER                                            :: nforce_eval
 
@@ -707,4 +702,3 @@ CONTAINS
    END SUBROUTINE multiple_fe_list
 
 END MODULE force_env_types
-

--- a/src/input/cp_output_handling.F
+++ b/src/input/cp_output_handling.F
@@ -344,10 +344,11 @@ CONTAINS
    FUNCTION cp_print_key_should_output(iteration_info, basis_section, &
                                        print_key_path, used_print_key, first_time) &
       RESULT(res)
-      TYPE(cp_iteration_info_type), POINTER              :: iteration_info
-      TYPE(section_vals_type), POINTER                   :: basis_section
+      TYPE(cp_iteration_info_type), INTENT(IN)           :: iteration_info
+      TYPE(section_vals_type), INTENT(IN), TARGET        :: basis_section
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: print_key_path
-      TYPE(section_vals_type), OPTIONAL, POINTER         :: used_print_key
+      TYPE(section_vals_type), INTENT(INOUT), OPTIONAL, &
+         POINTER                                         :: used_print_key
       LOGICAL, INTENT(OUT), OPTIONAL                     :: first_time
       INTEGER                                            :: res
 
@@ -357,13 +358,8 @@ CONTAINS
 
       res = 0
       IF (PRESENT(first_time)) first_time = .FALSE.
-      CPASSERT(ASSOCIATED(basis_section))
       CPASSERT(basis_section%ref_count > 0)
       IF (PRESENT(used_print_key)) NULLIFY (used_print_key)
-      ! IF (failure) THEN
-      !    IF (iteration_info%print_level>=debug_print_level) res=cp_out_default
-      !    RETURN
-      ! END IF
 
       IF (PRESENT(print_key_path)) THEN
          end_str = LEN_TRIM(print_key_path)
@@ -432,13 +428,12 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    FUNCTION cp_printkey_is_on(iteration_info, print_key) RESULT(res)
-      TYPE(cp_iteration_info_type), POINTER              :: iteration_info
+      TYPE(cp_iteration_info_type), INTENT(IN)           :: iteration_info
       TYPE(section_vals_type), POINTER                   :: print_key
       LOGICAL                                            :: res
 
       INTEGER                                            :: print_level
 
-      CPASSERT(ASSOCIATED(iteration_info))
       CPASSERT(iteration_info%ref_count > 0)
       IF (.NOT. ASSOCIATED(print_key)) THEN
          res = (iteration_info%print_level > debug_print_level)
@@ -462,7 +457,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION cp_printkey_is_iter(iteration_info, print_key, first_time) &
       RESULT(res)
-      TYPE(cp_iteration_info_type), POINTER              :: iteration_info
+      TYPE(cp_iteration_info_type), INTENT(IN)           :: iteration_info
       TYPE(section_vals_type), POINTER                   :: print_key
       LOGICAL, INTENT(OUT), OPTIONAL                     :: first_time
       LOGICAL                                            :: res
@@ -470,7 +465,6 @@ CONTAINS
       INTEGER                                            :: add_last, ilevel, iter_nr, ival
       LOGICAL                                            :: first, level_passed
 
-      CPASSERT(ASSOCIATED(iteration_info))
       CPASSERT(iteration_info%ref_count > 0)
       IF (.NOT. ASSOCIATED(print_key)) THEN
          res = (iteration_info%print_level > debug_print_level)
@@ -809,7 +803,7 @@ CONTAINS
                                  file_action, file_status, do_backup, on_file, is_new_file, mpi_io, &
                                  fout) RESULT(res)
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(section_vals_type), POINTER                   :: basis_section
+      TYPE(section_vals_type), INTENT(IN)                :: basis_section
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: print_key_path
       CHARACTER(len=*), INTENT(IN)                       :: extension
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: middle_name
@@ -876,7 +870,6 @@ CONTAINS
          mpi_io = my_mpi_io
       END IF
       NULLIFY (print_key)
-      CPASSERT(ASSOCIATED(basis_section))
       CPASSERT(ASSOCIATED(logger))
       CPASSERT(basis_section%ref_count > 0)
       CPASSERT(logger%ref_count > 0)
@@ -1020,7 +1013,7 @@ CONTAINS
                                            mpi_io)
       INTEGER, INTENT(INOUT)                             :: unit_nr
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(section_vals_type), POINTER                   :: basis_section
+      TYPE(section_vals_type), INTENT(IN)                :: basis_section
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: print_key_path
       LOGICAL, INTENT(IN), OPTIONAL                      :: local, ignore_should_output, on_file, &
                                                             mpi_io
@@ -1037,7 +1030,6 @@ CONTAINS
       IF (PRESENT(local)) my_local = local
       IF (PRESENT(on_file)) my_on_file = on_file
       IF (PRESENT(mpi_io)) my_mpi_io = mpi_io
-      CPASSERT(ASSOCIATED(basis_section))
       CPASSERT(ASSOCIATED(logger))
       CPASSERT(basis_section%ref_count > 0)
       CPASSERT(logger%ref_count > 0)
@@ -1091,4 +1083,3 @@ CONTAINS
    END FUNCTION cp_mpi_io_get
 
 END MODULE cp_output_handling
-

--- a/src/input/input_section_types.F
+++ b/src/input/input_section_types.F
@@ -263,7 +263,7 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    FUNCTION get_section_info(section) RESULT(message)
-      TYPE(section_type), POINTER                        :: section
+      TYPE(section_type), INTENT(IN)                     :: section
       CHARACTER(LEN=default_path_length)                 :: message
 
       INTEGER                                            :: length
@@ -295,7 +295,7 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE section_describe(section, unit_nr, level, hide_root, recurse)
-      TYPE(section_type), POINTER                        :: section
+      TYPE(section_type), INTENT(IN), POINTER            :: section
       INTEGER, INTENT(in)                                :: unit_nr, level
       LOGICAL, INTENT(in), OPTIONAL                      :: hide_root
       INTEGER, INTENT(in), OPTIONAL                      :: recurse
@@ -362,14 +362,13 @@ CONTAINS
 !>      private utility function
 ! **************************************************************************************************
    FUNCTION section_get_subsection_index(section, subsection_name) RESULT(res)
-      TYPE(section_type), POINTER                        :: section
-      CHARACTER(len=*), INTENT(in)                       :: subsection_name
+      TYPE(section_type), INTENT(IN)                     :: section
+      CHARACTER(len=*), INTENT(IN)                       :: subsection_name
       INTEGER                                            :: res
 
       CHARACTER(len=default_string_length)               :: upc_name
       INTEGER                                            :: isub
 
-      CPASSERT(ASSOCIATED(section))
       CPASSERT(section%ref_count > 0)
       res = -1
       upc_name = subsection_name
@@ -391,8 +390,8 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    FUNCTION section_get_subsection(section, subsection_name) RESULT(res)
-      TYPE(section_type), POINTER                        :: section
-      CHARACTER(len=*), INTENT(in)                       :: subsection_name
+      TYPE(section_type), INTENT(IN)                     :: section
+      CHARACTER(len=*), INTENT(IN)                       :: subsection_name
       TYPE(section_type), POINTER                        :: res
 
       INTEGER                                            :: isub
@@ -415,14 +414,13 @@ CONTAINS
 !>      private utility function
 ! **************************************************************************************************
    FUNCTION section_get_keyword_index(section, keyword_name) RESULT(res)
-      TYPE(section_type), POINTER                        :: section
-      CHARACTER(len=*), INTENT(in)                       :: keyword_name
+      TYPE(section_type), INTENT(IN)                     :: section
+      CHARACTER(len=*), INTENT(IN)                       :: keyword_name
       INTEGER                                            :: res
 
       INTEGER                                            :: ik, in
       CHARACTER(len=default_string_length)               :: upc_name
 
-      CPASSERT(ASSOCIATED(section))
       CPASSERT(section%ref_count > 0)
       CPASSERT(ASSOCIATED(section%keywords))
       res = -2
@@ -456,8 +454,8 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    RECURSIVE FUNCTION section_get_keyword(section, keyword_name) RESULT(res)
-      TYPE(section_type), POINTER                        :: section
-      CHARACTER(len=*), INTENT(in)                       :: keyword_name
+      TYPE(section_type), INTENT(IN)                     :: section
+      CHARACTER(len=*), INTENT(IN)                       :: keyword_name
       TYPE(keyword_type), POINTER                        :: res
 
       INTEGER                                            :: ik, my_index
@@ -487,13 +485,12 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE section_add_keyword(section, keyword)
-      TYPE(section_type), POINTER                        :: section
-      TYPE(keyword_type), POINTER                        :: keyword
+      TYPE(section_type), INTENT(INOUT)                  :: section
+      TYPE(keyword_type), INTENT(IN), POINTER            :: keyword
 
       INTEGER                                            :: i, j, k
       TYPE(keyword_p_type), DIMENSION(:), POINTER        :: new_keywords
 
-      CPASSERT(ASSOCIATED(section))
       CPASSERT(section%ref_count > 0)
       CPASSERT(.NOT. section%frozen)
       CPASSERT(ASSOCIATED(keyword))
@@ -542,12 +539,12 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE section_add_subsection(section, subsection)
-      TYPE(section_type), POINTER                        :: section, subsection
+      TYPE(section_type), INTENT(INOUT)                  :: section
+      TYPE(section_type), INTENT(IN), POINTER            :: subsection
 
       INTEGER                                            :: i
       TYPE(section_p_type), DIMENSION(:), POINTER        :: new_subsections
 
-      CPASSERT(ASSOCIATED(section))
       CPASSERT(section%ref_count > 0)
       CPASSERT(ASSOCIATED(subsection))
       CPASSERT(subsection%ref_count > 0)
@@ -673,13 +670,12 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE section_vals_get(section_vals, ref_count, id_nr, n_repetition, &
                                n_subs_vals_rep, section, explicit)
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       INTEGER, INTENT(out), OPTIONAL                     :: ref_count, id_nr, n_repetition, &
                                                             n_subs_vals_rep
       TYPE(section_type), OPTIONAL, POINTER              :: section
       LOGICAL, INTENT(out), OPTIONAL                     :: explicit
 
-      CPASSERT(ASSOCIATED(section_vals))
       CPASSERT(section_vals%ref_count > 0)
       IF (PRESENT(ref_count)) ref_count = section_vals%ref_count
       IF (PRESENT(id_nr)) id_nr = section_vals%id_nr
@@ -701,16 +697,15 @@ CONTAINS
 ! **************************************************************************************************
    RECURSIVE FUNCTION section_vals_get_subs_vals(section_vals, subsection_name, &
                                                  i_rep_section, can_return_null) RESULT(res)
-      TYPE(section_vals_type), POINTER                   :: section_vals
-      CHARACTER(len=*), INTENT(in)                       :: subsection_name
-      INTEGER, INTENT(in), OPTIONAL                      :: i_rep_section
-      LOGICAL, INTENT(in), OPTIONAL                      :: can_return_null
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
+      CHARACTER(len=*), INTENT(IN)                       :: subsection_name
+      INTEGER, INTENT(IN), OPTIONAL                      :: i_rep_section
+      LOGICAL, INTENT(IN), OPTIONAL                      :: can_return_null
       TYPE(section_vals_type), POINTER                   :: res
 
       INTEGER                                            :: irep, isection, my_index
       LOGICAL                                            :: is_path, my_can_return_null
 
-      CPASSERT(ASSOCIATED(section_vals))
       CPASSERT(section_vals%ref_count > 0)
 
       my_can_return_null = .FALSE.
@@ -793,14 +788,13 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION section_vals_get_subs_vals3(section_vals, subsection_name, &
                                         i_rep_section) RESULT(res)
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       CHARACTER(LEN=*), INTENT(IN)                       :: subsection_name
       INTEGER, INTENT(in), OPTIONAL                      :: i_rep_section
       TYPE(section_vals_type), POINTER                   :: res
 
       INTEGER                                            :: i_section, irep
 
-      CPASSERT(ASSOCIATED(section_vals))
       CPASSERT(section_vals%ref_count > 0)
       NULLIFY (res)
       irep = 1
@@ -816,14 +810,13 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE section_vals_add_values(section_vals)
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(INOUT)             :: section_vals
 
       INTEGER                                            :: i, j
       TYPE(cp_sll_val_p_type), DIMENSION(:, :), POINTER  :: new_values
       TYPE(section_vals_p_type), DIMENSION(:, :), &
          POINTER                                         :: new_sps
 
-      CPASSERT(ASSOCIATED(section_vals))
       CPASSERT(section_vals%ref_count > 0)
       ALLOCATE (new_values(-1:UBOUND(section_vals%values, 1), SIZE(section_vals%values, 2) + 1))
       DO j = 1, SIZE(section_vals%values, 2)
@@ -903,7 +896,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION section_get_cval(section_vals, keyword_name) RESULT(res)
 
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       CHARACTER(LEN=default_string_length)               :: res
 
@@ -919,7 +912,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION section_get_rval(section_vals, keyword_name) RESULT(res)
 
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       REAL(kind=dp)                                      :: res
 
@@ -935,7 +928,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION section_get_rvals(section_vals, keyword_name) RESULT(res)
 
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       REAL(kind=dp), DIMENSION(:), POINTER               :: res
 
@@ -951,7 +944,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION section_get_ival(section_vals, keyword_name) RESULT(res)
 
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       INTEGER                                            :: res
 
@@ -967,7 +960,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION section_get_ivals(section_vals, keyword_name) RESULT(res)
 
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       INTEGER, DIMENSION(:), POINTER                     :: res
 
@@ -983,7 +976,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION section_get_lval(section_vals, keyword_name) RESULT(res)
 
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       LOGICAL                                            :: res
 
@@ -1017,7 +1010,7 @@ CONTAINS
    SUBROUTINE section_vals_val_get(section_vals, keyword_name, i_rep_section, &
                                    i_rep_val, n_rep_val, val, l_val, i_val, r_val, c_val, l_vals, i_vals, r_vals, &
                                    c_vals, explicit)
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN), TARGET        :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       INTEGER, INTENT(in), OPTIONAL                      :: i_rep_section, i_rep_val
       INTEGER, INTENT(out), OPTIONAL                     :: n_rep_val
@@ -1042,7 +1035,6 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: s_vals
       TYPE(val_type), POINTER                            :: my_val
 
-      CPASSERT(ASSOCIATED(section_vals))
       CPASSERT(section_vals%ref_count > 0)
 
       my_index = INDEX(keyword_name, '%') + 1
@@ -1126,7 +1118,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE section_vals_list_get(section_vals, keyword_name, i_rep_section, &
                                     list)
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN), POINTER       :: section_vals
       CHARACTER(len=*), INTENT(in)                       :: keyword_name
       INTEGER, OPTIONAL                                  :: i_rep_section
       TYPE(cp_sll_val_type), POINTER                     :: list
@@ -1394,7 +1386,7 @@ CONTAINS
 !>      skips required sections which weren't read
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE section_vals_write(section_vals, unit_nr, hide_root, hide_defaults)
-      TYPE(section_vals_type), POINTER                   :: section_vals
+      TYPE(section_vals_type), INTENT(IN)                :: section_vals
       INTEGER, INTENT(in)                                :: unit_nr
       LOGICAL, INTENT(in), OPTIONAL                      :: hide_root, hide_defaults
 
@@ -1414,7 +1406,6 @@ CONTAINS
       IF (PRESENT(hide_root)) my_hide_root = hide_root
       IF (PRESENT(hide_defaults)) my_hide_defaults = hide_defaults
 
-      CPASSERT(ASSOCIATED(section_vals))
       CPASSERT(section_vals%ref_count > 0)
       IF (unit_nr > 0) THEN
          CALL section_vals_get(section_vals, explicit=explicit, n_repetition=nr, section=section)
@@ -1589,7 +1580,7 @@ CONTAINS
    RECURSIVE SUBROUTINE section_typo_match(section, section_name, unknown_string, location_string, &
                                            matching_rank, matching_string, bonus)
 
-      TYPE(section_type), POINTER                        :: section
+      TYPE(section_type), INTENT(IN), POINTER            :: section
       CHARACTER(LEN=*)                                   :: section_name, unknown_string, &
                                                             location_string
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: matching_rank

--- a/src/kpoint_types.F
+++ b/src/kpoint_types.F
@@ -316,7 +316,7 @@ CONTAINS
                               full_grid, use_real_wfn, eps_geo, parallel_group_size, kp_range, nkp, xkp, wkp, &
                               para_env, blacs_env_all, cart, para_env_full, para_env_kp, para_env_inter_kp, blacs_env, &
                               kp_env, mpools, iogrp, nkp_groups, kp_dist, cell_to_index, sab_nl)
-      TYPE(kpoint_type), POINTER                         :: kpoint
+      TYPE(kpoint_type), INTENT(IN)                      :: kpoint
       CHARACTER(LEN=*), OPTIONAL                         :: kp_scheme
       INTEGER, DIMENSION(3), OPTIONAL                    :: nkp_grid
       REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: kp_shift
@@ -343,8 +343,6 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :), OPTIONAL, POINTER     :: cell_to_index
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          OPTIONAL, POINTER                               :: sab_nl
-
-      CPASSERT(ASSOCIATED(kpoint))
 
       IF (PRESENT(kp_scheme)) kp_scheme = kpoint%kp_scheme
       IF (PRESENT(nkp_grid)) nkp_grid = kpoint%nkp_grid
@@ -419,7 +417,7 @@ CONTAINS
                               full_grid, use_real_wfn, eps_geo, parallel_group_size, kp_range, nkp, xkp, wkp, &
                               para_env, blacs_env_all, cart, para_env_full, para_env_kp, para_env_inter_kp, blacs_env, &
                               kp_env, mpools, iogrp, nkp_groups, kp_dist, cell_to_index, sab_nl)
-      TYPE(kpoint_type), POINTER                         :: kpoint
+      TYPE(kpoint_type), INTENT(INOUT)                   :: kpoint
       CHARACTER(LEN=*), OPTIONAL                         :: kp_scheme
       INTEGER, DIMENSION(3), OPTIONAL                    :: nkp_grid
       REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: kp_shift
@@ -446,8 +444,6 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :), OPTIONAL, POINTER     :: cell_to_index
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          OPTIONAL, POINTER                               :: sab_nl
-
-      CPASSERT(ASSOCIATED(kpoint))
 
       IF (PRESENT(kp_scheme)) kpoint%kp_scheme = kp_scheme
       IF (PRESENT(nkp_grid)) kpoint%nkp_grid = nkp_grid
@@ -495,7 +491,7 @@ CONTAINS
 !> \author JGH
 ! **************************************************************************************************
    SUBROUTINE read_kpoint_section(kpoint, kpoint_section, a_vec)
-      TYPE(kpoint_type), POINTER                         :: kpoint
+      TYPE(kpoint_type), INTENT(INOUT)                   :: kpoint
       TYPE(section_vals_type), POINTER                   :: kpoint_section
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: a_vec
 
@@ -506,8 +502,6 @@ CONTAINS
       LOGICAL                                            :: available
       REAL(KIND=dp)                                      :: ff
       REAL(KIND=dp), DIMENSION(:), POINTER               :: reallist
-
-      CPASSERT(ASSOCIATED(kpoint))
 
       CALL section_vals_get(kpoint_section, explicit=available)
 
@@ -599,13 +593,11 @@ CONTAINS
 !> \author JGH
 ! **************************************************************************************************
    SUBROUTINE write_kpoint_info(kpoint, dft_section)
-      TYPE(kpoint_type), POINTER                         :: kpoint
-      TYPE(section_vals_type), POINTER                   :: dft_section
+      TYPE(kpoint_type), INTENT(IN)                      :: kpoint
+      TYPE(section_vals_type), INTENT(IN)                :: dft_section
 
       INTEGER                                            :: i, punit
       TYPE(cp_logger_type), POINTER                      :: logger
-
-      CPASSERT(ASSOCIATED(kpoint))
 
       NULLIFY (logger)
       logger => cp_get_default_logger()
@@ -745,15 +737,13 @@ CONTAINS
 !> \author JGH
 ! **************************************************************************************************
    SUBROUTINE get_kpoint_env(kpoint_env, nkpoint, wkp, xkp, is_local, mos)
-      TYPE(kpoint_env_type), POINTER                     :: kpoint_env
+      TYPE(kpoint_env_type), INTENT(IN)                  :: kpoint_env
       INTEGER, OPTIONAL                                  :: nkpoint
       REAL(KIND=dp), OPTIONAL                            :: wkp
       REAL(KIND=dp), DIMENSION(3), OPTIONAL              :: xkp
       LOGICAL, OPTIONAL                                  :: is_local
       TYPE(mo_set_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: mos
-
-      CPASSERT(ASSOCIATED(kpoint_env))
 
       IF (PRESENT(nkpoint)) nkpoint = kpoint_env%nkpoint
       IF (PRESENT(wkp)) wkp = kpoint_env%wkp

--- a/src/nnp_environment_types.F
+++ b/src/nnp_environment_types.F
@@ -455,7 +455,7 @@ CONTAINS
                           nnp_input, force_env_input, cell, cell_ref, &
                           use_ref_cell, nnp_potential_energy, virial)
 
-      TYPE(nnp_type), INTENT(INOUT), POINTER             :: nnp_env
+      TYPE(nnp_type), INTENT(IN)                         :: nnp_env
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: nnp_forces
       TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
       TYPE(atomic_kind_type), DIMENSION(:), OPTIONAL, &
@@ -481,7 +481,6 @@ CONTAINS
 
       NULLIFY (atomic_kinds, particles, molecules, molecule_kinds)
 
-      CPASSERT(ASSOCIATED(nnp_env))
       CPASSERT(nnp_env%ref_count > 0)
 
       IF (PRESENT(nnp_potential_energy)) THEN
@@ -541,7 +540,7 @@ CONTAINS
                           nnp_input, force_env_input, cell_ref, &
                           use_ref_cell, nnp_potential_energy)
 
-      TYPE(nnp_type), INTENT(INOUT), POINTER             :: nnp_env
+      TYPE(nnp_type), INTENT(INOUT)                      :: nnp_env
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: nnp_forces
       TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
       TYPE(atomic_kind_type), DIMENSION(:), OPTIONAL, &
@@ -564,7 +563,6 @@ CONTAINS
       TYPE(molecule_list_type), POINTER                  :: molecules
       TYPE(particle_list_type), POINTER                  :: particles
 
-      CPASSERT(ASSOCIATED(nnp_env))
       CPASSERT(nnp_env%ref_count > 0)
 
       IF (PRESENT(nnp_potential_energy)) THEN

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -369,7 +369,7 @@ CONTAINS
                          nkind, natom, dft_control, dbcsr_dist, distribution_2d, pw_env, &
                          para_env, blacs_env, nelectron_total, nelectron_spin, admm_dm)
 
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+      TYPE(qs_ks_env_type), INTENT(IN)                   :: ks_env
       TYPE(pw_type), OPTIONAL, POINTER                   :: v_hartree_rspace
       LOGICAL, OPTIONAL                                  :: s_mstruct_changed, rho_changed, &
                                                             potential_changed, forces_up_to_date
@@ -426,7 +426,6 @@ CONTAINS
       INTEGER, DIMENSION(2), OPTIONAL                    :: nelectron_spin
       TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
 
-      IF (.NOT. ASSOCIATED(ks_env)) CPABORT("get_ks_env: not associated")
       IF (ks_env%ref_count < 1) CPABORT("get_ks_env: ks_env%ref_count<1")
       IF (.NOT. ASSOCIATED(ks_env%subsys)) CPABORT("get_ks_env: subsys not associated")
 
@@ -623,7 +622,7 @@ CONTAINS
                          subsys, dft_control, dbcsr_dist, distribution_2d, pw_env, &
                          para_env, blacs_env, admm_dm)
 
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+      TYPE(qs_ks_env_type), INTENT(INOUT)                :: ks_env
       TYPE(pw_type), OPTIONAL, POINTER                   :: v_hartree_rspace
       LOGICAL, OPTIONAL                                  :: s_mstruct_changed, rho_changed, &
                                                             potential_changed, forces_up_to_date
@@ -654,7 +653,6 @@ CONTAINS
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env
       TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
 
-      IF (.NOT. ASSOCIATED(ks_env)) CPABORT("set_ks_env: not associated")
       IF (ks_env%ref_count < 1) CPABORT("set_ks_env: ks_env%ref_count<1")
 
       IF (PRESENT(s_mstruct_changed)) ks_env%s_mstruct_changed = s_mstruct_changed
@@ -923,7 +921,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE qs_ks_did_change(ks_env, s_mstruct_changed, rho_changed, &
                                potential_changed, full_reset)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+      TYPE(qs_ks_env_type), INTENT(INOUT)                :: ks_env
       LOGICAL, INTENT(in), OPTIONAL                      :: s_mstruct_changed, rho_changed, &
                                                             potential_changed, full_reset
 
@@ -934,8 +932,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       my_mstruct_chg = .FALSE.
-
-      CPASSERT(ASSOCIATED(ks_env))
 
       IF (PRESENT(rho_changed)) THEN
          IF (rho_changed) ks_env%rho_changed = .TRUE.

--- a/src/subsys/atomic_kind_types.F
+++ b/src/subsys/atomic_kind_types.F
@@ -90,28 +90,26 @@ CONTAINS
 
       INTEGER                                            :: ikind, nkind
 
-      IF (ASSOCIATED(atomic_kind_set)) THEN
-
-         nkind = SIZE(atomic_kind_set)
-
-         DO ikind = 1, nkind
-            IF (ASSOCIATED(atomic_kind_set(ikind)%fist_potential)) THEN
-               CALL deallocate_potential(atomic_kind_set(ikind)%fist_potential)
-            END IF
-            IF (ASSOCIATED(atomic_kind_set(ikind)%atom_list)) THEN
-               DEALLOCATE (atomic_kind_set(ikind)%atom_list)
-            END IF
-            CALL shell_release(atomic_kind_set(ikind)%shell)
-
-            CALL damping_p_release(atomic_kind_set(ikind)%damping)
-         END DO
-         DEALLOCATE (atomic_kind_set)
-      ELSE
+      IF (.NOT. ASSOCIATED(atomic_kind_set)) THEN
          CALL cp_abort(__LOCATION__, &
                        "The pointer atomic_kind_set is not associated and "// &
                        "cannot be deallocated")
       END IF
 
+      nkind = SIZE(atomic_kind_set)
+
+      DO ikind = 1, nkind
+         IF (ASSOCIATED(atomic_kind_set(ikind)%fist_potential)) THEN
+            CALL deallocate_potential(atomic_kind_set(ikind)%fist_potential)
+         END IF
+         IF (ASSOCIATED(atomic_kind_set(ikind)%atom_list)) THEN
+            DEALLOCATE (atomic_kind_set(ikind)%atom_list)
+         END IF
+         CALL shell_release(atomic_kind_set(ikind)%shell)
+
+         CALL damping_p_release(atomic_kind_set(ikind)%damping)
+      END DO
+      DEALLOCATE (atomic_kind_set)
    END SUBROUTINE deallocate_atomic_kind_set
 
 ! **************************************************************************************************
@@ -140,7 +138,7 @@ CONTAINS
                               rcov, rvdw, z, qeff, apol, cpol, mm_radius, &
                               shell, shell_active, damping)
 
-      TYPE(atomic_kind_type)                             :: atomic_kind
+      TYPE(atomic_kind_type), INTENT(IN)                 :: atomic_kind
       TYPE(fist_potential_type), OPTIONAL, POINTER       :: fist_potential
       CHARACTER(LEN=2), INTENT(OUT), OPTIONAL            :: element_symbol
       CHARACTER(LEN=default_string_length), &
@@ -231,7 +229,7 @@ CONTAINS
                                   shell_check_distance, &
                                   damping_present)
 
-      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(atomic_kind_type), DIMENSION(:), INTENT(IN)   :: atomic_kind_set
       INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL       :: atom_of_kind, kind_of, natom_of_kind
       INTEGER, INTENT(OUT), OPTIONAL                     :: maxatom, natom, nshell
       LOGICAL, INTENT(OUT), OPTIONAL                     :: fist_potential_present, shell_present, &
@@ -239,27 +237,24 @@ CONTAINS
                                                             damping_present
 
       INTEGER                                            :: atom_a, iatom, ikind, nkind
-      TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(damping_p_type), POINTER                      :: damping
       TYPE(fist_potential_type), POINTER                 :: fist_potential
       TYPE(shell_kind_type), POINTER                     :: shell
 
-      IF (ASSOCIATED(atomic_kind_set)) THEN
+      IF (PRESENT(maxatom)) maxatom = 0
+      IF (PRESENT(natom)) natom = 0
+      IF (PRESENT(nshell)) nshell = 0
+      IF (PRESENT(shell_present)) shell_present = .FALSE.
+      IF (PRESENT(shell_adiabatic)) shell_adiabatic = .FALSE.
+      IF (PRESENT(shell_check_distance)) shell_check_distance = .FALSE.
+      IF (PRESENT(damping_present)) damping_present = .FALSE.
+      IF (PRESENT(atom_of_kind)) atom_of_kind(:) = 0
+      IF (PRESENT(kind_of)) kind_of(:) = 0
+      IF (PRESENT(natom_of_kind)) natom_of_kind(:) = 0
 
-         IF (PRESENT(maxatom)) maxatom = 0
-         IF (PRESENT(natom)) natom = 0
-         IF (PRESENT(nshell)) nshell = 0
-         IF (PRESENT(shell_present)) shell_present = .FALSE.
-         IF (PRESENT(shell_adiabatic)) shell_adiabatic = .FALSE.
-         IF (PRESENT(shell_check_distance)) shell_check_distance = .FALSE.
-         IF (PRESENT(damping_present)) damping_present = .FALSE.
-         IF (PRESENT(atom_of_kind)) atom_of_kind(:) = 0
-         IF (PRESENT(kind_of)) kind_of(:) = 0
-         IF (PRESENT(natom_of_kind)) natom_of_kind(:) = 0
-
-         nkind = SIZE(atomic_kind_set)
-         DO ikind = 1, nkind
-            atomic_kind => atomic_kind_set(ikind)
+      nkind = SIZE(atomic_kind_set)
+      DO ikind = 1, nkind
+         ASSOCIATE (atomic_kind=>atomic_kind_set(ikind))
             CALL get_atomic_kind(atomic_kind=atomic_kind, &
                                  fist_potential=fist_potential, &
                                  shell=shell, &
@@ -306,10 +301,8 @@ CONTAINS
             IF (PRESENT(natom_of_kind)) THEN
                natom_of_kind(ikind) = atomic_kind_set(ikind)%natom
             END IF
-         END DO
-      ELSE
-         CPABORT("The pointer atomic_kind_set is not associated")
-      END IF
+         END ASSOCIATE
+      END DO
 
    END SUBROUTINE get_atomic_kind_set
 
@@ -332,7 +325,7 @@ CONTAINS
                               fist_potential, shell, &
                               shell_active, damping)
 
-      TYPE(atomic_kind_type), POINTER                    :: atomic_kind
+      TYPE(atomic_kind_type), INTENT(INOUT)              :: atomic_kind
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: element_symbol, name
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: mass
       INTEGER, INTENT(IN), OPTIONAL                      :: kind_number, natom
@@ -344,38 +337,32 @@ CONTAINS
 
       INTEGER                                            :: n
 
-      IF (ASSOCIATED(atomic_kind)) THEN
-
-         IF (PRESENT(element_symbol)) atomic_kind%element_symbol = element_symbol
-         IF (PRESENT(name)) atomic_kind%name = name
-         IF (PRESENT(mass)) atomic_kind%mass = mass
-         IF (PRESENT(kind_number)) atomic_kind%kind_number = kind_number
-         IF (PRESENT(natom)) atomic_kind%natom = natom
-         IF (PRESENT(atom_list)) THEN
-            n = SIZE(atom_list)
-            IF (n > 0) THEN
-               IF (ASSOCIATED(atomic_kind%atom_list)) THEN
-                  DEALLOCATE (atomic_kind%atom_list)
-               END IF
-               ALLOCATE (atomic_kind%atom_list(n))
-               atomic_kind%atom_list(:) = atom_list(:)
-               atomic_kind%natom = n
-            ELSE
-               CPABORT("An invalid atom_list was supplied")
+      IF (PRESENT(element_symbol)) atomic_kind%element_symbol = element_symbol
+      IF (PRESENT(name)) atomic_kind%name = name
+      IF (PRESENT(mass)) atomic_kind%mass = mass
+      IF (PRESENT(kind_number)) atomic_kind%kind_number = kind_number
+      IF (PRESENT(natom)) atomic_kind%natom = natom
+      IF (PRESENT(atom_list)) THEN
+         n = SIZE(atom_list)
+         IF (n > 0) THEN
+            IF (ASSOCIATED(atomic_kind%atom_list)) THEN
+               DEALLOCATE (atomic_kind%atom_list)
             END IF
+            ALLOCATE (atomic_kind%atom_list(n))
+            atomic_kind%atom_list(:) = atom_list(:)
+            atomic_kind%natom = n
+         ELSE
+            CPABORT("An invalid atom_list was supplied")
          END IF
-         IF (PRESENT(fist_potential)) atomic_kind%fist_potential => fist_potential
-         IF (PRESENT(shell)) THEN
-            atomic_kind%shell => shell
-            CALL shell_retain(shell)
-         END IF
-         IF (PRESENT(shell_active)) atomic_kind%shell_active = shell_active
-
-         IF (PRESENT(damping)) atomic_kind%damping => damping
-
-      ELSE
-         CPABORT("The pointer atomic_kind is not associated")
       END IF
+      IF (PRESENT(fist_potential)) atomic_kind%fist_potential => fist_potential
+      IF (PRESENT(shell)) THEN
+         atomic_kind%shell => shell
+         CALL shell_retain(shell)
+      END IF
+      IF (PRESENT(shell_active)) atomic_kind%shell_active = shell_active
+
+      IF (PRESENT(damping)) atomic_kind%damping => damping
 
    END SUBROUTINE set_atomic_kind
 
@@ -386,7 +373,7 @@ CONTAINS
 !> \author Teodoro Laino [tlaino] - University of Zurich 10.2008
 ! **************************************************************************************************
    PURE FUNCTION is_hydrogen(atomic_kind) RESULT(res)
-      TYPE(atomic_kind_type), POINTER                    :: atomic_kind
+      TYPE(atomic_kind_type), INTENT(IN)                 :: atomic_kind
       LOGICAL                                            :: res
 
       res = TRIM(atomic_kind%element_symbol) == "H"

--- a/src/subsys/cell_types.F
+++ b/src/subsys/cell_types.F
@@ -97,10 +97,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cell_clone(cell_in, cell_out)
 
-      TYPE(cell_type), POINTER                           :: cell_in, cell_out
-
-      CPASSERT(ASSOCIATED(cell_in))
-      CPASSERT(ASSOCIATED(cell_out))
+      TYPE(cell_type), INTENT(IN)                        :: cell_in
+      TYPE(cell_type), INTENT(OUT)                       :: cell_out
 
       cell_out%deth = cell_in%deth
       cell_out%perd = cell_in%perd
@@ -121,10 +119,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cell_copy(cell_in, cell_out)
 
-      TYPE(cell_type), POINTER                           :: cell_in, cell_out
-
-      CPASSERT(ASSOCIATED(cell_in))
-      CPASSERT(ASSOCIATED(cell_out))
+      TYPE(cell_type), INTENT(IN)                        :: cell_in
+      TYPE(cell_type), INTENT(INOUT)                     :: cell_out
 
       cell_out%deth = cell_in%deth
       cell_out%perd = cell_in%perd
@@ -186,14 +182,14 @@ CONTAINS
    SUBROUTINE get_cell(cell, alpha, beta, gamma, deth, orthorhombic, abc, periodic, &
                        h, h_inv, id_nr, symmetry_id)
 
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
       REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: alpha, beta, gamma, deth
       LOGICAL, INTENT(OUT), OPTIONAL                     :: orthorhombic
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: abc
       INTEGER, DIMENSION(3), INTENT(OUT), OPTIONAL       :: periodic
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
          OPTIONAL                                        :: h, h_inv
-      INTEGER, INTENT(out), OPTIONAL                     :: id_nr, symmetry_id
+      INTEGER, INTENT(OUT), OPTIONAL                     :: id_nr, symmetry_id
 
       IF (PRESENT(deth)) deth = cell%deth ! the volume
       IF (PRESENT(orthorhombic)) orthorhombic = cell%orthorhombic
@@ -239,7 +235,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_cell_param(cell, cell_length, cell_angle, units_angle, periodic)
 
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: cell_length
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT), OPTIONAL :: cell_angle
       INTEGER, INTENT(IN), OPTIONAL                      :: units_angle
@@ -276,7 +272,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE set_cell_param(cell, cell_length, cell_angle, periodic, do_init_cell)
 
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(INOUT)                     :: cell
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: cell_length, cell_angle
       INTEGER, DIMENSION(3), INTENT(IN), OPTIONAL        :: periodic
       LOGICAL, INTENT(IN)                                :: do_init_cell
@@ -325,7 +321,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE init_cell(cell, hmat, periodic)
 
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(INOUT)                     :: cell
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN), &
          OPTIONAL                                        :: hmat
       INTEGER, DIMENSION(3), INTENT(IN), OPTIONAL        :: periodic
@@ -476,7 +472,7 @@ CONTAINS
    FUNCTION plane_distance(h, k, l, cell) RESULT(distance)
 
       INTEGER, INTENT(IN)                                :: h, k, l
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
       REAL(KIND=dp)                                      :: distance
 
       REAL(KIND=dp)                                      :: a, alpha, b, beta, c, cosa, cosb, cosg, &
@@ -540,7 +536,7 @@ CONTAINS
    FUNCTION pbc1(r, cell) RESULT(r_pbc)
 
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
       REAL(KIND=dp), DIMENSION(3)                        :: r_pbc
 
       REAL(KIND=dp), DIMENSION(3)                        :: s
@@ -577,7 +573,7 @@ CONTAINS
    FUNCTION pbc2(r, cell, nl) RESULT(r_pbc)
 
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
       INTEGER, DIMENSION(3), INTENT(IN)                  :: nl
       REAL(KIND=dp), DIMENSION(3)                        :: r_pbc
 
@@ -618,7 +614,7 @@ CONTAINS
    FUNCTION pbc3(ra, rb, cell) RESULT(rab_pbc)
 
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: ra, rb
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
       REAL(KIND=dp), DIMENSION(3)                        :: rab_pbc
 
       INTEGER                                            :: icell, jcell, kcell
@@ -663,7 +659,7 @@ CONTAINS
    FUNCTION pbc4(r, cell, positive_range) RESULT(r_pbc)
 
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
       LOGICAL                                            :: positive_range
       REAL(KIND=dp), DIMENSION(3)                        :: r_pbc
 
@@ -705,7 +701,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: s
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
 
       IF (cell%orthorhombic) THEN
          s(1) = cell%h_inv(1, 1)*r(1)
@@ -733,7 +729,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: r
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: s
-      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cell_type), INTENT(IN)                        :: cell
 
       IF (cell%orthorhombic) THEN
          r(1) = cell%hmat(1, 1)*s(1)

--- a/src/subsys/colvar_types.F
+++ b/src/subsys/colvar_types.F
@@ -530,12 +530,11 @@ CONTAINS
 !> \author Teodoro Laino, [teo] 09.03.2006
 ! **************************************************************************************************
    SUBROUTINE colvar_setup(colvar)
-      TYPE(colvar_type), POINTER                         :: colvar
+      TYPE(colvar_type), INTENT(INOUT)                   :: colvar
 
       INTEGER                                            :: i, idum, iend, ii, istart, j, np, stat
       INTEGER, DIMENSION(:), POINTER                     :: list
 
-      CPASSERT(ASSOCIATED(colvar))
       SELECT CASE (colvar%type_id)
       CASE (dist_colvar_id)
          np = 2
@@ -1028,7 +1027,7 @@ CONTAINS
 !> \author Dorothea Golze
 ! **************************************************************************************************
    SUBROUTINE setup_hydronium_colvars(colvar, colvar_id, list)
-      TYPE(colvar_type), POINTER                         :: colvar
+      TYPE(colvar_type), INTENT(INOUT)                   :: colvar
       INTEGER, INTENT(IN)                                :: colvar_id
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: list
 
@@ -1097,7 +1096,7 @@ CONTAINS
 !> \author Dorothea Golze
 ! **************************************************************************************************
    SUBROUTINE setup_acid_hydronium_colvars(colvar, colvar_id, list)
-      TYPE(colvar_type), POINTER                         :: colvar
+      TYPE(colvar_type), INTENT(INOUT)                   :: colvar
       INTEGER, INTENT(IN)                                :: colvar_id
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: list
 
@@ -1186,7 +1185,7 @@ CONTAINS
 !> \author Teodoro Laino - 03.2007
 ! **************************************************************************************************
    FUNCTION colv_size(colvar, i) RESULT(my_size)
-      TYPE(colvar_type), POINTER                         :: colvar
+      TYPE(colvar_type), INTENT(IN)                      :: colvar
       INTEGER                                            :: i, my_size
 
       my_size = 1
@@ -1382,13 +1381,13 @@ CONTAINS
 !> \author Teodoro Laino [tlaino] 04.2006
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE colvar_clone(colvar_out, colvar_in, i_atom_offset)
-      TYPE(colvar_type), POINTER                         :: colvar_out, colvar_in
+      TYPE(colvar_type), INTENT(INOUT), POINTER          :: colvar_out
+      TYPE(colvar_type), INTENT(IN)                      :: colvar_in
       INTEGER, INTENT(IN), OPTIONAL                      :: i_atom_offset
 
       INTEGER                                            :: i, my_offset, ndim, ndim2, stat
 
       my_offset = 0
-      CPASSERT(ASSOCIATED(colvar_in))
       CPASSERT(.NOT. ASSOCIATED(colvar_out))
       IF (PRESENT(i_atom_offset)) my_offset = i_atom_offset
       CALL colvar_create(colvar_out, colvar_in%type_id)
@@ -1794,7 +1793,8 @@ CONTAINS
 !> \author Teodoro Laino [tlaino] 03.2007
 ! **************************************************************************************************
    SUBROUTINE colvar_clone_points(colvar_out, colvar_in, offset)
-      TYPE(colvar_type), POINTER                         :: colvar_out, colvar_in
+      TYPE(colvar_type), INTENT(INOUT)                   :: colvar_out
+      TYPE(colvar_type), INTENT(IN)                      :: colvar_in
       INTEGER, INTENT(IN)                                :: offset
 
       INTEGER                                            :: i, natoms, npoints
@@ -1911,8 +1911,8 @@ CONTAINS
 !> \author Teodoro Laino - 03.2007
 ! **************************************************************************************************
    SUBROUTINE eval_point_pos(point, particles, r)
-      TYPE(point_type)                                   :: point
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particles
+      TYPE(point_type), INTENT(IN)                       :: point
+      TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: particles
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: r
 
       INTEGER                                            :: i
@@ -1936,8 +1936,8 @@ CONTAINS
 !> \param m ...
 ! **************************************************************************************************
    SUBROUTINE eval_point_mass(point, particles, m)
-      TYPE(point_type)                                   :: point
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particles
+      TYPE(point_type), INTENT(IN)                       :: point
+      TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: particles
       REAL(KIND=dp), INTENT(OUT)                         :: m
 
       INTEGER                                            :: i
@@ -1963,9 +1963,9 @@ CONTAINS
 !> \author Teodoro Laino - 03.2007
 ! **************************************************************************************************
    SUBROUTINE eval_point_der(points, i, dsdr, f)
-      TYPE(point_type), DIMENSION(:), POINTER            :: points
+      TYPE(point_type), DIMENSION(:), INTENT(IN)         :: points
       INTEGER, INTENT(IN)                                :: i
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: dsdr
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: dsdr
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: f
 
       INTEGER                                            :: ind, j
@@ -1998,7 +1998,7 @@ CONTAINS
 !> \author Teodoro Laino [tlaino] - University of Zurich 10.2008
 ! **************************************************************************************************
    FUNCTION diff_colvar(colvar, b) RESULT(diff)
-      TYPE(colvar_type), POINTER                         :: colvar
+      TYPE(colvar_type), INTENT(IN)                      :: colvar
       REAL(KIND=dp), INTENT(IN)                          :: b
       REAL(KIND=dp)                                      :: diff
 

--- a/src/subsys/cp_subsys_types.F
+++ b/src/subsys/cp_subsys_types.F
@@ -203,7 +203,7 @@ CONTAINS
    SUBROUTINE cp_subsys_set(subsys, atomic_kinds, particles, local_particles, &
                             molecules, molecule_kinds, local_molecules, para_env, &
                             colvar_p, shell_particles, core_particles, gci, multipoles, results, cell)
-      TYPE(cp_subsys_type), POINTER                      :: subsys
+      TYPE(cp_subsys_type), INTENT(INOUT)                :: subsys
       TYPE(atomic_kind_list_type), OPTIONAL, POINTER     :: atomic_kinds
       TYPE(particle_list_type), OPTIONAL, POINTER        :: particles
       TYPE(distribution_1d_type), OPTIONAL, POINTER      :: local_particles
@@ -219,7 +219,6 @@ CONTAINS
       TYPE(cp_result_type), OPTIONAL, POINTER            :: results
       TYPE(cell_type), OPTIONAL, POINTER                 :: cell
 
-      CPASSERT(ASSOCIATED(subsys))
       CPASSERT(subsys%ref_count > 0)
       IF (PRESENT(multipoles)) THEN
          CALL retain_multipole_type(multipoles)
@@ -340,7 +339,7 @@ CONTAINS
                             shell_particles, core_particles, gci, multipoles, &
                             natom, nparticle, ncore, nshell, nkind, atprop, virial, &
                             results, cell)
-      TYPE(cp_subsys_type), POINTER                      :: subsys
+      TYPE(cp_subsys_type), INTENT(IN)                   :: subsys
       INTEGER, INTENT(out), OPTIONAL                     :: ref_count
       TYPE(atomic_kind_list_type), OPTIONAL, POINTER     :: atomic_kinds
       TYPE(atomic_kind_type), DIMENSION(:), OPTIONAL, &
@@ -374,7 +373,6 @@ CONTAINS
       n_core = 0
       n_shell = 0
 
-      CPASSERT(ASSOCIATED(subsys))
       CPASSERT(subsys%ref_count > 0)
 
       IF (PRESENT(ref_count)) ref_count = subsys%ref_count
@@ -442,7 +440,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pack_subsys_particles(subsys, f, r, s, v, fscale, cell)
 
-      TYPE(cp_subsys_type), POINTER                      :: subsys
+      TYPE(cp_subsys_type), INTENT(IN)                   :: subsys
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT), OPTIONAL :: f, r, s, v
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: fscale
       TYPE(cell_type), OPTIONAL, POINTER                 :: cell
@@ -452,8 +450,6 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: rs
       TYPE(particle_list_type), POINTER                  :: core_particles, particles, &
                                                             shell_particles
-
-      CPASSERT(ASSOCIATED(subsys))
 
       IF (PRESENT(s)) THEN
          CPASSERT(PRESENT(cell))
@@ -594,7 +590,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE unpack_subsys_particles(subsys, f, r, s, v, fscale, cell)
 
-      TYPE(cp_subsys_type), POINTER                      :: subsys
+      TYPE(cp_subsys_type), INTENT(IN)                   :: subsys
       REAL(KIND=dp), DIMENSION(:), INTENT(IN), OPTIONAL  :: f, r, s, v
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: fscale
       TYPE(cell_type), OPTIONAL, POINTER                 :: cell
@@ -605,8 +601,6 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: rs
       TYPE(particle_list_type), POINTER                  :: core_particles, particles, &
                                                             shell_particles
-
-      CPASSERT(ASSOCIATED(subsys))
 
       NULLIFY (core_particles)
       NULLIFY (particles)

--- a/src/subsys/damping_dipole_types.F
+++ b/src/subsys/damping_dipole_types.F
@@ -101,7 +101,7 @@ CONTAINS
 !> \param damping ...
 ! **************************************************************************************************
    SUBROUTINE init_damping(damping)
-      TYPE(damping_type)                                 :: damping
+      TYPE(damping_type), INTENT(INOUT)                  :: damping
 
       damping%itype = no_damping
       damping%order = 1

--- a/src/subsys/external_potential_types.F
+++ b/src/subsys/external_potential_types.F
@@ -310,7 +310,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE allocate_all_potential(potential)
-      TYPE(all_potential_type), POINTER                  :: potential
+      TYPE(all_potential_type), INTENT(INOUT), POINTER   :: potential
 
       IF (ASSOCIATED(potential)) CALL deallocate_potential(potential)
 
@@ -330,7 +330,7 @@ CONTAINS
 !> \author  Toon.Verstraelen@gmail.com
 ! **************************************************************************************************
    SUBROUTINE allocate_fist_potential(potential)
-      TYPE(fist_potential_type), POINTER                 :: potential
+      TYPE(fist_potential_type), INTENT(INOUT), POINTER  :: potential
 
       IF (ASSOCIATED(potential)) CALL deallocate_potential(potential)
 
@@ -355,7 +355,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE allocate_local_potential(potential)
-      TYPE(local_potential_type), POINTER                :: potential
+      TYPE(local_potential_type), INTENT(INOUT), POINTER :: potential
 
       IF (ASSOCIATED(potential)) CALL deallocate_potential(potential)
 
@@ -379,7 +379,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE allocate_gth_potential(potential)
-      TYPE(gth_potential_type), POINTER                  :: potential
+      TYPE(gth_potential_type), INTENT(INOUT), POINTER   :: potential
 
       IF (ASSOCIATED(potential)) CALL deallocate_potential(potential)
 
@@ -417,7 +417,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE allocate_sgp_potential(potential)
-      TYPE(sgp_potential_type), POINTER                  :: potential
+      TYPE(sgp_potential_type), INTENT(INOUT), POINTER   :: potential
 
       IF (ASSOCIATED(potential)) CALL deallocate_potential(potential)
 
@@ -473,12 +473,12 @@ CONTAINS
    SUBROUTINE deallocate_all_potential(potential)
       TYPE(all_potential_type), POINTER                  :: potential
 
-      IF (ASSOCIATED(potential)) THEN
-         DEALLOCATE (potential%elec_conf)
-         DEALLOCATE (potential)
-      ELSE
+      IF (.NOT. ASSOCIATED(potential)) THEN
          CPABORT("The pointer potential is not associated.")
       END IF
+
+      DEALLOCATE (potential%elec_conf)
+      DEALLOCATE (potential)
 
    END SUBROUTINE deallocate_all_potential
 
@@ -491,12 +491,12 @@ CONTAINS
    SUBROUTINE deallocate_fist_potential(potential)
       TYPE(fist_potential_type), POINTER                 :: potential
 
-      IF (ASSOCIATED(potential)) THEN
-         ! Nothing exciting here yet.
-         DEALLOCATE (potential)
-      ELSE
+      IF (.NOT. ASSOCIATED(potential)) THEN
          CPABORT("The pointer potential is not associated.")
       END IF
+
+      ! Nothing exciting here yet.
+      DEALLOCATE (potential)
 
    END SUBROUTINE deallocate_fist_potential
 
@@ -510,22 +510,18 @@ CONTAINS
    SUBROUTINE deallocate_local_potential(potential)
       TYPE(local_potential_type), POINTER                :: potential
 
-      IF (ASSOCIATED(potential)) THEN
-
-         IF (ASSOCIATED(potential%alpha)) THEN
-            DEALLOCATE (potential%alpha)
-         END IF
-         IF (ASSOCIATED(potential%cval)) THEN
-            DEALLOCATE (potential%cval)
-         END IF
-
-         DEALLOCATE (potential)
-
-      ELSE
-
+      IF (.NOT. ASSOCIATED(potential)) THEN
          CPABORT("The pointer potential is not associated.")
-
       END IF
+
+      IF (ASSOCIATED(potential%alpha)) THEN
+         DEALLOCATE (potential%alpha)
+      END IF
+      IF (ASSOCIATED(potential%cval)) THEN
+         DEALLOCATE (potential%cval)
+      END IF
+
+      DEALLOCATE (potential)
 
    END SUBROUTINE deallocate_local_potential
 
@@ -539,48 +535,46 @@ CONTAINS
    SUBROUTINE deallocate_gth_potential(potential)
       TYPE(gth_potential_type), POINTER                  :: potential
 
-      IF (ASSOCIATED(potential)) THEN
-
-         DEALLOCATE (potential%elec_conf)
-         !     *** Deallocate the parameters of the local part ***
-
-         IF (ASSOCIATED(potential%cexp_ppl)) THEN
-            DEALLOCATE (potential%cexp_ppl)
-         END IF
-
-         !     *** Deallocate the parameters of the non-local part ***
-         IF (ASSOCIATED(potential%alpha_ppnl)) THEN
-            DEALLOCATE (potential%alpha_ppnl)
-            DEALLOCATE (potential%cprj)
-            DEALLOCATE (potential%cprj_ppnl)
-            DEALLOCATE (potential%hprj_ppnl)
-            DEALLOCATE (potential%nprj_ppnl)
-            DEALLOCATE (potential%vprj_ppnl)
-         END IF
-
-         IF (ASSOCIATED(potential%alpha_lpot)) THEN
-            DEALLOCATE (potential%alpha_lpot)
-            DEALLOCATE (potential%nct_lpot)
-            DEALLOCATE (potential%cval_lpot)
-         END IF
-
-         IF (ASSOCIATED(potential%alpha_lsd)) THEN
-            DEALLOCATE (potential%alpha_lsd)
-            DEALLOCATE (potential%nct_lsd)
-            DEALLOCATE (potential%cval_lsd)
-         END IF
-
-         IF (ASSOCIATED(potential%alpha_nlcc)) THEN
-            DEALLOCATE (potential%alpha_nlcc)
-            DEALLOCATE (potential%nct_nlcc)
-            DEALLOCATE (potential%cval_nlcc)
-         END IF
-
-         DEALLOCATE (potential)
-      ELSE
+      IF (.NOT. ASSOCIATED(potential)) THEN
          CPABORT("The pointer potential is not associated.")
       END IF
 
+      DEALLOCATE (potential%elec_conf)
+      !     *** Deallocate the parameters of the local part ***
+
+      IF (ASSOCIATED(potential%cexp_ppl)) THEN
+         DEALLOCATE (potential%cexp_ppl)
+      END IF
+
+      !     *** Deallocate the parameters of the non-local part ***
+      IF (ASSOCIATED(potential%alpha_ppnl)) THEN
+         DEALLOCATE (potential%alpha_ppnl)
+         DEALLOCATE (potential%cprj)
+         DEALLOCATE (potential%cprj_ppnl)
+         DEALLOCATE (potential%hprj_ppnl)
+         DEALLOCATE (potential%nprj_ppnl)
+         DEALLOCATE (potential%vprj_ppnl)
+      END IF
+
+      IF (ASSOCIATED(potential%alpha_lpot)) THEN
+         DEALLOCATE (potential%alpha_lpot)
+         DEALLOCATE (potential%nct_lpot)
+         DEALLOCATE (potential%cval_lpot)
+      END IF
+
+      IF (ASSOCIATED(potential%alpha_lsd)) THEN
+         DEALLOCATE (potential%alpha_lsd)
+         DEALLOCATE (potential%nct_lsd)
+         DEALLOCATE (potential%cval_lsd)
+      END IF
+
+      IF (ASSOCIATED(potential%alpha_nlcc)) THEN
+         DEALLOCATE (potential%alpha_nlcc)
+         DEALLOCATE (potential%nct_nlcc)
+         DEALLOCATE (potential%cval_nlcc)
+      END IF
+
+      DEALLOCATE (potential)
    END SUBROUTINE deallocate_gth_potential
 
 ! **************************************************************************************************
@@ -590,44 +584,44 @@ CONTAINS
    SUBROUTINE deallocate_sgp_potential(potential)
       TYPE(sgp_potential_type), POINTER                  :: potential
 
-      IF (ASSOCIATED(potential)) THEN
-         IF (ASSOCIATED(potential%elec_conf)) THEN
-            DEALLOCATE (potential%elec_conf)
-         END IF
-         IF (ASSOCIATED(potential%a_local)) THEN
-            DEALLOCATE (potential%a_local)
-         END IF
-         IF (ASSOCIATED(potential%c_local)) THEN
-            DEALLOCATE (potential%c_local)
-         END IF
-
-         IF (ASSOCIATED(potential%a_nonlocal)) THEN
-            DEALLOCATE (potential%a_nonlocal)
-         END IF
-         IF (ASSOCIATED(potential%h_nonlocal)) THEN
-            DEALLOCATE (potential%h_nonlocal)
-         END IF
-         IF (ASSOCIATED(potential%c_nonlocal)) THEN
-            DEALLOCATE (potential%c_nonlocal)
-         END IF
-         IF (ASSOCIATED(potential%cprj_ppnl)) THEN
-            DEALLOCATE (potential%cprj_ppnl)
-         END IF
-         IF (ASSOCIATED(potential%vprj_ppnl)) THEN
-            DEALLOCATE (potential%vprj_ppnl)
-         END IF
-
-         IF (ASSOCIATED(potential%a_nlcc)) THEN
-            DEALLOCATE (potential%a_nlcc)
-         END IF
-         IF (ASSOCIATED(potential%c_nlcc)) THEN
-            DEALLOCATE (potential%c_nlcc)
-         END IF
-
-         DEALLOCATE (potential)
-      ELSE
+      IF (.NOT. ASSOCIATED(potential)) THEN
          CPABORT("The pointer potential is not associated.")
       END IF
+
+      IF (ASSOCIATED(potential%elec_conf)) THEN
+         DEALLOCATE (potential%elec_conf)
+      END IF
+      IF (ASSOCIATED(potential%a_local)) THEN
+         DEALLOCATE (potential%a_local)
+      END IF
+      IF (ASSOCIATED(potential%c_local)) THEN
+         DEALLOCATE (potential%c_local)
+      END IF
+
+      IF (ASSOCIATED(potential%a_nonlocal)) THEN
+         DEALLOCATE (potential%a_nonlocal)
+      END IF
+      IF (ASSOCIATED(potential%h_nonlocal)) THEN
+         DEALLOCATE (potential%h_nonlocal)
+      END IF
+      IF (ASSOCIATED(potential%c_nonlocal)) THEN
+         DEALLOCATE (potential%c_nonlocal)
+      END IF
+      IF (ASSOCIATED(potential%cprj_ppnl)) THEN
+         DEALLOCATE (potential%cprj_ppnl)
+      END IF
+      IF (ASSOCIATED(potential%vprj_ppnl)) THEN
+         DEALLOCATE (potential%vprj_ppnl)
+      END IF
+
+      IF (ASSOCIATED(potential%a_nlcc)) THEN
+         DEALLOCATE (potential%a_nlcc)
+      END IF
+      IF (ASSOCIATED(potential%c_nlcc)) THEN
+         DEALLOCATE (potential%c_nlcc)
+      END IF
+
+      DEALLOCATE (potential)
 
    END SUBROUTINE deallocate_sgp_potential
 
@@ -3090,10 +3084,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE copy_sgp_potential(pot_in, pot_out)
 
-      TYPE(sgp_potential_type), INTENT(IN), POINTER      :: pot_in
+      TYPE(sgp_potential_type), INTENT(IN)               :: pot_in
       TYPE(sgp_potential_type), INTENT(INOUT), POINTER   :: pot_out
 
-      CPASSERT(ASSOCIATED(pot_in))
       CALL allocate_sgp_potential(pot_out)
 
       pot_out%name = pot_in%name

--- a/src/subsys/molecule_kind_types.F
+++ b/src/subsys/molecule_kind_types.F
@@ -571,7 +571,7 @@ CONTAINS
                                 ub_kind_set, impr_kind_set, opbend_kind_set, torsion_kind_set, &
                                 molname_generated)
 
-      TYPE(molecule_kind_type), POINTER                  :: molecule_kind
+      TYPE(molecule_kind_type), INTENT(IN)               :: molecule_kind
       TYPE(atom_type), DIMENSION(:), OPTIONAL, POINTER   :: atom_list
       TYPE(bond_type), DIMENSION(:), OPTIONAL, POINTER   :: bond_list
       TYPE(bend_type), DIMENSION(:), OPTIONAL, POINTER   :: bend_list
@@ -619,87 +619,79 @@ CONTAINS
 
       INTEGER                                            :: i
 
-      IF (ASSOCIATED(molecule_kind)) THEN
-
-         IF (PRESENT(atom_list)) atom_list => molecule_kind%atom_list
-         IF (PRESENT(bend_list)) bend_list => molecule_kind%bend_list
-         IF (PRESENT(bond_list)) bond_list => molecule_kind%bond_list
-         IF (PRESENT(impr_list)) impr_list => molecule_kind%impr_list
-         IF (PRESENT(opbend_list)) opbend_list => molecule_kind%opbend_list
-         IF (PRESENT(ub_list)) ub_list => molecule_kind%ub_list
-         IF (PRESENT(bond_kind_set)) bond_kind_set => molecule_kind%bond_kind_set
-         IF (PRESENT(bend_kind_set)) bend_kind_set => molecule_kind%bend_kind_set
-         IF (PRESENT(ub_kind_set)) ub_kind_set => molecule_kind%ub_kind_set
-         IF (PRESENT(impr_kind_set)) impr_kind_set => molecule_kind%impr_kind_set
-         IF (PRESENT(opbend_kind_set)) opbend_kind_set => molecule_kind%opbend_kind_set
-         IF (PRESENT(torsion_kind_set)) torsion_kind_set => molecule_kind%torsion_kind_set
-         IF (PRESENT(colv_list)) colv_list => molecule_kind%colv_list
-         IF (PRESENT(g3x3_list)) g3x3_list => molecule_kind%g3x3_list
-         IF (PRESENT(g4x6_list)) g4x6_list => molecule_kind%g4x6_list
-         IF (PRESENT(vsite_list)) vsite_list => molecule_kind%vsite_list
-         IF (PRESENT(fixd_list)) fixd_list => molecule_kind%fixd_list
-         IF (PRESENT(torsion_list)) torsion_list => molecule_kind%torsion_list
-         IF (PRESENT(shell_list)) shell_list => molecule_kind%shell_list
-         IF (PRESENT(name)) name = molecule_kind%name
-         IF (PRESENT(molname_generated)) molname_generated = molecule_kind%molname_generated
-         IF (PRESENT(mass)) mass = molecule_kind%mass
-         IF (PRESENT(charge)) charge = molecule_kind%charge
-         IF (PRESENT(kind_number)) kind_number = molecule_kind%kind_number
-         IF (PRESENT(natom)) natom = molecule_kind%natom
-         IF (PRESENT(nbend)) nbend = molecule_kind%nbend
-         IF (PRESENT(nbond)) nbond = molecule_kind%nbond
-         IF (PRESENT(nub)) nub = molecule_kind%nub
-         IF (PRESENT(nimpr)) nimpr = molecule_kind%nimpr
-         IF (PRESENT(nopbend)) nopbend = molecule_kind%nopbend
-         IF (PRESENT(nconstraint)) nconstraint = (molecule_kind%ncolv%ntot - molecule_kind%ncolv%nrestraint) + &
-                                                 3*(molecule_kind%ng3x3 - molecule_kind%ng3x3_restraint) + &
-                                                 6*(molecule_kind%ng4x6 - molecule_kind%ng4x6_restraint) + &
-                                                 3*(molecule_kind%nvsite - molecule_kind%nvsite_restraint)
-         IF (PRESENT(ncolv)) ncolv = molecule_kind%ncolv
-         IF (PRESENT(ng3x3)) ng3x3 = molecule_kind%ng3x3
-         IF (PRESENT(ng4x6)) ng4x6 = molecule_kind%ng4x6
-         IF (PRESENT(nvsite)) nvsite = molecule_kind%nvsite
-         ! Number of atoms that have one or more components fixed
-         IF (PRESENT(nfixd)) nfixd = molecule_kind%nfixd
-         ! Number of degrees of freedom fixed
-         IF (PRESENT(nconstraint_fixd)) THEN
-            nconstraint_fixd = 0
-            IF (molecule_kind%nfixd /= 0) THEN
-               DO i = 1, SIZE(molecule_kind%fixd_list)
-                  IF (molecule_kind%fixd_list(i)%restraint%active) CYCLE
-                  SELECT CASE (molecule_kind%fixd_list(i)%itype)
-                  CASE (use_perd_x, use_perd_y, use_perd_z)
-                     nconstraint_fixd = nconstraint_fixd + 1
-                  CASE (use_perd_xy, use_perd_xz, use_perd_yz)
-                     nconstraint_fixd = nconstraint_fixd + 2
-                  CASE (use_perd_xyz)
-                     nconstraint_fixd = nconstraint_fixd + 3
-                  END SELECT
-               END DO
-            END IF
+      IF (PRESENT(atom_list)) atom_list => molecule_kind%atom_list
+      IF (PRESENT(bend_list)) bend_list => molecule_kind%bend_list
+      IF (PRESENT(bond_list)) bond_list => molecule_kind%bond_list
+      IF (PRESENT(impr_list)) impr_list => molecule_kind%impr_list
+      IF (PRESENT(opbend_list)) opbend_list => molecule_kind%opbend_list
+      IF (PRESENT(ub_list)) ub_list => molecule_kind%ub_list
+      IF (PRESENT(bond_kind_set)) bond_kind_set => molecule_kind%bond_kind_set
+      IF (PRESENT(bend_kind_set)) bend_kind_set => molecule_kind%bend_kind_set
+      IF (PRESENT(ub_kind_set)) ub_kind_set => molecule_kind%ub_kind_set
+      IF (PRESENT(impr_kind_set)) impr_kind_set => molecule_kind%impr_kind_set
+      IF (PRESENT(opbend_kind_set)) opbend_kind_set => molecule_kind%opbend_kind_set
+      IF (PRESENT(torsion_kind_set)) torsion_kind_set => molecule_kind%torsion_kind_set
+      IF (PRESENT(colv_list)) colv_list => molecule_kind%colv_list
+      IF (PRESENT(g3x3_list)) g3x3_list => molecule_kind%g3x3_list
+      IF (PRESENT(g4x6_list)) g4x6_list => molecule_kind%g4x6_list
+      IF (PRESENT(vsite_list)) vsite_list => molecule_kind%vsite_list
+      IF (PRESENT(fixd_list)) fixd_list => molecule_kind%fixd_list
+      IF (PRESENT(torsion_list)) torsion_list => molecule_kind%torsion_list
+      IF (PRESENT(shell_list)) shell_list => molecule_kind%shell_list
+      IF (PRESENT(name)) name = molecule_kind%name
+      IF (PRESENT(molname_generated)) molname_generated = molecule_kind%molname_generated
+      IF (PRESENT(mass)) mass = molecule_kind%mass
+      IF (PRESENT(charge)) charge = molecule_kind%charge
+      IF (PRESENT(kind_number)) kind_number = molecule_kind%kind_number
+      IF (PRESENT(natom)) natom = molecule_kind%natom
+      IF (PRESENT(nbend)) nbend = molecule_kind%nbend
+      IF (PRESENT(nbond)) nbond = molecule_kind%nbond
+      IF (PRESENT(nub)) nub = molecule_kind%nub
+      IF (PRESENT(nimpr)) nimpr = molecule_kind%nimpr
+      IF (PRESENT(nopbend)) nopbend = molecule_kind%nopbend
+      IF (PRESENT(nconstraint)) nconstraint = (molecule_kind%ncolv%ntot - molecule_kind%ncolv%nrestraint) + &
+                                              3*(molecule_kind%ng3x3 - molecule_kind%ng3x3_restraint) + &
+                                              6*(molecule_kind%ng4x6 - molecule_kind%ng4x6_restraint) + &
+                                              3*(molecule_kind%nvsite - molecule_kind%nvsite_restraint)
+      IF (PRESENT(ncolv)) ncolv = molecule_kind%ncolv
+      IF (PRESENT(ng3x3)) ng3x3 = molecule_kind%ng3x3
+      IF (PRESENT(ng4x6)) ng4x6 = molecule_kind%ng4x6
+      IF (PRESENT(nvsite)) nvsite = molecule_kind%nvsite
+      ! Number of atoms that have one or more components fixed
+      IF (PRESENT(nfixd)) nfixd = molecule_kind%nfixd
+      ! Number of degrees of freedom fixed
+      IF (PRESENT(nconstraint_fixd)) THEN
+         nconstraint_fixd = 0
+         IF (molecule_kind%nfixd /= 0) THEN
+            DO i = 1, SIZE(molecule_kind%fixd_list)
+               IF (molecule_kind%fixd_list(i)%restraint%active) CYCLE
+               SELECT CASE (molecule_kind%fixd_list(i)%itype)
+               CASE (use_perd_x, use_perd_y, use_perd_z)
+                  nconstraint_fixd = nconstraint_fixd + 1
+               CASE (use_perd_xy, use_perd_xz, use_perd_yz)
+                  nconstraint_fixd = nconstraint_fixd + 2
+               CASE (use_perd_xyz)
+                  nconstraint_fixd = nconstraint_fixd + 3
+               END SELECT
+            END DO
          END IF
-         IF (PRESENT(ng3x3_restraint)) ng3x3_restraint = molecule_kind%ng3x3_restraint
-         IF (PRESENT(ng4x6_restraint)) ng4x6_restraint = molecule_kind%ng4x6_restraint
-         IF (PRESENT(nvsite_restraint)) nvsite_restraint = molecule_kind%nvsite_restraint
-         IF (PRESENT(nfixd_restraint)) nfixd_restraint = molecule_kind%nfixd_restraint
-         IF (PRESENT(nrestraints)) nrestraints = molecule_kind%ncolv%nrestraint + &
-                                                 molecule_kind%ng3x3_restraint + &
-                                                 molecule_kind%ng4x6_restraint + &
-                                                 molecule_kind%nvsite_restraint
-         IF (PRESENT(nmolecule)) nmolecule = molecule_kind%nmolecule
-         IF (PRESENT(nshell)) nshell = molecule_kind%nshell
-         IF (PRESENT(ntorsion)) ntorsion = molecule_kind%ntorsion
-         IF (PRESENT(nsgf)) nsgf = molecule_kind%nsgf
-         IF (PRESENT(nelectron)) nelectron = molecule_kind%nelectron
-         IF (PRESENT(nelectron_alpha)) nelectron_alpha = molecule_kind%nelectron_beta
-         IF (PRESENT(nelectron_beta)) nelectron_beta = molecule_kind%nelectron_alpha
-         IF (PRESENT(molecule_list)) molecule_list => molecule_kind%molecule_list
-
-      ELSE
-
-         CPABORT("The pointer molecule_kind is not associated")
-
       END IF
+      IF (PRESENT(ng3x3_restraint)) ng3x3_restraint = molecule_kind%ng3x3_restraint
+      IF (PRESENT(ng4x6_restraint)) ng4x6_restraint = molecule_kind%ng4x6_restraint
+      IF (PRESENT(nvsite_restraint)) nvsite_restraint = molecule_kind%nvsite_restraint
+      IF (PRESENT(nfixd_restraint)) nfixd_restraint = molecule_kind%nfixd_restraint
+      IF (PRESENT(nrestraints)) nrestraints = molecule_kind%ncolv%nrestraint + &
+                                              molecule_kind%ng3x3_restraint + &
+                                              molecule_kind%ng4x6_restraint + &
+                                              molecule_kind%nvsite_restraint
+      IF (PRESENT(nmolecule)) nmolecule = molecule_kind%nmolecule
+      IF (PRESENT(nshell)) nshell = molecule_kind%nshell
+      IF (PRESENT(ntorsion)) ntorsion = molecule_kind%ntorsion
+      IF (PRESENT(nsgf)) nsgf = molecule_kind%nsgf
+      IF (PRESENT(nelectron)) nelectron = molecule_kind%nelectron
+      IF (PRESENT(nelectron_alpha)) nelectron_alpha = molecule_kind%nelectron_beta
+      IF (PRESENT(nelectron_beta)) nelectron_beta = molecule_kind%nelectron_alpha
+      IF (PRESENT(molecule_list)) molecule_list => molecule_kind%molecule_list
 
    END SUBROUTINE get_molecule_kind
 
@@ -727,7 +719,7 @@ CONTAINS
                                     nconstraint, nconstraint_fixd, nmolecule, &
                                     nrestraints)
 
-      TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
+      TYPE(molecule_kind_type), DIMENSION(:), INTENT(IN) :: molecule_kind_set
       INTEGER, INTENT(OUT), OPTIONAL                     :: maxatom, natom, nbond, nbend, nub, &
                                                             ntorsion, nimpr, nopbend, nconstraint, &
                                                             nconstraint_fixd, nmolecule, &
@@ -735,28 +727,24 @@ CONTAINS
 
       INTEGER :: ibend, ibond, iimpr, imolecule_kind, iopbend, itorsion, iub, na, nc, nc_fixd, &
          nfixd_restraint, nm, nmolecule_kind, nrestraints_tot
-      TYPE(molecule_kind_type), POINTER                  :: molecule_kind
 
-      IF (ASSOCIATED(molecule_kind_set)) THEN
+      IF (PRESENT(maxatom)) maxatom = 0
+      IF (PRESENT(natom)) natom = 0
+      IF (PRESENT(nbond)) nbond = 0
+      IF (PRESENT(nbend)) nbend = 0
+      IF (PRESENT(nub)) nub = 0
+      IF (PRESENT(ntorsion)) ntorsion = 0
+      IF (PRESENT(nimpr)) nimpr = 0
+      IF (PRESENT(nopbend)) nopbend = 0
+      IF (PRESENT(nconstraint)) nconstraint = 0
+      IF (PRESENT(nconstraint_fixd)) nconstraint_fixd = 0
+      IF (PRESENT(nrestraints)) nrestraints = 0
+      IF (PRESENT(nmolecule)) nmolecule = 0
 
-         IF (PRESENT(maxatom)) maxatom = 0
-         IF (PRESENT(natom)) natom = 0
-         IF (PRESENT(nbond)) nbond = 0
-         IF (PRESENT(nbend)) nbend = 0
-         IF (PRESENT(nub)) nub = 0
-         IF (PRESENT(ntorsion)) ntorsion = 0
-         IF (PRESENT(nimpr)) nimpr = 0
-         IF (PRESENT(nopbend)) nopbend = 0
-         IF (PRESENT(nconstraint)) nconstraint = 0
-         IF (PRESENT(nconstraint_fixd)) nconstraint_fixd = 0
-         IF (PRESENT(nrestraints)) nrestraints = 0
-         IF (PRESENT(nmolecule)) nmolecule = 0
+      nmolecule_kind = SIZE(molecule_kind_set)
 
-         nmolecule_kind = SIZE(molecule_kind_set)
-
-         DO imolecule_kind = 1, nmolecule_kind
-
-            molecule_kind => molecule_kind_set(imolecule_kind)
+      DO imolecule_kind = 1, nmolecule_kind
+         ASSOCIATE (molecule_kind=>molecule_kind_set(imolecule_kind))
 
             CALL get_molecule_kind(molecule_kind=molecule_kind, &
                                    natom=na, &
@@ -784,13 +772,8 @@ CONTAINS
             IF (PRESENT(nmolecule)) nmolecule = nmolecule + nm
             IF (PRESENT(nrestraints)) nrestraints = nrestraints + nm*nrestraints_tot + nfixd_restraint
 
-         END DO
-
-      ELSE
-
-         CPABORT("The pointer molecule_kind_set is not associated")
-
-      END IF
+         END ASSOCIATE
+      END DO
 
    END SUBROUTINE get_molecule_kind_set
 
@@ -857,7 +840,7 @@ CONTAINS
                                 opbend_kind_set, nelectron, nsgf, &
                                 molname_generated)
 
-      TYPE(molecule_kind_type), POINTER                  :: molecule_kind
+      TYPE(molecule_kind_type), INTENT(INOUT)            :: molecule_kind
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: name
       REAL(KIND=dp), OPTIONAL                            :: mass, charge
       INTEGER, INTENT(IN), OPTIONAL                      :: kind_number
@@ -911,66 +894,57 @@ CONTAINS
 
       INTEGER                                            :: n
 
-      IF (ASSOCIATED(molecule_kind)) THEN
-
-         IF (PRESENT(atom_list)) THEN
-            n = SIZE(atom_list)
-            molecule_kind%natom = n
-            molecule_kind%atom_list => atom_list
-         END IF
-         IF (PRESENT(molname_generated)) molecule_kind%molname_generated = molname_generated
-         IF (PRESENT(name)) molecule_kind%name = name
-         IF (PRESENT(mass)) molecule_kind%mass = mass
-         IF (PRESENT(charge)) molecule_kind%charge = charge
-         IF (PRESENT(kind_number)) molecule_kind%kind_number = kind_number
-         IF (PRESENT(nbond)) molecule_kind%nbond = nbond
-         IF (PRESENT(bond_list)) molecule_kind%bond_list => bond_list
-         IF (PRESENT(nbend)) molecule_kind%nbend = nbend
-         IF (PRESENT(nelectron)) molecule_kind%nelectron = nelectron
-         IF (PRESENT(nsgf)) molecule_kind%nsgf = nsgf
-         IF (PRESENT(bend_list)) molecule_kind%bend_list => bend_list
-         IF (PRESENT(nub)) molecule_kind%nub = nub
-         IF (PRESENT(ub_list)) molecule_kind%ub_list => ub_list
-         IF (PRESENT(ntorsion)) molecule_kind%ntorsion = ntorsion
-         IF (PRESENT(torsion_list)) molecule_kind%torsion_list => torsion_list
-         IF (PRESENT(nimpr)) molecule_kind%nimpr = nimpr
-         IF (PRESENT(impr_list)) molecule_kind%impr_list => impr_list
-         IF (PRESENT(nopbend)) molecule_kind%nopbend = nopbend
-         IF (PRESENT(opbend_list)) molecule_kind%opbend_list => opbend_list
-         IF (PRESENT(ncolv)) molecule_kind%ncolv = ncolv
-         IF (PRESENT(colv_list)) molecule_kind%colv_list => colv_list
-         IF (PRESENT(ng3x3)) molecule_kind%ng3x3 = ng3x3
-         IF (PRESENT(g3x3_list)) molecule_kind%g3x3_list => g3x3_list
-         IF (PRESENT(ng4x6)) molecule_kind%ng4x6 = ng4x6
-         IF (PRESENT(nvsite)) molecule_kind%nvsite = nvsite
-         IF (PRESENT(nfixd)) molecule_kind%nfixd = nfixd
-         IF (PRESENT(nfixd_restraint)) molecule_kind%nfixd_restraint = nfixd_restraint
-         IF (PRESENT(ng3x3_restraint)) molecule_kind%ng3x3_restraint = ng3x3_restraint
-         IF (PRESENT(ng4x6_restraint)) molecule_kind%ng4x6_restraint = ng4x6_restraint
-         IF (PRESENT(nvsite_restraint)) molecule_kind%nvsite_restraint = nvsite_restraint
-         IF (PRESENT(g4x6_list)) molecule_kind%g4x6_list => g4x6_list
-         IF (PRESENT(vsite_list)) molecule_kind%vsite_list => vsite_list
-         IF (PRESENT(fixd_list)) molecule_kind%fixd_list => fixd_list
-         IF (PRESENT(bond_kind_set)) molecule_kind%bond_kind_set => bond_kind_set
-         IF (PRESENT(bend_kind_set)) molecule_kind%bend_kind_set => bend_kind_set
-         IF (PRESENT(ub_kind_set)) molecule_kind%ub_kind_set => ub_kind_set
-         IF (PRESENT(torsion_kind_set)) molecule_kind%torsion_kind_set => torsion_kind_set
-         IF (PRESENT(impr_kind_set)) molecule_kind%impr_kind_set => impr_kind_set
-         IF (PRESENT(opbend_kind_set)) molecule_kind%opbend_kind_set => opbend_kind_set
-         IF (PRESENT(nshell)) molecule_kind%nshell = nshell
-         IF (PRESENT(shell_list)) molecule_kind%shell_list => shell_list
-         IF (PRESENT(molecule_list)) THEN
-            n = SIZE(molecule_list)
-            molecule_kind%nmolecule = n
-            molecule_kind%molecule_list => molecule_list
-         END IF
-
-      ELSE
-
-         CPABORT("The pointer molecule_kind is not associated")
-
+      IF (PRESENT(atom_list)) THEN
+         n = SIZE(atom_list)
+         molecule_kind%natom = n
+         molecule_kind%atom_list => atom_list
       END IF
-
+      IF (PRESENT(molname_generated)) molecule_kind%molname_generated = molname_generated
+      IF (PRESENT(name)) molecule_kind%name = name
+      IF (PRESENT(mass)) molecule_kind%mass = mass
+      IF (PRESENT(charge)) molecule_kind%charge = charge
+      IF (PRESENT(kind_number)) molecule_kind%kind_number = kind_number
+      IF (PRESENT(nbond)) molecule_kind%nbond = nbond
+      IF (PRESENT(bond_list)) molecule_kind%bond_list => bond_list
+      IF (PRESENT(nbend)) molecule_kind%nbend = nbend
+      IF (PRESENT(nelectron)) molecule_kind%nelectron = nelectron
+      IF (PRESENT(nsgf)) molecule_kind%nsgf = nsgf
+      IF (PRESENT(bend_list)) molecule_kind%bend_list => bend_list
+      IF (PRESENT(nub)) molecule_kind%nub = nub
+      IF (PRESENT(ub_list)) molecule_kind%ub_list => ub_list
+      IF (PRESENT(ntorsion)) molecule_kind%ntorsion = ntorsion
+      IF (PRESENT(torsion_list)) molecule_kind%torsion_list => torsion_list
+      IF (PRESENT(nimpr)) molecule_kind%nimpr = nimpr
+      IF (PRESENT(impr_list)) molecule_kind%impr_list => impr_list
+      IF (PRESENT(nopbend)) molecule_kind%nopbend = nopbend
+      IF (PRESENT(opbend_list)) molecule_kind%opbend_list => opbend_list
+      IF (PRESENT(ncolv)) molecule_kind%ncolv = ncolv
+      IF (PRESENT(colv_list)) molecule_kind%colv_list => colv_list
+      IF (PRESENT(ng3x3)) molecule_kind%ng3x3 = ng3x3
+      IF (PRESENT(g3x3_list)) molecule_kind%g3x3_list => g3x3_list
+      IF (PRESENT(ng4x6)) molecule_kind%ng4x6 = ng4x6
+      IF (PRESENT(nvsite)) molecule_kind%nvsite = nvsite
+      IF (PRESENT(nfixd)) molecule_kind%nfixd = nfixd
+      IF (PRESENT(nfixd_restraint)) molecule_kind%nfixd_restraint = nfixd_restraint
+      IF (PRESENT(ng3x3_restraint)) molecule_kind%ng3x3_restraint = ng3x3_restraint
+      IF (PRESENT(ng4x6_restraint)) molecule_kind%ng4x6_restraint = ng4x6_restraint
+      IF (PRESENT(nvsite_restraint)) molecule_kind%nvsite_restraint = nvsite_restraint
+      IF (PRESENT(g4x6_list)) molecule_kind%g4x6_list => g4x6_list
+      IF (PRESENT(vsite_list)) molecule_kind%vsite_list => vsite_list
+      IF (PRESENT(fixd_list)) molecule_kind%fixd_list => fixd_list
+      IF (PRESENT(bond_kind_set)) molecule_kind%bond_kind_set => bond_kind_set
+      IF (PRESENT(bend_kind_set)) molecule_kind%bend_kind_set => bend_kind_set
+      IF (PRESENT(ub_kind_set)) molecule_kind%ub_kind_set => ub_kind_set
+      IF (PRESENT(torsion_kind_set)) molecule_kind%torsion_kind_set => torsion_kind_set
+      IF (PRESENT(impr_kind_set)) molecule_kind%impr_kind_set => impr_kind_set
+      IF (PRESENT(opbend_kind_set)) molecule_kind%opbend_kind_set => opbend_kind_set
+      IF (PRESENT(nshell)) molecule_kind%nshell = nshell
+      IF (PRESENT(shell_list)) molecule_kind%shell_list => shell_list
+      IF (PRESENT(molecule_list)) THEN
+         n = SIZE(molecule_list)
+         molecule_kind%nmolecule = n
+         molecule_kind%molecule_list => molecule_list
+      END IF
    END SUBROUTINE set_molecule_kind
 
 ! **************************************************************************************************
@@ -982,7 +956,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE write_molecule_kind(molecule_kind, output_unit)
-      TYPE(molecule_kind_type), POINTER                  :: molecule_kind
+      TYPE(molecule_kind_type), INTENT(IN)               :: molecule_kind
       INTEGER, INTENT(in)                                :: output_unit
 
       CHARACTER(LEN=default_string_length)               :: name
@@ -990,62 +964,56 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
 
       IF (output_unit > 0) THEN
-         IF (ASSOCIATED(molecule_kind)) THEN
-            natom = SIZE(molecule_kind%atom_list)
-            nmolecule = SIZE(molecule_kind%molecule_list)
+         natom = SIZE(molecule_kind%atom_list)
+         nmolecule = SIZE(molecule_kind%molecule_list)
 
-            IF (natom == 1) THEN
-               atomic_kind => molecule_kind%atom_list(1)%atomic_kind
-               CALL get_atomic_kind(atomic_kind=atomic_kind, name=name)
-               WRITE (UNIT=output_unit, FMT="(/,T2,I5,A,T36,A,A,T64,A)") &
-                  molecule_kind%kind_number, &
-                  ". Molecule kind: "//TRIM(molecule_kind%name), &
-                  "Atomic kind name:   ", TRIM(name)
-               WRITE (UNIT=output_unit, FMT="(T9,A,L1,T55,A,T75,I6)") &
-                  "Automatic name: ", molecule_kind%molname_generated, &
-                  "Number of molecules:", nmolecule
-            ELSE
-               WRITE (UNIT=output_unit, FMT="(/,T2,I5,A,T50,A,T75,I6,/,T22,A)") &
-                  molecule_kind%kind_number, &
-                  ". Molecule kind: "//TRIM(molecule_kind%name), &
-                  "Number of atoms:    ", natom, &
-                  "Atom         Atomic kind name"
-               DO iatom = 1, natom
-                  atomic_kind => molecule_kind%atom_list(iatom)%atomic_kind
-                  CALL get_atomic_kind(atomic_kind=atomic_kind, name=name)
-                  WRITE (UNIT=output_unit, FMT="(T20,I6,(7X,A18))") &
-                     iatom, TRIM(name)
-               END DO
-               WRITE (UNIT=output_unit, FMT="(/,T9,A,L1)") &
-                  "The name was automatically generated: ", &
-                  molecule_kind%molname_generated
-               WRITE (UNIT=output_unit, FMT="(T9,A,I6,/,T9,A,(T30,5I10))") &
-                  "Number of molecules: ", nmolecule, "Molecule list:", &
-                  (molecule_kind%molecule_list(imolecule), imolecule=1, nmolecule)
-               IF (molecule_kind%nbond > 0) &
-                  WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
-                  "Number of bonds:       ", molecule_kind%nbond
-               IF (molecule_kind%nbend > 0) &
-                  WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
-                  "Number of bends:       ", molecule_kind%nbend
-               IF (molecule_kind%nub > 0) &
-                  WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
-                  "Number of Urey-Bradley:", molecule_kind%nub
-               IF (molecule_kind%ntorsion > 0) &
-                  WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
-                  "Number of torsions:    ", molecule_kind%ntorsion
-               IF (molecule_kind%nimpr > 0) &
-                  WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
-                  "Number of improper:    ", molecule_kind%nimpr
-               IF (molecule_kind%nopbend > 0) &
-                  WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
-                  "Number of out opbends:    ", molecule_kind%nopbend
-            END IF
-
+         IF (natom == 1) THEN
+            atomic_kind => molecule_kind%atom_list(1)%atomic_kind
+            CALL get_atomic_kind(atomic_kind=atomic_kind, name=name)
+            WRITE (UNIT=output_unit, FMT="(/,T2,I5,A,T36,A,A,T64,A)") &
+               molecule_kind%kind_number, &
+               ". Molecule kind: "//TRIM(molecule_kind%name), &
+               "Atomic kind name:   ", TRIM(name)
+            WRITE (UNIT=output_unit, FMT="(T9,A,L1,T55,A,T75,I6)") &
+               "Automatic name: ", molecule_kind%molname_generated, &
+               "Number of molecules:", nmolecule
          ELSE
-            CPABORT("")
+            WRITE (UNIT=output_unit, FMT="(/,T2,I5,A,T50,A,T75,I6,/,T22,A)") &
+               molecule_kind%kind_number, &
+               ". Molecule kind: "//TRIM(molecule_kind%name), &
+               "Number of atoms:    ", natom, &
+               "Atom         Atomic kind name"
+            DO iatom = 1, natom
+               atomic_kind => molecule_kind%atom_list(iatom)%atomic_kind
+               CALL get_atomic_kind(atomic_kind=atomic_kind, name=name)
+               WRITE (UNIT=output_unit, FMT="(T20,I6,(7X,A18))") &
+                  iatom, TRIM(name)
+            END DO
+            WRITE (UNIT=output_unit, FMT="(/,T9,A,L1)") &
+               "The name was automatically generated: ", &
+               molecule_kind%molname_generated
+            WRITE (UNIT=output_unit, FMT="(T9,A,I6,/,T9,A,(T30,5I10))") &
+               "Number of molecules: ", nmolecule, "Molecule list:", &
+               (molecule_kind%molecule_list(imolecule), imolecule=1, nmolecule)
+            IF (molecule_kind%nbond > 0) &
+               WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
+               "Number of bonds:       ", molecule_kind%nbond
+            IF (molecule_kind%nbend > 0) &
+               WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
+               "Number of bends:       ", molecule_kind%nbend
+            IF (molecule_kind%nub > 0) &
+               WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
+               "Number of Urey-Bradley:", molecule_kind%nub
+            IF (molecule_kind%ntorsion > 0) &
+               WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
+               "Number of torsions:    ", molecule_kind%ntorsion
+            IF (molecule_kind%nimpr > 0) &
+               WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
+               "Number of improper:    ", molecule_kind%nimpr
+            IF (molecule_kind%nopbend > 0) &
+               WRITE (UNIT=output_unit, FMT="(1X,A30,I6)") &
+               "Number of out opbends:    ", molecule_kind%nopbend
          END IF
-
       END IF
    END SUBROUTINE write_molecule_kind
 
@@ -1058,8 +1026,8 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE write_molecule_kind_set(molecule_kind_set, subsys_section)
-      TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
-      TYPE(section_vals_type), POINTER                   :: subsys_section
+      TYPE(molecule_kind_type), DIMENSION(:), INTENT(IN) :: molecule_kind_set
+      TYPE(section_vals_type), INTENT(IN)                :: subsys_section
 
       CHARACTER(len=*), PARAMETER :: routineN = 'write_molecule_kind_set'
 
@@ -1069,7 +1037,6 @@ CONTAINS
                                                             ntotal, nub, output_unit
       LOGICAL                                            :: all_single_atoms
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(molecule_kind_type), POINTER                  :: molecule_kind
 
       CALL timeset(routineN, handle)
 
@@ -1078,55 +1045,49 @@ CONTAINS
       output_unit = cp_print_key_unit_nr(logger, subsys_section, &
                                          "PRINT%MOLECULES", extension=".Log")
       IF (output_unit > 0) THEN
-         IF (ASSOCIATED(molecule_kind_set)) THEN
-            WRITE (UNIT=output_unit, FMT="(/,/,T2,A)") "MOLECULE KIND INFORMATION"
+         WRITE (UNIT=output_unit, FMT="(/,/,T2,A)") "MOLECULE KIND INFORMATION"
 
-            nmolecule_kind = SIZE(molecule_kind_set)
+         nmolecule_kind = SIZE(molecule_kind_set)
 
-            all_single_atoms = .TRUE.
-            DO imolecule_kind = 1, nmolecule_kind
-               natom = SIZE(molecule_kind_set(imolecule_kind)%atom_list)
-               nmolecule = SIZE(molecule_kind_set(imolecule_kind)%molecule_list)
-               IF (natom*nmolecule > 1) all_single_atoms = .FALSE.
-            ENDDO
+         all_single_atoms = .TRUE.
+         DO imolecule_kind = 1, nmolecule_kind
+            natom = SIZE(molecule_kind_set(imolecule_kind)%atom_list)
+            nmolecule = SIZE(molecule_kind_set(imolecule_kind)%molecule_list)
+            IF (natom*nmolecule > 1) all_single_atoms = .FALSE.
+         ENDDO
 
-            IF (all_single_atoms) THEN
-               WRITE (UNIT=output_unit, FMT="(/,/,T2,A)") &
-                  "All atoms are their own molecule, skipping detailed information"
-            ELSE
-               DO imolecule_kind = 1, nmolecule_kind
-                  molecule_kind => molecule_kind_set(imolecule_kind)
-                  CALL write_molecule_kind(molecule_kind, output_unit)
-               END DO
-            ENDIF
-
-            CALL get_molecule_kind_set(molecule_kind_set=molecule_kind_set, &
-                                       nbond=nbond, &
-                                       nbend=nbend, &
-                                       nub=nub, &
-                                       ntorsion=ntors, &
-                                       nimpr=nimpr, &
-                                       nopbend=nopbend)
-            ntotal = nbond + nbend + nub + ntors + nimpr + nopbend
-            IF (ntotal > 0) THEN
-               WRITE (UNIT=output_unit, FMT="(/,/,T2,A,T45,A30,I6)") &
-                  "MOLECULE KIND SET INFORMATION", &
-                  "Total Number of bonds:       ", nbond
-               WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
-                  "Total Number of bends:       ", nbend
-               WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
-                  "Total Number of Urey-Bradley:", nub
-               WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
-                  "Total Number of torsions:    ", ntors
-               WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
-                  "Total Number of improper:    ", nimpr
-               WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
-                  "Total Number of opbends:    ", nopbend
-            END IF
+         IF (all_single_atoms) THEN
+            WRITE (UNIT=output_unit, FMT="(/,/,T2,A)") &
+               "All atoms are their own molecule, skipping detailed information"
          ELSE
-            CPABORT("")
-         END IF
+            DO imolecule_kind = 1, nmolecule_kind
+               CALL write_molecule_kind(molecule_kind_set(imolecule_kind), output_unit)
+            END DO
+         ENDIF
 
+         CALL get_molecule_kind_set(molecule_kind_set=molecule_kind_set, &
+                                    nbond=nbond, &
+                                    nbend=nbend, &
+                                    nub=nub, &
+                                    ntorsion=ntors, &
+                                    nimpr=nimpr, &
+                                    nopbend=nopbend)
+         ntotal = nbond + nbend + nub + ntors + nimpr + nopbend
+         IF (ntotal > 0) THEN
+            WRITE (UNIT=output_unit, FMT="(/,/,T2,A,T45,A30,I6)") &
+               "MOLECULE KIND SET INFORMATION", &
+               "Total Number of bonds:       ", nbond
+            WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
+               "Total Number of bends:       ", nbend
+            WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
+               "Total Number of Urey-Bradley:", nub
+            WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
+               "Total Number of torsions:    ", ntors
+            WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
+               "Total Number of improper:    ", nimpr
+            WRITE (UNIT=output_unit, FMT="(T45,A30,I6)") &
+               "Total Number of opbends:    ", nopbend
+         END IF
       END IF
       CALL cp_print_key_finished_output(output_unit, logger, subsys_section, &
                                         "PRINT%MOLECULES")

--- a/src/subsys/molecule_types.F
+++ b/src/subsys/molecule_types.F
@@ -289,7 +289,7 @@ CONTAINS
    SUBROUTINE get_molecule(molecule, molecule_kind, lmi, lci, lg3x3, lg4x6, lcolv, &
                            first_atom, last_atom, first_shell, last_shell)
 
-      TYPE(molecule_type), POINTER                       :: molecule
+      TYPE(molecule_type), INTENT(IN)                    :: molecule
       TYPE(molecule_kind_type), OPTIONAL, POINTER        :: molecule_kind
       TYPE(local_states_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: lmi
@@ -303,42 +303,34 @@ CONTAINS
       INTEGER, OPTIONAL                                  :: first_atom, last_atom, first_shell, &
                                                             last_shell
 
-      IF (ASSOCIATED(molecule)) THEN
-
-         IF (PRESENT(first_atom)) first_atom = molecule%first_atom
-         IF (PRESENT(last_atom)) last_atom = molecule%last_atom
-         IF (PRESENT(first_shell)) first_shell = molecule%first_shell
-         IF (PRESENT(last_shell)) last_shell = molecule%last_shell
-         IF (PRESENT(molecule_kind)) molecule_kind => molecule%molecule_kind
-         IF (PRESENT(lmi)) lmi => molecule%lmi
-         IF (PRESENT(lci)) lci => molecule%lci
-         IF (PRESENT(lcolv)) THEN
-            IF (ASSOCIATED(molecule%lci)) THEN
-               lcolv => molecule%lci%lcolv
-            ELSE
-               CPABORT("The pointer lci is not associated")
-            ENDIF
+      IF (PRESENT(first_atom)) first_atom = molecule%first_atom
+      IF (PRESENT(last_atom)) last_atom = molecule%last_atom
+      IF (PRESENT(first_shell)) first_shell = molecule%first_shell
+      IF (PRESENT(last_shell)) last_shell = molecule%last_shell
+      IF (PRESENT(molecule_kind)) molecule_kind => molecule%molecule_kind
+      IF (PRESENT(lmi)) lmi => molecule%lmi
+      IF (PRESENT(lci)) lci => molecule%lci
+      IF (PRESENT(lcolv)) THEN
+         IF (ASSOCIATED(molecule%lci)) THEN
+            lcolv => molecule%lci%lcolv
+         ELSE
+            CPABORT("The pointer lci is not associated")
          ENDIF
-         IF (PRESENT(lg3x3)) THEN
-            IF (ASSOCIATED(molecule%lci)) THEN
-               lg3x3 => molecule%lci%lg3x3
-            ELSE
-               CPABORT("The pointer lci is not associated")
-            ENDIF
+      ENDIF
+      IF (PRESENT(lg3x3)) THEN
+         IF (ASSOCIATED(molecule%lci)) THEN
+            lg3x3 => molecule%lci%lg3x3
+         ELSE
+            CPABORT("The pointer lci is not associated")
          ENDIF
-         IF (PRESENT(lg4x6)) THEN
-            IF (ASSOCIATED(molecule%lci)) THEN
-               lg4x6 => molecule%lci%lg4x6
-            ELSE
-               CPABORT("The pointer lci is not associated")
-            ENDIF
+      ENDIF
+      IF (PRESENT(lg4x6)) THEN
+         IF (ASSOCIATED(molecule%lci)) THEN
+            lg4x6 => molecule%lci%lg4x6
+         ELSE
+            CPABORT("The pointer lci is not associated")
          ENDIF
-
-      ELSE
-
-         CPABORT("The pointer lci is not associated")
-
-      END IF
+      ENDIF
 
    END SUBROUTINE get_molecule
 
@@ -356,7 +348,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE set_molecule(molecule, molecule_kind, lmi, lci, lcolv, lg3x3, lg4x6)
-      TYPE(molecule_type), POINTER                       :: molecule
+      TYPE(molecule_type), INTENT(INOUT)                 :: molecule
       TYPE(molecule_kind_type), OPTIONAL, POINTER        :: molecule_kind
       TYPE(local_states_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: lmi
@@ -368,37 +360,30 @@ CONTAINS
       TYPE(local_g4x6_constraint_type), OPTIONAL, &
          POINTER                                         :: lg4x6(:)
 
-      IF (ASSOCIATED(molecule)) THEN
-
-         IF (PRESENT(molecule_kind)) molecule%molecule_kind => molecule_kind
-         IF (PRESENT(lmi)) molecule%lmi => lmi
-         IF (PRESENT(lci)) molecule%lci => lci
-         IF (PRESENT(lcolv)) THEN
-            IF (ASSOCIATED(molecule%lci)) THEN
-               molecule%lci%lcolv => lcolv
-            ELSE
-               CPABORT("The pointer lci is not associated")
-            ENDIF
+      IF (PRESENT(molecule_kind)) molecule%molecule_kind => molecule_kind
+      IF (PRESENT(lmi)) molecule%lmi => lmi
+      IF (PRESENT(lci)) molecule%lci => lci
+      IF (PRESENT(lcolv)) THEN
+         IF (ASSOCIATED(molecule%lci)) THEN
+            molecule%lci%lcolv => lcolv
+         ELSE
+            CPABORT("The pointer lci is not associated")
          ENDIF
-         IF (PRESENT(lg3x3)) THEN
-            IF (ASSOCIATED(molecule%lci)) THEN
-               molecule%lci%lg3x3 => lg3x3
-            ELSE
-               CPABORT("The pointer lci is not associated")
-            ENDIF
+      ENDIF
+      IF (PRESENT(lg3x3)) THEN
+         IF (ASSOCIATED(molecule%lci)) THEN
+            molecule%lci%lg3x3 => lg3x3
+         ELSE
+            CPABORT("The pointer lci is not associated")
          ENDIF
-         IF (PRESENT(lg4x6)) THEN
-            IF (ASSOCIATED(molecule%lci)) THEN
-               molecule%lci%lg4x6 => lg4x6
-            ELSE
-               CPABORT("The pointer lci is not associated")
-            ENDIF
+      ENDIF
+      IF (PRESENT(lg4x6)) THEN
+         IF (ASSOCIATED(molecule%lci)) THEN
+            molecule%lci%lg4x6 => lg4x6
+         ELSE
+            CPABORT("The pointer lci is not associated")
          ENDIF
-      ELSE
-
-         CPABORT("The pointer molecule is not associated")
-
-      END IF
+      ENDIF
 
    END SUBROUTINE set_molecule
 
@@ -412,45 +397,33 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE set_molecule_set(molecule_set, first_atom, last_atom)
-      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(molecule_type), DIMENSION(:), INTENT(INOUT)   :: molecule_set
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: first_atom, last_atom
 
       INTEGER                                            :: imolecule
 
-      IF (ASSOCIATED(molecule_set)) THEN
-
-         IF (PRESENT(first_atom)) THEN
-
-            IF (SIZE(first_atom) /= SIZE(molecule_set)) THEN
-               CALL cp_abort(__LOCATION__, &
-                             "The sizes of first_atom and molecule_set "// &
-                             "are different")
-            END IF
-
-            DO imolecule = 1, SIZE(molecule_set)
-               molecule_set(imolecule)%first_atom = first_atom(imolecule)
-            END DO
-
+      IF (PRESENT(first_atom)) THEN
+         IF (SIZE(first_atom) /= SIZE(molecule_set)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The sizes of first_atom and molecule_set "// &
+                          "are different")
          END IF
 
-         IF (PRESENT(last_atom)) THEN
+         DO imolecule = 1, SIZE(molecule_set)
+            molecule_set(imolecule)%first_atom = first_atom(imolecule)
+         END DO
+      END IF
 
-            IF (SIZE(last_atom) /= SIZE(molecule_set)) THEN
-               CALL cp_abort(__LOCATION__, &
-                             "The sizes of last_atom and molecule_set "// &
-                             "are different")
-            END IF
-
-            DO imolecule = 1, SIZE(molecule_set)
-               molecule_set(imolecule)%last_atom = last_atom(imolecule)
-            END DO
-
+      IF (PRESENT(last_atom)) THEN
+         IF (SIZE(last_atom) /= SIZE(molecule_set)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The sizes of last_atom and molecule_set "// &
+                          "are different")
          END IF
 
-      ELSE
-
-         CPABORT("The pointer molecule_set is not associated")
-
+         DO imolecule = 1, SIZE(molecule_set)
+            molecule_set(imolecule)%last_atom = last_atom(imolecule)
+         END DO
       END IF
 
    END SUBROUTINE set_molecule_set
@@ -461,15 +434,13 @@ CONTAINS
 !> \param atom_to_mol ...
 ! **************************************************************************************************
    SUBROUTINE molecule_of_atom(molecule_set, atom_to_mol)
-      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(molecule_type), DIMENSION(:), INTENT(IN)      :: molecule_set
       INTEGER, DIMENSION(:), INTENT(OUT)                 :: atom_to_mol
 
       INTEGER                                            :: first_atom, iatom, imol, last_atom
-      TYPE(molecule_type), POINTER                       :: molecule
 
       DO imol = 1, SIZE(molecule_set)
-         molecule => molecule_set(imol)
-         CALL get_molecule(molecule=molecule, first_atom=first_atom, last_atom=last_atom)
+         CALL get_molecule(molecule=molecule_set(imol), first_atom=first_atom, last_atom=last_atom)
          DO iatom = first_atom, last_atom
             atom_to_mol(iatom) = imol
          ENDDO ! iatom
@@ -495,7 +466,7 @@ CONTAINS
                                     mol_to_last_atom, mol_to_nelectrons, mol_to_nbasis, mol_to_charge, &
                                     mol_to_multiplicity)
 
-      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(molecule_type), DIMENSION(:), INTENT(IN)      :: molecule_set
       INTEGER, DIMENSION(:), INTENT(OUT), OPTIONAL :: atom_to_mol, mol_to_first_atom, &
          mol_to_last_atom, mol_to_nelectrons, mol_to_nbasis, mol_to_charge, mol_to_multiplicity
 
@@ -503,12 +474,10 @@ CONTAINS
                                                             nbasis, nelec
       REAL(KIND=dp)                                      :: charge
       TYPE(molecule_kind_type), POINTER                  :: imol_kind
-      TYPE(molecule_type), POINTER                       :: molecule
 
       DO imol = 1, SIZE(molecule_set)
 
-         molecule => molecule_set(imol)
-         CALL get_molecule(molecule=molecule, molecule_kind=imol_kind, &
+         CALL get_molecule(molecule=molecule_set(imol), molecule_kind=imol_kind, &
                            first_atom=first_atom, last_atom=last_atom)
 
          IF (PRESENT(mol_to_nelectrons)) THEN

--- a/src/subsys/particle_types.F
+++ b/src/subsys/particle_types.F
@@ -119,7 +119,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE update_particle_set(particle_set, int_group, pos, vel, for, add)
 
-      TYPE(particle_type), POINTER                       :: particle_set(:)
+      TYPE(particle_type), INTENT(INOUT)                 :: particle_set(:)
       INTEGER, INTENT(IN)                                :: int_group
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: pos(:, :), vel(:, :), for(:, :)
       LOGICAL, INTENT(IN), OPTIONAL                      :: add
@@ -194,7 +194,7 @@ CONTAINS
    FUNCTION get_particle_pos_or_vel(iatom, particle_set, vector) RESULT(x)
 
       INTEGER, INTENT(IN)                                :: iatom
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: particle_set
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vector
       REAL(KIND=dp), DIMENSION(3)                        :: x
 
@@ -231,7 +231,7 @@ CONTAINS
    SUBROUTINE update_particle_pos_or_vel(iatom, particle_set, x, vector)
 
       INTEGER, INTENT(IN)                                :: iatom
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(particle_type), DIMENSION(:), INTENT(IN)      :: particle_set
       REAL(KIND=dp), DIMENSION(3), INTENT(INOUT)         :: x
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: vector
 

--- a/src/subsys/shell_potential_types.F
+++ b/src/subsys/shell_potential_types.F
@@ -70,22 +70,20 @@ CONTAINS
    SUBROUTINE get_shell(shell, charge, charge_core, charge_shell, mass_core, &
                         mass_shell, k2_spring, k4_spring, max_dist, shell_cutoff)
 
-      TYPE(shell_kind_type), POINTER                     :: shell
+      TYPE(shell_kind_type), INTENT(IN)                  :: shell
       REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: charge, charge_core, charge_shell, &
                                                             mass_core, mass_shell, k2_spring, &
                                                             k4_spring, max_dist, shell_cutoff
 
-      IF (ASSOCIATED(shell)) THEN
-         IF (PRESENT(charge)) charge = shell%charge_core + shell%charge_shell
-         IF (PRESENT(charge_core)) charge_core = shell%charge_core
-         IF (PRESENT(charge_shell)) charge_shell = shell%charge_shell
-         IF (PRESENT(mass_core)) mass_core = shell%mass_core
-         IF (PRESENT(mass_shell)) mass_shell = shell%mass_shell
-         IF (PRESENT(k2_spring)) k2_spring = shell%k2_spring
-         IF (PRESENT(k4_spring)) k4_spring = shell%k4_spring
-         IF (PRESENT(max_dist)) max_dist = shell%max_dist
-         IF (PRESENT(shell_cutoff)) shell_cutoff = shell%shell_cutoff
-      END IF
+      IF (PRESENT(charge)) charge = shell%charge_core + shell%charge_shell
+      IF (PRESENT(charge_core)) charge_core = shell%charge_core
+      IF (PRESENT(charge_shell)) charge_shell = shell%charge_shell
+      IF (PRESENT(mass_core)) mass_core = shell%mass_core
+      IF (PRESENT(mass_shell)) mass_shell = shell%mass_shell
+      IF (PRESENT(k2_spring)) k2_spring = shell%k2_spring
+      IF (PRESENT(k4_spring)) k4_spring = shell%k4_spring
+      IF (PRESENT(max_dist)) max_dist = shell%max_dist
+      IF (PRESENT(shell_cutoff)) shell_cutoff = shell%shell_cutoff
 
    END SUBROUTINE
 ! **************************************************************************************************

--- a/src/subsys/virial_types.F
+++ b/src/subsys/virial_types.F
@@ -68,7 +68,8 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE cp_virial(virial_in, virial_out)
-      TYPE(virial_type), POINTER                         :: virial_in, virial_out
+      TYPE(virial_type), INTENT(IN)                      :: virial_in
+      TYPE(virial_type), INTENT(INOUT)                   :: virial_out
 
       virial_out%pv_total = virial_in%pv_total
       virial_out%pv_kinetic = virial_in%pv_kinetic
@@ -104,7 +105,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE symmetrize_virial(virial)
-      TYPE(virial_type), POINTER                         :: virial
+      TYPE(virial_type), INTENT(INOUT)                   :: virial
 
       INTEGER                                            :: i, j
 
@@ -160,7 +161,7 @@ CONTAINS
 !> \param reset ...
 ! **************************************************************************************************
    SUBROUTINE zero_virial(virial, reset)
-      TYPE(virial_type), POINTER                         :: virial
+      TYPE(virial_type), INTENT(INOUT)                   :: virial
       LOGICAL, INTENT(IN), OPTIONAL                      :: reset
 
       LOGICAL                                            :: my_reset
@@ -230,7 +231,7 @@ CONTAINS
                          pv_exc, pv_exx, pv_vdw, pv_mp2, pv_nlcc, pv_gapw, pv_lrigpw, &
                          pv_availability, pv_calculate, pv_numer, pv_diagonal)
 
-      TYPE(virial_type), POINTER                         :: virial
+      TYPE(virial_type), INTENT(INOUT)                   :: virial
       REAL(KIND=dp), DIMENSION(3, 3), OPTIONAL :: pv_total, pv_kinetic, pv_virial, pv_xc, &
          pv_fock_4c, pv_constraint, pv_overlap, pv_ekinetic, pv_ppl, pv_ppnl, pv_ecore_overlap, &
          pv_ehartree, pv_exc, pv_exx, pv_vdw, pv_mp2, pv_nlcc, pv_gapw, pv_lrigpw

--- a/src/xc/xc_libxc.F
+++ b/src/xc/xc_libxc.F
@@ -143,6 +143,7 @@ CONTAINS
       CALL xc_f03_func_end(xc_func)
 #else
       MARK_USED(libxc_params)
+      MARK_USED(lsd)
       length = 0
       CPABORT("In order to use LibXC you have to download and install it!")
 #endif


### PR DESCRIPTION
While a POINTER can be passed as non-POINTER actual argument, it does not work the other way around. This makes it impossible to call any of the `get_*`, `set_*` functions with anything else than a pointer.

Also, an INTENT(IN) spec on a POINTER dummy argument acts on the
POINTER, meaning that while the POINTER can not be changed, its contents still can.

The only thing lost is that we can not check explicitly whether an actual POINTER argument is ASSOCIATED, but we have to rely on the compiler to provide those checks (-fcheck with gcc). Given that those assertions have been missing more often than not we will not lose much here while making it possible to switch to ALLOCATABLEs.

One note of caution: passing an unassociated pointer to such a function may work with GCC (w/o -fcheck), while code generated with Intel or Cray will reliably produce segfaults.