### PR TITLE
expand macro arguments

### DIFF
--- a/src/grid/common/grid_common.h
+++ b/src/grid/common/grid_common.h
@@ -8,11 +8,12 @@
 #define GRID_COMMON_H
 
 #define GRID_STRINGIFY(SYMBOL) #SYMBOL
+#define GRID_EXPAND(ARG) ARG
 
 #if defined(__GNUC__)
-#define GRID_PRAGMA_UNROLL(N) _Pragma(GRID_STRINGIFY(GCC unroll N))
+#define GRID_PRAGMA_UNROLL(N) _Pragma(GRID_STRINGIFY(GRID_EXPAND(GCC unroll N)))
 #else
-#define GRID_PRAGMA_UNROLL(N) _Pragma(GRID_STRINGIFY(unroll(N)))
+#define GRID_PRAGMA_UNROLL(N) _Pragma(GRID_STRINGIFY(GRID_EXPAND(unroll(N))))
 #endif
 
 #if defined(__CUDACC__)

--- a/src/libint_wrapper.F
+++ b/src/libint_wrapper.F
@@ -479,7 +479,7 @@ CONTAINS
       get_ssss_f_val = lib%prv(1)%f_aB_s___0__s___1___TwoPRep_s___0__s___1___Ab__up_0(1)
 #else
       MARK_USED(lib)
-      MARK_USED(get_ssss_f_val)
+      get_ssss_f_val = 0.0_dp
       CPABORT("This CP2K executable has not been linked against the required library libint.")
 #endif
 

--- a/src/motion/space_groups.F
+++ b/src/motion/space_groups.F
@@ -93,10 +93,11 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: print_atoms
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'spgr_create', routineP = moduleN//':'//routineN
-
+#ifdef __SPGLIB
       CHARACTER(LEN=1000)                                :: buffer
-      INTEGER                                            :: handle, i, ierr, j, n_sr_rep, nchars, &
-                                                            nop, tra_mat(3, 3)
+      INTEGER                                            :: ierr, nchars, nop, tra_mat(3, 3)
+#endif
+      INTEGER                                            :: handle, i, j, n_sr_rep
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: tmp_types
       LOGICAL                                            :: spglib
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: tmp_coor


### PR DESCRIPTION
Fixed GRID_PRAGMA_UNROLL(N) macro which needs one more macro expansion to populate final N-expression (e.g., GRID_PRAGMA_UNROLL(MAX_LP_OPTIMIZED + 1)).

Other:

* Avoid warnings about unused variables (due to __SPGLIB conditional compilation).
* Avoid warning about OUT dummy arg without assigned value (unused variable).
