### PR TITLE
Update library versions

### DIFF
--- a/arch/Linux-x86-64-gfortran-generic.ssmp
+++ b/arch/Linux-x86-64-gfortran-generic.ssmp
@@ -1,6 +1,6 @@
 # Tested with: GFortran 8.3.0, LAPACK 3.9.1, FFTW 3.3.9, LIBINT 2.6.0,
-#              LIBXC 5.1.5, SPGLIB 1.16.0, LIBVORI 210412
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, July 2021)
+#              LIBXC 5.1.6, SPGLIB 1.16.2, LIBVORI 210412
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, September 2021)
 
 CC          = gcc
 FC          = gfortran
@@ -15,11 +15,11 @@ LIBINT_LIB  = $(GNU_PATH)/libint/2.6.0-lmax-4/lib
 
 LIBVORI_LIB = $(GNU_PATH)/libvori/210412/lib
 
-LIBXC_INC   = $(GNU_PATH)/libxc/5.1.5/include
-LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.5/lib
+LIBXC_INC   = $(GNU_PATH)/libxc/5.1.6/include
+LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.6/lib
 
-SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.0/include
-SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.0/lib
+SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.2/include
+SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.2/lib
 
 CFLAGS      = -O2 -fopenmp -fopenmp-simd -g -mtune=generic
 

--- a/arch/Linux-x86-64-gfortran-regtest.psmp
+++ b/arch/Linux-x86-64-gfortran-regtest.psmp
@@ -1,8 +1,8 @@
-# Tested with: GFortran 8.3.0, MPICH 3.3, ScaLAPACK 6819b24, OpenBLAS 0.3.15,
-#              FFTW 3.3.9, LIBINT 2.6.0, LIBXC 5.1.5, ELPA 2021.05.001,
-#              PLUMED 2.7.2, SPGLIB 1.16.0, LIBVORI 210412,
+# Tested with: GFortran 8.3.0, MPICH 3.3, ScaLAPACK 6819b24, OpenBLAS 0.3.17,
+#              FFTW 3.3.9, LIBINT 2.6.0, LIBXC 5.1.6, ELPA 2021.05.002,
+#              PLUMED 2.7.2, SPGLIB 1.16.2, LIBVORI 210412, GSL 2.7,
 #              SIRIUS 7.2.5, COSMA 2.5.1
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, July 2021)
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, September 2021)
 
 CC          = mpicc
 FC          = mpif90
@@ -11,29 +11,35 @@ AR          = ar -r
 
 include       $(MPI_PATH)/plumed2/2.7.2/lib/plumed/src/lib/Plumed.inc.static
 
+BLAS_INC    = $(GNU_PATH)/OpenBLAS/0.3.17/include
+BLAS_LIB    = $(GNU_PATH)/OpenBLAS/0.3.17/lib
+
 COSMA_INC   = $(GNU_PATH)/COSMA/2.5.1/include
 COSMA_LIB   = $(GNU_PATH)/COSMA/2.5.1/lib
 
-ELPA_VER    = 2021.05.001
+ELPA_VER    = 2021.05.002
 ELPA_INC    = $(MPI_PATH)/elpa/$(ELPA_VER)/include/elpa_openmp-$(ELPA_VER)
 ELPA_LIB    = $(MPI_PATH)/elpa/$(ELPA_VER)/lib
 
 FFTW_INC    = $(GNU_PATH)/fftw/3.3.9/include
 FFTW_LIB    = $(GNU_PATH)/fftw/3.3.9/lib
 
+GSL_INC     = $(GNU_PATH)/gsl/2.7/include
+GSL_LIB     = $(GNU_PATH)/gsl/2.7/lib
+
 LIBINT_INC  = $(GNU_PATH)/libint/2.6.0-lmax-4/include
 LIBINT_LIB  = $(GNU_PATH)/libint/2.6.0-lmax-4/lib
 
 LIBVORI_LIB = $(GNU_PATH)/libvori/210412/lib
 
-LIBXC_INC   = $(GNU_PATH)/libxc/5.1.5/include
-LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.5/lib
+LIBXC_INC   = $(GNU_PATH)/libxc/5.1.6/include
+LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.6/lib
 
 SIRIUS_INC  = $(GNU_PATH)/sirius/7.2.5/include
 SIRIUS_LIB  = $(GNU_PATH)/sirius/7.2.5/lib
 
-SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.0/include
-SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.0/lib
+SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.2/include
+SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.2/lib
 
 CFLAGS      = -O2 -fopenmp -fopenmp-simd -g -march=native -mtune=native
 
@@ -75,9 +81,11 @@ FCFLAGS    += -ffree-line-length-none
 FCFLAGS    += -fimplicit-none
 FCFLAGS    += -fno-omit-frame-pointer
 FCFLAGS    += -std=f2008
+FCFLAGS    += -I$(BLAS_INC)
 FCFLAGS    += -I$(COSMA_INC)
 FCFLAGS    += -I$(ELPA_INC)/elpa -I$(ELPA_INC)/modules
 FCFLAGS    += -I$(FFTW_INC)
+FCFLAGS    += -I$(GSL_INC)
 FCFLAGS    += -I$(LIBINT_INC)
 FCFLAGS    += -I$(LIBXC_INC)
 FCFLAGS    += -I$(SIRIUS_INC)
@@ -95,7 +103,7 @@ LIBS       += $(SPGLIB_LIB)/libsymspg.a
 # Only needed for SIRIUS
 LIBS       += ${SIRIUS_LIB}/libsirius.a
 LIBS       += $(GNU_PATH)/SpFFT/1.0.4/lib/libspfft.a
-LIBS       += $(GNU_PATH)/SpLA/1.4.0/lib/libspla.a
+LIBS       += $(GNU_PATH)/SpLA/1.5.1/lib/libspla.a
 LIBS       += $(GNU_PATH)/hdf5/1.12.0/lib/libhdf5.a
 # Only needed for COSMA
 LIBS       += $(COSMA_LIB)/libcosma_prefixed_pxgemm.a
@@ -106,8 +114,8 @@ LIBS       += $(COSMA_LIB)/libcosta.a
 LIBS       += $(FFTW_LIB)/libfftw3_omp.a
 LIBS       += $(FFTW_LIB)/libfftw3.a
 LIBS       += $(MPI_LIBRARY_PATH)/libscalapack.a
-LIBS       += $(GNU_PATH)/OpenBLAS/0.3.15/lib/libopenblas.a
-LIBS       += $(GSL_LIBRARY_DIR)/libgsl.a $(GSL_LIBRARY_DIR)/libgslcblas.a
+LIBS       += $(BLAS_LIB)/libopenblas.a
+LIBS       += $(GSL_LIB)/libgsl.a $(GSL_LIB)/libgslcblas.a
 LIBS       += $(LIBPATH)/libz.a
 LIBS       += -ldl
 LIBS       += -lstdc++

--- a/arch/Linux-x86-64-gfortran-shared.psmp
+++ b/arch/Linux-x86-64-gfortran-shared.psmp
@@ -1,13 +1,13 @@
-# Tested with: GFortran 8.3.0, MPICH 3.3, ScaLAPACK 6819b24, OpenBLAS 0.3.15,
-#              FFTW 3.3.9, LIBINT 2.6.0, LIBXC 5.1.5, LIBXSMM 1.16.1, ELPA 2021.05.001
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, July 2021)
+# Tested with: GFortran 8.3.0, MPICH 3.3, ScaLAPACK 6819b24, OpenBLAS 0.3.17,
+#              FFTW 3.3.9, LIBINT 2.6.0, LIBXC 5.1.6, LIBXSMM 1.16.2, ELPA 2021.05.002
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, September 2021)
 
 CC          = mpicc
 FC          = mpif90
 LD          = mpif90
 AR          = ar -r
 
-ELPA_VER    = 2021.05.001
+ELPA_VER    = 2021.05.002
 ELPA_INC    = $(MPI_PATH)/elpa/$(ELPA_VER)/include/elpa_openmp-$(ELPA_VER)
 ELPA_LIB    = $(MPI_PATH)/elpa/$(ELPA_VER)/lib
 
@@ -17,11 +17,11 @@ FFTW_LIB    = $(GNU_PATH)/fftw/3.3.9/lib
 LIBINT_INC  = $(GNU_PATH)/libint/2.6.0-lmax-6/include
 LIBINT_LIB  = $(GNU_PATH)/libint/2.6.0-lmax-6/lib
 
-LIBXC_INC   = $(GNU_PATH)/libxc/5.1.5/include
-LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.5/lib
+LIBXC_INC   = $(GNU_PATH)/libxc/5.1.6/include
+LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.6/lib
 
-LIBXSMM_INC = $(GNU_PATH)/libxsmm/1.16.1/include
-LIBXSMM_LIB = $(GNU_PATH)/libxsmm/1.16.1/lib
+LIBXSMM_INC = $(GNU_PATH)/libxsmm/1.16.2/include
+LIBXSMM_LIB = $(GNU_PATH)/libxsmm/1.16.2/lib
 
 CFLAGS      = -O2 -fPIC -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -march=native -mtune=native
 
@@ -55,4 +55,4 @@ LIBS       += -L$(LIBINT_LIB) -lint2
 LIBS       += -L$(LIBXSMM_LIB) -lxsmmf -lxsmm
 LIBS       += -L$(FFTW_LIB) -lfftw3_omp -lfftw3
 LIBS       += -L$(MPI_LIBRARY_PATH) -lscalapack
-LIBS       += -L$(GNU_PATH)/OpenBLAS/0.3.15/lib -lopenblas
+LIBS       += -L$(GNU_PATH)/OpenBLAS/0.3.17/lib -lopenblas

--- a/arch/Linux-x86-64-gfortran.psmp
+++ b/arch/Linux-x86-64-gfortran.psmp
@@ -1,8 +1,8 @@
-# Tested with: GFortran 8.3.0, MPICH 3.3, ScaLAPACK 6819b24, OpenBLAS 0.3.15,
-#              FFTW 3.3.9, LIBINT 2.6.0, LIBXC 5.1.5, ELPA 2021.05.001,
-#              PLUMED 2.7.2, SPGLIB 1.16.0, LIBVORI 210412, LIBXSMM 1.16.1,
-#              SIRIUS 7.2.5, COSMA 2.5.1
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, July 2021)
+# Tested with: GFortran 8.3.0, MPICH 3.3, ScaLAPACK 6819b24, OpenBLAS 0.3.17,
+#              FFTW 3.3.9, LIBINT 2.6.0, LIBXC 5.1.6, ELPA 2021.05.002,
+#              PLUMED 2.7.2, SPGLIB 1.16.2, LIBVORI 210412, GSL 2.7,
+#              LIBXSMM 1.16.2, SIRIUS 7.2.5, COSMA 2.5.1
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, September 2021)
 
 CC          = mpicc
 FC          = mpif90
@@ -11,32 +11,38 @@ AR          = ar -r
 
 include       $(MPI_PATH)/plumed2/2.7.2/lib/plumed/src/lib/Plumed.inc.static
 
+BLAS_INC    = $(GNU_PATH)/OpenBLAS/0.3.17/include
+BLAS_LIB    = $(GNU_PATH)/OpenBLAS/0.3.17/lib
+
 COSMA_INC   = $(GNU_PATH)/COSMA/2.5.1/include
 COSMA_LIB   = $(GNU_PATH)/COSMA/2.5.1/lib
 
-ELPA_VER    = 2021.05.001
+ELPA_VER    = 2021.05.002
 ELPA_INC    = $(MPI_PATH)/elpa/$(ELPA_VER)/include/elpa_openmp-$(ELPA_VER)
 ELPA_LIB    = $(MPI_PATH)/elpa/$(ELPA_VER)/lib
 
 FFTW_INC    = $(GNU_PATH)/fftw/3.3.9/include
 FFTW_LIB    = $(GNU_PATH)/fftw/3.3.9/lib
 
+GSL_INC     = $(GNU_PATH)/gsl/2.7/include
+GSL_LIB     = $(GNU_PATH)/gsl/2.7/lib
+
 LIBINT_INC  = $(GNU_PATH)/libint/2.6.0-lmax-6/include
 LIBINT_LIB  = $(GNU_PATH)/libint/2.6.0-lmax-6/lib
 
 LIBVORI_LIB = $(GNU_PATH)/libvori/210412/lib
 
-LIBXC_INC   = $(GNU_PATH)/libxc/5.1.5/include
-LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.5/lib
+LIBXC_INC   = $(GNU_PATH)/libxc/5.1.6/include
+LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.6/lib
 
-LIBXSMM_INC = $(GNU_PATH)/libxsmm/1.16.1/include
-LIBXSMM_LIB = $(GNU_PATH)/libxsmm/1.16.1/lib
+LIBXSMM_INC = $(GNU_PATH)/libxsmm/1.16.2/include
+LIBXSMM_LIB = $(GNU_PATH)/libxsmm/1.16.2/lib
 
 SIRIUS_INC  = $(GNU_PATH)/sirius/7.2.5/include
 SIRIUS_LIB  = $(GNU_PATH)/sirius/7.2.5/lib
 
-SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.0/include
-SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.0/lib
+SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.2/include
+SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.2/lib
 
 CFLAGS      = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -march=native -mtune=native
 
@@ -62,9 +68,11 @@ FCFLAGS    += -ffree-form
 FCFLAGS    += -ffree-line-length-none
 FCFLAGS    += -fno-omit-frame-pointer
 FCFLAGS    += -std=f2008
+FCFLAGS    += -I$(BLAS_INC)
 FCFLAGS    += -I$(COSMA_INC)
 FCFLAGS    += -I$(ELPA_INC)/elpa -I$(ELPA_INC)/modules
 FCFLAGS    += -I$(FFTW_INC)
+FCFLAGS    += -I$(GSL_INC)
 FCFLAGS    += -I$(LIBINT_INC)
 FCFLAGS    += -I$(LIBXC_INC)
 FCFLAGS    += -I$(LIBXSMM_INC)
@@ -85,7 +93,7 @@ LIBS       += $(LIBXSMM_LIB)/libxsmm.a
 # Only needed for SIRIUS
 LIBS       += ${SIRIUS_LIB}/libsirius.a
 LIBS       += $(GNU_PATH)/SpFFT/1.0.4/lib/libspfft.a
-LIBS       += $(GNU_PATH)/SpLA/1.4.0/lib/libspla.a
+LIBS       += $(GNU_PATH)/SpLA/1.5.1/lib/libspla.a
 LIBS       += $(GNU_PATH)/hdf5/1.12.0/lib/libhdf5.a
 # Only needed for COSMA
 LIBS       += $(COSMA_LIB)/libcosma_prefixed_pxgemm.a
@@ -96,9 +104,8 @@ LIBS       += $(COSMA_LIB)/libcosta.a
 LIBS       += $(FFTW_LIB)/libfftw3_omp.a
 LIBS       += $(FFTW_LIB)/libfftw3.a
 LIBS       += $(MPI_LIBRARY_PATH)/libscalapack.a
-LIBS       += $(GNU_PATH)/OpenBLAS/0.3.15/lib/libopenblas.a
-LIBS       += $(GSL_LIBRARY_DIR)/libgsl.a $(GSL_LIBRARY_DIR)/libgslcblas.a
+LIBS       += $(BLAS_LIB)/libopenblas.a
+LIBS       += $(GSL_LIB)/libgsl.a $(GSL_LIB)/libgslcblas.a
 LIBS       += $(LIBPATH)/libz.a
 LIBS       += -ldl
-LIBS       += -lpthread
 LIBS       += -lstdc++

--- a/arch/Linux-x86-64-gfortran.ssmp
+++ b/arch/Linux-x86-64-gfortran.ssmp
@@ -1,6 +1,6 @@
 # Tested with: GFortran 8.3.0, LAPACK 3.9.1, FFTW 3.3.9, LIBINT 2.6.0,
-#              LIBXC 5.1.5, SPGLIB 1.16.0, LIBVORI 210412, LIBXSMM 1.16.1
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, July 2021)
+#              LIBXC 5.1.6, SPGLIB 1.16.2, LIBVORI 210412, LIBXSMM 1.16.2
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, September 2021)
 
 CC          = gcc
 FC          = gfortran
@@ -15,14 +15,14 @@ LIBINT_LIB  = $(GNU_PATH)/libint/2.6.0-lmax-6/lib
 
 LIBVORI_LIB = $(GNU_PATH)/libvori/210412/lib
 
-LIBXC_INC   = $(GNU_PATH)/libxc/5.1.5/include
-LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.5/lib
+LIBXC_INC   = $(GNU_PATH)/libxc/5.1.6/include
+LIBXC_LIB   = $(GNU_PATH)/libxc/5.1.6/lib
 
-LIBXSMM_INC = $(GNU_PATH)/libxsmm/1.16.1/include
-LIBXSMM_LIB = $(GNU_PATH)/libxsmm/1.16.1/lib
+LIBXSMM_INC = $(GNU_PATH)/libxsmm/1.16.2/include
+LIBXSMM_LIB = $(GNU_PATH)/libxsmm/1.16.2/lib
 
-SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.0/include
-SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.0/lib
+SPGLIB_INC  = $(GNU_PATH)/spglib/1.16.2/include
+SPGLIB_LIB  = $(GNU_PATH)/spglib/1.16.2/lib
 
 CFLAGS      = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -march=native -mtune=native
 

--- a/arch/Linux-x86-64-intel-minimal.psmp
+++ b/arch/Linux-x86-64-intel-minimal.psmp
@@ -3,14 +3,13 @@
 #              Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.3.304 Build 20200925
 #              Intel(R) Fortran Intel(R) 64 Compiler Classic for applications running on Intel(R) 64, Version 2021.1 Build 20201112
 #              Intel MPI, MKL
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, March 2021)
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, September 2021)
 
 CC        = mpiicc
 FC        = mpiifort
 LD        = mpiifort
 AR        = ar -r
 
-# Only one test input (CH4-rsLDA.inp) gives wrong results with inlining enabled
 CFLAGS    = -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost
 
 DFLAGS    = -D__FFTW3

--- a/arch/Linux-x86-64-intel-regtest.psmp
+++ b/arch/Linux-x86-64-intel-regtest.psmp
@@ -17,8 +17,8 @@ ELPA_VER    = 2021.05.002
 ELPA_INC    = $(MPI_PATH)/elpa/$(ELPA_VER)/include/elpa_openmp-$(ELPA_VER)
 ELPA_LIB    = $(MPI_PATH)/elpa/$(ELPA_VER)/lib
 
-GSL_INC     = $(GNU_PATH)/gsl/2.7/include
-GSL_LIB     = $(GNU_PATH)/gsl/2.7/lib
+GSL_INC     = $(INTEL_PATH)/gsl/2.7/include
+GSL_LIB     = $(INTEL_PATH)/gsl/2.7/lib
 
 LIBINT_INC  = $(INTEL_PATH)/libint/2.6.0-lmax-4/include
 LIBINT_LIB  = $(INTEL_PATH)/libint/2.6.0-lmax-4/lib

--- a/arch/Linux-x86-64-intel-regtest.psmp
+++ b/arch/Linux-x86-64-intel-regtest.psmp
@@ -2,9 +2,9 @@
 #              Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.1.3.304 Build 20200925
 #              Intel(R) Fortran Intel(R) 64 Compiler Classic for applications running on Intel(R) 64, Version 2021.1 Build 20201112
 #              Intel(R) Fortran Intel(R) 64 Compiler Classic for applications running on Intel(R) 64, Version 2021.3.0 Build 20210609_000000
-#              Intel MPI, MKL, LIBINT 2.6.0, LIBXC 5.1.5, LIBXSMM 1.16.1, ELPA 2021.05.001, PLUMED 2.7.2, SPGLIB 1.16.0,
-#              LIBVORI 210412, SIRIUS 7.2.5
-# Author: Matthias Krack (matthias.krack@psi.ch, PSI, July 2021)
+#              Intel MPI, MKL, LIBINT 2.6.0, LIBXC 5.1.6, LIBXSMM 1.16.2, ELPA 2021.05.002, PLUMED 2.7.2, GSL 2.7,
+#              SPGLIB 1.16.2, LIBVORI 210412, SIRIUS 7.2.5
+# Author: Matthias Krack (matthias.krack@psi.ch, PSI, September 2021)
 
 CC          = mpiicc
 FC          = mpiifort
@@ -13,26 +13,29 @@ AR          = ar -r
 
 include      $(MPI_PATH)/plumed2/2.7.2/lib/plumed/src/lib/Plumed.inc.static
 
-ELPA_VER    = 2021.05.001
+ELPA_VER    = 2021.05.002
 ELPA_INC    = $(MPI_PATH)/elpa/$(ELPA_VER)/include/elpa_openmp-$(ELPA_VER)
 ELPA_LIB    = $(MPI_PATH)/elpa/$(ELPA_VER)/lib
+
+GSL_INC     = $(GNU_PATH)/gsl/2.7/include
+GSL_LIB     = $(GNU_PATH)/gsl/2.7/lib
 
 LIBINT_INC  = $(INTEL_PATH)/libint/2.6.0-lmax-4/include
 LIBINT_LIB  = $(INTEL_PATH)/libint/2.6.0-lmax-4/lib
 
 LIBVORI_LIB = $(INTEL_PATH)/libvori/210412/lib
 
-LIBXC_INC   = $(INTEL_PATH)/libxc/5.1.5/include
-LIBXC_LIB   = $(INTEL_PATH)/libxc/5.1.5/lib
+LIBXC_INC   = $(INTEL_PATH)/libxc/5.1.6/include
+LIBXC_LIB   = $(INTEL_PATH)/libxc/5.1.6/lib
 
-LIBXSMM_INC = $(INTEL_PATH)/libxsmm/1.16.1/include
-LIBXSMM_LIB = $(INTEL_PATH)/libxsmm/1.16.1/lib
+LIBXSMM_INC = $(INTEL_PATH)/libxsmm/1.16.2/include
+LIBXSMM_LIB = $(INTEL_PATH)/libxsmm/1.16.2/lib
 
 SIRIUS_INC  = $(INTEL_PATH)/sirius/7.2.5/include
 SIRIUS_LIB  = $(INTEL_PATH)/sirius/7.2.5/lib
 
-SPGLIB_INC  = $(INTEL_PATH)/spglib/1.16.0/include
-SPGLIB_LIB  = $(INTEL_PATH)/spglib/1.16.0/lib
+SPGLIB_INC  = $(INTEL_PATH)/spglib/1.16.2/include
+SPGLIB_LIB  = $(INTEL_PATH)/spglib/1.16.2/lib
 
 CFLAGS      = -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost
 
@@ -60,6 +63,7 @@ FCFLAGS    += -fpp
 FCFLAGS    += -free
 FCFLAGS    += -I$(MKLROOT)/include -I$(MKLROOT)/include/fftw
 FCFLAGS    += -I$(ELPA_INC)/elpa -I$(ELPA_INC)/modules
+FCFLAGS    += -I$(GSL_INC)
 FCFLAGS    += -I$(LIBINT_INC)
 FCFLAGS    += -I$(LIBXC_INC)
 FCFLAGS    += -I$(LIBXSMM_INC)
@@ -81,7 +85,7 @@ LIBS       += $(SPGLIB_LIB)/libsymspg.a
 # Only needed for SIRIUS
 LIBS       += ${SIRIUS_LIB}/libsirius.a
 LIBS       += $(INTEL_PATH)/SpFFT/1.0.4/lib/libspfft.a
-LIBS       += $(INTEL_PATH)/SpLA/1.4.0/lib/libspla.a
+LIBS       += $(INTEL_PATH)/SpLA/1.5.1/lib/libspla.a
 LIBS       += $(INTEL_PATH)/hdf5/1.12.0/lib/libhdf5.a
 #
 LIBS       += $(MKL_LIB)/libmkl_scalapack_lp64.a
@@ -91,7 +95,7 @@ LIBS       += $(MKL_LIB)/libmkl_sequential.a
 LIBS       += $(MKL_LIB)/libmkl_core.a
 LIBS       += $(MKL_LIB)/libmkl_blacs_intelmpi_lp64.a
 LIBS       += -Wl,--end-group
-LIBS       += $(GSL_LIBRARY_DIR)/libgsl.a $(GSL_LIBRARY_DIR)/libgslcblas.a
+LIBS       += $(GSL_LIB)/libgsl.a $(GSL_LIB)/libgslcblas.a
 LIBS       += $(LIBPATH)/libz.a
 LIBS       += $(GCC_LIBRARY_DIR)/libstdc++.a
 


### PR DESCRIPTION
- GSL 2.5 -> 2.7
- libxc 5.1.4 -> 5.1.6
- libxsmm 1.16.1 -> 1.16.2
- libelpa 2021.05.001 -> 2021.05.002
- OpenBLAS 0.3.15 -> 0.3.17
- SPGLIB 1.16.0 -> 1.16.2
- SpLA 1.4.0 -> 1.5.1