### PR TITLE
toolchain: bump cmake version

### DIFF
--- a/tools/toolchain/scripts/stage0/install_cmake.sh
+++ b/tools/toolchain/scripts/stage0/install_cmake.sh
@@ -9,8 +9,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-cmake_ver="3.20.5"
-cmake_sha256="f582e02696ceee81818dc3378531804b2213ed41c2a8bc566253d16d894cefab"
+cmake_ver="3.22.1"
+cmake_sha256="808a712bcb039fd71f6960dca82a9befb977d8bdb074718218cf7646fd08bb7a"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -106,6 +106,10 @@ case "$with_sirius" in
       [ -d sirius-${sirius_ver} ] && rm -rf sirius-${sirius_ver}
       tar -xzf SIRIUS-${sirius_ver}.tar.gz
       cd SIRIUS-${sirius_ver}
+
+      # fix the CUDA include path
+      patch -p1 < "${SCRIPT_DIR}/stage8/sirius-7.3.0-cudatoolkit.patch"
+
       rm -Rf build
       mkdir build
       cd build
@@ -136,7 +140,7 @@ case "$with_sirius" in
       fi
 
       cmake -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
-        -DCMAKE_CXXFLAGS_RELEASE="${SIRIUS_OPT}" \
+        -DCMAKE_CXX_FLAGS_RELEASE="${SIRIUS_OPT}" \
         -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${SIRIUS_DBG}" \
         -DCMAKE_CXX_COMPILER="${MPICXX}" \
         -DCMAKE_C_COMPILER="${MPICC}" \
@@ -161,7 +165,7 @@ case "$with_sirius" in
         cd build-cuda
         CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${SPFFT_ROOT}/lib/cmake:${SPFFT_ROOT}/lib64/cmake" \
           cmake -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
-          -DCMAKE_CXXFLAGS_RELEASE="${SIRIUS_OPT}" \
+          -DCMAKE_CXX_FLAGS_RELEASE="${SIRIUS_OPT}" \
           -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${SIRIUS_DBG}" \
           -DCMAKE_CUDA_FLAGS="-std=c++14 -allow-unsupported-compiler" \
           -DUSE_CUDA=ON \

--- a/tools/toolchain/scripts/stage8/sirius-7.3.0-cudatoolkit.patch
+++ b/tools/toolchain/scripts/stage8/sirius-7.3.0-cudatoolkit.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/cudalibs_target.cmake b/cmake/cudalibs_target.cmake
+index 29802dd3..3d4d761b 100644
+--- a/cmake/cudalibs_target.cmake
++++ b/cmake/cudalibs_target.cmake
+@@ -1,6 +1,5 @@
++find_package(CUDAToolkit REQUIRED)
+ if (NOT TARGET sirius::cudalibs)
+   add_library(sirius::cudalibs INTERFACE IMPORTED)
+-  set_target_properties(sirius::cudalibs PROPERTIES
+-                                         INTERFACE_INCLUDE_DIRECTORIES "${CUDA_INCLUDE_DIRS}"
+-                                         INTERFACE_LINK_LIBRARIES "${CUDA_LIBRARIES};${CUDA_CUBLAS_LIBRARIES};${CUDA_CUFFT_LIBRARIES};${CUDA_cusolver_LIBRARY}")
++  target_link_libraries(sirius::cudalibs INTERFACE CUDA::cudart CUDA::cublas CUDA::cufft CUDA::cusolver)
+ endif()


### PR DESCRIPTION
CMake 3.22.0+ contains a [crucial fix in FindCUDAToolkit](https://github.com/Kitware/CMake/commit/32574814c78fb67cbe23dd1352ca304ec804d4e2#diff-b49d806903712080927ca1bb20ddc1894e844492fb2db431cd0bb8f1934ccef6) to correctly discover cu{blas,sparse,fftw,..} in newer SDK versions