### PR TITLE
Add -lfftw3_mpi conditionally to the arch files

### DIFF
--- a/tools/toolchain/scripts/stage2/install_mkl.sh
+++ b/tools/toolchain/scripts/stage2/install_mkl.sh
@@ -82,12 +82,12 @@ if [ "$with_mkl" != "__DONTUSE__" ]; then
 
   case $MPI_MODE in
     intelmpi | mpich)
-      mkl_scalapack_lib="-lmkl_scalapack_lp64"
-      mkl_blacs_lib="-lmkl_blacs_intelmpi_lp64"
+      mkl_scalapack_lib="IF_MPI(-lmkl_scalapack_lp64|)"
+      mkl_blacs_lib="IF_MPI(-lmkl_blacs_intelmpi_lp64|)"
       ;;
     openmpi)
-      mkl_scalapack_lib="-lmkl_scalapack_lp64"
-      mkl_blacs_lib="-lmkl_blacs_openmpi_lp64"
+      mkl_scalapack_lib="IF_MPI(-lmkl_scalapack_lp64|)"
+      mkl_blacs_lib="IF_MPI(-lmkl_blacs_openmpi_lp64|)"
       ;;
     *)
       echo "Not using MKL provided ScaLAPACK and BLACS"

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -83,7 +83,7 @@ case "$with_fftw" in
     ;;
 esac
 if [ "$with_fftw" != "__DONTUSE__" ]; then
-  [ "$MPI_MODE" != "no" ] && FFTW_LIBS="-lfftw3_mpi "
+  [ "$MPI_MODE" != "no" ] && FFTW_LIBS="IF_MPI(-lfftw3_mpi|) "
   FFTW_LIBS+="-lfftw3 -lfftw3_omp"
   if [ "$with_fftw" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_fftw"

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -123,7 +123,7 @@ case "$with_elpa" in
           CFLAGS="${CFLAGS} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags}" \
           CXXFLAGS="${CXXFLAGS} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags}" \
           LDFLAGS="-Wl,--enable-new-dtags ${MATH_LDFLAGS} ${SCALAPACK_LDFLAGS} ${cray_ldflags}" \
-          LIBS="${SCALAPACK_LIBS} ${MATH_LIBS}" \
+          LIBS="${SCALAPACK_LIBS} $(resolve_string "${MATH_LIBS}" "MPI")" \
           > configure.log 2>&1
         make -j $(get_nprocs) ${ELPA_MAKEOPTS} > make.log 2>&1
         make install > install.log 2>&1

--- a/tools/toolchain/scripts/stage5/install_pexsi.sh
+++ b/tools/toolchain/scripts/stage5/install_pexsi.sh
@@ -57,7 +57,7 @@ case "$with_pexsi" in
           -e "s|\(PEXSI_DIR *=\).*|\1 ${PWD}|g" \
           -e "s|\(PEXSI_BUILD_DIR *=\).*|\1 ${pkg_install_dir}|g" \
           -e "s|\(CPP_LIB *=\).*|\1 -lstdc++ ${MPI_LDFLAGS} ${MPI_LIBS} |g" \
-          -e "s|\(LAPACK_LIB *=\).*|\1 ${MATH_LDFLAGS} $(resolve_string "${MATH_LIBS}")|g" \
+          -e "s|\(LAPACK_LIB *=\).*|\1 ${MATH_LDFLAGS} $(resolve_string "${MATH_LIBS}" "MPI")|g" \
           -e "s|\(BLAS_LIB *=\).*|\1|g" \
           -e "s|\(\bMETIS_LIB *=\).*|\1 ${METIS_LDFLAGS} ${METIS_LIBS}|g" \
           -e "s|\(PARMETIS_LIB *=\).*|\1 |g" \

--- a/tools/toolchain/scripts/stage6/install_plumed.sh
+++ b/tools/toolchain/scripts/stage6/install_plumed.sh
@@ -52,7 +52,7 @@ case "$with_plumed" in
       # note: some MPI wrappers carry a -g forward, thus stripping is not enough
 
       libs=""
-      [ -n "${MKL_LIBS}" ] && libs+="${MKL_LIBS}"
+      [ -n "${MKL_LIBS}" ] && libs+="$(resolve_string "${MKL_LIBS}" "MPI")"
 
       ./configure \
         CXX="${MPICXX}" \

--- a/tools/toolchain/scripts/stage7/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/stage7/install_libvdwxc.sh
@@ -85,6 +85,7 @@ case "$with_libvdwxc" in
           --libdir="${pkg_install_dir}/lib" \
           --disable-shared \
           --with-mpi \
+          FFTW3_LIBS="$(resolve_string "${FFTW3_LIBS}" "MPI")" \
           >> configure.log 2>&1
       fi
       make -j $(get_nprocs) > compile.log 2>&1


### PR DESCRIPTION
Only link to libfftw3_mpi in the parallel arch files created by the toolchain. Fixes compiling issues with the ssmp and sdbg builds, e.g. here: https://groups.google.com/g/cp2k/c/Z3-D8zw5hJM