### PR TITLE
Update DBCSR v2.3.0-rc0

### DIFF
--- a/src/cp_dbcsr_cp2k_link.F
+++ b/src/cp_dbcsr_cp2k_link.F
@@ -254,30 +254,9 @@ CONTAINS
                           description="Configuration options for the ACC-Driver.", &
                           n_keywords=1, n_subsections=0, repeats=.FALSE.)
 
-      CALL dbcsr_get_default_config(accdrv_priority_buffers=idefault)
-      CALL keyword_create(keyword, __LOCATION__, name="priority_buffers", &
-                          description="Number of transfer-buffers associated with high priority streams.", &
-                          default_i_val=idefault)
-      CALL section_add_keyword(subsection, keyword)
-      CALL keyword_release(keyword)
-
-      CALL dbcsr_get_default_config(accdrv_posterior_buffers=idefault)
-      CALL keyword_create(keyword, __LOCATION__, name="posterior_buffers", &
-                          description="Number of transfer-buffers associated with low priority streams.", &
-                          default_i_val=idefault)
-      CALL section_add_keyword(subsection, keyword)
-      CALL keyword_release(keyword)
-
-      CALL dbcsr_get_default_config(accdrv_priority_streams=idefault)
-      CALL keyword_create(keyword, __LOCATION__, name="priority_streams", &
-                          description="Number of acc streams created with high priority.", &
-                          default_i_val=idefault)
-      CALL section_add_keyword(subsection, keyword)
-      CALL keyword_release(keyword)
-
-      CALL dbcsr_get_default_config(accdrv_posterior_streams=idefault)
-      CALL keyword_create(keyword, __LOCATION__, name="posterior_streams", &
-                          description="Number of acc streams created with low priority.", &
+      CALL dbcsr_get_default_config(accdrv_thread_buffers=idefault)
+      CALL keyword_create(keyword, __LOCATION__, name="thread_buffers", &
+                          description="Number of transfer-buffers associated with each thread and corresponding stream.", &
                           default_i_val=idefault)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -403,17 +382,8 @@ CONTAINS
       CALL section_vals_val_get(dbcsr_section, "TENSOR%tas_split_factor", r_val=rval)
       CALL dbcsr_set_config(tas_split_factor=rval)
 
-      CALL section_vals_val_get(dbcsr_section, "ACC%priority_streams", i_val=ival)
-      CALL dbcsr_set_config(accdrv_priority_streams=ival)
-
-      CALL section_vals_val_get(dbcsr_section, "ACC%priority_buffers", i_val=ival)
-      CALL dbcsr_set_config(accdrv_priority_buffers=ival)
-
-      CALL section_vals_val_get(dbcsr_section, "ACC%posterior_streams", i_val=ival)
-      CALL dbcsr_set_config(accdrv_posterior_streams=ival)
-
-      CALL section_vals_val_get(dbcsr_section, "ACC%posterior_buffers", i_val=ival)
-      CALL dbcsr_set_config(accdrv_posterior_buffers=ival)
+      CALL section_vals_val_get(dbcsr_section, "ACC%thread_buffers", i_val=ival)
+      CALL dbcsr_set_config(accdrv_thread_buffers=ival)
 
       CALL section_vals_val_get(dbcsr_section, "ACC%min_flop_process", i_val=ival)
       CALL dbcsr_set_config(accdrv_min_flop_process=ival)

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -194,7 +194,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_FLAGS+="-fPIE -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx908 -O3 --std=c++11 \$(DFLAGS)"
       LIBS+=" IF_HIP(-lamdhip64 -lhipfft -lhipblas -lrocblas IF_DEBUG(-lroctx64 -lroctracer64|)|)"
       PLATFORM_FLAGS='-D__HIP_PLATFORM_AMD__ '
-      DFLAGS+=' IF_HIP(-D__HIP_PLATFORM_AMD__ -D__OFFLOAD_HIP IF_DEBUG(-D__OFFLOAD_PROFILING|)|)' # -D__DBCSR_ACC
+      DFLAGS+=' IF_HIP(-D__HIP_PLATFORM_AMD__ -D__OFFLOAD_HIP IF_DEBUG(-D__OFFLOAD_PROFILING|)|) -D__DBCSR_ACC'
       CXXFLAGS+=" -fopenmp -std=c++11"
       ;;
     *)
@@ -204,7 +204,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       check_lib -lcuda "cuda"
       check_lib -lcufft "cuda"
       check_lib -lcublas "cuda"
-      DFLAGS+=" IF_HIP(-D__HIP_PLATFORM_NVIDIA__ -D__OFFLOAD_HIP |)" # -D__DBCSR_ACC
+      DFLAGS+=" IF_HIP(-D__HIP_PLATFORM_NVIDIA__ -D__HIP_PLATFORM_NVCC__ -D__OFFLOAD_HIP |) -D__DBCSR_ACC"
       HIP_FLAGS=" -g -arch sm_${ARCH_NUM} -O3 -Xcompiler='-fopenmp' --std=c++11 \$(DFLAGS)"
       add_include_from_paths CUDA_CFLAGS "cuda.h" $INCLUDE_PATHS
       HIP_INCLUDES+=" -I${CUDA_PATH:-${CUDA_HOME:-/CUDA_HOME-notset}}/include"
@@ -212,6 +212,8 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       CFLAGS+=" -Wno-error ${CUDA_CFLAGS}"
       CXXFLAGS+=" -Wno-error ${CUDA_CFLAGS}"
       # Set LD-flags
+      # Multiple definition because of hip/include/hip/nvidia_detail/nvidia_hiprtc.h
+      LDFLAGS+=" -Wl,--allow-multiple-definition"
       LIBS+=' -lhipfft -lhipblas -lhipfft -lnvrtc -lcudart -lcufft -lcublas -lcuda'
       add_lib_from_paths HIP_LDFLAGS "libcudart.*" $LIB_PATHS
       add_lib_from_paths HIP_LDFLAGS "libnvrtc.*" $LIB_PATHS

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -177,7 +177,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_FLAGS+="-fPIE -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx906 -O3 --std=c++11 \$(DFLAGS)"
       LIBS+=" IF_HIP(-lamdhip64 -lhipfft -lhipblas -lrocblas IF_DEBUG(-lroctx64 -lroctracer64|)|)"
       PLATFORM_FLAGS='-D__HIP_PLATFORM_AMD__'
-      DFLAGS+=' IF_HIP(-D__HIP_PLATFORM_AMD__ -D__OFFLOAD_HIP IF_DEBUG(-D__OFFLOAD_PROFILING|)|)' # -D__DBCSR_ACC
+      DFLAGS+=' IF_HIP(-D__HIP_PLATFORM_AMD__ -D__OFFLOAD_HIP IF_DEBUG(-D__OFFLOAD_PROFILING|)|)  -D__DBCSR_ACC'
       CXXFLAGS+=" -fopenmp -std=c++11"
       ;;
     Mi100)

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -97,7 +97,7 @@ G_CFLAGS="$G_CFLAGS IF_COVERAGE($COVERAGE_FLAGS|IF_DEBUG($NOOPT_FLAGS|$OPT_FLAGS
 G_CFLAGS="$G_CFLAGS IF_DEBUG(|$PROFOPT_FLAGS)"
 G_CFLAGS="$G_CFLAGS $CP_CFLAGS"
 # FCFLAGS, for gfortran
-FCFLAGS="$G_CFLAGS \$(FCDEBFLAGS) \$(WFLAGS) \$(DFLAGS)"
+FCFLAGS="$G_CFLAGS \$(FCDEBFLAGS) \$(WFLAGS) \$(DFLAGS) IF_MPI(-fallow-argument-mismatch|)"
 # CFLAGS, special flags for gcc
 
 # TODO: Remove -Wno-vla-parameter after upgrade to gcc 11.3.

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -97,7 +97,8 @@ G_CFLAGS="$G_CFLAGS IF_COVERAGE($COVERAGE_FLAGS|IF_DEBUG($NOOPT_FLAGS|$OPT_FLAGS
 G_CFLAGS="$G_CFLAGS IF_DEBUG(|$PROFOPT_FLAGS)"
 G_CFLAGS="$G_CFLAGS $CP_CFLAGS"
 # FCFLAGS, for gfortran
-FCFLAGS="$G_CFLAGS \$(FCDEBFLAGS) \$(WFLAGS) \$(DFLAGS) IF_MPI(-fallow-argument-mismatch|)"
+FCFLAGS="$G_CFLAGS \$(FCDEBFLAGS) \$(WFLAGS) \$(DFLAGS)"
+FCFLAGS+=" IF_MPI($(allowed_gfortran_flags "-fallow-argument-mismatch")|)"
 # CFLAGS, special flags for gcc
 
 # TODO: Remove -Wno-vla-parameter after upgrade to gcc 11.3.
@@ -149,11 +150,6 @@ fi
 
 # HIP handling
 if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
-  #
-  # TODO: Make toolchain oblivious to HIP_PLATFORM, currently it only works for Nvidia.
-  #
-  # DBCSR suffers from https://github.com/ROCm-Developer-Tools/HIP/issues/268
-
   check_command hipcc "hip"
   check_lib -lhipblas "hip"
   add_lib_from_paths HIP_LDFLAGS "libhipblas.*" $LIB_PATHS

--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -52,7 +52,7 @@ case "${with_mpich}" in
       # workaround for compilation with GCC >= 10, until properly fixed:
       #   https://github.com/pmodels/mpich/issues/4300
       if ("${FC}" --version | grep -q 'GNU'); then
-        ("${FC}" --help -v 2>&1 | grep -q 'fallow-argument-mismatch') && compat_flag="-fallow-argument-mismatch" || compat_flag=""
+        compat_flag=$(allowed_gfortran_flags "-fallow-argument-mismatch")
       fi
       ./configure \
         --prefix="${pkg_install_dir}" \

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -71,12 +71,14 @@ EOF
         CXX=$CXX \
         CC=$CC \
         FC=$FC \
+        INTRINSICS=1 \
         PREFIX=${pkg_install_dir} \
         > make.log 2>&1 || tail -n ${LOG_LINES} make.log
       make -j $(get_nprocs) \
         CXX=$CXX \
         CC=$CC \
         FC=$FC \
+        INTRINSICS=1 \
         PREFIX=${pkg_install_dir} \
         install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
       cd ..

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -28,6 +28,7 @@ ELPA_LDFLAGS=''
 ELPA_LIBS=''
 # ELPA 2019.05.001 has a parallel build issue, restricting to -j1
 ELPA_MAKEOPTS='-j1'
+elpa_dir_openmp="_openmp"
 
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
@@ -138,7 +139,8 @@ case "$with_elpa" in
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage5/$(basename ${SCRIPT_NAME})"
     fi
-    ELPA_CFLAGS="-I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa_openmp-${elpa_ver}/modules' -I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa_openmp-${elpa_ver}/elpa'"
+    [ "$enable_openmp" != "yes" ] && elpa_dir_openmp=""
+    ELPA_CFLAGS="-I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}/modules' -I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}/elpa'"
     ELPA_LDFLAGS="-L'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib' -Wl,-rpath='${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib'"
     ;;
   __SYSTEM__)
@@ -177,7 +179,7 @@ case "$with_elpa" in
     ;;
 esac
 if [ "$with_elpa" != "__DONTUSE__" ]; then
-  ELPA_LIBS="-lelpa_openmp"
+  ELPA_LIBS="-lelpa${elpa_dir_openmp}"
   cat << EOF > "${BUILDDIR}/setup_elpa"
 prepend_path CPATH "$elpa_include"
 EOF

--- a/tools/toolchain/scripts/stage6/install_quip.sh
+++ b/tools/toolchain/scripts/stage6/install_quip.sh
@@ -101,7 +101,9 @@ case "${with_quip}" in
 
       # workaround for compilation with GCC-10, until properly fixed:
       #   https://github.com/libAtoms/QUIP/issues/209
-      ("${FC}" --version | grep -Eq 'GNU.+\s10\.') && compat_flag="-fallow-argument-mismatch" || compat_flag=""
+      if ("${FC}" --version | grep -q 'GNU'); then
+        compat_flag=$(allowed_gfortran_flags "-fallow-argument-mismatch")
+      fi
 
       # enable debug symbols
       echo "F95FLAGS       += -g ${compat_flag}" >> arch/Makefile.linux_${quip_arch}_gfortran

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -90,7 +90,6 @@ case "$with_spla" in
         install -d ${pkg_install_dir}/lib/cuda
         [ -f src/libspla.a ] && install -m 644 src/*.a ${pkg_install_dir}/lib/cuda >> install.log 2>&1
         [ -f src/libspla.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/cuda >> install.log 2>&1
-        CP_DFLAGS+=' -D__OFFLOAD_GEMM'
       fi
 
       if [ "$ENABLE_HIP" = "__TRUE__" ]; then
@@ -140,7 +139,6 @@ case "$with_spla" in
             ;;
           *) ;;
         esac
-        CP_DFLAGS+=' -D__OFFLOAD_GEMM'
       fi
 
       # https://github.com/eth-cscs/spla/issues/17
@@ -197,7 +195,7 @@ export SPLA_CFLAGS="${SPLA_CFLAGS}"
 export SPLA_LDFLAGS="${SPLA_LDFLAGS}"
 export SPLA_CUDA_LDFLAGS="${SPLA_CUDA_LDFLAGS}"
 export SPLA_HIP_LDFLAGS="${SPLA_HIP_LDFLAGS}"
-export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__SPLA|)"
+export CP_DFLAGS="\${CP_DFLAGS} IF_HIP(-D__OFFLOAD_GEMM|) IF_CUDA(-D__OFFLOAD_GEMM|) ${OFFLOAD_DFLAGS} IF_MPI(-D__SPLA|)"
 export CP_CFLAGS="\${CP_CFLAGS} ${SPLA_CFLAGS}"
 export SPLA_LIBRARY="-lspla"
 export SPLA_ROOT="$pkg_install_dir"


### PR DESCRIPTION
Including the first release with tested support of the DBCSR HIP backend.
It passes HIP on NVIDIA test (part of the CI) and HIP on AMD Mi100 (internally tested at HPE), with ROCM v4.5.2.
Thanks to @gsitaram for the improved HIP code and @mtaillefumier for the Mi100 optimized kernel parameters!