### PR TITLE
Specialize calculate_wavefunction to a single gaussian

### DIFF
--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -54,7 +54,8 @@ MODULE mp2_eri_gpw
                                               pw_p_type,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec,&
-                                              calculate_wavefunction
+                                              calculate_wavefunction,&
+                                              collocate_single_gaussian
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_force_types,                  ONLY: qs_force_type
@@ -65,7 +66,8 @@ MODULE mp2_eri_gpw
                                               qs_kind_type
    USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
-   USE realspace_grid_types,            ONLY: realspace_grid_desc_p_type,&
+   USE realspace_grid_types,            ONLY: map_gaussian_here,&
+                                              realspace_grid_desc_p_type,&
                                               realspace_grid_p_type,&
                                               rs_grid_release,&
                                               rs_grid_retain
@@ -161,8 +163,6 @@ CONTAINS
 !> \brief Integrates the potential of an RI function
 !> \param qs_env ...
 !> \param para_env_sub ...
-!> \param dimen_RI ...
-!> \param mo_coeff ...
 !> \param my_group_L_start ...
 !> \param my_group_L_end ...
 !> \param natom ...
@@ -171,13 +171,11 @@ CONTAINS
 !> \param L_local_col ...
 !> \param kind_of ...
 ! **************************************************************************************************
-   SUBROUTINE mp2_eri_2c_integrate_gpw(qs_env, para_env_sub, dimen_RI, mo_coeff, my_group_L_start, my_group_L_end, &
+   SUBROUTINE mp2_eri_2c_integrate_gpw(qs_env, para_env_sub, my_group_L_start, my_group_L_end, &
                                        natom, potential_parameter, sab_orb_sub, L_local_col, kind_of)
 
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_sub
-      INTEGER, INTENT(IN)                                :: dimen_RI
-      TYPE(cp_fm_type), INTENT(IN), POINTER              :: mo_coeff
       INTEGER, INTENT(IN)                                :: my_group_L_start, my_group_L_end, natom
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
@@ -194,7 +192,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
       LOGICAL                                            :: map_it_here, use_subpatch
       REAL(KIND=dp)                                      :: cutoff_old, radius, relative_cutoff_old
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: e_cutoff_old, wf_vector
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: e_cutoff_old
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: I_ab
       REAL(KIND=dp), DIMENSION(3)                        :: ra
       REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a
@@ -219,8 +217,6 @@ CONTAINS
       CALL prepare_gpw(qs_env, dft_control, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
                        auxbas_pw_pool, poisson_env, task_list_sub, rho_r, rho_g, pot_g, psi_L, sab_orb_sub)
 
-      ALLOCATE (wf_vector(dimen_RI))
-
       CALL get_qs_env(qs_env, cell=cell, qs_kind_set=qs_kind_set, atomic_kind_set=atomic_kind_set, particle_set=particle_set)
 
       L_local_col = 0.0_dp
@@ -229,14 +225,10 @@ CONTAINS
       DO LLL = my_group_L_start, my_group_L_end
          i_counter = i_counter + 1
 
-         wf_vector = 0.0_dp
-         wf_vector(LLL) = 1.0_dp
-
          ! pseudo psi_L
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
-                                     qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
-                                     basis_type="RI_AUX", &
-                                     external_vector=wf_vector)
+         CALL collocate_single_gaussian(psi_L, rho_g, atomic_kind_set, &
+                                        qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
+                                        required_function=LLL, basis_type="RI_AUX")
 
          CALL timeset(routineN//"_pot_lm", handle2)
 
@@ -307,35 +299,10 @@ CONTAINS
                offset = offset_2d(iset, iatom)
 
                igrid_level = gaussian_gridlevel(pw_env_sub%gridlevel_info, MINVAL(zeta(:, iset)))
-               map_it_here = .FALSE.
-               use_subpatch = .FALSE.
-               IF (.NOT. ALL(rs_v(igrid_level)%rs_grid%desc%perd == 1)) THEN
-                  DO dir = 1, 3
-                     ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                     tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_v(igrid_level)%rs_grid%desc%npts(dir))
-                     tp(dir) = MODULO(tp(dir), rs_v(igrid_level)%rs_grid%desc%npts(dir))
-                     IF (rs_v(igrid_level)%rs_grid%desc%perd(dir) .NE. 1) THEN
-                        lb(dir) = rs_v(igrid_level)%rs_grid%lb_local(dir) + rs_v(igrid_level)%rs_grid%desc%border
-                        ub(dir) = rs_v(igrid_level)%rs_grid%ub_local(dir) - rs_v(igrid_level)%rs_grid%desc%border
-                     ELSE
-                        lb(dir) = rs_v(igrid_level)%rs_grid%lb_local(dir)
-                        ub(dir) = rs_v(igrid_level)%rs_grid%ub_local(dir)
-                     END IF
-                     ! distributed grid, only map if it is local to the grid
-                     location(dir) = tp(dir) + rs_v(igrid_level)%rs_grid%desc%lb(dir)
-                  END DO
-                  IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                      lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                      lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                     map_it_here = .TRUE.
-                  END IF
-                  use_subpatch = .TRUE.
-               ELSE
-                  ! not distributed, just a round-robin distribution over the full set of CPUs
-                  IF (MODULO(offset, para_env_sub%num_pe) == para_env_sub%mepos) map_it_here = .TRUE.
-               END IF
+               use_subpatch = .NOT. ALL(rs_v(igrid_level)%rs_grid%desc%perd == 1)
 
-               IF (map_it_here) THEN
+               IF (map_gaussian_here(rs_v(igrid_level)%rs_grid, cell%h_inv, ra, &
+                                     offset, para_env_sub%num_pe, para_env_sub%mepos)) THEN
                   DO ipgf = 1, npgfa(iset)
                      sgfa = first_sgfa(1, iset)
                      na1 = (ipgf - 1)*ncoset(la_max(iset)) + 1
@@ -349,8 +316,8 @@ CONTAINS
                                                        prefactor=1.0_dp, cutoff=1.0_dp)
 
                      CALL integrate_pgf_product( &
-                        la_max=la_max(iset), zeta=zeta(ipgf, iset)/2.0_dp, la_min=la_min(iset), &
-                        lb_max=0, zetb=zeta(ipgf, iset)/2.0_dp, lb_min=0, &
+                        la_max=la_max(iset), zeta=zeta(ipgf, iset), la_min=la_min(iset), &
+                        lb_max=0, zetb=0.0_dp, lb_min=0, &
                         ra=ra, rab=(/0.0_dp, 0.0_dp, 0.0_dp/), &
                         rsgrid=rs_v(igrid_level)%rs_grid, &
                         hab=I_tmp2, &
@@ -384,8 +351,6 @@ CONTAINS
 
       END DO
 
-      DEALLOCATE (wf_vector)
-
       CALL mp_sum(L_local_col, para_env_sub%group)
 
       CALL cleanup_gpw(qs_env, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
@@ -398,7 +363,7 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief Integrates the potential of a RI function obtaining the forces and stress tensor
 !> \param rho_r ...
-!> \param wf_vector ...
+!> \param LLL ...
 !> \param matrix ...
 !> \param rho_g ...
 !> \param atomic_kind_set ...
@@ -421,14 +386,14 @@ CONTAINS
 !> \param dft_control ...
 !> \param psi_L ...
 ! **************************************************************************************************
-   SUBROUTINE integrate_potential_forces_2c(rho_r, wf_vector, matrix, rho_g, atomic_kind_set, &
+   SUBROUTINE integrate_potential_forces_2c(rho_r, LLL, matrix, rho_g, atomic_kind_set, &
                                             qs_kind_set, particle_set, cell, pw_env_sub, poisson_env, pot_g, &
                                             potential_parameter, use_virial, rho_g_copy, dvg, &
                                             kind_of, atom_of_kind, G_PQ_local, force, h_stress, para_env_sub, &
                                             dft_control, psi_L)
 
       TYPE(pw_p_type), INTENT(INOUT)                     :: rho_r
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wf_vector
+      INTEGER, INTENT(IN)                                :: LLL
       TYPE(cp_fm_type), INTENT(IN), POINTER              :: matrix
       TYPE(pw_p_type), INTENT(INOUT)                     :: rho_g
       TYPE(atomic_kind_type), DIMENSION(:), INTENT(IN), &
@@ -464,10 +429,9 @@ CONTAINS
       ! pseudo psi_L
       CALL pw_zero(rho_r%pw)
       CALL pw_zero(rho_g%pw)
-      CALL calculate_wavefunction(matrix, 1, rho_r, rho_g, atomic_kind_set, &
-                                  qs_kind_set, cell, dft_control, particle_set, &
-                                  pw_env_sub, basis_type='RI_AUX', &
-                                  external_vector=wf_vector)
+      CALL collocate_single_gaussian(rho_r, rho_g, atomic_kind_set, &
+                                     qs_kind_set, cell, dft_control, particle_set, &
+                                     pw_env_sub, required_function=LLL, basis_type='RI_AUX')
       IF (use_virial) THEN
          CALL calc_potential_gpw(rho_r, rho_g, poisson_env, pot_g, potential_parameter, dvg)
       ELSE
@@ -597,8 +561,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'integrate_potential_forces_3c_2c'
 
-      INTEGER :: atom_a, dir, handle, handle2, i, iatom, igrid_level, ikind, iorb, ipgf, iset, &
-         lb(3), location(3), na1, na2, ncoa, nseta, offset, sgfa, tp(3), ub(3)
+      INTEGER                                            :: atom_a, handle, handle2, i, iatom, &
+                                                            igrid_level, ikind, iorb, ipgf, iset, &
+                                                            na1, na2, ncoa, nseta, offset, sgfa
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nsgfa
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
       LOGICAL                                            :: map_it_here, skip_shell, use_subpatch
@@ -703,37 +668,9 @@ CONTAINS
 
             igrid_level = gaussian_gridlevel(pw_env_sub%gridlevel_info, MINVAL(zeta(:, iset)))
             map_it_here = .FALSE.
-            use_subpatch = .FALSE.
+            use_subpatch = .NOT. ALL(rs_v(igrid_level)%rs_grid%desc%perd == 1)
 
-            IF (.NOT. ALL(rs_v(igrid_level)%rs_grid%desc%perd == 1)) THEN
-               DO dir = 1, 3
-                  ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                  tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_v(igrid_level)%rs_grid%desc%npts(dir))
-                  tp(dir) = MODULO(tp(dir), rs_v(igrid_level)%rs_grid%desc%npts(dir))
-                  IF (rs_v(igrid_level)%rs_grid%desc%perd(dir) .NE. 1) THEN
-                     lb(dir) = rs_v(igrid_level)%rs_grid%lb_local(dir) + rs_v(igrid_level)%rs_grid%desc%border
-                     ub(dir) = rs_v(igrid_level)%rs_grid%ub_local(dir) - rs_v(igrid_level)%rs_grid%desc%border
-                  ELSE
-                     lb(dir) = rs_v(igrid_level)%rs_grid%lb_local(dir)
-                     ub(dir) = rs_v(igrid_level)%rs_grid%ub_local(dir)
-                  END IF
-                  ! distributed grid, only map if it is local to the grid
-                  location(dir) = tp(dir) + rs_v(igrid_level)%rs_grid%desc%lb(dir)
-               END DO
-               IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                   lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                   lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                  map_it_here = .TRUE.
-               END IF
-               use_subpatch = .TRUE.
-            ELSE
-               ! not distributed, just a round-robin distribution over the full set of CPUs
-               IF (MODULO(offset, para_env_sub%num_pe) == para_env_sub%mepos) map_it_here = .TRUE.
-            END IF
-
-            offset = offset + nsgfa(iset)
-
-            IF (map_it_here) THEN
+            IF (map_gaussian_here(rs_v(igrid_level)%rs_grid, cell%h_inv, ra, offset, para_env_sub%num_pe, para_env_sub%mepos)) THEN
                DO ipgf = 1, npgfa(iset)
                   na1 = (ipgf - 1)*ncoset(la_max(iset)) + 1
                   na2 = ipgf*ncoset(la_max(iset))
@@ -766,6 +703,8 @@ CONTAINS
 
             DEALLOCATE (I_tmp2)
             DEALLOCATE (pab)
+
+            offset = offset + nsgfa(iset)
 
          END DO
 
@@ -932,13 +871,12 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'integrate_potential'
 
-      INTEGER                                            :: atom_a, dir, handle, i, iatom, &
-                                                            igrid_level, ikind, ipgf, iset, lb(3), &
-                                                            location(3), na1, na2, ncoa, nseta, &
-                                                            offset, sgfa, tp(3), ub(3)
+      INTEGER                                            :: atom_a, handle, i, iatom, igrid_level, &
+                                                            ikind, ipgf, iset, na1, na2, ncoa, &
+                                                            nseta, offset, sgfa
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nsgfa
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
-      LOGICAL                                            :: map_it_here, use_subpatch
+      LOGICAL                                            :: use_subpatch
       REAL(KIND=dp)                                      :: radius
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: I_ab
       REAL(KIND=dp), DIMENSION(3)                        :: force_a, force_b, ra
@@ -1008,37 +946,9 @@ CONTAINS
             I_ab = 0.0_dp
 
             igrid_level = gaussian_gridlevel(pw_env_sub%gridlevel_info, MINVAL(zeta(:, iset)))
-            map_it_here = .FALSE.
-            use_subpatch = .FALSE.
-            IF (.NOT. ALL(rs_v(igrid_level)%rs_grid%desc%perd == 1)) THEN
-               DO dir = 1, 3
-                  ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                  tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_v(igrid_level)%rs_grid%desc%npts(dir))
-                  tp(dir) = MODULO(tp(dir), rs_v(igrid_level)%rs_grid%desc%npts(dir))
-                  IF (rs_v(igrid_level)%rs_grid%desc%perd(dir) .NE. 1) THEN
-                     lb(dir) = rs_v(igrid_level)%rs_grid%lb_local(dir) + rs_v(igrid_level)%rs_grid%desc%border
-                     ub(dir) = rs_v(igrid_level)%rs_grid%ub_local(dir) - rs_v(igrid_level)%rs_grid%desc%border
-                  ELSE
-                     lb(dir) = rs_v(igrid_level)%rs_grid%lb_local(dir)
-                     ub(dir) = rs_v(igrid_level)%rs_grid%ub_local(dir)
-                  END IF
-                  ! distributed grid, only map if it is local to the grid
-                  location(dir) = tp(dir) + rs_v(igrid_level)%rs_grid%desc%lb(dir)
-               END DO
-               IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                   lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                   lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                  map_it_here = .TRUE.
-               END IF
-               use_subpatch = .TRUE.
-            ELSE
-               ! not distributed, just a round-robin distribution over the full set of CPUs
-               IF (MODULO(offset, para_env_sub%num_pe) == para_env_sub%mepos) map_it_here = .TRUE.
-            END IF
+            use_subpatch = .NOT. ALL(rs_v(igrid_level)%rs_grid%desc%perd == 1)
 
-            offset = offset + nsgfa(iset)
-
-            IF (map_it_here) THEN
+            IF (map_gaussian_here(rs_v(igrid_level)%rs_grid, cell%h_inv, ra, offset, para_env_sub%num_pe, para_env_sub%mepos)) THEN
                DO ipgf = 1, npgfa(iset)
                   na1 = (ipgf - 1)*ncoset(la_max(iset)) + 1
                   na2 = ipgf*ncoset(la_max(iset))
@@ -1074,6 +984,8 @@ CONTAINS
             DEALLOCATE (I_tmp2)
             DEALLOCATE (I_ab)
             DEALLOCATE (pab)
+
+            offset = offset + nsgfa(iset)
 
          END DO
 

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -345,7 +345,7 @@ CONTAINS
 
       CALL get_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, mp2_memory, &
                             my_Lrows, my_Vrows, fm_matrix_PQ, ngroup, color_sub, dimen_RI, dimen_RI_red, &
-                            kpoints, mo_coeff(1)%matrix, my_group_L_size, my_group_L_start, my_group_L_end, &
+                            kpoints, my_group_L_size, my_group_L_start, my_group_L_end, &
                             gd_array, calc_PQ_cond_num .AND. .NOT. do_svd, do_svd, &
                             qs_env%mp2_env%potential_parameter, ri_metric, &
                             fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -131,7 +131,6 @@ CONTAINS
 !> \param dimen_RI ...
 !> \param dimen_RI_red reduced RI dimension,  needed if we perform SVD instead of Cholesky
 !> \param kpoints ...
-!> \param mo_coeff ...
 !> \param my_group_L_size ...
 !> \param my_group_L_start ...
 !> \param my_group_L_end ...
@@ -152,7 +151,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, mp2_memory, &
                                my_Lrows, my_Vrows, fm_matrix_PQ, ngroup, color_sub, dimen_RI, dimen_RI_red, &
-                               kpoints, mo_coeff, my_group_L_size, my_group_L_start, my_group_L_end, &
+                               kpoints, my_group_L_size, my_group_L_start, my_group_L_end, &
                                gd_array, calc_PQ_cond_num, do_svd, &
                                potential, ri_metric, &
                                fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &
@@ -169,7 +168,6 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: ngroup, color_sub
       INTEGER, INTENT(OUT)                               :: dimen_RI, dimen_RI_red
       TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       INTEGER, INTENT(OUT)                               :: my_group_L_size, my_group_L_start, &
                                                             my_group_L_end
       TYPE(group_dist_d1_type), INTENT(OUT)              :: gd_array
@@ -201,7 +199,7 @@ CONTAINS
 
       ! calculate V and store it in fm_matrix_L
       CALL compute_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, para_env_L, mp2_memory, &
-                                fm_matrix_L, ngroup, color_sub, dimen_RI, mo_coeff, &
+                                fm_matrix_L, ngroup, color_sub, dimen_RI, &
                                 my_group_L_size, my_group_L_start, my_group_L_end, &
                                 gd_array, calc_PQ_cond_num, cond_num, &
                                 num_small_eigen, potential, sab_orb_sub, do_im_time=do_im_time)
@@ -245,7 +243,7 @@ CONTAINS
 
             ! Calculate matrix of RI operator (for overlap metric: S), store it in fm_matrix_L_RI_metric
             CALL compute_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, para_env_L, mp2_memory, &
-                                      fm_matrix_L_RI_metric(1, 1)%matrix, ngroup, color_sub, dimen_RI, mo_coeff, &
+                                      fm_matrix_L_RI_metric(1, 1)%matrix, ngroup, color_sub, dimen_RI, &
                                       my_group_L_size, my_group_L_start, my_group_L_end, &
                                       gd_array, calc_PQ_cond_num, cond_num, &
                                       num_small_eigen, ri_metric, sab_orb_sub, &
@@ -771,7 +769,6 @@ CONTAINS
 !> \param ngroup ...
 !> \param color_sub ...
 !> \param dimen_RI ...
-!> \param mo_coeff ...
 !> \param my_group_L_size ...
 !> \param my_group_L_start ...
 !> \param my_group_L_end ...
@@ -785,7 +782,7 @@ CONTAINS
 !> \param fm_matrix_L_extern ...
 ! **************************************************************************************************
    SUBROUTINE compute_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, para_env_L, mp2_memory, &
-                                   fm_matrix_L, ngroup, color_sub, dimen_RI, mo_coeff, &
+                                   fm_matrix_L, ngroup, color_sub, dimen_RI, &
                                    my_group_L_size, my_group_L_start, my_group_L_end, &
                                    gd_array, calc_PQ_cond_num, cond_num, num_small_eigen, potential, &
                                    sab_orb_sub, do_im_time, fm_matrix_L_extern)
@@ -798,10 +795,8 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: mp2_memory
       TYPE(cp_fm_type), POINTER                          :: fm_matrix_L
       INTEGER, INTENT(IN)                                :: ngroup, color_sub
-      INTEGER, INTENT(OUT)                               :: dimen_RI
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
-      INTEGER, INTENT(OUT)                               :: my_group_L_size, my_group_L_start, &
-                                                            my_group_L_end
+      INTEGER, INTENT(OUT)                               :: dimen_RI, my_group_L_size, &
+                                                            my_group_L_start, my_group_L_end
       TYPE(group_dist_d1_type), INTENT(OUT)              :: gd_array
       LOGICAL, INTENT(IN)                                :: calc_PQ_cond_num
       REAL(KIND=dp), INTENT(OUT)                         :: cond_num
@@ -893,7 +888,7 @@ CONTAINS
               (potential_type == do_potential_long .AND. qs_env%mp2_env%eri_method == do_eri_os) &
               .OR. (potential_type == do_potential_id .AND. qs_env%mp2_env%eri_method == do_eri_mme)) THEN
 
-         CALL mp2_eri_2c_integrate_gpw(qs_env, para_env_sub, dimen_RI, mo_coeff, my_group_L_start, my_group_L_end, &
+         CALL mp2_eri_2c_integrate_gpw(qs_env, para_env_sub, my_group_L_start, my_group_L_end, &
                                        natom, potential, sab_orb_sub, L_local_col, kind_of)
 
       ELSE

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -144,7 +144,7 @@ CONTAINS
       LOGICAL                                            :: alpha_beta, use_virial
       REAL(KIND=dp)                                      :: cutoff_old, eps_filter, factor, &
                                                             relative_cutoff_old
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: e_cutoff_old, wf_vector
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: e_cutoff_old
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: G_PQ_local, G_PQ_local_2
       REAL(KIND=dp), DIMENSION(3, 3)                     :: h_stress, pv_virial
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: I_tmp2
@@ -336,9 +336,6 @@ CONTAINS
          CALL prepare_gpw(qs_env, dft_control, e_cutoff_old, cutoff_old, relative_cutoff_old, para_env_sub, pw_env_sub, &
                           auxbas_pw_pool, poisson_env, task_list_sub, rho_r, rho_g, pot_g, psi_L, sab_orb_sub)
 
-         ! wave function vector and supporting stuff
-         ALLOCATE (wf_vector(dimen_RI))
-
          ! check if we want to calculate the virial
          use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
 
@@ -371,10 +368,7 @@ CONTAINS
                                         G_P_ia(:, L_counter), matrix_P_inu, &
                                         mo_coeff_v, mo_coeff_o, eps_filter)
 
-            wf_vector = 0.0_dp
-            wf_vector(LLL) = 1.0_dp
-
-            CALL integrate_potential_forces_2c(rho_r, wf_vector, mo_coeff(1)%matrix, rho_g, atomic_kind_set, &
+            CALL integrate_potential_forces_2c(rho_r, LLL, mo_coeff(1)%matrix, rho_g, atomic_kind_set, &
                                                qs_kind_set, particle_set, cell, pw_env_sub, poisson_env, &
                                                pot_g, mp2_env%potential_parameter, use_virial, &
                                                rho_g_copy, dvg, kind_of, atom_of_kind, G_PQ_local(:, L_counter), &
@@ -382,7 +376,7 @@ CONTAINS
 
             IF (.NOT. compare_potential_types(mp2_env%ri_metric, mp2_env%potential_parameter)) THEN
 
-               CALL integrate_potential_forces_2c(rho_r, wf_vector, mo_coeff(1)%matrix, rho_g, atomic_kind_set, &
+               CALL integrate_potential_forces_2c(rho_r, LLL, mo_coeff(1)%matrix, rho_g, atomic_kind_set, &
                                                   qs_kind_set, particle_set, cell, pw_env_sub, poisson_env, &
                                                   pot_g, mp2_env%ri_metric, use_virial, &
                                                   rho_g_copy, dvg, kind_of, atom_of_kind, G_PQ_local_2(:, L_counter), &
@@ -414,7 +408,6 @@ CONTAINS
 
          DEALLOCATE (kind_of)
          DEALLOCATE (atom_of_kind)
-         DEALLOCATE (wf_vector)
 
          IF (use_virial) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy%pw)

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -67,7 +67,8 @@ MODULE realspace_grid_types
              rs_grid_print, &
              rs_grid_locate_rank, &
              rs_grid_max_ngpts, &
-             rs_grid_mult_and_add
+             rs_grid_mult_and_add, &
+             map_gaussian_here
 
    INTEGER, PARAMETER, PUBLIC               :: rsgrid_distributed = 0, &
                                                rsgrid_replicated = 1, &
@@ -2187,5 +2188,52 @@ CONTAINS
       CALL timestop(handle)
 
    END FUNCTION rs_grid_max_ngpts
+
+! **************************************************************************************************
+!> \brief ...
+!> \param rs_grid ...
+!> \param h_inv ...
+!> \param ra ...
+!> \param offset ...
+!> \param group_size ...
+!> \param my_pos ...
+!> \return ...
+! **************************************************************************************************
+   PURE LOGICAL FUNCTION map_gaussian_here(rs_grid, h_inv, ra, offset, group_size, my_pos) RESULT(res)
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
+      REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: h_inv
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: ra
+      INTEGER, INTENT(IN), OPTIONAL                      :: offset, group_size, my_pos
+
+      INTEGER                                            :: dir, lb(3), location(3), tp(3), ub(3)
+
+      res = .FALSE.
+
+      IF (.NOT. ALL(rs_grid%desc%perd == 1)) THEN
+         DO dir = 1, 3
+            ! bounds of local grid (i.e. removing the 'wings'), if periodic
+            tp(dir) = FLOOR(DOT_PRODUCT(h_inv(dir, :), ra)*rs_grid%desc%npts(dir))
+            tp(dir) = MODULO(tp(dir), rs_grid%desc%npts(dir))
+            IF (rs_grid%desc%perd(dir) .NE. 1) THEN
+               lb(dir) = rs_grid%lb_local(dir) + rs_grid%desc%border
+               ub(dir) = rs_grid%ub_local(dir) - rs_grid%desc%border
+            ELSE
+               lb(dir) = rs_grid%lb_local(dir)
+               ub(dir) = rs_grid%ub_local(dir)
+            END IF
+            ! distributed grid, only map if it is local to the grid
+            location(dir) = tp(dir) + rs_grid%desc%lb(dir)
+         END DO
+         IF (ALL(lb(:) <= location(:)) .AND. ALL(location(:) <= ub(:))) THEN
+            res = .TRUE.
+         END IF
+      ELSE
+         IF (PRESENT(offset) .AND. PRESENT(group_size) .AND. PRESENT(my_pos)) THEN
+            ! not distributed, just a round-robin distribution over the full set of CPUs
+            IF (MODULO(offset, group_size) == my_pos) res = .TRUE.
+         END IF
+      END IF
+
+   END FUNCTION map_gaussian_here
 
 END MODULE realspace_grid_types

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -98,14 +98,9 @@ MODULE qs_collocate_density
    USE qs_ks_types,                     ONLY: get_ks_env,&
                                               qs_ks_env_type
    USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
-   USE realspace_grid_types,            ONLY: realspace_grid_desc_p_type,&
-                                              realspace_grid_p_type,&
-                                              realspace_grid_type,&
-                                              rs2pw,&
-                                              rs_grid_release,&
-                                              rs_grid_retain,&
-                                              rs_grid_zero,&
-                                              rs_pw_transfer
+   USE realspace_grid_types,            ONLY: &
+        map_gaussian_here, realspace_grid_desc_p_type, realspace_grid_p_type, realspace_grid_type, &
+        rs2pw, rs_grid_release, rs_grid_retain, rs_grid_zero, rs_pw_transfer
    USE rs_pw_interface,                 ONLY: density_rs2pw,&
                                               density_rs2pw_basic
    USE task_list_methods,               ONLY: rs_copy_to_buffer,&
@@ -138,9 +133,8 @@ MODULE qs_collocate_density
              calculate_wavefunction, &
              calculate_rho_nlcc, &
              calculate_drho_elec_dR, &
-             calculate_drho_core
-
-   INTEGER :: debug_count = 0
+             calculate_drho_core, &
+             collocate_single_gaussian
 
 CONTAINS
 
@@ -529,10 +523,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_lri_rho_elec'
 
-      INTEGER :: atom_a, dir, group_size, handle, iatom, igrid_level, ikind, ipgf, iset, jpgf, &
-         jset, m1, maxco, maxsgf_set, my_pos, na1, natom, nb1, ncoa, ncob, nseta, offset, sgfa, &
-         sgfb
-      INTEGER, DIMENSION(3)                              :: lb, location, tp, ub
+      INTEGER :: atom_a, group_size, handle, iatom, igrid_level, ikind, ipgf, iset, jpgf, jset, &
+         m1, maxco, maxsgf_set, my_pos, na1, natom, nb1, ncoa, ncob, nseta, offset, sgfa, sgfb
       INTEGER, DIMENSION(:), POINTER                     :: atom_list, la_max, la_min, npgfa, nsgfa
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
       LOGICAL                                            :: found
@@ -629,30 +621,7 @@ CONTAINS
                DO ipgf = 1, npgfa(iset)
                   igrid_level = gaussian_gridlevel(gridlevel_info, zeta(ipgf, iset))
                   rs_grid => rs_rho(igrid_level)%rs_grid
-                  IF (.NOT. ALL(rs_grid%desc%perd == 1)) THEN
-                     DO dir = 1, 3
-                        ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                        tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_grid%desc%npts(dir))
-                        tp(dir) = MODULO(tp(dir), rs_grid%desc%npts(dir))
-                        IF (rs_grid%desc%perd(dir) .NE. 1) THEN
-                           lb(dir) = rs_grid%lb_local(dir) + rs_grid%desc%border
-                           ub(dir) = rs_grid%ub_local(dir) - rs_grid%desc%border
-                        ELSE
-                           lb(dir) = rs_grid%lb_local(dir)
-                           ub(dir) = rs_grid%ub_local(dir)
-                        END IF
-                        ! distributed grid, only map if it is local to the grid
-                        location(dir) = tp(dir) + rs_grid%desc%lb(dir)
-                     END DO
-                     IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                         lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                         lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                        map_it(ipgf) = .TRUE.
-                     END IF
-                  ELSE
-                     ! not distributed, just a round-robin distribution over the full set of CPUs
-                     IF (MODULO(offset, group_size) == my_pos) map_it(ipgf) = .TRUE.
-                  END IF
+                  map_it(ipgf) = map_gaussian_here(rs_grid, cell%h_inv, ra, offset, group_size, my_pos)
                END DO
                offset = offset + 1
 
@@ -731,30 +700,7 @@ CONTAINS
                            zetp = zeta(ipgf, iset) + zeta(jpgf, jset)
                            igrid_level = gaussian_gridlevel(gridlevel_info, zetp)
                            rs_grid => rs_rho(igrid_level)%rs_grid
-                           IF (.NOT. ALL(rs_grid%desc%perd == 1)) THEN
-                              DO dir = 1, 3
-                                 ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                                 tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_grid%desc%npts(dir))
-                                 tp(dir) = MODULO(tp(dir), rs_grid%desc%npts(dir))
-                                 IF (rs_grid%desc%perd(dir) .NE. 1) THEN
-                                    lb(dir) = rs_grid%lb_local(dir) + rs_grid%desc%border
-                                    ub(dir) = rs_grid%ub_local(dir) - rs_grid%desc%border
-                                 ELSE
-                                    lb(dir) = rs_grid%lb_local(dir)
-                                    ub(dir) = rs_grid%ub_local(dir)
-                                 END IF
-                                 ! distributed grid, only map if it is local to the grid
-                                 location(dir) = tp(dir) + rs_grid%desc%lb(dir)
-                              END DO
-                              IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                                  lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                                  lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                                 map_it2(ipgf, jpgf) = .TRUE.
-                              END IF
-                           ELSE
-                              ! not distributed, just a round-robin distribution over the full set of CPUs
-                              IF (MODULO(offset, group_size) == my_pos) map_it2(ipgf, jpgf) = .TRUE.
-                           END IF
+                           map_it2(ipgf, jpgf) = map_gaussian_here(rs_grid, cell%h_inv, ra, offset, group_size, my_pos)
                         END DO
                      END DO
                      offset = offset + 1
@@ -1752,8 +1698,6 @@ CONTAINS
                lb_max, lb_min, npgfa, npgfb, nsgfa, nsgfb, p_block, sphi_a, &
                sphi_b, zeta, zetb, first_sgfa, first_sgfb, tasks, pabt, workt)
 
-      debug_count = debug_count + 1
-
       ! by default, the full density is calculated
       my_soft = .FALSE.
       IF (PRESENT(soft_valid)) my_soft = soft_valid
@@ -2136,8 +2080,6 @@ CONTAINS
                lb_min, npgfa, npgfb, nsgfa, nsgfb, p_block, sphi_a, sphi_b, &
                zeta, zetb, first_sgfa, first_sgfb, tasks, pabt, workt)
 
-      debug_count = debug_count + 1
-
       ! by default, the full density is calculated
       my_soft = .FALSE.
       IF (PRESENT(soft_valid)) my_soft = soft_valid
@@ -2468,6 +2410,192 @@ CONTAINS
    END SUBROUTINE calculate_drho_elec_dR
 
 ! **************************************************************************************************
+!> \brief maps a single gaussian on the grid
+!> \param rho ...
+!> \param rho_gspace ...
+!> \param atomic_kind_set ...
+!> \param qs_kind_set ...
+!> \param cell ...
+!> \param dft_control ...
+!> \param particle_set ...
+!> \param pw_env ...
+!> \param required_function ...
+!> \param basis_type ...
+!> \par History
+!>      08.2022 created from calculate_wavefunction
+!> \note
+!>      modified calculate_wave function assuming that the collocation of only a single Gaussian is required.
+!>      chooses a basis function (in contrast to calculate_rho_core or calculate_rho_single_gaussian)
+! **************************************************************************************************
+   SUBROUTINE collocate_single_gaussian(rho, rho_gspace, &
+                                        atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
+                                        pw_env, required_function, basis_type)
+
+      TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(pw_env_type), POINTER                         :: pw_env
+      INTEGER, INTENT(IN)                                :: required_function
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: basis_type
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'collocate_single_gaussian'
+
+      CHARACTER(LEN=default_string_length)               :: my_basis_type
+      INTEGER :: group, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, maxco, &
+         maxsgf_set, my_index, my_pos, na1, na2, natom, ncoa, nseta, offset, sgfa
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: where_is_the_point
+      INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nsgfa
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
+      LOGICAL                                            :: found
+      REAL(KIND=dp)                                      :: dab, eps_rho_rspace, radius, scale
+      REAL(KIND=dp), DIMENSION(3)                        :: ra
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: pab, sphi_a, zeta
+      TYPE(gridlevel_info_type), POINTER                 :: gridlevel_info
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: mgrid_gspace, mgrid_rspace
+      TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
+      TYPE(REALSPACE_GRID_P_TYPE), DIMENSION(:), POINTER :: rs_rho
+
+      IF (PRESENT(basis_type)) THEN
+         my_basis_type = basis_type
+      ELSE
+         my_basis_type = "ORB"
+      END IF
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (orb_basis_set, pab, la_max, la_min, npgfa, nsgfa, sphi_a, &
+               zeta, first_sgfa, rs_rho, pw_pools, mgrid_rspace, mgrid_gspace)
+
+      ! *** set up the pw multi-grids
+      CPASSERT(ASSOCIATED(pw_env))
+      CALL pw_env_get(pw_env, rs_grids=rs_rho, pw_pools=pw_pools, &
+                      gridlevel_info=gridlevel_info)
+
+      CALL pw_pools_create_pws(pw_pools, mgrid_gspace, &
+                               use_data=COMPLEXDATA1D, &
+                               in_space=RECIPROCALSPACE)
+      CALL pw_pools_create_pws(pw_pools, mgrid_rspace, &
+                               use_data=REALDATA3D, &
+                               in_space=REALSPACE)
+
+      ! *** set up rs multi-grids
+      DO igrid_level = 1, gridlevel_info%ngrid_levels
+         CALL rs_grid_retain(rs_rho(igrid_level)%rs_grid)
+         CALL rs_grid_zero(rs_rho(igrid_level)%rs_grid)
+      END DO
+
+      eps_rho_rspace = dft_control%qs_control%eps_rho_rspace
+!   *** Allocate work storage ***
+      CALL get_atomic_kind_set(atomic_kind_set, natom=natom)
+      CALL get_qs_kind_set(qs_kind_set, &
+                           maxco=maxco, &
+                           maxsgf_set=maxsgf_set, &
+                           basis_type=my_basis_type)
+
+      ALLOCATE (pab(maxco, 1))
+
+      offset = 0
+      group = mgrid_rspace(1)%pw%pw_grid%para%group
+      my_pos = mgrid_rspace(1)%pw%pw_grid%para%my_pos
+      group_size = mgrid_rspace(1)%pw%pw_grid%para%group_size
+      ALLOCATE (where_is_the_point(0:group_size - 1))
+
+      DO iatom = 1, natom
+         ikind = particle_set(iatom)%atomic_kind%kind_number
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set, basis_type=my_basis_type)
+         CALL get_gto_basis_set(gto_basis_set=orb_basis_set, &
+                                first_sgf=first_sgfa, &
+                                lmax=la_max, &
+                                lmin=la_min, &
+                                npgf=npgfa, &
+                                nset=nseta, &
+                                nsgf_set=nsgfa, &
+                                sphi=sphi_a, &
+                                zet=zeta)
+         ra(:) = pbc(particle_set(iatom)%r, cell)
+         dab = 0.0_dp
+
+         DO iset = 1, nseta
+
+            ncoa = npgfa(iset)*ncoset(la_max(iset))
+            sgfa = first_sgfa(1, iset)
+
+            found = .FALSE.
+            my_index = 0
+            DO i = 1, nsgfa(iset)
+               IF (offset + i == required_function) THEN
+                  my_index = i
+                  found = .TRUE.
+                  EXIT
+               END IF
+            END DO
+
+            IF (found) THEN
+
+               pab(1:ncoa, 1) = sphi_a(1:ncoa, sgfa + my_index - 1)
+
+               DO ipgf = 1, npgfa(iset)
+
+                  na1 = (ipgf - 1)*ncoset(la_max(iset)) + 1
+                  na2 = ipgf*ncoset(la_max(iset))
+
+                  scale = 1.0_dp
+                  igrid_level = gaussian_gridlevel(gridlevel_info, zeta(ipgf, iset))
+
+                  IF (map_gaussian_here(rs_rho(igrid_level)%rs_grid, cell%h_inv, ra, offset, group_size, my_pos)) THEN
+                     radius = exp_radius_very_extended(la_min=la_min(iset), la_max=la_max(iset), &
+                                                       lb_min=0, lb_max=0, ra=ra, rb=ra, rp=ra, &
+                                                       zetp=zeta(ipgf, iset), eps=eps_rho_rspace, &
+                                                       prefactor=1.0_dp, cutoff=1.0_dp)
+
+                     CALL collocate_pgf_product(la_max(iset), zeta(ipgf, iset), la_min(iset), &
+                                                0, 0.0_dp, 0, &
+                                                ra, (/0.0_dp, 0.0_dp, 0.0_dp/), &
+                                                scale, pab, na1 - 1, 0, rs_rho(igrid_level)%rs_grid, &
+                                                radius=radius, ga_gb_function=GRID_FUNC_AB)
+                  END IF
+
+               END DO
+
+            END IF
+
+            offset = offset + nsgfa(iset)
+
+         END DO
+
+      END DO
+
+      DO igrid_level = 1, gridlevel_info%ngrid_levels
+         CALL rs_pw_transfer(rs_rho(igrid_level)%rs_grid, &
+                             mgrid_rspace(igrid_level)%pw, rs2pw)
+         CALL rs_grid_release(rs_rho(igrid_level)%rs_grid)
+      END DO
+
+      CALL pw_zero(rho_gspace%pw)
+      DO igrid_level = 1, gridlevel_info%ngrid_levels
+         CALL pw_transfer(mgrid_rspace(igrid_level)%pw, &
+                          mgrid_gspace(igrid_level)%pw)
+         CALL pw_axpy(mgrid_gspace(igrid_level)%pw, rho_gspace%pw)
+      END DO
+
+      CALL pw_transfer(rho_gspace%pw, rho%pw)
+
+      ! Release work storage
+      DEALLOCATE (pab)
+
+      ! give back the pw multi-grids
+      CALL pw_pools_give_back_pws(pw_pools, mgrid_gspace)
+      CALL pw_pools_give_back_pws(pw_pools, mgrid_rspace)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE collocate_single_gaussian
+
+! **************************************************************************************************
 !> \brief maps a given wavefunction on the grid
 !> \param mo_vectors ...
 !> \param ivector ...
@@ -2511,13 +2639,12 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_wavefunction'
 
       CHARACTER(LEN=default_string_length)               :: my_basis_type
-      INTEGER :: dir, group, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, maxco, &
+      INTEGER :: group, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, maxco, &
          maxsgf_set, my_pos, na1, na2, nao, natom, ncoa, nseta, offset, sgfa
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: where_is_the_point
-      INTEGER, DIMENSION(3)                              :: lb, location, tp, ub
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nsgfa
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
-      LOGICAL                                            :: local, map_it_here
+      LOGICAL                                            :: local
       REAL(KIND=dp)                                      :: dab, eps_rho_rspace, radius, scale
       REAL(KIND=dp), DIMENSION(3)                        :: ra
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvector
@@ -2624,34 +2751,7 @@ CONTAINS
                scale = 1.0_dp
                igrid_level = gaussian_gridlevel(gridlevel_info, zeta(ipgf, iset))
 
-               map_it_here = .FALSE.
-
-               IF (.NOT. ALL(rs_rho(igrid_level)%rs_grid%desc%perd == 1)) THEN
-                  DO dir = 1, 3
-                     ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                     tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_rho(igrid_level)%rs_grid%desc%npts(dir))
-                     tp(dir) = MODULO(tp(dir), rs_rho(igrid_level)%rs_grid%desc%npts(dir))
-                     IF (rs_rho(igrid_level)%rs_grid%desc%perd(dir) .NE. 1) THEN
-                        lb(dir) = rs_rho(igrid_level)%rs_grid%lb_local(dir) + rs_rho(igrid_level)%rs_grid%desc%border
-                        ub(dir) = rs_rho(igrid_level)%rs_grid%ub_local(dir) - rs_rho(igrid_level)%rs_grid%desc%border
-                     ELSE
-                        lb(dir) = rs_rho(igrid_level)%rs_grid%lb_local(dir)
-                        ub(dir) = rs_rho(igrid_level)%rs_grid%ub_local(dir)
-                     END IF
-                     ! distributed grid, only map if it is local to the grid
-                     location(dir) = tp(dir) + rs_rho(igrid_level)%rs_grid%desc%lb(dir)
-                  END DO
-                  IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                      lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                      lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                     map_it_here = .TRUE.
-                  END IF
-               ELSE
-                  ! not distributed, just a round-robin distribution over the full set of CPUs
-                  IF (MODULO(offset, group_size) == my_pos) map_it_here = .TRUE.
-               END IF
-
-               IF (map_it_here) THEN
+               IF (map_gaussian_here(rs_rho(igrid_level)%rs_grid, cell%h_inv, ra, offset, group_size, my_pos)) THEN
                   radius = exp_radius_very_extended(la_min=la_min(iset), la_max=la_max(iset), &
                                                     lb_min=0, lb_max=0, ra=ra, rb=ra, rp=ra, &
                                                     zetp=zeta(ipgf, iset), eps=eps_rho_rspace, &

--- a/src/qs_integrate_potential_single.F
+++ b/src/qs_integrate_potential_single.F
@@ -61,7 +61,8 @@ MODULE qs_integrate_potential_single
    USE qs_force_types,                  ONLY: qs_force_type
    USE qs_kind_types,                   ONLY: get_qs_kind,&
                                               qs_kind_type
-   USE realspace_grid_types,            ONLY: pw2rs,&
+   USE realspace_grid_types,            ONLY: map_gaussian_here,&
+                                              pw2rs,&
                                               realspace_grid_p_type,&
                                               realspace_grid_type,&
                                               rs_grid_release,&
@@ -662,9 +663,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_v_rspace_one_center'
 
-      INTEGER :: atom_a, dir, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, m1, &
-         maxco, maxsgf_set, my_pos, na1, natom_of_kind, ncoa, nkind, nseta, offset, sgfa
-      INTEGER, DIMENSION(3)                              :: lb, location, tp, ub
+      INTEGER :: atom_a, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, m1, maxco, &
+         maxsgf_set, my_pos, na1, natom_of_kind, ncoa, nkind, nseta, offset, sgfa
       INTEGER, DIMENSION(:), POINTER                     :: atom_list, la_max, la_min, npgfa, &
                                                             nsgf_seta
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
@@ -769,30 +769,7 @@ CONTAINS
                DO ipgf = 1, npgfa(iset)
                   igrid_level = gaussian_gridlevel(gridlevel_info, zeta(ipgf, iset))
                   rs_grid => rs_v(igrid_level)%rs_grid
-                  IF (.NOT. ALL(rs_grid%desc%perd == 1)) THEN
-                     DO dir = 1, 3
-                        ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                        tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_grid%desc%npts(dir))
-                        tp(dir) = MODULO(tp(dir), rs_grid%desc%npts(dir))
-                        IF (rs_grid%desc%perd(dir) .NE. 1) THEN
-                           lb(dir) = rs_grid%lb_local(dir) + rs_grid%desc%border
-                           ub(dir) = rs_grid%ub_local(dir) - rs_grid%desc%border
-                        ELSE
-                           lb(dir) = rs_grid%lb_local(dir)
-                           ub(dir) = rs_grid%ub_local(dir)
-                        END IF
-                        ! distributed grid, only map if it is local to the grid
-                        location(dir) = tp(dir) + rs_grid%desc%lb(dir)
-                     END DO
-                     IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                         lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                         lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                        map_it(ipgf) = .TRUE.
-                     END IF
-                  ELSE
-                     ! not distributed, just a round-robin distribution over the full set of CPUs
-                     IF (MODULO(offset, group_size) == my_pos) map_it(ipgf) = .TRUE.
-                  END IF
+                  map_it(ipgf) = map_gaussian_here(rs_grid, cell%h_inv, ra, offset, group_size, my_pos)
                END DO
                offset = offset + 1
                !
@@ -900,10 +877,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_v_rspace_diagonal'
 
-      INTEGER :: atom_a, dir, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, jpgf, &
-         jset, m1, maxco, maxsgf_set, my_pos, na1, na2, natom_of_kind, nb1, nb2, ncoa, ncob, &
-         nkind, nseta, nsgfa, offset, sgfa, sgfb
-      INTEGER, DIMENSION(3)                              :: lb, location, tp, ub
+      INTEGER :: atom_a, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, jpgf, jset, &
+         m1, maxco, maxsgf_set, my_pos, na1, na2, natom_of_kind, nb1, nb2, ncoa, ncob, nkind, &
+         nseta, nsgfa, offset, sgfa, sgfb
       INTEGER, DIMENSION(:), POINTER                     :: atom_list, la_max, la_min, npgfa, &
                                                             nsgf_seta
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
@@ -1005,30 +981,7 @@ CONTAINS
                         zetp = zeta(ipgf, iset) + zeta(jpgf, jset)
                         igrid_level = gaussian_gridlevel(gridlevel_info, zetp)
                         rs_grid => rs_v(igrid_level)%rs_grid
-                        IF (.NOT. ALL(rs_grid%desc%perd == 1)) THEN
-                           DO dir = 1, 3
-                              ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                              tp(dir) = FLOOR(DOT_PRODUCT(cell%h_inv(dir, :), ra)*rs_grid%desc%npts(dir))
-                              tp(dir) = MODULO(tp(dir), rs_grid%desc%npts(dir))
-                              IF (rs_grid%desc%perd(dir) .NE. 1) THEN
-                                 lb(dir) = rs_grid%lb_local(dir) + rs_grid%desc%border
-                                 ub(dir) = rs_grid%ub_local(dir) - rs_grid%desc%border
-                              ELSE
-                                 lb(dir) = rs_grid%lb_local(dir)
-                                 ub(dir) = rs_grid%ub_local(dir)
-                              END IF
-                              ! distributed grid, only map if it is local to the grid
-                              location(dir) = tp(dir) + rs_grid%desc%lb(dir)
-                           END DO
-                           IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                               lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                               lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                              map_it2(ipgf, jpgf) = .TRUE.
-                           END IF
-                        ELSE
-                           ! not distributed, just a round-robin distribution over the full set of CPUs
-                           IF (MODULO(offset, group_size) == my_pos) map_it2(ipgf, jpgf) = .TRUE.
-                        END IF
+                        map_it2(ipgf, jpgf) = map_gaussian_here(rs_grid, cell%h_inv, ra, offset, group_size, my_pos)
                      END DO
                   END DO
                   offset = offset + 1

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -157,7 +157,8 @@ MODULE rpa_im_time_force_methods
                                               distribution_3d_create,&
                                               distribution_3d_type,&
                                               neighbor_list_3c_type
-   USE realspace_grid_types,            ONLY: realspace_grid_p_type,&
+   USE realspace_grid_types,            ONLY: map_gaussian_here,&
+                                              realspace_grid_p_type,&
                                               rs_grid_release,&
                                               rs_grid_retain
    USE response_solver,                 ONLY: ks_ref_potential,&
@@ -2627,14 +2628,14 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'get_2c_gpw_forces'
 
       INTEGER :: atom_a, color, handle, i, i_RI, i_xyz, iatom, igrid_level, ikind, ipgf, iset, j, &
-         j_RI, jatom, lb(3), lb_RI, location(3), n_RI, natom, ncoa, ncoms, nkind, nproc, nseta, &
-         o1, offset, pdims(2), sgfa, tp(3), ub(3), ub_RI
+         j_RI, jatom, lb_RI, n_RI, natom, ncoa, ncoms, nkind, nproc, nseta, o1, offset, pdims(2), &
+         sgfa, ub_RI
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, iproc_map, kind_of, &
                                                             sizes_RI
       INTEGER, DIMENSION(:), POINTER                     :: col_dist, la_max, la_min, npgfa, nsgfa, &
                                                             row_dist
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, pgrid
-      LOGICAL                                            :: found, map_it_here, one_proc_group
+      LOGICAL                                            :: found, one_proc_group
       REAL(dp)                                           :: cutoff_old, radius, relative_cutoff_old
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: e_cutoff_old, wf_vector
       REAL(dp), DIMENSION(3)                             :: force_a, force_b, ra
@@ -2865,33 +2866,10 @@ CONTAINS
                              I_ab(1, 1), nsgfa(iset), 0.0_dp, pab(1, 1), ncoa)
 
                   igrid_level = gaussian_gridlevel(pw_env_ext%gridlevel_info, MINVAL(zeta(:, iset)))
-                  map_it_here = .FALSE.
-                  IF (.NOT. ALL(rs_v(igrid_level)%rs_grid%desc%perd == 1)) THEN
-                     DO i_xyz = 1, 3
-                        ! bounds of local grid (i.e. removing the 'wings'), if periodic
-                        tp(i_xyz) = FLOOR(DOT_PRODUCT(cell%h_inv(i_xyz, :), ra)* &
-                                          rs_v(igrid_level)%rs_grid%desc%npts(i_xyz))
-                        tp(i_xyz) = MODULO(tp(i_xyz), rs_v(igrid_level)%rs_grid%desc%npts(i_xyz))
-                        IF (rs_v(igrid_level)%rs_grid%desc%perd(i_xyz) .NE. 1) THEN
-                           lb(i_xyz) = rs_v(igrid_level)%rs_grid%lb_local(i_xyz) + rs_v(igrid_level)%rs_grid%desc%border
-                           ub(i_xyz) = rs_v(igrid_level)%rs_grid%ub_local(i_xyz) - rs_v(igrid_level)%rs_grid%desc%border
-                        ELSE
-                           lb(i_xyz) = rs_v(igrid_level)%rs_grid%lb_local(i_xyz)
-                           ub(i_xyz) = rs_v(igrid_level)%rs_grid%ub_local(i_xyz)
-                        END IF
-                        ! distributed grid, only map if it is local to the grid
-                        location(i_xyz) = tp(i_xyz) + rs_v(igrid_level)%rs_grid%desc%lb(i_xyz)
-                     END DO
-                     IF (lb(1) <= location(1) .AND. location(1) <= ub(1) .AND. &
-                         lb(2) <= location(2) .AND. location(2) <= ub(2) .AND. &
-                         lb(3) <= location(3) .AND. location(3) <= ub(3)) THEN
-                        map_it_here = .TRUE.
-                     END IF
-                  ELSE
-                     map_it_here = .TRUE.
-                  END IF
 
-                  IF (map_it_here) THEN
+                  ! The last three parameters are used to check whether a given function is within the own range.
+                  ! Here, it is always the case, so let's enforce it because mod(0, 1)==0
+                  IF (map_gaussian_here(rs_v(igrid_level)%rs_grid, cell%h_inv, ra, 0, 1, 0)) THEN
                      DO ipgf = 1, npgfa(iset)
                         o1 = (ipgf - 1)*ncoset(la_max(iset))
                         igrid_level = gaussian_gridlevel(pw_env_ext%gridlevel_info, zeta(ipgf, iset))


### PR DESCRIPTION
This PR specializes the calculate_wavefunction routine in the case of a single Gaussian as required in the MP2 GPW Code. The use of this additional routine reduces computational costs of collocation operations compared to the original routine.

Misc: Refactoring of the calculation of variable map_it_here (and comparable arrays)