### PR TITLE
Libcp2k getcell

### DIFF
--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -130,7 +130,8 @@ MODULE f77_interface
    USE qmmmx_types,                     ONLY: qmmmx_env_release,&
                                               qmmmx_env_type
    USE qs_environment,                  ONLY: qs_init
-   USE qs_environment_types,            ONLY: qs_env_create,&
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_env_create,&
                                               qs_env_release,&
                                               qs_environment_type
    USE reference_manager,               ONLY: remove_all_references
@@ -179,7 +180,7 @@ MODULE f77_interface
              calc_energy, calc_force, check_input, get_natom, get_nparticle, &
              f_env_add_defaults, f_env_rm_defaults, f_env_type, &
              f_env_get_from_id, &
-             set_vel, set_cell, get_cell, get_result_r1
+             set_vel, set_cell, get_cell, get_qmmm_cell, get_result_r1
 CONTAINS
 
 ! **************************************************************************************************
@@ -1055,6 +1056,34 @@ CONTAINS
       CALL f_env_rm_defaults(f_env, ierr)
 
    END SUBROUTINE get_cell
+
+! **************************************************************************************************
+!> \brief gets the qmmm cell
+!> \param env_id id of the force_env
+!> \param cell the array with the cell matrix
+!> \param ierr will return a number different from 0 if there was an error
+!> \author Holly Judge
+! **************************************************************************************************
+   SUBROUTINE get_qmmm_cell(env_id, cell, ierr)
+
+      INTEGER, INTENT(IN)                                :: env_id
+      REAL(KIND=DP), DIMENSION(3, 3)                     :: cell
+      INTEGER, INTENT(OUT)                               :: ierr
+
+      TYPE(cell_type), POINTER                           :: cell_qmmm
+      TYPE(f_env_type), POINTER                          :: f_env
+      TYPE(qmmm_env_type), POINTER                       :: qmmm_env
+
+      NULLIFY (f_env)
+      CALL f_env_add_defaults(env_id, f_env)
+      NULLIFY (cell_qmmm)
+      CALL force_env_get(f_env%force_env, qmmm_env=qmmm_env)
+      CALL get_qs_env(qmmm_env%qs_env, cell=cell_qmmm)
+      CPASSERT(ASSOCIATED(cell_qmmm))
+      cell = cell_qmmm%hmat
+      CALL f_env_rm_defaults(f_env, ierr)
+
+   END SUBROUTINE get_qmmm_cell
 
 ! **************************************************************************************************
 !> \brief gets a result from CP2K that is a real 1D array

--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -30,7 +30,7 @@ MODULE libcp2k
    USE f77_interface,                   ONLY: &
         calc_energy_force, create_force_env, destroy_force_env, f_env_add_defaults, &
         f_env_rm_defaults, f_env_type, finalize_cp2k, get_cell, get_energy, get_force, get_natom, &
-        get_nparticle, get_pos, get_result_r1, get_qmmm_cell, init_cp2k, set_cell, set_pos, set_vel
+        get_nparticle, get_pos, get_qmmm_cell, get_result_r1, init_cp2k, set_cell, set_pos, set_vel
    USE force_env_types,                 ONLY: force_env_get,&
                                               use_qs_force
    USE input_cp2k,                      ONLY: create_cp2k_root_section
@@ -618,7 +618,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(active_space_env)) &
             EXIT try
 
-         ASSOCIATE (nze=>active_space_env%eri%eri(1)%csr_mat%nze_total)
+         ASSOCIATE (nze => active_space_env%eri%eri(1)%csr_mat%nze_total)
             IF (buf_coords_len < 4*nze .OR. buf_values_len < nze) &
                EXIT try
 

--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -29,8 +29,8 @@ MODULE libcp2k
    USE cp_fm_types,                     ONLY: cp_fm_get_element
    USE f77_interface,                   ONLY: &
         calc_energy_force, create_force_env, destroy_force_env, f_env_add_defaults, &
-        f_env_rm_defaults, f_env_type, finalize_cp2k, get_energy, get_force, get_natom, &
-        get_nparticle, get_pos, get_result_r1, init_cp2k, set_cell, set_pos, set_vel
+        f_env_rm_defaults, f_env_type, finalize_cp2k, get_cell, get_energy, get_force, get_natom, &
+        get_nparticle, get_pos, get_result_r1, get_qmmm_cell, init_cp2k, set_cell, set_pos, set_vel
    USE force_env_types,                 ONLY: force_env_get,&
                                               use_qs_force
    USE input_cp2k,                      ONLY: create_cp2k_root_section
@@ -335,6 +335,36 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param env_id ...
+!> \param cell ...
+! **************************************************************************************************
+   SUBROUTINE cp2k_get_cell(env_id, cell) BIND(C)
+      INTEGER(C_INT), VALUE                              :: env_id
+      REAL(C_DOUBLE), DIMENSION(3, 3), INTENT(OUT)       :: cell
+
+      INTEGER                                            :: ierr
+
+      CALL get_cell(env_id, cell=cell, ierr=ierr)
+      CPASSERT(ierr == 0)
+   END SUBROUTINE cp2k_get_cell
+
+! **************************************************************************************************
+!> \brief ...
+!> \param env_id ...
+!> \param cell ...
+! **************************************************************************************************
+   SUBROUTINE cp2k_get_qmmm_cell(env_id, cell) BIND(C)
+      INTEGER(C_INT), VALUE                              :: env_id
+      REAL(C_DOUBLE), DIMENSION(3, 3), INTENT(OUT)       :: cell
+
+      INTEGER                                            :: ierr
+
+      CALL get_qmmm_cell(env_id, cell=cell, ierr=ierr)
+      CPASSERT(ierr == 0)
+   END SUBROUTINE cp2k_get_qmmm_cell
+
+! **************************************************************************************************
+!> \brief ...
+!> \param env_id ...
 ! **************************************************************************************************
    SUBROUTINE cp2k_calc_energy_force(env_id) BIND(C)
       INTEGER(C_INT), VALUE                              :: env_id
@@ -588,7 +618,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(active_space_env)) &
             EXIT try
 
-         ASSOCIATE (nze => active_space_env%eri%eri(1)%csr_mat%nze_total)
+         ASSOCIATE (nze=>active_space_env%eri%eri(1)%csr_mat%nze_total)
             IF (buf_coords_len < 4*nze .OR. buf_values_len < nze) &
                EXIT try
 

--- a/src/start/libcp2k.h
+++ b/src/start/libcp2k.h
@@ -157,6 +157,20 @@ void cp2k_get_forces(force_env_t force_env, double *force, int n_el);
 void cp2k_get_potential_energy(force_env_t force_env, double *e_pot);
 
 /*******************************************************************************
+ * \brief Get the size of the cell
+ * \param force_env the force environment
+ * \param cell Array containing the cell
+ ******************************************************************************/
+void cp2k_get_cell(force_env_t force_env, const double *cell);
+
+/*******************************************************************************
+ * \brief Get the size of the qmmm cell
+ * \param force_env the force environment
+ * \param cell Array containing the qmmm cell
+ ******************************************************************************/
+void cp2k_get_qmmm_cell(force_env_t force_env, const double *cell);
+
+/*******************************************************************************
  * \brief Calculate energy and forces of the system
  * \param force_env the force environment
  ******************************************************************************/


### PR DESCRIPTION
We have added these routines in order to get the SUBSYS cell dimensions and the QMMM cell dimensions through libcp2k, so that they can be used in the GROMACS/CP2K interface