### PR TITLE
Added one keyword (MAX_OPEN_CYCLES) in worm MC sampling of helium 

### DIFF
--- a/src/motion/helium_io.F
+++ b/src/motion/helium_io.F
@@ -340,6 +340,13 @@ CONTAINS
             WRITE (stmp1, *) helium%worm_show_statistics
             WRITE (stmp2, *) "WORM| Print statistics: "//TRIM(ADJUSTL(stmp1))
             CALL helium_write_line(stmp2)
+            IF (helium%worm_max_open_cycles > 0 .AND. helium%worm_allow_open) THEN
+               stmp1 = ""
+               stmp2 = ""
+               WRITE (stmp1, *) helium%worm_max_open_cycles
+               WRITE (stmp2, *) "WORM| Max. nb of MC cycles in open sector: "//TRIM(ADJUSTL(stmp1))
+               CALL helium_write_line(stmp2)
+            END IF
             stmp1 = ""
             CALL helium_write_line(stmp1)
 

--- a/src/motion/helium_methods.F
+++ b/src/motion/helium_methods.F
@@ -190,12 +190,17 @@ CONTAINS
          CALL helium_rng_init(helium_env)
 
          DO k = 1, mepos
-            NULLIFY (helium_env(k)%helium%ptable, helium_env(k)%helium%permutation, &
+            NULLIFY (helium_env(k)%helium%ptable, &
+                     helium_env(k)%helium%permutation, &
+                     helium_env(k)%helium%savepermutation, &
                      helium_env(k)%helium%iperm, &
+                     helium_env(k)%helium%saveiperm, &
                      helium_env(k)%helium%itmp_atoms_1d, &
                      helium_env(k)%helium%ltmp_atoms_1d, &
                      helium_env(k)%helium%itmp_atoms_np_1d, &
-                     helium_env(k)%helium%pos, helium_env(k)%helium%work, &
+                     helium_env(k)%helium%pos, &
+                     helium_env(k)%helium%savepos, &
+                     helium_env(k)%helium%work, &
                      helium_env(k)%helium%force_avrg, &
                      helium_env(k)%helium%force_inst, &
                      helium_env(k)%helium%rtmp_3_np_1d, &
@@ -587,8 +592,11 @@ CONTAINS
                CALL section_vals_val_get(helium_section, "WORM%ALLOW_OPEN", &
                                          l_val=helium_env(k)%helium%worm_allow_open)
 
+               CALL section_vals_val_get(helium_section, "WORM%MAX_OPEN_CYCLES", &
+                                         i_val=helium_env(k)%helium%worm_max_open_cycles)
+
                IF (helium_env(k)%helium%worm_staging_l + 1 >= helium_env(k)%helium%beads) THEN
-                  msg_str = "STAGING_L for worm sampling is to large"
+                  msg_str = "STAGING_L for worm sampling is too large"
                   CPABORT(msg_str)
                ELSE IF (helium_env(k)%helium%worm_staging_l < 1) THEN
                   msg_str = "STAGING_L must be positive integer"
@@ -684,6 +692,11 @@ CONTAINS
             ALLOCATE (helium_env(k)%helium%plength_avrg(helium_env(k)%helium%atoms))
             ALLOCATE (helium_env(k)%helium%plength_inst(helium_env(k)%helium%atoms))
             ALLOCATE (helium_env(k)%helium%atom_plength(helium_env(k)%helium%atoms))
+            IF (helium_env(k)%helium%worm_max_open_cycles > 0) THEN
+               ALLOCATE (helium_env(k)%helium%savepermutation(i))
+               ALLOCATE (helium_env(k)%helium%saveiperm(i))
+               ALLOCATE (helium_env(k)%helium%savepos(3, i, j))
+            END IF
 
             ! check whether rdfs should be calculated and printed
             helium_env(k)%helium%rdf_present = helium_property_active(helium_env(k)%helium, "RDF")
@@ -934,6 +947,11 @@ CONTAINS
                   helium_env(k)%helium%ptable, &
                   helium_env(k)%helium%work, &
                   helium_env(k)%helium%pos)
+               IF (helium_env(k)%helium%worm_max_open_cycles > 0) THEN
+                  DEALLOCATE(helium_env(k)%helium%saveiperm, &
+                             helium_env(k)%helium%savepermutation, &
+                             helium_env(k)%helium%savepos)
+               END IF
                NULLIFY ( &
                   helium_env(k)%helium%atom_plength, &
                   helium_env(k)%helium%plength_inst, &
@@ -944,10 +962,13 @@ CONTAINS
                   helium_env(k)%helium%nmatrix, &
                   helium_env(k)%helium%tmatrix, &
                   helium_env(k)%helium%iperm, &
+                  helium_env(k)%helium%saveiperm, &
                   helium_env(k)%helium%permutation, &
+                  helium_env(k)%helium%savepermutation, &
                   helium_env(k)%helium%ptable, &
                   helium_env(k)%helium%work, &
-                  helium_env(k)%helium%pos &
+                  helium_env(k)%helium%pos, &
+                  helium_env(k)%helium%savepos &
                   )
 
                IF (k == 1) THEN

--- a/src/motion/helium_methods.F
+++ b/src/motion/helium_methods.F
@@ -948,9 +948,9 @@ CONTAINS
                   helium_env(k)%helium%work, &
                   helium_env(k)%helium%pos)
                IF (helium_env(k)%helium%worm_max_open_cycles > 0) THEN
-                  DEALLOCATE(helium_env(k)%helium%saveiperm, &
-                             helium_env(k)%helium%savepermutation, &
-                             helium_env(k)%helium%savepos)
+                  DEALLOCATE (helium_env(k)%helium%saveiperm, &
+                              helium_env(k)%helium%savepermutation, &
+                              helium_env(k)%helium%savepos)
                END IF
                NULLIFY ( &
                   helium_env(k)%helium%atom_plength, &

--- a/src/motion/helium_types.F
+++ b/src/motion/helium_types.F
@@ -137,6 +137,7 @@ MODULE helium_types
       INTEGER       :: worm_tail_min, worm_tail_max
       INTEGER       :: worm_swap_min, worm_swap_max
       INTEGER       :: worm_open_close_min, worm_open_close_max
+      INTEGER       :: worm_max_open_cycles
       REAL(KIND=dp) :: worm_open_close_scale
       REAL(KIND=dp) :: worm_ln_openclose_scale
       LOGICAL       :: worm_allow_open, worm_show_statistics
@@ -173,10 +174,13 @@ MODULE helium_types
       ! helium variables
       !
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER :: pos !< position of the helium atoms DIM(3,atoms,beads)
+      REAL(KIND=dp), DIMENSION(:, :, :), POINTER :: savepos !< saved position of the helium atoms DIM(3,atoms,beads)
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER :: work !< same dimensions as pos
       !
       INTEGER, DIMENSION(:), POINTER :: permutation !< current permutation state DIM(atoms)
+      INTEGER, DIMENSION(:), POINTER :: savepermutation !< saved permutation state DIM(atoms)
       INTEGER, DIMENSION(:), POINTER :: iperm !< inverse of the current permutation state DIM(atoms)
+      INTEGER, DIMENSION(:), POINTER :: saveiperm !< saved inverse of the current permutation state DIM(atoms)
       INTEGER, DIMENSION(:), POINTER :: ptable !< proposed cyclic permutation, DIM(max_cycle)
       INTEGER(KIND=int_8)              :: accepts !< number of accepted new configurations
       !

--- a/src/motion/helium_worm.F
+++ b/src/motion/helium_worm.F
@@ -53,9 +53,9 @@ CONTAINS
 
       CHARACTER(len=default_string_length)               :: stmp
       INTEGER :: ac, iatom, ibead, icrawl, iMC, imove, ncentracc, ncentratt, ncloseacc, ncloseatt, &
-         ncrawlbwdacc, ncrawlbwdatt, ncrawlfwdacc, ncrawlfwdatt, ncycle, nMC, nmoveheadacc, nmoveheadatt, &
-         nmovetailacc, nmovetailatt, nopenacc, nopenatt, npswapacc, nstagacc, nstagatt, nstat, &
-         nswapacc, nswapatt, ntot, staging_l
+         ncrawlbwdacc, ncrawlbwdatt, ncrawlfwdacc, ncrawlfwdatt, ncycle, nMC, nmoveheadacc, &
+         nmoveheadatt, nmovetailacc, nmovetailatt, nopenacc, nopenatt, npswapacc, nstagacc, &
+         nstagatt, nstat, nswapacc, nswapatt, ntot, staging_l
       REAL(KIND=dp)                                      :: rtmp
 
       CALL helium_update_coord_system(helium, pint_env)
@@ -90,7 +90,7 @@ CONTAINS
       helium%energy_avrg(:) = 0.0d0
       helium%plength_avrg(:) = 0.0d0
       IF (helium%worm_max_open_cycles > 0) THEN
-         helium%savepos(:,:,:) = helium%pos(:,:,:)
+         helium%savepos(:, :, :) = helium%pos(:, :, :)
          helium%saveiperm(:) = helium%iperm(:)
          helium%savepermutation(:) = helium%permutation(:)
       END IF

--- a/src/motion/helium_worm.F
+++ b/src/motion/helium_worm.F
@@ -53,7 +53,7 @@ CONTAINS
 
       CHARACTER(len=default_string_length)               :: stmp
       INTEGER :: ac, iatom, ibead, icrawl, iMC, imove, ncentracc, ncentratt, ncloseacc, ncloseatt, &
-         ncrawlbwdacc, ncrawlbwdatt, ncrawlfwdacc, ncrawlfwdatt, nMC, nmoveheadacc, nmoveheadatt, &
+         ncrawlbwdacc, ncrawlbwdatt, ncrawlfwdacc, ncrawlfwdatt, ncycle, nMC, nmoveheadacc, nmoveheadatt, &
          nmovetailacc, nmovetailatt, nopenacc, nopenatt, npswapacc, nstagacc, nstagatt, nstat, &
          nswapacc, nswapatt, ntot, staging_l
       REAL(KIND=dp)                                      :: rtmp
@@ -89,8 +89,14 @@ CONTAINS
       IF (helium%solute_present) helium%force_avrg(:, :) = 0.0d0
       helium%energy_avrg(:) = 0.0d0
       helium%plength_avrg(:) = 0.0d0
+      IF (helium%worm_max_open_cycles > 0) THEN
+         helium%savepos(:,:,:) = helium%pos(:,:,:)
+         helium%saveiperm(:) = helium%iperm(:)
+         helium%savepermutation(:) = helium%permutation(:)
+      END IF
 
       nMC = helium%iter_rot
+      ncycle = 0
       IF (helium%worm_allow_open) THEN
          DO ! Exit criterion at the end of the loop
             DO iMC = 1, nMC
@@ -213,7 +219,19 @@ CONTAINS
             IF (helium%worm_is_closed) THEN
                EXIT
             ELSE
-               nMC = MAX(helium%iter_rot/10, 10)
+               ncycle = ncycle + 1
+               ! reset position and permutation and start MC cycle again
+               ! if stuck in open position for too long
+               IF (helium%worm_max_open_cycles > 0 .AND. ncycle > helium%worm_max_open_cycles) THEN
+                  nMC = helium%iter_rot
+                  ncycle = 0
+                  helium%pos = helium%savepos
+                  helium%permutation = helium%savepermutation
+                  helium%iperm = helium%saveiperm
+                  CPWARN("Trapped in open state, reset helium to closed state from last MD step.")
+               ELSE
+                  nMC = MAX(helium%iter_rot/10, 10)
+               END IF
             END IF
          END DO !attempts loop
       ELSE ! only closed configurations allowed

--- a/src/start/input_cp2k_motion.F
+++ b/src/start/input_cp2k_motion.F
@@ -12,58 +12,58 @@
 !> \author teo & fawzi
 ! **************************************************************************************************
 MODULE input_cp2k_motion
-   USE bibliography,                    ONLY: Brieuc2016,&
-                                              Byrd1995,&
-                                              Ceriotti2010,&
-                                              Ceriotti2012,&
-                                              Ceriotti2014,&
-                                              Henkelman1999,&
-                                              Henkelman2014,&
-                                              Kapil2016
-   USE cp_output_handling,              ONLY: add_last_numeric,&
-                                              cp_print_key_section_create,&
-                                              debug_print_level,&
-                                              high_print_level,&
-                                              low_print_level,&
-                                              medium_print_level
-   USE cp_units,                        ONLY: cp_unit_to_cp2k
-   USE input_constants,                 ONLY: &
-        default_bfgs_method_id, default_cell_direct_id, default_cell_geo_opt_id, &
-        default_cell_md_id, default_cg_method_id, default_dimer_method_id, &
-        default_lbfgs_method_id, default_minimization_method_id, default_ts_method_id, &
-        do_mc_gemc_npt, do_mc_gemc_nvt, do_mc_traditional, do_mc_virial, fix_none, fix_x, fix_xy, &
-        fix_xz, fix_y, fix_yz, fix_z, fmt_id_pdb, fmt_id_xyz, gaussian, helium_cell_shape_cube, &
-        helium_cell_shape_octahedron, helium_forces_average, helium_forces_last, &
-        helium_mdist_exponential, helium_mdist_gaussian, helium_mdist_linear, &
-        helium_mdist_quadratic, helium_mdist_singlev, helium_mdist_uniform, &
-        helium_sampling_ceperley, helium_sampling_worm, helium_solute_intpot_mwater, &
-        helium_solute_intpot_none, integrate_exact, integrate_numeric, ls_2pnt, ls_3pnt, ls_fit, &
-        ls_gold, ls_none, matrix_init_cholesky, matrix_init_diagonal, numerical, perm_cycle, &
-        perm_plain, propagator_pimd, propagator_rpmd, transformation_normal, transformation_stage
-   USE input_cp2k_constraints,          ONLY: create_constraint_section
-   USE input_cp2k_free_energy,          ONLY: create_fe_section
-   USE input_cp2k_md,                   ONLY: create_md_section
-   USE input_cp2k_motion_print,         ONLY: add_format_keyword,&
-                                              create_motion_print_section
-   USE input_cp2k_neb,                  ONLY: create_band_section
-   USE input_cp2k_subsys,               ONLY: create_rng_section
-   USE input_cp2k_thermostats,          ONLY: create_coord_section,&
-                                              create_gle_section,&
-                                              create_velocity_section
-   USE input_cp2k_tmc,                  ONLY: create_TMC_section
-   USE input_keyword_types,             ONLY: keyword_create,&
-                                              keyword_release,&
-                                              keyword_type
-   USE input_section_types,             ONLY: section_add_keyword,&
-                                              section_add_subsection,&
-                                              section_create,&
-                                              section_release,&
-                                              section_type
-   USE input_val_types,                 ONLY: integer_t,&
-                                              logical_t,&
-                                              real_t
-   USE kinds,                           ONLY: dp
-   USE string_utilities,                ONLY: s2a
+   USE bibliography, ONLY: Brieuc2016, &
+                           Byrd1995, &
+                           Ceriotti2010, &
+                           Ceriotti2012, &
+                           Ceriotti2014, &
+                           Henkelman1999, &
+                           Henkelman2014, &
+                           Kapil2016
+   USE cp_output_handling, ONLY: add_last_numeric, &
+                                 cp_print_key_section_create, &
+                                 debug_print_level, &
+                                 high_print_level, &
+                                 low_print_level, &
+                                 medium_print_level
+   USE cp_units, ONLY: cp_unit_to_cp2k
+   USE input_constants, ONLY: &
+      default_bfgs_method_id, default_cell_direct_id, default_cell_geo_opt_id, &
+      default_cell_md_id, default_cg_method_id, default_dimer_method_id, &
+      default_lbfgs_method_id, default_minimization_method_id, default_ts_method_id, &
+      do_mc_gemc_npt, do_mc_gemc_nvt, do_mc_traditional, do_mc_virial, fix_none, fix_x, fix_xy, &
+      fix_xz, fix_y, fix_yz, fix_z, fmt_id_pdb, fmt_id_xyz, gaussian, helium_cell_shape_cube, &
+      helium_cell_shape_octahedron, helium_forces_average, helium_forces_last, &
+      helium_mdist_exponential, helium_mdist_gaussian, helium_mdist_linear, &
+      helium_mdist_quadratic, helium_mdist_singlev, helium_mdist_uniform, &
+      helium_sampling_ceperley, helium_sampling_worm, helium_solute_intpot_mwater, &
+      helium_solute_intpot_none, integrate_exact, integrate_numeric, ls_2pnt, ls_3pnt, ls_fit, &
+      ls_gold, ls_none, matrix_init_cholesky, matrix_init_diagonal, numerical, perm_cycle, &
+      perm_plain, propagator_pimd, propagator_rpmd, transformation_normal, transformation_stage
+   USE input_cp2k_constraints, ONLY: create_constraint_section
+   USE input_cp2k_free_energy, ONLY: create_fe_section
+   USE input_cp2k_md, ONLY: create_md_section
+   USE input_cp2k_motion_print, ONLY: add_format_keyword, &
+                                      create_motion_print_section
+   USE input_cp2k_neb, ONLY: create_band_section
+   USE input_cp2k_subsys, ONLY: create_rng_section
+   USE input_cp2k_thermostats, ONLY: create_coord_section, &
+                                     create_gle_section, &
+                                     create_velocity_section
+   USE input_cp2k_tmc, ONLY: create_TMC_section
+   USE input_keyword_types, ONLY: keyword_create, &
+                                  keyword_release, &
+                                  keyword_type
+   USE input_section_types, ONLY: section_add_keyword, &
+                                  section_add_subsection, &
+                                  section_create, &
+                                  section_release, &
+                                  section_type
+   USE input_val_types, ONLY: integer_t, &
+                              logical_t, &
+                              real_t
+   USE kinds, ONLY: dp
+   USE string_utilities, ONLY: s2a
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE

--- a/src/start/input_cp2k_motion.F
+++ b/src/start/input_cp2k_motion.F
@@ -2286,7 +2286,7 @@ CONTAINS
       NULLIFY (subsection)
       CALL section_create(subsection, __LOCATION__, name="WORM", &
                           description="Enables sampling via the canonical worm algorithm adapted from Bonisegni", &
-                          n_keywords=11, n_subsections=0, repeats=.FALSE.)
+                          n_keywords=12, n_subsections=0, repeats=.FALSE.)
 
       CALL keyword_create(keyword, __LOCATION__, name="CENTROID_DRMAX", &
                           description="Maximum displacement allowed for the centroid moves", &
@@ -2309,6 +2309,15 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="ALLOW_OPEN", &
                           description="Enable bosonic exchange sampling", &
                           repeats=.FALSE., default_l_val=.TRUE.)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="MAX_OPEN_CYCLES", &
+                         description="If > 0 then reset positions and permutations to the previous closed &
+                         & state if staying more than this amount of MC cycles in open state to avoid staying &
+                         & trapped in open state for too long. Use with caution as it can potentially introduce &
+                         & a bias in the sampling.", &
+                          repeats=.FALSE., default_i_val=0)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 


### PR DESCRIPTION
This keyword is added in order to avoid getting trapped in an open state for too long.
If the system spends more than MAX_OPEN_CYCLE in the open worm sector then it is reset to the last closed state. 