### PR TITLE
Refactoring of the ADMM environment

### DIFF
--- a/src/admm_dm_methods.F
+++ b/src/admm_dm_methods.F
@@ -14,6 +14,7 @@
 MODULE admm_dm_methods
    USE admm_dm_types,                   ONLY: admm_dm_type,&
                                               mcweeny_history_type
+   USE admm_types,                      ONLY: get_admm_env
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
    USE cp_log_handling,                 ONLY: cp_logger_get_default_unit_nr
@@ -28,8 +29,9 @@ MODULE admm_dm_methods
    USE kinds,                           ONLY: dp
    USE pw_types,                        ONLY: pw_p_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
-   USE qs_ks_types,                     ONLY: get_ks_env,&
-                                              qs_ks_env_type
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_set,&
                                               qs_rho_type
@@ -47,11 +49,11 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Entry methods: Calculates auxiliary density matrix from primary one.
-!> \param ks_env ...
+!> \param qs_env ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE admm_dm_calc_rho_aux(ks_env)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE admm_dm_calc_rho_aux(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'admm_dm_calc_rho_aux'
 
@@ -60,34 +62,34 @@ CONTAINS
 
       NULLIFY (admm_dm)
       CALL timeset(routineN, handle)
-      CALL get_ks_env(ks_env, admm_dm=admm_dm)
+      CALL get_admm_env(qs_env%admm_env, admm_dm=admm_dm)
 
       SELECT CASE (admm_dm%method)
       CASE (do_admm_basis_projection)
-         CALL map_dm_projection(ks_env)
+         CALL map_dm_projection(qs_env)
 
       CASE (do_admm_blocked_projection)
-         CALL map_dm_blocked(ks_env)
+         CALL map_dm_blocked(qs_env)
 
       CASE DEFAULT
          CPABORT("admm_dm_calc_rho_aux: unknown method")
       END SELECT
 
       IF (admm_dm%purify) &
-         CALL purify_mcweeny(ks_env)
+         CALL purify_mcweeny(qs_env)
 
-      CALL update_rho_aux(ks_env)
+      CALL update_rho_aux(qs_env)
 
       CALL timestop(handle)
    END SUBROUTINE admm_dm_calc_rho_aux
 
 ! **************************************************************************************************
 !> \brief Entry methods: Merges auxiliary Kohn-Sham matrix into primary one.
-!> \param ks_env ...
+!> \param qs_env ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE admm_dm_merge_ks_matrix(ks_env)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE admm_dm_merge_ks_matrix(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'admm_dm_merge_ks_matrix'
 
@@ -98,20 +100,20 @@ CONTAINS
       CALL timeset(routineN, handle)
       NULLIFY (admm_dm, matrix_ks_merge)
 
-      CALL get_ks_env(ks_env, admm_dm=admm_dm)
+      CALL get_admm_env(qs_env%admm_env, admm_dm=admm_dm)
 
       IF (admm_dm%purify) THEN
-         CALL revert_purify_mcweeny(ks_env, matrix_ks_merge)
+         CALL revert_purify_mcweeny(qs_env, matrix_ks_merge)
       ELSE
-         CALL get_ks_env(ks_env, matrix_ks_aux_fit=matrix_ks_merge)
+         CALL get_admm_env(qs_env%admm_env, matrix_ks_aux_fit=matrix_ks_merge)
       END IF
 
       SELECT CASE (admm_dm%method)
       CASE (do_admm_basis_projection)
-         CALL merge_dm_projection(ks_env, matrix_ks_merge)
+         CALL merge_dm_projection(qs_env, matrix_ks_merge)
 
       CASE (do_admm_blocked_projection)
-         CALL merge_dm_blocked(ks_env, matrix_ks_merge)
+         CALL merge_dm_blocked(qs_env, matrix_ks_merge)
 
       CASE DEFAULT
          CPABORT("admm_dm_merge_ks_matrix: unknown method")
@@ -126,11 +128,11 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Calculates auxiliary density matrix via basis projection.
-!> \param ks_env ...
+!> \param qs_env ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE map_dm_projection(ks_env)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE map_dm_projection(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
 
       INTEGER                                            :: ispin
       LOGICAL                                            :: s_mstruct_changed
@@ -145,14 +147,9 @@ CONTAINS
       NULLIFY (dft_control, admm_dm, matrix_s_aux, matrix_s_mixed, rho, rho_aux)
       NULLIFY (rho_ao, rho_ao_aux)
 
-      CALL get_ks_env(ks_env, &
-                      admm_dm=admm_dm, &
-                      dft_control=dft_control, &
-                      matrix_s_aux_fit=matrix_s_aux, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_mixed, &
-                      s_mstruct_changed=s_mstruct_changed, &
-                      rho=rho, &
-                      rho_aux_fit=rho_aux)
+      CALL get_qs_env(qs_env, dft_control=dft_control, s_mstruct_changed=s_mstruct_changed, rho=rho)
+      CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux, rho_aux_fit=rho_aux, &
+                        matrix_s_aux_fit_vs_orb=matrix_s_mixed, admm_dm=admm_dm)
 
       CALL qs_rho_get(rho, rho_ao=rho_ao)
       CALL qs_rho_get(rho_aux, rho_ao=rho_ao_aux)
@@ -186,11 +183,11 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Calculates auxiliary density matrix via blocking.
-!> \param ks_env ...
+!> \param qs_env ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE map_dm_blocked(ks_env)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE map_dm_blocked(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
 
       INTEGER                                            :: blk, iatom, ispin, jatom
       LOGICAL                                            :: found
@@ -203,11 +200,8 @@ CONTAINS
 
       NULLIFY (dft_control, admm_dm, rho, rho_aux, rho_ao, rho_ao_aux)
 
-      CALL get_ks_env(ks_env, &
-                      admm_dm=admm_dm, &
-                      dft_control=dft_control, &
-                      rho=rho, &
-                      rho_aux_fit=rho_aux)
+      CALL get_qs_env(qs_env, dft_control=dft_control, rho=rho)
+      CALL get_admm_env(qs_env%admm_env, rho_aux_fit=rho_aux, admm_dm=admm_dm)
 
       CALL qs_rho_get(rho, rho_ao=rho_ao)
       CALL qs_rho_get(rho_aux, rho_ao=rho_ao_aux)
@@ -233,10 +227,10 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Call calculate_rho_elec() for auxiliary density
-!> \param ks_env ...
+!> \param qs_env ...
 ! **************************************************************************************************
-   SUBROUTINE update_rho_aux(ks_env)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE update_rho_aux(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
 
       INTEGER                                            :: ispin
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_r_aux
@@ -244,17 +238,16 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao_aux
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_aux, rho_r_aux
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_aux
       TYPE(task_list_type), POINTER                      :: task_list_aux_fit
 
       NULLIFY (dft_control, admm_dm, rho_aux, rho_ao_aux, rho_r_aux, rho_g_aux, tot_rho_r_aux, &
-               task_list_aux_fit)
+               task_list_aux_fit, ks_env)
 
-      CALL get_ks_env(ks_env, &
-                      admm_dm=admm_dm, &
-                      dft_control=dft_control, &
-                      rho_aux_fit=rho_aux, &
-                      task_list_aux_fit=task_list_aux_fit)
+      CALL get_qs_env(qs_env, ks_env=ks_env, dft_control=dft_control)
+      CALL get_admm_env(qs_env%admm_env, task_list_aux_fit=task_list_aux_fit, rho_aux_fit=rho_aux, &
+                        admm_dm=admm_dm)
 
       CALL qs_rho_get(rho_aux, &
                       rho_ao=rho_ao_aux, &
@@ -279,12 +272,12 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Merges auxiliary Kohn-Sham matrix via basis projection.
-!> \param ks_env ...
+!> \param qs_env ...
 !> \param matrix_ks_merge Input: The KS matrix to be merged
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE merge_dm_projection(ks_env, matrix_ks_merge)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE merge_dm_projection(qs_env, matrix_ks_merge)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_merge
 
       INTEGER                                            :: ispin
@@ -295,10 +288,8 @@ CONTAINS
 
       NULLIFY (admm_dm, dft_control, matrix_ks)
 
-      CALL get_ks_env(ks_env, &
-                      admm_dm=admm_dm, &
-                      dft_control=dft_control, &
-                      matrix_ks=matrix_ks)
+      CALL get_qs_env(qs_env, dft_control=dft_control, matrix_ks=matrix_ks)
+      CALL get_admm_env(qs_env%admm_env, admm_dm=admm_dm)
 
       ! Calculate K += A^T * K_aux * A
       CALL dbcsr_create(matrix_tmp, template=admm_dm%matrix_A, matrix_type="N")
@@ -316,12 +307,12 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Merges auxiliary Kohn-Sham matrix via blocking.
-!> \param ks_env ...
+!> \param qs_env ...
 !> \param matrix_ks_merge Input: The KS matrix to be merged
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE merge_dm_blocked(ks_env, matrix_ks_merge)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE merge_dm_blocked(qs_env, matrix_ks_merge)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_merge
 
       INTEGER                                            :: blk, iatom, ispin, jatom
@@ -333,10 +324,8 @@ CONTAINS
 
       NULLIFY (admm_dm, dft_control, matrix_ks)
 
-      CALL get_ks_env(ks_env, &
-                      admm_dm=admm_dm, &
-                      dft_control=dft_control, &
-                      matrix_ks=matrix_ks)
+      CALL get_qs_env(qs_env, dft_control=dft_control, matrix_ks=matrix_ks)
+      CALL get_admm_env(qs_env%admm_env, admm_dm=admm_dm)
 
       DO ispin = 1, dft_control%nspins
          CALL dbcsr_iterator_start(iter, matrix_ks_merge(ispin)%matrix)
@@ -353,11 +342,11 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Apply McWeeny purification to auxiliary density matrix
-!> \param ks_env ...
+!> \param qs_env ...
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE purify_mcweeny(ks_env)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE purify_mcweeny(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'purify_mcweeny'
 
@@ -376,11 +365,9 @@ CONTAINS
                matrix_p, matrix_s, rho_ao_aux)
 
       unit_nr = cp_logger_get_default_unit_nr()
-      CALL get_ks_env(ks_env, &
-                      dft_control=dft_control, &
-                      admm_dm=admm_dm, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      rho_aux_fit=rho_aux_fit)
+      CALL get_qs_env(qs_env, dft_control=dft_control)
+      CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux_fit, &
+                        rho_aux_fit=rho_aux_fit, admm_dm=admm_dm)
 
       CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
 
@@ -440,12 +427,12 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Prepare auxiliary KS-matrix for merge using reverse McWeeny
-!> \param ks_env ...
+!> \param qs_env ...
 !> \param matrix_ks_merge Output: The KS matrix for the merge
 !> \author Ole Schuett
 ! **************************************************************************************************
-   SUBROUTINE revert_purify_mcweeny(ks_env, matrix_ks_merge)
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+   SUBROUTINE revert_purify_mcweeny(qs_env, matrix_ks_merge)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_merge
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'revert_purify_mcweeny'
@@ -465,13 +452,9 @@ CONTAINS
                matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
                history_next, history_curr, matrix_k)
 
-      CALL get_ks_env(ks_env, &
-                      admm_dm=admm_dm, &
-                      dft_control=dft_control, &
-                      matrix_ks=matrix_ks, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb)
+      CALL get_qs_env(qs_env, dft_control=dft_control, matrix_ks=matrix_ks)
+      CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux_fit, admm_dm=admm_dm, &
+                        matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, matrix_ks_aux_fit=matrix_ks_aux_fit)
 
       nspins = dft_control%nspins
       ALLOCATE (matrix_ks_merge(nspins))

--- a/src/admm_methods.F
+++ b/src/admm_methods.F
@@ -14,13 +14,11 @@
 ! **************************************************************************************************
 MODULE admm_methods
    USE admm_types,                      ONLY: admm_gapw_type,&
-                                              admm_type
+                                              admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
-   USE basis_set_types,                 ONLY: get_gto_basis_set,&
-                                              gto_basis_set_type
    USE bibliography,                    ONLY: Merlot2014,&
                                               cite_reference
-   USE cell_types,                      ONLY: cell_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
@@ -37,8 +35,10 @@ MODULE admm_methods
                                               cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
    USE cp_fm_diag,                      ONLY: cp_fm_syevd
-   USE cp_fm_types,                     ONLY: cp_fm_get_info,&
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_info,&
                                               cp_fm_p_type,&
+                                              cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_set_element,&
                                               cp_fm_to_fm,&
@@ -56,8 +56,6 @@ MODULE admm_methods
         dbcsr_dot, dbcsr_get_block_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
         dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, dbcsr_scale, &
         dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_symmetric
-   USE distribution_1d_types,           ONLY: distribution_1d_type
-   USE distribution_2d_types,           ONLY: distribution_2d_type
    USE input_constants,                 ONLY: do_admm_exch_scaling_merlot,&
                                               do_admm_exch_scaling_none,&
                                               do_admm_purify_cauchy,&
@@ -69,10 +67,6 @@ MODULE admm_methods
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE molecule_types,                  ONLY: molecule_type
-   USE particle_types,                  ONLY: particle_type
-   USE paw_proj_set_types,              ONLY: get_paw_proj_set,&
-                                              paw_proj_set_type
    USE pw_types,                        ONLY: pw_p_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_energy_types,                 ONLY: qs_energy_type
@@ -81,27 +75,15 @@ MODULE admm_methods
    USE qs_force_types,                  ONLY: add_qs_force,&
                                               qs_force_type
    USE qs_gapw_densities,               ONLY: prepare_gapw_den
-   USE qs_kind_types,                   ONLY: get_qs_kind,&
-                                              qs_kind_type
    USE qs_ks_atom,                      ONLY: update_ks_atom
-   USE qs_ks_types,                     ONLY: get_ks_env,&
-                                              qs_ks_env_type
+   USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_local_rho_types,              ONLY: local_rho_set_create,&
                                               local_rho_set_release,&
                                               local_rho_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_p_type,&
                                               mo_set_type
-   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type,&
-                                              release_neighbor_list_sets
-   USE qs_neighbor_lists,               ONLY: atom2d_build,&
-                                              atom2d_cleanup,&
-                                              build_neighbor_lists,&
-                                              local_atoms_type,&
-                                              pair_radius_setup
-   USE qs_oce_methods,                  ONLY: build_oce_matrices
-   USE qs_oce_types,                    ONLY: allocate_oce_set,&
-                                              create_oce_set
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE qs_overlap,                      ONLY: build_overlap_force
    USE qs_rho_atom_methods,             ONLY: allocate_rho_atom_internals,&
                                               calculate_rho_atom_coeff
@@ -110,10 +92,7 @@ MODULE admm_methods
                                               qs_rho_type
    USE qs_vxc,                          ONLY: qs_vxc_create
    USE qs_vxc_atom,                     ONLY: calculate_vxc_atom
-   USE task_list_methods,               ONLY: generate_qs_task_list
-   USE task_list_types,                 ONLY: allocate_task_list,&
-                                              deallocate_task_list,&
-                                              task_list_type
+   USE task_list_types,                 ONLY: task_list_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -127,7 +106,10 @@ MODULE admm_methods
              scale_dm, &
              admm_fit_mo_coeffs, &
              admm_update_ks_atom, &
-             admm_aux_reponse_density
+             admm_aux_reponse_density, &
+             calc_admm_mo_derivatives, &
+             calc_admm_ovlp_forces, &
+             admm_projection_derivative
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'admm_methods'
 
@@ -153,8 +135,6 @@ CONTAINS
                                                             rho_ao_aux
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_aux_fit
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_aux, rho_r_aux
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit
@@ -164,21 +144,19 @@ CONTAINS
 
       NULLIFY (ks_env, admm_env, mos, mos_aux_fit, matrix_s_aux_fit, &
                matrix_s_aux_fit_vs_orb, matrix_s, rho, rho_aux_fit, para_env)
-      NULLIFY (rho_g_aux, rho_r_aux, rho_ao, rho_ao_aux, tot_rho_r_aux, task_list, sab_aux_fit)
+      NULLIFY (rho_g_aux, rho_r_aux, rho_ao, rho_ao_aux, tot_rho_r_aux, task_list)
 
       CALL get_qs_env(qs_env, &
                       ks_env=ks_env, &
                       admm_env=admm_env, &
                       dft_control=dft_control, &
-                      mos_aux_fit=mos_aux_fit, &
                       mos=mos, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
                       matrix_s=matrix_s, &
                       para_env=para_env, &
                       s_mstruct_changed=s_mstruct_changed, &
-                      rho=rho, &
-                      rho_aux_fit=rho_aux_fit)
+                      rho=rho)
+      CALL get_admm_env(admm_env, mos_aux_fit=mos_aux_fit, matrix_s_aux_fit=matrix_s_aux_fit, &
+                        matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, rho_aux_fit=rho_aux_fit)
 
       CALL qs_rho_get(rho, rho_ao=rho_ao)
       CALL qs_rho_get(rho_aux_fit, &
@@ -199,9 +177,6 @@ CONTAINS
       ! fit mo coeffcients
       CALL admm_fit_mo_coeffs(admm_env, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
                               mos, mos_aux_fit, s_mstruct_changed)
-
-      ! update the GAPW internals if structure has changed
-      IF (s_mstruct_changed .AND. gapw) CALL update_admm_gapw(qs_env)
 
       DO ispin = 1, dft_control%nspins
          IF (admm_env%block_dm) THEN
@@ -234,7 +209,7 @@ CONTAINS
          !GPW is the default, PW density is computed using the AUX_FIT basis and task_list
          !If GAPW, the we use the AUX_FIT_SOFT basis and task list
          basis_type = "AUX_FIT"
-         CALL get_ks_env(ks_env, task_list_aux_fit=task_list)
+         task_list => admm_env%task_list_aux_fit
          IF (gapw) THEN
             basis_type = "AUX_FIT_SOFT"
             task_list => admm_env%admm_gapw_env%task_list
@@ -253,12 +228,11 @@ CONTAINS
 
       !If GAPW, also need to prepare the atomic densities
       IF (gapw) THEN
-         CALL get_qs_env(qs_env, sab_aux_fit=sab_aux_fit)
 
          CALL calculate_rho_atom_coeff(qs_env, rho_ao_aux, &
                                        rho_atom_set=admm_env%admm_gapw_env%local_rho_set%rho_atom_set, &
                                        qs_kind_set=admm_env%admm_gapw_env%admm_kind_set, &
-                                       oce=admm_env%admm_gapw_env%oce, sab=sab_aux_fit, para_env=para_env)
+                                       oce=admm_env%admm_gapw_env%oce, sab=admm_env%sab_aux_fit, para_env=para_env)
 
          CALL prepare_gapw_den(qs_env, local_rho_set=admm_env%admm_gapw_env%local_rho_set, &
                                do_rho0=.FALSE., kind_set_external=admm_env%admm_gapw_env%admm_kind_set)
@@ -294,26 +268,24 @@ CONTAINS
                                                             matrix_ks_aux_fit_dft, &
                                                             matrix_ks_aux_fit_hfx, rho_ao_aux
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit
       TYPE(qs_rho_type), POINTER                         :: rho_aux_fit
 
       NULLIFY (matrix_ks_aux_fit, matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, rho_ao_aux, rho_aux_fit)
-      NULLIFY (sab_aux_fit, admm_env, dft_control)
+      NULLIFY (admm_env, dft_control)
 
       CALL timeset(routineN, handle)
 
-      CALL get_qs_env(qs_env, rho_aux_fit=rho_aux_fit, matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, sab_aux_fit=sab_aux_fit, &
-                      matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx, admm_env=admm_env, &
-                      dft_control=dft_control)
+      CALL get_qs_env(qs_env, admm_env=admm_env, dft_control=dft_control)
+      CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, matrix_ks_aux_fit=matrix_ks_aux_fit, &
+                        matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, &
+                        matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
       CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
 
       CALL update_ks_atom(qs_env, matrix_ks_aux_fit, rho_ao_aux, calculate_forces, tddft=.FALSE., &
                           rho_atom_external=admm_env%admm_gapw_env%local_rho_set%rho_atom_set, &
                           kind_set_external=admm_env%admm_gapw_env%admm_kind_set, &
                           oce_external=admm_env%admm_gapw_env%oce, &
-                          sab_external=sab_aux_fit)
+                          sab_external=admm_env%sab_aux_fit)
 
       !Following the logic of sum_up_and_integrate to recover the pure DFT exchange contribution
       DO ispin = 1, dft_control%nspins
@@ -324,115 +296,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE admm_update_ks_atom
-
-! **************************************************************************************************
-!> \brief Update the admm_gapw_env internals to the current qs_env (i.e. atomic positions)
-!> \param qs_env ...
-! **************************************************************************************************
-   SUBROUTINE update_admm_gapw(qs_env)
-
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'update_admm_gapw'
-
-      INTEGER                                            :: handle, ikind, nkind
-      LOGICAL                                            :: paw_atom
-      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: aux_present, oce_present
-      REAL(dp)                                           :: subcells
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: aux_radius, oce_radius
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius
-      TYPE(admm_gapw_type), POINTER                      :: admm_gapw_env
-      TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(distribution_1d_type), POINTER                :: distribution_1d
-      TYPE(distribution_2d_type), POINTER                :: distribution_2d
-      TYPE(gto_basis_set_type), POINTER                  :: aux_fit_basis
-      TYPE(local_atoms_type), ALLOCATABLE, DIMENSION(:)  :: atom2d
-      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit, sap_oce
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      TYPE(paw_proj_set_type), POINTER                   :: paw_proj
-      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: admm_kind_set, qs_kind_set
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
-
-      NULLIFY (ks_env, sab_aux_fit, qs_kind_set, admm_kind_set, aux_fit_basis, cell, distribution_1d)
-      NULLIFY (distribution_2d, paw_proj, particle_set, molecule_set, admm_env, admm_gapw_env)
-      NULLIFY (dft_control, atomic_kind_set, sap_oce)
-
-      CALL timeset(routineN, handle)
-
-      CALL get_qs_env(qs_env, ks_env=ks_env, qs_kind_set=qs_kind_set, admm_env=admm_env, &
-                      dft_control=dft_control)
-      admm_gapw_env => admm_env%admm_gapw_env
-      admm_kind_set => admm_gapw_env%admm_kind_set
-      nkind = SIZE(qs_kind_set)
-
-      !Update the task lisft for the AUX_FIT_SOFT basis
-      CALL get_ks_env(ks_env, sab_aux_fit=sab_aux_fit)
-      IF (ASSOCIATED(admm_gapw_env%task_list)) CALL deallocate_task_list(admm_gapw_env%task_list)
-      CALL allocate_task_list(admm_gapw_env%task_list)
-
-      !note: we set soft_valid to .FALSE. want to use AUX_FIT_SOFT and not the normal ORB SOFT basis
-      CALL generate_qs_task_list(ks_env, admm_gapw_env%task_list, reorder_rs_grid_ranks=.FALSE., &
-                                 soft_valid=.FALSE., basis_type="AUX_FIT_SOFT", &
-                                 skip_load_balance_distributed=dft_control%qs_control%skip_load_balance_distributed, &
-                                 sab_orb_external=sab_aux_fit)
-
-      !Update the precomputed oce integrals
-      !a sap_oce neighbor list is required => build it here
-      ALLOCATE (aux_present(nkind), oce_present(nkind))
-      aux_present = .FALSE.; oce_present = .FALSE.
-      ALLOCATE (aux_radius(nkind), oce_radius(nkind))
-      aux_radius = 0.0_dp; oce_radius = 0.0_dp
-
-      DO ikind = 1, nkind
-         CALL get_qs_kind(qs_kind_set(ikind), basis_set=aux_fit_basis, basis_type="AUX_FIT")
-         IF (ASSOCIATED(aux_fit_basis)) THEN
-            aux_present(ikind) = .TRUE.
-            CALL get_gto_basis_set(aux_fit_basis, kind_radius=aux_radius(ikind))
-         END IF
-
-         !note: get oce info from admm_kind_set
-         CALL get_qs_kind(admm_kind_set(ikind), paw_atom=paw_atom, paw_proj_set=paw_proj)
-         IF (paw_atom) THEN
-            oce_present(ikind) = .TRUE.
-            CALL get_paw_proj_set(paw_proj, rcprj=oce_radius(ikind))
-         END IF
-      END DO
-
-      ALLOCATE (pair_radius(nkind, nkind))
-      pair_radius = 0.0_dp
-      CALL pair_radius_setup(aux_present, oce_present, aux_radius, oce_radius, pair_radius)
-
-      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, cell=cell, &
-                      distribution_2d=distribution_2d, local_particles=distribution_1d, &
-                      particle_set=particle_set, molecule_set=molecule_set)
-      CALL section_vals_val_get(qs_env%input, "DFT%SUBCELLS", r_val=subcells)
-
-      ALLOCATE (atom2d(nkind))
-      CALL atom2d_build(atom2d, distribution_1d, distribution_2d, atomic_kind_set, &
-                        molecule_set, .FALSE., particle_set)
-      CALL build_neighbor_lists(sap_oce, particle_set, atom2d, cell, pair_radius, &
-                                subcells=subcells, operator_type="ABBA", nlname="AUX_PAW-PRJ")
-      CALL atom2d_cleanup(atom2d)
-
-      !actually compute the oce matrices
-      CALL create_oce_set(admm_gapw_env%oce)
-      CALL allocate_oce_set(admm_gapw_env%oce, nkind)
-
-      !always compute the derivative, cheap anyways
-      CALL build_oce_matrices(admm_gapw_env%oce%intac, calculate_forces=.TRUE., nder=1, &
-                              qs_kind_set=admm_kind_set, particle_set=particle_set, &
-                              sap_oce=sap_oce, eps_fit=dft_control%qs_control%gapw_control%eps_fit)
-
-      CALL release_neighbor_list_sets(sap_oce)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE update_admm_gapw
 
 ! **************************************************************************************************
 !> \brief ...
@@ -941,8 +804,8 @@ CONTAINS
                       admm_env=admm_env, &
                       dft_control=dft_control, &
                       matrix_ks=matrix_ks, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
                       mos=mos)
+      CALL get_admm_env(admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit)
 
       DO ispin = 1, dft_control%nspins
          nao_aux_fit = admm_env%nao_aux_fit
@@ -1096,9 +959,8 @@ CONTAINS
                       admm_env=admm_env, &
                       dft_control=dft_control, &
                       matrix_ks=matrix_ks, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      mos=mos, &
-                      mos_aux_fit=mos_aux_fit)
+                      mos=mos)
+      CALL get_admm_env(admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit, mos_aux_fit=mos_aux_fit)
 
       DO ispin = 1, dft_control%nspins
          nao_aux_fit = admm_env%nao_aux_fit
@@ -1398,17 +1260,13 @@ CONTAINS
                       admm_env=admm_env, &
                       dft_control=dft_control, &
                       matrix_ks=matrix_ks, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, &
-                      matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx, &
-                      !mos=mos,&
-                      !mos_aux_fit=mos_aux_fit,&
                       rho=rho, &
-                      rho_aux_fit=rho_aux_fit, &
                       matrix_s=matrix_s, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
                       energy=energy, &
                       para_env=para_env)
+      CALL get_admm_env(admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit, matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, &
+                        matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx, rho_aux_fit=rho_aux_fit, &
+                        matrix_s_aux_fit=matrix_s_aux_fit)
 
       CALL qs_rho_get(rho, rho_ao=rho_ao)
       CALL qs_rho_get(rho_aux_fit, &
@@ -1649,8 +1507,6 @@ CONTAINS
                                                             rho_ao_aux_buffer
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(local_rho_type), POINTER                      :: local_rho_buffer
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, v_rspace_dummy, &
                                                             v_tau_rspace_dummy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
@@ -1662,17 +1518,16 @@ CONTAINS
 
       NULLIFY (ks_env, rho_aux_fit, rho_aux_fit_buffer, &
                xc_section_aux, v_rspace_dummy, v_tau_rspace_dummy, &
-               rho_ao_aux, rho_ao_aux_buffer, dft_control, sab_aux_fit, &
+               rho_ao_aux, rho_ao_aux_buffer, dft_control, &
                matrix_ks_aux_fit_hfx, task_list, local_rho_buffer, admm_gapw_env)
 
       NULLIFY (rho_g, rho_r, tot_rho_r)
 
       CALL get_qs_env(qs_env, &
                       ks_env=ks_env, &
-                      rho_aux_fit=rho_aux_fit, &
-                      rho_aux_fit_buffer=rho_aux_fit_buffer, &
-                      dft_control=dft_control, &
-                      matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
+                      dft_control=dft_control)
+      CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, rho_aux_fit_buffer=rho_aux_fit_buffer, &
+                        matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
 
       CALL qs_rho_get(rho_aux_fit, &
                       rho_ao=rho_ao_aux)
@@ -1693,7 +1548,7 @@ CONTAINS
 
       ! By default use standard AUX_FIT basis and task_list. IF GAPW use the soft ones
       basis_type = "AUX_FIT"
-      CALL get_ks_env(ks_env, task_list_aux_fit=task_list)
+      task_list => admm_env%task_list_aux_fit
       IF (gapw) THEN
          basis_type = "AUX_FIT_SOFT"
          task_list => admm_env%admm_gapw_env%task_list
@@ -1731,8 +1586,7 @@ CONTAINS
          admm_gapw_env => admm_env%admm_gapw_env
          CALL get_qs_env(qs_env, &
                          atomic_kind_set=atomic_kind_set, &
-                         para_env=para_env, &
-                         sab_aux_fit=sab_aux_fit)
+                         para_env=para_env)
 
          CALL local_rho_set_create(local_rho_buffer)
          CALL allocate_rho_atom_internals(local_rho_buffer%rho_atom_set, atomic_kind_set, &
@@ -1741,7 +1595,7 @@ CONTAINS
          CALL calculate_rho_atom_coeff(qs_env, rho_ao_aux_buffer, &
                                        rho_atom_set=local_rho_buffer%rho_atom_set, &
                                        qs_kind_set=admm_gapw_env%admm_kind_set, &
-                                       oce=admm_gapw_env%oce, sab=sab_aux_fit, &
+                                       oce=admm_gapw_env%oce, sab=admm_env%sab_aux_fit, &
                                        para_env=para_env)
 
          CALL prepare_gapw_den(qs_env, local_rho_set=local_rho_buffer, do_rho0=.FALSE., &
@@ -1934,6 +1788,197 @@ CONTAINS
    END SUBROUTINE merge_mo_derivs_no_diag
 
 ! **************************************************************************************************
+!> \brief Calculate the derivative of the AUX_FIT mo, based on the ORB mo_derivs
+!> \param qs_env ...
+!> \param mo_derivs the MO derivatives in the orbital basis
+! **************************************************************************************************
+   SUBROUTINE calc_admm_mo_derivatives(qs_env, mo_derivs)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mo_derivs
+
+      INTEGER                                            :: ispin, nspins
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_derivs_aux_fit, mo_derivs_fm
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mo_array, mos_aux_fit
+
+      NULLIFY (mo_array, mos_aux_fit, matrix_ks_aux_fit, mo_coeff_aux_fit, &
+               mo_derivs_aux_fit, mo_derivs_fm, mo_coeff)
+
+      CALL get_qs_env(qs_env, admm_env=admm_env, mos=mo_array)
+      CALL get_admm_env(admm_env, mos_aux_fit=mos_aux_fit, mo_derivs_aux_fit=mo_derivs_aux_fit, &
+                        matrix_ks_aux_fit=matrix_ks_aux_fit)
+
+      nspins = SIZE(mo_derivs)
+      ALLOCATE (mo_derivs_fm(nspins))
+      DO ispin = 1, nspins
+         CALL get_mo_set(mo_set=mo_array(ispin)%mo_set, mo_coeff=mo_coeff)
+         NULLIFY (mo_derivs_fm(ispin)%matrix)
+         CALL cp_fm_create(mo_derivs_fm(ispin)%matrix, mo_coeff%matrix_struct)
+      END DO
+
+      DO ispin = 1, nspins
+         CALL get_mo_set(mo_set=mo_array(ispin)%mo_set, mo_coeff=mo_coeff)
+         CALL get_mo_set(mo_set=mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit)
+
+         CALL copy_dbcsr_to_fm(mo_derivs(ispin)%matrix, mo_derivs_fm(ispin)%matrix)
+         CALL admm_mo_merge_derivs(ispin, admm_env, mo_array(ispin)%mo_set, mo_coeff, mo_coeff_aux_fit, &
+                                   mo_derivs_fm, mo_derivs_aux_fit, matrix_ks_aux_fit)
+         CALL copy_fm_to_dbcsr(mo_derivs_fm(ispin)%matrix, mo_derivs(ispin)%matrix)
+      END DO
+
+      DO ispin = 1, nspins
+         CALL cp_fm_release(mo_derivs_fm(ispin)%matrix)
+      END DO
+      DEALLOCATE (mo_derivs_fm)
+
+   END SUBROUTINE calc_admm_mo_derivatives
+
+! **************************************************************************************************
+!> \brief Calculate the forces due to the AUX/ORB basis overlap in ADMM
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE calc_admm_ovlp_forces(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: ispin
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit, matrix_s_aux_fit, &
+                                                            matrix_s_aux_fit_vs_orb
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_aux_fit
+      TYPE(mo_set_type), POINTER                         :: mo_set
+
+      CALL get_qs_env(qs_env, dft_control=dft_control)
+
+      IF (dft_control%do_admm_dm) THEN
+         CPABORT("Forces with ADMM DM methods not implemented")
+      END IF
+      IF (dft_control%do_admm_mo .AND. .NOT. qs_env%run_rtp) THEN
+         NULLIFY (matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, matrix_ks_aux_fit, &
+                  mos_aux_fit, mos, admm_env)
+         CALL get_qs_env(qs_env=qs_env, &
+                         mos=mos, &
+                         admm_env=admm_env)
+         CALL get_admm_env(admm_env, matrix_s_aux_fit=matrix_s_aux_fit, mos_aux_fit=mos_aux_fit, &
+                           matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, matrix_ks_aux_fit=matrix_ks_aux_fit)
+         DO ispin = 1, dft_control%nspins
+            mo_set => mos(ispin)%mo_set
+            CALL get_mo_set(mo_set=mo_set, mo_coeff=mo_coeff)
+            ! if no purification we need to calculate the H matrix for forces
+            IF (admm_env%purification_method == do_admm_purify_none) THEN
+               CALL get_mo_set(mo_set=mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit)
+               CALL calc_aux_mo_derivs_none(ispin, qs_env%admm_env, mo_set, &
+                                            mo_coeff_aux_fit, matrix_ks_aux_fit)
+            END IF
+         END DO
+         CALL calc_mixed_overlap_force(qs_env)
+      END IF
+
+   END SUBROUTINE calc_admm_ovlp_forces
+
+! **************************************************************************************************
+!> \brief Calculate derivatives terms from overlap matrices
+!> \param qs_env ...
+!> \param matrix_hz Fock matrix part using the response density in admm basis
+!> \param matrix_pz response density in orbital basis
+!> \param fval ...
+! **************************************************************************************************
+   SUBROUTINE admm_projection_derivative(qs_env, matrix_hz, matrix_pz, fval)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_hz, matrix_pz
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: fval
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'admm_projection_derivative'
+
+      INTEGER                                            :: handle, ispin, nao, natom, naux, nspins
+      REAL(KIND=dp)                                      :: my_fval
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: admm_force
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+      TYPE(dbcsr_type), POINTER                          :: matrix_w_q, matrix_w_s
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_aux_fit_asymm, sab_aux_fit_vs_orb
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+
+      CALL timeset(routineN, handle)
+
+      CPASSERT(ASSOCIATED(qs_env))
+
+      CALL get_qs_env(qs_env, ks_env=ks_env, admm_env=admm_env)
+      CALL get_admm_env(admm_env, matrix_s_aux_fit=matrix_s_aux_fit, sab_aux_fit_asymm=sab_aux_fit_asymm, &
+                        matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, sab_aux_fit_vs_orb=sab_aux_fit_vs_orb)
+
+      my_fval = 2.0_dp
+      IF (PRESENT(fval)) my_fval = fval
+
+      ALLOCATE (matrix_w_q)
+      CALL dbcsr_copy(matrix_w_q, matrix_s_aux_fit_vs_orb(1)%matrix, &
+                      "W MATRIX AUX Q")
+      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_q, sab_aux_fit_vs_orb)
+      ALLOCATE (matrix_w_s)
+      CALL dbcsr_create(matrix_w_s, template=matrix_s_aux_fit(1)%matrix, &
+                        name='W MATRIX AUX S', &
+                        matrix_type=dbcsr_type_no_symmetry)
+      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_s, sab_aux_fit_asymm)
+
+      CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, &
+                      natom=natom, force=force)
+      ALLOCATE (admm_force(3, natom))
+      admm_force = 0.0_dp
+
+      nspins = SIZE(matrix_pz)
+      nao = admm_env%nao_orb
+      naux = admm_env%nao_aux_fit
+
+      CALL cp_fm_set_all(admm_env%work_aux_orb2, 0.0_dp)
+
+      DO ispin = 1, nspins
+         CALL copy_dbcsr_to_fm(matrix_hz(ispin)%matrix, admm_env%work_aux_aux)
+         CALL cp_gemm("N", "T", naux, naux, naux, 1.0_dp, admm_env%s_inv, &
+                      admm_env%work_aux_aux, 0.0_dp, admm_env%work_aux_aux2)
+         CALL cp_gemm("N", "N", naux, nao, naux, 1.0_dp, admm_env%work_aux_aux2, &
+                      admm_env%A, 0.0_dp, admm_env%work_aux_orb)
+         CALL copy_dbcsr_to_fm(matrix_pz(ispin)%matrix, admm_env%work_orb_orb)
+         ! admm_env%work_aux_orb2 = S-1*H*A*P
+         CALL cp_gemm("N", "N", naux, nao, nao, 1.0_dp, admm_env%work_aux_orb, &
+                      admm_env%work_orb_orb, 1.0_dp, admm_env%work_aux_orb2)
+      END DO
+
+      CALL copy_fm_to_dbcsr(admm_env%work_aux_orb2, matrix_w_q, keep_sparsity=.TRUE.)
+
+      ! admm_env%work_aux_aux = S-1*H*A*P*A(T)
+      CALL cp_gemm("N", "T", naux, naux, nao, 1.0_dp, admm_env%work_aux_orb2, &
+                   admm_env%A, 0.0_dp, admm_env%work_aux_aux)
+      CALL copy_fm_to_dbcsr(admm_env%work_aux_aux, matrix_w_s, keep_sparsity=.TRUE.)
+
+      CALL dbcsr_scale(matrix_w_q, -my_fval)
+      CALL dbcsr_scale(matrix_w_s, my_fval)
+
+      CALL build_overlap_force(ks_env, admm_force, &
+                               basis_type_a="AUX_FIT", basis_type_b="AUX_FIT", &
+                               sab_nl=sab_aux_fit_asymm, matrix_p=matrix_w_s)
+      CALL build_overlap_force(ks_env, admm_force, &
+                               basis_type_a="AUX_FIT", basis_type_b="ORB", &
+                               sab_nl=sab_aux_fit_vs_orb, matrix_p=matrix_w_q)
+
+      ! add forces
+      CALL add_qs_force(admm_force, force, "overlap_admm", atomic_kind_set)
+
+      DEALLOCATE (admm_force)
+      CALL dbcsr_deallocate_matrix(matrix_w_s)
+      CALL dbcsr_deallocate_matrix(matrix_w_q)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE admm_projection_derivative
+
+! **************************************************************************************************
 !> \brief Calculates contribution of forces due to basis transformation
 !>
 !>        dE/dR = dE/dC'*dC'/dR
@@ -1983,8 +2028,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit, sab_aux_fit_asymm, &
-                                                            sab_aux_fit_vs_orb, sab_orb
+         POINTER                                         :: sab_orb
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
@@ -1993,26 +2037,21 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (admm_env, logger, dft_control, para_env, mos, mo_coeff, matrix_w_q, matrix_w_s, &
-               rho, rho_aux_fit, energy, sab_aux_fit, sab_aux_fit_asymm, &
-               sab_aux_fit_vs_orb, sab_orb, ks_env, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, matrix_s)
+               rho, rho_aux_fit, energy, sab_orb, ks_env, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, matrix_s)
 
       CALL get_qs_env(qs_env, &
                       admm_env=admm_env, &
                       ks_env=ks_env, &
                       dft_control=dft_control, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
                       matrix_s=matrix_s, &
                       neighbor_list_id=neighbor_list_id, &
                       rho=rho, &
-                      rho_aux_fit=rho_aux_fit, &
                       energy=energy, &
                       sab_orb=sab_orb, &
-                      sab_aux_fit=sab_aux_fit, &
-                      sab_aux_fit_asymm=sab_aux_fit_asymm, &
-                      sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
                       mos=mos, &
                       para_env=para_env)
+      CALL get_admm_env(admm_env, matrix_s_aux_fit=matrix_s_aux_fit, rho_aux_fit=rho_aux_fit, &
+                        matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb)
 
       CALL qs_rho_get(rho, rho_ao=rho_ao)
       CALL qs_rho_get(rho_aux_fit, &
@@ -2039,7 +2078,7 @@ CONTAINS
       CALL dbcsr_create(matrix_w_s, template=matrix_s_aux_fit(1)%matrix, &
                         name='W MATRIX AUX S', &
                         matrix_type=dbcsr_type_no_symmetry)
-      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_s, sab_aux_fit_asymm)
+      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_s, admm_env%sab_aux_fit_asymm)
 
       ALLOCATE (matrix_w_q)
       CALL dbcsr_copy(matrix_w_q, matrix_s_aux_fit_vs_orb(1)%matrix, &
@@ -2052,7 +2091,7 @@ CONTAINS
          ! *** S'^(-T)*H'
          IF (.NOT. admm_env%purification_method == do_admm_purify_none) THEN
             CALL cp_gemm('T', 'N', nao_aux_fit, nmo, nao_aux_fit, &
-                         1.0_dp, admm_env%S_inv, qs_env%mo_derivs_aux_fit(ispin)%matrix, 0.0_dp, &
+                         1.0_dp, admm_env%S_inv, admm_env%mo_derivs_aux_fit(ispin)%matrix, 0.0_dp, &
                          admm_env%work_aux_nmo(ispin)%matrix)
          ELSE
 
@@ -2215,10 +2254,10 @@ CONTAINS
          admm_force = 0.0_dp
          CALL build_overlap_force(ks_env, admm_force, &
                                   basis_type_a="AUX_FIT", basis_type_b="AUX_FIT", &
-                                  sab_nl=sab_aux_fit_asymm, matrix_p=matrix_w_s)
+                                  sab_nl=admm_env%sab_aux_fit_asymm, matrix_p=matrix_w_s)
          CALL build_overlap_force(ks_env, admm_force, &
                                   basis_type_a="AUX_FIT", basis_type_b="ORB", &
-                                  sab_nl=sab_aux_fit_vs_orb, matrix_p=matrix_w_q)
+                                  sab_nl=admm_env%sab_aux_fit_vs_orb, matrix_p=matrix_w_q)
 
          ! Add contribution of original basis set for ADMMQ
          IF (.NOT. admm_env%scaling_model == do_admm_exch_scaling_merlot .AND. admm_env%charge_constrain) THEN

--- a/src/admm_types.F
+++ b/src/admm_types.F
@@ -13,9 +13,12 @@
 !> \author Manuel Guidon
 ! **************************************************************************************************
 MODULE admm_types
+   USE admm_dm_types,                   ONLY: admm_dm_release,&
+                                              admm_dm_type
    USE bibliography,                    ONLY: Guidon2010,&
                                               cite_reference
    USE cp_control_types,                ONLY: admm_control_type
+   USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -24,6 +27,7 @@ MODULE admm_types
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE input_constants,                 ONLY: do_admm_blocked_projection,&
                                               do_admm_blocking_purify_full,&
                                               do_admm_charge_constrained_projection
@@ -34,17 +38,22 @@ MODULE admm_types
                                               qs_kind_type
    USE qs_local_rho_types,              ONLY: local_rho_set_release,&
                                               local_rho_type
-   USE qs_mo_types,                     ONLY: get_mo_set,&
+   USE qs_mo_types,                     ONLY: deallocate_mo_set,&
+                                              get_mo_set,&
                                               mo_set_p_type
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type,&
+                                              release_neighbor_list_sets
    USE qs_oce_types,                    ONLY: deallocate_oce_set,&
                                               oce_matrix_type
+   USE qs_rho_types,                    ONLY: qs_rho_release,&
+                                              qs_rho_type
    USE task_list_types,                 ONLY: deallocate_task_list,&
                                               task_list_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
    PRIVATE
-   PUBLIC :: admm_env_create, admm_env_release, admm_type, admm_gapw_type
+   PUBLIC :: admm_env_create, admm_env_release, admm_type, admm_gapw_type, set_admm_env, get_admm_env
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'admm_types'
 
@@ -159,6 +168,21 @@ MODULE admm_types
       INTEGER, DIMENSION(:, :), POINTER        :: block_map => Null()
       TYPE(admm_gapw_type), POINTER            :: admm_gapw_env
       LOGICAL                                  :: do_gapw = .FALSE.
+      TYPE(admm_dm_type), POINTER              :: admm_dm => Null()
+
+      TYPE(mo_set_p_type), DIMENSION(:), &
+         POINTER                               :: mos_aux_fit
+      TYPE(neighbor_list_set_p_type), &
+         DIMENSION(:), POINTER                 :: sab_aux_fit, sab_aux_fit_asymm, sab_aux_fit_vs_orb
+      TYPE(dbcsr_p_type), DIMENSION(:), &
+         POINTER                               :: matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
+                                                  matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, &
+                                                  matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+      TYPE(qs_rho_type), POINTER               :: rho_aux_fit, rho_aux_fit_buffer
+      TYPE(task_list_type), POINTER            :: task_list_aux_fit
+      TYPE(cp_fm_p_type), DIMENSION(:), &
+         POINTER                               :: mo_derivs_aux_fit
+
    END TYPE
 
 CONTAINS
@@ -169,22 +193,22 @@ CONTAINS
 !> \param admm_env The ADMM env
 !> \param admm_control ...
 !> \param mos the MO's of the orbital basis set
-!> \param mos_aux_fit the MO's of the auxiliary fitting basis set
 !> \param para_env The parallel env
 !> \param natoms ...
+!> \param nao_aux_fit ...
 !> \par History
 !>      05.2008 created [Manuel Guidon]
 !> \author Manuel Guidon
 ! **************************************************************************************************
-   SUBROUTINE admm_env_create(admm_env, admm_control, mos, mos_aux_fit, para_env, natoms)
+   SUBROUTINE admm_env_create(admm_env, admm_control, mos, para_env, natoms, nao_aux_fit)
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(admm_control_type), POINTER                   :: admm_control
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_aux_fit
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: natoms
+      INTEGER, INTENT(IN)                                :: natoms, nao_aux_fit
 
       INTEGER                                            :: i, iatom, iblock, ispin, j, jatom, &
-                                                            nao_aux_fit, nao_orb, nmo, nspins
+                                                            nao_orb, nmo, nspins
       TYPE(cp_fm_struct_type), POINTER :: fm_struct_aux_aux, fm_struct_aux_nmo, fm_struct_aux_orb, &
          fm_struct_nmo_nmo, fm_struct_orb_aux, fm_struct_orb_nmo, fm_struct_orb_orb
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
@@ -195,7 +219,6 @@ CONTAINS
 
       nspins = SIZE(mos)
       CALL get_mo_set(mos(1)%mo_set, mo_coeff=mo_coeff, nmo=nmo, nao=nao_orb)
-      CALL get_mo_set(mos_aux_fit(1)%mo_set, nao=nao_aux_fit)
       admm_env%nmo = 0
       admm_env%nao_aux_fit = nao_aux_fit
       admm_env%nao_orb = nao_orb
@@ -352,6 +375,11 @@ CONTAINS
       NULLIFY (admm_env%admm_gapw_env)
       admm_env%do_gapw = .FALSE.
 
+      NULLIFY (admm_env%mos_aux_fit, admm_env%sab_aux_fit, admm_env%sab_aux_fit_asymm, admm_env%sab_aux_fit_vs_orb)
+      NULLIFY (admm_env%matrix_ks_aux_fit, admm_env%matrix_ks_aux_fit_im, admm_env%matrix_ks_aux_fit_dft)
+      NULLIFY (admm_env%matrix_ks_aux_fit_hfx, admm_env%matrix_s_aux_fit, admm_env%matrix_s_aux_fit_vs_orb)
+      NULLIFY (admm_env%rho_aux_fit, admm_env%rho_aux_fit_buffer, admm_env%task_list_aux_fit, admm_env%mo_derivs_aux_fit)
+
    END SUBROUTINE admm_env_create
 
 ! **************************************************************************************************
@@ -446,6 +474,36 @@ CONTAINS
          CALL section_vals_release(admm_env%xc_section_aux)
 
       IF (ASSOCIATED(admm_env%admm_gapw_env)) CALL admm_gapw_env_release(admm_env%admm_gapw_env)
+      IF (ASSOCIATED(admm_env%admm_dm)) CALL admm_dm_release(admm_env%admm_dm)
+
+      IF (ASSOCIATED(admm_env%mos_aux_fit)) THEN
+         DO ispin = 1, SIZE(admm_env%mos_aux_fit)
+            IF (ASSOCIATED(admm_env%mos_aux_fit(ispin)%mo_set)) CALL deallocate_mo_set(admm_env%mos_aux_fit(ispin)%mo_set)
+         END DO
+         DEALLOCATE (admm_env%mos_aux_fit)
+      END IF
+      IF (ASSOCIATED(admm_env%mo_derivs_aux_fit)) THEN
+         DO ispin = 1, SIZE(admm_env%mo_derivs_aux_fit)
+            CALL cp_fm_release(admm_env%mo_derivs_aux_fit(ispin)%matrix)
+         END DO
+         DEALLOCATE (admm_env%mo_derivs_aux_fit)
+      END IF
+
+      IF (ASSOCIATED(admm_env%sab_aux_fit)) CALL release_neighbor_list_sets(admm_env%sab_aux_fit)
+      IF (ASSOCIATED(admm_env%sab_aux_fit_vs_orb)) CALL release_neighbor_list_sets(admm_env%sab_aux_fit_vs_orb)
+      IF (ASSOCIATED(admm_env%sab_aux_fit_asymm)) CALL release_neighbor_list_sets(admm_env%sab_aux_fit_asymm)
+
+      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit)
+      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_im)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_im)
+      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_dft)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_dft)
+      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_hfx)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_hfx)
+      IF (ASSOCIATED(admm_env%matrix_s_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit)
+      IF (ASSOCIATED(admm_env%matrix_s_aux_fit_vs_orb)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit_vs_orb)
+
+      IF (ASSOCIATED(admm_env%rho_aux_fit)) CALL qs_rho_release(admm_env%rho_aux_fit)
+      IF (ASSOCIATED(admm_env%rho_aux_fit_buffer)) CALL qs_rho_release(admm_env%rho_aux_fit_buffer)
+
+      IF (ASSOCIATED(admm_env%task_list_aux_fit)) CALL deallocate_task_list(admm_env%task_list_aux_fit)
 
       DEALLOCATE (admm_env)
 
@@ -478,6 +536,132 @@ CONTAINS
       DEALLOCATE (admm_gapw_env)
 
    END SUBROUTINE admm_gapw_env_release
+
+! **************************************************************************************************
+!> \brief Get routine for the ADMM env
+!> \param admm_env ...
+!> \param mo_derivs_aux_fit ...
+!> \param mos_aux_fit ...
+!> \param sab_aux_fit ...
+!> \param sab_aux_fit_asymm ...
+!> \param sab_aux_fit_vs_orb ...
+!> \param matrix_s_aux_fit ...
+!> \param matrix_s_aux_fit_vs_orb ...
+!> \param task_list_aux_fit ...
+!> \param matrix_ks_aux_fit ...
+!> \param matrix_ks_aux_fit_im ...
+!> \param matrix_ks_aux_fit_dft ...
+!> \param matrix_ks_aux_fit_hfx ...
+!> \param rho_aux_fit ...
+!> \param rho_aux_fit_buffer ...
+!> \param admm_dm ...
+! **************************************************************************************************
+   SUBROUTINE get_admm_env(admm_env, mo_derivs_aux_fit, mos_aux_fit, sab_aux_fit, sab_aux_fit_asymm, &
+                           sab_aux_fit_vs_orb, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
+                           task_list_aux_fit, matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
+                           matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, rho_aux_fit, &
+                           rho_aux_fit_buffer, admm_dm)
+
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: mo_derivs_aux_fit
+      TYPE(mo_set_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: mos_aux_fit
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         OPTIONAL, POINTER                               :: sab_aux_fit, sab_aux_fit_asymm, &
+                                                            sab_aux_fit_vs_orb
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
+                                                            matrix_ks_aux_fit_dft, &
+                                                            matrix_ks_aux_fit_hfx
+      TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_aux_fit, rho_aux_fit_buffer
+      TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
+
+      CPASSERT(ASSOCIATED(admm_env))
+
+      IF (PRESENT(mo_derivs_aux_fit)) mo_derivs_aux_fit => admm_env%mo_derivs_aux_fit
+      IF (PRESENT(mos_aux_fit)) mos_aux_fit => admm_env%mos_aux_fit
+      IF (PRESENT(sab_aux_fit)) sab_aux_fit => admm_env%sab_aux_fit
+      IF (PRESENT(sab_aux_fit_asymm)) sab_aux_fit_asymm => admm_env%sab_aux_fit_asymm
+      IF (PRESENT(sab_aux_fit_vs_orb)) sab_aux_fit_vs_orb => admm_env%sab_aux_fit_vs_orb
+      IF (PRESENT(matrix_s_aux_fit)) matrix_s_aux_fit => admm_env%matrix_s_aux_fit
+      IF (PRESENT(matrix_s_aux_fit_vs_orb)) matrix_s_aux_fit_vs_orb => admm_env%matrix_s_aux_fit_vs_orb
+      IF (PRESENT(task_list_aux_fit)) task_list_aux_fit => admm_env%task_list_aux_fit
+      IF (PRESENT(matrix_ks_aux_fit)) matrix_ks_aux_fit => admm_env%matrix_ks_aux_fit
+      IF (PRESENT(matrix_ks_aux_fit_im)) matrix_ks_aux_fit_im => admm_env%matrix_ks_aux_fit_im
+      IF (PRESENT(matrix_ks_aux_fit_dft)) matrix_ks_aux_fit_dft => admm_env%matrix_ks_aux_fit_dft
+      IF (PRESENT(matrix_ks_aux_fit_hfx)) matrix_ks_aux_fit_hfx => admm_env%matrix_ks_aux_fit_hfx
+      IF (PRESENT(rho_aux_fit)) rho_aux_fit => admm_env%rho_aux_fit
+      IF (PRESENT(rho_aux_fit_buffer)) rho_aux_fit_buffer => admm_env%rho_aux_fit_buffer
+      IF (PRESENT(admm_dm)) admm_dm => admm_env%admm_dm
+
+   END SUBROUTINE get_admm_env
+
+! **************************************************************************************************
+!> \brief Set routine for the ADMM env
+!> \param admm_env ...
+!> \param mo_derivs_aux_fit ...
+!> \param mos_aux_fit ...
+!> \param sab_aux_fit ...
+!> \param sab_aux_fit_asymm ...
+!> \param sab_aux_fit_vs_orb ...
+!> \param matrix_s_aux_fit ...
+!> \param matrix_s_aux_fit_vs_orb ...
+!> \param task_list_aux_fit ...
+!> \param matrix_ks_aux_fit ...
+!> \param matrix_ks_aux_fit_im ...
+!> \param matrix_ks_aux_fit_dft ...
+!> \param matrix_ks_aux_fit_hfx ...
+!> \param rho_aux_fit ...
+!> \param rho_aux_fit_buffer ...
+!> \param admm_dm ...
+! **************************************************************************************************
+   SUBROUTINE set_admm_env(admm_env, mo_derivs_aux_fit, mos_aux_fit, sab_aux_fit, sab_aux_fit_asymm, &
+                           sab_aux_fit_vs_orb, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
+                           task_list_aux_fit, matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
+                           matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, rho_aux_fit, &
+                           rho_aux_fit_buffer, admm_dm)
+
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: mo_derivs_aux_fit
+      TYPE(mo_set_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: mos_aux_fit
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         OPTIONAL, POINTER                               :: sab_aux_fit, sab_aux_fit_asymm, &
+                                                            sab_aux_fit_vs_orb
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
+                                                            matrix_ks_aux_fit_dft, &
+                                                            matrix_ks_aux_fit_hfx
+      TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_aux_fit, rho_aux_fit_buffer
+      TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
+
+      CPASSERT(ASSOCIATED(admm_env))
+
+      IF (PRESENT(mo_derivs_aux_fit)) admm_env%mo_derivs_aux_fit => mo_derivs_aux_fit
+      IF (PRESENT(mos_aux_fit)) admm_env%mos_aux_fit => mos_aux_fit
+      IF (PRESENT(sab_aux_fit)) admm_env%sab_aux_fit => sab_aux_fit
+      IF (PRESENT(sab_aux_fit_asymm)) admm_env%sab_aux_fit_asymm => sab_aux_fit_asymm
+      IF (PRESENT(sab_aux_fit_vs_orb)) admm_env%sab_aux_fit_vs_orb => sab_aux_fit_vs_orb
+      IF (PRESENT(matrix_s_aux_fit)) admm_env%matrix_s_aux_fit => matrix_s_aux_fit
+      IF (PRESENT(matrix_s_aux_fit_vs_orb)) admm_env%matrix_s_aux_fit_vs_orb => matrix_s_aux_fit_vs_orb
+      IF (PRESENT(task_list_aux_fit)) admm_env%task_list_aux_fit => task_list_aux_fit
+      IF (PRESENT(matrix_ks_aux_fit)) admm_env%matrix_ks_aux_fit => matrix_ks_aux_fit
+      IF (PRESENT(matrix_ks_aux_fit_im)) admm_env%matrix_ks_aux_fit_im => matrix_ks_aux_fit_im
+      IF (PRESENT(matrix_ks_aux_fit_dft)) admm_env%matrix_ks_aux_fit_dft => matrix_ks_aux_fit_dft
+      IF (PRESENT(matrix_ks_aux_fit_hfx)) admm_env%matrix_ks_aux_fit_hfx => matrix_ks_aux_fit_hfx
+      IF (PRESENT(rho_aux_fit)) admm_env%rho_aux_fit => rho_aux_fit
+      IF (PRESENT(rho_aux_fit_buffer)) admm_env%rho_aux_fit_buffer => rho_aux_fit_buffer
+      IF (PRESENT(admm_dm)) admm_env%admm_dm => admm_dm
+
+   END SUBROUTINE set_admm_env
 
 END MODULE admm_types
 

--- a/src/emd/rt_hfx_utils.F
+++ b/src/emd/rt_hfx_utils.F
@@ -13,6 +13,8 @@
 !> \author Florina Schiffmann
 ! **************************************************************************************************
 MODULE rt_hfx_utils
+   USE admm_types,                      ONLY: get_admm_env,&
+                                              set_admm_env
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: dbcsr_allocate_matrix_set,&
@@ -79,15 +81,15 @@ CONTAINS
       CALL qs_rho_set(rho, rho_ao_im=rho_ao_im)
 
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, &
-                         matrix_s_aux_fit=matrix_s_aux, &
-                         sab_aux_fit=sab_aux, &
-                         rho_aux_fit=rho_aux, &
-                         matrix_ks_aux_fit_im=matrix_ks_aux_im)
+         CALL get_admm_env(qs_env%admm_env, &
+                           matrix_s_aux_fit=matrix_s_aux, &
+                           sab_aux_fit=sab_aux, &
+                           rho_aux_fit=rho_aux, &
+                           matrix_ks_aux_fit_im=matrix_ks_aux_im)
          CALL qs_rho_get(rho_aux, rho_ao_im=rho_aux_ao_im)
          CALL rebuild_matrices(rho_aux_ao_im, matrix_ks_aux_im, sab_aux, matrix_s_aux, &
                                dft_control%nspins)
-         CALL set_ks_env(ks_env, matrix_ks_aux_fit_im=matrix_ks_aux_im)
+         CALL set_admm_env(qs_env%admm_env, matrix_ks_aux_fit_im=matrix_ks_aux_im)
          CALL qs_rho_set(rho_aux, rho_ao_im=rho_aux_ao_im)
       END IF
 

--- a/src/hfx_admm_utils.F
+++ b/src/hfx_admm_utils.F
@@ -15,25 +15,45 @@
 !> \author MI
 ! **************************************************************************************************
 MODULE hfx_admm_utils
-   USE admm_dm_types,                   ONLY: admm_dm_create,&
-                                              admm_dm_type
+   USE admm_dm_types,                   ONLY: admm_dm_create
    USE admm_methods,                    ONLY: scale_dm
    USE admm_types,                      ONLY: admm_env_create,&
                                               admm_gapw_type,&
-                                              admm_type
+                                              admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE basis_set_container_types,       ONLY: add_basis_set_to_container
    USE basis_set_types,                 ONLY: copy_gto_basis_set,&
+                                              get_gto_basis_set,&
                                               gto_basis_set_type
+   USE cell_types,                      ONLY: cell_type
+   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
+   USE cp_dbcsr_operations,             ONLY: cp_dbcsr_m_by_n_from_row_template,&
+                                              dbcsr_allocate_matrix_set,&
+                                              dbcsr_deallocate_matrix_set
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
+                                              cp_fm_struct_release,&
+                                              cp_fm_struct_type
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_info,&
+                                              cp_fm_p_type,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
-                                              cp_logger_type
+                                              cp_logger_type,&
+                                              cp_to_string
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: dbcsr_add,&
                                               dbcsr_copy,&
+                                              dbcsr_create,&
+                                              dbcsr_init_p,&
                                               dbcsr_p_type,&
-                                              dbcsr_set
+                                              dbcsr_set,&
+                                              dbcsr_type,&
+                                              dbcsr_type_no_symmetry
+   USE distribution_1d_types,           ONLY: distribution_1d_type
+   USE distribution_2d_types,           ONLY: distribution_2d_type
    USE external_potential_types,        ONLY: copy_potential
    USE hfx_derivatives,                 ONLY: derivatives_four_center
    USE hfx_energy_potential,            ONLY: integrate_four_center
@@ -57,7 +77,11 @@ MODULE hfx_admm_utils
                                               section_vals_val_get,&
                                               section_vals_val_set
    USE kinds,                           ONLY: dp
+   USE kpoint_types,                    ONLY: kpoint_type
+   USE molecule_types,                  ONLY: molecule_type
    USE particle_types,                  ONLY: particle_type
+   USE paw_proj_set_types,              ONLY: get_paw_proj_set,&
+                                              paw_proj_set_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_poisson_types,                ONLY: pw_poisson_type
@@ -69,17 +93,37 @@ MODULE hfx_admm_utils
                                               set_qs_env
    USE qs_interactions,                 ONLY: init_interaction_radii
    USE qs_kind_types,                   ONLY: get_qs_kind,&
+                                              get_qs_kind_set,&
                                               init_gapw_basis_set,&
                                               init_gapw_nlcc,&
                                               qs_kind_type
-   USE qs_ks_types,                     ONLY: qs_ks_env_type,&
-                                              set_ks_env
+   USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_local_rho_types,              ONLY: local_rho_set_create
-   USE qs_mo_types,                     ONLY: mo_set_p_type
+   USE qs_mo_types,                     ONLY: allocate_mo_set,&
+                                              get_mo_set,&
+                                              init_mo_set,&
+                                              mo_set_p_type
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type,&
+                                              release_neighbor_list_sets
+   USE qs_neighbor_lists,               ONLY: atom2d_build,&
+                                              atom2d_cleanup,&
+                                              build_neighbor_lists,&
+                                              local_atoms_type,&
+                                              pair_radius_setup,&
+                                              write_neighbor_lists
+   USE qs_oce_methods,                  ONLY: build_oce_matrices
+   USE qs_oce_types,                    ONLY: allocate_oce_set,&
+                                              create_oce_set
+   USE qs_overlap,                      ONLY: build_overlap_matrix
    USE qs_rho_atom_methods,             ONLY: init_rho_atom
-   USE qs_rho_types,                    ONLY: qs_rho_get,&
+   USE qs_rho_methods,                  ONLY: qs_rho_rebuild
+   USE qs_rho_types,                    ONLY: qs_rho_create,&
+                                              qs_rho_get,&
                                               qs_rho_type
    USE rt_propagation_types,            ONLY: rt_prop_type
+   USE task_list_methods,               ONLY: generate_qs_task_list
+   USE task_list_types,                 ONLY: allocate_task_list,&
+                                              deallocate_task_list
    USE virial_types,                    ONLY: virial_type
    USE xc_adiabatic_utils,              ONLY: rescale_xc_potential
 #include "./base/base_uses.f90"
@@ -107,44 +151,43 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_admm_init'
 
-      INTEGER                                            :: handle, n_rep_hf, natoms, nspins
+      INTEGER                                            :: handle, ispin, n_rep_hf, nao_aux_fit, &
+                                                            natoms, nelectron, nmo
       LOGICAL                                            :: do_hfx, my_do_mp2_hfx, s_mstruct_changed
-      TYPE(admm_dm_type), POINTER                        :: admm_dm
+      REAL(dp)                                           :: maxocc
       TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_derivs_aux_fit
+      TYPE(cp_fm_struct_type), POINTER                   :: aux_fit_fm_struct
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff_aux_fit
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+      TYPE(dbcsr_type), POINTER                          :: mo_coeff_b
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_aux_fit
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
-      TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit
+      TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: hfx_sections, input, xc_section
 
       my_do_mp2_hfx = .FALSE.
       IF (PRESENT(do_mp2_hfx)) my_do_mp2_hfx = do_mp2_hfx
 
       CALL timeset(routineN, handle)
-      NULLIFY (admm_env, admm_dm, hfx_sections, mos, mos_aux_fit, para_env, &
-               particle_set, xc_section, matrix_s_aux_fit, &
-               matrix_s_aux_fit_vs_orb, rho, rho_aux_fit, ks_env, dft_control, &
-               input)
+      NULLIFY (admm_env, hfx_sections, mos, mos_aux_fit, para_env, &
+               mo_coeff_aux_fit, xc_section, rho, ks_env, dft_control, input, &
+               qs_kind_set, mo_coeff_b, aux_fit_fm_struct, blacs_env, &
+               mo_derivs_aux_fit)
 
       CALL get_qs_env(qs_env, &
-                      mos_aux_fit=mos_aux_fit, &
                       mos=mos, &
                       admm_env=admm_env, &
-                      admm_dm=admm_dm, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
                       para_env=para_env, &
+                      blacs_env=blacs_env, &
                       s_mstruct_changed=s_mstruct_changed, &
                       rho=rho, &
-                      rho_aux_fit=rho_aux_fit, &
                       ks_env=ks_env, &
                       dft_control=dft_control, &
                       input=input)
-
-      nspins = dft_control%nspins
 
       IF (my_do_mp2_hfx) THEN
          hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%WF_CORRELATION%RI_RPA%HF")
@@ -164,10 +207,9 @@ CONTAINS
 
       IF (.NOT. ASSOCIATED(admm_env)) THEN
          ! setup admm environment
-         CALL get_qs_env(qs_env, input=input, particle_set=particle_set)
-         natoms = SIZE(particle_set, 1)
-         CALL admm_env_create(admm_env, dft_control%admm_control, mos, mos_aux_fit, &
-                              para_env, natoms)
+         CALL get_qs_env(qs_env, input=input, natom=natoms, qs_kind_set=qs_kind_set)
+         CALL get_qs_kind_set(qs_kind_set, nsgf=nao_aux_fit, basis_type="AUX_FIT")
+         CALL admm_env_create(admm_env, dft_control%admm_control, mos, para_env, natoms, nao_aux_fit)
          CALL set_qs_env(qs_env, admm_env=admm_env)
          xc_section => section_vals_get_subs_vals(input, "DFT%XC")
          CALL create_admm_xc_section(qs_env=qs_env, xc_section=xc_section, &
@@ -177,6 +219,74 @@ CONTAINS
          IF (dft_control%qs_control%gapw .OR. dft_control%qs_control%gapw_xc) &
             CALL init_admm_gapw(qs_env)
 
+         !TODO: go over the whole code and find where some ADMM specific actions are done, see if they
+         !      should be moved (e.g. ADMM overlap derivatives and such) (look for TODOs)
+         !TODO: allow for ADMM without HFX, then force no GGA exchange correction and no HFX calculation
+         !TODO: or talk to Juerg first options: one ADMM per HF section (but hard to change current logic)
+         !                                      one ADMM overall, but allow for no HF
+
+         ! ADMM neighbor lists and overlap matrices
+         CALL admm_init_hamiltonians(admm_env, qs_env)
+
+         !The aux_fit task list and densities
+         CALL qs_rho_create(admm_env%rho_aux_fit)
+         CALL qs_rho_create(admm_env%rho_aux_fit_buffer)
+         CALL admm_update_s_mstruct(admm_env, qs_env)
+         IF (admm_env%do_gapw) CALL update_admm_gapw(qs_env)
+
+         !The ADMM KS matrices
+         CALL admm_alloc_ks_matrices(admm_env, qs_env)
+
+         !The aux_fit MOs and derivatives
+         ALLOCATE (mos_aux_fit(dft_control%nspins))
+         DO ispin = 1, dft_control%nspins
+            CALL get_mo_set(mo_set=mos(ispin)%mo_set, nmo=nmo, nelectron=nelectron, maxocc=maxocc)
+            NULLIFY (mos_aux_fit(ispin)%mo_set)
+            CALL allocate_mo_set(mo_set=mos_aux_fit(ispin)%mo_set, &
+                                 nao=nao_aux_fit, &
+                                 nmo=nmo, &
+                                 nelectron=nelectron, &
+                                 n_el_f=REAL(nelectron, dp), &
+                                 maxocc=maxocc, &
+                                 flexible_electron_count=dft_control%relax_multiplicity)
+         END DO
+         admm_env%mos_aux_fit => mos_aux_fit
+
+         DO ispin = 1, dft_control%nspins
+            CALL get_mo_set(mo_set=mos(ispin)%mo_set, nmo=nmo)
+            CALL cp_fm_struct_create(aux_fit_fm_struct, context=blacs_env, para_env=para_env, &
+                                     nrow_global=nao_aux_fit, ncol_global=nmo)
+            CALL get_mo_set(mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit, mo_coeff_b=mo_coeff_b)
+            IF (.NOT. ASSOCIATED(mo_coeff_aux_fit)) THEN
+               CALL init_mo_set(mos_aux_fit(ispin)%mo_set, fm_struct=aux_fit_fm_struct, &
+                                name="qs_env"//TRIM(ADJUSTL(cp_to_string(qs_env%id_nr)))// &
+                                "%mo_aux_fit"//TRIM(ADJUSTL(cp_to_string(ispin))))
+            END IF
+            CALL cp_fm_struct_release(aux_fit_fm_struct)
+
+            IF (.NOT. ASSOCIATED(mo_coeff_b)) THEN
+               CALL cp_fm_get_info(mos_aux_fit(ispin)%mo_set%mo_coeff, ncol_global=nmo)
+               CALL dbcsr_init_p(mos_aux_fit(ispin)%mo_set%mo_coeff_b)
+               CALL cp_dbcsr_m_by_n_from_row_template(mos_aux_fit(ispin)%mo_set%mo_coeff_b, &
+                                                      template=admm_env%matrix_s_aux_fit(1)%matrix, &
+                                                      n=nmo, sym=dbcsr_type_no_symmetry)
+            END IF
+         END DO
+
+         IF (qs_env%requires_mo_derivs) THEN
+            ALLOCATE (mo_derivs_aux_fit(dft_control%nspins))
+            DO ispin = 1, dft_control%nspins
+               CALL get_mo_set(mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit)
+               CALL cp_fm_create(mo_derivs_aux_fit(ispin)%matrix, mo_coeff_aux_fit%matrix_struct)
+            END DO
+            admm_env%mo_derivs_aux_fit => mo_derivs_aux_fit
+         END IF
+
+      ELSE IF (s_mstruct_changed) THEN
+         CALL admm_init_hamiltonians(admm_env, qs_env)
+         CALL admm_update_s_mstruct(admm_env, qs_env)
+         CALL admm_alloc_ks_matrices(admm_env, qs_env)
+         IF (admm_env%do_gapw) CALL update_admm_gapw(qs_env)
       END IF
 
       IF (admm_env%do_gapw .AND. dft_control%do_admm_dm) THEN
@@ -187,9 +297,8 @@ CONTAINS
          CPABORT("GAPW ADMM not implemented for real-time propagation.")
       END IF
 
-      IF (dft_control%do_admm_dm .AND. .NOT. ASSOCIATED(admm_dm)) THEN
-         CALL admm_dm_create(admm_dm, dft_control%admm_control, nspins=nspins, natoms=natoms)
-         CALL set_ks_env(ks_env, admm_dm=admm_dm)
+      IF (dft_control%do_admm_dm .AND. .NOT. ASSOCIATED(admm_env%admm_dm)) THEN
+         CALL admm_dm_create(admm_env%admm_dm, dft_control%admm_control, nspins=dft_control%nspins, natoms=natoms)
       END IF
 
       CALL timestop(handle)
@@ -292,6 +401,330 @@ CONTAINS
    END SUBROUTINE init_admm_gapw
 
 ! **************************************************************************************************
+!> \brief Builds the ADMM nmeighbor lists and overlap matrix on the model of qs_energies_init_hamiltonians()
+!> \param admm_env ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE admm_init_hamiltonians(admm_env, qs_env)
+
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'admm_init_hamiltonians'
+
+      INTEGER                                            :: handle, ikind, nkind
+      LOGICAL                                            :: mic, molecule_only
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: aux_fit_present, orb_present
+      REAL(dp)                                           :: subcells
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: aux_fit_radius, orb_radius
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(distribution_1d_type), POINTER                :: distribution_1d
+      TYPE(distribution_2d_type), POINTER                :: distribution_2d
+      TYPE(gto_basis_set_type), POINTER                  :: aux_fit_basis_set, orb_basis_set
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(local_atoms_type), ALLOCATABLE, DIMENSION(:)  :: atom2d
+      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+      TYPE(section_vals_type), POINTER                   :: neighbor_list_section
+
+      NULLIFY (particle_set, cell, kpoints, distribution_1d, distribution_2d, molecule_set, &
+               atomic_kind_set, dft_control, neighbor_list_section, aux_fit_basis_set, orb_basis_set, &
+               ks_env, para_env, qs_kind_set)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, nkind=nkind, particle_set=particle_set, cell=cell, kpoints=kpoints, &
+                      local_particles=distribution_1d, distribution_2d=distribution_2d, &
+                      molecule_set=molecule_set, atomic_kind_set=atomic_kind_set, &
+                      dft_control=dft_control, para_env=para_env, qs_kind_set=qs_kind_set)
+      ALLOCATE (orb_present(nkind), aux_fit_present(nkind))
+      ALLOCATE (orb_radius(nkind), aux_fit_radius(nkind), pair_radius(nkind, nkind))
+      aux_fit_radius(:) = 0.0_dp
+
+      molecule_only = .FALSE.
+      IF (dft_control%qs_control%do_kg) molecule_only = .TRUE.
+      mic = molecule_only
+      IF (kpoints%nkp > 0) THEN
+         mic = .FALSE.
+      ELSEIF (dft_control%qs_control%semi_empirical) THEN
+         mic = .TRUE.
+      END IF
+
+      CALL section_vals_val_get(qs_env%input, "DFT%SUBCELLS", r_val=subcells)
+      neighbor_list_section => section_vals_get_subs_vals(qs_env%input, "DFT%PRINT%NEIGHBOR_LISTS")
+
+      ALLOCATE (atom2d(nkind))
+      CALL atom2d_build(atom2d, distribution_1d, distribution_2d, atomic_kind_set, &
+                        molecule_set, molecule_only, particle_set=particle_set)
+
+      DO ikind = 1, nkind
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set, basis_type="ORB")
+         IF (ASSOCIATED(orb_basis_set)) THEN
+            orb_present(ikind) = .TRUE.
+            CALL get_gto_basis_set(gto_basis_set=orb_basis_set, kind_radius=orb_radius(ikind))
+         ELSE
+            orb_present(ikind) = .FALSE.
+         END IF
+
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=aux_fit_basis_set, basis_type="AUX_FIT")
+         IF (ASSOCIATED(aux_fit_basis_set)) THEN
+            aux_fit_present(ikind) = .TRUE.
+            CALL get_gto_basis_set(gto_basis_set=aux_fit_basis_set, kind_radius=aux_fit_radius(ikind))
+         ELSE
+            aux_fit_present(ikind) = .FALSE.
+         END IF
+      END DO
+
+      CALL pair_radius_setup(aux_fit_present, aux_fit_present, aux_fit_radius, aux_fit_radius, pair_radius)
+      CALL build_neighbor_lists(admm_env%sab_aux_fit, particle_set, atom2d, cell, pair_radius, &
+                                mic=mic, molecular=molecule_only, subcells=subcells, nlname="sab_aux_fit")
+      CALL build_neighbor_lists(admm_env%sab_aux_fit_asymm, particle_set, atom2d, cell, pair_radius, &
+                                mic=mic, symmetric=.FALSE., molecular=molecule_only, subcells=subcells, &
+                                nlname="sab_aux_fit_asymm")
+      CALL pair_radius_setup(aux_fit_present, orb_present, aux_fit_radius, orb_radius, pair_radius)
+      CALL build_neighbor_lists(admm_env%sab_aux_fit_vs_orb, particle_set, atom2d, cell, pair_radius, &
+                                mic=mic, symmetric=.FALSE., molecular=molecule_only, subcells=subcells, &
+                                nlname="sab_aux_fit_vs_orb")
+
+      CALL write_neighbor_lists(admm_env%sab_aux_fit, particle_set, cell, para_env, neighbor_list_section, &
+                                "/SAB_AUX_FIT", "sab_aux_fit", "AUX_FIT_ORBITAL AUX_FIT_ORBITAL")
+      CALL write_neighbor_lists(admm_env%sab_aux_fit_vs_orb, particle_set, cell, para_env, neighbor_list_section, &
+                                "/SAB_AUX_FIT_VS_ORB", "sab_aux_fit_vs_orb", "ORBITAL AUX_FIT_ORBITAL")
+
+      CALL atom2d_cleanup(atom2d)
+
+      !The ADMM overlap matrices (initially in qs_core_hamiltonian.F)
+      CALL get_qs_env(qs_env, ks_env=ks_env)
+
+      IF (ASSOCIATED(admm_env%matrix_s_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit)
+      CALL build_overlap_matrix(ks_env, matrix_s=admm_env%matrix_s_aux_fit, &
+                                matrix_name="AUX_FIT_OVERLAP", &
+                                basis_type_a="AUX_FIT", &
+                                basis_type_b="AUX_FIT", &
+                                sab_nl=admm_env%sab_aux_fit)
+      IF (ASSOCIATED(admm_env%matrix_s_aux_fit_vs_orb)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit_vs_orb)
+      CALL build_overlap_matrix(ks_env, matrix_s=admm_env%matrix_s_aux_fit_vs_orb, &
+                                matrix_name="MIXED_OVERLAP", &
+                                basis_type_a="AUX_FIT", &
+                                basis_type_b="ORB", &
+                                sab_nl=admm_env%sab_aux_fit_vs_orb)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE admm_init_hamiltonians
+
+! **************************************************************************************************
+!> \brief Updates the ADMM task_list and density based on the model of qs_env_update_s_mstruct()
+!> \param admm_env ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE admm_update_s_mstruct(admm_env, qs_env)
+
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'admm_update_s_mstruct'
+
+      INTEGER                                            :: handle
+      LOGICAL                                            :: skip_load_balance_distributed
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+
+      NULLIFY (ks_env, dft_control)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, ks_env=ks_env, dft_control=dft_control)
+
+      !The aux_fit task_list
+      skip_load_balance_distributed = dft_control%qs_control%skip_load_balance_distributed
+      IF (ASSOCIATED(admm_env%task_list_aux_fit)) CALL deallocate_task_list(admm_env%task_list_aux_fit)
+      CALL allocate_task_list(admm_env%task_list_aux_fit)
+      CALL generate_qs_task_list(ks_env, admm_env%task_list_aux_fit, &
+                                 reorder_rs_grid_ranks=.FALSE., soft_valid=.FALSE., basis_type="AUX_FIT", &
+                                 skip_load_balance_distributed=skip_load_balance_distributed, &
+                                 sab_orb_external=admm_env%sab_aux_fit)
+
+      !The aux_fit densities
+      CALL qs_rho_rebuild(admm_env%rho_aux_fit, qs_env=qs_env, admm=.TRUE.)
+      CALL qs_rho_rebuild(admm_env%rho_aux_fit_buffer, qs_env=qs_env, admm=.TRUE.)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE admm_update_s_mstruct
+
+! **************************************************************************************************
+!> \brief Update the admm_gapw_env internals to the current qs_env (i.e. atomic positions)
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE update_admm_gapw(qs_env)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'update_admm_gapw'
+
+      INTEGER                                            :: handle, ikind, nkind
+      LOGICAL                                            :: paw_atom
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: aux_present, oce_present
+      REAL(dp)                                           :: subcells
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: aux_radius, oce_radius
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius
+      TYPE(admm_gapw_type), POINTER                      :: admm_gapw_env
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(distribution_1d_type), POINTER                :: distribution_1d
+      TYPE(distribution_2d_type), POINTER                :: distribution_2d
+      TYPE(gto_basis_set_type), POINTER                  :: aux_fit_basis
+      TYPE(local_atoms_type), ALLOCATABLE, DIMENSION(:)  :: atom2d
+      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sap_oce
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(paw_proj_set_type), POINTER                   :: paw_proj
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: admm_kind_set, qs_kind_set
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+
+      NULLIFY (ks_env, qs_kind_set, admm_kind_set, aux_fit_basis, cell, distribution_1d)
+      NULLIFY (distribution_2d, paw_proj, particle_set, molecule_set, admm_env, admm_gapw_env)
+      NULLIFY (dft_control, atomic_kind_set, sap_oce)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, ks_env=ks_env, qs_kind_set=qs_kind_set, admm_env=admm_env, &
+                      dft_control=dft_control)
+      admm_gapw_env => admm_env%admm_gapw_env
+      admm_kind_set => admm_gapw_env%admm_kind_set
+      nkind = SIZE(qs_kind_set)
+
+      !Update the task lisft for the AUX_FIT_SOFT basis
+      IF (ASSOCIATED(admm_gapw_env%task_list)) CALL deallocate_task_list(admm_gapw_env%task_list)
+      CALL allocate_task_list(admm_gapw_env%task_list)
+
+      !note: we set soft_valid to .FALSE. want to use AUX_FIT_SOFT and not the normal ORB SOFT basis
+      CALL generate_qs_task_list(ks_env, admm_gapw_env%task_list, reorder_rs_grid_ranks=.FALSE., &
+                                 soft_valid=.FALSE., basis_type="AUX_FIT_SOFT", &
+                                 skip_load_balance_distributed=dft_control%qs_control%skip_load_balance_distributed, &
+                                 sab_orb_external=admm_env%sab_aux_fit)
+
+      !Update the precomputed oce integrals
+      !a sap_oce neighbor list is required => build it here
+      ALLOCATE (aux_present(nkind), oce_present(nkind))
+      aux_present = .FALSE.; oce_present = .FALSE.
+      ALLOCATE (aux_radius(nkind), oce_radius(nkind))
+      aux_radius = 0.0_dp; oce_radius = 0.0_dp
+
+      DO ikind = 1, nkind
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=aux_fit_basis, basis_type="AUX_FIT")
+         IF (ASSOCIATED(aux_fit_basis)) THEN
+            aux_present(ikind) = .TRUE.
+            CALL get_gto_basis_set(aux_fit_basis, kind_radius=aux_radius(ikind))
+         END IF
+
+         !note: get oce info from admm_kind_set
+         CALL get_qs_kind(admm_kind_set(ikind), paw_atom=paw_atom, paw_proj_set=paw_proj)
+         IF (paw_atom) THEN
+            oce_present(ikind) = .TRUE.
+            CALL get_paw_proj_set(paw_proj, rcprj=oce_radius(ikind))
+         END IF
+      END DO
+
+      ALLOCATE (pair_radius(nkind, nkind))
+      pair_radius = 0.0_dp
+      CALL pair_radius_setup(aux_present, oce_present, aux_radius, oce_radius, pair_radius)
+
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, cell=cell, &
+                      distribution_2d=distribution_2d, local_particles=distribution_1d, &
+                      particle_set=particle_set, molecule_set=molecule_set)
+      CALL section_vals_val_get(qs_env%input, "DFT%SUBCELLS", r_val=subcells)
+
+      ALLOCATE (atom2d(nkind))
+      CALL atom2d_build(atom2d, distribution_1d, distribution_2d, atomic_kind_set, &
+                        molecule_set, .FALSE., particle_set)
+      CALL build_neighbor_lists(sap_oce, particle_set, atom2d, cell, pair_radius, &
+                                subcells=subcells, operator_type="ABBA", nlname="AUX_PAW-PRJ")
+      CALL atom2d_cleanup(atom2d)
+
+      !actually compute the oce matrices
+      CALL create_oce_set(admm_gapw_env%oce)
+      CALL allocate_oce_set(admm_gapw_env%oce, nkind)
+
+      !always compute the derivative, cheap anyways
+      CALL build_oce_matrices(admm_gapw_env%oce%intac, calculate_forces=.TRUE., nder=1, &
+                              qs_kind_set=admm_kind_set, particle_set=particle_set, &
+                              sap_oce=sap_oce, eps_fit=dft_control%qs_control%gapw_control%eps_fit)
+
+      CALL release_neighbor_list_sets(sap_oce)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE update_admm_gapw
+
+! **************************************************************************************************
+!> \brief Allocates the various ADMM KS matrices
+!> \param admm_env ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE admm_alloc_ks_matrices(admm_env, qs_env)
+
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'admm_alloc_ks_matrices'
+
+      INTEGER                                            :: handle, ispin
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit
+      TYPE(dft_control_type), POINTER                    :: dft_control
+
+      NULLIFY (dft_control, matrix_s_aux_fit)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, dft_control=dft_control)
+
+      matrix_s_aux_fit => admm_env%matrix_s_aux_fit
+      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit)
+      CALL dbcsr_allocate_matrix_set(admm_env%matrix_ks_aux_fit, dft_control%nspins)
+      DO ispin = 1, dft_control%nspins
+         ALLOCATE (admm_env%matrix_ks_aux_fit(ispin)%matrix)
+         CALL dbcsr_create(admm_env%matrix_ks_aux_fit(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
+                           name="KOHN-SHAM_MATRIX for ADMM")
+         CALL dbcsr_copy(admm_env%matrix_ks_aux_fit(ispin)%matrix, matrix_s_aux_fit(1)%matrix)
+         CALL dbcsr_set(admm_env%matrix_ks_aux_fit(ispin)%matrix, 0.0_dp)
+      END DO
+
+      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_dft)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_dft)
+      CALL dbcsr_allocate_matrix_set(admm_env%matrix_ks_aux_fit_dft, dft_control%nspins)
+      DO ispin = 1, dft_control%nspins
+         ALLOCATE (admm_env%matrix_ks_aux_fit_dft(ispin)%matrix)
+         CALL dbcsr_create(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
+                           name="KOHN-SHAM_MATRIX for ADMM")
+         CALL dbcsr_copy(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, matrix_s_aux_fit(1)%matrix)
+         CALL dbcsr_set(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, 0.0_dp)
+      END DO
+
+      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_hfx)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_hfx)
+      CALL dbcsr_allocate_matrix_set(admm_env%matrix_ks_aux_fit_hfx, dft_control%nspins)
+      DO ispin = 1, dft_control%nspins
+         ALLOCATE (admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix)
+         CALL dbcsr_create(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
+                           name="KOHN-SHAM_MATRIX for ADMM")
+         CALL dbcsr_copy(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, matrix_s_aux_fit(1)%matrix)
+         CALL dbcsr_set(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, 0.0_dp)
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE admm_alloc_ks_matrices
+
+! **************************************************************************************************
 !> \brief Add the hfx contributions to the Hamiltonian
 !>
 !> \param qs_env ...
@@ -357,14 +790,12 @@ CONTAINS
                       pw_env=pw_env, &
                       virial=virial, &
                       matrix_ks_im=matrix_ks_im, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      matrix_ks_aux_fit_im=matrix_ks_aux_fit_im, &
-                      matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx, &
                       s_mstruct_changed=s_mstruct_changed, &
                       x_data=x_data)
 
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env=qs_env, mos_aux_fit=mo_array)
+         CALL get_admm_env(qs_env%admm_env, mos_aux_fit=mo_array, matrix_ks_aux_fit=matrix_ks_aux_fit, &
+                           matrix_ks_aux_fit_im=matrix_ks_aux_fit_im, matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
       ELSE
          CALL get_qs_env(qs_env=qs_env, mos=mo_array)
       END IF
@@ -415,8 +846,7 @@ CONTAINS
 
          ! fetch the correct matrices for normal HFX or ADMM
          IF (dft_control%do_admm) THEN
-            CALL get_qs_env(qs_env=qs_env, matrix_ks_aux_fit=matrix_ks_1d, &
-                            rho_aux_fit=rho_orb)
+            CALL get_admm_env(qs_env%admm_env, matrix_ks_aux_fit=matrix_ks_1d, rho_aux_fit=rho_orb)
             ns = SIZE(matrix_ks_1d)
             matrix_ks_orb(1:ns, 1:1) => matrix_ks_1d(1:ns)
          ELSE

--- a/src/hfx_energy_potential.F
+++ b/src/hfx_energy_potential.F
@@ -12,6 +12,7 @@
 !> \author Manuel Guidon
 ! **************************************************************************************************
 MODULE hfx_energy_potential
+   USE admm_types, ONLY: get_admm_env
    USE atomic_kind_types, ONLY: atomic_kind_type, &
                                 get_atomic_kind_set
    USE bibliography, ONLY: cite_reference, &
@@ -248,7 +249,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
 
-      NULLIFY (dft_control)
+      NULLIFY (dft_control, matrix_ks_aux_fit_hfx)
 
       CALL timeset(routineN, handle)
 
@@ -279,8 +280,7 @@ CONTAINS
                                            "HF_INFO")
       END IF
 
-      CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, cell=cell, &
-                      matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
+      CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, cell=cell)
 
       NULLIFY (cell_to_index)
       CALL get_qs_env(qs_env=qs_env, do_kpoints=do_kpoints)
@@ -465,6 +465,7 @@ CONTAINS
                       atomic_kind_set=atomic_kind_set, &
                       particle_set=particle_set, &
                       dft_control=dft_control)
+      IF (dft_control%do_admm) CALL get_admm_env(qs_env%admm_env, matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
 
       do_p_screening = screening_parameter%do_initial_p_screening
       ! Special treatment for MP2 with initial density screening

--- a/src/motion/rt_propagation.F
+++ b/src/motion/rt_propagation.F
@@ -13,10 +13,13 @@
 MODULE rt_propagation
    USE bibliography,                    ONLY: Andermatt2016,&
                                               cite_reference
+   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type,&
                                               rtp_control_type
    USE cp_external_control,             ONLY: external_control
-   USE cp_fm_pool_types,                ONLY: cp_fm_pool_p_type
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
+                                              cp_fm_struct_release,&
+                                              cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_p_type,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -27,6 +30,7 @@ MODULE rt_propagation
    USE cp_output_handling,              ONLY: cp_add_iter_level,&
                                               cp_iterate,&
                                               cp_rm_iter_level
+   USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: dbcsr_copy,&
                                               dbcsr_p_type
    USE efield_utils,                    ONLY: calculate_ecore_efield
@@ -55,9 +59,10 @@ MODULE rt_propagation
                                               qs_environment_type
    USE qs_external_potential,           ONLY: external_c_potential,&
                                               external_e_potential
+   USE qs_kind_types,                   ONLY: get_qs_kind_set,&
+                                              qs_kind_type
    USE qs_ks_methods,                   ONLY: qs_ks_update_qs_env
    USE qs_ks_types,                     ONLY: qs_ks_did_change
-   USE qs_matrix_pools,                 ONLY: mpools_get
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               init_mo_set,&
                                               mo_set_p_type
@@ -396,14 +401,17 @@ CONTAINS
       TYPE(force_env_type), POINTER                      :: force_env
       TYPE(rtp_control_type), POINTER                    :: rtp_control
 
-      INTEGER                                            :: homo, ispin
+      INTEGER                                            :: homo, ispin, nao_aux_fit, nmo
       LOGICAL                                            :: energy_consistency
-      TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools_aux_fit
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_fm_struct_type), POINTER                   :: aux_fit_fm_struct
       TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit
+      TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
-      NULLIFY (matrix_s, dft_control)
+      NULLIFY (matrix_s, dft_control, blacs_env, para_env, qs_kind_set, aux_fit_fm_struct)
       CALL get_qs_env(qs_env, dft_control=dft_control)
 
       SELECT CASE (rtp_control%initial_wfn)
@@ -419,7 +427,7 @@ CONTAINS
          ALLOCATE (qs_env%rtp)
          CALL get_qs_env(qs_env, matrix_s=matrix_s)
          CALL rt_prop_create(qs_env%rtp, qs_env%mos, qs_env%mpools, dft_control, matrix_s(1)%matrix, &
-                             rtp_control%linear_scaling, qs_env%mos_aux_fit)
+                             rtp_control%linear_scaling, qs_env%admm_env%mos_aux_fit)
 
       CASE (use_restart_wfn, use_rt_restart)
          CALL qs_energies_init(qs_env, .FALSE.)
@@ -434,23 +442,28 @@ CONTAINS
                END IF
             END DO
             IF (dft_control%do_admm) THEN
-               CALL mpools_get(qs_env%mpools_aux_fit, ao_mo_fm_pools=ao_mo_fm_pools_aux_fit)
-               CPASSERT(ASSOCIATED(qs_env%mos_aux_fit))
-               DO ispin = 1, SIZE(qs_env%mos_aux_fit)
-                  CALL get_mo_set(qs_env%mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit, homo=homo)
+               CPASSERT(ASSOCIATED(qs_env%admm_env%mos_aux_fit))
+               CALL get_qs_env(qs_env, blacs_env=blacs_env, para_env=para_env, qs_kind_set=qs_kind_set)
+               CALL get_qs_kind_set(qs_kind_set, nsgf=nao_aux_fit, basis_type="AUX_FIT")
+               DO ispin = 1, SIZE(qs_env%admm_env%mos_aux_fit)
+                  CALL get_mo_set(mo_set=qs_env%mos(ispin)%mo_set, nmo=nmo)
+                  CALL cp_fm_struct_create(aux_fit_fm_struct, context=blacs_env, para_env=para_env, &
+                                           nrow_global=nao_aux_fit, ncol_global=nmo)
+                  CALL get_mo_set(qs_env%admm_env%mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit, homo=homo)
                   IF (.NOT. ASSOCIATED(mo_coeff_aux_fit)) THEN
-                     CALL init_mo_set(qs_env%mos_aux_fit(ispin)%mo_set, &
-                                      ao_mo_fm_pools_aux_fit(ispin)%pool, &
+                     CALL init_mo_set(qs_env%admm_env%mos_aux_fit(ispin)%mo_set, &
+                                      fm_struct=aux_fit_fm_struct, &
                                       name="qs_env"//TRIM(ADJUSTL(cp_to_string(qs_env%id_nr)))// &
                                       "%mo_aux_fit"//TRIM(ADJUSTL(cp_to_string(ispin))))
                   END IF
+                  CALL cp_fm_struct_release(aux_fit_fm_struct)
                END DO
             END IF
          END IF
          ALLOCATE (qs_env%rtp)
          CALL get_qs_env(qs_env, matrix_s=matrix_s)
          CALL rt_prop_create(qs_env%rtp, qs_env%mos, qs_env%mpools, dft_control, matrix_s(1)%matrix, &
-                             rtp_control%linear_scaling, qs_env%mos_aux_fit)
+                             rtp_control%linear_scaling, qs_env%admm_env%mos_aux_fit)
          CALL get_restart_wfn(qs_env)
 
          qs_env%run_rtp = .TRUE.

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -141,7 +141,7 @@ CONTAINS
                                                             fm_matrix_work, mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_aux, matrix_s
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_transl, matrix_s_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(hfx_basis_info_type)                          :: basis_info
@@ -215,7 +215,6 @@ CONTAINS
                          virial=virial, &
                          matrix_ks=matrix_ks, &
                          matrix_s=matrix_s, &
-                         matrix_ks_aux_fit=matrix_ks_aux, &
                          mp2_env=mp2_env, &
                          admm_env=admm_env)
 

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -12,7 +12,9 @@
 !>      11.2013 created [Mauro Del Ben]
 ! **************************************************************************************************
 MODULE mp2_cphf
-   USE admm_types,                      ONLY: admm_type
+   USE admm_methods,                    ONLY: admm_projection_derivative
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cell_types,                      ONLY: cell_type
    USE core_ppl,                        ONLY: build_core_ppl
@@ -91,8 +93,7 @@ MODULE mp2_cphf
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type
-   USE qs_2nd_kernel_ao,                ONLY: admm_projection_derivative,&
-                                              apply_2nd_order_kernel
+   USE qs_2nd_kernel_ao,                ONLY: apply_2nd_order_kernel
    USE qs_density_matrices,             ONLY: calculate_whz_matrix
    USE qs_dispersion_pairpot,           ONLY: calculate_dispersion_pairpot
    USE qs_dispersion_types,             ONLY: qs_dispersion_type
@@ -483,7 +484,7 @@ CONTAINS
       END DO
 
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, rho_aux_fit=rho_aux_fit)
+         CALL get_admm_env(qs_env%admm_env, rho_aux_fit=rho_aux_fit)
          CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux_fit)
 
          ! create mp2 DBCSR density in auxiliary basis
@@ -1716,7 +1717,7 @@ CONTAINS
       CALL section_vals_get(hfx_sections, explicit=do_hfx)
       IF (do_hfx) THEN
          IF (dft_control%do_admm) THEN
-            CALL get_qs_env(qs_env, rho_aux_fit=rho_aux)
+            CALL get_admm_env(qs_env%admm_env, rho_aux_fit=rho_aux)
             CALL qs_rho_get(rho_aux, rho_ao=rho_ao_aux, rho_ao_kp=rho_ao_kp)
             DO ispin = 1, nspins
                CALL dbcsr_add(rho_ao_aux(ispin)%matrix, p_env%p1_admm(ispin)%matrix, 1.0_dp, 1.0_dp)
@@ -1798,7 +1799,8 @@ CONTAINS
             CALL tddft_hfx_matrix(matrix_ks_aux, rho_ao_aux, qs_env, .FALSE.)
 
             IF (dft_control%admm_control%aux_exch_func /= do_admm_aux_exch_func_none) THEN
-               CALL get_qs_env(qs_env, ks_env=ks_env, task_list_aux_fit=task_list_aux_fit)
+               CALL get_qs_env(qs_env, ks_env=ks_env)
+               CALL get_admm_env(qs_env%admm_env, task_list_aux_fit=task_list_aux_fit)
 
                DO ispin = 1, nspins
                   CALL dbcsr_add(rho_ao_aux(ispin)%matrix, p_env%p1_admm(ispin)%matrix, 1.0_dp, 1.0_dp)

--- a/src/qs_2nd_kernel_ao.F
+++ b/src/qs_2nd_kernel_ao.F
@@ -13,23 +13,20 @@
 !> \author Frederick Stein
 ! **************************************************************************************************
 MODULE qs_2nd_kernel_ao
-   USE admm_types,                      ONLY: admm_type
-   USE atomic_kind_types,               ONLY: atomic_kind_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE cp_control_types,                ONLY: dft_control_type
-   USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
-   USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
-                                              copy_fm_to_dbcsr,&
-                                              cp_dbcsr_plus_fm_fm_t,&
+   USE cp_dbcsr_operations,             ONLY: cp_dbcsr_plus_fm_fm_t,&
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_scale
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
-                                              cp_fm_p_type,&
-                                              cp_fm_set_all
-   USE cp_gemm_interface,               ONLY: cp_gemm
-   USE dbcsr_api,                       ONLY: &
-        dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_p_type, dbcsr_release, &
-        dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry
+                                              cp_fm_p_type
+   USE dbcsr_api,                       ONLY: dbcsr_add,&
+                                              dbcsr_copy,&
+                                              dbcsr_create,&
+                                              dbcsr_p_type,&
+                                              dbcsr_release,&
+                                              dbcsr_set
    USE hfx_admm_utils,                  ONLY: tddft_hfx_matrix
    USE input_constants,                 ONLY: do_admm_aux_exch_func_none,&
                                               do_admm_basis_projection,&
@@ -46,14 +43,10 @@ MODULE qs_2nd_kernel_ao
    USE pw_types,                        ONLY: pw_p_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
-   USE qs_force_types,                  ONLY: add_qs_force,&
-                                              qs_force_type
    USE qs_integrate_potential,          ONLY: integrate_v_rspace
    USE qs_kpp1_env_methods,             ONLY: calc_kpp1
    USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_linres_types,                 ONLY: linres_control_type
-   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
-   USE qs_overlap,                      ONLY: build_overlap_force
    USE qs_p_env_methods,                ONLY: p_env_finish_kpp1
    USE qs_p_env_types,                  ONLY: qs_p_env_type
    USE qs_rho_types,                    ONLY: qs_rho_get,&
@@ -70,7 +63,6 @@ MODULE qs_2nd_kernel_ao
    PUBLIC :: build_dm_response, apply_2nd_order_kernel
    PUBLIC :: apply_hfx_ao
    PUBLIC :: apply_xc_admm_ao
-   PUBLIC :: admm_projection_derivative
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_2nd_kernel_ao'
 
@@ -329,7 +321,8 @@ CONTAINS
          NULLIFY (v_xc)
          ! calculate the xc potential
          lsd = (nspins == 2)
-         CALL get_qs_env(qs_env=qs_env, ks_env=ks_env, task_list_aux_fit=task_list_aux_fit, admm_env=admm_env)
+         CALL get_qs_env(qs_env=qs_env, ks_env=ks_env, admm_env=admm_env)
+         CALL get_admm_env(admm_env, task_list_aux_fit=task_list_aux_fit)
 
          CALL qs_rho_get(p_env%rho1_admm, rho_r=rho1_aux_r, rho_g=rho1_aux_g, tau_r=tau1_aux_r)
          xc_section => admm_env%xc_section_aux
@@ -346,7 +339,7 @@ CONTAINS
          alpha = 1.0_dp
          IF (nspins == 1) alpha = 2.0_dp
 
-         CALL get_qs_env(qs_env, rho_aux_fit=rho_aux)
+         CALL get_admm_env(qs_env%admm_env, rho_aux_fit=rho_aux)
          CALL qs_rho_get(rho_aux, rho_ao=rho_ao_aux)
 
          CALL cp_fm_get_info(admm_env%A, nrow_global=nao_aux, ncol_global=nao)
@@ -380,103 +373,4 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE apply_xc_admm_ao
-
-! **************************************************************************************************
-!> \brief Calculate derivatives terms from overlap matrices
-!> \param qs_env ...
-!> \param matrix_hz Fock matrix part using the response density in admm basis
-!> \param matrix_pz response density in orbital basis
-! **************************************************************************************************
-   SUBROUTINE admm_projection_derivative(qs_env, matrix_hz, matrix_pz)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_hz, matrix_pz
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'admm_projection_derivative'
-
-      INTEGER                                            :: handle, ispin, nao, natom, naux, nspins
-      REAL(KIND=dp)                                      :: fval
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: admm_force
-      TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
-      TYPE(dbcsr_type), POINTER                          :: matrix_w_q, matrix_w_s
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit_asymm, sab_aux_fit_vs_orb
-      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
-
-      CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(qs_env))
-
-      CALL get_qs_env(qs_env, &
-                      ks_env=ks_env, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
-                      sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
-                      sab_aux_fit_asymm=sab_aux_fit_asymm, &
-                      admm_env=admm_env)
-
-      ALLOCATE (matrix_w_q)
-      CALL dbcsr_copy(matrix_w_q, matrix_s_aux_fit_vs_orb(1)%matrix, &
-                      "W MATRIX AUX Q")
-      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_q, sab_aux_fit_vs_orb)
-      ALLOCATE (matrix_w_s)
-      CALL dbcsr_create(matrix_w_s, template=matrix_s_aux_fit(1)%matrix, &
-                        name='W MATRIX AUX S', &
-                        matrix_type=dbcsr_type_no_symmetry)
-      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_s, sab_aux_fit_asymm)
-
-      CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, &
-                      natom=natom, force=force)
-      ALLOCATE (admm_force(3, natom))
-      admm_force = 0.0_dp
-
-      nspins = SIZE(matrix_pz)
-      nao = admm_env%nao_orb
-      naux = admm_env%nao_aux_fit
-
-      CALL cp_fm_set_all(admm_env%work_aux_orb2, 0.0_dp)
-
-      fval = -2.0_dp
-
-      DO ispin = 1, nspins
-         CALL copy_dbcsr_to_fm(matrix_hz(ispin)%matrix, admm_env%work_aux_aux)
-         CALL cp_gemm("N", "N", naux, naux, naux, 1.0_dp, admm_env%s_inv, &
-                      admm_env%work_aux_aux, 0.0_dp, admm_env%work_aux_aux2)
-         CALL cp_gemm("N", "N", naux, nao, naux, 1.0_dp, admm_env%work_aux_aux2, &
-                      admm_env%A, 0.0_dp, admm_env%work_aux_orb)
-         CALL copy_dbcsr_to_fm(matrix_pz(ispin)%matrix, admm_env%work_orb_orb)
-         ! admm_env%work_aux_orb2 = S-1*H*A*P
-         CALL cp_gemm("N", "N", naux, nao, nao, 1.0_dp, admm_env%work_aux_orb, &
-                      admm_env%work_orb_orb, 1.0_dp, admm_env%work_aux_orb2)
-      END DO
-
-      CALL cp_fm_scale(fval, admm_env%work_aux_orb2)
-      !
-      CALL copy_fm_to_dbcsr(admm_env%work_aux_orb2, matrix_w_q, keep_sparsity=.TRUE.)
-      !
-      ! admm_env%work_aux_aux = S-1*H*A*P*A(T)
-      CALL cp_gemm("N", "T", naux, naux, nao, -1.0_dp, admm_env%work_aux_orb2, &
-                   admm_env%A, 0.0_dp, admm_env%work_aux_aux)
-      CALL copy_fm_to_dbcsr(admm_env%work_aux_aux, matrix_w_s, keep_sparsity=.TRUE.)
-      !
-      CALL build_overlap_force(ks_env, admm_force, &
-                               basis_type_a="AUX_FIT", basis_type_b="AUX_FIT", &
-                               sab_nl=sab_aux_fit_asymm, matrix_p=matrix_w_s)
-      CALL build_overlap_force(ks_env, admm_force, &
-                               basis_type_a="AUX_FIT", basis_type_b="ORB", &
-                               sab_nl=sab_aux_fit_vs_orb, matrix_p=matrix_w_q)
-
-      ! add forces
-      CALL add_qs_force(admm_force, force, "overlap_admm", atomic_kind_set)
-
-      DEALLOCATE (admm_force)
-      CALL dbcsr_deallocate_matrix(matrix_w_s)
-      CALL dbcsr_deallocate_matrix(matrix_w_q)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE admm_projection_derivative
-
 END MODULE qs_2nd_kernel_ao

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -36,6 +36,7 @@
 !>      Ole Schuett (2020)
 ! **************************************************************************************************
 MODULE qs_collocate_density
+   USE admm_types,                      ONLY: get_admm_env
    USE ao_util,                         ONLY: exp_radius_very_extended
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind,&
@@ -1788,8 +1789,8 @@ CONTAINS
                          task_list_soft=task_list_soft)
       CASE ("AUX_FIT")
          CALL get_qs_env(qs_env=qs_env, &
-                         task_list_aux_fit=task_list, &
                          task_list_soft=task_list_soft)
+         CALL get_admm_env(qs_env%admm_env, task_list_aux_fit=task_list)
       END SELECT
 
       ! *** assign from pw_env
@@ -2171,8 +2172,8 @@ CONTAINS
                          task_list_soft=task_list_soft)
       CASE ("AUX_FIT")
          CALL get_qs_env(qs_env=qs_env, &
-                         task_list_aux_fit=task_list, &
                          task_list_soft=task_list_soft)
+         CALL get_admm_env(qs_env%admm_env, task_list_aux_fit=task_list)
       END SELECT
 
       ! *** assign from pw_env

--- a/src/qs_core_hamiltonian.F
+++ b/src/qs_core_hamiltonian.F
@@ -170,15 +170,13 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_h, matrix_p, matrix_s, matrix_t, &
                                                             matrix_w
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kg_environment_type), POINTER                 :: kg_env
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit, sab_aux_fit_vs_orb, &
-                                                            sab_orb, sap_oce
+         POINTER                                         :: sab_orb, sap_oce
       TYPE(oce_matrix_type), POINTER                     :: oce
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
@@ -315,30 +313,6 @@ CONTAINS
                                       basis_type="ORB", &
                                       sab_nl=sab_orb, &
                                       eps_filter=eps_filter)
-      END IF
-
-      ! ADMM
-      IF (.NOT. calculate_forces) THEN
-         IF (dft_control%do_admm) THEN
-            NULLIFY (matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
-                     sab_aux_fit, sab_aux_fit_vs_orb)
-            CALL get_qs_env(qs_env=qs_env, matrix_s_aux_fit=matrix_s_aux_fit, &
-                            sab_aux_fit=sab_aux_fit)
-            CALL build_overlap_matrix(ks_env, matrix_s=matrix_s_aux_fit, &
-                                      matrix_name="AUX_FIT_OVERLAP", &
-                                      basis_type_a="AUX_FIT", &
-                                      basis_type_b="AUX_FIT", &
-                                      sab_nl=sab_aux_fit)
-            CALL set_ks_env(ks_env, matrix_s_aux_fit=matrix_s_aux_fit)
-            CALL get_qs_env(qs_env=qs_env, matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
-                            sab_aux_fit_vs_orb=sab_aux_fit_vs_orb)
-            CALL build_overlap_matrix(ks_env, matrix_s=matrix_s_aux_fit_vs_orb, &
-                                      matrix_name="MIXED_OVERLAP", &
-                                      basis_type_a="AUX_FIT", &
-                                      basis_type_b="ORB", &
-                                      sab_nl=sab_aux_fit_vs_orb)
-            CALL set_ks_env(ks_env, matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb)
-         END IF
       END IF
 
       ! initialize H matrix

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -527,8 +527,8 @@ CONTAINS
 
       CHARACTER(len=2)                                   :: element_symbol
       INTEGER :: handle, ikind, ispin, iw, lmax_sphere, maxl, maxlgto, maxlgto_lri, maxlppl, &
-         maxlppnl, method_id, multiplicity, my_ival, n_ao, n_ao_aux_fit, n_mo_add, natom, &
-         nelectron, ngauss, nkind, output_unit, sort_basis, tnadd_method
+         maxlppnl, method_id, multiplicity, my_ival, n_ao, n_mo_add, natom, nelectron, ngauss, &
+         nkind, output_unit, sort_basis, tnadd_method
       INTEGER, DIMENSION(2)                              :: n_mo, nelectron_spin
       LOGICAL :: all_potential_present, be_silent, do_kpoints, do_ri_hfx, do_ri_mp2, do_ri_rpa, &
          do_ri_sos_mp2, do_rpa_ri_exx, do_wfc_im_time, e1terms, has_unit_metric, lribas, &
@@ -550,7 +550,7 @@ CONTAINS
                                                             ri_xas_basis, tmp_basis_set
       TYPE(local_rho_type), POINTER                      :: local_rho_set
       TYPE(lri_environment_type), POINTER                :: lri_env
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_aux_fit, mos_last_converged
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_last_converged
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
       TYPE(mp2_type), POINTER                            :: mp2_env
@@ -591,7 +591,7 @@ CONTAINS
       CALL cite_reference(cp2kqs2020)
 
       ! Initialise the Quickstep environment
-      NULLIFY (mos, se_taper, mos_aux_fit)
+      NULLIFY (mos, se_taper)
       NULLIFY (dft_control)
       NULLIFY (energy)
       NULLIFY (force)
@@ -1543,26 +1543,6 @@ CONTAINS
       END IF
 
       CALL set_qs_env(qs_env, mos=mos)
-
-      ! If we use auxiliary density matrix methods , set mo_set_aux_fit
-      IF (dft_control%do_admm) THEN
-         !
-         CALL get_qs_kind_set(qs_kind_set, nelectron=nelectron, nsgf=n_ao_aux_fit, &
-                              basis_type="AUX_FIT")
-         ALLOCATE (mos_aux_fit(dft_control%nspins))
-
-         DO ispin = 1, dft_control%nspins
-            NULLIFY (mos_aux_fit(ispin)%mo_set)
-            CALL allocate_mo_set(mo_set=mos_aux_fit(ispin)%mo_set, &
-                                 nao=n_ao_aux_fit, &
-                                 nmo=n_mo(ispin), &
-                                 nelectron=nelectron_spin(ispin), &
-                                 n_el_f=REAL(nelectron_spin(ispin), dp), &
-                                 maxocc=maxocc, &
-                                 flexible_electron_count=dft_control%relax_multiplicity)
-         END DO
-         CALL set_qs_env(qs_env, mos_aux_fit=mos_aux_fit)
-      END IF
 
 ! allocate mos when switch_surf_dip is triggered [SGh]
       IF (dft_control%switch_surf_dip) THEN

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -51,8 +51,7 @@ MODULE qs_environment_methods
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
-   USE qs_kind_types,                   ONLY: get_qs_kind_set,&
-                                              has_nlcc,&
+   USE qs_kind_types,                   ONLY: has_nlcc,&
                                               qs_kind_type
    USE qs_ks_types,                     ONLY: get_ks_env,&
                                               qs_ks_env_type,&
@@ -93,8 +92,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'qs_env_setup'
 
-      INTEGER                                            :: handle, n_ao_aux_fit, nhistory, &
-                                                            nvariables
+      INTEGER                                            :: handle, nhistory, nvariables
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: gradient_history, outer_scf_history, &
                                                             variable_history
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -163,14 +161,6 @@ CONTAINS
       ! XXXX should get rid of the mpools
       IF (ASSOCIATED(qs_env%mos)) THEN
          CALL mpools_rebuild_fm_pools(qs_env%mpools, mos=qs_env%mos, &
-                                      blacs_env=blacs_env, para_env=para_env)
-      END IF
-
-      ! If we use auxiliary density matrix methods rebuild fm_pools
-      IF (dft_control%do_admm) THEN
-         CALL get_qs_kind_set(qs_kind_set, nsgf=n_ao_aux_fit, &
-                              basis_type="AUX_FIT")
-         CALL mpools_rebuild_fm_pools(qs_env%mpools_aux_fit, mos=qs_env%mos_aux_fit, &
                                       blacs_env=blacs_env, para_env=para_env)
       END IF
 

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -12,7 +12,6 @@
 !> \author MK (23.01.2002)
 ! **************************************************************************************************
 MODULE qs_environment_types
-   USE admm_dm_types,                   ONLY: admm_dm_type
    USE admm_types,                      ONLY: admm_env_release,&
                                               admm_type
    USE almo_scf_types,                  ONLY: almo_scf_env_release,&
@@ -249,8 +248,7 @@ MODULE qs_environment_types
       TYPE(almo_scf_env_type), POINTER                      :: almo_scf_env
       TYPE(transport_env_type), POINTER                     :: transport_env
       TYPE(cell_type), POINTER                              :: super_cell
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER            :: mos, mos_aux_fit
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER             :: mo_derivs_aux_fit
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER            :: mos
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER             :: mo_loc_history
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER             :: mo_derivs
       TYPE(scf_control_type), POINTER                       :: scf_control
@@ -266,7 +264,6 @@ MODULE qs_environment_types
       TYPE(qs_wf_history_type), POINTER                     :: wf_history
       TYPE(qs_scf_env_type), POINTER                        :: scf_env
       TYPE(qs_matrix_pools_type), POINTER                   :: mpools
-      TYPE(qs_matrix_pools_type), POINTER                   :: mpools_aux_fit
       TYPE(oce_matrix_type), POINTER                        :: oce
       TYPE(local_rho_type), POINTER                         :: local_rho_set
       TYPE(hartree_local_type), POINTER                     :: hartree_local
@@ -351,11 +348,7 @@ CONTAINS
 !> \param kpoints ...
 !> \param dft_control ...
 !> \param mos ...
-!> \param mos_aux_fit ...
 !> \param sab_orb ...
-!> \param sab_aux_fit ...
-!> \param sab_aux_fit_asymm ...
-!> \param sab_aux_fit_vs_orb ...
 !> \param sab_all ...
 !> \param qmmm ...
 !> \param qmmm_periodic ...
@@ -390,20 +383,12 @@ CONTAINS
 !> \param matrix_s_kp ...
 !> \param matrix_w_kp ...
 !> \param matrix_s_RI_aux_kp ...
-!> \param matrix_ks_aux_fit ...
-!> \param matrix_ks_aux_fit_im ...
-!> \param matrix_ks_aux_fit_dft ...
-!> \param matrix_ks_aux_fit_hfx ...
 !> \param matrix_s ...
-!> \param matrix_s_aux_fit ...
-!> \param matrix_s_aux_fit_vs_orb ...
 !> \param matrix_s_RI_aux ...
 !> \param matrix_w ...
 !> \param matrix_p_mp2 ...
 !> \param matrix_p_mp2_admm ...
 !> \param rho ...
-!> \param rho_aux_fit ...
-!> \param rho_aux_fit_buffer ...
 !> \param rho_buffer ...
 !> \param rho_xc ...
 !> \param pw_env ...
@@ -411,7 +396,6 @@ CONTAINS
 !> \param ewald_pw ...
 !> \param active_space ...
 !> \param mpools ...
-!> \param mpools_aux_fit ...
 !> \param input ...
 !> \param para_env ...
 !> \param blacs_env ...
@@ -440,7 +424,6 @@ CONTAINS
 !> \param local_rho_set ...
 !> \param rho_atom_set ...
 !> \param task_list ...
-!> \param task_list_aux_fit ...
 !> \param task_list_soft ...
 !> \param rho0_atom_set ...
 !> \param rho0_mpole ...
@@ -452,7 +435,6 @@ CONTAINS
 !> \param has_unit_metric ...
 !> \param requires_mo_derivs ...
 !> \param mo_derivs ...
-!> \param mo_derivs_aux_fit ...
 !> \param mo_loc_history ...
 !> \param nkind ...
 !> \param natom ...
@@ -476,7 +458,6 @@ CONTAINS
 !> \param se_nddo_mpole ...
 !> \param se_nonbond_env ...
 !> \param admm_env ...
-!> \param admm_dm ...
 !> \param lri_env ...
 !> \param lri_density ...
 !> \param exstate_env ...
@@ -513,28 +494,26 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE get_qs_env(qs_env, atomic_kind_set, qs_kind_set, cell, super_cell, cell_ref, use_ref_cell, kpoints, &
-                         dft_control, mos, mos_aux_fit, sab_orb, sab_aux_fit, sab_aux_fit_asymm, sab_aux_fit_vs_orb, &
+                         dft_control, mos, sab_orb, &
                          sab_all, qmmm, qmmm_periodic, sac_ae, sac_ppl, sac_lri, sap_ppnl, sab_vdw, sab_scp, sap_oce, sab_lrc, &
                          sab_se, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_almo, sab_kp, particle_set, energy, force, &
                          matrix_h, matrix_ks, matrix_ks_im, matrix_vxc, run_rtp, rtp, &
                          matrix_h_kp, matrix_ks_kp, matrix_vxc_kp, kinetic_kp, matrix_s_kp, matrix_w_kp, matrix_s_RI_aux_kp, &
-                         matrix_ks_aux_fit, matrix_ks_aux_fit_im, matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, &
-                         matrix_s, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, matrix_s_RI_aux, matrix_w, &
-                         matrix_p_mp2, matrix_p_mp2_admm, rho, rho_aux_fit, rho_aux_fit_buffer, &
+                         matrix_s, matrix_s_RI_aux, matrix_w, &
+                         matrix_p_mp2, matrix_p_mp2_admm, rho, &
                          rho_buffer, rho_xc, pw_env, ewald_env, ewald_pw, active_space, &
-                         mpools, mpools_aux_fit, input, para_env, blacs_env, scf_control, rel_control, kinetic, qs_charges, &
+                         mpools, input, para_env, blacs_env, scf_control, rel_control, kinetic, qs_charges, &
                          vppl, rho_core, rho_nlcc, rho_nlcc_g, ks_env, ks_qmmm_env, wf_history, scf_env, id_nr, local_particles, &
                          local_molecules, distribution_2d, dbcsr_dist, molecule_kind_set, &
                          molecule_set, subsys, cp_subsys, oce, local_rho_set, rho_atom_set, &
                          task_list, &
-                         task_list_aux_fit, &
                          task_list_soft, &
                          rho0_atom_set, rho0_mpole, rhoz_set, ecoul_1c, &
                          rho0_s_rs, rho0_s_gs, do_kpoints, has_unit_metric, requires_mo_derivs, mo_derivs, &
-                         mo_derivs_aux_fit, mo_loc_history, nkind, natom, nelectron_total, nelectron_spin, efield, &
+                         mo_loc_history, nkind, natom, nelectron_total, nelectron_spin, efield, &
                          neighbor_list_id, linres_control, xas_env, virial, cp_ddapc_env, cp_ddapc_ewald, &
                          outer_scf_history, outer_scf_ihistory, x_data, et_coupling, dftb_potential, results, &
-                         se_taper, se_store_int_env, se_nddo_mpole, se_nonbond_env, admm_env, admm_dm, &
+                         se_taper, se_store_int_env, se_nddo_mpole, se_nonbond_env, admm_env, &
                          lri_env, lri_density, exstate_env, ec_env, dispersion_env, gcp_env, vee, &
                          rho_external, external_vxc, mask, &
                          mp2_env, kg_env, WannierCentres, atprop, ls_scf_env, do_transport, transport_env, v_hartree_rspace, &
@@ -550,10 +529,9 @@ CONTAINS
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
       TYPE(dft_control_type), OPTIONAL, POINTER          :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mos, mos_aux_fit
+         POINTER                                         :: mos
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         OPTIONAL, POINTER                               :: sab_orb, sab_aux_fit, sab_aux_fit_asymm, &
-                                                            sab_aux_fit_vs_orb, sab_all
+         OPTIONAL, POINTER                               :: sab_orb, sab_all
       LOGICAL, OPTIONAL                                  :: qmmm, qmmm_periodic
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sac_ae, sac_ppl, sac_lri, &
          sap_ppnl, sab_vdw, sab_scp, sap_oce, sab_lrc, sab_se, sab_tbe, sab_core, sab_xb, &
@@ -573,17 +551,15 @@ CONTAINS
                                                             matrix_vxc_kp, kinetic_kp, &
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
-      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, POINTER :: matrix_ks_aux_fit, &
-         matrix_ks_aux_fit_im, matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, matrix_s, &
-         matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, matrix_s_RI_aux, matrix_w, matrix_p_mp2, &
-         matrix_p_mp2_admm
-      TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho, rho_aux_fit, rho_aux_fit_buffer, &
-                                                            rho_buffer, rho_xc
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_s, matrix_s_RI_aux, matrix_w, &
+                                                            matrix_p_mp2, matrix_p_mp2_admm
+      TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho, rho_buffer, rho_xc
       TYPE(pw_env_type), OPTIONAL, POINTER               :: pw_env
       TYPE(ewald_environment_type), OPTIONAL, POINTER    :: ewald_env
       TYPE(ewald_pw_type), OPTIONAL, POINTER             :: ewald_pw
       TYPE(active_space_type), OPTIONAL, POINTER         :: active_space
-      TYPE(qs_matrix_pools_type), OPTIONAL, POINTER      :: mpools, mpools_aux_fit
+      TYPE(qs_matrix_pools_type), OPTIONAL, POINTER      :: mpools
       TYPE(section_vals_type), OPTIONAL, POINTER         :: input
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env
@@ -611,8 +587,7 @@ CONTAINS
       TYPE(local_rho_type), OPTIONAL, POINTER            :: local_rho_set
       TYPE(rho_atom_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: rho_atom_set
-      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_aux_fit, &
-                                                            task_list_soft
+      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_soft
       TYPE(rho0_atom_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: rho0_atom_set
       TYPE(rho0_mpole_type), OPTIONAL, POINTER           :: rho0_mpole
@@ -625,7 +600,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: mo_derivs
       TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mo_derivs_aux_fit, mo_loc_history
+         POINTER                                         :: mo_loc_history
       INTEGER, OPTIONAL                                  :: nkind, natom, nelectron_total
       INTEGER, DIMENSION(2), OPTIONAL                    :: nelectron_spin
       TYPE(efield_berry_type), OPTIONAL, POINTER         :: efield
@@ -647,7 +622,6 @@ CONTAINS
       TYPE(nddo_mpole_type), OPTIONAL, POINTER           :: se_nddo_mpole
       TYPE(fist_nonbond_env_type), OPTIONAL, POINTER     :: se_nonbond_env
       TYPE(admm_type), OPTIONAL, POINTER                 :: admm_env
-      TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
       TYPE(lri_environment_type), OPTIONAL, POINTER      :: lri_env
       TYPE(lri_density_type), OPTIONAL, POINTER          :: lri_density
       TYPE(excited_energy_type), OPTIONAL, POINTER       :: exstate_env
@@ -695,12 +669,10 @@ CONTAINS
       IF (PRESENT(qmmm)) qmmm = qs_env%qmmm
       IF (PRESENT(qmmm_periodic)) qmmm_periodic = qs_env%qmmm_periodic
       IF (PRESENT(mos)) mos => qs_env%mos
-      IF (PRESENT(mos_aux_fit)) mos_aux_fit => qs_env%mos_aux_fit
       IF (PRESENT(mos_last_converged)) mos_last_converged => qs_env%mos_last_converged
       IF (PRESENT(ewald_env)) ewald_env => qs_env%ewald_env
       IF (PRESENT(ewald_pw)) ewald_pw => qs_env%ewald_pw
       IF (PRESENT(mpools)) mpools => qs_env%mpools
-      IF (PRESENT(mpools_aux_fit)) mpools_aux_fit => qs_env%mpools_aux_fit
       IF (PRESENT(scf_control)) scf_control => qs_env%scf_control
       IF (PRESENT(rel_control)) rel_control => qs_env%rel_control
       ! ZMP pointing vectors
@@ -717,14 +689,12 @@ CONTAINS
       IF (PRESENT(requires_mo_derivs)) requires_mo_derivs = qs_env%requires_mo_derivs
       IF (PRESENT(has_unit_metric)) has_unit_metric = qs_env%has_unit_metric
       IF (PRESENT(mo_derivs)) mo_derivs => qs_env%mo_derivs
-      IF (PRESENT(mo_derivs_aux_fit)) mo_derivs_aux_fit => qs_env%mo_derivs_aux_fit
       IF (PRESENT(mo_loc_history)) mo_loc_history => qs_env%mo_loc_history
       IF (PRESENT(linres_control)) linres_control => qs_env%linres_control
       IF (PRESENT(se_taper)) se_taper => qs_env%se_taper
       IF (PRESENT(se_store_int_env)) se_store_int_env => qs_env%se_store_int_env
       IF (PRESENT(se_nddo_mpole)) se_nddo_mpole => qs_env%se_nddo_mpole
       IF (PRESENT(se_nonbond_env)) se_nonbond_env => qs_env%se_nonbond_env
-      IF (PRESENT(admm_env)) admm_env => qs_env%admm_env
       IF (PRESENT(lri_env)) lri_env => qs_env%lri_env
       IF (PRESENT(lri_density)) lri_density => qs_env%lri_density
       IF (PRESENT(ec_env)) ec_env => qs_env%ec_env
@@ -739,6 +709,7 @@ CONTAINS
       IF (PRESENT(transport_env)) transport_env => qs_env%transport_env
       IF (PRESENT(mscfg_env)) mscfg_env => qs_env%molecular_scf_guess_env
       IF (PRESENT(active_space)) active_space => qs_env%active_space
+      IF (PRESENT(admm_env)) admm_env => qs_env%admm_env
 
       ! Embedding potential
       IF (PRESENT(embed_pot)) embed_pot => qs_env%embed_pot
@@ -795,14 +766,8 @@ CONTAINS
                       matrix_ks=matrix_ks, &
                       matrix_ks_im=matrix_ks_im, &
                       matrix_vxc=matrix_vxc, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      matrix_ks_aux_fit_im=matrix_ks_aux_fit_im, &
-                      matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, &
-                      matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx, &
                       kinetic=kinetic, &
                       matrix_s=matrix_s, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
                       matrix_s_RI_aux=matrix_s_RI_aux, &
                       matrix_w=matrix_w, &
                       matrix_p_mp2=matrix_p_mp2, &
@@ -817,8 +782,6 @@ CONTAINS
                       rho=rho, &
                       rho_buffer=rho_buffer, &
                       rho_xc=rho_xc, &
-                      rho_aux_fit=rho_aux_fit, &
-                      rho_aux_fit_buffer=rho_aux_fit_buffer, &
                       rho_core=rho_core, &
                       rho_nlcc=rho_nlcc, &
                       rho_nlcc_g=rho_nlcc_g, &
@@ -826,9 +789,6 @@ CONTAINS
                       vee=vee, &
                       neighbor_list_id=neighbor_list_id, &
                       sab_orb=sab_orb, &
-                      sab_aux_fit=sab_aux_fit, &
-                      sab_aux_fit_asymm=sab_aux_fit_asymm, &
-                      sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
                       sab_all=sab_all, &
                       sab_scp=sab_scp, &
                       sab_vdw=sab_vdw, &
@@ -846,7 +806,6 @@ CONTAINS
                       sab_almo=sab_almo, &
                       sab_kp=sab_kp, &
                       task_list=task_list, &
-                      task_list_aux_fit=task_list_aux_fit, &
                       task_list_soft=task_list_soft, &
                       kpoints=kpoints, &
                       do_kpoints=do_kpoints, &
@@ -876,8 +835,7 @@ CONTAINS
                       para_env=para_env, &
                       blacs_env=blacs_env, &
                       nelectron_total=nelectron_total, &
-                      nelectron_spin=nelectron_spin, &
-                      admm_dm=admm_dm)
+                      nelectron_spin=nelectron_spin)
 
    END SUBROUTINE get_qs_env
 
@@ -902,10 +860,8 @@ CONTAINS
       NULLIFY (qs_env%image_coeff)
       NULLIFY (qs_env%super_cell)
       NULLIFY (qs_env%mos)
-      NULLIFY (qs_env%mos_aux_fit)
       NULLIFY (qs_env%mos_last_converged)
       NULLIFY (qs_env%mpools)
-      NULLIFY (qs_env%mpools_aux_fit)
       NULLIFY (qs_env%ewald_env)
       NULLIFY (qs_env%ewald_pw)
       NULLIFY (qs_env%scf_control)
@@ -997,7 +953,6 @@ CONTAINS
 
       ! Zero all variables containing results
       NULLIFY (qs_env%mo_derivs)
-      NULLIFY (qs_env%mo_derivs_aux_fit)
       NULLIFY (qs_env%mo_loc_history)
 
    END SUBROUTINE init_qs_env
@@ -1007,13 +962,11 @@ CONTAINS
 !> \param qs_env ...
 !> \param super_cell ...
 !> \param mos ...
-!> \param mos_aux_fit ...
 !> \param qmmm ...
 !> \param qmmm_periodic ...
 !> \param ewald_env ...
 !> \param ewald_pw ...
 !> \param mpools ...
-!> \param mpools_aux_fit ...
 !> \param rho_external ...
 !> \param external_vxc ...
 !> \param mask ...
@@ -1038,7 +991,6 @@ CONTAINS
 !> \param has_unit_metric ...
 !> \param requires_mo_derivs ...
 !> \param mo_derivs ...
-!> \param mo_derivs_aux_fit ...
 !> \param mo_loc_history ...
 !> \param efield ...
 !> \param linres_control ...
@@ -1082,14 +1034,14 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE set_qs_env(qs_env, super_cell, &
-                         mos, mos_aux_fit, qmmm, qmmm_periodic, &
-                         ewald_env, ewald_pw, mpools, mpools_aux_fit, &
+                         mos, qmmm, qmmm_periodic, &
+                         ewald_env, ewald_pw, mpools, &
                          rho_external, external_vxc, mask, &
                          scf_control, rel_control, qs_charges, ks_env, &
                          ks_qmmm_env, wf_history, scf_env, active_space, &
                          input, oce, rho_atom_set, rho0_atom_set, rho0_mpole, run_rtp, rtp, &
                          rhoz_set, rhoz_tot, ecoul_1c, has_unit_metric, requires_mo_derivs, mo_derivs, &
-                         mo_derivs_aux_fit, mo_loc_history, efield, &
+                         mo_loc_history, efield, &
                          linres_control, xas_env, cp_ddapc_env, cp_ddapc_ewald, &
                          outer_scf_history, outer_scf_ihistory, x_data, et_coupling, dftb_potential, &
                          se_taper, se_store_int_env, se_nddo_mpole, se_nonbond_env, admm_env, ls_scf_env, &
@@ -1101,11 +1053,11 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cell_type), OPTIONAL, POINTER                 :: super_cell
       TYPE(mo_set_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mos, mos_aux_fit
+         POINTER                                         :: mos
       LOGICAL, OPTIONAL                                  :: qmmm, qmmm_periodic
       TYPE(ewald_environment_type), OPTIONAL, POINTER    :: ewald_env
       TYPE(ewald_pw_type), OPTIONAL, POINTER             :: ewald_pw
-      TYPE(qs_matrix_pools_type), OPTIONAL, POINTER      :: mpools, mpools_aux_fit
+      TYPE(qs_matrix_pools_type), OPTIONAL, POINTER      :: mpools
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_external
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: external_vxc, mask
       TYPE(scf_control_type), OPTIONAL, POINTER          :: scf_control
@@ -1133,7 +1085,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: mo_derivs
       TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mo_derivs_aux_fit, mo_loc_history
+         POINTER                                         :: mo_loc_history
       TYPE(efield_berry_type), OPTIONAL, POINTER         :: efield
       TYPE(linres_control_type), OPTIONAL, POINTER       :: linres_control
       TYPE(xas_environment_type), OPTIONAL, POINTER      :: xas_env
@@ -1190,7 +1142,6 @@ CONTAINS
       IF (PRESENT(qmmm)) qs_env%qmmm = qmmm
       IF (PRESENT(qmmm_periodic)) qs_env%qmmm_periodic = qmmm_periodic
       IF (PRESENT(mos)) qs_env%mos => mos
-      IF (PRESENT(mos_aux_fit)) qs_env%mos_aux_fit => mos_aux_fit
       IF (PRESENT(mos_last_converged)) qs_env%mos_last_converged => mos_last_converged
       IF (PRESENT(ls_scf_env)) qs_env%ls_scf_env => ls_scf_env
       IF (PRESENT(almo_scf_env)) qs_env%almo_scf_env => almo_scf_env
@@ -1206,7 +1157,6 @@ CONTAINS
       IF (PRESENT(requires_mo_derivs)) qs_env%requires_mo_derivs = requires_mo_derivs
       IF (PRESENT(has_unit_metric)) qs_env%has_unit_metric = has_unit_metric
       IF (PRESENT(mo_derivs)) qs_env%mo_derivs => mo_derivs
-      IF (PRESENT(mo_derivs_aux_fit)) qs_env%mo_derivs_aux_fit => mo_derivs_aux_fit
       IF (PRESENT(mo_loc_history)) qs_env%mo_loc_history => mo_loc_history
       IF (PRESENT(run_rtp)) qs_env%run_rtp = run_rtp
       IF (PRESENT(rtp)) qs_env%rtp => rtp
@@ -1287,11 +1237,6 @@ CONTAINS
          CALL mpools_retain(mpools)
          CALL mpools_release(qs_env%mpools)
          qs_env%mpools => mpools
-      END IF
-      IF (PRESENT(mpools_aux_fit)) THEN
-         CALL mpools_retain(mpools_aux_fit)
-         CALL mpools_release(qs_env%mpools_aux_fit)
-         qs_env%mpools_aux_fit => mpools_aux_fit
       END IF
       IF (PRESENT(rho_atom_set)) THEN
          CALL set_local_rho(qs_env%local_rho_set, rho_atom_set=rho_atom_set)
@@ -1416,12 +1361,6 @@ CONTAINS
                END DO
                DEALLOCATE (qs_env%mos)
             END IF
-            IF (ASSOCIATED(qs_env%mos_aux_fit)) THEN
-               DO i = 1, SIZE(qs_env%mos_aux_fit)
-                  CALL deallocate_mo_set(qs_env%mos_aux_fit(i)%mo_set)
-               END DO
-               DEALLOCATE (qs_env%mos_aux_fit)
-            END IF
             IF (ASSOCIATED(qs_env%mos_last_converged)) THEN
                DO i = 1, SIZE(qs_env%mos_last_converged)
                   CALL deallocate_mo_set(qs_env%mos_last_converged(i)%mo_set)
@@ -1435,14 +1374,6 @@ CONTAINS
                END DO
                DEALLOCATE (qs_env%mo_derivs)
             END IF
-
-            IF (ASSOCIATED(qs_env%mo_derivs_aux_fit)) THEN
-               DO I = 1, SIZE(qs_env%mo_derivs_aux_fit)
-                  CALL cp_fm_release(qs_env%mo_derivs_aux_fit(I)%matrix)
-               END DO
-               DEALLOCATE (qs_env%mo_derivs_aux_fit)
-            END IF
-
             IF (ASSOCIATED(qs_env%mo_loc_history)) THEN
                DO I = 1, SIZE(qs_env%mo_loc_history)
                   CALL cp_fm_release(qs_env%mo_loc_history(I)%matrix)
@@ -1537,7 +1468,6 @@ CONTAINS
             CALL wfi_release(qs_env%wf_history)
             CALL scf_env_release(qs_env%scf_env)
             CALL mpools_release(qs_env%mpools)
-            CALL mpools_release(qs_env%mpools_aux_fit)
             CALL section_vals_release(qs_env%input)
             CALL cp_ddapc_release(qs_env%cp_ddapc_env)
             CALL cp_ddapc_ewald_release(qs_env%cp_ddapc_ewald)
@@ -1626,12 +1556,6 @@ CONTAINS
       IF (ASSOCIATED(qs_env)) THEN
          CPASSERT(qs_env%ref_count > 0)
          IF (qs_env%ref_count == 1) THEN
-            IF (ASSOCIATED(qs_env%mos_aux_fit)) THEN
-               DO i = 1, SIZE(qs_env%mos_aux_fit)
-                  CALL deallocate_mo_set(qs_env%mos_aux_fit(i)%mo_set)
-               END DO
-               DEALLOCATE (qs_env%mos_aux_fit)
-            END IF
             IF (ASSOCIATED(qs_env%mos_last_converged)) THEN
                DO i = 1, SIZE(qs_env%mos_last_converged)
                   CALL deallocate_mo_set(qs_env%mos_last_converged(i)%mo_set)
@@ -1645,14 +1569,6 @@ CONTAINS
                END DO
                DEALLOCATE (qs_env%mo_derivs)
             END IF
-
-            IF (ASSOCIATED(qs_env%mo_derivs_aux_fit)) THEN
-               DO I = 1, SIZE(qs_env%mo_derivs_aux_fit)
-                  CALL cp_fm_release(qs_env%mo_derivs_aux_fit(I)%matrix)
-               END DO
-               DEALLOCATE (qs_env%mo_derivs_aux_fit)
-            END IF
-
             IF (ASSOCIATED(qs_env%mo_loc_history)) THEN
                DO I = 1, SIZE(qs_env%mo_loc_history)
                   CALL cp_fm_release(qs_env%mo_loc_history(I)%matrix)
@@ -1746,7 +1662,6 @@ CONTAINS
             CALL qs_ks_qmmm_release(qs_env%ks_qmmm_env)
             CALL wfi_release(qs_env%wf_history)
             CALL scf_env_release(qs_env%scf_env)
-            CALL mpools_release(qs_env%mpools_aux_fit)
             CALL cp_ddapc_release(qs_env%cp_ddapc_env)
             CALL cp_ddapc_ewald_release(qs_env%cp_ddapc_ewald)
             CALL efield_berry_release(qs_env%efield)

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -13,7 +13,8 @@
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
 MODULE qs_kpp1_env_methods
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_operations,             ONLY: dbcsr_allocate_matrix_set,&
@@ -766,7 +767,7 @@ CONTAINS
             IF (.NOT. ASSOCIATED(kpp1_env%deriv_set_admm)) THEN
                CPASSERT(.NOT. do_triplet)
                admm_xc_section => admm_env%xc_section_aux
-               CALL get_qs_env(qs_env=qs_env, rho_aux_fit=rho)
+               CALL get_admm_env(qs_env%admm_env, rho_aux_fit=rho)
                CALL qs_rho_get(rho, rho_r=rho_r)
                ALLOCATE (kpp1_env%deriv_set_admm, kpp1_env%rho_set_admm)
                CALL xc_prep_2nd_deriv(kpp1_env%deriv_set_admm, kpp1_env%rho_set_admm, &

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -23,24 +23,19 @@ MODULE qs_ks_methods
    USE admm_dm_methods,                 ONLY: admm_dm_calc_rho_aux,&
                                               admm_dm_merge_ks_matrix
    USE admm_methods,                    ONLY: admm_mo_calc_rho_aux,&
-                                              admm_mo_merge_derivs,&
                                               admm_mo_merge_ks_matrix,&
                                               admm_update_ks_atom,&
-                                              calc_aux_mo_derivs_none,&
-                                              calc_mixed_overlap_force
-   USE admm_types,                      ONLY: admm_type
+                                              calc_admm_mo_derivatives,&
+                                              calc_admm_ovlp_forces
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE cell_types,                      ONLY: cell_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
-   USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
-                                              copy_fm_to_dbcsr,&
-                                              dbcsr_allocate_matrix_set,&
+   USE cp_dbcsr_operations,             ONLY: dbcsr_allocate_matrix_set,&
                                               dbcsr_copy_columns_hack
    USE cp_ddapc,                        ONLY: qs_ks_ddapc
-   USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
-                                              cp_fm_release,&
-                                              cp_fm_type
+   USE cp_fm_types,                     ONLY: cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type
@@ -56,8 +51,7 @@ MODULE qs_ks_methods
    USE hartree_local_types,             ONLY: ecoul_1center_type
    USE hfx_admm_utils,                  ONLY: hfx_admm_init,&
                                               hfx_ks_matrix
-   USE input_constants,                 ONLY: do_admm_purify_none,&
-                                              do_ppl_grid,&
+   USE input_constants,                 ONLY: do_ppl_grid,&
                                               outer_scf_becke_constraint,&
                                               outer_scf_hirshfeld_constraint
    USE input_section_types,             ONLY: section_vals_get,&
@@ -124,8 +118,7 @@ MODULE qs_ks_methods
         sic_explicit_orbitals, sum_up_and_integrate
    USE qs_local_rho_types,              ONLY: local_rho_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
-                                              mo_set_p_type,&
-                                              mo_set_type
+                                              mo_set_p_type
    USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE qs_rho0_ggrid,                   ONLY: integrate_vhg0_rspace
    USE qs_rho_types,                    ONLY: qs_rho_get,&
@@ -518,7 +511,7 @@ CONTAINS
                CALL admm_mo_calc_rho_aux(qs_env)
             END IF
          ELSEIF (dft_control%do_admm_dm) THEN
-            CALL admm_dm_calc_rho_aux(ks_env)
+            CALL admm_dm_calc_rho_aux(qs_env)
          END IF
       END IF
 
@@ -531,7 +524,7 @@ CONTAINS
       IF (dft_control%do_admm) THEN
          CALL get_qs_env(qs_env, admm_env=admm_env)
          xc_section => admm_env%xc_section_aux
-         CALL get_qs_env(qs_env=qs_env, rho_aux_fit=rho_struct)
+         CALL get_admm_env(admm_env, rho_aux_fit=rho_struct)
 
          ! here we ignore a possible vdW section in admm_env%xc_section_aux
          CALL qs_vxc_create(ks_env=ks_env, rho_struct=rho_struct, xc_section=xc_section, &
@@ -809,7 +802,7 @@ CONTAINS
             CALL admm_mo_merge_ks_matrix(qs_env)
          END IF
       ELSEIF (dft_control%do_admm_dm) THEN
-         CALL admm_dm_merge_ks_matrix(ks_env)
+         CALL admm_dm_merge_ks_matrix(qs_env)
       END IF
 
       ! External field (nonperiodic case)
@@ -962,31 +955,17 @@ CONTAINS
       INTEGER                                            :: ispin
       LOGICAL                                            :: uniform_occupation
       REAL(KIND=dp), DIMENSION(:), POINTER               :: occupation_numbers
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_derivs_aux_fit, mo_derivs_tmp
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_type)                                   :: mo_derivs2_tmp1, mo_derivs2_tmp2
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_b
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mo_array, mos_aux_fit
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mo_array
 
-      NULLIFY (dft_control, mo_array, mo_coeff, mo_coeff_aux_fit, mo_coeff_b, &
-               mo_derivs_aux_fit, mo_derivs_tmp, mos_aux_fit, &
-               occupation_numbers, matrix_ks_aux_fit)
+      NULLIFY (dft_control, mo_array, mo_coeff, mo_coeff_b, occupation_numbers)
 
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
                       mos=mo_array)
-
-      IF (dft_control%do_admm_mo) THEN !fm->dbcsr
-         NULLIFY (mo_derivs_tmp) !fm->dbcsr
-         ALLOCATE (mo_derivs_tmp(SIZE(mo_derivs)))
-         DO ispin = 1, SIZE(mo_derivs) !fm->dbcsr
-            CALL get_mo_set(mo_set=mo_array(ispin)%mo_set, mo_coeff=mo_coeff) !fm->dbcsr
-            NULLIFY (mo_derivs_tmp(ispin)%matrix)
-            CALL cp_fm_create(mo_derivs_tmp(ispin)%matrix, mo_coeff%matrix_struct) !fm->dbcsr
-         END DO !fm->dbcsr
-      END IF !fm->dbcsr
 
       DO ispin = 1, SIZE(mo_derivs)
 
@@ -994,21 +973,6 @@ CONTAINS
                          mo_coeff_b=mo_coeff_b, occupation_numbers=occupation_numbers)
          CALL dbcsr_multiply('n', 'n', 1.0_dp, ks_matrix(ispin)%matrix, mo_coeff_b, &
                              0.0_dp, mo_derivs(ispin)%matrix)
-
-         IF (dft_control%do_admm_mo) THEN
-            CALL get_qs_env(qs_env, &
-                            mos_aux_fit=mos_aux_fit, &
-                            mo_derivs_aux_fit=mo_derivs_aux_fit, &
-                            matrix_ks_aux_fit=matrix_ks_aux_fit)
-            CALL get_mo_set(mo_set=mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit)
-
-            CALL copy_dbcsr_to_fm(mo_derivs(ispin)%matrix, &
-                                  mo_derivs_tmp(ispin)%matrix) !fm->dbcsr
-            CALL admm_mo_merge_derivs(ispin, qs_env%admm_env, mo_array(ispin)%mo_set, &
-                                      mo_coeff, mo_coeff_aux_fit, mo_derivs_tmp, mo_derivs_aux_fit, &
-                                      matrix_ks_aux_fit)
-            CALL copy_fm_to_dbcsr(mo_derivs_tmp(ispin)%matrix, mo_derivs(ispin)%matrix) !fm->dbcsr
-         END IF
 
          IF (dft_control%restricted) THEN
             ! only the first mo_set are actual variables, but we still need both
@@ -1046,64 +1010,13 @@ CONTAINS
             CALL dbcsr_release(mo_derivs2_tmp1)
             CALL dbcsr_release(mo_derivs2_tmp2)
          END IF
-
       END DO
 
-      IF (dft_control%do_admm_mo) THEN !fm->dbcsr
-         DO ispin = 1, SIZE(mo_derivs) !fm->dbcsr
-            CALL cp_fm_release(mo_derivs_tmp(ispin)%matrix) !fm->dbcsr
-         END DO !fm->dbcsr
-         DEALLOCATE (mo_derivs_tmp) !fm->dbcsr
-      END IF !fm->dbcsr
+      IF (dft_control%do_admm_mo) THEN
+         CALL calc_admm_mo_derivatives(qs_env, mo_derivs)
+      END IF
 
    END SUBROUTINE calc_mo_derivatives
-
-! **************************************************************************************************
-!> \brief Calculate the forces due to the AUX/ORB basis overlap in ADMM
-!> \param qs_env ...
-!> \par History Moved here from qs_force.F (A. Bussy, 05.2022)
-! **************************************************************************************************
-   SUBROUTINE calc_admm_ovlp_forces(qs_env)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-
-      INTEGER                                            :: ispin
-      TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit, matrix_s_aux_fit, &
-                                                            matrix_s_aux_fit_vs_orb
-      TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_aux_fit
-      TYPE(mo_set_type), POINTER                         :: mo_set
-
-      CALL get_qs_env(qs_env, dft_control=dft_control)
-
-      IF (dft_control%do_admm_dm) THEN
-         CPABORT("Forces with ADMM DM methods not implemented")
-      END IF
-      IF (dft_control%do_admm_mo .AND. .NOT. qs_env%run_rtp) THEN
-         NULLIFY (matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, matrix_ks_aux_fit, &
-                  mos_aux_fit, mos, admm_env)
-         CALL get_qs_env(qs_env=qs_env, &
-                         matrix_s_aux_fit=matrix_s_aux_fit, &
-                         matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
-                         matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                         mos_aux_fit=mos_aux_fit, &
-                         mos=mos, &
-                         admm_env=admm_env)
-         DO ispin = 1, dft_control%nspins
-            mo_set => mos(ispin)%mo_set
-            CALL get_mo_set(mo_set=mo_set, mo_coeff=mo_coeff)
-            ! if no purification we need to calculate the H matrix for forces
-            IF (admm_env%purification_method == do_admm_purify_none) THEN
-               CALL get_mo_set(mo_set=mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit)
-               CALL calc_aux_mo_derivs_none(ispin, qs_env%admm_env, mo_set, &
-                                            mo_coeff_aux_fit, matrix_ks_aux_fit)
-            END IF
-         END DO
-         CALL calc_mixed_overlap_force(qs_env)
-      END IF
-
-   END SUBROUTINE calc_admm_ovlp_forces
 
 ! **************************************************************************************************
 !> \brief updates the Kohn Sham matrix of the given qs_env (facility method)
@@ -1284,24 +1197,20 @@ CONTAINS
 
       CHARACTER(LEN=default_string_length)               :: headline
       INTEGER                                            :: ic, ispin, nimg
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit, &
-                                                            matrix_ks_aux_fit_dft, &
-                                                            matrix_ks_aux_fit_hfx, matrix_s_aux_fit
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrixkp_ks
       TYPE(dbcsr_type), POINTER                          :: refmatrix
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit, sab_orb
+         POINTER                                         :: sab_orb
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
 
-      NULLIFY (dft_control, ks_env, matrix_s_kp, matrix_s_aux_fit, sab_orb, sab_aux_fit, matrixkp_ks)
+      NULLIFY (dft_control, ks_env, matrix_s_kp, sab_orb, matrixkp_ks)
 
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
                       matrix_s_kp=matrix_s_kp, &
                       ks_env=ks_env, &
                       sab_orb=sab_orb, &
-                      sab_aux_fit=sab_aux_fit, &
                       matrix_ks_kp=matrixkp_ks)
 
       IF (.NOT. ASSOCIATED(matrixkp_ks)) THEN
@@ -1327,59 +1236,6 @@ CONTAINS
             END DO
          END DO
          CALL set_ks_env(ks_env, matrix_ks_kp=matrixkp_ks)
-      END IF
-
-      ! Allocate matrix_ks_aux_fit if requested and put it in the QS environment
-      ! Also matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx for ADMMS
-      IF (dft_control%do_admm) THEN
-         NULLIFY (matrix_ks_aux_fit, matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx)
-         CALL get_qs_env(qs_env, &
-                         matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                         matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, &
-                         matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx, &
-                         matrix_s_aux_fit=matrix_s_aux_fit)
-         IF (.NOT. ASSOCIATED(matrix_ks_aux_fit)) THEN
-            refmatrix => matrix_s_aux_fit(1)%matrix
-            CALL dbcsr_allocate_matrix_set(matrix_ks_aux_fit, dft_control%nspins)
-            DO ispin = 1, dft_control%nspins
-               ALLOCATE (matrix_ks_aux_fit(ispin)%matrix)
-               CALL dbcsr_create(matrix=matrix_ks_aux_fit(ispin)%matrix, template=refmatrix, &
-                                 name="KOHN-SHAM_MATRIX for ADMM", &
-                                 matrix_type=dbcsr_type_symmetric, nze=0)
-               CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_aux_fit(ispin)%matrix, sab_aux_fit)
-               CALL dbcsr_set(matrix_ks_aux_fit(ispin)%matrix, 0.0_dp)
-            END DO
-            CALL set_ks_env(ks_env, matrix_ks_aux_fit=matrix_ks_aux_fit)
-         END IF
-         ! same allocation procedure for matrix_ks_aux_fit_dft
-         IF (.NOT. ASSOCIATED(matrix_ks_aux_fit_dft)) THEN
-            refmatrix => matrix_s_aux_fit(1)%matrix
-            CALL dbcsr_allocate_matrix_set(matrix_ks_aux_fit_dft, dft_control%nspins)
-            DO ispin = 1, dft_control%nspins
-               ALLOCATE (matrix_ks_aux_fit_dft(ispin)%matrix)
-               CALL dbcsr_create(matrix=matrix_ks_aux_fit_dft(ispin)%matrix, template=refmatrix, &
-                                 name="AUX. KOHN-SHAM MATRIX FOR ADMM ONLY DFT EXCHANGE", &
-                                 matrix_type=dbcsr_type_symmetric, nze=0)
-               CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_aux_fit_dft(ispin)%matrix, sab_aux_fit)
-               CALL dbcsr_set(matrix_ks_aux_fit_dft(ispin)%matrix, 0.0_dp)
-            END DO
-            CALL set_ks_env(ks_env, matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft)
-         END IF
-         ! same allocation procedure for matrix_ks_aux_fit_hfx
-         IF (.NOT. ASSOCIATED(matrix_ks_aux_fit_hfx)) THEN
-            refmatrix => matrix_s_aux_fit(1)%matrix
-            CALL dbcsr_allocate_matrix_set(matrix_ks_aux_fit_hfx, dft_control%nspins)
-            DO ispin = 1, dft_control%nspins
-               ALLOCATE (matrix_ks_aux_fit_hfx(ispin)%matrix)
-               CALL dbcsr_create(matrix=matrix_ks_aux_fit_hfx(ispin)%matrix, template=refmatrix, &
-                                 name="AUX. KOHN-SHAM MATRIX FOR ADMM ONLY HF EXCHANGE", &
-                                 matrix_type=dbcsr_type_symmetric, nze=0)
-               CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_aux_fit_hfx(ispin)%matrix, sab_aux_fit)
-               CALL dbcsr_set(matrix_ks_aux_fit_hfx(ispin)%matrix, 0.0_dp)
-            END DO
-            CALL set_ks_env(ks_env, matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
-         END IF
-
       END IF
 
    END SUBROUTINE qs_ks_allocate_basics

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -13,8 +13,6 @@
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
 MODULE qs_ks_types
-   USE admm_dm_types,                   ONLY: admm_dm_release,&
-                                              admm_dm_type
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE atprop_types,                    ONLY: atprop_type
    USE cell_types,                      ONLY: cell_type
@@ -162,19 +160,11 @@ MODULE qs_ks_types
 
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_im => Null(), &
                                                             matrix_p_mp2 => Null(), &
-                                                            matrix_p_mp2_admm => Null(), &
-                                                            matrix_s_aux_fit => Null(), &
-                                                            matrix_s_aux_fit_vs_orb => Null(), &
-                                                            matrix_ks_aux_fit => Null(), &
-                                                            matrix_ks_aux_fit_im => Null(), &
-                                                            matrix_ks_aux_fit_dft => Null(), &
-                                                            matrix_ks_aux_fit_hfx => Null()
+                                                            matrix_p_mp2_admm => Null()
 
       TYPE(qs_rho_type), POINTER                            :: rho => Null(), &
                                                                rho_buffer => Null(), &
-                                                               rho_xc => Null(), &
-                                                               rho_aux_fit => Null(), &
-                                                               rho_aux_fit_buffer => Null()
+                                                               rho_xc => Null()
 
       TYPE(pw_p_type), POINTER                              :: rho_core => Null(), &
                                                                vppl => Null(), &
@@ -197,15 +187,11 @@ MODULE qs_ks_types
                                                                sab_xb => Null(), &
                                                                sab_xtb_nonbond => Null(), &
                                                                sab_all => Null(), &
-                                                               sab_aux_fit => Null(), &
-                                                               sab_aux_fit_vs_orb => Null(), &
-                                                               sab_aux_fit_asymm => Null(), &
                                                                sab_lrc => Null(), &
                                                                sab_almo => Null(), &
                                                                sab_kp => Null()
 
       TYPE(task_list_type), POINTER                         :: task_list => Null()
-      TYPE(task_list_type), POINTER                         :: task_list_aux_fit => Null()
       TYPE(task_list_type), POINTER                         :: task_list_soft => Null()
 
       TYPE(kpoint_type), POINTER                            :: kpoints => Null()
@@ -216,7 +202,6 @@ MODULE qs_ks_types
       TYPE(pw_env_type), POINTER                            :: pw_env => Null()
       TYPE(cp_para_env_type), POINTER                       :: para_env => Null()
       TYPE(cp_blacs_env_type), POINTER                      :: blacs_env => Null()
-      TYPE(admm_dm_type), POINTER                           :: admm_dm => Null()
    END TYPE qs_ks_env_type
 
 ! **************************************************************************************************
@@ -243,8 +228,6 @@ CONTAINS
       IF (ASSOCIATED(ks_env)) CPABORT("ks_env already associated")
       ALLOCATE (ks_env)
       CALL qs_rho_create(ks_env%rho)
-      CALL qs_rho_create(ks_env%rho_aux_fit)
-      CALL qs_rho_create(ks_env%rho_aux_fit_buffer)
       CALL qs_rho_create(ks_env%rho_xc)
       CALL qs_rho_create(ks_env%rho_buffer)
    END SUBROUTINE qs_ks_env_create
@@ -261,14 +244,8 @@ CONTAINS
 !> \param matrix_ks ...
 !> \param matrix_ks_im ...
 !> \param matrix_vxc ...
-!> \param matrix_ks_aux_fit ...
-!> \param matrix_ks_aux_fit_im ...
-!> \param matrix_ks_aux_fit_dft ...
-!> \param matrix_ks_aux_fit_hfx ...
 !> \param kinetic ...
 !> \param matrix_s ...
-!> \param matrix_s_aux_fit ...
-!> \param matrix_s_aux_fit_vs_orb ...
 !> \param matrix_s_RI_aux ...
 !> \param matrix_w ...
 !> \param matrix_p_mp2 ...
@@ -281,8 +258,6 @@ CONTAINS
 !> \param matrix_w_kp ...
 !> \param matrix_s_RI_aux_kp ...
 !> \param rho ...
-!> \param rho_aux_fit ...
-!> \param rho_aux_fit_buffer ...
 !> \param rho_buffer ...
 !> \param rho_xc ...
 !> \param vppl ...
@@ -292,9 +267,6 @@ CONTAINS
 !> \param vee ...
 !> \param neighbor_list_id ...
 !> \param sab_orb ...
-!> \param sab_aux_fit ...
-!> \param sab_aux_fit_asymm ...
-!> \param sab_aux_fit_vs_orb ...
 !> \param sab_all ...
 !> \param sac_ae ...
 !> \param sac_ppl ...
@@ -312,7 +284,6 @@ CONTAINS
 !> \param sab_almo ...
 !> \param sab_kp ...
 !> \param task_list ...
-!> \param task_list_aux_fit ...
 !> \param task_list_soft ...
 !> \param kpoints ...
 !> \param do_kpoints ...
@@ -343,55 +314,47 @@ CONTAINS
 !> \param blacs_env ...
 !> \param nelectron_total ...
 !> \param nelectron_spin ...
-!> \param admm_dm ...
 ! **************************************************************************************************
    SUBROUTINE get_ks_env(ks_env, v_hartree_rspace, &
                          s_mstruct_changed, rho_changed, &
                          potential_changed, forces_up_to_date, &
-                         matrix_h, matrix_ks, matrix_ks_im, matrix_vxc, matrix_ks_aux_fit, &
-                         matrix_ks_aux_fit_im, matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, &
-                         kinetic, matrix_s, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
+                         matrix_h, matrix_ks, matrix_ks_im, matrix_vxc, &
+                         kinetic, matrix_s, &
                          matrix_s_RI_aux, matrix_w, matrix_p_mp2, matrix_p_mp2_admm, &
                          matrix_h_kp, matrix_ks_kp, matrix_vxc_kp, kinetic_kp, matrix_s_kp, matrix_w_kp, &
                          matrix_s_RI_aux_kp, &
-                         rho, rho_aux_fit, rho_aux_fit_buffer, &
+                         rho, &
                          rho_buffer, rho_xc, &
                          vppl, rho_core, rho_nlcc, rho_nlcc_g, vee, &
                          neighbor_list_id, &
-                         sab_orb, sab_aux_fit, sab_aux_fit_asymm, &
-                         sab_aux_fit_vs_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, &
+                         sab_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, &
                          sab_se, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp, &
-                         task_list, task_list_aux_fit, task_list_soft, &
+                         task_list, task_list_soft, &
                          kpoints, do_kpoints, &
                          atomic_kind_set, qs_kind_set, cell, cell_ref, use_ref_cell, &
                          particle_set, energy, force, local_particles, local_molecules, &
                          molecule_kind_set, molecule_set, subsys, cp_subsys, virial, results, atprop, &
                          nkind, natom, dft_control, dbcsr_dist, distribution_2d, pw_env, &
-                         para_env, blacs_env, nelectron_total, nelectron_spin, admm_dm)
+                         para_env, blacs_env, nelectron_total, nelectron_spin)
 
       TYPE(qs_ks_env_type), INTENT(IN)                   :: ks_env
       TYPE(pw_type), OPTIONAL, POINTER                   :: v_hartree_rspace
       LOGICAL, OPTIONAL                                  :: s_mstruct_changed, rho_changed, &
                                                             potential_changed, forces_up_to_date
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, POINTER :: matrix_h, matrix_ks, matrix_ks_im, &
-         matrix_vxc, matrix_ks_aux_fit, matrix_ks_aux_fit_im, matrix_ks_aux_fit_dft, &
-         matrix_ks_aux_fit_hfx, kinetic, matrix_s, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
-         matrix_s_RI_aux, matrix_w, matrix_p_mp2, matrix_p_mp2_admm
+         matrix_vxc, kinetic, matrix_s, matrix_s_RI_aux, matrix_w, matrix_p_mp2, matrix_p_mp2_admm
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: matrix_h_kp, matrix_ks_kp, &
                                                             matrix_vxc_kp, kinetic_kp, &
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
-      TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho, rho_aux_fit, rho_aux_fit_buffer, &
-                                                            rho_buffer, rho_xc
+      TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho, rho_buffer, rho_xc
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g, vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_aux_fit, &
-         sab_aux_fit_asymm, sab_aux_fit_vs_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, &
-         sap_oce, sab_lrc, sab_se, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, &
-         sab_almo, sab_kp
-      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_aux_fit, &
-                                                            task_list_soft
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
+         sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, sab_se, sab_tbe, sab_core, sab_xb, &
+         sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp
+      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_soft
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
       LOGICAL, OPTIONAL                                  :: do_kpoints
       TYPE(atomic_kind_type), DIMENSION(:), OPTIONAL, &
@@ -424,7 +387,6 @@ CONTAINS
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env
       INTEGER, OPTIONAL                                  :: nelectron_total
       INTEGER, DIMENSION(2), OPTIONAL                    :: nelectron_spin
-      TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
 
       IF (ks_env%ref_count < 1) CPABORT("get_ks_env: ks_env%ref_count<1")
       IF (.NOT. ASSOCIATED(ks_env%subsys)) CPABORT("get_ks_env: subsys not associated")
@@ -452,17 +414,9 @@ CONTAINS
       IF (PRESENT(matrix_vxc_kp)) matrix_vxc_kp => get_2d_pointer(ks_env%matrix_vxc)
 
       IF (PRESENT(matrix_ks_im)) matrix_ks_im => ks_env%matrix_ks_im
-      IF (PRESENT(matrix_ks_aux_fit)) matrix_ks_aux_fit => ks_env%matrix_ks_aux_fit
-      IF (PRESENT(matrix_ks_aux_fit_im)) matrix_ks_aux_fit_im => ks_env%matrix_ks_aux_fit_im
-      IF (PRESENT(matrix_ks_aux_fit_dft)) matrix_ks_aux_fit_dft => ks_env%matrix_ks_aux_fit_dft
-      IF (PRESENT(matrix_ks_aux_fit_hfx)) matrix_ks_aux_fit_hfx => ks_env%matrix_ks_aux_fit_hfx
-      IF (PRESENT(matrix_s_aux_fit)) matrix_s_aux_fit => ks_env%matrix_s_aux_fit
-      IF (PRESENT(matrix_s_aux_fit_vs_orb)) matrix_s_aux_fit_vs_orb => ks_env%matrix_s_aux_fit_vs_orb
       IF (PRESENT(matrix_p_mp2)) matrix_p_mp2 => ks_env%matrix_p_mp2
       IF (PRESENT(matrix_p_mp2_admm)) matrix_p_mp2_admm => ks_env%matrix_p_mp2_admm
       IF (PRESENT(rho)) rho => ks_env%rho
-      IF (PRESENT(rho_aux_fit)) rho_aux_fit => ks_env%rho_aux_fit
-      IF (PRESENT(rho_aux_fit_buffer)) rho_aux_fit_buffer => ks_env%rho_aux_fit_buffer
       IF (PRESENT(rho_buffer)) rho_buffer => ks_env%rho_buffer
       IF (PRESENT(rho_xc)) rho_xc => ks_env%rho_xc
       IF (PRESENT(rho_core)) rho_core => ks_env%rho_core
@@ -473,9 +427,6 @@ CONTAINS
 
       IF (PRESENT(neighbor_list_id)) neighbor_list_id = ks_env%neighbor_list_id
       IF (PRESENT(sab_orb)) sab_orb => ks_env%sab_orb
-      IF (PRESENT(sab_aux_fit)) sab_aux_fit => ks_env%sab_aux_fit
-      IF (PRESENT(sab_aux_fit_asymm)) sab_aux_fit_asymm => ks_env%sab_aux_fit_asymm
-      IF (PRESENT(sab_aux_fit_vs_orb)) sab_aux_fit_vs_orb => ks_env%sab_aux_fit_vs_orb
       IF (PRESENT(sab_all)) sab_all => ks_env%sab_all
       IF (PRESENT(sab_vdw)) sab_vdw => ks_env%sab_vdw
       IF (PRESENT(sab_scp)) sab_scp => ks_env%sab_scp
@@ -498,10 +449,8 @@ CONTAINS
       IF (PRESENT(pw_env)) pw_env => ks_env%pw_env
       IF (PRESENT(para_env)) para_env => ks_env%para_env
       IF (PRESENT(blacs_env)) blacs_env => ks_env%blacs_env
-      IF (PRESENT(admm_dm)) admm_dm => ks_env%admm_dm
 
       IF (PRESENT(task_list)) task_list => ks_env%task_list
-      IF (PRESENT(task_list_aux_fit)) task_list_aux_fit => ks_env%task_list_aux_fit
       IF (PRESENT(task_list_soft)) task_list_soft => ks_env%task_list_soft
 
       IF (PRESENT(kpoints)) kpoints => ks_env%kpoints
@@ -546,14 +495,8 @@ CONTAINS
 !> \param matrix_ks ...
 !> \param matrix_ks_im ...
 !> \param matrix_vxc ...
-!> \param matrix_ks_aux_fit ...
-!> \param matrix_ks_aux_fit_im ...
-!> \param matrix_ks_aux_fit_dft ...
-!> \param matrix_ks_aux_fit_hfx ...
 !> \param kinetic ...
 !> \param matrix_s ...
-!> \param matrix_s_aux_fit ...
-!> \param matrix_s_aux_fit_vs_orb ...
 !> \param matrix_s_RI_aux ...
 !> \param matrix_w ...
 !> \param matrix_p_mp2 ...
@@ -573,9 +516,6 @@ CONTAINS
 !> \param neighbor_list_id ...
 !> \param kpoints ...
 !> \param sab_orb ...
-!> \param sab_aux_fit ...
-!> \param sab_aux_fit_asymm ...
-!> \param sab_aux_fit_vs_orb ...
 !> \param sab_all ...
 !> \param sac_ae ...
 !> \param sac_ppl ...
@@ -593,7 +533,6 @@ CONTAINS
 !> \param sab_almo ...
 !> \param sab_kp ...
 !> \param task_list ...
-!> \param task_list_aux_fit ...
 !> \param task_list_soft ...
 !> \param subsys ...
 !> \param dft_control ...
@@ -602,34 +541,30 @@ CONTAINS
 !> \param pw_env ...
 !> \param para_env ...
 !> \param blacs_env ...
-!> \param admm_dm ...
 ! **************************************************************************************************
    SUBROUTINE set_ks_env(ks_env, v_hartree_rspace, &
                          s_mstruct_changed, rho_changed, &
                          potential_changed, forces_up_to_date, &
-                         matrix_h, matrix_ks, matrix_ks_im, matrix_vxc, matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
-                         matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, kinetic, matrix_s, matrix_s_aux_fit, &
-                         matrix_s_aux_fit_vs_orb, matrix_s_RI_aux, matrix_w, matrix_p_mp2, matrix_p_mp2_admm, &
+                         matrix_h, matrix_ks, matrix_ks_im, matrix_vxc, &
+                         kinetic, matrix_s, &
+                         matrix_s_RI_aux, matrix_w, matrix_p_mp2, matrix_p_mp2_admm, &
                          matrix_h_kp, matrix_ks_kp, matrix_vxc_kp, kinetic_kp, matrix_s_kp, matrix_w_kp, &
                          matrix_s_RI_aux_kp, &
                          vppl, rho_core, rho_nlcc, rho_nlcc_g, vee, &
                          neighbor_list_id, &
                          kpoints, &
-                         sab_orb, sab_aux_fit, sab_aux_fit_asymm, &
-                         sab_aux_fit_vs_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, &
+                         sab_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, &
                          sab_se, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp, &
-                         task_list, task_list_aux_fit, task_list_soft, &
+                         task_list, task_list_soft, &
                          subsys, dft_control, dbcsr_dist, distribution_2d, pw_env, &
-                         para_env, blacs_env, admm_dm)
+                         para_env, blacs_env)
 
       TYPE(qs_ks_env_type), INTENT(INOUT)                :: ks_env
       TYPE(pw_type), OPTIONAL, POINTER                   :: v_hartree_rspace
       LOGICAL, OPTIONAL                                  :: s_mstruct_changed, rho_changed, &
                                                             potential_changed, forces_up_to_date
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, POINTER :: matrix_h, matrix_ks, matrix_ks_im, &
-         matrix_vxc, matrix_ks_aux_fit, matrix_ks_aux_fit_im, matrix_ks_aux_fit_dft, &
-         matrix_ks_aux_fit_hfx, kinetic, matrix_s, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
-         matrix_s_RI_aux, matrix_w, matrix_p_mp2, matrix_p_mp2_admm
+         matrix_vxc, kinetic, matrix_s, matrix_s_RI_aux, matrix_w, matrix_p_mp2, matrix_p_mp2_admm
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: matrix_h_kp, matrix_ks_kp, &
                                                             matrix_vxc_kp, kinetic_kp, &
@@ -638,12 +573,10 @@ CONTAINS
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g, vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_aux_fit, &
-         sab_aux_fit_asymm, sab_aux_fit_vs_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, &
-         sap_oce, sab_lrc, sab_se, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, &
-         sab_almo, sab_kp
-      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_aux_fit, &
-                                                            task_list_soft
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
+         sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, sab_se, sab_tbe, sab_core, sab_xb, &
+         sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp
+      TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_soft
       TYPE(qs_subsys_type), OPTIONAL, POINTER            :: subsys
       TYPE(dft_control_type), OPTIONAL, POINTER          :: dft_control
       TYPE(dbcsr_distribution_type), OPTIONAL, POINTER   :: dbcsr_dist
@@ -651,7 +584,6 @@ CONTAINS
       TYPE(pw_env_type), OPTIONAL, POINTER               :: pw_env
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env
-      TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
 
       IF (ks_env%ref_count < 1) CPABORT("set_ks_env: ks_env%ref_count<1")
 
@@ -685,12 +617,6 @@ CONTAINS
       IF (PRESENT(matrix_s_RI_aux_kp)) CALL set_2d_pointer(ks_env%matrix_s_RI_aux, matrix_s_RI_aux_kp)
 
       IF (PRESENT(matrix_ks_im)) ks_env%matrix_ks_im => matrix_ks_im
-      IF (PRESENT(matrix_ks_aux_fit)) ks_env%matrix_ks_aux_fit => matrix_ks_aux_fit
-      IF (PRESENT(matrix_ks_aux_fit_im)) ks_env%matrix_ks_aux_fit_im => matrix_ks_aux_fit_im
-      IF (PRESENT(matrix_ks_aux_fit_dft)) ks_env%matrix_ks_aux_fit_dft => matrix_ks_aux_fit_dft
-      IF (PRESENT(matrix_ks_aux_fit_hfx)) ks_env%matrix_ks_aux_fit_hfx => matrix_ks_aux_fit_hfx
-      IF (PRESENT(matrix_s_aux_fit)) ks_env%matrix_s_aux_fit => matrix_s_aux_fit
-      IF (PRESENT(matrix_s_aux_fit_vs_orb)) ks_env%matrix_s_aux_fit_vs_orb => matrix_s_aux_fit_vs_orb
       IF (PRESENT(matrix_p_mp2)) ks_env%matrix_p_mp2 => matrix_p_mp2
       IF (PRESENT(matrix_p_mp2_admm)) ks_env%matrix_p_mp2_admm => matrix_p_mp2_admm
       IF (PRESENT(rho_core)) ks_env%rho_core => rho_core
@@ -702,9 +628,6 @@ CONTAINS
       IF (PRESENT(neighbor_list_id)) ks_env%neighbor_list_id = neighbor_list_id
       IF (PRESENT(kpoints)) ks_env%kpoints => kpoints
       IF (PRESENT(sab_orb)) ks_env%sab_orb => sab_orb
-      IF (PRESENT(sab_aux_fit)) ks_env%sab_aux_fit => sab_aux_fit
-      IF (PRESENT(sab_aux_fit_asymm)) ks_env%sab_aux_fit_asymm => sab_aux_fit_asymm
-      IF (PRESENT(sab_aux_fit_vs_orb)) ks_env%sab_aux_fit_vs_orb => sab_aux_fit_vs_orb
       IF (PRESENT(sab_vdw)) ks_env%sab_vdw => sab_vdw
       IF (PRESENT(sab_scp)) ks_env%sab_scp => sab_scp
       IF (PRESENT(sab_all)) ks_env%sab_all => sab_all
@@ -721,10 +644,8 @@ CONTAINS
       IF (PRESENT(sab_xtb_nonbond)) ks_env%sab_xtb_nonbond => sab_xtb_nonbond
       IF (PRESENT(sab_almo)) ks_env%sab_almo => sab_almo
       IF (PRESENT(sab_kp)) ks_env%sab_kp => sab_kp
-      IF (PRESENT(admm_dm)) ks_env%admm_dm => admm_dm
 
       IF (PRESENT(task_list)) ks_env%task_list => task_list
-      IF (PRESENT(task_list_aux_fit)) ks_env%task_list_aux_fit => task_list_aux_fit
       IF (PRESENT(task_list_soft)) ks_env%task_list_soft => task_list_soft
 
       IF (PRESENT(subsys)) THEN
@@ -794,18 +715,6 @@ CONTAINS
             CALL kpoint_transitional_release(ks_env%kinetic)
             CALL kpoint_transitional_release(ks_env%matrix_s_RI_aux)
 
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit)
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit_im)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit_im)
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit_dft)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit_dft)
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit_hfx)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit_hfx)
-            IF (ASSOCIATED(ks_env%matrix_s_aux_fit)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_s_aux_fit)
-            IF (ASSOCIATED(ks_env%matrix_s_aux_fit_vs_orb)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_s_aux_fit_vs_orb)
             IF (ASSOCIATED(ks_env%matrix_p_mp2)) &
                CALL dbcsr_deallocate_matrix_set(ks_env%matrix_p_mp2)
             IF (ASSOCIATED(ks_env%matrix_p_mp2_admm)) &
@@ -816,16 +725,10 @@ CONTAINS
                CALL qs_rho_release(ks_env%rho_buffer)
             IF (ASSOCIATED(ks_env%rho_xc)) &
                CALL qs_rho_release(ks_env%rho_xc)
-            IF (ASSOCIATED(ks_env%rho_aux_fit)) &
-               CALL qs_rho_release(ks_env%rho_aux_fit)
-            IF (ASSOCIATED(ks_env%rho_aux_fit_buffer)) &
-               CALL qs_rho_release(ks_env%rho_aux_fit_buffer)
             IF (ASSOCIATED(ks_env%distribution_2d)) &
                CALL distribution_2d_release(ks_env%distribution_2d)
             IF (ASSOCIATED(ks_env%task_list)) &
                CALL deallocate_task_list(ks_env%task_list)
-            IF (ASSOCIATED(ks_env%task_list_aux_fit)) &
-               CALL deallocate_task_list(ks_env%task_list_aux_fit)
             IF (ASSOCIATED(ks_env%task_list_soft)) &
                CALL deallocate_task_list(ks_env%task_list_soft)
 
@@ -868,9 +771,6 @@ CONTAINS
             CALL release_neighbor_list_sets(ks_env%sab_xb)
             CALL release_neighbor_list_sets(ks_env%sab_xtb_nonbond)
             CALL release_neighbor_list_sets(ks_env%sab_all)
-            CALL release_neighbor_list_sets(ks_env%sab_aux_fit)
-            CALL release_neighbor_list_sets(ks_env%sab_aux_fit_vs_orb)
-            CALL release_neighbor_list_sets(ks_env%sab_aux_fit_asymm)
             CALL release_neighbor_list_sets(ks_env%sab_lrc)
             CALL release_neighbor_list_sets(ks_env%sab_almo)
             CALL release_neighbor_list_sets(ks_env%sab_kp)
@@ -880,7 +780,6 @@ CONTAINS
             CALL pw_env_release(ks_env%pw_env)
             CALL cp_para_env_release(ks_env%para_env)
             CALL cp_blacs_env_release(ks_env%blacs_env)
-            CALL admm_dm_release(ks_env%admm_dm)
 
             DEALLOCATE (ks_env)
          END IF
@@ -912,18 +811,6 @@ CONTAINS
             CALL kpoint_transitional_release(ks_env%kinetic)
             CALL kpoint_transitional_release(ks_env%matrix_s_RI_aux)
 
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit)
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit_im)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit_im)
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit_dft)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit_dft)
-            IF (ASSOCIATED(ks_env%matrix_ks_aux_fit_hfx)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit_hfx)
-            IF (ASSOCIATED(ks_env%matrix_s_aux_fit)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_s_aux_fit)
-            IF (ASSOCIATED(ks_env%matrix_s_aux_fit_vs_orb)) &
-               CALL dbcsr_deallocate_matrix_set(ks_env%matrix_s_aux_fit_vs_orb)
             IF (ASSOCIATED(ks_env%matrix_p_mp2)) &
                CALL dbcsr_deallocate_matrix_set(ks_env%matrix_p_mp2)
             IF (ASSOCIATED(ks_env%matrix_p_mp2_admm)) &
@@ -934,14 +821,8 @@ CONTAINS
                CALL qs_rho_release(ks_env%rho_buffer)
             IF (ASSOCIATED(ks_env%rho_xc)) &
                CALL qs_rho_release(ks_env%rho_xc)
-            IF (ASSOCIATED(ks_env%rho_aux_fit)) &
-               CALL qs_rho_release(ks_env%rho_aux_fit)
-            IF (ASSOCIATED(ks_env%rho_aux_fit_buffer)) &
-               CALL qs_rho_release(ks_env%rho_aux_fit_buffer)
             IF (ASSOCIATED(ks_env%task_list)) &
                CALL deallocate_task_list(ks_env%task_list)
-            IF (ASSOCIATED(ks_env%task_list_aux_fit)) &
-               CALL deallocate_task_list(ks_env%task_list_aux_fit)
             IF (ASSOCIATED(ks_env%task_list_soft)) &
                CALL deallocate_task_list(ks_env%task_list_soft)
 
@@ -979,15 +860,11 @@ CONTAINS
             CALL release_neighbor_list_sets(ks_env%sab_xb)
             CALL release_neighbor_list_sets(ks_env%sab_xtb_nonbond)
             CALL release_neighbor_list_sets(ks_env%sab_all)
-            CALL release_neighbor_list_sets(ks_env%sab_aux_fit)
-            CALL release_neighbor_list_sets(ks_env%sab_aux_fit_vs_orb)
-            CALL release_neighbor_list_sets(ks_env%sab_aux_fit_asymm)
             CALL release_neighbor_list_sets(ks_env%sab_lrc)
             CALL release_neighbor_list_sets(ks_env%sab_almo)
             CALL release_neighbor_list_sets(ks_env%sab_kp)
             CALL kpoint_release(ks_env%kpoints)
             CALL pw_env_release(ks_env%pw_env, ks_env%para_env)
-            CALL admm_dm_release(ks_env%admm_dm)
 
          END IF
       END IF
@@ -1061,7 +938,6 @@ CONTAINS
          ks_env%s_mstruct_changed = .TRUE.
          ! *** deallocate matrices that will have the wrong structure ***
          CALL kpoint_transitional_release(ks_env%matrix_ks)
-         CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit)
          !TODO: deallocate imaginary parts as well
          !CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_im)
          !CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_aux_fit_im)

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -20,7 +20,8 @@
 ! **************************************************************************************************
 
 MODULE qs_ks_utils
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cell_types,                      ONLY: cell_type
    USE cp_control_types,                ONLY: dft_control_type
@@ -1250,14 +1251,10 @@ CONTAINS
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
                       pw_env=pw_env, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, &
                       v_hartree_rspace=v_rspace%pw, &
-                      rho_aux_fit=rho_aux_fit, &
                       vee=vee)
 
       CALL qs_rho_get(rho, rho_ao_kp=rho_ao_kp)
-      CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
       CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
       gapw = dft_control%qs_control%gapw
       gapw_xc = dft_control%qs_control%gapw_xc
@@ -1564,6 +1561,9 @@ CONTAINS
       ! Add contributions from ADMM if requested
       IF (dft_control%do_admm) THEN
          CALL get_qs_env(qs_env, admm_env=admm_env)
+         CALL get_admm_env(admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit, rho_aux_fit=rho_aux_fit, &
+                           matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft)
+         CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
          IF (ASSOCIATED(v_rspace_new_aux_fit)) THEN
             DO ispin = 1, nspins
                ! Calculate the xc potential
@@ -1580,7 +1580,7 @@ CONTAINS
                IF (admm_env%aux_exch_func .NE. do_admm_aux_exch_func_none) THEN
 
                   !GPW by default. IF GAPW, then take relevant task list and basis
-                  CALL get_qs_env(qs_env, task_list_aux_fit=task_list)
+                  CALL get_admm_env(admm_env, task_list_aux_fit=task_list)
                   basis_type = "AUX_FIT"
                   IF (admm_env%do_gapw) THEN
                      task_list => admm_env%admm_gapw_env%task_list

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -12,7 +12,8 @@
 !> \author JGH
 ! **************************************************************************************************
 MODULE qs_linres_kernel
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind
    USE cp_control_types,                ONLY: dft_control_type
@@ -338,7 +339,7 @@ CONTAINS
             IF (.NOT. ASSOCIATED(kpp1_env%deriv_set_admm)) THEN
                CPASSERT(.NOT. lr_triplet)
                xc_section_aux => admm_env%xc_section_aux
-               CALL get_qs_env(qs_env=qs_env, rho_aux_fit=rho_aux)
+               CALL get_admm_env(qs_env%admm_env, rho_aux_fit=rho_aux)
                CALL qs_rho_get(rho_aux, rho_r=rho_r)
                ALLOCATE (kpp1_env%deriv_set_admm, kpp1_env%rho_set_admm)
                CALL xc_prep_2nd_deriv(kpp1_env%deriv_set_admm, kpp1_env%rho_set_admm, &
@@ -832,7 +833,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, task_list_aux_fit=task_list_aux_fit)
+      CALL get_qs_env(qs_env=qs_env, dft_control=dft_control)
 
       IF (dft_control%do_admm) THEN
          IF (dft_control%admm_control%aux_exch_func == do_admm_aux_exch_func_none) THEN
@@ -853,11 +854,12 @@ CONTAINS
             NULLIFY (tau_pw)
             ! calculate the xc potential
             lsd = (nspins == 2)
-            CALL get_qs_env(qs_env=qs_env, matrix_s_aux_fit=matrix_s)
+            CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s)
             ALLOCATE (xcmat%matrix)
             CALL dbcsr_create(xcmat%matrix, template=matrix_s(1)%matrix)
 
             CALL get_qs_env(qs_env, admm_env=admm_env)
+            CALL get_admm_env(admm_env, task_list_aux_fit=task_list_aux_fit)
             CALL qs_rho_get(p_env%rho1_admm, rho_r=rho1_aux_r, rho_g=rho1_aux_g)
             xc_section => admm_env%xc_section_aux
             bo = rho1_aux_r(1)%pw%pw_grid%bounds_local

--- a/src/qs_neighbor_lists.F
+++ b/src/qs_neighbor_lists.F
@@ -326,9 +326,8 @@ CONTAINS
       TYPE(local_atoms_type), ALLOCATABLE, DIMENSION(:)  :: atom2d
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
       TYPE(neighbor_list_set_p_type), DIMENSION(:), POINTER :: saa_list, sab_all, sab_almo, &
-         sab_aux_fit, sab_aux_fit_asymm, sab_aux_fit_vs_orb, sab_cn, sab_core, sab_gcp, sab_kp, &
-         sab_lrc, sab_orb, sab_scp, sab_se, sab_tbe, sab_vdw, sab_xb, sab_xtb_nonbond, sac_ae, &
-         sac_lri, sac_ppl, sap_oce, sap_ppnl, soa_list, soo_list
+         sab_cn, sab_core, sab_gcp, sab_kp, sab_lrc, sab_orb, sab_scp, sab_se, sab_tbe, sab_vdw, &
+         sab_xb, sab_xtb_nonbond, sac_ae, sac_lri, sac_ppl, sap_oce, sap_ppnl, soa_list, soo_list
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(paw_proj_set_type), POINTER                   :: paw_proj
       TYPE(qs_dftb_atom_type), POINTER                   :: dftb_atom
@@ -362,8 +361,6 @@ CONTAINS
       NULLIFY (sab_all)
       NULLIFY (sab_vdw)
       NULLIFY (sab_cn)
-      NULLIFY (sab_aux_fit)
-      NULLIFY (sab_aux_fit_vs_orb)
       NULLIFY (soo_list)
       NULLIFY (sab_scp)
       NULLIFY (sab_almo)
@@ -390,9 +387,6 @@ CONTAINS
 
       CALL get_ks_env(ks_env=ks_env, &
                       sab_orb=sab_orb, &
-                      sab_aux_fit=sab_aux_fit, &
-                      sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
-                      sab_aux_fit_asymm=sab_aux_fit_asymm, &
                       sac_ae=sac_ae, &
                       sac_ppl=sac_ppl, &
                       sac_lri=sac_lri, &
@@ -604,28 +598,6 @@ CONTAINS
          CALL set_ks_env(ks_env=ks_env, sab_core=sab_core)
          CALL write_neighbor_lists(sab_core, particle_set, cell, para_env, neighbor_list_section, &
                                    "/SAB_CORE", "sab_core", "CORE CORE")
-      END IF
-
-      IF (dft_control%do_admm) THEN
-         CALL pair_radius_setup(aux_fit_present, aux_fit_present, aux_fit_radius, aux_fit_radius, pair_radius)
-         CALL build_neighbor_lists(sab_aux_fit, particle_set, atom2d, cell, pair_radius, &
-                                   mic=mic, molecular=molecule_only, subcells=subcells, nlname="sab_aux_fit")
-         CALL build_neighbor_lists(sab_aux_fit_asymm, particle_set, atom2d, cell, pair_radius, &
-                                   mic=mic, symmetric=.FALSE., molecular=molecule_only, subcells=subcells, &
-                                   nlname="sab_aux_fit_asymm")
-         CALL pair_radius_setup(aux_fit_present, orb_present, aux_fit_radius, orb_radius, pair_radius)
-         CALL build_neighbor_lists(sab_aux_fit_vs_orb, particle_set, atom2d, cell, pair_radius, &
-                                   mic=mic, symmetric=.FALSE., molecular=molecule_only, subcells=subcells, &
-                                   nlname="sab_aux_fit_vs_orb")
-
-         CALL set_ks_env(ks_env=ks_env, sab_aux_fit=sab_aux_fit)
-         CALL set_ks_env(ks_env=ks_env, sab_aux_fit_vs_orb=sab_aux_fit_vs_orb)
-         CALL set_ks_env(ks_env=ks_env, sab_aux_fit_asymm=sab_aux_fit_asymm)
-
-         CALL write_neighbor_lists(sab_aux_fit, particle_set, cell, para_env, neighbor_list_section, &
-                                   "/SAB_AUX_FIT", "sab_aux_fit", "AUX_FIT_ORBITAL AUX_FIT_ORBITAL")
-         CALL write_neighbor_lists(sab_aux_fit_vs_orb, particle_set, cell, para_env, neighbor_list_section, &
-                                   "/SAB_AUX_FIT_VS_ORB", "sab_aux_fit_vs_orb", "ORBITAL AUX_FIT_ORBITAL")
       END IF
 
       IF (dokp) THEN

--- a/src/qs_p_env_methods.F
+++ b/src/qs_p_env_methods.F
@@ -15,7 +15,8 @@
 ! **************************************************************************************************
 MODULE qs_p_env_methods
    USE admm_methods,                    ONLY: admm_aux_reponse_density
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
@@ -156,7 +157,6 @@ CONTAINS
       NULLIFY (ao_mo_fm_pools, mo_mo_fm_pools, matrix_s, dft_control, para_env, blacs_env)
       CALL get_qs_env(qs_env, &
                       matrix_s=matrix_s, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
                       dft_control=dft_control, &
                       para_env=para_env, &
                       blacs_env=blacs_env)
@@ -184,6 +184,7 @@ CONTAINS
       END IF
 
       IF (dft_control%do_admm) THEN
+         CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux_fit)
          IF (dft_control%admm_control%aux_exch_func /= do_admm_aux_exch_func_none) THEN
             CALL qs_rho_create(p_env%rho1_admm)
          END IF
@@ -342,7 +343,7 @@ CONTAINS
       END IF
 
       IF (dft_control%do_admm .AND. .NOT. ASSOCIATED(p_env%kpp1_admm)) THEN
-         CALL get_qs_env(qs_env, matrix_s_aux_fit=matrix_s)
+         CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s)
          nspins = dft_control%nspins
 
          CALL dbcsr_allocate_matrix_set(p_env%kpp1_admm, nspins)
@@ -419,8 +420,8 @@ CONTAINS
 
             CALL get_qs_env(qs_env, &
                             ks_env=ks_env, &
-                            dft_control=dft_control, &
-                            task_list_aux_fit=task_list)
+                            dft_control=dft_control)
+            CALL get_admm_env(qs_env%admm_env, task_list_aux_fit=task_list)
 
             CALL qs_rho_get(p_env%rho1_admm, &
                             rho_ao=rho1_ao, &

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -13,6 +13,7 @@
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
 MODULE qs_rho_methods
+   USE admm_types,                      ONLY: get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
@@ -149,7 +150,7 @@ CONTAINS
 
       IF (my_admm) THEN
          CPASSERT(.NOT. do_kpoints)
-         CALL get_qs_env(qs_env, matrix_s_aux_fit=matrix_s, sab_aux_fit=sab_orb)
+         CALL get_admm_env(qs_env%admm_env, sab_aux_fit=sab_orb, matrix_s_aux_fit=matrix_s)
          refmatrix => matrix_s(1)%matrix
       ELSE
          CALL get_qs_env(qs_env, matrix_s_kp=matrix_s_kp, sab_orb=sab_orb)

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -26,7 +26,6 @@ MODULE qs_scf_initialization
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
                                               cp_fm_to_fm_triangular,&
@@ -542,23 +541,20 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'qs_scf_ensure_mos'
 
       INTEGER                                            :: handle, ic, ik, ikk, ispin, nmo, nmo_mat
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_derivs_aux_fit
-      TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools, ao_mo_fm_pools_aux_fit
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit, mo_coeff_last
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, mo_derivs
+      TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_last
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mo_derivs
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_b
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_aux_fit, mos_last_converged
+      TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_last_converged
       TYPE(mo_set_p_type), DIMENSION(:, :), POINTER      :: mos_k
       TYPE(xas_environment_type), POINTER                :: xas_env
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (ao_mo_fm_pools, dft_control, mos, ao_mo_fm_pools_aux_fit)
-      NULLIFY (mo_derivs, mo_coeff, mo_coeff_aux_fit, mo_derivs_aux_fit, xas_env, matrix_s)
-      NULLIFY (mos_last_converged, mo_coeff_last)
+      NULLIFY (ao_mo_fm_pools, dft_control, mos, xas_env, matrix_s, mos_last_converged, mo_coeff_last)
 
       CPASSERT(ASSOCIATED(scf_env))
       CPASSERT(scf_env%ref_count > 0)
@@ -568,7 +564,6 @@ CONTAINS
                       dft_control=dft_control, &
                       mos=mos, &
                       matrix_s_kp=matrix_s, &
-                      mos_aux_fit=mos_aux_fit, &
                       xas_env=xas_env)
       CALL mpools_get(qs_env%mpools, ao_mo_fm_pools=ao_mo_fm_pools)
       IF (dft_control%switch_surf_dip) THEN
@@ -617,40 +612,7 @@ CONTAINS
 
 !   *** finish initialization of the MOs for ADMM and derivs if needed ***
       IF (dft_control%do_admm) THEN
-         IF (dft_control%restricted) &
-            CPABORT("ROKS with ADMM is not implemented")
-         CPASSERT(ASSOCIATED(mos_aux_fit))
-         CALL mpools_get(qs_env%mpools_aux_fit, ao_mo_fm_pools=ao_mo_fm_pools_aux_fit)
-         DO ispin = 1, SIZE(mos_aux_fit)
-            CALL get_mo_set(mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit, mo_coeff_b=mo_coeff_b)
-            IF (.NOT. ASSOCIATED(mo_coeff_aux_fit)) THEN
-               CALL init_mo_set(mos_aux_fit(ispin)%mo_set, &
-                                fm_pool=ao_mo_fm_pools_aux_fit(ispin)%pool, &
-                                name="qs_env"//TRIM(ADJUSTL(cp_to_string(qs_env%id_nr)))// &
-                                "%mo_aux_fit"//TRIM(ADJUSTL(cp_to_string(ispin))))
-            END IF
-            IF (.NOT. ASSOCIATED(mo_coeff_b)) THEN
-               CALL cp_fm_get_info(mos_aux_fit(ispin)%mo_set%mo_coeff, ncol_global=nmo)
-               CALL dbcsr_init_p(mos_aux_fit(ispin)%mo_set%mo_coeff_b)
-               CALL get_qs_env(qs_env=qs_env, matrix_s_aux_fit=matrix_s_aux_fit)
-               CALL cp_dbcsr_m_by_n_from_row_template(mos_aux_fit(ispin)%mo_set%mo_coeff_b, &
-                                                      template=matrix_s_aux_fit(1)%matrix, n=nmo, &
-                                                      sym=dbcsr_type_no_symmetry)
-            END IF
-         END DO
-         IF (qs_env%requires_mo_derivs) THEN
-            CALL get_qs_env(qs_env, mo_derivs_aux_fit=mo_derivs_aux_fit)
-            IF (.NOT. ASSOCIATED(mo_derivs_aux_fit)) THEN
-               ALLOCATE (mo_derivs_aux_fit(nmo_mat))
-               DO ispin = 1, nmo_mat
-                  CALL get_mo_set(mos_aux_fit(ispin)%mo_set, mo_coeff=mo_coeff_aux_fit)
-                  CALL cp_fm_create(mo_derivs_aux_fit(ispin)%matrix, mo_coeff_aux_fit%matrix_struct)
-               END DO
-               CALL set_qs_env(qs_env, mo_derivs_aux_fit=mo_derivs_aux_fit)
-            END IF
-         ELSE
-            ! nothing should be done
-         END IF
+         IF (dft_control%restricted) CPABORT("ROKS with ADMM is not implemented")
       END IF
 
 ! *** finish initialization of mos_last_converged *** [SGh]

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -6,7 +6,9 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE qs_tddfpt2_fhxc_forces
-   USE admm_types,                      ONLY: admm_type
+   USE admm_methods,                    ONLY: admm_projection_derivative
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind_set
    USE atprop_types,                    ONLY: atprop_type
@@ -42,8 +44,8 @@ MODULE qs_tddfpt2_fhxc_forces
                                               cp_logger_type
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
-        dbcsr_add, dbcsr_complete_redistribute, dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, &
-        dbcsr_filter, dbcsr_get_block_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
+        dbcsr_add, dbcsr_complete_redistribute, dbcsr_copy, dbcsr_create, dbcsr_filter, &
+        dbcsr_get_block_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
         dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, &
         dbcsr_release, dbcsr_scale, dbcsr_set, dbcsr_transposed, dbcsr_type, &
         dbcsr_type_antisymmetric, dbcsr_type_no_symmetry
@@ -92,8 +94,7 @@ MODULE qs_tddfpt2_fhxc_forces
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
-   USE qs_force_types,                  ONLY: add_qs_force,&
-                                              qs_force_type
+   USE qs_force_types,                  ONLY: qs_force_type
    USE qs_fxc,                          ONLY: qs_fgxc_create,&
                                               qs_fgxc_release
    USE qs_integrate_potential,          ONLY: integrate_v_rspace
@@ -101,8 +102,7 @@ MODULE qs_tddfpt2_fhxc_forces
    USE qs_kind_types,                   ONLY: qs_kind_type
    USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
-   USE qs_overlap,                      ONLY: build_overlap_force,&
-                                              build_overlap_matrix
+   USE qs_overlap,                      ONLY: build_overlap_matrix
    USE qs_rho_types,                    ONLY: qs_rho_create,&
                                               qs_rho_get,&
                                               qs_rho_release,&
@@ -415,9 +415,9 @@ CONTAINS
                   CPABORT("ADMM KERNEL CORRECTION")
                END IF
                xc_section => admm_env%xc_section_aux
-               CALL get_qs_env(qs_env, admm_env=admm_env, rho_aux_fit=rho_aux_fit, &
-                               matrix_s_aux_fit=matrix_s_aux_fit, &
-                               task_list_aux_fit=task_list_aux_fit)
+               CALL get_qs_env(qs_env, admm_env=admm_env)
+               CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, matrix_s_aux_fit=matrix_s_aux_fit, &
+                                 task_list_aux_fit=task_list_aux_fit)
                !
                NULLIFY (mfx, mgx)
                CALL dbcsr_allocate_matrix_set(mfx, nspins)
@@ -515,7 +515,7 @@ CONTAINS
                !
                IF (debug_forces) fodeb(1:3) = force(1)%overlap_admm(1:3, 1)
                fval = 2.0_dp*REAL(nspins, KIND=dp)
-               CALL admm_projection_derivative(qs_env, admm_env, mfx, matrix_px1, fval)
+               CALL admm_projection_derivative(qs_env, mfx, matrix_px1, fval)
                IF (debug_forces) THEN
                   fodeb(1:3) = force(1)%overlap_admm(1:3, 1) - fodeb(1:3)
                   CALL mp_sum(fodeb, para_env%group)
@@ -523,7 +523,7 @@ CONTAINS
                END IF
                IF (debug_forces) fodeb(1:3) = force(1)%overlap_admm(1:3, 1)
                fval = 2.0_dp*REAL(nspins, KIND=dp)
-               CALL admm_projection_derivative(qs_env, admm_env, mgx, matrix_p, fval)
+               CALL admm_projection_derivative(qs_env, mgx, matrix_p, fval)
                IF (debug_forces) THEN
                   fodeb(1:3) = force(1)%overlap_admm(1:3, 1) - fodeb(1:3)
                   CALL mp_sum(fodeb, para_env%group)
@@ -606,7 +606,7 @@ CONTAINS
          distribute_fock_matrix = .TRUE.
          !
          IF (do_admm) THEN
-            CALL get_qs_env(qs_env=qs_env, matrix_s_aux_fit=matrix_s_aux_fit)
+            CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux_fit)
             NULLIFY (matrix_hfx_admm, matrix_hfx_admm_asymm)
             CALL dbcsr_allocate_matrix_set(matrix_hfx_admm, nspins)
             CALL dbcsr_allocate_matrix_set(matrix_hfx_admm_asymm, nspins)
@@ -693,8 +693,8 @@ CONTAINS
             ! ADMM Projection force
             IF (debug_forces) fodeb(1:3) = force(1)%overlap_admm(1:3, 1)
             fval = 4.0_dp*REAL(nspins, KIND=dp)*0.5_dp !0.5 for symm/anti-symm
-            CALL admm_projection_derivative(qs_env, admm_env, matrix_hfx_admm, matrix_px1, fval)
-            CALL admm_projection_derivative(qs_env, admm_env, matrix_hfx_admm_asymm, matrix_px1_asymm, fval)
+            CALL admm_projection_derivative(qs_env, matrix_hfx_admm, matrix_px1, fval)
+            CALL admm_projection_derivative(qs_env, matrix_hfx_admm_asymm, matrix_px1_asymm, fval)
             IF (debug_forces) THEN
                fodeb(1:3) = force(1)%overlap_admm(1:3, 1) - fodeb(1:3)
                CALL mp_sum(fodeb, para_env%group)
@@ -924,104 +924,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE fhxc_force
-
-! **************************************************************************************************
-!> \brief ...
-!> \param qs_env ...
-!> \param admm_env ...
-!> \param matrix_hfx ...
-!> \param matrix_pe ...
-!> \param fval ...
-! **************************************************************************************************
-   SUBROUTINE admm_projection_derivative(qs_env, admm_env, matrix_hfx, matrix_pe, fval)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_hfx, matrix_pe
-      REAL(KIND=dp), INTENT(IN)                          :: fval
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'admm_projection_derivative', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, ispin, nao, natom, naux, nspins
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: admm_force
-      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
-      TYPE(dbcsr_type), POINTER                          :: matrix_w_q, matrix_w_s
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit_asymm, sab_aux_fit_vs_orb
-      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
-
-      CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(qs_env))
-      CPASSERT(ASSOCIATED(admm_env))
-      CPASSERT(ASSOCIATED(matrix_hfx))
-      CPASSERT(ASSOCIATED(matrix_pe))
-
-      CALL get_qs_env(qs_env, &
-                      ks_env=ks_env, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
-                      sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
-                      sab_aux_fit_asymm=sab_aux_fit_asymm)
-
-      ALLOCATE (matrix_w_q)
-      CALL dbcsr_copy(matrix_w_q, matrix_s_aux_fit_vs_orb(1)%matrix, &
-                      "W MATRIX AUX Q")
-      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_q, sab_aux_fit_vs_orb)
-      ALLOCATE (matrix_w_s)
-      CALL dbcsr_create(matrix_w_s, template=matrix_s_aux_fit(1)%matrix, &
-                        name='W MATRIX AUX S', &
-                        matrix_type=dbcsr_type_no_symmetry)
-      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_s, sab_aux_fit_asymm)
-
-      CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, &
-                      natom=natom, force=force)
-      ALLOCATE (admm_force(3, natom))
-
-      nspins = SIZE(matrix_pe)
-      nao = admm_env%nao_orb
-      naux = admm_env%nao_aux_fit
-      DO ispin = 1, nspins
-         CALL copy_dbcsr_to_fm(matrix_hfx(ispin)%matrix, admm_env%work_aux_aux)
-
-         CALL cp_gemm("N", "T", naux, naux, naux, 1.0_dp, admm_env%s_inv, &
-                      admm_env%work_aux_aux, 0.0_dp, admm_env%work_aux_aux2)
-         CALL cp_gemm("N", "N", naux, nao, naux, 1.0_dp, admm_env%work_aux_aux2, &
-                      admm_env%A, 0.0_dp, admm_env%work_aux_orb)
-         CALL copy_dbcsr_to_fm(matrix_pe(ispin)%matrix, admm_env%work_orb_orb)
-         ! admm_env%work_aux_orb2 = S-1*H(P)*A*P
-         CALL cp_gemm("N", "N", naux, nao, nao, 1.0_dp, admm_env%work_aux_orb, &
-                      admm_env%work_orb_orb, 0.0_dp, admm_env%work_aux_orb2)
-         ! admm_env%work_aux_aux = [S-1*H(P)*A*P]*A(T)
-         CALL cp_gemm("N", "T", naux, naux, nao, 1.0_dp, admm_env%work_aux_orb2, &
-                      admm_env%A, 0.0_dp, admm_env%work_aux_aux)
-         !
-         CALL copy_fm_to_dbcsr(admm_env%work_aux_orb2, matrix_w_q, keep_sparsity=.TRUE.)
-         CALL copy_fm_to_dbcsr(admm_env%work_aux_aux, matrix_w_s, keep_sparsity=.TRUE.)
-         !
-         CALL dbcsr_scale(matrix_w_q, -fval)
-         CALL dbcsr_scale(matrix_w_s, fval)
-         !
-         admm_force = 0.0_dp
-         CALL build_overlap_force(ks_env, admm_force, &
-                                  basis_type_a="AUX_FIT", basis_type_b="AUX_FIT", &
-                                  sab_nl=sab_aux_fit_asymm, matrix_p=matrix_w_s)
-         CALL build_overlap_force(ks_env, admm_force, &
-                                  basis_type_a="AUX_FIT", basis_type_b="ORB", &
-                                  sab_nl=sab_aux_fit_vs_orb, matrix_p=matrix_w_q)
-         ! add forces
-         CALL add_qs_force(admm_force, force, "overlap_admm", atomic_kind_set)
-      END DO
-
-      DEALLOCATE (admm_force)
-      CALL dbcsr_deallocate_matrix(matrix_w_s)
-      CALL dbcsr_deallocate_matrix(matrix_w_q)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE admm_projection_derivative
 
 ! **************************************************************************************************
 !> \brief Simplified Tamm Dancoff approach (sTDA). Kernel contribution to forces

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -6,7 +6,8 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE qs_tddfpt2_forces
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind,&
                                               get_atomic_kind_set
@@ -662,8 +663,9 @@ CONTAINS
             ! nothing to do
          ELSE
             ! add ADMM xc_section_aux terms: f_x[rhoz_ADMM]
-            CALL get_qs_env(qs_env, admm_env=admm_env, rho_aux_fit=rho_aux_fit, &
-                            matrix_s_aux_fit=msaux, task_list_aux_fit=task_list_aux_fit)
+            CALL get_qs_env(qs_env, admm_env=admm_env)
+            CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, matrix_s_aux_fit=msaux, &
+                              task_list_aux_fit=task_list_aux_fit)
             !
             NULLIFY (mpe, mhz)
             ALLOCATE (mpe(nspins, 1))
@@ -760,7 +762,8 @@ CONTAINS
                          s_mstruct_changed=s_mstruct_changed)
          distribute_fock_matrix = .TRUE.
          IF (dft_control%do_admm) THEN
-            CALL get_qs_env(qs_env, admm_env=admm_env, matrix_s_aux_fit=msaux)
+            CALL get_qs_env(qs_env, admm_env=admm_env)
+            CALL get_admm_env(admm_env, matrix_s_aux_fit=msaux)
             NULLIFY (mpe, mhz)
             ALLOCATE (mpe(nspins, 1))
             CALL dbcsr_allocate_matrix_set(mhz, nspins, 1)

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -6,7 +6,8 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE qs_tddfpt2_methods
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE bibliography,                    ONLY: Grimme2013,&
                                               Grimme2016,&
                                               Iannuzzi2005,&
@@ -548,7 +549,8 @@ CONTAINS
             !
             ! ground state ADMM!
             IF (dft_control%do_admm) THEN
-               CALL get_qs_env(qs_env, admm_env=admm_env, matrix_s_aux_fit=matrix_s_aux_fit)
+               CALL get_qs_env(qs_env, admm_env=admm_env)
+               CALL get_admm_env(admm_env, matrix_s_aux_fit=matrix_s_aux_fit)
                CALL dbcsr_allocate_matrix_set(ex_env%matrix_pe_admm, nspins)
                DO ispin = 1, nspins
                   ALLOCATE (ex_env%matrix_pe_admm(ispin)%matrix)
@@ -590,7 +592,8 @@ CONTAINS
             END DO
             ! Kernel ADMM
             IF (tddfpt_control%do_admm) THEN
-               CALL get_qs_env(qs_env, admm_env=admm_env, matrix_s_aux_fit=matrix_s_aux_fit)
+               CALL get_qs_env(qs_env, admm_env=admm_env)
+               CALL get_admm_env(admm_env, matrix_s_aux_fit=matrix_s_aux_fit)
                CALL dbcsr_allocate_matrix_set(ex_env%matrix_px1_admm, nspins)
                CALL dbcsr_allocate_matrix_set(ex_env%matrix_px1_admm_asymm, nspins)
                DO ispin = 1, nspins

--- a/src/qs_tddfpt2_subgroups.F
+++ b/src/qs_tddfpt2_subgroups.F
@@ -6,7 +6,8 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE qs_tddfpt2_subgroups
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                               gto_basis_set_type
@@ -326,7 +327,8 @@ CONTAINS
             CALL get_qs_env(qs_env, dbcsr_dist=sub_env%dbcsr_dist, &
                             sab_orb=sub_env%sab_orb, task_list=sub_env%task_list_orb)
             IF (dft_control%do_admm) &
-               CALL get_qs_env(qs_env, sab_aux_fit=sub_env%sab_aux_fit, task_list_aux_fit=sub_env%task_list_aux_fit)
+               CALL get_admm_env(qs_env%admm_env, sab_aux_fit=sub_env%sab_aux_fit, &
+                                 task_list_aux_fit=sub_env%task_list_aux_fit)
             IF (qs_control%gapw .OR. qs_control%gapw_xc) THEN
                CALL get_qs_env(qs_env, task_list_soft=sub_env%task_list_orb_soft)
             END IF

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -6,7 +6,8 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE qs_tddfpt2_types
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type,&
                                               get_blacs_info
@@ -271,7 +272,7 @@ CONTAINS
       IF (do_admm) THEN
          CPASSERT(do_hfx)
          CPASSERT(ASSOCIATED(sub_env%admm_A))
-         CALL get_qs_env(qs_env, matrix_s_aux_fit=matrix_s_aux_fit)
+         CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux_fit)
          CALL dbcsr_get_info(matrix_s_aux_fit(1)%matrix, nfullrows_total=nao_aux)
       END IF
 
@@ -452,7 +453,8 @@ CONTAINS
                work_matrices%hfx_rho_ao_asymm, work_matrices%hfx_hmat_asymm)
       IF (do_hfx) THEN
          IF (do_admm) THEN
-            CALL get_qs_env(qs_env, dbcsr_dist=dbcsr_dist, sab_aux_fit=sab_hfx)
+            CALL get_qs_env(qs_env, dbcsr_dist=dbcsr_dist)
+            CALL get_admm_env(qs_env%admm_env, sab_aux_fit=sab_hfx)
             dbcsr_template_hfx => matrix_s_aux_fit(1)%matrix
          ELSE
             CALL get_qs_env(qs_env, dbcsr_dist=dbcsr_dist, sab_orb=sab_hfx)

--- a/src/qs_update_s_mstruct.F
+++ b/src/qs_update_s_mstruct.F
@@ -32,7 +32,6 @@ MODULE qs_update_s_mstruct
                                               qs_ks_did_change,&
                                               qs_ks_env_type,&
                                               set_ks_env
-   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE qs_rho_methods,                  ONLY: qs_rho_rebuild
    USE qs_rho_types,                    ONLY: qs_rho_type
    USE qs_scf_types,                    ONLY: scf_env_did_change
@@ -162,8 +161,6 @@ CONTAINS
       INTEGER                                            :: handle, isub
       LOGICAL                                            :: skip_load_balance_distributed, soft_valid
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_orb
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(task_list_type), POINTER                      :: task_list
 
@@ -197,20 +194,6 @@ CONTAINS
                                        reorder_rs_grid_ranks=.TRUE., soft_valid=.TRUE., &
                                        skip_load_balance_distributed=skip_load_balance_distributed)
          END IF
-      END IF
-
-      IF (dft_control%do_admm) THEN
-         ! generate the aux_fit task list
-         CALL get_ks_env(ks_env, task_list_aux_fit=task_list)
-         IF (.NOT. ASSOCIATED(task_list)) THEN
-            CALL allocate_task_list(task_list)
-            CALL set_ks_env(ks_env, task_list_aux_fit=task_list)
-         END IF
-         CALL get_ks_env(ks_env, sab_aux_fit=sab_orb)
-         CALL generate_qs_task_list(ks_env, task_list, &
-                                    reorder_rs_grid_ranks=.FALSE., soft_valid=.FALSE., basis_type="AUX_FIT", &
-                                    skip_load_balance_distributed=skip_load_balance_distributed, &
-                                    sab_orb_external=sab_orb)
       END IF
 
       IF (dft_control%qs_control%do_kg) THEN
@@ -270,8 +253,7 @@ CONTAINS
       INTEGER                                            :: handle
       LOGICAL                                            :: do_admm, gapw_xc
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit, rho_aux_fit_buffer, &
-                                                            rho_external, rho_xc
+      TYPE(qs_rho_type), POINTER                         :: rho, rho_external, rho_xc
 
       NULLIFY (rho)
       CALL timeset(routineN, handle)
@@ -280,8 +262,6 @@ CONTAINS
                       dft_control=dft_control, &
                       rho=rho, &
                       rho_xc=rho_xc, &
-                      rho_aux_fit=rho_aux_fit, &
-                      rho_aux_fit_buffer=rho_aux_fit_buffer, &
                       rho_external=rho_external)
 
       gapw_xc = dft_control%qs_control%gapw_xc
@@ -293,14 +273,7 @@ CONTAINS
          CALL qs_rho_rebuild(rho_xc, qs_env=qs_env, &
                              rebuild_ao=rebuild_ao, rebuild_grids=rebuild_grids)
       END IF
-      IF (do_admm) THEN
-         CALL qs_rho_rebuild(rho_aux_fit, qs_env=qs_env, &
-                             rebuild_ao=rebuild_ao, rebuild_grids=rebuild_grids, &
-                             admm=.TRUE.)
-         CALL qs_rho_rebuild(rho_aux_fit_buffer, qs_env=qs_env, &
-                             rebuild_ao=rebuild_ao, rebuild_grids=rebuild_grids, &
-                             admm=.TRUE.)
-      END IF
+
 ! ZMP rebuilding external density
       IF (dft_control%apply_external_density) THEN
          CALL qs_rho_rebuild(rho_external, qs_env=qs_env, &

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -15,7 +15,9 @@
 !> \author JGH
 ! **************************************************************************************************
 MODULE response_solver
-   USE admm_types,                      ONLY: admm_type
+   USE admm_methods,                    ONLY: admm_projection_derivative
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind
    USE cell_types,                      ONLY: cell_type
@@ -43,9 +45,8 @@ MODULE response_solver
                                               cp_logger_type
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
-        dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_distribution_type, &
-        dbcsr_multiply, dbcsr_p_type, dbcsr_release, dbcsr_scale, dbcsr_set, dbcsr_type, &
-        dbcsr_type_no_symmetry
+        dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_distribution_type, dbcsr_multiply, &
+        dbcsr_p_type, dbcsr_release, dbcsr_scale, dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry
    USE ec_env_types,                    ONLY: energy_correction_type
    USE ec_methods,                      ONLY: create_kernel,&
                                               ec_mos_init
@@ -107,8 +108,7 @@ MODULE response_solver
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
-   USE qs_force_types,                  ONLY: add_qs_force,&
-                                              qs_force_type,&
+   USE qs_force_types,                  ONLY: qs_force_type,&
                                               total_qs_force
    USE qs_fxc,                          ONLY: qs_fxc_analytic,&
                                               qs_fxc_fdiff
@@ -130,8 +130,7 @@ MODULE response_solver
                                               get_mo_set,&
                                               mo_set_p_type
    USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
-   USE qs_overlap,                      ONLY: build_overlap_force,&
-                                              build_overlap_matrix
+   USE qs_overlap,                      ONLY: build_overlap_matrix
    USE qs_p_env_methods,                ONLY: p_env_create,&
                                               p_env_psi0_changed
    USE qs_p_env_types,                  ONLY: p_env_release,&
@@ -163,7 +162,7 @@ MODULE response_solver
    LOGICAL, PARAMETER                   :: debug_forces = .TRUE.
 
    PUBLIC :: response_calculation, response_equation, response_force, response_force_xtb, &
-             ks_ref_potential, admm_projection_derivative, response_equation_new
+             ks_ref_potential, response_equation_new
 
 ! **************************************************************************************************
 
@@ -335,7 +334,7 @@ CONTAINS
             CALL cp_dbcsr_alloc_block_from_nbl(p_env%w1(ispin)%matrix, sab_orb)
          END DO
          IF (dft_control%do_admm) THEN
-            CALL get_qs_env(qs_env, matrix_s_aux_fit=matrix_s_aux)
+            CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux)
             CALL dbcsr_allocate_matrix_set(p_env%p1_admm, nspins)
             DO ispin = 1, nspins
                ALLOCATE (p_env%p1_admm(ispin)%matrix)
@@ -713,7 +712,7 @@ CONTAINS
          CALL cp_dbcsr_alloc_block_from_nbl(p_env%w1(ispin)%matrix, sab_orb)
       END DO
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, matrix_s_aux_fit=matrix_s_aux)
+         CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux)
          CALL dbcsr_allocate_matrix_set(p_env%p1_admm, nspins)
          DO ispin = 1, nspins
             ALLOCATE (p_env%p1_admm(ispin)%matrix)
@@ -1532,8 +1531,9 @@ CONTAINS
             NULLIFY (mpz, mhz, mhx, mhy)
          ELSE
             ! add ADMM xc_section_aux terms: Pz*Vxc + P0*K0[rhoz]
-            CALL get_qs_env(qs_env, admm_env=admm_env, rho_aux_fit=rho_aux_fit, &
-                            matrix_s_aux_fit=scrm, task_list_aux_fit=task_list_aux_fit)
+            CALL get_qs_env(qs_env, admm_env=admm_env)
+            CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, matrix_s_aux_fit=scrm, &
+                              task_list_aux_fit=task_list_aux_fit)
             !
             NULLIFY (mpz, mhz, mhx, mhy)
             CALL dbcsr_allocate_matrix_set(mhx, nspins, 1)
@@ -1665,8 +1665,7 @@ CONTAINS
          distribute_fock_matrix = .TRUE.
          IF (dft_control%do_admm) THEN
             CALL get_qs_env(qs_env=qs_env, admm_env=admm_env)
-            CALL get_qs_env(qs_env=qs_env, matrix_s_aux_fit=scrm)
-            CALL get_qs_env(qs_env=qs_env, rho_aux_fit=rho_aux_fit)
+            CALL get_admm_env(admm_env, matrix_s_aux_fit=scrm, rho_aux_fit=rho_aux_fit)
             CALL qs_rho_get(rho_aux_fit, rho_ao_kp=matrix_p)
             NULLIFY (mpz, mhz, mpd, mhd)
             CALL dbcsr_allocate_matrix_set(mpz, nspins, 1)
@@ -1750,7 +1749,8 @@ CONTAINS
                END DO
             END IF
             CALL qs_rho_get(rho, rho_ao=matrix_pd)
-            CALL admm_projection_derivative(qs_env, admm_env, mhd, mhz, matrix_pd, mpa)
+            CALL admm_projection_derivative(qs_env, mhd(:, 1), mpa)
+            CALL admm_projection_derivative(qs_env, mhz(:, 1), matrix_pd)
             IF (debug_forces) THEN
                fodeb(1:3) = force(1)%overlap_admm(1:3, 1) - fodeb(1:3)
                CALL mp_sum(fodeb, para_env%group)
@@ -2105,117 +2105,6 @@ CONTAINS
    END SUBROUTINE response_force_xtb
 
 ! **************************************************************************************************
-!> \brief ...
-!> \param qs_env ...
-!> \param admm_env ...
-!> \param matrix_hd ...
-!> \param matrix_hz ...
-!> \param matrix_pd ...
-!> \param matrix_pz ...
-! **************************************************************************************************
-   SUBROUTINE admm_projection_derivative(qs_env, admm_env, matrix_hd, matrix_hz, matrix_pd, matrix_pz)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_hd, matrix_hz
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_pd, matrix_pz
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'admm_projection_derivative', &
-         routineP = moduleN//':'//routineN
-
-      INTEGER                                            :: handle, ispin, nao, natom, naux, nspins
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: admm_force
-      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
-      TYPE(dbcsr_type), POINTER                          :: matrix_w_q, matrix_w_s
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_aux_fit_asymm, sab_aux_fit_vs_orb
-      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
-      TYPE(qs_ks_env_type), POINTER                      :: ks_env
-
-      CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(qs_env))
-      CPASSERT(ASSOCIATED(admm_env))
-      CPASSERT(ASSOCIATED(matrix_hd))
-      CPASSERT(ASSOCIATED(matrix_pd))
-      CPASSERT(ASSOCIATED(matrix_hz))
-      CPASSERT(ASSOCIATED(matrix_pz))
-
-      CALL get_qs_env(qs_env, &
-                      ks_env=ks_env, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
-                      sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
-                      sab_aux_fit_asymm=sab_aux_fit_asymm)
-
-      ALLOCATE (matrix_w_q)
-      CALL dbcsr_copy(matrix_w_q, matrix_s_aux_fit_vs_orb(1)%matrix, &
-                      "W MATRIX AUX Q")
-      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_q, sab_aux_fit_vs_orb)
-      ALLOCATE (matrix_w_s)
-      CALL dbcsr_create(matrix_w_s, template=matrix_s_aux_fit(1)%matrix, &
-                        name='W MATRIX AUX S', &
-                        matrix_type=dbcsr_type_no_symmetry)
-      CALL cp_dbcsr_alloc_block_from_nbl(matrix_w_s, sab_aux_fit_asymm)
-
-      CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, &
-                      natom=natom, force=force)
-      ALLOCATE (admm_force(3, natom))
-
-      nspins = SIZE(matrix_pz)
-      nao = admm_env%nao_orb
-      naux = admm_env%nao_aux_fit
-      DO ispin = 1, nspins
-         CALL copy_dbcsr_to_fm(matrix_hd(ispin, 1)%matrix, admm_env%work_aux_aux)
-         CALL cp_gemm("N", "N", naux, naux, naux, 1.0_dp, admm_env%s_inv, &
-                      admm_env%work_aux_aux, 0.0_dp, admm_env%work_aux_aux2)
-         CALL cp_gemm("N", "N", naux, nao, naux, 1.0_dp, admm_env%work_aux_aux2, &
-                      admm_env%A, 0.0_dp, admm_env%work_aux_orb)
-         CALL copy_dbcsr_to_fm(matrix_pz(ispin)%matrix, admm_env%work_orb_orb)
-         ! admm_env%work_aux_orb2 = S-1*H(D)*A*PZ
-         CALL cp_gemm("N", "N", naux, nao, nao, 1.0_dp, admm_env%work_aux_orb, &
-                      admm_env%work_orb_orb, 0.0_dp, admm_env%work_aux_orb2)
-
-         CALL copy_dbcsr_to_fm(matrix_hz(ispin, 1)%matrix, admm_env%work_aux_aux)
-         CALL cp_gemm("N", "N", naux, naux, naux, 1.0_dp, admm_env%s_inv, &
-                      admm_env%work_aux_aux, 0.0_dp, admm_env%work_aux_aux2)
-         CALL cp_gemm("N", "N", naux, nao, naux, 1.0_dp, admm_env%work_aux_aux2, &
-                      admm_env%A, 0.0_dp, admm_env%work_aux_orb)
-         CALL copy_dbcsr_to_fm(matrix_pd(ispin)%matrix, admm_env%work_orb_orb)
-         ! admm_env%work_aux_orb2 = S-1*H(Z)*A*PD
-         CALL cp_gemm("N", "N", naux, nao, nao, 1.0_dp, admm_env%work_aux_orb, &
-                      admm_env%work_orb_orb, 1.0_dp, admm_env%work_aux_orb2)
-
-         ! admm_env%work_aux_aux = [S-1*H(D)*A*PZ+S-1*H(Z)*A*PD]*A(T)
-         CALL cp_gemm("N", "T", naux, naux, nao, 1.0_dp, admm_env%work_aux_orb2, &
-                      admm_env%A, 0.0_dp, admm_env%work_aux_aux)
-         !
-         CALL copy_fm_to_dbcsr(admm_env%work_aux_orb2, matrix_w_q, keep_sparsity=.TRUE.)
-         CALL copy_fm_to_dbcsr(admm_env%work_aux_aux, matrix_w_s, keep_sparsity=.TRUE.)
-! focc = 2?
-         CALL dbcsr_scale(matrix_w_q, -2.0_dp)
-         CALL dbcsr_scale(matrix_w_s, 2.0_dp)
-         !
-         admm_force = 0.0_dp
-         CALL build_overlap_force(ks_env, admm_force, &
-                                  basis_type_a="AUX_FIT", basis_type_b="AUX_FIT", &
-                                  sab_nl=sab_aux_fit_asymm, matrix_p=matrix_w_s)
-         CALL build_overlap_force(ks_env, admm_force, &
-                                  basis_type_a="AUX_FIT", basis_type_b="ORB", &
-                                  sab_nl=sab_aux_fit_vs_orb, matrix_p=matrix_w_q)
-         ! add forces
-         CALL add_qs_force(admm_force, force, "overlap_admm", atomic_kind_set)
-      END DO
-
-      DEALLOCATE (admm_force)
-      CALL dbcsr_deallocate_matrix(matrix_w_s)
-      CALL dbcsr_deallocate_matrix(matrix_w_q)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE admm_projection_derivative
-
-! **************************************************************************************************
 !> \brief calculate the Kohn-Sham reference potential
 !> \param qs_env ...
 !> \param vh_rspace ...
@@ -2320,7 +2209,7 @@ CONTAINS
                CALL get_qs_env(qs_env, virial=virial)
                virial_xc = virial%pv_xc
             END IF
-            CALL get_qs_env(qs_env, rho_aux_fit=rho)
+            CALL get_admm_env(admm_env, rho_aux_fit=rho)
             xc_section => admm_env%xc_section_aux
             CALL qs_vxc_create(ks_env=ks_env, rho_struct=rho, xc_section=xc_section, &
                                vxc_rho=v_admm_rspace, vxc_tau=v_admm_tau_rspace, exc=eadmm, just_energy=.FALSE.)

--- a/src/rpa_gw_sigma.F
+++ b/src/rpa_gw_sigma.F
@@ -13,7 +13,8 @@
 ! **************************************************************************************************
 MODULE rpa_gw_sigma
    USE admm_methods,                    ONLY: admm_mo_merge_ks_matrix
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE admm_utils,                      ONLY: admm_correct_for_eigenvalues
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm,&
                                               cp_cfm_scale_and_add_fm
@@ -173,14 +174,13 @@ CONTAINS
          CALL get_qs_env(qs_env, &
                          admm_env=admm_env, &
                          matrix_ks=matrix_ks, &
-                         matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                         rho_aux_fit=rho, &
                          input=input, &
                          dft_control=dft_control, &
                          para_env=para_env, &
                          ks_env=ks_env, &
-                         energy=energy, &
-                         matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
+                         energy=energy)
+         CALL get_admm_env(admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit, rho_aux_fit=rho, &
+                           matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
 
          ! RPA/GW with ADMM for EXX or the exchange self-energy only implemented for
          ! ADMM_PURIFICATION_METHOD  NONE

--- a/src/rpa_hfx.F
+++ b/src/rpa_hfx.F
@@ -12,6 +12,8 @@
 !> \author Jan Wilhelm, Frederick Stein
 ! **************************************************************************************************
 MODULE rpa_hfx
+   USE admm_methods,                    ONLY: admm_projection_derivative
+   USE admm_types,                      ONLY: get_admm_env
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type,&
@@ -27,7 +29,6 @@ MODULE rpa_hfx
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
    USE machine,                         ONLY: m_walltime
-   USE qs_2nd_kernel_ao,                ONLY: admm_projection_derivative
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -94,11 +95,10 @@ CONTAINS
                          input=input, &
                          para_env=para_env, &
                          energy=energy, &
-                         rho_aux_fit=rho, &
                          matrix_ks=matrix_ks, &
-                         matrix_ks_aux_fit=matrix_ks_aux_fit, &
                          virial=virial, &
                          dft_control=dft_control)
+         CALL get_admm_env(qs_env%admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit, rho_aux_fit=rho)
 
          IF (.NOT. dft_control%admm_control%aux_exch_func == do_admm_aux_exch_func_none) THEN
             CPWARN("ADMM for RI_RPA%HF ignores the GGA correction (=EXCH_CORRECTION_FUNC NONE)")
@@ -110,7 +110,6 @@ CONTAINS
                          energy=energy, &
                          rho=rho, &
                          matrix_ks=matrix_ks, &
-                         matrix_ks_aux_fit=matrix_ks_aux_fit, &
                          virial=virial, &
                          dft_control=dft_control)
       END IF

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -10,7 +10,9 @@
 !> \author Augustin Bussy
 ! **************************************************************************************************
 MODULE rpa_im_time_force_methods
-   USE admm_types,                      ONLY: admm_type
+   USE admm_methods,                    ONLY: admm_projection_derivative
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE ao_util,                         ONLY: exp_radius_very_extended
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind_set
@@ -115,7 +117,6 @@ MODULE rpa_im_time_force_methods
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type
-   USE qs_2nd_kernel_ao,                ONLY: admm_projection_derivative
    USE qs_collocate_density,            ONLY: calculate_rho_elec,&
                                               calculate_wavefunction
    USE qs_density_matrices,             ONLY: calculate_whz_matrix
@@ -2066,7 +2067,7 @@ CONTAINS
       END DO
 
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, matrix_s_aux_fit=matrix_s_aux)
+         CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux)
          CALL dbcsr_allocate_matrix_set(p_env%p1_admm, nspins)
          CALL dbcsr_allocate_matrix_set(work_admm, nspins)
          DO ispin = 1, nspins
@@ -2209,7 +2210,7 @@ CONTAINS
          CALL dbcsr_copy(dbcsr_work(ispin)%matrix, matrix_ks(ispin)%matrix)
       END DO
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, matrix_s_aux_fit=matrix_s_aux, task_list_aux_fit=task_list_aux_fit)
+         CALL get_admm_env(qs_env%admm_env, matrix_s_aux_fit=matrix_s_aux, task_list_aux_fit=task_list_aux_fit)
          CALL dbcsr_allocate_matrix_set(work_admm, nspins)
          DO ispin = 1, nspins
             ALLOCATE (work_admm(ispin)%matrix)
@@ -2244,7 +2245,8 @@ CONTAINS
       END DO
 
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, rho_aux_fit=rho_aux_fit, admm_env=admm_env)
+         CALL get_qs_env(qs_env, admm_env=admm_env)
+         CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit)
          nao = admm_env%nao_orb
          nao_aux = admm_env%nao_aux_fit
          CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
@@ -2454,8 +2456,9 @@ CONTAINS
 
       !Auxiliary xc kernel (admm)
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, admm_env=admm_env, matrix_s_aux_fit=matrix_s_aux, &
-                         task_list_aux_fit=task_list_aux_fit, rho_aux_fit=rho_aux_fit)
+         CALL get_qs_env(qs_env, admm_env=admm_env)
+         CALL get_admm_env(admm_env, matrix_s_aux_fit=matrix_s_aux, &
+                           task_list_aux_fit=task_list_aux_fit, rho_aux_fit=rho_aux_fit)
 
          CALL qs_rho_get(rho_aux_fit, tau_r_valid=do_tau_admm)
 
@@ -3139,7 +3142,7 @@ CONTAINS
       CALL get_qs_env(qs_env, rho=rho, dft_control=dft_control, matrix_s=matrix_s, admm_env=admm_env, &
                       sab_orb=sab_orb, sac_ppl=sac_ppl, sap_ppnl=sap_ppnl, force=force, virial=virial, &
                       particle_set=particle_set, qs_kind_set=qs_kind_set, atomic_kind_set=atomic_kind_set, &
-                      x_data=x_data, para_env=para_env, matrix_s_aux_fit=matrix_s_aux_fit)
+                      x_data=x_data, para_env=para_env)
       nspins = dft_control%nspins
 
       use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
@@ -3275,7 +3278,8 @@ CONTAINS
 
       !The admm projection contribution (mp2 + SCF densities). If EXX, then only mp2 density
       IF (dft_control%do_admm) THEN
-         CALL get_qs_env(qs_env, task_list_aux_fit=task_list_aux_fit, rho_aux_fit=rho_aux_fit)
+         CALL get_admm_env(admm_env, task_list_aux_fit=task_list_aux_fit, rho_aux_fit=rho_aux_fit, &
+                           matrix_s_aux_fit=matrix_s_aux_fit)
          CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
          CALL dbcsr_allocate_matrix_set(scrm_admm, nspins)
          DO ispin = 1, nspins
@@ -3327,7 +3331,7 @@ CONTAINS
          !In case of EXX, only want to response HFX forces, as the SCF will change according to RI_RPA%HF
          IF (do_exx) THEN
             IF (dft_control%do_admm) THEN
-               CALL get_qs_env(qs_env, rho_aux_fit=rho_aux_fit)
+               CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit)
                CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux, rho_ao_kp=dbcsr_work_p)
                IF (x_data(1, 1)%do_hfx_ri) THEN
 
@@ -3361,7 +3365,7 @@ CONTAINS
 
          ELSE !No Exx
             IF (dft_control%do_admm) THEN
-               CALL get_qs_env(qs_env, rho_aux_fit=rho_aux_fit)
+               CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit)
                CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux, rho_ao_kp=dbcsr_work_p)
                DO ispin = 1, nspins
                   CALL dbcsr_add(rho_ao_aux(ispin)%matrix, matrix_p_mp2_admm(ispin)%matrix, 1.0_dp, 1.0_dp)
@@ -3583,7 +3587,7 @@ CONTAINS
             CALL qs_rho_get(rho_aux_fit, tau_r_valid=do_tau_admm)
 
             IF (.NOT. dft_control%admm_control%aux_exch_func == do_admm_aux_exch_func_none) THEN
-               CALL get_qs_env(qs_env, rho_aux_fit=rho_aux_fit)
+               CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit)
                DO ispin = 1, nspins
                   CALL pw_zero(rhoz_r(ispin)%pw)
                   CALL pw_zero(rhoz_g(ispin)%pw)

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -15,7 +15,6 @@
 !>      03.2019 Refactoring [Frederick Stein]
 ! **************************************************************************************************
 MODULE rpa_main
-   USE admm_types,                      ONLY: admm_env_release
    USE bibliography,                    ONLY: &
         Bates2013, DelBen2013, DelBen2015, Ren2011, Ren2013, Wilhelm2016a, Wilhelm2016b, &
         Wilhelm2017, Wilhelm2018, cite_reference
@@ -788,7 +787,7 @@ CONTAINS
       DEALLOCATE (qs_env%mp2_env%ri_g0w0%matrix_ks(1)%matrix)
       DEALLOCATE (qs_env%mp2_env%ri_g0w0%matrix_ks)
 
-      CALL release_hfx_admm_stuff(qs_env)
+      CALL release_hfx_stuff(qs_env)
 
       CALL timestop(handle)
 
@@ -798,17 +797,14 @@ CONTAINS
 !> \brief releases part of the given qs_env in order to save memory
 !> \param qs_env the object to release
 ! **************************************************************************************************
-   SUBROUTINE release_hfx_admm_stuff(qs_env)
+   SUBROUTINE release_hfx_stuff(qs_env)
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       IF (ASSOCIATED(qs_env%x_data) .AND. .NOT. qs_env%mp2_env%ri_g0w0%do_ri_Sigma_x) THEN
          CALL hfx_release(qs_env%x_data)
       END IF
-      IF (ASSOCIATED(qs_env%admm_env)) THEN
-         CALL admm_env_release(qs_env%admm_env)
-      END IF
 
-   END SUBROUTINE release_hfx_admm_stuff
+   END SUBROUTINE release_hfx_stuff
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/rt_propagation_forces.F
+++ b/src/rt_propagation_forces.F
@@ -11,7 +11,8 @@
 ! **************************************************************************************************
 
 MODULE rt_propagation_forces
-   USE admm_types,                      ONLY: admm_type
+   USE admm_types,                      ONLY: admm_type,&
+                                              get_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind_set
    USE cp_control_types,                ONLY: dft_control_type,&
@@ -344,11 +345,11 @@ CONTAINS
 
       CALL get_qs_env(qs_env, &
                       admm_env=admm_env, &
-                      rtp=rtp, &
-                      matrix_ks_aux_fit=KS_aux_re, &
-                      matrix_ks_aux_fit_im=KS_aux_im, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb)
+                      rtp=rtp)
+      CALL get_admm_env(admm_env, matrix_ks_aux_fit=KS_aux_re, &
+                        matrix_ks_aux_fit_im=KS_aux_im, &
+                        matrix_s_aux_fit=matrix_s_aux_fit, &
+                        matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb)
 
       CALL get_rtp(rtp=rtp, mos_new=mos, admm_mos=mos_admm)
 
@@ -391,10 +392,9 @@ CONTAINS
       NULLIFY (sab_aux_fit_asymm, sab_aux_fit_vs_orb, ks_env)
 !   CALL cp_fm_create(tmp_aux_aux,admm_env%fm_struct_tmp,name="fm matrix")
 
-      CALL get_qs_env(qs_env, &
-                      sab_aux_fit_asymm=sab_aux_fit_asymm, &
-                      sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
-                      ks_env=ks_env)
+      CALL get_qs_env(qs_env, ks_env=ks_env)
+      CALL get_admm_env(admm_env, sab_aux_fit_asymm=sab_aux_fit_asymm, &
+                        sab_aux_fit_vs_orb=sab_aux_fit_vs_orb)
 
       ALLOCATE (matrix_w_s)
       CALL dbcsr_create(matrix_w_s, template=matrix_s_aux_fit(1)%matrix, &

--- a/src/rtp_admm_methods.F
+++ b/src/rtp_admm_methods.F
@@ -14,7 +14,8 @@
 ! **************************************************************************************************
 MODULE rtp_admm_methods
    USE admm_types,                      ONLY: admm_env_create,&
-                                              admm_type
+                                              admm_type,&
+                                              get_admm_env
    USE cp_control_types,                ONLY: admm_control_type,&
                                               dft_control_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
@@ -40,12 +41,13 @@ MODULE rtp_admm_methods
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: one,&
                                               zero
-   USE particle_types,                  ONLY: particle_type
    USE pw_types,                        ONLY: pw_p_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
+   USE qs_kind_types,                   ONLY: get_qs_kind_set,&
+                                              qs_kind_type
    USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_p_type
@@ -107,15 +109,13 @@ CONTAINS
                       ks_env=ks_env, &
                       dft_control=dft_control, &
                       para_env=para_env, &
-                      matrix_s_aux_fit=matrix_s_aux_fit, &
-                      matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, &
                       mos=mos, &
-                      mos_aux_fit=mos_aux_fit, &
                       rtp=rtp, &
                       rho=rho, &
-                      rho_aux_fit=rho_aux_fit, &
-                      s_mstruct_changed=s_mstruct_changed, &
-                      task_list_aux_fit=task_list_aux_fit)
+                      s_mstruct_changed=s_mstruct_changed)
+      CALL get_admm_env(admm_env, matrix_s_aux_fit=matrix_s_aux_fit, task_list_aux_fit=task_list_aux_fit, &
+                        matrix_s_aux_fit_vs_orb=matrix_s_aux_fit_vs_orb, mos_aux_fit=mos_aux_fit, &
+                        rho_aux_fit=rho_aux_fit)
 
       IF (admm_env%do_gapw) THEN
          CPABORT("GAPW ADMM not implemented for real time propagation")
@@ -219,21 +219,20 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rtp_admm_fit_mo_coeffs'
 
-      INTEGER                                            :: handle, natoms
+      INTEGER                                            :: handle, nao_aux_fit, natoms
       LOGICAL                                            :: recalc_S
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(section_vals_type), POINTER                   :: input, xc_section
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (xc_section, particle_set)
+      NULLIFY (xc_section, qs_kind_set)
 
       IF (.NOT. (ASSOCIATED(admm_env))) THEN
          ! setup admm environment
-         CALL get_qs_env(qs_env, input=input, particle_set=particle_set)
-         natoms = SIZE(particle_set, 1)
-         CALL admm_env_create(admm_env, admm_control, mos, mos_aux_fit, &
-                              para_env, natoms)
+         CALL get_qs_env(qs_env, input=input, natom=natoms, qs_kind_set=qs_kind_set)
+         CALL get_qs_kind_set(qs_kind_set, nsgf=nao_aux_fit, basis_type="AUX_FIT")
+         CALL admm_env_create(admm_env, admm_control, mos, para_env, natoms, nao_aux_fit)
          xc_section => section_vals_get_subs_vals(input, "DFT%XC")
          CALL create_admm_xc_section(qs_env=qs_env, xc_section=xc_section, &
                                      admm_env=admm_env)
@@ -295,17 +294,17 @@ CONTAINS
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mos_new
       TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(section_vals_type), POINTER                   :: input, xc_section
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (dft_control, particle_set)
+      NULLIFY (dft_control, qs_kind_set)
 
       IF (.NOT. (ASSOCIATED(admm_env))) THEN
-         CALL get_qs_env(qs_env, input=input, particle_set=particle_set, dft_control=dft_control)
-         natoms = SIZE(particle_set, 1)
-         CALL admm_env_create(admm_env, dft_control%admm_control, mos, mos_aux_fit, para_env, natoms)
+         CALL get_qs_env(qs_env, input=input, natom=natoms, dft_control=dft_control, qs_kind_set=qs_kind_set)
+         CALL get_qs_kind_set(qs_kind_set, nsgf=nao_aux_fit, basis_type="AUX_FIT")
+         CALL admm_env_create(admm_env, dft_control%admm_control, mos, para_env, natoms, nao_aux_fit)
          xc_section => section_vals_get_subs_vals(input, "DFT%XC")
          CALL create_admm_xc_section(qs_env=qs_env, xc_section=xc_section, &
                                      admm_env=admm_env)
@@ -431,17 +430,15 @@ CONTAINS
                                                             matrix_ks_aux_fit_im, matrix_ks_im
       TYPE(dft_control_type), POINTER                    :: dft_control
 
-      NULLIFY (admm_env, dft_control, &
-               matrix_ks, matrix_ks_im, matrix_ks_aux_fit, matrix_ks_aux_fit_im)
+      NULLIFY (admm_env, dft_control, matrix_ks, matrix_ks_im, matrix_ks_aux_fit, matrix_ks_aux_fit_im)
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, &
                       admm_env=admm_env, &
                       dft_control=dft_control, &
                       matrix_ks=matrix_ks, &
-                      matrix_ks_im=matrix_ks_im, &
-                      matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                      matrix_ks_aux_fit_im=matrix_ks_aux_fit_im)
+                      matrix_ks_im=matrix_ks_im)
+      CALL get_admm_env(admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit, matrix_ks_aux_fit_im=matrix_ks_aux_fit_im)
 
       DO ispin = 1, dft_control%nspins
 


### PR DESCRIPTION
This is a low-level refactoring of the ADMM environment. There were many ADMM related quantities (`aux_fit` densities, `aux_fit` KS and overlap matrices, `aux_fit` task lists, `aux_fit` MO coefficients, etc.) scattered across the code. All of these are now gathered together in the `admm_env`, itself part of the `qs_env`.

Moreover, the initialization of these quantities was also generally done all over the code. This is not the case anymore, as all these were moved to the `hfx_admm_init` routine. The same was done for the calculation of other ADMM related quantities, which were moved to new routines in the `admm_methods.F` module (`calc_admm_mo_derivatives`, `calc_admm_ovlp_forces`, `admm_projection_derivative`).

There is no visible change for the users of CP2K. This is solely an effort to improve the code.  