### PR TITLE
Shell: Bump version to signify changed LIBXC section

### DIFF
--- a/src/start/cp2k_shell.F
+++ b/src/start/cp2k_shell.F
@@ -72,7 +72,7 @@ MODULE cp2k_shell
    PRIVATE
 
    ! Queried by ASE. Increase version after bug-fixing or behavior changes.
-   CHARACTER(LEN=*), PARAMETER                           :: CP2K_SHELL_VERSION = "4.0"
+   CHARACTER(LEN=*), PARAMETER                           :: CP2K_SHELL_VERSION = "5.0"
 
    TYPE cp2k_shell_type
       REAL(dp)                                           :: pos_fact = 1.0_dp


### PR DESCRIPTION
As a follow up to #1921 the [ASE calculator](https://gitlab.com/ase/ase/-/blob/master/ase/calculators/cp2k.py) needs to be patched.