### PR TITLE
Update Intel arch file

### DIFF
--- a/arch/Linux-x86-64-intel-regtest.psmp
+++ b/arch/Linux-x86-64-intel-regtest.psmp
@@ -1,10 +1,9 @@
-# Tested with: Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 18.0.5.274 Build 20180823
-#              Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.1.217 Build 20200306
+# Tested with: Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.1.217 Build 20200306
 #              Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.3.304 Build 20200925
 #              Intel(R) Fortran Intel(R) 64 Compiler Classic for applications running on Intel(R) 64, Version 2021.1 Build 20201112
 #              Intel MPI, MKL, LIBINT 2.6.0, LIBXC 5.1.4, LIBXSMM 1.16.1, ELPA 2021.05.001, PLUMED 2.6.2, SPGLIB 1.16.0,
-#              LIBVORI 210412, SIRIUS 7.0.2
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, June 2021)
+#              LIBVORI 210412, SIRIUS 7.2.5
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, July 2021)
 
 CC          = mpiicc
 FC          = mpiifort
@@ -28,8 +27,8 @@ LIBXC_LIB   = $(INTEL_PATH)/libxc/5.1.4/lib
 LIBXSMM_INC = $(INTEL_PATH)/libxsmm/1.16.1/include
 LIBXSMM_LIB = $(INTEL_PATH)/libxsmm/1.16.1/lib
 
-SIRIUS_INC  = $(INTEL_PATH)/sirius/7.0.2/include
-SIRIUS_LIB  = $(INTEL_PATH)/sirius/7.0.2/lib
+SIRIUS_INC  = $(INTEL_PATH)/sirius/7.2.5/include
+SIRIUS_LIB  = $(INTEL_PATH)/sirius/7.2.5/lib
 
 SPGLIB_INC  = $(INTEL_PATH)/spglib/1.16.0/include
 SPGLIB_LIB  = $(INTEL_PATH)/spglib/1.16.0/lib
@@ -81,8 +80,8 @@ LIBS       += $(LIBXSMM_LIB)/libxsmmf.a $(LIBXSMM_LIB)/libxsmm.a
 LIBS       += $(SPGLIB_LIB)/libsymspg.a
 # Only needed for SIRIUS
 LIBS       += ${SIRIUS_LIB}/libsirius.a
-LIBS       += $(INTEL_PATH)/SpFFT/0.9.13/lib/libspfft.a
-LIBS       += $(INTEL_PATH)/SpLA/1.2.1/lib/libspla.a
+LIBS       += $(INTEL_PATH)/SpFFT/1.0.4/lib/libspfft.a
+LIBS       += $(INTEL_PATH)/SpLA/1.4.0/lib/libspla.a
 LIBS       += $(INTEL_PATH)/hdf5/1.12.0/lib/libhdf5.a
 #
 LIBS       += $(MKL_LIB)/libmkl_scalapack_lp64.a

--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -5,12 +5,12 @@ host:        PSI, Merlin
 report_url:  http://www.cp2k.org/static/regtest/trunk/Linux-x86-64-gfortran-regtest/psmp/regtest-0
 info_url:    http://www.cp2k.org/static/regtest/trunk/Linux-x86-64-gfortran-regtest/psmp/index.html
 
-[psi-intel-psmp]
-sortkey:     140
-name:        Linux-x86-64-intel-regtest.psmp
-host:        PSI, Merlin
-report_url:  http://www.cp2k.org/static/regtest/trunk/Linux-x86-64-intel-regtest/psmp/regtest-0
-info_url:    http://www.cp2k.org/static/regtest/trunk/Linux-x86-64-intel-regtest/psmp/index.html
+# [psi-intel-psmp]
+# sortkey:     140
+# name:        Linux-x86-64-intel-regtest.psmp
+# host:        PSI, Merlin
+# report_url:  http://www.cp2k.org/static/regtest/trunk/Linux-x86-64-intel-regtest/psmp/regtest-0
+# info_url:    http://www.cp2k.org/static/regtest/trunk/Linux-x86-64-intel-regtest/psmp/index.html
 
 [psi-intel1911-psmp]
 sortkey:     150


### PR DESCRIPTION
- Update Intel arch file
- Retire Intel 18.0.5 regression tester, because of a [compiler bug](https://github.com/eth-cscs/SpFFT/issues/48) appearing for recent SpFFT versions which are needed for the latest SIRIUS release.