### PR TITLE
RI_HFX| fix RI_FLAVOR test with smearing

### DIFF
--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -1059,7 +1059,7 @@ CONTAINS
                                   orb_basis_type, ri_basis_type, para_env, unit_nr, unit_nr_dbcsr, &
                                   nelectron_total, t_c_filename=t_c_filename)
 
-      IF (dft_control%smear) THEN
+      IF (dft_control%smear .AND. ri_data%flavor == ri_mo) THEN
          CPABORT("RI_FLAVOR MO is not consistent with smearing. Please use RI_FLAVOR RHO.")
       END IF
 


### PR DESCRIPTION
An erroneous test prevented RI_HFX to run with smearing whatever the RI_FLAVOR, whereas it should have allowed it for RI_FLAVOR RHO. 