### PR TITLE
Read cell parameters from REFTRAJ file generated with dumpdcd

### DIFF
--- a/src/cell_methods.F
+++ b/src/cell_methods.F
@@ -284,7 +284,7 @@ CONTAINS
             CALL parser_get_next_line(parser, 1, at_end=my_end)
          END DO
          CALL parser_release(parser)
-         ! Conver to CP2K units
+         ! Convert to CP2K units
          DO i = 1, 3
             DO j = 1, 3
                hmat(j, i) = cp_unit_to_cp2k(hmat(j, i), "angstrom")
@@ -295,7 +295,7 @@ CONTAINS
          CALL parser_get_next_line(parser, 1)
          READ (parser%input_line, *) idum, hmat(:, 1), hmat(:, 2), hmat(:, 3)
          CALL parser_release(parser)
-         ! Conver to CP2K units
+         ! Convert to CP2K units
          DO i = 1, 3
             DO j = 1, 3
                hmat(j, i) = cp_unit_to_cp2k(hmat(j, i), "angstrom")

--- a/src/motion/dumpdcd.F
+++ b/src/motion/dumpdcd.F
@@ -7,7 +7,7 @@
 
 PROGRAM dumpdcd
 
-! Version: 3.1
+! Version: 3.2
 ! Author:  Matthias Krack (MK)
 ! History: - Creation (13.02.2012,MK)
 !          - XYZ file option added (13.02.2012,MK)
@@ -24,6 +24,7 @@ PROGRAM dumpdcd
 !          - Option -eformat added (15.02.2016,MK)
 !          - Fix box unit string for velocity dump (07.06.2020,MK)
 !          - Dump cell information to comment line of XMOL file if requested and available (15.02.2021,MK)
+!          - Write comment line compliant with REFTRAJ format (16.06.2022,MK)
 !
 ! Note: For -ekin a XYZ file is required to obtain the atomic labels.
 !       The -info and the -debug flags provide a more detailed output which is especially handy for tracing problems.
@@ -46,7 +47,7 @@ PROGRAM dumpdcd
 
    ! Parameters
    CHARACTER(LEN=*), PARAMETER :: routineN = "dumpdcd", &
-                                  version_info = routineN//" v3.1 (24.02.2021)"
+                                  version_info = routineN//" v3.2 (16.06.2022)"
 
    INTEGER, PARAMETER :: dp = SELECTED_REAL_KIND(14, 200), &
                          sp = SELECTED_REAL_KIND(6, 30)
@@ -69,7 +70,7 @@ PROGRAM dumpdcd
    CHARACTER(LEN=5), DIMENSION(:), ALLOCATABLE        :: atomic_label
    CHARACTER(LEN=80), DIMENSION(2)                    :: remark_dcd
    INTEGER                                            :: first_frame, have_unit_cell, i, iarg, iatom, &
-                                                         iframe, iskip, istat, istep, last_frame, narg, &
+                                                         iframe, istat, istep_dcd, istride_dcd, last_frame, narg, &
                                                          natom_dcd, natom_xyz, ndcd_file, nframe, &
                                                          nframe_read, nremark, stride
    LOGICAL                                            :: apply_pbc, debug, dump_frame, eformat, ekin, eo, &
@@ -79,7 +80,7 @@ PROGRAM dumpdcd
                                                          print_scaled_pbc_coordinates, trace_atoms, vel2cord
    REAL(KIND=sp)                                      :: dt_dcd
    REAL(KIND=dp)                                      :: a, a_dcd, alpha, alpha_dcd, b, b_dcd, beta, beta_dcd, c, c_dcd, &
-                                                         cell_volume, dt, eps_angle, eps_geo, eps_out_of_box, &
+                                                         cell_volume, dt, energy, eps_angle, eps_geo, eps_out_of_box, &
                                                          first_step_time, gamma, gamma_dcd, md_time_step, ndt, step_time, &
                                                          tavg, tavg_frame
    INTEGER, DIMENSION(16)                             :: idum
@@ -140,6 +141,7 @@ PROGRAM dumpdcd
    step_time = 0.0_dp
    tavg = 0.0_dp
    tavg_frame = 0.0_dp
+   energy = 0.0_dp
 
    narg = command_argument_count()
 
@@ -487,12 +489,12 @@ PROGRAM dumpdcd
       END IF
 
       ! Read 1st record of DCD file
-      READ (UNIT=input_unit) id_dcd, idum(1), istep, iskip, idum(2:7), dt_dcd, have_unit_cell, idum(8:16)
+      READ (UNIT=input_unit) id_dcd, idum(1), istep_dcd, istride_dcd, idum(2:7), dt_dcd, have_unit_cell, idum(8:16)
       IF (info) THEN
          WRITE (UNIT=error_unit, FMT="(A,2(/,A,I0),/,A,F9.3,/,A,I0)") &
             "# DCD id string   : "//id_dcd, &
-            "# Step            : ", istep, &
-            "# Print frequency : ", iskip, &
+            "# Step            : ", istep_dcd, &
+            "# Print frequency : ", istride_dcd, &
             "# Time step [fs]  : ", dt_dcd, &
             "# Unit cell       : ", have_unit_cell
       END IF
@@ -539,13 +541,19 @@ PROGRAM dumpdcd
          END IF
       END IF
 
+      ! Overwrite MD time step, if requested
+      IF (md_time_step > 0.0_dp) THEN
+         dt_dcd = REAL(md_time_step, KIND=sp)
+         dt = md_time_step
+      ELSE
+         dt = REAL(dt_dcd, KIND=dp)
+      END IF
+
       ! Dump output in DCD format => dcd2dcd functionality
       IF (output_format_dcd) THEN
          IF (vel2cord) id_dcd = "CORD"
-         ! Overwrite MD time step, if supplied
-         IF (md_time_step > 0.0_dp) dt_dcd = REAL(md_time_step, KIND=sp)
          ! Note, dt_dcd is REAL*4 and the rest is INTEGER*4
-         WRITE (UNIT=output_unit) id_dcd, idum(1), istep, iskip, idum(2:7), dt_dcd, have_unit_cell, idum(8:16)
+         WRITE (UNIT=output_unit) id_dcd, idum(1), istep_dcd, istride_dcd, idum(2:7), dt_dcd, have_unit_cell, idum(8:16)
          WRITE (UNIT=output_unit) nremark, remark_dcd(1), remark_dcd(2)
          WRITE (UNIT=output_unit) natom_dcd
       END IF
@@ -626,10 +634,8 @@ PROGRAM dumpdcd
                   ! Check consistency of DCD and cell file information
                   IF (.NOT. ignore_warnings) THEN
                      IF (md_time_step > 0.0_dp) THEN
-                        dt = md_time_step
                         string = "Time step (requested)   ="
                      ELSE
-                        dt = REAL(dt_dcd, KIND=dp)
                         string = "Time step (DCD header)  ="
                      END IF
                      ndt = (step_time - first_step_time)/dt
@@ -862,12 +868,27 @@ PROGRAM dumpdcd
                      END IF
                   ELSE
                      IF (output_format_xmol) THEN
-                        IF (have_cell_file .OR. (have_unit_cell == 1)) THEN
+                        IF (have_cell_file) THEN
                            WRITE (UNIT=output_unit, FMT="(T2,I0,/,3(1X,F14.6),3(1X,F9.3))") &
                               natom_dcd, a, b, c, alpha, beta, gamma
                         ELSE
-                           WRITE (UNIT=output_unit, FMT="(T2,I0,/,A,2(I0,A))") &
-                              natom_dcd, "Frame: ", nframe_read + 1, ", Step: ", nframe, ", "//TRIM(remark_xyz)
+                           IF (have_unit_cell == 1) THEN
+                              WRITE (UNIT=output_unit, FMT="(T2,I0,/,A,I8,A,F12.3,A,F20.10,3(A,F14.6),3(A,F8.3))") &
+                                 natom_dcd, " i = ", istep_dcd + nframe - 1, &
+                                 ", time = ", REAL((nframe - 1)**istride_dcd, KIND=dp)*dt, &
+                                 ", E = ", energy, &
+                                 ", a = ", a, &
+                                 ", b = ", b, &
+                                 ", c = ", c, &
+                                 ", alpha = ", alpha, &
+                                 ", beta  = ", beta, &
+                                 ", gamma = ", gamma
+                           ELSE
+                              WRITE (UNIT=output_unit, FMT="(T2,I0,/,A,I8,A,F12.3,A,F20.10)") &
+                                 natom_dcd, " i = ", istep_dcd + nframe - 1, &
+                                 ", time = ", REAL((nframe - 1)**istride_dcd, KIND=dp)*dt, &
+                                 ", E = ", energy
+                           END IF
                         END IF
                         DO iatom = 1, natom_dcd
                            WRITE (UNIT=output_unit, FMT=fmt_string) ADJUSTL(atomic_label(iatom)), r(iatom, 1:3)
@@ -969,7 +990,7 @@ CONTAINS
 
       error_message = "*** ERROR in "//TRIM(routine)//": "//TRIM(message)//" ***"
       WRITE (UNIT=default_error_unit, FMT="(/,A,/)") TRIM(error_message)
-      STOP "*** ABNORMAL PROGRAM TERMINATION of dumpdcd v3.1 ***"
+      STOP "*** ABNORMAL PROGRAM TERMINATION of dumpdcd v3.2 ***"
 
    END SUBROUTINE abort_program
 
@@ -1310,8 +1331,8 @@ CONTAINS
          " dumpdcd project-pos-1.dcd (without atomic labels from XYZ file)", &
          " dumpdcd -xyz project.xyz project-pos-1.dcd (single DCD file)", &
          " dumpdcd -xyz project.xyz project-pos-1.dcd project-pos-2.dcd ... (multiple DCD files are dumped consecutively)", &
-         " dumpdcd -xyz project.xyz -cell_file project-1.cell -of xmol project-pos-1.dcd (check and print cell parameter to ", &
-         "                                                                                XMOL comment line, e.g. for TRAVIS)", &
+         " dumpdcd -xyz project.xyz -cell_file project-1.cell -of xmol project-pos-1.dcd (check and print cell parameters in ", &
+         "          XMOL comment line, e.g. for TRAVIS, instead of the default REFTRAJ information)", &
          " dumpdcd -info -xyz project.xyz project-pos-1.dcd project-pos-2.dcd (print additional information)", &
          " dumpdcd -debug -xyz project.xyz project-pos-1.dcd project-pos-2.dcd (print debug information)", &
          " dumpdcd -ekin -d -xyz project.xyz project-vel-1.dcd (print the ""temperature"" of each atom)", &
@@ -1330,7 +1351,7 @@ CONTAINS
          " dumpdcd -i -disp project-pos-1.dcd (dump the displacements of all atoms w.r.t. their positions in the first frame)", &
          " dumpdcd -i -of dcd -disp project-pos-1.dcd (dump the atomic displacements as x-coordinates of a DCD CORD file)", &
          " dumpdcd -i -of dcd -ekin -v2c -xyz project.xyz project-vel-1.dcd (dump the atomic temperatures as x-coordinates of a ", &
-         "                                                                   DCD CORD file -> hack for VMD)", &
+         "          DCD CORD file -> hack for VMD)", &
          ""
 
       WRITE (UNIT=*, FMT="(T2,A)") &

--- a/src/motion/integrator.F
+++ b/src/motion/integrator.F
@@ -31,7 +31,8 @@ MODULE integrator
    USE barostat_types,                  ONLY: barostat_type
    USE cell_types,                      ONLY: cell_type,&
                                               init_cell,&
-                                              parse_cell_line
+                                              parse_cell_line,&
+                                              set_cell_param
    USE constraint,                      ONLY: rattle_control,&
                                               shake_control,&
                                               shake_roll_control,&
@@ -65,7 +66,8 @@ MODULE integrator
         allocate_old, allocate_tmp, damp_v, damp_veps, deallocate_old, get_s_ds, &
         old_variables_type, rattle_roll_setup, set, tmp_variables_type, update_dealloc_tmp, &
         update_pv, update_veps, variable_timestep, vv_first, vv_second
-   USE kinds,                           ONLY: dp
+   USE kinds,                           ONLY: dp,&
+                                              max_line_length
    USE mathlib,                         ONLY: matmul_3x3,&
                                               transpose_3d
    USE md_environment_types,            ONLY: get_md_env,&
@@ -82,8 +84,7 @@ MODULE integrator
    USE particle_list_types,             ONLY: particle_list_type
    USE particle_types,                  ONLY: particle_type,&
                                               update_particle_set
-   USE physcon,                         ONLY: bohr,&
-                                              femtoseconds
+   USE physcon,                         ONLY: femtoseconds
    USE qmmm_util,                       ONLY: apply_qmmm_walls_reflective
    USE qmmmx_update,                    ONLY: qmmmx_update_force_env
    USE qs_environment_types,            ONLY: get_qs_env
@@ -94,6 +95,7 @@ MODULE integrator
    USE rt_propagation_types,            ONLY: rt_prop_type
    USE shell_opt,                       ONLY: optimize_shell_core
    USE simpar_types,                    ONLY: simpar_type
+   USE string_utilities,                ONLY: uppercase
    USE thermal_region_types,            ONLY: thermal_region_type,&
                                               thermal_regions_type
    USE thermostat_methods,              ONLY: apply_thermostat_baro,&
@@ -1502,13 +1504,15 @@ CONTAINS
    SUBROUTINE reftraj(md_env)
       TYPE(md_environment_type), POINTER                 :: md_env
 
-      CHARACTER(LEN=10)                                  :: AA
-      INTEGER                                            :: cell_itimes, I, nparticle, Nread, &
+      CHARACTER(LEN=2)                                   :: element_symbol, element_symbol_ref0
+      CHARACTER(LEN=max_line_length)                     :: errmsg
+      INTEGER                                            :: cell_itimes, i, nparticle, Nread, &
                                                             trj_itimes
       INTEGER, POINTER                                   :: itimes
-      LOGICAL                                            :: init, my_end, test_ok
+      LOGICAL                                            :: init, my_end, test_ok, traj_has_cell_info
       REAL(KIND=dp)                                      :: cell_time, h(3, 3), trj_epot, trj_time, &
                                                             vol
+      REAL(KIND=dp), DIMENSION(3)                        :: abc, albega
       REAL(KIND=dp), POINTER                             :: time
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1531,16 +1535,30 @@ CONTAINS
       CALL cp_subsys_get(subsys=subsys, particles=particles)
       nparticle = particles%n_els
       particle_set => particles%els
+      abc(:) = 0.0_dp
+      albega(:) = 0.0_dp
 
       ! SnapShots read from an external file (parsers calls are buffered! please
       ! don't put any additional MPI call!) [tlaino]
       CALL parser_read_line(reftraj_env%info%traj_parser, 1)
       READ (reftraj_env%info%traj_parser%input_line, FMT="(I8)") nread
-      CPASSERT(nread == nparticle)
       CALL parser_read_line(reftraj_env%info%traj_parser, 1)
       test_ok = .FALSE.
-      READ (reftraj_env%info%traj_parser%input_line, FMT="(T6,I8,T23,F12.3,T41,F20.10)", ERR=999) &
-         trj_itimes, trj_time, trj_epot
+      IF (INDEX(reftraj_env%info%traj_parser%input_line, ", a = ") > 60) THEN
+         traj_has_cell_info = .TRUE.
+         READ (reftraj_env%info%traj_parser%input_line, &
+               FMT="(T6,I8,T23,F12.3,T41,F20.10,T67,F14.6,T87,F14.6,T107,F14.6,T131,F8.3,T149,F8.3,T167,F8.3)", &
+               ERR=999) trj_itimes, trj_time, trj_epot, abc(1:3), albega(1:3)
+         ! Convert cell parameters from angstrom and degree to the internal CP2K units
+         DO i = 1, 3
+            abc(i) = cp_unit_to_cp2k(abc(i), "angstrom")
+            albega(i) = cp_unit_to_cp2k(albega(i), "deg")
+         END DO
+      ELSE
+         traj_has_cell_info = .FALSE.
+         READ (reftraj_env%info%traj_parser%input_line, FMT="(T6,I8,T23,F12.3,T41,F20.10)", ERR=999) &
+            trj_itimes, trj_time, trj_epot
+      END IF
       test_ok = .TRUE.
 999   IF (.NOT. test_ok) THEN
          ! Handling properly the error when reading the title of an XYZ
@@ -1549,16 +1567,42 @@ CONTAINS
          trj_time = 0.0_dp
          trj_epot = 0.0_dp
       END IF
+      ! Delayed print of error message until the step number is known
+      IF (nread /= nparticle) THEN
+         errmsg = "Number of atoms for step "//TRIM(ADJUSTL(cp_to_string(trj_itimes)))// &
+                  " in the trajectory file does not match the reference configuration: "// &
+                  TRIM(ADJUSTL(cp_to_string(nread)))//" != "//TRIM(ADJUSTL(cp_to_string(nparticle)))
+         CPABORT(errmsg)
+      END IF
       DO i = 1, nread - 1
          CALL parser_read_line(reftraj_env%info%traj_parser, 1)
-        READ (reftraj_env%info%traj_parser%input_line(1:LEN_TRIM(reftraj_env%info%traj_parser%input_line)), *) AA, particle_set(i)%r
-         particle_set(i)%r = particle_set(i)%r*bohr
+         READ (UNIT=reftraj_env%info%traj_parser%input_line(1:LEN_TRIM(reftraj_env%info%traj_parser%input_line)), FMT=*) &
+            element_symbol, particle_set(i)%r
+         CALL uppercase(element_symbol)
+         element_symbol_ref0 = particle_set(i)%atomic_kind%element_symbol
+         CALL uppercase(element_symbol_ref0)
+         IF (element_symbol /= element_symbol_ref0) THEN
+            errmsg = "Atomic configuration from trajectory file does not match the reference configuration: Check atom "// &
+                     TRIM(ADJUSTL(cp_to_string(i)))//" of step "//TRIM(ADJUSTL(cp_to_string(trj_itimes)))
+            CPABORT(errmsg)
+         END IF
+         particle_set(i)%r(1) = cp_unit_to_cp2k(particle_set(i)%r(1), "angstrom")
+         particle_set(i)%r(2) = cp_unit_to_cp2k(particle_set(i)%r(2), "angstrom")
+         particle_set(i)%r(3) = cp_unit_to_cp2k(particle_set(i)%r(3), "angstrom")
       END DO
       ! End of file is properly addressed in the previous call..
       ! Let's check directly (providing some info) also for the last
       ! line of this frame..
       CALL parser_read_line(reftraj_env%info%traj_parser, 1, at_end=my_end)
-      READ (unit=reftraj_env%info%traj_parser%input_line, fmt=*) AA, particle_set(i)%r
+      READ (UNIT=reftraj_env%info%traj_parser%input_line, FMT=*) element_symbol, particle_set(i)%r
+      CALL uppercase(element_symbol)
+      element_symbol_ref0 = particle_set(i)%atomic_kind%element_symbol
+      CALL uppercase(element_symbol_ref0)
+      IF (element_symbol /= element_symbol_ref0) THEN
+         errmsg = "Atomic configuration from trajectory file does not match the reference configuration: Check atom "// &
+                  TRIM(ADJUSTL(cp_to_string(i)))//" of step "//TRIM(ADJUSTL(cp_to_string(trj_itimes)))
+         CPABORT(errmsg)
+      END IF
       particle_set(i)%r(1) = cp_unit_to_cp2k(particle_set(i)%r(1), "angstrom")
       particle_set(i)%r(2) = cp_unit_to_cp2k(particle_set(i)%r(2), "angstrom")
       particle_set(i)%r(3) = cp_unit_to_cp2k(particle_set(i)%r(3), "angstrom")
@@ -1571,7 +1615,8 @@ CONTAINS
                           "missing frames ("//cp_to_string((simpar%nsteps - 1) - reftraj_env%isnap)//").")
       END IF
 
-      IF (reftraj_env%info%variable_volume) THEN
+      ! Read cell parameters from cell file if requested and if not yet available
+      IF (reftraj_env%info%variable_volume .AND. (.NOT. traj_has_cell_info)) THEN
          CALL parser_get_next_line(reftraj_env%info%cell_parser, 1, at_end=my_end)
          CALL parse_cell_line(reftraj_env%info%cell_parser%input_line, cell_itimes, cell_time, h, vol)
          CPASSERT(trj_itimes == cell_itimes)
@@ -1598,7 +1643,9 @@ CONTAINS
       CALL get_md_env(md_env, t=time)
       time = reftraj_env%time
 
-      IF (reftraj_env%info%variable_volume) THEN
+      IF (traj_has_cell_info) THEN
+         CALL set_cell_param(cell, cell_length=abc, cell_angle=albega, do_init_cell=.TRUE.)
+      ELSE IF (reftraj_env%info%variable_volume) THEN
          cell%hmat = h
          CALL init_cell(cell)
       END IF

--- a/src/motion/reftraj_util.F
+++ b/src/motion/reftraj_util.F
@@ -37,7 +37,8 @@ MODULE reftraj_util
                                               section_vals_val_get
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
-                                              dp
+                                              dp,&
+                                              max_line_length
    USE machine,                         ONLY: m_flush
    USE md_environment_types,            ONLY: get_md_env,&
                                               md_environment_type
@@ -56,6 +57,7 @@ MODULE reftraj_util
    USE reftraj_types,                   ONLY: reftraj_msd_type,&
                                               reftraj_type
    USE simpar_types,                    ONLY: simpar_type
+   USE string_utilities,                ONLY: uppercase
    USE util,                            ONLY: get_limit
 #include "../base/base_uses.f90"
 
@@ -157,9 +159,10 @@ CONTAINS
       TYPE(reftraj_type), POINTER                        :: reftraj
       TYPE(md_environment_type), POINTER                 :: md_env
 
-      CHARACTER(LEN=10)                                  :: AA
+      CHARACTER(LEN=2)                                   :: element_symbol, element_symbol_ref0
       CHARACTER(LEN=default_path_length)                 :: filename
-      CHARACTER(LEN=default_string_length)               :: name, title
+      CHARACTER(LEN=default_string_length)               :: title
+      CHARACTER(LEN=max_line_length)                     :: errmsg
       INTEGER                                            :: first_atom, iatom, ikind, imol, &
                                                             last_atom, natom_read, nkind, nmol, &
                                                             nmolecule, nmolkind, npart
@@ -206,15 +209,25 @@ CONTAINS
       IF (para_env%mepos == para_env%source) THEN
          REWIND (msd%ref0_unit)
          READ (msd%ref0_unit, *, ERR=999, END=998) natom_read
-         CPASSERT(natom_read == reftraj%natom)
+         IF (natom_read /= reftraj%natom) THEN
+            errmsg = "The MSD reference configuration has a different number of atoms: "// &
+                     TRIM(ADJUSTL(cp_to_string(natom_read)))//" != "// &
+                     TRIM(ADJUSTL(cp_to_string(reftraj%natom)))
+            CPABORT(errmsg)
+         END IF
          READ (msd%ref0_unit, '(A)', ERR=999, END=998) title
          msd%total_mass = 0.0_dp
          msd%ref0_com = 0.0_dp
          DO iatom = 1, natom_read
-            READ (msd%ref0_unit, *, ERR=999, END=998) AA, x, y, z
-            name = TRIM(particle_set(iatom)%atomic_kind%element_symbol)
-            CPASSERT((TRIM(AA) == name))
-
+            READ (msd%ref0_unit, *, ERR=999, END=998) element_symbol_ref0, x, y, z
+            CALL uppercase(element_symbol_ref0)
+            element_symbol = TRIM(particle_set(iatom)%atomic_kind%element_symbol)
+            CALL uppercase(element_symbol)
+            IF (element_symbol /= element_symbol_ref0) THEN
+               errmsg = "The MSD reference configuration shows a mismatch: Check atom "// &
+                        TRIM(ADJUSTL(cp_to_string(iatom)))
+               CPABORT(errmsg)
+            END IF
             x = cp_unit_to_cp2k(x, "angstrom")
             y = cp_unit_to_cp2k(y, "angstrom")
             z = cp_unit_to_cp2k(z, "angstrom")


### PR DESCRIPTION
- Cell parameters written by dumpdcd to the XMOL comment line are automatically read during a CP2K REFTRAJ run.
- The CP2K cell file is ignored in this case even if present, because the coordinates and the cell dumped from a CP2K DCD trajectory file written with DCD_ALIGNED_CELL are different.
- Improved checks and error messages for REFTRAJ runs.
