### PR TITLE
fix HFX summation over neighboring cells for 1d and 2d periodic case

### DIFF
--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -1940,7 +1940,7 @@ CONTAINS
       CHARACTER(LEN=512)                                 :: error_msg
       CHARACTER(LEN=64)                                  :: char_nshells
       INTEGER :: i, idx, ikind, ipgf, iset, ishell, j, jkind, jpgf, jset, jshell, k, kshell, l, &
-         m(3), max_shell, nseta, nsetb, total_number_of_cells, ub, ub_max
+         m(3), max_shell, nseta, nsetb, perd(3), total_number_of_cells, ub, ub_max
       INTEGER, DIMENSION(:), POINTER                     :: la_max, lb_max, npgfa, npgfb
       LOGICAL                                            :: image_cell_found, nothing_more_to_add
       REAL(dp) :: cross_product(3), dist_min, distance(14), l_min, normal(3, 6), P(3, 14), &
@@ -2069,9 +2069,11 @@ CONTAINS
 
             DEALLOCATE (tmp_neighbor_cells)
 
-            DO ishell = -max_shell, max_shell
-            DO jshell = -max_shell, max_shell
-            DO kshell = -max_shell, max_shell
+            perd(1:3) = x_data%periodic_parameter%perd(1:3)
+
+            DO ishell = -max_shell*perd(1), max_shell*perd(1)
+            DO jshell = -max_shell*perd(2), max_shell*perd(2)
+            DO kshell = -max_shell*perd(3), max_shell*perd(3)
                IF (MAX(ABS(ishell), ABS(jshell), ABS(kshell)) /= max_shell) CYCLE
                idx = 0
                DO j = 0, 1

--- a/tests/QS/regtest-hfx-periodic/TEST_FILES
+++ b/tests/QS/regtest-hfx-periodic/TEST_FILES
@@ -12,4 +12,5 @@ CH3-coul-0.inp                                         1      9e-14            -
 h2o-respa.inp                                          1      6e-13            -76.023109187259081
 h2o-respa_restart.inp                                  1      5e-12            -76.022672170936700
 H2O-id-auto.inp                                        1      1e-10            -88.00800458674919
+graphene_periodic_XY.inp                               1      1e-10            -77.259924663247261
 #EOF

--- a/tests/QS/regtest-hfx-periodic/graphene_periodic_XY.inp
+++ b/tests/QS/regtest-hfx-periodic/graphene_periodic_XY.inp
@@ -1,0 +1,64 @@
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    LSD
+    BASIS_SET_FILE_NAME EMSL_BASIS_SETS
+    POTENTIAL_FILE_NAME POTENTIAL
+    &MGRID
+      CUTOFF 200
+      REL_CUTOFF 50
+    &END MGRID
+    &QS
+      METHOD GAPW
+    &END QS
+    &SCF
+      EPS_SCF 1.0E-6
+      SCF_GUESS ATOMIC
+      MAX_SCF 50
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL NONE
+      &END XC_FUNCTIONAL
+      &HF
+        &SCREENING
+          EPS_SCHWARZ 1.0E-7
+          SCREEN_ON_INITIAL_P FALSE
+        &END
+        &INTERACTION_POTENTIAL
+          POTENTIAL_TYPE TRUNCATED
+          CUTOFF_RADIUS 4.0
+          T_C_G_DATA t_c_g.dat
+        &END
+        &MEMORY
+          MAX_MEMORY 10
+        &END
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom] 4.0 4.0 3.0
+      ALPHA_BETA_GAMMA 90. 90. 60.
+      SYMMETRY HEXAGONAL
+      PERIODIC XY
+      MULTIPLE_UNIT_CELL 1 1 1
+    &END CELL
+    &TOPOLOGY
+      MULTIPLE_UNIT_CELL 1 1 1
+    &END TOPOLOGY
+    &COORD
+      SCALED
+      C  1./3.  1./3.  0.
+      C  2./3.  2./3.  0.
+    &END
+    &KIND C
+      BASIS_SET 3-21Gx
+      POTENTIAL ALL
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+  PROJECT stretched-graphene
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+&END GLOBAL


### PR DESCRIPTION
Previous status: In case of 1d or 2d periodic systems, 4-center HFX integrals have been computed by a sum over all 3d-periodic neighboring cells. In a practical 1d- and 2d-periodic calculation, the arising issue could be circumvented by choosing a large cell size in the non-periodic direction. However, this is not practical in some cases, for example for a 2d-periodic unit cell that is large in the two periodic directions, but small in the non-periodic direction. 

Fix: Sum for 4-center HFX integrals only running over neighboring cells in periodic directions; do not sum over neighboring cells in non-periodic directions. 

Some benchmark data is collected in a github repository on the 2d-periodic MoS2 monolayer:

https://github.com/JWilhelm/MoS2_HFX_CP2K

I would be happy about comments or opinions to correct and/or further improve the PR. 