### PR TITLE
Added Mulliken and Hirshfeld charges to the results framework

### DIFF
--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -20,6 +20,9 @@ MODULE hirshfeld_methods
                                               pbc
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_para_types,                   ONLY: cp_para_env_type
+   USE cp_result_methods,               ONLY: cp_results_erase,&
+                                              put_results
+   USE cp_result_types,                 ONLY: cp_result_type
    USE cp_units,                        ONLY: cp_unit_to_cp2k
    USE grid_api,                        ONLY: GRID_FUNC_AB,&
                                               collocate_pgf_product,&
@@ -34,7 +37,8 @@ MODULE hirshfeld_methods
                                               radius_vdw,&
                                               shape_function_density,&
                                               shape_function_gaussian
-   USE kinds,                           ONLY: dp
+   USE kinds,                           ONLY: dp,&
+                                              default_string_length
    USE mathconstants,                   ONLY: pi
    USE message_passing,                 ONLY: mp_sum
    USE particle_types,                  ONLY: particle_type
@@ -71,7 +75,8 @@ MODULE hirshfeld_methods
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'hirshfeld_methods'
 
    PUBLIC :: create_shape_function, comp_hirshfeld_charges, &
-             comp_hirshfeld_i_charges, write_hirshfeld_charges
+             comp_hirshfeld_i_charges, write_hirshfeld_charges, &
+             save_hirshfeld_charges
 
 ! **************************************************************************************************
 
@@ -128,6 +133,48 @@ CONTAINS
       WRITE (unit_nr, '(T2,A)') '!-----------------------------------------------------------------------------!'
 
    END SUBROUTINE write_hirshfeld_charges
+
+! **************************************************************************************************
+!> \brief saves the Hirshfeld charges to the results structure
+!> \param charges the calculated Hirshfeld charges
+!> \param particle_set the particle set
+!> \param qs_kind_set the kind set
+!> \param qs_env the environment
+! **************************************************************************************************
+   SUBROUTINE save_hirshfeld_charges(charges, particle_set, qs_kind_set, qs_env)
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(inout)      :: charges
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: iatom, ikind, natom
+      REAL(KIND=dp)                                      :: zeff
+      CHARACTER(LEN=default_string_length)               :: description
+      TYPE(cp_result_type), POINTER                      :: results
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: charges_save
+
+      NULLIFY (results)
+      CALL get_qs_env(qs_env, results=results)
+      
+      natom = SIZE(charges, 1)
+      ALLOCATE (charges_save(natom))
+      
+      DO iatom = 1, natom
+         CALL get_atomic_kind(atomic_kind=particle_set(iatom)%atomic_kind, &
+                              kind_number=ikind)
+         CALL get_qs_kind(qs_kind_set(ikind), zeff=zeff)
+         charges_save(iatom) = zeff - SUM(charges(iatom, :))
+      END DO
+      
+      ! Store charges in results
+      description = "[HIRSHFELD-CHARGES]"
+      CALL cp_results_erase(results=results, description=description)
+      CALL put_results(results=results, description=description, & 
+                       values=charges_save)
+      
+      DEALLOCATE (charges_save)
+      
+   END SUBROUTINE save_hirshfeld_charges
 
 ! **************************************************************************************************
 !> \brief creates kind specific shape functions for Hirshfeld charges

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -37,8 +37,8 @@ MODULE hirshfeld_methods
                                               radius_vdw,&
                                               shape_function_density,&
                                               shape_function_gaussian
-   USE kinds,                           ONLY: dp,&
-                                              default_string_length
+   USE kinds,                           ONLY: default_string_length,&
+                                              dp
    USE mathconstants,                   ONLY: pi
    USE message_passing,                 ONLY: mp_sum
    USE particle_types,                  ONLY: particle_type
@@ -147,33 +147,33 @@ CONTAINS
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
+      CHARACTER(LEN=default_string_length)               :: description
       INTEGER                                            :: iatom, ikind, natom
       REAL(KIND=dp)                                      :: zeff
-      CHARACTER(LEN=default_string_length)               :: description
-      TYPE(cp_result_type), POINTER                      :: results
       REAL(KIND=dp), DIMENSION(:), POINTER               :: charges_save
+      TYPE(cp_result_type), POINTER                      :: results
 
       NULLIFY (results)
       CALL get_qs_env(qs_env, results=results)
-      
+
       natom = SIZE(charges, 1)
       ALLOCATE (charges_save(natom))
-      
+
       DO iatom = 1, natom
          CALL get_atomic_kind(atomic_kind=particle_set(iatom)%atomic_kind, &
                               kind_number=ikind)
          CALL get_qs_kind(qs_kind_set(ikind), zeff=zeff)
          charges_save(iatom) = zeff - SUM(charges(iatom, :))
       END DO
-      
+
       ! Store charges in results
       description = "[HIRSHFELD-CHARGES]"
       CALL cp_results_erase(results=results, description=description)
-      CALL put_results(results=results, description=description, & 
+      CALL put_results(results=results, description=description, &
                        values=charges_save)
-      
+
       DEALLOCATE (charges_save)
-      
+
    END SUBROUTINE save_hirshfeld_charges
 
 ! **************************************************************************************************

--- a/src/population_analyses.F
+++ b/src/population_analyses.F
@@ -34,6 +34,9 @@ MODULE population_analyses
                                               cp_fm_type
    USE cp_gemm_interface,               ONLY: cp_gemm
    USE cp_para_types,                   ONLY: cp_para_env_type
+   USE cp_result_methods,               ONLY: cp_results_erase,&
+                                              put_results
+   USE cp_result_types,                 ONLY: cp_result_type
    USE dbcsr_api,                       ONLY: &
         dbcsr_copy, dbcsr_deallocate_matrix, dbcsr_get_block_p, dbcsr_iterator_blocks_left, &
         dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
@@ -409,6 +412,9 @@ CONTAINS
          CALL write_orbpop(orbpop, atomic_kind_set, qs_kind_set, particle_set, output_unit, print_gop)
       END IF
 
+      ! Save the Mulliken charges to results
+      CALL save_mulliken_charges(orbpop, atomic_kind_set, qs_kind_set, particle_set, qs_env)
+
       ! Release local working storage
       IF (ASSOCIATED(sm_ps)) CALL dbcsr_deallocate_matrix(sm_ps)
       IF (ASSOCIATED(orbpop)) THEN
@@ -426,6 +432,102 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE mulliken_population_analysis
+
+! **************************************************************************************************
+!> \brief Save the Mulliken charges in results
+!>
+!> \param orbpop ...
+!> \param atomic_kind_set ...
+!> \param qs_kind_set ...
+!> \param particle_set ...
+!> \param qs_env ...
+!> \date    27.05.2022
+!> \author  Bo Thomsen (BT)
+!> \version 1.0
+! **************************************************************************************************
+   SUBROUTINE save_mulliken_charges(orbpop, atomic_kind_set, qs_kind_set, particle_set, qs_env)      
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: orbpop
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+   
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: charges_save
+      CHARACTER(LEN=default_string_length)               :: description
+      TYPE(cp_result_type), POINTER                      :: results
+      INTEGER                                            :: iao, iatom, ikind, iset, isgf, &
+                                                            ishell, iso, l, natom, nset, nsgf, &
+                                                            nspin
+      INTEGER, DIMENSION(:), POINTER                     :: nshell
+      INTEGER, DIMENSION(:, :), POINTER                  :: lshell
+      REAL(KIND=dp)                                      :: zeff
+      REAL(KIND=dp), DIMENSION(3)                        :: sumorbpop
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      
+      
+      NULLIFY (lshell)
+      NULLIFY (nshell)
+      NULLIFY (orb_basis_set)
+
+      CPASSERT(ASSOCIATED(orbpop))
+      CPASSERT(ASSOCIATED(atomic_kind_set))
+      CPASSERT(ASSOCIATED(particle_set))
+
+      nspin = SIZE(orbpop, 2)
+
+      CALL get_atomic_kind_set(atomic_kind_set, natom=natom)
+      CALL get_qs_kind_set(qs_kind_set, nsgf=nsgf)
+      CALL get_atomic_kind_set(atomic_kind_set, natom=natom)
+      NULLIFY (results)
+      CALL get_qs_env(qs_env, results=results)
+      ALLOCATE (charges_save(natom))
+      
+      iao = 1
+      DO iatom = 1, natom
+         sumorbpop(:) = 0.0_dp
+         NULLIFY (orb_basis_set)
+         CALL get_atomic_kind(atomic_kind=particle_set(iatom)%atomic_kind, &
+                              kind_number=ikind)
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set, zeff=zeff)
+         IF (ASSOCIATED(orb_basis_set)) THEN
+            CALL get_gto_basis_set(gto_basis_set=orb_basis_set, &
+                                   nset=nset, &
+                                   nshell=nshell, &
+                                   l=lshell)
+            isgf = 1
+            DO iset = 1, nset
+               DO ishell = 1, nshell(iset)
+                  l = lshell(ishell, iset)
+                  DO iso = 1, nso(l)
+                     IF (nspin == 1) THEN
+                        sumorbpop(1) = sumorbpop(1) + orbpop(iao, 1)
+                     ELSE
+                        sumorbpop(1:2) = sumorbpop(1:2) + orbpop(iao, 1:2)
+                        sumorbpop(3) = sumorbpop(3) + orbpop(iao, 1) - orbpop(iao, 2)
+                     END IF
+                     isgf = isgf + 1
+                     iao = iao + 1
+                  END DO
+               END DO
+            END DO
+            IF (nspin == 1) THEN
+               charges_save(iatom) = zeff - sumorbpop(1)
+            ELSE
+               charges_save(iatom) = zeff - sumorbpop(1) - sumorbpop(2)
+            END IF
+         END IF ! atom has an orbital basis
+      END DO ! next atom iatom
+      
+      ! Store charges in results
+      description = "[MULLIKEN-CHARGES]"
+      CALL cp_results_erase(results=results, description=description)
+      CALL put_results(results=results, description=description, & 
+                       values=charges_save)
+
+      DEALLOCATE (charges_save)
+
+      
+   END SUBROUTINE save_mulliken_charges
 
 ! **************************************************************************************************
 !> \brief Write atomic orbital populations and net atomic charges

--- a/src/population_analyses.F
+++ b/src/population_analyses.F
@@ -445,26 +445,24 @@ CONTAINS
 !> \author  Bo Thomsen (BT)
 !> \version 1.0
 ! **************************************************************************************************
-   SUBROUTINE save_mulliken_charges(orbpop, atomic_kind_set, qs_kind_set, particle_set, qs_env)      
+   SUBROUTINE save_mulliken_charges(orbpop, atomic_kind_set, qs_kind_set, particle_set, qs_env)
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: orbpop
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_environment_type), POINTER                 :: qs_env
-   
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: charges_save
+
       CHARACTER(LEN=default_string_length)               :: description
-      TYPE(cp_result_type), POINTER                      :: results
-      INTEGER                                            :: iao, iatom, ikind, iset, isgf, &
-                                                            ishell, iso, l, natom, nset, nsgf, &
-                                                            nspin
+      INTEGER                                            :: iao, iatom, ikind, iset, isgf, ishell, &
+                                                            iso, l, natom, nset, nsgf, nspin
       INTEGER, DIMENSION(:), POINTER                     :: nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: lshell
       REAL(KIND=dp)                                      :: zeff
       REAL(KIND=dp), DIMENSION(3)                        :: sumorbpop
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: charges_save
+      TYPE(cp_result_type), POINTER                      :: results
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
-      
-      
+
       NULLIFY (lshell)
       NULLIFY (nshell)
       NULLIFY (orb_basis_set)
@@ -481,7 +479,7 @@ CONTAINS
       NULLIFY (results)
       CALL get_qs_env(qs_env, results=results)
       ALLOCATE (charges_save(natom))
-      
+
       iao = 1
       DO iatom = 1, natom
          sumorbpop(:) = 0.0_dp
@@ -517,16 +515,15 @@ CONTAINS
             END IF
          END IF ! atom has an orbital basis
       END DO ! next atom iatom
-      
+
       ! Store charges in results
       description = "[MULLIKEN-CHARGES]"
       CALL cp_results_erase(results=results, description=description)
-      CALL put_results(results=results, description=description, & 
+      CALL put_results(results=results, description=description, &
                        values=charges_save)
 
       DEALLOCATE (charges_save)
 
-      
    END SUBROUTINE save_mulliken_charges
 
 ! **************************************************************************************************

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -60,7 +60,8 @@ MODULE qs_scf_post_gpw
    USE hirshfeld_methods,               ONLY: comp_hirshfeld_charges,&
                                               comp_hirshfeld_i_charges,&
                                               create_shape_function,&
-                                              write_hirshfeld_charges
+                                              write_hirshfeld_charges,&
+                                              save_hirshfeld_charges
    USE hirshfeld_types,                 ONLY: create_hirshfeld_type,&
                                               hirshfeld_type,&
                                               release_hirshfeld_type,&
@@ -2692,6 +2693,8 @@ CONTAINS
          CALL write_hirshfeld_charges(charges, hirshfeld_env, particle_set, &
                                       qs_kind_set, unit_nr)
       END IF
+      ! Save the charges to the results under the tag [HIRSHFELD-CHARGES]
+      CALL save_hirshfeld_charges(charges, particle_set, qs_kind_set, qs_env)
       !
       CALL release_hirshfeld_type(hirshfeld_env)
       DEALLOCATE (charges)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -60,8 +60,8 @@ MODULE qs_scf_post_gpw
    USE hirshfeld_methods,               ONLY: comp_hirshfeld_charges,&
                                               comp_hirshfeld_i_charges,&
                                               create_shape_function,&
-                                              write_hirshfeld_charges,&
-                                              save_hirshfeld_charges
+                                              save_hirshfeld_charges,&
+                                              write_hirshfeld_charges
    USE hirshfeld_types,                 ONLY: create_hirshfeld_type,&
                                               hirshfeld_type,&
                                               release_hirshfeld_type,&


### PR DESCRIPTION
As mentioned in #2130 I have added the` [MULLIKEN-CHARGES]` and `[HIRSHFELD-CHARGES]` to the fortran/C++ interface for CP2K.