### PR TITLE
Fix DBCSR HIP build to use CC and not OFFLOAD_CC

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -179,7 +179,8 @@ the FFTW3 threading library libfftw3_threads (or libfftw3_omp) is required.
 
 - Specify OFFLOAD_CC (e.g. `OFFLOAD_CC = nvcc`) and
   OFFLOAD_FLAGS (e.g. `OFFLOAD_FLAGS = -O3 -g -w --std=c++11`) variables.
-- Use the `-D__DBCSR_ACC` and `USE_ACCEL=cuda` to enable accelerator support for matrix multiplications.
+- Use the `-D__DBCSR_ACC` and `USE_ACCEL=cuda` to enable accelerator support for 
+  matrix multiplications.
 - Add `-lstdc++ -lcudart -lnvrtc -lcuda -lcublas` to LIBS.
 - Specify the GPU type (e.g. `GPUVER   = P100`),
   possible values are K20X, K40, K80, P100, V100.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -179,7 +179,7 @@ the FFTW3 threading library libfftw3_threads (or libfftw3_omp) is required.
 
 - Specify OFFLOAD_CC (e.g. `OFFLOAD_CC = nvcc`) and
   OFFLOAD_FLAGS (e.g. `OFFLOAD_FLAGS = -O3 -g -w --std=c++11`) variables.
-- Use the `-D__DBCSR_ACC` and `USE_ACCEL=cuda` to enable accelerator support for 
+- Use the `-D__DBCSR_ACC` and `USE_ACCEL=cuda` to enable accelerator support for
   matrix multiplications.
 - Add `-lstdc++ -lcudart -lnvrtc -lcuda -lcublas` to LIBS.
 - Specify the GPU type (e.g. `GPUVER   = P100`),
@@ -339,9 +339,9 @@ out of the box on Nvidia hardware as well.
   and set the `OFFLOAD_FLAGS` with right `nvcc` parameters (see the cuda section
   of this document). The environment variable `HIP_PLATFORM` should be set to
   `HIP_PLATFORM=nvidia` to indicate to hipcc to use the nvcc compiler instead.
-- When the HIP backend is enabled for DBCSR using `-D__DBCSR_ACC`, then add 
-  `-D__HIP_PLATFORM_AMD__` to `CXXFLAGS` and `USE_ACCEL=hip` in the CP2K arch file. 
-  DBCSR will then be built with `CC` and `CXXFLAGS` and avoid linking with 
+- When the HIP backend is enabled for DBCSR using `-D__DBCSR_ACC`, then add
+  `-D__HIP_PLATFORM_AMD__` to `CXXFLAGS` and `USE_ACCEL=hip` in the CP2K arch file.
+  DBCSR will then be built with `CC` and `CXXFLAGS` and avoid linking with
   multiple conflicting OpenMP runtimes.
 
 <!---

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -179,7 +179,7 @@ the FFTW3 threading library libfftw3_threads (or libfftw3_omp) is required.
 
 - Specify OFFLOAD_CC (e.g. `OFFLOAD_CC = nvcc`) and
   OFFLOAD_FLAGS (e.g. `OFFLOAD_FLAGS = -O3 -g -w --std=c++11`) variables.
-- Use the `-D__DBCSR_ACC` to enable accelerator support for matrix multiplications.
+- Use the `-D__DBCSR_ACC` and `USE_ACCEL=cuda` to enable accelerator support for matrix multiplications.
 - Add `-lstdc++ -lcudart -lnvrtc -lcuda -lcublas` to LIBS.
 - Specify the GPU type (e.g. `GPUVER   = P100`),
   possible values are K20X, K40, K80, P100, V100.
@@ -331,13 +331,17 @@ out of the box on Nvidia hardware as well.
 - Add  `-lamdhip64` to the `LIBS` variable
 - Add `OFFLOAD_FLAGS ='-fopenmp -m64 -pthread -fPIC -D__GRID_HIP -O2
   --offload-arch=gfx908 --rocm-path=$(ROCM_PATH)`' where 'ROCM_PATH' is the path
-  where the rocm dsk resides. Architectures Mi100 (gfx908), Mi50 (gfx906)
+  where the rocm sdk resides. Architectures Mi100 (gfx908), Mi50 (gfx906)
 - the hip backend for the grid library supports nvidia hardware as well. It uses
   the same code and can be used to validate the backend in case of access to
   Nvidia hardware only. To get the compilation working, follow the steps above
   and set the `OFFLOAD_FLAGS` with right `nvcc` parameters (see the cuda section
   of this document). The environment variable `HIP_PLATFORM` should be set to
   `HIP_PLATFORM=nvidia` to indicate to hipcc to use the nvcc compiler instead.
+- When the HIP backend is enabled for DBCSR using `-D__DBCSR_ACC`, then add 
+  `-D__HIP_PLATFORM_AMD__` to `CXXFLAGS` and `USE_ACCEL=hip` in the CP2K arch file. 
+  DBCSR will then be built with `CC` and `CXXFLAGS` and avoid linking with 
+  multiple conflicting OpenMP runtimes.
 
 <!---
 ### 2u. LibMaxwell (External Maxwell Solver)

--- a/exts/Makefile.inc
+++ b/exts/Makefile.inc
@@ -7,9 +7,12 @@ EXTSDEPS_LIB  = $(LIBEXTSDIR)/dbcsr/libdbcsr$(ARCHIVE_EXT)
 EXTSDEPS_MOD = $(OBJEXTSDIR)/dbcsr/dbcsr_api.mod $(OBJEXTSDIR)/dbcsr/dbcsr_tensor_api.mod
 $(EXTSDEPS_MOD) : ; # override builtin .mod rule to prevent circular dependency
 
-ifneq (,$(findstring __DBCSR_ACC,$(OFFLOAD_FLAGS)))
+ifeq (cuda,$(USE_ACCEL))
 ACC := $(OFFLOAD_CC)
 ACCFLAGS := $(OFFLOAD_FLAGS)
+else ifeq (hip,$(USE_ACCEL))
+ACC := $(CC)
+ACCFLAGS := $(CXXFLAGS)
 else
 ACC := ""
 ACCFLAGS := ""
@@ -25,11 +28,13 @@ dbcsr:
 	   INCLUDEMAKE=$(ARCHDIR)/$(ARCH).$(ONEVERSION) \
 	   LIBDIR=$(LIBEXTSDIR)/$@ \
 	   OBJDIR=$(OBJEXTSDIR)/$@ \
+	   USE_ACCEL="$(USE_ACCEL)" \
 	   ACC="$(ACC)" \
 	   ACCFLAGS="$(ACCFLAGS)"
 
 dbcsrversion:
 	@$(MAKE) -C $(EXTSHOME)/dbcsr -f .cp2k/Makefile \
+	   USE_ACCEL="$(USE_ACCEL)" \
 	   ACC="$(ACC)" \
 	   ACCFLAGS="$(ACCFLAGS)" \
 	   version
@@ -37,6 +42,7 @@ dbcsrversion:
 dbcsrclean:
 	@echo "Clean DBCSR"
 	@$(MAKE) -C $(EXTSHOME)/dbcsr -f .cp2k/Makefile \
+	   USE_ACCEL="$(USE_ACCEL)" \
 	   ACC="$(ACC)" \
 	   ACCFLAGS="$(ACCFLAGS)" \
 	   clean

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -228,6 +228,7 @@ gen_arch_file() {
 GPUVER        = \${GPUVER}
 OFFLOAD_CC    = \${NVCC}
 OFFLOAD_FLAGS = \${NVFLAGS}
+USE_ACCEL     = cuda
 EOF
   fi
 
@@ -237,6 +238,7 @@ EOF
 GPUVER        = \${GPUVER}
 OFFLOAD_CC    = \${ROCM_PATH}/hip/bin/hipcc
 OFFLOAD_FLAGS = \${HIP_FLAGS} \${HIP_INCLUDES}
+USE_ACCEL     = hip
 EOF
   fi
 


### PR DESCRIPTION
When linking with OpenBLAS that is built with g++ with OpenMP support and enabling DBCSR's HIP backend, if hipcc is used to build DBCSR's cpp files, then in the final CP2K executable, we see two OpenMP runtimes linked. One (libgomp.so) that OpenBLAS pulled in, and another (libomp.so) that DBCSR pulled in. To avoid this, it is best to build DBCSR using the same host compiler as CP2K and add a flag to indicate that the HIP_PLATFORM is AMD. This commit and an equivalent commit to DBCSR will rely on the setting of USE_ACCEL to determine which compiler and flags to use for compiling DBCSR's cpp files for AMD devices.

I tested on AMD and NVIDIA devices, but not with the OpenCL backend. Also, I am not sure if other parts of CP2K need to be modified, I only fixed INSTALL.md and the generate_arch_files.sh script. Please test and let me know if more modifications are necessary.