### PR TITLE
dbm: minor correction related to miniapp

### DIFF
--- a/src/dbm/Makefile
+++ b/src/dbm/Makefile
@@ -26,7 +26,7 @@ NVCC := $(shell which nvcc)
 ifneq ($(NVCC),)
 LIBS += -lcudart -lcuda -lcublas -L${CUDA_PATH}/lib64
 CFLAGS += -I${CUDA_PATH}/include -D__DBM_CUDA
-ALL_OBJECTS += dbm_multiply_cuda.o
+ALL_OBJECTS += dbm_multiply_gpu.o
 
 %.o: %.cu $(ALL_HEADERS)
 	cd $(dir $<); $(NVCC) -c $(NVFLAGS) $(notdir $<)

--- a/src/dbm/dbm_miniapp.c
+++ b/src/dbm/dbm_miniapp.c
@@ -172,7 +172,7 @@ int main(int argc, char *argv[]) {
 
   const double t = time_diff(time_start, time_end);
   if (my_rank == 0) {
-    printf("matrix multiply: %.3f s, %.1f MFLOP/s \n", t, 1e-9 * flop / t);
+    printf("matrix multiply: %.3f s, %.1f MFLOP/s \n", t, 1e-6 * flop / t);
     printf("done :-)\n");
   }
 


### PR DESCRIPTION
* Account for renamed translation unit/symlink (Makefile).
* Print performance in MFLOP/s (1e-9 would be GFLOP/s).