### PR TITLE
Unset FORTRAN before libxsmm is built

### DIFF
--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -65,6 +65,8 @@ EOF
       # stage of building an executable that uses the libxsmm
       # library
       cd libxsmm-${libxsmm_ver}
+      # Avoid an unintended (incompatible) setting of FORTRAN
+      unset FORTRAN
       make -j $(get_nprocs) \
         CXX=$CXX \
         CC=$CC \


### PR DESCRIPTION
Avoid interference with a potentially present environment variable FORTRAN when libxsmm is built