### PR TITLE
ocl: allow unknown GPU in case of OpenCL backend

### DIFF
--- a/exts/build_dbcsr/Makefile
+++ b/exts/build_dbcsr/Makefile
@@ -93,7 +93,9 @@ else ifeq ($(GPUVER),Mi50)
 else ifeq ($(GPUVER),Mi100)
   ARCH_NUMBER = gfx908
 else ifneq ($(GPUVER),)
+ifneq (opencl,$(USE_ACCEL))
   $(error GPUVER not recognized)
+endif
 endif
 
 # If compiling with nvcc


### PR DESCRIPTION
* An "unknown GPU" may be not know to the build system (Makefile)
* The mechanism to pickup parameters is different from CUDA/HIP