### PR TITLE
grid: Add explicit barrier before reduction in ref collocate

### DIFF
--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -350,6 +350,10 @@ static void collocate_one_grid_level(
       } // end of task loop
     }   // end of block loop
 
+// While there should be an implicit barrier at the end of the block loop, this
+// explicit barrier eliminates occasional seg faults with icc compiled binaries.
+#pragma omp barrier
+
     // Merge thread-local grids via an efficient tree reduction.
     const int nreduction_cycles = ceil(log(nthreads) / log(2)); // tree depth
     for (int icycle = 1; icycle <= nreduction_cycles; icycle++) {


### PR DESCRIPTION
Our intel regtests show occasional segmentation faults in [grid_ref_task_list.c:370](https://github.com/cp2k/cp2k/blob/master/src/grid/ref/grid_ref_task_list.c#L370) when running `dftd3_t3.inp`, e.g. [here](https://dashboard.cp2k.org/archive/psi-intel1911-psmp/commit_20acf7466a80a3b56b2adf3c762ee4982e352f98.txt) and [here](https://dashboard.cp2k.org/archive/psi-intel20211-psmp/commit_3bec98f16ad4e43bb650bc2b7719517799202ac2.txt).

I managed to reproduce this problem locally in 6 out of 1k runs.

After adding the explicit barrier none out of 10k runs failed.