### PR TITLE
Use SPLA for offloading dgemm on GPUs in the mp2 module

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -399,12 +399,12 @@ The SPLA library is a hard dependency of SIRIUS but can also be used as a
 standalone library. It provides a generic interface to the blas gemm family with
 offloading on GPU. Offloading supports both CUDA and ROCM.
 
-To make the functionality available, add the flag `-D__SPLA` to the `DFLAGS`
-variable and compile SPLA with Fortran interface and GPU support. Please note
-that only the functions replacing the dgemm calls with `offload_dgemm` will
-eventually be offloaded to the GPU. The SPLA library has internal criteria to
-decide if it is worth to do the operation on GPU or not. Calls to `offload_dgemm`
-also accept pointers on GPU or a combination of them.
+To make the functionality available, add the flag `-D__SPLA -D__OFFLOAD_GEMM` to
+the `DFLAGS` variable and compile SPLA with Fortran interface and GPU support.
+Please note that only the functions replacing the dgemm calls with
+`offload_dgemm` will eventually be offloaded to the GPU. The SPLA library has
+internal criteria to decide if it is worth to do the operation on GPU or not.
+Calls to `offload_dgemm` also accept pointers on GPU or a combination of them.
 
 <!---
 ### 2w. LibMaxwell (External Maxwell Solver)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -396,14 +396,14 @@ CP2K's grid backend does not yet support OpenCL devices.
 ### 2w. matrix-matrix multiplication offloading on GPU using SPLA
 
 The SPLA library is a hard dependency of SIRIUS but can also be used as a
-standalone library. It provide a generic interface to the blas gemm family with
+standalone library. It provides a generic interface to the blas gemm family with
 offloading on GPU. Offloading supports both CUDA and ROCM.
 
-To make the functionality availablem, add the flag `-D__SPLA` to the `DFLAGS`
-variable and compile SPLA with fortran interface and GPU support. Please note
+To make the functionality available, add the flag `-D__SPLA` to the `DFLAGS`
+variable and compile SPLA with Fortran interface and GPU support. Please note
 that only the functions replacing the dgemm calls with `offload_dgemm` will
-eventually be offloaded to the GPU. The spla library has a internal criteria to
-decide if it is worth to do the operation on GPU or not. Calling offload_dgemm
+eventually be offloaded to the GPU. The SPLA library has internal criteria to
+decide if it is worth to do the operation on GPU or not. Calls to `offload_dgemm`
 also accept pointers on GPU or a combination of them.
 
 <!---

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -393,6 +393,19 @@ CP2K's grid backend does not yet support OpenCL devices.
 - Refer to <https://cp2k.github.io/dbcsr/> for more information, e.g.,
   environment variables or how to tune kernels (auto tuned parameters).
 
+### 2w. matrix-matrix multiplication offloading on GPU using SPLA
+
+The SPLA library is a hard dependency of SIRIUS but can also be used as a
+standalone library. It provide a generic interface to the blas gemm family with
+offloading on GPU. Offloading supports both CUDA and ROCM.
+
+To make the functionality availablem, add the flag `-D__SPLA` to the `DFLAGS`
+variable and compile SPLA with fortran interface and GPU support. Please note
+that only the functions replacing the dgemm calls with `offload_dgemm` will
+eventually be offloaded to the GPU. The spla library has a internal criteria to
+decide if it is worth to do the operation on GPU or not. Calling offload_dgemm
+also accept pointers on GPU or a combination of them.
+
 <!---
 ### 2w. LibMaxwell (External Maxwell Solver)
 

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -304,8 +304,8 @@ CONTAINS
       flags = TRIM(flags)//" offload_profiling"
 #endif
 
-#if defined(__SPLA)
-      flags = TRIM(flags)//" slpa_gemm_offloading"
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
+      flags = TRIM(flags)//" spla_gemm_offloading"
 #endif
 
    END FUNCTION cp2k_flags

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -304,6 +304,10 @@ CONTAINS
       flags = TRIM(flags)//" offload_profiling"
 #endif
 
+#if defined(__SPLA)
+      flags = TRIM(flags)//" slpa_gemm_offloading"
+#endif
+
    END FUNCTION cp2k_flags
 
 ! **************************************************************************************************

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -386,11 +386,6 @@ CONTAINS
                            local_ba = 0.0_dp
                         END IF
                         CALL dgemm_counter_start(dgemm_counter)
-#if __GNUC__ >= 9
-                        CPASSERT(IS_CONTIGUOUS(my_local_i_aL))
-                        CPASSERT(IS_CONTIGUOUS(my_local_j_aL))
-                        CPASSERT(IS_CONTIGUOUS(local_ab))
-#endif
                         CALL offload_dgemm('T', 'N', my_B_size(ispin), my_B_size(jspin), dimen_RI, 1.0_dp, &
                                            my_local_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
                                          0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -41,6 +41,7 @@ MODULE mp2_ri_gpw
                                               mp2_type,&
                                               three_dim_real_array,&
                                               two_dim_int_array
+   USE offload_gemm,                    ONLY: offload_dgemm
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num
 #include "./base/base_uses.f90"
@@ -114,9 +115,11 @@ CONTAINS
                                                             my_beta_beta_case, my_open_shell_SS
       REAL(KIND=dp) :: amp_fac, mem_for_aK, mem_for_comm, mem_for_iaK, mem_for_rep, mem_min, &
          mem_per_group, mem_real, my_Emp2_Cou, my_Emp2_EX, sym_fac, t_new, t_start
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: external_ab, external_i_aL, local_ab, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         TARGET                                          :: external_ab, external_i_aL, local_ab, &
                                                             local_ba, t_ab
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: BI_C_rec, local_i_aL, local_j_aL, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
+         TARGET                                          :: BI_C_rec, local_i_aL, local_j_aL, &
                                                             Y_i_aP, Y_j_aP
       TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_P, &
                                                             para_env_rep
@@ -375,7 +378,6 @@ CONTAINS
                DO iiB = 1, my_block_size
                   DO jjB = 1, my_block_size
                      CALL timeset(routineN//"_expansion", handle3)
-
                      ASSOCIATE (my_local_i_aL => local_i_aL(:, :, iiB), my_local_j_aL => local_j_aL(:, :, jjB))
 
                         ! calculate the integrals (ia|jb) strating from my local data ...
@@ -384,9 +386,15 @@ CONTAINS
                            local_ba = 0.0_dp
                         END IF
                         CALL dgemm_counter_start(dgemm_counter)
-                        CALL dgemm('T', 'N', my_B_size(ispin), my_B_size(jspin), dimen_RI, 1.0_dp, &
-                                   my_local_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
-                                   0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin))
+#if __GNUC__ >= 9
+                        CPASSERT(IS_CONTIGUOUS(my_local_i_aL))
+                        CPASSERT(IS_CONTIGUOUS(my_local_j_aL))
+                        CPASSERT(IS_CONTIGUOUS(local_ab))
+#endif
+                        CALL offload_dgemm('T', 'N', my_B_size(ispin), my_B_size(jspin), dimen_RI, 1.0_dp, &
+                                           my_local_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
+                                         0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
+                                           mp2_env%offload_gemm_ctx)
                         ! Additional integrals only for alpha_beta case and forces
                         IF (my_alpha_beta_case .AND. calc_forces) THEN
                            local_ba(my_B_virtual_start(jspin):my_B_virtual_end(jspin), :) = &
@@ -407,9 +415,10 @@ CONTAINS
                                             external_i_aL, proc_receive, &
                                             para_env_sub%group, tag)
 
-                           CALL dgemm('T', 'N', rec_B_size, my_B_size(jspin), dimen_RI, 1.0_dp, &
-                                      external_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
-                                      0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(jspin)), rec_B_size)
+                           CALL offload_dgemm('T', 'N', rec_B_size, my_B_size(jspin), dimen_RI, 1.0_dp, &
+                                              external_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
+                                          0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(jspin)), rec_B_size, &
+                                              mp2_env%offload_gemm_ctx)
 
                            DEALLOCATE (external_i_aL)
                            ! Additional integrals only for alpha_beta case and forces
@@ -425,13 +434,12 @@ CONTAINS
                                                external_i_aL, proc_receive, &
                                                para_env_sub%group, tag)
 
-                              CALL dgemm('T', 'N', rec_B_size, my_B_size(ispin), dimen_RI, 1.0_dp, &
-                                         external_i_aL, dimen_RI, my_local_i_aL, dimen_RI, &
-                                         0.0_dp, local_ba(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(ispin)), rec_B_size)
-
+                              CALL offload_dgemm('T', 'N', rec_B_size, my_B_size(ispin), dimen_RI, 1.0_dp, &
+                                                 external_i_aL, dimen_RI, my_local_i_aL, dimen_RI, &
+                                          0.0_dp, local_ba(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(ispin)), rec_B_size, &
+                                                 mp2_env%offload_gemm_ctx)
                               DEALLOCATE (external_i_aL)
                            END IF
-
                         END DO
                         IF (my_alpha_beta_case .AND. calc_forces) THEN
                            ! Is just an approximation, but the call does not allow it, it ought to be (virtual_i*B_size_j+virtual_j*B_size_i)*dimen_RI
@@ -469,11 +477,12 @@ CONTAINS
                                  my_Emp2_Ex = my_Emp2_Ex + sym_fac*local_ab(a_global, b)*local_ab(b_global, a)/ &
                                               (Eigenval(homo(ispin) + a_global, ispin) + Eigenval(homo(ispin) + b_global, ispin) - &
                                                Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
-                                 IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) &
+                                 IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) THEN
                                     t_ab(a_global, b) = -(amp_fac*local_ab(a_global, b) - mp2_env%scale_T*local_ab(b_global, a))/ &
                                                         (Eigenval(homo(ispin) + a_global, ispin) + &
                                                          Eigenval(homo(ispin) + b_global, ispin) - &
                                                          Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
+                                 END IF
                               END DO
                            END DO
                            ! ... and then with external data
@@ -1410,10 +1419,12 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: virtual
       INTEGER, DIMENSION(-para_env_sub%num_pe:), &
          INTENT(IN)                                      :: sub_proc_map
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: local_ab
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: t_ab, my_local_i_aL, my_local_j_aL
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
+         TARGET                                          :: local_ab
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), TARGET :: t_ab, my_local_i_aL, my_local_j_aL
       LOGICAL, INTENT(IN)                                :: open_ss
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: Y_i_aP, Y_j_aP, local_ba
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
+         TARGET                                          :: Y_i_aP, Y_j_aP, local_ba
       INTEGER, INTENT(IN)                                :: ispin, jspin
       TYPE(dgemm_counter_type), INTENT(INOUT)            :: dgemm_counter
 
@@ -1422,7 +1433,8 @@ CONTAINS
       INTEGER :: a, b, b_global, handle, proc_receive, proc_send, proc_shift, rec_B_size, &
          rec_B_virtual_end, rec_B_virtual_start, send_B_size, send_B_virtual_end, &
          send_B_virtual_start
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: external_ab, send_ab
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         TARGET                                          :: external_ab, send_ab
       REAL(KIND=dp)                                      :: factor, P_ij_diag
       LOGICAL                                            :: alpha_beta
 
@@ -1431,6 +1443,7 @@ CONTAINS
 !
 
       CALL timeset(routineN//"_Pia", handle)
+
 ! Find out whether we have an alpha-beta case
 ! update P_ab, Gamma_P_ia
 ! First, P_ab
@@ -1469,21 +1482,26 @@ CONTAINS
 
       CALL dgemm_counter_start(dgemm_counter)
       IF (.NOT. (alpha_beta)) THEN
-         CALL dgemm('T', 'N', my_B_size(ispin), my_B_size(ispin), virtual(ispin), 1.0_dp, &
-                    t_ab, virtual(ispin), local_ab, virtual(ispin), &
-                    1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array(:, &
-                                                              my_B_virtual_start(ispin):my_B_virtual_end(ispin)), my_B_size(ispin))
+         CALL offload_dgemm('T', 'N', my_B_size(ispin), my_B_size(ispin), virtual(ispin), 1.0_dp, &
+                            t_ab, virtual(ispin), local_ab, virtual(ispin), &
+                            1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array(:, &
+                                     my_B_virtual_start(ispin):my_B_virtual_end(ispin)), my_B_size(ispin), mp2_env%offload_gemm_ctx)
          mp2_env%ri_grad%P_ij(ispin)%array(my_i + iiB - 1, my_i + iiB - 1) = &
             mp2_env%ri_grad%P_ij(ispin)%array(my_i + iiB - 1, my_i + iiB - 1) + P_ij_diag
       ELSE
-         CALL dgemm('T', 'N', my_B_size(ispin), my_B_size(ispin), virtual(jspin), mp2_env%scale_S, &
-                    local_ba, virtual(jspin), local_ba, virtual(jspin), 1.0_dp, &
-                    mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_virtual_start(ispin):my_B_virtual_end(ispin)), my_B_size(ispin))
+         CALL offload_dgemm('T', 'N', my_B_size(ispin), my_B_size(ispin), virtual(jspin), mp2_env%scale_S, &
+                            local_ba, virtual(jspin), local_ba, virtual(jspin), 1.0_dp, &
+                        mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_virtual_start(ispin):my_B_virtual_end(ispin)), my_B_size(ispin), &
+                            mp2_env%offload_gemm_ctx)
+
          mp2_env%ri_grad%P_ij(ispin)%array(my_i + iiB - 1, my_i + iiB - 1) = &
             mp2_env%ri_grad%P_ij(ispin)%array(my_i + iiB - 1, my_i + iiB - 1) + P_ij_diag
-         CALL dgemm('T', 'N', my_B_size(jspin), my_B_size(jspin), virtual(ispin), mp2_env%scale_S, &
-                    local_ab, virtual(ispin), local_ab, virtual(ispin), 1.0_dp, &
-                    mp2_env%ri_grad%P_ab(jspin)%array(:, my_B_virtual_start(jspin):my_B_virtual_end(jspin)), my_B_size(jspin))
+
+         CALL offload_dgemm('T', 'N', my_B_size(jspin), my_B_size(jspin), virtual(ispin), mp2_env%scale_S, &
+                            local_ab, virtual(ispin), local_ab, virtual(ispin), 1.0_dp, &
+                        mp2_env%ri_grad%P_ab(jspin)%array(:, my_B_virtual_start(jspin):my_B_virtual_end(jspin)), my_B_size(jspin), &
+                            mp2_env%offload_gemm_ctx)
+
          mp2_env%ri_grad%P_ij(jspin)%array(my_j + jjB - 1, my_j + jjB - 1) = &
             mp2_env%ri_grad%P_ij(jspin)%array(my_j + jjB - 1, my_j + jjB - 1) + P_ij_diag
       END IF
@@ -1491,10 +1509,13 @@ CONTAINS
       ! both i^alpha,j^beta and i^beta,j^alpha. Formally, my_i can be equal to my_j, but they are different
       ! due to spin in alpha-beta case.
       IF ((my_i /= my_j) .AND. (.NOT. alpha_beta)) THEN
-         CALL dgemm('N', 'T', my_B_size(ispin), virtual(ispin), my_B_size(ispin), 1.0_dp, &
-                    t_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
-                    local_ab, virtual(ispin), &
-                    1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array, my_B_size(ispin))
+
+         CALL offload_dgemm('N', 'T', my_B_size(ispin), virtual(ispin), my_B_size(ispin), 1.0_dp, &
+                            t_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
+                            local_ab, virtual(ispin), &
+                            1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array, my_B_size(ispin), &
+                            mp2_env%offload_gemm_ctx)
+
          mp2_env%ri_grad%P_ij(ispin)%array(my_j + jjB - 1, my_j + jjB - 1) = &
             mp2_env%ri_grad%P_ij(ispin)%array(my_j + jjB - 1, my_j + jjB - 1) + P_ij_diag
       END IF
@@ -1513,14 +1534,15 @@ CONTAINS
                           para_env_sub%group)
 
          IF (.NOT. (alpha_beta)) THEN
-            CALL dgemm('T', 'N', my_B_size(ispin), rec_B_size, virtual(ispin), 1.0_dp, &
-                       t_ab, virtual(ispin), external_ab, virtual(ispin), &
-                       1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array(:, rec_B_virtual_start:rec_B_virtual_end), my_B_size(ispin))
+            CALL offload_dgemm('T', 'N', my_B_size(ispin), rec_B_size, virtual(ispin), 1.0_dp, &
+                               t_ab, virtual(ispin), external_ab, virtual(ispin), &
+                            1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array(:, rec_B_virtual_start:rec_B_virtual_end), my_B_size(ispin), &
+                               mp2_env%offload_gemm_ctx)
          ELSE
-            CALL dgemm('T', 'N', my_B_size(jspin), rec_B_size, virtual(ispin), mp2_env%scale_S, &
-                       local_ab, virtual(ispin), external_ab, virtual(ispin), &
-                       1.0_dp, mp2_env%ri_grad%P_ab(jspin)%array(:, rec_B_virtual_start:rec_B_virtual_end), &
-                       my_B_size(jspin))
+            CALL offload_dgemm('T', 'N', my_B_size(jspin), rec_B_size, virtual(ispin), mp2_env%scale_S, &
+                               local_ab, virtual(ispin), external_ab, virtual(ispin), &
+                               1.0_dp, mp2_env%ri_grad%P_ab(jspin)%array(:, rec_B_virtual_start:rec_B_virtual_end), &
+                               my_B_size(jspin), mp2_env%offload_gemm_ctx)
 
             ! For alpha-beta part of alpha-density we need a new parallel code
             DEALLOCATE (external_ab)
@@ -1532,9 +1554,10 @@ CONTAINS
             CALL mp_sendrecv(local_ba, proc_send, &
                              external_ab, proc_receive, &
                              para_env_sub%group)
-            CALL dgemm('T', 'N', my_B_size(ispin), rec_B_size, virtual(jspin), mp2_env%scale_S, &
-                       local_ba, virtual(jspin), external_ab, virtual(jspin), &
-                       1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array(:, rec_B_virtual_start:rec_B_virtual_end), my_B_size(ispin))
+            CALL offload_dgemm('T', 'N', my_B_size(ispin), rec_B_size, virtual(jspin), mp2_env%scale_S, &
+                               local_ba, virtual(jspin), external_ab, virtual(jspin), &
+                            1.0_dp, mp2_env%ri_grad%P_ab(ispin)%array(:, rec_B_virtual_start:rec_B_virtual_end), my_B_size(ispin), &
+                               mp2_env%offload_gemm_ctx)
          END IF
 
          DEALLOCATE (external_ab)
@@ -1546,11 +1569,11 @@ CONTAINS
             ALLOCATE (send_ab(send_B_size, virtual(ispin)))
             send_ab = 0.0_dp
 
-            CALL dgemm('N', 'T', send_B_size, virtual(ispin), my_B_size(ispin), 1.0_dp, &
-                       t_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
-                       local_ab, virtual(ispin), &
-                       0.0_dp, send_ab, send_B_size)
-
+            CALL offload_dgemm('N', 'T', send_B_size, virtual(ispin), my_B_size(ispin), 1.0_dp, &
+                               t_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
+                               local_ab, virtual(ispin), &
+                               0.0_dp, send_ab, send_B_size, &
+                               mp2_env%offload_gemm_ctx)
             CALL mp_sendrecv(send_ab, proc_send, &
                              external_ab, proc_receive, &
                              para_env_sub%group)
@@ -1579,17 +1602,17 @@ CONTAINS
       CALL dgemm_counter_start(dgemm_counter)
       IF (.NOT. alpha_beta) THEN
          ! Alpha-alpha, beta-beta and closed shell
-         CALL dgemm('N', 'T', my_B_size(ispin), dimen_RI, my_B_size(ispin), 1.0_dp, &
-                    t_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
-                    my_local_j_aL, dimen_RI, 1.0_dp, Y_i_aP, my_B_size(ispin))
+         CALL offload_dgemm('N', 'T', my_B_size(ispin), dimen_RI, my_B_size(ispin), 1.0_dp, &
+                            t_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
+                            my_local_j_aL, dimen_RI, 1.0_dp, Y_i_aP, my_B_size(ispin), &
+                            mp2_env%offload_gemm_ctx)
       ELSE ! Alpha-beta
-         CALL dgemm('N', 'T', my_B_size(ispin), dimen_RI, my_B_size(jspin), mp2_env%scale_S, &
-                    local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
-                    my_local_j_aL, dimen_RI, 1.0_dp, Y_i_aP, my_B_size(ispin))
-         CALL dgemm('T', 'T', my_B_size(jspin), dimen_RI, my_B_size(ispin), mp2_env%scale_S, &
-                    local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
-                    my_local_i_aL, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(jspin))
-
+         CALL offload_dgemm('N', 'T', my_B_size(ispin), dimen_RI, my_B_size(jspin), mp2_env%scale_S, &
+                            local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
+                            my_local_j_aL, dimen_RI, 1.0_dp, Y_i_aP, my_B_size(ispin), mp2_env%offload_gemm_ctx)
+         CALL offload_dgemm('T', 'T', my_B_size(jspin), dimen_RI, my_B_size(ispin), mp2_env%scale_S, &
+                            local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
+                            my_local_i_aL, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(jspin), mp2_env%offload_gemm_ctx)
       END IF
 
       ALLOCATE (external_ab(my_B_size(ispin), dimen_RI))
@@ -1605,9 +1628,10 @@ CONTAINS
          IF (.NOT. alpha_beta) THEN
             ALLOCATE (send_ab(send_B_size, dimen_RI))
             send_ab = 0.0_dp
-            CALL dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), 1.0_dp, &
-                       t_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
-                       my_local_j_aL, dimen_RI, 0.0_dp, send_ab, send_B_size)
+            CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), 1.0_dp, &
+                               t_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
+                               my_local_j_aL, dimen_RI, 0.0_dp, send_ab, send_B_size, &
+                               mp2_env%offload_gemm_ctx)
             CALL mp_sendrecv(send_ab, proc_send, external_ab, proc_receive, para_env_sub%group)
 
             Y_i_aP(:, :) = Y_i_aP + external_ab
@@ -1617,9 +1641,10 @@ CONTAINS
             ! Alpha-alpha part
             ALLOCATE (send_ab(send_B_size, dimen_RI))
             send_ab = 0.0_dp
-            CALL dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(jspin), mp2_env%scale_S, &
-                       local_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
-                       my_local_j_aL, dimen_RI, 0.0_dp, send_ab, send_B_size)
+            CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(jspin), mp2_env%scale_S, &
+                               local_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
+                               my_local_j_aL, dimen_RI, 0.0_dp, send_ab, send_B_size, &
+                               mp2_env%offload_gemm_ctx)
             CALL mp_sendrecv(send_ab, proc_send, external_ab, proc_receive, para_env_sub%group)
             Y_i_aP(:, :) = Y_i_aP + external_ab
             DEALLOCATE (send_ab)
@@ -1638,10 +1663,10 @@ CONTAINS
             CALL get_group_dist(gd_B_virtual(jspin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
             ALLOCATE (send_ab(send_B_size, dimen_RI))
             send_ab = 0.0_dp
-
-            CALL dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), mp2_env%scale_S, &
-                       local_ba(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
-                       my_local_i_aL, dimen_RI, 0.0_dp, send_ab, send_B_size)
+            CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), mp2_env%scale_S, &
+                               local_ba(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
+                               my_local_i_aL, dimen_RI, 0.0_dp, send_ab, send_B_size, &
+                               mp2_env%offload_gemm_ctx)
             CALL mp_sendrecv(send_ab, proc_send, external_ab, proc_receive, para_env_sub%group)
             Y_j_aP(:, :) = Y_j_aP + external_ab
             DEALLOCATE (send_ab)
@@ -1658,10 +1683,10 @@ CONTAINS
       IF ((my_i /= my_j) .AND. (.NOT. alpha_beta)) THEN
          ! Alpha-alpha, beta-beta and closed shell
          CALL dgemm_counter_start(dgemm_counter)
-         CALL dgemm('T', 'T', my_B_size(ispin), dimen_RI, my_B_size(ispin), 1.0_dp, &
-                    t_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
-                    my_local_i_aL, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(ispin))
-
+         CALL offload_dgemm('T', 'T', my_B_size(ispin), dimen_RI, my_B_size(ispin), 1.0_dp, &
+                            t_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
+                            my_local_i_aL, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(ispin), &
+                            mp2_env%offload_gemm_ctx)
          DO proc_shift = 1, para_env_sub%num_pe - 1
             proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
             proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
@@ -1675,10 +1700,9 @@ CONTAINS
                              external_ab, proc_receive, para_env_sub%group)
 
             ! Alpha-alpha, beta-beta and closed shell
-            CALL dgemm('T', 'T', my_B_size(ispin), dimen_RI, rec_B_size, 1.0_dp, &
-                       t_ab(rec_B_virtual_start:rec_B_virtual_end, :), rec_B_size, &
-                       external_ab, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(ispin))
-
+            CALL offload_dgemm('T', 'T', my_B_size(ispin), dimen_RI, rec_B_size, 1.0_dp, &
+                               t_ab(rec_B_virtual_start:rec_B_virtual_end, :), rec_B_size, &
+                               external_ab, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(ispin), mp2_env%offload_gemm_ctx)
             DEALLOCATE (external_ab)
          END DO
 
@@ -1686,7 +1710,6 @@ CONTAINS
       END IF
 
       CALL timestop(handle)
-
    END SUBROUTINE mp2_update_P_gamma
 
 ! **************************************************************************************************
@@ -1971,7 +1994,8 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: num_ijk
       LOGICAL                                            :: alpha_beta
       REAL(KIND=dp)                                      :: amp_fac, P_ij_elem
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: BI_C_rec, external_ab, external_aL, &
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         TARGET                                          :: BI_C_rec, external_ab, external_aL, &
                                                             local_ab, local_aL, t_ab
       TYPE(two_dim_int_array), ALLOCATABLE, DIMENSION(:) :: ijk_map
 
@@ -2187,9 +2211,10 @@ CONTAINS
                CALL dgemm_counter_start(dgemm_counter)
                ALLOCATE (local_ab(my_virtual, size_B_k))
                local_ab = 0.0_dp
-               CALL dgemm('T', 'N', size_B_i, size_B_k, dimen_RI, 1.0_dp, &
-                          local_aL(:, :size_B_i), dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
-                          0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), 1:size_B_k), size_B_i)
+               CALL offload_dgemm('T', 'N', size_B_i, size_B_k, dimen_RI, 1.0_dp, &
+                                  local_aL(:, :size_B_i), dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
+                                  0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), 1:size_B_k), size_B_i, &
+                                  mp2_env%offload_gemm_ctx)
                DO proc_shift = 1, para_env_sub%num_pe - 1
                   proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
                   proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
@@ -2203,10 +2228,10 @@ CONTAINS
                                    external_aL, proc_receive, &
                                    para_env_sub%group, tag)
 
-                  CALL dgemm('T', 'N', rec_B_size, size_B_k, dimen_RI, 1.0_dp, &
-                             external_aL, dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
-                             0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:size_B_k), rec_B_size)
-
+                  CALL offload_dgemm('T', 'N', rec_B_size, size_B_k, dimen_RI, 1.0_dp, &
+                                     external_aL, dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
+                                     0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:size_B_k), rec_B_size, &
+                                     mp2_env%offload_gemm_ctx)
                   DEALLOCATE (external_aL)
                END DO
                CALL dgemm_counter_stop(dgemm_counter, my_virtual, size_B_k, dimen_RI)
@@ -2269,10 +2294,10 @@ CONTAINS
                CALL timeset(routineN//"_exp_jk", handle2)
                local_ab = 0.0_dp
                CALL dgemm_counter_start(dgemm_counter)
-               CALL dgemm('T', 'N', size_B_i, size_B_k, dimen_RI, 1.0_dp, &
-                          local_aL(:, size_B_i + 1:size_B_ij), dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
-                          0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), 1:size_B_k), size_B_i)
-
+               CALL offload_dgemm('T', 'N', size_B_i, size_B_k, dimen_RI, 1.0_dp, &
+                                  local_aL(:, size_B_i + 1:size_B_ij), dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
+                                  0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), 1:size_B_k), size_B_i, &
+                                  mp2_env%offload_gemm_ctx)
                DO proc_shift = 1, para_env_sub%num_pe - 1
                   proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
                   proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
@@ -2285,11 +2310,10 @@ CONTAINS
                   CALL mp_sendrecv(local_aL(:, size_B_i + 1:size_B_ij), proc_send, &
                                    external_aL, proc_receive, &
                                    para_env_sub%group, tag)
-
-                  CALL dgemm('T', 'N', rec_B_size, size_B_k, dimen_RI, 1.0_dp, &
-                             external_aL, dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
-                             0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:size_B_k), rec_B_size)
-
+                  CALL offload_dgemm('T', 'N', rec_B_size, size_B_k, dimen_RI, 1.0_dp, &
+                                     external_aL, dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
+                                     0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:size_B_k), rec_B_size, &
+                                     mp2_env%offload_gemm_ctx)
                   DEALLOCATE (external_aL)
                END DO
                CALL dgemm_counter_stop(dgemm_counter, my_virtual, size_B_k, dimen_RI)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -61,7 +61,9 @@ MODULE mp2_types
              ri_mp2_laplace, &
              init_TShPSC_lmax
 
-   PUBLIC :: mp2_env_release, mp2_biel_type, &
+   PUBLIC :: mp2_env_create, &
+             mp2_env_release, &
+             mp2_biel_type, &
              pair_list_type_mp2, &
              one_dim_int_array, &
              two_dim_int_array, &
@@ -305,8 +307,6 @@ CONTAINS
       IF (ASSOCIATED(mp2_env%eri_mme_param)) DEALLOCATE (mp2_env%eri_mme_param)
 
       CALL offload_gemm_destroy(mp2_env%offload_gemm_ctx)
-
-      DEALLOCATE (mp2_env)
 
       CALL timestop(handle)
 

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -35,9 +35,7 @@ MODULE mp2_types
    USE libint_2c_3c,                    ONLY: libint_potential_type
    USE machine,                         ONLY: m_walltime
    USE message_passing,                 ONLY: mp_sum
-   USE offload_api,                     ONLY: offload_set_device
    USE offload_gemm,                    ONLY: OFFLOAD_GEMM_PU_GPU,&
-                                              OFFLOAD_GEMM_PU_HOST,&
                                               offload_gemm_create,&
                                               offload_gemm_destroy,&
                                               offload_gemm_set_op_threshold_gpu
@@ -331,13 +329,10 @@ CONTAINS
 
       ALLOCATE (mp2_env)
 
-      CALL offload_set_device()
+      ! these two functions are empty if spla is build without gpu support and
+      ! OFFLOAD_GEMM is not given at compilation time
 
-#if defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP)
       CALL offload_gemm_create(mp2_env%offload_gemm_ctx, OFFLOAD_GEMM_PU_GPU)
-#else
-      CALL offload_gemm_create(mp2_env%offload_gemm_ctx, OFFLOAD_GEMM_PU_HOST)
-#endif
       CALL offload_gemm_set_op_threshold_gpu(mp2_env%offload_gemm_ctx, 128*128*128*2)
 
       NULLIFY (mp2_env%ri_rpa%x_data)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -29,11 +29,18 @@ MODULE mp2_types
                                               ri_mp2_laplace,&
                                               ri_mp2_method_gpw,&
                                               ri_rpa_method_gpw
+   USE iso_c_binding,                   ONLY: c_ptr
    USE kinds,                           ONLY: dp
    USE kpoint_types,                    ONLY: kpoint_type
    USE libint_2c_3c,                    ONLY: libint_potential_type
    USE machine,                         ONLY: m_walltime
    USE message_passing,                 ONLY: mp_sum
+   USE offload_api,                     ONLY: offload_set_device
+   USE offload_gemm,                    ONLY: OFFLOAD_GEMM_PU_GPU,&
+                                              OFFLOAD_GEMM_PU_HOST,&
+                                              offload_gemm_create,&
+                                              offload_gemm_destroy,&
+                                              offload_gemm_set_op_threshold_gpu
    USE qs_force_types,                  ONLY: qs_force_type
    USE qs_p_env_types,                  ONLY: qs_p_env_type
 #include "./base/base_uses.f90"
@@ -247,6 +254,7 @@ MODULE mp2_types
       LOGICAL  :: do_svd
       REAL(KIND=dp) :: eps_range
       TYPE(libint_potential_type) :: ri_metric
+      TYPE(C_ptr)                 :: offload_gemm_ctx
    END TYPE
 
    TYPE integ_mat_buffer_type
@@ -298,9 +306,45 @@ CONTAINS
       IF (mp2_env%eri_method .EQ. do_eri_mme) CALL cp_eri_mme_finalize(mp2_env%eri_mme_param)
       IF (ASSOCIATED(mp2_env%eri_mme_param)) DEALLOCATE (mp2_env%eri_mme_param)
 
+      CALL offload_gemm_destroy(mp2_env%offload_gemm_ctx)
+
+      DEALLOCATE (mp2_env)
+
       CALL timestop(handle)
 
    END SUBROUTINE mp2_env_release
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mp2_env ...
+! **************************************************************************************************
+   SUBROUTINE mp2_env_create(mp2_env)
+      TYPE(mp2_type), POINTER                            :: mp2_env
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mp2_env_create'
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      CPASSERT(.NOT. ASSOCIATED(mp2_env))
+
+      ALLOCATE (mp2_env)
+
+      CALL offload_set_device()
+
+#if defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP)
+      CALL offload_gemm_create(mp2_env%offload_gemm_ctx, OFFLOAD_GEMM_PU_GPU)
+#else
+      CALL offload_gemm_create(mp2_env%offload_gemm_ctx, OFFLOAD_GEMM_PU_HOST)
+#endif
+      CALL offload_gemm_set_op_threshold_gpu(mp2_env%offload_gemm_ctx, 128*128*128*2)
+
+      NULLIFY (mp2_env%ri_rpa%x_data)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE mp2_env_create
 
 ! **************************************************************************************************
 !> \brief Initialize a dgemm_counter

--- a/src/offload_gemm.F
+++ b/src/offload_gemm.F
@@ -1,0 +1,408 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2022 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE offload_gemm
+   USE ISO_C_BINDING, ONLY: C_LOC, &
+                            C_NULL_CHAR, &
+                            C_NULL_PTR, &
+                            C_PTR, &
+                            C_int
+#if defined(__SPLA)
+   USE spla, ONLY: SPLA_PU_HOST, &
+                   SPLA_PU_GPU, &
+                   SPLA_OP_NONE, &
+                   SPLA_OP_TRANSPOSE, &
+                   SPLA_OP_CONJ_TRANSPOSE, &
+                   spla_ctx_create, &
+                   spla_ctx_destroy, &
+                   spla_dgemm, &
+                   spla_sgemm, &
+                   spla_cgemm, &
+                   spla_zgemm, &
+                   spla_ctx_set_op_threshold_gpu, &
+                   SPLA_SUCCESS
+#endif
+
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+
+   PRIVATE
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'offload_gemm'
+
+   PUBLIC :: offload_dgemm, &
+             offload_gemm_create, &
+             offload_gemm_destroy, &
+             offload_gemm_set_op_threshold_gpu
+
+   INTEGER, PARAMETER, PUBLIC :: &
+      OFFLOAD_GEMM_PU_HOST = 0, &
+      OFFLOAD_GEMM_PU_GPU = 1
+CONTAINS
+
+! **************************************************************************************************
+!> \brief ...
+!> \param opA ...
+!> \param opB ...
+!> \param m ...
+!> \param n ...
+!> \param k ...
+!> \param alpha ...
+!> \param A ...
+!> \param lda ...
+!> \param B ...
+!> \param ldb ...
+!> \param beta ...
+!> \param C ...
+!> \param ldc ...
+!> \param ctx ...
+! **************************************************************************************************
+   SUBROUTINE offload_dgemm(opA, opB, m, n, k, &
+                            alpha, A, lda, B, ldb, &
+                            beta, C, ldc, ctx)
+      CHARACTER, INTENT(in) :: opA
+      CHARACTER, INTENT(in) :: opB
+      INTEGER, INTENT(in) :: m
+      INTEGER, INTENT(in) :: n
+      INTEGER, INTENT(in) :: k
+      REAL(8), INTENT(in) :: alpha
+      REAL(8), DIMENSION(*), INTENT(in), TARGET :: A
+      INTEGER, INTENT(in) :: lda
+      REAL(8), DIMENSION(*), INTENT(in), TARGET :: B
+      INTEGER, INTENT(in) :: ldb
+      REAL(8), INTENT(in) :: beta
+      REAL(8), DIMENSION(*), INTENT(inout), TARGET ::C
+      INTEGER, INTENT(in) :: ldc
+      TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
+
+      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
+      INTEGER                               :: i, j
+      ! no point of using SPLA offloading on CPU ONLY nodes
+#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+      INTEGER :: spla_op_A, spla_op_B, spla_error
+
+      IF (PRESENT(ctx)) THEN
+
+         IF (opA == 'N') spla_op_A = SPLA_OP_NONE
+         IF (opA == 'T') spla_op_A = SPLA_OP_TRANSPOSE
+
+         IF (opB == 'N') spla_op_B = SPLA_OP_NONE
+         IF (opB == 'T') spla_op_B = SPLA_OP_TRANSPOSE
+
+#if __GNUC__ >= 9
+         CPASSERT(IS_CONTIGUOUS(A))
+         CPASSERT(IS_CONTIGUOUS(B))
+         CPASSERT(IS_CONTIGUOUS(C))
+#endif
+
+         spla_error = spla_dgemm(spla_op_A, spla_op_B, &
+                                 m, n, k, alpha, &
+                                 c_loc(A), lda, &
+                                 c_loc(B), ldb, &
+                                 beta, c_loc(C), ldc, ctx)
+         CPASSERT(spla_error == SPLA_SUCCESS)
+      ELSE
+#endif
+         CALL dgemm(opA, opB, m, n, k, alpha, &
+                    A, lda, &
+                    B, ldb, beta, C, ldc)
+
+#if defined(__SPLA)
+      END IF
+#else
+      MARK_USED(ctx)
+#endif
+   END SUBROUTINE offload_dgemm
+
+! **************************************************************************************************
+!> \brief offload sgemm to GPU when beneficial. All arguemnts identical to blas sgemm
+!> \param opA ...
+!> \param opB ...
+!> \param m ...
+!> \param n ...
+!> \param k ...
+!> \param alpha ...
+!> \param A ...
+!> \param lda ...
+!> \param B ...
+!> \param ldb ...
+!> \param beta ...
+!> \param C ...
+!> \param ldc ...
+!> \param ctx ...
+! **************************************************************************************************
+   SUBROUTINE offload_sgemm(opA, opB, m, n, k, &
+                            alpha, A, lda, B, ldb, &
+                            beta, C, ldc, ctx)
+      CHARACTER, INTENT(in) :: opA
+      CHARACTER, INTENT(in) :: opB
+      INTEGER, INTENT(in) :: m
+      INTEGER, INTENT(in) :: n
+      INTEGER, INTENT(in) :: k
+      REAL(4), INTENT(in) :: alpha
+      REAL(4), DIMENSION(*), INTENT(in), TARGET :: A
+      INTEGER, INTENT(in) :: lda
+      REAL(4), DIMENSION(*), INTENT(in), TARGET :: B
+      INTEGER, INTENT(in) :: ldb
+      REAL(4), INTENT(in) :: beta
+      REAL(4), DIMENSION(*), INTENT(inout), TARGET ::C
+      INTEGER, INTENT(in) :: ldc
+      TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
+
+      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
+      INTEGER                               :: i, j
+      ! no point of using SPLA offloading on CPU ONLY nodes
+#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+      INTEGER :: spla_op_A, spla_op_B, spla_error
+
+      IF (PRESENT(ctx)) THEN
+
+         IF (opA == 'N') spla_op_A = SPLA_OP_NONE
+         IF (opA == 'T') spla_op_A = SPLA_OP_TRANSPOSE
+
+         IF (opB == 'N') spla_op_B = SPLA_OP_NONE
+         IF (opB == 'T') spla_op_B = SPLA_OP_TRANSPOSE
+
+#if __GNUC__ >= 9
+         CPASSERT(IS_CONTIGUOUS(A))
+         CPASSERT(IS_CONTIGUOUS(B))
+         CPASSERT(IS_CONTIGUOUS(C))
+#endif
+
+         spla_error = spla_sgemm(spla_op_A, spla_op_B, &
+                                 m, n, k, alpha, &
+                                 c_loc(A), lda, &
+                                 c_loc(B), ldb, &
+                                 beta, c_loc(C), ldc, ctx)
+         CPASSERT(spla_error == SPLA_SUCCESS)
+      ELSE
+#endif
+         CALL sgemm(opA, opB, m, n, k, alpha, &
+                    A, lda, &
+                    B, ldb, beta, C, ldc)
+
+#if defined(__SPLA)
+      END IF
+#else
+      MARK_USED(ctx)
+#endif
+   END SUBROUTINE offload_sgemm
+
+! **************************************************************************************************
+!> \brief offload cgemm to GPU when beneficial. All arguemnts identical to blas cgemm
+!> \param opA ...
+!> \param opB ...
+!> \param m ...
+!> \param n ...
+!> \param k ...
+!> \param alpha ...
+!> \param A ...
+!> \param lda ...
+!> \param B ...
+!> \param ldb ...
+!> \param beta ...
+!> \param C ...
+!> \param ldc ...
+!> \param ctx ...
+! **************************************************************************************************
+   SUBROUTINE offload_cgemm(opA, opB, m, n, k, &
+                            alpha, A, lda, B, ldb, &
+                            beta, C, ldc, ctx)
+      CHARACTER, INTENT(in) :: opA
+      CHARACTER, INTENT(in) :: opB
+      INTEGER, INTENT(in) :: m
+      INTEGER, INTENT(in) :: n
+      INTEGER, INTENT(in) :: k
+      COMPLEX(4), INTENT(in) :: alpha
+      COMPLEX(4), DIMENSION(*), INTENT(in), TARGET :: A
+      INTEGER, INTENT(in) :: lda
+      COMPLEX(4), DIMENSION(*), INTENT(in), TARGET :: B
+      INTEGER, INTENT(in) :: ldb
+      COMPLEX(4), INTENT(in) :: beta
+      COMPLEX(4), DIMENSION(*), INTENT(inout), TARGET ::C
+      INTEGER, INTENT(in) :: ldc
+      TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
+
+      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
+      INTEGER                               :: i, j
+      ! no point of using SPLA offloading on CPU ONLY nodes
+#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+      INTEGER :: spla_op_A, spla_op_B, spla_error
+
+      IF (PRESENT(ctx)) THEN
+
+         IF (opA == 'N') spla_op_A = SPLA_OP_NONE
+         IF (opA == 'T') spla_op_A = SPLA_OP_TRANSPOSE
+         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
+
+         IF (opB == 'N') spla_op_B = SPLA_OP_NONE
+         IF (opB == 'T') spla_op_B = SPLA_OP_TRANSPOSE
+         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
+
+#if __GNUC__ >= 9
+         CPASSERT(IS_CONTIGUOUS(A))
+         CPASSERT(IS_CONTIGUOUS(B))
+         CPASSERT(IS_CONTIGUOUS(C))
+#endif
+
+         spla_error = spla_cgemm(spla_op_A, spla_op_B, &
+                                 m, n, k, alpha, &
+                                 c_loc(A), lda, &
+                                 c_loc(B), ldb, &
+                                 beta, c_loc(C), ldc, ctx)
+         CPASSERT(spla_error == SPLA_SUCCESS)
+      ELSE
+#endif
+         CALL cgemm(opA, opB, m, n, k, alpha, &
+                    A, lda, &
+                    B, ldb, beta, C, ldc)
+
+#if defined(__SPLA)
+      END IF
+#else
+      MARK_USED(ctx)
+#endif
+   END SUBROUTINE offload_cgemm
+
+! **************************************************************************************************
+!> \brief offload zgemm to GPU when beneficial. All arguemnts identical to blas cgemm
+!> \param opA ...
+!> \param opB ...
+!> \param m ...
+!> \param n ...
+!> \param k ...
+!> \param alpha ...
+!> \param A ...
+!> \param lda ...
+!> \param B ...
+!> \param ldb ...
+!> \param beta ...
+!> \param C ...
+!> \param ldc ...
+!> \param ctx ...
+! **************************************************************************************************
+   SUBROUTINE offload_zgemm(opA, opB, m, n, k, &
+                            alpha, A, lda, B, ldb, &
+                            beta, C, ldc, ctx)
+      CHARACTER, INTENT(in) :: opA
+      CHARACTER, INTENT(in) :: opB
+      INTEGER, INTENT(in) :: m
+      INTEGER, INTENT(in) :: n
+      INTEGER, INTENT(in) :: k
+      COMPLEX(8), INTENT(in) :: alpha
+      COMPLEX(8), DIMENSION(*), INTENT(in), TARGET :: A
+      INTEGER, INTENT(in) :: lda
+      COMPLEX(8), DIMENSION(*), INTENT(in), TARGET :: B
+      INTEGER, INTENT(in) :: ldb
+      COMPLEX(8), INTENT(in) :: beta
+      COMPLEX(8), DIMENSION(*), INTENT(inout), TARGET ::C
+      INTEGER, INTENT(in) :: ldc
+      TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
+
+      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
+      INTEGER                               :: i, j
+      ! no point of using SPLA offloading on CPU ONLY nodes
+#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+      INTEGER :: spla_op_A, spla_op_B, spla_error
+
+      IF (PRESENT(ctx)) THEN
+
+         IF (opA == 'N') spla_op_A = SPLA_OP_NONE
+         IF (opA == 'T') spla_op_A = SPLA_OP_TRANSPOSE
+         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
+
+         IF (opB == 'N') spla_op_B = SPLA_OP_NONE
+         IF (opB == 'T') spla_op_B = SPLA_OP_TRANSPOSE
+         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
+
+#if __GNUC__ >= 9
+         CPASSERT(IS_CONTIGUOUS(A))
+         CPASSERT(IS_CONTIGUOUS(B))
+         CPASSERT(IS_CONTIGUOUS(C))
+#endif
+
+         spla_error = spla_zgemm(spla_op_A, spla_op_B, &
+                                 m, n, k, alpha, &
+                                 c_loc(A), lda, &
+                                 c_loc(B), ldb, &
+                                 beta, c_loc(C), ldc, ctx)
+         CPASSERT(spla_error == SPLA_SUCCESS)
+      ELSE
+#endif
+         CALL zgemm(opA, opB, m, n, k, alpha, &
+                    A, lda, &
+                    B, ldb, beta, C, ldc)
+
+#if defined(__SPLA)
+      END IF
+#else
+      MARK_USED(ctx)
+#endif
+   END SUBROUTINE offload_zgemm
+
+! **************************************************************************************************
+!> \brief create a context for handling gemm offloading
+!> \param ctx newly created context
+!> \param pu processing unit to run the (s,d,c,z}dgemm
+! **************************************************************************************************
+   SUBROUTINE offload_gemm_create(ctx, pu)
+      TYPE(c_ptr), INTENT(out) :: ctx
+      INTEGER, INTENT(in) :: pu
+
+      INTEGER error_
+
+#if defined(__SPLA)
+      error_ = spla_ctx_create(ctx, pu)
+      CPASSERT(error_ == SPLA_SUCCESS)
+#else
+      MARK_USED(pu)
+      MARK_USED(ctx)
+      error_ = 0
+      ctx = C_NULL_PTR
+#endif
+   END SUBROUTINE offload_gemm_create
+
+! **************************************************************************************************
+!> \brief release resources associated to a gemm context
+!> \param ctx handle
+! **************************************************************************************************
+   SUBROUTINE offload_gemm_destroy(ctx)
+      TYPE(c_ptr), INTENT(inout) :: ctx
+
+      INTEGER error_
+
+#if defined(__SPLA)
+      error_ = spla_ctx_destroy(ctx)
+      CPASSERT(error_ == SPLA_SUCCESS)
+#else
+      MARK_USED(ctx)
+      error_ = 0
+#endif
+      ctx = C_NULL_PTR
+   END SUBROUTINE offload_gemm_destroy
+
+! **************************************************************************************************
+!> \brief ...
+!> \param ctx ...
+!> \param opThresholdGPU ...
+! **************************************************************************************************
+   SUBROUTINE offload_gemm_set_op_threshold_gpu(ctx, opThresholdGPU)
+      TYPE(c_ptr)                                        :: ctx
+      INTEGER, INTENT(in)                                :: opThresholdGPU
+
+      INTEGER                                            :: error__
+
+      error__ = 0
+#if defined(__SPLA)
+      error__ = spla_ctx_set_op_threshold_gpu(ctx, opThresholdGPU)
+#else
+      MARK_USED(ctx)
+      MARK_USED(opThresholdGPU)
+#endif
+   END SUBROUTINE offload_gemm_set_op_threshold_gpu
+END MODULE offload_gemm

--- a/src/offload_gemm.F
+++ b/src/offload_gemm.F
@@ -79,11 +79,8 @@ CONTAINS
       REAL(8), DIMENSION(*), INTENT(inout), TARGET ::C
       INTEGER, INTENT(in) :: ldc
       TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-
-      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
-      INTEGER                               :: i, j
       ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+#if defined(__SPLA)
       INTEGER :: spla_op_A, spla_op_B, spla_error
 
       IF (PRESENT(ctx)) THEN
@@ -111,7 +108,6 @@ CONTAINS
          CALL dgemm(opA, opB, m, n, k, alpha, &
                     A, lda, &
                     B, ldb, beta, C, ldc)
-
 #if defined(__SPLA)
       END IF
 #else
@@ -153,11 +149,8 @@ CONTAINS
       REAL(4), DIMENSION(*), INTENT(inout), TARGET ::C
       INTEGER, INTENT(in) :: ldc
       TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-
-      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
-      INTEGER                               :: i, j
       ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+#if defined(__SPLA)
       INTEGER :: spla_op_A, spla_op_B, spla_error
 
       IF (PRESENT(ctx)) THEN
@@ -227,11 +220,8 @@ CONTAINS
       COMPLEX(4), DIMENSION(*), INTENT(inout), TARGET ::C
       INTEGER, INTENT(in) :: ldc
       TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-
-      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
-      INTEGER                               :: i, j
       ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+#if defined(__SPLA)
       INTEGER :: spla_op_A, spla_op_B, spla_error
 
       IF (PRESENT(ctx)) THEN
@@ -303,11 +293,8 @@ CONTAINS
       COMPLEX(8), DIMENSION(*), INTENT(inout), TARGET ::C
       INTEGER, INTENT(in) :: ldc
       TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-
-      REAL(8), ALLOCATABLE, DIMENSION(:, :)  :: Ctest
-      INTEGER                               :: i, j
       ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA) && (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP))
+#if defined(__SPLA)
       INTEGER :: spla_op_A, spla_op_B, spla_error
 
       IF (PRESENT(ctx)) THEN

--- a/src/offload_gemm.F
+++ b/src/offload_gemm.F
@@ -27,6 +27,8 @@ MODULE offload_gemm
                    SPLA_SUCCESS
 #endif
 
+   USE offload_api, ONLY: offload_set_device
+
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -71,18 +73,38 @@ CONTAINS
       INTEGER, INTENT(in) :: n
       INTEGER, INTENT(in) :: k
       REAL(8), INTENT(in) :: alpha
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
       REAL(8), DIMENSION(*), INTENT(in), TARGET :: A
+#else
+      REAL(8), DIMENSION(:, :), INTENT(in), TARGET :: A
+#endif
       INTEGER, INTENT(in) :: lda
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
       REAL(8), DIMENSION(*), INTENT(in), TARGET :: B
+#else
+      REAL(8), DIMENSION(:, :), INTENT(in), TARGET :: B
+#endif
+
       INTEGER, INTENT(in) :: ldb
       REAL(8), INTENT(in) :: beta
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
       REAL(8), DIMENSION(*), INTENT(inout), TARGET ::C
+#else
+      REAL(8), DIMENSION(:, :), INTENT(in), TARGET :: C
+#endif
       INTEGER, INTENT(in) :: ldc
       TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-      ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA)
-      INTEGER :: spla_op_A, spla_op_B, spla_error
 
+      INTEGER                                            :: handle
+!     no point of using SPLA offloading on CPU ONLY nodes
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
+      INTEGER :: spla_op_A, spla_op_B, spla_error
+#endif
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'offload_gemm'
+      CALL timeset(routineN, handle)
+
+!     no point of using SPLA offloading on CPU ONLY nodes
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
       IF (PRESENT(ctx)) THEN
 
          IF (opA == 'N') spla_op_A = SPLA_OP_NONE
@@ -97,6 +119,7 @@ CONTAINS
          CPASSERT(IS_CONTIGUOUS(C))
 #endif
 
+         CALL offload_set_device()
          spla_error = spla_dgemm(spla_op_A, spla_op_B, &
                                  m, n, k, alpha, &
                                  c_loc(A), lda, &
@@ -108,229 +131,14 @@ CONTAINS
          CALL dgemm(opA, opB, m, n, k, alpha, &
                     A, lda, &
                     B, ldb, beta, C, ldc)
-#if defined(__SPLA)
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
       END IF
 #else
       MARK_USED(ctx)
 #endif
+      CALL timestop(handle)
+
    END SUBROUTINE offload_dgemm
-
-! **************************************************************************************************
-!> \brief offload sgemm to GPU when beneficial. All arguemnts identical to blas sgemm
-!> \param opA ...
-!> \param opB ...
-!> \param m ...
-!> \param n ...
-!> \param k ...
-!> \param alpha ...
-!> \param A ...
-!> \param lda ...
-!> \param B ...
-!> \param ldb ...
-!> \param beta ...
-!> \param C ...
-!> \param ldc ...
-!> \param ctx ...
-! **************************************************************************************************
-   SUBROUTINE offload_sgemm(opA, opB, m, n, k, &
-                            alpha, A, lda, B, ldb, &
-                            beta, C, ldc, ctx)
-      CHARACTER, INTENT(in) :: opA
-      CHARACTER, INTENT(in) :: opB
-      INTEGER, INTENT(in) :: m
-      INTEGER, INTENT(in) :: n
-      INTEGER, INTENT(in) :: k
-      REAL(4), INTENT(in) :: alpha
-      REAL(4), DIMENSION(*), INTENT(in), TARGET :: A
-      INTEGER, INTENT(in) :: lda
-      REAL(4), DIMENSION(*), INTENT(in), TARGET :: B
-      INTEGER, INTENT(in) :: ldb
-      REAL(4), INTENT(in) :: beta
-      REAL(4), DIMENSION(*), INTENT(inout), TARGET ::C
-      INTEGER, INTENT(in) :: ldc
-      TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-      ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA)
-      INTEGER :: spla_op_A, spla_op_B, spla_error
-
-      IF (PRESENT(ctx)) THEN
-
-         IF (opA == 'N') spla_op_A = SPLA_OP_NONE
-         IF (opA == 'T') spla_op_A = SPLA_OP_TRANSPOSE
-
-         IF (opB == 'N') spla_op_B = SPLA_OP_NONE
-         IF (opB == 'T') spla_op_B = SPLA_OP_TRANSPOSE
-
-#if __GNUC__ >= 9
-         CPASSERT(IS_CONTIGUOUS(A))
-         CPASSERT(IS_CONTIGUOUS(B))
-         CPASSERT(IS_CONTIGUOUS(C))
-#endif
-
-         spla_error = spla_sgemm(spla_op_A, spla_op_B, &
-                                 m, n, k, alpha, &
-                                 c_loc(A), lda, &
-                                 c_loc(B), ldb, &
-                                 beta, c_loc(C), ldc, ctx)
-         CPASSERT(spla_error == SPLA_SUCCESS)
-      ELSE
-#endif
-         CALL sgemm(opA, opB, m, n, k, alpha, &
-                    A, lda, &
-                    B, ldb, beta, C, ldc)
-
-#if defined(__SPLA)
-      END IF
-#else
-      MARK_USED(ctx)
-#endif
-   END SUBROUTINE offload_sgemm
-
-! **************************************************************************************************
-!> \brief offload cgemm to GPU when beneficial. All arguemnts identical to blas cgemm
-!> \param opA ...
-!> \param opB ...
-!> \param m ...
-!> \param n ...
-!> \param k ...
-!> \param alpha ...
-!> \param A ...
-!> \param lda ...
-!> \param B ...
-!> \param ldb ...
-!> \param beta ...
-!> \param C ...
-!> \param ldc ...
-!> \param ctx ...
-! **************************************************************************************************
-   SUBROUTINE offload_cgemm(opA, opB, m, n, k, &
-                            alpha, A, lda, B, ldb, &
-                            beta, C, ldc, ctx)
-      CHARACTER, INTENT(in) :: opA
-      CHARACTER, INTENT(in) :: opB
-      INTEGER, INTENT(in) :: m
-      INTEGER, INTENT(in) :: n
-      INTEGER, INTENT(in) :: k
-      COMPLEX(4), INTENT(in) :: alpha
-      COMPLEX(4), DIMENSION(*), INTENT(in), TARGET :: A
-      INTEGER, INTENT(in) :: lda
-      COMPLEX(4), DIMENSION(*), INTENT(in), TARGET :: B
-      INTEGER, INTENT(in) :: ldb
-      COMPLEX(4), INTENT(in) :: beta
-      COMPLEX(4), DIMENSION(*), INTENT(inout), TARGET ::C
-      INTEGER, INTENT(in) :: ldc
-      TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-      ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA)
-      INTEGER :: spla_op_A, spla_op_B, spla_error
-
-      IF (PRESENT(ctx)) THEN
-
-         IF (opA == 'N') spla_op_A = SPLA_OP_NONE
-         IF (opA == 'T') spla_op_A = SPLA_OP_TRANSPOSE
-         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
-
-         IF (opB == 'N') spla_op_B = SPLA_OP_NONE
-         IF (opB == 'T') spla_op_B = SPLA_OP_TRANSPOSE
-         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
-
-#if __GNUC__ >= 9
-         CPASSERT(IS_CONTIGUOUS(A))
-         CPASSERT(IS_CONTIGUOUS(B))
-         CPASSERT(IS_CONTIGUOUS(C))
-#endif
-
-         spla_error = spla_cgemm(spla_op_A, spla_op_B, &
-                                 m, n, k, alpha, &
-                                 c_loc(A), lda, &
-                                 c_loc(B), ldb, &
-                                 beta, c_loc(C), ldc, ctx)
-         CPASSERT(spla_error == SPLA_SUCCESS)
-      ELSE
-#endif
-         CALL cgemm(opA, opB, m, n, k, alpha, &
-                    A, lda, &
-                    B, ldb, beta, C, ldc)
-
-#if defined(__SPLA)
-      END IF
-#else
-      MARK_USED(ctx)
-#endif
-   END SUBROUTINE offload_cgemm
-
-! **************************************************************************************************
-!> \brief offload zgemm to GPU when beneficial. All arguemnts identical to blas cgemm
-!> \param opA ...
-!> \param opB ...
-!> \param m ...
-!> \param n ...
-!> \param k ...
-!> \param alpha ...
-!> \param A ...
-!> \param lda ...
-!> \param B ...
-!> \param ldb ...
-!> \param beta ...
-!> \param C ...
-!> \param ldc ...
-!> \param ctx ...
-! **************************************************************************************************
-   SUBROUTINE offload_zgemm(opA, opB, m, n, k, &
-                            alpha, A, lda, B, ldb, &
-                            beta, C, ldc, ctx)
-      CHARACTER, INTENT(in) :: opA
-      CHARACTER, INTENT(in) :: opB
-      INTEGER, INTENT(in) :: m
-      INTEGER, INTENT(in) :: n
-      INTEGER, INTENT(in) :: k
-      COMPLEX(8), INTENT(in) :: alpha
-      COMPLEX(8), DIMENSION(*), INTENT(in), TARGET :: A
-      INTEGER, INTENT(in) :: lda
-      COMPLEX(8), DIMENSION(*), INTENT(in), TARGET :: B
-      INTEGER, INTENT(in) :: ldb
-      COMPLEX(8), INTENT(in) :: beta
-      COMPLEX(8), DIMENSION(*), INTENT(inout), TARGET ::C
-      INTEGER, INTENT(in) :: ldc
-      TYPE(C_ptr), OPTIONAL, INTENT(inout) :: ctx
-      ! no point of using SPLA offloading on CPU ONLY nodes
-#if defined(__SPLA)
-      INTEGER :: spla_op_A, spla_op_B, spla_error
-
-      IF (PRESENT(ctx)) THEN
-
-         IF (opA == 'N') spla_op_A = SPLA_OP_NONE
-         IF (opA == 'T') spla_op_A = SPLA_OP_TRANSPOSE
-         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
-
-         IF (opB == 'N') spla_op_B = SPLA_OP_NONE
-         IF (opB == 'T') spla_op_B = SPLA_OP_TRANSPOSE
-         IF (opA == 'C') spla_op_A = SPLA_OP_CONJ_TRANSPOSE
-
-#if __GNUC__ >= 9
-         CPASSERT(IS_CONTIGUOUS(A))
-         CPASSERT(IS_CONTIGUOUS(B))
-         CPASSERT(IS_CONTIGUOUS(C))
-#endif
-
-         spla_error = spla_zgemm(spla_op_A, spla_op_B, &
-                                 m, n, k, alpha, &
-                                 c_loc(A), lda, &
-                                 c_loc(B), ldb, &
-                                 beta, c_loc(C), ldc, ctx)
-         CPASSERT(spla_error == SPLA_SUCCESS)
-      ELSE
-#endif
-         CALL zgemm(opA, opB, m, n, k, alpha, &
-                    A, lda, &
-                    B, ldb, beta, C, ldc)
-
-#if defined(__SPLA)
-      END IF
-#else
-      MARK_USED(ctx)
-#endif
-   END SUBROUTINE offload_zgemm
 
 ! **************************************************************************************************
 !> \brief create a context for handling gemm offloading
@@ -343,7 +151,9 @@ CONTAINS
 
       INTEGER error_
 
-#if defined(__SPLA)
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
+      CALL offload_set_device()
+
       error_ = spla_ctx_create(ctx, pu)
       CPASSERT(error_ == SPLA_SUCCESS)
 #else
@@ -363,7 +173,9 @@ CONTAINS
 
       INTEGER error_
 
-#if defined(__SPLA)
+#if defined(__SPLA)  && defined(__OFFLOAD_GEMM)
+      CALL offload_set_device()
+
       error_ = spla_ctx_destroy(ctx)
       CPASSERT(error_ == SPLA_SUCCESS)
 #else
@@ -385,7 +197,8 @@ CONTAINS
       INTEGER                                            :: error__
 
       error__ = 0
-#if defined(__SPLA)
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
+      CALL offload_set_device()
       error__ = spla_ctx_set_op_threshold_gpu(ctx, opThresholdGPU)
 #else
       MARK_USED(ctx)

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -127,7 +127,8 @@ MODULE qs_environment
                                               write_molecule_kind_set
    USE molecule_types,                  ONLY: molecule_type
    USE mp2_setup,                       ONLY: read_mp2_section
-   USE mp2_types,                       ONLY: mp2_type
+   USE mp2_types,                       ONLY: mp2_env_create,&
+                                              mp2_type
    USE multipole_types,                 ONLY: do_multipole_none
    USE orbital_pointers,                ONLY: init_orbital_pointers
    USE orbital_transformation_matrices, ONLY: init_spherical_harmonics
@@ -888,7 +889,7 @@ CONTAINS
          END IF
 
          ! Check if RI_AUX basis (for MP2/RPA) is given, auto-generate if not
-         ALLOCATE (qs_env%mp2_env)
+         CALL mp2_env_create(qs_env%mp2_env)
          CALL get_qs_env(qs_env, mp2_env=mp2_env, nkind=nkind)
          CALL section_vals_val_get(qs_env%input, "DFT%XC%WF_CORRELATION%RI_MP2%_SECTION_PARAMETERS_", l_val=do_ri_mp2)
          CALL section_vals_val_get(qs_env%input, "DFT%XC%WF_CORRELATION%RI_SOS_MP2%_SECTION_PARAMETERS_", l_val=do_ri_sos_mp2)

--- a/tools/precommit/check_file_properties.py
+++ b/tools/precommit/check_file_properties.py
@@ -65,6 +65,7 @@ FLAG_EXCEPTIONS = (
     r"LIBXSMM_VERSION3",
     r"LIBXSMM_VERSION4",
     r"__PW_CUDA_HIP_KERNELS",
+    r"__SPLA",
 )
 
 FLAG_EXCEPTIONS_RE = re.compile(r"|".join(FLAG_EXCEPTIONS))

--- a/tools/precommit/check_file_properties.py
+++ b/tools/precommit/check_file_properties.py
@@ -65,7 +65,6 @@ FLAG_EXCEPTIONS = (
     r"LIBXSMM_VERSION3",
     r"LIBXSMM_VERSION4",
     r"__PW_CUDA_HIP_KERNELS",
-    r"__SPLA",
 )
 
 FLAG_EXCEPTIONS_RE = re.compile(r"|".join(FLAG_EXCEPTIONS))

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -60,7 +60,7 @@ case "$with_spla" in
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-        -DSPLA_OMP=ON \
+        -DSPLA_OMP=OFF \
         -DSPLA_FORTRAN=ON \
         -DSPLA_INSTALL=ON \
         -DSPLA_STATIC=ON \
@@ -79,7 +79,7 @@ case "$with_spla" in
           -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-          -DSPLA_OMP=ON \
+          -DSPLA_OMP=OFF \
           -DSPLA_FORTRAN=ON \
           -DSPLA_INSTALL=ON \
           -DSPLA_STATIC=ON \
@@ -104,7 +104,7 @@ case "$with_spla" in
               -DCMAKE_INSTALL_LIBDIR=lib \
               -DCMAKE_VERBOSE_MAKEFILE=ON \
               -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-              -DSPLA_OMP=ON \
+              -DSPLA_OMP=OFF \
               -DSPLA_FORTRAN=ON \
               -DSPLA_INSTALL=ON \
               -DSPLA_STATIC=ON \
@@ -125,7 +125,7 @@ case "$with_spla" in
               -DCMAKE_INSTALL_LIBDIR=lib \
               -DCMAKE_VERBOSE_MAKEFILE=ON \
               -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
-              -DSPLA_OMP=ON \
+              -DSPLA_OMP=OFF \
               -DSPLA_FORTRAN=ON \
               -DSPLA_INSTALL=ON \
               -DSPLA_STATIC=ON \

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -90,6 +90,7 @@ case "$with_spla" in
         install -d ${pkg_install_dir}/lib/cuda
         [ -f src/libspla.a ] && install -m 644 src/*.a ${pkg_install_dir}/lib/cuda >> install.log 2>&1
         [ -f src/libspla.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/cuda >> install.log 2>&1
+        CP_DFLAGS+=' -D__OFFLOAD_GEMM'
       fi
 
       if [ "$ENABLE_HIP" = "__TRUE__" ]; then
@@ -137,8 +138,8 @@ case "$with_spla" in
             [ -f src/libspla.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/rocm >> install.log 2>&1
             ;;
           *) ;;
-
         esac
+        CP_DFLAGS+=' -D__OFFLOAD_GEMM'
       fi
 
       # https://github.com/eth-cscs/spla/issues/17

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -147,7 +147,7 @@ case "$with_spla" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
     SPLA_ROOT="${pkg_install_dir}"
-    SPLA_CFLAGS="-I'${pkg_install_dir}/include'"
+    SPLA_CFLAGS="-I'${pkg_install_dir}/include/spla'"
     SPLA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
     SPLA_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath='${pkg_install_dir}/lib/cuda'"
     SPLA_HIP_LDFLAGS="-L'${pkg_install_dir}/lib/rocm' -Wl,-rpath='${pkg_install_dir}/lib/rocm'"

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -9,8 +9,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-spla_ver="1.5.2"
-spla_sha256="344c34986dfae182ec2e1eb539c9a57f75683aaa7a61a024fd0c594d81d97016"
+spla_ver="1.5.3"
+spla_sha256="527c06e316ce46ec87309a16bfa4138b1abad23fd276fe789c78a2de84f05637"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh
@@ -92,6 +92,55 @@ case "$with_spla" in
         [ -f src/libspla.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/cuda >> install.log 2>&1
       fi
 
+      if [ "$ENABLE_HIP" = "__TRUE__" ]; then
+        case "${GPUVER}" in
+          K20X | K40 | K80 | P100 | V100 | A100)
+            [ -d build-cuda ] && rm -rf "build-cuda"
+            mkdir build-cuda
+            cd build-cuda
+            cmake \
+              -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
+              -DCMAKE_INSTALL_LIBDIR=lib \
+              -DCMAKE_VERBOSE_MAKEFILE=ON \
+              -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+              -DSPLA_OMP=ON \
+              -DSPLA_FORTRAN=ON \
+              -DSPLA_INSTALL=ON \
+              -DSPLA_STATIC=ON \
+              -DSPLA_GPU_BACKEND=CUDA \
+              ${EXTRA_CMAKE_FLAGS} .. \
+              > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
+            make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+            install -d ${pkg_install_dir}/lib/cuda
+            [ -f src/libspla.a ] && install -m 644 src/*.a ${pkg_install_dir}/lib/cuda >> install.log 2>&1
+            [ -f src/libspla.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/cuda >> install.log 2>&1
+            ;;
+          Mi50 | Mi100 | Mi200)
+            [ -d build-hip ] && rm -rf "build-hip"
+            mkdir build-hip
+            cd build-hip
+            cmake \
+              -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
+              -DCMAKE_INSTALL_LIBDIR=lib \
+              -DCMAKE_VERBOSE_MAKEFILE=ON \
+              -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+              -DSPLA_OMP=ON \
+              -DSPLA_FORTRAN=ON \
+              -DSPLA_INSTALL=ON \
+              -DSPLA_STATIC=ON \
+              -DSPLA_GPU_BACKEND=ROCM \
+              ${EXTRA_CMAKE_FLAGS} .. \
+              > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
+            make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+            install -d ${pkg_install_dir}/lib/rocm
+            [ -f src/libspla.a ] && install -m 644 src/*.a ${pkg_install_dir}/lib/rocm >> install.log 2>&1
+            [ -f src/libspla.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/rocm >> install.log 2>&1
+            ;;
+          *) ;;
+
+        esac
+      fi
+
       # https://github.com/eth-cscs/spla/issues/17
       [ -d "${pkg_install_dir}/lib/cmake/spla/modules" ] && mv "${pkg_install_dir}/lib/cmake/spla/modules" "${pkg_install_dir}/lib/cmake/SPLA/modules"
 
@@ -101,6 +150,8 @@ case "$with_spla" in
     SPLA_CFLAGS="-I'${pkg_install_dir}/include'"
     SPLA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
     SPLA_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath='${pkg_install_dir}/lib/cuda'"
+    SPLA_HIP_LDFLAGS="-L'${pkg_install_dir}/lib/rocm' -Wl,-rpath='${pkg_install_dir}/lib/rocm'"
+
     ;;
   __SYSTEM__)
     echo "==================== Finding spla from system paths ===================="
@@ -119,8 +170,8 @@ case "$with_spla" in
     [ -d "${pkg_install_dir}/lib64" ] && SPLA_LIBDIR="${pkg_install_dir}/lib64"
 
     check_dir "${SPLA_LIBDIR}"
-    check_dir "${pkg_install_dir}/include"
-    SPLA_CFLAGS="-I'${pkg_install_dir}/include'"
+    check_dir "${pkg_install_dir}/include/spla"
+    SPLA_CFLAGS="-I'${pkg_install_dir}/include/spla'"
     SPLA_LDFLAGS="-L'${SPLA_LIBDIR}' -Wl,-rpath='${SPLA_LIBDIR}'"
     ;;
 esac
@@ -131,8 +182,8 @@ if [ "$with_spla" != "__DONTUSE__" ]; then
 prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-export SPLA_INCLUDE_DIR="$pkg_install_dir/include"
+prepend_path CPATH "$pkg_install_dir/include/spla"
+export SPLA_INCLUDE_DIR="$pkg_install_dir/include/spla"
 export SPLA_LIBS="-lspla"
 export SPLA_ROOT="${pkg_install_dir}"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}/lib/cmake"
@@ -148,7 +199,7 @@ export CP_CFLAGS="\${CP_CFLAGS} ${SPLA_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_CUDA(${SPLA_CUDA_LDFLAGS}|${SPLA_LDFLAGS})"
 export SPLA_LIBRARY="-lspla"
 export SPLA_ROOT="$pkg_install_dir"
-export SPLA_INCLUDE_DIR="$pkg_install_dir/include"
+export SPLA_INCLUDE_DIR="$pkg_install_dir/include/spla"
 export SPLA_VERSION=${spla-ver}
 export CP_LIBS="IF_MPI(${SPLA_LIBS}|) \${CP_LIBS}"
 EOF


### PR DESCRIPTION
dgemm in the mp2 module are offloaded to GPU using SPLA which already has this feature implemented. It is similar to what libsci_acc would do but it is now vendor agnostic and will support any blas vendor implementation.

- SPLA update to the latest.
- SPLA will offload the dgemm when the product 2 m n k is above a given threshold. The value is hardcoded but we can add an extra input option to set it up manually. I Fixed it to 2 * (128 ^ 3) but it can be increased further. 
- SPLA is not a hard dependency.

They are several direction for improvement. 
- Some of the matrices can be loaded only one time for instance on GPU, etc... 
- Dgemms can also be batched. But the prize to pay is code cluttering in absence of a generic interface.
- maybe use some of spla functionalities to handle mpi communication. 