### PR TITLE
DBM: Fix array bounds of per_thread_counters

### DIFF
--- a/src/dbm/dbm_library.h
+++ b/src/dbm/dbm_library.h
@@ -22,7 +22,7 @@ void dbm_library_init(void);
 void dbm_library_finalize(void);
 
 /*******************************************************************************
- * \brief Add given block multiplication to the stats.
+ * \brief Add given block multiplication to stats. This routine is thread-safe.
  * \author Ole Schuett
  ******************************************************************************/
 void dbm_library_counter_increment(const int m, const int n, const int k);


### PR DESCRIPTION
This bug only triggered with >64 threads. Great find @mkrack!