### PR TITLE
Correct the description of `whittaker_c0a`

### DIFF
--- a/src/common/whittaker.F
+++ b/src/common/whittaker.F
@@ -29,7 +29,7 @@ MODULE whittaker
 CONTAINS
 
 ! **************************************************************************************************
-!> \brief int(y^(2+l) * exp(-alpha*y*y),y=0..x);
+!> \brief int(y^(2+l1+l2) * exp(-alpha*y*y),y=0..x) / x^(l2+1);
 !>        wc(:)    :: output
 !>        r(:)     :: coordinate
 !>        expa(:)  :: exp(-alpha*r(:)**2)


### PR DESCRIPTION
In commit 1b077fe44c713442c7e325725758c8dee54eeced, `whittaker_c0a` was
introduced to replace `whittaker_c0`. This function evaluates the
integral along with 1/r^(l2+1) to remove noise when r is extremely
small. However, the documentation was partly copied from that of
`whittaker_c0` and therefore the description does not match the purpose
of the function. Update the description to match it.