### PR TITLE
Cleanup offload_gemm

### DIFF
--- a/src/offload_gemm.F
+++ b/src/offload_gemm.F
@@ -11,7 +11,7 @@ MODULE offload_gemm
                             C_NULL_PTR, &
                             C_PTR, &
                             C_int
-#if defined(__SPLA)
+#if defined(__SPLA) && defined(__OFFLOAD_GEMM)
    USE spla, ONLY: SPLA_PU_HOST, &
                    SPLA_PU_GPU, &
                    SPLA_OP_NONE, &

--- a/src/offload_gemm.F
+++ b/src/offload_gemm.F
@@ -7,10 +7,8 @@
 
 MODULE offload_gemm
    USE ISO_C_BINDING, ONLY: C_LOC, &
-                            C_NULL_CHAR, &
                             C_NULL_PTR, &
-                            C_PTR, &
-                            C_int
+                            C_PTR
 #if defined(__SPLA) && defined(__OFFLOAD_GEMM)
    USE spla, ONLY: SPLA_PU_HOST, &
                    SPLA_PU_GPU, &


### PR DESCRIPTION
- make preprocessor flags consistent within the module (it could lead to compilation errors if CP2K is compiled without SIRIUS but (by default) with spla)
- remove unused symbols