### PR TITLE
Use generic api for gpu to hide vendor specific api

### DIFF
--- a/src/grid/hip/grid_hip_context.cc
+++ b/src/grid/hip/grid_hip_context.cc
@@ -19,8 +19,8 @@
 #include <hip/hip_runtime_api.h>
 #include <iostream>
 
-extern "C" {
 #include "../../offload/offload_library.h"
+extern "C" {
 #include "../common/grid_basis_set.h"
 #include "../common/grid_constants.h"
 #include "../common/grid_library.h"

--- a/src/offload/PACKAGE
+++ b/src/offload/PACKAGE
@@ -1,5 +1,12 @@
 {
     "description": "Common infrastructure for offloading to accelerator devices",
     "requires": ["../base",],
-    "public": ["offload_api.F", "offload_buffer.h", "offload_library.h"],
+    "public": [
+        "offload_api.F",
+        "offload_buffer.h",
+        "offload_library.h",
+        "offload_operations.h",
+        "offload_cuda_internal.h",
+        "offload_hip_internal.h",
+    ],
 }

--- a/src/offload/offload_cuda_internal.h
+++ b/src/offload/offload_cuda_internal.h
@@ -1,0 +1,93 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2022 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: BSD-3-Clause                                     */
+/*----------------------------------------------------------------------------*/
+
+#ifndef OFFLOAD_CUDA_INTERNAL_H
+#define OFFLOAD_CUDA_INTERNAL_H
+#include <cuda_runtime.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef cudaStream_t offloadStream_t;
+typedef cudaEvent_t offloadEvent_t;
+
+/*******************************************************************************
+ * \brief Check given Cuda status and upon failure abort with a nice message.
+ * \author Ole Schuett
+ ******************************************************************************/
+#define OFFLOAD_CHECK(status)                                                  \
+  if (status != cudaSuccess) {                                                 \
+    fprintf(stderr, "ERROR: %s %s %d\n", cudaGetErrorString(status), __FILE__, \
+            __LINE__);                                                         \
+    abort();                                                                   \
+  }
+
+static inline void offloadMemsetAsync(void *ptr__, int val__, size_t size__,
+                                      offloadStream_t stream__) {
+  OFFLOAD_CHECK(cudaMemsetAsync(ptr__, val__, size__, stream__));
+}
+
+static inline void offloadMemcpyAsyncHtoD(void *ptr1__, void *ptr2__,
+                                          size_t size__,
+                                          offloadStream_t stream__) {
+  OFFLOAD_CHECK(cudaMemcpyAsync(ptr1__, ptr2__, size__, cudaMemcpyHostToDevice,
+                                stream__));
+}
+
+static inline void offloadMemcpyAsyncDtoH(void *ptr1__, void *ptr2__,
+                                          size_t size__,
+                                          offloadStream_t stream__) {
+  OFFLOAD_CHECK(cudaMemcpyAsync(ptr1__, ptr2__, size__, cudaMemcpyDeviceToHost,
+                                stream__));
+}
+
+static inline void offloadEventCreate(offloadEvent_t *event__) {
+  OFFLOAD_CHECK(cudaEventCreate(event__));
+}
+
+static inline void offloadEventDestroy(offloadEvent_t event__) {
+  OFFLOAD_CHECK(cudaEventDestroy(event__));
+}
+
+static inline void offloadStreamCreate(offloadStream_t *stream__) {
+  OFFLOAD_CHECK(cudaStreamCreate(stream__));
+}
+
+static inline void offloadStreamDestroy(offloadStream_t stream__) {
+  OFFLOAD_CHECK(cudaStreamDestroy(stream__));
+}
+
+static inline void offloadEventSynchronize(offloadEvent_t event__) {
+  OFFLOAD_CHECK(cudaEventSynchronize(event__));
+}
+
+static inline void offloadStreamSynchronize(offloadStream_t stream__) {
+  OFFLOAD_CHECK(cudaStreamSynchronize(stream__));
+}
+
+static inline void offloadEventRecord(offloadEvent_t event__,
+                                      offloadStream_t stream__) {
+  OFFLOAD_CHECK(cudaEventRecord(event__, stream__));
+}
+
+static inline void offloadMalloc(void *ptr__, size_t size__) {
+  OFFLOAD_CHECK(cudaMalloc((void **)ptr__, size__));
+}
+
+static inline void offloadFree(void *ptr__) { OFFLOAD_CHECK(cudaFree(ptr__)); }
+
+static inline void offloadStreamWaitEvent(offloadStream_t stream__,
+                                          offloadEvent_t event__,
+                                          const int val__) {
+  cudaStreamWaitEvent(stream__, event__, val__);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/offload/offload_hip_internal.h
+++ b/src/offload/offload_hip_internal.h
@@ -1,0 +1,115 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2022 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: BSD-3-Clause                                     */
+/*----------------------------------------------------------------------------*/
+
+#ifndef OFFLOAD_HIP_INTERNAL_H
+#define OFFLOAD_HIP_INTERNAL_H
+#include <hip/hip_runtime_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef hipStream_t offloadStream_t;
+typedef hipEvent_t offloadEvent_t;
+
+/*******************************************************************************
+ * \brief Check given Hip status and upon failure abort with a nice message.
+ * \author Ole Schuett
+ ******************************************************************************/
+#define OFFLOAD_CHECK(status)                                                  \
+  if (status != hipSuccess) {                                                  \
+    fprintf(stderr, "ERROR: %s %s %d\n", hipGetErrorString(status), __FILE__,  \
+            __LINE__);                                                         \
+    abort();                                                                   \
+  }
+
+static inline void offloadMemsetAsync(void *ptr__, int val__, size_t size__,
+                                      offloadStream_t stream__) {
+  OFFLOAD_CHECK(hipMemsetAsync(ptr__, val__, size__, stream__));
+}
+
+static inline void offloadMemcpyAsyncHtoD(void *ptr1__, const void *ptr2__,
+                                          const size_t size__,
+                                          offloadStream_t stream__) {
+  OFFLOAD_CHECK(
+      hipMemcpyAsync(ptr1__, ptr2__, size__, hipMemcpyHostToDevice, stream__));
+}
+
+static inline void offloadMemcpyAsyncDtoH(void *ptr1__, const void *ptr2__,
+                                          const size_t size__,
+                                          offloadStream_t stream__) {
+  OFFLOAD_CHECK(
+      hipMemcpyAsync(ptr1__, ptr2__, size__, hipMemcpyDeviceToHost, stream__));
+}
+
+static inline void offloadMemcpyHtoD(void *ptr1__, const void *ptr2__,
+                                     const size_t size__) {
+  OFFLOAD_CHECK(hipMemcpy(ptr1__, ptr2__, size__, hipMemcpyHostToDevice));
+}
+
+static inline void offloadMemcpyDtoH(void *ptr1__, const void *ptr2__,
+                                     const size_t size__) {
+  OFFLOAD_CHECK(hipMemcpy(ptr1__, ptr2__, size__, hipMemcpyDeviceToHost));
+}
+
+static inline void offloadEventCreate(offloadEvent_t *event__) {
+  OFFLOAD_CHECK(hipEventCreate(event__));
+}
+
+static inline void offloadEventDestroy(offloadEvent_t event__) {
+  OFFLOAD_CHECK(hipEventDestroy(event__));
+}
+
+static inline void offloadStreamCreate(offloadStream_t *stream__) {
+  OFFLOAD_CHECK(hipStreamCreate(stream__));
+}
+
+static inline void offloadStreamDestroy(offloadStream_t stream__) {
+  OFFLOAD_CHECK(hipStreamDestroy(stream__));
+}
+
+static inline void offloadEventSynchronize(offloadEvent_t event__) {
+  OFFLOAD_CHECK(hipEventSynchronize(event__));
+}
+
+static inline void offloadStreamSynchronize(offloadStream_t stream__) {
+  OFFLOAD_CHECK(hipStreamSynchronize(stream__));
+}
+
+static inline void offloadEventRecord(offloadEvent_t event__,
+                                      offloadStream_t stream__) {
+  OFFLOAD_CHECK(hipEventRecord(event__, stream__));
+}
+
+static inline void offloadMalloc(void *ptr__, size_t size__) {
+  OFFLOAD_CHECK(hipMalloc((void **)ptr__, size__));
+}
+
+static inline void offloadFree(void *ptr__) { OFFLOAD_CHECK(hipFree(ptr__)); }
+
+static inline void offloadStreamWaitEvent(offloadStream_t stream__,
+                                          offloadEvent_t event__,
+                                          const int val__) {
+  OFFLOAD_CHECK(hipStreamWaitEvent(stream__, event__, val__));
+}
+
+static inline void offloadSetDevice(const int dev_id__) {
+  OFFLOAD_CHECK(hipSetDevice(dev_id__));
+}
+
+static inline void offloadDeviceSynchronize() {
+  OFFLOAD_CHECK(hipDeviceSynchronize());
+}
+
+static inline void offloadMemset(void *ptr__, const int val__, size_t size__) {
+  OFFLOAD_CHECK(hipMemset(ptr__, val__, size__));
+}
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/offload/offload_library.h
+++ b/src/offload/offload_library.h
@@ -7,6 +7,10 @@
 #ifndef OFFLOAD_LIBRARY_H
 #define OFFLOAD_LIBRARY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(__GRID_CUDA) || defined(__PW_CUDA)
 #define __OFFLOAD_CUDA
 #elif defined(__GRID_HIP)
@@ -20,35 +24,7 @@
 #include <hip/hip_runtime_api.h>
 #endif
 
-#if defined(__OFFLOAD_CUDA)
-/*******************************************************************************
- * \brief Checks given Cuda status and upon failure abort with a nice message.
- * \author Ole Schuett
- ******************************************************************************/
-#define OFFLOAD_CHECK(status)                                                  \
-  if (status != cudaSuccess) {                                                 \
-    fprintf(stderr, "ERROR: %s %s %d\n", cudaGetErrorString(status), __FILE__, \
-            __LINE__);                                                         \
-    abort();                                                                   \
-  }
-#endif
-
-#if defined(__OFFLOAD_HIP)
-/*******************************************************************************
- * \brief Checks given rocm status and upon failure abort with a nice message.
- ******************************************************************************/
-#define OFFLOAD_CHECK(status)                                                  \
-  if (status != hipSuccess) {                                                  \
-    fprintf(stderr, "ERROR: %s %s %d\n", hipGetErrorString(status), __FILE__,  \
-            __LINE__);                                                         \
-    abort();                                                                   \
-  }
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+#include "offload_operations.h"
 /*******************************************************************************
  * \brief Returns the number of available devices.
  * \author Ole Schuett

--- a/src/offload/offload_operations.h
+++ b/src/offload/offload_operations.h
@@ -1,0 +1,19 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2022 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: BSD-3-Clause                                     */
+/*----------------------------------------------------------------------------*/
+
+#ifndef OFFLOAD_OPERATIONS_H
+#define OFFLOAD_OPERATIONS_H
+
+#if defined __OFFLOAD_HIP
+#include "offload_hip_internal.h"
+#endif
+
+#if defined __OFFLOAD_CUDA
+#include "offload_cuda_internal.h"
+#endif
+
+#endif


### PR DESCRIPTION
- use generic names instead of cuda/hip functions. this should simplify things when porting code to accelerators.
- It does not support all functions of the cuda or hip api though.