### PR TITLE
RPA| small i/o changes

### DIFF
--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -45,7 +45,8 @@ MODULE rpa_im_time
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_env_type,&
                                               kpoint_type
-   USE machine,                         ONLY: m_walltime
+   USE machine,                         ONLY: m_flush,&
+                                              m_walltime
    USE mathconstants,                   ONLY: twopi
    USE message_passing,                 ONLY: mp_sync
    USE mp2_types,                       ONLY: mp2_type
@@ -587,6 +588,7 @@ CONTAINS
                   'Occupancy of M virt:', REAL(nze_M_virt, dp), '/', occ_M_virt*100, '%'
             END IF
             WRITE (unit_nr, *)
+            CALL m_flush(unit_nr)
          END IF
 
       END DO ! time points

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -898,7 +898,7 @@ CONTAINS
             WRITE (unit_nr, '(/T3,A,1X,I3,A)') &
                'RPA_LOW_SCALING_INFO| Info for time point', jquad, '    (gradients)'
             WRITE (unit_nr, '(T6,A,T56,F25.6)') &
-               'Time:', t2 - t1
+               'Execution time (s):', t2 - t1
             WRITE (unit_nr, '(T6,A,T63,ES7.1,1X,A1,1X,F7.3,A1)') &
                'Occupancy of 3c AO derivs:', REAL(nze_der_AO, dp), '/', occ_der_AO*100, '%'
             WRITE (unit_nr, '(T6,A,T63,ES7.1,1X,A1,1X,F7.3,A1)') &


### PR DESCRIPTION
Print low-scaling RPA time for each quadrature point as it finishes. This allows to make an accurate estimation of the total running time at a lower cost.