### PR TITLE
Fixes in dcdr

### DIFF
--- a/src/aobasis/ai_moments.F
+++ b/src/aobasis/ai_moments.F
@@ -97,7 +97,7 @@ CONTAINS
          OPTIONAL, POINTER                               :: deltaR
       INTEGER, INTENT(IN), OPTIONAL                      :: iatom, jatom
 
-      INTEGER                                            :: imom, istat, lda, lda_min, ldb, ldb_min
+      INTEGER                                            :: imom, lda, lda_min, ldb, ldb_min
       REAL(KIND=dp)                                      :: dab, rab(3)
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: difmab_tmp
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: mab
@@ -115,7 +115,7 @@ CONTAINS
          mab => mab_ext
       ELSE
          ALLOCATE (mab(npgfa*ncoset(la_max + 1), npgfb*ncoset(lb_max + 1), &
-                       ncoset(order) - 1), STAT=istat)
+                       ncoset(order) - 1))
          mab = 0.0_dp
 !     *** Calculate the primitive moment integrals ***
          CALL moment(la_max + 1, npgfa, zeta, rpgfa, lda_min, &

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -1041,7 +1041,6 @@ CONTAINS
       CASE (3)
          dabqadb_func = GRID_FUNC_CORE_Z
       CASE DEFAULT
-         PRINT *, 'beta', beta
          CPABORT("invalid beta")
       END SELECT
       DO ikind = 1, SIZE(atomic_kind_set)

--- a/src/qs_dcdr.F
+++ b/src/qs_dcdr.F
@@ -20,8 +20,7 @@ MODULE qs_dcdr
    USE cp_dbcsr_operations,             ONLY: cp_dbcsr_sm_fm_multiply,&
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_gemm,&
-                                              cp_fm_scale,&
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_scale,&
                                               cp_fm_scale_and_add,&
                                               cp_fm_trace
    USE cp_fm_types,                     ONLY: cp_fm_create,&
@@ -388,16 +387,16 @@ CONTAINS
       CALL cp_fm_scale_and_add(0._dp, dcdr_env%dCR_prime(1)%matrix, 1._dp, dcdr_env%dCR(1)%matrix)
       CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_s1(dcdr_env%beta + 1)%matrix, mo_coeff, &
                                    tmp_fm_like_mos%matrix, ncol=nmo)
-      CALL cp_fm_gemm("T", "N", nmo, nmo, nao, &
-                      1.0_dp, mo_coeff, tmp_fm_like_mos%matrix, &
-                      0.0_dp, overlap1_MO%matrix)
+      CALL cp_gemm("T", "N", nmo, nmo, nao, &
+                   1.0_dp, mo_coeff, tmp_fm_like_mos%matrix, &
+                   0.0_dp, overlap1_MO%matrix)
 
       !   C^1 <- -dCR - 0.5 * mo_coeff @ S1_ij
       !    We get the negative of the coefficients out of the linres solver
       !    And apply the constant correction due to the overlap derivative.
-      CALL cp_fm_gemm("N", "N", nao, nmo, nmo, &
-                      -0.5_dp, mo_coeff, overlap1_MO%matrix, &
-                      -1.0_dp, dcdr_env%dCR_prime(1)%matrix)
+      CALL cp_gemm("N", "N", nao, nmo, nmo, &
+                   -0.5_dp, mo_coeff, overlap1_MO%matrix, &
+                   -1.0_dp, dcdr_env%dCR_prime(1)%matrix)
 
       DO alpha = 1, 3
          ! FIRST CONTRIBUTION: dCR * moments * mo
@@ -554,14 +553,14 @@ CONTAINS
       CALL cp_fm_scale_and_add(0._dp, dcdr_env%dCR_prime(1)%matrix, 1._dp, dcdr_env%dCR(1)%matrix)
       CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_s1(dcdr_env%beta + 1)%matrix, mo_coeff, &
                                    tmp_fm%matrix, ncol=nmo)
-      CALL cp_fm_gemm("T", "N", nmo, nmo, nao, &
-                      1.0_dp, mo_coeff, tmp_fm%matrix, &
-                      0.0_dp, tmp_fm_momo(1)%matrix)
+      CALL cp_gemm("T", "N", nmo, nmo, nao, &
+                   1.0_dp, mo_coeff, tmp_fm%matrix, &
+                   0.0_dp, tmp_fm_momo(1)%matrix)
 
       !   C^1 <- -dCR - 0.5 * mo_coeff @ S1_ij
-      CALL cp_fm_gemm("N", "N", nao, nmo, nmo, &
-                      -0.5_dp, mo_coeff, tmp_fm_momo(1)%matrix, &
-                      -1.0_dp, dcdr_env%dCR_prime(1)%matrix)
+      CALL cp_gemm("N", "N", nao, nmo, nmo, &
+                   -0.5_dp, mo_coeff, tmp_fm_momo(1)%matrix, &
+                   -1.0_dp, dcdr_env%dCR_prime(1)%matrix)
 
       ! FIRST CONTRIBUTION: dCR * moments * mo
       this_factor = -2._dp*f_spin
@@ -576,9 +575,9 @@ CONTAINS
             CALL dbcsr_set(dcdr_env%moments(alpha)%matrix, 0.0_dp)
          END DO
 
-         CALL cp_fm_gemm("T", "N", nmo, nmo, nao, &
-                         1.0_dp, mo_coeff, tmp_fm_like_mos(alpha)%matrix, &
-                         0.0_dp, tmp_fm_momo(alpha)%matrix)
+         CALL cp_gemm("T", "N", nmo, nmo, nao, &
+                      1.0_dp, mo_coeff, tmp_fm_like_mos(alpha)%matrix, &
+                      0.0_dp, tmp_fm_momo(alpha)%matrix)
          CALL cp_fm_get_diag(tmp_fm_momo(alpha)%matrix, diagonal_elements)
 
          DO icenter = 1, dcdr_env%nbr_center(1)
@@ -617,9 +616,9 @@ CONTAINS
                                        res=tmp_fm_like_mos(alpha)%matrix)
          END DO ! icenter
 
-         CALL cp_fm_gemm("T", "N", nmo, nmo, nao, &
-                         1.0_dp, mo_coeff, tmp_fm_like_mos(alpha)%matrix, &
-                         0.0_dp, tmp_fm_momo(alpha)%matrix)
+         CALL cp_gemm("T", "N", nmo, nmo, nao, &
+                      1.0_dp, mo_coeff, tmp_fm_like_mos(alpha)%matrix, &
+                      0.0_dp, tmp_fm_momo(alpha)%matrix)
          CALL cp_fm_get_diag(tmp_fm_momo(alpha)%matrix, diagonal_elements)
 
          DO icenter = 1, dcdr_env%nbr_center(1)

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -890,6 +890,7 @@ CONTAINS
       CALL dbcsr_allocate_matrix_set(dcdr_env%matrix_hc, 3)
       CALL dbcsr_allocate_matrix_set(dcdr_env%matrix_ppnl_1, 3)
 
+      NULLIFY (dcdr_env%perturbed_dm_correction)
       CALL dbcsr_init_p(dcdr_env%perturbed_dm_correction)
       CALL dbcsr_copy(dcdr_env%perturbed_dm_correction, matrix_ks(1)%matrix)
 

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -740,6 +740,7 @@ CONTAINS
          CPABORT("NYE")
       END IF
 
+      NULLIFY(dcdr_env%matrix_s)
       CALL build_overlap_matrix(ks_env, matrix_s=dcdr_env%matrix_s, &
                                 matrix_name="OVERLAP MATRIX", &
                                 nderivative=1, &
@@ -747,6 +748,7 @@ CONTAINS
                                 basis_type_b="ORB", &
                                 sab_nl=sab_orb)
 
+      NULLIFY(dcdr_env%matrix_t)
       CALL build_kinetic_matrix(ks_env, matrix_t=dcdr_env%matrix_t, &
                                 matrix_name="KINETIC ENERGY MATRIX", &
                                 basis_type="ORB", &

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -740,7 +740,7 @@ CONTAINS
          CPABORT("NYE")
       END IF
 
-      NULLIFY(dcdr_env%matrix_s)
+      NULLIFY (dcdr_env%matrix_s)
       CALL build_overlap_matrix(ks_env, matrix_s=dcdr_env%matrix_s, &
                                 matrix_name="OVERLAP MATRIX", &
                                 nderivative=1, &
@@ -748,7 +748,7 @@ CONTAINS
                                 basis_type_b="ORB", &
                                 sab_nl=sab_orb)
 
-      NULLIFY(dcdr_env%matrix_t)
+      NULLIFY (dcdr_env%matrix_t)
       CALL build_kinetic_matrix(ks_env, matrix_t=dcdr_env%matrix_t, &
                                 matrix_name="KINETIC ENERGY MATRIX", &
                                 basis_type="ORB", &


### PR DESCRIPTION
Follow up PR to https://github.com/cp2k/cp2k/pull/1706

- Remove a `STAT=` and a `print` statement;
- replace calls to `cp_fm_gemm` by `cp_gemm`
- nullify DBCSR matrix before initializing
