### PR TITLE
Fix MP2 I/O

### DIFF
--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -284,6 +284,15 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
+         name="PRINT_DGEMM_INFO", &
+         description="Print details about all DGEMM calls.", &
+         lone_keyword_l_val=.TRUE., &
+         default_l_val=.FALSE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
    END SUBROUTINE create_ri_mp2
 
 ! **************************************************************************************************
@@ -524,6 +533,15 @@ CONTAINS
          description="Scales RPA energy contributions (RPA, AXK).", &
          usage="SCALE_RPA 1.0", &
          default_r_val=1.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
+         name="PRINT_DGEMM_INFO", &
+         description="Print details about all DGEMM calls.", &
+         lone_keyword_l_val=.TRUE., &
+         default_l_val=.FALSE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -426,7 +426,6 @@ CONTAINS
          free_hfx_buffer = .TRUE.
          IF (calc_forces .AND. (.NOT. mp2_env%ri_mp2%free_hfx_buffer)) free_hfx_buffer = .FALSE.
          IF (qs_env%x_data(1, 1)%do_hfx_ri) free_hfx_buffer = .FALSE.
-         !TODO: look deeper into this, currently necessary to run
          IF (calc_forces .AND. mp2_env%method == ri_mp2_laplace) free_hfx_buffer = .FALSE.
       END IF
 

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -383,7 +383,7 @@ CONTAINS
 
       CALL mp_sum(L_local_col, para_env_sub%group)
 
-      CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, pw_env_sub, &
+      CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
                        task_list_sub, auxbas_pw_pool, rho_r, rho_g, pot_g, psi_L)
 
       CALL timestop(handle)
@@ -1182,6 +1182,7 @@ CONTAINS
 !> \param e_cutoff_old ...
 !> \param cutoff_old ...
 !> \param relative_cutoff_old ...
+!> \param para_env_sub ...
 !> \param pw_env_sub ...
 !> \param task_list_sub ...
 !> \param auxbas_pw_pool ...
@@ -1190,12 +1191,13 @@ CONTAINS
 !> \param pot_g ...
 !> \param psi_L ...
 ! **************************************************************************************************
-   SUBROUTINE cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, pw_env_sub, &
+   SUBROUTINE cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
                           task_list_sub, auxbas_pw_pool, rho_r, rho_g, pot_g, psi_L)
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: e_cutoff_old
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_old, relative_cutoff_old
+      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_sub
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
       TYPE(task_list_type), POINTER                      :: task_list_sub
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: auxbas_pw_pool
@@ -1215,7 +1217,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L%pw)
 
       CALL deallocate_task_list(task_list_sub)
-      CALL pw_env_release(pw_env_sub)
+      CALL pw_env_release(pw_env_sub, para_env=para_env_sub)
 
       CALL get_qs_env(qs_env, dft_control=dft_control)
 

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -605,7 +605,7 @@ CONTAINS
       END DO
       DEALLOCATE (psi_i)
 
-      CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, pw_env_sub, &
+      CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
                        task_list_sub, auxbas_pw_pool, rho_r, rho_g, pot_g, psi_a)
 
       CALL timestop(handle)

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -651,7 +651,7 @@ CONTAINS
 
             END DO
 
-            CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, pw_env_sub, &
+            CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
                              task_list_sub, auxbas_pw_pool, rho_r, rho_g, pot_g, psi_L)
          ELSE
             CPABORT("Integration method not implemented!")

--- a/src/mp2_laplace_force_methods.F
+++ b/src/mp2_laplace_force_methods.F
@@ -1941,7 +1941,7 @@ CONTAINS
       END DO
       CALL dbcsr_release(dbcsr_work)
 
-      CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, pw_env_ext, &
+      CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_ext, pw_env_ext, &
                        task_list_ext, auxbas_pw_pool, rho_r, rho_g, pot_g, psi_L)
 
       CALL dbcsr_distribution_release(dbcsr_dist)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -142,7 +142,7 @@ CONTAINS
 
       CALL get_group_dist(gd_array, color_sub, my_group_L_start, my_group_L_end, my_group_L_size)
 
-      CALL dgemm_counter_init(dgemm_counter, unit_nr)
+      CALL dgemm_counter_init(dgemm_counter, unit_nr, mp2_env%ri_mp2%print_dgemm_info)
 
       ! We cannot fix the tag because of the recv routine
       tag = 42

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -426,7 +426,7 @@ CONTAINS
             END DO
          END IF
 
-         CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, pw_env_sub, &
+         CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
                           task_list_sub, auxbas_pw_pool, rho_r, rho_g, pot_g, psi_L)
 
          CALL dbcsr_release(matrix_P_munu%matrix)

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -107,6 +107,7 @@ CONTAINS
       CALL section_vals_val_get(mp2_section, "RI_RPA%AXK", l_val=mp2_env%ri_rpa%do_ri_axk)
 
       CALL section_vals_val_get(mp2_section, "RI_RPA%RSE", l_val=mp2_env%ri_rpa%do_rse)
+      CALL section_vals_val_get(mp2_section, "RI_RPA%PRINT_DGEMM_INFO", l_val=mp2_env%ri_rpa%print_dgemm_info)
 
       NULLIFY (gw_section)
       gw_section => section_vals_get_subs_vals(mp2_section, "RI_RPA%GW")
@@ -271,6 +272,7 @@ CONTAINS
       CALL section_vals_val_get(mp2_section, "RI_MP2%BLOCK_SIZE", i_val=mp2_env%ri_mp2%block_size)
       CALL section_vals_val_get(mp2_section, "RI_MP2%EPS_CANONICAL", r_val=mp2_env%ri_mp2%eps_canonical)
       CALL section_vals_val_get(mp2_section, "RI_MP2%FREE_HFX_BUFFER", l_val=mp2_env%ri_mp2%free_hfx_buffer)
+      CALL section_vals_val_get(mp2_section, "RI_MP2%PRINT_DGEMM_INFO", l_val=mp2_env%ri_mp2%print_dgemm_info)
 
       CALL section_vals_val_get(mp2_section, "RI_MP2%CPHF%MAX_ITER", i_val=mp2_env%ri_grad%cphf_max_num_iter)
       CALL section_vals_val_get(mp2_section, "RI_MP2%CPHF%EPS_CONV", r_val=mp2_env%ri_grad%cphf_eps_conv)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -127,6 +127,7 @@ MODULE mp2_types
       INTEGER                  :: block_size
       REAL(dp)                 :: eps_canonical
       LOGICAL                  :: free_hfx_buffer
+      LOGICAL                  :: print_dgemm_info
       LOGICAL                  :: use_old_grad
    END TYPE
 
@@ -141,6 +142,7 @@ MODULE mp2_types
       LOGICAL                  :: do_admm
       LOGICAL                  :: do_ri_axk
       LOGICAL                  :: do_rse
+      LOGICAL                  :: print_dgemm_info
       TYPE(dbcsr_type), POINTER             :: mo_coeff_o, &
                                                mo_coeff_v
       REAL(KIND=dp)            :: ener_axk
@@ -281,6 +283,7 @@ MODULE mp2_types
       REAL(KIND=dp) :: flop_rate, t_start
       INTEGER :: num_dgemm_call
       INTEGER :: unit_nr
+      LOGICAL :: print_info
    END TYPE
 
 CONTAINS
@@ -347,14 +350,17 @@ CONTAINS
 !> \brief Initialize a dgemm_counter
 !> \param dgemm_counter ...
 !> \param unit_nr ...
+!> \param print_info ...
 ! **************************************************************************************************
-   ELEMENTAL SUBROUTINE dgemm_counter_init(dgemm_counter, unit_nr)
+   ELEMENTAL SUBROUTINE dgemm_counter_init(dgemm_counter, unit_nr, print_info)
       TYPE(dgemm_counter_type), INTENT(OUT)              :: dgemm_counter
       INTEGER, INTENT(IN)                                :: unit_nr
+      LOGICAL, INTENT(IN)                                :: print_info
 
       dgemm_counter%num_dgemm_call = 0
       dgemm_counter%flop_rate = 0.0
       dgemm_counter%unit_nr = unit_nr
+      dgemm_counter%print_info = print_info
 
    END SUBROUTINE dgemm_counter_init
 
@@ -385,7 +391,7 @@ CONTAINS
       t_end = m_walltime()
       flop_rate = 2.0_dp*REAL(size1, dp)*REAL(size2, dp)*REAL(size3, dp)/MAX(0.001_dp, t_end - dgemm_counter%t_start)
       dgemm_counter%num_dgemm_call = dgemm_counter%num_dgemm_call + 1
-      IF (dgemm_counter%unit_nr > 0) THEN
+      IF (dgemm_counter%unit_nr > 0 .AND. dgemm_counter%print_info) THEN
          WRITE (UNIT=dgemm_counter%unit_nr, FMT="(T3,A,I10)") &
             "PERFORMANCE| DGEMM call #", dgemm_counter%num_dgemm_call
          WRITE (UNIT=dgemm_counter%unit_nr, FMT="(T3,A,I12,A,I12,A,I12)") &

--- a/src/pw/pw_grids.F
+++ b/src/pw/pw_grids.F
@@ -669,7 +669,7 @@ CONTAINS
 !
 
       IF (pw_grid%para%mode == PW_MODE_LOCAL) THEN
-         IF (info >= 0) THEN
+         IF (info > 0) THEN
             WRITE (info, '(/,A,T71,I10)') &
                " PW_GRID| Information for grid number ", pw_grid%id_nr
             IF (pw_grid%reference > 0) THEN
@@ -716,7 +716,7 @@ CONTAINS
          n(3) = MINVAL(pw_grid%para%nyzray)
          rv(:, 3) = REAL(n, KIND=dp)
 
-         IF (pw_grid%para%group_head .AND. info >= 0) THEN
+         IF (pw_grid%para%group_head .AND. info > 0) THEN
             WRITE (info, '(/,A,T71,I10)') &
                " PW_GRID| Information for grid number ", pw_grid%id_nr
             IF (pw_grid%reference > 0) THEN

--- a/src/pw_env/gaussian_gridlevels.F
+++ b/src/pw_env/gaussian_gridlevels.F
@@ -87,43 +87,49 @@ CONTAINS
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
 
       INTEGER                                            :: group, i, output_unit
+      LOGICAL                                            :: do_io
       TYPE(cp_logger_type), POINTER                      :: logger
 
       NULLIFY (logger)
       logger => cp_get_default_logger()
       IF (PRESENT(para_env)) THEN
          group = para_env%group
+         do_io = .FALSE. !subgroups completely mess up the output file
       ELSE
          group = logger%para_env%group
+         do_io = .TRUE.
       END IF
-      output_unit = cp_print_key_unit_nr(logger, gridlevel_info%print_section, &
-                                         "", extension=".Log")
 
       CALL mp_sum(gridlevel_info%total_count, group)
       CALL mp_sum(gridlevel_info%count, group)
-      IF (output_unit > 0) THEN
-         WRITE (output_unit, '(/,T2,A,A)') "----------------------------------------", &
-            "---------------------------------------"
-         WRITE (output_unit, '(T2,A,T35,A,T77,A)') "----", "MULTIGRID INFO", "----"
-         WRITE (output_unit, '(T2,A,A)') "----------------------------------------", &
-            "---------------------------------------"
-         IF (gridlevel_info%ngrid_levels > 1) THEN
-            DO i = 1, gridlevel_info%ngrid_levels
-               WRITE (output_unit, '(T2,A,I4,A,I14,9x,A,F12.2)') "count for grid     ", i, ": ", &
-                  gridlevel_info%count(i), " cutoff [a.u.]    ", gridlevel_info%cutoff(i)
-            END DO
-            WRITE (output_unit, '(T2,A,I14)') "total gridlevel count  : ", &
-               gridlevel_info%total_count
-         ELSE
-            WRITE (output_unit, '(T2,A,I14,T51,A,F12.2)') "total grid count     :", &
-               gridlevel_info%count(1), " cutoff [a.u.]    ", gridlevel_info%cutoff(1)
+
+      IF (do_io) THEN
+         output_unit = cp_print_key_unit_nr(logger, gridlevel_info%print_section, &
+                                            "", extension=".Log")
+
+         IF (output_unit > 0) THEN
+            WRITE (output_unit, '(/,T2,A,A)') "----------------------------------------", &
+               "---------------------------------------"
+            WRITE (output_unit, '(T2,A,T35,A,T77,A)') "----", "MULTIGRID INFO", "----"
+            WRITE (output_unit, '(T2,A,A)') "----------------------------------------", &
+               "---------------------------------------"
+            IF (gridlevel_info%ngrid_levels > 1) THEN
+               DO i = 1, gridlevel_info%ngrid_levels
+                  WRITE (output_unit, '(T2,A,I4,A,I14,9x,A,F12.2)') "count for grid     ", i, ": ", &
+                     gridlevel_info%count(i), " cutoff [a.u.]    ", gridlevel_info%cutoff(i)
+               END DO
+               WRITE (output_unit, '(T2,A,I14)') "total gridlevel count  : ", &
+                  gridlevel_info%total_count
+            ELSE
+               WRITE (output_unit, '(T2,A,I14,T51,A,F12.2)') "total grid count     :", &
+                  gridlevel_info%count(1), " cutoff [a.u.]    ", gridlevel_info%cutoff(1)
+            END IF
          END IF
+
+         CALL cp_print_key_finished_output(output_unit, logger, gridlevel_info%print_section, "")
       END IF
 
       DEALLOCATE (gridlevel_info%cutoff)
-
-      CALL cp_print_key_finished_output(output_unit, logger, gridlevel_info%print_section, &
-                                        "")
 
       CALL section_vals_release(gridlevel_info%print_section)
 

--- a/src/pw_env/pw_env_types.F
+++ b/src/pw_env/pw_env_types.F
@@ -12,6 +12,7 @@
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
 MODULE pw_env_types
+   USE cp_para_types,                   ONLY: cp_para_env_type
    USE cube_utils,                      ONLY: cube_info_type,&
                                               destroy_cube_info
    USE gaussian_gridlevels,             ONLY: destroy_gaussian_gridlevel,&
@@ -172,13 +173,15 @@ CONTAINS
 !> \brief releases the given pw_env (see doc/ReferenceCounting.html)
 !> \param pw_env the pw_env to release
 !> \param kg ...
+!> \param para_env ...
 !> \par History
 !>      10.2002 created [fawzi]
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
-   SUBROUTINE pw_env_release(pw_env, kg)
+   SUBROUTINE pw_env_release(pw_env, kg, para_env)
       TYPE(pw_env_type), POINTER                         :: pw_env
       LOGICAL, OPTIONAL                                  :: kg
+      TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
 
       INTEGER                                            :: i, igrid_level
       LOGICAL                                            :: my_kg
@@ -197,7 +200,7 @@ CONTAINS
                   CALL section_vals_release(pw_env%gridlevel_info%print_section)
                   DEALLOCATE (pw_env%gridlevel_info%count)
                ELSE
-                  CALL destroy_gaussian_gridlevel(pw_env%gridlevel_info)
+                  CALL destroy_gaussian_gridlevel(pw_env%gridlevel_info, para_env)
                END IF
                DEALLOCATE (pw_env%gridlevel_info)
             END IF

--- a/src/pw_env_methods.F
+++ b/src/pw_env_methods.F
@@ -159,10 +159,8 @@ CONTAINS
          igrid_level, iounit, ncommensurate, ngrid_level, xc_deriv_method_id, xc_smooth_method_id
       INTEGER, DIMENSION(2)                              :: distribution_layout
       INTEGER, DIMENSION(3)                              :: higher_grid_layout
-      LOGICAL                                            :: efg_present, linres_present, odd, &
-                                                            set_vdw_pool, should_output, &
-                                                            smooth_required, spherical, uf_grid, &
-                                                            use_ref_cell
+      LOGICAL :: do_io, efg_present, linres_present, odd, set_vdw_pool, should_output, &
+         smooth_required, spherical, uf_grid, use_ref_cell
       REAL(KIND=dp)                                      :: cutilev, rel_cutoff
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: radius
       REAL(KIND=dp), DIMENSION(:), POINTER               :: cutoff
@@ -248,9 +246,11 @@ CONTAINS
       !
       !
 
+      do_io = .TRUE.
       IF (PRESENT(external_para_env)) THEN
          para_env => external_para_env
          CPASSERT(ASSOCIATED(para_env))
+         do_io = .FALSE. !multiple MPI subgroups mess-up the output file
       END IF
       ! interpolation section
       pw_env%interp_section => section_vals_get_subs_vals(input, "DFT%MGRID%INTERPOLATOR")
@@ -306,8 +306,13 @@ CONTAINS
       !
       ! Setup of the multi-grid pw_grid and pw_pools
       !
-      logger => cp_get_default_logger()
-      iounit = cp_print_key_unit_nr(logger, print_section, '', extension='.Log')
+
+      IF (do_io) THEN
+         logger => cp_get_default_logger()
+         iounit = cp_print_key_unit_nr(logger, print_section, '', extension='.Log')
+      ELSE
+         iounit = 0
+      END IF
 
       IF (dft_control%qs_control%pw_grid_opt%spherical) THEN
          grid_span = HALFSPACE
@@ -472,7 +477,7 @@ CONTAINS
          CALL pw_pool_retain(pw_env%vdw_pw_pool)
       END IF
 
-      CALL cp_print_key_finished_output(iounit, logger, print_section, '')
+      IF (do_io) CALL cp_print_key_finished_output(iounit, logger, print_section, '')
 
       ! complete init of the poisson_env
       IF (.NOT. ASSOCIATED(pw_env%poisson_env)) THEN
@@ -585,9 +590,10 @@ CONTAINS
 
       ! Print grid information
 
-      logger => cp_get_default_logger()
-      iounit = cp_print_key_unit_nr(logger, print_section, '', &
-                                    extension='.Log')
+      IF (do_io) THEN
+         logger => cp_get_default_logger()
+         iounit = cp_print_key_unit_nr(logger, print_section, '', extension='.Log')
+      END IF
       IF (iounit > 0) THEN
          SELECT CASE (poisson_params%solver)
          CASE (pw_poisson_periodic)
@@ -713,14 +719,17 @@ CONTAINS
             END IF
          END IF
       END IF
-      should_output = BTEST(cp_print_key_should_output(logger%iter_info, &
-                                                       print_section, ''), cp_p_file)
-      IF (should_output) THEN
-         DO igrid_level = 1, ngrid_level
-            CALL rs_grid_print(rs_grids(igrid_level)%rs_grid, iounit)
-         END DO
+
+      IF (do_io) THEN
+         should_output = BTEST(cp_print_key_should_output(logger%iter_info, &
+                                                          print_section, ''), cp_p_file)
+         IF (should_output) THEN
+            DO igrid_level = 1, ngrid_level
+               CALL rs_grid_print(rs_grids(igrid_level)%rs_grid, iounit)
+            END DO
+         END IF
+         CALL cp_print_key_finished_output(iounit, logger, print_section, "")
       END IF
-      CALL cp_print_key_finished_output(iounit, logger, print_section, "")
 
       CALL timestop(handle)
 

--- a/src/qs_force.F
+++ b/src/qs_force.F
@@ -319,13 +319,12 @@ CONTAINS
       END IF
 
       ! MP2 Code
-      ! TODO: unify all this such that a single call can be done
       IF (ASSOCIATED(qs_env%mp2_env)) THEN
          IF (.NOT. qs_env%mp2_env%method == ri_mp2_laplace) THEN
             NULLIFY (energy)
             CALL get_qs_env(qs_env, energy=energy)
             CALL qs_scf_compute_properties(qs_env, wf_type='MP2   ', do_mp2=.TRUE.)
-            CALL qs_ks_update_qs_env(qs_env, just_energy=.TRUE.) !TODO: necessary at all to recompute energy ?
+            CALL qs_ks_update_qs_env(qs_env, just_energy=.TRUE.)
             energy%total = energy%total + energy%mp2
          ELSE
             NULLIFY (energy)

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -1601,7 +1601,7 @@ CONTAINS
       IF (mp2_env%ri_rpa%do_ri_axk) e_axk = 0.0_dp
       first_cycle = .TRUE.
       omega_old = 0.0_dp
-      CALL dgemm_counter_init(dgemm_counter, unit_nr)
+      CALL dgemm_counter_init(dgemm_counter, unit_nr, mp2_env%ri_rpa%print_dgemm_info)
 
       DO count_ev_sc_GW = 1, iter_evGW
 


### PR DESCRIPTION
There was a problem with the I/O in GPW MP2. Each time GPW integrals are to be computed, the `prepare_gpw` routine is called on each MPI sub-communicator. This leads to PW grid info to be printed to the output, by each sub-communicator.

This was a massive mess, as the default is on sub-communicator per MPI rank. Moreover, most of the GRID info would be printed from the beginning of the output file, therefore gradually overwriting the rest of the info (especially annoying during a MD run). As a fix, I disabled I/O if the call is made from a sub-communicator. I believe no info is lost since PW_CUTOFF and other GPW parameters are printed to the output anyways.

I also added a new keyword to control the printing of DGEMM performance info to the output file. Currently, every single DGEMM call of the MP2 code leads to 3 lines being printed. This results in some 1000s of lines per MD step, which kind of pollutes the output file. The new default is to only print the average DGEMM flop rate per MPI rank, but the full output can be recovered by setting the new `PRINT_DGEMM_INFO` keyword.