### PR TITLE
Forces were not calculated when running with one unique thread

### DIFF
--- a/src/grid/cpu/grid_integrate_dgemm.c
+++ b/src/grid/cpu/grid_integrate_dgemm.c
@@ -1016,6 +1016,10 @@ void integrate_one_grid_level_dgemm(
           cblas_daxpy(forces_local_.alloc_size_, 1.0, forces_local_.data, 1,
                       forces_->data, 1);
         }
+      } else {
+        // we are running with OMP_NUM_THREADS=1
+        cblas_daxpy(forces_local_.alloc_size_, 1.0, forces_local_.data, 1,
+                    forces_->data, 1);
       }
     }
 


### PR DESCRIPTION
a cblas_daxpy was missing.

 I get this now with this change

OMP=2
H2O-1_ortho_grid_auto.inp : -17.17857475634941
H2O-1_ortho_grid_dgemm.inp : -17.17857476455124

OMP=1
H2O-1_ortho_grid_dgemm.inp : -17.17857476455108
H2O-1_ortho_grid_auto.inp : -17.17857475634940

