### PR TITLE
fixed compiler warnings

### DIFF
--- a/src/grid/common/grid_library.c
+++ b/src/grid/common/grid_library.c
@@ -32,7 +32,7 @@ static grid_library_config config = {.backend = GRID_BACKEND_AUTO,
  * \brief Initializes the grid library.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_library_init() {
+void grid_library_init(void) {
   if (library_initialized) {
     printf("Error: Grid library was already initialized.\n");
     abort();
@@ -56,7 +56,7 @@ void grid_library_init() {
  * \brief Finalizes the grid library.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_library_finalize() {
+void grid_library_finalize(void) {
   if (!library_initialized) {
     printf("Error: Grid library is not initialized.\n");
     abort();
@@ -75,7 +75,7 @@ void grid_library_finalize() {
  * \brief Returns a pointer to the thread local sphere cache.
  * \author Ole Schuett
  ******************************************************************************/
-grid_sphere_cache *grid_library_get_sphere_cache() {
+grid_sphere_cache *grid_library_get_sphere_cache(void) {
   return &per_thread_globals[omp_get_thread_num()]->sphere_cache;
 }
 
@@ -97,7 +97,7 @@ void grid_library_set_config(const enum grid_backend backend,
  * \brief Returns the library config.
  * \author Ole Schuett
  ******************************************************************************/
-grid_library_config grid_library_get_config() { return config; }
+grid_library_config grid_library_get_config(void) { return config; }
 
 /*******************************************************************************
  * \brief Adds given increment to counter specified by lp, backend, and kernel.

--- a/src/grid/common/grid_library.h
+++ b/src/grid/common/grid_library.h
@@ -19,13 +19,13 @@ extern "C" {
  * \brief Initializes the grid library.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_library_init();
+void grid_library_init(void);
 
 /*******************************************************************************
  * \brief Finalizes the grid library.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_library_finalize();
+void grid_library_finalize(void);
 
 /*******************************************************************************
  * \brief Configuration of the grid library.
@@ -52,7 +52,7 @@ void grid_library_set_config(const enum grid_backend backend,
  * \brief Returns the library config.
  * \author Ole Schuett
  ******************************************************************************/
-grid_library_config grid_library_get_config();
+grid_library_config grid_library_get_config(void);
 
 /*******************************************************************************
  * \brief Prints statistics gathered by the grid library.
@@ -86,7 +86,7 @@ enum grid_library_kernel {
  * \brief Returns a pointer to the thread local sphere cache.
  * \author Ole Schuett
  ******************************************************************************/
-grid_sphere_cache *grid_library_get_sphere_cache();
+grid_sphere_cache *grid_library_get_sphere_cache(void);
 
 /*******************************************************************************
  * \brief Adds given increment to counter specified by lp, backend, and kernel.

--- a/src/grid/cpu/collocation_integration.c
+++ b/src/grid/cpu/collocation_integration.c
@@ -22,7 +22,7 @@
 #include "tensor_local.h"
 #include "utils.h"
 
-struct collocation_integration_ *collocate_create_handle() {
+struct collocation_integration_ *collocate_create_handle(void) {
   struct collocation_integration_ *handle = NULL;
   handle = (struct collocation_integration_ *)malloc(
       sizeof(struct collocation_integration_));

--- a/src/grid/cpu/collocation_integration.h
+++ b/src/grid/cpu/collocation_integration.h
@@ -170,7 +170,7 @@ typedef struct collocation_integration_ {
 
 } collocation_integration;
 
-extern struct collocation_integration_ *collocate_create_handle();
+extern struct collocation_integration_ *collocate_create_handle(void);
 extern void collocate_synchronize(void *gaussian_handler);
 extern void collocate_destroy_handle(void *gaussian_handle);
 extern void calculate_collocation(void *const in);

--- a/src/libint_wrapper.F
+++ b/src/libint_wrapper.F
@@ -479,7 +479,7 @@ CONTAINS
       get_ssss_f_val = lib%prv(1)%f_aB_s___0__s___1___TwoPRep_s___0__s___1___Ab__up_0(1)
 #else
       MARK_USED(lib)
-      MARK_USED(get_ssss_f_val)
+      get_ssss_f_val = 0.0_dp
       CPABORT("This CP2K executable has not been linked against the required library libint.")
 #endif
 

--- a/src/motion/space_groups.F
+++ b/src/motion/space_groups.F
@@ -93,10 +93,11 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: print_atoms
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'spgr_create', routineP = moduleN//':'//routineN
-
+#ifdef __SPGLIB
       CHARACTER(LEN=1000)                                :: buffer
-      INTEGER                                            :: handle, i, ierr, j, n_sr_rep, nchars, &
-                                                            nop, tra_mat(3, 3)
+      INTEGER                                            :: ierr, nchars, nop, tra_mat(3, 3)
+#endif
+      INTEGER                                            :: handle, i, j, n_sr_rep
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: tmp_types
       LOGICAL                                            :: spglib
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: tmp_coor

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -196,7 +196,6 @@ CONTAINS
 
       ! DBCSR sets the GPU device, make sure it is the first GPU call
       CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
-      CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
 
       CALL cuda_nvtx_init()
 


### PR DESCRIPTION
* Avoid warnings about unused variables (due to __SPGLIB conditional compilation).
* Avoid warning about dummy OUT-arg without assigned value (unused variable).