### PR TITLE
Make calculation of total density in calculate_rho_elec optional

### DIFF
--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -654,7 +654,6 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'write_matrix_to_cube'
 
       INTEGER                                            :: handle
-      REAL(KIND=dp)                                      :: tot_rho
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks
       TYPE(dbcsr_type), POINTER                          :: matrix_p_qs
       TYPE(particle_list_type), POINTER                  :: particles
@@ -700,7 +699,6 @@ CONTAINS
       CALL calculate_rho_elec(matrix_p=matrix_p_qs, &
                               rho=wf_r, &
                               rho_gspace=wf_g, &
-                              total_rho=tot_rho, &
                               ks_env=ks_env)
 
       ! write this to a cube

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -937,7 +937,7 @@ CONTAINS
       INTEGER                                            :: handle, i, iounit, ispin, natom, nspins
       LOGICAL                                            :: use_virial
       REAL(dp)                                           :: dehartree, eexc, ehartree, eovrl, exc, &
-                                                            fconv, total_rhoout
+                                                            fconv
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: ftot
       REAL(dp), DIMENSION(3)                             :: fodeb
       REAL(KIND=dp), DIMENSION(3, 3)                     :: h_stress, pv_loc, stdeb, sttot
@@ -1039,7 +1039,6 @@ CONTAINS
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=ec_env%matrix_p(ispin, 1)%matrix, &
                                  rho=rhoout_r(ispin), &
                                  rho_gspace=rhoout_g(ispin), &
-                                 total_rho=total_rhoout, &
                                  basis_type="HARRIS", &
                                  task_list_external=ec_env%task_list)
       END DO

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -599,7 +599,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nsgfa
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
       LOGICAL                                            :: map_it_here, skip_shell
-      REAL(KIND=dp)                                      :: radius, total_rho
+      REAL(KIND=dp)                                      :: radius
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: I_ab
       REAL(KIND=dp), DIMENSION(3)                        :: force_a, force_b, ra
       REAL(KIND=dp), DIMENSION(3, 3)                     :: my_virial_a, my_virial_b
@@ -619,7 +619,6 @@ CONTAINS
       CALL calculate_rho_elec(matrix_p=matrix_P_munu%matrix, &
                               rho=rho_r, &
                               rho_gspace=rho_g, &
-                              total_rho=total_rho, &
                               task_list_external=task_list_sub, &
                               pw_env_external=pw_env_sub, &
                               ks_env=ks_env)

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -1547,7 +1547,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
       TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
-      REAL(KIND=dp), INTENT(OUT)                         :: total_rho
+      REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: total_rho
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: soft_valid, compute_tau, compute_grad
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: basis_type
@@ -1690,7 +1690,7 @@ CONTAINS
 
       ! Merge realspace multi-grids into single planewave grid.
       CALL density_rs2pw(pw_env, rs_rho, rho, rho_gspace)
-      total_rho = pw_integrate_function(rho%pw, isign=-1)
+      IF (PRESENT(total_rho)) total_rho = pw_integrate_function(rho%pw, isign=-1)
 
       CALL timestop(handle)
 

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -71,8 +71,8 @@ CONTAINS
       INTEGER, DIMENSION(2, 3)                           :: bo
       INTEGER, DIMENSION(3, 3)                           :: nd
       LOGICAL                                            :: deriv_pw, drho_r_valid, tau_r_valid
-      REAL(kind=dp)                                      :: cfermi, dum, elf_kernel, norm_drho, &
-                                                            rho_53, udvol
+      REAL(kind=dp)                                      :: cfermi, elf_kernel, norm_drho, rho_53, &
+                                                            udvol
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_struct_ao
       TYPE(pw_env_type), POINTER                         :: pw_env
@@ -125,7 +125,6 @@ CONTAINS
             CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
                                     rho=tau_r(ispin), &
                                     rho_gspace=tau_g(ispin), &
-                                    total_rho=dum, &
                                     ks_env=ks_env, soft_valid=.FALSE., &
                                     compute_tau=.TRUE.)
          END IF
@@ -160,7 +159,6 @@ CONTAINS
                   CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
                                           rho=drho_r(3*(ispin - 1) + idir), &
                                           rho_gspace=drho_g(3*(ispin - 1) + idir), &
-                                          total_rho=dum, &
                                           ks_env=ks_env, soft_valid=.FALSE., &
                                           compute_tau=.FALSE., compute_grad=.TRUE., idir=idir)
 

--- a/src/qs_energy_window.F
+++ b/src/qs_energy_window.F
@@ -96,7 +96,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: stride(:)
       LOGICAL                                            :: mpi_io, print_cube, restrict_range
       REAL(KIND=dp) :: bin_width, density_ewindow_total, density_total, energy_range, fermi_level, &
-         filter_eps, frob_norm, lanzcos_threshold, lower_bound, occupation, total_rho, upper_bound
+         filter_eps, frob_norm, lanzcos_threshold, lower_bound, occupation, upper_bound
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eigenvalues, P_eigenvalues, &
                                                             window_eigenvalues
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
@@ -215,7 +215,6 @@ CONTAINS
          CALL calculate_rho_elec(matrix_p=window, &
                                  rho=rho_r, &
                                  rho_gspace=rho_g, &
-                                 total_rho=total_rho, &
                                  ks_env=ks_env)
          density_total = pw_integrate_function(rho_r%pw)
          IF (unit_nr > 0) WRITE (unit_nr, *) " Ground-state density: ", density_total
@@ -283,7 +282,6 @@ CONTAINS
             CALL calculate_rho_elec(matrix_p=window, &
                                     rho=rho_r, &
                                     rho_gspace=rho_g, &
-                                    total_rho=total_rho, &
                                     ks_env=ks_env)
             WRITE (ext, "(A14,I5.5,A)") "-ENERGY-WINDOW", i, TRIM(cp_iter_string(logger%iter_info))//".cube"
             mpi_io = .TRUE.

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -163,7 +163,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :), POINTER               :: occupations
       LOGICAL                                            :: compute_virial, in_range, &
                                                             uniform_occupation
-      REAL(KIND=dp)                                      :: exc, total_rho
+      REAL(KIND=dp)                                      :: exc
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc_tmp
       REAL(KIND=dp), DIMENSION(:), POINTER               :: energy_scaling, rvec, scaling
       TYPE(cell_type), POINTER                           :: cell
@@ -311,7 +311,7 @@ CONTAINS
                                 0.0_dp, matrix_p(ispin)%matrix, retain_sparsity=.TRUE.)
             ! compute the densities on the grid
             CALL calculate_rho_elec(matrix_p=matrix_p(ispin)%matrix, &
-                                    rho=rho_r(ispin), rho_gspace=rho_g(ispin), total_rho=total_rho, &
+                                    rho=rho_r(ispin), rho_gspace=rho_g(ispin), &
                                     ks_env=ks_env)
          END DO
 
@@ -406,7 +406,7 @@ CONTAINS
       INTEGER                                            :: handle, i, Iorb, k_alpha, k_beta, Norb
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: sic_orbital_list
       LOGICAL                                            :: compute_virial, uniform_occupation
-      REAL(KIND=dp)                                      :: ener, exc, total_rho
+      REAL(KIND=dp)                                      :: ener, exc
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc_tmp
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_derivs_local
@@ -613,11 +613,8 @@ CONTAINS
                                     alpha=1.0_dp)
 
          CALL calculate_rho_elec(matrix_p=orb_density_matrix, &
-                                 rho=orb_rho_r, rho_gspace=orb_rho_g, total_rho=total_rho, &
+                                 rho=orb_rho_r, rho_gspace=orb_rho_g, &
                                  ks_env=ks_env)
-
-         ! write(*,*) 'Orbital ',sic_orbital_list(1,iorb),sic_orbital_list(2,iorb)
-         ! write(*,*) 'Total orbital rho= ',total_rho
 
          ! compute the energy functional for this orbital and its derivative
 
@@ -1650,7 +1647,7 @@ CONTAINS
       INTEGER                                            :: handle, my_val, nelectron, nspins, stat
       INTEGER, DIMENSION(2)                              :: nelectron_spin
       LOGICAL                                            :: do_zmp_read, fermi_amaldi
-      REAL(KIND=dp)                                      :: factor, lambda, total_rho
+      REAL(KIND=dp)                                      :: factor, lambda
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_ext_r
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
@@ -1716,7 +1713,6 @@ CONTAINS
 
          CALL pw_axpy(rho_g(1)%pw, rho_eff_gspace%pw, alpha=factor)
          CALL pw_axpy(rho_ext_g(1)%pw, rho_eff_gspace%pw, alpha=-1.0_dp)
-         total_rho = pw_integrate_function(rho_eff_gspace%pw, isign=1)
          ext_den_section => section_vals_get_subs_vals(input, "DFT%EXTERNAL_DENSITY")
          CALL section_vals_val_get(ext_den_section, "LAMBDA", r_val=lambda)
          CALL section_vals_val_get(ext_den_section, "ZMP_CONSTRAINT", i_val=my_val)

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -1023,7 +1023,6 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'admm_aux_reponse_density'
 
       INTEGER                                            :: handle, ispin, nao, nao_aux, ncol, nspins
-      REAL(KIND=dp)                                      :: tot_rho_aux
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cp_fm_type), POINTER                          :: tc0, tc1
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, rho1_ao
@@ -1072,7 +1071,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL calculate_rho_elec(matrix_p=rho1_ao(ispin)%matrix, &
                                  rho=rho1_aux_r(ispin), rho_gspace=rho1_aux_g(ispin), &
-                                 total_rho=tot_rho_aux, ks_env=ks_env, &
+                                 ks_env=ks_env, &
                                  basis_type="AUX_FIT", &
                                  task_list_external=task_list_aux_fit)
       END DO

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -91,7 +91,6 @@ CONTAINS
                                                             nkind, nspins
       LOGICAL                                            :: gapw, gapw_xc
       REAL(KIND=dp)                                      :: eban, eband, eh, exc, ovol
-      REAL(KIND=dp), DIMENSION(2)                        :: band_energy
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_s, matrix_w, rho_ao_kp
@@ -152,7 +151,6 @@ CONTAINS
       END IF
       ! band structure energy density
       CALL qs_energies_compute_w(qs_env, .TRUE.)
-      band_energy = 0.0_dp
       CALL get_qs_env(qs_env, ks_env=ks_env, matrix_w_kp=matrix_w)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              edens_r%pw, &
@@ -168,7 +166,6 @@ CONTAINS
          CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
                                  rho=edens_r, &
                                  rho_gspace=edens_g, &
-                                 total_rho=band_energy(ispin), &
                                  ks_env=ks_env, soft_valid=(gapw .OR. gapw_xc))
          CALL pw_axpy(edens_r%pw, band_density%pw)
       END DO

--- a/src/qs_p_env_methods.F
+++ b/src/qs_p_env_methods.F
@@ -429,7 +429,6 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'p_env_update_rho'
 
       INTEGER                                            :: handle, ispin
-      REAL(KIND=dp)                                      :: tot_rho_r_aux
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho1_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_aux, rho_r_aux
@@ -473,7 +472,6 @@ CONTAINS
                                        matrix_p=rho1_ao(ispin)%matrix, &
                                        rho=rho_r_aux(ispin), &
                                        rho_gspace=rho_g_aux(ispin), &
-                                       total_rho=tot_rho_r_aux, &
                                        soft_valid=.FALSE., &
                                        basis_type="AUX_FIT", &
                                        task_list_external=task_list)

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -155,8 +155,7 @@ CONTAINS
                                                             n_rep_hf, nao, nao_aux, norb, nspins
       LOGICAL :: distribute_fock_matrix, do_admm, do_analytic, do_hfx, do_numeric, &
          hfx_treat_lsd_in_core, is_rks_triplets, s_mstruct_changed, use_virial
-      REAL(KIND=dp)                                      :: eh1, focc, fval, total_rhox, &
-                                                            total_rhox_aux, xehartree
+      REAL(KIND=dp)                                      :: eh1, focc, fval, xehartree
       REAL(KIND=dp), DIMENSION(3)                        :: fodeb
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos, evect
@@ -262,8 +261,7 @@ CONTAINS
       DO ispin = 1, nspins
          IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 2.0_dp)
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_px1(ispin)%matrix, &
-                                 rho=rhox_r(ispin), rho_gspace=rhox_g(ispin), &
-                                 total_rho=total_rhox)
+                                 rho=rhox_r(ispin), rho_gspace=rhox_g(ispin))
          CALL pw_axpy(rhox_g(ispin)%pw, rhox_tot_gspace%pw)
          IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 0.5_dp)
       END DO
@@ -424,7 +422,7 @@ CONTAINS
                DO ispin = 1, nspins
                   CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_px1_admm(ispin)%matrix, &
                                           rho=rhox_r_aux(ispin), rho_gspace=rhox_g_aux(ispin), &
-                                          total_rho=total_rhox_aux, basis_type="AUX_FIT", &
+                                          basis_type="AUX_FIT", &
                                           task_list_external=task_list_aux_fit)
                END DO
                !

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -528,8 +528,7 @@ CONTAINS
       LOGICAL                                            :: deriv2_analytic, distribute_fock_matrix, &
                                                             do_hfx, hfx_treat_lsd_in_core, &
                                                             s_mstruct_changed
-      REAL(KIND=dp)                                      :: eh1, focc, thartree, total_rho, &
-                                                            total_rhoz_aux
+      REAL(KIND=dp)                                      :: eh1, focc, thartree, total_rho
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cp_fm_type), POINTER                          :: mos
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -686,7 +685,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpe(ispin, 1)%matrix, &
                                        rho=rhoz_r_aux(ispin), rho_gspace=rhoz_g_aux(ispin), &
-                                       total_rho=total_rhoz_aux, basis_type="AUX_FIT", &
+                                       basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)
             END DO
             !

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -812,8 +812,7 @@ CONTAINS
       LOGICAL :: deriv2_analytic, distribute_fock_matrix, do_ex, do_hfx, hfx_treat_lsd_in_core, &
          resp_only, s_mstruct_changed, use_virial
       REAL(KIND=dp)                                      :: eh1, ehartree, ekin_mol, eps_filter, &
-                                                            eps_ppnl, exc, fconv, focc, &
-                                                            total_rhoz, total_rhoz_aux
+                                                            eps_ppnl, exc, fconv, focc
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: ftot1, ftot2, ftot3
       REAL(KIND=dp), DIMENSION(3)                        :: fodeb
       REAL(KIND=dp), DIMENSION(3, 3)                     :: h_stress, pv_loc, stdeb, sttot, sttot2
@@ -1197,8 +1196,7 @@ CONTAINS
       CALL pw_zero(rhoz_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
-                                 rho=rhoz_r(ispin), rho_gspace=rhoz_g(ispin), &
-                                 total_rho=total_rhoz)
+                                 rho=rhoz_r(ispin), rho_gspace=rhoz_g(ispin))
          CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace%pw)
       END DO
 
@@ -1516,7 +1514,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpz(ispin, 1)%matrix, &
                                        rho=rhoz_r_aux(ispin), rho_gspace=rhoz_g_aux(ispin), &
-                                       total_rho=total_rhoz_aux, basis_type="AUX_FIT", &
+                                       basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)
             END DO
             !

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -282,7 +282,7 @@ CONTAINS
                                                             istates, nmo, nspin, nstates(2), &
                                                             state_start(2), unit_nr
       LOGICAL                                            :: mpi_io
-      REAL(KIND=dp)                                      :: alpha, total_rho
+      REAL(KIND=dp)                                      :: alpha
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: occ_tot
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
       TYPE(cp_fm_type), POINTER                          :: matrix_v, matrix_vf
@@ -370,7 +370,7 @@ CONTAINS
          DO i = 1, SIZE(stm_th_torb)
             iorb = stm_th_torb(i)
             CALL calculate_rho_elec(matrix_p=stm_density_ao, &
-                                    rho=wf_r, rho_gspace=wf_g, total_rho=total_rho, &
+                                    rho=wf_r, rho_gspace=wf_g, &
                                     ks_env=ks_env, der_type=iorb)
 
             oname = torb_string(iorb)

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -137,8 +137,7 @@ CONTAINS
       INTEGER, DIMENSION(2, 3)                           :: bo
       LOGICAL                                            :: compute_virial, gapw, lsd
       REAL(KIND=dp)                                      :: density_cut, efac, gradient_cut, &
-                                                            tau_cut, tot_rho_psi, we_GLLB, we_LB, &
-                                                            xc_energy
+                                                            tau_cut, we_GLLB, we_LB, xc_energy
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: coeff_col
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc_tmp
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
@@ -351,7 +350,7 @@ CONTAINS
             CALL pw_zero(orbital_g%pw)
             CALL calculate_rho_elec(matrix_p=orbital_density_matrix(ispin)%matrix, &
                                     rho=orbital, rho_gspace=orbital_g, &
-                                    total_rho=tot_rho_psi, ks_env=ks_env)
+                                    ks_env=ks_env)
 
             vxc_tmp(ispin)%pw%cr3d = vxc_tmp(ispin)%pw%cr3d + &
                                      efac*orbital%pw%cr3d
@@ -420,7 +419,7 @@ CONTAINS
             CALL pw_zero(orbital_g%pw)
             CALL calculate_rho_elec(matrix_p=orbital_density_matrix(ispin)%matrix, &
                                     rho=orbital, rho_gspace=orbital_g, &
-                                    total_rho=tot_rho_psi, ks_env=ks_env)
+                                    ks_env=ks_env)
 
 !TC          CALL calculate_wavefunction(mo_coeff,orb,orbital2,orbital2_g,qs_env)
 !TC          write (*,*) orb, maxval(abs(orbital2%pw%cr3d-orbital%pw%cr3d))


### PR DESCRIPTION
The calculation of the total density is not always required.