### PR TITLE
Fix output redirection with -o flag (#226)

### DIFF
--- a/src/start/cp2k.F
+++ b/src/start/cp2k.F
@@ -51,6 +51,7 @@ PROGRAM cp2k
    USE cp2k_runs,                       ONLY: run_input,&
                                               write_xml_file
    USE cp2k_shell,                      ONLY: launch_cp2k_shell
+   USE cp_files,                        ONLY: open_file
    USE f77_interface,                   ONLY: check_input,&
                                               default_para_env,&
                                               finalize_cp2k,&
@@ -101,8 +102,8 @@ PROGRAM cp2k
    output_file_name = "__STD_OUT__" ! by default we go to std_out
    ALLOCATE (initial_variables(2, 1:0))
 
-   ! get command and strip path
-   CALL GET_COMMAND_ARGUMENT(0, command, status=ierr)
+   ! Get command and strip path
+   CALL GET_COMMAND_ARGUMENT(NUMBER=0, VALUE=command, STATUS=ierr)
    CPASSERT(ierr == 0)
    l = LEN_TRIM(command)
    DO i = l, 1, -1
@@ -110,7 +111,42 @@ PROGRAM cp2k
    END DO
    command = command(i + 1:l)
 
-   ! check if binary was invoked as cp2k_shell
+   ! Consider output redirection
+   i_arg = 0
+   DO WHILE (i_arg < COMMAND_ARGUMENT_COUNT())
+      i_arg = i_arg + 1
+      CALL GET_COMMAND_ARGUMENT(NUMBER=i_arg, VALUE=arg_att, STATUS=ierr)
+      CPASSERT(ierr == 0)
+      SELECT CASE (arg_att)
+      CASE ("-o")
+         IF (output_file_name == "__STD_OUT__") THEN
+            ! Consider only the first -o flag
+            i_arg = i_arg + 1
+            CALL GET_COMMAND_ARGUMENT(NUMBER=i_arg, VALUE=arg_att, STATUS=ierr)
+            CPASSERT(ierr == 0)
+            IF (arg_att(1:1) == "-") THEN
+               WRITE (output_unit, "(/,T2,A)") &
+                  "ERROR: The output file name "//TRIM(arg_att)//" starts with -"
+               command_line_error = .TRUE.
+            ELSE
+               output_file_name = arg_att
+               CALL open_file(file_name=output_file_name, &
+                              file_status="UNKNOWN", &
+                              file_action="WRITE", &
+                              file_position="APPEND", &
+                              skip_get_unit_number=.TRUE., &
+                              unit_number=output_unit)
+            END IF
+         ELSE
+            i_arg = i_arg + 1
+            WRITE (output_unit, "(/,T2,A)") &
+               "ERROR: The command line flag -o has been specified multiple times"
+            command_line_error = .TRUE.
+         END IF
+      END SELECT
+   END DO
+
+   ! Check if binary was invoked as cp2k_shell
    IF (command(1:10) == "cp2k_shell") THEN
       shell_mode = .TRUE.
       run_it = .FALSE.
@@ -120,11 +156,11 @@ PROGRAM cp2k
       command_line_error = .TRUE.
    END IF
 
-   ! check if binary was invoked as sopt or popt alias
+   ! Check if binary was invoked as sopt or popt alias
    l = LEN_TRIM(command)
    IF (command(l - 4:l) == ".sopt" .OR. command(l - 4:l) == ".popt") THEN
       CALL omp_set_num_threads(1)
-   ENDIF
+   END IF
 
 #ifdef __ACCELERATE
    IF (omp_get_max_threads() > 1) THEN
@@ -183,10 +219,10 @@ PROGRAM cp2k
             has_input = .TRUE.
          ELSE
             WRITE (output_unit, "(/,T2,A)") &
-               "ERROR: The input file name"//TRIM(arg_att)//" starts with -"
+               "ERROR: The input file name "//TRIM(arg_att)//" starts with -"
             command_line_error = .TRUE.
             EXIT arg_loop
-         ENDIF
+         END IF
       CASE ("-E", "--set")
          i_arg = i_arg + 1
          CALL GET_COMMAND_ARGUMENT(i_arg, arg_att, status=ierr)
@@ -198,7 +234,7 @@ PROGRAM cp2k
             WRITE (output_unit, "(/,T2,A)") "ERROR: Invalid initializer for preprocessor variable: "//TRIM(arg_att)
             command_line_error = .TRUE.
             EXIT arg_loop
-         ENDIF
+         END IF
 
          DO inp_var_idx = 1, SIZE(initial_variables, 2)
             ! check whether the variable was already set, in this case, overwrite
@@ -211,27 +247,20 @@ PROGRAM cp2k
             ALLOCATE (initial_variables_tmp(2, SIZE(initial_variables, 2) + 1))
             initial_variables_tmp(:, 1:SIZE(initial_variables, 2)) = initial_variables
             CALL MOVE_ALLOC(initial_variables_tmp, initial_variables)
-         ENDIF
+         END IF
 
          initial_variables(1, inp_var_idx) = arg_att(:var_set_sep - 1)
          initial_variables(2, inp_var_idx) = arg_att(var_set_sep + 1:)
       CASE ("-o")
+         ! Skip -o flag which have been processed already
          i_arg = i_arg + 1
          CALL GET_COMMAND_ARGUMENT(i_arg, arg_att, status=ierr)
          CPASSERT(ierr == 0)
-         ! argument does not start with a - it is an filename
-         IF (.NOT. arg_att(1:1) == "-") THEN
-            output_file_name = arg_att
-         ELSE
-            WRITE (output_unit, "(/,T2,A)") &
-               "ERROR: The output file name"//TRIM(arg_att)//" starts with -"
-            command_line_error = .TRUE.
-            EXIT arg_loop
-         ENDIF
+         IF (arg_att(1:1) == "-") EXIT arg_loop
       CASE ("--xml")
          xml = .TRUE.
          run_it = .FALSE.
-      CASE default
+      CASE DEFAULT
          ! if the last argument does not start with a - it is an input filename
          !MK in order to digest the additional flags of mpirun
          IF ((.NOT. has_input) .AND. &
@@ -239,8 +268,8 @@ PROGRAM cp2k
              (.NOT. arg_att(1:1) == "-")) THEN
             input_file_name = arg_att
             has_input = .TRUE.
-         ELSEIF (has_input .AND. &
-                 (.NOT. arg_att(1:1) == "-")) THEN
+         ELSE IF (has_input .AND. &
+                  (.NOT. arg_att(1:1) == "-")) THEN
             WRITE (output_unit, "(/,T2,A)") &
                "Error: Tried to specify two input files"
             command_line_error = .TRUE.
@@ -248,6 +277,7 @@ PROGRAM cp2k
          END IF
       END SELECT
    END DO arg_loop
+
    IF ((run_it .OR. force_run .OR. check .OR. echo_input) .AND. &
        (.NOT. has_input) .AND. (.NOT. command_line_error)) THEN
       WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
@@ -321,8 +351,8 @@ PROGRAM cp2k
          IF (print_license) THEN
             IF (default_para_env%ionode) THEN
                CALL print_cp2k_license(output_unit)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
 
          IF (xml) THEN
             IF (default_para_env%ionode) THEN
@@ -341,24 +371,24 @@ PROGRAM cp2k
                      WRITE (output_unit, "(A)") "SUCCESS, the input could be parsed correctly."
                      WRITE (output_unit, "(A)") "         This does not guarantee that this input is meaningful"
                      WRITE (output_unit, "(A)") "         or will run successfully"
-                  ENDIF
+                  END IF
                ELSE
                   WRITE (output_unit, "(A)") "ERROR,   the input could *NOT* be parsed correctly."
                   WRITE (output_unit, "(A)") "         Please, check and correct it"
                END IF
             END IF
-         ENDIF
+         END IF
 
          IF (shell_mode) THEN
             CALL launch_cp2k_shell(input_declaration)
-         ENDIF
+         END IF
 
          IF (run_it .OR. force_run) THEN
             CALL run_input(input_declaration, input_file_name, output_file_name, initial_variables)
          END IF
 
          CALL section_release(input_declaration)
-      ENDIF
+      END IF
    ELSE
       WRITE (UNIT=output_unit, FMT="(/,A)") "initial setup (MPI ?) error"
    END IF

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -145,8 +145,11 @@ MODULE cp2k_runs
    IMPLICIT NONE
 
    PRIVATE
+
    PUBLIC :: write_xml_file, run_input
+
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'cp2k_runs'
+
 CONTAINS
 
 ! **************************************************************************************************
@@ -978,24 +981,22 @@ CONTAINS
 
       IF (PRESENT(mpi_comm)) THEN
          NULLIFY (para_env)
-         CALL cp_para_env_create(para_env, group=mpi_comm, owns_group=.FALSE.) !XXXXXXXXXXXX uninitiliased error
+         CALL cp_para_env_create(para_env, group=mpi_comm, owns_group=.FALSE.)
       ELSE
          para_env => f77_default_para_env
-         CALL cp_para_env_retain(para_env) !XXXXXXXXXXXX uninitiliased error
+         CALL cp_para_env_retain(para_env)
       END IF
       IF (para_env%ionode) THEN
          IF (output_file_path == "__STD_OUT__") THEN
             unit_nr = default_output_unit
          ELSE
-            CALL open_file(file_name=output_file_path, file_status="UNKNOWN", &
-                           file_action="WRITE", file_position="APPEND", &
-                           unit_number=unit_nr)
+            INQUIRE (FILE=output_file_path, NUMBER=unit_nr)
          END IF
       ELSE
          unit_nr = -1
       END IF
       CALL cp2k_run(input_declaration, input_file_path, unit_nr, para_env%group, initial_variables)
-      CALL cp_para_env_release(para_env) !XXXXXXXXXXXX uninitiliased error
+      CALL cp_para_env_release(para_env)
    END SUBROUTINE run_input
 
 END MODULE cp2k_runs


### PR DESCRIPTION
Output to stdout/stderr from external libraries (e.g. SIRIUS) still occurs even though an output redirection with the -o flag has been requested (to be fixed)