### PR TITLE
aligned_alloc requires the allocated size to be a multiple of the ali…

### DIFF
--- a/src/grid/cpu/collocation_integration.c
+++ b/src/grid/cpu/collocation_integration.c
@@ -108,8 +108,7 @@ void initialize_W_and_T(collocation_integration *const handler,
 
     if (handler->scratch)
       free(handler->scratch);
-    handler->scratch =
-        aligned_alloc(64, sizeof(double) * handler->scratch_alloc_size);
+    handler->scratch = malloc(sizeof(double) * handler->scratch_alloc_size);
     if (handler->scratch == NULL)
       abort();
   }
@@ -139,8 +138,7 @@ void initialize_W_and_T_integrate(collocation_integration *const handler,
 
     if (handler->scratch)
       free(handler->scratch);
-    handler->scratch =
-        aligned_alloc(64, sizeof(double) * handler->scratch_alloc_size);
+    handler->scratch = malloc(sizeof(double) * handler->scratch_alloc_size);
     if (handler->scratch == NULL)
       abort();
   }

--- a/src/grid/cpu/grid_integrate_dgemm.c
+++ b/src/grid/cpu/grid_integrate_dgemm.c
@@ -1068,8 +1068,7 @@ void grid_cpu_integrate_task_list(
   const int max_threads = omp_get_max_threads();
 
   if (ctx->scratch == NULL)
-    ctx->scratch =
-        aligned_alloc(sysconf(_SC_PAGESIZE), hab_blocks->size * max_threads);
+    ctx->scratch = malloc(hab_blocks->size * max_threads);
 
   ctx->orthorhombic = orthorhombic;
 

--- a/src/grid/cpu/non_orthorombic_corrections.c
+++ b/src/grid/cpu/non_orthorombic_corrections.c
@@ -119,8 +119,8 @@ void calculate_non_orthorombic_corrections_tensor(
   initialize_tensor_3(Exp, 3, max_elem, max_elem);
   realloc_tensor(Exp);
 
-  x1 = aligned_alloc(64, sizeof(double) * max_elem);
-  x2 = aligned_alloc(64, sizeof(double) * max_elem);
+  x1 = grid_allocate_scratch(sizeof(double) * max_elem);
+  x2 = grid_allocate_scratch(sizeof(double) * max_elem);
   initialize_tensor_2(&exp_tmp, Exp->size[1], Exp->size[2]);
 
   memset(&idx3(Exp[0], 0, 0, 0), 0, sizeof(double) * Exp->alloc_size_);
@@ -142,8 +142,8 @@ void calculate_non_orthorombic_corrections_tensor(
              &exp_tmp);
     }
   }
-  free(x1);
-  free(x2);
+  grid_free_scratch(x1);
+  grid_free_scratch(x2);
 }
 
 void calculate_non_orthorombic_corrections_tensor_blocked(
@@ -198,8 +198,8 @@ void calculate_non_orthorombic_corrections_tensor_blocked(
                                 block_size[2]};
 
   const int max_elem = imax(imax(cube_size[0], cube_size[1]), cube_size[2]);
-  x1 = aligned_alloc(64, sizeof(double) * max_elem);
-  x2 = aligned_alloc(64, sizeof(double) * max_elem);
+  x1 = grid_allocate_scratch(sizeof(double) * max_elem);
+  x2 = grid_allocate_scratch(sizeof(double) * max_elem);
 
   initialize_tensor_4(Exp, 3,
                       imax(upper_corner[0] - lower_corner[0],
@@ -248,8 +248,8 @@ void calculate_non_orthorombic_corrections_tensor_blocked(
     }
   }
 
-  free(x1);
-  free(x2);
+  grid_free_scratch(x1);
+  grid_free_scratch(x2);
   /* free(exp_tmp.data); */
 }
 

--- a/src/grid/cpu/tensor_local.c
+++ b/src/grid/cpu/tensor_local.c
@@ -28,8 +28,7 @@ size_t realloc_tensor(tensor *t) {
   t->data = NULL;
 
   if (t->data == NULL) {
-    t->data =
-        aligned_alloc(sysconf(_SC_PAGESIZE), sizeof(double) * t->alloc_size_);
+    t->data = malloc(sizeof(double) * t->alloc_size_);
     if (!t->data)
       abort();
     t->old_alloc_size_ = t->alloc_size_;
@@ -43,8 +42,7 @@ void alloc_tensor(tensor *t) {
     abort();
   }
 
-  t->data =
-      aligned_alloc(sysconf(_SC_PAGESIZE), sizeof(double) * t->alloc_size_);
+  t->data = malloc(sizeof(double) * t->alloc_size_);
   if (!t->data)
     abort();
   t->old_alloc_size_ = t->alloc_size_;

--- a/src/grid/cpu/tensor_local.h
+++ b/src/grid/cpu/tensor_local.h
@@ -115,7 +115,7 @@ static inline tensor *create_tensor(const int dim, const int *sizes) {
     abort();
 
   initialize_tensor(a, dim, sizes);
-  a->data = (double *)aligned_alloc(64, sizeof(double) * a->alloc_size_);
+  a->data = (double *)malloc(sizeof(double) * a->alloc_size_);
   if (a->data == NULL)
     abort();
   a->old_alloc_size_ = a->alloc_size_;


### PR DESCRIPTION
…gnment. Replace by malloc and grid_allocate_scratch()

the doc of aligned_alloc states that the size allocation should be a multiple of the alignment (posix_memalign does not).
so revert back to malloc and grid_allocate_scratch (call libxsmm routine if found)