### PR TITLE
dbm: renamed dgemm to dbm_dgemm avoiding symbol/name clashes

### DIFF
--- a/src/dbm/dbm_multiply_cpu.c
+++ b/src/dbm/dbm_multiply_cpu.c
@@ -126,8 +126,8 @@ void dbm_multiply_cpu_process_batch(const int ntasks, dbm_task_t batch[ntasks],
       const int lda = (transa) ? task.k : task.m;
       const int ldb = (transb) ? task.n : task.k;
       const int ldc = task.m;
-      dbm_dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda, data_b,
-                ldb, 1.0, data_c, ldc);
+      dbm_dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda,
+                data_b, ldb, 1.0, data_c, ldc);
     }
   }
 
@@ -142,8 +142,8 @@ void dbm_multiply_cpu_process_batch(const int ntasks, dbm_task_t batch[ntasks],
     const double *data_a = &pack_a->data[task.offset_a];
     const double *data_b = &pack_b->data[task.offset_b];
     double *data_c = &shard_c->data[task.offset_c];
-    dbm_dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda, data_b,
-              ldb, 1.0, data_c, ldc);
+    dbm_dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda,
+              data_b, ldb, 1.0, data_c, ldc);
   }
 
 #endif

--- a/src/dbm/dbm_multiply_cpu.c
+++ b/src/dbm/dbm_multiply_cpu.c
@@ -29,11 +29,11 @@ void dgemm_(const char *transa, const char *transb, const int *m, const int *n,
  * \brief Private convenient wrapper to hide Fortran nature of dgemm_.
  * \author Ole Schuett
  ******************************************************************************/
-static inline void dgemm(const bool transa, const bool transb, const int m,
-                         const int n, const int k, const double alpha,
-                         const double *a, const int lda, const double *b,
-                         const int ldb, const double beta, double *c,
-                         const int ldc) {
+static inline void dbm_dgemm(const bool transa, const bool transb, const int m,
+                             const int n, const int k, const double alpha,
+                             const double *a, const int lda, const double *b,
+                             const int ldb, const double beta, double *c,
+                             const int ldc) {
   const char transa_char = (transa) ? 'T' : 'N';
   const char transb_char = (transb) ? 'T' : 'N';
 
@@ -126,8 +126,8 @@ void dbm_multiply_cpu_process_batch(const int ntasks, dbm_task_t batch[ntasks],
       const int lda = (transa) ? task.k : task.m;
       const int ldb = (transb) ? task.n : task.k;
       const int ldc = task.m;
-      dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda, data_b,
-            ldb, 1.0, data_c, ldc);
+      dbm_dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda, data_b,
+                ldb, 1.0, data_c, ldc);
     }
   }
 
@@ -142,8 +142,8 @@ void dbm_multiply_cpu_process_batch(const int ntasks, dbm_task_t batch[ntasks],
     const double *data_a = &pack_a->data[task.offset_a];
     const double *data_b = &pack_b->data[task.offset_b];
     double *data_c = &shard_c->data[task.offset_c];
-    dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda, data_b,
-          ldb, 1.0, data_c, ldc);
+    dbm_dgemm(transa, transb, task.m, task.n, task.k, alpha, data_a, lda, data_b,
+              ldb, 1.0, data_c, ldc);
   }
 
 #endif


### PR DESCRIPTION
* For example when mkl.h is (indirectly) included.