### PR TITLE
[grid] Add hip backend

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -319,6 +319,26 @@ SIRIUS is a domain specific library for electronic structure calculations.
   please see <https://brehm-research.de/bqb> for more information as well as
   the `bqbtool` to inspect BQB files.
 
+### 2u. ROCM/HIP (Support for AMD GPU)
+
+The code for the grid backend was developed and tested on Mi100 but should work
+out of the box on Nvidia hardware as well.
+
+- USE `-D__GRID_HIP` to enable AMD GPU support for collocate and integrate
+  runtines.
+- Add `GPUVER=Mi50, Mi60, Mi100`
+- Add 'OFFLOAD_CC = hipcc'
+- Add  `-lamdhip64` to the `LIBS` variable
+- Add `OFFLOAD_FLAGS ='-fopenmp -m64 -pthread -fPIC -D__GRID_HIP -O2
+  --offload-arch=gfx908 --rocm-path=$(ROCM_PATH)`' where 'ROCM_PATH' is the path
+  where the rocm dsk resides. Architectures Mi100 (gfx908), Mi50 (gfx906)
+- the hip backend for the grid library supports nvidia hardware as well. It uses
+  the same code and can be used to validate the backend in case of access to
+  Nvidia hardware only. To get the compilation working, follow the steps above
+  and set the `OFFLOAD_FLAGS` with right `nvcc` parameters (see the cuda section
+  of this document). The environment variable `HIP_PLATFORM` should be set to
+  `HIP_PLATFORM=nvidia` to indicate to hipcc to use the nvcc compiler instead.
+
 <!---
 ### 2u. LibMaxwell (External Maxwell Solver)
 

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -289,6 +289,9 @@ CONTAINS
 #if defined(__GRID_CUDA)
       flags = TRIM(flags)//" grid_cuda"
 #endif
+#if defined(__GRID_HIP)
+      flags = TRIM(flags)//" grid_hip"
+#endif
 
    END FUNCTION cp2k_flags
 

--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -112,7 +112,6 @@ MODULE f77_interface
                                               nnp_env_release,&
                                               nnp_type
    USE offload_api,                     ONLY: offload_get_device_count,&
-                                              offload_get_device_id,&
                                               offload_set_device_id
    USE periodic_table,                  ONLY: init_periodic_table
    USE pw_cuda,                         ONLY: pw_cuda_finalize,&
@@ -277,6 +276,7 @@ CONTAINS
 
          ! Initialize the DBCSR configuration
          ! Attach the time handler hooks to DBCSR
+#if defined __DBCSR_ACC
          IF (offload_get_device_count() > 0) THEN
             CALL dbcsr_init_lib(default_para_env%group, timeset_hook, timestop_hook, &
                                 cp_abort_hook, cp_warn_hook, io_unit=unit_nr, &
@@ -285,7 +285,10 @@ CONTAINS
             CALL dbcsr_init_lib(default_para_env%group, timeset_hook, timestop_hook, &
                                 cp_abort_hook, cp_warn_hook, io_unit=unit_nr)
          ENDIF
-
+#else
+         CALL dbcsr_init_lib(default_para_env%group, timeset_hook, timestop_hook, &
+                             cp_abort_hook, cp_warn_hook, io_unit=unit_nr)
+#endif
          CALL pw_cuda_init()
 
          CALL grid_library_init()

--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -112,6 +112,7 @@ MODULE f77_interface
                                               nnp_env_release,&
                                               nnp_type
    USE offload_api,                     ONLY: offload_get_device_count,&
+                                              offload_get_device_id,&
                                               offload_set_device_id
    USE periodic_table,                  ONLY: init_periodic_table
    USE pw_cuda,                         ONLY: pw_cuda_finalize,&

--- a/src/grid/PACKAGE
+++ b/src/grid/PACKAGE
@@ -12,6 +12,7 @@
         "./ref",
         "./cpu",
         "./gpu",
+        "./hip",
     ],
     "public": ["grid_api.F"],
 }

--- a/src/grid/grid_task_list.h
+++ b/src/grid/grid_task_list.h
@@ -14,6 +14,7 @@
 #include "common/grid_constants.h"
 #include "cpu/grid_cpu_task_list.h"
 #include "gpu/grid_gpu_task_list.h"
+#include "hip/grid_hip_task_list.h"
 #include "ref/grid_ref_task_list.h"
 
 /*******************************************************************************
@@ -27,6 +28,8 @@ typedef struct {
   grid_ref_task_list *ref;
   grid_cpu_task_list *cpu;
 #ifdef __GRID_CUDA
+  grid_gpu_task_list *gpu;
+#elif defined(__GRID_HIP)
   grid_gpu_task_list *gpu;
 #endif
   // more backends to be added here

--- a/src/grid/hip/PACKAGE
+++ b/src/grid/hip/PACKAGE
@@ -1,0 +1,5 @@
+{
+    "description": "Optimized GPU backend (ROCM)",
+    "requires": ["../common", "../../offload",],
+    "archive": "libcp2kgridrocm",
+}

--- a/src/grid/hip/grid_hip_collocate.cc
+++ b/src/grid/hip/grid_hip_collocate.cc
@@ -1,0 +1,494 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * Authors :
+ - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+ - Advanced Micro Devices, Inc.
+*/
+
+#ifdef __GRID_HIP
+
+#include <algorithm>
+#include <assert.h>
+#include <climits>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <hip/hip_runtime.h>
+
+#include "grid_hip_internal_header.h"
+
+namespace rocm_backend {
+#include "grid_hip_prepare_pab.h"
+
+/*******************************************************************************
+ * \brief Decontracts the subblock, going from spherical to cartesian harmonics.
+ ******************************************************************************/
+template <typename T, bool IS_FUNC_AB>
+__device__ __inline__ void block_to_cab(const kernel_params &params,
+                                        const smem_task<T> &task, T *cab) {
+
+  // The spherical index runs over angular momentum and then over contractions.
+  // The cartesian index runs over exponents and then over angular momentum.
+
+  // This is a T matrix product. Since the pab block can be quite large the
+  // two products are fused to conserve shared memory.
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  for (int i = 0; i < task.nsgf_setb; i++) {
+    for (int j = 0; j < task.nsgf_seta; j++) {
+      T block_val;
+      if (task.block_transposed) {
+        block_val = task.pab_block[j * task.nsgfb + i] * task.off_diag_twice;
+      } else {
+        block_val = task.pab_block[i * task.nsgfa + j] * task.off_diag_twice;
+      }
+
+      // fast path for common case
+      // const int jco_start = task.first_cosetb;
+      for (int jco = task.first_cosetb + tid / 8; jco < task.ncosetb;
+           jco += 8) {
+        const T sphib = task.sphib[i * task.maxcob + jco];
+        for (int ico = task.first_coseta + (tid % 8); ico < task.ncoseta;
+             ico += 8) {
+          const T sphia = task.sphia[j * task.maxcoa + ico];
+          const T pab_val = block_val * sphia * sphib;
+          if (IS_FUNC_AB) {
+            cab[jco * task.ncoseta + ico] += pab_val;
+          } else {
+            const auto a = coset_inv[ico];
+            const auto b = coset_inv[jco];
+            prepare_pab(params.func, a, b, task.zeta, task.zetb, pab_val,
+                        task.n1, cab);
+          }
+        }
+      }
+      __syncthreads();
+    }
+  }
+}
+
+template <typename T, bool IS_FUNC_AB>
+__global__ void calculate_coefficients(const kernel_params dev_) {
+  __shared__ smem_task<T> task;
+  if (dev_.tasks[dev_.first_task + blockIdx.x].skip_task)
+    return;
+
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+
+  fill_smem_task_coef(dev_, dev_.first_task + blockIdx.x, task);
+  extern __shared__ T shared_memory[];
+  T *smem_cab = &shared_memory[dev_.smem_cab_offset];
+  T *smem_alpha = &shared_memory[dev_.smem_alpha_offset];
+  T *coef_ =
+      &dev_.ptr_dev[2][dev_.tasks[dev_.first_task + blockIdx.x].coef_offset];
+  T *coefs_ = &shared_memory[0];
+
+  for (int z = tid; z < task.n1 * task.n2;
+       z += blockDim.x * blockDim.y * blockDim.z)
+    smem_cab[z] = 0.0;
+
+  __syncthreads();
+  block_to_cab<T, IS_FUNC_AB>(dev_, task, smem_cab);
+  __syncthreads();
+  compute_alpha(dev_, task, smem_alpha);
+  __syncthreads();
+  cab_to_cxyz(dev_, task, smem_alpha, smem_cab, coefs_);
+  __syncthreads();
+
+  for (int z = tid; z < ncoset(task.lp);
+       z += blockDim.x * blockDim.y * blockDim.z)
+    coef_[z] = coefs_[z];
+}
+
+/*
+  \brief compute the real space representation of an operator expressed in the
+  gaussian basis
+
+  this kernel does the following operation
+
+  n_{ijk} = \f[
+  \sum_{p,\alpha,\beta,\gamma} C^p_{\alpha\beta\gamma} X_{\alpha,i} Y_{\beta, j}
+  Z_{\gamma, k} \exp\left(- \eta (r_{ijk} - r_c) ^ 2\right)
+  ]
+
+  where $X_{\alpha,i}, Y_{\beta, j}, Z_{\gamma, k}$ are polynomials of degree
+  $\alpha,\beta,\gamma$ and $r_{ijk}% a point (in cartesian coordinates) on a 3D
+  grid. C^p_{\alpha\beta\gamma} are also constrained such that 0 <= \alpha +
+  \beta + \gamma <= lmax. It means in practice that we need store (lmax + 1) *
+  (lamax + 2) * (lmax + 3) / 6 coefficients all the other coefficients are zero
+
+  to reduce computation, a spherical cutoff is applied such that all points
+  $|r_{ijk} - r_c| > radius$ are not computed. The sum over p extends over all
+  relevant pairs of gaussians (which are called task in the code).
+
+  the kernel computes the polynomials and the gaussian then sums the result
+  back to the grid.
+
+  the coefficients $C^p_{\alpha\beta\gamma}$ are computed by
+  calculate_coefficients. We only keep the non zero elements to same memory.
+*/
+
+  template <typename T, typename T3, bool distributed__, bool orthorhombic_>
+__global__ __launch_bounds__(64) void collocate_kernel(const kernel_params dev_) {
+  // Copy task from global to shared memory and precompute some stuff.
+  __shared__ smem_task_reduced<T, T3> task;
+
+  if (dev_.tasks[dev_.first_task + blockIdx.x].skip_task)
+    return;
+
+  fill_smem_task_reduced(dev_, dev_.first_task + blockIdx.x, task);
+
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+
+  //  Alloc shared memory.
+  extern __shared__ T coefs_[];
+
+  T *coef_ =
+      &dev_.ptr_dev[2][dev_.tasks[dev_.first_task + blockIdx.x].coef_offset];
+  __shared__ T dh_[9], dh_inv_[9];
+
+  // matrix from lattice coordinates to cartesian coordinates
+  for (int i = tid; i < 9; i += blockDim.x * blockDim.y * blockDim.z) {
+    dh_[i] = dev_.dh_[i];
+  }
+
+  // matrix from  cartesian coordinates to lattice coordinates.
+  for (int i = tid; i < 9; i += blockDim.x * blockDim.y * blockDim.z) {
+    dh_inv_[i] = dev_.dh_inv_[i];
+  }
+
+  __syncthreads();
+  for (int i = tid; i < ncoset(task.lp);
+       i += blockDim.x * blockDim.y * blockDim.z)
+    coefs_[i] = coef_[i];
+
+  if (tid == 0) {
+    // the cube center is initialy expressed in lattice coordinates but we
+    // always do something like this. x = x + lower_corner + cube_center (+
+    // roffset) - grid_lower_corner so shift the cube center already
+    task.cube_center.z += task.lb_cube.z - dev_.grid_lower_corner_[0];
+    task.cube_center.y += task.lb_cube.y - dev_.grid_lower_corner_[1];
+    task.cube_center.x += task.lb_cube.x - dev_.grid_lower_corner_[2];
+
+    if (distributed__) {
+      if (task.apply_border_mask) {
+        compute_window_size(dev_.grid_local_size_, dev_.grid_lower_corner_,
+                            dev_.grid_full_size_, // also full size of the grid
+                            dev_.tasks[dev_.first_task + blockIdx.x].border_mask,
+                            dev_.grid_border_width_, &task.window_size,
+                            &task.window_shift);
+      }
+    }
+  }
+  __syncthreads();
+
+  for (int z = threadIdx.z; z < task.cube_size.z; z += blockDim.z) {
+    int z2 = (z + task.cube_center.z) % dev_.grid_full_size_[0];
+
+    if (z2 < 0)
+      z2 += dev_.grid_full_size_[0];
+
+    if (distributed__) {
+      // check if the point is within the window
+      if (task.apply_border_mask) {
+        // this test is only relevant when the grid is split over several mpi
+        // ranks. in that case we take only the points contributing to local part
+        // of the grid.
+        if ((z2 < task.window_shift.z) || (z2 > task.window_size.z)) {
+        continue;
+        }
+      }
+    }
+
+    // compute the coordinates of the point in atomic coordinates
+    T kremain;
+    short int ymin = 0;
+    short int ymax = task.cube_size.y - 1;
+
+    if (orthorhombic_ && !task.apply_border_mask) {
+      ymin = (2 * (z + task.lb_cube.z) - 1) / 2;
+      ymin *= ymin;
+      kremain = task.discrete_radius * task.discrete_radius -
+                ((T)ymin) * dh_[8] * dh_[8];
+      ymin = ceil(-1.0e-8 - sqrt(fmax(0.0, kremain)) * dh_inv_[4]);
+      ymax = 1 - ymin - task.lb_cube.y;
+      ymin = ymin - task.lb_cube.y;
+    }
+
+    for (int y = ymin + threadIdx.y; y <= ymax; y += blockDim.y) {
+      int y2 = (y + task.cube_center.y) % dev_.grid_full_size_[1];
+      if (y2 < 0)
+        y2 += dev_.grid_full_size_[1];
+
+      if (distributed__) {
+        if (task.apply_border_mask) {
+          // check if the point is within the window
+          if ((y2 < task.window_shift.y) || (y2 > task.window_size.y)) {
+            continue;
+          }
+        }
+      }
+
+      short int xmin = 0;
+      short int xmax = task.cube_size.x - 1;
+      if (orthorhombic_ && !task.apply_border_mask) {
+        xmin = (2 * (y + task.lb_cube.y) - 1) / 2;
+        xmin *= xmin;
+        xmin =
+            ceil(-1.0e-8 - sqrt(fmax(0.0, kremain - xmin * dh_[4] * dh_[4])) *
+                               dh_inv_[0]);
+        xmax = 1 - xmin - task.lb_cube.x;
+        xmin = xmin - task.lb_cube.x;
+      }
+
+      for (int x = xmin + threadIdx.x; x <= xmax; x += blockDim.x) {
+        int x2 = (x + task.cube_center.x) % dev_.grid_full_size_[2];
+
+        if (x2 < 0)
+          x2 += dev_.grid_full_size_[2];
+
+        if (distributed__) {
+          if (task.apply_border_mask) {
+            // check if the point is within the window (only true or false
+            // when using mpi) otherwise MPI=1 always true
+            if ((x2 < task.window_shift.x) || (x2 > task.window_size.x)) {
+              continue;
+            }
+          }
+        }
+
+        // I make no distinction between orthorhombic and non orthorhombic
+        // cases
+
+        T3 r3;
+        if (orthorhombic_) {
+          r3.x = (x + task.lb_cube.x + task.roffset.x) * dh_[0];
+          r3.y = (y + task.lb_cube.y + task.roffset.y) * dh_[4];
+          r3.z = (z + task.lb_cube.z + task.roffset.z) * dh_[8];
+        } else {
+          r3 =
+            compute_coordinates(dh_, (x + task.lb_cube.x + task.roffset.x),
+                                (y + task.lb_cube.y + task.roffset.y),
+                                (z + task.lb_cube.z + task.roffset.z));
+        }
+
+        if (distributed__) {
+          // check if the point is inside the sphere or not. Note that it does not
+          // apply for the orthorhombic case when the full sphere is inside the
+          // region of interest.
+
+          if (((task.radius * task.radius) <=
+               (r3.x * r3.x + r3.y * r3.y + r3.z * r3.z)) &&
+              (!orthorhombic_ || task.apply_border_mask))
+            continue;
+        } else {
+          // we do not need to do this test for the orthorhombic case
+          if ((!orthorhombic_) && ((task.radius * task.radius) <=
+                                   (r3.x * r3.x + r3.y * r3.y + r3.z * r3.z)))
+            continue;
+        }
+
+        // allow computation of the address in parallel to starting the
+        // computations
+        // T *grid_elem =
+        //     dev_.ptr_dev[1] +
+        //     (z2 * dev_.grid_local_size_[1] + y2) * dev_.grid_local_size_[2] +
+        //     x2;
+
+        T res = coefs_[0];
+
+        if (task.lp >= 1) {
+          res += coefs_[1] * r3.x;
+          res += coefs_[2] * r3.y;
+          res += coefs_[3] * r3.z;
+        }
+        const T r3xy = r3.x * r3.y;
+        const T r3xz = r3.x * r3.z;
+        const T r3yz = r3.y * r3.z;
+        const T r3x2 = r3.x * r3.x;
+        const T r3y2 = r3.y * r3.y;
+        const T r3z2 = r3.z * r3.z;
+
+        if (task.lp >= 2) {
+          res += coefs_[4] * r3x2;
+          res += coefs_[5] * r3xy;
+          res += coefs_[6] * r3xz;
+          res += coefs_[7] * r3y2;
+          res += coefs_[8] * r3yz;
+          res += coefs_[9] * r3z2;
+        }
+
+        if (task.lp >= 3) {
+          res += coefs_[10] * r3x2 * r3.x;
+          res += coefs_[11] * r3x2 * r3.y;
+          res += coefs_[12] * r3x2 * r3.z;
+          res += coefs_[13] * r3.x * r3y2;
+          res += coefs_[14] * r3xy * r3.z;
+          res += coefs_[15] * r3.x * r3z2;
+          res += coefs_[16] * r3y2 * r3.y;
+          res += coefs_[17] * r3y2 * r3.z;
+          res += coefs_[18] * r3.y * r3z2;
+          res += coefs_[19] * r3z2 * r3.z;
+        }
+
+        if (task.lp >= 4) {
+          res += coefs_[20] * r3x2 * r3x2;
+          res += coefs_[21] * r3x2 * r3xy;
+          res += coefs_[22] * r3x2 * r3xz;
+          res += coefs_[23] * r3x2 * r3y2;
+          res += coefs_[24] * r3x2 * r3yz;
+          res += coefs_[25] * r3x2 * r3z2;
+          res += coefs_[26] * r3xy * r3y2;
+          res += coefs_[27] * r3xz * r3y2;
+          res += coefs_[28] * r3xy * r3z2;
+          res += coefs_[29] * r3xz * r3z2;
+          res += coefs_[30] * r3y2 * r3y2;
+          res += coefs_[31] * r3y2 * r3yz;
+          res += coefs_[32] * r3y2 * r3z2;
+          res += coefs_[33] * r3yz * r3z2;
+          res += coefs_[34] * r3z2 * r3z2;
+        }
+
+        if (task.lp > 4) {
+          for (int ic = 35; ic < ncoset(task.lp); ic++) {
+            auto &co = coset_inv[ic];
+            T tmp = coefs_[ic];
+            for (int po = 0; po < co.l[2]; po++)
+              tmp *= r3.z;
+            for (int po = 0; po < co.l[1]; po++)
+              tmp *= r3.y;
+            for (int po = 0; po < co.l[0]; po++)
+              tmp *= r3.x;
+            res += tmp;
+          }
+        }
+
+        atomicAdd(
+            dev_.ptr_dev[1] +
+                (z2 * dev_.grid_local_size_[1] + y2) *
+                    dev_.grid_local_size_[2] +
+                x2,
+            res * exp(-(r3.x * r3.x + r3.y * r3.y + r3.z * r3.z) * task.zetp));
+      }
+    }
+  }
+  __syncthreads();
+}
+/*******************************************************************************
+ * \brief Launches the Cuda kernel that collocates all tasks of one grid level.
+ ******************************************************************************/
+void context_info::collocate_one_grid_level(const int level,
+                                            const int first_task,
+                                            const int last_task,
+                                            const enum grid_func func,
+                                            int *lp_diff) {
+
+  if ((last_task - first_task) == 0)
+    return;
+
+  // Compute max angular momentum.
+  const ldiffs_value ldiffs = prepare_get_ldiffs(func);
+  *lp_diff = ldiffs.la_max_diff + ldiffs.lb_max_diff; // for reporting stats
+  const int la_max = this->lmax() + ldiffs.la_max_diff;
+  const int lb_max = this->lmax() + ldiffs.lb_max_diff;
+  const int lp_max = la_max + lb_max;
+
+  const int ntasks = last_task - first_task;
+  if (ntasks == 0) {
+    return; // Nothing to do and lp_diff already set.
+  }
+
+  init_constant_memory();
+
+  // Compute required shared memory.
+  // TODO: Currently, cab's indices run over 0...ncoset[lmax],
+  //       however only ncoset(lmin)...ncoset(lmax) are actually needed.
+  const int cab_len = ncoset(lb_max) * ncoset(la_max);
+  const int alpha_len = 3 * (lb_max + 1) * (la_max + 1) * (lp_max + 1);
+  const int cxyz_len = ncoset(lp_max);
+  const size_t smem_per_block =
+      (cab_len + alpha_len + cxyz_len) * sizeof(double);
+
+  if (smem_per_block > 64 * 1024) {
+    fprintf(stderr, "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
+    fprintf(stderr, "cab_len: %i, ", cab_len);
+    fprintf(stderr, "alpha_len: %i, ", alpha_len);
+    fprintf(stderr, "cxyz_len: %i, ", cxyz_len);
+    fprintf(stderr, "total smem_per_block: %f kb\n\n", smem_per_block / 1024.0);
+    abort();
+  }
+
+  // kernel parameters
+  kernel_params params;
+  params.smem_cab_offset = cxyz_len;
+  params.smem_alpha_offset = cab_len + params.smem_cab_offset;
+  params.first_task = first_task;
+  params.func = func;
+  params.la_min_diff = ldiffs.la_min_diff;
+  params.lb_min_diff = ldiffs.lb_min_diff;
+
+  params.la_max_diff = ldiffs.la_max_diff;
+  params.lb_max_diff = ldiffs.lb_max_diff;
+  // params.lp_max = 2 * this->lmax() + ldiffs.la_max_diff + ldiffs.lb_max_diff;
+  params.tasks = this->tasks_dev.data();
+  params.block_offsets = this->block_offsets_dev.data();
+  memcpy(params.dh_, grid_[level].dh(), 9 * sizeof(double));
+  memcpy(params.dh_inv_, grid_[level].dh_inv(), 9 * sizeof(double));
+  params.ptr_dev[0] = pab_block_.data();
+  params.ptr_dev[1] = grid_[level].data();
+  params.ptr_dev[2] = this->coef_dev_.data();
+  params.ptr_dev[3] = nullptr;
+  params.ptr_dev[4] = nullptr;
+  params.ptr_dev[5] = nullptr;
+  params.sphi_dev = this->sphi_dev.data();
+  for (int i = 0; i < 3; i++) {
+    params.grid_full_size_[i] = grid_[level].full_size(i);
+    params.grid_local_size_[i] = grid_[level].local_size(i);
+    params.grid_lower_corner_[i] = grid_[level].lower_corner(i);
+    params.grid_border_width_[i] = grid_[level].border_width(i);
+  }
+  // Launch !
+  const int nblocks = ntasks;
+  const dim3 threads_per_block(4, 4, 4);
+
+  if (func == GRID_FUNC_AB) {
+    calculate_coefficients<double, true>
+        <<<nblocks, threads_per_block, smem_per_block, level_streams[level]>>>(
+            params);
+  } else {
+    calculate_coefficients<double, false>
+        <<<nblocks, threads_per_block, smem_per_block, level_streams[level]>>>(
+            params);
+  }
+
+  if (grid_[level].is_distributed()) {
+    if (grid_[level].is_orthorhombic())
+      collocate_kernel<double, double3, true, true>
+        <<<nblocks, threads_per_block, cxyz_len * sizeof(double),
+      level_streams[level]>>>(params);
+    else
+      collocate_kernel<double, double3, true, false>
+        <<<nblocks, threads_per_block, cxyz_len * sizeof(double),
+      level_streams[level]>>>(params);
+  } else {
+    if (grid_[level].is_orthorhombic())
+      collocate_kernel<double, double3, false, true>
+        <<<nblocks, threads_per_block, cxyz_len * sizeof(double),
+        level_streams[level]>>>(params);
+    else
+      collocate_kernel<double, double3, false, false>
+        <<<nblocks, threads_per_block, cxyz_len * sizeof(double),
+        level_streams[level]>>>(params);
+  }
+}
+} // namespace rocm_backend
+#endif // __GRID_ROCM

--- a/src/grid/hip/grid_hip_context.cc
+++ b/src/grid/hip/grid_hip_context.cc
@@ -1,0 +1,534 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * Authors :
+ - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+ - Advanced Micro Devices, Inc.
+*/
+
+#ifdef __GRID_HIP
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <hip/hip_runtime_api.h>
+#include <iostream>
+
+extern "C" {
+#include "../../offload/offload_library.h"
+#include "../common/grid_basis_set.h"
+#include "../common/grid_constants.h"
+#include "../common/grid_library.h"
+}
+
+#include "grid_hip_context.hpp"
+#include "grid_hip_internal_header.h"
+
+#include "grid_hip_task_list.h"
+
+/*******************************************************************************
+ * \brief Allocates a task list for the GPU backend.
+ *        See grid_ctx.h for details.
+ ******************************************************************************/
+extern "C" void grid_hip_create_task_list(
+    const bool ortho, const int ntasks, const int nlevels, const int natoms,
+    const int nkinds, const int nblocks, const int *block_offsets,
+    const double *atom_positions, const int *atom_kinds,
+    const grid_basis_set **basis_sets, const int *level_list,
+    const int *iatom_list, const int *jatom_list, const int *iset_list,
+    const int *jset_list, const int *ipgf_list, const int *jpgf_list,
+    const int *border_mask_list, const int *block_num_list,
+    const double *radius_list, const double *rab_list, const int *npts_global,
+    const int *npts_local, const int *shift_local, const int *border_width,
+    const double *dh, const double *dh_inv, void *ptr) {
+
+  rocm_backend::context_info **ctx_out = (rocm_backend::context_info **)ptr;
+  // Select GPU device.
+  rocm_backend::context_info *ctx = nullptr;
+  if (*ctx_out == nullptr) {
+    ctx = new rocm_backend::context_info(offload_get_device_id());
+    *ctx_out = ctx;
+  } else {
+    ctx = *ctx_out;
+    // verify that the object is the right one
+    ctx->verify_checksum();
+  }
+
+  ctx->ntasks = ntasks;
+  ctx->nlevels = nlevels;
+  ctx->natoms = natoms;
+  ctx->nblocks = nblocks;
+
+  ctx->grid_.resize(nlevels);
+  ctx->set_device();
+  std::vector<double> dh_max(ctx->nlevels, 0);
+
+  for (int level = 0; level < ctx->nlevels; level++) {
+    ctx->grid_[level].resize(npts_global + 3 * level, npts_local + 3 * level,
+                             shift_local + 3 * level, border_width + 3 * level);
+    ctx->grid_[level].is_distributed(false);
+    ctx->grid_[level].set_lattice_vectors(&dh[9 * level], &dh_inv[9 * level]);
+    ctx->grid_[level].check_orthorhombicity(ortho);
+    for (int i = 0; i < 9; i++)
+      dh_max[level] = std::max(dh_max[level], std::abs(dh[9 * level + i]));
+  }
+
+  ctx->block_offsets_dev.resize(nblocks);
+  ctx->block_offsets_dev.copy_to_gpu(block_offsets);
+  ctx->initialize_basis_sets(basis_sets, nkinds);
+
+  ctx->first_task_per_level_.resize(nlevels, 0);
+  ctx->number_of_tasks_per_level_.resize(nlevels, 0);
+
+  std::vector<rocm_backend::task_info> tasks_host(ntasks);
+  memset(&tasks_host[0], 0, sizeof(rocm_backend::task_info) * ntasks);
+
+  size_t coef_size = 0;
+
+  for (int i = 0; i < ntasks; i++) {
+    ctx->number_of_tasks_per_level_[level_list[i] - 1]++;
+    const int iatom = iatom_list[i] - 1;
+    const int jatom = jatom_list[i] - 1;
+    const int iset = iset_list[i] - 1;
+    const int jset = jset_list[i] - 1;
+    const int ipgf = ipgf_list[i] - 1;
+    const int jpgf = jpgf_list[i] - 1;
+    const int ikind = atom_kinds[iatom] - 1;
+    const int jkind = atom_kinds[jatom] - 1;
+
+    /* set parameters related to atom type orbital etc....  */
+    const grid_basis_set *ibasis = basis_sets[ikind];
+    const grid_basis_set *jbasis = basis_sets[jkind];
+    tasks_host[i].level = level_list[i] - 1;
+    tasks_host[i].iatom = iatom;
+    tasks_host[i].jatom = jatom;
+    tasks_host[i].iset = iset;
+    tasks_host[i].jset = jset;
+    tasks_host[i].ipgf = ipgf;
+    tasks_host[i].jpgf = jpgf;
+    tasks_host[i].ikind = ikind;
+    tasks_host[i].jkind = jkind;
+    tasks_host[i].border_mask = border_mask_list[i];
+    tasks_host[i].block_num = block_num_list[i] - 1;
+
+    if (border_mask_list[i]){
+      ctx->grid_[level_list[i] - 1].is_distributed(true);
+    }
+    /* parameters for the gaussian  */
+    tasks_host[i].radius = radius_list[i];
+    tasks_host[i].rab[0] = rab_list[3 * i];
+    tasks_host[i].rab[1] = rab_list[3 * i + 1];
+    tasks_host[i].rab[2] = rab_list[3 * i + 2];
+    tasks_host[i].zeta = ibasis->zet[iset * ibasis->maxpgf + ipgf];
+    tasks_host[i].zetb = jbasis->zet[jset * jbasis->maxpgf + jpgf];
+    tasks_host[i].zetp = tasks_host[i].zeta + tasks_host[i].zetb;
+    const double f = tasks_host[i].zetb / tasks_host[i].zetp;
+    tasks_host[i].rab2 = 0.0;
+    for (int d = 0; d < 3; d++) {
+      tasks_host[i].rab[d] = tasks_host[i].rab[d];
+      tasks_host[i].rab2 += tasks_host[i].rab[d] * tasks_host[i].rab[d];
+      tasks_host[i].ra[d] = atom_positions[3 * iatom + d];
+      tasks_host[i].rb[d] = tasks_host[i].ra[d] + tasks_host[i].rab[d];
+      tasks_host[i].rp[d] = tasks_host[i].ra[d] + tasks_host[i].rab[d] * f;
+    }
+
+    tasks_host[i].skip_task = (2 * tasks_host[i].radius < dh_max[level_list[i] - 1]);
+    tasks_host[i].prefactor = exp(-tasks_host[i].zeta * f * tasks_host[i].rab2);
+
+    tasks_host[i].off_diag_twice = (iatom == jatom) ? 1.0 : 2.0;
+    // angular momentum range of basis set
+    const int la_max_basis = ibasis->lmax[iset];
+    const int lb_max_basis = jbasis->lmax[jset];
+    const int la_min_basis = ibasis->lmin[iset];
+    const int lb_min_basis = jbasis->lmin[jset];
+
+    // angular momentum range for the actual collocate/integrate opteration.
+    tasks_host[i].la_max = la_max_basis;
+    tasks_host[i].lb_max = lb_max_basis;
+    tasks_host[i].la_min = la_min_basis;
+    tasks_host[i].lb_min = lb_min_basis;
+
+    // start of decontracted set, ie. pab and hab
+    tasks_host[i].first_coseta =
+        (la_min_basis > 0) ? rocm_backend::ncoset(la_min_basis - 1) : 0;
+    tasks_host[i].first_cosetb =
+        (lb_min_basis > 0) ? rocm_backend::ncoset(lb_min_basis - 1) : 0;
+
+    // size of decontracted set, ie. pab and hab
+    tasks_host[i].ncoseta = rocm_backend::ncoset(la_max_basis);
+    tasks_host[i].ncosetb = rocm_backend::ncoset(lb_max_basis);
+
+    // size of entire spherical basis
+    tasks_host[i].nsgfa = ibasis->nsgf;
+    tasks_host[i].nsgfb = jbasis->nsgf;
+
+    // size of spherical set
+    tasks_host[i].nsgf_seta = ibasis->nsgf_set[iset];
+    tasks_host[i].nsgf_setb = jbasis->nsgf_set[jset];
+
+    // strides of the sphi transformation matrices
+    tasks_host[i].maxcoa = ibasis->maxco;
+    tasks_host[i].maxcob = jbasis->maxco;
+
+    tasks_host[i].sgfa = ibasis->first_sgf[iset] - 1;
+    tasks_host[i].sgfb = jbasis->first_sgf[jset] - 1;
+
+    tasks_host[i].block_transposed = (iatom > jatom);
+    tasks_host[i].subblock_offset =
+      (tasks_host[i].block_transposed)
+            ? (tasks_host[i].sgfa * tasks_host[i].nsgfb + tasks_host[i].sgfb)
+            : (tasks_host[i].sgfb * tasks_host[i].nsgfa + tasks_host[i].sgfa);
+
+    /* the constant 6 is important here since we do not know ahead of time what
+     * specific operation we will be doing. collocate functions can go up to 4
+     * while integrate can go up to 5 (but put 6 for safety reasons) */
+
+    /* this block is only as temporary scratch for calculating the coefficients.
+     * Doing this avoid a lot of atomic operations that are costly on hardware
+     * that only have partial support of them. For better performance we should
+     * most probably align the offsets as well. it is 256 bytes on Mi100 and above */
+    tasks_host[i].lp_max = tasks_host[i].lb_max + tasks_host[i].la_max + 6;
+    if (i == 0) {
+      tasks_host[i].coef_offset = 0;
+    } else {
+      tasks_host[i].coef_offset = tasks_host[i - 1].coef_offset +
+                                  rocm_backend::ncoset(tasks_host[i].lp_max);
+    }
+    coef_size += rocm_backend::ncoset(tasks_host[i].lp_max);
+
+    auto &grid = ctx->grid_[tasks_host[i].level];
+    // compute the cube properties
+
+    tasks_host[i].apply_border_mask = (tasks_host[i].border_mask != 0);
+
+    if (grid.is_orthorhombic() && (tasks_host[i].border_mask == 0)) {
+      tasks_host[i]
+        .discrete_radius = rocm_backend::compute_cube_properties<double, double3, true>(
+          tasks_host[i].radius, grid.dh(), grid.dh_inv(),
+          (double3 *)tasks_host[i].rp, // center of the gaussian
+          &tasks_host[i].roffset, // offset compared to the closest grid point
+          &tasks_host[i].cube_center, // center coordinates in grid space
+          &tasks_host[i].lb_cube,     // lower boundary
+          &tasks_host[i].cube_size);
+    } else {
+      tasks_host[i]
+        .discrete_radius = rocm_backend::compute_cube_properties<double, double3, false>(
+          tasks_host[i].radius, grid.dh(), grid.dh_inv(),
+          (double3 *)tasks_host[i].rp, // center of the gaussian
+          &tasks_host[i].roffset, // offset compared to the closest grid point
+          &tasks_host[i].cube_center, // center coordinates in grid space
+          &tasks_host[i].lb_cube,     // lower boundary
+          &tasks_host[i].cube_size);
+    }
+  }
+
+  // we need to sort the task list although I expect it to be sorted already
+/*
+ * sorting with this lambda does not work
+std::sort(tasks_host.begin(), tasks_host.end(), [](rocm_backend::task_info a, rocm_backend::task_info b) {
+    if (a.level == b.level) {
+      if (a.block_num <= b.block_num)
+        return true;
+      else
+        return false;
+    } else {
+      return (a.level < b.level);
+    }
+  });
+*/
+  // it is a exclusive scan actually
+  for (int level = 1; level < ctx->number_of_tasks_per_level_.size(); level++) {
+    ctx->first_task_per_level_[level] = ctx->first_task_per_level_[level - 1] +
+      ctx->number_of_tasks_per_level_[level - 1];
+  }
+
+  ctx->tasks_dev.clear();
+  ctx->tasks_dev.resize(tasks_host.size());
+  ctx->tasks_dev.copy_to_gpu(tasks_host);
+
+  /* Sort the blocks */
+  std::vector<std::vector<int>> task_sorted_by_block(nblocks);
+  std::vector<int> sorted_blocks(ntasks, 0);
+  std::vector<int> num_tasks_per_block(nblocks, 0);
+  std::vector<int> sorted_blocks_offset(nblocks, 0);
+  for (auto &block : task_sorted_by_block)
+    block.clear();
+
+  for (int i = 0; i < ntasks; i++) {
+    task_sorted_by_block[block_num_list[i] - 1].push_back(i);
+    num_tasks_per_block[block_num_list[i] - 1]++;
+  }
+
+  int offset = 0;
+  // flatten the task_sorted_by_block and compute the offsets
+  for (int i = 0; i < task_sorted_by_block.size(); i++) {
+    auto &task_list = task_sorted_by_block[i];
+
+    // take care of the case where the blocks are not associated to a given
+    // task. (and also a workaround in the grid_replay.c file)
+    if (!task_list.empty()) {
+      memcpy(&sorted_blocks[offset], &task_list[0],
+             sizeof(int) * task_list.size());
+    }
+    sorted_blocks_offset[i] = offset;
+    offset += task_list.size();
+  }
+
+  // copy the blocks offsets
+  ctx->sorted_blocks_offset_dev.resize(sorted_blocks_offset.size());
+  ctx->sorted_blocks_offset_dev.copy_to_gpu(sorted_blocks_offset);
+
+  // copy the task list sorted by block (not by level) to the gpu
+  ctx->task_sorted_by_blocks_dev.resize(sorted_blocks.size());
+  ctx->task_sorted_by_blocks_dev.copy_to_gpu(sorted_blocks);
+
+  for (int i = 0; i < sorted_blocks_offset.size(); i++) {
+    int num_tasks = 0;
+    if (i == sorted_blocks_offset.size() - 1)
+      num_tasks = ntasks - sorted_blocks_offset[i];
+    else
+      num_tasks = sorted_blocks_offset[i + 1] - sorted_blocks_offset[i];
+
+    // pointless tests since they should be equal.
+    assert(num_tasks == num_tasks_per_block[i]);
+
+    // check that all tasks point to the same block
+#ifndef NDEBUG
+    for (int tk = 0; tk < num_tasks; tk++)
+      assert(
+          tasks_host[sorted_blocks[tk + sorted_blocks_offset[i]]].block_num ==
+          i);
+#endif
+  }
+  for (auto &block : task_sorted_by_block)
+    block.clear();
+  task_sorted_by_block.clear();
+
+  sorted_blocks.clear();
+  sorted_blocks_offset.clear();
+
+  // Count tasks per level.
+  ctx->tasks_per_level.resize(nlevels);
+  memset(ctx->tasks_per_level.data(), 0, sizeof(int) * nlevels);
+  for (int i = 0; i < ntasks; i++) {
+    ctx->tasks_per_level[level_list[i] - 1]++;
+    assert(i == 0 || level_list[i] >= level_list[i - 1]); // expect ordered list
+  }
+
+  ctx->num_tasks_per_block_dev_.resize(num_tasks_per_block.size());
+  ctx->num_tasks_per_block_dev_.copy_to_gpu(num_tasks_per_block);
+
+// collect stats
+  memset(ctx->stats, 0, 2 * 20 * sizeof(int));
+  for (int itask = 0; itask < ntasks; itask++) {
+    const int iatom = iatom_list[itask] - 1;
+    const int jatom = jatom_list[itask] - 1;
+    const int ikind = atom_kinds[iatom] - 1;
+    const int jkind = atom_kinds[jatom] - 1;
+    const int iset = iset_list[itask] - 1;
+    const int jset = jset_list[itask] - 1;
+    const int la_max = basis_sets[ikind]->lmax[iset];
+    const int lb_max = basis_sets[jkind]->lmax[jset];
+    const int lp = std::min(la_max + lb_max, 19);
+    const bool has_border_mask = (border_mask_list[itask] != 0);
+    ctx->stats[has_border_mask][lp]++;
+  }
+
+  ctx->create_streams();
+
+  tasks_host.clear();
+  ctx->coef_dev_.resize(coef_size);
+  ctx->compute_checksum();
+  // return newly created or updated context
+  *ctx_out = ctx;
+}
+
+/*******************************************************************************
+ * \brief destroy a context
+ ******************************************************************************/
+extern "C" void grid_hip_free_task_list(void *ptr) {
+
+  rocm_backend::context_info *ctx = (rocm_backend::context_info *)ptr;
+  // Select GPU device.
+  if (ctx == nullptr)
+    return;
+  ctx->verify_checksum();
+  ctx->set_device();
+  delete ctx;
+}
+
+/*******************************************************************************
+ * \brief Collocate all tasks of in given list onto given grids.
+ ******************************************************************************/
+extern "C" void grid_hip_collocate_task_list(const void *ptr,
+                                             const enum grid_func func,
+                                             const int nlevels,
+                                             const offload_buffer *pab_blocks,
+                                             offload_buffer **grids) {
+  rocm_backend::context_info *ctx = (rocm_backend::context_info *)ptr;
+
+  if (ptr == nullptr)
+    return;
+
+  ctx->verify_checksum();
+  ctx->set_device();
+  ctx->pab_block_.resize(pab_blocks->size / sizeof(double));
+  ctx->pab_block_.copy_to_gpu(pab_blocks->host_buffer, ctx->main_stream);
+
+  // record an event so the level streams can wait for the blocks to be uploaded
+
+  int lp_diff;
+  int first_task = 0;
+  assert(ctx->nlevels == nlevels);
+
+  for (int level = 0; level < ctx->nlevels; level++) {
+    ctx->grid_[level].zero(ctx->level_streams[level]);
+  }
+
+  ctx->synchronize(ctx->main_stream);
+
+  for (int level = 0; level < ctx->nlevels; level++) {
+    const int last_task = first_task + ctx->tasks_per_level[level];
+    ctx->collocate_one_grid_level(level, first_task, last_task, func, &lp_diff);
+    // ctx->grid_[level].copy_to_host(grids[level]->host_buffer,
+    //                                ctx->level_streams[level]);
+    first_task = last_task;
+  }
+
+  // update counters while we wait for kernels to finish. It is not thread safe
+  // at all since the function grid_library_counter_add has global static
+  // states. We need a much better mechanism than this for instance move this
+  // information one level up and encapsulate it in the context associated to
+  // the library.
+
+  for (int has_border_mask = 0; has_border_mask <= 1; has_border_mask++) {
+    for (int lp = 0; lp < 20; lp++) {
+      const int count = ctx->stats[has_border_mask][lp];
+      if (ctx->grid_[0].is_orthorhombic() && !has_border_mask) {
+        grid_library_counter_add(lp + lp_diff, GRID_BACKEND_GPU,
+                                 GRID_COLLOCATE_ORTHO, count);
+      } else {
+        grid_library_counter_add(lp + lp_diff, GRID_BACKEND_GPU,
+                                 GRID_COLLOCATE_GENERAL, count);
+      }
+    }
+  }
+
+  // download result from device to host.
+  for (int level = 0; level < ctx->nlevels; level++) {
+    ctx->grid_[level].copy_to_host(grids[level]->host_buffer,
+                                   ctx->level_streams[level]);
+  }
+
+  // need to wait for all streams to finish
+  for (int level = 0; level < ctx->nlevels; level++) {
+    ctx->synchronize(ctx->level_streams[level]);
+  }
+}
+
+/*******************************************************************************
+ * \brief Integrate all tasks of in given list onto given grids.
+ *        See grid_ctx.h for details.
+ ******************************************************************************/
+extern "C" void grid_hip_integrate_task_list(
+    const void *ptr, const bool compute_tau, const int nlevels,
+    const offload_buffer *pab_blocks, const offload_buffer **grids,
+    offload_buffer *hab_blocks, double *forces, double *virial) {
+
+  rocm_backend::context_info *ctx = (rocm_backend::context_info *)ptr;
+
+  if(ptr == nullptr)
+    return;
+
+  ctx->verify_checksum();
+  // Select GPU device.
+  ctx->set_device();
+
+  // ctx->coef_dev_.zero(ctx->level_streams[0]);
+
+  for (int level = 0; level < ctx->nlevels; level++) {
+    ctx->grid_[level].copy_to_gpu(grids[level]->host_buffer,
+                                  ctx->level_streams[level]);
+  }
+
+  if ((forces != nullptr) || (virial != nullptr)) {
+    ctx->pab_block_.resize(pab_blocks->size / sizeof(double));
+    ctx->pab_block_.copy_to_gpu(pab_blocks->host_buffer, ctx->main_stream);
+  }
+
+  // we do not need to wait for this to start the computations since the matrix
+  // elements are computed after all coefficients are calculated.
+
+  ctx->hab_block_.resize(hab_blocks->size / sizeof(double));
+  ctx->hab_block_.zero(ctx->main_stream);
+
+  ctx->calculate_forces = (forces != nullptr);
+  ctx->calculate_virial = (virial != nullptr);
+  ctx->compute_tau = compute_tau;
+  if (forces != nullptr) {
+    ctx->forces_.resize(3 * ctx->natoms);
+    ctx->forces_.zero(ctx->main_stream);
+  }
+
+  if (virial != nullptr) {
+    ctx->virial_.resize(9);
+    ctx->virial_.zero(ctx->main_stream);
+  }
+
+  int lp_diff;
+  int first_task = 0;
+  assert(ctx->nlevels == nlevels);
+
+  // ctx->synchronize(ctx->level_streams[0]);
+
+  // we can actually treat the full task list without bothering about the level
+  // at that stage. This can be taken care of inside the kernel.
+
+  for (int level = 0; level < ctx->nlevels; level++) {
+    const int last_task = first_task + ctx->tasks_per_level[level];
+    const hipStream_t level_stream = ctx->level_streams[level];
+    // launch kernel, but only after grid has arrived
+    ctx->integrate_one_grid_level(level, first_task, last_task, &lp_diff);
+    first_task = last_task;
+  }
+
+  // update counters while we wait for kernels to finish
+  for (int has_border_mask = 0; has_border_mask <= 1; has_border_mask++) {
+    for (int lp = 0; lp < 20; lp++) {
+      const int count = ctx->stats[has_border_mask][lp];
+      if (ctx->grid_[0].is_orthorhombic() && !has_border_mask) {
+        grid_library_counter_add(lp + lp_diff, GRID_BACKEND_GPU,
+                                 GRID_INTEGRATE_ORTHO, count);
+      } else {
+        grid_library_counter_add(lp + lp_diff, GRID_BACKEND_GPU,
+                                 GRID_INTEGRATE_GENERAL, count);
+      }
+    }
+  }
+
+  // need to wait for all streams to finish
+  for (int level = 0; level < ctx->nlevels; level++) {
+    ctx->synchronize(ctx->level_streams[level]);
+  }
+
+  // computing the hab coefficients does not depend on the number of grids so we
+  // can run these calculations on the main stream
+  ctx->compute_hab_coefficients();
+  ctx->hab_block_.copy_from_gpu(hab_blocks->host_buffer, ctx->main_stream);
+
+  if (forces != NULL) {
+    ctx->forces_.copy_from_gpu(forces, ctx->main_stream);
+  }
+  if (virial != NULL) {
+    ctx->virial_.copy_from_gpu(virial, ctx->main_stream);
+  }
+
+  ctx->synchronize(ctx->main_stream);
+}
+
+#endif // __GRID_ROCM

--- a/src/grid/hip/grid_hip_context.hpp
+++ b/src/grid/hip/grid_hip_context.hpp
@@ -39,6 +39,7 @@ namespace rocm_backend {
 // somewhere. Maybe possible to get the same thing with std::vector and
 // specific allocator.
 
+class smem_parameters;
 template <typename T> class gpu_vector {
   size_t allocated_size_{0};
   size_t current_size_{0};
@@ -313,7 +314,6 @@ struct kernel_params {
   int smem_alpha_offset{0};
   int smem_cab_offset{0};
   int first_task{0};
-  // int lp_max{0};
   int grid_full_size_[3] = {0, 0, 0};
   int grid_local_size_[3] = {0, 0, 0};
   int grid_lower_corner_[3] = {0, 0, 0};
@@ -474,11 +474,9 @@ public:
 
   void set_device() { CHECK(hipSetDevice(device_id_)); }
 
-  void collocate_one_grid_level(const int level, const int first_task,
-                                const int last_task, const enum grid_func func,
+  void collocate_one_grid_level(const int level, const enum grid_func func,
                                 int *lp_diff);
-  void integrate_one_grid_level(const int level, const int first_task,
-                                const int last_task, int *lp_diff);
+  void integrate_one_grid_level(const int level, int *lp_diff);
   void compute_hab_coefficients();
   /* basic checksum computation for simple verification that the object is sane
    */
@@ -492,6 +490,8 @@ public:
   }
 
 private:
+  kernel_params set_kernel_parameters(const int level,
+                                      const smem_parameters &smem_params);
   unsigned int compute_checksum_() {
     return natoms ^ ntasks ^ nlevels ^ nkinds ^ nblocks ^ 0x4F2C5D1A;
   }

--- a/src/grid/hip/grid_hip_context.hpp
+++ b/src/grid/hip/grid_hip_context.hpp
@@ -349,7 +349,6 @@ public:
   int nkinds{0};
   int nblocks{0};
   std::vector<double *> sphi;
-  std::vector<int> tasks_per_level;
   std::vector<hipStream_t> level_streams;
   hipStream_t main_stream;
   int stats[2][20]; // [has_border_mask][lp]
@@ -409,8 +408,6 @@ public:
       grid.reset();
     }
     grid_.clear();
-
-    tasks_per_level.clear();
   }
 
   int lmax() const { return lmax_; }

--- a/src/grid/hip/grid_hip_context.hpp
+++ b/src/grid/hip/grid_hip_context.hpp
@@ -1,0 +1,503 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * Authors :
+   - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+   - Advanced Micro Devices, Inc.
+*/
+
+#ifndef GRID_HIP_CONTEXT_HPP
+#define GRID_HIP_CONTEXT_HPP
+
+#include <hip/hip_runtime_api.h>
+#include <vector>
+
+extern "C" {
+#include "../common/grid_basis_set.h"
+#include "../common/grid_constants.h"
+}
+
+#ifndef CHECK
+/*******************************************************************************
+ * \brief Checks given rocm status and upon failure abort with a nice message.
+ ******************************************************************************/
+#define CHECK(status)                                                          \
+  if (status != hipSuccess) {                                                  \
+    fprintf(stderr, "ERROR: %s %s %d\n", hipGetErrorString(status), __FILE__,  \
+            __LINE__);                                                         \
+    abort();                                                                   \
+  }
+#endif
+
+namespace rocm_backend {
+// a little helper class in the same spirit than std::vector. it must exist
+// somewhere. Maybe possible to get the same thing with std::vector and
+// specific allocator.
+
+template <typename T> class gpu_vector {
+  size_t allocated_size_{0};
+  size_t current_size_{0};
+  T *ptr = nullptr;
+
+public:
+  gpu_vector() {
+    ptr = nullptr;
+    allocated_size_ = 0;
+    current_size_ = 0;
+  }
+  // size is the number of elements not the memory size
+  gpu_vector(const size_t size_) {
+    if (size_ < 16) {
+      allocated_size_ = 16;
+    } else {
+      allocated_size_ = (size_ / 16 + 1) * 16;
+    }
+    current_size_ = size_;
+
+    CHECK(hipMalloc((void **)&ptr, sizeof(T) * allocated_size_));
+  }
+
+  ~gpu_vector() { reset(); }
+
+  inline size_t size() { return current_size_; }
+
+  inline void copy_to_gpu(const T *data__) {
+    CHECK(hipMemcpy(ptr, data__, sizeof(T) * current_size_,
+                    hipMemcpyHostToDevice));
+  }
+
+  inline void copy_to_gpu(const T *data__, hipStream_t &stream) {
+    CHECK(hipMemcpyAsync(ptr, data__, sizeof(T) * current_size_,
+                         hipMemcpyHostToDevice, stream));
+  }
+
+  inline void copy_from_gpu(T *data__, hipStream_t &stream) {
+    CHECK(hipMemcpyAsync(data__, ptr, sizeof(T) * current_size_,
+                         hipMemcpyDeviceToHost, stream));
+  }
+
+  inline void zero(hipStream_t &stream) {
+    // zero device grid buffers
+    CHECK(hipMemsetAsync(ptr, 0, sizeof(T) * current_size_, stream));
+  }
+
+  inline void zero() {
+    // zero device grid buffers
+    CHECK(hipMemset(ptr, 0, sizeof(T) * current_size_));
+  }
+
+  inline void copy_to_gpu(const std::vector<T> &data__) {
+    assert(data__.size() == current_size_);
+    // if it fails it means that the vector on the gpu does not have the right
+    // size. two option then
+    // - resize the gpu vector
+    // - or the cpu vector and gpu vector are not representing the quantity.
+
+    CHECK(hipMemcpy(ptr, data__.data(), sizeof(T) * data__.size(),
+                    hipMemcpyHostToDevice));
+  }
+
+  inline void resize(const size_t new_size_) {
+    if (allocated_size_ < new_size_) {
+      if (ptr != nullptr)
+        CHECK(hipFree(ptr));
+      allocated_size_ = (new_size_ / 16 + (new_size_ % 16 != 0)) * 16;
+      hipMalloc((void **)&ptr, sizeof(T) * allocated_size_);
+    }
+    current_size_ = new_size_;
+  }
+
+  // does not invalidate the pointer. The memory is still allocated
+  inline void clear() { current_size_ = 0; }
+
+  // reset the class and free memory
+  inline void reset() {
+    if (ptr != nullptr)
+      CHECK(hipFree(ptr));
+
+    allocated_size_ = 0;
+    current_size_ = 0;
+    ptr = nullptr;
+  }
+
+  inline T *data() { return ptr; }
+};
+
+template <typename T> class grid_info {
+  int full_size_[3] = {0, 0, 0};
+  int local_size_[3] = {0, 0, 0};
+  // origin of the local part of the grid in grid point
+  int lower_corner_[3] = {0, 0, 0};
+  int border_width_[3] = {0, 0, 0};
+  double dh_[9];
+  double dh_inv_[9];
+  bool orthorhombic_{false};
+  bool is_distributed_{false};
+  gpu_vector<T> grid_;
+
+public:
+  grid_info(){};
+
+  grid_info(const int *full_size__, const int *local_size__,
+            const int *border_width__) {
+    initialize(full_size__, local_size__, border_width__);
+  }
+
+  ~grid_info() { grid_.reset(); };
+
+  inline T *data() { return grid_.data(); }
+
+  inline void copy_to_gpu(const T *data, hipStream_t &stream) {
+    grid_.copy_to_gpu(data, stream);
+  }
+
+  inline void reset() { grid_.reset(); }
+
+  inline void resize(const int *full_size__, const int *local_size__,
+                     const int *const roffset__,
+                     const int *const border_width__) {
+    initialize(full_size__, local_size__, roffset__, border_width__);
+  }
+
+  inline size_t size() const { return grid_.size(); }
+
+  inline void zero(hipStream_t &stream) { grid_.zero(stream); }
+  inline gpu_vector<T> &grid() { return grid_; }
+  inline void set_lattice_vectors(const double *dh__, const double *dh_inv__) {
+    memcpy(dh_, dh__, sizeof(double) * 9);
+    memcpy(dh_inv_, dh_inv__, sizeof(double) * 9);
+  }
+
+  inline T *dh() { return dh_; }
+
+  inline T *dh_inv() { return dh_inv_; }
+
+  inline bool is_orthorhombic() { return orthorhombic_; }
+
+  inline void is_distributed(const bool distributed__) {
+    is_distributed_ = distributed__;
+  }
+
+  void check_orthorhombicity(const bool ortho) {
+    if (ortho) {
+      orthorhombic_ = true;
+      return;
+    }
+    double norm1, norm2, norm3;
+    bool orthogonal[3] = {false, false, false};
+    norm1 = dh_[0] * dh_[0] + dh_[1] * dh_[1] + dh_[2] * dh_[2];
+    norm2 = dh_[3] * dh_[3] + dh_[4] * dh_[4] + dh_[5] * dh_[5];
+    norm3 = dh_[6] * dh_[6] + dh_[7] * dh_[7] + dh_[8] * dh_[8];
+
+    norm1 = 1.0 / sqrt(norm1);
+    norm2 = 1.0 / sqrt(norm2);
+    norm3 = 1.0 / sqrt(norm3);
+
+    /* x z */
+    orthogonal[0] =
+        ((fabs(dh_[0] * dh_[6] + dh_[1] * dh_[7] + dh_[2] * dh_[8]) * norm1 *
+          norm3) < 1e-12);
+    /* y z */
+    orthogonal[1] =
+        ((fabs(dh_[3] * dh_[6] + dh_[4] * dh_[7] + dh_[5] * dh_[8]) * norm2 *
+          norm3) < 1e-12);
+    /* x y */
+    orthogonal[2] =
+        ((fabs(dh_[0] * dh_[3] + dh_[1] * dh_[4] + dh_[2] * dh_[5]) * norm1 *
+          norm2) < 1e-12);
+
+    orthorhombic_ = orthogonal[0] * orthogonal[1] * orthogonal[2];
+  }
+
+  inline void copy_to_host(double *data__, hipStream_t &stream) {
+    grid_.copy_from_gpu(data__, stream);
+  }
+
+  inline bool is_distributed() { return is_distributed_; }
+
+  inline int full_size(const int i) {
+    assert(i < 3);
+    return full_size_[i];
+  }
+
+  inline int local_size(const int i) {
+    assert(i < 3);
+    return local_size_[i];
+  }
+
+  inline int lower_corner(const int i) {
+    assert(i < 3);
+    return lower_corner_[i];
+  }
+
+  inline int border_width(const int i) {
+    assert(i < 3);
+    return border_width_[i];
+  }
+
+private:
+  void initialize(const int *const full_size__, const int *const local_size__,
+                  const int *const roffset__, const int *const border_width__) {
+    // the calling code store things like this cube[z][y][x] (in fortran
+    // cube(x,y,z)) so all sizes are [x,y,z] while we are working in C/C++ so we
+    // have to permute the indices to get this right.
+
+    full_size_[2] = full_size__[0];
+    full_size_[1] = full_size__[1];
+    full_size_[0] = full_size__[2];
+
+    local_size_[2] = local_size__[0];
+    local_size_[1] = local_size__[1];
+    local_size_[0] = local_size__[2];
+
+    lower_corner_[0] = roffset__[2];
+    lower_corner_[1] = roffset__[1];
+    lower_corner_[2] = roffset__[0];
+
+    is_distributed_ = (full_size_[2] != local_size_[2]) ||
+                      (full_size_[1] != local_size_[1]) ||
+                      (full_size_[0] != local_size_[0]);
+
+    border_width_[2] = border_width__[0];
+    border_width_[1] = border_width__[1];
+    border_width_[0] = border_width__[2];
+
+    grid_.resize(local_size_[0] * local_size_[1] * local_size_[2]);
+  }
+};
+
+/*******************************************************************************
+ * \brief Internal representation of a task.
+ ******************************************************************************/
+struct task_info {
+  int level;
+  int iatom;
+  int jatom;
+  int iset;
+  int jset;
+  int ipgf;
+  int jpgf;
+  int ikind, jkind;
+  int border_mask;
+  int block_num;
+  double radius;
+  double ra[3], rb[3], rp[3];
+  double rab2;
+  double zeta, zetb, zetp, prefactor, off_diag_twice;
+  double rab[3];
+  int lp_max{0};
+  size_t coef_offset{0};
+  int la_max, lb_max, la_min, lb_min, first_coseta, first_cosetb, ncoseta,
+      ncosetb, nsgfa, nsgfb, nsgf_seta, nsgf_setb, maxcoa, maxcob;
+  int sgfa, sgfb, subblock_offset;
+  double3 roffset;
+  int3 cube_size;
+  int3 lb_cube;
+  int3 cube_center;
+  double discrete_radius;
+  bool apply_border_mask;
+  bool block_transposed;
+  bool skip_task;
+};
+
+/*******************************************************************************
+ * \brief Parameters of the collocate kernel.
+ ******************************************************************************/
+
+struct kernel_params {
+  int smem_alpha_offset{0};
+  int smem_cab_offset{0};
+  int first_task{0};
+  // int lp_max{0};
+  int grid_full_size_[3] = {0, 0, 0};
+  int grid_local_size_[3] = {0, 0, 0};
+  int grid_lower_corner_[3] = {0, 0, 0};
+  int grid_border_width_[3] = {0, 0, 0};
+  double dh_[9];
+  double dh_inv_[9];
+  task_info *tasks;
+  int *block_offsets{nullptr};
+  char la_min_diff{0};
+  char lb_min_diff{0};
+  char la_max_diff{0};
+  char lb_max_diff{0};
+  enum grid_func func;
+  double *ptr_dev[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  double **sphi_dev{nullptr};
+  int ntasks{0};
+  int *task_sorted_by_blocks_dev{nullptr};
+  int *sorted_blocks_offset_dev{nullptr};
+  int *num_tasks_per_block_dev{nullptr};
+};
+
+/* regroup all information about the context. */
+class context_info {
+private:
+  int device_id_{-1};
+  int lmax_{0};
+  unsigned int checksum_{0};
+
+public:
+  int ntasks{0};
+  int nlevels{0};
+  int natoms{0};
+  int nkinds{0};
+  int nblocks{0};
+  std::vector<double *> sphi;
+  std::vector<int> tasks_per_level;
+  std::vector<hipStream_t> level_streams;
+  hipStream_t main_stream;
+  int stats[2][20]; // [has_border_mask][lp]
+  // all these tables are on the gpu. we can resize them copy to them and copy
+  // from them
+  gpu_vector<int> block_offsets_dev;
+  gpu_vector<double> coef_dev_;
+  gpu_vector<double> pab_block_;
+  gpu_vector<double> hab_block_;
+  gpu_vector<double> forces_;
+  gpu_vector<double> virial_;
+  gpu_vector<task_info> tasks_dev;
+  gpu_vector<int> num_tasks_per_block_dev_;
+  std::vector<grid_info<double>> grid_;
+  std::vector<int> number_of_tasks_per_level_;
+  std::vector<int> first_task_per_level_;
+  std::vector<int> sphi_size;
+  gpu_vector<double *> sphi_dev;
+  gpu_vector<int> task_sorted_by_blocks_dev, sorted_blocks_offset_dev;
+  bool calculate_forces{false};
+  bool calculate_virial{false};
+  bool compute_tau{false};
+  bool apply_border_mask{false};
+
+  context_info() {}
+  context_info(const int device_id__) {
+    if (device_id__ < 0)
+      device_id_ = 0;
+    else
+      device_id_ = device_id__;
+  }
+  ~context_info() { clear(); }
+
+  void clear() {
+    CHECK(hipSetDevice(device_id_));
+    tasks_dev.reset();
+    block_offsets_dev.reset();
+    coef_dev_.reset();
+    task_sorted_by_blocks_dev.reset();
+    sorted_blocks_offset_dev.reset();
+    sphi_dev.reset();
+    forces_.reset();
+    virial_.reset();
+    for (auto &phi : sphi)
+      if (phi != nullptr)
+        CHECK(hipFree(phi));
+    sphi.clear();
+
+    CHECK(hipStreamDestroy(main_stream));
+
+    for (int i = 0; i < nlevels; i++) {
+      CHECK(hipStreamDestroy(level_streams[i]));
+    }
+    level_streams.clear();
+
+    for (auto &grid : grid_) {
+      grid.reset();
+    }
+    grid_.clear();
+
+    tasks_per_level.clear();
+  }
+
+  int lmax() const { return lmax_; }
+
+  void initialize_basis_sets(const grid_basis_set **basis_sets,
+                             const int nkinds__) {
+    nkinds = nkinds__;
+    if (nkinds__ > sphi.size()) {
+      for (auto &phi : sphi)
+        if (phi != nullptr) {
+          CHECK(hipFree(phi));
+        }
+
+      sphi_dev.resize(nkinds__);
+
+      sphi.resize(nkinds__, nullptr);
+      sphi_size.clear();
+      sphi_size.resize(nkinds__, 0);
+      sphi_dev.resize(nkinds__);
+    }
+
+    // Upload basis sets to device.
+    for (int i = 0; i < nkinds__; i++) {
+      const auto &basis_set = basis_sets[i];
+      if (sphi_size[i] < basis_set->nsgf * basis_set->maxco) {
+        CHECK(hipMalloc((void **)&sphi[i],
+                        basis_set->nsgf * basis_set->maxco * sizeof(double)));
+        sphi_size[i] = basis_set->nsgf * basis_set->maxco;
+      }
+      CHECK(hipMemset(sphi[i], 0, sizeof(double) * sphi_size[i]));
+      CHECK(hipMemcpy(sphi[i], basis_set->sphi,
+                      basis_set->nsgf * basis_set->maxco * sizeof(double),
+                      hipMemcpyHostToDevice));
+    }
+    sphi_dev.copy_to_gpu(sphi);
+    // Find largest angular momentum.
+    lmax_ = 0;
+    for (int ikind = 0; ikind < nkinds; ikind++) {
+      for (int iset = 0; iset < basis_sets[ikind]->nset; iset++) {
+        lmax_ = std::max(lmax_, basis_sets[ikind]->lmax[iset]);
+      }
+    }
+  }
+
+  void create_streams() {
+    // allocate main hip stream
+    CHECK(hipStreamCreate(&main_stream));
+
+    // allocate one hip stream per grid level
+    if (level_streams.size() < nlevels) {
+      level_streams.resize(nlevels);
+      for (auto &stream : level_streams) {
+        CHECK(hipStreamCreate(&stream));
+      }
+    }
+  }
+
+  void synchronize(hipStream_t &stream) { CHECK(hipStreamSynchronize(stream)); }
+
+  void synchornize() {
+    // wait for all the streams to finish
+    CHECK(hipDeviceSynchronize());
+  }
+
+  void set_device() { CHECK(hipSetDevice(device_id_)); }
+
+  void collocate_one_grid_level(const int level, const int first_task,
+                                const int last_task, const enum grid_func func,
+                                int *lp_diff);
+  void integrate_one_grid_level(const int level, const int first_task,
+                                const int last_task, int *lp_diff);
+  void compute_hab_coefficients();
+  /* basic checksum computation for simple verification that the object is sane
+   */
+  void compute_checksum() { checksum_ = compute_checksum_(); }
+  void verify_checksum() {
+    if (checksum_ != compute_checksum_()) {
+      fprintf(stderr, "This object does not seem to have the right structure.\n"
+                      "A casting went wrong or the object is corrupted\n");
+      abort();
+    }
+  }
+
+private:
+  unsigned int compute_checksum_() {
+    return natoms ^ ntasks ^ nlevels ^ nkinds ^ nblocks ^ 0x4F2C5D1A;
+  }
+};
+} // namespace rocm_backend
+#endif

--- a/src/grid/hip/grid_hip_integrate.cc
+++ b/src/grid/hip/grid_hip_integrate.cc
@@ -1,0 +1,828 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * inspirartions from the gpu backend
+ * Authors :
+ - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+ - Advanced Micro Devices, Inc.
+*/
+
+#ifdef __GRID_HIP
+
+#include <algorithm>
+#include <assert.h>
+#include <hip/hip_runtime.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "grid_hip_context.hpp"
+#include "grid_hip_internal_header.h"
+#include "grid_hip_process_vab.h"
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#include <cooperative_groups.h>
+#if CUDA_VERSION >= 11000
+#include <cooperative_groups/reduce.h>
+#endif
+namespace cg = cooperative_groups;
+#endif
+
+namespace rocm_backend {
+// #ifdef __HIP_PLATFORM_NVIDIA__
+//   template <typename T>
+//   __device__ __inline__ T warp_reduce(T *table, const int tid) {
+//     if (tid >= 32)
+//       return 0.0;
+//     cg::coalesced_group g = cg::coalesced_threads();
+// #if CUDA_VERSION > 10000
+//     return cg::reduce(g, table[tid], cg::plus<double>());
+// #else
+//     double val = table[tid];
+//     for (int i = g.size() / 2; i > 0; i /= 2) {
+//       val += g.shfl_down(val, i);
+//     }
+//     g.sync();
+//     return val;
+// #endif
+//   }
+
+// #else
+// do a warp reduction and return the final sum to thread_id = 0
+template <typename T>
+__device__ __inline__ T warp_reduce(T *table, const int tid) {
+  // AMD GPU have warp size of 64 while nvidia GPUs have warpSize of 32 so the
+  // first step is common to both platforms.
+
+  if (tid < 32) {
+    table[tid] += table[tid + 32];
+  }
+  __syncthreads();
+  if (tid < 16) {
+    table[tid] += table[tid + 16];
+  }
+  __syncthreads();
+  if (tid < 8) {
+    table[tid] += table[tid + 8];
+  }
+  __syncthreads();
+  if (tid < 4) {
+    table[tid] += table[tid + 4];
+  }
+  __syncthreads();
+  if (tid < 2) {
+    table[tid] += table[tid + 2];
+  }
+  __syncthreads();
+  return (table[0] + table[1]);
+}
+// #endif
+
+template <typename T, typename T3, bool COMPUTE_TAU, bool CALCULATE_FORCES>
+__global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_,
+                                                     const int ntasks) {
+  // Copy task from global to shared memory and precompute some stuff.
+  extern __shared__ T shared_memory[];
+  T *coef_shared = &shared_memory[0];
+  T *smem_cab = &shared_memory[dev_.smem_cab_offset];
+  T *smem_alpha = &shared_memory[dev_.smem_alpha_offset];
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  const int offset = dev_.sorted_blocks_offset_dev[blockIdx.x];
+  const int number_of_tasks = dev_.num_tasks_per_block_dev[blockIdx.x];
+
+  if (number_of_tasks == 0)
+    return;
+
+  T fa[3], fb[3];
+  T virial[9];
+
+  fa[0] = 0.0;
+  fa[1] = 0.0;
+  fa[2] = 0.0;
+  fb[0] = 0.0;
+  fb[1] = 0.0;
+  fb[2] = 0.0;
+
+  virial[0] = 0.0;
+  virial[1] = 0.0;
+  virial[2] = 0.0;
+  virial[3] = 0.0;
+  virial[4] = 0.0;
+  virial[5] = 0.0;
+  virial[6] = 0.0;
+  virial[7] = 0.0;
+  virial[8] = 0.0;
+
+  for (int tk = 0; tk < number_of_tasks; tk++) {
+    __shared__ smem_task<T> task;
+    const int task_id = dev_.task_sorted_by_blocks_dev[offset + tk];
+    if (dev_.tasks[task_id].skip_task)
+      continue;
+    fill_smem_task_coef(dev_, task_id, task);
+
+    T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+
+    for (int i = tid; i < ncoset(task.lp);
+         i += blockDim.x * blockDim.y * blockDim.z)
+      coef_shared[i] = coef_[i];
+    compute_alpha(dev_, task, smem_alpha);
+    __syncthreads();
+    cxyz_to_cab(dev_, task, smem_alpha, coef_shared, smem_cab);
+    __syncthreads();
+
+    for (int i = tid / 8; i < task.nsgf_setb; i += 8) {
+      for (int j = tid % 8; j < task.nsgf_seta; j += 8) {
+        T res = 0.0;
+
+        T block_val1 = 0.0;
+
+        if (CALCULATE_FORCES) {
+          if (task.block_transposed) {
+            block_val1 =
+                task.pab_block[j * task.nsgfb + i] * task.off_diag_twice;
+          } else {
+            block_val1 =
+                task.pab_block[i * task.nsgfa + j] * task.off_diag_twice;
+          }
+        }
+
+        for (int jco = task.first_cosetb; jco < task.ncosetb; jco++) {
+          const auto &b = coset_inv[jco];
+          T block_val = 0.0;
+          const T sphib = task.sphib[i * task.maxcob + jco];
+          for (int ico = task.first_coseta; ico < task.ncoseta; ico++) {
+            const auto &a = coset_inv[ico];
+            const T hab = get_hab<COMPUTE_TAU, T>(a, b, task.zeta, task.zetb,
+                                                  task.n1, smem_cab);
+            const T sphia = task.sphia[j * task.maxcoa + ico];
+            block_val += hab * sphia * sphib;
+
+            if (CALCULATE_FORCES) {
+              for (int k = 0; k < 3; k++) {
+                fa[k] += block_val1 * sphia * sphib *
+                  get_force_a<COMPUTE_TAU, T>(a, b, k, task.zeta, task.zetb,
+                                                  task.n1, smem_cab);
+                fb[k] += block_val1 * sphia * sphib *
+                  get_force_b<COMPUTE_TAU, T>(a, b, k, task.zeta, task.zetb,
+                                                  task.rab, task.n1, smem_cab);
+              }
+              if (dev_.ptr_dev[5] != nullptr) {
+                for (int k = 0; k < 3; k++) {
+                  for (int l = 0; l < 3; l++) {
+                    virial[3 * k + l] +=
+                      (get_virial_a<COMPUTE_TAU, T>(a, b, k, l, task.zeta,
+                                                   task.zetb, task.n1,
+                                                   smem_cab) +
+                       get_virial_b<COMPUTE_TAU, T>(a, b, k, l, task.zeta,
+                                                   task.zetb, task.rab, task.n1,
+                                                   smem_cab)) *
+                        block_val1 * sphia * sphib;
+                  }
+                }
+              }
+            }
+          }
+
+          res += block_val;
+        }
+
+        // we can use shuffle_down if it exists for T
+
+        if (task.block_transposed) {
+          task.hab_block[j * task.nsgfb + i] += res;
+        } else {
+          task.hab_block[i * task.nsgfa + j] += res;
+        }
+      }
+    }
+    __syncthreads();
+  }
+
+  if (CALCULATE_FORCES) {
+    const int task_id = dev_.task_sorted_by_blocks_dev[offset];
+    const auto &glb_task = dev_.tasks[task_id];
+    const int iatom = glb_task.iatom;
+    const int jatom = glb_task.jatom;
+    T *forces_a = &dev_.ptr_dev[4][3 * iatom];
+    T *forces_b = &dev_.ptr_dev[4][3 * jatom];
+
+    T *sum = (T *)shared_memory;
+    if (dev_.ptr_dev[5] != nullptr) {
+
+      for (int i = 0; i < 9; i++) {
+        sum[tid] = virial[i];
+        __syncthreads();
+
+        virial[i] = warp_reduce<T>(sum, tid);
+        __syncthreads();
+
+        if (tid == 0)
+          atomicAdd(dev_.ptr_dev[5] + i, virial[i]);
+        __syncthreads();
+      }
+    }
+
+    for (int i = 0; i < 3; i++) {
+      sum[tid] = fa[i];
+      __syncthreads();
+      fa[i] = warp_reduce<T>(sum, tid);
+      __syncthreads();
+      if (tid == 0)
+        atomicAdd(forces_a + i, fa[i]);
+      __syncthreads();
+
+      sum[tid] = fb[i];
+      __syncthreads();
+      fb[i] = warp_reduce<T>(sum, tid);
+      __syncthreads();
+      if (tid == 0)
+        atomicAdd(forces_b + i, fb[i]);
+      __syncthreads();
+    }
+  }
+}
+
+/*******************************************************************************
+ * Cuda kernel for calcualting the coefficients of a potential (density,
+ etc...) for a given pair of gaussian basis sets
+
+We compute the discretized version of the following integral
+
+$$\int _\infty ^\infty V_{ijk} P^\alpha_iP^beta_j P ^ \gamma _ k Exp(- \eta
+|r_{ijk} - r_c|^2)$$
+
+where in practice the summation is over a finite domain. The discrete form has
+this shape
+
+$$
+\sum_{ijk < dmoain} V_{ijk} (x_i - x_c)^\alpha (y_j - y_c)^\beta (z_k - z_c) ^
+\gamma Exp(- \eta |r_{ijk} - r_c|^2)
+$$
+
+where $0 \le \alpha + \beta + \gamma \le lmax$
+
+It is formely the same operation than collocate (from a discrete point of view)
+but the implementation differ because of technical reasons.
+
+So most of the code is the same except the core of the routine that is
+specialized to the integration.
+
+******************************************************************************/
+  template <typename T, typename T3, bool distributed__, bool orthorhombic_, int lbatch = 10>
+__global__ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
+  if (dev_.tasks[dev_.first_task + blockIdx.x].skip_task)
+    return;
+
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+
+  __shared__ T dh_inv_[9];
+  __shared__ T dh_[9];
+
+  for (int d = tid; d < 9; d += blockDim.x * blockDim.y * blockDim.z)
+    dh_inv_[d] = dev_.dh_inv_[d];
+
+  for (int d = tid; d < 9; d += blockDim.x * blockDim.y * blockDim.z)
+    dh_[d] = dev_.dh_[d];
+
+  __shared__ smem_task_reduced<T, T3> task;
+  fill_smem_task_reduced(dev_, dev_.first_task + blockIdx.x, task);
+
+  if (tid == 0) {
+    task.cube_center.z += task.lb_cube.z - dev_.grid_lower_corner_[0];
+    task.cube_center.y += task.lb_cube.y - dev_.grid_lower_corner_[1];
+    task.cube_center.x += task.lb_cube.x - dev_.grid_lower_corner_[2];
+
+    if (distributed__) {
+      if (task.apply_border_mask) {
+        compute_window_size(dev_.grid_local_size_, dev_.grid_lower_corner_,
+                            dev_.grid_full_size_, /* also full size of the grid */
+                            dev_.tasks[dev_.first_task + blockIdx.x].border_mask,
+                            dev_.grid_border_width_, &task.window_size,
+                            &task.window_shift);
+      }
+    }
+  }
+  __syncthreads();
+
+  __shared__ T accumulator[lbatch][64];
+  __shared__ T sum[lbatch];
+
+  // we use a multi pass algorithm here because shared memory usage (or
+  // register) would become too high for high angular momentum
+
+  const short int size_loop =
+      (ncoset(task.lp) / lbatch + ((ncoset(task.lp) % lbatch) != 0)) * lbatch;
+  const short int length = ncoset(task.lp);
+  for (int ico = 0; ico < size_loop; ico += lbatch) {
+#pragma unroll lbatch
+    for (int i = 0; i < lbatch; i++)
+      accumulator[i][tid] = 0.0;
+
+    __syncthreads();
+
+    for (int z = threadIdx.z; z < task.cube_size.z; z += blockDim.z) {
+      int z2 = (z + task.cube_center.z) % dev_.grid_full_size_[0];
+
+      if (z2 < 0)
+        z2 += dev_.grid_full_size_[0];
+
+      if (distributed__) {
+        // known at compile time. Will be stripped away
+        if (task.apply_border_mask) {
+          /* check if the point is within the window */
+          if ((z2 < task.window_shift.z) || (z2 > task.window_size.z)) {
+            continue;
+          }
+        }
+      }
+
+      /* compute the coordinates of the point in atomic coordinates */
+      int ymin = 0;
+      int ymax = task.cube_size.y - 1;
+      T kremain = 0.0;
+
+      if (orthorhombic_ && !task.apply_border_mask) {
+        ymin = (2 * (z + task.lb_cube.z) - 1) / 2;
+        ymin *= ymin;
+        kremain = task.discrete_radius * task.discrete_radius -
+                  ymin * dh_[8] * dh_[8];
+        ymin = ceil(-1.0e-8 - sqrt(fmax(0.0, kremain)) * dh_inv_[4]);
+        ymax = 1 - ymin - task.lb_cube.y;
+        ymin = ymin - task.lb_cube.y;
+      }
+
+      for (int y = ymin + threadIdx.y; y <= ymax; y += blockDim.y) {
+        int y2 = (y + task.cube_center.y) % dev_.grid_full_size_[1];
+
+        if (y2 < 0)
+          y2 += dev_.grid_full_size_[1];
+
+        if (distributed__) {
+/* check if the point is within the window */
+          if (task.apply_border_mask) {
+            if ((y2 < task.window_shift.y) || (y2 > task.window_size.y)) {
+              continue;
+            }
+          }
+        }
+
+        int xmin = 0;
+        int xmax = task.cube_size.x - 1;
+
+        if (orthorhombic_ && !task.apply_border_mask) {
+          xmin = (2 * (y + task.lb_cube.y) - 1) / 2;
+          xmin *= xmin;
+          xmin =
+              ceil(-1.0e-8 - sqrt(fmax(0.0, kremain - xmin * dh_[4] * dh_[4])) *
+                                 dh_inv_[0]);
+          xmax = 1 - xmin - task.lb_cube.x;
+          xmin -= task.lb_cube.x;
+        }
+
+        for (int x = xmin + threadIdx.x; x <= xmax; x += blockDim.x) {
+          int x2 = (x + task.cube_center.x) % dev_.grid_full_size_[2];
+
+          if (x2 < 0)
+            x2 += dev_.grid_full_size_[2];
+
+          if (distributed__) {
+            /* check if the point is within the window */
+            if (task.apply_border_mask) {
+              if ((x2 < task.window_shift.x) || (x2 > task.window_size.x)) {
+                continue;
+              }
+            }
+          }
+
+          // I make no distinction between orthorhombic and non orthorhombic
+          // cases
+          T3 r3;
+
+          if (orthorhombic_) {
+            r3.x = (x + task.lb_cube.x + task.roffset.x) * dh_[0];
+            r3.y = (y + task.lb_cube.y + task.roffset.y) * dh_[4];
+            r3.z = (z + task.lb_cube.z + task.roffset.z) * dh_[8];
+          } else {
+          r3 =
+            compute_coordinates(dh_, (x + task.lb_cube.x + task.roffset.x),
+                                (y + task.lb_cube.y + task.roffset.y),
+                                (z + task.lb_cube.z + task.roffset.z));
+          }
+          // check if the point is inside the sphere or not. Note that it does
+          // not apply for the orthorhombic case when the full sphere is inside
+          // the region of interest.
+
+          if (distributed__) {
+            if (((task.radius * task.radius) <=
+                 (r3.x * r3.x + r3.y * r3.y + r3.z * r3.z)) &&
+                (!orthorhombic_ || task.apply_border_mask))
+              continue;
+          } else {
+            if (!orthorhombic_) {
+              if ((task.radius * task.radius) <=
+                  (r3.x * r3.x + r3.y * r3.y + r3.z * r3.z))
+                continue;
+            }
+          }
+
+          // read the next point assuming that reading is non blocking untill
+          // the register is actually needed for computation. This is true on
+          // NVIDIA hardware
+
+          T grid_value =
+              __ldg(&dev_.ptr_dev[1][(z2 * dev_.grid_local_size_[1] + y2) *
+                                         dev_.grid_local_size_[2] +
+                                     x2]);
+
+          const T r3x2 = r3.x * r3.x;
+          const T r3y2 = r3.y * r3.y;
+          const T r3z2 = r3.z * r3.z;
+
+          const T r3xy = r3.x * r3.y;
+          const T r3xz = r3.x * r3.z;
+          const T r3yz = r3.y * r3.z;
+
+          grid_value *= exp(-(r3x2 + r3y2 + r3z2) * task.zetp);
+
+          switch (ico / lbatch) {
+          case 0: {
+            accumulator[0][tid] += grid_value;
+
+            if (task.lp >= 1) {
+              accumulator[1][tid] += grid_value * r3.x;
+              accumulator[2][tid] += grid_value * r3.y;
+              accumulator[3][tid] += grid_value * r3.z;
+            }
+
+            if (task.lp >= 2) {
+              accumulator[4][tid] += grid_value * r3x2;
+              accumulator[5][tid] += grid_value * r3xy;
+              accumulator[6][tid] += grid_value * r3xz;
+              accumulator[7][tid] += grid_value * r3y2;
+              accumulator[8][tid] += grid_value * r3yz;
+              accumulator[9][tid] += grid_value * r3z2;
+            }
+          } break;
+          case 1: {
+            if (task.lp >= 3) {
+              accumulator[0][tid] += grid_value * r3x2 * r3.x;
+              accumulator[1][tid] += grid_value * r3x2 * r3.y;
+              accumulator[2][tid] += grid_value * r3x2 * r3.z;
+              accumulator[3][tid] += grid_value * r3.x * r3y2;
+              accumulator[4][tid] += grid_value * r3xy * r3.z;
+              accumulator[5][tid] += grid_value * r3.x * r3z2;
+              accumulator[6][tid] += grid_value * r3y2 * r3.y;
+              accumulator[7][tid] += grid_value * r3y2 * r3.z;
+              accumulator[8][tid] += grid_value * r3.y * r3z2;
+              accumulator[9][tid] += grid_value * r3z2 * r3.z;
+            }
+          } break;
+          case 2: {
+            if (task.lp >= 4) {
+              accumulator[0][tid] += grid_value * r3x2 * r3x2;
+              accumulator[1][tid] += grid_value * r3x2 * r3xy;
+              accumulator[2][tid] += grid_value * r3x2 * r3xz;
+              accumulator[3][tid] += grid_value * r3x2 * r3y2;
+              accumulator[4][tid] += grid_value * r3x2 * r3yz;
+              accumulator[5][tid] += grid_value * r3x2 * r3z2;
+              accumulator[6][tid] += grid_value * r3xy * r3y2;
+              accumulator[7][tid] += grid_value * r3xz * r3y2;
+              accumulator[8][tid] += grid_value * r3xy * r3z2;
+              accumulator[9][tid] += grid_value * r3xz * r3z2;
+            }
+          } break;
+          case 3: {
+            if (task.lp >= 4) {
+              accumulator[0][tid] += grid_value * r3y2 * r3y2;
+              accumulator[1][tid] += grid_value * r3y2 * r3yz;
+              accumulator[2][tid] += grid_value * r3y2 * r3z2;
+              accumulator[3][tid] += grid_value * r3yz * r3z2;
+              accumulator[4][tid] += grid_value * r3z2 * r3z2;
+            }
+            if (task.lp >= 5) {
+              accumulator[5][tid] += grid_value * r3x2 * r3x2 * r3.x;
+              accumulator[6][tid] += grid_value * r3x2 * r3x2 * r3.y;
+              accumulator[7][tid] += grid_value * r3x2 * r3x2 * r3.z;
+              accumulator[8][tid] += grid_value * r3x2 * r3.x * r3y2;
+              accumulator[9][tid] += grid_value * r3x2 * r3xy * r3.z;
+            }
+          } break;
+          case 4: {
+            accumulator[0][tid] += grid_value * r3x2 * r3.x * r3z2;
+            accumulator[1][tid] += grid_value * r3x2 * r3y2 * r3.y;
+            accumulator[2][tid] += grid_value * r3x2 * r3y2 * r3.z;
+            accumulator[3][tid] += grid_value * r3x2 * r3.y * r3z2;
+            accumulator[4][tid] += grid_value * r3x2 * r3z2 * r3.z;
+            accumulator[5][tid] += grid_value * r3.x * r3y2 * r3y2;
+            accumulator[6][tid] += grid_value * r3.x * r3y2 * r3yz;
+            accumulator[7][tid] += grid_value * r3.x * r3y2 * r3z2;
+            accumulator[8][tid] += grid_value * r3xy * r3z2 * r3.z;
+            accumulator[9][tid] += grid_value * r3.x * r3z2 * r3z2;
+          } break;
+          case 5: {
+            accumulator[0][tid] += grid_value * r3y2 * r3y2 * r3.y;
+            accumulator[1][tid] += grid_value * r3y2 * r3y2 * r3.z;
+            accumulator[2][tid] += grid_value * r3y2 * r3.y * r3z2;
+            accumulator[3][tid] += grid_value * r3y2 * r3z2 * r3.z;
+            accumulator[4][tid] += grid_value * r3.y * r3z2 * r3z2;
+            accumulator[5][tid] += grid_value * r3z2 * r3z2 * r3.z;
+            if (task.lp >= 6) {
+              accumulator[6][tid] += grid_value * r3x2 * r3x2 * r3x2; // x^6
+              accumulator[7][tid] += grid_value * r3x2 * r3x2 * r3xy; // x^5 y
+              accumulator[8][tid] += grid_value * r3x2 * r3x2 * r3xz; // x^5 z
+              accumulator[9][tid] += grid_value * r3x2 * r3x2 * r3y2; // x^4 y^2
+            }
+          } break;
+          case 6: {
+            accumulator[0][tid] += grid_value * r3x2 * r3x2 * r3yz; // x^4 y z
+            accumulator[1][tid] += grid_value * r3x2 * r3x2 * r3z2; // x^4 z^2
+            accumulator[2][tid] += grid_value * r3x2 * r3y2 * r3xy; // x^3 y^3
+            accumulator[3][tid] += grid_value * r3x2 * r3y2 * r3xz; // x^3 y^2 z
+            accumulator[4][tid] += grid_value * r3x2 * r3xy * r3z2; // x^3 y z^2
+            accumulator[5][tid] += grid_value * r3x2 * r3z2 * r3xz; // x^3 z^3
+            accumulator[6][tid] += grid_value * r3x2 * r3y2 * r3y2; // x^2 y^4
+            accumulator[7][tid] += grid_value * r3x2 * r3y2 * r3yz; // x^3 y^2 z
+            accumulator[8][tid] +=
+                grid_value * r3x2 * r3y2 * r3z2; // x^2 y^2 z^2
+            accumulator[9][tid] += grid_value * r3x2 * r3z2 * r3yz; // x^2 y z^3
+          } break;
+          case 7: {
+            accumulator[0][tid] += grid_value * r3x2 * r3z2 * r3z2; // x^2 z^4
+            accumulator[1][tid] += grid_value * r3y2 * r3y2 * r3xy; // x y^5
+            accumulator[2][tid] += grid_value * r3y2 * r3y2 * r3xz; // x y^4 z
+            accumulator[3][tid] += grid_value * r3y2 * r3xy * r3z2; // x y^3 z^2
+            accumulator[4][tid] += grid_value * r3y2 * r3z2 * r3xz; // x y^2 z^3
+            accumulator[5][tid] += grid_value * r3xy * r3z2 * r3z2; // x y z^4
+            accumulator[6][tid] += grid_value * r3z2 * r3z2 * r3xz; // x z^5
+            accumulator[7][tid] += grid_value * r3y2 * r3y2 * r3y2; // y^6
+            accumulator[8][tid] += grid_value * r3y2 * r3y2 * r3yz; // y^5 z
+            accumulator[9][tid] += grid_value * r3y2 * r3y2 * r3z2; // y^4 z^2
+          } break;
+          // case 8: {
+          //   accumulator[0][tid]+= grid_value * r3y2 * r3z2 * r3yz; // y^3 z^3
+          //   accumulator[1][tid]+= grid_value * r3y2 * r3z2 * r3z2; // y^2 z^4
+          //   accumulator[2][tid]+= grid_value * r3z2 * r3z2 * r3yz; // y z^5
+          //   accumulator[3][tid]+= grid_value * r3z2 * r3z2 * r3z2; // z^6
+          //   if (task.lp >= 7) {
+          //     accumulator[4][tid]+= grid_value * r3x2 * r3x2 * r3x2 * r3.x;
+          //     accumulator[5][tid]+= grid_value * r3x2 * r3x2 * r3x2 * r3.y;
+          //     accumulator[6][tid]+= grid_value * r3x2 * r3x2 * r3x2 * r3.z;
+          //     accumulator[7][tid]+= grid_value * r3x2 * r3x2 * r3.x * r3y2;
+          //     accumulator[8][tid]+= grid_value * r3x2 * r3x2 * r3xy * r3.z;
+          //     accumulator[9][tid]+= grid_value * r3x2 * r3x2 * r3.x * r3z2;
+          //   }
+          // }
+          default:
+            for (int ic = 0; (ic < lbatch) && ((ic + ico) < length); ic++) {
+              auto &co = coset_inv[ic + ico];
+              T tmp = 1.0;
+              for (int po = 0; po < co.l[2]; po++)
+                tmp *= r3.z;
+              for (int po = 0; po < co.l[1]; po++)
+                tmp *= r3.y;
+              for (int po = 0; po < co.l[0]; po++)
+                tmp *= r3.x;
+              accumulator[ic][tid] += tmp * grid_value;
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    __syncthreads();
+
+    // we know there is only 1 wavefront in each block
+    // lbatch threads could reduce the values saved by all threads of the warp
+    // and save results do a shuffle_down by hand
+    for (int i = 0; i < min(length - ico, lbatch); i++) {
+      if (tid < 32) {
+        accumulator[i][tid] += accumulator[i][tid + 32];
+      }
+      __syncthreads();
+      if (tid < 16) {
+        accumulator[i][tid] += accumulator[i][tid + 16];
+      }
+      __syncthreads();
+      if (tid < 8) {
+        accumulator[i][tid] += accumulator[i][tid + 8];
+      }
+      __syncthreads();
+      if (tid < 4) {
+        accumulator[i][tid] += accumulator[i][tid + 4];
+      }
+      __syncthreads();
+      if (tid < 2) {
+        accumulator[i][tid] += accumulator[i][tid + 2];
+      }
+      __syncthreads();
+      if (tid == 0)
+        sum[i] = accumulator[i][0] + accumulator[i][1];
+    }
+    __syncthreads();
+
+    for (int i = tid; i < min(length - ico, lbatch); i += lbatch)
+      dev_.ptr_dev[2][dev_.tasks[dev_.first_task + blockIdx.x].coef_offset + i +
+                      ico] = sum[i];
+    __syncthreads();
+    // if (tid == 0)
+    //   printf("%.15lf\n", sum[0]);
+  }
+}
+
+/*******************************************************************************
+ * \brief Launches the Cuda kernel that integrates all tasks of one grid level.
+ ******************************************************************************/
+void context_info::integrate_one_grid_level(const int level,
+                                            const int first_task,
+                                            const int last_task, int *lp_diff) {
+  const int ntasks = last_task - first_task;
+
+  // Compute max angular momentum.
+  assert(!calculate_virial || calculate_forces);
+  const ldiffs_value ldiffs =
+      process_get_ldiffs(calculate_forces, calculate_virial, compute_tau);
+  *lp_diff = ldiffs.la_max_diff + ldiffs.lb_max_diff; // for reporting stats
+  const int la_max = this->lmax() + ldiffs.la_max_diff;
+  const int lb_max = this->lmax() + ldiffs.lb_max_diff;
+  const int lp_max = la_max + lb_max;
+
+  if (ntasks == 0) {
+    return; // Nothing to do and lp_diff already set.
+  }
+
+  init_constant_memory();
+
+  // Compute required shared memory.
+  // TODO: Currently, cab's indices run over 0...ncoset[lmax],
+  //       however only ncoset(lmin)...ncoset(lmax) are actually needed.
+  const int cab_len = ncoset(lb_max) * ncoset(la_max);
+  const int alpha_len = 3 * (lb_max + 1) * (la_max + 1) * (lp_max + 1);
+  const int cxyz_len = ncoset(lp_max);
+  const size_t smem_per_block =
+      (cab_len + alpha_len + cxyz_len) * sizeof(double);
+
+  if (smem_per_block > 48 * 1024) {
+    fprintf(stderr, "ERROR: Not enough shared memory in grid_gpu_integrate.\n");
+    fprintf(stderr, "cab_len: %i, ", cab_len);
+    fprintf(stderr, "alpha_len: %i, ", alpha_len);
+    fprintf(stderr, "cxyz_len: %i, ", cxyz_len);
+    fprintf(stderr, "total smem_per_block: %f kb\n\n", smem_per_block / 1024.0);
+    abort();
+  }
+
+  // kernel parameters
+  kernel_params params;
+  params.smem_cab_offset = cxyz_len;
+  params.smem_alpha_offset = params.smem_cab_offset + cab_len;
+  params.first_task = first_task;
+  params.tasks = this->tasks_dev.data();
+  params.block_offsets = this->block_offsets_dev.data();
+  params.num_tasks_per_block_dev = this->num_tasks_per_block_dev_.data();
+  params.la_min_diff = ldiffs.la_min_diff;
+  params.lb_min_diff = ldiffs.lb_min_diff;
+  params.la_max_diff = ldiffs.la_max_diff;
+  params.lb_max_diff = ldiffs.lb_max_diff;
+  params.ptr_dev[0] = nullptr;
+  params.ptr_dev[1] = grid_[level].data();
+  params.ptr_dev[2] = coef_dev_.data();
+  params.ptr_dev[3] = hab_block_.data();
+  params.ptr_dev[4] = nullptr;
+  params.ptr_dev[5] = nullptr;
+  params.sphi_dev = this->sphi_dev.data();
+
+  memcpy(params.dh_, this->grid_[level].dh(), 9 * sizeof(double));
+  memcpy(params.dh_inv_, this->grid_[level].dh_inv(), 9 * sizeof(double));
+  for (int i = 0; i < 3; i++) {
+    params.grid_full_size_[i] = this->grid_[level].full_size(i);
+    params.grid_local_size_[i] = this->grid_[level].local_size(i);
+    params.grid_lower_corner_[i] = this->grid_[level].lower_corner(i);
+    params.grid_border_width_[i] = this->grid_[level].border_width(i);
+  }
+
+  // Launch !
+  const int nblocks = ntasks;
+
+  /* WARNING : if you change the block size please be aware of that the number
+   * of warps is hardcoded when we do the block reduction in the integrate
+   * kernel. The number of warps should be explicitly indicated in the
+   * templating parameters or simply adjust the switch statements inside the
+   * integrate kernels */
+
+  const dim3 threads_per_block(4, 4, 4);
+  if (grid_[level].is_distributed()) {
+    if (grid_[level].is_orthorhombic()) {
+      integrate_kernel<double, double3, true, true, 10>
+        <<<nblocks, threads_per_block, 0, level_streams[level]>>>(params);
+    } else {
+      integrate_kernel<double, double3, true, false, 10>
+        <<<nblocks, threads_per_block, 0, level_streams[level]>>>(params);
+    }
+  } else {
+    if (grid_[level].is_orthorhombic()) {
+      integrate_kernel<double, double3, false, true, 10>
+        <<<nblocks, threads_per_block, 0, level_streams[level]>>>(params);
+    } else {
+      integrate_kernel<double, double3, false, false, 10>
+        <<<nblocks, threads_per_block, 0, level_streams[level]>>>(params);
+    }
+  }
+}
+
+void context_info::compute_hab_coefficients() {
+  // Compute max angular momentum.
+  assert(!calculate_virial || calculate_forces);
+  const ldiffs_value ldiffs =
+      process_get_ldiffs(calculate_forces, calculate_virial, compute_tau);
+  const int la_max = this->lmax() + ldiffs.la_max_diff;
+  const int lb_max = this->lmax() + ldiffs.lb_max_diff;
+  const int lp_max = la_max + lb_max;
+
+  init_constant_memory();
+
+  // Compute required shared memory.
+  // TODO: Currently, cab's indices run over 0...ncoset[lmax],
+  //       however only ncoset(lmin)...ncoset(lmax) are actually needed.
+  const int cab_len = ncoset(lb_max) * ncoset(la_max);
+  const int alpha_len = 3 * (lb_max + 1) * (la_max + 1) * (lp_max + 1);
+  const int cxyz_len = ncoset(lp_max);
+  const size_t smem_per_block =
+      std::max(cab_len + alpha_len + cxyz_len, 64) * sizeof(double);
+
+  if (smem_per_block > 48 * 1024) {
+    fprintf(stderr, "ERROR: Not enough shared memory in grid_gpu_integrate.\n");
+    fprintf(stderr, "cab_len: %i, ", cab_len);
+    fprintf(stderr, "alpha_len: %i, ", alpha_len);
+    fprintf(stderr, "cxyz_len: %i, ", cxyz_len);
+    fprintf(stderr, "total smem_per_block: %f kb\n\n", smem_per_block / 1024.0);
+    abort();
+  }
+
+  // kernel parameters
+  kernel_params params;
+  params.smem_cab_offset = cxyz_len;
+  params.smem_alpha_offset = params.smem_cab_offset + cab_len;
+  params.first_task = 0;
+  params.tasks = this->tasks_dev.data();
+  params.task_sorted_by_blocks_dev = task_sorted_by_blocks_dev.data();
+  params.sorted_blocks_offset_dev = sorted_blocks_offset_dev.data();
+  params.num_tasks_per_block_dev = this->num_tasks_per_block_dev_.data();
+  params.block_offsets = this->block_offsets_dev.data();
+  params.la_min_diff = ldiffs.la_min_diff;
+  params.lb_min_diff = ldiffs.lb_min_diff;
+  params.la_max_diff = ldiffs.la_max_diff;
+  params.lb_max_diff = ldiffs.lb_max_diff;
+
+  params.ptr_dev[0] = pab_block_.data();
+  // params.ptr_dev[1] = grid_[level].data();
+  params.ptr_dev[2] = this->coef_dev_.data();
+  params.ptr_dev[3] = hab_block_.data();
+  params.ptr_dev[4] = forces_.data();
+  params.ptr_dev[5] = virial_.data();
+  params.sphi_dev = this->sphi_dev.data();
+  // Launch !
+  const int nblocks = this->nblocks;
+
+  /* WARNING if you change the block size. The number
+   * of warps is hardcoded when we do the block reduction in the integrate
+   * kernel. */
+
+  const dim3 threads_per_block(4, 4, 4);
+
+  if (!compute_tau && !calculate_forces) {
+    compute_hab_v2<double, double3, false, false>
+        <<<nblocks, threads_per_block, smem_per_block, this->main_stream>>>(
+            params, this->ntasks);
+    return;
+  }
+
+  if (!compute_tau && calculate_forces) {
+    compute_hab_v2<double, double3, false, true>
+        <<<nblocks, threads_per_block, smem_per_block, this->main_stream>>>(
+            params, this->ntasks);
+    return;
+  }
+
+  if (compute_tau && calculate_forces) {
+    compute_hab_v2<double, double3, true, true>
+        <<<nblocks, threads_per_block, smem_per_block, this->main_stream>>>(
+            params, this->ntasks);
+  }
+
+  if (compute_tau && !calculate_forces) {
+    compute_hab_v2<double, double3, true, false>
+        <<<nblocks, threads_per_block, smem_per_block, this->main_stream>>>(
+            params, this->ntasks);
+  }
+}
+};     // namespace rocm_backend
+#endif // __GRID_ROCM

--- a/src/grid/hip/grid_hip_internal_header.h
+++ b/src/grid/hip/grid_hip_internal_header.h
@@ -1,0 +1,792 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * Authors :
+ - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+ - Advanced Micro Devices, Inc.
+*/
+
+#ifndef GRID_HIP_INTERNAL_HEADER_H
+#define GRID_HIP_INTERNAL_HEADER_H
+
+#include <algorithm>
+#include <assert.h>
+#include <hip/hip_runtime.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define GRID_DEVICE __device__
+extern "C" {
+#include "../common/grid_basis_set.h"
+#include "../common/grid_constants.h"
+}
+
+#include "grid_hip_context.hpp"
+
+namespace rocm_backend {
+
+#if defined(__HIP_PLATFORM_NVIDIA__)
+#if __CUDA_ARCH__ < 600
+__device__ __inline__ double atomicAdd(double *address, double val) {
+  unsigned long long int *address_as_ull = (unsigned long long int *)address;
+  unsigned long long int old = *address_as_ull, assumed;
+
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(val + __longlong_as_double(assumed)));
+
+    // Note: uses integer comparison to avoid hang in case of NaN (since NaN !=
+    // NaN)
+  } while (assumed != old);
+
+  return __longlong_as_double(old);
+}
+#endif
+#endif
+
+/*******************************************************************************
+ * \brief Orbital angular momentum.
+ ******************************************************************************/
+struct orbital {
+  int l[3];
+};
+
+__constant__ orbital coset_inv[1330];
+__constant__ int binomial_coef[19][19];
+
+/*******************************************************************************
+ * \brief Differences in angular momentum.
+ ******************************************************************************/
+struct ldiffs_value {
+  int la_max_diff{0};
+  int la_min_diff{0};
+  int lb_max_diff{0};
+  int lb_min_diff{0};
+};
+
+/*******************************************************************************
+ * \brief data needed for calculating the coefficients, forces, and stress
+ ******************************************************************************/
+template <typename T> struct smem_task {
+  bool block_transposed;
+  T ra[3];
+  T rb[3];
+  T rp[3];
+  T rab[3];
+  T zeta;
+  T zetb;
+  T zetp;
+  T prefactor;
+  T off_diag_twice;
+  char la_max;
+  char lb_max;
+  char la_min;
+  char lb_min;
+  char lp;
+  // size of the cab matrix
+  unsigned short int n1;
+  unsigned short int n2;
+  // size of entire spherical basis
+  unsigned short int nsgfa;
+  unsigned short int nsgfb;
+  // size of spherical set
+  unsigned short int nsgf_seta;
+  unsigned short int nsgf_setb;
+  // start of decontracted set, ie. pab and hab
+  int first_coseta;
+  int first_cosetb;
+  // size of decontracted set, ie. pab and hab
+  int ncoseta;
+  int ncosetb;
+  // strides of the sphi transformation matrices
+  int maxcoa;
+  int maxcob;
+  // pointers matrices
+  T *pab_block;
+  T *sphia;
+  T *sphib;
+  // integrate
+  T *hab_block;
+  T *forces_a;
+  T *forces_b;
+};
+
+/*******************************************************************************
+ * \brief data needed for collocate and integrate kernels
+ ******************************************************************************/
+template <typename T, typename T3> struct smem_task_reduced {
+  // bool block_transposed;
+  T radius, discrete_radius;
+  int3 cube_center, lb_cube, cube_size, window_size, window_shift;
+  T3 roffset;
+  T zetp;
+  // char la_max;
+  // char lb_max;
+  // char la_min;
+  // char lb_min;
+  char lp;
+  bool apply_border_mask;
+};
+
+/*******************************************************************************
+ * \brief Factorial function, e.g. fac(5) = 5! = 120.
+ * \author Ole Schuett
+ ******************************************************************************/
+__device__ __inline__ double fac(const int i) {
+  static const double table[] = {
+      0.10000000000000000000E+01, 0.10000000000000000000E+01,
+      0.20000000000000000000E+01, 0.60000000000000000000E+01,
+      0.24000000000000000000E+02, 0.12000000000000000000E+03,
+      0.72000000000000000000E+03, 0.50400000000000000000E+04,
+      0.40320000000000000000E+05, 0.36288000000000000000E+06,
+      0.36288000000000000000E+07, 0.39916800000000000000E+08,
+      0.47900160000000000000E+09, 0.62270208000000000000E+10,
+      0.87178291200000000000E+11, 0.13076743680000000000E+13,
+      0.20922789888000000000E+14, 0.35568742809600000000E+15,
+      0.64023737057280000000E+16, 0.12164510040883200000E+18,
+      0.24329020081766400000E+19, 0.51090942171709440000E+20,
+      0.11240007277776076800E+22, 0.25852016738884976640E+23,
+      0.62044840173323943936E+24, 0.15511210043330985984E+26,
+      0.40329146112660563558E+27, 0.10888869450418352161E+29,
+      0.30488834461171386050E+30, 0.88417619937397019545E+31,
+      0.26525285981219105864E+33};
+  return table[i];
+}
+
+/*******************************************************************************
+ * \brief Number of Cartesian orbitals up to given angular momentum quantum.
+ * \author Ole Schuett
+ ******************************************************************************/
+__host__ __device__ __inline__ int ncoset(const int l) {
+  static const int table[] = {1,  // l=0
+                              4,  // l=1
+                              10, // l=2 ...
+                              20,  35,  56,  84,  120, 165, 220,  286,
+                              364, 455, 560, 680, 816, 969, 1140, 1330};
+  return table[l];
+}
+
+/*******************************************************************************
+ * \brief Maps three angular momentum components to a single zero based index.
+ ******************************************************************************/
+__host__ __device__ __inline__ int coset(int lx, int ly, int lz) {
+  const int l = lx + ly + lz;
+  if (l == 0) {
+    return 0;
+  } else {
+    return ncoset(l - 1) + ((l - lx) * (l - lx + 1)) / 2 + lz;
+  }
+}
+
+/*******************************************************************************
+ * \brief Increase i'th component of given orbital angular momentum.
+ ******************************************************************************/
+__device__ __inline__ orbital up(const int i, const orbital &a) {
+  orbital b = a;
+  b.l[i] += 1;
+  return b;
+}
+
+/*******************************************************************************
+ * \brief Decrease i'th component of given orbital angular momentum.
+ ******************************************************************************/
+__inline__ __device__ orbital down(const int i, const orbital &a) {
+  orbital b = a;
+  b.l[i] = max(0, a.l[i] - 1);
+  return b;
+}
+
+/*******************************************************************************
+ * \brief Return coset index of given orbital angular momentum.
+ ******************************************************************************/
+__inline__ __device__ int idx(const orbital a) {
+  return coset(a.l[0], a.l[1], a.l[2]);
+}
+
+__device__ __inline__ double power(const double x, const int expo) {
+  double tmp = 1.0;
+  for (int i = 1; i <= expo; i++)
+    tmp *= x;
+  return tmp;
+}
+
+/*******************************************************************************
+ * \brief Adds given value to matrix element cab[idx(b)][idx(a)].
+ ******************************************************************************/
+template <typename T = double>
+__device__ __inline__ void prep_term(const orbital a, const orbital b,
+                                     const T value, const int n, T *cab) {
+  atomicAdd(&cab[idx(b) * n + idx(a)], value);
+}
+
+/*******************************************************************************
+ * \brief Initializes the device's constant memory.
+ * \author Ole Schuett
+ ******************************************************************************/
+inline static void init_constant_memory() {
+  static bool initialized = false;
+  if (initialized) {
+    return; // constant memory has to be initialized only once
+  }
+
+  // Inverse coset mapping
+  orbital coset_inv_host[1330];
+  for (int lx = 0; lx <= 18; lx++) {
+    for (int ly = 0; ly <= 18 - lx; ly++) {
+      for (int lz = 0; lz <= 18 - lx - ly; lz++) {
+        const int i = coset(lx, ly, lz);
+        coset_inv_host[i] = {{lx, ly, lz}};
+      }
+    }
+  }
+  hipError_t error =
+      hipMemcpyToSymbol(coset_inv, &coset_inv_host, sizeof(coset_inv_host), 0,
+                        hipMemcpyHostToDevice);
+  assert(error == hipSuccess);
+
+  // Binomial coefficient
+  int binomial_coef_host[19][19] = {
+      {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 3, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 4, 6, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 5, 10, 10, 5, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 6, 15, 20, 15, 6, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 7, 21, 35, 35, 21, 7, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 8, 28, 56, 70, 56, 28, 8, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 9, 36, 84, 126, 126, 84, 36, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 10, 45, 120, 210, 252, 210, 120, 45, 10, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+      {1, 11, 55, 165, 330, 462, 462, 330, 165, 55, 11, 1, 0, 0, 0, 0, 0, 0, 0},
+      {1, 12, 66, 220, 495, 792, 924, 792, 495, 220, 66, 12, 1, 0, 0, 0, 0, 0,
+       0},
+      {1, 13, 78, 286, 715, 1287, 1716, 1716, 1287, 715, 286, 78, 13, 1, 0, 0,
+       0, 0, 0},
+      {1, 14, 91, 364, 1001, 2002, 3003, 3432, 3003, 2002, 1001, 364, 91, 14, 1,
+       0, 0, 0, 0},
+      {1, 15, 105, 455, 1365, 3003, 5005, 6435, 6435, 5005, 3003, 1365, 455,
+       105, 15, 1, 0, 0, 0},
+      {1, 16, 120, 560, 1820, 4368, 8008, 11440, 12870, 11440, 8008, 4368, 1820,
+       560, 120, 16, 1, 0, 0},
+      {1, 17, 136, 680, 2380, 6188, 12376, 19448, 24310, 24310, 19448, 12376,
+       6188, 2380, 680, 136, 17, 1, 0},
+      {1, 18, 153, 816, 3060, 8568, 18564, 31824, 43758, 48620, 43758, 31824,
+       18564, 8568, 3060, 816, 153, 18, 1}};
+  error =
+      hipMemcpyToSymbol(binomial_coef, &binomial_coef_host[0][0],
+                        sizeof(binomial_coef_host), 0, hipMemcpyHostToDevice);
+  assert(error == hipSuccess);
+
+  initialized = true;
+}
+
+__inline__ __device__ double3
+compute_coordinates(const double *__restrict__ dh_, const double x,
+                    const double y, const double z) {
+
+  double3 r3;
+  // I make no distinction between orthorhombic and non orthorhombic
+  // cases
+
+  r3.x = z * dh_[6] + y * dh_[3] + x * dh_[0];
+  r3.y = z * dh_[7] + y * dh_[4] + x * dh_[1];
+  r3.z = z * dh_[8] + y * dh_[5] + x * dh_[2];
+  return r3;
+}
+
+__inline__ __device__ float3 compute_coordinates(const float *__restrict__ dh_,
+                                                 const float x, const float y,
+                                                 const float z) {
+
+  float3 r3;
+  // I make no distinction between orthorhombic and non orthorhombic
+  // cases
+
+  r3.x = z * dh_[6] + y * dh_[3] + x * dh_[0];
+  r3.y = z * dh_[7] + y * dh_[4] + x * dh_[1];
+  r3.z = z * dh_[8] + y * dh_[5] + x * dh_[2];
+  return r3;
+}
+
+/*******************************************************************************
+ * \brief Computes the polynomial expansion coefficients:
+ *        (x-a)**lxa (x-b)**lxb -> sum_{ls} alpha(ls,lxa,lxb,1)*(x-p)**ls
+ ******************************************************************************/
+template <typename T>
+__inline__ __device__ void compute_alpha(const kernel_params &params,
+                                         const smem_task<T> &task,
+                                         T *__restrict__ alpha) {
+  // strides for accessing alpha
+  const int s3 = (task.lp + 1);
+  const int s2 = (task.la_max + 1) * s3;
+  const int s1 = (task.lb_max + 1) * s2;
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  for (int i = tid; i < 3 * s1; i += blockDim.x * blockDim.y * blockDim.z)
+    alpha[i] = 0.0;
+
+  __syncthreads();
+
+  for (int idir = threadIdx.z; idir < 3; idir += blockDim.z) {
+    const T drpa = task.rp[idir] - task.ra[idir];
+    const T drpb = task.rp[idir] - task.rb[idir];
+    for (int la = threadIdx.y; la <= task.la_max; la += blockDim.y) {
+      for (int lb = threadIdx.x; lb <= task.lb_max; lb += blockDim.x) {
+        T a = 1.0;
+        for (int k = 0; k <= la; k++) {
+          T b = 1.0;
+          const int base = idir * s1 + lb * s2 + la * s3;
+          for (int l = 0; l <= lb; l++) {
+            alpha[base + la - l + lb - k] +=
+                a * b * binomial_coef[la][k] * binomial_coef[lb][l];
+            b *= drpb;
+          }
+          a *= drpa;
+        }
+      }
+    }
+  }
+  __syncthreads(); // because of concurrent writes to alpha
+}
+
+__host__ __inline__ __device__ void
+convert_to_lattice_coordinates(const double *dh_inv_,
+                               const double3 *__restrict__ const rp,
+                               double3 *__restrict__ rp_c) {
+  rp_c->x = dh_inv_[0] * rp->x + dh_inv_[3] * rp->y + dh_inv_[6] * rp->z;
+  rp_c->y = dh_inv_[1] * rp->x + dh_inv_[4] * rp->y + dh_inv_[7] * rp->z;
+  rp_c->z = dh_inv_[2] * rp->x + dh_inv_[5] * rp->y + dh_inv_[8] * rp->z;
+}
+
+__host__ __inline__ __device__ void
+convert_from_lattice_coordinates_to_cartesian(
+    const double *__restrict__ dh_, const double3 *__restrict__ const rp,
+    double3 *__restrict__ rp_c) {
+  rp_c->x = dh_[0] * rp->x + dh_[3] * rp->y + dh_[6] * rp->z;
+  rp_c->y = dh_[1] * rp->x + dh_[4] * rp->y + dh_[7] * rp->z;
+  rp_c->z = dh_[2] * rp->x + dh_[5] * rp->y + dh_[8] * rp->z;
+}
+
+__host__ __inline__ __device__ void
+convert_to_lattice_coordinates(const float *dh_inv_,
+                               const float3 *__restrict__ const rp,
+                               float3 *__restrict__ rp_c) {
+  rp_c->x = dh_inv_[0] * rp->x + dh_inv_[3] * rp->y + dh_inv_[6] * rp->z;
+  rp_c->y = dh_inv_[1] * rp->x + dh_inv_[4] * rp->y + dh_inv_[7] * rp->z;
+  rp_c->z = dh_inv_[2] * rp->x + dh_inv_[5] * rp->y + dh_inv_[8] * rp->z;
+}
+
+__host__ __inline__ __device__ void
+convert_from_lattice_coordinates_to_cartesian(
+    const float *__restrict__ dh_, const float3 *__restrict__ const rp,
+    float3 *__restrict__ rp_c) {
+  rp_c->x = dh_[0] * rp->x + dh_[3] * rp->y + dh_[6] * rp->z;
+  rp_c->y = dh_[1] * rp->x + dh_[4] * rp->y + dh_[7] * rp->z;
+  rp_c->z = dh_[2] * rp->x + dh_[5] * rp->y + dh_[8] * rp->z;
+}
+
+template <typename T, typename T3, bool orthorhombic_>
+__inline__ T compute_cube_properties(
+    const T radius, const T *const __restrict__ dh_,
+    const T *const __restrict__ dh_inv_, const T3 *__restrict__ rp,
+    T3 *__restrict__ roffset, int3 *__restrict__ cubecenter,
+    int3 *__restrict__ lb_cube, int3 *__restrict__ cube_size) {
+
+  /* center of the gaussian in the lattice coordinates */
+  T3 rp1, rp2, rp3;
+
+  /* it is in the lattice vector frame */
+  convert_to_lattice_coordinates(dh_inv_, rp, &rp1);
+
+  /* compute the grid point that is the closest to the sphere center. */
+  cubecenter->x = std::floor(rp1.x);
+  cubecenter->y = std::floor(rp1.y);
+  cubecenter->z = std::floor(rp1.z);
+
+  /* seting up the cube parameters */
+
+  if (orthorhombic_) {
+
+    // the cube is actually slightly bigger than the sphere of radius r. that's
+    // why we need to discretize it to get the cube size "right".
+
+    // disc_radius >= radius always. somehow despite the fact that we compile
+    // things with a c++ compiler on the host side, we need to use fmin instead
+    // of std::min since std::min is not allowed on the device side
+
+    // We assume no specific form for the orthogonal matrix. (can be diaognal or
+    // completely full, the only constraint is that the tree vectors are
+    // orthogonal)
+
+    T norm1, norm2, norm3;
+    norm1 = dh_[0] * dh_[0] + dh_[1] * dh_[1] + dh_[2] * dh_[2];
+    norm2 = dh_[3] * dh_[3] + dh_[4] * dh_[4] + dh_[5] * dh_[5];
+    norm3 = dh_[6] * dh_[6] + dh_[7] * dh_[7] + dh_[8] * dh_[8];
+
+    norm1 = std::sqrt(norm1);
+    norm2 = std::sqrt(norm2);
+    norm3 = std::sqrt(norm3);
+
+    const T disr_radius =
+        std::min(norm1, std::min(norm2, norm3)) *
+        std::max(1,
+                 (int)ceil(radius / std::min(norm1, std::min(norm2, norm3))));
+
+    rp2.x = cubecenter->x;
+    rp2.y = cubecenter->y;
+    rp2.z = cubecenter->z;
+
+    /* convert the cube center from grid points coordinates to cartesian */
+    convert_from_lattice_coordinates_to_cartesian(dh_, &rp2, roffset);
+    /* cube center */
+    roffset->x -= rp->x;
+    roffset->y -= rp->y;
+    roffset->z -= rp->z;
+
+    rp2.x = disr_radius;
+    rp2.y = disr_radius;
+    rp2.z = disr_radius;
+
+    /* it is in the lattice vector frame */
+    convert_to_lattice_coordinates(dh_inv_, &rp2, &rp3);
+    /* lower and upper bounds */
+    lb_cube->x = std::ceil(-1e-8 - rp3.x);
+    lb_cube->y = std::ceil(-1e-8 - rp3.y);
+    lb_cube->z = std::ceil(-1e-8 - rp3.z);
+
+    /* it is in the lattice vector frame */
+    convert_to_lattice_coordinates(dh_inv_, roffset, &rp2);
+
+    /* Express the offset in lattice coordinates */
+    roffset->x = rp2.x;
+    roffset->y = rp2.y;
+    roffset->z = rp2.z;
+
+    /* compute the cube size ignoring periodicity */
+    /* the interval is not symmetrical for some curious reasons. it should go
+     * from [-L..L+1] so the number of points is multiple of two */
+    cube_size->x = 2 - 2 * lb_cube->x;
+    cube_size->y = 2 - 2 * lb_cube->y;
+    cube_size->z = 2 - 2 * lb_cube->z;
+    return disr_radius;
+  } else {
+    int3 ub_cube;
+
+    lb_cube->x = INT_MAX;
+    ub_cube.x = INT_MIN;
+    lb_cube->y = INT_MAX;
+    ub_cube.y = INT_MIN;
+    lb_cube->z = INT_MAX;
+    ub_cube.z = INT_MIN;
+
+    for (int i = -1; i <= 1; i++) {
+      for (int j = -1; j <= 1; j++) {
+        for (int k = -1; k <= 1; k++) {
+          T3 r;
+          r.x = rp->x + ((T)i) * radius;
+          r.y = rp->y + ((T)j) * radius;
+          r.z = rp->z + ((T)k) * radius;
+          convert_to_lattice_coordinates(dh_inv_, &r, roffset);
+
+          lb_cube->x = std::min(lb_cube->x, (int)std::floor(roffset->x));
+          ub_cube.x = std::max(ub_cube.x, (int)std::ceil(roffset->x));
+
+          lb_cube->y = std::min(lb_cube->y, (int)std::floor(roffset->y));
+          ub_cube.y = std::max(ub_cube.y, (int)std::ceil(roffset->y));
+
+          lb_cube->z = std::min(lb_cube->z, (int)std::floor(roffset->z));
+          ub_cube.z = std::max(ub_cube.z, (int)std::ceil(roffset->z));
+        }
+      }
+    }
+    /* compute the cube size ignoring periodicity */
+    cube_size->x = ub_cube.x - lb_cube->x;
+    cube_size->y = ub_cube.y - lb_cube->y;
+    cube_size->z = ub_cube.z - lb_cube->z;
+
+    /* compute the offset in lattice coordinates */
+
+    roffset->x = cubecenter->x - rp1.x;
+    roffset->y = cubecenter->y - rp1.y;
+    roffset->z = cubecenter->z - rp1.z;
+
+    // shift the boundaries compared to the cube center so that the
+    // specialization ortho / non ortho is minimal
+    lb_cube->x -= cubecenter->x;
+    lb_cube->y -= cubecenter->y;
+    lb_cube->z -= cubecenter->z;
+
+    return radius;
+  }
+}
+
+__inline__ __device__ void
+compute_window_size(const int *const grid_size, const int *const lower_corner_,
+                    const int *const period_, /* also full size of the grid */
+                    const int border_mask, const int *border_width,
+                    int3 *const window_size, int3 *const window_shift) {
+  window_shift->x = 0;
+  window_shift->y = 0;
+  window_shift->z = 0;
+
+  window_size->x = grid_size[2] - 1;
+  window_size->y = grid_size[1] - 1;
+  window_size->z = grid_size[0] - 1;
+
+  if (border_mask & (1 << 0))
+    window_shift->x += border_width[2];
+  if (border_mask & (1 << 1))
+    window_size->x -= border_width[2];
+  if (border_mask & (1 << 2))
+    window_shift->y += border_width[1];
+  if (border_mask & (1 << 3))
+    window_size->y -= border_width[1];
+  if (border_mask & (1 << 4))
+    window_shift->z += border_width[0];
+  if (border_mask & (1 << 5))
+    window_size->z -= border_width[0];
+}
+
+/*******************************************************************************
+ * \brief Transforms coefficients C_ab into C_xyz.
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ static void
+cab_to_cxyz(const kernel_params &params, const smem_task<T> &task,
+            const T *__restrict__ alpha, const T *__restrict__ cab,
+            T *__restrict__ cxyz) {
+
+  //   *** initialise the coefficient matrix, we transform the sum
+  //
+  // sum_{lxa,lya,lza,lxb,lyb,lzb} P_{lxa,lya,lza,lxb,lyb,lzb} *
+  //         (x-a_x)**lxa (y-a_y)**lya (z-a_z)**lza (x-b_x)**lxb (y-a_y)**lya
+  //         (z-a_z)**lza
+  //
+  // into
+  //
+  // sum_{lxp,lyp,lzp} P_{lxp,lyp,lzp} (x-p_x)**lxp (y-p_y)**lyp (z-p_z)**lzp
+  //
+  // where p is center of the product gaussian, and lp = la_max + lb_max
+  // (current implementation is l**7)
+
+  // strides for accessing alpha
+  const int s3 = (task.lp + 1);
+  const int s2 = (task.la_max + 1) * s3;
+  const int s1 = (task.lb_max + 1) * s2;
+
+  // TODO: Maybe we can transpose alpha to index it directly with ico and jco.
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+
+  for (int i = tid; i < ncoset(task.lp);
+       i += blockDim.x * blockDim.y * blockDim.z) {
+    auto &co = coset_inv[i];
+    T reg = 0.0; // accumulate into a register
+    for (int jco = 0; jco < ncoset(task.lb_max); jco++) {
+      const auto &b = coset_inv[jco];
+      for (int ico = 0; ico < ncoset(task.la_max); ico++) {
+        const auto &a = coset_inv[ico];
+        const T p = task.prefactor *
+                    alpha[0 * s1 + b.l[0] * s2 + a.l[0] * s3 + co.l[0]] *
+                    alpha[1 * s1 + b.l[1] * s2 + a.l[1] * s3 + co.l[1]] *
+                    alpha[2 * s1 + b.l[2] * s2 + a.l[2] * s3 + co.l[2]];
+        reg += p * cab[jco * task.n1 + ico]; // collocate
+      }
+    }
+
+    cxyz[i] = reg;
+  }
+  __syncthreads(); // because of concurrent writes to cxyz / cab
+}
+
+/*******************************************************************************
+ * \brief Transforms coefficients C_xyz into C_ab.
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ static void
+cxyz_to_cab(const kernel_params &params, const smem_task<T> &task,
+            const T *__restrict__ alpha, const T *__restrict__ cxyz,
+            T *__restrict__ cab) {
+
+  //   *** initialise the coefficient matrix, we transform the sum
+  //
+  // sum_{lxa,lya,lza,lxb,lyb,lzb} P_{lxa,lya,lza,lxb,lyb,lzb} *
+  //         (x-a_x)**lxa (y-a_y)**lya (z-a_z)**lza (x-b_x)**lxb (y-a_y)**lya
+  //         (z-a_z)**lza
+  //
+  // into
+  //
+  // sum_{lxp,lyp,lzp} P_{lxp,lyp,lzp} (x-p_x)**lxp (y-p_y)**lyp (z-p_z)**lzp
+  //
+  // where p is center of the product gaussian, and lp = la_max + lb_max
+  // (current implementation is l**7)
+
+  // strides for accessing alpha
+  const int s3 = (task.lp + 1);
+  const int s2 = (task.la_max + 1) * s3;
+  const int s1 = (task.lb_max + 1) * s2;
+
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  for (int jco = tid / 8; jco < ncoset(task.lb_max); jco += 8) {
+    const orbital b = coset_inv[jco];
+    for (int ico = tid % 8; ico < ncoset(task.la_max); ico += 8) {
+      const auto &a = coset_inv[ico];
+      T reg = 0.0; // accumulate into a register
+      for (int ic = 0; ic < ncoset(task.lp); ic++) {
+        const auto &co = coset_inv[ic];
+        const T p = task.prefactor *
+                    alpha[b.l[0] * s2 + a.l[0] * s3 + co.l[0]] *
+                    alpha[s1 + b.l[1] * s2 + a.l[1] * s3 + co.l[1]] *
+                    alpha[2 * s1 + b.l[2] * s2 + a.l[2] * s3 + co.l[2]];
+
+        reg += p * cxyz[ic]; // integrate
+      }
+      cab[jco * task.n1 + ico] = reg; // partial loop coverage -> zero it
+    }
+  }
+  __syncthreads(); // because of concurrent writes to cxyz / cab
+}
+
+/*******************************************************************************
+ * \brief Copies a task from global to shared memory.
+ ******************************************************************************/
+
+/* Collocate and integrate do not care about the sphi etc... computing the
+ * coefficients do not care about the exponentials (the parameters are still
+ * needed), so simplify the amount of information to save shared memory (it is
+ * crucial on AMD GPU to max out occupancy) */
+template <typename T, typename T3>
+__device__ __inline__ void
+fill_smem_task_reduced(const kernel_params &dev, const int task_id,
+                       smem_task_reduced<T, T3> &task) {
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    const auto &glb_task = dev.tasks[task_id];
+    task.zetp = glb_task.zeta + glb_task.zetb;
+    task.radius = glb_task.radius;
+    task.discrete_radius = glb_task.discrete_radius;
+
+    // angular momentum range for the actual collocate/integrate operation.
+    task.lp =
+        glb_task.la_max + dev.la_max_diff + glb_task.lb_max + dev.lb_max_diff;
+
+    task.cube_size.x = glb_task.cube_size.x;
+    task.cube_size.y = glb_task.cube_size.y;
+    task.cube_size.z = glb_task.cube_size.z;
+
+    task.cube_center.x = glb_task.cube_center.x;
+    task.cube_center.y = glb_task.cube_center.y;
+    task.cube_center.z = glb_task.cube_center.z;
+
+    task.roffset.x = glb_task.roffset.x;
+    task.roffset.y = glb_task.roffset.y;
+    task.roffset.z = glb_task.roffset.z;
+
+    task.lb_cube.x = glb_task.lb_cube.x;
+    task.lb_cube.y = glb_task.lb_cube.y;
+    task.lb_cube.z = glb_task.lb_cube.z;
+
+    task.apply_border_mask = glb_task.apply_border_mask;
+  }
+  __syncthreads();
+}
+
+/*******************************************************************************
+ * \brief Copies a task from global to shared memory and does precomputations.
+ ******************************************************************************/
+
+/*  computing the coefficients do not care about many of the exponentials
+ * parameters, etc.. so */
+template <typename T>
+__device__ __inline__ void fill_smem_task_coef(const kernel_params &dev,
+                                               const int task_id,
+                                               smem_task<T> &task) {
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    const auto &glb_task = dev.tasks[task_id];
+    const int iatom = glb_task.iatom;
+    const int jatom = glb_task.jatom;
+    task.zeta = glb_task.zeta;
+    task.zetb = glb_task.zetb;
+
+    for (int i = 0; i < 3; i++) {
+      task.rab[i] = glb_task.rab[i];
+      task.ra[i] = glb_task.ra[i];
+      task.rb[i] = task.ra[i] + task.rab[i];
+      task.rp[i] =
+          task.ra[i] + task.rab[i] * task.zetb / (task.zeta + task.zetb);
+    }
+
+    task.prefactor = glb_task.prefactor;
+
+    // task.radius = glb_task.radius;
+    task.off_diag_twice = glb_task.off_diag_twice;
+
+    // angular momentum range of basis set
+    const int la_max_basis = glb_task.la_max;
+    const int lb_max_basis = glb_task.lb_max;
+    const int la_min_basis = glb_task.la_min;
+    const int lb_min_basis = glb_task.lb_min;
+
+    // angular momentum range for the actual collocate/integrate opteration.
+    task.la_max = la_max_basis + dev.la_max_diff;
+    task.lb_max = lb_max_basis + dev.lb_max_diff;
+    task.la_min = max(la_min_basis + (int)dev.la_min_diff, 0);
+    task.lb_min = max(lb_min_basis + (int)dev.lb_min_diff, 0);
+    task.lp = task.la_max + task.lb_max;
+
+    // start of decontracted set, ie. pab and hab
+    task.first_coseta = (la_min_basis > 0) ? ncoset(la_min_basis - 1) : 0;
+    task.first_cosetb = (lb_min_basis > 0) ? ncoset(lb_min_basis - 1) : 0;
+
+    // size of decontracted set, ie. pab and hab
+    task.ncoseta = ncoset(la_max_basis);
+    task.ncosetb = ncoset(lb_max_basis);
+    // size of the cab matrix
+    task.n1 = ncoset(task.la_max);
+    task.n2 = ncoset(task.lb_max);
+
+    // size of entire spherical basis
+    task.nsgfa = glb_task.nsgfa; // ibasis.nsgf;
+    task.nsgfb = glb_task.nsgfb;
+
+    // size of spherical set
+    task.nsgf_seta = glb_task.nsgf_seta;
+    task.nsgf_setb = glb_task.nsgf_setb;
+
+    // strides of the sphi transformation matrices
+    task.maxcoa = glb_task.maxcoa;
+    task.maxcob = glb_task.maxcob;
+
+    // transformations from contracted spherical to primitive cartesian basis
+    task.sphia = &dev.sphi_dev[glb_task.ikind][glb_task.sgfa * task.maxcoa +
+                                               glb_task.ipgf * task.ncoseta];
+    task.sphib = &dev.sphi_dev[glb_task.jkind][glb_task.sgfb * task.maxcob +
+                                               glb_task.jpgf * task.ncosetb];
+
+    // Locate current matrix block within the buffer.
+    const int block_offset = dev.block_offsets[glb_task.block_num];
+    task.block_transposed = glb_task.block_transposed;
+    task.pab_block = dev.ptr_dev[0] + block_offset + glb_task.subblock_offset;
+
+    if (dev.ptr_dev[3] != nullptr) {
+      task.hab_block = dev.ptr_dev[3] + block_offset + glb_task.subblock_offset;
+      if (dev.ptr_dev[4] != nullptr) {
+        task.forces_a = &dev.ptr_dev[4][3 * iatom];
+        task.forces_b = &dev.ptr_dev[4][3 * jatom];
+      }
+    }
+  }
+  __syncthreads();
+}
+
+} // namespace rocm_backend
+#endif

--- a/src/grid/hip/grid_hip_prepare_pab.h
+++ b/src/grid/hip/grid_hip_prepare_pab.h
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+namespace rocm_backend {
 /*******************************************************************************
  * \brief Implementation of function GRID_FUNC_AB, ie. identity transformation.
  ******************************************************************************/
@@ -340,7 +341,7 @@ prepare_pab(const enum grid_func func, const orbital a, const orbital b,
  * \brief Returns difference in angular momentum range for given func.
  * \author Ole Schuett
  ******************************************************************************/
-ldiffs_value prepare_get_ldiffs(const enum grid_func func) {
+inline ldiffs_value prepare_get_ldiffs(const enum grid_func func) {
   ldiffs_value ldiffs;
 
   switch (func) {
@@ -402,3 +403,4 @@ ldiffs_value prepare_get_ldiffs(const enum grid_func func) {
 
   return ldiffs;
 }
+} // namespace rocm_backend

--- a/src/grid/hip/grid_hip_prepare_pab.h
+++ b/src/grid/hip/grid_hip_prepare_pab.h
@@ -1,0 +1,404 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * NOTE : derived from the reference and GPU backends
+ * Authors :
+ - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+ - Advanced Micro Devices, Inc.
+*/
+
+#include "../common/grid_constants.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_AB, ie. identity transformation.
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ void prepare_pab_AB(const orbital a, const orbital b,
+                                          const T pab_val, const int n,
+                                          T *cab) {
+
+  // simply copy pab to cab
+  prep_term<T>(a, b, pab_val, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_DADB.
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ void
+prepare_pab_DADB(const orbital a, const orbital b, const T zeta, const T zetb,
+                 const T pab_val, const int n, T *cab) {
+
+  // creates cab such that mapping it with pgf_a pgf_b
+  // is equivalent to mapping pab with 0.5 * (nabla pgf_a) . (nabla pgf_b)
+  // (ddx pgf_a ) (ddx pgf_b) = (lax pgf_{a-1x} - 2*zeta*pgf_{a+1x})*(lbx
+  // pgf_{b-1x} - 2*zetb*pgf_{b+1x})
+
+  for (int i = 0; i < 3; i++) {
+    prep_term<T>(down(i, a), down(i, b), 0.5 * a.l[i] * b.l[i] * pab_val, n,
+                 cab);
+    prep_term<T>(down(i, a), up(i, b), -1.0 * a.l[i] * zetb * pab_val, n, cab);
+    prep_term<T>(up(i, a), down(i, b), -1.0 * zeta * b.l[i] * pab_val, n, cab);
+    prep_term<T>(up(i, a), up(i, b), 2.0 * zeta * zetb * pab_val, n, cab);
+  }
+}
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_ADBmDAB_{X,Y,Z}.
+ ******************************************************************************/
+template <typename T>
+__device__ void prepare_pab_ADBmDAB(const int idir, const orbital a,
+                                    const orbital b, const T zeta, const T zetb,
+                                    const T pab_val, const int n, T *cab) {
+
+  // creates cab such that mapping it with pgf_a pgf_b
+  // is equivalent to mapping pab with
+  //    pgf_a (nabla_{idir} pgf_b) - (nabla_{idir} pgf_a) pgf_b
+  // ( pgf_a ) (ddx pgf_b) - (ddx pgf_a)( pgf_b ) =
+  //          pgf_a *(lbx pgf_{b-1x} - 2*zetb*pgf_{b+1x}) -
+  //                   (lax pgf_{a-1x} - 2*zeta*pgf_{a+1x}) pgf_b
+
+  prep_term<T>(a, down(idir, b), +b.l[idir] * pab_val, n, cab);
+  prep_term<T>(a, up(idir, b), -2.0 * zetb * pab_val, n, cab);
+  prep_term<T>(down(idir, a), b, -a.l[idir] * pab_val, n, cab);
+  prep_term<T>(up(idir, a), b, +2.0 * zeta * pab_val, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_ARDBmDARB_{X,Y,Z}{X,Y,Z}.
+ ******************************************************************************/
+template <typename T>
+__device__ void prepare_pab_ARDBmDARB(const int idir, const int ir,
+                                      const orbital a, const orbital b,
+                                      const T zeta, const T zetb,
+                                      const T pab_val, const int n, T *cab) {
+
+  // creates cab such that mapping it with pgf_a pgf_b
+  // is equivalent to mapping pab with
+  // pgf_a (r-Rb)_{ir} (nabla_{idir} pgf_b) - (nabla_{idir} pgf_a) (r-Rb)_{ir}
+  // pgf_b ( pgf_a )(r-Rb)_{ir} (ddx pgf_b) - (ddx pgf_a) (r-Rb)_{ir} ( pgf_b )
+  // =
+  //                        pgf_a *(lbx pgf_{b-1x+1ir} - 2*zetb*pgf_{b+1x+1ir})
+  //                        -
+  //                       (lax pgf_{a-1x} - 2*zeta*pgf_{a+1x}) pgf_{b+1ir}
+
+  prep_term<T>(a, down(idir, up(ir, b)), b.l[idir] * pab_val, n, cab);
+  prep_term<T>(a, up(idir, up(ir, b)), -2.0 * zetb * pab_val, n, cab);
+  prep_term<T>(down(idir, a), up(ir, b), -a.l[idir] * pab_val, n, cab);
+  prep_term<T>(up(idir, a), up(ir, b), +2.0 * zeta * pab_val, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_DABpADB_{X,Y,Z}.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ void prepare_pab_DABpADB(const int idir, const orbital a,
+                                    const orbital b, const T zeta, const T zetb,
+                                    const T pab_val, const int n, T *cab) {
+
+  // creates cab such that mapping it with pgf_a pgf_b
+  // is equivalent to mapping pab with
+  //    pgf_a (nabla_{idir} pgf_b) + (nabla_{idir} pgf_a) pgf_b
+  // ( pgf_a ) (ddx pgf_b) + (ddx pgf_a)( pgf_b ) =
+  //          pgf_a *(lbx pgf_{b-1x} + 2*zetb*pgf_{b+1x}) +
+  //                   (lax pgf_{a-1x} + 2*zeta*pgf_{a+1x}) pgf_b
+
+  prep_term<T>(a, down(idir, b), b.l[idir] * pab_val, n, cab);
+  prep_term<T>(a, up(idir, b), -2.0 * zetb * pab_val, n, cab);
+  prep_term<T>(down(idir, a), b, a.l[idir] * pab_val, n, cab);
+  prep_term<T>(up(idir, a), b, -2.0 * zeta * pab_val, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_{DX,DY,DZ}.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ void
+prepare_pab_Di(const int ider, const orbital a, const orbital b, const T zeta,
+               const T zetb, const T pab_val, const int n, T *cab) {
+
+  // creates cab such that mapping it with pgf_a pgf_b
+  // is equivalent to mapping pab with
+  //   d_{ider1} pgf_a d_{ider1} pgf_b
+  // dx pgf_a dx pgf_b =
+  //        (lax pgf_{a-1x})*(lbx pgf_{b-1x}) - 2*zetb*lax*pgf_{a-1x}*pgf_{b+1x}
+  //        -
+  //         lbx pgf_{b-1x}*2*zeta*pgf_{a+1x}+ 4*zeta*zetab*pgf_{a+1x}pgf_{b+1x}
+
+  prep_term<T>(down(ider, a), down(ider, b), a.l[ider] * b.l[ider] * pab_val, n,
+               cab);
+  prep_term<T>(down(ider, a), up(ider, b), -2.0 * a.l[ider] * zetb * pab_val, n,
+               cab);
+  prep_term<T>(up(ider, a), down(ider, b), -2.0 * zeta * b.l[ider] * pab_val, n,
+               cab);
+  prep_term<T>(up(ider, a), up(ider, b), +4.0 * zeta * zetb * pab_val, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Helper for grid_prepare_pab_DiDj.
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ void oneterm_dijdij(const int idir, const T func_a,
+                                          const orbital a, const orbital b,
+                                          const T zetb, const int n, T *cab) {
+
+  int i1, i2;
+  if (idir == 0) {
+    i1 = 0;
+    i2 = 1;
+  } else if (idir == 1) {
+    i1 = 1;
+    i2 = 2;
+  } else if (idir == 2) {
+    i1 = 2;
+    i2 = 0;
+  } else {
+    return; // error
+  }
+
+  prep_term<T>(a, down(i1, down(i2, b)), b.l[i1] * b.l[i2] * func_a, n, cab);
+  prep_term<T>(a, up(i1, down(i2, b)), -2.0 * zetb * b.l[i2] * func_a, n, cab);
+  prep_term<T>(a, down(i1, up(i2, b)), -2.0 * zetb * b.l[i1] * func_a, n, cab);
+  prep_term<T>(a, up(i1, up(i2, b)), +4.0 * zetb * zetb * func_a, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_{DXDY,DYDZ,DZDX}
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ void
+prepare_pab_DiDj(const int ider1, const int ider2, const orbital a,
+                 const orbital b, const T zeta, const T zetb, const T pab_val,
+                 const int n, T *cab) {
+
+  // creates cab such that mapping it with pgf_a pgf_b
+  // is equivalent to mapping pab with
+  //   d_{ider1} pgf_a d_{ider1} pgf_b
+
+  const T func_a1 = a.l[ider1] * a.l[ider2] * pab_val;
+  oneterm_dijdij<T>(ider1, func_a1, down(ider1, down(ider2, a)), b, zetb, n,
+                    cab);
+
+  const T func_a2 = -2.0 * zeta * a.l[ider2] * pab_val;
+  oneterm_dijdij<T>(ider1, func_a2, up(ider1, down(ider2, a)), b, zetb, n, cab);
+
+  const T func_a3 = -2.0 * zeta * a.l[ider1] * pab_val;
+  oneterm_dijdij<T>(ider1, func_a3, down(ider1, up(ider2, a)), b, zetb, n, cab);
+
+  const T func_a4 = 4.0 * zeta * zeta * pab_val;
+  oneterm_dijdij<T>(ider1, func_a4, up(ider1, up(ider2, a)), b, zetb, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Helper for grid_prepare_pab_Di2.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ void oneterm_diidii(const int idir, const T func_a, const orbital a,
+                               const orbital b, const T zetb, const int n,
+                               T *cab) {
+
+  prep_term<T>(a, down(idir, down(idir, b)),
+               b.l[idir] * (b.l[idir] - 1) * func_a, n, cab);
+  prep_term<T>(a, b, -2.0 * zetb * (2 * b.l[idir] + 1) * func_a, n, cab);
+  prep_term<T>(a, up(idir, up(idir, b)), +4.0 * zetb * zetb * func_a, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Implementation of function GRID_FUNC_{DXDX,DYDY,DZDZ}
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ void
+prepare_pab_Di2(const int ider, const orbital a, const orbital b, const T zeta,
+                const T zetb, const T pab_val, const int n, T *cab) {
+
+  // creates cab such that mapping it with pgf_a pgf_b
+  // is equivalent to mapping pab with
+  //   dd_{ider1} pgf_a dd_{ider1} pgf_b
+
+  const T func_a1 = a.l[ider] * (a.l[ider] - 1) * pab_val;
+  oneterm_diidii<T>(ider, func_a1, down(ider, down(ider, a)), b, zetb, n, cab);
+
+  const T func_a2 = -2.0 * zeta * (2 * a.l[ider] + 1) * pab_val;
+  oneterm_diidii<T>(ider, func_a2, a, b, zetb, n, cab);
+
+  const T func_a3 = 4.0 * zeta * zeta * pab_val;
+  oneterm_diidii<T>(ider, func_a3, up(ider, up(ider, a)), b, zetb, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Transforms a given element of the density matrix according to func.
+ * \param func          Transformation function to apply, one of GRID_FUNC_*.
+ * \param {a,b}         Orbital angular momenta.
+ * \param zet_{a,b}     Gaussian exponents.
+ * \param pab_val       Input matrix element of pab.
+ * \param n             Leading dimensions of output matrix cab.
+ * \param cab           Output matrix.
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ void
+prepare_pab(const enum grid_func func, const orbital a, const orbital b,
+            const T zeta, const T zetb, const T pab_val, const int n, T *cab) {
+
+  // This switch statment will be in an inner loop but only with few iterations.
+  switch (func) {
+  case GRID_FUNC_AB:
+    prepare_pab_AB<T>(a, b, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DADB:
+    prepare_pab_DADB<T>(a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ADBmDAB_X:
+    prepare_pab_ADBmDAB<T>(0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ADBmDAB_Y:
+    prepare_pab_ADBmDAB<T>(1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ADBmDAB_Z:
+    prepare_pab_ADBmDAB<T>(2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_XX:
+    prepare_pab_ARDBmDARB<T>(0, 0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_XY:
+    prepare_pab_ARDBmDARB<T>(0, 1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_XZ:
+    prepare_pab_ARDBmDARB<T>(0, 2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_YX:
+    prepare_pab_ARDBmDARB<T>(1, 0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_YY:
+    prepare_pab_ARDBmDARB<T>(1, 1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_YZ:
+    prepare_pab_ARDBmDARB<T>(1, 2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_ZX:
+    prepare_pab_ARDBmDARB<T>(2, 0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_ZY:
+    prepare_pab_ARDBmDARB<T>(2, 1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_ARDBmDARB_ZZ:
+    prepare_pab_ARDBmDARB<T>(2, 2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DABpADB_X:
+    prepare_pab_DABpADB<T>(0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DABpADB_Y:
+    prepare_pab_DABpADB<T>(1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DABpADB_Z:
+    prepare_pab_DABpADB<T>(2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DX:
+    prepare_pab_Di<T>(0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DY:
+    prepare_pab_Di<T>(1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DZ:
+    prepare_pab_Di<T>(2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DXDY:
+    prepare_pab_DiDj<T>(0, 1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DYDZ:
+    prepare_pab_DiDj<T>(1, 2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DZDX:
+    prepare_pab_DiDj<T>(2, 0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DXDX:
+    prepare_pab_Di2<T>(0, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DYDY:
+    prepare_pab_Di2<T>(1, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  case GRID_FUNC_DZDZ:
+    prepare_pab_Di2<T>(2, a, b, zeta, zetb, pab_val, n, cab);
+    break;
+  default:
+    break; // Error: Unknown ga_gb_function - do nothing.
+  }
+}
+
+/*******************************************************************************
+ * \brief Returns difference in angular momentum range for given func.
+ * \author Ole Schuett
+ ******************************************************************************/
+ldiffs_value prepare_get_ldiffs(const enum grid_func func) {
+  ldiffs_value ldiffs;
+
+  switch (func) {
+  case GRID_FUNC_AB:
+    ldiffs.la_max_diff = 0;
+    ldiffs.la_min_diff = 0;
+    ldiffs.lb_max_diff = 0;
+    ldiffs.lb_min_diff = 0;
+    break;
+  case GRID_FUNC_DADB:
+  case GRID_FUNC_ADBmDAB_X:
+  case GRID_FUNC_ADBmDAB_Y:
+  case GRID_FUNC_ADBmDAB_Z:
+  case GRID_FUNC_DABpADB_X:
+  case GRID_FUNC_DABpADB_Y:
+  case GRID_FUNC_DABpADB_Z:
+    ldiffs.la_max_diff = +1;
+    ldiffs.la_min_diff = -1;
+    ldiffs.lb_max_diff = +1;
+    ldiffs.lb_min_diff = -1;
+    break;
+  case GRID_FUNC_ARDBmDARB_XX:
+  case GRID_FUNC_ARDBmDARB_XY:
+  case GRID_FUNC_ARDBmDARB_XZ:
+  case GRID_FUNC_ARDBmDARB_YX:
+  case GRID_FUNC_ARDBmDARB_YY:
+  case GRID_FUNC_ARDBmDARB_YZ:
+  case GRID_FUNC_ARDBmDARB_ZX:
+  case GRID_FUNC_ARDBmDARB_ZY:
+  case GRID_FUNC_ARDBmDARB_ZZ:
+    ldiffs.la_max_diff = +1;
+    ldiffs.la_min_diff = -1;
+    ldiffs.lb_max_diff = +2; // this is legit
+    ldiffs.lb_min_diff = -1;
+    break;
+  case GRID_FUNC_DX:
+  case GRID_FUNC_DY:
+  case GRID_FUNC_DZ:
+    ldiffs.la_max_diff = +1;
+    ldiffs.la_min_diff = -1;
+    ldiffs.lb_max_diff = +1;
+    ldiffs.lb_min_diff = -1;
+    break;
+  case GRID_FUNC_DXDY:
+  case GRID_FUNC_DYDZ:
+  case GRID_FUNC_DZDX:
+  case GRID_FUNC_DXDX:
+  case GRID_FUNC_DYDY:
+  case GRID_FUNC_DZDZ:
+    ldiffs.la_max_diff = +2;
+    ldiffs.la_min_diff = -2;
+    ldiffs.lb_max_diff = +2;
+    ldiffs.lb_min_diff = -2;
+    break;
+  default:
+    fprintf(stderr, "Error: Unknown ga_gb_function %i.\n", func);
+    abort();
+  }
+
+  return ldiffs;
+}

--- a/src/grid/hip/grid_hip_process_vab.h
+++ b/src/grid/hip/grid_hip_process_vab.h
@@ -1,0 +1,272 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+
+/*
+ * NOTE : derived from the reference and GPU backends
+ * Authors :
+ - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+ - Advanced Micro Devices, Inc.
+*/
+
+#ifndef GRID_HIP_PROCESS_VAB_H
+#define GRID_HIP_PROCESS_VAB_H
+
+#include "grid_hip_internal_header.h"
+
+/* taken from ../common/grid_process_vab.h but added template parameter */
+namespace rocm_backend {
+/*******************************************************************************
+ * \brief Returns matrix element cab[idx(b)][idx(a)].
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ T get_term(const orbital &a, const orbital &b,
+                                 const int n, const T *cab) {
+  return cab[idx(b) * n + idx(a)];
+}
+
+/*******************************************************************************
+ * \brief Returns i'th component of force on atom a for compute_tau=false.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ T get_force_a_normal(const orbital &a, const orbital &b,
+                                           const int i, const T zeta,
+                                           const int n, const T *cab) {
+  const T aip1 = get_term(up(i, a), b, n, cab);
+  const T aim1 = get_term(down(i, a), b, n, cab);
+  return 2.0 * zeta * aip1 - a.l[i] * aim1;
+}
+
+/*******************************************************************************
+ * \brief Returns i'th component of force on atom a.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <bool compute_tau, typename T>
+__device__ __inline__ double
+get_force_a(const orbital &a, const orbital &b, const int i, const T zeta,
+            const T zetb, const int n, const T *cab) {
+  if (!compute_tau) {
+    return get_force_a_normal(a, b, i, zeta, n, cab);
+  } else {
+    T force = 0.0;
+    for (int k = 0; k < 3; k++) {
+      auto a_up = up(k, a);
+      auto a_down = down(k, a);
+      auto b_up = up(k, b);
+      auto b_down = down(k, b);
+      force += 0.5 * a.l[k] * b.l[k] *
+               get_force_a_normal(a_down, b_down, i, zeta, n, cab);
+      force -=
+          zeta * b.l[k] * get_force_a_normal(a_up, b_down, i, zeta, n, cab);
+      force -=
+          a.l[k] * zetb * get_force_a_normal(a_down, b_up, i, zeta, n, cab);
+      force +=
+          2.0 * zeta * zetb * get_force_a_normal(a_up, b_up, i, zeta, n, cab);
+    }
+    return force;
+  }
+}
+
+/*******************************************************************************
+ * \brief Returns i'th component of force on atom b for compute_tau=false.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ double
+get_force_b_normal(const orbital &a, const orbital &b, const int i,
+                   const T zetb, const T rab[3], const int n, const T *cab) {
+  const T axpm0 = get_term(a, b, n, cab);
+  const T aip1 = get_term(up(i, a), b, n, cab);
+  const T bim1 = get_term(a, down(i, b), n, cab);
+  return 2.0 * zetb * (aip1 - rab[i] * axpm0) - b.l[i] * bim1;
+}
+
+/*******************************************************************************
+ * \brief Returns i'th component of force on atom b.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <bool compute_tau, typename T>
+__device__ __inline__ T get_force_b(const orbital &a, const orbital &b,
+                                    const int i, const T zeta, const T zetb,
+                                    const T rab[3], const int n, const T *cab) {
+  if (!compute_tau) {
+    return get_force_b_normal(a, b, i, zetb, rab, n, cab);
+  } else {
+    T force = 0.0;
+    for (int k = 0; k < 3; k++) {
+      const auto a_up = up(k, a);
+      const auto a_down = down(k, a);
+      const auto b_up = up(k, b);
+      const auto b_down = down(k, b);
+      force += 0.5 * a.l[k] * b.l[k] *
+               get_force_b_normal(a_down, b_down, i, zetb, rab, n, cab);
+      force -= zeta * b.l[k] *
+               get_force_b_normal(a_up, b_down, i, zetb, rab, n, cab);
+      force -= a.l[k] * zetb *
+               get_force_b_normal(a_down, b_up, i, zetb, rab, n, cab);
+      force += 2.0 * zeta * zetb *
+               get_force_b_normal(a_up, b_up, i, zetb, rab, n, cab);
+    }
+    return force;
+  }
+}
+
+/*******************************************************************************
+ * \brief Returns element i,j of virial on atom a for compute_tau=false.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ double
+get_virial_a_normal(const orbital &a, const orbital &b, const int i,
+                    const int j, const T zeta, const int n, const T *cab) {
+  return 2.0 * zeta * get_term(up(i, up(j, a)), b, n, cab) -
+         a.l[j] * get_term(up(i, down(j, a)), b, n, cab);
+}
+
+/*******************************************************************************
+ * \brief Returns element i,j of virial on atom a.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <bool compute_tau, typename T>
+__device__ __inline__ T get_virial_a(const orbital &a, const orbital &b,
+                                     const int i, const int j, const T zeta,
+                                     const T zetb, const int n, const T *cab) {
+
+  if (!compute_tau) {
+    return get_virial_a_normal(a, b, i, j, zeta, n, cab);
+  } else {
+    T virial = 0.0;
+    for (int k = 0; k < 3; k++) {
+      const auto a_up = up(k, a);
+      const auto a_down = down(k, a);
+      const auto b_up = up(k, b);
+      const auto b_down = down(k, b);
+      virial += 0.5 * a.l[k] * b.l[k] *
+                get_virial_a_normal(a_down, b_down, i, j, zeta, n, cab);
+      virial -=
+          zeta * b.l[k] * get_virial_a_normal(a_up, b_down, i, j, zeta, n, cab);
+      virial -=
+          a.l[k] * zetb * get_virial_a_normal(a_down, b_up, i, j, zeta, n, cab);
+      virial += 2.0 * zeta * zetb *
+                get_virial_a_normal(a_up, b_up, i, j, zeta, n, cab);
+    }
+    return virial;
+  }
+}
+
+/*******************************************************************************
+ * \brief Returns element i,j of virial on atom b for compute_tau=false.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <typename T>
+__device__ __inline__ double
+get_virial_b_normal(const orbital &a, const orbital &b, const int i,
+                    const int j, const T zetb, const T rab[3], const int n,
+                    const T *cab) {
+
+  return 2.0 * zetb *
+             (get_term(up(i, up(j, a)), b, n, cab) -
+              get_term(up(i, a), b, n, cab) * rab[j] -
+              get_term(up(j, a), b, n, cab) * rab[i] +
+              get_term(a, b, n, cab) * rab[j] * rab[i]) -
+         b.l[j] * get_term(a, up(i, down(j, b)), n, cab);
+}
+
+/*******************************************************************************
+ * \brief Returns element i,j of virial on atom b.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <bool compute_tau, typename T>
+__device__ __inline__ double
+get_virial_b(const orbital &a, const orbital &b, const int i, const int j,
+             const T zeta, const T zetb, const T rab[3], const int n,
+             const T *cab) {
+
+  if (!compute_tau) {
+    return get_virial_b_normal(a, b, i, j, zetb, rab, n, cab);
+  } else {
+    T virial = 0.0;
+    for (int k = 0; k < 3; k++) {
+      const auto a_up = up(k, a);
+      const auto a_down = down(k, a);
+      const auto b_up = up(k, b);
+      const auto b_down = down(k, b);
+      virial += 0.5 * a.l[k] * b.l[k] *
+                get_virial_b_normal(a_down, b_down, i, j, zetb, rab, n, cab);
+      virial -= zeta * b.l[k] *
+                get_virial_b_normal(a_up, b_down, i, j, zetb, rab, n, cab);
+      virial -= a.l[k] * zetb *
+                get_virial_b_normal(a_down, b_up, i, j, zetb, rab, n, cab);
+      virial += 2.0 * zeta * zetb *
+                get_virial_b_normal(a_up, b_up, i, j, zetb, rab, n, cab);
+    }
+    return virial;
+  }
+}
+
+/*******************************************************************************
+ * \brief Returns element i,j of hab matrix.
+ * \author Ole Schuett
+ ******************************************************************************/
+template <bool compute_tau, typename T>
+__device__ __inline__ T get_hab(const orbital &a, const orbital &b,
+                                const T zeta, const T zetb, const int n,
+                                const T *cab) {
+  if (!compute_tau) {
+    return get_term(a, b, n, cab);
+  } else {
+    T hab = 0.0;
+    for (int k = 0; k < 3; k++) {
+      const auto a_up = up(k, a);
+      const auto a_down = down(k, a);
+      const auto b_up = up(k, b);
+      const auto b_down = down(k, b);
+      hab += 0.5 * a.l[k] * b.l[k] * get_term(a_down, b_down, n, cab);
+      hab -= zeta * b.l[k] * get_term(a_up, b_down, n, cab);
+      hab -= a.l[k] * zetb * get_term(a_down, b_up, n, cab);
+      hab += 2.0 * zeta * zetb * get_term(a_up, b_up, n, cab);
+    }
+    return hab;
+  }
+}
+
+/*******************************************************************************
+ * \brief Returns difference in angular momentum range for given flags.
+ ******************************************************************************/
+inline ldiffs_value process_get_ldiffs(bool calculate_forces,
+                                       bool calculate_virial,
+                                       bool compute_tau) {
+  ldiffs_value ldiffs;
+
+  ldiffs.la_max_diff = 0;
+  ldiffs.lb_max_diff = 0;
+  ldiffs.la_min_diff = 0;
+  ldiffs.lb_min_diff = 0;
+
+  if (calculate_forces || calculate_virial) {
+    ldiffs.la_max_diff += 1; // for deriv. of gaussian, unimportant which one
+    ldiffs.la_min_diff -= 1;
+    ldiffs.lb_min_diff -= 1;
+  }
+
+  if (calculate_virial) {
+    ldiffs.la_max_diff += 1;
+    ldiffs.lb_max_diff += 1;
+  }
+
+  if (compute_tau) {
+    ldiffs.la_max_diff += 1;
+    ldiffs.lb_max_diff += 1;
+    ldiffs.la_min_diff -= 1;
+    ldiffs.lb_min_diff -= 1;
+  }
+
+  return ldiffs;
+}
+}; // namespace rocm_backend
+#endif

--- a/src/grid/hip/grid_hip_task_list.h
+++ b/src/grid/hip/grid_hip_task_list.h
@@ -1,0 +1,67 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2021 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+#ifndef GRID_HIP_TASK_LIST_H
+#define GRID_HIP_TASK_LIST_H
+
+#ifdef __GRID_HIP
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../../offload/offload_buffer.h"
+#include "../common/grid_basis_set.h"
+#include "../common/grid_constants.h"
+
+typedef void grid_gpu_task_list;
+/*******************************************************************************
+ * \brief Allocates a task list for the GPU backend.
+ *        See grid_task_list.h for details.
+ ******************************************************************************/
+void grid_hip_create_task_list(
+    const bool ortho, const int ntasks, const int nlevels, const int natoms,
+    const int nkinds, const int nblocks, const int *block_offsets,
+    const double *atom_positions, const int *atom_kinds,
+    const grid_basis_set **basis_sets, const int *level_list,
+    const int *iatom_list, const int *jatom_list, const int *iset_list,
+    const int *jset_list, const int *ipgf_list, const int *jpgf_list,
+    const int *border_mask_list, const int *block_num_list,
+    const double *radius_list, const double *rab_list, const int *npts_global,
+    const int *npts_local, const int *shift_local, const int *border_width,
+    const double *dh, const double *dh_inv, void *ptr);
+/*******************************************************************************
+ * \brief Deallocates given task list, basis_sets have to be freed separately.
+ ******************************************************************************/
+void grid_hip_free_task_list(void *ptr);
+
+/*******************************************************************************
+ * \brief Collocate all tasks of in given list onto given grids.
+ *        See grid_task_list.h for details.
+ ******************************************************************************/
+void grid_hip_collocate_task_list(const void *ptr, const enum grid_func func,
+                                  const int nlevels,
+                                  const offload_buffer *pab_blocks,
+                                  offload_buffer **grids);
+
+/*******************************************************************************
+ * \brief Integrate all tasks of in given list onto given grids.
+ *        See grid_task_list.h for details.
+ ******************************************************************************/
+void grid_hip_integrate_task_list(const void *ptr, const bool compute_tau,
+                                  const int nlevels,
+                                  const offload_buffer *pab_blocks,
+                                  const offload_buffer **grids,
+                                  offload_buffer *hab_blocks, double *forces,
+                                  double *virial);
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+#endif

--- a/src/offload/offload_library.c
+++ b/src/offload/offload_library.c
@@ -21,6 +21,8 @@ int offload_get_device_count(void) {
   int count = 0;
 #ifdef __OFFLOAD_CUDA
   OFFLOAD_CHECK(cudaGetDeviceCount(&count));
+#elif defined(__OFFLOAD_HIP)
+  OFFLOAD_CHECK(hipGetDeviceCount(&count));
 #endif
   return count;
 }
@@ -44,6 +46,8 @@ int offload_get_device_id(void) { return current_device_id; }
 void offload_set_device(void) {
 #ifdef __OFFLOAD_CUDA
   OFFLOAD_CHECK(cudaSetDevice(current_device_id));
+#elif defined(__OFFLOAD_HIP)
+  OFFLOAD_CHECK(hipSetDevice(current_device_id));
 #endif
 }
 

--- a/src/offload/offload_library.h
+++ b/src/offload/offload_library.h
@@ -11,7 +11,18 @@
 #define __OFFLOAD_CUDA
 #endif
 
+#if defined(__GRID_HIP)
+
+#if defined(__HIP_PLATFORM_NVIDIA__)
+// we can use cuda calls directly instead of relying on hip headers files
+#define __OFFLOAD_CUDA
+#else
+#define __OFFLOAD_HIP
+#endif
+#endif
+
 #ifdef __OFFLOAD_CUDA
+#include <cuda.h>
 #include <cuda_runtime.h>
 
 /*******************************************************************************
@@ -25,6 +36,20 @@
     abort();                                                                   \
   }
 
+#endif
+
+#ifdef __OFFLOAD_HIP
+#include <hip/hip_runtime_api.h>
+
+/*******************************************************************************
+ * \brief Checks given rocm status and upon failure abort with a nice message.
+ ******************************************************************************/
+#define OFFLOAD_CHECK(status)                                                  \
+  if (status != hipSuccess) {                                                  \
+    fprintf(stderr, "ERROR: %s %s %d\n", hipGetErrorString(status), __FILE__,  \
+            __LINE__);                                                         \
+    abort();                                                                   \
+  }
 #endif
 
 #ifdef __cplusplus

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -196,13 +196,16 @@ CONTAINS
       NULLIFY (para_env, f_env, dft_control)
       CALL cp_para_env_create(para_env, group=mpi_comm, owns_group=.FALSE.)
 
+#if defined(__DBCSR_ACC)
       IF (offload_get_device_count() > 0) THEN
          CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit, &
                              accdrv_active_device_id=offload_get_device_id())
       ELSE
          CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
       ENDIF
-
+#else
+      CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
+#endif
       CALL cuda_nvtx_init()
 
       CALL pw_cuda_init()
@@ -282,12 +285,16 @@ CONTAINS
          CALL pw_cuda_finalize()
          CALL pw_fpga_finalize()
          CALL farming_run(input_declaration, root_section, para_env, initial_variables)
+#if defined(__DBCSR_ACC)
          IF (offload_get_device_count() > 0) THEN
             CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit, &
                                 accdrv_active_device_id=offload_get_device_id())
          ELSE
             CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
          ENDIF
+#else
+         CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
+#endif
          CALL pw_cuda_init()
          CALL pw_fpga_init()
          CALL cp_sirius_init()

--- a/tests/Pimd/regtest-1/TEST_FILES
+++ b/tests/Pimd/regtest-1/TEST_FILES
@@ -3,8 +3,8 @@
 # see regtest/TEST_FILES
 h2o_pint_fist_nose.inp                                 9      2e-14        1.0721132870718006E-002
 h2o_pint_fist_nose_restart.inp                         9      2e-14        1.0723685835629522E-002
-h2o_pint_qs_nve.inp                                    9    1.0E-14            -17.137404051037059
-h2o_pint_qs_nose.inp                                   9    1.0E-14            -17.129537082566628
+h2o_pint_qs_nve.inp                                    9      2E-14            -17.137404051037059
+h2o_pint_qs_nose.inp                                   9      2E-14            -17.129537082566628
 h2o_pint_qs_nose_restart.inp                           9      2e-09              -17.1295368929579
 h2o_pint_exact_harm.inp                                9      3e-14        2.8542777100474888E-003
 h2o_pint_rpmd.inp                                      9      2e-14        1.1503487725277912E-002

--- a/tests/QS/regtest-gpw-4/TEST_FILES
+++ b/tests/QS/regtest-gpw-4/TEST_FILES
@@ -34,7 +34,7 @@ spin_restraint.inp                                     1      9e-11            -
 #New grouping colvar
 H2O-meta_g.inp                                         1      2e-14             -17.16168353866058
 #Colvar for hydronium
-H2O-meta_hydro.inp                                     1      2e-13             -77.65379785769734
+H2O-meta_hydro.inp                                     1      1e-12             -77.65379785769734
 #NPT ensemble with QS
 H2O-7.inp                                              1      3e-14             -17.14737299451047
 #test wavelet based poisson solver for different boundary conditions

--- a/tools/precommit/check_file_properties.py
+++ b/tools/precommit/check_file_properties.py
@@ -46,6 +46,7 @@ FLAG_EXCEPTIONS = (
     "__HAS_smm_ztt",
     "__INTEL_COMPILER",
     "__OFFLOAD_CUDA",
+    "__OFFLOAD_HIP",
     "__PILAENV_BLOCKSIZE",
     "__PW_CUDA_NO_HOSTALLOC",
     "__PW_CUDA_NO_HOSTALLOC",

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -101,7 +101,7 @@ OPTIONS:
                           --with-acml, --with-mkl or --with-openblas options will
                           switch --math-mode to the respective modes.
 --gpu-ver                 Selects the GPU architecture for which to compile. Available
-                          options are: K20X, K40, K80, P100, V100, no. Default: no.
+                          options are: K20X, K40, K80, P100, V100, Mi50, Mi100, no. Default: no.
                           The script will determine the correct corresponding value for
                           nvcc's '-arch' flag.
 --libint-lmax             Maximum supported angular momentum by libint.
@@ -441,13 +441,22 @@ while [ $# -ge 1 ]; do
         V100)
           export GPUVER=V100
           ;;
+        A100)
+          export GPUVER=A100
+          ;;
+        Mi50)
+          export GPUVER=Mi50
+          ;;
+        Mi100)
+          export GPUVER=Mi100
+          ;;
         no)
           export GPUVER=no
           ;;
         *)
           export GPUVER=no
           report_error ${LINENO} \
-            "--gpu-ver currently only supports K20X, K40, K80, P100, V100 and no as options"
+            "--gpu-ver currently only supports K20X, K40, K80, P100, V100, A100, Mi50, Mi100 and no as options"
           exit 1
           ;;
       esac
@@ -859,12 +868,19 @@ case $GPUVER in
   V100)
     export ARCH_NUM=70
     ;;
+  A100)
+    export ARCH_NUM=80
+    ;;
+  Mi50) ;;
+
+  Mi100) ;;
+
   no)
     export ARCH_NUM=no
     ;;
   *)
     report_error ${LINENO} \
-      "--gpu-ver currently only supports K20X, K40, K80, P100, V100 as options"
+      "--gpu-ver currently only supports K20X, K40, K80, P100, V100, A100, Mi50, Mi100 as options"
     ;;
 esac
 

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -122,10 +122,11 @@ if [ "${ENABLE_CUDA}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
   check_lib -lcublas "cuda"
 
   # Set include flags
-  CUDA_CFLAGS=''
-  add_include_from_paths CUDA_CFLAGS "cuda.h" $INCLUDE_PATHS
-  export CUDA_CFLAGS="${CUDA_CFLAGS}"
-  CFLAGS+=" ${CUDA_CFLAGS}"
+  CUDA_FLAGS=''
+  add_include_from_paths CUDA_FLAGS "cuda.h" $INCLUDE_PATHS
+  NVFLAGS+=" ${CUDA_FLAGS}"
+  CFLAGS+=" -I${CUDA_PATH}/include"
+  CXXFLAGS+=" -I${CUDA_PATH}/include"
 
   # Set LD-flags
   CUDA_LDFLAGS=''


### PR DESCRIPTION
- Add hip backend for AMD GPU support. The same code can also be used for NVIDIA
- simple template programming used for the hip kernels. The interface is agnostic (use of template functions for cuda/hipMemcpy etc...) and the task list data structure can be reused across backend.
- cross platform compatible since there are no hardware specific (such as inline asm) code.
- algorithm are tailored for minimal use of atomic operations (not possible to avoid them for collocate) at the prize of more memory use. It means in particular that calculating the hab or the coefficients for collocate is split from the main collocate and integrate kernels. It improves occupancy and has no drawbacks in performance.
- does not assume specific device_id. If cp2k provides one then it will take it otherwise defaulting to 0 (since the backend is not mpi aware).
- Minimal changes to the Makefile (it is hacky) -> cmake
- single kernel for orthorhombic and non orthorhombic cases. Orthorhombic case consider the generic case of a orthogonal basis for the grid lattice vectors (the dh is not necessarily diagonal).  
- Performances : H2O-32.inp (benchmarks/QS) in seconds. Results taken from cp2k timings

| V100                            |                  |           |           |             |              |             |
|------------------------------ | -------------- | ------- | -------- | --------- | ---------- | --------- |
| grid_integrate_task_list |           116 | 12.3  |  4.437 |   4.437 |   4.437 |   4.437 |
| grid_collocate_task_list |           116 | 9.6  |  2.614  |  2.614  |  2.614  |  2.614 |

| Mi100                         |                   |           |             |         |            |        |
| ----------------------------- | -------------- | -------- | --------- | ------ | -------- | ------ |
|grid_integrate_task_list     |      116| 12.3 |   4.140  |  4.140  |  4.140 |   4.140|
|grid_collocate_task_list     |      116|  9.6  |  4.459  |  4.459   | 4.459  |  4.459 |
