### PR TITLE
acc: revised build_dbcsr

### DIFF
--- a/exts/build_dbcsr/Makefile
+++ b/exts/build_dbcsr/Makefile
@@ -88,14 +88,16 @@ else ifeq ($(GPUVER),P100)
   ARCH_NUMBER = 60
 else ifeq ($(GPUVER),V100)
   ARCH_NUMBER = 70
+else ifeq ($(GPUVER),A100)
+  # TODO: update for A100 tuned parameters
+  override GPUVER := V100
+  ARCH_NUMBER = 80
 else ifeq ($(GPUVER),Mi50)
   ARCH_NUMBER = gfx906
 else ifeq ($(GPUVER),Mi100)
   ARCH_NUMBER = gfx908
-else ifneq ($(GPUVER),)
-ifneq (opencl,$(USE_ACCEL))
-  $(error GPUVER not recognized)
-endif
+else ifeq (,$(ARCH_NUMBER))
+  $(error Unknown ARCH_NUMBER since GPUVER="$(GPUVER)" is not recognized)
 endif
 
 # If compiling with nvcc
@@ -206,7 +208,7 @@ clean:
 ifneq ($(ACC),)
 ifneq (opencl,$(USE_ACCEL))
 ACC_KERNEL := $(wildcard $(LIBSMM_ACC_ABS_DIR)/kernels/*.h)
-ACC_PARAMS := $(wildcard $(LIBSMM_ACC_ABS_DIR)/parameters_*.txt)
+ACC_PARAMS := $(wildcard $(LIBSMM_ACC_ABS_DIR)/parameters/parameters_$(GPUVER).json)
 ACC_PARDEP := $(if $(ACC_MAKEDEP),$(shell $(ACC_MAKEDEP) $(LIBSMM_ACC_ABS_DIR)/.with_gpu $(GPUVER)))
 $(LIBSMM_ACC_ABS_DIR)/parameters.h: $(LIBSMM_ACC_ABS_DIR)/generate_parameters.py $(ACC_PARAMS) $(ACC_PARDEP)
 	cd $(LIBSMM_ACC_ABS_DIR); $(PYTHON) generate_parameters.py --gpu_version=$(GPUVER)


### PR DESCRIPTION
* Support GPUVER=A100 and fallback to parameters of V100 but with ARCH_NUMBER=80.
* Error only if GPUVER is not given and ARCH_NUMBER is not specified (CUDA/HIP).
* Allows future experiment with an unspecific GPU (no tuned parameters).
* Fixed Makefile dependency (parameter files).