### PR TITLE
Bump COSMA to version 2.6.1

### DIFF
--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -6,8 +6,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-cosma_ver="2.6.0"
-cosma_sha256="88405e382b37d247b67403dc3386758b1d2f133a46a902b4be08ffbc43397539"
+cosma_ver="2.6.1"
+cosma_sha256="69aa6634a030674f0d9be61e7b0bf0dc17acf0fc9e7a90b40e3179e2254c8d67"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh


### PR DESCRIPTION
Fixes memory reallocation issues of the COSMA library on GPU.

Fixes #2207 