### PR TITLE
Warning and issues reported by CCE #1490

### DIFF
--- a/src/commutator_rpnl.F
+++ b/src/commutator_rpnl.F
@@ -528,12 +528,12 @@ CONTAINS
 !$OMP PARALLEL &
 !$OMP DEFAULT (NONE) &
 !$OMP SHARED  (basis_set, matrix_rv, matrix_rxrv, matrix_rrv, &
-!$OMP          sap_int, nkind, eps_ppnl, my_rv, my_rxrv, my_rrv, locks, sab_all) &
+!$OMP          sap_int, natom, nkind, eps_ppnl, my_rv, my_rxrv, my_rrv, locks, sab_all) &
 !$OMP PRIVATE (ikind, jkind, iatom, jatom, cell_b, rab, &
 !$OMP          iab, irow, icol, blocks_rv, blocks_rxrv, blocks_rrv, &
 !$OMP          found, iac, ibc, alist_ac, alist_bc, acint, bcint, &
 !$OMP          achint, bchint, na, np, nb, kkind, kac, kbc, i, &
-!$OMP          go, asso_rv, asso_rxrv, asso_rrv, hash, natom)
+!$OMP          go, asso_rv, asso_rxrv, asso_rrv, hash)
 
 !$OMP SINGLE
 !$    ALLOCATE (locks(nlock))

--- a/src/core_ppnl.F
+++ b/src/core_ppnl.F
@@ -432,12 +432,12 @@ CONTAINS
 !$OMP DEFAULT (NONE) &
 !$OMP SHARED  (dokp, basis_set, matrix_h, cell_to_index,&
 !$OMP          sab_orb, matrix_p, sap_int, nkind, eps_ppnl, force, &
-!$OMP          locks, virial, use_virial, calculate_forces) &
+!$OMP          locks, natom, virial, use_virial, calculate_forces) &
 !$OMP PRIVATE (ikind, jkind, iatom, jatom, cell_b, rab, &
 !$OMP          slot, iab, atom_a, f0, irow, icol, h_block, &
 !$OMP          found,p_block, iac, ibc, alist_ac, alist_bc, acint, bcint, &
 !$OMP          achint, bchint, na, np, nb, katom, j, fa, fb, rbc, rac, &
-!$OMP          kkind, kac, kbc, i, img, hash, iatom8, natom) &
+!$OMP          kkind, kac, kbc, i, img, hash, iatom8) &
 !$OMP REDUCTION (+ : pv_thread, force_thread )
 
 !$OMP SINGLE

--- a/src/iterate_matrix.F
+++ b/src/iterate_matrix.F
@@ -1575,8 +1575,7 @@ CONTAINS
          !$OMP PARALLEL DEFAULT(NONE) &
 #endif
          !$OMP          PRIVATE(sm, sm_sign, sm_size, sm_firstcol, sm_lastcol, j) &
-         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, eigbufs, mu, new_mu) &
-         !$OMP          REDUCTION(+:trace)
+         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, eigbufs, mu, new_mu)
          !$OMP DO SCHEDULE(GUIDED)
          DO i = 1, SIZE(my_sms)
             WRITE (unit_nr, '(T3,A,1X,I4,1X,A,1X,I6)') "Rank", myrank, "finalizing submatrix", my_sms(i)
@@ -1603,8 +1602,7 @@ CONTAINS
          !$OMP PARALLEL DEFAULT(NONE) &
 #endif
          !$OMP          PRIVATE(sm, sm_sign, sm_size, sm_firstcol, sm_lastcol, j) &
-         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, eigbufs, mu, new_mu) &
-         !$OMP          REDUCTION(+:trace)
+         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, eigbufs, mu, new_mu)
          !$OMP DO SCHEDULE(GUIDED)
          DO i = 1, SIZE(my_sms)
             WRITE (unit_nr, '(T3,A,1X,I4,1X,A,1X,I6)') "Rank", myrank, "reprocessing submatrix", my_sms(i)

--- a/src/qs_kind_types.F
+++ b/src/qs_kind_types.F
@@ -2011,7 +2011,7 @@ CONTAINS
                          "Information provided in the input file regarding POTENTIAL for KIND <"// &
                          TRIM(qs_kind%name)//"> will be ignored!")
 
-         check = ((nb_rep > 0) .OR. explicit_basis)
+         check = ((k_rep > 0) .OR. explicit_basis)
          IF (check) &
             CALL cp_warn(__LOCATION__, &
                          "Information provided in the input file regarding BASIS for KIND <"// &
@@ -2044,7 +2044,7 @@ CONTAINS
                          "Information provided in the input file regarding POTENTIAL for KIND <"// &
                          TRIM(qs_kind%name)//"> will be ignored!")
 
-         check = ((nb_rep > 0) .OR. explicit_basis)
+         check = ((k_rep > 0) .OR. explicit_basis)
          IF (check) &
             CALL cp_warn(__LOCATION__, &
                          "Information provided in the input file regarding BASIS for KIND <"// &

--- a/src/xc/xc_tpss.F
+++ b/src/xc/xc_tpss.F
@@ -178,6 +178,10 @@ CONTAINS
 !$OMP     END PARALLEL
 
       logger => cp_get_default_logger()
+      ! we could check if tau/grad were consistent, but don't do anything here
+      IF (non_coer > 0) THEN
+         non_coer = 0
+      END IF
 
       CALL timestop(handle)
    END SUBROUTINE tpss_lda_eval

--- a/src/xtb_matrices.F
+++ b/src/xtb_matrices.F
@@ -1443,9 +1443,14 @@ CONTAINS
       LOGICAL                                            :: found
       REAL(KIND=dp)                                      :: ewald_rcut
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
+      TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(pair_potential_single_type), POINTER          :: pot
 
-      NULLIFY (pot)
+      NULLIFY (pot, logger)
+
+      logger => cp_get_default_logger()
+      iw = cp_logger_get_default_io_unit(logger)
+
       DO ikind = 1, SIZE(atomic_kind_set)
          atomic_kind => atomic_kind_set(ikind)
          CALL get_atomic_kind(atomic_kind=atomic_kind, name=name_atm_a_local)


### PR DESCRIPTION
Correct for CCE Compiler Warnings:
iterate_matrix.F, Line = 1602 OpenMP reduction result, trace, does not have a subsequent use.
/xc/xc_tpss.F, Line = 168 OpenMP reduction result, non_coer, does not have a subsequent use.
core_ppnl.F, Line = 520 Privatized version of variable "natom" is used before it is defined.
commutator_rpnl.F, Line = 646 Privatized version of variable "natom" is used before it is defined.
xtb_matrices.F, Line = 1467 Variable "iw" is used before it is defined.

Still open:
nnp_model.F, Line = 187 Variable "j" is used before it is defined.
sap_kind_types.F, Line = 243 A loop starting at line 243 which was marked for worksharing will not be workshared.
