### PR TITLE
switch XOPEN_SOURCE => POSIX_C_SOURCE

### DIFF
--- a/src/grid/grid_replay.c
+++ b/src/grid/grid_replay.c
@@ -6,7 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 // needed for struct timespec
-#define _XOPEN_SOURCE 700 /* Enable POSIX 2008/13 */
+#define _POSIX_C_SOURCE 200809L
 
 #include <assert.h>
 #include <fenv.h>

--- a/src/sockets.c
+++ b/src/sockets.c
@@ -38,7 +38,7 @@
  ******************************************************************************/
 #ifndef __NO_IPI_DRIVER
 
-#define _XOPEN_SOURCE 700 /* Enable POSIX 2008/13 */
+#define _POSIX_C_SOURCE 200809L
 
 #include <math.h>
 #include <netdb.h>

--- a/tools/autotools/INSTALL
+++ b/tools/autotools/INSTALL
@@ -221,7 +221,7 @@ Particular systems
 is not installed, it is recommended to use the following options in
 order to use an ANSI C compiler:
 
-     ./configure CC="cc -Ae -D_XOPEN_SOURCE=500"
+     ./configure CC="cc -Ae -D_POSIX_C_SOURCE=200809L"
 
 and if that doesn't work, install pre-built binaries of GCC for HP-UX.
 


### PR DESCRIPTION
Defining _XOPEN_SOURCE 700 is equivalent to defining the more
self-explanatory _POSIX_C_SOURCE 200809L