### PR TITLE
Revise MO information printout

### DIFF
--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -77,7 +77,6 @@ MODULE qs_mo_io
    USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: mo_set_p_type,&
                                               mo_set_type
-   USE string_utilities,                ONLY: compress
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -138,11 +137,11 @@ CONTAINS
             DO ispin = 1, SIZE(mo_array)
                IF (.NOT. ASSOCIATED(mo_array(ispin)%mo_set%mo_coeff_b)) THEN
                   CPASSERT(.FALSE.)
-               ENDIF
+               END IF
                CALL copy_dbcsr_to_fm(mo_array(ispin)%mo_set%mo_coeff_b, &
                                      mo_array(ispin)%mo_set%mo_coeff) !fm->dbcsr
-            ENDDO
-         ENDIF
+            END DO
+         END IF
 
          DO ikey = 1, SIZE(keys)
 
@@ -194,7 +193,7 @@ CONTAINS
          unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       ELSE
          unit_nr = -1
-      ENDIF
+      END IF
 
       project_name = logger%iter_info%project_name
       CALL section_vals_val_get(dft_section, "SCF%PRINT%DM_RESTART_WRITE", l_val=do_dm_restart)
@@ -215,11 +214,11 @@ CONTAINS
             cs_pos = dbcsr_checksum(matrix_p_tmp, pos=.TRUE.)
             IF (unit_nr > 0) THEN
                WRITE (unit_nr, '(T2,A,E20.8)') "Writing restart DM "//TRIM(file_name)//" with checksum: ", cs_pos
-            ENDIF
+            END IF
             CALL dbcsr_binary_write(matrix_p_tmp, file_name)
 
             CALL dbcsr_release(matrix_p_tmp)
-         ENDDO
+         END DO
          DEALLOCATE (matrix_p_tmp)
       END IF
 
@@ -474,7 +473,7 @@ CONTAINS
             filename = cp_print_key_generate_filename(logger, print_key, &
                                                       extension=".wfn", my_local=.FALSE.)
          END IF
-      ENDIF
+      END IF
       IF (.NOT. my_xas) THEN
          INQUIRE (FILE=filename, exist=exist)
       END IF
@@ -554,8 +553,8 @@ CONTAINS
             IF (para_env%ionode) CALL close_file(unit_number=restart_unit)
             CALL timestop(handle)
             RETURN
-         ENDIF
-      ENDIF
+         END IF
+      END IF
 
       ! Close restart file
       IF (para_env%ionode) CALL close_file(unit_number=restart_unit)
@@ -564,13 +563,14 @@ CONTAINS
       IF (.NOT. my_cdft) THEN
          DO ispin = 1, nspin
             CALL write_mo_set(mo_array(ispin)%mo_set, atomic_kind_set, qs_kind_set, &
-                              particle_set, 4, dft_section)
+                              particle_set, dft_section, 4, 0, last_mos=.FALSE.)
          END DO
       END IF
 
       CALL timestop(handle)
 
    END SUBROUTINE read_mo_set_from_restart
+
 ! **************************************************************************************************
 !> \brief ...
 !> \param mo_array ...
@@ -638,7 +638,7 @@ CONTAINS
 
       DO ispin = 1, nspin
          CALL write_mo_set(mo_array(ispin)%mo_set, atomic_kind_set, qs_kind_set, &
-                           particle_set, 4, dft_section)
+                           particle_set, dft_section, 4, 0, last_mos=.FALSE.)
       END DO
 
       CALL timestop(handle)
@@ -711,7 +711,7 @@ CONTAINS
             ! this case needs fixing of homo/lfomo/nelec/occupations ...
             IF (nspin_read > nspin) THEN
                CPABORT("Reducing nspin is not possible. ")
-            ENDIF
+            END IF
          END IF
 
          natom_match = (natom_read == natom)
@@ -761,8 +761,8 @@ CONTAINS
             RETURN
          ELSE
             CPABORT("Incorrect number of atoms in restart file. ")
-         ENDIF
-      ENDIF
+         END IF
+      END IF
 
       CALL mp_bcast(nspin_read, source, group)
 
@@ -959,47 +959,47 @@ CONTAINS
    END SUBROUTINE read_mos_restart_low
 
 ! **************************************************************************************************
-!> \brief   Write the MO eigenvalues, MO occupation numbers and
-!>          MO mo_coeff.
+!> \brief Write MO information to output file (eigenvalues, occupation numbers, coefficients)
 !> \param mo_set ...
 !> \param atomic_kind_set ...
 !> \param qs_kind_set ...
 !> \param particle_set ...
-!> \param before ...
 !> \param dft_section ...
+!> \param before Digits before the dot
+!> \param kpoint An integer that labels the current k point, e.g. its index
+!> \param last_mos ...
 !> \param spin ...
-!> \param last ...
-!> \param kpt An integer that labels the current k point, e.g. its index
 !> \date    15.05.2001
 !> \par History:
-!>       - Optionally print Cartesian MOs (20.04.2005,MK)
+!>       - Optionally print Cartesian MOs (20.04.2005, MK)
+!>       - Revise printout of MO information (05.05.2021, MK)
 !> \par Variables
 !>       - after : Number of digits after point.
 !>       - before: Number of digits before point.
-!> \author  MK
-!> \version 1.0
+!> \author  Matthias Krack (MK)
+!> \version 1.1
 ! **************************************************************************************************
    SUBROUTINE write_mo_set_to_output_unit(mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                          before, dft_section, spin, last, kpt)
+                                          dft_section, before, kpoint, last_mos, spin)
 
       TYPE(mo_set_type), POINTER                         :: mo_set
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      INTEGER, INTENT(IN)                                :: before
       TYPE(section_vals_type), POINTER                   :: dft_section
+      INTEGER, INTENT(IN)                                :: before, kpoint
+      LOGICAL, INTENT(IN), OPTIONAL                      :: last_mos
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: spin
-      LOGICAL, INTENT(IN), OPTIONAL                      :: last
-      INTEGER, INTENT(IN), OPTIONAL                      :: kpt
 
       CHARACTER(LEN=12)                                  :: symbol
       CHARACTER(LEN=12), DIMENSION(:), POINTER           :: bcgf_symbol
-      CHARACTER(LEN=16)                                  :: fmtstr5, fmtstr6
+      CHARACTER(LEN=16)                                  :: fmtstr5
       CHARACTER(LEN=2)                                   :: element_symbol
       CHARACTER(LEN=2*default_string_length)             :: name
+      CHARACTER(LEN=20)                                  :: fmtstr4
       CHARACTER(LEN=22)                                  :: fmtstr2
-      CHARACTER(LEN=25)                                  :: fmtstr1, fmtstr7
-      CHARACTER(LEN=27)                                  :: fmtstr4
+      CHARACTER(LEN=25)                                  :: fmtstr1
+      CHARACTER(LEN=29)                                  :: fmtstr6
       CHARACTER(LEN=38)                                  :: fmtstr3
       CHARACTER(LEN=6), DIMENSION(:), POINTER            :: bsgf_symbol
       INTEGER :: after, first_mo, from, iatom, icgf, ico, icol, ikind, imo, irow, iset, isgf, &
@@ -1007,8 +1007,9 @@ CONTAINS
          nrow_global, nset, nsgf, right, scf_step, to, width
       INTEGER, DIMENSION(:), POINTER                     :: mo_index_range, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l
-      LOGICAL                                            :: ionode, my_last, p_cart, p_eval, p_evec, &
-                                                            p_occ, should_output
+      LOGICAL                                            :: ionode, my_last, print_cartesian, &
+                                                            print_eigvals, print_eigvecs, &
+                                                            print_occup, should_output
       REAL(KIND=dp)                                      :: gap
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: cmatrix, smatrix
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -1023,27 +1024,26 @@ CONTAINS
 
       logger => cp_get_default_logger()
       ionode = logger%para_env%ionode
-      CALL section_vals_val_get(dft_section, "PRINT%MO%EIGENVALUES", l_val=p_eval)
-      CALL section_vals_val_get(dft_section, "PRINT%MO%EIGENVECTORS", l_val=p_evec)
-      CALL section_vals_val_get(dft_section, "PRINT%MO%OCCUPATION_NUMBERS", l_val=p_occ)
-      CALL section_vals_val_get(dft_section, "PRINT%MO%CARTESIAN", l_val=p_cart)
+      CALL section_vals_val_get(dft_section, "PRINT%MO%EIGENVALUES", l_val=print_eigvals)
+      CALL section_vals_val_get(dft_section, "PRINT%MO%EIGENVECTORS", l_val=print_eigvecs)
+      CALL section_vals_val_get(dft_section, "PRINT%MO%OCCUPATION_NUMBERS", l_val=print_occup)
+      CALL section_vals_val_get(dft_section, "PRINT%MO%CARTESIAN", l_val=print_cartesian)
       CALL section_vals_val_get(dft_section, "PRINT%MO%MO_INDEX_RANGE", i_vals=mo_index_range)
       CALL section_vals_val_get(dft_section, "PRINT%MO%NDIGITS", i_val=after)
       after = MIN(MAX(after, 1), 16)
       should_output = BTEST(cp_print_key_should_output(logger%iter_info, dft_section, &
                                                        "PRINT%MO"), cp_p_file)
 
-      IF ((.NOT. should_output) .OR. (.NOT. (p_eval .OR. p_evec .OR. p_occ))) RETURN
+      IF ((.NOT. should_output) .OR. (.NOT. (print_eigvals .OR. print_eigvecs .OR. print_occup))) RETURN
 
-      IF (PRESENT(last)) THEN
-         my_last = last
+      IF (PRESENT(last_mos)) THEN
+         my_last = last_mos
       ELSE
          my_last = .FALSE.
       END IF
+      scf_step = MAX(0, logger%iter_info%iteration(logger%iter_info%n_rlevel) - 1)
 
-      scf_step = logger%iter_info%iteration(logger%iter_info%n_rlevel) - 1
-
-      IF (p_evec) THEN
+      IF (print_eigvecs) THEN
          CALL cp_fm_get_info(mo_set%mo_coeff, &
                              nrow_global=nrow_global, &
                              ncol_global=ncol_global)
@@ -1087,15 +1087,15 @@ CONTAINS
          WRITE (UNIT=fmtstr3(32:33), FMT="(I2)") width - 1
          WRITE (UNIT=fmtstr3(35:36), FMT="(I2)") after
 
-         IF (p_evec) THEN
+         IF (print_eigvecs) THEN
 
-            IF (p_cart) THEN
+            IF (print_cartesian) THEN
 
                IF (my_last) THEN
                   name = "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
                          "CARTESIAN MO EIGENVECTORS"
                ELSE
-                  WRITE (UNIT=name, FMT="(A,I6)") &
+                  WRITE (UNIT=name, FMT="(A,1X,I0)") &
                      "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
                      "CARTESIAN MO EIGENVECTORS AFTER SCF STEP", scf_step
                END IF
@@ -1142,7 +1142,7 @@ CONTAINS
                         isgf = isgf + nso(lshell)
                      END DO
                   ELSE
-                     CPABORT("Unknown basis set type. ")
+                     CPABORT("Unknown basis set type")
                   END IF
                END DO ! iatom
 
@@ -1152,36 +1152,34 @@ CONTAINS
                   name = "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
                          "SPHERICAL MO EIGENVECTORS"
                ELSE
-                  WRITE (UNIT=name, FMT="(A,I6)") &
+                  WRITE (UNIT=name, FMT="(A,1X,I0)") &
                      "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
                      "SPHERICAL MO EIGENVECTORS AFTER SCF STEP", scf_step
                END IF
 
-            END IF ! p_cart
+            END IF ! print_cartesian
 
-         ELSE IF (p_occ .OR. p_eval) THEN
+         ELSE IF (print_occup .OR. print_eigvals) THEN
 
             IF (my_last) THEN
                name = "MO EIGENVALUES AND MO OCCUPATION NUMBERS"
             ELSE
-               WRITE (UNIT=name, FMT="(A,I6)") &
+               WRITE (UNIT=name, FMT="(A,1X,I0)") &
                   "MO EIGENVALUES AND MO OCCUPATION NUMBERS AFTER "// &
                   "SCF STEP", scf_step
             END IF
 
-         END IF ! p_evec
-
-         CALL compress(name)
+         END IF ! print_eigvecs
 
          ! Print headline
-         IF (PRESENT(spin) .AND. PRESENT(kpt)) THEN
-            WRITE (UNIT=iw, FMT="(/,/,T2,A,I5)") spin//" "//TRIM(name)//" FOR K-POINT: ", kpt
+         IF (PRESENT(spin) .AND. (kpoint > 0)) THEN
+            WRITE (UNIT=iw, FMT="(/,T2,A,I0)") spin//" "//TRIM(name)//" FOR K POINT ", kpoint
          ELSE IF (PRESENT(spin)) THEN
-            WRITE (UNIT=iw, FMT="(/,/,T2,A)") spin//" "//TRIM(name)
-         ELSE IF (PRESENT(kpt)) THEN
-            WRITE (UNIT=iw, FMT="(/,/,T2,A,I5)") TRIM(name)//" FOR K-POINT: ", kpt
+            WRITE (UNIT=iw, FMT="(/,T2,A)") spin//" "//TRIM(name)
+         ELSE IF (kpoint > 0) THEN
+            WRITE (UNIT=iw, FMT="(/,T2,A,I0)") TRIM(name)//" FOR K POINT ", kpoint
          ELSE
-            WRITE (UNIT=iw, FMT="(/,/,T2,A)") TRIM(name)
+            WRITE (UNIT=iw, FMT="(/,T2,A)") TRIM(name)
          END IF
 
          ! Check if only a subset of the MOs has to be printed
@@ -1195,7 +1193,7 @@ CONTAINS
             last_mo = mo_set%nmo
          END IF
 
-         IF (p_evec) THEN
+         IF (print_eigvecs) THEN
 
             ! Print full MO information
 
@@ -1224,7 +1222,7 @@ CONTAINS
                                    basis_set=orb_basis_set, &
                                    dftb_parameter=dftb_parameter)
 
-                  IF (p_cart) THEN
+                  IF (print_cartesian) THEN
 
                      IF (ASSOCIATED(orb_basis_set)) THEN
                         CALL get_gto_basis_set(gto_basis_set=orb_basis_set, &
@@ -1262,7 +1260,7 @@ CONTAINS
                            END DO
                         END DO
                      ELSE
-                        CPABORT("Unknown basis set type. ")
+                        CPABORT("Unknown basis set type")
                      END IF
 
                   ELSE
@@ -1302,10 +1300,10 @@ CONTAINS
                            END DO
                         END DO
                      ELSE
-                        CPABORT("Unknown basis type. ")
+                        CPABORT("Unknown basis type")
                      END IF
 
-                  END IF ! p_cart
+                  END IF ! print_cartesian
 
                END DO ! iatom
 
@@ -1316,41 +1314,43 @@ CONTAINS
             ! Release work storage
 
             DEALLOCATE (smatrix)
-            IF (p_cart) THEN
+            IF (print_cartesian) THEN
                DEALLOCATE (cmatrix)
             END IF
 
-         ELSE IF (p_occ .OR. p_eval) THEN
+         ELSE IF (print_occup .OR. print_eigvals) THEN
 
-            fmtstr4 = "(T2,I9,2X,F28.  ,1X,F24.  )"
-            WRITE (UNIT=fmtstr4(15:16), FMT="(I2)") after
-            WRITE (UNIT=fmtstr4(25:26), FMT="(I2)") after
+            fmtstr4 = "(T2,I9,3(1X,F22.  ))"
+            WRITE (UNIT=fmtstr4(17:18), FMT="(I2)") after
             WRITE (UNIT=iw, FMT="(/,A)") &
-               "# MO index          MO eigenvalue [a.u.]            MO occupation"
+               "# MO index   MO eigenvalue [a.u.]     MO eigenvalue [eV]          MO occupation"
             DO imo = first_mo, last_mo
                WRITE (UNIT=iw, FMT=fmtstr4) &
-                  imo, mo_set%eigenvalues(imo), mo_set%occupation_numbers(imo)
+                  imo, mo_set%eigenvalues(imo), &
+                  mo_set%eigenvalues(imo)*evolt, &
+                  mo_set%occupation_numbers(imo)
             END DO
-            fmtstr5 = "(A,T42,F24.  ,/)"
+            fmtstr5 = "(A,T58,F22.  ,/)"
             WRITE (UNIT=fmtstr5(12:13), FMT="(I2)") after
             WRITE (UNIT=iw, FMT=fmtstr5) &
                "# Sum", accurate_sum(mo_set%occupation_numbers(:))
 
-         END IF ! p_evec
+         END IF ! print_eigvecs
 
-         fmtstr6 = "(A,T17,F24.  ,/)"
+         fmtstr6 = "(A,T17,F17.  ,A,T40,F17.  ,A)"
          WRITE (UNIT=fmtstr6(12:13), FMT="(I2)") after
-         WRITE (UNIT=iw, FMT=fmtstr6) "  Fermi energy:", mo_set%mu
+         WRITE (UNIT=fmtstr6(25:26), FMT="(I2)") after
+         WRITE (UNIT=iw, FMT=fmtstr6) &
+            "  Fermi energy:", mo_set%mu, " a.u.", mo_set%mu*evolt, " eV"
          IF ((mo_set%homo > 0)) THEN
             IF ((mo_set%occupation_numbers(mo_set%homo) == mo_set%maxocc) .AND. (last_mo > mo_set%homo)) THEN
                gap = mo_set%eigenvalues(mo_set%homo + 1) - &
                      mo_set%eigenvalues(mo_set%homo)
-               fmtstr7 = "(A,T17,F24.  ,A,F6.2,A,/)"
-               WRITE (UNIT=fmtstr7(12:13), FMT="(I2)") after
-               WRITE (UNIT=iw, FMT=fmtstr7) &
-                  "  HOMO-LUMO gap:", gap, " = ", gap*evolt, " eV"
+               WRITE (UNIT=iw, FMT=fmtstr6) &
+                  "  HOMO-LUMO gap:", gap, " a.u.", gap*evolt, " eV"
             END IF
          END IF
+         WRITE (UNIT=iw, FMT="(A)") ""
 
       END IF ! iw
 

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -473,8 +473,8 @@ CONTAINS
                CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, energy_only)
             END IF
 
-            ! another heavy weight print object, print controlled by dft_section
-            CALL qs_scf_write_mos(mos, atomic_kind_set, qs_kind_set, particle_set, dft_section)
+            ! Print requested MO information (can be computationally expensive with OT)
+            CALL qs_scf_write_mos(qs_env, scf_env, last_mos=.FALSE.)
 
             CALL qs_scf_density_mixing(scf_env, rho, para_env, diis_step)
 

--- a/src/qs_scf_output.F
+++ b/src/qs_scf_output.F
@@ -6,9 +6,13 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE qs_scf_output
+   USE admm_types,                      ONLY: admm_type
+   USE admm_utils,                      ONLY: admm_correct_for_eigenvalues,&
+                                              admm_uncorrect_for_eigenvalues
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
+   USE cp_fm_types,                     ONLY: cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_p_file,&
@@ -17,7 +21,8 @@ MODULE qs_scf_output
                                               cp_print_key_unit_nr
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE cp_units,                        ONLY: cp_unit_from_cp2k
-   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE dbcsr_api,                       ONLY: dbcsr_p_type,&
+                                              dbcsr_type
    USE input_constants,                 ONLY: &
         becke_cutoff_element, becke_cutoff_global, cdft_alpha_constraint, cdft_beta_constraint, &
         cdft_charge_constraint, cdft_magnetization_constraint, outer_scf_becke_constraint, &
@@ -30,6 +35,7 @@ MODULE qs_scf_output
                                               section_vals_val_get
    USE kahan_sum,                       ONLY: accurate_sum
    USE kinds,                           ONLY: dp
+   USE kpoint_types,                    ONLY: kpoint_type
    USE machine,                         ONLY: m_flush
    USE particle_types,                  ONLY: particle_type
    USE physcon,                         ONLY: evolt,&
@@ -50,12 +56,15 @@ MODULE qs_scf_output
    USE qs_kind_types,                   ONLY: qs_kind_type
    USE qs_mo_io,                        ONLY: write_mo_set
    USE qs_mo_methods,                   ONLY: calculate_magnitude,&
-                                              calculate_orthonormality
+                                              calculate_orthonormality,&
+                                              calculate_subspace_eigenvalues
+   USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_p_type
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
-   USE qs_scf_types,                    ONLY: qs_scf_env_type,&
+   USE qs_scf_types,                    ONLY: ot_method_nr,&
+                                              qs_scf_env_type,&
                                               special_diag_method_nr
    USE scf_control_types,               ONLY: scf_control_type
 #include "./base/base_uses.f90"
@@ -122,8 +131,6 @@ CONTAINS
 
       INTEGER                                            :: homo, ispin, nao, nelectron_spin, nmo
 
-! print occupation numbers
-
       IF (output_unit > 0) THEN
          DO ispin = 1, dft_control%nspins
             CALL get_mo_set(mo_set=mos(ispin)%mo_set, &
@@ -146,31 +153,134 @@ CONTAINS
    END SUBROUTINE qs_scf_initial_info
 
 ! **************************************************************************************************
-!> \brief writes out the mos in the scf loop if needed
-!> \param mos ...
-!> \param atomic_kind_set ...
-!> \param qs_kind_set ...
-!> \param particle_set ...
-!> \param dft_section ...
+!> \brief Write the MO eigenvector, eigenvalues, and occupation numbers to the output unit
+!> \param qs_env ...
+!> \param scf_env ...
+!> \param last_mos ...
+!> \par History
+!>      - Revise MO printout to enable eigenvalues with OT (05.05.2021, MK)
 ! **************************************************************************************************
-   SUBROUTINE qs_scf_write_mos(mos, atomic_kind_set, qs_kind_set, particle_set, dft_section)
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
-      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      TYPE(section_vals_type), POINTER                   :: dft_section
+   SUBROUTINE qs_scf_write_mos(qs_env, scf_env, last_mos)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
+      LOGICAL, INTENT(IN)                                :: last_mos
 
-      IF (SIZE(mos) > 1) THEN
-         CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                           dft_section, spin="ALPHA", last=.FALSE.)
-         CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                           dft_section, spin="BETA", last=.FALSE.)
-      ELSE
-         CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                           dft_section, last=.FALSE.)
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_scf_write_mos'
+
+      INTEGER                                            :: handle, ikp, ispin, kpoint, nkp
+      LOGICAL                                            :: do_kpoints, print_eigvals, &
+                                                            print_eigvecs, print_mo_info, &
+                                                            print_occup
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
+      TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks
+      TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(section_vals_type), POINTER                   :: dft_section, input
+
+      CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(qs_env))
+
+      ! Retrieve the required information for the requested print output
+      CALL get_qs_env(qs_env, &
+                      atomic_kind_set=atomic_kind_set, &
+                      dft_control=dft_control, &
+                      input=input, &
+                      do_kpoints=do_kpoints, &
+                      particle_set=particle_set, &
+                      qs_kind_set=qs_kind_set)
+
+      ! Quick return, if no printout of MO information is requested
+      dft_section => section_vals_get_subs_vals(input, "DFT")
+      CALL section_vals_val_get(dft_section, "PRINT%MO%EIGENVALUES", l_val=print_eigvals)
+      CALL section_vals_val_get(dft_section, "PRINT%MO%EIGENVECTORS", l_val=print_eigvecs)
+      CALL section_vals_val_get(dft_section, "PRINT%MO%OCCUPATION_NUMBERS", l_val=print_occup)
+      logger => cp_get_default_logger()
+      print_mo_info = (cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%MO") /= 0)
+      IF ((.NOT. print_mo_info) .OR. (.NOT. (print_eigvals .OR. print_eigvecs .OR. print_occup))) THEN
+         CALL timestop(handle)
+         RETURN
       END IF
 
+      ! Check, if we have k points
+      IF (do_kpoints) THEN
+         CALL get_qs_env(qs_env, kpoints=kpoints)
+         nkp = SIZE(kpoints%kp_env)
+      ELSE
+         CALL get_qs_env(qs_env, matrix_ks=ks, mos=mos)
+         CPASSERT(ASSOCIATED(ks))
+         nkp = 1
+      END IF
+
+      DO ikp = 1, nkp
+
+         IF (do_kpoints) THEN
+            mos => kpoints%kp_env(ikp)%kpoint_env%mos(1, :)
+            kpoint = ikp
+         ELSE
+            CALL get_qs_env(qs_env, matrix_ks=ks, mos=mos)
+            kpoint = 0 ! Gamma point only
+         END IF
+         CPASSERT(ASSOCIATED(mos))
+
+         ! Prepare MO information for printout
+         DO ispin = 1, dft_control%nspins
+            ! With ADMM, we have to modify the Kohn-Sham matrix
+            IF (dft_control%do_admm) THEN
+               CALL get_qs_env(qs_env, admm_env=admm_env)
+               CALL admm_correct_for_eigenvalues(ispin, admm_env, ks(ispin)%matrix)
+            END IF
+            ! Calculate MO eigenvalues in case OT is used
+            IF (scf_env%method == ot_method_nr) THEN
+               IF (do_kpoints) THEN
+                  CPABORT("The OT method is not implemented for k points")
+               END IF
+               CALL get_mo_set(mo_set=mos(ispin)%mo_set, &
+                               mo_coeff=mo_coeff, &
+                               eigenvalues=mo_eigenvalues)
+               IF (ASSOCIATED(qs_env%mo_derivs)) THEN
+                  mo_coeff_deriv => qs_env%mo_derivs(ispin)%matrix
+               ELSE
+                  mo_coeff_deriv => NULL()
+               END IF
+               CALL calculate_subspace_eigenvalues(orbitals=mo_coeff, &
+                                                   ks_matrix=ks(ispin)%matrix, &
+                                                   evals_arg=mo_eigenvalues, &
+                                                   do_rotation=.TRUE., &
+                                                   co_rotate_dbcsr=mo_coeff_deriv)
+               CALL set_mo_occupation(mo_set=mos(ispin)%mo_set)
+            END IF
+            ! With ADMM, we have to undo the modification of the Kohn-Sham matrix
+            IF (dft_control%do_admm) THEN
+               CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, ks(ispin)%matrix)
+            END IF
+         END DO
+
+         ! Print MO information
+         IF (SIZE(mos) > 1) THEN
+            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                              dft_section, 4, kpoint, last_mos=last_mos, spin="ALPHA")
+            CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                              dft_section, 4, kpoint, last_mos=last_mos, spin="BETA")
+         ELSE
+            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                              dft_section, 4, kpoint, last_mos=last_mos)
+         END IF
+
+      END DO ! k point loop
+
+      CALL timestop(handle)
+
    END SUBROUTINE qs_scf_write_mos
+
 ! **************************************************************************************************
 !> \brief writes basic information obtained in a scf outer loop step
 !> \param output_unit ...
@@ -181,7 +291,6 @@ CONTAINS
 !> \param should_stop ...
 !> \param outer_loop_converged ...
 ! **************************************************************************************************
-
    SUBROUTINE qs_scf_outer_loop_info(output_unit, scf_control, scf_env, &
                                      energy, total_steps, should_stop, outer_loop_converged)
       INTEGER                                            :: output_unit
@@ -220,7 +329,6 @@ CONTAINS
 !> \param t2 ...
 !> \param energy ...
 ! **************************************************************************************************
-
    SUBROUTINE qs_scf_loop_info(scf_env, output_unit, just_energy, t1, t2, energy)
 
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
@@ -314,7 +422,7 @@ CONTAINS
                   "Total dipole moment perpendicular to ", &
                   "the slab [electrons-Angstroem]: ", &
                   qs_env%surface_dipole_moment
-            ENDIF
+            END IF
 
             IF (gapw) THEN
                tot1_h = qs_charges%total_rho1_hard(1)
@@ -465,7 +573,7 @@ CONTAINS
             IF (qs_env%qmmm_env_qm%image_charge) THEN
                WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.14)") &
                   "QM/MM image charge energy:                ", energy%image_charge
-            ENDIF
+            END IF
          END IF
          IF (dft_control%qs_control%mulliken_restraint) THEN
             WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.14)") &
@@ -485,8 +593,8 @@ CONTAINS
          IF (qmmm) THEN
             IF (qs_env%qmmm_env_qm%image_charge) THEN
                CALL print_image_coefficients(qs_env%image_coeff, qs_env)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
          CALL m_flush(output_unit)
       END IF
 
@@ -567,7 +675,7 @@ CONTAINS
                                               "PRINT%AO_MATRICES/KOHN_SHAM_MATRIX")
          END IF
 
-      ENDDO
+      END DO
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, &
                                            scf_section, "PRINT%MO_ORTHONORMALITY"), cp_p_file)) THEN
@@ -577,7 +685,7 @@ CONTAINS
             IF (iw > 0) THEN
                WRITE (iw, '(T8,A)') &
                   " K-points: Maximum deviation from MO S-orthonormality not determined"
-            ENDIF
+            END IF
             CALL cp_print_key_finished_output(iw, logger, scf_section, &
                                               "PRINT%MO_ORTHONORMALITY")
          ELSE
@@ -593,11 +701,11 @@ CONTAINS
             IF (iw > 0) THEN
                WRITE (iw, '(T8,A,T61,E20.4)') &
                   " Maximum deviation from MO S-orthonormality", orthonormality
-            ENDIF
+            END IF
             CALL cp_print_key_finished_output(iw, logger, scf_section, &
                                               "PRINT%MO_ORTHONORMALITY")
          END IF
-      ENDIF
+      END IF
       IF (BTEST(cp_print_key_should_output(logger%iter_info, &
                                            scf_section, "PRINT%MO_MAGNITUDE"), cp_p_file)) THEN
          IF (do_kpoints) THEN
@@ -606,7 +714,7 @@ CONTAINS
             IF (iw > 0) THEN
                WRITE (iw, '(T8,A)') &
                   " K-points: Minimum/Maximum MO magnitude not determined"
-            ENDIF
+            END IF
             CALL cp_print_key_finished_output(iw, logger, scf_section, &
                                               "PRINT%MO_MAGNITUDE")
          ELSE
@@ -617,11 +725,11 @@ CONTAINS
             IF (iw > 0) THEN
                WRITE (iw, '(T8,A,T41,2E20.4)') &
                   " Minimum/Maximum MO magnitude ", mo_mag_min, mo_mag_max
-            ENDIF
+            END IF
             CALL cp_print_key_finished_output(iw, logger, scf_section, &
                                               "PRINT%MO_MAGNITUDE")
          END IF
-      ENDIF
+      END IF
 
       CALL timestop(handle)
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -162,8 +162,7 @@ MODULE qs_scf_post_gpw
                                               retain_history
    USE qs_local_properties,             ONLY: qs_local_energy,&
                                               qs_local_stress
-   USE qs_mo_io,                        ONLY: write_dm_binary_restart,&
-                                              write_mo_set
+   USE qs_mo_io,                        ONLY: write_dm_binary_restart
    USE qs_mo_methods,                   ONLY: calculate_subspace_eigenvalues,&
                                               make_mo_eig
    USE qs_mo_occupation,                ONLY: set_mo_occupation
@@ -189,6 +188,7 @@ MODULE qs_scf_post_gpw
                                               qs_rho_type
    USE qs_scf_csr_write,                ONLY: write_ks_matrix_csr,&
                                               write_s_matrix_csr
+   USE qs_scf_output,                   ONLY: qs_scf_write_mos
    USE qs_scf_types,                    ONLY: ot_method_nr,&
                                               qs_scf_env_type
    USE qs_scf_wfn_mix,                  ONLY: wfn_mix
@@ -294,8 +294,8 @@ CONTAINS
             WRITE (UNIT=output_unit, FMT='(/,(T1,A))') REPEAT("-", 40)
             WRITE (UNIT=output_unit, FMT='(/,(T3,A,T19,A,T25,A))') "Properties from ", wf_type, " density"
             WRITE (UNIT=output_unit, FMT='(/,(T1,A))') REPEAT("-", 40)
-         ENDIF
-      ENDIF
+         END IF
+      END IF
 
       ! Writes the data that is already available in qs_env
       CALL get_qs_env(qs_env, scf_env=scf_env)
@@ -349,7 +349,7 @@ CONTAINS
                                         extension=".Log")
          IF (unit_nr > 0) THEN
             WRITE (unit_nr, '(T3,A,T55,F25.14)') "Electronic kinetic energy:", e_kin
-         ENDIF
+         END IF
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%KINETIC_ENERGY")
       END IF
@@ -476,8 +476,8 @@ CONTAINS
                CALL qs_scf_post_occ_cubes(input, dft_section, dft_control, logger, qs_env, &
                                           mo_coeff, wf_g, wf_r, particles, homo, ispin)
             END DO
-         ENDIF
-      ENDIF
+         END IF
+      END IF
 
       ! Initialize the localization environment, needed e.g. for wannier functions and molecular states
       ! Gets localization info for the occupied orbs
@@ -516,7 +516,7 @@ CONTAINS
             IF (qs_loc_env_homo%localized_wfn_control%use_history) THEN
                CALL retain_history(mo_loc_history, homo_localized)
                CALL set_qs_env(qs_env, mo_loc_history=mo_loc_history)
-            ENDIF
+            END IF
 
             !write restart for localization of occupied orbitals
             CALL loc_write_restart(qs_loc_env_homo, loc_print_section, mos, &
@@ -529,7 +529,7 @@ CONTAINS
                CALL loc_dipole(input, dft_control, qs_loc_env_homo, logger, qs_env)
             END IF
          END IF
-      ENDIF
+      END IF
 
       ! Gets the lumos, and eigenvalues for the lumos, and localize them if requested
       IF (do_kpoints) THEN
@@ -629,7 +629,7 @@ CONTAINS
                                       evals=unoccupied_evals)
                lumo_ptr => lumo_localized
             END IF
-         ENDIF
+         END IF
 
          IF (has_homo .AND. has_lumo) THEN
             IF (output_unit > 0) WRITE (output_unit, *) " "
@@ -639,9 +639,9 @@ CONTAINS
                   IF (output_unit > 0) WRITE (output_unit, '(T2,A,F12.6)') &
                      "HOMO - LUMO gap [eV] :", gap*evolt
                END IF
-            ENDDO
-         ENDIF
-      ENDIF
+            END DO
+         END IF
+      END IF
 
       ! Deallocate grids needed to compute wavefunctions
       IF (((do_mo_cubes .OR. do_wannier_cubes) .AND. (nlumo /= 0 .OR. nhomo /= 0)) .OR. p_loc) THEN
@@ -675,13 +675,13 @@ CONTAINS
                DEALLOCATE (unoccupied_evals(ispin)%array)
                IF (.NOT. dft_control%do_tddfpt_calculation) &
                   CALL cp_fm_release(unoccupied_orbs(ispin)%matrix)
-            ENDDO
+            END DO
             DEALLOCATE (unoccupied_evals)
             IF (.NOT. dft_control%do_tddfpt_calculation) THEN
                DEALLOCATE (unoccupied_orbs)
             END IF
-         ENDIF
-      ENDIF
+         END IF
+      END IF
 
       !stm images
       IF (do_stm) THEN
@@ -702,7 +702,7 @@ CONTAINS
                DO ispin = 1, dft_control%nspins
                   DEALLOCATE (unoccupied_evals_stm(ispin)%array)
                   CALL cp_fm_release(unoccupied_orbs_stm(ispin)%matrix)
-               ENDDO
+               END DO
                DEALLOCATE (unoccupied_evals_stm)
                DEALLOCATE (unoccupied_orbs_stm)
             END IF
@@ -812,8 +812,8 @@ CONTAINS
             ! this one can for sure not be right (as it has to match a given C0)
             IF (local_preconditioner%in_use == ot_precond_full_all) THEN
                NULLIFY (local_preconditioner)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
 
          ! ** If we do ADMM, we add have to modify the kohn-sham matrix
          IF (dft_control%do_admm) THEN
@@ -993,7 +993,7 @@ CONTAINS
             CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
                                stride=section_get_ivals(dft_section, "PRINT%MO_CUBES%STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, "DFT%PRINT%MO_CUBES", mpi_io=mpi_io)
-         ENDDO
+         END DO
          IF (ASSOCIATED(list_index)) DEALLOCATE (list_index)
       END IF
 
@@ -1078,8 +1078,8 @@ CONTAINS
             CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
                                stride=section_get_ivals(dft_section, "PRINT%MO_CUBES%STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, "DFT%PRINT%MO_CUBES", mpi_io=mpi_io)
-         ENDDO
-      ENDIF
+         END DO
+      END IF
 
       CALL timestop(handle)
 
@@ -1192,7 +1192,7 @@ CONTAINS
             END IF
             CALL cp_print_key_finished_output(unit_nr=unit_nr, logger=logger, &
                                               basis_section=input, print_key_path="DFT%PRINT%MOMENTS")
-         ENDIF
+         END IF
 
       END IF
 
@@ -1505,7 +1505,7 @@ CONTAINS
             ! optimizations
             WRITE (unit_nr, '(T2,A28,2A25)') "", "Tot. Ener.", "S Cond. Numb."
             WRITE (unit_nr, '(T2,A28,2E25.17)') "BASIS_MOLOPT_QUANTITIES", energy%total, S_cond_number
-         ENDIF
+         END IF
 
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%BASIS_MOLOPT_QUANTITIES")
@@ -1585,7 +1585,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'write_mo_dependent_results'
 
-      INTEGER                                            :: handle, homo, ik, ispin, nmo, output_unit
+      INTEGER                                            :: handle, homo, ispin, nmo, output_unit
       LOGICAL                                            :: all_equal, do_kpoints
       REAL(KIND=dp)                                      :: maxocc, s_square, s_square_ideal, &
                                                             total_abs_spin_dens
@@ -1600,7 +1600,6 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
-      TYPE(mo_set_p_type), DIMENSION(:, :), POINTER      :: mos_k
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1617,6 +1616,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: dft_section, input, sprint_section
 
       CALL timeset(routineN, handle)
+
       NULLIFY (cell, dft_control, pw_env, auxbas_pw_pool, pw_pools, mo_coeff, &
                mo_coeff_deriv, mo_eigenvalues, mos, atomic_kind_set, qs_kind_set, &
                particle_set, rho, ks_rmpv, matrix_s, scf_control, dft_section, &
@@ -1641,56 +1641,27 @@ CONTAINS
       CALL get_qs_env(qs_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r)
 
-      ! kpoints
+      ! k points
       CALL get_qs_env(qs_env, do_kpoints=do_kpoints)
 
-      ! *** if the dft_section tells you to do so, write last wavefunction to screen
+      ! Write last MO information to output file if requested
       dft_section => section_vals_get_subs_vals(input, "DFT")
       IF (.NOT. qs_env%run_rtp) THEN
+         CALL qs_scf_write_mos(qs_env, scf_env, last_mos=.TRUE.)
          IF (.NOT. do_kpoints) THEN
-            CALL get_qs_env(qs_env, mos=mos)
-            IF (dft_control%nspins == 2) THEN
-               CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                 dft_section, spin="ALPHA", last=.TRUE.)
-               CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                 dft_section, spin="BETA", last=.TRUE.)
-            ELSE
-               CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                 dft_section, last=.TRUE.)
-            END IF
-            CALL get_qs_env(qs_env, matrix_ks=ks_rmpv)
+            CALL get_qs_env(qs_env, mos=mos, matrix_ks=ks_rmpv)
             CALL write_dm_binary_restart(mos, dft_section, ks_rmpv)
             sprint_section => section_vals_get_subs_vals(dft_section, "PRINT%MO_MOLDEN")
             CALL write_mos_molden(mos, qs_kind_set, particle_set, sprint_section)
-
             ! Write Chargemol .wfx
             IF (BTEST(cp_print_key_should_output(logger%iter_info, &
-                                                 dft_section, "PRINT%CHARGEMOL"), cp_p_file)) THEN
+                                                 dft_section, "PRINT%CHARGEMOL"), &
+                      cp_p_file)) THEN
                CALL write_wfx(qs_env, dft_section)
-            END IF
-
-         ELSE ! *** if we have k points, let's print the eigenvalues at each of them
-            CALL get_qs_env(qs_env=qs_env, kpoints=kpoints)
-
-            IF (kpoints%nkp /= 0) THEN
-               DO ik = 1, SIZE(kpoints%kp_env)
-                  mos_k => kpoints%kp_env(ik)%kpoint_env%mos
-                  CPASSERT(ASSOCIATED(mos_k))
-
-                  IF (dft_control%nspins == 2) THEN
-                     CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                       dft_section, spin="ALPHA", last=.TRUE., kpt=ik)
-                     CALL write_mo_set(mos_k(1, 2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                       dft_section, spin="BETA", last=.TRUE., kpt=ik)
-                  ELSE
-                     CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                       dft_section, last=.TRUE., kpt=ik)
-                  END IF
-               END DO
             END IF
          END IF
 
-         ! *** at the end of scf print out dos
+         ! DOS printout after the SCF cycle is completed
          IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%DOS") &
                    , cp_p_file)) THEN
             IF (do_kpoints) THEN
@@ -1699,21 +1670,20 @@ CONTAINS
             ELSE
                CALL get_qs_env(qs_env, mos=mos)
                CALL calculate_dos(mos, qs_env, dft_section)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
 
-         ! *** at the end of scf print out the projected dos per kind
-         IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%PDOS") &
-                   , cp_p_file)) THEN
+         ! Print the projected density of states (pDOS) for each atomic kind
+         IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%PDOS"), &
+                   cp_p_file)) THEN
             IF (do_kpoints) THEN
-               CPWARN("Projected density of states not implemented for k-points.")
+               CPWARN("Projected density of states (pDOS) is not implemented for k points")
             ELSE
                CALL get_qs_env(qs_env, &
                                mos=mos, &
                                matrix_ks=ks_rmpv)
                DO ispin = 1, dft_control%nspins
-
-                  ! ** If we do ADMM, we add have to modify the kohn-sham matrix
+                  ! With ADMM, we have to modify the Kohn-Sham matrix
                   IF (dft_control%do_admm) THEN
                      CALL admm_correct_for_eigenvalues(ispin, admm_env, ks_rmpv(ispin)%matrix)
                   END IF
@@ -1725,13 +1695,11 @@ CONTAINS
                            mo_coeff_deriv => qs_env%mo_derivs(ispin)%matrix
                         ELSE
                            mo_coeff_deriv => NULL()
-                        ENDIF
-
+                        END IF
                         CALL calculate_subspace_eigenvalues(mo_coeff, ks_rmpv(ispin)%matrix, mo_eigenvalues, &
                                                             do_rotation=.TRUE., &
                                                             co_rotate_dbcsr=mo_coeff_deriv)
                         CALL set_mo_occupation(mo_set=mos(ispin)%mo_set)
-
                      END IF
                   END IF
                   IF (dft_control%nspins == 2) THEN
@@ -1741,19 +1709,17 @@ CONTAINS
                      CALL calculate_projected_dos(mos(ispin)%mo_set, atomic_kind_set, &
                                                   qs_kind_set, particle_set, qs_env, dft_section)
                   END IF
-
-                  ! ** If we do ADMM, we add have to modify the kohn-sham matrix
+                  ! With ADMM, we have to undo the modification of the Kohn-Sham matrix
                   IF (dft_control%do_admm) THEN
                      CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, ks_rmpv(ispin)%matrix)
                   END IF
-
                END DO
-            ENDIF
-         ENDIF
+            END IF
+         END IF
       END IF
 
-      !   *** Integrated absolute spin density and spin contamination ***
-      IF (dft_control%nspins .EQ. 2) THEN
+      ! Integrated absolute spin density and spin contamination ***
+      IF (dft_control%nspins == 2) THEN
          CALL get_qs_env(qs_env, mos=mos)
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
@@ -1801,8 +1767,8 @@ CONTAINS
                   "Ideal and single determinant S**2 : ", s_square_ideal, s_square
                energy%s_square = s_square
             END IF
-         ENDIF
-      ENDIF
+         END IF
+      END IF
 
       CALL timestop(handle)
 
@@ -2011,7 +1977,7 @@ CONTAINS
                   ELSE
                      nr = 0
                      niso = 0
-                  ENDIF
+                  END IF
                   CALL mp_sum(nr, para_env%group)
                   CALL mp_sum(niso, para_env%group)
 
@@ -2247,7 +2213,7 @@ CONTAINS
       IF (BTEST(cp_print_key_should_output(logger%iter_info, &
                                            dft_section, "PRINT%ENERGY_WINDOWS"), cp_p_file) .AND. .NOT. do_kpoints) THEN
          CALL energy_windows(qs_env)
-      ENDIF
+      END IF
 
       ! Print the hartree potential
       IF (BTEST(cp_print_key_should_output(logger%iter_info, input, &
@@ -2283,7 +2249,7 @@ CONTAINS
                                            "DFT%PRINT%V_HARTREE_CUBE", mpi_io=mpi_io)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-      ENDIF
+      END IF
 
       ! Print the external potential
       IF (BTEST(cp_print_key_should_output(logger%iter_info, input, &
@@ -2314,8 +2280,8 @@ CONTAINS
                                               "DFT%PRINT%EXTERNAL_POTENTIAL_CUBE", mpi_io=mpi_io)
 
             CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-         ENDIF
-      ENDIF
+         END IF
+      END IF
 
       ! Print the Electrical Field Components
       IF (BTEST(cp_print_key_should_output(logger%iter_info, input, &
@@ -2506,12 +2472,12 @@ CONTAINS
          should_print_voro = 1
       ELSE
          should_print_voro = 0
-      ENDIF
+      END IF
       IF (BTEST(cp_print_key_should_output(logger%iter_info, print_key_bqb), cp_p_file)) THEN
          should_print_bqb = 1
       ELSE
          should_print_bqb = 0
-      ENDIF
+      END IF
       IF ((should_print_voro /= 0) .OR. (should_print_bqb /= 0)) THEN
 
          ! we check if real space density is available
@@ -2554,7 +2520,7 @@ CONTAINS
                END IF
             ELSE
                unit_nr_voro = 0
-            ENDIF
+            END IF
 
             CALL entry_voronoi_or_bqb(should_print_voro, should_print_bqb, print_key_voro, print_key_bqb, &
                                       unit_nr_voro, qs_env, mb_rho)
@@ -3009,7 +2975,7 @@ CONTAINS
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE", mpi_io=mpi_io)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-      ENDIF
+      END IF
 
       ! Write Dirichlet constraint charges into a cube file
       do_cstr_charge_cube = BTEST(cp_print_key_should_output(logger%iter_info, input, &
@@ -3057,7 +3023,7 @@ CONTAINS
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE", mpi_io=mpi_io)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-      ENDIF
+      END IF
 
       ! Write Dirichlet type constranits into cube files
       do_dirichlet_bc_cube = BTEST(cp_print_key_should_output(logger%iter_info, input, &
@@ -3132,7 +3098,7 @@ CONTAINS
          END IF
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-      ENDIF
+      END IF
 
       CALL timestop(handle)
 
@@ -3228,7 +3194,7 @@ CONTAINS
             interact_adjm((ind - 1)*4 + 2) = colind
             interact_adjm((ind - 1)*4 + 3) = ikind
             interact_adjm((ind - 1)*4 + 4) = jkind
-         ENDDO
+         END DO
 
          CALL mp_sum(interact_adjm, para_env%group)
 
@@ -3304,7 +3270,7 @@ CONTAINS
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
-      ENDIF
+      END IF
 
    END SUBROUTINE update_hartree_with_mp2
 

--- a/src/qs_scf_post_se.F
+++ b/src/qs_scf_post_se.F
@@ -637,16 +637,16 @@ CONTAINS
       CALL qs_subsys_get(subsys, particles=particles)
 
       CALL qs_rho_get(rho, rho_ao=rho_ao)
-      ! *** if the dft_section tells you to do so, write last wavefunction to screen
+      ! Print MO information if requested
       dft_section => section_vals_get_subs_vals(input, "DFT")
       IF (dft_control%nspins == 2) THEN
-         CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                           dft_section, spin="ALPHA", last=.TRUE.)
-         CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                           dft_section, spin="BETA", last=.TRUE.)
+         CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                           dft_section, 4, 0, last_mos=.TRUE., spin="ALPHA")
+         CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                           dft_section, 4, 0, last_mos=.TRUE., spin="BETA")
       ELSE
-         CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                           dft_section, last=.TRUE.)
+         CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                           dft_section, 4, 0, last_mos=.TRUE.)
       END IF
 
       ! *** at the end of scf print out the projected dos per kind

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -393,9 +393,9 @@ CONTAINS
             ELSE
                CALL get_qs_env(qs_env, mos=mos)
                CALL calculate_dos(mos, qs_env, dft_section)
-            ENDIF
-         ENDIF
-      ENDIF
+            END IF
+         END IF
+      END IF
 
       ! PDOS
       IF (.NOT. no_mos) THEN
@@ -413,7 +413,7 @@ CONTAINS
                         mo_coeff_deriv => qs_env%mo_derivs(ispin)%matrix
                      ELSE
                         mo_coeff_deriv => NULL()
-                     ENDIF
+                     END IF
                      CALL calculate_subspace_eigenvalues(mo_coeff, ks_rmpv(ispin)%matrix, mo_eigenvalues, &
                                                          do_rotation=.TRUE., &
                                                          co_rotate_dbcsr=mo_coeff_deriv)
@@ -426,8 +426,8 @@ CONTAINS
                      CALL calculate_projected_dos(mos(ispin)%mo_set, atomic_kind_set, &
                                                   qs_kind_set, particle_set, qs_env, dft_section)
                   END IF
-               ENDDO
-            ENDIF
+               END DO
+            END IF
          END IF
       END IF
 
@@ -459,7 +459,7 @@ CONTAINS
          ELSE
             CPWARN("Energy Windows not implemented for TB methods.")
          END IF
-      ENDIF
+      END IF
 
       ! DENSITY CUBE FILE
       print_key => section_vals_get_subs_vals(print_section, "E_DENSITY_CUBE")
@@ -585,7 +585,7 @@ CONTAINS
                      DO ispin = 1, dft_control%nspins
                         DEALLOCATE (unoccupied_evals_stm(ispin)%array)
                         CALL cp_fm_release(unoccupied_orbs_stm(ispin)%matrix)
-                     ENDDO
+                     END DO
                      DEALLOCATE (unoccupied_evals_stm)
                      DEALLOCATE (unoccupied_orbs_stm)
                   END IF
@@ -739,7 +739,7 @@ CONTAINS
 ! endif
 !deb
                END DO
-            ENDDO
+            END DO
          END DO
          dggamma = dggamma*zphase + ggamma*dzphase
          ggamma = ggamma*zphase
@@ -923,13 +923,13 @@ CONTAINS
       IF (.NOT. do_kpoints) THEN
          CALL get_qs_env(qs_env, mos=mos)
          IF (dft_control%nspins == 2) THEN
-            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                              dft_section, spin="ALPHA", last=.TRUE.)
-            CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                              dft_section, spin="BETA", last=.TRUE.)
+            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                              dft_section, 4, 0, last_mos=.TRUE., spin="ALPHA")
+            CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                              dft_section, 4, 0, last_mos=.TRUE., spin="BETA")
          ELSE
-            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                              dft_section, last=.TRUE.)
+            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                              dft_section, 4, 0, last_mos=.TRUE.)
          END IF
          !
          SELECT CASE (tb_type)
@@ -939,7 +939,7 @@ CONTAINS
             sprint_section => section_vals_get_subs_vals(dft_section, "PRINT%MO_MOLDEN")
             CALL write_mos_molden(mos, qs_kind_set, particle_set, sprint_section)
          CASE DEFAULT
-            CPABORT("unknown TB type")
+            CPABORT("Unknown TB type")
          END SELECT
       ELSE
          CALL get_qs_env(qs_env=qs_env, kpoints=kpoints)
@@ -948,13 +948,13 @@ CONTAINS
                mos_k => kpoints%kp_env(ik)%kpoint_env%mos
                CPASSERT(ASSOCIATED(mos_k))
                IF (dft_control%nspins == 2) THEN
-                  CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                    dft_section, spin="ALPHA", last=.TRUE., kpt=ik)
-                  CALL write_mo_set(mos_k(1, 2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                    dft_section, spin="BETA", last=.TRUE., kpt=ik)
+                  CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, kpoint=ik, last_mos=.TRUE., spin="ALPHA")
+                  CALL write_mo_set(mos_k(1, 2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, kpoint=ik, last_mos=.TRUE., spin="BETA")
                ELSE
-                  CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                    dft_section, last=.TRUE., kpt=ik)
+                  CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, kpoint=ik, last_mos=.TRUE.)
                END IF
             END DO
          END IF
@@ -1030,8 +1030,8 @@ CONTAINS
             ! this one can for sure not be right (as it has to match a given C0)
             IF (local_preconditioner%in_use == ot_precond_full_all) THEN
                NULLIFY (local_preconditioner)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
 
          CALL ot_eigensolver(matrix_h=ks_rmpv(ispin)%matrix, matrix_s=matrix_s(1)%matrix, &
                              matrix_c_fm=unoccupied_orbs(ispin)%matrix, &
@@ -1070,7 +1070,7 @@ CONTAINS
          CALL pw_env_create(new_pw_env)
          CALL set_ks_env(ks_env, pw_env=new_pw_env)
          CALL pw_env_release(new_pw_env)
-      ENDIF
+      END IF
       CALL get_qs_env(qs_env, pw_env=new_pw_env, dft_control=dft_control, cell=cell)
 
       new_pw_env%cell_hmat = cell%hmat
@@ -1081,7 +1081,7 @@ CONTAINS
       IF (.NOT. ASSOCIATED(task_list)) THEN
          CALL allocate_task_list(task_list)
          CALL set_ks_env(ks_env, task_list=task_list)
-      ENDIF
+      END IF
       skip_load_balance_distributed = dft_control%qs_control%skip_load_balance_distributed
       CALL generate_qs_task_list(ks_env, task_list, &
                                  reorder_rs_grid_ranks=.TRUE., soft_valid=.FALSE., &
@@ -1647,10 +1647,10 @@ CONTAINS
                   CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
                                      stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-               ENDDO
-            ENDIF
+               END DO
+            END IF
          END DO
-      ENDIF
+      END IF
 
       IF (nlumo /= 0) THEN
          DO ispin = 1, dft_control%nspins
@@ -1677,7 +1677,7 @@ CONTAINS
                   CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
                                      stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-               ENDDO
+               END DO
             END IF
          END DO
       END IF

--- a/src/xas_methods.F
+++ b/src/xas_methods.F
@@ -475,14 +475,14 @@ CONTAINS
                      CALL get_xas_env(xas_env=xas_env, scf_env=scf_env)
                   ELSE
                      CALL qs_scf_env_initialize(qs_env, scf_env, scf_control, scf_section)
-                  ENDIF
+                  END IF
 
                   DO ispin = 1, SIZE(mos)
                      IF (ASSOCIATED(mos(ispin)%mo_set%mo_coeff_b)) THEN !fm->dbcsr
                         CALL copy_fm_to_dbcsr(mos(ispin)%mo_set%mo_coeff, &
                                               mos(ispin)%mo_set%mo_coeff_b) !fm->dbcsr
-                     ENDIF !fm->dbcsr
-                  ENDDO !fm->dbcsr
+                     END IF !fm->dbcsr
+                  END DO !fm->dbcsr
 
                   IF (.NOT. scf_env%skip_diis) THEN
                      IF (.NOT. ASSOCIATED(scf_env%scf_diis_buffer)) THEN
@@ -504,11 +504,16 @@ CONTAINS
                END IF
                ! SCF DONE
 
-!   *** Write last wavefunction to screen ***
-               DO ispin = 1, nspins
-                  CALL write_mo_set(mos(ispin)%mo_set, atomic_kind_set, qs_kind_set, particle_set, 4, &
-                                    dft_section)
-               ENDDO
+               ! Write last wavefunction to screen
+               IF (SIZE(mos) > 1) THEN
+                  CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, 0, last_mos=.FALSE., spin="XAS ALPHA")
+                  CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, 0, last_mos=.FALSE., spin="XAS BETA")
+               ELSE
+                  CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, 0, last_mos=.FALSE., spin="XAS")
+               END IF
 
             ELSE
                ! Core level spectroscopy by TDDFT is not yet implemented
@@ -740,7 +745,7 @@ CONTAINS
          occ_estate = REAL(xas_control%xas_core_occupation, dp)
          IF (nele < 0.0_dp) nele = REAL(nelectron, dp) - (1.0_dp - occ_estate)
          occ_homo = 1.0_dp
-      ENDIF
+      END IF
       CALL set_xas_env(xas_env=xas_env, occ_estate=occ_estate, xas_nelectron=nele, &
                        nvirtual2=nvirtual2, nvirtual=nvirtual, homo_occ=occ_homo)
 
@@ -790,7 +795,7 @@ CONTAINS
          END IF
       ELSE
          NULLIFY (xas_control%list_cubes)
-      ENDIF
+      END IF
 
       NULLIFY (tmp_fm_struct)
       ALLOCATE (xas_env%groundstate_coeff(nspins))


### PR DESCRIPTION
- Fix printout of MO energies with OT using the `&MO` section
- Enable MO information printout with k points during the SCF using the `&MO` section
- Printout of MO energies (eigenvalues) in a.u. and eV