### PR TITLE
Update GNU and Intel arch files

### DIFF
--- a/arch/Linux-gnu-x86_64.psmp
+++ b/arch/Linux-gnu-x86_64.psmp
@@ -1,19 +1,19 @@
 #!/bin/bash
 #
-# CP2K (Intel/MKL) arch file for Linux clusters
+# CP2K (GNU x86_64) arch file for Linux clusters
 #
-# Tested with: Intel 20.4/21.4/22.1 , Intel MPI, Intel MKL,
-#              LIBINT 2.6.0, LIBXC 5.1.7, ELPA 2021.11.001,
-#              PLUMED 2.7.3, SPGLIB 1.16.2, LIBVORI 210412,
-#              GSL 2.7, COSMA 2.5.1, SIRIUS 7.3.0
+# Tested with: GNU 10.3.0 (and 11.2.0), MPICH 3.3.2 (and OpenMPI 4.1.1),
+#              ScaLAPACK 2.1.0, OpenBLAS 0.3.19, FFTW 3.3.10, LIBINT 2.6.0,
+#              LIBXC 5.2.0, ELPA 2021.11.001, PLUMED 2.7.3, SPGLIB 1.16.2,
+#              LIBVORI 210412, GSL 2.7, COSMA 2.5.1, SIRIUS 7.3.1
 # on the Merlin cluster (PSI)
 #
 # Usage: Source this arch file and then run make as instructed.
 #        A full toolchain installation is performed as default.
-#        Optionally, the Intel compiler version can be specified as argument.
+#        Optionally, GNU compiler and MPICH version can be specified as arguments.
 #        Replace or adapt the "module add" commands below if needed.
 #
-# Author: Matthias Krack (18.01.2022)
+# Author: Matthias Krack (24.01.2022)
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -24,10 +24,13 @@
    this_file=${BASH_SOURCE##*/}; \
    cd tools/toolchain; \
    if [[ -n "${1}" ]]; then \
-      module add intel/${1}; \
+      module add ${1}; \
+      [[ -n "${2}" ]] && module add ${2}; \
       module list; \
+      ./install_cp2k_toolchain.sh --install-all --with-gcc=system --with-mpich=system; \
+   else \
+      ./install_cp2k_toolchain.sh --install-all --with-gcc --with-mpich; \
    fi; \
-   ./install_cp2k_toolchain.sh --install-all --with-intelmpi --with-mkl; \
    source ./install/setup; \
    cd ../..; \
    echo; \
@@ -47,13 +50,17 @@ DO_CHECKS      := no
 SHARED         := no
 USE_COSMA      := 2.5.1
 USE_ELPA       := 2021.11.001
+USE_FFTW       := 3.3.10
 USE_LIBINT     := 2.6.0
 USE_LIBPEXSI   := 1.2.0
 USE_LIBVORI    := 210412
-USE_LIBXC      := 5.1.7
+USE_LIBXC      := 5.2.0
 USE_LIBXSMM    := 1.17
+USE_OPENBLAS   := 0.3.19
 USE_PLUMED     := 2.7.3
-USE_SIRIUS     := 7.3.0
+USE_QUIP       := b4336484fb65b0e73211a8f920ae4361c7c353fd
+USE_SCALAPACK  := 2.1.0
+USE_SIRIUS     := 7.3.1
 USE_SPGLIB     := 1.16.2
 # Only needed for SIRIUS
 LIBVDWXC_VER   := 0.4.0
@@ -67,23 +74,20 @@ SUPERLU_VER    := 6.1.0
 LMAX           := 5
 MAX_CONTR      := 4
 
-CC             := mpiicc
-FC             := mpiifort
-LD             := mpiifort
+CC             := mpicc
+FC             := mpif90
+LD             := mpif90
 AR             := ar -r
 
-CFLAGS         := -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost
+CFLAGS         := -O3 -fopenmp -funroll-loops -g -mtune=native
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__SCALAPACK
-DFLAGS         += -D__MKL
-DFLAGS         += -D__FFTW3
+DFLAGS         += -D__HAS_IEEE_EXCEPTIONS
 DFLAGS         += -D__MPI_VERSION=3
 DFLAGS         += -D__MAX_CONTR=$(strip $(MAX_CONTR))
 
 INSTALL_PATH   := $(PWD)/tools/toolchain/install
-
-MKL_LIB        := $(MKLROOT)/lib/intel64
 
 ifeq ($(SHARED), yes)
    LD_SHARED      := $(FC) -shared
@@ -92,13 +96,34 @@ ifeq ($(SHARED), yes)
    CP2K_LIB       := $(PWD)/lib/$(ARCH)/$(ONEVERSION)
    LDFLAGS        += -Wl,-rpath=$(CP2K_LIB)
    LDFLAGS        += -Wl,-rpath=$(CP2K_LIB)/exts/dbcsr
-else
-   LDFLAGS        := -static-intel -static_mpi
 endif
 
 # Settings for regression testing
 ifeq ($(DO_CHECKS), yes)
    DFLAGS         += -D__CHECK_DIAG
+   FCFLAGS_DEBUG  := -fcheck=bounds,do,recursion,pointer
+   FCFLAGS_DEBUG  += -fcheck=all,no-array-temps
+   FCFLAGS_DEBUG  += -ffpe-trap=invalid,overflow,zero
+   FCFLAGS_DEBUG  += -fimplicit-none
+   FCFLAGS_DEBUG  += -finit-derived
+   FCFLAGS_DEBUG  += -finit-real=snan
+   FCFLAGS_DEBUG  += -finit-integer=-42
+   FCFLAGS_DEBUG  += -finline-matmul-limit=0
+   LDFLAGS        += -fsanitize=leak
+   WFLAGS         := -Werror=aliasing
+   WFLAGS         += -Werror=ampersand
+   WFLAGS         += -Werror=c-binding-type
+   WFLAGS         += -Werror=conversion
+   WFLAGS         += -Werror=intrinsic-shadow
+   WFLAGS         += -Werror=intrinsics-std
+   WFLAGS         += -Werror=line-truncation
+   WFLAGS         += -Wrealloc-lhs
+   WFLAGS         += -Werror=tabs
+   WFLAGS         += -Werror=target-lifetime
+   WFLAGS         += -Werror=underflow
+   WFLAGS         += -Werror=unused-but-set-variable
+   WFLAGS         += -Werror=unused-dummy-argument
+   WFLAGS         += -Werror=unused-variable
 endif
 
 ifneq ($(USE_PLUMED),)
@@ -124,6 +149,20 @@ ifneq ($(USE_ELPA),)
    else
       LIBS           += $(ELPA_LIB)/libelpa_openmp.a
    endif
+endif
+
+ifneq ($(USE_QUIP),)
+   USE_QUIP       := $(strip $(USE_QUIP))
+   QUIP_INC       := $(INSTALL_PATH)/quip-$(USE_QUIP)/include
+   QUIP_LIB       := $(INSTALL_PATH)/quip-$(USE_QUIP)/lib
+   CFLAGS         += -I$(QUIP_INC)
+   DFLAGS         += -D__QUIP
+   LIBS           += $(QUIP_LIB)/libquip_core.a
+   LIBS           += $(QUIP_LIB)/libatoms.a
+   LIBS           += $(QUIP_LIB)/libFoX_sax.a
+   LIBS           += $(QUIP_LIB)/libFoX_common.a
+   LIBS           += $(QUIP_LIB)/libFoX_utils.a
+   LIBS           += $(QUIP_LIB)/libFoX_fsys.a
 endif
 
 ifneq ($(USE_LIBPEXSI),)
@@ -216,36 +255,30 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
-   LIBVDWXC_VER   := $(strip $(LIBVDWXC_VER))
-   SPFFT_VER      := $(strip $(SPFFT_VER))
-   SPLA_VER       := $(strip $(SPLA_VER))
-   HDF5_VER       := $(strip $(HDF5_VER))
    SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
-   LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
-   LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
    SPFFT_LIB      := $(INSTALL_PATH)/SpFFT-$(SPFFT_VER)/lib
    SPLA_LIB       := $(INSTALL_PATH)/SpLA-$(SPLA_VER)/lib
    HDF5_LIB       := $(INSTALL_PATH)/hdf5-$(HDF5_VER)/lib
+   LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
    CFLAGS         += -I$(SIRIUS_INC)
-   CFLAGS         += -I$(LIBVDWXC_INC)
-   DFLAGS         += -D__SIRIUS
-   DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SPFFT
    DFLAGS         += -D__SPLA
    DFLAGS         += -D__HDF5
+   DFLAGS         += -D__LIBVDWXC
+   DFLAGS         += -D__SIRIUS
    ifeq ($(SHARED), yes)
       LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
-      LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
       LIBS           += -Wl,-rpath=$(SPFFT_LIB) -L$(SPFFT_LIB) -lspfft
       LIBS           += -Wl,-rpath=$(SPLA_LIB) -L$(SPLA_LIB) -lspla
       LIBS           += -Wl,-rpath=$(HDF5_LIB) -L$(HDF5_LIB) -lhdf5
+      LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
    else
       LIBS           += $(SIRIUS_LIB)/libsirius.a
-      LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
       LIBS           += $(SPFFT_LIB)/libspfft.a
       LIBS           += $(SPLA_LIB)/libspla.a
       LIBS           += $(HDF5_LIB)/libhdf5.a
+      LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
    endif
 endif
 
@@ -265,22 +298,28 @@ ifneq ($(USE_COSMA),)
    endif
 endif
 
-ifeq ($(SHARED), yes)
-   LIBS           += -Wl,-rpath=$(MKL_LIB) -L$(MKL_LIB) -lbmkl_scalapack_lp64
-   LIBS           += -Wl,--start-group
-   LIBS           += -lmkl_intel_lp64
-   LIBS           += -lmkl_sequential
-   LIBS           += -lmkl_core
-   LIBS           += -lmkl_blacs_intelmpi_lp64
-   LIBS           += -Wl,--end-group
-else
-   LIBS           += $(MKL_LIB)/libmkl_scalapack_lp64.a
-   LIBS           += -Wl,--start-group
-   LIBS           += $(MKL_LIB)/libmkl_intel_lp64.a
-   LIBS           += $(MKL_LIB)/libmkl_sequential.a
-   LIBS           += $(MKL_LIB)/libmkl_core.a
-   LIBS           += $(MKL_LIB)/libmkl_blacs_intelmpi_lp64.a
-   LIBS           += -Wl,--end-group
+ifneq ($(USE_FFTW),)
+   USE_FFTW       := $(strip $(USE_FFTW))
+   FFTW_INC       := $(INSTALL_PATH)/fftw-$(USE_FFTW)/include
+   FFTW_LIB       := $(INSTALL_PATH)/fftw-$(USE_FFTW)/lib
+   CFLAGS         += -I$(FFTW_INC)
+   DFLAGS         += -D__FFTW3
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath=$(FFTW_LIB) -L$(FFTW_LIB) -lfftw3_mpi -lfftw3_omp -lfftw3
+   else
+      LIBS           += $(FFTW_LIB)/libfftw3_mpi.a
+      LIBS           += $(FFTW_LIB)/libfftw3_omp.a
+      LIBS           += $(FFTW_LIB)/libfftw3.a
+   endif
+endif
+
+ifneq ($(USE_SCALAPACK),)
+   SCALAPACK_LIB  := $(INSTALL_PATH)/scalapack-$(USE_SCALAPACK)/lib
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath=$(SCALAPACK_LIB) -L$(SCALAPACK_LIB) -lscalapack
+   else
+      LIBS           += $(SCALAPACK_LIB)/libscalapack.a
+   endif
 endif
 
 ifneq ($(USE_GSL),)
@@ -297,23 +336,32 @@ ifneq ($(USE_GSL),)
    endif
 endif
 
-CFLAGS         += $(DFLAGS)
-CFLAGS         += -I$(MKLROOT)/include
-CFLAGS         += -I$(MKLROOT)/include/fftw
+ifneq ($(USE_OPENBLAS),)
+   USE_OPENBLAS   := $(strip $(USE_OPENBLAS))
+   OPENBLAS_INC   := $(INSTALL_PATH)/openblas-$(USE_OPENBLAS)/include
+   OPENBLAS_LIB   := $(INSTALL_PATH)/openblas-$(USE_OPENBLAS)/lib
+   CFLAGS         += -I$(OPENBLAS_INC)
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath=$(OPENBLAS_LIB) -L$(OPENBLAS_LIB) -lopenblas
+   else
+      LIBS           += $(OPENBLAS_LIB)/libopenblas.a
+   endif
+endif
 
-FCFLAGS        := $(CFLAGS)
-FCFLAGS        += -diag-disable=8291
-FCFLAGS        += -diag-disable=8293
-FCFLAGS        += -fpp
-FCFLAGS        += -free
+CFLAGS         += $(DFLAGS)
+
+FCFLAGS        := $(CFLAGS) $(FCFLAGS_DEBUG) $(WFLAGS)
+ifeq ($(shell [ $(shell gcc -dumpversion | cut -d. -f1) -gt 9 ] && echo yes), yes)
+   FCFLAGS        += -fallow-argument-mismatch
+endif
+FCFLAGS        += -fbacktrace
+FCFLAGS        += -ffree-form
+FCFLAGS        += -ffree-line-length-none
+FCFLAGS        += -fno-omit-frame-pointer
+FCFLAGS        += -std=f2008
 
 LDFLAGS        += $(FCFLAGS)
-LDFLAGS_C      := -nofor-main
 
-LIBS           += -lz -lstdc++
-
-# Required due to memory leak that occurs if high optimisations are used
-mp2_optimize_ri_basis.o: mp2_optimize_ri_basis.F
-	$(FC) -c $(subst O2,O0,$(FCFLAGS)) $<
+LIBS           += -lz -ldl -lstdc++
 
 # End

--- a/arch/Linux-intel-x86_64.psmp
+++ b/arch/Linux-intel-x86_64.psmp
@@ -1,19 +1,19 @@
 #!/bin/bash
 #
-# CP2K (GNU) arch file for Linux clusters
+# CP2K (Intel/MKL x86_64) arch file for Linux clusters
 #
-# Tested with: GNU 10.3.0 (and 11.2.0), MPICH 3.3.2 (and OpenMPI 4.1.1),
-#              ScaLAPACK 2.1.0, OpenBLAS 0.3.19, FFTW 3.3.10, LIBINT 2.6.0,
-#              LIBXC 5.1.7, ELPA 2021.11.001, PLUMED 2.7.3, SPGLIB 1.16.2,
-#              LIBVORI 210412, GSL 2.7, COSMA 2.5.1, SIRIUS 7.3.0
+# Tested with: Intel 20.4/21.4/22.1 , Intel MPI, Intel MKL,
+#              LIBINT 2.6.0, LIBXC 5.2.0, ELPA 2021.11.001,
+#              PLUMED 2.7.3, SPGLIB 1.16.2, LIBVORI 210412,
+#              GSL 2.7, COSMA 2.5.1, SIRIUS 7.3.1
 # on the Merlin cluster (PSI)
 #
 # Usage: Source this arch file and then run make as instructed.
 #        A full toolchain installation is performed as default.
-#        Optionally, GNU compiler and MPICH version can be specified as arguments.
+#        Optionally, the Intel compiler version can be specified as argument.
 #        Replace or adapt the "module add" commands below if needed.
 #
-# Author: Matthias Krack (18.01.2022)
+# Author: Matthias Krack (24.01.2022)
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -24,13 +24,10 @@
    this_file=${BASH_SOURCE##*/}; \
    cd tools/toolchain; \
    if [[ -n "${1}" ]]; then \
-      module add gcc/${1}; \
-      [[ -n "${2}" ]] && module add mpich/${2}; \
+      module add ${1}; \
       module list; \
-      ./install_cp2k_toolchain.sh --install-all --with-gcc=system --with-mpich=system; \
-   else \
-      ./install_cp2k_toolchain.sh --install-all --with-gcc --with-mpich; \
    fi; \
+   ./install_cp2k_toolchain.sh --install-all --with-intelmpi --with-mkl; \
    source ./install/setup; \
    cd ../..; \
    echo; \
@@ -50,17 +47,13 @@ DO_CHECKS      := no
 SHARED         := no
 USE_COSMA      := 2.5.1
 USE_ELPA       := 2021.11.001
-USE_FFTW       := 3.3.10
 USE_LIBINT     := 2.6.0
 USE_LIBPEXSI   := 1.2.0
 USE_LIBVORI    := 210412
-USE_LIBXC      := 5.1.7
+USE_LIBXC      := 5.2.0
 USE_LIBXSMM    := 1.17
-USE_OPENBLAS   := 0.3.19
 USE_PLUMED     := 2.7.3
-USE_QUIP       := b4336484fb65b0e73211a8f920ae4361c7c353fd
-USE_SCALAPACK  := 2.1.0
-USE_SIRIUS     := 7.3.0
+USE_SIRIUS     := 7.3.1
 USE_SPGLIB     := 1.16.2
 # Only needed for SIRIUS
 LIBVDWXC_VER   := 0.4.0
@@ -74,20 +67,23 @@ SUPERLU_VER    := 6.1.0
 LMAX           := 5
 MAX_CONTR      := 4
 
-CC             := mpicc
-FC             := mpif90
-LD             := mpif90
+CC             := mpiicc
+FC             := mpiifort
+LD             := mpiifort
 AR             := ar -r
 
-CFLAGS         := -O3 -fopenmp -funroll-loops -g -mtune=native
+CFLAGS         := -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__SCALAPACK
-DFLAGS         += -D__HAS_IEEE_EXCEPTIONS
+DFLAGS         += -D__MKL
+DFLAGS         += -D__FFTW3
 DFLAGS         += -D__MPI_VERSION=3
 DFLAGS         += -D__MAX_CONTR=$(strip $(MAX_CONTR))
 
 INSTALL_PATH   := $(PWD)/tools/toolchain/install
+
+MKL_LIB        := $(MKLROOT)/lib/intel64
 
 ifeq ($(SHARED), yes)
    LD_SHARED      := $(FC) -shared
@@ -96,34 +92,13 @@ ifeq ($(SHARED), yes)
    CP2K_LIB       := $(PWD)/lib/$(ARCH)/$(ONEVERSION)
    LDFLAGS        += -Wl,-rpath=$(CP2K_LIB)
    LDFLAGS        += -Wl,-rpath=$(CP2K_LIB)/exts/dbcsr
+else
+   LDFLAGS        := -static-intel -static_mpi
 endif
 
 # Settings for regression testing
 ifeq ($(DO_CHECKS), yes)
    DFLAGS         += -D__CHECK_DIAG
-   FCFLAGS_DEBUG  := -fcheck=bounds,do,recursion,pointer
-   FCFLAGS_DEBUG  += -fcheck=all,no-array-temps
-   FCFLAGS_DEBUG  += -ffpe-trap=invalid,overflow,zero
-   FCFLAGS_DEBUG  += -fimplicit-none
-   FCFLAGS_DEBUG  += -finit-derived
-   FCFLAGS_DEBUG  += -finit-real=snan
-   FCFLAGS_DEBUG  += -finit-integer=-42
-   FCFLAGS_DEBUG  += -finline-matmul-limit=0
-   LDFLAGS        += -fsanitize=leak
-   WFLAGS         := -Werror=aliasing
-   WFLAGS         += -Werror=ampersand
-   WFLAGS         += -Werror=c-binding-type
-   WFLAGS         += -Werror=conversion
-   WFLAGS         += -Werror=intrinsic-shadow
-   WFLAGS         += -Werror=intrinsics-std
-   WFLAGS         += -Werror=line-truncation
-   WFLAGS         += -Wrealloc-lhs
-   WFLAGS         += -Werror=tabs
-   WFLAGS         += -Werror=target-lifetime
-   WFLAGS         += -Werror=underflow
-   WFLAGS         += -Werror=unused-but-set-variable
-   WFLAGS         += -Werror=unused-dummy-argument
-   WFLAGS         += -Werror=unused-variable
 endif
 
 ifneq ($(USE_PLUMED),)
@@ -149,20 +124,6 @@ ifneq ($(USE_ELPA),)
    else
       LIBS           += $(ELPA_LIB)/libelpa_openmp.a
    endif
-endif
-
-ifneq ($(USE_QUIP),)
-   USE_QUIP       := $(strip $(USE_QUIP))
-   QUIP_INC       := $(INSTALL_PATH)/quip-$(USE_QUIP)/include
-   QUIP_LIB       := $(INSTALL_PATH)/quip-$(USE_QUIP)/lib
-   CFLAGS         += -I$(QUIP_INC)
-   DFLAGS         += -D__QUIP
-   LIBS           += $(QUIP_LIB)/libquip_core.a
-   LIBS           += $(QUIP_LIB)/libatoms.a
-   LIBS           += $(QUIP_LIB)/libFoX_sax.a
-   LIBS           += $(QUIP_LIB)/libFoX_common.a
-   LIBS           += $(QUIP_LIB)/libFoX_utils.a
-   LIBS           += $(QUIP_LIB)/libFoX_fsys.a
 endif
 
 ifneq ($(USE_LIBPEXSI),)
@@ -255,30 +216,36 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
+   LIBVDWXC_VER   := $(strip $(LIBVDWXC_VER))
+   SPFFT_VER      := $(strip $(SPFFT_VER))
+   SPLA_VER       := $(strip $(SPLA_VER))
+   HDF5_VER       := $(strip $(HDF5_VER))
    SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
+   LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
    SPFFT_LIB      := $(INSTALL_PATH)/SpFFT-$(SPFFT_VER)/lib
    SPLA_LIB       := $(INSTALL_PATH)/SpLA-$(SPLA_VER)/lib
    HDF5_LIB       := $(INSTALL_PATH)/hdf5-$(HDF5_VER)/lib
-   LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
    CFLAGS         += -I$(SIRIUS_INC)
+   CFLAGS         += -I$(LIBVDWXC_INC)
+   DFLAGS         += -D__SIRIUS
+   DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SPFFT
    DFLAGS         += -D__SPLA
    DFLAGS         += -D__HDF5
-   DFLAGS         += -D__LIBVDWXC
-   DFLAGS         += -D__SIRIUS
    ifeq ($(SHARED), yes)
       LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
+      LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
       LIBS           += -Wl,-rpath=$(SPFFT_LIB) -L$(SPFFT_LIB) -lspfft
       LIBS           += -Wl,-rpath=$(SPLA_LIB) -L$(SPLA_LIB) -lspla
       LIBS           += -Wl,-rpath=$(HDF5_LIB) -L$(HDF5_LIB) -lhdf5
-      LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
    else
       LIBS           += $(SIRIUS_LIB)/libsirius.a
+      LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
       LIBS           += $(SPFFT_LIB)/libspfft.a
       LIBS           += $(SPLA_LIB)/libspla.a
       LIBS           += $(HDF5_LIB)/libhdf5.a
-      LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
    endif
 endif
 
@@ -298,28 +265,22 @@ ifneq ($(USE_COSMA),)
    endif
 endif
 
-ifneq ($(USE_FFTW),)
-   USE_FFTW       := $(strip $(USE_FFTW))
-   FFTW_INC       := $(INSTALL_PATH)/fftw-$(USE_FFTW)/include
-   FFTW_LIB       := $(INSTALL_PATH)/fftw-$(USE_FFTW)/lib
-   CFLAGS         += -I$(FFTW_INC)
-   DFLAGS         += -D__FFTW3
-   ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(FFTW_LIB) -L$(FFTW_LIB) -lfftw3_mpi -lfftw3_omp -lfftw3
-   else
-      LIBS           += $(FFTW_LIB)/libfftw3_mpi.a
-      LIBS           += $(FFTW_LIB)/libfftw3_omp.a
-      LIBS           += $(FFTW_LIB)/libfftw3.a
-   endif
-endif
-
-ifneq ($(USE_SCALAPACK),)
-   SCALAPACK_LIB  := $(INSTALL_PATH)/scalapack-$(USE_SCALAPACK)/lib
-   ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(SCALAPACK_LIB) -L$(SCALAPACK_LIB) -lscalapack
-   else
-      LIBS           += $(SCALAPACK_LIB)/libscalapack.a
-   endif
+ifeq ($(SHARED), yes)
+   LIBS           += -Wl,-rpath=$(MKL_LIB) -L$(MKL_LIB) -lbmkl_scalapack_lp64
+   LIBS           += -Wl,--start-group
+   LIBS           += -lmkl_intel_lp64
+   LIBS           += -lmkl_sequential
+   LIBS           += -lmkl_core
+   LIBS           += -lmkl_blacs_intelmpi_lp64
+   LIBS           += -Wl,--end-group
+else
+   LIBS           += $(MKL_LIB)/libmkl_scalapack_lp64.a
+   LIBS           += -Wl,--start-group
+   LIBS           += $(MKL_LIB)/libmkl_intel_lp64.a
+   LIBS           += $(MKL_LIB)/libmkl_sequential.a
+   LIBS           += $(MKL_LIB)/libmkl_core.a
+   LIBS           += $(MKL_LIB)/libmkl_blacs_intelmpi_lp64.a
+   LIBS           += -Wl,--end-group
 endif
 
 ifneq ($(USE_GSL),)
@@ -336,32 +297,23 @@ ifneq ($(USE_GSL),)
    endif
 endif
 
-ifneq ($(USE_OPENBLAS),)
-   USE_OPENBLAS   := $(strip $(USE_OPENBLAS))
-   OPENBLAS_INC   := $(INSTALL_PATH)/openblas-$(USE_OPENBLAS)/include
-   OPENBLAS_LIB   := $(INSTALL_PATH)/openblas-$(USE_OPENBLAS)/lib
-   CFLAGS         += -I$(OPENBLAS_INC)
-   ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(OPENBLAS_LIB) -L$(OPENBLAS_LIB) -lopenblas
-   else
-      LIBS           += $(OPENBLAS_LIB)/libopenblas.a
-   endif
-endif
-
 CFLAGS         += $(DFLAGS)
+CFLAGS         += -I$(MKLROOT)/include
+CFLAGS         += -I$(MKLROOT)/include/fftw
 
-FCFLAGS        := $(CFLAGS) $(FCFLAGS_DEBUG) $(WFLAGS)
-ifeq ($(shell [ $(shell gcc -dumpversion | cut -d. -f1) -gt 9 ] && echo yes), yes)
-   FCFLAGS        += -fallow-argument-mismatch
-endif
-FCFLAGS        += -fbacktrace
-FCFLAGS        += -ffree-form
-FCFLAGS        += -ffree-line-length-none
-FCFLAGS        += -fno-omit-frame-pointer
-FCFLAGS        += -std=f2008
+FCFLAGS        := $(CFLAGS)
+FCFLAGS        += -diag-disable=8291
+FCFLAGS        += -diag-disable=8293
+FCFLAGS        += -fpp
+FCFLAGS        += -free
 
 LDFLAGS        += $(FCFLAGS)
+LDFLAGS_C      := -nofor-main
 
-LIBS           += -lz -ldl -lstdc++
+LIBS           += -lz -lstdc++
+
+# Required due to memory leak that occurs if high optimisations are used
+mp2_optimize_ri_basis.o: mp2_optimize_ri_basis.F
+	$(FC) -c $(subst O2,O0,$(FCFLAGS)) $<
 
 # End


### PR DESCRIPTION
- Change arch file names
- Bump SIRIUS version 7.3.0 to 7.3.1
- Bump LIBXC version 5.1.7 to 5.2.0
- Require full module names