### PR TITLE
aobasis: fallback to dgemm if libxsmm kernel unavailable for contraction

### DIFF
--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -20,6 +20,7 @@ MODULE ai_contraction_sphi
                       libxsmm_blasint_kind, &
                       libxsmm_dgemm, &
                       libxsmm_dispatch, &
+                      libxsmm_available, &
                       libxsmm_dmmcall, &
                       libxsmm_dmmfunction
 #endif
@@ -253,12 +254,14 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'libxsmm_abc_contract'
 
       INTEGER                                            :: handle, i
+      LOGICAL                                            :: libxsmm_kernels_available
 #if(__LIBXSMM)
       INTEGER(libxsmm_blasint_kind)                      :: m, n, k
       TYPE(libxsmm_dmmfunction)                          :: xmm1, xmm2
 #endif
 
       CALL timeset(routineN, handle)
+      libxsmm_kernels_available = .FALSE.
 
 #if(__LIBXSMM)
       !We make use of libxsmm code dispatching feature and call the same kernel multiple times
@@ -270,27 +273,31 @@ CONTAINS
       m = nsgfa; n = nsgfb; k = ncob
       CALL libxsmm_dispatch(xmm2, m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
 
-      !contractions over a and b
-      DO i = 1, ncoc
-         CALL libxsmm_dmmcall(xmm1, tsphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
-         CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
-      END DO
+      libxsmm_kernels_available = libxsmm_available(xmm1) .AND. libxsmm_available(xmm2)
 
-#else
-
-      !we follow the same flow as for libxsmm above, but use BLAS dgemm
-
-      !contractions over a and b
-      DO i = 1, ncoc
-         CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, tsphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
-                    ncoa, 0.0_dp, cpp_buffer, nsgfa)
-         CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1.0_dp, cpp_buffer, nsgfa, sphi_b, ncob, 0.0_dp, &
-                    ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
-      END DO
-
+      IF (libxsmm_kernels_available) THEN
+         ! contractions over a and b
+         DO i = 1, ncoc
+            CALL libxsmm_dmmcall(xmm1, tsphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
+            CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
+         END DO
+      ELSE
+         CPWARN("libxsmm available, but kernels are not, fallback to dgemm")
+      END IF
 #endif
 
-      !last contraciton, over c, as a larger MM
+      IF (.NOT. libxsmm_kernels_available) THEN
+         ! we follow the same flow as for libxsmm above, but use BLAS dgemm
+         ! contractions over a and b
+         DO i = 1, ncoc
+            CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, tsphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
+                       ncoa, 0.0_dp, cpp_buffer, nsgfa)
+            CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1.0_dp, cpp_buffer, nsgfa, sphi_b, ncob, 0.0_dp, &
+                       ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
+         END DO
+      END IF
+
+      ! last contraction, over c, as a larger MM
       CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, 1.0_dp, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
                  0.0_dp, abcint, nsgfa*nsgfb)
 

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -9,8 +9,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-libxsmm_ver="1.16.1"
-libxsmm_sha256="93dc7a3ec40401988729ddb2c6ea2294911261f7e6cd979cf061b5c3691d729d"
+libxsmm_ver="1.16.2"
+libxsmm_sha256="bdc7554b56b9e0a380fc9c7b4f4394b41be863344858bc633bc9c25835c4c64e"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh


### PR DESCRIPTION
this fixes segfaults occurring on Intel Westmere-EP
