### PR TITLE
Fixes for the Intel compiler related to #1664

### DIFF
--- a/src/ec_orth_solver.F
+++ b/src/ec_orth_solver.F
@@ -75,11 +75,11 @@ MODULE ec_orth_solver
 
    PRIVATE
 
-! *** Global parameters ***
+   ! Global parameters
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'ec_orth_solver'
 
-! *** Public subroutines ***
+   ! Public subroutines
 
    PUBLIC :: ec_response_ao
 
@@ -111,7 +111,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: matrix_ks, matrix_p, matrix_rhs
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(OUT), &
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
          POINTER                                         :: matrix_cg_z
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       INTEGER, INTENT(IN)                                :: iounit
@@ -128,6 +128,12 @@ CONTAINS
       TYPE(linres_control_type), POINTER                 :: linres_control
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(qs_env))
+      CPASSERT(ASSOCIATED(matrix_ks))
+      CPASSERT(ASSOCIATED(matrix_p))
+      CPASSERT(ASSOCIATED(matrix_rhs))
+      CPASSERT(ASSOCIATED(matrix_cg_z))
 
       NULLIFY (dft_control, linres_control)
 
@@ -209,7 +215,7 @@ CONTAINS
          WRITE (iounit, "(/,T10,A,T25,A,T42,A,T62,A,/,T10,A)") &
             "Iteration", "Stepsize", "Convergence", "Time", &
             REPEAT("-", 58)
-      ENDIF
+      END IF
 
       alpha(:) = 0.0_dp
       max_iter = 200
@@ -283,7 +289,7 @@ CONTAINS
          ! Convergence criteria
          IF (norm_res .LT. linres_control%eps) THEN
             converged = .TRUE.
-         ENDIF
+         END IF
 
          t2 = m_walltime()
          IF (i .EQ. 1 .OR. MOD(i, 1) .EQ. 0 .OR. converged) THEN
@@ -294,15 +300,15 @@ CONTAINS
                !WRITE (iounit, "(T10,I5,T25,1E8.2,T42,1E14.8,T58,F8.2)") &
                !   i, MAXVAL(alpha), norm_res, t2 - t1
                CALL m_flush(iounit)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
          IF (converged) THEN
             IF (iounit > 0) THEN
                WRITE (iounit, "(/,T10,A,I4,A,/)") "The precon solver converged in ", i, " iterations."
                CALL m_flush(iounit)
-            ENDIF
+            END IF
             EXIT iteration
-         ENDIF
+         END IF
 
          ! Max number of iteration reached
          IF (i == max_iter) THEN
@@ -310,9 +316,9 @@ CONTAINS
                WRITE (iounit, "(/,T10,A/)") &
                   "The precon solver didnt converge! Maximum number of iterations reached."
                CALL m_flush(iounit)
-            ENDIF
+            END IF
             converged = .FALSE.
-         ENDIF
+         END IF
 
       END DO iteration
 
@@ -352,7 +358,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: matrix_hz
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(OUT), &
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
          POINTER                                         :: matrix_pz, matrix_wz
       INTEGER, INTENT(IN)                                :: iounit
       LOGICAL, INTENT(OUT)                               :: should_stop
@@ -377,6 +383,11 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: solver_section
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(qs_env))
+      CPASSERT(ASSOCIATED(matrix_hz))
+      CPASSERT(ASSOCIATED(matrix_pz))
+      CPASSERT(ASSOCIATED(matrix_wz))
 
       NULLIFY (dft_control, ksmat, matrix_s, linres_control, rho)
 
@@ -583,7 +594,7 @@ CONTAINS
          WRITE (iounit, "(/,T3,A,T16,A,T25,A,T38,A,T52,A,/,T3,A)") &
             "Iteration", "Method", "Stepsize", "Convergence", "Time", &
             REPEAT("-", 80)
-      ENDIF
+      END IF
 
       alpha(:) = 0.0_dp
       restart = .FALSE.
@@ -597,7 +608,7 @@ CONTAINS
          ! default for eps 10E-6 in MO_linres
          IF (norm_res .LT. linres_control%eps) THEN
             linres_control%converged = .TRUE.
-         ENDIF
+         END IF
 
          t2 = m_walltime()
          IF (i .EQ. 1 .OR. MOD(i, 1) .EQ. 0 .OR. linres_control%converged &
@@ -606,13 +617,13 @@ CONTAINS
                WRITE (iounit, "(T5,I5,T18,A3,T28,L1,T38,1E8.2,T48,F16.10,T68,F8.2)") &
                   i, linres_control%flag, restart, MAXVAL(alpha), norm_res, t2 - t1
                CALL m_flush(iounit)
-            ENDIF
-         ENDIF
+            END IF
+         END IF
          IF (linres_control%converged) THEN
             IF (iounit > 0) THEN
                WRITE (iounit, "(/,T2,A,I4,A,/)") "The linear solver converged in ", i, " iterations."
                CALL m_flush(iounit)
-            ENDIF
+            END IF
             EXIT iteration
          ELSE IF (should_stop) THEN
             IF (iounit > 0) THEN
@@ -620,7 +631,7 @@ CONTAINS
                CALL m_flush(iounit)
             END IF
             EXIT iteration
-         ENDIF
+         END IF
 
          ! Max number of iteration reached
          IF (i == linres_control%max_iter) THEN
@@ -628,9 +639,9 @@ CONTAINS
                WRITE (iounit, "(/,T2,A/)") &
                   "The linear solver didnt converge! Maximum number of iterations reached."
                CALL m_flush(iounit)
-            ENDIF
+            END IF
             linres_control%converged = .FALSE.
-         ENDIF
+         END IF
 
          ! Hessian Ax = [F,B] + [G(B),P]
          CALL build_hessian_op(qs_env=qs_env, &
@@ -730,9 +741,9 @@ CONTAINS
             ! r_j+1 = r_j - alpha * Ap_j
             DO ispin = 1, nspins
                CALL dbcsr_add(matrix_res(ispin)%matrix, matrix_Ax(ispin)%matrix, 1.0_dp, -alpha(ispin))
-            ENDDO
+            END DO
             restart = .FALSE.
-         ENDIF
+         END IF
 
          ! Preconditioner
          linres_control%flag = ""
@@ -843,7 +854,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: matrix_z
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(OUT), &
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
          POINTER                                         :: matrix_wz
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
 
@@ -858,6 +869,10 @@ CONTAINS
       TYPE(qs_rho_type), POINTER                         :: rho
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(qs_env))
+      CPASSERT(ASSOCIATED(matrix_z))
+      CPASSERT(ASSOCIATED(matrix_wz))
 
       CALL get_qs_env(qs_env=qs_env, &
                       dft_control=dft_control, &
@@ -902,7 +917,7 @@ CONTAINS
          ! Whz = ZFP + PFZ
          CALL dbcsr_copy(matrix_wz(ispin)%matrix, matrix_tmp, keep_sparsity=.TRUE.)
 
-      ENDDO
+      END DO
 
       ! Release matrices
       CALL dbcsr_release(matrix_tmp)
@@ -933,7 +948,7 @@ CONTAINS
 
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: matrix_ks, matrix_p, matrix_cg
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(OUT), &
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
          POINTER                                         :: matrix_b, matrix_Ax
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
 
@@ -942,6 +957,12 @@ CONTAINS
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(matrix_ks))
+      CPASSERT(ASSOCIATED(matrix_p))
+      CPASSERT(ASSOCIATED(matrix_cg))
+      CPASSERT(ASSOCIATED(matrix_b))
+      CPASSERT(ASSOCIATED(matrix_Ax))
 
       ! Build intermediate density matrix
       ! B = [cg, P] = cg*P - P*cg = cg*P + (cg*P)^T
@@ -953,7 +974,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE
+   END SUBROUTINE hessian_op1
 
 ! **************************************************************************************************
 !> \brief  calculate lin transformation of Hessian matrix on a trial vector (matrix) matrix_cg
@@ -980,7 +1001,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(IN)                       :: matrix_s_sqrt_inv
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: matrix_cg
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(OUT), &
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
          POINTER                                         :: matrix_Ax
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
 
@@ -995,6 +1016,12 @@ CONTAINS
       TYPE(qs_rho_type), POINTER                         :: rho, rho1
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(qs_env))
+      CPASSERT(ASSOCIATED(matrix_ks))
+      CPASSERT(ASSOCIATED(matrix_p))
+      CPASSERT(ASSOCIATED(matrix_cg))
+      CPASSERT(ASSOCIATED(matrix_Ax))
 
       CALL get_qs_env(qs_env=qs_env, &
                       dft_control=dft_control, &
@@ -1022,7 +1049,7 @@ CONTAINS
       chksum = 0.0_dp
       DO ispin = 1, nspins
          chksum = chksum + dbcsr_checksum(matrix_b(ispin)%matrix)
-      ENDDO
+      END DO
 
       ! skip the kernel if the DM is very small
       IF (chksum .GT. 1.0E-14_dp) THEN
@@ -1065,7 +1092,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE
+   END SUBROUTINE build_hessian_op
 
 ! **************************************************************************************************
 !> \brief  Calculate lin transformation of Hessian matrix on a trial vector (matrix) matrix_cg
@@ -1265,7 +1292,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE commutator(a, b, res, eps_filter, anticomm, alpha, beta)
 
-      TYPE(dbcsr_p_type), DIMENSION(:)                   :: a, b, res
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN), &
+         POINTER                                         :: a, b, res
       REAL(KIND=dp)                                      :: eps_filter
       LOGICAL                                            :: anticomm
       REAL(KIND=dp), OPTIONAL                            :: alpha, beta
@@ -1277,6 +1305,10 @@ CONTAINS
       TYPE(dbcsr_type)                                   :: work, work2
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(a))
+      CPASSERT(ASSOCIATED(b))
+      CPASSERT(ASSOCIATED(res))
 
       CALL dbcsr_create(work, template=a(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(work2, template=a(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
@@ -1382,7 +1414,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE
+   END SUBROUTINE projector
 
 ! **************************************************************************************************
 !> \brief performs a tranformation of a matrix back to/into orthonormal basis
@@ -1427,6 +1459,6 @@ CONTAINS
       CALL dbcsr_release(matrix_work)
       CALL timestop(handle)
 
-   END SUBROUTINE
+   END SUBROUTINE transform_m_orth
 
 END MODULE ec_orth_solver

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -222,7 +222,7 @@ CONTAINS
          unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       ELSE
          unit_nr = -1
-      ENDIF
+      END IF
 
       NULLIFY (ec_env)
       CALL get_qs_env(qs_env, ec_env=ec_env)
@@ -593,7 +593,7 @@ CONTAINS
                            template=ec_env%matrix_s(1, 1)%matrix, matrix_type=dbcsr_type_symmetric)
          CALL cp_dbcsr_alloc_block_from_nbl(ec_env%matrix_ks(ispin, 1)%matrix, ec_env%sab_orb)
          CALL dbcsr_set(ec_env%matrix_ks(ispin, 1)%matrix, 0.0_dp)
-      ENDDO
+      END DO
 
       NULLIFY (pw_env)
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
@@ -611,7 +611,7 @@ CONTAINS
             CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin)%pw)
-         ENDDO
+         END DO
       END IF
 
       evhxc = 0.0_dp
@@ -656,7 +656,7 @@ CONTAINS
          IF (ASSOCIATED(v_tau_rspace)) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
          END IF
-      ENDDO
+      END DO
       DEALLOCATE (v_rspace)
 
       ! energies
@@ -980,7 +980,7 @@ CONTAINS
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoout_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      ENDDO
+      END DO
       CALL pw_pool_create_pw(auxbas_pw_pool, dv_hartree_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, vtot_rspace%pw, &
@@ -1225,7 +1225,7 @@ CONTAINS
             CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin)%pw)
-         ENDDO
+         END DO
       END IF
 
       ! Stress-tensor contribution derivative of integrand
@@ -1288,7 +1288,7 @@ CONTAINS
          IF (ASSOCIATED(v_tau_rspace)) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
          END IF
-      ENDDO
+      END DO
 
       ! Core overlap
       IF (debug_forces) fodeb(1:3) = force(1)%core_overlap(1:3, 1)
@@ -1464,7 +1464,7 @@ CONTAINS
          smat => ec_env%matrix_s
          pmat => ec_env%matrix_p
          wmat => ec_env%matrix_w
-      ENDIF
+      END IF
 
       SELECT CASE (ec_env%ks_solver)
       CASE (ec_diagonalization)
@@ -1480,7 +1480,7 @@ CONTAINS
 
       IF (ec_env%mao) THEN
          CALL mao_release_matrices(ec_env, ksmat, smat, pmat, wmat)
-      ENDIF
+      END IF
 
       CALL timestop(handle)
 
@@ -2094,7 +2094,7 @@ CONTAINS
                   WRITE (unit_nr, "(T5,3(A,A,F14.8,1X),T60,A,T67,F14.8)") &
                      (TRIM(rlab(i)), "=", tdip(i)*debye, i=1, 3), "Total=", dd
                END IF
-            ENDIF
+            END IF
          END IF
 
          CALL cp_print_key_finished_output(unit_nr=unit_nr, logger=logger, &
@@ -2139,7 +2139,7 @@ CONTAINS
       IF (ALLOCATED(ls_env%matrix_p)) THEN
          DO ispin = 1, SIZE(ls_env%matrix_p)
             CALL dbcsr_release(ls_env%matrix_p(ispin))
-         ENDDO
+         END DO
       ELSE
          ALLOCATE (ls_env%matrix_p(nspins))
       END IF
@@ -2147,13 +2147,13 @@ CONTAINS
       DO ispin = 1, nspins
          CALL dbcsr_create(ls_env%matrix_p(ispin), template=ls_env%matrix_s, &
                            matrix_type=dbcsr_type_no_symmetry)
-      ENDDO
+      END DO
 
       ALLOCATE (ls_env%matrix_ks(nspins))
       DO ispin = 1, nspins
          CALL dbcsr_create(ls_env%matrix_ks(ispin), template=ls_env%matrix_s, &
                            matrix_type=dbcsr_type_no_symmetry)
-      ENDDO
+      END DO
 
       ! Set up S matrix and needed functions of S
       CALL ls_scf_init_matrix_s(ec_env%matrix_s(1, 1)%matrix, ls_env)
@@ -2219,7 +2219,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL dbcsr_create(matrix_ks_deviation(ispin), template=ls_env%matrix_ks(ispin))
          CALL dbcsr_set(matrix_ks_deviation(ispin), 0.0_dp)
-      ENDDO
+      END DO
 
       ! F = S^-1/2 * F * S^-1/2
       IF (ls_env%has_s_preconditioner) THEN
@@ -2289,7 +2289,7 @@ CONTAINS
 
             CALL dbcsr_filter(ls_env%matrix_p(ispin), ls_env%eps_filter)
          END DO
-      ENDIF
+      END IF
 
       ! Closed-shell
       IF (nspins == 1) CALL dbcsr_scale(ls_env%matrix_p(1), 2.0_dp)
@@ -2313,23 +2313,23 @@ CONTAINS
       IF (ls_env%has_s_preconditioner) THEN
          CALL dbcsr_release(ls_env%matrix_bs_sqrt)
          CALL dbcsr_release(ls_env%matrix_bs_sqrt_inv)
-      ENDIF
+      END IF
       IF (ls_env%needs_s_inv) THEN
          CALL dbcsr_release(ls_env%matrix_s_inv)
-      ENDIF
+      END IF
       IF (ls_env%use_s_sqrt) THEN
          CALL dbcsr_release(ls_env%matrix_s_sqrt)
          CALL dbcsr_release(ls_env%matrix_s_sqrt_inv)
-      ENDIF
+      END IF
 
       DO ispin = 1, SIZE(ls_env%matrix_ks)
          CALL dbcsr_release(ls_env%matrix_ks(ispin))
-      ENDDO
+      END DO
       DEALLOCATE (ls_env%matrix_ks)
 
       DO ispin = 1, nspins
          CALL dbcsr_release(matrix_ks_deviation(ispin))
-      ENDDO
+      END DO
       DEALLOCATE (matrix_ks_deviation)
 
       CALL timestop(handle)
@@ -2357,8 +2357,8 @@ CONTAINS
       TYPE(energy_correction_type), POINTER              :: ec_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(IN), &
          POINTER                                         :: matrix_ks, matrix_s
-      TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(OUT), &
-         POINTER                                         :: matrix_p, matrix_w
+      TYPE(dbcsr_p_type), DIMENSION(:, :), &
+         INTENT(INOUT), POINTER                          :: matrix_p, matrix_w
 
       CHARACTER(len=*), PARAMETER :: routineN = 'ec_ot_diag_solver', &
          routineP = moduleN//':'//routineN
@@ -2387,6 +2387,13 @@ CONTAINS
 
       logger => cp_get_default_logger()
       iounit = cp_logger_get_default_unit_nr(logger)
+
+      CPASSERT(ASSOCIATED(qs_env))
+      CPASSERT(ASSOCIATED(ec_env))
+      CPASSERT(ASSOCIATED(matrix_ks))
+      CPASSERT(ASSOCIATED(matrix_s))
+      CPASSERT(ASSOCIATED(matrix_p))
+      CPASSERT(ASSOCIATED(matrix_w))
 
       CALL get_qs_env(qs_env=qs_env, &
                       atomic_kind_set=atomic_kind_set, &

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -202,7 +202,7 @@ CONTAINS
          unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       ELSE
          unit_nr = -1
-      ENDIF
+      END IF
 
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
@@ -363,7 +363,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             CALL cp_fm_release(cpmos(ispin)%matrix)
-         ENDDO
+         END DO
          DEALLOCATE (cpmos)
 
          ! Get rid of MO environment again
@@ -482,7 +482,7 @@ CONTAINS
          WRITE (unit_nr, '(T2,A)') REPEAT("-", 79)
 
          CALL m_flush(unit_nr)
-      ENDIF
+      END IF
 
       CALL timestop(handle)
 
@@ -535,7 +535,7 @@ CONTAINS
          NULLIFY (psi1(ispin)%matrix)
          CALL cp_fm_create(psi1(ispin)%matrix, fm_struct)
          CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
-      ENDDO
+      END DO
 
       should_stop = .FALSE.
       ! The response solver
@@ -948,7 +948,7 @@ CONTAINS
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      ENDDO
+      END DO
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace%pw, &
@@ -1250,7 +1250,7 @@ CONTAINS
                                       use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g_aux(ispin)%pw, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-            ENDDO
+            END DO
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpz(ispin, 1)%matrix, &
                                        rho=rhoz_r_aux(ispin), rho_gspace=rhoz_g_aux(ispin), &
@@ -1870,14 +1870,14 @@ CONTAINS
             IF (ASSOCIATED(v_tau_rspace)) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
             END IF
-         ENDDO
+         END DO
          DEALLOCATE (v_rspace)
       END IF
       IF (ASSOCIATED(v_tau_rspace)) DEALLOCATE (v_tau_rspace)
       IF (ASSOCIATED(v_admm_rspace)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_admm_rspace(ispin)%pw)
-         ENDDO
+         END DO
          DEALLOCATE (v_admm_rspace)
       END IF
 
@@ -1903,7 +1903,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: matrix_hz
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(OUT), &
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT), &
          POINTER                                         :: matrix_whz
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
 
@@ -1919,6 +1919,10 @@ CONTAINS
       TYPE(qs_rho_type), POINTER                         :: rho
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(qs_env))
+      CPASSERT(ASSOCIATED(matrix_hz))
+      CPASSERT(ASSOCIATED(matrix_whz))
 
       CALL get_qs_env(qs_env=qs_env, &
                       dft_control=dft_control, &


### PR DESCRIPTION
- Using the `INTENT(OUT)` attribute for `POINTER` arguments is delicate as the status of the pointer might become undefined after the routine is left. At least this happens with the Intel compiler. Therefore all `INTENT(OUT)` attributes for `POINTER` arguments have been replaced by `INTENT(INOUT)` attributes.
- Added routine name to `END SUBROUTINE` where missing
- Replaced `ENDIF` by `END IF` and `ENDDO` by `END DO`