### PR TITLE
Use ELPA as default only for large matrices

### DIFF
--- a/src/environment.F
+++ b/src/environment.F
@@ -527,6 +527,7 @@ CONTAINS
       CALL section_vals_val_get(global_section, "ENABLE_MPI_IO", l_val=flag)
       CALL cp_mpi_io_set(flag)
       CALL section_vals_val_get(global_section, "ELPA_KERNEL", i_val=globenv%k_elpa)
+      CALL section_vals_val_get(global_section, "ELPA_NEIGVEC_MIN", i_val=globenv%elpa_neigvec_min)
       CALL section_vals_val_get(global_section, "ELPA_QR", l_val=globenv%elpa_qr)
       CALL section_vals_val_get(global_section, "ELPA_QR_UNSAFE", l_val=globenv%elpa_qr_unsafe)
       unit_nr = cp_print_key_unit_nr(logger, global_section, "PRINT_ELPA", extension=".Log")
@@ -751,12 +752,18 @@ CONTAINS
             ADJUSTR(TRIM(enum_i2c(enum1, globenv%prog_name_id))), &
             start_section_label//"| Project name", &
             ADJUSTR(project_name(:40)), &
+            start_section_label//"| Run type", &
+            ADJUSTR(TRIM(enum_i2c(enum2, globenv%run_type_id))), &
             start_section_label//"| FFT library", &
             ADJUSTR(globenv%default_fft_library(:40)), &
             start_section_label//"| Diagonalization library", &
-            ADJUSTR(globenv%diag_library(:40)), &
-            start_section_label//"| Run type", &
-            ADJUSTR(TRIM(enum_i2c(enum2, globenv%run_type_id)))
+            ADJUSTR(globenv%diag_library(:40))
+
+         IF (globenv%diag_library == "ELPA") THEN
+            WRITE (UNIT=output_unit, FMT="(T2,A,T71,I10)") &
+               start_section_label//"| Minimum number of eigenvectors for ELPA usage", &
+               globenv%elpa_neigvec_min
+         END IF
 
 #if defined(__CHECK_DIAG)
          ! Perform default check if no threshold value has been specified explicitly
@@ -1006,6 +1013,7 @@ CONTAINS
       CALL diag_init(diag_lib=TRIM(globenv%diag_library), &
                      fallback_applied=fallback_applied, &
                      elpa_kernel=globenv%k_elpa, &
+                     elpa_neigvec_min_input=globenv%elpa_neigvec_min, &
                      elpa_qr=globenv%elpa_qr, &
                      elpa_print=globenv%elpa_print, &
                      elpa_qr_unsafe=globenv%elpa_qr_unsafe, &

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -63,8 +63,14 @@ MODULE cp_fm_diag
 
    REAL(KIND=dp), PARAMETER, PUBLIC :: eps_check_diag_default = 5.0E-14_dp
 
-   ! These saved variables are diagonalization global
+   ! The following saved variables are diagonalization global
+   ! Stores the default library for diagonalization
    INTEGER, SAVE       :: diag_type = 0
+   ! Minimum number of eigenvectors for the use of the ELPA eigensolver.
+   ! The ScaLAPACK eigensolver is used as fallback for all smaller cases.
+   INTEGER, SAVE       :: elpa_neigvec_min = 0
+   ! Threshold value for the orthonormality check of the eigenvectors obtained
+   ! after a diagonalization. A negative value disables the check.
    REAL(KIND=dp), SAVE :: eps_check_diag = -1.0_dp
 
    ! Constants for the diag_type above
@@ -90,6 +96,7 @@ CONTAINS
 !> \param fallback_applied .TRUE. if support for the requested library was not compiled-in and fallback
 !>                         to ScaLAPACK was applied, .FALSE. otherwise.
 !> \param elpa_kernel integer that determines which ELPA kernel to use for diagonalization
+!> \param elpa_neigvec_min_input ...
 !> \param elpa_qr logical that determines if ELPA should try to use QR to accelerate the
 !>                diagonalization procedure of suitably sized matrices
 !> \param elpa_print logical that determines if information about the ELPA diagonalization should
@@ -98,11 +105,11 @@ CONTAINS
 !> \param eps_check_diag_input ...
 !> \author  MI 11.2013
 ! **************************************************************************************************
-   SUBROUTINE diag_init(diag_lib, fallback_applied, elpa_kernel, elpa_qr, elpa_print, &
-                        elpa_qr_unsafe, eps_check_diag_input)
+   SUBROUTINE diag_init(diag_lib, fallback_applied, elpa_kernel, elpa_neigvec_min_input, elpa_qr, &
+                        elpa_print, elpa_qr_unsafe, eps_check_diag_input)
       CHARACTER(LEN=*), INTENT(IN)                       :: diag_lib
       LOGICAL, INTENT(OUT)                               :: fallback_applied
-      INTEGER, INTENT(IN)                                :: elpa_kernel
+      INTEGER, INTENT(IN)                                :: elpa_kernel, elpa_neigvec_min_input
       LOGICAL, INTENT(IN)                                :: elpa_qr, elpa_print, elpa_qr_unsafe
       REAL(KIND=dp), INTENT(IN)                          :: eps_check_diag_input
 
@@ -131,6 +138,7 @@ CONTAINS
          CALL set_elpa_print(elpa_print)
       END IF
 
+      elpa_neigvec_min = elpa_neigvec_min_input
       eps_check_diag = eps_check_diag_input
 
    END SUBROUTINE diag_init
@@ -175,7 +183,7 @@ CONTAINS
       ! Sample peak memory
       CALL m_memory()
 
-      IF ((nmo < 16) .OR. (diag_type == DIAG_TYPE_SCALAPACK)) THEN
+      IF ((nmo < elpa_neigvec_min) .OR. (diag_type == DIAG_TYPE_SCALAPACK)) THEN
          IF (PRESENT(info)) THEN
             CALL cp_fm_syevd(matrix, eigenvectors, eigenvalues, info=myinfo)
          ELSE

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -147,14 +147,16 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief   Choose the Eigensolver depending on which library is available
-!>           ELPA seems to be unstable for small systems
+!>          ELPA seems to be unstable for small systems
 !> \param matrix ...
 !> \param eigenvectors ...
 !> \param eigenvalues ...
 !> \param info ...
 !> \par     info If present returns error code and prevents program stops.
-!>               Works currently only for cp_fm_syevd with scalapack.
+!>               Works currently only for cp_fm_syevd with ScaLAPACK.
 !>               Other solvers will end the program regardless of PRESENT(info).
+!> \par History
+!>      - Do not use ELPA for small matrices and use instead ScaLAPACK as fallback (10.05.2021, MK)
 ! **************************************************************************************************
    SUBROUTINE choose_eigv_solver(matrix, eigenvectors, eigenvalues, info)
 
@@ -173,14 +175,14 @@ CONTAINS
       ! Sample peak memory
       CALL m_memory()
 
-      IF (diag_type == DIAG_TYPE_ELPA) THEN
-         CALL cp_fm_diag_elpa(matrix, eigenvectors, eigenvalues)
-      ELSE IF (diag_type == DIAG_TYPE_SCALAPACK) THEN
+      IF ((nmo < 16) .OR. (diag_type == DIAG_TYPE_SCALAPACK)) THEN
          IF (PRESENT(info)) THEN
             CALL cp_fm_syevd(matrix, eigenvectors, eigenvalues, info=myinfo)
          ELSE
             CALL cp_fm_syevd(matrix, eigenvectors, eigenvalues)
          END IF
+      ELSE IF (diag_type == DIAG_TYPE_ELPA) THEN
+         CALL cp_fm_diag_elpa(matrix, eigenvectors, eigenvalues)
       ELSE
          CPABORT("ERROR in "//routineN//": Invalid diagonalization type requested")
       END IF

--- a/src/fm/cp_fm_diag_utils.F
+++ b/src/fm/cp_fm_diag_utils.F
@@ -91,21 +91,29 @@ CONTAINS
       CLASS(cp_fm_redistribute_info), INTENT(IN) :: self
       INTEGER, INTENT(IN) :: io_unit
 
-      WRITE (io_unit, '(/,A,I10)') "CP_FM_DIAG| Matrix order:           ", self%matrix_order
-      WRITE (io_unit, '(A,I6,A)') "CP_FM_DIAG| Matrix distributed on ", self%num_pe_old, " processes"
-      WRITE (io_unit, '(A,I5)') "CP_FM_DIAG| Optimal number of CPUs:      ", self%num_pe_opt
+      WRITE (UNIT=io_unit, FMT="(A)") ""
+      WRITE (UNIT=io_unit, FMT="(T2,A,T71,I10)") &
+         "CP_FM_DIAG| Number of processes over which the matrix is distributed ", self%num_pe_old, &
+         "CP_FM_DIAG| Matrix order ", self%matrix_order
+      WRITE (UNIT=io_unit, FMT="(T2,A,T71,I10)") &
+         "CP_FM_DIAG| Optimal number of CPUs ", self%num_pe_opt
       IF (self%num_pe_max_nz_col < 0) THEN
-         WRITE (io_unit, '(A,A)') "CP_FM_DIAG| Max number of CPUs (with non-zero columns): ", "<N/A>"
+         WRITE (UNIT=io_unit, FMT="(T2,A,T71,A10)") &
+            "CP_FM_DIAG| Maximum number of CPUs (with non-zero columns) ", "<N/A>"
       ELSE
-         WRITE (io_unit, '(A,I5)') "CP_FM_DIAG| Max number of CPUs (with non-zero columns): ", self%num_pe_max_nz_col
+         WRITE (UNIT=io_unit, FMT="(T2,A,T71,I10)") &
+            "CP_FM_DIAG| Maximum number of CPUs (with non-zero columns): ", self%num_pe_max_nz_col
       END IF
       IF (self%redistribute) THEN
-         WRITE (io_unit, '(A,I5,A)') "CP_FM_DIAG| The matrix will be redistributed onto ", self%num_pe_new, " processes"
+         WRITE (UNIT=io_unit, FMT="(T2,A,T71,I10)") &
+            "CP_FM_DIAG| Number of processes for the redistribution ", self%num_pe_new
       ELSE
-         WRITE (io_unit, '(A)') "CP_FM_DIAG| The matrix will NOT be redistributed"
+         WRITE (UNIT=io_unit, FMT="(T2,A)") &
+            "CP_FM_DIAG| The matrix will NOT be redistributed"
       END IF
-      WRITE (io_unit, '(A)') " "
-   END SUBROUTINE
+      WRITE (UNIT=io_unit, FMT="(A)") ""
+
+   END SUBROUTINE cp_fm_redistribute_info_write
 
 ! **************************************************************************************************
 !> \brief  Initializes temporary storage needed when redistributing arrays
@@ -357,11 +365,18 @@ CONTAINS
       rdinfo%redistribute = (rdinfo%num_pe_old > rdinfo%num_pe_new)
 
       IF (work_redistribute%should_print .AND. io_unit > 0) THEN
-         IF (is_elpa) &
-            WRITE (io_unit, '(A,L5)') "CP_FM_DIAG| Force redistribute (ELPA):", work_redistribute%elpa_force_redistribute
-
+         IF (is_elpa) THEN
+            IF (work_redistribute%elpa_force_redistribute) THEN
+               WRITE (UNIT=io_unit, FMT="(T2,A,T78,A3)") &
+                  "CP_FM_DIAG| Force redistribute (ELPA):", "YES"
+            ELSE
+               WRITE (UNIT=io_unit, FMT="(T2,A,T79,A2)") &
+                  "CP_FM_DIAG| Force redistribute (ELPA):", "NO"
+            END IF
+         END IF
          CALL rdinfo%write(io_unit)
       END IF
+      CALL mp_sync(para_env%group)
 
       ! if the optimal is smaller than num_pe, we will redistribute the input matrix
       IF (rdinfo%redistribute) THEN

--- a/src/fm/cp_fm_elpa.F
+++ b/src/fm/cp_fm_elpa.F
@@ -395,7 +395,8 @@ CONTAINS
       END IF
 
       IF (io_unit > 0 .AND. elpa_should_print) THEN
-         WRITE (io_unit, '(/,A)') "ELPA| Matrix diagonalization information"
+         WRITE (UNIT=io_unit, FMT="(/,T2,A)") &
+            "ELPA| Matrix diagonalization information"
 
          ! Find name for given kernel id.
          ! In case ELPA_2STAGE_REAL_DEFAULT was used it might not be in our elpa_kernel_ids list.
@@ -404,25 +405,37 @@ CONTAINS
             IF (elpa_kernel_ids(i) == elpa_kernel) THEN
                kernel_name = elpa_kernel_names(i)
             ENDIF
-         ENDDO
+         END DO
 
-         WRITE (io_unit, '(A,I14)') "ELPA| Matrix order             : ", n
-         WRITE (io_unit, '(A,I14)') "ELPA| Matrix block size        : ", nblk
-         WRITE (io_unit, '(A,A14)') "ELPA| Kernel                   : ", ADJUSTR(TRIM(kernel_name))
-         WRITE (io_unit, '(A,L14)') "ELPA| QR step requested        : ", elpa_qr
+         WRITE (UNIT=io_unit, FMT="(T2,A,I14)") &
+            "ELPA| Matrix order (NA)                  : ", n, &
+            "ELPA| Matrix block size (NBLK)           : ", nblk, &
+            "ELPA| Number of eigenvectors (NEV)       : ", neig, &
+            "ELPA| Local rows (LOCAL_NROWS)           : ", n_rows, &
+            "ELPA| Local columns (LOCAL_NCOLS)        : ", n_cols
+         WRITE (UNIT=io_unit, FMT="(T2,A,A14)") &
+            "ELPA| Kernel                             : ", ADJUSTR(TRIM(kernel_name))
+         WRITE (UNIT=io_unit, FMT="(T2,A,L14)") &
+            "ELPA| QR step requested                  : ", elpa_qr
 
          IF (elpa_qr) THEN
-            WRITE (io_unit, '(A,L14)') "ELPA| Use potentially unsafe QR: ", elpa_qr_unsafe
-            WRITE (io_unit, '(A,L14)') "ELPA| Matrix is suitable for QR: ", use_qr
-
+            WRITE (UNIT=io_unit, FMT="(T2,A,L14)") &
+               "ELPA| Use potentially unsafe QR          : ", elpa_qr_unsafe, &
+               "ELPA| Matrix is suitable for QR          : ", use_qr
             IF (.NOT. use_qr) THEN
-               IF (MOD(n, 2) .NE. 0) &
-                  WRITE (io_unit, '(A)') "ELPA| Matrix order is NOT even"
-               IF (nblk .LT. 64 .AND. .NOT. elpa_qr_unsafe) &
-                  WRITE (io_unit, '(A)') "ELPA| Matrix block size is NOT 64 or greater"
+               IF (MODULO(n, 2) /= 0) THEN
+                  WRITE (UNIT=io_unit, FMT="(T2,A)") &
+                     "ELPA| Matrix order is NOT even"
+               END IF
+               IF ((nblk < 64) .AND. (.NOT. elpa_qr_unsafe)) THEN
+                  WRITE (UNIT=io_unit, FMT="(T2,A)") &
+                     "ELPA| Matrix block size is NOT 64 or greater"
+               END IF
             ELSE
-               IF (nblk .LT. 64 .AND. elpa_qr_unsafe) &
-                  WRITE (io_unit, '(A,L14)') "ELPA| Matrix block size check was bypassed"
+               IF ((nblk < 64) .AND. elpa_qr_unsafe) THEN
+                  WRITE (UNIT=io_unit, FMT="(T2,A,L14)") &
+                     "ELPA| Matrix block size check was bypassed"
+               END IF
             END IF
          END IF
       END IF
@@ -515,4 +528,3 @@ CONTAINS
 #endif
 
 END MODULE cp_fm_elpa
-

--- a/src/fm/cp_fm_elpa.F
+++ b/src/fm/cp_fm_elpa.F
@@ -218,13 +218,13 @@ CONTAINS
             CPWARN("ELPA GPU kernel is available, but not enabled automatically.")
             !TODO: Enable GPU kernel automatically once the segfaults have been fixed.
             !elpa_kernel = ELPA_2STAGE_REAL_GPU  ! Select GPU over CPU kernel when available.
-         ENDIF
+         END IF
          CALL elpa_deallocate(elpa_obj)
 
          ! If we could not find a suitable kernel then use ELPA_2STAGE_REAL_DEFAULT.
          IF (elpa_kernel == ELPA_2STAGE_REAL_INVALID) THEN
             elpa_kernel = ELPA_2STAGE_REAL_DEFAULT
-         ENDIF
+         END IF
       END IF
 #else
       MARK_USED(requested_kernel)
@@ -374,7 +374,7 @@ CONTAINS
       !     - Proper block size:    test/Fortran/test.F90
       ! Note that the names of these files might change in different ELPA versions
       ! Matrix order must be even
-      use_qr = elpa_qr .AND. (MOD(n, 2) .EQ. 0)
+      use_qr = elpa_qr .AND. (MODULO(n, 2) .EQ. 0)
       ! Matrix order and block size must be greater than or equal to 64
       IF (.NOT. elpa_qr_unsafe) &
          use_qr = use_qr .AND. (n .GE. 64) .AND. (nblk .GE. 64)
@@ -404,24 +404,40 @@ CONTAINS
          DO i = 1, SIZE(elpa_kernel_ids)
             IF (elpa_kernel_ids(i) == elpa_kernel) THEN
                kernel_name = elpa_kernel_names(i)
-            ENDIF
+            END IF
          END DO
 
-         WRITE (UNIT=io_unit, FMT="(T2,A,I14)") &
-            "ELPA| Matrix order (NA)                  : ", n, &
-            "ELPA| Matrix block size (NBLK)           : ", nblk, &
-            "ELPA| Number of eigenvectors (NEV)       : ", neig, &
-            "ELPA| Local rows (LOCAL_NROWS)           : ", n_rows, &
-            "ELPA| Local columns (LOCAL_NCOLS)        : ", n_cols
-         WRITE (UNIT=io_unit, FMT="(T2,A,A14)") &
-            "ELPA| Kernel                             : ", ADJUSTR(TRIM(kernel_name))
-         WRITE (UNIT=io_unit, FMT="(T2,A,L14)") &
-            "ELPA| QR step requested                  : ", elpa_qr
+         WRITE (UNIT=io_unit, FMT="(T2,A,T71,I10)") &
+            "ELPA| Matrix order (NA) ", n, &
+            "ELPA| Matrix block size (NBLK) ", nblk, &
+            "ELPA| Number of eigenvectors (NEV) ", neig, &
+            "ELPA| Local rows (LOCAL_NROWS) ", n_rows, &
+            "ELPA| Local columns (LOCAL_NCOLS) ", n_cols
+         WRITE (UNIT=io_unit, FMT="(T2,A,T61,A20)") &
+            "ELPA| Kernel ", ADJUSTR(TRIM(kernel_name))
+         IF (elpa_qr) THEN
+            WRITE (UNIT=io_unit, FMT="(T2,A,T78,A3)") &
+               "ELPA| QR step requested ", "YES"
+         ELSE
+            WRITE (UNIT=io_unit, FMT="(T2,A,T79,A2)") &
+               "ELPA| QR step requested ", "NO"
+         END IF
 
          IF (elpa_qr) THEN
-            WRITE (UNIT=io_unit, FMT="(T2,A,L14)") &
-               "ELPA| Use potentially unsafe QR          : ", elpa_qr_unsafe, &
-               "ELPA| Matrix is suitable for QR          : ", use_qr
+            IF (elpa_qr_unsafe) THEN
+               WRITE (UNIT=io_unit, FMT="(T2,A,T78,A3)") &
+                  "ELPA| Use potentially unsafe QR ", "YES"
+            ELSE
+               WRITE (UNIT=io_unit, FMT="(T2,A,T79,A2)") &
+                  "ELPA| Use potentially unsafe QR ", "NO"
+            END IF
+            IF (use_qr) THEN
+               WRITE (UNIT=io_unit, FMT="(T2,A,T78,A3)") &
+                  "ELPA| Matrix is suitable for QR ", "YES"
+            ELSE
+               WRITE (UNIT=io_unit, FMT="(T2,A,T79,A2)") &
+                  "ELPA| Matrix is suitable for QR ", "NO"
+            END IF
             IF (.NOT. use_qr) THEN
                IF (MODULO(n, 2) /= 0) THEN
                   WRITE (UNIT=io_unit, FMT="(T2,A)") &
@@ -433,7 +449,7 @@ CONTAINS
                END IF
             ELSE
                IF ((nblk < 64) .AND. elpa_qr_unsafe) THEN
-                  WRITE (UNIT=io_unit, FMT="(T2,A,L14)") &
+                  WRITE (UNIT=io_unit, FMT="(T2,A)") &
                      "ELPA| Matrix block size check was bypassed"
                END IF
             END IF
@@ -479,7 +495,7 @@ CONTAINS
       IF (elpa_kernel == ELPA_2STAGE_REAL_GPU) THEN
          CALL elpa_obj%set("gpu", 1, success)
          CPASSERT(success == elpa_ok)
-      ENDIF
+      END IF
 
       CALL elpa_obj%set("real_kernel", elpa_kernel, success)
       CPASSERT(success == elpa_ok)
@@ -487,13 +503,13 @@ CONTAINS
       IF (use_qr) THEN
          CALL elpa_obj%set("qr", 1, success)
          CPASSERT(success == elpa_ok)
-      ENDIF
+      END IF
 
       ! Set number of threads only when ELPA was built with OpenMP support.
       IF (elpa_obj%can_set("omp_threads", omp_get_max_threads()) == ELPA_OK) THEN
          CALL elpa_obj%set("omp_threads", omp_get_max_threads(), success)
          CPASSERT(success == elpa_ok)
-      ENDIF
+      END IF
 
       CALL elpa_obj%eigenvectors(matrix%local_data, eval, eigenvectors%local_data, success)
       IF (success /= elpa_ok) &

--- a/src/global_types.F
+++ b/src/global_types.F
@@ -77,6 +77,7 @@ MODULE global_types
       INTEGER :: run_type_id = 0 ! index to define the run_tupe
       INTEGER :: blacs_grid_layout = BLACS_GRID_SQUARE ! will store the user preference for the BLACS grid
       INTEGER :: k_elpa = 1 ! optimized kernel for the ELPA diagonalization library
+      INTEGER :: elpa_neigvec_min = 0 ! Minimum number of eigenvectors for ELPA usage
       LOGICAL :: elpa_qr = .FALSE. ! allow ELPA to use QR during diagonalization
       LOGICAL :: elpa_print = .FALSE. ! if additional information about ELPA diagonalization should be printed
       LOGICAL :: elpa_qr_unsafe = .FALSE. ! enable potentially unsafe ELPA options

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -113,15 +113,15 @@ CONTAINS
 #else
       default_diag = do_diag_scalapack
 #endif
-      CALL keyword_create( &
-         keyword, __LOCATION__, name="PREFERRED_DIAG_LIBRARY", &
-         description="Specifies the diagonalization library to be used. If not available, the ScaLAPACK library is used", &
-         usage="PREFERRED_DIAG_LIBRARY ELPA", &
-         default_i_val=default_diag, &
-         enum_i_vals=(/do_diag_elpa, do_diag_scalapack, do_diag_scalapack/), &
-         enum_c_vals=s2a("ELPA", "ScaLAPACK", "SL"), &
-         enum_desc=s2a("ELPA library", "ScaLAPACK library", "ScaLAPACK library"), &
-         citations=(/Marek2014/))
+      CALL keyword_create(keyword, __LOCATION__, name="PREFERRED_DIAG_LIBRARY", &
+                          description="Specifies the diagonalization library to be used. If not available, "// &
+                          "the ScaLAPACK library is used", &
+                          usage="PREFERRED_DIAG_LIBRARY ELPA", &
+                          default_i_val=default_diag, &
+                          enum_i_vals=(/do_diag_elpa, do_diag_scalapack, do_diag_scalapack/), &
+                          enum_c_vals=s2a("ELPA", "ScaLAPACK", "SL"), &
+                          enum_desc=s2a("ELPA library", "ScaLAPACK library", "ScaLAPACK library"), &
+                          citations=(/Marek2014/))
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -133,13 +133,21 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
-      CALL keyword_create( &
-         keyword, __LOCATION__, name="ELPA_KERNEL", &
-         description="Specifies the kernel to be used when ELPA is in use", &
-         default_i_val=elpa_kernel_ids(1), &
-         enum_i_vals=elpa_kernel_ids, &
-         enum_c_vals=elpa_kernel_names, &
-         enum_desc=elpa_kernel_descriptions)
+      CALL keyword_create(keyword, __LOCATION__, name="ELPA_KERNEL", &
+                          description="Specifies the kernel to be used when ELPA is in use", &
+                          default_i_val=elpa_kernel_ids(1), &
+                          enum_i_vals=elpa_kernel_ids, &
+                          enum_c_vals=elpa_kernel_names, &
+                          enum_desc=elpa_kernel_descriptions)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="ELPA_NEIGVEC_MIN", &
+                          description="Minimum number of eigenvectors for the use of the eigensolver from "// &
+                          "the ELPA library. The eigensolver from the ScaLAPACK library is used as fallback "// &
+                          "for all smaller cases", &
+                          usage="ELPA_NEIGVEC_MIN 32", &
+                          default_i_val=16)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -688,10 +696,10 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="ELPA_FORCE_REDISTRIBUTE", &
                           description="Controls how to perform redistribution when ELPA is used for diagonalization. "// &
                           "By default, matrices are redistributed only to prevent crashes in the ELPA library "// &
-                          "which happen when the original matrix is distributed on too many processors. "// &
+                          "which happens when the original matrix is distributed over too many processors. "// &
                           "By turning on this keyword, redistribution is always performed using the defined rules. ", &
                           usage="ELPA_FORCE_REDISTRIBUTE", type_of_var=logical_t, &
-                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+                          default_l_val=.TRUE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 


### PR DESCRIPTION
The eigensolver from the ELPA library will only be used for problems with more than 16 eigenvectors, even if ELPA is the default (PREFERRED_DIAG_LIBRARY) library. The ScaLAPACK library is used as fallback. This will avoid potential instabilities for small systems.