### PR TITLE
toolchain: MPI warning, CMake dependency, and LIBXSMM update

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -326,7 +326,7 @@ if (command -v mpirun >&- 2>&-); then
     export MPI_MODE=mpich
   fi
 else
-  report_warning $LINENO "No MPI installation detected on your system. Ignore this message if you are using Cray Linux Environment"
+  report_warning $LINENO "No MPI installation detected (ignore this message in Cray Linux Environment or when MPI installation was requested)."
   export MPI_MODE=no
 fi
 
@@ -715,8 +715,16 @@ else
   fi
 fi
 
-# spglib and libvori require cmake.
-if [ "$with_spglib" = "__INSTALL__" ] || [ "$with_libvori" = "__INSTALL__" ]; then
+# several packages require cmake.
+if [ "$with_spglib" = "__INSTALL__" ] \
+|| [ "$with_libvori" = "__INSTALL__" ] \
+|| [ "$with_scalapack" = "__INSTALL__" ] \
+|| [ "$with_superlu" = "__INSTALL__" ] \
+|| [ "$with_sirius" = "__INSTALL__" ] \
+|| [ "$with_cosma" = "__INSTALL__" ] \
+|| [ "$with_spfft" = "__INSTALL__" ] \
+|| [ "$with_spla" = "__INSTALL__" ];
+then
   [ "$with_cmake" = "__DONTUSE__" ] && with_cmake="__INSTALL__"
 fi
 

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -716,15 +716,14 @@ else
 fi
 
 # several packages require cmake.
-if [ "$with_spglib" = "__INSTALL__" ] \
-|| [ "$with_libvori" = "__INSTALL__" ] \
-|| [ "$with_scalapack" = "__INSTALL__" ] \
-|| [ "$with_superlu" = "__INSTALL__" ] \
-|| [ "$with_sirius" = "__INSTALL__" ] \
-|| [ "$with_cosma" = "__INSTALL__" ] \
-|| [ "$with_spfft" = "__INSTALL__" ] \
-|| [ "$with_spla" = "__INSTALL__" ];
-then
+if [ "$with_spglib" = "__INSTALL__" ] ||
+  [ "$with_libvori" = "__INSTALL__" ] ||
+  [ "$with_scalapack" = "__INSTALL__" ] ||
+  [ "$with_superlu" = "__INSTALL__" ] ||
+  [ "$with_sirius" = "__INSTALL__" ] ||
+  [ "$with_cosma" = "__INSTALL__" ] ||
+  [ "$with_spfft" = "__INSTALL__" ] ||
+  [ "$with_spla" = "__INSTALL__" ]; then
   [ "$with_cmake" = "__DONTUSE__" ] && with_cmake="__INSTALL__"
 fi
 

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -28,7 +28,9 @@ cd "${BUILDDIR}"
 case "$with_libxsmm" in
   __INSTALL__)
     echo "==================== Installing Libxsmm ===================="
-    if [ "$OPENBLAS_ARCH" != "x86_64" ]; then
+    if [[ ("$OPENBLAS_ARCH" != "x86_64") && \
+          ("$OPENBLAS_ARCH" != "arm64" || "$libxsmm_ver" != "master") ]];
+    then
       report_warning $LINENO "libxsmm is not supported on arch ${OPENBLAS_ARCH}"
       cat << EOF > "${BUILDDIR}/setup_libxsmm"
 with_libxsmm="__DONTUSE__"

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -28,9 +28,8 @@ cd "${BUILDDIR}"
 case "$with_libxsmm" in
   __INSTALL__)
     echo "==================== Installing Libxsmm ===================="
-    if [[ ("$OPENBLAS_ARCH" != "x86_64") && \
-          ("$OPENBLAS_ARCH" != "arm64" || "$libxsmm_ver" != "master") ]];
-    then
+    if [[ ("$OPENBLAS_ARCH" != "x86_64") && (\
+      "$OPENBLAS_ARCH" != "arm64" || "$libxsmm_ver" != "master") ]]; then
       report_warning $LINENO "libxsmm is not supported on arch ${OPENBLAS_ARCH}"
       cat << EOF > "${BUILDDIR}/setup_libxsmm"
 with_libxsmm="__DONTUSE__"


### PR DESCRIPTION
* Improved warning if MPI was requested (e.g., --with-openmpi=install).
* Install CMake if required by other packages.
* Enabled LIBXSMM for ARM64 (experimental).