### PR TITLE
MP2: Improve communication and memory management

### DIFF
--- a/benchmarks/QS_single_node/RI-MP2_ammonia.inp
+++ b/benchmarks/QS_single_node/RI-MP2_ammonia.inp
@@ -16,7 +16,7 @@
             EPS_CONV 1.0E-4
             MAX_ITER 20
           &END
-          BLOCK_SIZE 1
+          BLOCK_SIZE -1
         &END RI_MP2
         &INTEGRALS
           &WFC_GPW

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -115,12 +115,11 @@ CONTAINS
          name="GROUP_SIZE", &
          variants=(/"NUMBER_PROC"/), &
          description="Group size used in the computation of GPW and MME integrals and the MP2 correlation energy. "// &
-         "A smaller GROUP_SIZE (for example GROUP_SIZE = number of MPI ranks per node) "// &
-         "accelerates the computation of integrals but a too small "// &
-         "GROUP_SIZE may lead to out of memory. To use all processors set GROUP_SIZE -1 "// &
-         "(might lead to VERY high computation times). GROUP_SIZE must be a divisor of the total number "// &
-         "of MPI ranks.", &
-         usage="GROUP_SIZE 32", &
+         "The group size must be a divisor of the total number of MPI ranks. "// &
+         "A smaller group size (for example the number of MPI ranks per node) "// &
+         "accelerates the computation of integrals but a too large group size increases communication costs. "// &
+         "A too small group size may lead to out of memory.", &
+         usage="GROUP_SIZE 2", &
          default_i_val=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -258,12 +258,15 @@ CONTAINS
          mp2_env%mp2_num_proc = 1
       END IF
 
-      IF (mp2_env%mp2_num_proc <= 0 .OR. mp2_env%mp2_num_proc > para_env%num_pe .OR. &
-          MOD(para_env%num_pe, mp2_env%mp2_num_proc) .NE. 0) THEN
-         IF (unit_nr > 0 .AND. mp2_env%mp2_num_proc .NE. -1) &
-            WRITE (unit_nr, '(T3,A,T76,I5)') 'Requested number of processes per group:', mp2_env%mp2_num_proc
-         mp2_env%mp2_num_proc = para_env%num_pe
+      IF (mp2_env%mp2_num_proc <= 1 .OR. mp2_env%mp2_num_proc > para_env%num_pe) THEN
+         CPWARN("GROUP_SIZE is reset because of a too small or too large value.")
+         mp2_env%mp2_num_proc = MAX(MIN(para_env%num_pe, mp2_env%mp2_num_proc), 1)
       END IF
+
+      IF (MOD(para_env%num_pe, mp2_env%mp2_num_proc) /= 0) THEN
+         CPABORT("GROUP_SIZE must be a divisor of the total number of MPI ranks!")
+      END IF
+
       IF (.NOT. mp2_env%do_im_time) THEN
          IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T76,I5)') 'Used number of processes per group:', mp2_env%mp2_num_proc
          IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'Maximum allowed memory usage per MPI process:', &

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -258,7 +258,7 @@ CONTAINS
          mp2_env%mp2_num_proc = 1
       END IF
 
-      IF (mp2_env%mp2_num_proc <= 1 .OR. mp2_env%mp2_num_proc > para_env%num_pe) THEN
+      IF (mp2_env%mp2_num_proc < 1 .OR. mp2_env%mp2_num_proc > para_env%num_pe) THEN
          CPWARN("GROUP_SIZE is reset because of a too small or too large value.")
          mp2_env%mp2_num_proc = MAX(MIN(para_env%num_pe, mp2_env%mp2_num_proc), 1)
       END IF

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -118,6 +118,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: ranges_info_array
       LOGICAL                                            :: my_alpha_alpha_case, my_alpha_beta_case, &
                                                             my_beta_beta_case, my_open_shell_SS
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: replicated
       REAL(KIND=dp)                                      :: amp_fac, my_Emp2_Cou, my_Emp2_EX, &
                                                             sym_fac, t_new, t_start
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
@@ -162,6 +163,9 @@ CONTAINS
          integ_group_size, ngroup, &
          num_integ_group, virtual, calc_forces)
 
+      ALLOCATE (replicated(nspins))
+      replicated = .FALSE.
+
       ! We cannot fix the tag because of the recv routine
       tag = 42
 
@@ -197,9 +201,14 @@ CONTAINS
             integ_group_pos2color_sub, proc_map, proc_map_rep, sizes_array_orig, &
             sub_proc_map, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
 
-         CALL replicate_iaK_2intgroup(BIb_C(ispin)%array, para_env_exchange, para_env_rep, &
-                                      homo(ispin), proc_map_rep, gd_array%sizes, my_B_size(ispin), &
-                                      my_group_L_size, ranges_info_array)
+         DO kspin = ispin, jspin
+         IF (.NOT. replicated(kspin)) THEN
+            CALL replicate_iaK_2intgroup(BIb_C(kspin)%array, para_env_exchange, para_env_rep, &
+                                         homo(ispin), proc_map_rep, gd_array%sizes, my_B_size(kspin), &
+                                         my_group_L_size, ranges_info_array)
+            replicated(kspin) = .TRUE.
+         END IF
+         END DO
 
          CALL mp2_ri_allocate_no_blk(local_ab, t_ab, mp2_env, homo, virtual, my_B_size, &
                                      my_group_L_size, calc_forces, ispin, jspin, local_ba)
@@ -711,6 +720,8 @@ CONTAINS
 
       END DO
       END DO
+
+      DEALLOCATE (replicated)
 
       ! We do not need this matrix later, so deallocate it here to safe memory
       IF (calc_forces) DEALLOCATE (mp2_env%ri_grad%PQ_half)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -201,6 +201,9 @@ CONTAINS
                                       homo(ispin), proc_map_rep, gd_array%sizes, my_B_size(ispin), &
                                       my_group_L_size, ranges_info_array)
 
+         CALL mp2_ri_allocate_no_blk(local_ab, t_ab, mp2_env, homo, virtual, my_B_size, &
+                                     my_group_L_size, calc_forces, ispin, jspin, local_ba)
+
          CALL mp2_ri_get_block_size( &
             mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
             homo(ispin), dimen_RI, unit_nr, block_size, &
@@ -225,10 +228,8 @@ CONTAINS
          max_ij_pairs = MAXVAL(num_ij_pairs)
 
          ! start real stuff
-         CALL mp2_ri_allocate(local_ab, t_ab, mp2_env, homo, virtual, dimen_RI, my_B_size, &
-                              block_size, my_group_L_size, local_i_aL, &
-                              local_j_aL, calc_forces, Y_i_aP, Y_j_aP, &
-                              ispin, jspin, local_ba)
+         CALL mp2_ri_allocate_blk(dimen_RI, my_B_size, block_size, local_i_aL, &
+                                  local_j_aL, calc_forces, Y_i_aP, Y_j_aP, ispin, jspin)
 
          IF (unit_nr > 0) THEN
             IF (nspins == 1) THEN
@@ -837,61 +838,39 @@ CONTAINS
 !> \param mp2_env ...
 !> \param homo ...
 !> \param virtual ...
-!> \param dimen_RI ...
 !> \param my_B_size ...
-!> \param block_size ...
 !> \param my_group_L_size ...
-!> \param local_i_aL ...
-!> \param local_j_aL ...
 !> \param calc_forces ...
-!> \param Y_i_aP ...
-!> \param Y_j_aP ...
 !> \param ispin ...
 !> \param jspin ...
 !> \param local_ba ...
 ! **************************************************************************************************
-   SUBROUTINE mp2_ri_allocate(local_ab, t_ab, mp2_env, homo, virtual, dimen_RI, my_B_size, &
-                              block_size, my_group_L_size, &
-                              local_i_aL, local_j_aL, calc_forces, &
-                              Y_i_aP, Y_j_aP, ispin, jspin, &
-                              local_ba)
+   SUBROUTINE mp2_ri_allocate_no_blk(local_ab, t_ab, mp2_env, homo, virtual, my_B_size, &
+                                     my_group_L_size, calc_forces, ispin, jspin, local_ba)
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(OUT)                                     :: local_ab, t_ab
       TYPE(mp2_type)                                     :: mp2_env
-      INTEGER, INTENT(IN)                                :: homo(2), virtual(2), dimen_RI, &
-                                                            my_B_size(2), block_size, &
+      INTEGER, INTENT(IN)                                :: homo(2), virtual(2), my_B_size(2), &
                                                             my_group_L_size
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(OUT)                                     :: local_i_aL, local_j_aL
       LOGICAL, INTENT(IN)                                :: calc_forces
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(OUT)                                     :: Y_i_aP, Y_j_aP
       INTEGER, INTENT(IN)                                :: ispin, jspin
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(OUT)                                     :: local_ba
 
-      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mp2_ri_allocate'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_allocate_no_blk'
 
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
 
-      ALLOCATE (local_i_aL(dimen_RI, my_B_size(ispin), block_size))
-      ALLOCATE (local_j_aL(dimen_RI, my_B_size(jspin), block_size))
       ALLOCATE (local_ab(virtual(ispin), my_B_size(jspin)))
+      local_ab = 0.0_dp
 
       IF (calc_forces) THEN
-         ALLOCATE (Y_i_aP(my_B_size(ispin), dimen_RI, block_size))
-         Y_i_aP = 0.0_dp
-         ! For  closed-shell, alpha-alpha and beta-beta my_B_size_beta=my_b_size
-         ! Not for alpha-beta case: Y_j_aP_beta is sent and received as Y_j_aP
-         ALLOCATE (Y_j_aP(my_B_size(jspin), dimen_RI, block_size))
-         Y_j_aP = 0.0_dp
-         ! Closed shell or alpha-alpha case
          IF (ispin == jspin) THEN
             ALLOCATE (mp2_env%ri_grad%P_ij(ispin)%array(homo(ispin), homo(ispin)))
-            ALLOCATE (mp2_env%ri_grad%P_ab(ispin)%array(my_B_size(ispin), virtual(ispin)))
             mp2_env%ri_grad%P_ij(ispin)%array = 0.0_dp
+            ALLOCATE (mp2_env%ri_grad%P_ab(ispin)%array(my_B_size(ispin), virtual(ispin)))
             mp2_env%ri_grad%P_ab(ispin)%array = 0.0_dp
             ALLOCATE (mp2_env%ri_grad%Gamma_P_ia(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size))
             mp2_env%ri_grad%Gamma_P_ia(ispin)%array = 0.0_dp
@@ -910,7 +889,56 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE mp2_ri_allocate
+   END SUBROUTINE mp2_ri_allocate_no_blk
+
+! **************************************************************************************************
+!> \brief ...
+!> \param dimen_RI ...
+!> \param my_B_size ...
+!> \param block_size ...
+!> \param local_i_aL ...
+!> \param local_j_aL ...
+!> \param calc_forces ...
+!> \param Y_i_aP ...
+!> \param Y_j_aP ...
+!> \param ispin ...
+!> \param jspin ...
+! **************************************************************************************************
+   SUBROUTINE mp2_ri_allocate_blk(dimen_RI, my_B_size, block_size, &
+                                  local_i_aL, local_j_aL, calc_forces, &
+                                  Y_i_aP, Y_j_aP, ispin, jspin)
+      INTEGER, INTENT(IN)                                :: dimen_RI, my_B_size(2), block_size
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
+         INTENT(OUT)                                     :: local_i_aL, local_j_aL
+      LOGICAL, INTENT(IN)                                :: calc_forces
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
+         INTENT(OUT)                                     :: Y_i_aP, Y_j_aP
+      INTEGER, INTENT(IN)                                :: ispin, jspin
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_allocate_blk'
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      ALLOCATE (local_i_aL(dimen_RI, my_B_size(ispin), block_size))
+      local_i_aL = 0.0_dp
+      ALLOCATE (local_j_aL(dimen_RI, my_B_size(jspin), block_size))
+      local_j_aL = 0.0_dp
+
+      IF (calc_forces) THEN
+         ALLOCATE (Y_i_aP(my_B_size(ispin), dimen_RI, block_size))
+         Y_i_aP = 0.0_dp
+         ! For  closed-shell, alpha-alpha and beta-beta my_B_size_beta=my_b_size
+         ! Not for alpha-beta case: Y_j_aP_beta is sent and received as Y_j_aP
+         ALLOCATE (Y_j_aP(my_B_size(jspin), dimen_RI, block_size))
+         Y_j_aP = 0.0_dp
+      END IF
+      !
+
+      CALL timestop(handle)
+
+   END SUBROUTINE mp2_ri_allocate_blk
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -218,7 +218,7 @@ CONTAINS
 
             CALL mp2_ri_get_block_size( &
                mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin:jspin), &
-               homo(ispin:jspin), dimen_RI, unit_nr, block_size, &
+               homo(ispin:jspin), virtual(ispin:jspin), dimen_RI, unit_nr, block_size, &
                ngroup, num_integ_group, my_open_shell_ss, calc_forces)
 
             ! *****************************************************************
@@ -1441,6 +1441,7 @@ CONTAINS
 !> \param gd_array ...
 !> \param gd_B_virtual ...
 !> \param homo ...
+!> \param virtual ...
 !> \param dimen_RI ...
 !> \param unit_nr ...
 !> \param block_size ...
@@ -1450,14 +1451,14 @@ CONTAINS
 !> \param calc_forces ...
 ! **************************************************************************************************
    SUBROUTINE mp2_ri_get_block_size(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
-                                    homo, dimen_RI, unit_nr, &
+                                    homo, virtual, dimen_RI, unit_nr, &
                                     block_size, ngroup, num_integ_group, &
                                     my_open_shell_ss, calc_forces)
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array
       TYPE(group_dist_d1_type), DIMENSION(:), INTENT(IN) :: gd_B_virtual
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo, virtual
       INTEGER, INTENT(IN)                                :: dimen_RI, unit_nr
       INTEGER, INTENT(OUT)                               :: block_size, ngroup, num_integ_group
       LOGICAL, INTENT(IN)                                :: my_open_shell_ss, calc_forces
@@ -1483,8 +1484,10 @@ CONTAINS
       mem_per_blk = 0.0_dp
       mem_per_repl_blk = 0.0_dp
 
-! external_i_aL
+      ! external_i_aL
       mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
+      ! external_ab
+      mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*MAXVAL(virtual)*8.0_dp/(1024**2)
       ! BIB_C_rec
       mem_per_repl_blk = mem_per_repl_blk + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -109,7 +109,7 @@ CONTAINS
          my_group_L_start, my_i, my_ij_pairs, my_j, my_new_group_L_size, ngroup, nspins, &
          num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, rec_B_virtual_end, &
          rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end, send_B_virtual_start, &
-         send_block_size, send_i, send_ij_index, send_j, start_point, sub_P_color, tag
+         send_i, send_ij_index, send_j, start_point, sub_P_color, tag
       INTEGER :: total_ij_pairs
       INTEGER, ALLOCATABLE, DIMENSION(:) :: integ_group_pos2color_sub, my_B_size, &
          my_B_virtual_end, my_B_virtual_start, num_ij_pairs, proc_map, proc_map_rep, &
@@ -298,13 +298,12 @@ CONTAINS
                                           integ_group_pos2color_sub(proc_send)
                         send_i = ij_map(1, ij_counter_send)
                         send_j = ij_map(2, ij_counter_send)
-                        send_block_size = ij_map(3, ij_counter_send)
 
                         ! occupied i
-                        BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:send_block_size) => &
-                           buffer_1D(1:rec_L_size*my_B_size(ispin)*send_block_size)
+                        BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:my_block_size) => &
+                           buffer_1D(1:rec_L_size*my_B_size(ispin)*my_block_size)
                         BI_C_rec = 0.0_dp
-                        CALL mp_sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
+                        CALL mp_sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + my_block_size - 1), &
                                          proc_send, BI_C_rec, proc_receive, &
                                          para_env_exchange%group, tag)
 
@@ -312,10 +311,10 @@ CONTAINS
                                              BI_C_rec(:, 1:my_B_size(ispin), :))
 
                         ! occupied j
-                        BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:send_block_size) => &
-                           buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*send_block_size)
+                        BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:my_block_size) => &
+                           buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*my_block_size)
                         BI_C_rec = 0.0_dp
-                        CALL mp_sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
+                        CALL mp_sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + my_block_size - 1), &
                                          proc_send, BI_C_rec, proc_receive, &
                                          para_env_exchange%group, tag)
 
@@ -530,13 +529,12 @@ CONTAINS
                                           integ_group_pos2color_sub(proc_send)
                         send_i = ij_map(1, ij_counter_send)
                         send_j = ij_map(2, ij_counter_send)
-                        send_block_size = ij_map(3, ij_counter_send)
 
                         ! occupied i
-                        CALL mp_send(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
+                        CALL mp_send(BIb_C(ispin)%array(:, :, send_i:send_i + my_block_size - 1), &
                                      proc_send, tag, para_env_exchange%group)
                         ! occupied j
-                        CALL mp_send(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
+                        CALL mp_send(BIb_C(jspin)%array(:, :, send_j:send_j + my_block_size - 1), &
                                      proc_send, tag, para_env_exchange%group)
                      END IF
                   END DO
@@ -1941,7 +1939,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_redistribute_gamma'
 
       INTEGER :: end_point, handle, handle2, iiB, ij_counter_rec, irep, kkk, lll, Lstart_pos, &
-         proc_receive, proc_send, proc_shift, rec_block_size, rec_i, rec_ij_index, send_L_size, &
+         proc_receive, proc_send, proc_shift, rec_i, rec_ij_index, send_L_size, &
          start_point, tag
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: BI_C_rec_1D, BI_C_send_1D
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
@@ -2014,10 +2012,9 @@ CONTAINS
                   (ij_index - MIN(1, integ_group_pos2color_sub(proc_receive)))*ngroup + integ_group_pos2color_sub(proc_receive)
 
                rec_i = ij_map(spin, ij_counter_rec)
-               rec_block_size = ij_map(3, ij_counter_rec)
 
-               BI_C_rec(1:my_B_size, 1:rec_block_size, 1:my_group_L_size) => &
-                  BI_C_rec_1D(1:INT(my_B_size, int_8)*rec_block_size*my_group_L_size)
+               BI_C_rec(1:my_B_size, 1:my_block_size, 1:my_group_L_size) => &
+                  BI_C_rec_1D(1:INT(my_B_size, int_8)*my_block_size*my_group_L_size)
                BI_C_rec = 0.0_dp
 
                CALL mp_sendrecv(BI_C_send, proc_send, &
@@ -2028,10 +2025,10 @@ CONTAINS
                DO irep = 0, num_integ_group - 1
                   start_point = ranges_info_array(3, irep, para_env_exchange%mepos)
                   end_point = ranges_info_array(4, irep, para_env_exchange%mepos)
-!$OMP             PARALLEL WORKSHARE DEFAULT(NONE) SHARED(start_point,end_point,rec_block_size,&
+!$OMP             PARALLEL WORKSHARE DEFAULT(NONE) SHARED(start_point,end_point,my_block_size,&
 !$OMP                                           Gamma_P_ia,rec_i,iiB,my_B_size,BI_C_rec)
-                  Gamma_P_ia(:, rec_i:rec_i + rec_block_size - 1, start_point:end_point) = &
-                     Gamma_P_ia(:, rec_i:rec_i + rec_block_size - 1, start_point:end_point) + &
+                  Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) = &
+                     Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) + &
                      BI_C_rec(1:my_B_size, :, start_point:end_point)
 !$OMP             END PARALLEL WORKSHARE
                END DO
@@ -2061,10 +2058,9 @@ CONTAINS
                   (ij_index - MIN(1, integ_group_pos2color_sub(proc_receive)))*ngroup + integ_group_pos2color_sub(proc_receive)
 
                rec_i = ij_map(spin, ij_counter_rec)
-               rec_block_size = ij_map(3, ij_counter_rec)
 
-               BI_C_rec(1:my_B_size, 1:rec_block_size, 1:my_group_L_size) => &
-                  BI_C_rec_1D(1:INT(my_B_size, int_8)*rec_block_size*my_group_L_size)
+               BI_C_rec(1:my_B_size, 1:my_block_size, 1:my_group_L_size) => &
+                  BI_C_rec_1D(1:INT(my_B_size, int_8)*my_block_size*my_group_L_size)
 
                BI_C_rec = 0.0_dp
 
@@ -2074,10 +2070,10 @@ CONTAINS
                DO irep = 0, num_integ_group - 1
                   start_point = ranges_info_array(3, irep, para_env_exchange%mepos)
                   end_point = ranges_info_array(4, irep, para_env_exchange%mepos)
-!$OMP             PARALLEL WORKSHARE DEFAULT(NONE) SHARED(start_point,end_point,rec_block_size,&
+!$OMP             PARALLEL WORKSHARE DEFAULT(NONE) SHARED(start_point,end_point,my_block_size,&
 !$OMP                                           Gamma_P_ia,rec_i,iiB,my_B_size,BI_C_rec)
-                  Gamma_P_ia(:, rec_i:rec_i + rec_block_size - 1, start_point:end_point) = &
-                     Gamma_P_ia(:, rec_i:rec_i + rec_block_size - 1, start_point:end_point) + &
+                  Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) = &
+                     Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) + &
                      BI_C_rec(1:my_B_size, :, start_point:end_point)
 !$OMP             END PARALLEL WORKSHARE
                END DO

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -706,15 +706,6 @@ CONTAINS
          DEALLOCATE (proc_map_rep)
          DEALLOCATE (ranges_info_array)
 
-         IF (.NOT. my_open_shell_SS) THEN
-            ! keep the array for the next calculations
-            IF (ALLOCATED(BIb_C(ispin)%array)) DEALLOCATE (BIb_C(ispin)%array)
-            CALL release_group_dist(gd_array)
-            DO kspin = ispin, jspin
-               CALL release_group_dist(gd_B_virtual(kspin))
-            END DO
-         END IF
-
          CALL cp_para_env_release(para_env_exchange)
          CALL cp_para_env_release(para_env_rep)
 
@@ -722,6 +713,12 @@ CONTAINS
       END DO
 
       DEALLOCATE (replicated)
+
+      CALL release_group_dist(gd_array)
+      DO ispin = 1, nspins
+         IF (ALLOCATED(BIb_C(ispin)%array)) DEALLOCATE (BIb_C(ispin)%array)
+         CALL release_group_dist(gd_B_virtual(ispin))
+      END DO
 
       ! We do not need this matrix later, so deallocate it here to safe memory
       IF (calc_forces) DEALLOCATE (mp2_env%ri_grad%PQ_half)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -600,59 +600,6 @@ CONTAINS
                CALL cp_para_env_release(para_env_P)
             END IF
 
-            ! make a copy of the original integrals (ia|Q)
-            my_group_L_size = my_group_L_size_orig
-            ALLOCATE (B_ia_Q(ispin:jspin))
-            DO kspin = ispin, jspin
-               ALLOCATE (B_ia_Q(kspin)%array(homo(kspin), my_B_size(kspin), my_group_L_size))
-               B_ia_Q(kspin)%array = 0.0_dp
-               DO jjB = 1, homo(kspin)
-                  DO iiB = 1, my_B_size(kspin)
-                     B_ia_Q(kspin)%array(jjB, iiB, 1:my_group_L_size) = &
-                        BIb_C(kspin)%array(1:my_group_L_size, iiB, jjB)
-                  END DO
-               END DO
-               DEALLOCATE (BIb_C(kspin)%array)
-            END DO
-
-            ! sum Gamma and dereplicate
-            DO kspin = ispin, jspin
-               ALLOCATE (BIb_C(kspin)%array(my_B_size(kspin), homo(kspin), my_group_L_size))
-               DO proc_shift = 1, para_env_rep%num_pe - 1
-                  ! invert order
-                  proc_send = proc_map_rep(para_env_rep%mepos - proc_shift)
-                  proc_receive = proc_map_rep(para_env_rep%mepos + proc_shift)
-
-                  start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
-                  end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
-
-                  CALL mp_sendrecv(mp2_env%ri_grad%Gamma_P_ia(kspin)%array(:, :, start_point:end_point), &
-                                   proc_send, BIb_C(kspin)%array, proc_receive, para_env_rep%group, tag)
-!$OMP PARALLEL WORKSHARE DEFAULT(NONE) &
-!$OMP          SHARED(mp2_env,BIb_C,kspin,homo,my_B_size,my_group_L_size)
-                  mp2_env%ri_grad%Gamma_P_ia(kspin)%array(1:my_B_size(kspin), 1:homo(kspin), 1:my_group_L_size) = &
-                     mp2_env%ri_grad%Gamma_P_ia(kspin)%array(1:my_B_size(kspin), 1:homo(kspin), 1:my_group_L_size) &
-                     + BIb_C(kspin)%array(:, :, :)
-!$OMP END PARALLEL WORKSHARE
-               END DO
-               DEALLOCATE (BIb_C(kspin)%array)
-            END DO
-
-            IF (my_open_shell_ss) THEN
-               ALLOCATE (BIb_C(ispin)%array(my_group_L_size, my_B_size(ispin), homo(ispin)))
-               BIb_C(ispin)%array = 0.0_dp
-               ! copy the integrals (ia|Q) back
-               DO jjB = 1, homo(ispin)
-                  DO iiB = 1, my_B_size(ispin)
-                     BIb_C(ispin)%array(1:my_group_L_size, iiB, jjB) = &
-                        B_ia_Q(ispin)%array(jjB, iiB, 1:my_group_L_size)
-                  END DO
-               END DO
-               ! There is only one B_ia_Q allocated in this case
-               DEALLOCATE (B_ia_Q(ispin)%array)
-               DEALLOCATE (B_ia_Q)
-            END IF
-
          END IF
 
          IF (my_open_shell_SS .OR. my_alpha_beta_case) THEN
@@ -673,14 +620,6 @@ CONTAINS
       END DO
       END DO
 
-      DEALLOCATE (integ_group_pos2color_sub)
-      DEALLOCATE (proc_map)
-      DEALLOCATE (proc_map_rep)
-      DEALLOCATE (ranges_info_array)
-
-      CALL cp_para_env_release(para_env_exchange)
-      CALL cp_para_env_release(para_env_rep)
-
       DEALLOCATE (replicated)
 
       IF (calc_forces) THEN
@@ -691,13 +630,54 @@ CONTAINS
          gd_array%sizes(:) = sizes_array_orig
          DEALLOCATE (sizes_array_orig)
 
-         ! Reduce size of Gamma_P_ia to save memory
+         ! make a copy of the original integrals (ia|Q)
+         my_group_L_size = my_group_L_size_orig
+         ALLOCATE (B_ia_Q(ispin:jspin))
+         DO ispin = 1, nspins
+            ALLOCATE (B_ia_Q(ispin)%array(homo(ispin), my_B_size(ispin), my_group_L_size))
+            B_ia_Q(ispin)%array = 0.0_dp
+            DO jjB = 1, homo(ispin)
+               DO iiB = 1, my_B_size(ispin)
+                  B_ia_Q(ispin)%array(jjB, iiB, 1:my_group_L_size) = &
+                     BIb_C(ispin)%array(1:my_group_L_size, iiB, jjB)
+               END DO
+            END DO
+            DEALLOCATE (BIb_C(ispin)%array)
+         END DO
+
+         ! sum Gamma and dereplicate
          DO ispin = 1, nspins
             ALLOCATE (BIb_C(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size))
+            DO proc_shift = 1, para_env_rep%num_pe - 1
+               ! invert order
+               proc_send = proc_map_rep(para_env_rep%mepos - proc_shift)
+               proc_receive = proc_map_rep(para_env_rep%mepos + proc_shift)
+
+               start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
+               end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
+
+               CALL mp_sendrecv(mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, start_point:end_point), &
+                                proc_send, BIb_C(ispin)%array, proc_receive, para_env_rep%group, tag)
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) &
+!$OMP          SHARED(mp2_env,BIb_C,ispin,homo,my_B_size,my_group_L_size)
+               mp2_env%ri_grad%Gamma_P_ia(ispin)%array(1:my_B_size(ispin), 1:homo(ispin), 1:my_group_L_size) = &
+                  mp2_env%ri_grad%Gamma_P_ia(ispin)%array(1:my_B_size(ispin), 1:homo(ispin), 1:my_group_L_size) &
+                  + BIb_C(ispin)%array(:, :, :)
+!$OMP END PARALLEL WORKSHARE
+            END DO
+
             BIb_C(ispin)%array(:, :, :) = mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size)
             DEALLOCATE (mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
             CALL MOVE_ALLOC(BIb_C(ispin)%array, mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
          END DO
+
+         DEALLOCATE (integ_group_pos2color_sub)
+         DEALLOCATE (proc_map)
+         DEALLOCATE (proc_map_rep)
+         DEALLOCATE (ranges_info_array)
+
+         CALL cp_para_env_release(para_env_exchange)
+         CALL cp_para_env_release(para_env_rep)
 
          ! B_ia_Q(ispin)%array will be deallocated inside of complete_gamma
          DO ispin = 1, nspins
@@ -709,6 +689,15 @@ CONTAINS
                                 sub_proc_map, ispin)
          END DO
          DEALLOCATE (B_ia_Q)
+      ELSE
+
+         DEALLOCATE (integ_group_pos2color_sub)
+         DEALLOCATE (proc_map)
+         DEALLOCATE (proc_map_rep)
+         DEALLOCATE (ranges_info_array)
+
+         CALL cp_para_env_release(para_env_exchange)
+         CALL cp_para_env_release(para_env_rep)
       END IF
       DEALLOCATE (sub_proc_map)
 

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -104,7 +104,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_gpw_compute_en'
 
       INTEGER :: a, a_global, b, b_global, block_size, decil, end_point, handle, handle2, handle3, &
-         iiB, ij_counter, ij_counter_send, ij_index, integ_group_size, ispin, jjB, jspin, kspin, &
+         iiB, ij_counter, ij_counter_send, ij_index, integ_group_size, ispin, jjB, jspin, &
          max_ij_pairs, my_block_size, my_group_L_end, my_group_L_size, my_group_L_size_orig, &
          my_group_L_start, my_i, my_ij_pairs, my_j, my_new_group_L_size, ngroup, nspins, &
          num_IJ_blocks, num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, &
@@ -118,7 +118,6 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: ranges_info_array
       LOGICAL                                            :: my_alpha_alpha_case, my_alpha_beta_case, &
                                                             my_beta_beta_case, my_open_shell_SS
-      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: replicated
       REAL(KIND=dp)                                      :: amp_fac, my_Emp2_Cou, my_Emp2_EX, &
                                                             sym_fac, t_new, t_start
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
@@ -173,439 +172,430 @@ CONTAINS
          integ_group_pos2color_sub, proc_map, proc_map_rep, sizes_array_orig, &
          sub_proc_map, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
 
-      ALLOCATE (replicated(nspins))
-      replicated = .FALSE.
-
       ! We cannot fix the tag because of the recv routine
       tag = 42
 
       DO jspin = 1, nspins
-      DO ispin = 1, jspin
 
-         my_open_shell_SS = (nspins == 2) .AND. (ispin == jspin)
+         CALL replicate_iaK_2intgroup(BIb_C(jspin)%array, para_env_exchange, para_env_rep, &
+                                      homo(jspin), proc_map_rep, gd_array%sizes, my_B_size(jspin), &
+                                      my_group_L_size, ranges_info_array)
 
-         ! t_ab = amp_fac*(:,a|:,b)-(:,b|:,a)
-         ! If we calculate the gradient we need to distinguish
-         ! between alpha-alpha and beta-beta cases for UMP2
+         DO ispin = 1, jspin
 
-         my_alpha_alpha_case = .FALSE.
-         my_beta_beta_case = .FALSE.
-         my_alpha_beta_case = .FALSE.
-         IF (ispin /= jspin) THEN
-            my_alpha_beta_case = .TRUE.
-         ELSE IF (my_open_shell_SS) THEN
-            IF (ispin == 1) my_alpha_alpha_case = .TRUE.
-            IF (ispin == 2) my_beta_beta_case = .TRUE.
-         END IF
+            my_open_shell_SS = (nspins == 2) .AND. (ispin == jspin)
 
-         amp_fac = mp2_env%scale_S + mp2_env%scale_T
-         IF (my_alpha_beta_case .OR. my_open_shell_SS) amp_fac = mp2_env%scale_T
+            ! t_ab = amp_fac*(:,a|:,b)-(:,b|:,a)
+            ! If we calculate the gradient we need to distinguish
+            ! between alpha-alpha and beta-beta cases for UMP2
 
-         DO kspin = ispin, jspin
-         IF (.NOT. replicated(kspin)) THEN
-            CALL replicate_iaK_2intgroup(BIb_C(kspin)%array, para_env_exchange, para_env_rep, &
-                                         homo(kspin), proc_map_rep, gd_array%sizes, my_B_size(kspin), &
-                                         my_group_L_size, ranges_info_array)
-            replicated(kspin) = .TRUE.
-         END IF
-         END DO
-
-         CALL mp2_ri_allocate_no_blk(local_ab, t_ab, mp2_env, homo, virtual, my_B_size, &
-                                     my_group_L_size, calc_forces, ispin, jspin, local_ba)
-
-         CALL mp2_ri_get_block_size( &
-            mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
-            homo(ispin), dimen_RI, unit_nr, block_size, &
-            ngroup, num_IJ_blocks, &
-            virtual(ispin), my_alpha_beta_case, &
-            my_open_shell_SS, calc_forces)
-
-         ! *****************************************************************
-         ! **********  REPLICATION-BLOCKED COMMUNICATION SCHEME  ***********
-         ! *****************************************************************
-         ! introduce block size, the number of occupied orbitals has to be a
-         ! multiple of the block size
-
-         ! Calculate the maximum number of ij pairs that have to be computed
-         ! among groups
-         CALL mp2_ri_communication(my_alpha_beta_case, total_ij_pairs, homo(ispin), homo(jspin), num_IJ_blocks, &
-                                   block_size, ngroup, ij_map, color_sub, my_ij_pairs, my_open_shell_SS, unit_nr)
-
-         ALLOCATE (num_ij_pairs(0:para_env_exchange%num_pe - 1))
-         CALL mp_allgather(my_ij_pairs, num_ij_pairs, para_env_exchange%group)
-
-         max_ij_pairs = MAXVAL(num_ij_pairs)
-
-         ! start real stuff
-         CALL mp2_ri_allocate_blk(dimen_RI, my_B_size, block_size, local_i_aL, &
-                                  local_j_aL, calc_forces, Y_i_aP, Y_j_aP, ispin, jspin)
-
-         IF (unit_nr > 0) THEN
-            IF (nspins == 1) THEN
-               WRITE (unit_nr, *) "Start loop run"
-            ELSE IF (ispin == 1 .AND. jspin == 1) THEN
-               WRITE (unit_nr, *) "Start loop run alpha-alpha"
-            ELSE IF (ispin == 1 .AND. jspin == 2) THEN
-               WRITE (unit_nr, *) "Start loop run alpha-beta"
-            ELSE IF (ispin == 2 .AND. jspin == 2) THEN
-               WRITE (unit_nr, *) "Start loop run beta-beta"
+            my_alpha_alpha_case = .FALSE.
+            my_beta_beta_case = .FALSE.
+            my_alpha_beta_case = .FALSE.
+            IF (ispin /= jspin) THEN
+               my_alpha_beta_case = .TRUE.
+            ELSE IF (my_open_shell_SS) THEN
+               IF (ispin == 1) my_alpha_alpha_case = .TRUE.
+               IF (ispin == 2) my_beta_beta_case = .TRUE.
             END IF
-            CALL m_flush(unit_nr)
-            t_start = m_walltime()
-         END IF
 
-         CALL timeset(routineN//"_RI_loop", handle2)
-         my_Emp2_Cou = 0.0_dp
-         my_Emp2_EX = 0.0_dp
-         DO ij_index = 1, max_ij_pairs
+            amp_fac = mp2_env%scale_S + mp2_env%scale_T
+            IF (my_alpha_beta_case .OR. my_open_shell_SS) amp_fac = mp2_env%scale_T
+
+            CALL mp2_ri_allocate_no_blk(local_ab, t_ab, mp2_env, homo, virtual, my_B_size, &
+                                        my_group_L_size, calc_forces, ispin, jspin, local_ba)
+
+            CALL mp2_ri_get_block_size( &
+               mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
+               homo(ispin), dimen_RI, unit_nr, block_size, &
+               ngroup, num_IJ_blocks, &
+               virtual(ispin), my_alpha_beta_case, &
+               my_open_shell_SS, calc_forces)
+
+            ! *****************************************************************
+            ! **********  REPLICATION-BLOCKED COMMUNICATION SCHEME  ***********
+            ! *****************************************************************
+            ! introduce block size, the number of occupied orbitals has to be a
+            ! multiple of the block size
+
+            ! Calculate the maximum number of ij pairs that have to be computed
+            ! among groups
+            CALL mp2_ri_communication(my_alpha_beta_case, total_ij_pairs, homo(ispin), homo(jspin), num_IJ_blocks, &
+                                      block_size, ngroup, ij_map, color_sub, my_ij_pairs, my_open_shell_SS, unit_nr)
+
+            ALLOCATE (num_ij_pairs(0:para_env_exchange%num_pe - 1))
+            CALL mp_allgather(my_ij_pairs, num_ij_pairs, para_env_exchange%group)
+
+            max_ij_pairs = MAXVAL(num_ij_pairs)
+
+            ! start real stuff
+            CALL mp2_ri_allocate_blk(dimen_RI, my_B_size, block_size, local_i_aL, &
+                                     local_j_aL, calc_forces, Y_i_aP, Y_j_aP, ispin, jspin)
 
             IF (unit_nr > 0) THEN
-               decil = ij_index*10/max_ij_pairs
-               IF (decil /= (ij_index - 1)*10/max_ij_pairs) THEN
-                  t_new = m_walltime()
-                  t_new = (t_new - t_start)/60.0_dp*(max_ij_pairs - ij_index + 1)/MAX(ij_index - 1, 1)
-                  WRITE (unit_nr, FMT="(T3,A)") "Percentage of finished loop: "// &
-                     cp_to_string(decil*10)//". Minutes left: "//cp_to_string(t_new)
-                  CALL m_flush(unit_nr)
+               IF (nspins == 1) THEN
+                  WRITE (unit_nr, *) "Start loop run"
+               ELSE IF (ispin == 1 .AND. jspin == 1) THEN
+                  WRITE (unit_nr, *) "Start loop run alpha-alpha"
+               ELSE IF (ispin == 1 .AND. jspin == 2) THEN
+                  WRITE (unit_nr, *) "Start loop run alpha-beta"
+               ELSE IF (ispin == 2 .AND. jspin == 2) THEN
+                  WRITE (unit_nr, *) "Start loop run beta-beta"
                END IF
+               CALL m_flush(unit_nr)
+               t_start = m_walltime()
             END IF
 
-            IF (calc_forces) THEN
-               Y_i_aP = 0.0_dp
-               Y_j_aP = 0.0_dp
-            END IF
+            CALL timeset(routineN//"_RI_loop", handle2)
+            my_Emp2_Cou = 0.0_dp
+            my_Emp2_EX = 0.0_dp
+            DO ij_index = 1, max_ij_pairs
 
-            IF (ij_index <= my_ij_pairs) THEN
-               ! We have work to do
-               ij_counter = (ij_index - MIN(1, color_sub))*ngroup + color_sub
-               my_i = ij_map(1, ij_counter)
-               my_j = ij_map(2, ij_counter)
-               my_block_size = ij_map(3, ij_counter)
-
-               local_i_aL = 0.0_dp
-               CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
-                                    BIb_C(ispin)%array(:, :, my_i:my_i + my_block_size - 1))
-
-               local_j_aL = 0.0_dp
-               CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
-                                    BIb_C(jspin)%array(:, :, my_j:my_j + my_block_size - 1))
-
-               ! collect data from other proc
-               CALL timeset(routineN//"_comm", handle3)
-               DO proc_shift = 1, para_env_exchange%num_pe - 1
-                  proc_send = proc_map(para_env_exchange%mepos + proc_shift)
-                  proc_receive = proc_map(para_env_exchange%mepos - proc_shift)
-
-                  send_ij_index = num_ij_pairs(proc_send)
-
-                  CALL get_group_dist(gd_array, proc_receive, sizes=rec_L_size)
-                  ALLOCATE (BI_C_rec(rec_L_size, MAXVAL(my_B_size), my_block_size))
-
-                  IF (ij_index <= send_ij_index) THEN
-                     ij_counter_send = (ij_index - MIN(1, integ_group_pos2color_sub(proc_send)))*ngroup + &
-                                       integ_group_pos2color_sub(proc_send)
-                     send_i = ij_map(1, ij_counter_send)
-                     send_j = ij_map(2, ij_counter_send)
-                     send_block_size = ij_map(3, ij_counter_send)
-
-                     ! occupied i
-                     BI_C_rec = 0.0_dp
-                     CALL mp_sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
-                                      proc_send, BI_C_rec, proc_receive, &
-                                      para_env_exchange%group, tag)
-
-                     CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
-                                          BI_C_rec(:, 1:my_B_size(ispin), :))
-
-                     ! occupied j
-                     BI_C_rec = 0.0_dp
-                     CALL mp_sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
-                                      proc_send, BI_C_rec, proc_receive, &
-                                      para_env_exchange%group, tag)
-
-                     CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
-                                          BI_C_rec(:, 1:my_B_size(jspin), :))
-
-                  ELSE
-                     ! we send nothing while we know that we have to receive something
-
-                     ! occupied i
-                     BI_C_rec = 0.0_dp
-                     CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
-
-                     CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
-                                          BI_C_rec(:, 1:my_B_size(ispin), :))
-
-                     ! occupied j
-                     BI_C_rec = 0.0_dp
-                     CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
-
-                     CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
-                                          BI_C_rec(:, 1:my_B_size(jspin), :))
-
+               IF (unit_nr > 0) THEN
+                  decil = ij_index*10/max_ij_pairs
+                  IF (decil /= (ij_index - 1)*10/max_ij_pairs) THEN
+                     t_new = m_walltime()
+                     t_new = (t_new - t_start)/60.0_dp*(max_ij_pairs - ij_index + 1)/MAX(ij_index - 1, 1)
+                     WRITE (unit_nr, FMT="(T3,A)") "Percentage of finished loop: "// &
+                        cp_to_string(decil*10)//". Minutes left: "//cp_to_string(t_new)
+                     CALL m_flush(unit_nr)
                   END IF
+               END IF
 
-                  DEALLOCATE (BI_C_rec)
+               IF (calc_forces) THEN
+                  Y_i_aP = 0.0_dp
+                  Y_j_aP = 0.0_dp
+               END IF
 
-               END DO
-               CALL timestop(handle3)
+               IF (ij_index <= my_ij_pairs) THEN
+                  ! We have work to do
+                  ij_counter = (ij_index - MIN(1, color_sub))*ngroup + color_sub
+                  my_i = ij_map(1, ij_counter)
+                  my_j = ij_map(2, ij_counter)
+                  my_block_size = ij_map(3, ij_counter)
 
-               ! loop over the block elements
-               DO iiB = 1, my_block_size
-                  DO jjB = 1, my_block_size
-                     CALL timeset(routineN//"_expansion", handle3)
-                     ASSOCIATE (my_local_i_aL => local_i_aL(:, :, iiB), my_local_j_aL => local_j_aL(:, :, jjB))
+                  local_i_aL = 0.0_dp
+                  CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
+                                       BIb_C(ispin)%array(:, :, my_i:my_i + my_block_size - 1))
 
-                        ! calculate the integrals (ia|jb) strating from my local data ...
-                        local_ab = 0.0_dp
-                        IF ((my_alpha_beta_case) .AND. (calc_forces)) THEN
-                           local_ba = 0.0_dp
-                        END IF
-                        CALL dgemm_counter_start(dgemm_counter)
-                        CALL offload_dgemm('T', 'N', my_B_size(ispin), my_B_size(jspin), dimen_RI, 1.0_dp, &
-                                           my_local_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
-                                         0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), my_B_size(ispin), &
-                                           mp2_env%offload_gemm_ctx)
-                        ! Additional integrals only for alpha_beta case and forces
-                        IF (my_alpha_beta_case .AND. calc_forces) THEN
-                           local_ba(my_B_virtual_start(jspin):my_B_virtual_end(jspin), :) = &
-                              TRANSPOSE(local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :))
-                        END IF
-                        ! ... and from the other of my subgroup
-                        DO proc_shift = 1, para_env_sub%num_pe - 1
-                           proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
-                           proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
+                  local_j_aL = 0.0_dp
+                  CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
+                                       BIb_C(jspin)%array(:, :, my_j:my_j + my_block_size - 1))
 
-                           CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, &
-                                               rec_B_virtual_end, rec_B_size)
+                  ! collect data from other proc
+                  CALL timeset(routineN//"_comm", handle3)
+                  DO proc_shift = 1, para_env_exchange%num_pe - 1
+                     proc_send = proc_map(para_env_exchange%mepos + proc_shift)
+                     proc_receive = proc_map(para_env_exchange%mepos - proc_shift)
 
-                           ALLOCATE (external_i_aL(dimen_RI, rec_B_size))
-                           external_i_aL = 0.0_dp
+                     send_ij_index = num_ij_pairs(proc_send)
 
-                           CALL mp_sendrecv(my_local_i_aL, proc_send, &
-                                            external_i_aL, proc_receive, &
-                                            para_env_sub%group, tag)
+                     CALL get_group_dist(gd_array, proc_receive, sizes=rec_L_size)
+                     ALLOCATE (BI_C_rec(rec_L_size, MAXVAL(my_B_size), my_block_size))
 
-                           CALL offload_dgemm('T', 'N', rec_B_size, my_B_size(jspin), dimen_RI, 1.0_dp, &
-                                              external_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
-                                          0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(jspin)), rec_B_size, &
-                                              mp2_env%offload_gemm_ctx)
+                     IF (ij_index <= send_ij_index) THEN
+                        ij_counter_send = (ij_index - MIN(1, integ_group_pos2color_sub(proc_send)))*ngroup + &
+                                          integ_group_pos2color_sub(proc_send)
+                        send_i = ij_map(1, ij_counter_send)
+                        send_j = ij_map(2, ij_counter_send)
+                        send_block_size = ij_map(3, ij_counter_send)
 
-                           DEALLOCATE (external_i_aL)
+                        ! occupied i
+                        BI_C_rec = 0.0_dp
+                        CALL mp_sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
+                                         proc_send, BI_C_rec, proc_receive, &
+                                         para_env_exchange%group, tag)
+
+                        CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
+                                             BI_C_rec(:, 1:my_B_size(ispin), :))
+
+                        ! occupied j
+                        BI_C_rec = 0.0_dp
+                        CALL mp_sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
+                                         proc_send, BI_C_rec, proc_receive, &
+                                         para_env_exchange%group, tag)
+
+                        CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
+                                             BI_C_rec(:, 1:my_B_size(jspin), :))
+
+                     ELSE
+                        ! we send nothing while we know that we have to receive something
+
+                        ! occupied i
+                        BI_C_rec = 0.0_dp
+                        CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
+
+                        CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
+                                             BI_C_rec(:, 1:my_B_size(ispin), :))
+
+                        ! occupied j
+                        BI_C_rec = 0.0_dp
+                        CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
+
+                        CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
+                                             BI_C_rec(:, 1:my_B_size(jspin), :))
+
+                     END IF
+
+                     DEALLOCATE (BI_C_rec)
+
+                  END DO
+                  CALL timestop(handle3)
+
+                  ! loop over the block elements
+                  DO iiB = 1, my_block_size
+                     DO jjB = 1, my_block_size
+                        CALL timeset(routineN//"_expansion", handle3)
+                        ASSOCIATE (my_local_i_aL => local_i_aL(:, :, iiB), my_local_j_aL => local_j_aL(:, :, jjB))
+
+                           ! calculate the integrals (ia|jb) strating from my local data ...
+                           local_ab = 0.0_dp
+                           IF ((my_alpha_beta_case) .AND. (calc_forces)) THEN
+                              local_ba = 0.0_dp
+                           END IF
+                           CALL dgemm_counter_start(dgemm_counter)
+                           CALL offload_dgemm('T', 'N', my_B_size(ispin), my_B_size(jspin), dimen_RI, 1.0_dp, &
+                                              my_local_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
+                                              0.0_dp, local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :), &
+                                              my_B_size(ispin), mp2_env%offload_gemm_ctx)
                            ! Additional integrals only for alpha_beta case and forces
                            IF (my_alpha_beta_case .AND. calc_forces) THEN
+                              local_ba(my_B_virtual_start(jspin):my_B_virtual_end(jspin), :) = &
+                                 TRANSPOSE(local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :))
+                           END IF
+                           ! ... and from the other of my subgroup
+                           DO proc_shift = 1, para_env_sub%num_pe - 1
+                              proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
+                              proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
 
-                              CALL get_group_dist(gd_B_virtual(jspin), proc_receive, rec_B_virtual_start, &
+                              CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, &
                                                   rec_B_virtual_end, rec_B_size)
 
                               ALLOCATE (external_i_aL(dimen_RI, rec_B_size))
                               external_i_aL = 0.0_dp
 
-                              CALL mp_sendrecv(my_local_j_aL, proc_send, &
+                              CALL mp_sendrecv(my_local_i_aL, proc_send, &
                                                external_i_aL, proc_receive, &
                                                para_env_sub%group, tag)
 
-                              CALL offload_dgemm('T', 'N', rec_B_size, my_B_size(ispin), dimen_RI, 1.0_dp, &
-                                                 external_i_aL, dimen_RI, my_local_i_aL, dimen_RI, &
-                                          0.0_dp, local_ba(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(ispin)), rec_B_size, &
+                              CALL offload_dgemm('T', 'N', rec_B_size, my_B_size(jspin), dimen_RI, 1.0_dp, &
+                                                 external_i_aL, dimen_RI, my_local_j_aL, dimen_RI, &
+                                          0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(jspin)), rec_B_size, &
                                                  mp2_env%offload_gemm_ctx)
+
                               DEALLOCATE (external_i_aL)
-                           END IF
-                        END DO
-                        IF (my_alpha_beta_case .AND. calc_forces) THEN
-                           ! Is just an approximation, but the call does not allow it, it ought to be (virtual_i*B_size_j+virtual_j*B_size_i)*dimen_RI
-                           CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), my_B_size(ispin) + my_B_size(jspin), dimen_RI)
-                        ELSE
-                           CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), my_B_size(jspin), dimen_RI)
-                        END IF
-                        CALL timestop(handle3)
+                              ! Additional integrals only for alpha_beta case and forces
+                              IF (my_alpha_beta_case .AND. calc_forces) THEN
 
-                        !sample peak memory
-                        CALL m_memory()
+                                 CALL get_group_dist(gd_B_virtual(jspin), proc_receive, rec_B_virtual_start, &
+                                                     rec_B_virtual_end, rec_B_size)
 
-                        CALL timeset(routineN//"_ener", handle3)
-                        ! calculate coulomb only MP2
-                        sym_fac = 2.0_dp
-                        IF (my_i == my_j) sym_fac = 1.0_dp
-                        IF (my_alpha_beta_case) sym_fac = 0.5_dp
-                        DO b = 1, my_B_size(jspin)
-                           b_global = b + my_B_virtual_start(jspin) - 1
-                           DO a = 1, virtual(ispin)
-                              my_Emp2_Cou = my_Emp2_Cou - sym_fac*2.0_dp*local_ab(a, b)**2/ &
-                                            (Eigenval(homo(ispin) + a, ispin) + Eigenval(homo(jspin) + b_global, jspin) - &
-                                             Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, jspin))
+                                 ALLOCATE (external_i_aL(dimen_RI, rec_B_size))
+                                 external_i_aL = 0.0_dp
+
+                                 CALL mp_sendrecv(my_local_j_aL, proc_send, &
+                                                  external_i_aL, proc_receive, &
+                                                  para_env_sub%group, tag)
+
+                                 CALL offload_dgemm('T', 'N', rec_B_size, my_B_size(ispin), dimen_RI, 1.0_dp, &
+                                                    external_i_aL, dimen_RI, my_local_i_aL, dimen_RI, &
+                                          0.0_dp, local_ba(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(ispin)), rec_B_size, &
+                                                    mp2_env%offload_gemm_ctx)
+                                 DEALLOCATE (external_i_aL)
+                              END IF
                            END DO
-                        END DO
+                           IF (my_alpha_beta_case .AND. calc_forces) THEN
+                              ! Is just an approximation, but the call does not allow it, it ought to be (virtual_i*B_size_j+virtual_j*B_size_i)*dimen_RI
+                              CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), my_B_size(ispin) + my_B_size(jspin), dimen_RI)
+                           ELSE
+                              CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), my_B_size(jspin), dimen_RI)
+                           END IF
+                           CALL timestop(handle3)
 
-                        IF (calc_ex) THEN
-                           ! contract integrals with orbital energies for exchange MP2 energy
-                           ! starting with local ...
-                           IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) t_ab = 0.0_dp
-                           DO b = 1, my_B_size(ispin)
-                              b_global = b + my_B_virtual_start(ispin) - 1
-                              DO a = 1, my_B_size(ispin)
-                                 a_global = a + my_B_virtual_start(ispin) - 1
-                                 my_Emp2_Ex = my_Emp2_Ex + sym_fac*local_ab(a_global, b)*local_ab(b_global, a)/ &
-                                              (Eigenval(homo(ispin) + a_global, ispin) + Eigenval(homo(ispin) + b_global, ispin) - &
-                                               Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
-                                 IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) THEN
-                                    t_ab(a_global, b) = -(amp_fac*local_ab(a_global, b) - mp2_env%scale_T*local_ab(b_global, a))/ &
-                                                        (Eigenval(homo(ispin) + a_global, ispin) + &
-                                                         Eigenval(homo(ispin) + b_global, ispin) - &
-                                                         Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
-                                 END IF
+                           !sample peak memory
+                           CALL m_memory()
+
+                           CALL timeset(routineN//"_ener", handle3)
+                           ! calculate coulomb only MP2
+                           sym_fac = 2.0_dp
+                           IF (my_i == my_j) sym_fac = 1.0_dp
+                           IF (my_alpha_beta_case) sym_fac = 0.5_dp
+                           DO b = 1, my_B_size(jspin)
+                              b_global = b + my_B_virtual_start(jspin) - 1
+                              DO a = 1, virtual(ispin)
+                                 my_Emp2_Cou = my_Emp2_Cou - sym_fac*2.0_dp*local_ab(a, b)**2/ &
+                                               (Eigenval(homo(ispin) + a, ispin) + Eigenval(homo(jspin) + b_global, jspin) - &
+                                                Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, jspin))
                               END DO
                            END DO
-                           ! ... and then with external data
-                           DO proc_shift = 1, para_env_sub%num_pe - 1
-                              proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
-                              proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
+
+                           IF (calc_ex) THEN
+                              ! contract integrals with orbital energies for exchange MP2 energy
+                              ! starting with local ...
+                              IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) t_ab = 0.0_dp
+                              DO b = 1, my_B_size(ispin)
+                                 b_global = b + my_B_virtual_start(ispin) - 1
+                                 DO a = 1, my_B_size(ispin)
+                                    a_global = a + my_B_virtual_start(ispin) - 1
+                                    my_Emp2_Ex = my_Emp2_Ex + sym_fac*local_ab(a_global, b)*local_ab(b_global, a)/ &
+                                              (Eigenval(homo(ispin) + a_global, ispin) + Eigenval(homo(ispin) + b_global, ispin) - &
+                                                  Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
+                                    IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) THEN
+                                     t_ab(a_global, b) = -(amp_fac*local_ab(a_global, b) - mp2_env%scale_T*local_ab(b_global, a))/ &
+                                                           (Eigenval(homo(ispin) + a_global, ispin) + &
+                                                            Eigenval(homo(ispin) + b_global, ispin) - &
+                                                            Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
+                                    END IF
+                                 END DO
+                              END DO
+                              ! ... and then with external data
+                              DO proc_shift = 1, para_env_sub%num_pe - 1
+                                 proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
+                                 proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
 
                           CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
                           CALL get_group_dist(gd_B_virtual(ispin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
 
-                              ALLOCATE (external_ab(my_B_size(ispin), rec_B_size))
-                              external_ab = 0.0_dp
+                                 ALLOCATE (external_ab(my_B_size(ispin), rec_B_size))
+                                 external_ab = 0.0_dp
 
-                              CALL mp_sendrecv(local_ab(send_B_virtual_start:send_B_virtual_end, 1:my_B_size(ispin)), proc_send, &
-                                               external_ab(1:my_B_size(ispin), 1:rec_B_size), proc_receive, &
-                                               para_env_sub%group, tag)
+                                CALL mp_sendrecv(local_ab(send_B_virtual_start:send_B_virtual_end, 1:my_B_size(ispin)), proc_send, &
+                                                  external_ab(1:my_B_size(ispin), 1:rec_B_size), proc_receive, &
+                                                  para_env_sub%group, tag)
 
-                              DO b = 1, my_B_size(ispin)
-                                 b_global = b + my_B_virtual_start(ispin) - 1
-                                 DO a = 1, rec_B_size
-                                    a_global = a + rec_B_virtual_start - 1
-                                    my_Emp2_Ex = my_Emp2_Ex + sym_fac*local_ab(a_global, b)*external_ab(b, a)/ &
+                                 DO b = 1, my_B_size(ispin)
+                                    b_global = b + my_B_virtual_start(ispin) - 1
+                                    DO a = 1, rec_B_size
+                                       a_global = a + rec_B_virtual_start - 1
+                                       my_Emp2_Ex = my_Emp2_Ex + sym_fac*local_ab(a_global, b)*external_ab(b, a)/ &
                                               (Eigenval(homo(ispin) + a_global, ispin) + Eigenval(homo(ispin) + b_global, ispin) - &
-                                                  Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
-                                    IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) &
-                                       t_ab(a_global, b) = -(amp_fac*local_ab(a_global, b) - mp2_env%scale_T*external_ab(b, a))/ &
-                                                           (Eigenval(homo(ispin) + a_global, ispin) + &
-                                                            Eigenval(homo(ispin) + b_global, ispin) - &
-                                                            Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
+                                                     Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
+                                       IF (calc_forces .AND. (.NOT. my_alpha_beta_case)) &
+                                         t_ab(a_global, b) = -(amp_fac*local_ab(a_global, b) - mp2_env%scale_T*external_ab(b, a))/ &
+                                                              (Eigenval(homo(ispin) + a_global, ispin) + &
+                                                               Eigenval(homo(ispin) + b_global, ispin) - &
+                                                               Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
+                                    END DO
                                  END DO
+
+                                 DEALLOCATE (external_ab)
                               END DO
+                           END IF
+                           CALL timestop(handle3)
 
-                              DEALLOCATE (external_ab)
-                           END DO
-                        END IF
-                        CALL timestop(handle3)
+                           IF (calc_forces) THEN
+                              ! update P_ab, Gamma_P_ia
+                              CALL mp2_update_P_gamma(mp2_env, para_env_sub, gd_B_virtual, &
+                                                      Eigenval, homo, dimen_RI, iiB, jjB, my_B_size, &
+                                                      my_B_virtual_end, my_B_virtual_start, my_i, my_j, virtual, &
+                                                      sub_proc_map, local_ab, t_ab, my_local_i_aL, my_local_j_aL, &
+                                                      my_open_shell_ss, Y_i_aP(:, :, iiB), Y_j_aP(:, :, jjB), local_ba, &
+                                                      ispin, jspin, dgemm_counter)
 
-                        IF (calc_forces) THEN
-                           ! update P_ab, Gamma_P_ia
-                           CALL mp2_update_P_gamma(mp2_env, para_env_sub, gd_B_virtual, &
-                                                   Eigenval, homo, dimen_RI, iiB, jjB, my_B_size, &
-                                                   my_B_virtual_end, my_B_virtual_start, my_i, my_j, virtual, &
-                                                   sub_proc_map, local_ab, t_ab, my_local_i_aL, my_local_j_aL, &
-                                                   my_open_shell_ss, Y_i_aP(:, :, iiB), Y_j_aP(:, :, jjB), local_ba, &
-                                                   ispin, jspin, dgemm_counter)
+                           END IF
 
-                        END IF
+                        END ASSOCIATE
 
-                     END ASSOCIATE
+                     END DO ! jjB
+                  END DO ! iiB
 
-                  END DO ! jjB
-               END DO ! iiB
+               ELSE
+                  CALL timeset(routineN//"_comm", handle3)
+                  ! No work to do and we know that we have to receive nothing, but send something
+                  ! send data to other proc
+                  DO proc_shift = 1, para_env_exchange%num_pe - 1
+                     proc_send = proc_map(para_env_exchange%mepos + proc_shift)
+                     proc_receive = proc_map(para_env_exchange%mepos - proc_shift)
 
-            ELSE
-               CALL timeset(routineN//"_comm", handle3)
-               ! No work to do and we know that we have to receive nothing, but send something
-               ! send data to other proc
-               DO proc_shift = 1, para_env_exchange%num_pe - 1
-                  proc_send = proc_map(para_env_exchange%mepos + proc_shift)
-                  proc_receive = proc_map(para_env_exchange%mepos - proc_shift)
+                     send_ij_index = num_ij_pairs(proc_send)
 
-                  send_ij_index = num_ij_pairs(proc_send)
+                     IF (ij_index <= send_ij_index) THEN
+                        ! something to send
+                        ij_counter_send = (ij_index - MIN(1, integ_group_pos2color_sub(proc_send)))*ngroup + &
+                                          integ_group_pos2color_sub(proc_send)
+                        send_i = ij_map(1, ij_counter_send)
+                        send_j = ij_map(2, ij_counter_send)
+                        send_block_size = ij_map(3, ij_counter_send)
 
-                  IF (ij_index <= send_ij_index) THEN
-                     ! something to send
-                     ij_counter_send = (ij_index - MIN(1, integ_group_pos2color_sub(proc_send)))*ngroup + &
-                                       integ_group_pos2color_sub(proc_send)
-                     send_i = ij_map(1, ij_counter_send)
-                     send_j = ij_map(2, ij_counter_send)
-                     send_block_size = ij_map(3, ij_counter_send)
+                        ! occupied i
+                        CALL mp_send(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
+                                     proc_send, tag, para_env_exchange%group)
+                        ! occupied j
+                        CALL mp_send(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
+                                     proc_send, tag, para_env_exchange%group)
+                     END IF
+                  END DO
+                  CALL timestop(handle3)
+               END IF
 
-                     ! occupied i
-                     CALL mp_send(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
-                                  proc_send, tag, para_env_exchange%group)
-                     ! occupied j
-                     CALL mp_send(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
-                                  proc_send, tag, para_env_exchange%group)
-                  END IF
-               END DO
-               CALL timestop(handle3)
-            END IF
+               ! redistribute gamma
+               IF (calc_forces) THEN
+                  CALL mp2_redistribute_gamma(mp2_env%ri_grad%Gamma_P_ia(ispin)%array, ij_index, my_B_size(ispin), &
+                                              my_block_size, my_group_L_size, my_i, my_ij_pairs, ngroup, &
+                                              num_integ_group, integ_group_pos2color_sub, num_ij_pairs, proc_map, &
+                                              ij_map, ranges_info_array, Y_i_aP(:, :, 1:my_block_size), para_env_exchange, &
+                                              gd_array%sizes, 1)
+                  CALL mp2_redistribute_gamma(mp2_env%ri_grad%Gamma_P_ia(jspin)%array, ij_index, my_B_size(jspin), &
+                                              my_block_size, my_group_L_size, my_j, my_ij_pairs, ngroup, &
+                                              num_integ_group, integ_group_pos2color_sub, num_ij_pairs, proc_map, &
+                                              ij_map, ranges_info_array, Y_j_aP(:, :, 1:my_block_size), para_env_exchange, &
+                                              gd_array%sizes, 2)
+               END IF
 
-            ! redistribute gamma
+            END DO
+            CALL timestop(handle2)
+
+            DEALLOCATE (local_i_aL)
+            DEALLOCATE (local_j_aL)
+            DEALLOCATE (ij_map)
+            DEALLOCATE (num_ij_pairs)
+            DEALLOCATE (local_ab)
+
             IF (calc_forces) THEN
-               CALL mp2_redistribute_gamma(mp2_env%ri_grad%Gamma_P_ia(ispin)%array, ij_index, my_B_size(ispin), &
-                                           my_block_size, my_group_L_size, my_i, my_ij_pairs, ngroup, &
-                                           num_integ_group, integ_group_pos2color_sub, num_ij_pairs, proc_map, &
-                                           ij_map, ranges_info_array, Y_i_aP(:, :, 1:my_block_size), para_env_exchange, &
-                                           gd_array%sizes, 1)
-               CALL mp2_redistribute_gamma(mp2_env%ri_grad%Gamma_P_ia(jspin)%array, ij_index, my_B_size(jspin), &
-                                           my_block_size, my_group_L_size, my_j, my_ij_pairs, ngroup, &
-                                           num_integ_group, integ_group_pos2color_sub, num_ij_pairs, proc_map, &
-                                           ij_map, ranges_info_array, Y_j_aP(:, :, 1:my_block_size), para_env_exchange, &
-                                           gd_array%sizes, 2)
+               DEALLOCATE (Y_i_aP)
+               DEALLOCATE (Y_j_aP)
+               IF (ALLOCATED(t_ab)) THEN
+                  DEALLOCATE (t_ab)
+               END IF
+               DEALLOCATE (local_ba)
+
+               ! here we check if there are almost degenerate ij
+               ! pairs and we update P_ij with these contribution.
+               ! If all pairs are degenerate with each other this step will scale O(N^6),
+               ! if the number of degenerate pairs scales linearly with the system size
+               ! this step will scale O(N^5).
+               ! Start counting the number of almost degenerate ij pairs according
+               ! to eps_canonical
+               CALL quasi_degenerate_P_ij( &
+                  mp2_env, Eigenval(:, ispin:jspin), homo(ispin:jspin), virtual(ispin:jspin), my_open_shell_ss, &
+                  my_beta_beta_case, Bib_C(ispin:jspin), unit_nr, dimen_RI, &
+                  my_B_size(ispin:jspin), ngroup, num_integ_group, my_group_L_size, &
+                  color_sub, ranges_info_array, para_env_exchange, para_env_sub, proc_map, &
+                  my_B_virtual_start(ispin:jspin), my_B_virtual_end(ispin:jspin), gd_array%sizes, gd_B_virtual(ispin:jspin), &
+                  sub_proc_map, integ_group_pos2color_sub, dgemm_counter)
+
             END IF
 
-         END DO
-         CALL timestop(handle2)
+            CALL mp_sum(my_Emp2_Cou, para_env%group)
+            CALL mp_sum(my_Emp2_Ex, para_env%group)
 
-         DEALLOCATE (local_i_aL)
-         DEALLOCATE (local_j_aL)
-         DEALLOCATE (ij_map)
-         DEALLOCATE (num_ij_pairs)
-         DEALLOCATE (local_ab)
-
-         IF (calc_forces) THEN
-            DEALLOCATE (Y_i_aP)
-            DEALLOCATE (Y_j_aP)
-            IF (ALLOCATED(t_ab)) THEN
-               DEALLOCATE (t_ab)
-            END IF
-            DEALLOCATE (local_ba)
-
-            ! here we check if there are almost degenerate ij
-            ! pairs and we update P_ij with these contribution.
-            ! If all pairs are degenerate with each other this step will scale O(N^6),
-            ! if the number of degenerate pairs scales linearly with the system size
-            ! this step will scale O(N^5).
-            ! Start counting the number of almost degenerate ij pairs according
-            ! to eps_canonical
-            CALL quasi_degenerate_P_ij( &
-               mp2_env, Eigenval(:, ispin:jspin), homo(ispin:jspin), virtual(ispin:jspin), my_open_shell_ss, &
-               my_beta_beta_case, Bib_C(ispin:jspin), unit_nr, dimen_RI, &
-               my_B_size(ispin:jspin), ngroup, num_integ_group, my_group_L_size, &
-               color_sub, ranges_info_array, para_env_exchange, para_env_sub, proc_map, &
-               my_B_virtual_start(ispin:jspin), my_B_virtual_end(ispin:jspin), gd_array%sizes, gd_B_virtual(ispin:jspin), &
-               sub_proc_map, integ_group_pos2color_sub, dgemm_counter)
-
-         END IF
-
-         CALL mp_sum(my_Emp2_Cou, para_env%group)
-         CALL mp_sum(my_Emp2_Ex, para_env%group)
-
-         IF (my_open_shell_SS .OR. my_alpha_beta_case) THEN
-            IF (my_alpha_beta_case) THEN
-               Emp2_S = Emp2_S + my_Emp2_Cou
-               Emp2_Cou = Emp2_Cou + my_Emp2_Cou
+            IF (my_open_shell_SS .OR. my_alpha_beta_case) THEN
+               IF (my_alpha_beta_case) THEN
+                  Emp2_S = Emp2_S + my_Emp2_Cou
+                  Emp2_Cou = Emp2_Cou + my_Emp2_Cou
+               ELSE
+                  my_Emp2_Cou = my_Emp2_Cou*0.25_dp
+                  my_Emp2_EX = my_Emp2_EX*0.5_dp
+                  Emp2_T = Emp2_T + my_Emp2_Cou + my_Emp2_EX
+                  Emp2_Cou = Emp2_Cou + my_Emp2_Cou
+                  Emp2_EX = Emp2_EX + my_Emp2_EX
+               END IF
             ELSE
-               my_Emp2_Cou = my_Emp2_Cou*0.25_dp
-               my_Emp2_EX = my_Emp2_EX*0.5_dp
-               Emp2_T = Emp2_T + my_Emp2_Cou + my_Emp2_EX
                Emp2_Cou = Emp2_Cou + my_Emp2_Cou
                Emp2_EX = Emp2_EX + my_Emp2_EX
             END IF
-         ELSE
-            Emp2_Cou = Emp2_Cou + my_Emp2_Cou
-            Emp2_EX = Emp2_EX + my_Emp2_EX
-         END IF
+         END DO
       END DO
-      END DO
-
-      DEALLOCATE (replicated)
 
       IF (calc_forces) THEN
          ! recover original information (before replication)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -156,6 +156,12 @@ CONTAINS
          CALL offload_gemm_set_op_threshold_gpu(mp2_env%offload_gemm_ctx, 128*128*128*2)
       END IF
 
+      CALL mp2_ri_get_integ_group_size( &
+         mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
+         homo, dimen_RI, unit_nr, &
+         integ_group_size, ngroup, &
+         num_integ_group, virtual, calc_forces)
+
       ! We cannot fix the tag because of the recv routine
       tag = 42
 
@@ -180,13 +186,6 @@ CONTAINS
 
          amp_fac = mp2_env%scale_S + mp2_env%scale_T
          IF (my_alpha_beta_case .OR. my_open_shell_SS) amp_fac = mp2_env%scale_T
-
-         CALL mp2_ri_get_integ_group_size( &
-            mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
-            homo(ispin), dimen_RI, unit_nr, &
-            integ_group_size, ngroup, &
-            num_integ_group, virtual(ispin), my_alpha_beta_case, &
-            my_open_shell_SS, calc_forces)
 
          ! now create a group that contains all the proc that have the same virtual starting point
          ! in the integ group
@@ -1208,24 +1207,22 @@ CONTAINS
 !> \param ngroup ...
 !> \param num_integ_group ...
 !> \param virtual ...
-!> \param my_alpha_beta_case ...
-!> \param my_open_shell_SS ...
 !> \param calc_forces ...
 ! **************************************************************************************************
    SUBROUTINE mp2_ri_get_integ_group_size(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
                                           homo, dimen_RI, unit_nr, &
                                           integ_group_size, &
                                           ngroup, num_integ_group, &
-                                          virtual, my_alpha_beta_case, &
-                                          my_open_shell_SS, calc_forces)
+                                          virtual, calc_forces)
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
-      TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array, gd_B_virtual
-      INTEGER, INTENT(IN)                                :: homo, dimen_RI, unit_nr
+      TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array
+      TYPE(group_dist_d1_type), DIMENSION(:), INTENT(IN) :: gd_B_virtual
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
+      INTEGER, INTENT(IN)                                :: dimen_RI, unit_nr
       INTEGER, INTENT(OUT)                               :: integ_group_size, ngroup, num_integ_group
-      INTEGER, INTENT(IN)                                :: virtual
-      LOGICAL, INTENT(IN)                                :: my_alpha_beta_case, my_open_shell_SS, &
-                                                            calc_forces
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: virtual
+      LOGICAL, INTENT(IN)                                :: calc_forces
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_get_integ_group_size'
 
@@ -1241,8 +1238,8 @@ CONTAINS
 
       ! Calculate available memory and create integral group according to that
       ! mem_for_iaK is the memory needed for storing the 3 centre integrals
-      mem_for_iaK = REAL(homo, KIND=dp)*virtual*dimen_RI*8.0_dp/(1024_dp**2)
-      mem_for_aK = REAL(virtual, KIND=dp)*dimen_RI*8.0_dp/(1024_dp**2)
+      mem_for_iaK = MAXVAL(REAL(homo, KIND=dp)*virtual)*dimen_RI*8.0_dp/(1024_dp**2)
+      mem_for_aK = REAL(MAXVAL(virtual), KIND=dp)*dimen_RI*8.0_dp/(1024_dp**2)
 
       CALL m_memory(mem)
       mem_real = (mem + 1024*1024 - 1)/(1024*1024)
@@ -1251,31 +1248,29 @@ CONTAINS
       CALL mp_min(mem_real, para_env%group)
 
       ! BIB_C_copy/external_i_aL/Gamma_P_ia
-      mem_min = MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
+      mem_min = MAXVAL(MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
       IF (calc_forces) THEN
-         mem_min = MAX(mem_min, 2.0_dp*maxsize(gd_array)*maxsize(gd_B_virtual)*8.0_dp/(1024**2))
+         mem_min = MAX(mem_min, 2.0_dp*MAXVAL(maxsize(gd_array)*maxsize(gd_B_virtual))*8.0_dp/(1024**2))
       END IF
       ! BIB_C
-      mem_min = REAL(homo, KIND=dp)*maxsize(gd_B_virtual)*maxsize(gd_array)*8.0_dp/(1024**2)
+      mem_min = MAXVAL(REAL(homo, KIND=dp)*maxsize(gd_B_virtual))*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL
-      mem_min = mem_min + 2.0_dp*maxsize(gd_B_virtual)*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
+      mem_min = mem_min + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
       ! local_ab
-      mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
+      mem_min = mem_min + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
 
       IF (calc_forces) THEN
          ! Y_i_aP+Y_j_aP
-         mem_min = mem_min + 2.0_dp*maxsize(gd_B_virtual)*dimen_RI*8.0_dp/(1024**2)
+         mem_min = mem_min + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
          ! local_ba/t_ab
-         mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
-         IF (.NOT. my_alpha_beta_case) THEN
-            ! P_ij
-            mem_min = mem_min + REAL(homo, KIND=dp)*homo*8.0_dp/(1024**2)
-            ! P_ab
-            mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
-         END IF
+         mem_min = mem_min + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+         ! P_ij
+         mem_min = mem_min + SUM(REAL(homo, KIND=dp)*homo)*8.0_dp/(1024**2)
+         ! P_ab
+         mem_min = mem_min + SUM(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
       END IF
 
-      IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
+      IF (SIZE(homo) == 1) THEN
          IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'RI_INFO| Minimum required memory per MPI process:', &
             mem_min, ' MiB'
       END IF
@@ -1289,7 +1284,7 @@ CONTAINS
       best_block_size = 1
 
       ! in the open shell case no replication and no block communication is done
-      IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
+      IF (SIZE(homo) == 1) THEN
          ! Here we split the memory half for the communication, half for replication
          IF (mp2_env%ri_mp2%block_size > 0) THEN
             best_block_size = mp2_env%ri_mp2%block_size
@@ -1315,7 +1310,7 @@ CONTAINS
 
       integ_group_size = best_integ_group_size
 
-      IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
+      IF (SIZE(homo) == 1) THEN
          IF (unit_nr > 0) THEN
             WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
                "RI_INFO| Group size for integral replication:", integ_group_size*para_env_sub%num_pe

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -1360,19 +1360,22 @@ CONTAINS
       mem_per_repl = 0.0_dp
       mem_per_repl_blk = 0.0_dp
 
-      ! BIB_C_copy/external_i_aL/Gamma_P_ia
+      ! BIB_C_copy/external_i_aL
       mem_per_repl = mem_per_repl + MAXVAL(MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))* &
                                            maxsize(gd_B_virtual))*8.0_dp/(1024**2)
       ! BIB_C
       mem_per_repl = mem_per_repl + SUM(REAL(homo, KIND=dp)*maxsize(gd_B_virtual))*maxsize(gd_array)*8.0_dp/(1024**2)
-      ! BIB_C
+      ! BIB_C_rec
       mem_per_repl_blk = mem_per_repl_blk + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL
       mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
-      ! local_ab
-      mem_base = mem_base + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+      ! local_ab+external_ab
+      mem_base = mem_base + 2.0_dp*MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
 
       IF (calc_forces) THEN
+         ! Gamma_P_ia
+         mem_per_repl = mem_per_repl + SUM(MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))* &
+                                           maxsize(gd_B_virtual))*8.0_dp/(1024**2)
          ! Y_i_aP+Y_j_aP
          mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
          ! local_ba/t_ab
@@ -1510,9 +1513,9 @@ CONTAINS
       IF (calc_forces) THEN
          ! Y_i_aP+Y_j_aP+BIb_C_send
          mem_per_blk = mem_per_blk + 3.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
+         ! send_ab
+         mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*MAXVAL(virtual)*8.0_dp/(1024**2)
       END IF
-
-      !mem_real = MIN(mp2_env%mp2_memory, mem_real)
 
       best_block_size = 1
 

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -221,7 +221,7 @@ CONTAINS
             CALL mp2_ri_get_block_size( &
                mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin:jspin), &
                homo(ispin:jspin), virtual(ispin:jspin), dimen_RI, unit_nr, block_size, &
-               ngroup, num_integ_group, my_open_shell_ss, calc_forces)
+               ngroup, num_integ_group, my_open_shell_ss, calc_forces, buffer_1D)
 
             ! *****************************************************************
             ! **********  REPLICATION-BLOCKED COMMUNICATION SCHEME  ***********
@@ -279,9 +279,6 @@ CONTAINS
                   local_j_aL = 0.0_dp
                   CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
                                        BIb_C(jspin)%array(:, :, my_j:my_j + my_block_size - 1))
-
-                  IF (para_env_exchange%num_pe > 1) &
-                     ALLOCATE (buffer_1D(INT(maxsize(gd_array), int_8)*MAXVAL(my_B_size)*my_block_size))
 
                   ! collect data from other proc
                   CALL timeset(routineN//"_comm", handle3)
@@ -346,8 +343,6 @@ CONTAINS
 
                   END DO
 
-                  IF (para_env_exchange%num_pe > 1) DEALLOCATE (buffer_1D)
-
                   CALL timestop(handle3)
 
                   ! loop over the block elements
@@ -371,7 +366,6 @@ CONTAINS
                               local_ba(my_B_virtual_start(jspin):my_B_virtual_end(jspin), :) = &
                                  TRANSPOSE(local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :))
                            END IF
-                           IF (para_env_sub%num_pe > 1) ALLOCATE (buffer_1D(INT(dimen_RI, int_8)*MAXVAL(maxsize(gd_B_virtual))))
                            ! ... and from the other of my subgroup
                            DO proc_shift = 1, para_env_sub%num_pe - 1
                               proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
@@ -411,7 +405,6 @@ CONTAINS
                                                     mp2_env%offload_gemm_ctx)
                               END IF
                            END DO
-                           IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_1D)
                            IF (my_alpha_beta_case .AND. calc_forces) THEN
                               ! Is just an approximation, but the call does not allow it, it ought to be (virtual_i*B_size_j+virtual_j*B_size_i)*dimen_RI
                               CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), my_B_size(ispin) + my_B_size(jspin), dimen_RI)
@@ -456,8 +449,6 @@ CONTAINS
                                     END IF
                                  END DO
                               END DO
-                              IF (para_env_sub%num_pe > 1) &
-                                 ALLOCATE (buffer_1D(1:INT(my_B_size(ispin), int_8)*maxsize(gd_B_virtual(ispin))))
                               ! ... and then with external data
                               DO proc_shift = 1, para_env_sub%num_pe - 1
                                  proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
@@ -491,7 +482,6 @@ CONTAINS
                                     END DO
                                  END DO
                               END DO
-                              IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_1D)
                            END IF
                            CALL timestop(handle3)
 
@@ -502,7 +492,7 @@ CONTAINS
                                                       my_B_virtual_end, my_B_virtual_start, my_i, my_j, virtual, &
                                                       sub_proc_map, local_ab, t_ab, my_local_i_aL, my_local_j_aL, &
                                                       my_open_shell_ss, Y_i_aP(:, :, iiB), Y_j_aP(:, :, jjB), local_ba, &
-                                                      ispin, jspin, dgemm_counter)
+                                                      ispin, jspin, dgemm_counter, buffer_1D)
 
                            END IF
 
@@ -548,12 +538,12 @@ CONTAINS
                                               my_block_size, my_group_L_size, my_i, my_ij_pairs, ngroup, &
                                               num_integ_group, integ_group_pos2color_sub, num_ij_pairs, proc_map, &
                                               ij_map, ranges_info_array, Y_i_aP(:, :, 1:my_block_size), para_env_exchange, &
-                                              gd_array%sizes, 1)
+                                              gd_array%sizes, 1, buffer_1D)
                   CALL mp2_redistribute_gamma(mp2_env%ri_grad%Gamma_P_ia(jspin)%array, ij_index, my_B_size(jspin), &
                                               my_block_size, my_group_L_size, my_j, my_ij_pairs, ngroup, &
                                               num_integ_group, integ_group_pos2color_sub, num_ij_pairs, proc_map, &
                                               ij_map, ranges_info_array, Y_j_aP(:, :, 1:my_block_size), para_env_exchange, &
-                                              gd_array%sizes, 2)
+                                              gd_array%sizes, 2, buffer_1D)
                END IF
 
             END DO
@@ -564,6 +554,7 @@ CONTAINS
             DEALLOCATE (ij_map)
             DEALLOCATE (num_ij_pairs)
             DEALLOCATE (local_ab)
+            DEALLOCATE (buffer_1D)
 
             IF (calc_forces) THEN
                DEALLOCATE (Y_i_aP)
@@ -1466,11 +1457,12 @@ CONTAINS
 !> \param num_integ_group ...
 !> \param my_open_shell_ss ...
 !> \param calc_forces ...
+!> \param buffer_1D ...
 ! **************************************************************************************************
    SUBROUTINE mp2_ri_get_block_size(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
                                     homo, virtual, dimen_RI, unit_nr, &
                                     block_size, ngroup, num_integ_group, &
-                                    my_open_shell_ss, calc_forces)
+                                    my_open_shell_ss, calc_forces, buffer_1D)
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array
@@ -1479,11 +1471,13 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: dimen_RI, unit_nr
       INTEGER, INTENT(OUT)                               :: block_size, ngroup, num_integ_group
       LOGICAL, INTENT(IN)                                :: my_open_shell_ss, calc_forces
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: buffer_1D
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_get_block_size'
 
       INTEGER                                            :: best_block_size, handle, num_IJ_blocks
-      INTEGER(KIND=int_8)                                :: mem
+      INTEGER(KIND=int_8)                                :: buffer_size, mem
       REAL(KIND=dp)                                      :: mem_base, mem_per_blk, mem_per_repl_blk, &
                                                             mem_real
 
@@ -1537,23 +1531,24 @@ CONTAINS
             ELSE
             num_ij_blocks = PRODUCT(homo/best_block_size)
             END IF
-            IF (num_IJ_blocks > ngroup .OR. best_block_size == 1) THEN
+            ! Enforce at least one large block for each subgroup
+            IF ((num_IJ_blocks >= ngroup .AND. num_IJ_blocks > 0) .OR. best_block_size == 1) THEN
                EXIT
             ELSE
                best_block_size = best_block_size - 1
             END IF
          END DO
-      END IF
 
-      IF (SIZE(homo) == 1) THEN
-      IF (my_open_shell_ss) THEN
-         ! check that best_block_size is not bigger than sqrt(homo-1)
-         ! Diagonal elements do not have to be considered
-         best_block_size = MIN(FLOOR(SQRT(REAL(homo(1) - 1, KIND=dp))), best_block_size)
-      ELSE
-         ! check that best_block_size is not bigger than sqrt(homo)
-         best_block_size = MIN(FLOOR(SQRT(REAL(homo(1), KIND=dp))), best_block_size)
-      END IF
+         IF (SIZE(homo) == 1) THEN
+         IF (my_open_shell_ss) THEN
+            ! check that best_block_size is not bigger than sqrt(homo-1)
+            ! Diagonal elements do not have to be considered
+            best_block_size = MIN(FLOOR(SQRT(REAL(homo(1) - 1, KIND=dp))), best_block_size)
+         ELSE
+            ! check that best_block_size is not bigger than sqrt(homo)
+            best_block_size = MIN(FLOOR(SQRT(REAL(homo(1), KIND=dp))), best_block_size)
+         END IF
+         END IF
       END IF
       block_size = best_block_size
 
@@ -1562,6 +1557,13 @@ CONTAINS
             "RI_INFO| Block size:", block_size
          CALL m_flush(unit_nr)
       END IF
+
+      ! Determine recv buffer size (BI_C_recv, external_i_aL, external_ab)
+      buffer_size = MAX(INT(maxsize(gd_array), KIND=int_8)*block_size, INT(MAX(dimen_RI, MAXVAL(virtual)), KIND=int_8)) &
+                    *MAXVAL(maxsize(gd_B_virtual))
+      ! The send buffer has the same size as the recv buffer
+      IF (calc_forces) buffer_size = buffer_size*2
+      ALLOCATE (buffer_1D(buffer_size))
 
       CALL timestop(handle)
 
@@ -1595,12 +1597,13 @@ CONTAINS
 !> \param ispin ...
 !> \param jspin ...
 !> \param dgemm_counter ...
+!> \param buffer_1D ...
 ! **************************************************************************************************
    SUBROUTINE mp2_update_P_gamma(mp2_env, para_env_sub, gd_B_virtual, &
                                  Eigenval, homo, dimen_RI, iiB, jjB, my_B_size, &
                                  my_B_virtual_end, my_B_virtual_start, my_i, my_j, virtual, sub_proc_map, local_ab, &
                                  t_ab, my_local_i_aL, my_local_j_aL, open_ss, Y_i_aP, Y_j_aP, &
-                                 local_ba, ispin, jspin, dgemm_counter)
+                                 local_ba, ispin, jspin, dgemm_counter, buffer_1D)
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
       TYPE(group_dist_d1_type), DIMENSION(:), INTENT(IN) :: gd_B_virtual
@@ -1621,15 +1624,16 @@ CONTAINS
          TARGET                                          :: Y_i_aP, Y_j_aP, local_ba
       INTEGER, INTENT(IN)                                :: ispin, jspin
       TYPE(dgemm_counter_type), INTENT(INOUT)            :: dgemm_counter
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:), TARGET    :: buffer_1D
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_update_P_gamma'
 
       INTEGER :: a, b, b_global, handle, proc_receive, proc_send, proc_shift, rec_B_size, &
          rec_B_virtual_end, rec_B_virtual_start, send_B_size, send_B_virtual_end, &
          send_B_virtual_start
+      INTEGER(KIND=int_8)                                :: offset
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          POINTER                                         :: external_ab, send_ab
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: buffer_1D, buffer_2_1D
       REAL(KIND=dp)                                      :: factor, P_ij_diag
       LOGICAL                                            :: alpha_beta
 
@@ -1707,10 +1711,6 @@ CONTAINS
          mp2_env%ri_grad%P_ij(ispin)%array(my_j + jjB - 1, my_j + jjB - 1) = &
             mp2_env%ri_grad%P_ij(ispin)%array(my_j + jjB - 1, my_j + jjB - 1) + P_ij_diag
       END IF
-      IF (para_env_sub%num_pe > 1) THEN
-         ALLOCATE (buffer_1D(INT(MAX(MAXVAL(virtual), dimen_RI), int_8)*MAXVAL(maxsize(gd_B_virtual))))
-         ALLOCATE (buffer_2_1D(INT(MAXVAL(maxsize(gd_B_virtual)), KIND=int_8)*MAX(MAXVAL(virtual), dimen_RI)))
-      END IF
       DO proc_shift = 1, para_env_sub%num_pe - 1
          proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
          proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
@@ -1756,7 +1756,9 @@ CONTAINS
                buffer_1D(1:INT(virtual(ispin), int_8)*my_B_size(ispin))
             external_ab = 0.0_dp
 
-            send_ab(1:send_B_size, 1:virtual(ispin)) => buffer_2_1D(1:INT(send_B_size, int_8)*virtual(ispin))
+            offset = INT(virtual(ispin), int_8)*my_B_size(ispin)
+
+            send_ab(1:send_B_size, 1:virtual(ispin)) => buffer_1D(offset + 1:offset + INT(send_B_size, int_8)*virtual(ispin))
             send_ab = 0.0_dp
 
             CALL offload_dgemm('N', 'T', send_B_size, virtual(ispin), my_B_size(ispin), 1.0_dp, &
@@ -1805,6 +1807,8 @@ CONTAINS
       IF (para_env_sub%num_pe > 1) THEN
          external_ab(1:my_B_size(ispin), 1:dimen_RI) => buffer_1D(1:INT(my_B_size(ispin), int_8)*dimen_RI)
          external_ab = 0.0_dp
+
+         offset = INT(my_B_size(ispin), int_8)*dimen_RI
       END IF
       !
       DO proc_shift = 1, para_env_sub%num_pe - 1
@@ -1814,7 +1818,7 @@ CONTAINS
          CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
          CALL get_group_dist(gd_B_virtual(ispin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
 
-         send_ab(1:send_B_size, 1:dimen_RI) => buffer_2_1D(1:INT(dimen_RI, int_8)*send_B_size)
+         send_ab(1:send_B_size, 1:dimen_RI) => buffer_1D(offset + 1:offset + INT(dimen_RI, int_8)*send_B_size)
          send_ab = 0.0_dp
          IF (.NOT. alpha_beta) THEN
             CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), 1.0_dp, &
@@ -1841,13 +1845,15 @@ CONTAINS
          IF (para_env_sub%num_pe > 1) THEN
             external_ab(1:my_B_size(jspin), 1:dimen_RI) => buffer_1D(1:INT(my_B_size(jspin), int_8)*dimen_RI)
             external_ab = 0.0_dp
+
+            offset = INT(my_B_size(jspin), int_8)*dimen_RI
          END IF
          DO proc_shift = 1, para_env_sub%num_pe - 1
             proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
             proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
 
             CALL get_group_dist(gd_B_virtual(jspin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
-            send_ab(1:send_B_size, 1:dimen_RI) => buffer_2_1D(1:INT(dimen_RI, int_8)*send_B_size)
+            send_ab(1:send_B_size, 1:dimen_RI) => buffer_1D(offset + 1:offset + INT(dimen_RI, int_8)*send_B_size)
             send_ab = 0.0_dp
             CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), mp2_env%scale_S, &
                                local_ba(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
@@ -1863,7 +1869,6 @@ CONTAINS
       ELSE
          CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), dimen_RI, my_B_size(ispin))
       END IF
-      IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_2_1D)
 
       IF ((my_i /= my_j) .AND. (.NOT. alpha_beta)) THEN
          ! Alpha-alpha, beta-beta and closed shell
@@ -1892,7 +1897,6 @@ CONTAINS
 
          CALL dgemm_counter_stop(dgemm_counter, my_B_size(ispin), dimen_RI, virtual(ispin))
       END IF
-      IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_1D)
 
       CALL timestop(handle)
    END SUBROUTINE mp2_update_P_gamma
@@ -1917,12 +1921,13 @@ CONTAINS
 !> \param para_env_exchange ...
 !> \param sizes_array ...
 !> \param spin ...
+!> \param buffer_1D ...
 ! **************************************************************************************************
    SUBROUTINE mp2_redistribute_gamma(Gamma_P_ia, ij_index, my_B_size, &
                                      my_block_size, my_group_L_size, my_i, my_ij_pairs, ngroup, &
                                      num_integ_group, integ_group_pos2color_sub, num_ij_pairs, proc_map, &
                                      ij_map, ranges_info_array, Y_i_aP, para_env_exchange, &
-                                     sizes_array, spin)
+                                     sizes_array, spin, buffer_1D)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT)   :: Gamma_P_ia
       INTEGER, INTENT(IN)                                :: ij_index, my_B_size, my_block_size, &
@@ -1937,12 +1942,13 @@ CONTAINS
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_exchange
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: sizes_array
       INTEGER, INTENT(IN)                                :: spin
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:), TARGET    :: buffer_1D
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_redistribute_gamma'
 
       INTEGER :: end_point, handle, handle2, iiB, ij_counter_rec, irep, kkk, lll, Lstart_pos, &
          proc_receive, proc_send, proc_shift, rec_i, rec_ij_index, send_L_size, start_point, tag
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: BI_C_rec_1D, BI_C_send_1D
+      INTEGER(KIND=int_8)                                :: offset
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: BI_C_rec, BI_C_send
 
@@ -1976,10 +1982,6 @@ CONTAINS
          CALL timestop(handle2)
 
          ! Y_i_aP(my_B_size,dimen_RI,block_size)
-         IF (para_env_exchange%num_pe > 1) THEN
-            ALLOCATE (BI_C_send_1D(INT(my_B_size, int_8)*my_block_size*MAXVAL(sizes_array)))
-            ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
-         END IF
 
          DO proc_shift = 1, para_env_exchange%num_pe - 1
             proc_send = proc_map(para_env_exchange%mepos + proc_shift)
@@ -1987,7 +1989,10 @@ CONTAINS
 
             send_L_size = sizes_array(proc_send)
             BI_C_send(1:my_B_size, 1:my_block_size, 1:send_L_size) => &
-               BI_C_send_1D(1:INT(my_B_size, int_8)*my_block_size*send_L_size)
+               buffer_1D(1:INT(my_B_size, int_8)*my_block_size*send_L_size)
+
+            offset = INT(my_B_size, int_8)*my_block_size*send_L_size
+
             CALL timeset(routineN//"_comm2_w", handle2)
             BI_C_send = 0.0_dp
             DO irep = 0, num_integ_group - 1
@@ -2017,7 +2022,7 @@ CONTAINS
                rec_i = ij_map(spin, ij_counter_rec)
 
                BI_C_rec(1:my_B_size, 1:my_block_size, 1:my_group_L_size) => &
-                  BI_C_rec_1D(1:INT(my_B_size, int_8)*my_block_size*my_group_L_size)
+                  buffer_1D(offset + 1:offset + INT(my_B_size, int_8)*my_block_size*my_group_L_size)
                BI_C_rec = 0.0_dp
 
                CALL mp_sendrecv(BI_C_send, proc_send, &
@@ -2045,10 +2050,7 @@ CONTAINS
 
          END DO
 
-         IF (para_env_exchange%num_pe > 1) DEALLOCATE (BI_C_send_1D, BI_C_rec_1D)
-
       ELSE
-         IF (para_env_exchange%num_pe > 1) ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
          ! noting to send check if we have to receive
          DO proc_shift = 1, para_env_exchange%num_pe - 1
             proc_send = proc_map(para_env_exchange%mepos + proc_shift)
@@ -2063,7 +2065,7 @@ CONTAINS
                rec_i = ij_map(spin, ij_counter_rec)
 
                BI_C_rec(1:my_B_size, 1:my_block_size, 1:my_group_L_size) => &
-                  BI_C_rec_1D(1:INT(my_B_size, int_8)*my_block_size*my_group_L_size)
+                  buffer_1D(1:INT(my_B_size, int_8)*my_block_size*my_group_L_size)
 
                BI_C_rec = 0.0_dp
 
@@ -2084,8 +2086,6 @@ CONTAINS
 
             END IF
          END DO
-
-         IF (para_env_exchange%num_pe > 1) DEALLOCATE (BI_C_rec_1D)
 
       END IF
       CALL timestop(handle)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -1239,7 +1239,7 @@ CONTAINS
                                                             max_repl_group_size, &
                                                             min_integ_group_size
       INTEGER(KIND=int_8)                                :: mem
-      REAL(KIND=dp)                                      :: mem_base, mem_min, mem_per_blk, &
+      REAL(KIND=dp)                                      :: factor, mem_base, mem_min, mem_per_blk, &
                                                             mem_per_repl, mem_per_repl_blk, &
                                                             mem_real
 
@@ -1293,23 +1293,47 @@ CONTAINS
 
       mem_real = mp2_env%mp2_memory
 
-      ! here we try to find the best block_size and integ_group_size
-      integ_group_size = ngroup
-      ! Remove the fixed memory and divide by the memory per replication group size
-      max_repl_group_size = MIN(MAX(FLOOR((mem_real - mem_base - mem_per_blk*block_size)/ &
-                                          (mem_per_repl + mem_per_repl_blk*block_size)), 1), ngroup)
-      ! Convert to an integration group size
-      min_integ_group_size = ngroup/max_repl_group_size
+      ! We use the following communication model
+      ! Comm(replication)+Comm(collection of data for ij pair)+Comm(contraction)
+      ! One can show that the costs of the contraction step are independent of the block size and the replication group size
+      ! With gradients, both steps are carried out twice (Y_i_aP -> Gamma_i_aP, and dereplication)
+      ! NL ... number of RI basis functions
+      ! NR ... replication group size
+      ! NG ... number of sub groups
+      ! NB ... Block size
+      ! o  ... number of occupied orbitals
+      ! Then, we have the communication costs (in multiples of the original BIb_C matrix)
+      ! (NR/NG)+(1-(NR/NG))*(o/NB+NB-2)/NG = (NR/NG)*(1-(o/NB+NB-2)/NG)+(o/NB+NB-2)/NG
+      ! and with gradients
+      ! 2*(NR/NG)+2*(1-(NR/NG))*(o/NB+NB-2)/NG = (NR/NG)*(1-(o/NB+NB-2)/NG)+(o/NB+NB-2)/NG
+      ! We are looking for the minimum of the communication volume,
+      ! thus, if the prefactor of (NR/NG) is smaller than zero, use the largest possible replication group size.
+      ! If the factor is larger than zero, set the replicaiton group size to 1. (For small systems and a large number of subgroups)
+      ! Replication group size = 1 implies that the integration group size equals the number of subgroups
 
-      ! Ensure that the integration group size is a divisor of the number of sub groups
-      DO iiB = MAX(MIN(min_integ_group_size, ngroup), 1), ngroup
-         ! check that the ngroup is a multiple of  integ_group_size
-         IF (MOD(ngroup, iiB) == 0) THEN
-            integ_group_size = iiB
-            EXIT
-         END IF
-         integ_group_size = integ_group_size + 1
-      END DO
+      integ_group_size = ngroup
+
+      factor = REAL(SUM(homo*virtual), KIND=dp) &
+               - SUM((REAL(MAXVAL(homo), KIND=dp)/block_size + block_size - 2.0_dp)*homo*virtual)/ngroup
+      IF (SIZE(homo) == 2) factor = factor - 2.0_dp*PRODUCT(homo)/block_size/ngroup*SUM(homo*virtual)
+
+      IF (factor <= 0.0_dp) THEN
+         ! Remove the fixed memory and divide by the memory per replication group size
+         max_repl_group_size = MIN(MAX(FLOOR((mem_real - mem_base - mem_per_blk*block_size)/ &
+                                             (mem_per_repl + mem_per_repl_blk*block_size)), 1), ngroup)
+         ! Convert to an integration group size
+         min_integ_group_size = ngroup/max_repl_group_size
+
+         ! Ensure that the integration group size is a divisor of the number of sub groups
+         DO iiB = MAX(MIN(min_integ_group_size, ngroup), 1), ngroup
+            ! check that the ngroup is a multiple of  integ_group_size
+            IF (MOD(ngroup, iiB) == 0) THEN
+               integ_group_size = iiB
+               EXIT
+            END IF
+            integ_group_size = integ_group_size + 1
+         END DO
+      END IF
 
       IF (unit_nr > 0) THEN
          WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -208,7 +208,7 @@ CONTAINS
                homo(ispin), dimen_RI, unit_nr, block_size, &
                ngroup, num_IJ_blocks, &
                virtual(ispin), my_alpha_beta_case, &
-               my_open_shell_SS, calc_forces)
+               calc_forces)
 
             ! *****************************************************************
             ! **********  REPLICATION-BLOCKED COMMUNICATION SCHEME  ***********
@@ -952,8 +952,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_communication'
 
       INTEGER :: assigned_blocks, first_I_block, first_J_block, handle, iiB, ij_block_counter, &
-         ij_counter, jjB, last_i_block, last_J_block, num_block_per_group, total_ij_block, &
-         total_ij_pairs_blocks
+         ij_counter, jjB, last_i_block, last_J_block, num_block_per_group, num_IJ_blocks_beta, &
+         total_ij_block, total_ij_pairs_blocks
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: ij_marker
 
 ! Calculate the maximum number of ij pairs that have to be computed
@@ -961,7 +961,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      IF (.NOT. my_alpha_beta_case) THEN
+      IF (.NOT. my_open_shell_ss .AND. .NOT. my_alpha_beta_case) THEN
          total_ij_pairs = homo*(1 + homo)/2
          num_IJ_blocks = homo/block_size - 1
 
@@ -1014,36 +1014,126 @@ CONTAINS
          END DO
          DEALLOCATE (ij_marker)
 
-         IF ((.NOT. my_open_shell_SS)) THEN
-            IF (unit_nr > 0) THEN
-               IF (block_size == 1) THEN
-                  WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.1)") &
-                     "RI_INFO| Percentage of ij pairs communicated with block size 1:", 100.0_dp
-               ELSE
-                  WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.1)") &
-                     "RI_INFO| Percentage of ij pairs communicated with block size 1:", &
-                     100.0_dp*REAL((total_ij_pairs - assigned_blocks*(block_size**2)), KIND=dp)/REAL(total_ij_pairs, KIND=dp)
-               END IF
-               CALL m_flush(unit_nr)
-            END IF
-         END IF
+      ELSE IF (.NOT. my_alpha_beta_case) THEN
+         ! THese are the cases alpha/alpha and beta/beta
+         ! We do not have to consider the diagonal elements
+         total_ij_pairs = homo*(homo - 1)/2
+         num_IJ_blocks = (homo - 1)/block_size - 1
 
-      ELSE
-         ! alpha-beta case no index symmetry
-         total_ij_pairs = homo*homo_beta
-         ALLOCATE (ij_map(3, total_ij_pairs))
+         first_I_block = 1
+         last_i_block = block_size*(num_IJ_blocks - 1)
+
+         first_J_block = block_size + 1
+         last_J_block = block_size*(num_IJ_blocks + 1) + 1
+
+         ij_block_counter = 0
+         DO iiB = first_I_block, last_i_block, block_size
+            DO jjB = iiB + block_size, last_J_block, block_size
+               ij_block_counter = ij_block_counter + 1
+            END DO
+         END DO
+
+         total_ij_block = ij_block_counter
+         num_block_per_group = total_ij_block/ngroup
+         assigned_blocks = num_block_per_group*ngroup
+
+         total_ij_pairs_blocks = assigned_blocks + (total_ij_pairs - assigned_blocks*(block_size**2))
+
+         ALLOCATE (ij_marker(homo, homo))
+         ij_marker = 0
+         ALLOCATE (ij_map(3, total_ij_pairs_blocks))
          ij_map = 0
          ij_counter = 0
          my_ij_pairs = 0
-         DO iiB = 1, homo
-            DO jjB = 1, homo_beta
+         DO iiB = first_I_block, last_i_block, block_size
+            DO jjB = iiB + block_size, last_J_block, block_size
+               IF (ij_counter + 1 > assigned_blocks) EXIT
                ij_counter = ij_counter + 1
+               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = 1
                ij_map(1, ij_counter) = iiB
                ij_map(2, ij_counter) = jjB
-               ij_map(3, ij_counter) = 1
+               ij_map(3, ij_counter) = block_size
                IF (MOD(ij_counter, ngroup) == color_sub) my_ij_pairs = my_ij_pairs + 1
             END DO
          END DO
+         DO iiB = 1, homo
+            DO jjB = iiB + 1, homo
+               IF (ij_marker(iiB, jjB) == 0) THEN
+                  ij_counter = ij_counter + 1
+                  ij_map(1, ij_counter) = iiB
+                  ij_map(2, ij_counter) = jjB
+                  ij_map(3, ij_counter) = 1
+                  IF (MOD(ij_counter, ngroup) == color_sub) my_ij_pairs = my_ij_pairs + 1
+               END IF
+            END DO
+         END DO
+         DEALLOCATE (ij_marker)
+
+      ELSE
+         total_ij_pairs = homo*homo_beta
+         num_IJ_blocks = homo/block_size
+         num_IJ_blocks_beta = homo_beta/block_size
+
+         first_I_block = 1
+         last_i_block = block_size*(num_IJ_blocks - 1)
+
+         first_J_block = 1
+         last_J_block = block_size*(num_IJ_blocks_beta - 1)
+
+         ij_block_counter = 0
+         DO iiB = first_I_block, last_i_block, block_size
+            DO jjB = iiB + block_size, last_J_block, block_size
+               ij_block_counter = ij_block_counter + 1
+            END DO
+         END DO
+
+         total_ij_block = ij_block_counter
+         num_block_per_group = total_ij_block/ngroup
+         assigned_blocks = num_block_per_group*ngroup
+
+         total_ij_pairs_blocks = assigned_blocks + (total_ij_pairs - assigned_blocks*(block_size**2))
+
+         ALLOCATE (ij_marker(homo, homo_beta))
+         ij_marker = 0
+         ALLOCATE (ij_map(3, total_ij_pairs_blocks))
+         ij_map = 0
+         ij_counter = 0
+         my_ij_pairs = 0
+         DO iiB = first_I_block, last_i_block, block_size
+            DO jjB = first_J_block, last_J_block, block_size
+               IF (ij_counter + 1 > assigned_blocks) EXIT
+               ij_counter = ij_counter + 1
+               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = 1
+               ij_map(1, ij_counter) = iiB
+               ij_map(2, ij_counter) = jjB
+               ij_map(3, ij_counter) = block_size
+               IF (MOD(ij_counter, ngroup) == color_sub) my_ij_pairs = my_ij_pairs + 1
+            END DO
+         END DO
+         DO iiB = 1, homo
+            DO jjB = 1, homo_beta
+               IF (ij_marker(iiB, jjB) == 0) THEN
+                  ij_counter = ij_counter + 1
+                  ij_map(1, ij_counter) = iiB
+                  ij_map(2, ij_counter) = jjB
+                  ij_map(3, ij_counter) = 1
+                  IF (MOD(ij_counter, ngroup) == color_sub) my_ij_pairs = my_ij_pairs + 1
+               END IF
+            END DO
+         END DO
+         DEALLOCATE (ij_marker)
+      END IF
+
+      IF (unit_nr > 0) THEN
+         IF (block_size == 1) THEN
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.1)") &
+               "RI_INFO| Percentage of ij pairs communicated with block size 1:", 100.0_dp
+         ELSE
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.1)") &
+               "RI_INFO| Percentage of ij pairs communicated with block size 1:", &
+               100.0_dp*REAL((total_ij_pairs - assigned_blocks*(block_size**2)), KIND=dp)/REAL(total_ij_pairs, KIND=dp)
+         END IF
+         CALL m_flush(unit_nr)
       END IF
 
       CALL timestop(handle)
@@ -1362,22 +1452,20 @@ CONTAINS
 !> \param num_IJ_blocks ...
 !> \param virtual ...
 !> \param my_alpha_beta_case ...
-!> \param my_open_shell_SS ...
 !> \param calc_forces ...
 ! **************************************************************************************************
    SUBROUTINE mp2_ri_get_block_size(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
                                     homo, dimen_RI, unit_nr, &
                                     block_size, ngroup, num_IJ_blocks, &
                                     virtual, my_alpha_beta_case, &
-                                    my_open_shell_SS, calc_forces)
+                                    calc_forces)
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array, gd_B_virtual
       INTEGER, INTENT(IN)                                :: homo, dimen_RI, unit_nr
       INTEGER, INTENT(OUT)                               :: block_size, ngroup, num_IJ_blocks
       INTEGER, INTENT(IN)                                :: virtual
-      LOGICAL, INTENT(IN)                                :: my_alpha_beta_case, my_open_shell_SS, &
-                                                            calc_forces
+      LOGICAL, INTENT(IN)                                :: my_alpha_beta_case, calc_forces
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_get_block_size'
 
@@ -1432,37 +1520,29 @@ CONTAINS
 
       best_block_size = 1
 
-      ! in the open shell case no replication and no block communication is done
-      IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
-         ! Here we split the memory half for the communication, half for replication
-         IF (mp2_env%ri_mp2%block_size > 0) THEN
-            best_block_size = mp2_env%ri_mp2%block_size
-         END IF
-
-         IF (.NOT. (mp2_env%ri_mp2%block_size > 0)) THEN
-            DO
-               num_IJ_blocks = (homo/best_block_size)
-               num_IJ_blocks = (num_IJ_blocks*num_IJ_blocks - num_IJ_blocks)/2
-               IF (num_IJ_blocks > ngroup .OR. best_block_size == 1) THEN
-                  EXIT
-               ELSE
-                  best_block_size = best_block_size - 1
-               END IF
-            END DO
-         END IF
-
-         ! check that best_block_size is not bigger than homo/2-1
-         best_block_size = MIN(MAX(homo/2 - 1 + MOD(homo, 2), 1), best_block_size)
+      ! Here we split the memory half for the communication, half for replication
+      IF (mp2_env%ri_mp2%block_size > 0) THEN
+         best_block_size = mp2_env%ri_mp2%block_size
+      ELSE
+         DO
+            num_IJ_blocks = (homo/best_block_size)
+            num_IJ_blocks = (num_IJ_blocks*num_IJ_blocks - num_IJ_blocks)/2
+            IF (num_IJ_blocks > ngroup .OR. best_block_size == 1) THEN
+               EXIT
+            ELSE
+               best_block_size = best_block_size - 1
+            END IF
+         END DO
       END IF
 
+      ! check that best_block_size is not bigger than homo/2-1
+      best_block_size = MIN(MAX(homo/2 - 1 + MOD(homo, 2), 1), best_block_size)
       block_size = best_block_size
 
-      IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
-         IF (unit_nr > 0) THEN
-            WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
-               "RI_INFO| Block size:", block_size
-            CALL m_flush(unit_nr)
-         END IF
+      IF (unit_nr > 0) THEN
+         WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
+            "RI_INFO| Block size:", block_size
+         CALL m_flush(unit_nr)
       END IF
 
       CALL timestop(handle)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -456,7 +456,8 @@ CONTAINS
                                     END IF
                                  END DO
                               END DO
-                      IF (para_env_sub%num_pe > 1) ALLOCATE (buffer_1D(1:INT(my_B_size(ispin), int_8)*maxsize(gd_B_virtual(ispin))))
+                              IF (para_env_sub%num_pe > 1) &
+                                 ALLOCATE (buffer_1D(1:INT(my_B_size(ispin), int_8)*maxsize(gd_B_virtual(ispin))))
                               ! ... and then with external data
                               DO proc_shift = 1, para_env_sub%num_pe - 1
                                  proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
@@ -1704,7 +1705,7 @@ CONTAINS
       END IF
       IF (para_env_sub%num_pe > 1) THEN
          ALLOCATE (buffer_1D(INT(MAX(MAXVAL(virtual), dimen_RI), int_8)*MAXVAL(maxsize(gd_B_virtual))))
-         ALLOCATE (buffer_2_1D(INT(MAXVAL(maxsize(gd_B_virtual)), KIND=int_8)*MAXVAL(virtual)))
+         ALLOCATE (buffer_2_1D(INT(MAXVAL(maxsize(gd_B_virtual)), KIND=int_8)*MAX(MAXVAL(virtual), dimen_RI)))
       END IF
       DO proc_shift = 1, para_env_sub%num_pe - 1
          proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
@@ -1776,7 +1777,6 @@ CONTAINS
       ELSE
          CALL dgemm_counter_stop(dgemm_counter, SUM(my_B_size), virtual(ispin), virtual(jspin))
       END IF
-      IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_2_1D)
       CALL timestop(handle)
 
       ! Now, Gamma_P_ia (made of Y_ia_P)
@@ -1801,8 +1801,6 @@ CONTAINS
       IF (para_env_sub%num_pe > 1) THEN
          external_ab(1:my_B_size(ispin), 1:dimen_RI) => buffer_1D(1:INT(my_B_size(ispin), int_8)*dimen_RI)
          external_ab = 0.0_dp
-
-         ALLOCATE (buffer_2_1D(INT(MAXVAL(maxsize(gd_B_virtual)), KIND=int_8)*dimen_RI))
       END IF
       !
       DO proc_shift = 1, para_env_sub%num_pe - 1
@@ -1975,8 +1973,10 @@ CONTAINS
          CALL timestop(handle2)
 
          ! Y_i_aP(my_B_size,dimen_RI,block_size)
-         ALLOCATE (BI_C_send_1D(INT(my_B_size, int_8)*my_block_size*MAXVAL(sizes_array)))
-         ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
+         IF (para_env_exchange%num_pe > 1) THEN
+            ALLOCATE (BI_C_send_1D(INT(my_B_size, int_8)*my_block_size*MAXVAL(sizes_array)))
+            ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
+         END IF
 
          DO proc_shift = 1, para_env_exchange%num_pe - 1
             proc_send = proc_map(para_env_exchange%mepos + proc_shift)
@@ -2042,10 +2042,10 @@ CONTAINS
 
          END DO
 
-         DEALLOCATE (BI_C_send_1D, BI_C_rec_1D)
+         IF (para_env_exchange%num_pe > 1) DEALLOCATE (BI_C_send_1D, BI_C_rec_1D)
 
       ELSE
-         ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
+         IF (para_env_exchange%num_pe > 1) ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
          ! noting to send check if we have to receive
          DO proc_shift = 1, para_env_exchange%num_pe - 1
             proc_send = proc_map(para_env_exchange%mepos + proc_shift)
@@ -2082,7 +2082,7 @@ CONTAINS
             END IF
          END DO
 
-         DEALLOCATE (BI_C_rec_1D)
+         IF (para_env_exchange%num_pe > 1) DEALLOCATE (BI_C_rec_1D)
 
       END IF
       CALL timestop(handle)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -1389,8 +1389,6 @@ CONTAINS
       IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'RI_INFO| Minimum required memory per MPI process:', &
          mem_min, ' MiB'
 
-      mem_real = MIN(mem_real, mp2_env%mp2_memory)
-
       ! We use the following communication model
       ! Comm(replication)+Comm(collection of data for ij pair)+Comm(contraction)
       ! One can show that the costs of the contraction step are independent of the block size and the replication group size
@@ -1947,7 +1945,9 @@ CONTAINS
       INTEGER :: end_point, handle, handle2, iiB, ij_counter_rec, irep, kkk, lll, Lstart_pos, &
          proc_receive, proc_send, proc_shift, rec_block_size, rec_i, rec_ij_index, send_L_size, &
          start_point, tag
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: BI_C_rec, BI_C_send
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: BI_C_rec_1D, BI_C_send_1D
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
+         POINTER                                         :: BI_C_rec, BI_C_send
 
 ! In alpha-beta case Y_i_aP_beta is sent as Y_j_aP
 
@@ -1979,13 +1979,16 @@ CONTAINS
          CALL timestop(handle2)
 
          ! Y_i_aP(my_B_size,dimen_RI,block_size)
+         ALLOCATE (BI_C_send_1D(INT(my_B_size, int_8)*my_block_size*MAXVAL(sizes_array)))
+         ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
 
          DO proc_shift = 1, para_env_exchange%num_pe - 1
             proc_send = proc_map(para_env_exchange%mepos + proc_shift)
             proc_receive = proc_map(para_env_exchange%mepos - proc_shift)
 
             send_L_size = sizes_array(proc_send)
-            ALLOCATE (BI_C_send(my_B_size, my_block_size, send_L_size))
+            BI_C_send(1:my_B_size, 1:my_block_size, 1:send_L_size) => &
+               BI_C_send_1D(1:INT(my_B_size, int_8)*my_block_size*send_L_size)
             CALL timeset(routineN//"_comm2_w", handle2)
             BI_C_send = 0.0_dp
             DO irep = 0, num_integ_group - 1
@@ -2015,7 +2018,8 @@ CONTAINS
                rec_i = ij_map(spin, ij_counter_rec)
                rec_block_size = ij_map(3, ij_counter_rec)
 
-               ALLOCATE (BI_C_rec(my_B_size, rec_block_size, my_group_L_size))
+               BI_C_rec(1:my_B_size, 1:rec_block_size, 1:my_group_L_size) => &
+                  BI_C_rec_1D(1:INT(my_B_size, int_8)*rec_block_size*my_group_L_size)
                BI_C_rec = 0.0_dp
 
                CALL mp_sendrecv(BI_C_send, proc_send, &
@@ -2035,18 +2039,18 @@ CONTAINS
                END DO
                CALL timestop(handle2)
 
-               DEALLOCATE (BI_C_rec)
-
             ELSE
                ! we have something to send but nothing to receive
                CALL mp_send(BI_C_send, proc_send, tag, para_env_exchange%group)
 
             END IF
 
-            DEALLOCATE (BI_C_send)
          END DO
 
+         DEALLOCATE (BI_C_send_1D, BI_C_rec_1D)
+
       ELSE
+         ALLOCATE (BI_C_rec_1D(INT(my_B_size, int_8)*my_block_size*my_group_L_size))
          ! noting to send check if we have to receive
          DO proc_shift = 1, para_env_exchange%num_pe - 1
             proc_send = proc_map(para_env_exchange%mepos + proc_shift)
@@ -2061,7 +2065,8 @@ CONTAINS
                rec_i = ij_map(spin, ij_counter_rec)
                rec_block_size = ij_map(3, ij_counter_rec)
 
-               ALLOCATE (BI_C_rec(my_B_size, rec_block_size, my_group_L_size))
+               BI_C_rec(1:my_B_size, 1:rec_block_size, 1:my_group_L_size) => &
+                  BI_C_rec_1D(1:INT(my_B_size, int_8)*rec_block_size*my_group_L_size)
 
                BI_C_rec = 0.0_dp
 
@@ -2080,10 +2085,10 @@ CONTAINS
                END DO
                CALL timestop(handle2)
 
-               DEALLOCATE (BI_C_rec)
-
             END IF
          END DO
+
+         DEALLOCATE (BI_C_rec_1D)
 
       END IF
       CALL timestop(handle)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -180,7 +180,7 @@ CONTAINS
       tag = 42
 
       DO jspin = 1, nspins
-      DO ispin = jspin, 1, -1
+      DO ispin = 1, jspin
 
          my_open_shell_SS = (nspins == 2) .AND. (ispin == jspin)
 
@@ -204,7 +204,7 @@ CONTAINS
          DO kspin = ispin, jspin
          IF (.NOT. replicated(kspin)) THEN
             CALL replicate_iaK_2intgroup(BIb_C(kspin)%array, para_env_exchange, para_env_rep, &
-                                         homo(ispin), proc_map_rep, gd_array%sizes, my_B_size(kspin), &
+                                         homo(kspin), proc_map_rep, gd_array%sizes, my_B_size(kspin), &
                                          my_group_L_size, ranges_info_array)
             replicated(kspin) = .TRUE.
          END IF
@@ -617,7 +617,7 @@ CONTAINS
 
          ! Remove replication from BIb_C and reorder the matrix
          my_group_L_size = my_group_L_size_orig
-         ALLOCATE (B_ia_Q(ispin:jspin))
+         ALLOCATE (B_ia_Q(nspins))
          DO ispin = 1, nspins
             ALLOCATE (B_ia_Q(ispin)%array(homo(ispin), my_B_size(ispin), my_group_L_size))
             B_ia_Q(ispin)%array = 0.0_dp
@@ -856,14 +856,20 @@ CONTAINS
       local_ab = 0.0_dp
 
       IF (calc_forces) THEN
-         IF (ispin == jspin) THEN
-            ALLOCATE (mp2_env%ri_grad%P_ij(ispin)%array(homo(ispin), homo(ispin)))
-            mp2_env%ri_grad%P_ij(ispin)%array = 0.0_dp
-            ALLOCATE (mp2_env%ri_grad%P_ab(ispin)%array(my_B_size(ispin), virtual(ispin)))
-            mp2_env%ri_grad%P_ab(ispin)%array = 0.0_dp
-            ALLOCATE (mp2_env%ri_grad%Gamma_P_ia(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size))
-            mp2_env%ri_grad%Gamma_P_ia(ispin)%array = 0.0_dp
+         IF (.NOT. ALLOCATED(mp2_env%ri_grad%P_ij(jspin)%array)) THEN
+            ALLOCATE (mp2_env%ri_grad%P_ij(jspin)%array(homo(ispin), homo(ispin)))
+            mp2_env%ri_grad%P_ij(jspin)%array = 0.0_dp
+         END IF
+         IF (.NOT. ALLOCATED(mp2_env%ri_grad%P_ab(jspin)%array)) THEN
+            ALLOCATE (mp2_env%ri_grad%P_ab(jspin)%array(my_B_size(jspin), virtual(jspin)))
+            mp2_env%ri_grad%P_ab(jspin)%array = 0.0_dp
+         END IF
+         IF (.NOT. ALLOCATED(mp2_env%ri_grad%Gamma_P_ia(jspin)%array)) THEN
+            ALLOCATE (mp2_env%ri_grad%Gamma_P_ia(jspin)%array(my_B_size(jspin), homo(jspin), my_group_L_size))
+            mp2_env%ri_grad%Gamma_P_ia(jspin)%array = 0.0_dp
+         END IF
 
+         IF (ispin == jspin) THEN
             ! For non-alpha-beta case we need amplitudes
             ALLOCATE (t_ab(virtual(ispin), my_B_size(jspin)))
 

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -574,6 +574,48 @@ CONTAINS
 
             END IF
 
+            ! Dereplicate BIb_C and Gamma_P_ia to save memory
+            ! These matrices will not be needed in that fashion anymore
+            ! B_ia_Q will needed later
+            IF (calc_forces .AND. jspin == nspins) THEN
+               IF (.NOT. ALLOCATED(B_ia_Q)) ALLOCATE (B_ia_Q(nspins))
+               ALLOCATE (B_ia_Q(ispin)%array(homo(ispin), my_B_size(ispin), my_group_L_size_orig))
+               B_ia_Q(ispin)%array = 0.0_dp
+               DO jjB = 1, homo(ispin)
+                  DO iiB = 1, my_B_size(ispin)
+                     B_ia_Q(ispin)%array(jjB, iiB, 1:my_group_L_size_orig) = &
+                        BIb_C(ispin)%array(1:my_group_L_size_orig, iiB, jjB)
+                  END DO
+               END DO
+               DEALLOCATE (BIb_C(ispin)%array)
+
+               ! sum Gamma and dereplicate
+               ALLOCATE (BIb_C(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size_orig))
+               DO proc_shift = 1, para_env_rep%num_pe - 1
+                  ! invert order
+                  proc_send = proc_map_rep(para_env_rep%mepos - proc_shift)
+                  proc_receive = proc_map_rep(para_env_rep%mepos + proc_shift)
+
+                  start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
+                  end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
+
+                  CALL mp_sendrecv(mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, start_point:end_point), &
+                                   proc_send, BIb_C(ispin)%array, proc_receive, para_env_rep%group, tag)
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) &
+!$OMP          SHARED(mp2_env,BIb_C,ispin,homo,my_B_size,my_group_L_size_orig)
+                  mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size_orig) = &
+                     mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size_orig) &
+                     + BIb_C(ispin)%array(:, :, :)
+!$OMP END PARALLEL WORKSHARE
+               END DO
+
+               BIb_C(ispin)%array(:, :, :) = mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size_orig)
+               DEALLOCATE (mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
+               CALL MOVE_ALLOC(BIb_C(ispin)%array, mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
+            ELSE IF (jspin == nspins) THEN
+               DEALLOCATE (BIb_C(ispin)%array)
+            END IF
+
             CALL mp_sum(my_Emp2_Cou, para_env%group)
             CALL mp_sum(my_Emp2_Ex, para_env%group)
 
@@ -593,7 +635,16 @@ CONTAINS
                Emp2_EX = Emp2_EX + my_Emp2_EX
             END IF
          END DO
+
       END DO
+
+      DEALLOCATE (integ_group_pos2color_sub)
+      DEALLOCATE (proc_map)
+      DEALLOCATE (proc_map_rep)
+      DEALLOCATE (ranges_info_array)
+
+      CALL cp_para_env_release(para_env_exchange)
+      CALL cp_para_env_release(para_env_rep)
 
       IF (calc_forces) THEN
          ! recover original information (before replication)
@@ -605,52 +656,6 @@ CONTAINS
 
          ! Remove replication from BIb_C and reorder the matrix
          my_group_L_size = my_group_L_size_orig
-         ALLOCATE (B_ia_Q(nspins))
-         DO ispin = 1, nspins
-            ALLOCATE (B_ia_Q(ispin)%array(homo(ispin), my_B_size(ispin), my_group_L_size))
-            B_ia_Q(ispin)%array = 0.0_dp
-            DO jjB = 1, homo(ispin)
-               DO iiB = 1, my_B_size(ispin)
-                  B_ia_Q(ispin)%array(jjB, iiB, 1:my_group_L_size) = &
-                     BIb_C(ispin)%array(1:my_group_L_size, iiB, jjB)
-               END DO
-            END DO
-            DEALLOCATE (BIb_C(ispin)%array)
-         END DO
-
-         ! sum Gamma and dereplicate
-         DO ispin = 1, nspins
-            ALLOCATE (BIb_C(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size))
-            DO proc_shift = 1, para_env_rep%num_pe - 1
-               ! invert order
-               proc_send = proc_map_rep(para_env_rep%mepos - proc_shift)
-               proc_receive = proc_map_rep(para_env_rep%mepos + proc_shift)
-
-               start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
-               end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
-
-               CALL mp_sendrecv(mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, start_point:end_point), &
-                                proc_send, BIb_C(ispin)%array, proc_receive, para_env_rep%group, tag)
-!$OMP PARALLEL WORKSHARE DEFAULT(NONE) &
-!$OMP          SHARED(mp2_env,BIb_C,ispin,homo,my_B_size,my_group_L_size)
-               mp2_env%ri_grad%Gamma_P_ia(ispin)%array(1:my_B_size(ispin), 1:homo(ispin), 1:my_group_L_size) = &
-                  mp2_env%ri_grad%Gamma_P_ia(ispin)%array(1:my_B_size(ispin), 1:homo(ispin), 1:my_group_L_size) &
-                  + BIb_C(ispin)%array(:, :, :)
-!$OMP END PARALLEL WORKSHARE
-            END DO
-
-            BIb_C(ispin)%array(:, :, :) = mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size)
-            DEALLOCATE (mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
-            CALL MOVE_ALLOC(BIb_C(ispin)%array, mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
-         END DO
-
-         DEALLOCATE (integ_group_pos2color_sub)
-         DEALLOCATE (proc_map)
-         DEALLOCATE (proc_map_rep)
-         DEALLOCATE (ranges_info_array)
-
-         CALL cp_para_env_release(para_env_exchange)
-         CALL cp_para_env_release(para_env_rep)
 
          ! B_ia_Q(ispin)%array will be deallocated inside of complete_gamma
          DO ispin = 1, nspins
@@ -671,15 +676,6 @@ CONTAINS
          END DO
          ! release para_env_P
          CALL cp_para_env_release(para_env_P)
-      ELSE
-
-         DEALLOCATE (integ_group_pos2color_sub)
-         DEALLOCATE (proc_map)
-         DEALLOCATE (proc_map_rep)
-         DEALLOCATE (ranges_info_array)
-
-         CALL cp_para_env_release(para_env_exchange)
-         CALL cp_para_env_release(para_env_rep)
       END IF
       DEALLOCATE (sub_proc_map)
 

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -103,15 +103,14 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_gpw_compute_en'
 
-      INTEGER :: a, a_global, b, b_global, best_block_size, best_integ_group_size, block_size, &
-         decil, end_point, handle, handle2, handle3, iiB, ij_counter, ij_counter_send, ij_index, &
-         integ_group_size, ispin, jjB, jspin, kspin, max_ij_pairs, min_integ_group_size, &
-         my_block_size, my_group_L_end, my_group_L_size, my_group_L_size_orig, my_group_L_start, &
-         my_i, my_ij_pairs, my_j, my_new_group_L_size, ngroup, nspins, num_IJ_blocks, &
-         num_integ_group, pos_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, &
-         rec_B_virtual_end, rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end
-      INTEGER :: send_B_virtual_start, send_block_size, send_i, send_ij_index, send_j, &
-         start_point, sub_P_color, sub_sub_color, tag, total_ij_pairs
+      INTEGER :: a, a_global, b, b_global, block_size, decil, end_point, handle, handle2, handle3, &
+         iiB, ij_counter, ij_counter_send, ij_index, integ_group_size, ispin, jjB, jspin, kspin, &
+         max_ij_pairs, my_block_size, my_group_L_end, my_group_L_size, my_group_L_size_orig, &
+         my_group_L_start, my_i, my_ij_pairs, my_j, my_new_group_L_size, ngroup, nspins, &
+         num_IJ_blocks, num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, &
+         rec_B_virtual_end, rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end, &
+         send_B_virtual_start, send_block_size, send_i, send_ij_index, send_j, start_point
+      INTEGER :: sub_P_color, sub_sub_color, tag, total_ij_pairs
       INTEGER, ALLOCATABLE, DIMENSION(:) :: integ_group_pos2color_sub, my_B_size, &
          my_B_virtual_end, my_B_virtual_start, num_ij_pairs, proc_map, proc_map_rep, &
          sizes_array_orig, sub_proc_map, virtual
@@ -182,12 +181,18 @@ CONTAINS
          amp_fac = mp2_env%scale_S + mp2_env%scale_T
          IF (my_alpha_beta_case .OR. my_open_shell_SS) amp_fac = mp2_env%scale_T
 
-         CALL mp2_ri_get_sizes( &
+         CALL mp2_ri_get_integ_group_size( &
             mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
-            homo(ispin), dimen_RI, unit_nr, color_sub, best_block_size, best_integ_group_size, block_size, &
-            integ_group_size, min_integ_group_size, &
+            homo(ispin), dimen_RI, unit_nr, &
+            integ_group_size, ngroup, &
+            num_integ_group, virtual(ispin), my_alpha_beta_case, &
+            my_open_shell_SS, calc_forces)
+
+         CALL mp2_ri_get_block_size( &
+            mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
+            homo(ispin), dimen_RI, unit_nr, block_size, &
             ngroup, num_IJ_blocks, &
-            num_integ_group, pos_integ_group, virtual(ispin), my_alpha_beta_case, &
+            virtual(ispin), my_alpha_beta_case, &
             my_open_shell_SS, calc_forces)
 
          ! now create a group that contains all the proc that have the same virtual starting point
@@ -1228,46 +1233,36 @@ CONTAINS
 !> \param homo ...
 !> \param dimen_RI ...
 !> \param unit_nr ...
-!> \param color_sub ...
-!> \param best_block_size ...
-!> \param best_integ_group_size ...
-!> \param block_size ...
 !> \param integ_group_size ...
-!> \param min_integ_group_size ...
 !> \param ngroup ...
-!> \param num_IJ_blocks ...
 !> \param num_integ_group ...
-!> \param pos_integ_group ...
 !> \param virtual ...
 !> \param my_alpha_beta_case ...
 !> \param my_open_shell_SS ...
 !> \param calc_forces ...
 ! **************************************************************************************************
-   SUBROUTINE mp2_ri_get_sizes(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
-                               homo, dimen_RI, unit_nr, color_sub, &
-                               best_block_size, best_integ_group_size, block_size, &
-                               integ_group_size, min_integ_group_size, &
-                               ngroup, num_IJ_blocks, num_integ_group, &
-                               pos_integ_group, virtual, my_alpha_beta_case, &
-                               my_open_shell_SS, calc_forces)
+   SUBROUTINE mp2_ri_get_integ_group_size(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
+                                          homo, dimen_RI, unit_nr, &
+                                          integ_group_size, &
+                                          ngroup, num_integ_group, &
+                                          virtual, my_alpha_beta_case, &
+                                          my_open_shell_SS, calc_forces)
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array, gd_B_virtual
-      INTEGER, INTENT(IN)                                :: homo, dimen_RI, unit_nr, color_sub
-      INTEGER, INTENT(OUT) :: best_block_size, best_integ_group_size, block_size, &
-         integ_group_size, min_integ_group_size, ngroup, num_IJ_blocks, num_integ_group, &
-         pos_integ_group
+      INTEGER, INTENT(IN)                                :: homo, dimen_RI, unit_nr
+      INTEGER, INTENT(OUT)                               :: integ_group_size, ngroup, num_integ_group
       INTEGER, INTENT(IN)                                :: virtual
       LOGICAL, INTENT(IN)                                :: my_alpha_beta_case, my_open_shell_SS, &
                                                             calc_forces
 
-      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mp2_ri_get_sizes'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_get_integ_group_size'
 
-      INTEGER                                            :: handle, iiB
+      INTEGER                                            :: best_block_size, best_integ_group_size, &
+                                                            handle, iiB, min_integ_group_size
       INTEGER(KIND=int_8)                                :: mem
-      REAL(KIND=dp)                                      :: mem_for_aK, mem_for_comm, mem_for_iaK, &
-                                                            mem_for_rep, mem_min, mem_per_group, &
-                                                            mem_real
+      REAL(KIND=dp)                                      :: mem_for_aK, mem_for_iaK, mem_for_rep, &
+                                                            mem_min, mem_per_group, mem_real
 
       CALL timeset(routineN, handle)
 
@@ -1345,9 +1340,117 @@ CONTAINS
             best_integ_group_size = integ_group_size
             EXIT
          END DO
+      END IF
+
+      integ_group_size = best_integ_group_size
+
+      IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
+         IF (unit_nr > 0) THEN
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
+               "RI_INFO| Group size for integral replication:", integ_group_size*para_env_sub%num_pe
+            CALL m_flush(unit_nr)
+         END IF
+      END IF
+
+      num_integ_group = ngroup/integ_group_size
+
+      CALL timestop(handle)
+
+   END SUBROUTINE mp2_ri_get_integ_group_size
+
+! **************************************************************************************************
+!> \brief ...
+!> \param mp2_env ...
+!> \param para_env ...
+!> \param para_env_sub ...
+!> \param gd_array ...
+!> \param gd_B_virtual ...
+!> \param homo ...
+!> \param dimen_RI ...
+!> \param unit_nr ...
+!> \param block_size ...
+!> \param ngroup ...
+!> \param num_IJ_blocks ...
+!> \param virtual ...
+!> \param my_alpha_beta_case ...
+!> \param my_open_shell_SS ...
+!> \param calc_forces ...
+! **************************************************************************************************
+   SUBROUTINE mp2_ri_get_block_size(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
+                                    homo, dimen_RI, unit_nr, &
+                                    block_size, ngroup, num_IJ_blocks, &
+                                    virtual, my_alpha_beta_case, &
+                                    my_open_shell_SS, calc_forces)
+      TYPE(mp2_type)                                     :: mp2_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
+      TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array, gd_B_virtual
+      INTEGER, INTENT(IN)                                :: homo, dimen_RI, unit_nr
+      INTEGER, INTENT(OUT)                               :: block_size, ngroup, num_IJ_blocks
+      INTEGER, INTENT(IN)                                :: virtual
+      LOGICAL, INTENT(IN)                                :: my_alpha_beta_case, my_open_shell_SS, &
+                                                            calc_forces
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_get_block_size'
+
+      INTEGER                                            :: best_block_size, handle
+      INTEGER(KIND=int_8)                                :: mem
+      REAL(KIND=dp)                                      :: mem_for_aK, mem_for_iaK, mem_min, &
+                                                            mem_per_group, mem_real
+
+      CALL timeset(routineN, handle)
+
+      ngroup = para_env%num_pe/para_env_sub%num_pe
+
+      ! Calculate available memory and create integral group according to that
+      ! mem_for_iaK is the memory needed for storing the 3 centre integrals
+      mem_for_iaK = REAL(homo, KIND=dp)*virtual*dimen_RI*8.0_dp/(1024_dp**2)
+      mem_for_aK = REAL(virtual, KIND=dp)*dimen_RI*8.0_dp/(1024_dp**2)
+
+      CALL m_memory(mem)
+      mem_real = (mem + 1024*1024 - 1)/(1024*1024)
+      ! mp_min .... a hack.. it should be mp_max, but as it turns out, on some processes the previously freed memory (hfx)
+      ! has not been given back to the OS yet.
+      CALL mp_min(mem_real, para_env%group)
+
+      ! BIB_C_copy/external_i_aL/Gamma_P_ia
+      mem_min = MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
+      IF (calc_forces) THEN
+         mem_min = MAX(mem_min, 2.0_dp*maxsize(gd_array)*maxsize(gd_B_virtual)*8.0_dp/(1024**2))
+      END IF
+      ! BIB_C
+      mem_min = REAL(homo, KIND=dp)*maxsize(gd_B_virtual)*maxsize(gd_array)*8.0_dp/(1024**2)
+      ! local_i_aL+local_j_aL
+      mem_min = mem_min + 2.0_dp*maxsize(gd_B_virtual)*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
+      ! local_ab
+      mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
+
+      IF (calc_forces) THEN
+         ! Y_i_aP+Y_j_aP
+         mem_min = mem_min + 2.0_dp*maxsize(gd_B_virtual)*dimen_RI*8.0_dp/(1024**2)
+         ! local_ba/t_ab
+         mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
+         IF (.NOT. my_alpha_beta_case) THEN
+            ! P_ij
+            mem_min = mem_min + REAL(homo, KIND=dp)*homo*8.0_dp/(1024**2)
+            ! P_ab
+            mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
+         END IF
+      END IF
+
+      mem_real = mp2_env%mp2_memory
+
+      mem_per_group = mem_real*para_env_sub%num_pe
+
+      best_block_size = 1
+
+      ! in the open shell case no replication and no block communication is done
+      IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
+         ! Here we split the memory half for the communication, half for replication
+         IF (mp2_env%ri_mp2%block_size > 0) THEN
+            best_block_size = mp2_env%ri_mp2%block_size
+         END IF
 
          IF (.NOT. (mp2_env%ri_mp2%block_size > 0)) THEN
-            mem_for_comm = mem_per_group - 2.0_dp*mem_for_iaK/best_integ_group_size
             DO
                num_IJ_blocks = (homo/best_block_size)
                num_IJ_blocks = (num_IJ_blocks*num_IJ_blocks - num_IJ_blocks)/2
@@ -1363,25 +1466,19 @@ CONTAINS
          best_block_size = MIN(MAX(homo/2 - 1 + MOD(homo, 2), 1), best_block_size)
       END IF
 
-      integ_group_size = best_integ_group_size
       block_size = best_block_size
 
       IF ((.NOT. my_open_shell_SS) .AND. (.NOT. my_alpha_beta_case)) THEN
          IF (unit_nr > 0) THEN
-            WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
-               "RI_INFO| Group size for integral replication:", integ_group_size*para_env_sub%num_pe
             WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
                "RI_INFO| Block size:", block_size
             CALL m_flush(unit_nr)
          END IF
       END IF
 
-      num_integ_group = ngroup/integ_group_size
-      pos_integ_group = MOD(color_sub, integ_group_size)
-
       CALL timestop(handle)
 
-   END SUBROUTINE mp2_ri_get_sizes
+   END SUBROUTINE mp2_ri_get_block_size
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -107,10 +107,10 @@ CONTAINS
          iiB, ij_counter, ij_counter_send, ij_index, integ_group_size, ispin, jjB, jspin, &
          max_ij_pairs, my_block_size, my_group_L_end, my_group_L_size, my_group_L_size_orig, &
          my_group_L_start, my_i, my_ij_pairs, my_j, my_new_group_L_size, ngroup, nspins, &
-         num_IJ_blocks, num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, &
-         rec_B_virtual_end, rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end, &
-         send_B_virtual_start, send_block_size, send_i, send_ij_index, send_j, start_point
-      INTEGER :: sub_P_color, tag, total_ij_pairs
+         num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, rec_B_virtual_end, &
+         rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end, send_B_virtual_start, &
+         send_block_size, send_i, send_ij_index, send_j, start_point, sub_P_color, tag
+      INTEGER :: total_ij_pairs
       INTEGER, ALLOCATABLE, DIMENSION(:) :: integ_group_pos2color_sub, my_B_size, &
          my_B_virtual_end, my_B_virtual_start, num_ij_pairs, proc_map, proc_map_rep, &
          sizes_array_orig, sub_proc_map, virtual
@@ -204,11 +204,9 @@ CONTAINS
                                         my_group_L_size, calc_forces, ispin, jspin, local_ba)
 
             CALL mp2_ri_get_block_size( &
-               mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
-               homo(ispin), dimen_RI, unit_nr, block_size, &
-               ngroup, num_IJ_blocks, &
-               virtual(ispin), my_alpha_beta_case, &
-               calc_forces)
+               mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin:jspin), &
+               homo(ispin:jspin), dimen_RI, unit_nr, block_size, &
+               ngroup, num_integ_group, my_open_shell_ss, calc_forces)
 
             ! *****************************************************************
             ! **********  REPLICATION-BLOCKED COMMUNICATION SCHEME  ***********
@@ -218,7 +216,7 @@ CONTAINS
 
             ! Calculate the maximum number of ij pairs that have to be computed
             ! among groups
-            CALL mp2_ri_communication(my_alpha_beta_case, total_ij_pairs, homo(ispin), homo(jspin), num_IJ_blocks, &
+            CALL mp2_ri_communication(my_alpha_beta_case, total_ij_pairs, homo(ispin), homo(jspin), &
                                       block_size, ngroup, ij_map, color_sub, my_ij_pairs, my_open_shell_SS, unit_nr)
 
             ALLOCATE (num_ij_pairs(0:para_env_exchange%num_pe - 1))
@@ -927,7 +925,6 @@ CONTAINS
 !> \param total_ij_pairs ...
 !> \param homo ...
 !> \param homo_beta ...
-!> \param num_IJ_blocks ...
 !> \param block_size ...
 !> \param ngroup ...
 !> \param ij_map ...
@@ -936,13 +933,11 @@ CONTAINS
 !> \param my_open_shell_SS ...
 !> \param unit_nr ...
 ! **************************************************************************************************
-   SUBROUTINE mp2_ri_communication(my_alpha_beta_case, total_ij_pairs, homo, homo_beta, num_IJ_blocks, &
+   SUBROUTINE mp2_ri_communication(my_alpha_beta_case, total_ij_pairs, homo, homo_beta, &
                                    block_size, ngroup, ij_map, color_sub, my_ij_pairs, my_open_shell_SS, unit_nr)
       LOGICAL, INTENT(IN)                                :: my_alpha_beta_case
       INTEGER, INTENT(OUT)                               :: total_ij_pairs
-      INTEGER, INTENT(IN)                                :: homo, homo_beta
-      INTEGER, INTENT(OUT)                               :: num_IJ_blocks
-      INTEGER, INTENT(IN)                                :: block_size, ngroup
+      INTEGER, INTENT(IN)                                :: homo, homo_beta, block_size, ngroup
       INTEGER, ALLOCATABLE, DIMENSION(:, :), INTENT(OUT) :: ij_map
       INTEGER, INTENT(IN)                                :: color_sub
       INTEGER, INTENT(OUT)                               :: my_ij_pairs
@@ -952,8 +947,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_communication'
 
       INTEGER :: assigned_blocks, first_I_block, first_J_block, handle, iiB, ij_block_counter, &
-         ij_counter, jjB, last_i_block, last_J_block, num_block_per_group, num_IJ_blocks_beta, &
-         total_ij_block, total_ij_pairs_blocks
+         ij_counter, jjB, last_i_block, last_J_block, num_block_per_group, num_IJ_blocks, &
+         num_IJ_blocks_beta, total_ij_block, total_ij_pairs_blocks
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: ij_marker
 
 ! Calculate the maximum number of ij pairs that have to be computed
@@ -1381,7 +1376,7 @@ CONTAINS
       IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'RI_INFO| Minimum required memory per MPI process:', &
          mem_min, ' MiB'
 
-      mem_real = mp2_env%mp2_memory
+      mem_real = MIN(mem_real, mp2_env%mp2_memory)
 
       ! We use the following communication model
       ! Comm(replication)+Comm(collection of data for ij pair)+Comm(contraction)
@@ -1449,39 +1444,32 @@ CONTAINS
 !> \param unit_nr ...
 !> \param block_size ...
 !> \param ngroup ...
-!> \param num_IJ_blocks ...
-!> \param virtual ...
-!> \param my_alpha_beta_case ...
+!> \param num_integ_group ...
+!> \param my_open_shell_ss ...
 !> \param calc_forces ...
 ! **************************************************************************************************
    SUBROUTINE mp2_ri_get_block_size(mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual, &
                                     homo, dimen_RI, unit_nr, &
-                                    block_size, ngroup, num_IJ_blocks, &
-                                    virtual, my_alpha_beta_case, &
-                                    calc_forces)
+                                    block_size, ngroup, num_integ_group, &
+                                    my_open_shell_ss, calc_forces)
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
-      TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array, gd_B_virtual
-      INTEGER, INTENT(IN)                                :: homo, dimen_RI, unit_nr
-      INTEGER, INTENT(OUT)                               :: block_size, ngroup, num_IJ_blocks
-      INTEGER, INTENT(IN)                                :: virtual
-      LOGICAL, INTENT(IN)                                :: my_alpha_beta_case, calc_forces
+      TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array
+      TYPE(group_dist_d1_type), DIMENSION(:), INTENT(IN) :: gd_B_virtual
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
+      INTEGER, INTENT(IN)                                :: dimen_RI, unit_nr
+      INTEGER, INTENT(OUT)                               :: block_size, ngroup, num_integ_group
+      LOGICAL, INTENT(IN)                                :: my_open_shell_ss, calc_forces
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_get_block_size'
 
-      INTEGER                                            :: best_block_size, handle
+      INTEGER                                            :: best_block_size, handle, num_IJ_blocks
       INTEGER(KIND=int_8)                                :: mem
-      REAL(KIND=dp)                                      :: mem_for_aK, mem_for_iaK, mem_min, &
-                                                            mem_per_group, mem_real
+      REAL(KIND=dp)                                      :: mem_per_blk, mem_per_repl_blk, mem_real
 
       CALL timeset(routineN, handle)
 
       ngroup = para_env%num_pe/para_env_sub%num_pe
-
-      ! Calculate available memory and create integral group according to that
-      ! mem_for_iaK is the memory needed for storing the 3 centre integrals
-      mem_for_iaK = REAL(homo, KIND=dp)*virtual*dimen_RI*8.0_dp/(1024_dp**2)
-      mem_for_aK = REAL(virtual, KIND=dp)*dimen_RI*8.0_dp/(1024_dp**2)
 
       CALL m_memory(mem)
       mem_real = (mem + 1024*1024 - 1)/(1024*1024)
@@ -1489,34 +1477,20 @@ CONTAINS
       ! has not been given back to the OS yet.
       CALL mp_min(mem_real, para_env%group)
 
-      ! BIB_C_copy/external_i_aL/Gamma_P_ia
-      mem_min = MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
-      IF (calc_forces) THEN
-         mem_min = MAX(mem_min, 2.0_dp*maxsize(gd_array)*maxsize(gd_B_virtual)*8.0_dp/(1024**2))
-      END IF
-      ! BIB_C
-      mem_min = REAL(homo, KIND=dp)*maxsize(gd_B_virtual)*maxsize(gd_array)*8.0_dp/(1024**2)
+      mem_per_blk = 0.0_dp
+      mem_per_repl_blk = 0.0_dp
+
+      ! BIB_C_rec
+      mem_per_repl_blk = mem_per_repl_blk + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL
-      mem_min = mem_min + 2.0_dp*maxsize(gd_B_virtual)*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
-      ! local_ab
-      mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
+      mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
 
       IF (calc_forces) THEN
-         ! Y_i_aP+Y_j_aP
-         mem_min = mem_min + 2.0_dp*maxsize(gd_B_virtual)*dimen_RI*8.0_dp/(1024**2)
-         ! local_ba/t_ab
-         mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
-         IF (.NOT. my_alpha_beta_case) THEN
-            ! P_ij
-            mem_min = mem_min + REAL(homo, KIND=dp)*homo*8.0_dp/(1024**2)
-            ! P_ab
-            mem_min = mem_min + REAL(virtual, KIND=dp)*maxsize(gd_B_virtual)*8.0_dp/(1024**2)
-         END IF
+         ! Y_i_aP+Y_j_aP+BIb_C_send
+         mem_per_blk = mem_per_blk + 3.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
       END IF
 
-      mem_real = mp2_env%mp2_memory
-
-      mem_per_group = mem_real*para_env_sub%num_pe
+      mem_real = MIN(mp2_env%mp2_memory, mem_real)
 
       best_block_size = 1
 
@@ -1524,9 +1498,20 @@ CONTAINS
       IF (mp2_env%ri_mp2%block_size > 0) THEN
          best_block_size = mp2_env%ri_mp2%block_size
       ELSE
+         best_block_size = MAX(FLOOR(mem_real/(mem_per_blk + mem_per_repl_blk*ngroup/num_integ_group)), 1)
+
          DO
-            num_IJ_blocks = (homo/best_block_size)
-            num_IJ_blocks = (num_IJ_blocks*num_IJ_blocks - num_IJ_blocks)/2
+            IF (SIZE(homo) == 1) THEN
+            IF (.NOT. my_open_shell_ss) THEN
+               num_IJ_blocks = (homo(1)/best_block_size)
+               num_IJ_blocks = (num_IJ_blocks*num_IJ_blocks - num_IJ_blocks)/2
+            ELSE
+               num_IJ_blocks = ((homo(1) - 1)/best_block_size)
+               num_IJ_blocks = (num_IJ_blocks*num_IJ_blocks - num_IJ_blocks)/2
+            END IF
+            ELSE
+            num_ij_blocks = PRODUCT(homo/best_block_size)
+            END IF
             IF (num_IJ_blocks > ngroup .OR. best_block_size == 1) THEN
                EXIT
             ELSE
@@ -1535,8 +1520,15 @@ CONTAINS
          END DO
       END IF
 
-      ! check that best_block_size is not bigger than homo/2-1
-      best_block_size = MIN(MAX(homo/2 - 1 + MOD(homo, 2), 1), best_block_size)
+      IF (SIZE(homo) == 1) THEN
+      IF (my_open_shell_ss) THEN
+         ! check that best_block_size is not bigger than sqrt(homo-1)
+         best_block_size = MIN(FLOOR(SQRT(REAL(homo(1) - 1, KIND=dp))), best_block_size)
+      ELSE
+         ! check that best_block_size is not bigger than sqrt(homo)
+         best_block_size = MIN(FLOOR(SQRT(REAL(homo(1), KIND=dp))), best_block_size)
+      END IF
+      END IF
       block_size = best_block_size
 
       IF (unit_nr > 0) THEN

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -627,16 +627,14 @@ CONTAINS
             ! sum Gamma and dereplicate
             DO kspin = ispin, jspin
                ALLOCATE (BIb_C(kspin)%array(my_B_size(kspin), homo(kspin), my_group_L_size))
-            END DO
-            DO proc_shift = 1, para_env_rep%num_pe - 1
-               ! invert order
-               proc_send = proc_map_rep(para_env_rep%mepos - proc_shift)
-               proc_receive = proc_map_rep(para_env_rep%mepos + proc_shift)
+               DO proc_shift = 1, para_env_rep%num_pe - 1
+                  ! invert order
+                  proc_send = proc_map_rep(para_env_rep%mepos - proc_shift)
+                  proc_receive = proc_map_rep(para_env_rep%mepos + proc_shift)
 
-               start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
-               end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
+                  start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
+                  end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
 
-               DO kspin = ispin, jspin
                   CALL mp_sendrecv(mp2_env%ri_grad%Gamma_P_ia(kspin)%array(:, :, start_point:end_point), &
                                    proc_send, BIb_C(kspin)%array, proc_receive, para_env_rep%group, tag)
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) &
@@ -646,12 +644,10 @@ CONTAINS
                      + BIb_C(kspin)%array(:, :, :)
 !$OMP END PARALLEL WORKSHARE
                END DO
+               DEALLOCATE (BIb_C(kspin)%array)
             END DO
 
             IF (my_open_shell_ss) THEN
-               DO kspin = ispin, jspin
-                  DEALLOCATE (BIb_C(kspin)%array)
-               END DO
                ALLOCATE (BIb_C(ispin)%array(my_group_L_size, my_B_size(ispin), homo(ispin)))
                BIb_C(ispin)%array = 0.0_dp
                ! copy the integrals (ia|Q) back
@@ -690,11 +686,6 @@ CONTAINS
 
          CALL cp_para_env_release(para_env_exchange)
          CALL cp_para_env_release(para_env_rep)
-
-         WRITE (*, *) ispin, jspin
-      END DO
-      DO kspin = 1, nspins
-         WRITE (*, *) ALLOCATED(mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
       END DO
       END DO
 
@@ -703,6 +694,7 @@ CONTAINS
       IF (calc_forces) THEN
          ! Reduce size of Gamma_P_ia to save memory
          DO ispin = 1, nspins
+            ALLOCATE (BIb_C(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size))
             BIb_C(ispin)%array(:, :, :) = mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size)
             DEALLOCATE (mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
             CALL MOVE_ALLOC(BIb_C(ispin)%array, mp2_env%ri_grad%Gamma_P_ia(ispin)%array)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -1235,20 +1235,17 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_get_integ_group_size'
 
-      INTEGER                                            :: best_block_size, best_integ_group_size, &
-                                                            handle, iiB, min_integ_group_size
+      INTEGER                                            :: block_size, handle, iiB, &
+                                                            max_repl_group_size, &
+                                                            min_integ_group_size
       INTEGER(KIND=int_8)                                :: mem
-      REAL(KIND=dp)                                      :: mem_for_aK, mem_for_iaK, mem_for_rep, &
-                                                            mem_min, mem_per_group, mem_real
+      REAL(KIND=dp)                                      :: mem_base, mem_min, mem_per_blk, &
+                                                            mem_per_repl, mem_per_repl_blk, &
+                                                            mem_real
 
       CALL timeset(routineN, handle)
 
       ngroup = para_env%num_pe/para_env_sub%num_pe
-
-      ! Calculate available memory and create integral group according to that
-      ! mem_for_iaK is the memory needed for storing the 3 centre integrals
-      mem_for_iaK = MAXVAL(REAL(homo, KIND=dp)*virtual)*dimen_RI*8.0_dp/(1024_dp**2)
-      mem_for_aK = REAL(MAXVAL(virtual), KIND=dp)*dimen_RI*8.0_dp/(1024_dp**2)
 
       CALL m_memory(mem)
       mem_real = (mem + 1024*1024 - 1)/(1024*1024)
@@ -1256,75 +1253,68 @@ CONTAINS
       ! has not been given back to the OS yet.
       CALL mp_min(mem_real, para_env%group)
 
+      mem_base = 0.0_dp
+      mem_per_blk = 0.0_dp
+      mem_per_repl = 0.0_dp
+      mem_per_repl_blk = 0.0_dp
+
       ! BIB_C_copy/external_i_aL/Gamma_P_ia
-      mem_min = MAXVAL(MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
-      IF (calc_forces) THEN
-         mem_min = MAX(mem_min, 2.0_dp*MAXVAL(maxsize(gd_array)*maxsize(gd_B_virtual))*8.0_dp/(1024**2))
-      END IF
+      mem_per_repl = mem_per_repl + MAXVAL(MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))* &
+                                           maxsize(gd_B_virtual))*8.0_dp/(1024**2)
       ! BIB_C
-      mem_min = MAXVAL(REAL(homo, KIND=dp)*maxsize(gd_B_virtual))*maxsize(gd_array)*8.0_dp/(1024**2)
+      mem_per_repl = mem_per_repl + SUM(REAL(homo, KIND=dp)*maxsize(gd_B_virtual))*maxsize(gd_array)*8.0_dp/(1024**2)
+      ! BIB_C
+      mem_per_repl_blk = mem_per_repl_blk + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL
-      mem_min = mem_min + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
+      mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
       ! local_ab
-      mem_min = mem_min + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+      mem_base = mem_base + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
 
       IF (calc_forces) THEN
          ! Y_i_aP+Y_j_aP
-         mem_min = mem_min + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
+         mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
          ! local_ba/t_ab
-         mem_min = mem_min + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+         mem_base = mem_base + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
          ! P_ij
-         mem_min = mem_min + SUM(REAL(homo, KIND=dp)*homo)*8.0_dp/(1024**2)
+         mem_base = mem_base + SUM(REAL(homo, KIND=dp)*homo)*8.0_dp/(1024**2)
          ! P_ab
-         mem_min = mem_min + SUM(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+         mem_base = mem_base + SUM(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
       END IF
 
-      IF (SIZE(homo) == 1) THEN
-         IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'RI_INFO| Minimum required memory per MPI process:', &
-            mem_min, ' MiB'
-      END IF
+      block_size = 1
+      IF (mp2_env%ri_mp2%block_size > 0) block_size = mp2_env%ri_mp2%block_size
+
+      mem_min = mem_base + mem_per_repl + (mem_per_blk + mem_per_repl_blk)*block_size
+
+      IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'RI_INFO| Minimum available memory per MPI process:', &
+         mem_real, ' MiB'
+      IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T68,F9.2,A4)') 'RI_INFO| Minimum required memory per MPI process:', &
+         mem_min, ' MiB'
 
       mem_real = mp2_env%mp2_memory
 
-      mem_per_group = mem_real*para_env_sub%num_pe
-
       ! here we try to find the best block_size and integ_group_size
-      best_integ_group_size = ngroup
-      best_block_size = 1
+      integ_group_size = ngroup
+      ! Remove the fixed memory and divide by the memory per replication group size
+      max_repl_group_size = MIN(MAX(FLOOR((mem_real - mem_base - mem_per_blk*block_size)/ &
+                                          (mem_per_repl + mem_per_repl_blk*block_size)), 1), ngroup)
+      ! Convert to an integration group size
+      min_integ_group_size = ngroup/max_repl_group_size
 
-      ! in the open shell case no replication and no block communication is done
-      IF (SIZE(homo) == 1) THEN
-         ! Here we split the memory half for the communication, half for replication
-         IF (mp2_env%ri_mp2%block_size > 0) THEN
-            best_block_size = mp2_env%ri_mp2%block_size
-            mem_for_rep = MAX(mem_min, mem_per_group - 2.0_dp*mem_for_aK*best_block_size)
-         ELSE
-            mem_for_rep = mem_per_group/2.0_dp
-         END IF
-         ! calculate the minimum replication group size according to the available memory
-         min_integ_group_size = CEILING(2.0_dp*mem_for_iaK/mem_for_rep)
-
-         integ_group_size = MIN(min_integ_group_size, ngroup) - 1
-         DO iiB = min_integ_group_size + 1, ngroup
-            integ_group_size = integ_group_size + 1
-            ! check that the ngroup is a multiple of  integ_group_size
-            IF (MOD(ngroup, integ_group_size) /= 0) CYCLE
-            ! check that the integ group size is not too small (10% is empirical for now)
-            IF (REAL(integ_group_size, KIND=dp)/REAL(ngroup, KIND=dp) < 0.1_dp) CYCLE
-
-            best_integ_group_size = integ_group_size
+      ! Ensure that the integration group size is a divisor of the number of sub groups
+      DO iiB = MAX(MIN(min_integ_group_size, ngroup), 1), ngroup
+         ! check that the ngroup is a multiple of  integ_group_size
+         IF (MOD(ngroup, iiB) == 0) THEN
+            integ_group_size = iiB
             EXIT
-         END DO
-      END IF
-
-      integ_group_size = best_integ_group_size
-
-      IF (SIZE(homo) == 1) THEN
-         IF (unit_nr > 0) THEN
-            WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
-               "RI_INFO| Group size for integral replication:", integ_group_size*para_env_sub%num_pe
-            CALL m_flush(unit_nr)
          END IF
+         integ_group_size = integ_group_size + 1
+      END DO
+
+      IF (unit_nr > 0) THEN
+         WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
+            "RI_INFO| Group size for integral replication:", integ_group_size*para_env_sub%num_pe
+         CALL m_flush(unit_nr)
       END IF
 
       num_integ_group = ngroup/integ_group_size

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -451,8 +451,10 @@ CONTAINS
                                  proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
                                  proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
 
-                          CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
-                          CALL get_group_dist(gd_B_virtual(ispin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
+                                 CALL get_group_dist(gd_B_virtual(ispin), proc_receive, &
+                                                     rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
+                                 CALL get_group_dist(gd_B_virtual(ispin), proc_send, &
+                                                     send_B_virtual_start, send_B_virtual_end, send_B_size)
 
                                  ALLOCATE (external_ab(my_B_size(ispin), rec_B_size))
                                  external_ab = 0.0_dp

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -120,14 +120,14 @@ CONTAINS
                                                             my_open_shell_SS
       REAL(KIND=dp)                                      :: amp_fac, my_Emp2_Cou, my_Emp2_EX, &
                                                             sym_fac, t_new, t_start
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: BI_C_rec_1D
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: buffer_1D
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         TARGET                                          :: external_ab, external_i_aL, local_ab, &
-                                                            local_ba, t_ab
+         TARGET                                          :: local_ab, local_ba, t_ab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          TARGET                                          :: local_i_aL, local_j_aL, Y_i_aP, Y_j_aP
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: BI_C_rec
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: external_ab, external_i_aL
       TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_P, &
                                                             para_env_rep
       TYPE(dgemm_counter_type)                           :: dgemm_counter
@@ -280,7 +280,8 @@ CONTAINS
                   CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
                                        BIb_C(jspin)%array(:, :, my_j:my_j + my_block_size - 1))
 
-                  ALLOCATE (BI_C_rec_1D(INT(maxsize(gd_array), int_8)*MAXVAL(my_B_size)*my_block_size))
+                  IF (para_env_exchange%num_pe > 1) &
+                     ALLOCATE (buffer_1D(INT(maxsize(gd_array), int_8)*MAXVAL(my_B_size)*my_block_size))
 
                   ! collect data from other proc
                   CALL timeset(routineN//"_comm", handle3)
@@ -301,7 +302,7 @@ CONTAINS
 
                         ! occupied i
                         BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:send_block_size) => &
-                           BI_C_rec_1D(1:rec_L_size*my_B_size(ispin)*send_block_size)
+                           buffer_1D(1:rec_L_size*my_B_size(ispin)*send_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
                                          proc_send, BI_C_rec, proc_receive, &
@@ -312,7 +313,7 @@ CONTAINS
 
                         ! occupied j
                         BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:send_block_size) => &
-                           BI_C_rec_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*send_block_size)
+                           buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*send_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
                                          proc_send, BI_C_rec, proc_receive, &
@@ -326,7 +327,7 @@ CONTAINS
 
                         ! occupied i
                         BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:my_block_size) => &
-                           BI_C_rec_1D(1:INT(rec_L_size, int_8)*my_B_size(ispin)*my_block_size)
+                           buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(ispin)*my_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
 
@@ -335,7 +336,7 @@ CONTAINS
 
                         ! occupied j
                         BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:my_block_size) => &
-                           BI_C_rec_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*my_block_size)
+                           buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*my_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
 
@@ -346,7 +347,7 @@ CONTAINS
 
                   END DO
 
-                  DEALLOCATE (BI_C_rec_1D)
+                  IF (para_env_exchange%num_pe > 1) DEALLOCATE (buffer_1D)
 
                   CALL timestop(handle3)
 
@@ -371,6 +372,7 @@ CONTAINS
                               local_ba(my_B_virtual_start(jspin):my_B_virtual_end(jspin), :) = &
                                  TRANSPOSE(local_ab(my_B_virtual_start(ispin):my_B_virtual_end(ispin), :))
                            END IF
+                           IF (para_env_sub%num_pe > 1) ALLOCATE (buffer_1D(INT(dimen_RI, int_8)*MAXVAL(maxsize(gd_B_virtual))))
                            ! ... and from the other of my subgroup
                            DO proc_shift = 1, para_env_sub%num_pe - 1
                               proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
@@ -379,7 +381,7 @@ CONTAINS
                               CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, &
                                                   rec_B_virtual_end, rec_B_size)
 
-                              ALLOCATE (external_i_aL(dimen_RI, rec_B_size))
+                              external_i_aL(1:dimen_RI, 1:rec_B_size) => buffer_1D(1:INT(dimen_RI, int_8)*rec_B_size)
                               external_i_aL = 0.0_dp
 
                               CALL mp_sendrecv(my_local_i_aL, proc_send, &
@@ -391,14 +393,13 @@ CONTAINS
                                           0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(jspin)), rec_B_size, &
                                                  mp2_env%offload_gemm_ctx)
 
-                              DEALLOCATE (external_i_aL)
                               ! Additional integrals only for alpha_beta case and forces
                               IF (my_alpha_beta_case .AND. calc_forces) THEN
 
                                  CALL get_group_dist(gd_B_virtual(jspin), proc_receive, rec_B_virtual_start, &
                                                      rec_B_virtual_end, rec_B_size)
 
-                                 ALLOCATE (external_i_aL(dimen_RI, rec_B_size))
+                                 external_i_aL(1:dimen_RI, 1:rec_B_size) => buffer_1D(1:INT(dimen_RI, int_8)*rec_B_size)
                                  external_i_aL = 0.0_dp
 
                                  CALL mp_sendrecv(my_local_j_aL, proc_send, &
@@ -409,9 +410,9 @@ CONTAINS
                                                     external_i_aL, dimen_RI, my_local_i_aL, dimen_RI, &
                                           0.0_dp, local_ba(rec_B_virtual_start:rec_B_virtual_end, 1:my_B_size(ispin)), rec_B_size, &
                                                     mp2_env%offload_gemm_ctx)
-                                 DEALLOCATE (external_i_aL)
                               END IF
                            END DO
+                           IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_1D)
                            IF (my_alpha_beta_case .AND. calc_forces) THEN
                               ! Is just an approximation, but the call does not allow it, it ought to be (virtual_i*B_size_j+virtual_j*B_size_i)*dimen_RI
                               CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), my_B_size(ispin) + my_B_size(jspin), dimen_RI)
@@ -456,6 +457,7 @@ CONTAINS
                                     END IF
                                  END DO
                               END DO
+                      IF (para_env_sub%num_pe > 1) ALLOCATE (buffer_1D(1:INT(my_B_size(ispin), int_8)*maxsize(gd_B_virtual(ispin))))
                               ! ... and then with external data
                               DO proc_shift = 1, para_env_sub%num_pe - 1
                                  proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
@@ -466,7 +468,8 @@ CONTAINS
                                  CALL get_group_dist(gd_B_virtual(ispin), proc_send, &
                                                      send_B_virtual_start, send_B_virtual_end, send_B_size)
 
-                                 ALLOCATE (external_ab(my_B_size(ispin), rec_B_size))
+                                 external_ab(1:my_B_size(ispin), 1:rec_B_size) => &
+                                    buffer_1D(1:INT(rec_B_size, int_8)*my_B_size(ispin))
                                  external_ab = 0.0_dp
 
                                 CALL mp_sendrecv(local_ab(send_B_virtual_start:send_B_virtual_end, 1:my_B_size(ispin)), proc_send, &
@@ -487,9 +490,8 @@ CONTAINS
                                                                Eigenval(my_i + iiB - 1, ispin) - Eigenval(my_j + jjB - 1, ispin))
                                     END DO
                                  END DO
-
-                                 DEALLOCATE (external_ab)
                               END DO
+                              IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_1D)
                            END IF
                            CALL timestop(handle3)
 
@@ -510,6 +512,9 @@ CONTAINS
                   END DO ! iiB
 
                ELSE
+                  ! We need it later in case of gradients
+                  my_block_size = 1
+
                   CALL timeset(routineN//"_comm", handle3)
                   ! No work to do and we know that we have to receive nothing, but send something
                   ! send data to other proc
@@ -1620,20 +1625,13 @@ CONTAINS
       INTEGER :: a, b, b_global, handle, proc_receive, proc_send, proc_shift, rec_B_size, &
          rec_B_virtual_end, rec_B_virtual_start, send_B_size, send_B_virtual_end, &
          send_B_virtual_start
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         TARGET                                          :: external_ab, send_ab
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: external_ab, send_ab
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: buffer_1D, buffer_2_1D
       REAL(KIND=dp)                                      :: factor, P_ij_diag
       LOGICAL                                            :: alpha_beta
 
-!
-!  In alpha-beta case Y_j_aP_beta is sent and is received as Y_j_aP
-!
-
       CALL timeset(routineN//"_Pia", handle)
 
-! Find out whether we have an alpha-beta case
-! update P_ab, Gamma_P_ia
-! First, P_ab
       alpha_beta = .NOT. (ispin == jspin)
       IF (open_ss) THEN
          factor = 1.0_dp
@@ -1706,6 +1704,10 @@ CONTAINS
          mp2_env%ri_grad%P_ij(ispin)%array(my_j + jjB - 1, my_j + jjB - 1) = &
             mp2_env%ri_grad%P_ij(ispin)%array(my_j + jjB - 1, my_j + jjB - 1) + P_ij_diag
       END IF
+      IF (para_env_sub%num_pe > 1) THEN
+         ALLOCATE (buffer_1D(INT(MAX(MAXVAL(virtual), dimen_RI), int_8)*MAXVAL(maxsize(gd_B_virtual))))
+         ALLOCATE (buffer_2_1D(INT(MAXVAL(maxsize(gd_B_virtual)), KIND=int_8)*MAXVAL(virtual)))
+      END IF
       DO proc_shift = 1, para_env_sub%num_pe - 1
          proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
          proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
@@ -1713,7 +1715,7 @@ CONTAINS
          CALL get_group_dist(gd_B_virtual(jspin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
          CALL get_group_dist(gd_B_virtual(jspin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
 
-         ALLOCATE (external_ab(virtual(ispin), rec_B_size))
+         external_ab(1:virtual(ispin), 1:rec_B_size) => buffer_1D(1:INT(virtual(ispin), int_8)*rec_B_size)
          external_ab = 0.0_dp
 
          CALL mp_sendrecv(local_ab, proc_send, &
@@ -1732,11 +1734,10 @@ CONTAINS
                                my_B_size(jspin), mp2_env%offload_gemm_ctx)
 
             ! For alpha-beta part of alpha-density we need a new parallel code
-            DEALLOCATE (external_ab)
             ! And new external_ab (of a different size)
             CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
             CALL get_group_dist(gd_B_virtual(ispin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
-            ALLOCATE (external_ab(virtual(jspin), rec_B_size))
+            external_ab(1:virtual(jspin), 1:rec_B_size) => buffer_1D(1:INT(virtual(jspin), int_8)*rec_B_size)
             external_ab = 0.0_dp
             CALL mp_sendrecv(local_ba, proc_send, &
                              external_ab, proc_receive, &
@@ -1747,13 +1748,12 @@ CONTAINS
                                mp2_env%offload_gemm_ctx)
          END IF
 
-         DEALLOCATE (external_ab)
-
          IF ((my_i /= my_j) .AND. (.NOT. alpha_beta)) THEN
-            ALLOCATE (external_ab(my_B_size(ispin), virtual(ispin)))
+            external_ab(1:my_B_size(ispin), 1:virtual(ispin)) => &
+               buffer_1D(1:INT(virtual(ispin), int_8)*my_B_size(ispin))
             external_ab = 0.0_dp
 
-            ALLOCATE (send_ab(send_B_size, virtual(ispin)))
+            send_ab(1:send_B_size, 1:virtual(ispin)) => buffer_2_1D(1:INT(send_B_size, int_8)*virtual(ispin))
             send_ab = 0.0_dp
 
             CALL offload_dgemm('N', 'T', send_B_size, virtual(ispin), my_B_size(ispin), 1.0_dp, &
@@ -1766,9 +1766,6 @@ CONTAINS
                              para_env_sub%group)
 
             mp2_env%ri_grad%P_ab(ispin)%array(:, :) = mp2_env%ri_grad%P_ab(ispin)%array + external_ab
-
-            DEALLOCATE (external_ab)
-            DEALLOCATE (send_ab)
          END IF
 
       END DO
@@ -1781,6 +1778,7 @@ CONTAINS
       ELSE
          CALL dgemm_counter_stop(dgemm_counter, SUM(my_B_size), virtual(ispin), virtual(jspin))
       END IF
+      IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_2_1D)
       CALL timestop(handle)
 
       ! Now, Gamma_P_ia (made of Y_ia_P)
@@ -1802,8 +1800,12 @@ CONTAINS
                             my_local_i_aL, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(jspin), mp2_env%offload_gemm_ctx)
       END IF
 
-      ALLOCATE (external_ab(my_B_size(ispin), dimen_RI))
-      external_ab = 0.0_dp
+      IF (para_env_sub%num_pe > 1) THEN
+         external_ab(1:my_B_size(ispin), 1:dimen_RI) => buffer_1D(1:INT(my_B_size(ispin), int_8)*dimen_RI)
+         external_ab = 0.0_dp
+
+         ALLOCATE (buffer_2_1D(INT(MAXVAL(maxsize(gd_B_virtual)), KIND=int_8)*dimen_RI))
+      END IF
       !
       DO proc_shift = 1, para_env_sub%num_pe - 1
          proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
@@ -1812,9 +1814,9 @@ CONTAINS
          CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
          CALL get_group_dist(gd_B_virtual(ispin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
 
+         send_ab(1:send_B_size, 1:dimen_RI) => buffer_2_1D(1:INT(dimen_RI, int_8)*send_B_size)
+         send_ab = 0.0_dp
          IF (.NOT. alpha_beta) THEN
-            ALLOCATE (send_ab(send_B_size, dimen_RI))
-            send_ab = 0.0_dp
             CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), 1.0_dp, &
                                t_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
                                my_local_j_aL, dimen_RI, 0.0_dp, send_ab, send_B_size, &
@@ -1823,32 +1825,29 @@ CONTAINS
 
             Y_i_aP(:, :) = Y_i_aP + external_ab
 
-            DEALLOCATE (send_ab)
          ELSE ! Alpha-beta case
             ! Alpha-alpha part
-            ALLOCATE (send_ab(send_B_size, dimen_RI))
-            send_ab = 0.0_dp
             CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(jspin), mp2_env%scale_S, &
                                local_ab(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
                                my_local_j_aL, dimen_RI, 0.0_dp, send_ab, send_B_size, &
                                mp2_env%offload_gemm_ctx)
             CALL mp_sendrecv(send_ab, proc_send, external_ab, proc_receive, para_env_sub%group)
             Y_i_aP(:, :) = Y_i_aP + external_ab
-            DEALLOCATE (send_ab)
          END IF
       END DO
-      DEALLOCATE (external_ab)
 
       IF (alpha_beta) THEN
          ! For beta-beta part (in alpha-beta case) we need a new parallel code
-         ALLOCATE (external_ab(my_B_size(jspin), dimen_RI))
-         external_ab = 0.0_dp
+         IF (para_env_sub%num_pe > 1) THEN
+            external_ab(1:my_B_size(jspin), 1:dimen_RI) => buffer_1D(1:INT(my_B_size(jspin), int_8)*dimen_RI)
+            external_ab = 0.0_dp
+         END IF
          DO proc_shift = 1, para_env_sub%num_pe - 1
             proc_send = sub_proc_map(para_env_sub%mepos + proc_shift)
             proc_receive = sub_proc_map(para_env_sub%mepos - proc_shift)
 
             CALL get_group_dist(gd_B_virtual(jspin), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
-            ALLOCATE (send_ab(send_B_size, dimen_RI))
+            send_ab(1:send_B_size, 1:dimen_RI) => buffer_2_1D(1:INT(dimen_RI, int_8)*send_B_size)
             send_ab = 0.0_dp
             CALL offload_dgemm('N', 'T', send_B_size, dimen_RI, my_B_size(ispin), mp2_env%scale_S, &
                                local_ba(send_B_virtual_start:send_B_virtual_end, :), send_B_size, &
@@ -1856,16 +1855,15 @@ CONTAINS
                                mp2_env%offload_gemm_ctx)
             CALL mp_sendrecv(send_ab, proc_send, external_ab, proc_receive, para_env_sub%group)
             Y_j_aP(:, :) = Y_j_aP + external_ab
-            DEALLOCATE (send_ab)
 
          END DO
-         DEALLOCATE (external_ab)
 
          ! Here, we just use approximate bounds. For large systems virtual(ispin) is approx virtual(jspin), same for B_size
          CALL dgemm_counter_stop(dgemm_counter, 3*virtual(ispin), dimen_RI, my_B_size(jspin))
       ELSE
          CALL dgemm_counter_stop(dgemm_counter, virtual(ispin), dimen_RI, my_B_size(ispin))
       END IF
+      IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_2_1D)
 
       IF ((my_i /= my_j) .AND. (.NOT. alpha_beta)) THEN
          ! Alpha-alpha, beta-beta and closed shell
@@ -1880,7 +1878,7 @@ CONTAINS
 
             CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
 
-            ALLOCATE (external_ab(dimen_RI, rec_B_size))
+            external_ab(1:dimen_RI, 1:rec_B_size) => buffer_1D(1:INT(dimen_RI, int_8)*rec_B_size)
             external_ab = 0.0_dp
 
             CALL mp_sendrecv(my_local_i_aL, proc_send, &
@@ -1890,11 +1888,11 @@ CONTAINS
             CALL offload_dgemm('T', 'T', my_B_size(ispin), dimen_RI, rec_B_size, 1.0_dp, &
                                t_ab(rec_B_virtual_start:rec_B_virtual_end, :), rec_B_size, &
                                external_ab, dimen_RI, 1.0_dp, Y_j_aP, my_B_size(ispin), mp2_env%offload_gemm_ctx)
-            DEALLOCATE (external_ab)
          END DO
 
          CALL dgemm_counter_stop(dgemm_counter, my_B_size(ispin), dimen_RI, virtual(ispin))
       END IF
+      IF (para_env_sub%num_pe > 1) DEALLOCATE (buffer_1D)
 
       CALL timestop(handle)
    END SUBROUTINE mp2_update_P_gamma

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -1351,7 +1351,7 @@ CONTAINS
       mem_per_repl = 0.0_dp
       mem_per_repl_blk = 0.0_dp
 
-      ! BIB_C_copy/external_i_aL
+      ! BIB_C_copy
       mem_per_repl = mem_per_repl + MAXVAL(MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))* &
                                            maxsize(gd_B_virtual))*8.0_dp/(1024**2)
       ! BIB_C
@@ -1360,21 +1360,25 @@ CONTAINS
       mem_per_repl_blk = mem_per_repl_blk + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL
       mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
-      ! local_ab+external_ab
-      mem_base = mem_base + 2.0_dp*MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+      ! local_ab
+      mem_base = mem_base + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+      ! external_ab/external_i_aL
+      mem_base = mem_base + REAL(MAX(dimen_RI, MAXVAL(virtual)), KIND=dp)*MAXVAL(maxsize(gd_B_virtual))*8.0_dp/(1024**2)
 
       IF (calc_forces) THEN
          ! Gamma_P_ia
-         mem_per_repl = mem_per_repl + SUM(MAX(REAL(homo, KIND=dp)*maxsize(gd_array), REAL(dimen_RI, KIND=dp))* &
+         mem_per_repl = mem_per_repl + SUM(REAL(homo, KIND=dp)*maxsize(gd_array)* &
                                            maxsize(gd_B_virtual))*8.0_dp/(1024**2)
          ! Y_i_aP+Y_j_aP
          mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
          ! local_ba/t_ab
-         mem_base = mem_base + MAXVAL(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+         mem_base = mem_base + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*MAX(dimen_RI, MAXVAL(virtual))*8.0_dp/(1024**2)
          ! P_ij
          mem_base = mem_base + SUM(REAL(homo, KIND=dp)*homo)*8.0_dp/(1024**2)
          ! P_ab
          mem_base = mem_base + SUM(REAL(virtual, KIND=dp)*maxsize(gd_B_virtual))*8.0_dp/(1024**2)
+         ! send_ab/send_i_aL
+         mem_base = mem_base + REAL(MAX(dimen_RI, MAXVAL(virtual)), KIND=dp)*MAXVAL(maxsize(gd_B_virtual))*8.0_dp/(1024**2)
       END IF
 
       block_size = 1
@@ -1495,20 +1499,20 @@ CONTAINS
       mem_per_blk = 0.0_dp
       mem_per_repl_blk = 0.0_dp
 
-      ! external_i_aL
-      mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
       ! external_ab
-      mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*MAXVAL(virtual)*8.0_dp/(1024**2)
+      mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*MAX(dimen_RI, MAXVAL(virtual))*8.0_dp/(1024**2)
       ! BIB_C_rec
       mem_per_repl_blk = mem_per_repl_blk + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL
       mem_per_blk = mem_per_blk + 2.0_dp*MAXVAL(maxsize(gd_B_virtual))*REAL(dimen_RI, KIND=dp)*8.0_dp/(1024**2)
+      ! Copy to keep arrays contiguous
+      mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*MAX(dimen_RI, MAXVAL(virtual))*8.0_dp/(1024**2)
 
       IF (calc_forces) THEN
          ! Y_i_aP+Y_j_aP+BIb_C_send
          mem_per_blk = mem_per_blk + 3.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
          ! send_ab
-         mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*MAXVAL(virtual)*8.0_dp/(1024**2)
+         mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*MAX(dimen_RI, MAXVAL(virtual))*8.0_dp/(1024**2)
       END IF
 
       best_block_size = 1
@@ -1616,12 +1620,13 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: virtual
       INTEGER, DIMENSION(-para_env_sub%num_pe:), &
          INTENT(IN)                                      :: sub_proc_map
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
-         TARGET                                          :: local_ab
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), TARGET :: t_ab, my_local_i_aL, my_local_j_aL
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(INOUT), TARGET                           :: local_ab
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN), TARGET                              :: t_ab, my_local_i_aL, my_local_j_aL
       LOGICAL, INTENT(IN)                                :: open_ss
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
-         TARGET                                          :: Y_i_aP, Y_j_aP, local_ba
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(INOUT), TARGET                           :: Y_i_aP, Y_j_aP, local_ba
       INTEGER, INTENT(IN)                                :: ispin, jspin
       TYPE(dgemm_counter_type), INTENT(INOUT)            :: dgemm_counter
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:), TARGET    :: buffer_1D

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -110,7 +110,7 @@ CONTAINS
          num_IJ_blocks, num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, &
          rec_B_virtual_end, rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end, &
          send_B_virtual_start, send_block_size, send_i, send_ij_index, send_j, start_point
-      INTEGER :: sub_P_color, sub_sub_color, tag, total_ij_pairs
+      INTEGER :: sub_P_color, tag, total_ij_pairs
       INTEGER, ALLOCATABLE, DIMENSION(:) :: integ_group_pos2color_sub, my_B_size, &
          my_B_virtual_end, my_B_virtual_start, num_ij_pairs, proc_map, proc_map_rep, &
          sizes_array_orig, sub_proc_map, virtual
@@ -188,23 +188,26 @@ CONTAINS
             num_integ_group, virtual(ispin), my_alpha_beta_case, &
             my_open_shell_SS, calc_forces)
 
+         ! now create a group that contains all the proc that have the same virtual starting point
+         ! in the integ group
+         CALL mp2_ri_create_group( &
+            para_env, para_env_sub, color_sub, &
+            gd_array%sizes, calc_forces, &
+            integ_group_size, my_group_L_end, &
+            my_group_L_size, my_group_L_size_orig, my_group_L_start, my_new_group_L_size, &
+            integ_group_pos2color_sub, proc_map, proc_map_rep, sizes_array_orig, &
+            sub_proc_map, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
+
+         CALL replicate_iaK_2intgroup(BIb_C(ispin)%array, para_env_exchange, para_env_rep, &
+                                      homo(ispin), proc_map_rep, gd_array%sizes, my_B_size(ispin), &
+                                      my_group_L_size, ranges_info_array)
+
          CALL mp2_ri_get_block_size( &
             mp2_env, para_env, para_env_sub, gd_array, gd_B_virtual(ispin), &
             homo(ispin), dimen_RI, unit_nr, block_size, &
             ngroup, num_IJ_blocks, &
             virtual(ispin), my_alpha_beta_case, &
             my_open_shell_SS, calc_forces)
-
-         ! now create a group that contains all the proc that have the same virtual starting point
-         ! in the integ group
-         ! sub_sub_color=para_env_sub%mepos
-         CALL mp2_ri_create_group( &
-            BIb_C(ispin)%array, para_env, para_env_sub, homo(ispin), color_sub, &
-            gd_array%sizes, calc_forces, &
-            integ_group_size, my_B_size(ispin), iiB, my_group_L_end, &
-            my_group_L_size, my_group_L_size_orig, my_group_L_start, my_new_group_L_size, &
-            sub_sub_color, integ_group_pos2color_sub, proc_map, proc_map_rep, sizes_array_orig, &
-            sub_proc_map, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
 
          ! *****************************************************************
          ! **********  REPLICATION-BLOCKED COMMUNICATION SCHEME  ***********
@@ -760,8 +763,6 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param BIb_C ...
-!> \param para_env ...
-!> \param para_env_sub ...
 !> \param para_env_exchange ...
 !> \param para_env_rep ...
 !> \param homo ...
@@ -769,99 +770,28 @@ CONTAINS
 !> \param sizes_array ...
 !> \param my_B_size ...
 !> \param my_group_L_size ...
-!> \param my_group_L_start ...
-!> \param my_group_L_end ...
-!> \param my_new_group_L_size ...
-!> \param new_sizes_array ...
 !> \param ranges_info_array ...
 ! **************************************************************************************************
-   SUBROUTINE replicate_iaK_2intgroup(BIb_C, para_env, para_env_sub, para_env_exchange, para_env_rep, &
-                                      homo, proc_map_rep, &
-                                      sizes_array, &
-                                      my_B_size, &
-                                      my_group_L_size, my_group_L_start, my_group_L_end, &
-                                      my_new_group_L_size, new_sizes_array, ranges_info_array)
+   SUBROUTINE replicate_iaK_2intgroup(BIb_C, para_env_exchange, para_env_rep, homo, proc_map_rep, sizes_array, my_B_size, &
+                                      my_group_L_size, ranges_info_array)
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: BIb_C
-      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_rep
+      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_exchange, para_env_rep
       INTEGER, INTENT(IN)                                :: homo
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: proc_map_rep
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: sizes_array
-      INTEGER, INTENT(IN)                                :: my_B_size, my_group_L_size, &
-                                                            my_group_L_start, my_group_L_end
-      INTEGER, INTENT(INOUT)                             :: my_new_group_L_size
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: new_sizes_array
-      INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(OUT)                                     :: ranges_info_array
+      INTEGER, DIMENSION(-para_env_rep%num_pe:), &
+         INTENT(IN)                                      :: proc_map_rep
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: sizes_array
+      INTEGER, INTENT(IN)                                :: my_B_size, my_group_L_size
+      INTEGER, DIMENSION(:, 0:, 0:), INTENT(IN)          :: ranges_info_array
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'replicate_iaK_2intgroup'
 
-      INTEGER                                            :: end_point, handle, i, max_L_size, &
-                                                            proc_receive, proc_shift, start_point, &
-                                                            sub_sub_color
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rep_ends_array, rep_sizes_array, &
-                                                            rep_starts_array
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: my_info
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: BIb_C_copy
+      INTEGER                                            :: end_point, handle, max_L_size, &
+                                                            proc_receive, proc_shift, start_point
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: BIb_C_gather
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: BIb_C_copy
 
       CALL timeset(routineN, handle)
-
-      ! create the replication group
-      sub_sub_color = para_env_sub%mepos*para_env_exchange%num_pe + para_env_exchange%mepos
-      CALL cp_para_env_split(para_env_rep, para_env, sub_sub_color)
-
-      ! crate the proc maps
-      ALLOCATE (proc_map_rep(-para_env_rep%num_pe:2*para_env_rep%num_pe - 1))
-      DO i = 0, para_env_rep%num_pe - 1
-         proc_map_rep(i) = i
-         proc_map_rep(-i - 1) = para_env_rep%num_pe - i - 1
-         proc_map_rep(para_env_rep%num_pe + i) = i
-      END DO
-
-      ! create the new limits for K according to the size
-      ! of the integral group
-
-      ! info array for replication
-      ALLOCATE (rep_ends_array(0:para_env_rep%num_pe - 1))
-      ALLOCATE (rep_starts_array(0:para_env_rep%num_pe - 1))
-      ALLOCATE (rep_sizes_array(0:para_env_rep%num_pe - 1))
-
-      CALL mp_allgather(my_group_L_size, rep_sizes_array, para_env_rep%group)
-      CALL mp_allgather(my_group_L_start, rep_starts_array, para_env_rep%group)
-      CALL mp_allgather(my_group_L_end, rep_ends_array, para_env_rep%group)
-
-      ! calculate my_new_group_L_size according to sizes_array
-      my_new_group_L_size = my_group_L_size
-
-      ! Info of this process
-      ALLOCATE (my_info(4, 0:para_env_rep%num_pe - 1))
-      my_info(1, 0) = my_group_L_start
-      my_info(2, 0) = my_group_L_end
-      my_info(3, 0) = 1
-      my_info(4, 0) = my_group_L_size
-
-      DO proc_shift = 1, para_env_rep%num_pe - 1
-         proc_receive = proc_map_rep(para_env_rep%mepos - proc_shift)
-
-         my_new_group_L_size = my_new_group_L_size + rep_sizes_array(proc_receive)
-
-         my_info(1, proc_shift) = rep_starts_array(proc_receive)
-         my_info(2, proc_shift) = rep_ends_array(proc_receive)
-         my_info(3, proc_shift) = my_info(4, proc_shift - 1) + 1
-         my_info(4, proc_shift) = my_new_group_L_size
-
-      END DO
-
-      ALLOCATE (new_sizes_array(0:para_env_exchange%num_pe - 1))
-      ALLOCATE (ranges_info_array(4, 0:para_env_rep%num_pe - 1, 0:para_env_exchange%num_pe - 1))
-      CALL mp_allgather(my_new_group_L_size, new_sizes_array, para_env_exchange%group)
-      CALL mp_allgather(my_info, ranges_info_array, para_env_exchange%group)
-
-      DEALLOCATE (rep_sizes_array)
-      DEALLOCATE (rep_starts_array)
-      DEALLOCATE (rep_ends_array)
 
       ! replication scheme using mp_allgather
       ! get the max L size of the
@@ -869,7 +799,7 @@ CONTAINS
 
       ALLOCATE (BIb_C_copy(max_L_size, my_B_size, homo))
       BIb_C_copy = 0.0_dp
-      BIb_C_copy(1:my_group_L_size, 1:my_B_size, 1:homo) = BIb_C
+      BIb_C_copy(1:SIZE(BIb_C, 1), 1:my_B_size, 1:homo) = BIb_C
 
       DEALLOCATE (BIb_C)
 
@@ -880,15 +810,15 @@ CONTAINS
 
       DEALLOCATE (BIb_C_copy)
 
-      ALLOCATE (BIb_C(my_new_group_L_size, my_B_size, homo))
+      ALLOCATE (BIb_C(my_group_L_size, my_B_size, homo))
       BIb_C = 0.0_dp
 
       ! reorder data
       DO proc_shift = 0, para_env_rep%num_pe - 1
          proc_receive = proc_map_rep(para_env_rep%mepos - proc_shift)
 
-         start_point = my_info(3, proc_shift)
-         end_point = my_info(4, proc_shift)
+         start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
+         end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
 
          BIb_C(start_point:end_point, 1:my_B_size, 1:homo) = &
             BIb_C_gather(1:end_point - start_point + 1, 1:my_B_size, 1:homo, proc_receive)
@@ -1114,22 +1044,17 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param BIb_C ...
 !> \param para_env ...
 !> \param para_env_sub ...
-!> \param homo ...
 !> \param color_sub ...
 !> \param sizes_array ...
 !> \param calc_forces ...
 !> \param integ_group_size ...
-!> \param my_B_size ...
-!> \param iiB ...
 !> \param my_group_L_end ...
 !> \param my_group_L_size ...
 !> \param my_group_L_size_orig ...
 !> \param my_group_L_start ...
 !> \param my_new_group_L_size ...
-!> \param sub_sub_color ...
 !> \param integ_group_pos2color_sub ...
 !> \param proc_map ...
 !> \param proc_map_rep ...
@@ -1140,27 +1065,22 @@ CONTAINS
 !> \param para_env_rep ...
 !> \param num_integ_group ...
 ! **************************************************************************************************
-   SUBROUTINE mp2_ri_create_group(BIb_C, para_env, para_env_sub, homo, color_sub, &
+   SUBROUTINE mp2_ri_create_group(para_env, para_env_sub, color_sub, &
                                   sizes_array, calc_forces, &
-                                  integ_group_size, my_B_size, iiB, my_group_L_end, &
+                                  integ_group_size, my_group_L_end, &
                                   my_group_L_size, my_group_L_size_orig, my_group_L_start, my_new_group_L_size, &
-                                  sub_sub_color, integ_group_pos2color_sub, &
+                                  integ_group_pos2color_sub, &
                                   proc_map, proc_map_rep, sizes_array_orig, &
                                   sub_proc_map, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         INTENT(INOUT)                                   :: BIb_C
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
-      INTEGER, INTENT(IN)                                :: homo, color_sub
+      INTEGER, INTENT(IN)                                :: color_sub
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(INOUT)  :: sizes_array
       LOGICAL, INTENT(IN)                                :: calc_forces
-      INTEGER, INTENT(IN)                                :: integ_group_size, my_B_size
-      INTEGER, INTENT(OUT)                               :: iiB
-      INTEGER, INTENT(IN)                                :: my_group_L_end
+      INTEGER, INTENT(IN)                                :: integ_group_size, my_group_L_end
       INTEGER, INTENT(INOUT)                             :: my_group_L_size
       INTEGER, INTENT(OUT)                               :: my_group_L_size_orig
       INTEGER, INTENT(IN)                                :: my_group_L_start
       INTEGER, INTENT(INOUT)                             :: my_new_group_L_size
-      INTEGER, INTENT(OUT)                               :: sub_sub_color
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: integ_group_pos2color_sub, proc_map, &
                                                             proc_map_rep, sizes_array_orig, &
                                                             sub_proc_map
@@ -1171,8 +1091,11 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_create_group'
 
-      INTEGER                                            :: handle, i
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: new_sizes_array
+      INTEGER                                            :: handle, i, iiB, proc_receive, &
+                                                            proc_shift, sub_sub_color
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: new_sizes_array, rep_ends_array, &
+                                                            rep_sizes_array, rep_starts_array
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: my_info
 
       CALL timeset(routineN, handle)
       !
@@ -1194,12 +1117,60 @@ CONTAINS
          sub_proc_map(para_env_sub%num_pe + i) = i
       END DO
 
-      CALL replicate_iaK_2intgroup(BIb_C, para_env, para_env_sub, para_env_exchange, para_env_rep, &
-                                   homo, proc_map_rep, &
-                                   sizes_array, &
-                                   my_B_size, &
-                                   my_group_L_size, my_group_L_start, my_group_L_end, &
-                                   my_new_group_L_size, new_sizes_array, ranges_info_array)
+      ! create the replication group
+      sub_sub_color = para_env_sub%mepos*para_env_exchange%num_pe + para_env_exchange%mepos
+      CALL cp_para_env_split(para_env_rep, para_env, sub_sub_color)
+
+      ! crate the proc maps
+      ALLOCATE (proc_map_rep(-para_env_rep%num_pe:2*para_env_rep%num_pe - 1))
+      DO i = 0, para_env_rep%num_pe - 1
+         proc_map_rep(i) = i
+         proc_map_rep(-i - 1) = para_env_rep%num_pe - i - 1
+         proc_map_rep(para_env_rep%num_pe + i) = i
+      END DO
+
+      ! create the new limits for K according to the size
+      ! of the integral group
+
+      ! info array for replication
+      ALLOCATE (rep_ends_array(0:para_env_rep%num_pe - 1))
+      ALLOCATE (rep_starts_array(0:para_env_rep%num_pe - 1))
+      ALLOCATE (rep_sizes_array(0:para_env_rep%num_pe - 1))
+
+      CALL mp_allgather(my_group_L_size, rep_sizes_array, para_env_rep%group)
+      CALL mp_allgather(my_group_L_start, rep_starts_array, para_env_rep%group)
+      CALL mp_allgather(my_group_L_end, rep_ends_array, para_env_rep%group)
+
+      ! calculate my_new_group_L_size according to sizes_array
+      my_new_group_L_size = my_group_L_size
+
+      ! Info of this process
+      ALLOCATE (my_info(4, 0:para_env_rep%num_pe - 1))
+      my_info(1, 0) = my_group_L_start
+      my_info(2, 0) = my_group_L_end
+      my_info(3, 0) = 1
+      my_info(4, 0) = my_group_L_size
+
+      DO proc_shift = 1, para_env_rep%num_pe - 1
+         proc_receive = proc_map_rep(para_env_rep%mepos - proc_shift)
+
+         my_new_group_L_size = my_new_group_L_size + rep_sizes_array(proc_receive)
+
+         my_info(1, proc_shift) = rep_starts_array(proc_receive)
+         my_info(2, proc_shift) = rep_ends_array(proc_receive)
+         my_info(3, proc_shift) = my_info(4, proc_shift - 1) + 1
+         my_info(4, proc_shift) = my_new_group_L_size
+
+      END DO
+
+      ALLOCATE (new_sizes_array(0:para_env_exchange%num_pe - 1))
+      ALLOCATE (ranges_info_array(4, 0:para_env_rep%num_pe - 1, 0:para_env_exchange%num_pe - 1))
+      CALL mp_allgather(my_new_group_L_size, new_sizes_array, para_env_exchange%group)
+      CALL mp_allgather(my_info, ranges_info_array, para_env_exchange%group)
+
+      DEALLOCATE (rep_sizes_array)
+      DEALLOCATE (rep_starts_array)
+      DEALLOCATE (rep_ends_array)
 
       ALLOCATE (integ_group_pos2color_sub(0:para_env_exchange%num_pe - 1))
       CALL mp_allgather(color_sub, integ_group_pos2color_sub, para_env_exchange%group)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -183,6 +183,19 @@ CONTAINS
 
          DO ispin = 1, jspin
 
+            IF (unit_nr > 0) THEN
+               IF (nspins == 1) THEN
+                  WRITE (unit_nr, *) "Start loop run"
+               ELSE IF (ispin == 1 .AND. jspin == 1) THEN
+                  WRITE (unit_nr, *) "Start loop run alpha-alpha"
+               ELSE IF (ispin == 1 .AND. jspin == 2) THEN
+                  WRITE (unit_nr, *) "Start loop run alpha-beta"
+               ELSE IF (ispin == 2 .AND. jspin == 2) THEN
+                  WRITE (unit_nr, *) "Start loop run beta-beta"
+               END IF
+               CALL m_flush(unit_nr)
+            END IF
+
             my_open_shell_SS = (nspins == 2) .AND. (ispin == jspin)
 
             ! t_ab = amp_fac*(:,a|:,b)-(:,b|:,a)
@@ -228,23 +241,10 @@ CONTAINS
             CALL mp2_ri_allocate_blk(dimen_RI, my_B_size, block_size, local_i_aL, &
                                      local_j_aL, calc_forces, Y_i_aP, Y_j_aP, ispin, jspin)
 
-            IF (unit_nr > 0) THEN
-               IF (nspins == 1) THEN
-                  WRITE (unit_nr, *) "Start loop run"
-               ELSE IF (ispin == 1 .AND. jspin == 1) THEN
-                  WRITE (unit_nr, *) "Start loop run alpha-alpha"
-               ELSE IF (ispin == 1 .AND. jspin == 2) THEN
-                  WRITE (unit_nr, *) "Start loop run alpha-beta"
-               ELSE IF (ispin == 2 .AND. jspin == 2) THEN
-                  WRITE (unit_nr, *) "Start loop run beta-beta"
-               END IF
-               CALL m_flush(unit_nr)
-               t_start = m_walltime()
-            END IF
-
             CALL timeset(routineN//"_RI_loop", handle2)
             my_Emp2_Cou = 0.0_dp
             my_Emp2_EX = 0.0_dp
+            t_start = m_walltime()
             DO ij_index = 1, max_ij_pairs
 
                IF (unit_nr > 0) THEN
@@ -949,7 +949,7 @@ CONTAINS
       INTEGER :: assigned_blocks, first_I_block, first_J_block, handle, iiB, ij_block_counter, &
          ij_counter, jjB, last_i_block, last_J_block, num_block_per_group, num_IJ_blocks, &
          num_IJ_blocks_beta, total_ij_block, total_ij_pairs_blocks
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: ij_marker
+      LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: ij_marker
 
 ! Calculate the maximum number of ij pairs that have to be computed
 ! among groups
@@ -980,7 +980,7 @@ CONTAINS
          total_ij_pairs_blocks = assigned_blocks + (total_ij_pairs - assigned_blocks*(block_size**2))
 
          ALLOCATE (ij_marker(homo, homo))
-         ij_marker = 0
+         ij_marker = .TRUE.
          ALLOCATE (ij_map(3, total_ij_pairs_blocks))
          ij_map = 0
          ij_counter = 0
@@ -989,7 +989,7 @@ CONTAINS
             DO jjB = iiB + block_size, last_J_block, block_size
                IF (ij_counter + 1 > assigned_blocks) EXIT
                ij_counter = ij_counter + 1
-               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = 1
+               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = .FALSE.
                ij_map(1, ij_counter) = iiB
                ij_map(2, ij_counter) = jjB
                ij_map(3, ij_counter) = block_size
@@ -998,7 +998,7 @@ CONTAINS
          END DO
          DO iiB = 1, homo
             DO jjB = iiB, homo
-               IF (ij_marker(iiB, jjB) == 0) THEN
+               IF (ij_marker(iiB, jjB)) THEN
                   ij_counter = ij_counter + 1
                   ij_map(1, ij_counter) = iiB
                   ij_map(2, ij_counter) = jjB
@@ -1018,12 +1018,13 @@ CONTAINS
          first_I_block = 1
          last_i_block = block_size*(num_IJ_blocks - 1)
 
-         first_J_block = block_size + 1
+         ! We shift the blocks to prevent the calculation of the diagonal elements which always give zero
+         first_J_block = block_size + 2
          last_J_block = block_size*(num_IJ_blocks + 1) + 1
 
          ij_block_counter = 0
          DO iiB = first_I_block, last_i_block, block_size
-            DO jjB = iiB + block_size, last_J_block, block_size
+            DO jjB = iiB + block_size + 1, last_J_block, block_size
                ij_block_counter = ij_block_counter + 1
             END DO
          END DO
@@ -1035,16 +1036,16 @@ CONTAINS
          total_ij_pairs_blocks = assigned_blocks + (total_ij_pairs - assigned_blocks*(block_size**2))
 
          ALLOCATE (ij_marker(homo, homo))
-         ij_marker = 0
+         ij_marker = .TRUE.
          ALLOCATE (ij_map(3, total_ij_pairs_blocks))
          ij_map = 0
          ij_counter = 0
          my_ij_pairs = 0
          DO iiB = first_I_block, last_i_block, block_size
-            DO jjB = iiB + block_size, last_J_block, block_size
+            DO jjB = iiB + block_size + 1, last_J_block, block_size
                IF (ij_counter + 1 > assigned_blocks) EXIT
                ij_counter = ij_counter + 1
-               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = 1
+               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = .FALSE.
                ij_map(1, ij_counter) = iiB
                ij_map(2, ij_counter) = jjB
                ij_map(3, ij_counter) = block_size
@@ -1053,7 +1054,7 @@ CONTAINS
          END DO
          DO iiB = 1, homo
             DO jjB = iiB + 1, homo
-               IF (ij_marker(iiB, jjB) == 0) THEN
+               IF (ij_marker(iiB, jjB)) THEN
                   ij_counter = ij_counter + 1
                   ij_map(1, ij_counter) = iiB
                   ij_map(2, ij_counter) = jjB
@@ -1077,7 +1078,7 @@ CONTAINS
 
          ij_block_counter = 0
          DO iiB = first_I_block, last_i_block, block_size
-            DO jjB = iiB + block_size, last_J_block, block_size
+            DO jjB = first_J_block, last_J_block, block_size
                ij_block_counter = ij_block_counter + 1
             END DO
          END DO
@@ -1089,7 +1090,7 @@ CONTAINS
          total_ij_pairs_blocks = assigned_blocks + (total_ij_pairs - assigned_blocks*(block_size**2))
 
          ALLOCATE (ij_marker(homo, homo_beta))
-         ij_marker = 0
+         ij_marker = .TRUE.
          ALLOCATE (ij_map(3, total_ij_pairs_blocks))
          ij_map = 0
          ij_counter = 0
@@ -1098,7 +1099,7 @@ CONTAINS
             DO jjB = first_J_block, last_J_block, block_size
                IF (ij_counter + 1 > assigned_blocks) EXIT
                ij_counter = ij_counter + 1
-               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = 1
+               ij_marker(iiB:iiB + block_size - 1, jjB:jjB + block_size - 1) = .FALSE.
                ij_map(1, ij_counter) = iiB
                ij_map(2, ij_counter) = jjB
                ij_map(3, ij_counter) = block_size
@@ -1107,7 +1108,7 @@ CONTAINS
          END DO
          DO iiB = 1, homo
             DO jjB = 1, homo_beta
-               IF (ij_marker(iiB, jjB) == 0) THEN
+               IF (ij_marker(iiB, jjB)) THEN
                   ij_counter = ij_counter + 1
                   ij_map(1, ij_counter) = iiB
                   ij_map(2, ij_counter) = jjB
@@ -1465,7 +1466,8 @@ CONTAINS
 
       INTEGER                                            :: best_block_size, handle, num_IJ_blocks
       INTEGER(KIND=int_8)                                :: mem
-      REAL(KIND=dp)                                      :: mem_per_blk, mem_per_repl_blk, mem_real
+      REAL(KIND=dp)                                      :: mem_base, mem_per_blk, mem_per_repl_blk, &
+                                                            mem_real
 
       CALL timeset(routineN, handle)
 
@@ -1477,9 +1479,12 @@ CONTAINS
       ! has not been given back to the OS yet.
       CALL mp_min(mem_real, para_env%group)
 
+      mem_base = 0.0_dp
       mem_per_blk = 0.0_dp
       mem_per_repl_blk = 0.0_dp
 
+! external_i_aL
+      mem_base = mem_base + MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
       ! BIB_C_rec
       mem_per_repl_blk = mem_per_repl_blk + REAL(MAXVAL(maxsize(gd_B_virtual)), KIND=dp)*maxsize(gd_array)*8.0_dp/(1024**2)
       ! local_i_aL+local_j_aL
@@ -1490,7 +1495,7 @@ CONTAINS
          mem_per_blk = mem_per_blk + 3.0_dp*MAXVAL(maxsize(gd_B_virtual))*dimen_RI*8.0_dp/(1024**2)
       END IF
 
-      mem_real = MIN(mp2_env%mp2_memory, mem_real)
+      !mem_real = MIN(mp2_env%mp2_memory, mem_real)
 
       best_block_size = 1
 
@@ -1498,7 +1503,7 @@ CONTAINS
       IF (mp2_env%ri_mp2%block_size > 0) THEN
          best_block_size = mp2_env%ri_mp2%block_size
       ELSE
-         best_block_size = MAX(FLOOR(mem_real/(mem_per_blk + mem_per_repl_blk*ngroup/num_integ_group)), 1)
+         best_block_size = MAX(FLOOR((mem_real - mem_base)/(mem_per_blk + mem_per_repl_blk*ngroup/num_integ_group)), 1)
 
          DO
             IF (SIZE(homo) == 1) THEN
@@ -1523,6 +1528,7 @@ CONTAINS
       IF (SIZE(homo) == 1) THEN
       IF (my_open_shell_ss) THEN
          ! check that best_block_size is not bigger than sqrt(homo-1)
+         ! Diagonal elements do not have to be considered
          best_block_size = MIN(FLOOR(SQRT(REAL(homo(1) - 1, KIND=dp))), best_block_size)
       ELSE
          ! check that best_block_size is not bigger than sqrt(homo)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -163,6 +163,16 @@ CONTAINS
          integ_group_size, ngroup, &
          num_integ_group, virtual, calc_forces)
 
+      ! now create a group that contains all the proc that have the same virtual starting point
+      ! in the integ group
+      CALL mp2_ri_create_group( &
+         para_env, para_env_sub, color_sub, &
+         gd_array%sizes, calc_forces, &
+         integ_group_size, my_group_L_end, &
+         my_group_L_size, my_group_L_size_orig, my_group_L_start, my_new_group_L_size, &
+         integ_group_pos2color_sub, proc_map, proc_map_rep, sizes_array_orig, &
+         sub_proc_map, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
+
       ALLOCATE (replicated(nspins))
       replicated = .FALSE.
 
@@ -190,16 +200,6 @@ CONTAINS
 
          amp_fac = mp2_env%scale_S + mp2_env%scale_T
          IF (my_alpha_beta_case .OR. my_open_shell_SS) amp_fac = mp2_env%scale_T
-
-         ! now create a group that contains all the proc that have the same virtual starting point
-         ! in the integ group
-         CALL mp2_ri_create_group( &
-            para_env, para_env_sub, color_sub, &
-            gd_array%sizes, calc_forces, &
-            integ_group_size, my_group_L_end, &
-            my_group_L_size, my_group_L_size_orig, my_group_L_start, my_new_group_L_size, &
-            integ_group_pos2color_sub, proc_map, proc_map_rep, sizes_array_orig, &
-            sub_proc_map, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
 
          DO kspin = ispin, jspin
          IF (.NOT. replicated(kspin)) THEN
@@ -584,8 +584,6 @@ CONTAINS
 
          END IF
 
-         DEALLOCATE (integ_group_pos2color_sub)
-
          CALL mp_sum(my_Emp2_Cou, para_env%group)
          CALL mp_sum(my_Emp2_Ex, para_env%group)
 
@@ -601,13 +599,6 @@ CONTAINS
                ! release para_env_P
                CALL cp_para_env_release(para_env_P)
             END IF
-
-            ! recover original information (before replication)
-            DEALLOCATE (gd_array%sizes)
-            iiB = SIZE(sizes_array_orig)
-            ALLOCATE (gd_array%sizes(0:iiB - 1))
-            gd_array%sizes(:) = sizes_array_orig
-            DEALLOCATE (sizes_array_orig)
 
             ! make a copy of the original integrals (ia|Q)
             my_group_L_size = my_group_L_size_orig
@@ -679,19 +670,27 @@ CONTAINS
             Emp2_Cou = Emp2_Cou + my_Emp2_Cou
             Emp2_EX = Emp2_EX + my_Emp2_EX
          END IF
-
-         DEALLOCATE (proc_map)
-         DEALLOCATE (proc_map_rep)
-         DEALLOCATE (ranges_info_array)
-
-         CALL cp_para_env_release(para_env_exchange)
-         CALL cp_para_env_release(para_env_rep)
       END DO
       END DO
+
+      DEALLOCATE (integ_group_pos2color_sub)
+      DEALLOCATE (proc_map)
+      DEALLOCATE (proc_map_rep)
+      DEALLOCATE (ranges_info_array)
+
+      CALL cp_para_env_release(para_env_exchange)
+      CALL cp_para_env_release(para_env_rep)
 
       DEALLOCATE (replicated)
 
       IF (calc_forces) THEN
+         ! recover original information (before replication)
+         DEALLOCATE (gd_array%sizes)
+         iiB = SIZE(sizes_array_orig)
+         ALLOCATE (gd_array%sizes(0:iiB - 1))
+         gd_array%sizes(:) = sizes_array_orig
+         DEALLOCATE (sizes_array_orig)
+
          ! Reduce size of Gamma_P_ia to save memory
          DO ispin = 1, nspins
             ALLOCATE (BIb_C(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size))

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -109,8 +109,7 @@ CONTAINS
          my_group_L_start, my_i, my_ij_pairs, my_j, my_new_group_L_size, ngroup, nspins, &
          num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, rec_B_virtual_end, &
          rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end, send_B_virtual_start, &
-         send_i, send_ij_index, send_j, start_point, sub_P_color, tag
-      INTEGER :: total_ij_pairs
+         send_i, send_ij_index, send_j, start_point, sub_P_color, tag, total_ij_pairs
       INTEGER, ALLOCATABLE, DIMENSION(:) :: integ_group_pos2color_sub, my_B_size, &
          my_B_virtual_end, my_B_virtual_start, num_ij_pairs, proc_map, proc_map_rep, &
          sizes_array_orig, sub_proc_map, virtual
@@ -125,9 +124,10 @@ CONTAINS
          TARGET                                          :: local_ab, local_ba, t_ab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          TARGET                                          :: local_i_aL, local_j_aL, Y_i_aP, Y_j_aP
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: external_ab, external_i_aL
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: BI_C_rec
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: external_ab, external_i_aL
       TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_P, &
                                                             para_env_rep
       TYPE(dgemm_counter_type)                           :: dgemm_counter
@@ -1624,7 +1624,8 @@ CONTAINS
       INTEGER :: a, b, b_global, handle, proc_receive, proc_send, proc_shift, rec_B_size, &
          rec_B_virtual_end, rec_B_virtual_start, send_B_size, send_B_virtual_end, &
          send_B_virtual_start
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: external_ab, send_ab
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: external_ab, send_ab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: buffer_1D, buffer_2_1D
       REAL(KIND=dp)                                      :: factor, P_ij_diag
       LOGICAL                                            :: alpha_beta
@@ -1937,8 +1938,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_redistribute_gamma'
 
       INTEGER :: end_point, handle, handle2, iiB, ij_counter_rec, irep, kkk, lll, Lstart_pos, &
-         proc_receive, proc_send, proc_shift, rec_i, rec_ij_index, send_L_size, &
-         start_point, tag
+         proc_receive, proc_send, proc_shift, rec_i, rec_ij_index, send_L_size, start_point, tag
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: BI_C_rec_1D, BI_C_send_1D
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: BI_C_rec, BI_C_send

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -648,24 +648,7 @@ CONTAINS
                END DO
             END DO
 
-            IF (.NOT. my_open_shell_ss) THEN
-               ! Reduce size of Gamma_P_ia to save memory
-               DO kspin = ispin, jspin
-                  BIb_C(kspin)%array(:, :, :) = mp2_env%ri_grad%Gamma_P_ia(kspin)%array(:, :, 1:my_group_L_size)
-                  DEALLOCATE (mp2_env%ri_grad%Gamma_P_ia(kspin)%array)
-                  CALL MOVE_ALLOC(BIb_C(kspin)%array, mp2_env%ri_grad%Gamma_P_ia(kspin)%array)
-               END DO
-
-               ! B_ia_Q(kspin)%array will be deallocated inside of complete_gamma
-               DO kspin = ispin, jspin
-                  CALL complete_gamma(mp2_env, B_ia_Q(kspin)%array, dimen_RI, homo(kspin), &
-                                      virtual(kspin), para_env, para_env_sub, ngroup, &
-                                      my_group_L_size, my_group_L_start, my_group_L_end, &
-                                      my_B_size(kspin), my_B_virtual_start(kspin), &
-                                      gd_array, gd_B_virtual(kspin), &
-                                      sub_proc_map, kspin)
-               END DO
-            ELSE
+            IF (my_open_shell_ss) THEN
                DO kspin = ispin, jspin
                   DEALLOCATE (BIb_C(kspin)%array)
                END DO
@@ -680,8 +663,8 @@ CONTAINS
                END DO
                ! There is only one B_ia_Q allocated in this case
                DEALLOCATE (B_ia_Q(ispin)%array)
+               DEALLOCATE (B_ia_Q)
             END IF
-            DEALLOCATE (B_ia_Q)
 
          END IF
 
@@ -702,17 +685,41 @@ CONTAINS
          END IF
 
          DEALLOCATE (proc_map)
-         DEALLOCATE (sub_proc_map)
          DEALLOCATE (proc_map_rep)
          DEALLOCATE (ranges_info_array)
 
          CALL cp_para_env_release(para_env_exchange)
          CALL cp_para_env_release(para_env_rep)
 
+         WRITE (*, *) ispin, jspin
+      END DO
+      DO kspin = 1, nspins
+         WRITE (*, *) ALLOCATED(mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
       END DO
       END DO
 
       DEALLOCATE (replicated)
+
+      IF (calc_forces) THEN
+         ! Reduce size of Gamma_P_ia to save memory
+         DO ispin = 1, nspins
+            BIb_C(ispin)%array(:, :, :) = mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size)
+            DEALLOCATE (mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
+            CALL MOVE_ALLOC(BIb_C(ispin)%array, mp2_env%ri_grad%Gamma_P_ia(ispin)%array)
+         END DO
+
+         ! B_ia_Q(ispin)%array will be deallocated inside of complete_gamma
+         DO ispin = 1, nspins
+            CALL complete_gamma(mp2_env, B_ia_Q(ispin)%array, dimen_RI, homo(ispin), &
+                                virtual(ispin), para_env, para_env_sub, ngroup, &
+                                my_group_L_size, my_group_L_start, my_group_L_end, &
+                                my_B_size(ispin), my_B_virtual_start(ispin), &
+                                gd_array, gd_B_virtual(ispin), &
+                                sub_proc_map, ispin)
+         END DO
+         DEALLOCATE (B_ia_Q)
+      END IF
+      DEALLOCATE (sub_proc_map)
 
       CALL release_group_dist(gd_array)
       DO ispin = 1, nspins

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -587,21 +587,6 @@ CONTAINS
          CALL mp_sum(my_Emp2_Cou, para_env%group)
          CALL mp_sum(my_Emp2_Ex, para_env%group)
 
-         IF (calc_forces) THEN
-            ! sum P_ab
-            IF (.NOT. my_open_shell_ss) THEN
-               IF (nspins == 1) mp2_env%ri_grad%P_ab(1)%array(:, :) = mp2_env%ri_grad%P_ab(1)%array(:, :)*2.0_dp
-               sub_P_color = para_env_sub%mepos
-               CALL cp_para_env_split(para_env_P, para_env, sub_P_color)
-               DO kspin = ispin, jspin
-                  CALL mp_sum(mp2_env%ri_grad%P_ab(kspin)%array, para_env_P%group)
-               END DO
-               ! release para_env_P
-               CALL cp_para_env_release(para_env_P)
-            END IF
-
-         END IF
-
          IF (my_open_shell_SS .OR. my_alpha_beta_case) THEN
             IF (my_alpha_beta_case) THEN
                Emp2_S = Emp2_S + my_Emp2_Cou
@@ -630,7 +615,7 @@ CONTAINS
          gd_array%sizes(:) = sizes_array_orig
          DEALLOCATE (sizes_array_orig)
 
-         ! make a copy of the original integrals (ia|Q)
+         ! Remove replication from BIb_C and reorder the matrix
          my_group_L_size = my_group_L_size_orig
          ALLOCATE (B_ia_Q(ispin:jspin))
          DO ispin = 1, nspins
@@ -689,6 +674,15 @@ CONTAINS
                                 sub_proc_map, ispin)
          END DO
          DEALLOCATE (B_ia_Q)
+
+         IF (nspins == 1) mp2_env%ri_grad%P_ab(1)%array(:, :) = mp2_env%ri_grad%P_ab(1)%array(:, :)*2.0_dp
+         sub_P_color = para_env_sub%mepos
+         CALL cp_para_env_split(para_env_P, para_env, sub_P_color)
+         DO ispin = 1, nspins
+            CALL mp_sum(mp2_env%ri_grad%P_ab(ispin)%array, para_env_P%group)
+         END DO
+         ! release para_env_P
+         CALL cp_para_env_release(para_env_P)
       ELSE
 
          DEALLOCATE (integ_group_pos2color_sub)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -120,12 +120,14 @@ CONTAINS
                                                             my_open_shell_SS
       REAL(KIND=dp)                                      :: amp_fac, my_Emp2_Cou, my_Emp2_EX, &
                                                             sym_fac, t_new, t_start
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: BI_C_rec_1D
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          TARGET                                          :: external_ab, external_i_aL, local_ab, &
                                                             local_ba, t_ab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
-         TARGET                                          :: BI_C_rec, local_i_aL, local_j_aL, &
-                                                            Y_i_aP, Y_j_aP
+         TARGET                                          :: local_i_aL, local_j_aL, Y_i_aP, Y_j_aP
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
+         POINTER                                         :: BI_C_rec
       TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_P, &
                                                             para_env_rep
       TYPE(dgemm_counter_type)                           :: dgemm_counter
@@ -278,6 +280,8 @@ CONTAINS
                   CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
                                        BIb_C(jspin)%array(:, :, my_j:my_j + my_block_size - 1))
 
+                  ALLOCATE (BI_C_rec_1D(INT(maxsize(gd_array), int_8)*MAXVAL(my_B_size)*my_block_size))
+
                   ! collect data from other proc
                   CALL timeset(routineN//"_comm", handle3)
                   DO proc_shift = 1, para_env_exchange%num_pe - 1
@@ -287,7 +291,6 @@ CONTAINS
                      send_ij_index = num_ij_pairs(proc_send)
 
                      CALL get_group_dist(gd_array, proc_receive, sizes=rec_L_size)
-                     ALLOCATE (BI_C_rec(rec_L_size, MAXVAL(my_B_size), my_block_size))
 
                      IF (ij_index <= send_ij_index) THEN
                         ij_counter_send = (ij_index - MIN(1, integ_group_pos2color_sub(proc_send)))*ngroup + &
@@ -297,6 +300,8 @@ CONTAINS
                         send_block_size = ij_map(3, ij_counter_send)
 
                         ! occupied i
+                        BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:send_block_size) => &
+                           BI_C_rec_1D(1:rec_L_size*my_B_size(ispin)*send_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + send_block_size - 1), &
                                          proc_send, BI_C_rec, proc_receive, &
@@ -306,6 +311,8 @@ CONTAINS
                                              BI_C_rec(:, 1:my_B_size(ispin), :))
 
                         ! occupied j
+                        BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:send_block_size) => &
+                           BI_C_rec_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*send_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + send_block_size - 1), &
                                          proc_send, BI_C_rec, proc_receive, &
@@ -318,24 +325,29 @@ CONTAINS
                         ! we send nothing while we know that we have to receive something
 
                         ! occupied i
+                        BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:my_block_size) => &
+                           BI_C_rec_1D(1:INT(rec_L_size, int_8)*my_B_size(ispin)*my_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
 
                         CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
-                                             BI_C_rec(:, 1:my_B_size(ispin), :))
+                                             BI_C_rec(:, 1:my_B_size(ispin), 1:my_block_size))
 
                         ! occupied j
+                        BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:my_block_size) => &
+                           BI_C_rec_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*my_block_size)
                         BI_C_rec = 0.0_dp
                         CALL mp_recv(BI_C_rec, proc_receive, tag, para_env_exchange%group)
 
                         CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
-                                             BI_C_rec(:, 1:my_B_size(jspin), :))
+                                             BI_C_rec(:, 1:my_B_size(jspin), 1:my_block_size))
 
                      END IF
 
-                     DEALLOCATE (BI_C_rec)
-
                   END DO
+
+                  DEALLOCATE (BI_C_rec_1D)
+
                   CALL timestop(handle3)
 
                   ! loop over the block elements

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -116,8 +116,8 @@ CONTAINS
          sizes_array_orig, sub_proc_map, virtual
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: ij_map
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: ranges_info_array
-      LOGICAL                                            :: my_alpha_alpha_case, my_alpha_beta_case, &
-                                                            my_beta_beta_case, my_open_shell_SS
+      LOGICAL                                            :: my_alpha_beta_case, my_beta_beta_case, &
+                                                            my_open_shell_SS
       REAL(KIND=dp)                                      :: amp_fac, my_Emp2_Cou, my_Emp2_EX, &
                                                             sym_fac, t_new, t_start
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
@@ -189,13 +189,11 @@ CONTAINS
             ! If we calculate the gradient we need to distinguish
             ! between alpha-alpha and beta-beta cases for UMP2
 
-            my_alpha_alpha_case = .FALSE.
             my_beta_beta_case = .FALSE.
             my_alpha_beta_case = .FALSE.
             IF (ispin /= jspin) THEN
                my_alpha_beta_case = .TRUE.
             ELSE IF (my_open_shell_SS) THEN
-               IF (ispin == 1) my_alpha_alpha_case = .TRUE.
                IF (ispin == 2) my_beta_beta_case = .TRUE.
             END IF
 

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -249,11 +249,12 @@ CONTAINS
             t_start = m_walltime()
             DO ij_index = 1, max_ij_pairs
 
-               IF (unit_nr > 0) THEN
+               ! Prediction is unreliable if we are in the first step of the loop
+               IF (unit_nr > 0 .AND. ij_index > 1) THEN
                   decil = ij_index*10/max_ij_pairs
                   IF (decil /= (ij_index - 1)*10/max_ij_pairs) THEN
                      t_new = m_walltime()
-                     t_new = (t_new - t_start)/60.0_dp*(max_ij_pairs - ij_index + 1)/MAX(ij_index - 1, 1)
+                     t_new = (t_new - t_start)/60.0_dp*(max_ij_pairs - ij_index + 1)/(ij_index - 1)
                      WRITE (unit_nr, FMT="(T3,A)") "Percentage of finished loop: "// &
                         cp_to_string(decil*10)//". Minutes left: "//cp_to_string(t_new)
                      CALL m_flush(unit_nr)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -554,7 +554,6 @@ CONTAINS
             DEALLOCATE (ij_map)
             DEALLOCATE (num_ij_pairs)
             DEALLOCATE (local_ab)
-            DEALLOCATE (buffer_1D)
 
             IF (calc_forces) THEN
                DEALLOCATE (Y_i_aP)
@@ -577,9 +576,11 @@ CONTAINS
                   my_B_size(ispin:jspin), ngroup, num_integ_group, my_group_L_size, &
                   color_sub, ranges_info_array, para_env_exchange, para_env_sub, proc_map, &
                   my_B_virtual_start(ispin:jspin), my_B_virtual_end(ispin:jspin), gd_array%sizes, gd_B_virtual(ispin:jspin), &
-                  sub_proc_map, integ_group_pos2color_sub, dgemm_counter)
+                  sub_proc_map, integ_group_pos2color_sub, dgemm_counter, buffer_1D)
 
             END IF
+
+            DEALLOCATE (buffer_1D)
 
             ! Dereplicate BIb_C and Gamma_P_ia to save memory
             ! These matrices will not be needed in that fashion anymore
@@ -2124,13 +2125,14 @@ CONTAINS
 !> \param sub_proc_map ...
 !> \param integ_group_pos2color_sub ...
 !> \param dgemm_counter ...
+!> \param buffer_1D ...
 ! **************************************************************************************************
    SUBROUTINE quasi_degenerate_P_ij(mp2_env, Eigenval, homo, virtual, open_shell, &
                                     beta_beta, Bib_C, unit_nr, dimen_RI, &
                                     my_B_size, ngroup, num_integ_group, my_group_L_size, &
                                     color_sub, ranges_info_array, para_env_exchange, para_env_sub, proc_map, &
                                     my_B_virtual_start, my_B_virtual_end, sizes_array, gd_B_virtual, &
-                                    sub_proc_map, integ_group_pos2color_sub, dgemm_counter)
+                                    sub_proc_map, integ_group_pos2color_sub, dgemm_counter, buffer_1D)
       TYPE(mp2_type)                                     :: mp2_env
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: Eigenval
       INTEGER, DIMENSION(:), INTENT(IN)                  :: homo, virtual
@@ -2150,6 +2152,7 @@ CONTAINS
       TYPE(group_dist_d1_type), DIMENSION(:), INTENT(IN) :: gd_B_virtual
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: sub_proc_map, integ_group_pos2color_sub
       TYPE(dgemm_counter_type), INTENT(INOUT)            :: dgemm_counter
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:), TARGET    :: buffer_1D
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'quasi_degenerate_P_ij'
 
@@ -2164,8 +2167,8 @@ CONTAINS
       LOGICAL                                            :: alpha_beta
       REAL(KIND=dp)                                      :: amp_fac, P_ij_elem
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
-         TARGET                                          :: BI_C_rec, external_ab, external_aL, &
-                                                            local_ab, local_aL, t_ab
+         TARGET                                          :: local_ab, local_aL, t_ab
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: BI_C_rec, external_ab, external_aL
       TYPE(two_dim_int_array), ALLOCATABLE, DIMENSION(:) :: ijk_map
 
       CALL timeset(routineN//"_ij_sing", handle)
@@ -2240,7 +2243,7 @@ CONTAINS
                   send_ijk_index = num_ijk(proc_send, ispin)
 
                   rec_L_size = sizes_array(proc_receive)
-                  ALLOCATE (BI_C_rec(rec_L_size, size_B_i))
+                  BI_C_rec(1:rec_L_size, 1:size_B_i) => buffer_1D(1:INT(rec_L_size, KIND=int_8)*size_B_i)
 
                   IF (ijk_index <= send_ijk_index) THEN
                      ! something to send
@@ -2322,17 +2325,13 @@ CONTAINS
                   IF ((my_i /= my_k .AND. my_j /= my_k) .OR. alpha_beta) THEN
                      IF ((send_i /= send_k .AND. send_j /= send_k) .OR. alpha_beta) THEN
                         ! occupied k
-                        BI_C_rec = 0.0_dp
-                        DEALLOCATE (BI_C_rec)
-                        ALLOCATE (BI_C_rec(rec_L_size, size_B_k))
-                        BI_C_rec = 0.0_dp
+                        BI_C_rec(1:rec_L_size, 1:size_B_k) => buffer_1D(1:INT(rec_L_size, KIND=int_8)*size_B_k)
                         IF (ijk_index <= send_ijk_index) THEN
                            CALL mp_sendrecv(BIb_C(kspin)%array(1:my_group_L_size, 1:size_B_k, send_k), proc_send, &
                                             BI_C_rec(1:rec_L_size, 1:size_B_k), proc_receive, &
                                             para_env_exchange%group, tag)
                         ELSE
                            ! nothing to send
-                           BI_C_rec = 0.0_dp
                            CALL mp_recv(BI_C_rec(1:rec_L_size, 1:size_B_k), proc_receive, tag, &
                                         para_env_exchange%group)
                         END IF
@@ -2348,11 +2347,7 @@ CONTAINS
                         END DO
                      ELSE IF (.NOT. alpha_beta) THEN
                         ! occupied k
-                        BI_C_rec = 0.0_dp
-                        DEALLOCATE (BI_C_rec)
-                        ALLOCATE (BI_C_rec(rec_L_size, size_B_k))
-                        BI_C_rec = 0.0_dp
-                        BI_C_rec = 0.0_dp
+                        BI_C_rec(1:rec_L_size, 1:size_B_k) => buffer_1D(1:INT(rec_L_size, KIND=int_8)*size_B_k)
                         CALL mp_recv(BI_C_rec(1:rec_L_size, 1:size_B_k), proc_receive, tag, &
                                      para_env_exchange%group)
                         DO irep = 0, num_integ_group - 1
@@ -2370,8 +2365,6 @@ CONTAINS
                      CALL mp_send(BIb_C(kspin)%array(1:my_group_L_size, 1:size_B_k, send_k), proc_send, &
                                   tag, para_env_exchange%group)
                   END IF
-
-                  DEALLOCATE (BI_C_rec)
                END DO
                CALL timestop(handle2)
 
@@ -2390,8 +2383,7 @@ CONTAINS
 
                   CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
 
-                  ALLOCATE (external_aL(dimen_RI, rec_B_size))
-                  external_aL = 0.0_dp
+                  external_aL(1:dimen_RI, 1:rec_B_size) => buffer_1D(1:INT(dimen_RI, KIND=int_8)*rec_B_size)
 
                   CALL mp_sendrecv(local_aL(:, :size_B_i), proc_send, &
                                    external_aL, proc_receive, &
@@ -2401,7 +2393,6 @@ CONTAINS
                                      external_aL, dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
                                      0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:size_B_k), rec_B_size, &
                                      mp2_env%offload_gemm_ctx)
-                  DEALLOCATE (external_aL)
                END DO
                CALL dgemm_counter_stop(dgemm_counter, my_virtual, size_B_k, dimen_RI)
                CALL timestop(handle2)
@@ -2439,8 +2430,7 @@ CONTAINS
                      CALL get_group_dist(gd_B_virtual(1), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
                      CALL get_group_dist(gd_B_virtual(1), proc_send, send_B_virtual_start, send_B_virtual_end, send_B_size)
 
-                     ALLOCATE (external_ab(size_B_i, rec_B_size))
-                     external_ab = 0.0_dp
+                     external_ab(1:size_B_i, 1:rec_B_size) => buffer_1D(1:INT(size_B_i, KIND=int_8)*rec_B_size)
                      CALL mp_sendrecv(local_ab(send_B_virtual_start:send_B_virtual_end, 1:size_B_k), proc_send, &
                                       external_ab(1:size_B_i, 1:rec_B_size), proc_receive, para_env_sub%group, tag)
 
@@ -2453,8 +2443,6 @@ CONTAINS
                                                 - Eigenval(homo(1) + a_global, 1) - Eigenval(homo(1) + b_global, 1))
                         END DO
                      END DO
-
-                     DEALLOCATE (external_ab)
                   END DO
                END IF
                CALL timestop(handle2)
@@ -2473,8 +2461,7 @@ CONTAINS
 
                   CALL get_group_dist(gd_B_virtual(ispin), proc_receive, rec_B_virtual_start, rec_B_virtual_end, rec_B_size)
 
-                  ALLOCATE (external_aL(dimen_RI, rec_B_size))
-                  external_aL = 0.0_dp
+                  external_aL(1:dimen_RI, 1:rec_B_size) => buffer_1D(1:INT(dimen_RI, KIND=int_8)*rec_B_size)
 
                   CALL mp_sendrecv(local_aL(:, size_B_i + 1:size_B_ij), proc_send, &
                                    external_aL, proc_receive, &
@@ -2483,7 +2470,6 @@ CONTAINS
                                      external_aL, dimen_RI, local_aL(:, size_B_ij + 1:), dimen_RI, &
                                      0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:size_B_k), rec_B_size, &
                                      mp2_env%offload_gemm_ctx)
-                  DEALLOCATE (external_aL)
                END DO
                CALL dgemm_counter_stop(dgemm_counter, my_virtual, size_B_k, dimen_RI)
                CALL timestop(handle2)

--- a/tests/QS/regtest-double-hybrid-grad-laplace/CH_br89_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-laplace/CH_br89_mp2.inp
@@ -37,7 +37,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad-laplace/H2O_br89_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-laplace/H2O_br89_mp2.inp
@@ -34,7 +34,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad-meta/CH_tpss_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-meta/CH_tpss_mp2.inp
@@ -37,7 +37,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad-meta/H2O_tpss_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-meta/H2O_tpss_mp2.inp
@@ -34,7 +34,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad-numer-meta/CH_tpss_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-numer-meta/CH_tpss_mp2.inp
@@ -43,7 +43,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad-numer-meta/H2O_tpss_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-numer-meta/H2O_tpss_mp2.inp
@@ -35,7 +35,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad-numer/CH_pbe_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-numer/CH_pbe_mp2.inp
@@ -39,7 +39,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad-numer/H2O_pbe_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad-numer/H2O_pbe_mp2.inp
@@ -34,7 +34,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad/CH_pbe_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad/CH_pbe_mp2.inp
@@ -34,7 +34,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-grad/H2O_pbe_mp2.inp
+++ b/tests/QS/regtest-double-hybrid-grad/H2O_pbe_mp2.inp
@@ -32,7 +32,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-stress-laplace/CH3_br89_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress-laplace/CH3_br89_mp2_an.inp
@@ -41,7 +41,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.1
           FREE_HFX_BUFFER .TRUE.
         &END RI_MP2

--- a/tests/QS/regtest-double-hybrid-stress-laplace/H2O_br89_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress-laplace/H2O_br89_mp2_an.inp
@@ -42,7 +42,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-stress-meta/CH3_tpss_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress-meta/CH3_tpss_mp2_an.inp
@@ -43,7 +43,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.1
           FREE_HFX_BUFFER .TRUE.
         &END RI_MP2

--- a/tests/QS/regtest-double-hybrid-stress-meta/H2O_tpss_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress-meta/H2O_tpss_mp2_an.inp
@@ -42,7 +42,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-stress-numer-laplace/CH3_br89_mp2_numer.inp
+++ b/tests/QS/regtest-double-hybrid-stress-numer-laplace/CH3_br89_mp2_numer.inp
@@ -44,7 +44,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.1
           FREE_HFX_BUFFER .TRUE.
         &END RI_MP2

--- a/tests/QS/regtest-double-hybrid-stress-numer-laplace/H2O_br89_mp2_numer.inp
+++ b/tests/QS/regtest-double-hybrid-stress-numer-laplace/H2O_br89_mp2_numer.inp
@@ -44,7 +44,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-stress-numer-meta/CH3_tpss_mp2_numer.inp
+++ b/tests/QS/regtest-double-hybrid-stress-numer-meta/CH3_tpss_mp2_numer.inp
@@ -44,7 +44,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.1
           FREE_HFX_BUFFER .TRUE.
         &END RI_MP2

--- a/tests/QS/regtest-double-hybrid-stress-numer-meta/H2O_tpss_mp2_numer.inp
+++ b/tests/QS/regtest-double-hybrid-stress-numer-meta/H2O_tpss_mp2_numer.inp
@@ -45,7 +45,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-stress-numer/CH3_pbe_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress-numer/CH3_pbe_mp2_an.inp
@@ -40,7 +40,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.1
           FREE_HFX_BUFFER .TRUE.
         &END RI_MP2

--- a/tests/QS/regtest-double-hybrid-stress-numer/H2O_pbe_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress-numer/H2O_pbe_mp2_an.inp
@@ -41,7 +41,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-double-hybrid-stress/CH3_pbe_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress/CH3_pbe_mp2_an.inp
@@ -39,7 +39,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.1
           FREE_HFX_BUFFER .TRUE.
         &END RI_MP2

--- a/tests/QS/regtest-double-hybrid-stress/H2O_pbe_mp2_an.inp
+++ b/tests/QS/regtest-double-hybrid-stress/H2O_pbe_mp2_an.inp
@@ -40,7 +40,7 @@
       &END XC_FUNCTIONAL
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-grad-numer/CH_grad_admm_default.inp
+++ b/tests/QS/regtest-mp2-admm-grad-numer/CH_grad_admm_default.inp
@@ -59,7 +59,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-grad-numer/H2O_grad_admm_default.inp
+++ b/tests/QS/regtest-mp2-admm-grad-numer/H2O_grad_admm_default.inp
@@ -57,7 +57,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-grad/CH_grad_admm.inp
+++ b/tests/QS/regtest-mp2-admm-grad/CH_grad_admm.inp
@@ -57,7 +57,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-grad/CH_grad_admm_none.inp
+++ b/tests/QS/regtest-mp2-admm-grad/CH_grad_admm_none.inp
@@ -57,7 +57,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-grad/H2O_grad_admm.inp
+++ b/tests/QS/regtest-mp2-admm-grad/H2O_grad_admm.inp
@@ -55,7 +55,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-grad/H2O_grad_admm_none.inp
+++ b/tests/QS/regtest-mp2-admm-grad/H2O_grad_admm_none.inp
@@ -55,7 +55,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-stress-numer/CH_grad_admm_numerical.inp
+++ b/tests/QS/regtest-mp2-admm-stress-numer/CH_grad_admm_numerical.inp
@@ -56,7 +56,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-stress-numer/H2O_grad_admm_numerical.inp
+++ b/tests/QS/regtest-mp2-admm-stress-numer/H2O_grad_admm_numerical.inp
@@ -53,7 +53,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-stress/CH_stress_admm.inp
+++ b/tests/QS/regtest-mp2-admm-stress/CH_stress_admm.inp
@@ -52,7 +52,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-stress/CH_stress_admm_none.inp
+++ b/tests/QS/regtest-mp2-admm-stress/CH_stress_admm_none.inp
@@ -52,7 +52,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-stress/H2O_stress_admm.inp
+++ b/tests/QS/regtest-mp2-admm-stress/H2O_stress_admm.inp
@@ -50,7 +50,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-admm-stress/H2O_stress_admm_none.inp
+++ b/tests/QS/regtest-mp2-admm-stress/H2O_stress_admm_none.inp
@@ -50,7 +50,7 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
+          BLOCK_SIZE  -1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .FALSE.
           &CPHF

--- a/tests/QS/regtest-mp2-grad/HF_dipole.inp
+++ b/tests/QS/regtest-mp2-grad/HF_dipole.inp
@@ -50,7 +50,6 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
           &CPHF

--- a/tests/QS/regtest-mp2-grad/O2_dyn_mme.inp
+++ b/tests/QS/regtest-mp2-grad/O2_dyn_mme.inp
@@ -47,7 +47,6 @@
       &END HF
       &WF_CORRELATION
         &RI_MP2
-          BLOCK_SIZE  1
           EPS_CANONICAL 0.0001
           FREE_HFX_BUFFER .TRUE.
         &END RI_MP2


### PR DESCRIPTION
This PR
 - extends the idea of partial replication and blocking to open-shell systems
 - implements a reasonable automatic determination of block sizes
 - adjusts the regtests accordingly
 - changes the communication buffer to a central one to prevent OOM from too many memory (de-)allocation steps and the use of pointers to access the required parts of this buffer
 - improves the description of a few keywords

Some comments:
 - The employed memory estimates are very conservative, i.e. although we allocate a central buffer to support all required communication steps, we still consider them separately in our memory model. In that fashion, the MPI communication should not be affected too much as MPI may use its own buffers.
 - The commits will be squashed later