### PR TITLE
python: change shebang to /usr/bin/env python3

### DIFF
--- a/tools/minimax_tools/minimax_to_fortran_source.py
+++ b/tools/minimax_tools/minimax_to_fortran_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import argparse

--- a/tools/precommit/precommit.py
+++ b/tools/precommit/precommit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # author: Ole Schuett
 

--- a/tools/precommit/precommit_server.py
+++ b/tools/precommit/precommit_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # author: Ole Schuett
 

--- a/tools/regtesting/do_regtest.py
+++ b/tools/regtesting/do_regtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # author: Ole Schuett
 

--- a/tools/regtesting/optimize_test_dirs.py
+++ b/tools/regtesting/optimize_test_dirs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # author: Ole Schuett
 


### PR DESCRIPTION
Most python files use /usr/bin/env python3. A few however point to /usr/bin/python3.
This pr changes the few /usr/bin/python3 to /usr/bin/env python3.