### PR TITLE
Enable printout of unoccupied MOs also with OT using the MO print section

### DIFF
--- a/src/fm/cp_fm_types.F
+++ b/src/fm/cp_fm_types.F
@@ -199,14 +199,14 @@ CONTAINS
          ALLOCATE (matrix%local_data_sp(nrow_local, ncol_local))
       ELSE
          ALLOCATE (matrix%local_data(nrow_local, ncol_local))
-      ENDIF
+      END IF
 
       ! JVDV we should remove this, as it is up to the user to zero afterwards
       IF (matrix%use_sp) THEN
          matrix%local_data_sp(1:nrow_local, 1:ncol_local) = 0.0_sp
       ELSE
          matrix%local_data(1:nrow_local, 1:ncol_local) = 0.0_dp
-      ENDIF
+      END IF
 
       IF (PRESENT(name)) THEN
          matrix%name = name
@@ -301,7 +301,7 @@ CONTAINS
       IF (FIRST) THEN
          seed(:, :) = RESHAPE((/1.0_dp, 2.0_dp, 3.0_dp, 4.0_dp, 5.0_dp, 6.0_dp/), (/3, 2/))
          FIRST = .FALSE.
-      ENDIF
+      END IF
       ! guarantee same seed over all tasks
       CALL mp_bcast(seed, 0, matrix%matrix_struct%para_env%group)
 
@@ -335,12 +335,12 @@ CONTAINS
             CALL rng%reset_to_next_substream()
             icol_global = icol_global + 1
             IF (icol_global == col_indices(icol_local)) EXIT
-         ENDDO
+         END DO
          CALL rng%fill(buff)
          DO irow_local = 1, nrow_local
             local_data(irow_local, icol_local) = buff(row_indices(irow_local))
-         ENDDO
-      ENDDO
+         END DO
+      END DO
 
       DEALLOCATE (buff)
 
@@ -377,7 +377,7 @@ CONTAINS
          matrix%local_data_sp(:, :) = REAL(alpha, sp)
       ELSE
          matrix%local_data(:, :) = alpha
-      ENDIF
+      END IF
 
       IF (PRESENT(beta)) THEN
          CPASSERT(.NOT. matrix%use_sp)
@@ -438,8 +438,8 @@ CONTAINS
                diag(i) = REAL(a_sp(irow_local, icol_local), dp)
             ELSE
                diag(i) = a(irow_local, icol_local)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
       END DO
 #else
       DO i = 1, nrow_global
@@ -447,8 +447,8 @@ CONTAINS
             diag(i) = REAL(matrix%local_data_sp(i, i), dp)
          ELSE
             diag(i) = matrix%local_data(i, i)
-         ENDIF
-      ENDDO
+         END IF
+      END DO
 #endif
       CALL mp_sum(diag, matrix%matrix_struct%para_env%group)
 
@@ -871,10 +871,10 @@ CONTAINS
       IF (PRESENT(local_data)) local_data => matrix%local_data ! not hiding things anymore :-(
       IF (PRESENT(row_indices)) THEN
          CALL cp_fm_struct_get(matrix%matrix_struct, row_indices=row_indices)
-      ENDIF
+      END IF
       IF (PRESENT(col_indices)) THEN
          CALL cp_fm_struct_get(matrix%matrix_struct, col_indices=col_indices)
-      ENDIF
+      END IF
       IF (PRESENT(nrow_locals)) THEN
          nrow_locals => matrix%matrix_struct%nrow_locals
       END IF
@@ -941,7 +941,7 @@ CONTAINS
          a_max = REAL(MAXVAL(ABS(my_block_sp(1:nrow_local, 1:ncol_local))), dp)
       ELSE
          a_max = MAXVAL(ABS(my_block(1:nrow_local, 1:ncol_local)))
-      ENDIF
+      END IF
 
       IF (PRESENT(ir_max)) THEN
          num_pe = matrix%matrix_struct%para_env%num_pe
@@ -962,13 +962,13 @@ CONTAINS
                         my_max = REAL(my_block_sp(j, i), dp)
                         ir_max_local = j
                         ic_max_local = i
-                     ENDIF
+                     END IF
                   ELSE
                      IF (ABS(my_block(j, i)) > my_max) THEN
                         my_max = my_block(j, i)
                         ir_max_local = j
                         ic_max_local = i
-                     ENDIF
+                     END IF
                   END IF
                END DO
             END DO
@@ -1041,8 +1041,8 @@ CONTAINS
       DO j = 1, ncol_local
          DO i = 1, nrow_local
             values(row_indices(i)) = values(row_indices(i)) + ABS(my_block(i, j))
-         ENDDO
-      ENDDO
+         END DO
+      END DO
       CALL mp_sum(values, matrix%matrix_struct%para_env%group)
       a_max = MAXVAL(values)
       DEALLOCATE (values)
@@ -1080,8 +1080,8 @@ CONTAINS
       DO j = 1, ncol_local
          DO i = 1, nrow_local
             norm_array(col_indices(j)) = norm_array(col_indices(j)) + my_block(i, j)*my_block(i, j)
-         ENDDO
-      ENDDO
+         END DO
+      END DO
       CALL mp_sum(norm_array, matrix%matrix_struct%para_env%group)
       norm_array = SQRT(norm_array)
 
@@ -1139,14 +1139,14 @@ CONTAINS
       DO j = 1, ncol_local
          DO i = 1, nrow_local
             sum_array(col_indices(j)) = sum_array(col_indices(j)) + my_block(i, j)
-         ENDDO
-      ENDDO
+         END DO
+      END DO
       ELSE
       DO j = 1, ncol_local
          DO i = 1, nrow_local
             sum_array(row_indices(i)) = sum_array(row_indices(i)) + my_block(i, j)
-         ENDDO
-      ENDDO
+         END DO
+      END DO
       END IF
       CALL mp_sum(sum_array, matrix%matrix_struct%para_env%group)
 
@@ -1185,7 +1185,7 @@ CONTAINS
                              ">. The local_data blocks have different sizes.")
             CALL scopy(SIZE(source%local_data_sp, 1)*SIZE(source%local_data_sp, 2), &
                        source%local_data_sp, 1, destination%local_data_sp, 1)
-         ELSEIF (source%use_sp .AND. .NOT. destination%use_sp) THEN
+         ELSE IF (source%use_sp .AND. .NOT. destination%use_sp) THEN
             IF (SIZE(source%local_data_sp, 1) /= SIZE(destination%local_data, 1) .OR. &
                 SIZE(source%local_data_sp, 2) /= SIZE(destination%local_data, 2)) &
                CALL cp_abort(__LOCATION__, &
@@ -1193,7 +1193,7 @@ CONTAINS
                              "> to full matrix <"//TRIM(destination%name)// &
                              ">. The local_data blocks have different sizes.")
             destination%local_data = REAL(source%local_data_sp, dp)
-         ELSEIF (.NOT. source%use_sp .AND. destination%use_sp) THEN
+         ELSE IF (.NOT. source%use_sp .AND. destination%use_sp) THEN
             IF (SIZE(source%local_data, 1) /= SIZE(destination%local_data_sp, 1) .OR. &
                 SIZE(source%local_data, 2) /= SIZE(destination%local_data_sp, 2)) &
                CALL cp_abort(__LOCATION__, &
@@ -1210,9 +1210,9 @@ CONTAINS
                              ">. The local_data blocks have different sizes.")
             CALL dcopy(SIZE(source%local_data, 1)*SIZE(source%local_data, 2), &
                        source%local_data, 1, destination%local_data, 1)
-         ENDIF
+         END IF
       ELSE
-         CPABORT("")
+         CPABORT("Data structures of source and target full matrix are not equivalent")
       END IF
 
       CALL timestop(handle)
@@ -1857,7 +1857,7 @@ CONTAINS
          ! Was already done in cp_fm_finish_copy_general
          IF (ASSOCIATED(src_blacs2mpi)) THEN
             DEALLOCATE (src_blacs2mpi)
-         ENDIF
+         END IF
          CALL mp_waitall(send_request(:))
          DEALLOCATE (send_request, send_buf)
          ! Invalidate the stored state
@@ -2108,11 +2108,11 @@ CONTAINS
          ELSE
             IF (ipcol == mypcol) THEN
                CALL mp_send(vecbuf(:), 0, tag, para_env%group)
-            ENDIF
+            END IF
             IF (mypcol == 0) THEN
                CALL mp_recv(vecbuf(:), ipcol, tag, para_env%group)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
 
          IF (unit > 0) THEN
             DO j = 1, i_block
@@ -2228,11 +2228,11 @@ CONTAINS
          ELSE
             IF (ipcol == mypcol) THEN
                CALL mp_send(vecbuf(:), 0, tag, para_env%group)
-            ENDIF
+            END IF
             IF (mypcol == 0) THEN
                CALL mp_recv(vecbuf(:), ipcol, tag, para_env%group)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
 
          IF (unit > 0) THEN
             DO j = 1, i_block
@@ -2305,12 +2305,12 @@ CONTAINS
          IF (para_env%mepos == 0) THEN
             DO k = 1, n_cols
                READ (unit) vecbuf(:, k)
-            ENDDO
-         ENDIF
+            END DO
+         END IF
          CALL mp_bcast(vecbuf, 0, para_env%group)
          CALL cp_fm_set_submatrix(fm, vecbuf, start_row=1, start_col=j, n_cols=n_cols)
 
-      ENDDO
+      END DO
 
       DEALLOCATE (vecbuf)
 

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -1292,39 +1292,46 @@ CONTAINS
 
       CALL cp_print_key_section_create( &
          print_key, __LOCATION__, "MO", &
-         description="Controls the printing of the molecular orbitals. "// &
-         "Note that this is only functional with diagonalization based methods, in particular not with OT (see MO_CUBES)", &
+         description="Controls the printing of the molecular orbital (MO) information. The requested MO information "// &
+         "is printed for all occupied MOs by default. Use the MO_INDEX_RANGE keyword to restrict the number "// &
+         "of the MOs or to print the MO information for unoccupied MOs. With diagonalization, additional MOs "// &
+         "have to be made available for printout using the ADDED_MOS keyword in the SCF section. With OT, "// &
+         "it is sufficient to specify the desired MO_INDEX_RANGE. The OT eigensolver can be controlled with "// &
+         "the EPS_LUMO and MAX_ITER_LUMO keywords in the SCF section.", &
          print_level=high_print_level, filename="__STD_OUT__")
-      CALL keyword_create(keyword, __LOCATION__, name="Cartesian", &
-                          description="If the printkey is activated controls the printing of the mo in the cartesian basis", &
+      CALL keyword_create(keyword, __LOCATION__, name="CARTESIAN", &
+                          description="Print the MOs in the Cartesian basis instead of the default spherical basis.", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="EIGENVALUES", variants=s2a("EIGVALS"), &
-                          description="If the printkey is activated controls the printing of the eigenvalues of the mos", &
+      CALL keyword_create(keyword, __LOCATION__, name="ENERGIES", &
+                          variants=s2a("EIGENVALUES", "EIGVALS"), &
+                          description="Print the MO energies (eigenvalues).", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="EIGENVECTORS", variants=s2a("EIGVECS"), &
-                          description="If the printkey is activated controls the printing of the eigenvectors of the mos", &
+      CALL keyword_create(keyword, __LOCATION__, name="COEFFICIENTS", &
+                          variants=s2a("EIGENVECTORS", "EIGVECS"), &
+                          description="Print the MO coefficients (eigenvectors).", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="OCCUPATION_NUMBERS", variants=s2a("OCCNUMS"), &
-                          description="If the printkey is activated controls the printing of the occupation numbers of the mos", &
+      CALL keyword_create(keyword, __LOCATION__, name="OCCUPATION_NUMBERS", &
+                          variants=s2a("OCCNUMS"), &
+                          description="Print the MO occupation numbers.", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="NDIGITS", &
-                          description="Specify the number of digits used to print the MO eigenvalues and occupation numbers", &
+                          description="Specify the number of digits used to print the MO information.", &
                           default_i_val=6)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, &
                           name="MO_INDEX_RANGE", &
                           variants=s2a("MO_RANGE", "RANGE"), &
-                          description="Allows to print only a subset of the MO eigenvectors or eigenvalues. "// &
-                          "The indices of the first and the last MO have to be specified", &
+                          description="Print only the requested subset of MOs. The indices of the first and "// &
+                          " the last MO have to be specified to define the range.", &
                           repeats=.FALSE., &
                           n_var=2, &
                           type_of_var=integer_t, &
@@ -2692,7 +2699,7 @@ CONTAINS
       NULLIFY (keyword)
 
       CALL cp_print_key_section_create(print_key, __LOCATION__, "MO_CUBES", &
-                                       description="Controls the printing of cubes of the molecular orbitals.", &
+                                       description="Controls the printing of the molecular orbitals (MOs) as cube files.", &
                                        print_level=high_print_level, filename="")
       CALL keyword_create(keyword, __LOCATION__, name="stride", &
                           description="The stride (X,Y,Z) used to write the cube file "// &
@@ -5171,15 +5178,16 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="MAX_ITER_LUMO", &
                           variants=(/"MAX_ITER_LUMOS"/), &
-                          description="The maximum number of iteration for the lumo computation", &
+                          description="Maximum number of iterations for the calculation of the LUMO energies "// &
+                          "with the OT eigensolver.", &
                           usage="MAX_ITER_LUMO 100", default_i_val=299)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="EPS_LUMO", &
                           variants=(/"EPS_LUMOS"/), &
-                          description="target accuracy of the computation of the lumo energy", &
-                          usage="EPS_LUMO 1.e-6", default_r_val=1.0e-5_dp)
+                          description="Target accuracy for the calculation of the LUMO energies with the OT eigensolver.", &
+                          usage="EPS_LUMO 1.0E-6", default_r_val=1.0E-5_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -563,7 +563,7 @@ CONTAINS
       IF (.NOT. my_cdft) THEN
          DO ispin = 1, nspin
             CALL write_mo_set(mo_array(ispin)%mo_set, atomic_kind_set, qs_kind_set, &
-                              particle_set, dft_section, 4, 0, last_mos=.FALSE.)
+                              particle_set, dft_section, 4, 0, final_mos=.FALSE.)
          END DO
       END IF
 
@@ -638,7 +638,7 @@ CONTAINS
 
       DO ispin = 1, nspin
          CALL write_mo_set(mo_array(ispin)%mo_set, atomic_kind_set, qs_kind_set, &
-                           particle_set, dft_section, 4, 0, last_mos=.FALSE.)
+                           particle_set, dft_section, 4, 0, final_mos=.FALSE.)
       END DO
 
       CALL timestop(handle)
@@ -967,8 +967,9 @@ CONTAINS
 !> \param dft_section ...
 !> \param before Digits before the dot
 !> \param kpoint An integer that labels the current k point, e.g. its index
-!> \param last_mos ...
+!> \param final_mos ...
 !> \param spin ...
+!> \param solver_method ...
 !> \date    15.05.2001
 !> \par History:
 !>       - Optionally print Cartesian MOs (20.04.2005, MK)
@@ -980,7 +981,8 @@ CONTAINS
 !> \version 1.1
 ! **************************************************************************************************
    SUBROUTINE write_mo_set_to_output_unit(mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                          dft_section, before, kpoint, last_mos, spin)
+                                          dft_section, before, kpoint, final_mos, spin, &
+                                          solver_method)
 
       TYPE(mo_set_type), POINTER                         :: mo_set
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -988,26 +990,28 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: dft_section
       INTEGER, INTENT(IN)                                :: before, kpoint
-      LOGICAL, INTENT(IN), OPTIONAL                      :: last_mos
+      LOGICAL, INTENT(IN), OPTIONAL                      :: final_mos
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: spin
+      CHARACTER(LEN=2), INTENT(IN), OPTIONAL             :: solver_method
 
       CHARACTER(LEN=12)                                  :: symbol
       CHARACTER(LEN=12), DIMENSION(:), POINTER           :: bcgf_symbol
-      CHARACTER(LEN=16)                                  :: fmtstr5
-      CHARACTER(LEN=2)                                   :: element_symbol
+      CHARACTER(LEN=14)                                  :: fmtstr5
+      CHARACTER(LEN=15)                                  :: energy_str, orbital_str, vector_str
+      CHARACTER(LEN=2)                                   :: element_symbol, my_solver_method
       CHARACTER(LEN=2*default_string_length)             :: name
-      CHARACTER(LEN=20)                                  :: fmtstr4
-      CHARACTER(LEN=22)                                  :: fmtstr2
+      CHARACTER(LEN=22)                                  :: fmtstr4
+      CHARACTER(LEN=24)                                  :: fmtstr2
       CHARACTER(LEN=25)                                  :: fmtstr1
       CHARACTER(LEN=29)                                  :: fmtstr6
-      CHARACTER(LEN=38)                                  :: fmtstr3
+      CHARACTER(LEN=40)                                  :: fmtstr3
       CHARACTER(LEN=6), DIMENSION(:), POINTER            :: bsgf_symbol
       INTEGER :: after, first_mo, from, iatom, icgf, ico, icol, ikind, imo, irow, iset, isgf, &
          ishell, iso, iw, jcol, last_mo, left, lmax, lshell, natom, ncgf, ncol, ncol_global, &
          nrow_global, nset, nsgf, right, scf_step, to, width
       INTEGER, DIMENSION(:), POINTER                     :: mo_index_range, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l
-      LOGICAL                                            :: ionode, my_last, print_cartesian, &
+      LOGICAL                                            :: ionode, my_final, print_cartesian, &
                                                             print_eigvals, print_eigvecs, &
                                                             print_occup, should_output
       REAL(KIND=dp)                                      :: gap
@@ -1036,12 +1040,20 @@ CONTAINS
 
       IF ((.NOT. should_output) .OR. (.NOT. (print_eigvals .OR. print_eigvecs .OR. print_occup))) RETURN
 
-      IF (PRESENT(last_mos)) THEN
-         my_last = last_mos
+      ! Do we print the final MO information after SCF convergence is reached (default: no)
+      IF (PRESENT(final_mos)) THEN
+         my_final = final_mos
       ELSE
-         my_last = .FALSE.
+         my_final = .FALSE.
       END IF
       scf_step = MAX(0, logger%iter_info%iteration(logger%iter_info%n_rlevel) - 1)
+
+      IF (PRESENT(solver_method)) THEN
+         my_solver_method = solver_method
+      ELSE
+         ! Traditional diagonalization is assumed as default solver method
+         my_solver_method = "TD"
+      END IF
 
       IF (print_eigvecs) THEN
          CALL cp_fm_get_info(mo_set%mo_coeff, &
@@ -1065,9 +1077,9 @@ CONTAINS
 
          ! Definition of the variable formats
 
-         fmtstr1 = "(/,T2,21X,  (  X,I5,  X))"
-         fmtstr2 = "(T2,21X,  (1X,F  .  ))"
-         fmtstr3 = "(T2,I5,1X,I5,1X,A,1X,A6,  (1X,F  .  ))"
+         fmtstr1 = "(T2,A,21X,  (  X,I5,  X))"
+         fmtstr2 = "(T2,A,21X,  (1X,F  .  ))"
+         fmtstr3 = "(T2,A,I5,1X,I5,1X,A,1X,A6,  (1X,F  .  ))"
 
          width = before + after + 3
          ncol = INT(56/width)
@@ -1079,33 +1091,32 @@ CONTAINS
          WRITE (UNIT=fmtstr1(14:15), FMT="(I2)") left
          WRITE (UNIT=fmtstr1(21:22), FMT="(I2)") right
 
-         WRITE (UNIT=fmtstr2(9:10), FMT="(I2)") ncol
-         WRITE (UNIT=fmtstr2(16:17), FMT="(I2)") width - 1
-         WRITE (UNIT=fmtstr2(19:20), FMT="(I2)") after
+         WRITE (UNIT=fmtstr2(11:12), FMT="(I2)") ncol
+         WRITE (UNIT=fmtstr2(18:19), FMT="(I2)") width - 1
+         WRITE (UNIT=fmtstr2(21:22), FMT="(I2)") after
 
-         WRITE (UNIT=fmtstr3(25:26), FMT="(I2)") ncol
-         WRITE (UNIT=fmtstr3(32:33), FMT="(I2)") width - 1
-         WRITE (UNIT=fmtstr3(35:36), FMT="(I2)") after
+         WRITE (UNIT=fmtstr3(27:28), FMT="(I2)") ncol
+         WRITE (UNIT=fmtstr3(34:35), FMT="(I2)") width - 1
+         WRITE (UNIT=fmtstr3(37:38), FMT="(I2)") after
+
+         IF (my_final .OR. (my_solver_method == "TD")) THEN
+            energy_str = "EIGENVALUES"
+            vector_str = "EIGENVECTORS"
+         ELSE
+            energy_str = "ENERGIES"
+            vector_str = "COEFFICIENTS"
+         END IF
 
          IF (print_eigvecs) THEN
 
             IF (print_cartesian) THEN
 
-               IF (my_last) THEN
-                  name = "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
-                         "CARTESIAN MO EIGENVECTORS"
-               ELSE
-                  WRITE (UNIT=name, FMT="(A,1X,I0)") &
-                     "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
-                     "CARTESIAN MO EIGENVECTORS AFTER SCF STEP", scf_step
-               END IF
+               orbital_str = "CARTESIAN"
 
                ALLOCATE (cmatrix(ncgf, ncgf))
-
                cmatrix = 0.0_dp
 
                ! Transform spherical MOs to Cartesian MOs
-
                icgf = 1
                isgf = 1
                DO iatom = 1, natom
@@ -1148,38 +1159,45 @@ CONTAINS
 
             ELSE
 
-               IF (my_last) THEN
-                  name = "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
-                         "SPHERICAL MO EIGENVECTORS"
-               ELSE
-                  WRITE (UNIT=name, FMT="(A,1X,I0)") &
-                     "MO EIGENVALUES, MO OCCUPATION NUMBERS, AND "// &
-                     "SPHERICAL MO EIGENVECTORS AFTER SCF STEP", scf_step
-               END IF
+               orbital_str = "SPHERICAL"
 
             END IF ! print_cartesian
 
-         ELSE IF (print_occup .OR. print_eigvals) THEN
-
-            IF (my_last) THEN
-               name = "MO EIGENVALUES AND MO OCCUPATION NUMBERS"
+            IF (my_final) THEN
+               name = TRIM(energy_str)//", OCCUPATION NUMBERS, AND "// &
+                      TRIM(orbital_str)//" "//TRIM(vector_str)
             ELSE
                WRITE (UNIT=name, FMT="(A,1X,I0)") &
-                  "MO EIGENVALUES AND MO OCCUPATION NUMBERS AFTER "// &
-                  "SCF STEP", scf_step
+                  TRIM(energy_str)//", OCCUPATION NUMBERS, AND "// &
+                  TRIM(orbital_str)//" "//TRIM(vector_str)//" AFTER SCF STEP", &
+                  scf_step
+            END IF
+
+         ELSE IF (print_occup .OR. print_eigvals) THEN
+
+            IF (my_final) THEN
+               name = TRIM(energy_str)//" AND OCCUPATION NUMBERS"
+            ELSE
+               WRITE (UNIT=name, FMT="(A,1X,I0)") &
+                  TRIM(energy_str)//" AND OCCUPATION NUMBERS "// &
+                  "AFTER SCF STEP", scf_step
             END IF
 
          END IF ! print_eigvecs
 
          ! Print headline
          IF (PRESENT(spin) .AND. (kpoint > 0)) THEN
-            WRITE (UNIT=iw, FMT="(/,T2,A,I0)") spin//" "//TRIM(name)//" FOR K POINT ", kpoint
+            WRITE (UNIT=iw, FMT="(/,T2,A,I0)") &
+               "MO| "//TRIM(spin)//" "//TRIM(name)//" FOR K POINT ", kpoint
          ELSE IF (PRESENT(spin)) THEN
-            WRITE (UNIT=iw, FMT="(/,T2,A)") spin//" "//TRIM(name)
+            WRITE (UNIT=iw, FMT="(/,T2,A)") &
+               "MO| "//TRIM(spin)//" "//TRIM(name)
          ELSE IF (kpoint > 0) THEN
-            WRITE (UNIT=iw, FMT="(/,T2,A,I0)") TRIM(name)//" FOR K POINT ", kpoint
+            WRITE (UNIT=iw, FMT="(/,T2,A,I0)") &
+               "MO| "//TRIM(name)//" FOR K POINT ", kpoint
          ELSE
-            WRITE (UNIT=iw, FMT="(/,T2,A)") TRIM(name)
+            WRITE (UNIT=iw, FMT="(/,T2,A)") &
+               "MO| "//TRIM(name)
          END IF
 
          ! Check if only a subset of the MOs has to be printed
@@ -1202,18 +1220,21 @@ CONTAINS
                from = icol
                to = MIN((from + ncol - 1), last_mo)
 
-               WRITE (UNIT=iw, FMT=fmtstr1) (jcol, jcol=from, to)
-               WRITE (UNIT=iw, FMT=fmtstr2) (mo_set%eigenvalues(jcol), jcol=from, to)
-               WRITE (UNIT=iw, FMT="(A)") ""
-
-               WRITE (UNIT=iw, FMT=fmtstr2) (mo_set%occupation_numbers(jcol), jcol=from, to)
-               WRITE (UNIT=iw, FMT="(A)") ""
+               WRITE (UNIT=iw, FMT="(T2,A)") "MO|"
+               WRITE (UNIT=iw, FMT=fmtstr1) &
+                  "MO|", (jcol, jcol=from, to)
+               WRITE (UNIT=iw, FMT=fmtstr2) &
+                  "MO|", (mo_set%eigenvalues(jcol), jcol=from, to)
+               WRITE (UNIT=iw, FMT="(T2,A)") "MO|"
+               WRITE (UNIT=iw, FMT=fmtstr2) &
+                  "MO|", (mo_set%occupation_numbers(jcol), jcol=from, to)
+               WRITE (UNIT=iw, FMT="(T2,A)") "MO|"
 
                irow = 1
 
                DO iatom = 1, natom
 
-                  IF (iatom /= 1) WRITE (UNIT=iw, FMT="(A)") ""
+                  IF (iatom /= 1) WRITE (UNIT=iw, FMT="(T2,A)") "MO|"
 
                   NULLIFY (orb_basis_set, dftb_parameter)
                   CALL get_atomic_kind(particle_set(iatom)%atomic_kind, &
@@ -1237,7 +1258,7 @@ CONTAINS
                               lshell = l(ishell, iset)
                               DO ico = 1, nco(lshell)
                                  WRITE (UNIT=iw, FMT=fmtstr3) &
-                                    irow, iatom, ADJUSTR(element_symbol), bcgf_symbol(icgf), &
+                                    "MO|", irow, iatom, ADJUSTR(element_symbol), bcgf_symbol(icgf), &
                                     (cmatrix(irow, jcol), jcol=from, to)
                                  icgf = icgf + 1
                                  irow = irow + 1
@@ -1253,7 +1274,7 @@ CONTAINS
                               symbol = cgf_symbol(1, indco(1:3, icgf))
                               symbol(1:2) = "  "
                               WRITE (UNIT=iw, FMT=fmtstr3) &
-                                 irow, iatom, ADJUSTR(element_symbol), symbol, &
+                                 "MO|", irow, iatom, ADJUSTR(element_symbol), symbol, &
                                  (cmatrix(irow, jcol), jcol=from, to)
                               icgf = icgf + 1
                               irow = irow + 1
@@ -1277,7 +1298,7 @@ CONTAINS
                               lshell = l(ishell, iset)
                               DO iso = 1, nso(lshell)
                                  WRITE (UNIT=iw, FMT=fmtstr3) &
-                                    irow, iatom, ADJUSTR(element_symbol), bsgf_symbol(isgf), &
+                                    "MO|", irow, iatom, ADJUSTR(element_symbol), bsgf_symbol(isgf), &
                                     (smatrix(irow, jcol), jcol=from, to)
                                  isgf = isgf + 1
                                  irow = irow + 1
@@ -1293,7 +1314,7 @@ CONTAINS
                               symbol = sgf_symbol(1, lshell, -lshell + iso - 1)
                               symbol(1:2) = "  "
                               WRITE (UNIT=iw, FMT=fmtstr3) &
-                                 irow, iatom, ADJUSTR(element_symbol), symbol, &
+                                 "MO|", irow, iatom, ADJUSTR(element_symbol), symbol, &
                                  (smatrix(irow, jcol), jcol=from, to)
                               isgf = isgf + 1
                               irow = irow + 1
@@ -1309,7 +1330,7 @@ CONTAINS
 
             END DO ! icol
 
-            WRITE (UNIT=iw, FMT="(/)")
+            WRITE (UNIT=iw, FMT="(T2,A)") "MO|"
 
             ! Release work storage
 
@@ -1320,34 +1341,40 @@ CONTAINS
 
          ELSE IF (print_occup .OR. print_eigvals) THEN
 
-            fmtstr4 = "(T2,I9,3(1X,F22.  ))"
-            WRITE (UNIT=fmtstr4(17:18), FMT="(I2)") after
-            WRITE (UNIT=iw, FMT="(/,A)") &
-               "# MO index   MO eigenvalue [a.u.]     MO eigenvalue [eV]          MO occupation"
+            WRITE (UNIT=iw, FMT="(T2,A)") "MO|"
+            fmtstr4 = "(T2,A,I7,3(1X,F22.  ))"
+            WRITE (UNIT=fmtstr4(19:20), FMT="(I2)") after
+            IF (my_final .OR. (my_solver_method == "TD")) THEN
+               WRITE (UNIT=iw, FMT="(A)") &
+                  " MO|  Index      Eigenvalue [a.u.]        Eigenvalue [eV]             Occupation"
+            ELSE
+               WRITE (UNIT=iw, FMT="(A)") &
+                  " MO|  Index          Energy [a.u.]            Energy [eV]             Occupation"
+            END IF
             DO imo = first_mo, last_mo
                WRITE (UNIT=iw, FMT=fmtstr4) &
-                  imo, mo_set%eigenvalues(imo), &
+                  "MO|", imo, mo_set%eigenvalues(imo), &
                   mo_set%eigenvalues(imo)*evolt, &
                   mo_set%occupation_numbers(imo)
             END DO
-            fmtstr5 = "(A,T58,F22.  ,/)"
+            fmtstr5 = "(A,T59,F22.  )"
             WRITE (UNIT=fmtstr5(12:13), FMT="(I2)") after
             WRITE (UNIT=iw, FMT=fmtstr5) &
-               "# Sum", accurate_sum(mo_set%occupation_numbers(:))
+               " MO| Sum:", accurate_sum(mo_set%occupation_numbers(:))
 
          END IF ! print_eigvecs
 
-         fmtstr6 = "(A,T17,F17.  ,A,T40,F17.  ,A)"
+         fmtstr6 = "(A,T18,F17.  ,A,T41,F17.  ,A)"
          WRITE (UNIT=fmtstr6(12:13), FMT="(I2)") after
          WRITE (UNIT=fmtstr6(25:26), FMT="(I2)") after
          WRITE (UNIT=iw, FMT=fmtstr6) &
-            "  Fermi energy:", mo_set%mu, " a.u.", mo_set%mu*evolt, " eV"
+            " MO| E(Fermi):", mo_set%mu, " a.u.", mo_set%mu*evolt, " eV"
          IF ((mo_set%homo > 0)) THEN
             IF ((mo_set%occupation_numbers(mo_set%homo) == mo_set%maxocc) .AND. (last_mo > mo_set%homo)) THEN
                gap = mo_set%eigenvalues(mo_set%homo + 1) - &
                      mo_set%eigenvalues(mo_set%homo)
                WRITE (UNIT=iw, FMT=fmtstr6) &
-                  "  HOMO-LUMO gap:", gap, " a.u.", gap*evolt, " eV"
+                  " MO| Band gap:", gap, " a.u.", gap*evolt, " eV"
             END IF
          END IF
          WRITE (UNIT=iw, FMT="(A)") ""

--- a/src/qs_mo_types.F
+++ b/src/qs_mo_types.F
@@ -24,6 +24,7 @@ MODULE qs_mo_types
    USE cp_dbcsr_operations,             ONLY: dbcsr_copy_columns_hack
    USE cp_fm_pool_types,                ONLY: cp_fm_pool_type,&
                                               fm_pool_create_fm
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_release,&
@@ -122,7 +123,7 @@ CONTAINS
 
       !IF (ASSOCIATED(mo_set_old%mo_coeff_b)) THEN
       !   CALL dbcsr_copy(mo_set_new%mo_coeff_b, mo_set_old%mo_coeff_b)
-      !ENDIF
+      !END IF
       !mo_set_new%use_mo_coeff_b = mo_set_old%use_mo_coeff_b
 
       mo_set_new%eigenvalues = mo_set_old%eigenvalues
@@ -168,7 +169,7 @@ CONTAINS
       IF (ASSOCIATED(mo_set_old%mo_coeff_b)) THEN
          CALL dbcsr_init_p(mo_set_new%mo_coeff_b)
          CALL dbcsr_copy(mo_set_new%mo_coeff_b, mo_set_old%mo_coeff_b)
-      ENDIF
+      END IF
       mo_set_new%use_mo_coeff_b = mo_set_old%use_mo_coeff_b
 
       ALLOCATE (mo_set_new%eigenvalues(nmo))
@@ -233,16 +234,18 @@ CONTAINS
 !> \param mo_set the mo_set to initialize
 !> \param fm_pool a pool out which you initialize the mo_set
 !> \param fm_ref  a reference  matrix from which you initialize the mo_set
+!> \param fm_struct ...
 !> \param name ...
 !> \par History
 !>      11.2002 rewamped [fawzi]
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
-   SUBROUTINE init_mo_set(mo_set, fm_pool, fm_ref, name)
+   SUBROUTINE init_mo_set(mo_set, fm_pool, fm_ref, fm_struct, name)
 
       TYPE(mo_set_type), POINTER                         :: mo_set
       TYPE(cp_fm_pool_type), OPTIONAL, POINTER           :: fm_pool
       TYPE(cp_fm_type), OPTIONAL, POINTER                :: fm_ref
+      TYPE(cp_fm_struct_type), OPTIONAL, POINTER         :: fm_struct
       CHARACTER(LEN=*), INTENT(in)                       :: name
 
       INTEGER                                            :: nao, nmo, nomo
@@ -252,13 +255,16 @@ CONTAINS
       CPASSERT(.NOT. ASSOCIATED(mo_set%occupation_numbers))
       CPASSERT(.NOT. ASSOCIATED(mo_set%mo_coeff))
 
-      CPASSERT(PRESENT(fm_pool) .OR. PRESENT(fm_ref))
+      CPASSERT(PRESENT(fm_pool) .NEQV. (PRESENT(fm_ref) .NEQV. PRESENT(fm_struct)))
       IF (PRESENT(fm_pool)) THEN
          CPASSERT(ASSOCIATED(fm_pool))
          CALL fm_pool_create_fm(fm_pool, mo_set%mo_coeff, name=name)
       ELSE IF (PRESENT(fm_ref)) THEN
          CPASSERT(ASSOCIATED(fm_ref))
          CALL cp_fm_create(mo_set%mo_coeff, fm_ref%matrix_struct, name=name)
+      ELSE IF (PRESENT(fm_struct)) THEN
+         CPASSERT(ASSOCIATED(fm_struct))
+         CALL cp_fm_create(mo_set%mo_coeff, fm_struct, name=name)
       END IF
       CALL cp_fm_get_info(mo_set%mo_coeff, nrow_global=nao, ncol_global=nmo)
 
@@ -329,7 +335,7 @@ CONTAINS
                                       blacs_env=mo_array(1)%mo_set%mo_coeff%matrix_struct%context) !fm->dbcsr
       ELSE !fm->dbcsr
          CALL cp_fm_to_fm(mo_array(1)%mo_set%mo_coeff, mo_array(2)%mo_set%mo_coeff, mo_array(2)%mo_set%nmo)
-      ENDIF
+      END IF
 
       CALL timestop(handle)
 

--- a/src/qs_ot_eigensolver.F
+++ b/src/qs_ot_eigensolver.F
@@ -151,7 +151,7 @@ CONTAINS
             ortho_k = ortho_space_k + k
          ELSE
             ortho_k = k
-         ENDIF
+         END IF
 
          ! allocate
          CALL qs_ot_allocate(qs_ot_env(1), matrix_s, matrix_c_fm%matrix_struct, ortho_k=ortho_k)
@@ -222,7 +222,7 @@ CONTAINS
 
             CALL make_basis_sv(qs_ot_env(1)%matrix_c0, k, qs_ot_env(1)%matrix_sc0, &
                                qs_ot_env(1)%para_env, qs_ot_env(1)%blacs_env)
-         ENDIF
+         END IF
 
          ! init
          CALL qs_ot_init(qs_ot_env(1))
@@ -245,8 +245,8 @@ CONTAINS
                ELSE
                   ! we should presumably make one
                END IF
-            ENDIF
-         ENDIF
+            END IF
+         END IF
 
 !     *** Eigensolver loop ***
          ieigensolver = 0
@@ -261,7 +261,7 @@ CONTAINS
             CALL dbcsr_dot(matrix_c, matrix_hc(1)%matrix, energy)
             IF (.NOT. energy_only) THEN
                CALL dbcsr_scale(matrix_hc(1)%matrix, 2.0_dp)
-            ENDIF
+            END IF
 
             qs_ot_env(1)%etotal = energy
             CALL ot_mini(qs_ot_env, matrix_hc)
@@ -289,10 +289,11 @@ CONTAINS
 
          IF (delta < eps_gradient) THEN
             IF ((output_unit > 0) .AND. .NOT. my_silent) THEN
-               WRITE (output_unit, *) " Reached convergence in ", iter_total, " iterations "
-            ENDIF
+               WRITE (UNIT=output_unit, FMT="(T2,A,I0,A)") &
+                  "OT| Eigensolver reached convergence in ", iter_total, " iterations"
+            END IF
             EXIT outer_scf
-         ENDIF
+         END IF
          IF (iter_total >= iter_max) THEN
             IF (output_unit > 0) THEN
                IF (my_silent) THEN
@@ -302,11 +303,11 @@ CONTAINS
                   WRITE (output_unit, *) "number of iterations ", iter_total, " exceeded maximum"
                   WRITE (output_unit, *) "current gradient / target gradient", delta, " / ", eps_gradient
                END IF
-            ENDIF
+            END IF
             EXIT outer_scf
-         ENDIF
+         END IF
 
-      ENDDO outer_scf
+      END DO outer_scf
 
       CALL copy_dbcsr_to_fm(matrix_c, matrix_c_fm) ! fm->dbcsr
       CALL dbcsr_release_p(matrix_c) ! fm->dbcsr

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -474,7 +474,7 @@ CONTAINS
             END IF
 
             ! Print requested MO information (can be computationally expensive with OT)
-            CALL qs_scf_write_mos(qs_env, scf_env, last_mos=.FALSE.)
+            CALL qs_scf_write_mos(qs_env, scf_env, final_mos=.FALSE.)
 
             CALL qs_scf_density_mixing(scf_env, rho, para_env, diis_step)
 

--- a/src/qs_scf_output.F
+++ b/src/qs_scf_output.F
@@ -10,9 +10,15 @@ MODULE qs_scf_output
    USE admm_utils,                      ONLY: admm_correct_for_eigenvalues,&
                                               admm_uncorrect_for_eigenvalues
    USE atomic_kind_types,               ONLY: atomic_kind_type
+   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
-   USE cp_fm_types,                     ONLY: cp_fm_type
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
+                                              cp_fm_struct_release,&
+                                              cp_fm_struct_type
+   USE cp_fm_types,                     ONLY: cp_fm_init_random,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_p_file,&
@@ -25,21 +31,25 @@ MODULE qs_scf_output
                                               dbcsr_type
    USE input_constants,                 ONLY: &
         becke_cutoff_element, becke_cutoff_global, cdft_alpha_constraint, cdft_beta_constraint, &
-        cdft_charge_constraint, cdft_magnetization_constraint, outer_scf_becke_constraint, &
-        outer_scf_hirshfeld_constraint, outer_scf_optimizer_bisect, outer_scf_optimizer_broyden, &
-        outer_scf_optimizer_diis, outer_scf_optimizer_newton, outer_scf_optimizer_newton_ls, &
-        outer_scf_optimizer_sd, outer_scf_optimizer_secant, radius_covalent, radius_default, &
-        radius_single, radius_user, radius_vdw, shape_function_density, shape_function_gaussian
-   USE input_section_types,             ONLY: section_vals_get_subs_vals,&
+        cdft_charge_constraint, cdft_magnetization_constraint, ot_precond_full_all, &
+        outer_scf_becke_constraint, outer_scf_hirshfeld_constraint, outer_scf_optimizer_bisect, &
+        outer_scf_optimizer_broyden, outer_scf_optimizer_diis, outer_scf_optimizer_newton, &
+        outer_scf_optimizer_newton_ls, outer_scf_optimizer_sd, outer_scf_optimizer_secant, &
+        radius_covalent, radius_default, radius_single, radius_user, radius_vdw, &
+        shape_function_density, shape_function_gaussian
+   USE input_section_types,             ONLY: section_get_ivals,&
+                                              section_vals_get_subs_vals,&
                                               section_vals_type,&
                                               section_vals_val_get
    USE kahan_sum,                       ONLY: accurate_sum
-   USE kinds,                           ONLY: dp
+   USE kinds,                           ONLY: default_string_length,&
+                                              dp
    USE kpoint_types,                    ONLY: kpoint_type
    USE machine,                         ONLY: m_flush
    USE particle_types,                  ONLY: particle_type
    USE physcon,                         ONLY: evolt,&
                                               kcalmol
+   USE preconditioner_types,            ONLY: preconditioner_type
    USE ps_implicit_types,               ONLY: MIXED_BC,&
                                               MIXED_PERIODIC_BC,&
                                               NEUMANN_BC,&
@@ -59,8 +69,13 @@ MODULE qs_scf_output
                                               calculate_orthonormality,&
                                               calculate_subspace_eigenvalues
    USE qs_mo_occupation,                ONLY: set_mo_occupation
-   USE qs_mo_types,                     ONLY: get_mo_set,&
-                                              mo_set_p_type
+   USE qs_mo_types,                     ONLY: allocate_mo_set,&
+                                              deallocate_mo_set,&
+                                              get_mo_set,&
+                                              init_mo_set,&
+                                              mo_set_p_type,&
+                                              mo_set_type
+   USE qs_ot_eigensolver,               ONLY: ot_eigensolver
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
    USE qs_scf_types,                    ONLY: ot_method_nr,&
@@ -156,33 +171,44 @@ CONTAINS
 !> \brief Write the MO eigenvector, eigenvalues, and occupation numbers to the output unit
 !> \param qs_env ...
 !> \param scf_env ...
-!> \param last_mos ...
+!> \param final_mos ...
 !> \par History
 !>      - Revise MO printout to enable eigenvalues with OT (05.05.2021, MK)
 ! **************************************************************************************************
-   SUBROUTINE qs_scf_write_mos(qs_env, scf_env, last_mos)
+   SUBROUTINE qs_scf_write_mos(qs_env, scf_env, final_mos)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
-      LOGICAL, INTENT(IN)                                :: last_mos
+      LOGICAL, INTENT(IN)                                :: final_mos
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_scf_write_mos'
 
-      INTEGER                                            :: handle, ikp, ispin, kpoint, nkp
+      CHARACTER(LEN=2)                                   :: solver_method
+      CHARACTER(LEN=3*default_string_length)             :: message
+      INTEGER                                            :: handle, ikp, ispin, kpoint, nao, &
+                                                            nelectron, nkp, nmo, nmo_tmp, nspin
+      INTEGER, DIMENSION(:), POINTER                     :: mo_index_range
       LOGICAL                                            :: do_kpoints, print_eigvals, &
                                                             print_eigvecs, print_mo_info, &
                                                             print_occup
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
+      REAL(KIND=dp)                                      :: flexible_electron_count, maxocc, n_el_f
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues, mo_eigenvalues_tmp
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_tmp
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks
-      TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks, s
+      TYPE(dbcsr_type), POINTER                          :: matrix_ks, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
+      TYPE(mo_set_type), POINTER                         :: mo_set_tmp
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(preconditioner_type), POINTER                 :: local_preconditioner
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(scf_control_type), POINTER                    :: scf_control
       TYPE(section_vals_type), POINTER                   :: dft_section, input
 
       CALL timeset(routineN, handle)
@@ -192,11 +218,14 @@ CONTAINS
       ! Retrieve the required information for the requested print output
       CALL get_qs_env(qs_env, &
                       atomic_kind_set=atomic_kind_set, &
+                      blacs_env=blacs_env, &
                       dft_control=dft_control, &
-                      input=input, &
                       do_kpoints=do_kpoints, &
+                      input=input, &
+                      qs_kind_set=qs_kind_set, &
+                      para_env=para_env, &
                       particle_set=particle_set, &
-                      qs_kind_set=qs_kind_set)
+                      scf_control=scf_control)
 
       ! Quick return, if no printout of MO information is requested
       dft_section => section_vals_get_subs_vals(input, "DFT")
@@ -210,13 +239,21 @@ CONTAINS
          RETURN
       END IF
 
+      NULLIFY (fm_struct_tmp)
+      NULLIFY (mo_coeff)
+      NULLIFY (mo_coeff_tmp)
+      NULLIFY (mo_set_tmp)
+
+      nspin = dft_control%nspins
+
       ! Check, if we have k points
       IF (do_kpoints) THEN
          CALL get_qs_env(qs_env, kpoints=kpoints)
          nkp = SIZE(kpoints%kp_env)
       ELSE
-         CALL get_qs_env(qs_env, matrix_ks=ks, mos=mos)
+         CALL get_qs_env(qs_env, matrix_ks=ks, matrix_s=s, mos=mos)
          CPASSERT(ASSOCIATED(ks))
+         CPASSERT(ASSOCIATED(s))
          nkp = 1
       END IF
 
@@ -232,48 +269,148 @@ CONTAINS
          CPASSERT(ASSOCIATED(mos))
 
          ! Prepare MO information for printout
-         DO ispin = 1, dft_control%nspins
-            ! With ADMM, we have to modify the Kohn-Sham matrix
-            IF (dft_control%do_admm) THEN
-               CALL get_qs_env(qs_env, admm_env=admm_env)
-               CALL admm_correct_for_eigenvalues(ispin, admm_env, ks(ispin)%matrix)
-            END IF
-            ! Calculate MO eigenvalues in case OT is used
+         DO ispin = 1, nspin
+
+            ! Calculate MO eigenvalues and eigenvector when OT is used
             IF (scf_env%method == ot_method_nr) THEN
+               solver_method = "OT"
+
                IF (do_kpoints) THEN
                   CPABORT("The OT method is not implemented for k points")
                END IF
+
+               matrix_ks => ks(ispin)%matrix
+               matrix_s => s(1)%matrix
+
+               ! With ADMM, we have to modify the Kohn-Sham matrix
+               IF (dft_control%do_admm) THEN
+                  CALL get_qs_env(qs_env, admm_env=admm_env)
+                  CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks)
+               END IF
+
                CALL get_mo_set(mo_set=mos(ispin)%mo_set, &
                                mo_coeff=mo_coeff, &
-                               eigenvalues=mo_eigenvalues)
-               IF (ASSOCIATED(qs_env%mo_derivs)) THEN
-                  mo_coeff_deriv => qs_env%mo_derivs(ispin)%matrix
-               ELSE
-                  mo_coeff_deriv => NULL()
-               END IF
-               CALL calculate_subspace_eigenvalues(orbitals=mo_coeff, &
-                                                   ks_matrix=ks(ispin)%matrix, &
-                                                   evals_arg=mo_eigenvalues, &
-                                                   do_rotation=.TRUE., &
-                                                   co_rotate_dbcsr=mo_coeff_deriv)
-               CALL set_mo_occupation(mo_set=mos(ispin)%mo_set)
-            END IF
-            ! With ADMM, we have to undo the modification of the Kohn-Sham matrix
-            IF (dft_control%do_admm) THEN
-               CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, ks(ispin)%matrix)
-            END IF
-         END DO
+                               eigenvalues=mo_eigenvalues, &
+                               maxocc=maxocc, &
+                               nelectron=nelectron, &
+                               n_el_f=n_el_f, &
+                               nao=nao, &
+                               nmo=nmo, &
+                               flexible_electron_count=flexible_electron_count)
 
-         ! Print MO information
-         IF (SIZE(mos) > 1) THEN
-            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                              dft_section, 4, kpoint, last_mos=last_mos, spin="ALPHA")
-            CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                              dft_section, 4, kpoint, last_mos=last_mos, spin="BETA")
-         ELSE
-            CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                              dft_section, 4, kpoint, last_mos=last_mos)
-         END IF
+               mo_index_range => section_get_ivals(dft_section, "PRINT%MO%MO_INDEX_RANGE")
+               CPASSERT(ASSOCIATED(mo_index_range))
+
+               ! Retrieve the index of the last MO for which a printout is requested
+               nmo_tmp = mo_index_range(2)
+               IF (nmo_tmp <= nmo) THEN
+                  nmo_tmp = nmo
+               ELSE
+                  IF (.NOT. final_mos) THEN
+                     message = "The MO information for unoccupied MOs is only calculated after "// &
+                               "SCF convergence is achieved when the orbital transformation (OT) "// &
+                               "method is used"
+                     CPWARN(TRIM(message))
+                     nmo_tmp = nmo
+                  END IF
+               END IF
+
+               ! Create temporary MO set for printout
+               CALL cp_fm_struct_create(fm_struct_tmp, &
+                                        context=blacs_env, &
+                                        para_env=para_env, &
+                                        nrow_global=nao, &
+                                        ncol_global=nmo_tmp)
+               CALL allocate_mo_set(mo_set=mo_set_tmp, &
+                                    nao=nao, &
+                                    nmo=nmo_tmp, &
+                                    nelectron=nelectron, &
+                                    n_el_f=n_el_f, &
+                                    maxocc=maxocc, &
+                                    flexible_electron_count=flexible_electron_count)
+               CALL init_mo_set(mo_set=mo_set_tmp, &
+                                fm_struct=fm_struct_tmp, &
+                                name="Temporary MO set for printout")
+               CALL cp_fm_struct_release(fm_struct_tmp)
+
+               mo_coeff_tmp => mo_set_tmp%mo_coeff
+               mo_eigenvalues_tmp => mo_set_tmp%eigenvalues
+
+               ! Calculate MOs information for the request MO index range
+               IF (final_mos) THEN
+                  ! Prepare printout of additional unoccupied MOs
+                  IF (nmo_tmp > nmo) THEN
+                     CALL cp_fm_init_random(mo_set_tmp%mo_coeff, nmo_tmp)
+                     ! The FULL_ALL preconditioner makes not much sense for the unoccupied orbitals
+                     NULLIFY (local_preconditioner)
+                     IF (ASSOCIATED(scf_env%ot_preconditioner)) THEN
+                        local_preconditioner => scf_env%ot_preconditioner(1)%preconditioner
+                        IF (local_preconditioner%in_use == ot_precond_full_all) THEN
+                           NULLIFY (local_preconditioner)
+                        END IF
+                     END IF
+                     CALL ot_eigensolver(matrix_h=matrix_ks, &
+                                         matrix_s=matrix_s, &
+                                         matrix_c_fm=mo_coeff_tmp, &
+                                         matrix_orthogonal_space_fm=mo_coeff, &
+                                         eps_gradient=scf_control%eps_lumos, &
+                                         preconditioner=local_preconditioner, &
+                                         iter_max=scf_control%max_iter_lumos, &
+                                         size_ortho_space=nmo)
+                  ELSE
+                     CALL cp_fm_to_fm(mo_coeff, mo_coeff_tmp, nmo)
+                  END IF
+               ELSE
+                  CALL cp_fm_to_fm(mo_coeff, mo_coeff_tmp, nmo)
+               END IF ! final MOs
+
+               CALL calculate_subspace_eigenvalues(orbitals=mo_coeff_tmp, &
+                                                   ks_matrix=matrix_ks, &
+                                                   evals_arg=mo_eigenvalues_tmp, &
+                                                   do_rotation=.TRUE.)
+               CALL set_mo_occupation(mo_set=mo_set_tmp)
+
+               ! With ADMM, we have to undo the modification of the Kohn-Sham matrix
+               IF (dft_control%do_admm) THEN
+                  CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, matrix_ks)
+               END IF
+
+            ELSE
+
+               solver_method = "TD"
+               mo_set_tmp => mos(ispin)%mo_set
+
+            END IF ! OT is used
+
+            ! Print MO information
+            IF (SIZE(mos) > 1) THEN
+               SELECT CASE (ispin)
+               CASE (1)
+                  CALL write_mo_set(mo_set_tmp, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, kpoint, final_mos=final_mos, spin="ALPHA", &
+                                    solver_method=solver_method)
+               CASE (2)
+                  CALL write_mo_set(mo_set_tmp, atomic_kind_set, qs_kind_set, particle_set, &
+                                    dft_section, 4, kpoint, final_mos=final_mos, spin="BETA", &
+                                    solver_method=solver_method)
+               CASE DEFAULT
+                  CPABORT("Invalid spin")
+               END SELECT
+            ELSE
+               CALL write_mo_set(mo_set_tmp, atomic_kind_set, qs_kind_set, particle_set, &
+                                 dft_section, 4, kpoint, final_mos=final_mos, &
+                                 solver_method=solver_method)
+            END IF
+
+            ! Deallocate temporary objects needed for OT
+            IF (scf_env%method == ot_method_nr) THEN
+               CALL deallocate_mo_set(mo_set_tmp)
+               NULLIFY (matrix_ks)
+               NULLIFY (matrix_s)
+            END IF
+            NULLIFY (mo_set_tmp)
+
+         END DO ! ispin
 
       END DO ! k point loop
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1647,7 +1647,7 @@ CONTAINS
       ! Write last MO information to output file if requested
       dft_section => section_vals_get_subs_vals(input, "DFT")
       IF (.NOT. qs_env%run_rtp) THEN
-         CALL qs_scf_write_mos(qs_env, scf_env, last_mos=.TRUE.)
+         CALL qs_scf_write_mos(qs_env, scf_env, final_mos=.TRUE.)
          IF (.NOT. do_kpoints) THEN
             CALL get_qs_env(qs_env, mos=mos, matrix_ks=ks_rmpv)
             CALL write_dm_binary_restart(mos, dft_section, ks_rmpv)

--- a/src/qs_scf_post_se.F
+++ b/src/qs_scf_post_se.F
@@ -641,12 +641,12 @@ CONTAINS
       dft_section => section_vals_get_subs_vals(input, "DFT")
       IF (dft_control%nspins == 2) THEN
          CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                           dft_section, 4, 0, last_mos=.TRUE., spin="ALPHA")
+                           dft_section, 4, 0, final_mos=.TRUE., spin="ALPHA")
          CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                           dft_section, 4, 0, last_mos=.TRUE., spin="BETA")
+                           dft_section, 4, 0, final_mos=.TRUE., spin="BETA")
       ELSE
          CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                           dft_section, 4, 0, last_mos=.TRUE.)
+                           dft_section, 4, 0, final_mos=.TRUE.)
       END IF
 
       ! *** at the end of scf print out the projected dos per kind

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -924,12 +924,12 @@ CONTAINS
          CALL get_qs_env(qs_env, mos=mos)
          IF (dft_control%nspins == 2) THEN
             CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                              dft_section, 4, 0, last_mos=.TRUE., spin="ALPHA")
+                              dft_section, 4, 0, final_mos=.TRUE., spin="ALPHA")
             CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                              dft_section, 4, 0, last_mos=.TRUE., spin="BETA")
+                              dft_section, 4, 0, final_mos=.TRUE., spin="BETA")
          ELSE
             CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                              dft_section, 4, 0, last_mos=.TRUE.)
+                              dft_section, 4, 0, final_mos=.TRUE.)
          END IF
          !
          SELECT CASE (tb_type)
@@ -949,12 +949,12 @@ CONTAINS
                CPASSERT(ASSOCIATED(mos_k))
                IF (dft_control%nspins == 2) THEN
                   CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                    dft_section, 4, kpoint=ik, last_mos=.TRUE., spin="ALPHA")
+                                    dft_section, 4, kpoint=ik, final_mos=.TRUE., spin="ALPHA")
                   CALL write_mo_set(mos_k(1, 2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                    dft_section, 4, kpoint=ik, last_mos=.TRUE., spin="BETA")
+                                    dft_section, 4, kpoint=ik, final_mos=.TRUE., spin="BETA")
                ELSE
                   CALL write_mo_set(mos_k(1, 1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                    dft_section, 4, kpoint=ik, last_mos=.TRUE.)
+                                    dft_section, 4, kpoint=ik, final_mos=.TRUE.)
                END IF
             END DO
          END IF

--- a/src/xas_methods.F
+++ b/src/xas_methods.F
@@ -507,12 +507,12 @@ CONTAINS
                ! Write last wavefunction to screen
                IF (SIZE(mos) > 1) THEN
                   CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                    dft_section, 4, 0, last_mos=.FALSE., spin="XAS ALPHA")
+                                    dft_section, 4, 0, final_mos=.FALSE., spin="XAS ALPHA")
                   CALL write_mo_set(mos(2)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                    dft_section, 4, 0, last_mos=.FALSE., spin="XAS BETA")
+                                    dft_section, 4, 0, final_mos=.FALSE., spin="XAS BETA")
                ELSE
                   CALL write_mo_set(mos(1)%mo_set, atomic_kind_set, qs_kind_set, particle_set, &
-                                    dft_section, 4, 0, last_mos=.FALSE., spin="XAS")
+                                    dft_section, 4, 0, final_mos=.FALSE., spin="XAS")
                END IF
 
             ELSE

--- a/tests/QS/regtest-kp-1/cn_1.inp
+++ b/tests/QS/regtest-kp-1/cn_1.inp
@@ -8,6 +8,17 @@
       CUTOFF 120
       REL_CUTOFF 30
     &END MGRID
+    &PRINT
+      &DFT_CONTROL_PARAMETERS
+      &END DFT_CONTROL_PARAMETERS
+      &MO
+        NDIGITS 10
+        RANGE 4 25
+        &EACH
+          QS_SCF 3
+        &END EACH
+      &END MO
+    &END PRINT
     &QS
       METHOD GPW
       EPS_DEFAULT 1.0E-12

--- a/tests/QS/regtest-kp-2/Al_1_4.inp
+++ b/tests/QS/regtest-kp-2/Al_1_4.inp
@@ -62,7 +62,7 @@
     NDIGITS 12
     OCCUPATION_NUMBERS
     &EACH
-     QS_SCF 0
+     QS_SCF 5
     &END EACH
    &END MO
   &END PRINT

--- a/tests/QS/regtest-plus_u/H2O-rks-diag-mulliken.inp
+++ b/tests/QS/regtest-plus_u/H2O-rks-diag-mulliken.inp
@@ -23,17 +23,27 @@
     &PRINT
       &DFT_CONTROL_PARAMETERS
       &END DFT_CONTROL_PARAMETERS
+      &MO
+        EIGENVECTORS
+        EIGENVALUES
+        NDIGITS 8
+        &EACH
+          QS_SCF 5
+        &END EACH
+      &END MO
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-8
     &END QS
     &SCF
+      ADDED_MOS 2
       EPS_SCF 1.0E-5
       MAX_SCF 30
+      SCF_GUESS atomic
       &OT OFF
         MINIMIZER cg
       &END OT
-      &OUTER_SCF OFF
+      &OUTER_SCF off
         EPS_SCF 1.0E-5
         MAX_SCF 10
       &END OUTER_SCF
@@ -48,7 +58,6 @@
           BACKUP_COPIES 0
         &END RESTART
       &END PRINT
-      SCF_GUESS atomic
     &END SCF
     &XC
       &XC_FUNCTIONAL PBE

--- a/tests/QS/regtest-plus_u/H2O-rks-otcg-mulliken.inp
+++ b/tests/QS/regtest-plus_u/H2O-rks-otcg-mulliken.inp
@@ -26,6 +26,13 @@
     &PRINT
       &DFT_CONTROL_PARAMETERS
       &END DFT_CONTROL_PARAMETERS
+      &MO
+        MO_RANGE 1 12
+        EIGENVALUES
+        &EACH
+          QS_SCF 0
+        &END EACH
+      &END MO
       &PLUS_U
       &END PLUS_U
     &END PRINT
@@ -35,10 +42,10 @@
     &SCF
       EPS_SCF 1.0E-5
       MAX_SCF 30
-      &OT ON
-        MINIMIZER cg
+      &OT on
+        MINIMIZER CG
       &END OT
-      &OUTER_SCF ON
+      &OUTER_SCF on
         EPS_SCF 1.0E-5
         MAX_SCF 10
       &END OUTER_SCF

--- a/tests/QS/regtest-plus_u/H2O-uks-diag-mulliken.inp
+++ b/tests/QS/regtest-plus_u/H2O-uks-diag-mulliken.inp
@@ -25,6 +25,14 @@
     &PRINT
       &DFT_CONTROL_PARAMETERS
       &END DFT_CONTROL_PARAMETERS
+      &MO
+        RANGE 2 12
+        EIGENVALUES
+        NDIGITS 12
+        &EACH
+          QS_SCF 5
+        &END EACH
+      &END MO
       &PLUS_U
        &EACH
         QS_SCF 1
@@ -35,12 +43,14 @@
       EPS_DEFAULT 1.0E-8
     &END QS
     &SCF
+      ADDED_MOS 8 2
       EPS_SCF 1.0E-5
       MAX_SCF 30
-      &OT OFF
-        MINIMIZER cg
+      SCF_GUESS atomic
+      &OT off
+        MINIMIZER CG
       &END OT
-      &OUTER_SCF OFF
+      &OUTER_SCF off
         EPS_SCF 1.0E-5
         MAX_SCF 10
       &END OUTER_SCF
@@ -55,7 +65,6 @@
           BACKUP_COPIES 0
         &END RESTART
       &END PRINT
-      SCF_GUESS atomic
     &END SCF
     &XC
       &XC_FUNCTIONAL PADE

--- a/tests/QS/regtest-plus_u/H2O-uks-diag.inp
+++ b/tests/QS/regtest-plus_u/H2O-uks-diag.inp
@@ -32,10 +32,11 @@
     &SCF
       EPS_SCF 1.0E-5
       MAX_SCF 30
-      &OT OFF
-        MINIMIZER cg
+      SCF_GUESS atomic
+      &OT off
+        MINIMIZER CG
       &END OT
-      &OUTER_SCF OFF
+      &OUTER_SCF off
         EPS_SCF 1.0E-5
         MAX_SCF 10
       &END OUTER_SCF
@@ -50,7 +51,6 @@
           BACKUP_COPIES 0
         &END RESTART
       &END PRINT
-      SCF_GUESS atomic
     &END SCF
     &XC
       &XC_FUNCTIONAL PADE

--- a/tests/QS/regtest-plus_u/H2O-uks-otcg-mulliken.inp
+++ b/tests/QS/regtest-plus_u/H2O-uks-otcg-mulliken.inp
@@ -28,6 +28,14 @@
     &PRINT
       &DFT_CONTROL_PARAMETERS
       &END DFT_CONTROL_PARAMETERS
+      &MO
+        COEFFICIENTS
+        ENERGIES
+        MO_INDEX_RANGE 1 9
+        &EACH
+          QS_SCF 5
+        &END EACH
+      &END MO
       &PLUS_U
       &END PLUS_U
     &END PRINT
@@ -37,10 +45,11 @@
     &SCF
       EPS_SCF 1.0E-5
       MAX_SCF 30
-      &OT ON
-        MINIMIZER cg
+      SCF_GUESS restart
+      &OT on
+        MINIMIZER CG
       &END OT
-      &OUTER_SCF ON
+      &OUTER_SCF on
         EPS_SCF 1.0E-5
         MAX_SCF 10
       &END OUTER_SCF
@@ -55,7 +64,6 @@
           BACKUP_COPIES 0
         &END RESTART
       &END PRINT
-      SCF_GUESS restart
     &END SCF
     &XC
       &XC_FUNCTIONAL PADE

--- a/tests/QS/regtest-plus_u/H2O-uks-otcg.inp
+++ b/tests/QS/regtest-plus_u/H2O-uks-otcg.inp
@@ -40,10 +40,11 @@
     &SCF
       EPS_SCF 1.0E-5
       MAX_SCF 30
-      &OT ON
-        MINIMIZER cg
+      SCF_GUESS restart
+      &OT on
+        MINIMIZER CG
       &END OT
-      &OUTER_SCF ON
+      &OUTER_SCF on
         EPS_SCF 1.0E-5
         MAX_SCF 10
       &END OUTER_SCF
@@ -58,7 +59,6 @@
           BACKUP_COPIES 0
         &END RESTART
       &END PRINT
-      SCF_GUESS restart
     &END SCF
     &XC
       &XC_FUNCTIONAL PADE

--- a/tests/QS/regtest-plus_u/TEST_FILES
+++ b/tests/QS/regtest-plus_u/TEST_FILES
@@ -2,10 +2,10 @@ H2O-rks-diag.inp                                      24      1E-11          0.0
 H2O-rks-otcg.inp                                      24      2e-07          0.0081042461219499994
 H2O-uks-diag.inp                                      24      3e-12          0.0070826097691200000
 H2O-uks-otcg.inp                                      24      1e-07          0.0070825676291199997
-H2O-rks-diag-mulliken.inp                             24      2e-11          0.0401646116479500000
+H2O-rks-diag-mulliken.inp                             24      2e-11          0.04016461029714
 H2O-rks-otcg-mulliken.inp                             24      9e-08          0.0401616150180899990
-H2O-uks-diag-mulliken.inp                             24      5e-13          0.0434047728284000000
-H2O-uks-otcg-mulliken.inp                             24      2e-08          0.0434080727848500030
+H2O-uks-diag-mulliken.inp                             24      5e-13          0.04340509184236
+H2O-uks-otcg-mulliken.inp                             24      2e-08          0.04340807378074
 H2O-rks-diag-lowdin.inp                               24      1E-12          0.07674874415138
 H2O-rks-otcg-lowdin.inp                               24      1E-12          0.07674870925125
 H2O-uks-diag-lowdin.inp                               24      1E-12          0.08364867485442

--- a/tests/TEST_TYPES
+++ b/tests/TEST_TYPES
@@ -46,11 +46,11 @@ SUM OF SHELL FORCES !8
 PRM01!2
 Final value !6
 SUMMARY:: Number of molecule kinds found:!7
-Fermi energy: !3
+E(Fermi): !3
 Total Multiplication !9
 Direct MP2 Canonical Energy =!6
 RESP       1!4
-HOMO-LUMO gap: !3
+Band gap: !4
 Exchange-correlation energy: !3
 GRAND TOTAL FORCE !7
 BASOPT| Total residuum value: !5


### PR DESCRIPTION
- Revised MO information printout working with diagonalisation, OT, and k points for occupied and unoccupied MOs
- No need to use the MO_CUBES print section with OT any longer
- The printout of unoccupied MOs is requested by the MO_INDEX_RANGE keyword for OT and by the ADDED_MOS keyword in the SCF section for diagonalisation (as before)
- Documentation for MO and MO_CUBES print section updated correspondingly
- Test files and types updated correspondingly
- MO printout labelled to facilitate output parsing and data extraction