### PR TITLE
Fix coding conventions

### DIFF
--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -1667,7 +1667,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'xc_calc_2nd_deriv_numerical', &
                                      routineP = moduleN//':'//routineN
-      REAL(KIND=dp), DIMENSION(-4:4, 4) :: &
+      REAL(KIND=dp), DIMENSION(-4:4, 4), PARAMETER :: &
          weights = RESHAPE([0.0_dp, 0.0_dp, 0.0_dp, -0.5_dp, 0.0_dp, 0.5_dp, 0.0_dp, 0.0_dp, 0.0_dp, &
                            0.0_dp, 0.0_dp, 1.0_dp/12.0_dp, -2.0_dp/3.0_dp, 0.0_dp, 2.0_dp/3.0_dp, -1.0_dp/12.0_dp, 0.0_dp, 0.0_dp, &
                             0.0_dp, -1.0_dp/60.0_dp, 0.15_dp, -0.75_dp, 0.0_dp, 0.75_dp, -0.15_dp, 1.0_dp/60.0_dp, 0.0_dp, &


### PR DESCRIPTION
The fix is related to my last PR #2037 where I have added higher order finite difference schemes. There, I have forgotten to mark a variable as parameter such that is implicitly treated to have the save attribute in accordance to the Fortran standards.