### PR TITLE
automatically extrapolate k-point mesh size for periodic GW calculations

### DIFF
--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -2591,10 +2591,10 @@ CONTAINS
                   "HFX_RI_INFO| Omega:     ", ri_metric%omega
             CASE (do_potential_id)
                WRITE (UNIT=iw, FMT="(T3,A,T73,A)") &
-                  "HFX_RI_INFO| RI metric: ", "IDENTITY"
+                  "HFX_RI_INFO| RI metric: ", "OVERLAP"
             CASE (do_potential_truncated)
                WRITE (UNIT=iw, FMT="(T3,A,T72,A)") &
-                  "HFX_RI_INFO| RI metric: ", "TRUNCATED"
+                  "HFX_RI_INFO| RI metric: ", "TRUNCATED COULOMB"
                rc_ang = cp_unit_from_cp2k(ri_metric%cutoff_radius, "angstrom")
                WRITE (iw, '(T3,A,T61,F20.10)') &
                   "HFX_RI_INFO| Cutoff Radius [angstrom]:     ", rc_ang

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -1210,7 +1210,7 @@ CONTAINS
                        "(3D: alpha = -2 for 3D, 2D: alpha = -1 for exchange self-energy, uniform "// &
                        "weights for correlation self-energy).", &
                        "Choose the same weight for every k-point (original Monkhorst-Pack method)."), &
-         default_i_val=kp_weights_W_auto)
+         default_i_val=kp_weights_W_uniform)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1253,7 +1253,7 @@ CONTAINS
          description="Parameter to reduce the expansion coefficients in RI for periodic GW. Removes all "// &
          "eigenvectors and eigenvalues of S_PQ(k) that are smaller than EPS_EIGVAL_S. ", &
          usage="EPS_EIGVAL_S 1.0E-3", &
-         default_r_val=1.0E-5_dp)
+         default_r_val=0.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1271,21 +1271,33 @@ CONTAINS
 
       CALL keyword_create( &
          keyword, __LOCATION__, &
-         name="TRUNC_COLOUMB_RI_X", &
-         description="If true, use the truncated Coulomb operator for the exchange-self-energy in "// &
-         "periodic GW.", &
-         usage="TRUNCATED_COLOUMB_RI_X", &
-         default_l_val=.FALSE., &
+         name="DO_EXTRAPOLATE_KPOINTS", &
+         description="If true, use a larger k-mesh to extrapolate the k-point integration of W. "// &
+         "For example, in 2D, when using  KPOINTS 4 4 1, an additional 6x6x1 mesh will be used to "// &
+         "extrapolate the k-point integration of W with N_k^-0.5, where Nk is the number of k-points.", &
+         usage="DO_EXTRAPOLATE_KPOINTS FALSE", &
+         default_l_val=.TRUE., &
          lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create( &
          keyword, __LOCATION__, &
-         name="REL_CUTOFF_TRUNC_COLOUMB_RI_X", &
-         description="Only active in case TRUNC_COLOUMB_RI_X = True. Normally, relative cutoff = 0.5 is "// &
+         name="TRUNC_COULOMB_RI_X", &
+         description="If true, use the truncated Coulomb operator for the exchange-self-energy in "// &
+         "periodic GW.", &
+         usage="TRUNC_COULOMB_RI_X", &
+         default_l_val=.TRUE., &
+         lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
+         name="REL_CUTOFF_TRUNC_COULOMB_RI_X", &
+         description="Only active in case TRUNC_COULOMB_RI_X = True. Normally, relative cutoff = 0.5 is "// &
          "good choice; still needs to be evaluated for RI schemes. ", &
-         usage="REL_CUTOFF_TRUNC_COLOUMB_RI_X 0.3", &
+         usage="REL_CUTOFF_TRUNC_COULOMB_RI_X 0.3", &
          default_r_val=0.5_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/kpoint_coulomb_2c.F
+++ b/src/kpoint_coulomb_2c.F
@@ -61,9 +61,11 @@ CONTAINS
 !> \param atomic_kind_set ...
 !> \param size_lattice_sum ...
 !> \param operator_type ...
+!> \param ikp_start ...
+!> \param ikp_end ...
 ! **************************************************************************************************
    SUBROUTINE build_2c_coulomb_matrix_kp(matrix_v_kp, kpoints, basis_type, cell, particle_set, qs_kind_set, &
-                                         atomic_kind_set, size_lattice_sum, operator_type)
+                                         atomic_kind_set, size_lattice_sum, operator_type, ikp_start, ikp_end)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_v_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -72,7 +74,8 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      INTEGER                                            :: size_lattice_sum, operator_type
+      INTEGER                                            :: size_lattice_sum, operator_type, &
+                                                            ikp_start, ikp_end
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_2c_coulomb_matrix_kp'
 
@@ -87,7 +90,7 @@ CONTAINS
 
       CALL lattice_sum(matrix_v_kp, kpoints, basis_type, cell, particle_set, &
                        qs_kind_set, atomic_kind_set, size_lattice_sum, matrix_v_L_tmp, &
-                       operator_type)
+                       operator_type, ikp_start, ikp_end)
 
       CALL deallocate_tmp(matrix_v_L_tmp)
 
@@ -107,10 +110,12 @@ CONTAINS
 !> \param size_lattice_sum ...
 !> \param matrix_v_L_tmp ...
 !> \param operator_type ...
+!> \param ikp_start ...
+!> \param ikp_end ...
 ! **************************************************************************************************
    SUBROUTINE lattice_sum(matrix_v_kp, kpoints, basis_type, cell, particle_set, &
                           qs_kind_set, atomic_kind_set, size_lattice_sum, matrix_v_L_tmp, &
-                          operator_type)
+                          operator_type, ikp_start, ikp_end)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_v_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -121,7 +126,7 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       INTEGER                                            :: size_lattice_sum
       TYPE(dbcsr_type), POINTER                          :: matrix_v_L_tmp
-      INTEGER                                            :: operator_type
+      INTEGER                                            :: operator_type, ikp_start, ikp_end
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'lattice_sum'
 
@@ -221,7 +226,7 @@ CONTAINS
                END DO
 
                ! add exp(iq*vec_L) * (P 0 | Q vec_L) to V_PQ(q)
-               DO ik = 1, nkp
+               DO ik = ikp_start, ikp_end
 
                   ! coskl and sinkl are identical for all i_x_outer, j_y_outer, k_z_outer
                   coskl = COS(twopi*DOT_PRODUCT(vec_s(1:3), kpoints%xkp(1:3, ik)))
@@ -248,7 +253,7 @@ CONTAINS
          END DO
       END DO
 
-      CALL set_blocks_to_matrix_v_kp(matrix_v_kp, blocks_of_v_kp)
+      CALL set_blocks_to_matrix_v_kp(matrix_v_kp, blocks_of_v_kp, ikp_start, ikp_end)
 
       CALL deallocate_blocks_of_v_kp(blocks_of_v_kp)
       CALL deallocate_blocks_of_v_L(blocks_of_v_L)
@@ -262,12 +267,15 @@ CONTAINS
 !> \brief ...
 !> \param matrix_v_kp ...
 !> \param blocks_of_v_kp ...
+!> \param ikp_start ...
+!> \param ikp_end ...
 ! **************************************************************************************************
-   SUBROUTINE set_blocks_to_matrix_v_kp(matrix_v_kp, blocks_of_v_kp)
+   SUBROUTINE set_blocks_to_matrix_v_kp(matrix_v_kp, blocks_of_v_kp, ikp_start, ikp_end)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_v_kp
       TYPE(two_d_util_type), ALLOCATABLE, &
          DIMENSION(:, :, :)                              :: blocks_of_v_kp
+      INTEGER                                            :: ikp_start, ikp_end
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_blocks_to_matrix_v_kp'
 
@@ -277,7 +285,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      DO ik = 1, SIZE(matrix_v_kp, 1)
+      DO ik = ikp_start, ikp_end
 
          DO i_real_im = 1, 2
 

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -373,10 +373,10 @@ CONTAINS
                   "RI_INFO| Omega:     ", ri_metric%omega
             CASE (do_potential_id)
                WRITE (unit_nr, FMT="(T3,A,T73,A)") &
-                  "RI_INFO| RI metric: ", "IDENTITY"
+                  "RI_INFO| RI metric: ", "OVERLAP"
             CASE (do_potential_truncated)
                WRITE (unit_nr, FMT="(T3,A,T72,A)") &
-                  "RI_INFO| RI metric: ", "TRUNCATED"
+                  "RI_INFO| RI metric: ", "TRUNCATED COULOMB"
                rc_ang = cp_unit_from_cp2k(ri_metric%cutoff_radius, "angstrom")
                WRITE (unit_nr, '(T3,A,T61,F20.2)') &
                   "RI_INFO| Cutoff Radius [angstrom]:     ", rc_ang
@@ -1201,9 +1201,11 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'compute_kpoints'
 
-      INTEGER                                            :: handle, i, i_dim, ix, iy, iz, nkp, &
-                                                            num_dim
-      INTEGER, DIMENSION(3)                              :: nkp_grid, periodic
+      INTEGER                                            :: handle, i, i_dim, ix, iy, iz, &
+                                                            n_periodic_dir, nkp, nkp_extra, &
+                                                            nkp_orig
+      INTEGER, DIMENSION(3)                              :: nkp_grid, nkp_grid_extra, periodic
+      LOGICAL                                            :: do_extrapolate_kpoints
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -1224,39 +1226,89 @@ CONTAINS
       kpoints%use_real_wfn = .FALSE.
       kpoints%eps_geo = 1.e-6_dp
       nkp_grid(1:3) = qs_env%mp2_env%ri_rpa_im_time%kp_grid(1:3)
-      num_dim = periodic(1) + periodic(2) + periodic(3)
+      do_extrapolate_kpoints = qs_env%mp2_env%ri_rpa_im_time%do_extrapolate_kpoints
+      n_periodic_dir = periodic(1) + periodic(2) + periodic(3)
 
       DO i_dim = 1, 3
          IF (periodic(i_dim) == 1) THEN
             CPASSERT(MODULO(nkp_grid(i_dim), 2) == 0)
          END IF
+         IF (periodic(i_dim) == 0) THEN
+            CPASSERT(nkp_grid(i_dim) == 1)
+         END IF
       END DO
 
-      IF (num_dim == 3) THEN
-         nkp = nkp_grid(1)*nkp_grid(2)*nkp_grid(3)/2
-      ELSE IF (num_dim == 2) THEN
-         nkp = MAX(nkp_grid(1)*nkp_grid(2)/2, nkp_grid(1)*nkp_grid(3)/2, nkp_grid(2)*nkp_grid(3)/2)
-      ELSE IF (num_dim == 1) THEN
-         nkp = MAX(nkp_grid(1)/2, nkp_grid(2)/2, nkp_grid(3)/2)
+      nkp_orig = nkp_grid(1)*nkp_grid(2)*nkp_grid(3)/2
+
+      IF (do_extrapolate_kpoints) THEN
+
+         CPASSERT(qs_env%mp2_env%ri_rpa_im_time%kpoint_weights_W_method == kp_weights_W_uniform)
+
+         DO i_dim = 1, 3
+            IF (periodic(i_dim) == 1) nkp_grid_extra(i_dim) = nkp_grid(i_dim) + 2
+            IF (periodic(i_dim) == 0) nkp_grid_extra(i_dim) = 1
+         END DO
+
+         qs_env%mp2_env%ri_rpa_im_time%kp_grid_extra(1:3) = nkp_grid_extra(1:3)
+
+         nkp_extra = nkp_grid_extra(1)*nkp_grid_extra(2)*nkp_grid_extra(3)/2
+
+      ELSE
+
+         nkp_grid_extra(1:3) = 0
+         nkp_extra = 0
+
       END IF
+
+      nkp = nkp_orig + nkp_extra
+
+      qs_env%mp2_env%ri_rpa_im_time%nkp_orig = nkp_orig
+      qs_env%mp2_env%ri_rpa_im_time%nkp_extra = nkp_extra
 
       ALLOCATE (kpoints%xkp(3, nkp), kpoints%wkp(nkp))
 
       kpoints%nkp_grid(1:3) = nkp_grid(1:3)
       kpoints%nkp = nkp
-      kpoints%wkp(:) = 1.0_dp/REAL(nkp, KIND=dp)
+
+      ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%wkp_V(nkp))
+      IF (do_extrapolate_kpoints) THEN
+         kpoints%wkp(1:nkp_orig) = 1.0_dp/REAL(nkp_orig, KIND=dp) &
+                                   /(1.0_dp - SQRT(REAL(nkp_extra, KIND=dp)/REAL(nkp_orig, KIND=dp)))
+         kpoints%wkp(nkp_orig + 1:nkp) = 1.0_dp/REAL(nkp_extra, KIND=dp) &
+                                         /(1.0_dp - SQRT(REAL(nkp_orig, KIND=dp)/REAL(nkp_extra, KIND=dp)))
+         qs_env%mp2_env%ri_rpa_im_time%wkp_V(1:nkp_orig) = 0.0_dp
+         qs_env%mp2_env%ri_rpa_im_time%wkp_V(nkp_orig + 1:nkp) = 1.0_dp/REAL(nkp_extra, KIND=dp)
+      ELSE
+         kpoints%wkp(:) = 1.0_dp/REAL(nkp, KIND=dp)
+         qs_env%mp2_env%ri_rpa_im_time%wkp_V(:) = kpoints%wkp(:)
+      END IF
 
       i = 0
       DO ix = 1, nkp_grid(1)
          DO iy = 1, nkp_grid(2)
             DO iz = 1, nkp_grid(3)
 
+               IF (i == nkp_orig) CYCLE
                i = i + 1
-               IF (i > nkp) CYCLE
 
                kpoints%xkp(1, i) = REAL(2*ix - nkp_grid(1) - 1, KIND=dp)/(2._dp*REAL(nkp_grid(1), KIND=dp))
                kpoints%xkp(2, i) = REAL(2*iy - nkp_grid(2) - 1, KIND=dp)/(2._dp*REAL(nkp_grid(2), KIND=dp))
                kpoints%xkp(3, i) = REAL(2*iz - nkp_grid(3) - 1, KIND=dp)/(2._dp*REAL(nkp_grid(3), KIND=dp))
+
+            END DO
+         END DO
+      END DO
+
+      DO ix = 1, nkp_grid_extra(1)
+         DO iy = 1, nkp_grid_extra(2)
+            DO iz = 1, nkp_grid_extra(3)
+
+               i = i + 1
+               IF (i > nkp) CYCLE
+
+               kpoints%xkp(1, i) = REAL(2*ix - nkp_grid_extra(1) - 1, KIND=dp)/(2._dp*REAL(nkp_grid_extra(1), KIND=dp))
+               kpoints%xkp(2, i) = REAL(2*iy - nkp_grid_extra(2) - 1, KIND=dp)/(2._dp*REAL(nkp_grid_extra(2), KIND=dp))
+               kpoints%xkp(3, i) = REAL(2*iz - nkp_grid_extra(3) - 1, KIND=dp)/(2._dp*REAL(nkp_grid_extra(3), KIND=dp))
 
             END DO
          END DO
@@ -1268,8 +1320,15 @@ CONTAINS
 
       IF (unit_nr > 0) THEN
 
-         WRITE (UNIT=unit_nr, FMT="(T3,A,T69,3I4)") "KPOINT_INFO| K-point mesh for V and W:", nkp_grid(1:3)
-         WRITE (UNIT=unit_nr, FMT="(T3,A,T75,I6)") "KPOINT_INFO| Number of kpoints for V and W:", nkp
+         IF (do_extrapolate_kpoints) THEN
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T69,3I4)") "KPOINT_INFO| K-point mesh for V (leading to Sigma^x):", nkp_grid(1:3)
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T69)") "KPOINT_INFO| K-point extrapolation for W^c is used (W^c leads to Sigma^c):"
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T69,3I4)") "KPOINT_INFO| K-point mesh 1 for W^c:", nkp_grid(1:3)
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T69,3I4)") "KPOINT_INFO| K-point mesh 2 for W^c:", nkp_grid_extra(1:3)
+         ELSE
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T69,3I4)") "KPOINT_INFO| K-point mesh for V and W:", nkp_grid(1:3)
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T75,I6)") "KPOINT_INFO| Number of kpoints for V and W:", nkp
+         END IF
 
          SELECT CASE (qs_env%mp2_env%ri_rpa_im_time%kpoint_weights_W_method)
          CASE (kp_weights_W_tailored)

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -426,8 +426,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_V_by_lattice_sum'
 
-      INTEGER                                            :: handle, i_dim, i_real_imag, ikp, nkp
-      INTEGER, DIMENSION(3)                              :: periodic
+      INTEGER                                            :: handle, i_dim, i_real_imag, ikp, nkp, &
+                                                            nkp_extra, nkp_orig
+      INTEGER, DIMENSION(3)                              :: nkp_grid_orig, periodic
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_RI_aux_transl, matrix_v_RI_kp
@@ -465,6 +466,66 @@ CONTAINS
          END DO
       END DO
 
+      CALL allocate_matrix_v_RI_kp(matrix_v_RI_kp, matrix_s_RI_aux_transl, nkp)
+
+      IF (qs_env%mp2_env%ri_rpa_im_time%do_extrapolate_kpoints) THEN
+
+         nkp_orig = qs_env%mp2_env%ri_rpa_im_time%nkp_orig
+         nkp_extra = qs_env%mp2_env%ri_rpa_im_time%nkp_extra
+
+         CALL build_2c_coulomb_matrix_kp(matrix_v_RI_kp, kpoints, basis_type="RI_AUX", &
+                                         cell=cell, particle_set=particle_set, qs_kind_set=qs_kind_set, &
+                                         atomic_kind_set=atomic_kind_set, &
+                                         size_lattice_sum=qs_env%mp2_env%mp2_gpw%size_lattice_sum, &
+                                         operator_type=operator_coulomb, ikp_start=1, ikp_end=nkp_orig)
+
+         nkp_grid_orig = kpoints%nkp_grid
+         kpoints%nkp_grid(1:3) = qs_env%mp2_env%ri_rpa_im_time%kp_grid_extra(1:3)
+
+         CALL build_2c_coulomb_matrix_kp(matrix_v_RI_kp, kpoints, basis_type="RI_AUX", &
+                                         cell=cell, particle_set=particle_set, qs_kind_set=qs_kind_set, &
+                                         atomic_kind_set=atomic_kind_set, &
+                                         size_lattice_sum=qs_env%mp2_env%mp2_gpw%size_lattice_sum, &
+                                         operator_type=operator_coulomb, ikp_start=nkp_orig + 1, ikp_end=nkp)
+
+         kpoints%nkp_grid = nkp_grid_orig
+
+      ELSE
+
+         CALL build_2c_coulomb_matrix_kp(matrix_v_RI_kp, kpoints, basis_type="RI_AUX", &
+                                         cell=cell, particle_set=particle_set, qs_kind_set=qs_kind_set, &
+                                         atomic_kind_set=atomic_kind_set, &
+                                         size_lattice_sum=qs_env%mp2_env%mp2_gpw%size_lattice_sum, &
+                                         operator_type=operator_coulomb, ikp_start=1, ikp_end=nkp)
+
+      END IF
+
+      DO ikp = 1, nkp
+
+         CALL copy_dbcsr_to_fm(matrix_v_RI_kp(ikp, 1)%matrix, fm_matrix_L_kpoints(ikp, 1)%matrix)
+         CALL copy_dbcsr_to_fm(matrix_v_RI_kp(ikp, 2)%matrix, fm_matrix_L_kpoints(ikp, 2)%matrix)
+
+      END DO
+
+      CALL dbcsr_deallocate_matrix_set(matrix_v_RI_kp)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE compute_V_by_lattice_sum
+
+! **************************************************************************************************
+!> \brief ...
+!> \param matrix_v_RI_kp ...
+!> \param matrix_s_RI_aux_transl ...
+!> \param nkp ...
+! **************************************************************************************************
+   SUBROUTINE allocate_matrix_v_RI_kp(matrix_v_RI_kp, matrix_s_RI_aux_transl, nkp)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_v_RI_kp, matrix_s_RI_aux_transl
+      INTEGER                                            :: nkp
+
+      INTEGER                                            :: ikp
+
       NULLIFY (matrix_v_RI_kp)
       CALL dbcsr_allocate_matrix_set(matrix_v_RI_kp, nkp, 2)
 
@@ -484,24 +545,7 @@ CONTAINS
 
       END DO
 
-      CALL build_2c_coulomb_matrix_kp(matrix_v_RI_kp, kpoints, basis_type="RI_AUX", &
-                                      cell=cell, particle_set=particle_set, qs_kind_set=qs_kind_set, &
-                                      atomic_kind_set=atomic_kind_set, &
-                                      size_lattice_sum=qs_env%mp2_env%mp2_gpw%size_lattice_sum, &
-                                      operator_type=operator_coulomb)
-
-      DO ikp = 1, nkp
-
-         CALL copy_dbcsr_to_fm(matrix_v_RI_kp(ikp, 1)%matrix, fm_matrix_L_kpoints(ikp, 1)%matrix)
-         CALL copy_dbcsr_to_fm(matrix_v_RI_kp(ikp, 2)%matrix, fm_matrix_L_kpoints(ikp, 2)%matrix)
-
-      END DO
-
-      CALL dbcsr_deallocate_matrix_set(matrix_v_RI_kp)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE compute_V_by_lattice_sum
+   END SUBROUTINE allocate_matrix_v_RI_kp
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -253,9 +253,11 @@ CONTAINS
                                 r_val=mp2_env%ri_rpa_im_time%eps_eigval_S)
       CALL section_vals_val_get(low_scaling_section, "MAKE_CHI_POS_DEFINITE", &
                                 l_val=mp2_env%ri_rpa_im_time%make_chi_pos_definite)
-      CALL section_vals_val_get(low_scaling_section, "TRUNC_COLOUMB_RI_X", &
+      CALL section_vals_val_get(low_scaling_section, "TRUNC_COULOMB_RI_X", &
                                 l_val=mp2_env%ri_rpa_im_time%trunc_coulomb_ri_x)
-      CALL section_vals_val_get(low_scaling_section, "REL_CUTOFF_TRUNC_COLOUMB_RI_X", &
+      CALL section_vals_val_get(low_scaling_section, "DO_EXTRAPOLATE_KPOINTS", &
+                                l_val=mp2_env%ri_rpa_im_time%do_extrapolate_kpoints)
+      CALL section_vals_val_get(low_scaling_section, "REL_CUTOFF_TRUNC_COULOMB_RI_X", &
                                 r_val=mp2_env%ri_rpa_im_time%rel_cutoff_trunc_coulomb_ri_x)
       CALL section_vals_val_get(low_scaling_section, "K_MESH_G_FACTOR", &
                                 i_val=mp2_env%ri_rpa_im_time%k_mesh_g_factor)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -146,18 +146,19 @@ MODULE mp2_types
    TYPE ri_rpa_im_time_type
       INTEGER                  :: cut_memory
       LOGICAL                  :: memory_info, make_chi_pos_definite, trunc_coulomb_ri_x, keep_quad, &
-                                  do_kpoints_from_Gamma
+                                  do_kpoints_from_Gamma, do_extrapolate_kpoints
       REAL(KIND=dp)            :: eps_filter, &
                                   eps_filter_factor, eps_compress, exp_tailored_weights, regularization_RI, &
                                   eps_eigval_S, rel_cutoff_trunc_coulomb_ri_x
       REAL(KIND=dp), DIMENSION(:), POINTER :: rel_cutoffs_chi_W, tau_tj, tau_wj, tj, wj
       REAL(KIND=dp), DIMENSION(:, :), POINTER :: weights_cos_tf_t_to_w, weights_cos_tf_w_to_t
       REAL(KIND=dp), DIMENSION(2) :: abs_cutoffs_chi_W
-      REAL(KIND=dp), DIMENSION(:), ALLOCATABLE :: Eigenval_Gamma
+      REAL(KIND=dp), DIMENSION(:), ALLOCATABLE :: Eigenval_Gamma, wkp_V
       INTEGER                  :: group_size_P, group_size_3c, kpoint_weights_W_method, k_mesh_g_factor
       INTEGER, DIMENSION(:), POINTER     :: kp_grid
+      INTEGER, DIMENSION(3) ::  kp_grid_extra
       LOGICAL                  :: do_im_time_kpoints
-      INTEGER                  :: min_bsize, min_bsize_mo, periodic_gf
+      INTEGER                  :: min_bsize, min_bsize_mo, periodic_gf, nkp_orig, nkp_extra
       TYPE(kpoint_type), POINTER :: kpoints_G, kpoints_Sigma, kpoints_Sigma_no_xc
       INTEGER, ALLOCATABLE, DIMENSION(:)      :: starts_array_mc_RI, ends_array_mc_RI, &
                                                  starts_array_mc_block_RI, &

--- a/src/rpa_gw_kpoints.F
+++ b/src/rpa_gw_kpoints.F
@@ -536,116 +536,116 @@ CONTAINS
       ! by SUM(periodic) == 3
       ALLOCATE (wkp_V(nkp), wkp_W(nkp))
 
+      ! for exchange part of self-energy, we use truncated Coulomb operator that should be fine
+      ! with uniform weights (without k-point extrapolation)
+      IF (ALLOCATED(qs_env%mp2_env%ri_rpa_im_time%wkp_V)) THEN
+         wkp_V(:) = qs_env%mp2_env%ri_rpa_im_time%wkp_V(:)
+      ELSE
+         wkp_V(:) = wkp(:)
+      END IF
+
       IF (kpoint_weights_W_method == kp_weights_W_uniform) THEN
 
-         wkp_V(:) = wkp(:)
+         !  in the k-point weights wkp, there might be k-point extrapolation included
          wkp_W(:) = wkp(:)
 
       ELSE IF (kpoint_weights_W_method == kp_weights_W_tailored .OR. &
                kpoint_weights_W_method == kp_weights_W_auto) THEN
 
-         IF (SUM(periodic) == 1 .OR. SUM(periodic) == 2) THEN
+         IF (kpoint_weights_W_method == kp_weights_W_tailored) &
+            exp_kpoints = qs_env%mp2_env%ri_rpa_im_time%exp_tailored_weights
 
-            wkp_V(:) = wkp(:)
-            wkp_W(:) = wkp(:)
+         IF (kpoint_weights_W_method == kp_weights_W_auto) THEN
+            IF (SUM(periodic) == 2) exp_kpoints = -1.0_dp
+         END IF
 
-         ELSE IF (SUM(periodic) == 3) THEN
+         ! first, compute the integral of f(k)=1/k^2 and 1/k on super fine grid
+         nsuperfine = 500
+         integral = 0.0_dp
 
-            IF (kpoint_weights_W_method == kp_weights_W_tailored) &
-               exp_kpoints = qs_env%mp2_env%ri_rpa_im_time%exp_tailored_weights
-            IF (kpoint_weights_W_method == kp_weights_W_auto) exp_kpoints = -2.0_dp
+         IF (periodic(1) == 1) THEN
+            n_x = nsuperfine
+         ELSE
+            n_x = 1
+         END IF
+         IF (periodic(2) == 1) THEN
+            n_y = nsuperfine
+         ELSE
+            n_y = 1
+         END IF
+         IF (periodic(3) == 1) THEN
+            n_z = nsuperfine
+         ELSE
+            n_z = 1
+         END IF
 
-            ! first, compute the integral of f(k)=1/k^2 and 1/k on super fine grid
-            nsuperfine = 500
-            integral = 0.0_dp
+         ! actually, there is the factor *det_3x3(h_inv) missing to account for the
+         ! integration volume but for wkp det_3x3(h_inv) is needed
+         weight = 1.0_dp/(REAL(n_x, dp)*REAL(n_y, dp)*REAL(n_z, dp))
+         DO i_x = 1, n_x
+            DO j_y = 1, n_y
+               DO k_z = 1, n_z
 
-            IF (periodic(1) == 1) THEN
-               n_x = nsuperfine
-            ELSE
-               n_x = 1
-            END IF
-            IF (periodic(2) == 1) THEN
-               n_y = nsuperfine
-            ELSE
-               n_y = 1
-            END IF
-            IF (periodic(3) == 1) THEN
-               n_z = nsuperfine
-            ELSE
-               n_z = 1
-            END IF
+                  IF (periodic(1) == 1) THEN
+                     x_vec(1) = (REAL(i_x - nsuperfine/2, dp) - 0.5_dp)/REAL(nsuperfine, dp)
+                  ELSE
+                     x_vec(1) = 0.0_dp
+                  END IF
+                  IF (periodic(2) == 1) THEN
+                     x_vec(2) = (REAL(j_y - nsuperfine/2, dp) - 0.5_dp)/REAL(nsuperfine, dp)
+                  ELSE
+                     x_vec(2) = 0.0_dp
+                  END IF
+                  IF (periodic(3) == 1) THEN
+                     x_vec(3) = (REAL(k_z - nsuperfine/2, dp) - 0.5_dp)/REAL(nsuperfine, dp)
+                  ELSE
+                     x_vec(3) = 0.0_dp
+                  END IF
 
-            ! actually, there is the factor *det_3x3(h_inv) missing to account for the
-            ! integration volume but for wkp det_3x3(h_inv) is needed
-            weight = 1.0_dp/(REAL(n_x, dp)*REAL(n_y, dp)*REAL(n_z, dp))
-            DO i_x = 1, n_x
-               DO j_y = 1, n_y
-                  DO k_z = 1, n_z
+                  k_vec = MATMUL(h_inv(1:3, 1:3), x_vec)
+                  k_sq = k_vec(1)**2 + k_vec(2)**2 + k_vec(3)**2
+                  integral = integral + weight*k_sq**(exp_kpoints*0.5_dp)
 
-                     IF (periodic(1) == 1) THEN
-                        x_vec(1) = (REAL(i_x - nsuperfine/2, dp) - 0.5_dp)/REAL(nsuperfine, dp)
-                     ELSE
-                        x_vec(1) = 0.0_dp
-                     END IF
-                     IF (periodic(2) == 1) THEN
-                        x_vec(2) = (REAL(j_y - nsuperfine/2, dp) - 0.5_dp)/REAL(nsuperfine, dp)
-                     ELSE
-                        x_vec(2) = 0.0_dp
-                     END IF
-                     IF (periodic(3) == 1) THEN
-                        x_vec(3) = (REAL(k_z - nsuperfine/2, dp) - 0.5_dp)/REAL(nsuperfine, dp)
-                     ELSE
-                        x_vec(3) = 0.0_dp
-                     END IF
-
-                     k_vec = MATMUL(h_inv(1:3, 1:3), x_vec)
-                     k_sq = k_vec(1)**2 + k_vec(2)**2 + k_vec(3)**2
-                     integral = integral + weight*k_sq**(exp_kpoints*0.5_dp)
-
-                  END DO
                END DO
             END DO
+         END DO
 
-            num_lin_eqs = nkp + 2
+         num_lin_eqs = nkp + 2
 
-            ALLOCATE (matrix_lin_eqs(num_lin_eqs, num_lin_eqs))
-            matrix_lin_eqs(:, :) = 0.0_dp
+         ALLOCATE (matrix_lin_eqs(num_lin_eqs, num_lin_eqs))
+         matrix_lin_eqs(:, :) = 0.0_dp
 
-            DO ikp = 1, nkp
+         DO ikp = 1, nkp
 
-               k_vec = MATMUL(h_inv(1:3, 1:3), xkp(1:3, ikp))
-               k_sq = k_vec(1)**2 + k_vec(2)**2 + k_vec(3)**2
+            k_vec = MATMUL(h_inv(1:3, 1:3), xkp(1:3, ikp))
+            k_sq = k_vec(1)**2 + k_vec(2)**2 + k_vec(3)**2
 
-               matrix_lin_eqs(ikp, ikp) = 2.0_dp
-               matrix_lin_eqs(ikp, nkp + 1) = 1.0_dp
-               matrix_lin_eqs(nkp + 1, ikp) = 1.0_dp
+            matrix_lin_eqs(ikp, ikp) = 2.0_dp
+            matrix_lin_eqs(ikp, nkp + 1) = 1.0_dp
+            matrix_lin_eqs(nkp + 1, ikp) = 1.0_dp
 
-               matrix_lin_eqs(ikp, nkp + 2) = k_sq**(exp_kpoints*0.5_dp)
-               matrix_lin_eqs(nkp + 2, ikp) = k_sq**(exp_kpoints*0.5_dp)
+            matrix_lin_eqs(ikp, nkp + 2) = k_sq**(exp_kpoints*0.5_dp)
+            matrix_lin_eqs(nkp + 2, ikp) = k_sq**(exp_kpoints*0.5_dp)
 
-            END DO
+         END DO
 
-            CALL invmat(matrix_lin_eqs, info)
-            ! check whether inversion was successful
-            CPASSERT(info == 0)
+         CALL invmat(matrix_lin_eqs, info)
+         ! check whether inversion was successful
+         CPASSERT(info == 0)
 
-            ALLOCATE (right_side(num_lin_eqs))
-            right_side = 0.0_dp
-            right_side(nkp + 1) = 1.0_dp
-            ! divide integral by two because CP2K k-mesh already considers symmetry k <-> -k
-            right_side(nkp + 2) = integral
+         ALLOCATE (right_side(num_lin_eqs))
+         right_side = 0.0_dp
+         right_side(nkp + 1) = 1.0_dp
+         ! divide integral by two because CP2K k-mesh already considers symmetry k <-> -k
+         right_side(nkp + 2) = integral
 
-            ALLOCATE (wkp_tmp(num_lin_eqs))
+         ALLOCATE (wkp_tmp(num_lin_eqs))
 
-            wkp_tmp(1:num_lin_eqs) = MATMUL(matrix_lin_eqs, right_side)
+         wkp_tmp(1:num_lin_eqs) = MATMUL(matrix_lin_eqs, right_side)
 
-            wkp_V(1:nkp) = wkp_tmp(1:nkp)
+         wkp_W(1:nkp) = wkp_tmp(1:nkp)
 
-            DEALLOCATE (matrix_lin_eqs, right_side, wkp_tmp)
-
-            wkp_W(:) = wkp_V(:)
-
-         END IF
+         DEALLOCATE (matrix_lin_eqs, right_side, wkp_tmp)
 
       END IF
 

--- a/tests/QS/regtest-gw-kpoints/TEST_FILES
+++ b/tests/QS/regtest-gw-kpoints/TEST_FILES
@@ -1,7 +1,7 @@
-G0W0_kpoints_from_Gamma.inp                                       78      1e-05       14.753
-G0W0_kpoints_from_Gamma_RI_regularization_1E-3.inp                78      1e-05       14.682
-G0W0_kpoints_in_self_energy.inp                                   98      1e-05       12.090
-G0W0_kpoints_in_self_energy_at_HSE06.inp                          98      1e-05       12.569
-G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX.inp       98      1e-05       15.438
-G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX_ADMM.inp  98      1e-05       15.515
+G0W0_kpoints_from_Gamma.inp                                       78      1e-05       15.316
+G0W0_kpoints_from_Gamma_RI_regularization_1E-3.inp                78      1e-05       15.231
+G0W0_kpoints_in_self_energy.inp                                   98      1e-05       12.586
+G0W0_kpoints_in_self_energy_at_HSE06.inp                          98      1e-05       13.097
+G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX.inp       98      1e-05       15.414
+G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX_ADMM.inp  98      1e-05       15.491
 #EOF

--- a/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O.inp
+++ b/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O.inp
@@ -32,7 +32,7 @@
       ADDED_MOS 10000000
     &END SCF
     &KPOINTS
-       SCHEME  MONKHORST-PACK 4 4 4
+       SCHEME  MONKHORST-PACK 1 1 4
        SYMMETRY ON
        EPS_GEO 1.e-8
        FULL_GRID ON
@@ -62,9 +62,10 @@
   &END DFT
   &SUBSYS
     &CELL
-      ABC [angstrom]  10.000   10.000  10.000
+      ! warning: cell very small
+      ABC [angstrom]  5.000   5.000  10.000
       MULTIPLE_UNIT_CELL  1 1 1
-      PERIODIC XYZ
+      PERIODIC Z
     &END CELL
     &KIND H
       BASIS_SET ORB        DZVP-GTH

--- a/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O.inp
+++ b/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O.inp
@@ -52,6 +52,7 @@
           MEMORY_CUT 1
           !MEMORY_INFO
           DO_KPOINTS
+          DO_EXTRAPOLATE_KPOINTS FALSE
         &END LOW_SCALING
         &RI_RPA
           RPA_NUM_QUAD_POINTS  6

--- a/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O_batched.inp
+++ b/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O_batched.inp
@@ -32,7 +32,7 @@
       ADDED_MOS 10000000
     &END SCF
     &KPOINTS
-       SCHEME  MONKHORST-PACK 4 4 4
+       SCHEME  MONKHORST-PACK 1 1 4
        SYMMETRY ON
        EPS_GEO 1.e-8
        FULL_GRID ON
@@ -62,9 +62,10 @@
   &END DFT
   &SUBSYS
     &CELL
-      ABC [angstrom]  10.000   10.000  10.000
+      ! cell very small in x and y direction
+      ABC [angstrom]  5.000   5.000  10.000
       MULTIPLE_UNIT_CELL  1 1 1
-      PERIODIC XYZ
+      PERIODIC Z
     &END CELL
     &KIND H
       BASIS_SET ORB        DZVP-GTH

--- a/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O_batched.inp
+++ b/tests/QS/regtest-rpa-cubic-scaling/RPA_kpoints_H2O_batched.inp
@@ -51,6 +51,7 @@
         &LOW_SCALING
           !MEMORY_INFO
           DO_KPOINTS
+          DO_EXTRAPOLATE_KPOINTS FALSE
           MEMORY_CUT 2
         &END LOW_SCALING
         &RI_RPA

--- a/tests/QS/regtest-rpa-cubic-scaling/TEST_FILES
+++ b/tests/QS/regtest-rpa-cubic-scaling/TEST_FILES
@@ -3,8 +3,8 @@ Cubic_RPA_H2O_check_filtering.inp                     11      1e-08            -
 Cubic_RPA_2x_H2_check_filtering.inp                   11      1e-08             -2.119159936957426
 Cubic_RPA_CH3.inp                                     11      3e-07             -7.414901056476346
 Cubic_RPA_H2O_standard_svd.inp                        11      1e-08            -17.160104846594532
-RPA_kpoints_H2O.inp                                   11      1e-08            -17.384612021546573
-RPA_kpoints_H2O_batched.inp                           11      1e-08            -17.384612040108440
+RPA_kpoints_H2O.inp                                   11      1e-08            -17.383888363367134
+RPA_kpoints_H2O_batched.inp                           11      1e-08            -17.383888384535968
 Cubic_RPA_H2O_admm.inp                                11      1e-08            -17.147065793237985
 Cubic_RPA_CH3_ri-hfx.inp                              11      1e-08             -7.414775787676669
 Cubic_RPA_H2O_ri-hfx.inp                              11      1e-08            -17.159865017693086


### PR DESCRIPTION
k-point mesh extrapolation for k-point integration of W(k). Bandgap of MoS2 monolayer converges now with the cell size, see figure below. 

Open issue: GW bandgap is not yet converged with RI basis set size. 

Possible solution: Use truncated Coulomb metric (tCm); probably tCm needs removal of G=0 component of RI s-functions. 

![image](https://user-images.githubusercontent.com/9572864/182249236-94db6754-bda6-43e9-94dc-055adb4bf0c1.png)
