### PR TITLE
Optionally print peak memory usage after each MD/Opt step

### DIFF
--- a/src/input_cp2k_motion_print.F
+++ b/src/input_cp2k_motion_print.F
@@ -58,8 +58,17 @@ CONTAINS
       NULLIFY (keyword, section, print_key)
 
       CALL section_create(section, __LOCATION__, name="print", &
-                          description="Controls the printing properties during an MD run", &
-                          n_keywords=0, n_subsections=1, repeats=.TRUE.)
+                          description="Controls the printing properties during an MD/Optimization run", &
+                          n_keywords=1, n_subsections=1, repeats=.TRUE.)
+
+      CALL keyword_create(keyword, __LOCATION__, name="MEMORY_INFO", &
+                          variants=(/"MEMORY"/), &
+                          description="Whether overall memory usage should be sampled and printed "// &
+                          "at each MD/Optimization step.", &
+                          usage="MEMORY_INFO LOGICAL", &
+                          default_l_val=.TRUE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
 
       CALL cp_print_key_section_create(print_key, __LOCATION__, "TRAJECTORY", &
                                        description="Controls the output of the trajectory", &

--- a/src/motion/gopt_f_methods.F
+++ b/src/motion/gopt_f_methods.F
@@ -49,10 +49,11 @@ MODULE gopt_f_methods
                               default_ts_method_id, &
                               fix_none
    USE input_cp2k_restarts, ONLY: write_restart
-   USE input_section_types, ONLY: section_vals_type
+   USE input_section_types, ONLY: section_vals_type, section_vals_val_get
    USE kinds, ONLY: default_string_length, &
-                    dp
+                    dp, int_8
    USE machine, ONLY: m_flush
+   USE md_energies, ONLY: sample_memory
    USE motion_utils, ONLY: write_simulation_cell, &
                            write_stress_tensor, &
                            write_trajectory
@@ -256,6 +257,17 @@ CONTAINS
 
       REAL(KIND=dp)                                      :: pres_diff, pres_diff_constr, pres_int, &
                                                             pres_tol
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      INTEGER(KIND=int_8)                                :: max_memory
+      LOGICAL                                            :: print_memory
+
+      NULLIFY (para_env)
+      CALL section_vals_val_get(gopt_env%motion_section, "PRINT%MEMORY_INFO", l_val=print_memory)
+      max_memory = 0
+      IF (print_memory) THEN
+         CALL force_env_get(force_env, para_env=para_env)
+         max_memory = sample_memory(para_env)
+      END IF
 
       SELECT CASE (gopt_env%type_id)
       CASE (default_ts_method_id, default_minimization_method_id)
@@ -270,7 +282,7 @@ CONTAINS
                CPASSERT(PRESENT(ndf))
                CPASSERT(PRESENT(dx))
                CPASSERT(PRESENT(xi))
-               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param)
+               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, max_memory)
             END IF
          ELSE
             CALL update_dimer_vec(gopt_env%dimer_env, gopt_env%motion_section)
@@ -299,10 +311,11 @@ CONTAINS
             CPASSERT(PRESENT(dx))
             CPASSERT(PRESENT(xi))
             IF (gopt_env%cell_env%constraint_id == fix_none) THEN
-               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, pres_diff, pres_tol)
+               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, max_memory, pres_diff, pres_tol)
             ELSE
                pres_diff_constr = gopt_env%cell_env%pres_constr - gopt_env%cell_env%pres_ext
-               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, pres_diff, pres_tol, pres_diff_constr)
+               CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, max_memory, pres_diff, &
+                                  pres_tol, pres_diff_constr)
             END IF
          END IF
       CASE (default_shellcore_method_id)
@@ -313,9 +326,10 @@ CONTAINS
             CPASSERT(PRESENT(ndf))
             CPASSERT(PRESENT(dx))
             CPASSERT(PRESENT(xi))
-            CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param)
+            CALL check_converg(ndf, dx, xi, output_unit, conv, gopt_param, max_memory)
          END IF
       END SELECT
+
    END SUBROUTINE gopt_f_io
 
 ! **************************************************************************************************
@@ -494,7 +508,7 @@ CONTAINS
 !> \param pres_tol ...
 !> \param pres_diff_constr ...
 ! **************************************************************************************************
-   SUBROUTINE check_converg(ndf, dr, g, output_unit, conv, gopt_param, pres_diff, &
+   SUBROUTINE check_converg(ndf, dr, g, output_unit, conv, gopt_param, max_memory, pres_diff, &
                             pres_tol, pres_diff_constr)
 
       INTEGER, INTENT(IN)                                :: ndf
@@ -502,6 +516,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: output_unit
       LOGICAL, INTENT(OUT)                               :: conv
       TYPE(gopt_param_type), POINTER                     :: gopt_param
+      INTEGER(KIND=int_8), INTENT(IN)                    :: max_memory
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pres_diff, pres_tol, pres_diff_constr
 
       INTEGER                                            :: indf
@@ -634,6 +649,11 @@ CONTAINS
             END IF
          END IF
          WRITE (UNIT=output_unit, FMT="(T2,51('-'))")
+         IF (max_memory .NE. 0) THEN
+            WRITE (output_unit, '(T2,A,T73,I8)') &
+               'Estimated peak process memory after this step [MiB]', &
+               (max_memory + (1024*1024) - 1)/(1024*1024)
+         END IF
       END IF
 
       IF (conv_dx .AND. conv_rdx .AND. conv_g .AND. conv_rg .AND. conv_p) conv = .TRUE.

--- a/src/motion/md_energies.F
+++ b/src/motion/md_energies.F
@@ -53,10 +53,14 @@ MODULE md_energies
                                               section_release,&
                                               section_type,&
                                               section_vals_get_subs_vals,&
-                                              section_vals_type
+                                              section_vals_type,&
+                                              section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
-                                              dp
-   USE machine,                         ONLY: m_flush
+                                              dp,&
+                                              int_8
+   USE machine,                         ONLY: m_flush,&
+                                              m_memory,&
+                                              m_memory_max
    USE md_conserved_quantities,         ONLY: calc_nfree_qm,&
                                               compute_conserved_quantity
    USE md_ener_types,                   ONLY: md_ener_type,&
@@ -64,6 +68,7 @@ MODULE md_energies
    USE md_environment_types,            ONLY: get_md_env,&
                                               md_environment_type,&
                                               set_md_env
+   USE message_passing,                 ONLY: mp_max
    USE motion_utils,                    ONLY: write_simulation_cell,&
                                               write_stress_tensor,&
                                               write_trajectory
@@ -92,7 +97,8 @@ MODULE md_energies
    PUBLIC :: initialize_md_ener, &
              md_energy, &
              md_ener_reftraj, &
-             md_write_output
+             md_write_output, &
+             sample_memory
 
 CONTAINS
 
@@ -251,9 +257,10 @@ CONTAINS
       CHARACTER(LEN=default_string_length)               :: fmd, my_act, my_pos
       INTEGER                                            :: ene, ener_mix, handle, i, nat, nkind, &
                                                             shene, tempkind, trsl
+      INTEGER(KIND=int_8)                                :: max_memory
       INTEGER, POINTER                                   :: itimes
-      LOGICAL                                            :: init, is_mixed, new_file, qmmm, &
-                                                            shell_adiabatic, shell_present
+      LOGICAL                                            :: init, is_mixed, new_file, print_memory, &
+                                                            qmmm, shell_adiabatic, shell_present
       REAL(dp)                                           :: abc(3), cell_angle(3), dt, econs, &
                                                             pv_scalar, pv_xx, pv_xx_nc
       REAL(KIND=dp)                                      :: harm_shell, hugoniot
@@ -377,10 +384,17 @@ CONTAINS
                                my_act)
       END IF
 
+      ! Sample memory, if requested
+      CALL section_vals_val_get(motion_section, "PRINT%MEMORY_INFO", l_val=print_memory)
+      max_memory = 0
+      IF (print_memory) THEN
+         max_memory = sample_memory(para_env)
+      END IF
+
       ! Print md information
       CALL md_write_info_low(simpar, md_ener, qmmm, virial, reftraj, cell, abc, &
                              cell_angle, itimes, dt, time, used_time, averages, econs, pv_scalar, pv_xx, &
-                             hugoniot, nat, init, logger, motion_section, my_pos, my_act)
+                             hugoniot, nat, init, logger, motion_section, my_pos, my_act, max_memory)
 
       ! Real Output driven by the PRINT sections
       IF ((.NOT. init) .OR. (itimes == 0) .OR. simpar%ensemble == reftraj_ensemble) THEN
@@ -583,6 +597,7 @@ CONTAINS
 !> \param motion_section ...
 !> \param my_pos ...
 !> \param my_act ...
+!> \param max_memory ...
 !> \par History
 !>   - 10.2008 - Teodoro Laino [tlaino] - University of Zurich
 !>               Refactoring: split into an independent routine.
@@ -591,7 +606,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE md_write_info_low(simpar, md_ener, qmmm, virial, reftraj, cell, &
                                 abc, cell_angle, itimes, dt, time, used_time, averages, econs, pv_scalar, &
-                                pv_xx, hugoniot, nat, init, logger, motion_section, my_pos, my_act)
+                                pv_xx, hugoniot, nat, init, logger, motion_section, my_pos, my_act, &
+                                max_memory)
 
       TYPE(simpar_type), POINTER                         :: simpar
       TYPE(md_ener_type), POINTER                        :: md_ener
@@ -610,6 +626,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: motion_section
       CHARACTER(LEN=default_string_length), INTENT(IN)   :: my_pos, my_act
+      INTEGER(KIND=int_8), INTENT(IN)                    :: max_memory
 
       INTEGER                                            :: iw
       TYPE(enumeration_type), POINTER                    :: enum
@@ -773,11 +790,32 @@ CONTAINS
                END IF
             END IF
             WRITE (iw, '(T2,A)') 'MD| '//REPEAT('*', 75)
+            IF (max_memory .NE. 0) THEN
+               WRITE (iw, '(T2,A,T73,I8)') &
+                  'MD| Estimated peak process memory after this step [MiB]', &
+                  (max_memory + (1024*1024) - 1)/(1024*1024)
+            END IF
          END IF
       END IF
       CALL section_release(section)
       CALL cp_print_key_finished_output(iw, logger, motion_section, &
                                         "MD%PRINT%PROGRAM_RUN_INFO")
    END SUBROUTINE md_write_info_low
+
+! **************************************************************************************************
+!> \brief Samples memory usage
+!> \param para_env ...
+!> \return ...
+!> \note based on what is done in start/cp2k_runs.F
+! **************************************************************************************************
+   FUNCTION sample_memory(para_env) RESULT(max_memory)
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      INTEGER(KIND=int_8)                                :: max_memory
+
+      CALL m_memory()
+      max_memory = m_memory_max
+      CALL mp_max(max_memory, para_env%group)
+
+   END FUNCTION sample_memory
 
 END MODULE md_energies


### PR DESCRIPTION
A new keyword, `MEMORY_INFO`,  was introduced in `&MOTION%PRINT`. If set to .TRUE. (its default value), peak memory usage is sampled and printed at each MD/Optimization step. This should help identify the presence of memory leaks when jobs crash randomly.