### PR TITLE
Docker: Add test for Intel oneAPI

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -124,6 +124,12 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_hip-rocm-build_rep
 # host:        AMD Cloud
 # report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_hip-mi100_report.txt
 
+[intel-psmp]
+sortkey:     509
+name:        Intel oneAPI (psmp)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-psmp_report.txt
+
 [openmpi-psmp]
 sortkey:     510
 name:        OpenMPI Toolchain (psmp)

--- a/tools/docker/Dockerfile.test_cuda_A100
+++ b/tools/docker/Dockerfile.test_cuda_A100
@@ -88,7 +88,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -88,7 +88,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -103,7 +103,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_gcc7
+++ b/tools/docker/Dockerfile.test_gcc7
@@ -103,7 +103,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_gcc8
+++ b/tools/docker/Dockerfile.test_gcc8
@@ -103,7 +103,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -103,7 +103,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_generic_pdbg
+++ b/tools/docker/Dockerfile.test_generic_pdbg
@@ -78,7 +78,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -78,7 +78,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_generic_sdbg
+++ b/tools/docker/Dockerfile.test_generic_sdbg
@@ -78,7 +78,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_generic_ssmp
+++ b/tools/docker/Dockerfile.test_generic_ssmp
@@ -78,7 +78,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_hip_cuda_A100
+++ b/tools/docker/Dockerfile.test_hip_cuda_A100
@@ -170,7 +170,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_hip_cuda_P100
+++ b/tools/docker/Dockerfile.test_hip_cuda_P100
@@ -170,7 +170,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_hip_cuda_V100
+++ b/tools/docker/Dockerfile.test_hip_cuda_V100
@@ -170,7 +170,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_i386
+++ b/tools/docker/Dockerfile.test_i386
@@ -103,7 +103,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_intel-psmp
+++ b/tools/docker/Dockerfile.test_intel-psmp
@@ -1,20 +1,17 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_cuda_V100 ../../
+# Usage: docker build -f ./Dockerfile.test_intel-psmp ../../
 #
 
-FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+FROM intel/oneapi-hpckit:2021.4-devel-ubuntu18.04
 
-# Setup CUDA environment.
-ENV CUDA_PATH /usr/local/cuda
-ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
+ENV PATH=/opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64:/opt/intel/oneapi/mpi/2021.4.0/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/mpi/2021.4.0/lib/release:/opt/intel/oneapi/mpi/2021.4.0/lib:/opt/intel/oneapi/mpi/2021.4.0/libfabric/lib:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:${LD_LIBRARY_PATH}
+ENV MKLROOT=/opt/intel/oneapi/mkl/2021.4.0
+ENV I_MPI_ROOT=/opt/intel/oneapi/mpi/2021.4.0
+ENV FI_PROVIDER_PATH='/opt/intel/oneapi/mpi/2021.4.0/libfabric/lib/prov'
 
-# Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    gfortran                                                          \
-    mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT []
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
@@ -32,9 +29,13 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
-    --mpi-mode=mpich \
-    --enable-cuda=yes \
-    --gpu-ver=V100 \
+    --with-intel \
+    --with-intelmpi \
+    --with-libint=no \
+    --with-elpa=no \
+    --with-quip=no \
+    --with-spfft=no \
+    --with-sirius=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
@@ -71,7 +72,9 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local_cuda.psmp.
+# TODO: Remove --mpiranks=1, see github.com/cp2k/cp2k/issues/2103
+
+# Install CP2K using local.psmp.
 WORKDIR /opt/cp2k
 COPY ./Makefile .
 COPY ./src ./src
@@ -79,20 +82,20 @@ COPY ./exts ./exts
 COPY ./tools/build_utils ./tools/build_utils
 RUN /bin/bash -c " \
     mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local_cuda.psmp ./arch/ && \
+    ln -vs /opt/cp2k-toolchain/install/arch/local.psmp ./arch/ && \
     echo 'Compiling cp2k...' && \
     source /opt/cp2k-toolchain/install/setup && \
-    ( make -j ARCH=local_cuda VERSION=psmp &> /dev/null || true )"
+    ( make -j ARCH=local VERSION=psmp &> /dev/null || true )"
 COPY ./data ./data
 COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS=""
+ARG TESTOPTS="--mpiranks=1"
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \
-    ./test_regtest.sh 'local_cuda' 'psmp' |& tee report.log && \
+    ./test_regtest.sh 'local' 'psmp' |& tee report.log && \
     rm -rf regtesting"
 
 # Output the report if the image is old and was therefore pulled from the build cache.

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -76,7 +76,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -77,7 +77,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -77,7 +77,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -77,7 +77,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -77,7 +77,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -77,7 +77,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -c " \
     TESTOPTS="${TESTOPTS}" \

--- a/tools/docker/scripts/test_regtest.sh
+++ b/tools/docker/scripts/test_regtest.sh
@@ -12,6 +12,17 @@ VERSION=$2
 
 ulimit -c 0 # Disable core dumps as they can take a very long time to write.
 
+# Extend stack size - needed when using Intel compilers.
+ulimit -s unlimited
+export OMP_STACKSIZE=64m
+
+# Check available shared memory - needed for MPI inter-process communication.
+SHM_AVAIL=$(df --output=avail -m /dev/shm | tail -1)
+if ((SHM_AVAIL < 1024)); then
+  echo "ERROR: Not enough shared memory. If you're running docker use --shm-size=1g."
+  exit 1
+fi
+
 # shellcheck disable=SC1091
 source /opt/cp2k-toolchain/install/setup
 

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -36,11 +36,14 @@ FC_arch="IF_MPI(${MPIFC}|${FC})"
 LD_arch="IF_MPI(${MPIFC}|${FC})"
 
 # we always want good line information and backtraces
-if [ "${generic}" = "__TRUE__" ]; then
+if [ "${with_intel}" != "__DONTUSE__" ]; then
+  BASEFLAGS="-nofor-main -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost"
+elif [ "${generic}" = "__TRUE__" ]; then
   BASEFLAGS="-fno-omit-frame-pointer -fopenmp -g -mtune=generic"
 else
   BASEFLAGS="-fno-omit-frame-pointer -fopenmp -g -march=native -mtune=native"
 fi
+
 OPT_FLAGS="-O3 -funroll-loops"
 NOOPT_FLAGS="-O1"
 
@@ -70,7 +73,6 @@ IEEE_EXCEPTIONS_DFLAGS="-D__HAS_IEEE_EXCEPTIONS"
 
 # check all of the above flags, filter out incompatible flags for the
 # current version of gcc in use
-BASEFLAGS=$(allowed_gfortran_flags $BASEFLAGS)
 OPT_FLAGS=$(allowed_gfortran_flags $OPT_FLAGS)
 NOOPT_FLAGS=$(allowed_gfortran_flags $NOOPT_FLAGS)
 FCDEB_FLAGS=$(allowed_gfortran_flags $FCDEB_FLAGS)

--- a/tools/toolchain/scripts/stage6/install_quip.sh
+++ b/tools/toolchain/scripts/stage6/install_quip.sh
@@ -28,11 +28,8 @@ EOF
   exit 0
 fi
 
-if [ "${with_intel}" != "__DONTUSE__" ]; then
+if [ "${with_quip}" != "__DONTUSE__" ] && [ "${with_intel}" != "__DONTUSE__" ]; then
   report_warning "A QUIP installation using the Intel compiler is currently not supported. The QUIP package will not be installed."
-  cat << EOF > ${BUILDDIR}/setup_quip
-with_quip="__DONTUSE__"
-EOF
   exit 0
 fi
 


### PR DESCRIPTION
For the time being this test runs with `--mpiranks=1` because of #2103.

I'm using a slightly dated version of oneAPI because I ran into #1936.

Furthermore, I disabled libint, elpa, quip, spfft, and sirius because of build problems.