### PR TITLE
Update install_openmpi.sh

### DIFF
--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -111,8 +111,8 @@ EOF
         OPENMPI_LDFLAGS="${OPENMPI_LDFLAGS//-l${lib}}"
     done
     # old versions didn't support MPI 3, so adjust __MPI_VERSION accordingly (needed e.g. for pexsi)
-    if [ $major_version -lt 1 ] || \
-       [ $major_version -eq 1 -a $minor_version -lt 7 ] ; then
+    if [[ "$major_version" =~ ^[0-9]+$ ]] && ( [ $major_version -lt 1 ] || \
+       [ $major_version -eq 1 -a $minor_version -lt 7 ] ) ; then
         mpi2_dflags="-D__MPI_VERSION=2"
     else
         mpi2_dflags=''


### PR DESCRIPTION
This fixes a syntax error in case open-mpi is selected, but the mpirun command returns something unexpected like, e.g.:
"mpirun (IBM Spectrum MPI) 10.3.1.02rtm0"
This assumes mpi3 is available in such cases.

Explanation: the new test uses bash's regexp match to check whether major_version is non-empty and numeric.