### PR TITLE
CP2K functionals

### DIFF
--- a/src/hfx_admm_utils.F
+++ b/src/hfx_admm_utils.F
@@ -44,7 +44,7 @@ MODULE hfx_admm_utils
         do_admm_aux_exch_func_bee, do_admm_aux_exch_func_default, do_admm_aux_exch_func_none, &
         do_admm_aux_exch_func_opt, do_admm_aux_exch_func_pbex, do_potential_coulomb, &
         do_potential_long, do_potential_mix_cl, do_potential_mix_cl_trunc, do_potential_short, &
-        do_potential_truncated, xc_funct_no_shortcut
+        do_potential_truncated, xc_funct_no_shortcut, xc_none
    USE input_section_types,             ONLY: section_vals_duplicate,&
                                               section_vals_get,&
                                               section_vals_get_subs_vals,&
@@ -663,7 +663,8 @@ CONTAINS
       !in case of no admm exchange corr., no auxiliary exchange functional needed
       IF (admm_env%aux_exch_func == do_admm_aux_exch_func_none) THEN
          hfx_fraction = 0.0_dp
-         ! default PBE Functional
+         CALL section_vals_val_set(xc_fun_section, "_SECTION_PARAMETERS_", &
+                                   i_val=xc_none)
       ELSE IF (admm_env%aux_exch_func == do_admm_aux_exch_func_default) THEN
          !! ** Add functionals evaluated with auxiliary basis
          SELECT CASE (hfx_potential_type)

--- a/src/hfx_admm_utils.F
+++ b/src/hfx_admm_utils.F
@@ -596,12 +596,17 @@ CONTAINS
 !>          XWPBEX0:        PBE exchange hole for standard coulomb potential
 !>          PBE_HOLE_TC_LR: PBE exchange hole for longrange truncated coulomb potential
 !>
+!>        Above explanation is correct for the deafult case. If a specific functional is requested
+!>        for the correction term (cfun), we get
+!>        Ex,hf = Ex,hf' + (cfun-cfun')
+!>        for all cases of operators.
 !>
 !> \param qs_env the qs environment
 !> \param xc_section the original xc_section
 !> \param admm_env the ADMM environment
 !> \par History
 !>      12.2009 created [Manuel Guidon]
+!>      05.2021 simplify for case of no correction [JGH]
 !> \author Manuel Guidon
 ! **************************************************************************************************
    SUBROUTINE create_admm_xc_section(qs_env, xc_section, admm_env)
@@ -658,12 +663,8 @@ CONTAINS
       !in case of no admm exchange corr., no auxiliary exchange functional needed
       IF (admm_env%aux_exch_func == do_admm_aux_exch_func_none) THEN
          hfx_fraction = 0.0_dp
-      END IF
-
-      ! default PBE Functional
-      IF (admm_env%aux_exch_func == do_admm_aux_exch_func_default .OR. &
-          admm_env%aux_exch_func == do_admm_aux_exch_func_none) THEN
-
+         ! default PBE Functional
+      ELSE IF (admm_env%aux_exch_func == do_admm_aux_exch_func_default) THEN
          !! ** Add functionals evaluated with auxiliary basis
          SELECT CASE (hfx_potential_type)
          CASE (do_potential_coulomb)

--- a/src/xc/xc_xpbe_hole_t_c_lr.F
+++ b/src/xc/xc_xpbe_hole_t_c_lr.F
@@ -196,7 +196,7 @@ CONTAINS
          CALL xc_derivative_get(deriv, deriv_data=e_ndrho)
       END IF
       IF (order > 1 .OR. order < -1) THEN
-         CPABORT("derivatives bigger than 2 not implemented")
+         CPABORT("derivatives bigger than 1 not implemented")
       END IF
 
       IF (R == 0.0_dp) THEN
@@ -361,7 +361,7 @@ CONTAINS
          CALL xc_derivative_get(deriv, deriv_data=e_ndrhob)
       END IF
       IF (order > 1 .OR. order < -1) THEN
-         CPABORT("derivatives bigger than 2 not implemented")
+         CPABORT("derivatives bigger than 1 not implemented")
       END IF
 
       IF (R == 0.0_dp) THEN

--- a/src/xc/xc_xwpbe.F
+++ b/src/xc/xc_xwpbe.F
@@ -118,7 +118,9 @@ CONTAINS
          needs%rho = .TRUE.
          needs%norm_drho = .TRUE.
       END IF
-      IF (PRESENT(max_deriv)) max_deriv = 2
+      ! deriv > 1 are not correct
+      ! IF (PRESENT(max_deriv)) max_deriv = 2
+      IF (PRESENT(max_deriv)) max_deriv = 1
    END SUBROUTINE xwpbe_lda_info
 
 ! **************************************************************************************************
@@ -207,6 +209,9 @@ CONTAINS
          deriv => xc_dset_get_derivative(deriv_set, &
                                          "(norm_drho)(norm_drho)", allocate_deriv=.TRUE.)
          CALL xc_derivative_get(deriv, deriv_data=e_ndrho_ndrho)
+      END IF
+      IF (order > 1 .OR. order < -1) THEN
+         CPABORT("derivatives bigger than 1 do not work correctly")
       END IF
       IF (order > 2 .OR. order < -2) THEN
          CPABORT("derivatives bigger than 2 not implemented")


### PR DESCRIPTION
Correct error message for LTC functional derivatives
Disable higher derivatives for XWPBE (most likely wrong)