### PR TITLE
ocl: support OpenCL devices in DBCSR

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,8 +162,9 @@ the FFTW3 threading library libfftw3_threads (or libfftw3_omp) is required.
 
 - A library for small matrix multiplies can be built from the included source
   (see exts/dbcsr/tools/build_libsmm/README).  Usually only the double precision
-  real and perhaps complex types are needed.  Link to the generated libraries. For a
-  couple of architectures, prebuilt LIBSMMs are available at <https://www.cp2k.org/static/downloads/libsmm/>.
+  real and perhaps complex types are needed.  Link to the generated libraries.
+  For a couple of architectures, prebuilt LIBSMMs are available at
+  <https://www.cp2k.org/static/downloads/libsmm/>.
 - Add `-D__HAS_smm_dnn` to the defines to enable using the double precision
   real library.  Similarly use `-D__HAS_smm_snn` for single precision real and
   `-D__HAS_smm_znn` / `-D__HAS_smm_cnn` for double / single precision complex.
@@ -328,8 +329,8 @@ SIRIUS is a domain specific library for electronic structure calculations.
 
 ### 2u. ROCM/HIP (Support for AMD GPU)
 
-The code for the HIP based grid backend was developed and tested on Mi100 but should work
-out of the box on Nvidia hardware as well.
+The code for the HIP based grid backend was developed and tested on Mi100 but
+should work out of the box on Nvidia hardware as well.
 
 - USE `-D__GRID_HIP` to enable AMD GPU support for collocate and integrate
   rountines.
@@ -374,12 +375,13 @@ CP2K's grid backend does not yet support OpenCL devices.
   `exts/dbcsr/src/acc/opencl/smm/params/tune_multiply_A100.csv` exists). If `GPUVER`
   is not specified (or the related file does not exist), `exts/dbcsr/src/acc/opencl/smm/tune_multiply.csv`
   is used. If no parameter file exists, default parameters are used to populate kernels.
-  The content of a successfully specified parameter file is embedded into the binary,
-  i.e., the final application does not depend on a certain path. The environment variable
-  `OPENCL_LIBSMM_SMM_PARAMS=/path/to/file` can be used to supply parameters at runtime
-  of the application, or `OPENCL_LIBSMM_SMM_PARAMS=0` disables using tuned parameters.
-- The environment variable `ACC_OPENCL_VERBOSE=2` can be helpful to print information
-  about kernels generated at runtime and thereby check the installation.
+  The content of a successfully specified parameter file is embedded into the
+  binary, i.e., the final application does not depend on a certain path. The
+  environment variable `OPENCL_LIBSMM_SMM_PARAMS=/path/to/file` can be used
+  to supply parameters at runtime of the application,
+  or `OPENCL_LIBSMM_SMM_PARAMS=0` disables using tuned parameters.
+- The environment variable `ACC_OPENCL_VERBOSE=2` prints information about
+  kernels generated at runtime and thereby check the installation.
 - Refer to <https://cp2k.github.io/dbcsr/> for more information, e.g.,
   environment variables or how to tune kernels (auto tuned parameters).
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -139,16 +139,16 @@ the FFTW3 threading library libfftw3_threads (or libfftw3_omp) is required.
 ### 2g. LIBINT (optional, enables methods including HF exchange)
 
 - Hartree-Fock exchange (optional, use `-D__LIBINT`)
-  requires the libint package to be installed.
-- Recommended way to build libint: Download a CP2K-configured libint library
+  requires the LIBINT package to be installed.
+- Recommended way to build LIBINT: Download a CP2K-configured LIBINT library
   from [libint-cp2k](https://github.com/cp2k/libint-cp2k). Build and install
-  libint by following the instructions provided there. Note that using a library
+  LIBINT by following the instructions provided there. Note that using a library
   configured for higher maximum angular momentum will increase build time and
   binary size of CP2K executable (assuming static linking).
-- CP2K is not hardwired to these provided libraries and any other libint
+- CP2K is not hardwired to these provided libraries and any other LIBINT
   library (version >= 2.5.0) should be compatible as long as it was compiled
   with `--enable-eri=1` and default ordering.
-- Avoid debugging information (`-g` flag) for compiling libint since this will
+- Avoid debugging information (`-g` flag) for compiling LIBINT since this will
   increase library size by a large factor.
 - In the arch file of CP2K: add `-D__LIBINT` to the `DFLAGS`.
   Add `-L$(LIBINT_DIR)/lib -lint2 -lstdc++` to `LIBS` and `-I$(LIBINT_DIR)/include`
@@ -158,33 +158,35 @@ the FFTW3 threading library libfftw3_threads (or libfftw3_omp) is required.
 - `-D__MAX_CONTR=4` (default=2) can be used to compile efficient contraction
   kernels up to l=4, but the build time will increase accordingly.
 
-### 2h. libsmm (optional, improved performance for matrix multiplication)
+### 2h. LIBSMM (optional, improved performance for matrix multiplication)
 
 - A library for small matrix multiplies can be built from the included source
   (see exts/dbcsr/tools/build_libsmm/README).  Usually only the double precision
-  real and perhaps complex is needed.  Link to the generated libraries. For a
-  couple of architectures prebuilt libsmm are available at <https://www.cp2k.org/static/downloads/libsmm/>.
-- Add `-D__HAS_smm_dnn` to the defines to make the code use the double precision
+  real and perhaps complex types are needed.  Link to the generated libraries. For a
+  couple of architectures, prebuilt LIBSMMs are available at <https://www.cp2k.org/static/downloads/libsmm/>.
+- Add `-D__HAS_smm_dnn` to the defines to enable using the double precision
   real library.  Similarly use `-D__HAS_smm_snn` for single precision real and
   `-D__HAS_smm_znn` / `-D__HAS_smm_cnn` for double / single precision complex.
-- Add `-D__HAS_smm_vec` to enable the new vectorized interfaces of libsmm.
+- Add `-D__HAS_smm_vec` to enable the new vectorized interfaces of LIBSMM.
+- If LIBXSMM is available, LIBSMM is not necessary or used (see LIBXSMM section).
 
-### 2i. libxsmm (optional, improved performance for matrix multiplication)
+### 2i. LIBXSMM (optional, improved performance for matrix multiplication)
 
 - A library for matrix operations and deep learning primitives: <https://github.com/hfp/libxsmm/>.
 - Add `-D__LIBXSMM` to enable it, with suitable include and library paths,
   e.g. `FCFLAGS += -I${LIBXSMM_DIR}/include -D__LIBXSMM`
   and `LIBS += -L${LIBXSMM_DIR}/lib -lxsmmf -lxsmm -ldl`
+- LIBSMM is not used if LIBXSMM is enabled.
 
 ### 2j. CUDA (optional, improved performance on GPU systems)
 
 - Specify OFFLOAD_CC (e.g. `OFFLOAD_CC = nvcc`) and
   OFFLOAD_FLAGS (e.g. `OFFLOAD_FLAGS = -O3 -g -w --std=c++11`) variables.
   Remember to include the support for the C++11 standard.
-- Use the `-D__DBCSR_ACC` and `OFFLOAD_TARGET=cuda` to enable
+- Use the `-D__DBCSR_ACC` and `OFFLOAD_TARGET = cuda` to enable
   accelerator support for matrix multiplications.
 - Add `-lstdc++ -lcudart -lnvrtc -lcuda -lcublas` to LIBS.
-- Specify the GPU type (e.g. `GPUVER   = P100`),
+- Specify the GPU type (e.g. `GPUVER = P100`),
   possible values are K20X, K40, K80, P100, V100.
 - Specify the C++ compiler (e.g. `CXX = g++`) and the CXXFLAGS to support
   the C++11 standard.
@@ -197,11 +199,11 @@ the FFTW3 threading library libfftw3_threads (or libfftw3_omp) is required.
 - Link to a blas/scalapack library that accelerates large DGEMMs (e.g. libsci_acc)
 - Use the `-D__GRID_CUDA` to compile the GPU and HYBRID backends for the grid library.
 
-### 2k. libxc (optional, wider choice of xc functionals)
+### 2k. LIBXC (optional, wider choice of xc functionals)
 
-- The version 5.1.0 (or later) of libxc can be downloaded from <https://www.tddft.org/programs/libxc>
-- CP2K does not make use of fourth derivates such that libxc may be configured
-  with './configure --disable-lxc \<other libxc configuration flags\>'.
+- The version 5.1.0 (or later) of LIBXC can be downloaded from <https://www.tddft.org/programs/libxc>
+- CP2K does not make use of fourth derivates such that LIBXC may be configured
+  with './configure --disable-lxc \<other LIBXC configuration flags\>'.
 - During the installation, the directories `$(LIBXC_DIR)/lib`
   and `$(LIBXC_DIR)/include` are created.
 - Add `-D__LIBXC` to DFLAGS, `-I$(LIBXC_DIR)/include` to FCFLAGS
@@ -311,7 +313,7 @@ SIRIUS is a domain specific library for electronic structure calculations.
 - COSMA is an alternative for the pdgemm routine included in ScaLAPACK.
   The library supports both CPU and GPUs.
 - Add `-D__COSMA` to the DFLAGS to enable support for COSMA.
-- see <https://github.com/eth-cscs/COSMA> for more information.
+- See <https://github.com/eth-cscs/COSMA> for more information.
 
 ### 2t. LibVori (Voronoi Integration for Electrostatic Properties from Electron Density)
 
@@ -319,14 +321,14 @@ SIRIUS is a domain specific library for electronic structure calculations.
   (charge, dipole vector, quadrupole tensor, etc.) via integration of the total
   electron density in the Voronoi cell of each atom.
 - Add `-D__LIBVORI` to the DFLAGS to enable support for LibVori.
-- see <https://brehm-research.de/libvori> for more information.
+- See <https://brehm-research.de/libvori> for more information.
 - LibVori also enables support for the BQB file format for compressed trajectories,
   please see <https://brehm-research.de/bqb> for more information as well as
   the `bqbtool` to inspect BQB files.
 
 ### 2u. ROCM/HIP (Support for AMD GPU)
 
-The code for the grid backend was developed and tested on Mi100 but should work
+The code for the HIP based grid backend was developed and tested on Mi100 but should work
 out of the box on Nvidia hardware as well.
 
 - USE `-D__GRID_HIP` to enable AMD GPU support for collocate and integrate
@@ -334,7 +336,7 @@ out of the box on Nvidia hardware as well.
 - Add `GPUVER=Mi50, Mi60, Mi100`
 - Add `OFFLOAD_CC = hipcc`
 - Add  `-lamdhip64` to the `LIBS` variable
-- Add `OFFLOAD_FLAGS ='-fopenmp -m64 -pthread -fPIC -D__GRID_HIP -O2
+- Add `OFFLOAD_FLAGS = '-fopenmp -m64 -pthread -fPIC -D__GRID_HIP -O2
   --offload-arch=gfx908 --rocm-path=$(ROCM_PATH)'` where `ROCM_PATH` is the path
   where the rocm sdk resides. Architectures Mi100 (gfx908), Mi50 (gfx906)
 - the hip backend for the grid library supports nvidia hardware as well. It uses
@@ -346,17 +348,48 @@ out of the box on Nvidia hardware as well.
 - Specify the C++ compiler (e.g. `CXX = g++`). Remember to set the
   CXXFLAGS flags to support C++11 standard and OpenMP.
 - When the HIP backend is enabled for DBCSR using `-D__DBCSR_ACC`, then add
-  `-D__HIP_PLATFORM_AMD__` to `CXXFLAGS` and `OFFLOAD_TARGET=hip`.
+  `-D__HIP_PLATFORM_AMD__` to `CXXFLAGS` and set `OFFLOAD_TARGET = hip`.
 - Use `-D__OFFLOAD_PROFILING` to turn on the AMD ROC TX and Tracer libray.
   It requires to link `-lroctx64 -lroctracer64`.
 
+### 2v. OpenCL Devices
+
+OpenCL devices are currently supported by DBCSR and can cover GPUs and other devices.
+Kernels can be automatically tuned similar to the CUDA/HIP backend in DBCSR.
+CP2K's grid backend does not yet support OpenCL devices.
+
+- To install an OpenCL runtime depends on operating system and the device vendor.
+  However, packages like `opencl-headers` and `ocl-icd-opencl-dev` can be typically
+  installed in addition (the ICD portion "jumps" into a vendor's OpenCL runtime).
+  For example, a CUDA installation is fully equipped with an OpenCL runtime as well
+  (if no `opencl-headers` are installed, CPATH can be needed to point into the CUDA
+  installation similarly to `LIBRARY_PATH` to find `libOpenCL.so` at link-time).
+- There is no special offload compiler needed hence regular `CC` and `CFLAGS` are
+  suffient to build the OpenCL backend as well as the OpenCL based LIBSMM library.
+- To enable the OpenCL backend for DBCSR set `OFFLOAD_TARGET = opencl` and add
+  `-D__DBCSR_ACC` and `-D__OPENCL` to `CFLAGS`, i.e., `OFFLOAD_CC` and
+  `OFFLOAD_FLAGS` are set accordingly (can be used to deviate if desired).
+  Add  `-lOpenCL` to the `LIBS` variable.
+- Add `GPUVER = \<id of parameter file\>`, e.g., `GPUVER = A100` (if
+  `exts/dbcsr/src/acc/opencl/smm/params/tune_multiply_A100.csv` exists). If `GPUVER`
+  is not specified (or the related file does not exist), `exts/dbcsr/src/acc/opencl/smm/tune_multiply.csv`
+  is used. If no parameter file exists, default parameters are used to populate kernels.
+  The content of a successfully specified parameter file is embedded into the binary,
+  i.e., the final application does not depend on a certain path. The environment variable
+  `OPENCL_LIBSMM_SMM_PARAMS=/path/to/file` can be used to supply parameters at runtime
+  of the application, or `OPENCL_LIBSMM_SMM_PARAMS=0` disables using tuned parameters.
+- The environment variable `ACC_OPENCL_VERBOSE=2` can be helpful to print information
+  about kernels generated at runtime and thereby check the installation.
+- Refer to <https://cp2k.github.io/dbcsr/> for more information, e.g.,
+  environment variables or how to tune kernels (auto tuned parameters).
+
 <!---
-### 2u. LibMaxwell (External Maxwell Solver)
+### 2w. LibMaxwell (External Maxwell Solver)
 
 - LibMaxwell is a library to solve the time-dependent Maxwell equations
   and use the resulting electric field in MD runs or real-time propagation.
 - Add `-D__LIBMAXWELL` to DFLAGS to enable support for LibMaxwell.
-- see <https://brehm-research.de> for more information.
+- See <https://brehm-research.de> for more information.
 -->
 
 ## 3. Compile
@@ -434,8 +467,8 @@ The following flags should be present (or not) in the arch file,
 partially depending on installed libraries (see 2.)
 
 - `-D__parallel -D__SCALAPACK` parallel runs
-- `-D__LIBINT` use libint (needed for HF exchange)
-- `-D__LIBXC` use libxc
+- `-D__LIBINT` use LIBINT (needed for HF exchange)
+- `-D__LIBXC` use LIBXC
 - `-D__ELPA` use ELPA in place of SYEVD  to solve the eigenvalue problem
 - `-D__FFTW3` FFTW version 3 is recommended
 - `-D__PW_CUDA` CUDA FFT and associated gather/scatter on the GPU

--- a/arch/Linux-x86-64-gfortran-opencl.psmp
+++ b/arch/Linux-x86-64-gfortran-opencl.psmp
@@ -1,0 +1,90 @@
+# Tested with: GFortran 9.4.0, Intel MPI, Intel MKL,
+#              LIBINT 2.6.0, LIBXC 5.1.6, ELPA 2021.05.002,
+#              PLUMED 2.7.2, LIBXSMM
+
+CC          = mpicc
+FC          = mpif90
+LD          = mpif90
+AR          = gcc-ar -r
+
+GPUVER      = P100
+OFFLOAD_TARGET = opencl
+
+GNU_PATH   ?= $(HOME)
+MPI_PATH   ?= $(GNU_PATH)
+
+include       $(MPI_PATH)/plumed2/gnu/lib/plumed/src/lib/Plumed.inc.static
+
+BLAS_INC    = $(MKLROOT)/include
+BLAS_LIB    = -Wl,--start-group \
+                $(MKLROOT)/lib/intel64/libmkl_scalapack_lp64.a \
+                $(MKLROOT)/lib/intel64/libmkl_gf_lp64.a \
+                $(MKLROOT)/lib/intel64/libmkl_core.a \
+                $(MKLROOT)/lib/intel64/libmkl_gnu_thread.a \
+                $(MKLROOT)/lib/intel64/libmkl_blacs_intelmpi_lp64.a \
+              -Wl,--end-group
+
+# ELPA 2021.05.002
+ELPA_INC    = $(MPI_PATH)/elpa/gnu/include/elpa
+ELPA_LIB    = $(MPI_PATH)/elpa/gnu/lib
+
+LIBINT_INC  = $(GNU_PATH)/libint/gnu/include
+LIBINT_LIB  = $(GNU_PATH)/libint/gnu/lib
+
+LIBXC_INC   = $(GNU_PATH)/libxc/gnu/include
+LIBXC_LIB   = $(GNU_PATH)/libxc/gnu/lib
+
+LIBXSMM_INC = $(GNU_PATH)/libxsmm/include
+LIBXSMM_LIB = $(GNU_PATH)/libxsmm/lib
+
+CFLAGS      = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -march=native -mtune=native
+
+DFLAGS     += -D__DBCSR_ACC
+DFLAGS     += -D__ELPA
+DFLAGS     += -D__MKL -D__FFTW3
+DFLAGS     += -D__LIBINT -D__MAX_CONTR=4
+DFLAGS     += -D__LIBXC
+DFLAGS     += -D__LIBXSMM
+DFLAGS     += -D__MPI_VERSION=3
+DFLAGS     += -D__PLUMED2
+DFLAGS     += -D__parallel
+DFLAGS     += -D__SCALAPACK
+#DFLAGS     += -D__CHECK_DIAG
+
+FCFLAGS     = $(CFLAGS) $(DFLAGS)
+FCFLAGS    += -fbacktrace
+FCFLAGS    += -ffree-form
+FCFLAGS    += -ffree-line-length-none
+FCFLAGS    += -fno-omit-frame-pointer
+FCFLAGS    += -std=f2008
+FCFLAGS    += -I$(BLAS_INC) -I$(BLAS_INC)/fftw
+FCFLAGS    += -I$(ELPA_INC)/elpa -I$(ELPA_INC)/modules
+FCFLAGS    += -I$(LIBINT_INC)
+FCFLAGS    += -I$(LIBXC_INC)
+FCFLAGS    += -I$(LIBXSMM_INC)
+
+LDFLAGS     = $(CFLAGS) -static-libgfortran
+
+LIBS        = $(PLUMED_DEPENDENCIES) -lz
+LIBS       += $(ELPA_LIB)/libelpa.a
+LIBS       += $(LIBXC_LIB)/libxcf03.a
+LIBS       += $(LIBXC_LIB)/libxc.a
+LIBS       += $(LIBINT_LIB)/libint2.a
+LIBS       += $(LIBXSMM_LIB)/libxsmmf.a
+LIBS       += $(LIBXSMM_LIB)/libxsmm.a
+LIBS       += $(BLAS_LIB)
+LIBS       += -ldl -lstdc++
+
+# collect header and/or library from non-default location
+ifeq (,$(CUDATOOLKIT_HOME))
+  CUDATOOLKIT_HOME := $(NVSDKCOMPUTE_ROOT)
+endif
+ifeq (,$(CUDATOOLKIT_HOME))
+  NVCC := $(call which,nvcc)
+  CUDATOOLKIT_HOME := $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
+endif
+ifneq (,$(CUDATOOLKIT_HOME))
+  LDFLAGS += -L$(CUDATOOLKIT_HOME)/lib64
+  LDFLAGS += -Wl,-rpath=$(CUDATOOLKIT_HOME)/lib64
+endif
+LIBS += -lOpenCL

--- a/exts/Makefile.inc
+++ b/exts/Makefile.inc
@@ -7,11 +7,8 @@ EXTSDEPS_LIB  = $(LIBEXTSDIR)/dbcsr/libdbcsr$(ARCHIVE_EXT)
 EXTSDEPS_MOD = $(OBJEXTSDIR)/dbcsr/dbcsr_api.mod $(OBJEXTSDIR)/dbcsr/dbcsr_tensor_api.mod
 $(EXTSDEPS_MOD) : ; # override builtin .mod rule to prevent circular dependency
 
-# Set Acceleration flags
-DBCSR_USE_ACCEL := ""
-DBCSR_ACC       := ""
-DBCSR_ACCFLAGS  := ""
-ifneq (,$(findstring __DBCSR_ACC,$(OFFLOAD_FLAGS)))
+# Set Acceleration flags if glue code is supposed to be accelerated
+ifneq (,$(findstring __DBCSR_ACC,$(OFFLOAD_FLAGS) $(FCFLAGS)))
 # By default, we use CUDA if OFFLOAD_TARGET is not specified
 ifeq (,$(OFFLOAD_TARGET))
 DBCSR_USE_ACCEL=cuda
@@ -24,6 +21,9 @@ DBCSR_ACCFLAGS := $(OFFLOAD_FLAGS)
 else ifeq (hip,$(DBCSR_USE_ACCEL))
 DBCSR_ACC := $(CXX)
 DBCSR_ACCFLAGS := $(CXXFLAGS)
+else ifeq (opencl,$(DBCSR_USE_ACCEL))
+DBCSR_ACC := $(if $(OFFLOAD_CC),$(OFFLOAD_CC),$(CC))
+DBCSR_ACCFLAGS := $(if $(OFFLOAD_FLAGS),$(OFFLOAD_FLAGS),$(CFLAGS) $(DFLAGS))
 else
 $(error "Invalid OFFLOAD_TARGET=$(OFFLOAD_TARGET)")
 endif

--- a/exts/build_dbcsr/Makefile
+++ b/exts/build_dbcsr/Makefile
@@ -14,21 +14,22 @@
 # FC  => Fortran compiler, e.g. gfortran or mpifort
 # LD  => Linker, e.g. gfortran or mpifort
 # AR  => Archive command, e.g. ar -r
-# CXXFLAGS => C++ compilation flags
-# CFLAGS   => C compilation flags
-# FCFLAGS  => Fortran compilation flags
-# LDFLAGS  => Linker flags
-# LIBS     => Libraries
-# ACC      => ACC can be nvcc (CUDA), mpicxx/mpicc or gcc/g++ (HIP), or mpicc/gcc (OpenCL)
-# ACCFLAGS => ACC flags
+# CXXFLAGS  => C++ compilation flags
+# CFLAGS    => C compilation flags
+# FCFLAGS   => Fortran compilation flags
+# LDFLAGS   => Linker flags
+# LIBS      => Libraries
+# ACC       => ACC can be nvcc (CUDA), mpicxx/mpicc or gcc/g++ (HIP), or mpicc/gcc (OpenCL)
+# ACCFLAGS  => ACC flags
 # USE_ACCEL => hip, cuda, or opencl
-# GPUVER   =>
+# GPUVER    =>
 #          - for CUDA, possible values correspond to NVIDIA GPUs:
 #            possible values are K20X, K40, K80, P100, V100
 #          - for HIP, possible values correspond to NVIDIA and AMD GPUs:
 #            possible values are K20X, K40, K80, P100, V100, Mi50, Mi100
-#          - for OpenCL, GPUVER is currently not used
-#            (TODO: represent set of tuned parameters)
+#          - for OpenCL, GPUVER maps to a file with tuned parameters:
+#            src/acc/opencl/smm/params/tune_multiply_GPUVER.csv, or
+#            src/acc/opencl/smm/tune_multiply.csv (default)
 #
 # Libraries for accelerator:
 #    - e.g. for CUDA:   LIBS += -lstdc++ -lcudart -lnvrtc -lcuda -lcublas
@@ -61,7 +62,7 @@ default_target: $(LIBRARY)
 # Read the version ==========================================================
 include $(DBCSRHOME)/VERSION
 ifeq ($(DATE),)
-DATE = "Development Version"
+  DATE = "Development Version"
 endif
 
 # Read the configuration ====================================================
@@ -69,64 +70,68 @@ ifeq (,$(ARCHFILE))
 $(error ARCH file must be provided: ARCHFILE=<CP2K ARCH file>)
 endif
 ifeq (, $(wildcard $(ARCHFILE)))
-$(error ARCH file `$(ARCHFILE)` not found)
+  $(error ARCH file `$(ARCHFILE)` not found)
 endif
 include $(ARCHFILE)
 
 # Set the compute version and ACCFLAGS =======================================
 ifneq ($(ACC),)
+
 # Set ARCH version
 ifeq ($(GPUVER),K20X)
- ARCH_NUMBER = 35
+  ARCH_NUMBER = 35
 else ifeq ($(GPUVER),K40)
- ARCH_NUMBER = 35
+  ARCH_NUMBER = 35
 else ifeq ($(GPUVER),K80)
- ARCH_NUMBER = 37
+  ARCH_NUMBER = 37
 else ifeq ($(GPUVER),P100)
- ARCH_NUMBER = 60
+  ARCH_NUMBER = 60
 else ifeq ($(GPUVER),V100)
- ARCH_NUMBER = 70
+  ARCH_NUMBER = 70
 else ifeq ($(GPUVER),Mi50)
- ARCH_NUMBER = gfx906
+  ARCH_NUMBER = gfx906
 else ifeq ($(GPUVER),Mi100)
- ARCH_NUMBER = gfx908
+  ARCH_NUMBER = gfx908
 else ifneq ($(GPUVER),)
- $(error GPUVER not recognized)
+  $(error GPUVER not recognized)
 endif
 
 # If compiling with nvcc
 ifeq (cuda,$(USE_ACCEL))
-override ACCFLAGS += -D__CUDA
-FCFLAGS += -D__CUDA
-CXXFLAGS += -D__CUDA
-#if "-arch" has not yet been set in ACCFLAGS
-ifeq (,$(findstring -arch,$(ACCFLAGS)))
-override ACCFLAGS += -arch sm_$(ARCH_NUMBER)
-endif
-ifeq (,$(findstring -Xcompiler,$(ACCFLAGS)))
-override ACCFLAGS += -Xcompiler="$(CXXFLAGS)"
-endif
+  override ACCFLAGS += -D__CUDA
+  FCFLAGS += -D__CUDA
+  CXXFLAGS += -D__CUDA
+  #if "-arch" has not yet been set in ACCFLAGS
+  ifeq (,$(findstring -arch,$(ACCFLAGS)))
+    override ACCFLAGS += -arch sm_$(ARCH_NUMBER)
+  endif
+  ifeq (,$(findstring -Xcompiler,$(ACCFLAGS)))
+    override ACCFLAGS += -Xcompiler="$(CXXFLAGS)"
+  endif
 # If compiling with hipcc
 else ifeq (hip,$(USE_ACCEL))
-override ACCFLAGS += -D__HIP
-FCFLAGS += -D__HIP
+  override ACCFLAGS += -D__HIP
+  FCFLAGS += -D__HIP
 # OpenCL backend
 else ifeq (opencl,$(USE_ACCEL))
-CFLAGS += -D__OPENCL
-LIBXSMMROOT := $(if $(LIBXSMMROOT),$(LIBXSMMROOT),$(wildcard ../../../libxsmm))
-LIBXSMMROOT := $(if $(LIBXSMMROOT),$(LIBXSMMROOT),$(wildcard $(HOME)/libxsmm))
-ifneq (,$(LIBXSMMROOT))
-CFLAGS += -I$(LIBXSMMROOT)/include
+  CFLAGS = $(ACCFLAGS) -D__OPENCL
+  # LIBXSMM is eventually included privately/quietly (header-only)
+  LIBXSMMROOT := $(if $(LIBXSMMROOT),$(LIBXSMMROOT),$(wildcard $(LIBXSMM_INC)/..))
+  LIBXSMMROOT := $(if $(LIBXSMMROOT),$(LIBXSMMROOT),$(wildcard ../../../libxsmm))
+  LIBXSMMROOT := $(if $(LIBXSMMROOT),$(LIBXSMMROOT),$(wildcard $(HOME)/libxsmm))
+  ifneq (,$(LIBXSMMROOT))
+    CFLAGS += -I$(LIBXSMMROOT)/include
+  endif
 endif
-endif
-endif
+
+endif # ACC
 
 # Set the configuration ============================================
 #
 ifneq ($(LD_SHARED),)
- ARCHIVE_EXT := .so
+  ARCHIVE_EXT := .so
 else
- ARCHIVE_EXT := .a
+  ARCHIVE_EXT := .a
 endif
 
 # Declare PHONY targets =====================================================
@@ -170,20 +175,17 @@ ALL_SRC_FILES += $(shell find $(SRCDIR) -name "*.hpp")
 ifeq ($(INCLUDE_DEPS),)
 $(LIBRARY): dirs makedep
 	@+$(MAKE) --no-print-directory -C $(OBJDIR) -f $(MAKEFILE) $(LIBDIR)/$(LIBRARY)$(ARCHIVE_EXT) INCLUDE_DEPS=true DBCSRHOME=$(DBCSRHOME)
-
 dirs:
 	@mkdir -p $(OBJDIR)
 	@mkdir -p $(LIBDIR)
-
 version:
 	@echo "DBCSR Version: "$(MAJOR)"."$(MINOR)"."$(PATCH)" ("$(DATE)")"
-
 else
 # stage 2: Include $(OBJDIR)/all.dep, expand target all, and get list of dependencies.
 
 # Check if FYPP is available  ===============================================
 ifeq (, $(shell which $(FYPPEXE) 2>/dev/null ))
-$(error No FYPP submodule available, please read README.md on how to properly download DBCSR)
+  $(error No FYPP submodule available, please read README.md on how to properly download DBCSR)
 endif
 
 endif
@@ -221,7 +223,7 @@ endif
 
 # at stage 2, load the rules generated by makedep.py
 ifeq ($(INCLUDE_DEPS), true)
-include $(OBJDIR)/all.dep
+  include $(OBJDIR)/all.dep
 endif
 
 
@@ -284,9 +286,27 @@ acc_hip.o: acc_hip.cpp acc_hip.h
 else ifeq (opencl,$(USE_ACCEL))
 OPENCL_KERNELS := $(wildcard $(LIBSMM_ACC_ABS_DIR)/../opencl/smm/kernels/*.cl)
 OPENCL_KRNLGEN := $(LIBSMM_ACC_ABS_DIR)/../opencl/acc_opencl.sh
-$(LIBSMM_ACC_ABS_DIR)/../opencl/smm/opencl_kernels.h: $(OPENCL_KRNLGEN) $(OPENCL_KERNELS)
-	$(OPENCL_KRNLGEN) $(OPENCL_KERNELS) $(LIBSMM_ACC_ABS_DIR)/../opencl/smm/tune_multiply.csv $@
+OPENCL_DEFAULT := $(LIBSMM_ACC_ABS_DIR)/../opencl/smm/tune_multiply.csv
+OPENCL_WITHGPU := $(LIBSMM_ACC_ABS_DIR)/../opencl/smm/params/tune_multiply_$(GPUVER).csv
+OPENCL_PARAMS := $(if $(wildcard $(OPENCL_WITHGPU)),$(OPENCL_WITHGPU),$(wildcard $(OPENCL_DEFAULT)))
+$(LIBSMM_ACC_ABS_DIR)/../opencl/smm/opencl_kernels.h: $(OPENCL_KRNLGEN) $(OPENCL_KERNELS) $(OPENCL_PARAMS)
+	$(OPENCL_KRNLGEN) $(OPENCL_KERNELS) $(OPENCL_PARAMS) $@
 opencl_libsmm.o: opencl_libsmm.c $(LIBSMM_ACC_ABS_DIR)/../opencl/smm/opencl_kernels.h
+ifeq (Darwin,$(shell uname))
+  LDFLAGS += -framework OpenCL
+else
+  # OpenCL include directory (cl.h not installed per "opencl-headers" package)
+  ifeq (,$(CUDATOOLKIT_HOME))
+    CUDATOOLKIT_HOME := $(NVSDKCOMPUTE_ROOT)
+  endif
+  ifeq (,$(CUDATOOLKIT_HOME))
+    NVCC := $(call which,nvcc)
+    CUDATOOLKIT_HOME := $(if $(NVCC),$(abspath $(dir $(NVCC))/..))
+  endif
+  ifneq (,$(CUDATOOLKIT_HOME))
+    CFLAGS += -I$(CUDATOOLKIT_HOME)/include
+  endif
+endif
 endif
 
 $(LIBDIR)/%:


### PR DESCRIPTION
* Slightly revised CP2K's installation manual and added section about OpenCL Devices.
* Support OFFLOAD_TARGET=opencl and added ARCH-file for GNU Fortran and OpenCL.
* Map GPUVER to a file with tuned parameters (to be embedded into the build).