### PR TITLE
citation for libxsmm

### DIFF
--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -13,19 +13,16 @@
 !>      of documentation.
 !>
 !>      reference_manager.F provides an easy way to cite these references from the code
-!>      (e.g. whenever the relevant part of the code is executed)
+!>      (e.g., whenever the relevant part of the code is executed)
 !>      and to add citations to the input
-!>      at the end of the run a bibliography is printed that can be used e.g. in papers
+!>      at the end of the run a bibliography is printed that can be used, e.g., in papers
 !> \note
 !>      references need to be input using the ISI citation format, because it is
 !>      uniform, easy to parse, and can be exported for example from web of science.
 !>      (mark the reference, and click 'export to reference software', open the resulting file)
 !>      Furthermore, it can be easily converted to and from using the bibutils tools
 !>      a collection of easy to use conversion programs that can be found at
-!>      http://www.scripps.edu/~cdputnam/software/bibutils/ by Chris Putnam
-!> \par History
-!>      08.2007 [Joost VandeVondele] Created
-!>      01.2014 [Lianheng Tong] Added Kantorovich2008, Kantorovich2008a
+!>      https://ctan.org/pkg/bibutils by Chris Putnam
 !> \author Joost VandeVondele
 ! **************************************************************************************************
 MODULE bibliography
@@ -91,7 +88,7 @@ MODULE bibliography
                             Toulouse2004, Limpanuparb2011, Martin2003, Yin2017, Goerigk2017, &
                             Wilhelm2016a, Wilhelm2016b, Wilhelm2017, Wilhelm2018, Lass2018, cp2kqs2020, &
                             Behler2007, Behler2011, Schran2020a, Schran2020b, &
-                            Rycroft2009, Thomas2015, Brehm2018, Brehm2020, Shigeta2001
+                            Rycroft2009, Thomas2015, Brehm2018, Brehm2020, Shigeta2001, Heinecke2016
 
 CONTAINS
 
@@ -4687,6 +4684,28 @@ CONTAINS
                          "IS 4-5", &
                          "ER"), &
                          DOI="10.1002/qua.1543")
+
+      CALL add_reference(key=Heinecke2016, ISI_record=s2a( &
+                         "PT S", &
+                         "AU Heinecke, A", &
+                         "   Henry, G", &
+                         "   Hutchinson, M", &
+                         "   Pabst, H", &
+                         "TI LIBXSMM: Accelerating Small Matrix Multiplications", &
+                         "   by Runtime Code Generation", &
+                         "CT SC'16: International Conference for High Performance Computing,", &
+                         "   Networking, Storage, and Analysis", &
+                         "SO Proceedings of Intl. Supercomputing Conference", &
+                         "CL Salt Lake City, UT, USA", &
+                         "PU IEEE", &
+                         "EI 2167-4337", &
+                         "UT 16757864", &
+                         "PY 2016", &
+                         "BP 981", &
+                         "EP 991", &
+                         "DI 10.1109/SC.2016.83", &
+                         "ER"), &
+                         DOI="10.1109/SC.2016.83")
 
    END SUBROUTINE add_all_references
 

--- a/src/cp_dbcsr_cp2k_link.F
+++ b/src/cp_dbcsr_cp2k_link.F
@@ -18,6 +18,7 @@ MODULE cp_dbcsr_cp2k_link
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
                                               gto_basis_set_type
    USE bibliography,                    ONLY: Borstnik2014,&
+                                              Heinecke2016,&
                                               Schuett2016,&
                                               cite_reference
    USE cp_control_types,                ONLY: dft_control_type
@@ -123,7 +124,8 @@ CONTAINS
                                         "Fortran MATMUL", &
                                         "Library optimised for Small Matrix Multiplies "// &
                                         "(requires the SMM library at link time)", &
-                                        "Intel's libxsmm"))
+                                        "LIBXSMM"), &
+                          citations=(/Heinecke2016/))
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -438,6 +440,9 @@ CONTAINS
       SELECT CASE (ival)
       CASE (mm_driver_auto)
          CALL dbcsr_set_config(mm_driver="AUTO")
+#if defined(__LIBXSMM)
+         CALL cite_reference(Heinecke2016)
+#endif
       CASE (mm_driver_blas)
          CALL dbcsr_set_config(mm_driver="BLAS")
       CASE (mm_driver_matmul)
@@ -446,6 +451,7 @@ CONTAINS
          CALL dbcsr_set_config(mm_driver="SMM")
       CASE (mm_driver_xsmm)
          CALL dbcsr_set_config(mm_driver="XSMM")
+         CALL cite_reference(Heinecke2016)
       CASE DEFAULT
          CPABORT("Unknown mm_driver")
       END SELECT


### PR DESCRIPTION
Introduced, exported, and triggered citation for LIBXSMM's primary/initial publication. Note, public DBCSR API does not permit to query `mm_driver`, which must be accounted for in case of `mm_driver="AUTO"` (per `__LIBXSMM`).