### PR TITLE
tools: remove angle brackets from get_revision_number output if .git is absent

### DIFF
--- a/tools/build_utils/get_revision_number
+++ b/tools/build_utils/get_revision_number
@@ -15,7 +15,7 @@ GIT_DIR="$1/../.git"
 GIT_HEAD="${GIT_DIR}/HEAD"
 
 if [ ! -s "${GIT_HEAD}" ] ; then
-  echo "<unknown revision>"
+  echo "unknown revision"
   >&2 echo "WARNING: $0 failed to determine the Git commit and no REVISION file available"
   exit 1
 fi


### PR DESCRIPTION
Fixes: #1270