### PR TITLE
Fix INTENT of calc_energy_func_der

### DIFF
--- a/src/mp2_optimize_ri_basis.F
+++ b/src/mp2_optimize_ri_basis.F
@@ -586,7 +586,8 @@ CONTAINS
                                    p, lower_B, max_dev, &
                                    deriv)
       REAL(KIND=dp), INTENT(IN)                          :: Emp2
-      REAL(KIND=dp), INTENT(OUT)                         :: Emp2_AA, Emp2_BB, Emp2_AB, DI_ref
+      REAL(KIND=dp), INTENT(OUT)                         :: Emp2_AA, Emp2_BB, Emp2_AB
+      REAL(KIND=dp), INTENT(IN)                          :: DI_ref
       REAL(KIND=dp), DIMENSION(:, :, :, :), INTENT(IN)   :: Integ_MP2, Integ_MP2_AA, Integ_MP2_BB, &
                                                             Integ_MP2_AB
       REAL(KIND=dp), INTENT(IN)                          :: eps


### PR DESCRIPTION
This is very trivial—the parameter `DI_ref` is only used at https://github.com/cp2k/cp2k/blob/afcbbb421550295b055d59c69282c7c442168028/src/mp2_optimize_ri_basis.F#L662