### PR TITLE
Specify that versioned tarballs should be used instead of source code.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## 1. Acquire the code
 
-For users, the preferred method is to [download a release](https://github.com/cp2k/cp2k/releases/).
+For users, the preferred method is to [download a release](https://github.com/cp2k/cp2k/releases/) (use the versioned tarballs, `cp2k-X.Y.tar.bz2`).
 For developers, the preferred method is to [download from Git](./README.md#downloading-cp2k-source-code).
 
 For more details on downloading CP2K, see <https://www.cp2k.org/download>.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,8 +2,9 @@
 
 ## 1. Acquire the code
 
-For users, the preferred method is to [download a release](https://github.com/cp2k/cp2k/releases/) (use the versioned tarballs, `cp2k-X.Y.tar.bz2`).
-For developers, the preferred method is to [download from Git](./README.md#downloading-cp2k-source-code).
+For users, the preferred method is to [download a release](https://github.com/cp2k/cp2k/releases/)
+(use the versioned tarballs, `cp2k-X.Y.tar.bz2`). For developers, the preferred
+method is to [download from Git](./README.md#downloading-cp2k-source-code).
 
 For more details on downloading CP2K, see <https://www.cp2k.org/download>.
 


### PR DESCRIPTION
This is mentioned in the [download page](https://www.cp2k.org/download) but not in `INSTALL.md`. Might be better to mention here also? This is the second time I faced #1302.