### PR TITLE
benchmarks: Add RI-MP2_ammonia.inp (Frederick Stein)

### DIFF
--- a/benchmarks/QS_single_node/RI-MP2_ammonia.inp
+++ b/benchmarks/QS_single_node/RI-MP2_ammonia.inp
@@ -1,0 +1,77 @@
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME    BASIS_RI_cc-TZ
+    POTENTIAL_FILE_NAME    POTENTIAL
+    &XC
+      !
+      ! Since this is a benchmark of MP2 we're simply skipping HFX here.
+      ! Don't try this at home!
+      !
+      &XC_FUNCTIONAL NONE
+      &END XC_FUNCTIONAL
+      &WF_CORRELATION
+        &RI_MP2
+          &CPHF
+            EPS_CONV 1.0E-4
+            MAX_ITER 20
+          &END
+          BLOCK_SIZE 1
+        &END RI_MP2
+        &INTEGRALS
+          &WFC_GPW
+            CUTOFF      150
+            REL_CUTOFF  35
+            EPS_FILTER  1.0E-9
+            EPS_GRID    1.0E-8
+          &END
+        &END INTEGRALS
+        MEMORY    3000
+        NUMBER_PROC  1
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom] 5.048 5.048 5.048
+      MULTIPLE_UNIT_CELL 1 1 2
+    &END CELL
+    &TOPOLOGY
+      MULTIPLE_UNIT_CELL 1 1 2
+    &END TOPOLOGY
+    &COORD
+      N    0.988906    0.988906    0.988906
+      N    1.535094    4.059094    3.512906
+      N    4.059094    3.512906    1.535094
+      N    3.512906    1.535094    4.059094
+      H    1.774270    1.378902    0.464078
+      H    0.749730    3.669098    2.988078
+      H    3.273730    3.902902    2.059922
+      H    4.298270    1.145098    4.583922
+      H    0.464078    1.774270    1.378902
+      H    2.988078    0.749730    3.669098
+      H    2.059922    3.273730    3.902902
+      H    4.583922    4.298270    1.145098
+      H    1.378902    0.464078    1.774270
+      H    3.669098    2.988078    0.749730
+      H    3.902902    2.059922    3.273730
+      H    1.145098    4.583922    4.298270
+    &END COORD
+    &KIND H
+      BASIS_SET         cc-TZ
+      BASIS_SET RI_AUX  RI_TZ
+      POTENTIAL         GTH-HF-q1
+    &END KIND
+    &KIND N
+      BASIS_SET         cc-TZ
+      BASIS_SET RI_AUX  RI_TZ
+      POTENTIAL         GTH-HF-q5
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+  PROJECT     RI-MP2_ammonia
+  RUN_TYPE    ENERGY
+  PREFERRED_DIAG_LIBRARY SL
+  PRINT_LEVEL MEDIUM
+&END GLOBAL

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -23,7 +23,7 @@ The only prerequisite is to [install Docker](https://docs.docker.com/get-docker/
 
     <!-- markdownlint-disable MD013 -->
     ```shell
-    docker run -ti -v "$(pwd)":/mnt cp2k_prod_psmp mpiexec -genv OMP_NUM_THREADS=2 -np 16 cp2k dbcsr.inp
+    docker run --shm-size=1g -ti -v "$(pwd)":/mnt cp2k_prod_psmp mpiexec -genv OMP_NUM_THREADS=2 -np 16 cp2k dbcsr.inp
     ```
     <!-- markdownlint-enable MD013 -->
 
@@ -35,7 +35,7 @@ to check pull requests and populate the [dashboard](https://dashboard.cp2k.org).
 Building a test image executes the test:
 
 ```shell
-docker build -f Dockerfile.test_sdbg -t cp2k_test_sdbg ../../
+docker build --shm-size=1g -f Dockerfile.test_sdbg -t cp2k_test_sdbg ../../
 ```
 
 To retrieve the cached report of an old image simply run it:

--- a/tools/docker/scripts/test_performance.sh
+++ b/tools/docker/scripts/test_performance.sh
@@ -16,7 +16,7 @@ function run_benchmark {
   INPUT=$3
   OUTPUT=$4
   echo -n "Running ${INPUT} with ${OMP_THREADS} threads and ${MPI_RANKS} ranks... "
-  if OMP_NUM_THREADS="${OMP_THREADS}" mpiexec -np "${MPI_RANKS}" \
+  if OMP_NUM_THREADS="${OMP_THREADS}" mpiexec -bind-to socket -np "${MPI_RANKS}" \
     "/workspace/cp2k/exe/${ARCH}/cp2k.psmp" "${INPUT}" &> "${OUTPUT}"; then
     echo "done."
   else

--- a/tools/docker/scripts/test_performance.sh
+++ b/tools/docker/scripts/test_performance.sh
@@ -64,6 +64,7 @@ BENCHMARKS=(
   "QS_single_node/H2O-hyb.inp"
   "QS_single_node/GW_PBE_4benzene.inp"
   "QS_single_node/RI-HFX_H2O-32.inp"
+  "QS_single_node/RI-MP2_ammonia.inp"
   "QS_single_node/diag_cu144_broy.inp"
   "QS_single_node/bench_dftb.inp"
   "QS_single_node/dbcsr.inp"


### PR DESCRIPTION
@fstein93, thanks a lot for the benchmark input. I butchered it pretty badly by skipping the HFX computation. As a result it now runs in 30s of which 10s are taken up by dgemm.