### PR TITLE
[toolchain] Add missing dflags when compiling grid_hip on AMD GPU

### DIFF
--- a/arch/Linux-x86-64-gfortran-regtest.psmp
+++ b/arch/Linux-x86-64-gfortran-regtest.psmp
@@ -93,7 +93,7 @@ LIBS       += $(LIBINT_LIB)/libint2.a
 LIBS       += $(SPGLIB_LIB)/libsymspg.a
 # Only needed for SIRIUS
 LIBS       += ${SIRIUS_LIB}/libsirius.a
-LIBS       += $(GNU_PATH)/SpFFT/1.0.3/lib/libspfft.a
+LIBS       += $(GNU_PATH)/SpFFT/1.0.4/lib/libspfft.a
 LIBS       += $(GNU_PATH)/SpLA/1.4.0/lib/libspla.a
 LIBS       += $(GNU_PATH)/hdf5/1.12.0/lib/libhdf5.a
 # Only needed for COSMA

--- a/src/offload/offload_buffer.c
+++ b/src/offload/offload_buffer.c
@@ -42,8 +42,8 @@ void offload_create_buffer(const int length, offload_buffer **buffer) {
   // With size 0 cudaMallocHost doesn't null the pointer and cudaFreeHost fails.
   (*buffer)->host_buffer = NULL;
   offload_set_device();
-  OFFLOAD_CHECK(
-      hipMallocHost((void **)&(*buffer)->host_buffer, requested_size));
+  OFFLOAD_CHECK(hipHostMalloc((void **)&(*buffer)->host_buffer, requested_size,
+                              hipHostMallocDefault));
   OFFLOAD_CHECK(hipMalloc((void **)&(*buffer)->device_buffer, requested_size));
 #else
   (*buffer)->host_buffer = malloc(requested_size);
@@ -65,7 +65,7 @@ void offload_free_buffer(offload_buffer *buffer) {
   OFFLOAD_CHECK(cudaFreeHost(buffer->host_buffer));
   OFFLOAD_CHECK(cudaFree(buffer->device_buffer));
 #elif defined(__OFFLOAD_HIP)
-  OFFLOAD_CHECK(hipFreeHost(buffer->host_buffer));
+  OFFLOAD_CHECK(hipHostFree(buffer->host_buffer));
   OFFLOAD_CHECK(hipFree(buffer->device_buffer));
 #else
   free(buffer->host_buffer);

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -158,6 +158,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_FLAGS+=" -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx906 -O3 -Xarch_host'-fopenmp' --std=c++11 \$(DFLAGS)"
       LIBS+=" IF_HIP(-lhipblas -lamdhip64|)"
       PLATFORM_FLAGS='-D__HIP_PLATFORM_AMD__'
+      DFLAGS+=' IF_HIP(-D__GRID_HIP -D__HIP_PLATFORM_AMD__|)'
       ;;
     Mi100)
       check_lib -lamdhip64 "hip"
@@ -165,6 +166,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_FLAGS+=" -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx908 -O3 -Xarch_host='-fopenmp' --std=c++11 \$(DFLAGS)"
       LIBS+=" IF_HIP(-lhipblas -lamdhip64|)"
       PLATFORM_FLAGS='-D__HIP_PLATFORM_AMD__ '
+      DFLAGS+=' IF_HIP(-D__GRID_HIP -D__HIP_PLATFORM_AMD__|)'
       ;;
     *)
       check_command nvcc "cuda"

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -155,7 +155,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
     Mi50)
       check_lib -lamdhip64 "hip"
       add_lib_from_paths HIP_LDFLAGS "libamdhip64.*" $LIB_PATHS
-      HIP_FLAGS+=" -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx906 -O3 -Xarch_host'-fopenmp' --std=c++11 \$(DFLAGS)"
+      HIP_FLAGS+="-fPIE -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx906 -O3 --std=c++11 \$(DFLAGS)"
       LIBS+=" IF_HIP(-lhipblas -lamdhip64|)"
       PLATFORM_FLAGS='-D__HIP_PLATFORM_AMD__'
       DFLAGS+=' IF_HIP(-D__GRID_HIP -D__HIP_PLATFORM_AMD__|)'
@@ -163,7 +163,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
     Mi100)
       check_lib -lamdhip64 "hip"
       add_lib_from_paths HIP_LDFLAGS "libamdhip64.*" $LIB_PATHS
-      HIP_FLAGS+=" -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx908 -O3 -Xarch_host='-fopenmp' --std=c++11 \$(DFLAGS)"
+      HIP_FLAGS+="-fPIE -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx908 -O3 --std=c++11 \$(DFLAGS)"
       LIBS+=" IF_HIP(-lhipblas -lamdhip64|)"
       PLATFORM_FLAGS='-D__HIP_PLATFORM_AMD__ '
       DFLAGS+=' IF_HIP(-D__GRID_HIP -D__HIP_PLATFORM_AMD__|)'


### PR DESCRIPTION
I forgot to add the -D__GRID_HIP to the mix