### PR TITLE
Retire ARMv7l regression tester

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -217,13 +217,6 @@ host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_i386_report.txt
 
 # ==============================================================================
-[armv7l-gnu-psmp]
-sortkey:     700
-name:        Linux-armv7l-gnu.psmp (8.3.0)
-host:        Raspberry Pi 4
-report_url:  http://www.cp2k.org/static/regtest/trunk/Linux-armv7l-gnu/psmp/regtest-0
-info_url:    http://www.cp2k.org/static/regtest/trunk/Linux-armv7l-gnu/psmp/index.html
-
 [arm64-gnu-psmp]
 sortkey:     702
 name:        Linux-arm64-gnu.psmp (11.2.0)


### PR DESCRIPTION
SIRIUS v7.3.1 requires now cmake v3.18 or newer and only v3.16 is available for armv7l