### PR TITLE
Fix work array size

### DIFF
--- a/src/fm/cp_cfm_diag.F
+++ b/src/fm/cp_cfm_diag.F
@@ -90,7 +90,9 @@ CONTAINS
       descv(:) = eigenvectors%matrix_struct%descriptor(:)
       CALL PZHEEVD('V', 'U', n, m(1, 1), 1, 1, descm, eigenvalues(1), v(1, 1), 1, 1, descv, &
                    work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
-      lwork = CEILING(REAL(work(1), KIND=dp))
+      ! The work space query for lwork does not return always sufficiently large values.
+      ! Let's add some margin to avoid crashes.
+      lwork = CEILING(REAL(work(1), KIND=dp)) + 1000
       ! needed to correct for a bug in scalapack, unclear how much the right number is
       lrwork = CEILING(REAL(rwork(1), KIND=dp)) + 1000000
       liwork = iwork(1)


### PR DESCRIPTION
The work space query for lwork does not return always sufficiently large values. This looks like a ScaLAPACK bug.
Let's add some margin as workaround to avoid crashes.