### PR TITLE
Run tests in classic mode failing with keepalive

### DIFF
--- a/tests/QS/regtest-gpw-5/TEST_FILES
+++ b/tests/QS/regtest-gpw-5/TEST_FILES
@@ -8,7 +8,7 @@ si8_pmix.inp                                           1      7e-14            -
 si8_kerker.inp                                         1      1e-13            -31.15224294859119
 si8_pulay.inp                                          1      2e-13            -31.16058546019718
 si8_broy.inp                                           1      7e-14            -31.14863007620936
-si8_pulay_md.inp                                       1      3e-12            -31.16216174849309
+si8_pulay_md.inp                                       1      5e-12            -31.16216174849309
 si8_pulay_skip.inp                                     1      5e-14            -31.16145405092692
 # cholesky methods
 si8_pulay_reduce.inp                                   1      2e-13            -31.16058546019707

--- a/tools/regtesting/do_regtest.py
+++ b/tools/regtesting/do_regtest.py
@@ -121,8 +121,6 @@ async def main() -> None:
             print(f"Skipping {batch.name} because its requirements are not satisfied.")
         elif not any(re.match(p, batch.name) for p in cfg.restrictdirs):
             num_restrictdirs += 1
-        elif cfg.keepalive and batch.name in KEEPALIVE_SKIP_DIRS:
-            print(f"Skipping {batch.name} because it doesn't work with --keepalive.")
         else:
             tasks.append(asyncio.get_event_loop().create_task(run_batch(batch, cfg)))
 
@@ -452,7 +450,7 @@ async def run_unittests(batch: Batch, cfg: Config) -> List[TestResult]:
 
 # ======================================================================================
 async def run_regtests(batch: Batch, cfg: Config) -> List[TestResult]:
-    if cfg.keepalive:
+    if cfg.keepalive and not batch.name in KEEPALIVE_SKIP_DIRS:
         return await run_regtests_keepalive(batch, cfg)
     else:
         return await run_regtests_classic(batch, cfg)


### PR DESCRIPTION
Do not skip the tests failing with the keepalive flag, i.e. being run with the shell mechanism of cp2k, but run these in the "classic mode". The regression test runs faster using cp2k's shell mechanism (more efficient node usage under slurm). Thus the "keepalive mode" could become the default in this way without dropping tests.