### PR TITLE
Fix and change directive error if OpenMP flag is missing

### DIFF
--- a/src/base/base_uses.f90
+++ b/src/base/base_uses.f90
@@ -14,7 +14,7 @@
 
 ! Check for OpenMP early on - ideally before the compiler fails with a cryptic message.
 #if !defined(_OPENMP)
-#error "OpenMP is required. Please add the corresponding flag (eg. -fopenmp for GFortran) to your Fortran compiler flags."
+   "OpenMP is required. Please add the corresponding flag (eg. -fopenmp for GFortran) to your Fortran compiler flags."
 #endif
 
 ! Dangerous: Full path can be arbitrarily long and might overflow Fortran line.

--- a/src/base/base_uses.f90
+++ b/src/base/base_uses.f90
@@ -14,7 +14,7 @@
 
 ! Check for OpenMP early on - ideally before the compiler fails with a cryptic message.
 #if !defined(_OPENMP)
-   "OpenMP is required. Please add -fopenmp to your Fortran compiler flags."
+#error "OpenMP is required. Please add the corresponding flag (eg. -fopenmp for GFortran) to your Fortran compiler flags."
 #endif
 
 ! Dangerous: Full path can be arbitrarily long and might overflow Fortran line.


### PR DESCRIPTION
CCE has `-homp` flag to enable OpenMP, need to be more general in the error message.