### PR TITLE
Stop the user from using non-implemented TDDFT kernels

### DIFF
--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -106,7 +106,8 @@ MODULE hfx_types
              hfx_pgf_product_list, hfx_block_range_type, &
              alloc_containers, dealloc_containers, hfx_task_list_type, init_t_c_g0_lmax, &
              hfx_create_neighbor_cells, hfx_create_basis_types, hfx_release_basis_types, &
-             hfx_ri_type, hfx_compression_type, block_ind_type, hfx_ri_init, hfx_ri_release
+             hfx_ri_type, hfx_compression_type, block_ind_type, hfx_ri_init, hfx_ri_release, &
+             compare_hfx_sections
 
 #define CACHE_SIZE 1024
 #define BITS_MAX_VAL 6
@@ -2817,6 +2818,167 @@ CONTAINS
       END DO
 
    END SUBROUTINE alloc_containers
+
+! **************************************************************************************************
+!> \brief Compares the non-technical parts of two HFX input section and check whether they are the same
+!>        Ignore things that would not change results (MEMORY, LOAD_BALANCE)
+!> \param hfx_section1 ...
+!> \param hfx_section2 ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION compare_hfx_sections(hfx_section1, hfx_section2) RESULT(is_identical)
+
+      TYPE(section_vals_type), POINTER                   :: hfx_section1, hfx_section2
+      LOGICAL                                            :: is_identical
+
+      CHARACTER(LEN=default_path_length)                 :: cval1, cval2
+      INTEGER                                            :: irep, ival1, ival2, n_rep_hf1, n_rep_hf2
+      LOGICAL                                            :: lval1, lval2
+      REAL(dp)                                           :: rval1, rval2
+      TYPE(section_vals_type), POINTER                   :: hfx_sub_section1, hfx_sub_section2
+
+      is_identical = .TRUE.
+
+      CALL section_vals_get(hfx_section1, n_repetition=n_rep_hf1)
+      CALL section_vals_get(hfx_section2, n_repetition=n_rep_hf2)
+      is_identical = n_rep_hf1 == n_rep_hf2
+      IF (.NOT. is_identical) RETURN
+
+      DO irep = 1, n_rep_hf1
+         CALL section_vals_val_get(hfx_section1, "FRACTION", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_section2, "FRACTION", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_section1, "PW_HFX", l_val=lval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_section2, "PW_HFX", l_val=lval2, i_rep_section=irep)
+         IF (lval1 .NEQV. lval2) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_section1, "PW_HFX_BLOCKSIZE", i_val=ival1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_section2, "PW_HFX_BLOCKSIZE", i_val=ival2, i_rep_section=irep)
+         IF (ival1 .NE. ival2) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_section1, "TREAT_LSD_IN_CORE", l_val=lval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_section2, "TREAT_LSD_IN_CORE", l_val=lval2, i_rep_section=irep)
+         IF (lval1 .NEQV. lval2) is_identical = .FALSE.
+
+         hfx_sub_section1 => section_vals_get_subs_vals(hfx_section1, "INTERACTION_POTENTIAL", i_rep_section=irep)
+         hfx_sub_section2 => section_vals_get_subs_vals(hfx_section2, "INTERACTION_POTENTIAL", i_rep_section=irep)
+
+         CALL section_vals_val_get(hfx_sub_section1, "OMEGA", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "OMEGA", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "POTENTIAL_TYPE", i_val=ival1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "POTENTIAL_TYPE", i_val=ival2, i_rep_section=irep)
+         IF (ival1 .NE. ival2) is_identical = .FALSE.
+         IF (.NOT. is_identical) RETURN
+
+         IF (ival1 == do_potential_truncated .OR. ival1 == do_potential_mix_cl_trunc) THEN
+            CALL section_vals_val_get(hfx_sub_section1, "CUTOFF_RADIUS", r_val=rval1, i_rep_section=irep)
+            CALL section_vals_val_get(hfx_sub_section2, "CUTOFF_RADIUS", r_val=rval2, i_rep_section=irep)
+            IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+            CALL section_vals_val_get(hfx_sub_section1, "T_C_G_DATA", c_val=cval1, i_rep_section=irep)
+            CALL section_vals_val_get(hfx_sub_section2, "T_C_G_DATA", c_val=cval2, i_rep_section=irep)
+            IF (cval1 .NE. cval2) is_identical = .FALSE.
+         END IF
+
+         CALL section_vals_val_get(hfx_sub_section1, "SCALE_COULOMB", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "SCALE_COULOMB", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "SCALE_GAUSSIAN", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "SCALE_GAUSSIAN", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "SCALE_LONGRANGE", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "SCALE_LONGRANGE", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         hfx_sub_section1 => section_vals_get_subs_vals(hfx_section1, "PERIODIC", i_rep_section=irep)
+         hfx_sub_section2 => section_vals_get_subs_vals(hfx_section2, "PERIODIC", i_rep_section=irep)
+
+         CALL section_vals_val_get(hfx_sub_section1, "NUMBER_OF_SHELLS", i_val=ival1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "NUMBER_OF_SHELLS", i_val=ival2, i_rep_section=irep)
+         IF (ival1 .NE. ival2) is_identical = .FALSE.
+
+         hfx_sub_section1 => section_vals_get_subs_vals(hfx_section1, "RI", i_rep_section=irep)
+         hfx_sub_section2 => section_vals_get_subs_vals(hfx_section2, "RI", i_rep_section=irep)
+
+         CALL section_vals_val_get(hfx_sub_section1, "_SECTION_PARAMETERS_", l_val=lval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "_SECTION_PARAMETERS_", l_val=lval2, i_rep_section=irep)
+         IF (lval1 .NEQV. lval2) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "CUTOFF_RADIUS", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "CUTOFF_RADIUS", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "EPS_EIGVAL", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "EPS_EIGVAL", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "EPS_FILTER", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "EPS_FILTER", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "EPS_FILTER_2C", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "EPS_FILTER_2C", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "EPS_FILTER_MO", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "EPS_FILTER_MO", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "EPS_PGF_ORB", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "EPS_PGF_ORB", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "MAX_BLOCK_SIZE_MO", i_val=ival1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "MAX_BLOCK_SIZE_MO", i_val=ival2, i_rep_section=irep)
+         IF (ival1 .NE. ival2) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "MIN_BLOCK_SIZE", i_val=ival1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "MIN_BLOCK_SIZE", i_val=ival2, i_rep_section=irep)
+         IF (ival1 .NE. ival2) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "OMEGA", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "OMEGA", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "RI_FLAVOR", i_val=ival1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "RI_FLAVOR", i_val=ival2, i_rep_section=irep)
+         IF (ival1 .NE. ival2) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "RI_METRIC", i_val=ival1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "RI_METRIC", i_val=ival2, i_rep_section=irep)
+         IF (ival1 .NE. ival2) is_identical = .FALSE.
+
+         hfx_sub_section1 => section_vals_get_subs_vals(hfx_section1, "SCREENING", i_rep_section=irep)
+         hfx_sub_section2 => section_vals_get_subs_vals(hfx_section2, "SCREENING", i_rep_section=irep)
+
+         CALL section_vals_val_get(hfx_sub_section1, "EPS_SCHWARZ", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "EPS_SCHWARZ", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "EPS_SCHWARZ_FORCES", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "EPS_SCHWARZ_FORCES", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "P_SCREEN_CORRECTION_FACTOR", r_val=rval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "P_SCREEN_CORRECTION_FACTOR", r_val=rval2, i_rep_section=irep)
+         IF (ABS(rval1 - rval2) > EPSILON(1.0_dp)) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "SCREEN_ON_INITIAL_P", l_val=lval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "SCREEN_ON_INITIAL_P", l_val=lval2, i_rep_section=irep)
+         IF (lval1 .NEQV. lval2) is_identical = .FALSE.
+
+         CALL section_vals_val_get(hfx_sub_section1, "SCREEN_P_FORCES", l_val=lval1, i_rep_section=irep)
+         CALL section_vals_val_get(hfx_sub_section2, "SCREEN_P_FORCES", l_val=lval2, i_rep_section=irep)
+         IF (lval1 .NEQV. lval2) is_identical = .FALSE.
+
+      END DO
+
+   END FUNCTION compare_hfx_sections
 
 END MODULE hfx_types
 

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -43,6 +43,7 @@ MODULE qs_tddfpt2_methods
                                               dbcsr_type_antisymmetric
    USE exstates_types,                  ONLY: excited_energy_type
    USE header,                          ONLY: tddfpt_header
+   USE hfx_types,                       ONLY: compare_hfx_sections
    USE input_constants,                 ONLY: tddfpt_dipole_velocity,&
                                               tddfpt_kernel_full,&
                                               tddfpt_kernel_none,&
@@ -685,8 +686,8 @@ CONTAINS
                                                             explicit_root, expot, exvdw, exwfn
       REAL(kind=dp)                                      :: C_hf
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(section_vals_type), POINTER                   :: hfx_section, input, tddfpt_section, &
-                                                            xc_root, xc_sub
+      TYPE(section_vals_type), POINTER                   :: hfx_section, hfx_section_gs, input, &
+                                                            tddfpt_section, xc_root, xc_sub
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
 
       NULLIFY (dft_control, input)
@@ -782,6 +783,14 @@ CONTAINS
                CALL section_vals_val_get(hfx_section, "FRACTION", r_val=C_hf)
                do_hfx = (C_hf /= 0.0_dp)
             END IF
+            !TDDFPT only works if the kernel has the same HF section as the DFT%XC one
+            IF (do_hfx) THEN
+               hfx_section_gs => section_vals_get_subs_vals(input, "DFT%XC%HF")
+               IF (.NOT. compare_hfx_sections(hfx_section, hfx_section_gs)) THEN
+                  CPABORT("TDDFPT Kernel must use the same HF section as DFT%XC or no HF at all.")
+               END IF
+            END IF
+
             do_admm = do_hfx .AND. dft_control%do_admm
             IF (do_admm) THEN
                ! 'admm_env%xc_section_primary' and 'admm_env%xc_section_aux' need to be redefined


### PR DESCRIPTION
There was no safeguard preventing users from defining some non-implemented TDDFT kernels. In particular, calculations using a different `HF` section in the definition of the kernel and in the main `DFT%XC` could go ahead. Since TDDFT relies on the `DFT%XC%HF` section exclusively, results would have been wrong (without warning). This is not the case anymore thanks to a `CPABORT`. Note that the newly defined `compare_hfx_sections` function might soon have other uses.