### PR TITLE
Adjust tolerance of QS/regtest-gpw-2-3/hcn_meta_chaincoord.inp

### DIFF
--- a/tests/QS/regtest-gpw-2-3/TEST_FILES
+++ b/tests/QS/regtest-gpw-2-3/TEST_FILES
@@ -9,7 +9,7 @@ hcn_ts_fix_z.inp                                      65      1e-14             
 # chain of two coordination numbers
 hcn_md.inp                                             1      6e-14             -16.50121471895406
 hcn_meta_coord.inp                                     1      6e-14             -16.65113632013810
-hcn_meta_chaincoord.inp                                1      1e-13             -16.64019903493714
+hcn_meta_chaincoord.inp                                1      2e-13             -16.64019903493714
 hcn_meta_chaincoord_kind.inp                           1      2e-13             -16.64019903493714
 # Population colvar
 H2O_meta_pop.inp                                       1      5e-08            -17.155197480118499


### PR DESCRIPTION
Relative error of 1.08e-13 encountered on Linux psmp conda-forge build.

See https://github.com/conda-forge/cp2k-feedstock/pull/23#issuecomment-819811635