### PR TITLE
Bump COSMA to version 2.6.0

### DIFF
--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -161,6 +161,13 @@ export COSMA_VERSION=${cosma_ver}
 export CP_LIBS="IF_MPI(${COSMA_LIBS}|) \${CP_LIBS}"
 EOF
   cat "${BUILDDIR}/setup_cosma" >> $SETUPFILE
+
+  cat << EOF >> ${INSTALLDIR}/lsan.supp
+# leaks related to COSMA (probably, only the last one is actually needed)
+leak:cosma::communicator::communicator
+leak:cosma::cosma_context<double>::register_state
+leak:cosma::pxgemm<double>
+EOF
 fi
 
 load "${BUILDDIR}/setup_cosma"

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -6,8 +6,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-cosma_ver="2.5.1"
-cosma_sha256="085b7787597374244bbb1eb89bc69bf58c35f6c85be805e881e1c0b25166c3ce"
+cosma_ver="2.6.0"
+cosma_sha256="88405e382b37d247b67403dc3386758b1d2f133a46a902b4be08ffbc43397539"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh


### PR DESCRIPTION
Can one of the admins add the new tarball (https://github.com/eth-cscs/COSMA/releases/download/v2.6.0/COSMA-v2.6.0.tar.gz) ?

Questions/Comments for the GPU-specialists:
1. The new release enables GPU2GPU communication which requires to set a new variable -DCOSMA_WITH_GPU_AWARE_MPI for COSMA. As far as I know, some people are working on this kind of transfers in other parts of the code. Would it be better to have an additional flag for the whole toolchain or for COSMA only? Probably, we cannot hope that all MPI implementations are GPU aware, can we?
2. Related to question 1, COSMA can use the NCCL and RCCL libraries for enhanced communication.
3. There is now support for AMD GPUs.