### PR TITLE
Docker: Exclude SIRIUS from farming test

### DIFF
--- a/tools/docker/scripts/test_farming.sh
+++ b/tools/docker/scripts/test_farming.sh
@@ -7,6 +7,6 @@ source /opt/cp2k-toolchain/install/setup
 
 echo -e "\n========== Running Regtests =========="
 cd /workspace/cp2k
-make VERSION=psmp test TESTOPTS="-farming -ompthreads 1 -skipunittest -skipdir TMC/regtest_ana_on_the_fly -skipdir TMC/regtest_ana_post_proc -skipdir TMC/regtest -skipdir LIBTEST/libvori -skipdir LIBTEST/libbqb ${TESTOPTS}"
+make VERSION=psmp test TESTOPTS="-farming -ompthreads 1 -skipunittest -skipdir TMC/regtest_ana_on_the_fly -skipdir TMC/regtest_ana_post_proc -skipdir TMC/regtest -skipdir LIBTEST/libvori -skipdir LIBTEST/libbqb -skipdir SIRIUS/regtest-1 ${TESTOPTS}"
 
 #EOF


### PR DESCRIPTION
While SIRIUS and [farming](https://dashboard.cp2k.org/archive/farming/index.html) never really [got along well](https://github.com/electronic-structure/SIRIUS/issues/520), since #1680 it causes a dead lock.