### PR TITLE
Restore version number for development branch

### DIFF
--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -37,8 +37,7 @@ MODULE cp2k_info
    CHARACTER(LEN=*), PARAMETER :: compile_revision = "unknown"
 #endif
 
-   ! The cp2k_version string should be changed for release branches.
-   CHARACTER(LEN=*), PARAMETER :: cp2k_version = "CP2K development version"
+   CHARACTER(LEN=*), PARAMETER :: cp2k_version = "CP2K version 2022.1 (Development Version)"
    CHARACTER(LEN=*), PARAMETER :: cp2k_year = "2022"
    CHARACTER(LEN=*), PARAMETER :: cp2k_home = "https://www.cp2k.org/"
 


### PR DESCRIPTION
Essentially a rollback of #2188 because tools like AiiDA rely on the version number for dealing with output format changes.

Since we switched the versioning scheme to `<year>.<number>` and most tools assume that the version can be cast to float, there is no good way to assign development versions. Hence, we'll simply show the latest release version with the disclaimer `(Development Version)`.

See also https://github.com/aiidateam/aiida-cp2k/issues/163.