### PR TITLE
Store 3c derivative tensors in compressed format

### DIFF
--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -48,7 +48,11 @@ MODULE hfx_ri
         dbt_iterator_type, dbt_mp_environ_pgrid, dbt_nd_mp_comm, dbt_pgrid_create, &
         dbt_pgrid_destroy, dbt_pgrid_type, dbt_type
    USE distribution_2d_types,           ONLY: distribution_2d_type
-   USE hfx_types,                       ONLY: hfx_ri_init,&
+   USE hfx_types,                       ONLY: alloc_containers,&
+                                              block_ind_type,&
+                                              dealloc_containers,&
+                                              hfx_compression_type,&
+                                              hfx_ri_init,&
                                               hfx_ri_release,&
                                               hfx_ri_type
    USE input_constants,                 ONLY: hfx_ri_do_2c_cholesky,&
@@ -482,7 +486,7 @@ CONTAINS
       END DO
 
       n_mem = ri_data%n_mem
-      CALL create_tensor_batches(sizes_AO, n_mem, starts_array_mc_int, ends_array_mc_int, &
+      CALL create_tensor_batches(sizes_RI, n_mem, starts_array_mc_int, ends_array_mc_int, &
                                  starts_array_mc_block_int, ends_array_mc_block_int)
 
       DEALLOCATE (starts_array_mc_int, ends_array_mc_int)
@@ -513,7 +517,7 @@ CONTAINS
                                  basis_set_RI, basis_set_AO, basis_set_AO, &
                                  ri_data%ri_metric, int_eps=ri_data%eps_schwarz, op_pos=1, &
                                  desymmetrize=.FALSE., &
-                                 bounds_j=[starts_array_mc_block_int(i_mem), ends_array_mc_block_int(i_mem)])
+                                 bounds_i=[starts_array_mc_block_int(i_mem), ends_array_mc_block_int(i_mem)])
          CALL dbt_copy(t_3c_int_batched(1, 1), t_3c_int(1, 1), summation=.TRUE., move_data=.TRUE.)
          CALL dbt_filter(t_3c_int(1, 1), ri_data%filter_eps/2)
       END DO
@@ -784,7 +788,7 @@ CONTAINS
 
       IF (unit_nr > 0) THEN
          WRITE (UNIT=unit_nr, FMT="((T3,A,T66,F11.2,A4))") &
-            "MEMORY_INFO| Memory for 3-center integrals (compressed):", memory_3c, ' MiB'
+            "MEMORY_INFO| Memory for 3-center HFX integrals (compressed):", memory_3c, ' MiB'
 
          WRITE (UNIT=unit_nr, FMT="((T3,A,T60,F21.2))") &
             "MEMORY_INFO| Compression factor:                  ", compression_factor
@@ -1677,8 +1681,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_ri_forces_mo'
 
-      INTEGER :: handle, i_mem, i_xyz, ispin, j_mem, j_xyz, k_mem, k_xyz, n_mem, n_mem_input, &
-         n_mem_input_RI, n_mem_RI, n_mem_RI_fit, n_mos, natom, unit_nr_dbcsr
+      INTEGER :: dummy_int, handle, i_mem, i_xyz, ispin, j_mem, j_xyz, k_mem, k_xyz, n_mem, &
+         n_mem_input, n_mem_input_RI, n_mem_RI, n_mem_RI_fit, n_mos, natom, unit_nr_dbcsr
       INTEGER(int_8)                                     :: nflop
       INTEGER, ALLOCATABLE, DIMENSION(:) :: atom_of_kind, batch_blk_end, batch_blk_start, &
          batch_end, batch_end_RI, batch_end_RI_fit, batch_ranges, batch_ranges_RI, &
@@ -1691,6 +1695,7 @@ CONTAINS
       REAL(dp)                                           :: pref, spin_fac, t1, t2
       REAL(dp), DIMENSION(3, 3)                          :: work_virial
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(block_ind_type), ALLOCATABLE, DIMENSION(:, :) :: t_3c_der_AO_ind, t_3c_der_RI_ind
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
@@ -1700,8 +1705,9 @@ CONTAINS
          t_3c_mo_ri_ao, t_3c_mo_ri_mo, t_3c_ri_ao_ao, t_3c_RI_ctr, t_3c_ri_mo_mo, &
          t_3c_ri_mo_mo_fit, t_3c_work, t_mo_coeff, t_mo_cpy
       TYPE(dbt_type), DIMENSION(3) :: t_2c_der_metric, t_2c_der_RI, t_2c_MO_AO, t_2c_MO_AO_ctr, &
-         t_3c_der_AO, t_3c_der_AO_ctr_1, t_3c_der_RI, t_3c_der_RI_ctr_1, t_3c_der_RI_ctr_2, &
-         t_3c_tmp_RI
+         t_3c_der_AO, t_3c_der_AO_ctr_1, t_3c_der_RI, t_3c_der_RI_ctr_1, t_3c_der_RI_ctr_2
+      TYPE(hfx_compression_type), ALLOCATABLE, &
+         DIMENSION(:, :)                                 :: t_3c_der_AO_comp, t_3c_der_RI_comp
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(virial_type), POINTER                         :: virial
@@ -1744,13 +1750,32 @@ CONTAINS
       DEALLOCATE (dist1, dist2, dist3)
 
       ! 1) Precompute the derivatives
-      CALL precalc_derivatives(t_3c_tmp_RI, t_3c_der_AO, t_2c_der_RI, t_2c_der_metric, &
-                               t_3c_ri_ao_ao, t_3c_ao_ri_ao, ri_data, qs_env)
+      CALL precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
+                               t_2c_der_RI, t_2c_der_metric, t_3c_ri_ao_ao, ri_data, qs_env)
+
+      n_mem = SIZE(t_3c_der_RI_comp, 1)
       DO i_xyz = 1, 3
          CALL dbt_create(t_3c_ao_ri_ao, t_3c_der_RI(i_xyz))
-         CALL dbt_copy(t_3c_tmp_RI(i_xyz), t_3c_der_RI(i_xyz), order=[2, 1, 3], move_data=.TRUE.)
-         CALL dbt_destroy(t_3c_tmp_RI(i_xyz))
+         CALL dbt_create(t_3c_ao_ri_ao, t_3c_der_AO(i_xyz))
+
+         DO i_mem = 1, n_mem
+            CALL decompress_tensor(t_3c_ri_ao_ao, t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                   t_3c_der_RI_comp(i_mem, i_xyz), ri_data%filter_eps_storage)
+            CALL dbt_copy(t_3c_ri_ao_ao, t_3c_der_RI(i_xyz), order=[2, 1, 3], move_data=.TRUE., summation=.TRUE.)
+
+            CALL decompress_tensor(t_3c_ri_ao_ao, t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                   t_3c_der_AO_comp(i_mem, i_xyz), ri_data%filter_eps_storage)
+            CALL dbt_copy(t_3c_ri_ao_ao, t_3c_der_AO(i_xyz), order=[2, 1, 3], move_data=.TRUE., summation=.TRUE.)
+         END DO
       END DO
+
+      DO i_xyz = 1, 3
+         DO i_mem = 1, n_mem
+            CALL dealloc_containers(t_3c_der_AO_comp(i_mem, i_xyz), dummy_int)
+            CALL dealloc_containers(t_3c_der_RI_comp(i_mem, i_xyz), dummy_int)
+         END DO
+      END DO
+      DEALLOCATE (t_3c_der_AO_ind, t_3c_der_RI_ind)
 
       ! Get the 3c integrals (desymmetrized)
       CALL dbt_create(t_3c_ao_ri_ao, t_3c_desymm)
@@ -2353,8 +2378,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_ri_forces_Pmat'
 
-      INTEGER                                            :: handle, i_mem, i_spin, i_xyz, j_mem, &
-                                                            j_xyz, k_xyz, n_mem, natom, &
+      INTEGER                                            :: dummy_int, handle, i_mem, i_spin, i_xyz, &
+                                                            j_mem, j_xyz, k_xyz, n_mem, natom, &
                                                             unit_nr_dbcsr
       INTEGER(int_8)                                     :: nflop
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, batch_end, batch_ranges, &
@@ -2367,6 +2392,7 @@ CONTAINS
       REAL(dp)                                           :: pref, spin_fac, t1, t2
       REAL(dp), DIMENSION(3, 3)                          :: work_virial
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(block_ind_type), ALLOCATABLE, DIMENSION(:, :) :: t_3c_der_AO_ind, t_3c_der_RI_ind
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_type)                                   :: dbcsr_tmp
@@ -2374,7 +2400,9 @@ CONTAINS
          t_3c_3, t_3c_4, t_3c_5, t_3c_ao_ri_ao, t_3c_help_1, t_3c_help_2, t_3c_int, t_3c_int_2, &
          t_3c_ri_ao_ao, t_3c_sparse, t_R, t_SVS
       TYPE(dbt_type), DIMENSION(3)                       :: t_2c_der_metric, t_2c_der_RI, &
-                                                            t_3c_der_AO, t_3c_der_RI, t_3c_tmp
+                                                            t_3c_der_AO, t_3c_der_RI
+      TYPE(hfx_compression_type), ALLOCATABLE, &
+         DIMENSION(:, :)                                 :: t_3c_der_AO_comp, t_3c_der_RI_comp
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(virial_type), POINTER                         :: virial
@@ -2421,18 +2449,27 @@ CONTAINS
       DEALLOCATE (dist1, dist2, dist3)
 
       ! Precompute the derivatives
-      CALL precalc_derivatives(t_3c_der_RI, t_3c_tmp, t_2c_der_RI, t_2c_der_metric, &
-                               t_3c_ri_ao_ao, t_3c_ao_ri_ao, ri_data, qs_env)
+      CALL precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
+                               t_2c_der_RI, t_2c_der_metric, t_3c_ri_ao_ao, ri_data, qs_env)
 
+      ! Keep track of derivative sparsity to be able to use retain_sparsity in contraction
       CALL dbt_create(t_3c_ri_ao_ao, t_3c_sparse)
       DO i_xyz = 1, 3
-         CALL dbt_create(t_3c_ri_ao_ao, t_3c_der_AO(i_xyz))
-         CALL dbt_copy(t_3c_tmp(i_xyz), t_3c_der_AO(i_xyz), order=[2, 1, 3], move_data=.TRUE.)
-         CALL dbt_destroy(t_3c_tmp(i_xyz))
+         DO i_mem = 1, SIZE(t_3c_der_RI_comp, 1)
+            CALL decompress_tensor(t_3c_ri_ao_ao, t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                   t_3c_der_RI_comp(i_mem, i_xyz), ri_data%filter_eps_storage)
+            CALL dbt_copy(t_3c_ri_ao_ao, t_3c_sparse, summation=.TRUE., move_data=.TRUE.)
 
-         CALL dbt_copy(t_3c_der_RI(i_xyz), t_3c_sparse, summation=.TRUE.)
-         CALL dbt_copy(t_3c_der_AO(i_xyz), t_3c_sparse, summation=.TRUE.)
-         CALL dbt_copy(t_3c_der_AO(i_xyz), t_3c_sparse, order=[1, 3, 2], summation=.TRUE.)
+            CALL decompress_tensor(t_3c_ri_ao_ao, t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                   t_3c_der_AO_comp(i_mem, i_xyz), ri_data%filter_eps_storage)
+            CALL dbt_copy(t_3c_ri_ao_ao, t_3c_sparse, summation=.TRUE.)
+            CALL dbt_copy(t_3c_ri_ao_ao, t_3c_sparse, order=[1, 3, 2], summation=.TRUE., move_data=.TRUE.)
+         END DO
+      END DO
+
+      DO i_xyz = 1, 3
+         CALL dbt_create(t_3c_ri_ao_ao, t_3c_der_RI(i_xyz))
+         CALL dbt_create(t_3c_ri_ao_ao, t_3c_der_AO(i_xyz))
       END DO
 
       ! Some utilities
@@ -2622,34 +2659,55 @@ CONTAINS
 
          !The force from the 3c derivatives
          pref = -0.5_dp*2.0_dp*hf_fraction*spin_fac
-         IF (use_virial_prv) THEN
-            CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_RI, atom_of_kind, kind_of, &
-                                         idx_to_at_RI, pref, work_virial, cell, particle_set)
-         ELSE
-            CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_RI, atom_of_kind, kind_of, &
-                                         idx_to_at_RI, pref)
-         END IF
+
+         DO i_mem = 1, SIZE(t_3c_der_RI_comp, 1)
+            DO i_xyz = 1, 3
+               CALL dbt_clear(t_3c_der_RI(i_xyz))
+               CALL decompress_tensor(t_3c_der_RI(i_xyz), t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                      t_3c_der_RI_comp(i_mem, i_xyz), ri_data%filter_eps_storage)
+            END DO
+            IF (use_virial_prv) THEN
+               CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_RI, atom_of_kind, kind_of, &
+                                            idx_to_at_RI, pref, work_virial, cell, particle_set)
+            ELSE
+               CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_RI, atom_of_kind, kind_of, &
+                                            idx_to_at_RI, pref)
+            END IF
+         END DO
 
          pref = -0.5_dp*4.0_dp*hf_fraction*spin_fac
-         IF (do_resp) pref = 0.5_dp*pref
-         IF (use_virial_prv) THEN
-            CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_AO, atom_of_kind, kind_of, &
-                                         idx_to_at_AO, pref, work_virial, cell, particle_set, deriv_dim=2)
-         ELSE
-            CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_AO, atom_of_kind, kind_of, &
-                                         idx_to_at_AO, pref, deriv_dim=2)
+         IF (do_resp) THEN
+            pref = 0.5_dp*pref
+            CALL dbt_copy(t_3c_help_1, t_3c_help_2, order=[1, 3, 2])
          END IF
 
-         IF (do_resp) THEN
-            CALL dbt_copy(t_3c_help_1, t_3c_help_2, order=[1, 3, 2], move_data=.TRUE.)
+         DO i_mem = 1, SIZE(t_3c_der_AO_comp, 1)
+            DO i_xyz = 1, 3
+               CALL dbt_clear(t_3c_der_AO(i_xyz))
+               CALL decompress_tensor(t_3c_der_AO(i_xyz), t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                      t_3c_der_AO_comp(i_mem, i_xyz), ri_data%filter_eps_storage)
+            END DO
+
             IF (use_virial_prv) THEN
-               CALL get_force_from_3c_trace(force, t_3c_help_2, t_3c_der_AO, atom_of_kind, kind_of, &
+               CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_AO, atom_of_kind, kind_of, &
                                             idx_to_at_AO, pref, work_virial, cell, particle_set, deriv_dim=2)
             ELSE
-               CALL get_force_from_3c_trace(force, t_3c_help_2, t_3c_der_AO, atom_of_kind, kind_of, &
+               CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_AO, atom_of_kind, kind_of, &
                                             idx_to_at_AO, pref, deriv_dim=2)
             END IF
-         END IF
+
+            IF (do_resp) THEN
+               IF (use_virial_prv) THEN
+                  CALL get_force_from_3c_trace(force, t_3c_help_2, t_3c_der_AO, atom_of_kind, kind_of, &
+                                               idx_to_at_AO, pref, work_virial, cell, particle_set, deriv_dim=2)
+               ELSE
+                  CALL get_force_from_3c_trace(force, t_3c_help_2, t_3c_der_AO, atom_of_kind, kind_of, &
+                                               idx_to_at_AO, pref, deriv_dim=2)
+               END IF
+            END IF
+         END DO
+         CALL dbt_clear(t_3c_help_1)
+         CALL dbt_clear(t_3c_help_2)
          CALL timestop(handle)
 
          CALL timeset(routineN//"_2c", handle)
@@ -2765,6 +2823,14 @@ CONTAINS
          CALL dbt_destroy(t_2c_der_RI(i_xyz))
          IF (.NOT. ri_data%same_op) CALL dbt_destroy(t_2c_der_metric(i_xyz))
       END DO
+
+      DO i_xyz = 1, 3
+         DO i_mem = 1, SIZE(t_3c_der_AO_comp, 1)
+            CALL dealloc_containers(t_3c_der_AO_comp(i_mem, i_xyz), dummy_int)
+            CALL dealloc_containers(t_3c_der_RI_comp(i_mem, i_xyz), dummy_int)
+         END DO
+      END DO
+      DEALLOCATE (t_3c_der_AO_ind, t_3c_der_RI_ind)
 
    END SUBROUTINE hfx_ri_forces_Pmat
 
@@ -2887,21 +2953,24 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Calculate the derivatives tensors for the force, in a format fit for contractions
-!> \param t_3c_der_RI format based on template
-!> \param t_3c_der_AO format based on template
+!> \param t_3c_der_RI_comp compressed RI derivatives
+!> \param t_3c_der_AO_comp compressed AO derivatives
+!> \param t_3c_der_RI_ind ...
+!> \param t_3c_der_AO_ind ...
 !> \param t_2c_der_RI format based on standard atomic block sizes
 !> \param t_2c_der_metric format based on standard atomic block sizes
 !> \param ri_ao_ao_template ...
-!> \param ao_ri_ao_template ...
 !> \param ri_data ...
 !> \param qs_env ...
 ! **************************************************************************************************
-   SUBROUTINE precalc_derivatives(t_3c_der_RI, t_3c_der_AO, t_2c_der_RI, t_2c_der_metric, &
-                                  ri_ao_ao_template, ao_ri_ao_template, ri_data, qs_env)
+   SUBROUTINE precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
+                                  t_2c_der_RI, t_2c_der_metric, ri_ao_ao_template, ri_data, qs_env)
 
-      TYPE(dbt_type), DIMENSION(3), INTENT(OUT)          :: t_3c_der_RI, t_3c_der_AO, t_2c_der_RI, &
-                                                            t_2c_der_metric
-      TYPE(dbt_type), INTENT(INOUT)                      :: ri_ao_ao_template, ao_ri_ao_template
+      TYPE(hfx_compression_type), ALLOCATABLE, &
+         DIMENSION(:, :), INTENT(INOUT)                  :: t_3c_der_RI_comp, t_3c_der_AO_comp
+      TYPE(block_ind_type), ALLOCATABLE, DIMENSION(:, :) :: t_3c_der_RI_ind, t_3c_der_AO_ind
+      TYPE(dbt_type), DIMENSION(3), INTENT(OUT)          :: t_2c_der_RI, t_2c_der_metric
+      TYPE(dbt_type), INTENT(INOUT)                      :: ri_ao_ao_template
       TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
@@ -2909,11 +2978,14 @@ CONTAINS
 
       INTEGER                                            :: handle, i_mem, i_xyz, ibasis, &
                                                             mp_comm_t3c, n_mem, nkind
+      INTEGER(int_8)                                     :: nze, nze_tot
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist_AO_1, dist_AO_2, &
                                                             dist_RI, dummy_end, dummy_start, &
                                                             end_blocks, start_blocks
       INTEGER, DIMENSION(3)                              :: pcoord, pdims
       INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
+      REAL(dp)                                           :: compression_factor, memory, occ
+      TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbcsr_type), DIMENSION(1, 3)                  :: t_2c_der_metric_prv, t_2c_der_RI_prv
       TYPE(dbt_type)                                     :: t_2c_template, t_2c_tmp, t_3c_template
@@ -2930,12 +3002,12 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
-      NULLIFY (qs_kind_set, orb_basis, dist_2d, nl_2c, particle_set, dft_control)
+      NULLIFY (qs_kind_set, orb_basis, dist_2d, nl_2c, particle_set, dft_control, para_env)
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, nkind=nkind, qs_kind_set=qs_kind_set, distribution_2d=dist_2d, &
-                      particle_set=particle_set, dft_control=dft_control)
+                      particle_set=particle_set, dft_control=dft_control, para_env=para_env)
 
       ALLOCATE (basis_set_RI(nkind), basis_set_AO(nkind))
       CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
@@ -2971,42 +3043,61 @@ CONTAINS
       CALL build_3c_neighbor_lists(nl_3c, basis_set_RI, basis_set_AO, basis_set_AO, dist_3d, ri_data%ri_metric, &
                                    "HFX_3c_nl", qs_env, op_pos=1, sym_jk=.TRUE., own_dist=.TRUE.)
 
-      !Output tensor must be in a format fit for contraction, with splitted blocks
-      DO i_xyz = 1, 3
-         CALL dbt_create(ri_ao_ao_template, t_3c_der_RI(i_xyz)) ! (RI | AO AO) format
-         CALL dbt_create(ao_ri_ao_template, t_3c_der_AO(i_xyz)) !(AO RI | AO) format
-      END DO
-
       n_mem = ri_data%n_mem
-      CALL create_tensor_batches(ri_data%bsizes_AO, n_mem, dummy_start, dummy_end, &
+      CALL create_tensor_batches(ri_data%bsizes_RI, n_mem, dummy_start, dummy_end, &
                                  start_blocks, end_blocks)
       DEALLOCATE (dummy_start, dummy_end)
 
+      ALLOCATE (t_3c_der_AO_comp(n_mem, 3), t_3c_der_RI_comp(n_mem, 3))
+      ALLOCATE (t_3c_der_AO_ind(n_mem, 3), t_3c_der_RI_ind(n_mem, 3))
+
+      memory = 0.0_dp
+      nze_tot = 0
       DO i_mem = 1, n_mem
          CALL build_3c_derivatives(t_3c_der_RI_prv, t_3c_der_AO_prv, ri_data%filter_eps, qs_env, &
                                    nl_3c, basis_set_RI, basis_set_AO, basis_set_AO, &
                                    ri_data%ri_metric, der_eps=ri_data%eps_schwarz_forces, op_pos=1, &
-                                   bounds_j=[start_blocks(i_mem), end_blocks(i_mem)])
+                                   bounds_i=[start_blocks(i_mem), end_blocks(i_mem)])
 
          DO i_xyz = 1, 3
-            CALL dbt_copy(t_3c_der_RI_prv(1, 1, i_xyz), t_3c_der_RI(i_xyz), &
-                          move_data=.TRUE., summation=.TRUE.)
-            CALL dbt_filter(t_3c_der_RI(i_xyz), ri_data%filter_eps)
+            CALL dbt_copy(t_3c_der_RI_prv(1, 1, i_xyz), ri_ao_ao_template, move_data=.TRUE.)
+            CALL dbt_filter(ri_ao_ao_template, ri_data%filter_eps)
+            CALL get_tensor_occupancy(ri_ao_ao_template, nze, occ)
+            nze_tot = nze_tot + nze
 
-            !put AO derivative as first index (intermediat step needed)
-            CALL dbt_copy(t_3c_der_AO_prv(1, 1, i_xyz), ao_ri_ao_template, order=[2, 1, 3], move_data=.TRUE.)
-            CALL dbt_copy(ao_ri_ao_template, t_3c_der_AO(i_xyz), order=[3, 2, 1], move_data=.TRUE., summation=.TRUE.)
-            CALL dbt_filter(t_3c_der_AO(i_xyz), ri_data%filter_eps)
+            CALL alloc_containers(t_3c_der_RI_comp(i_mem, i_xyz), 1)
+            CALL compress_tensor(ri_ao_ao_template, t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                 t_3c_der_RI_comp(i_mem, i_xyz), ri_data%filter_eps_storage, memory)
+            CALL dbt_clear(ri_ao_ao_template)
+
+            !put AO derivative as middle index
+            CALL dbt_copy(t_3c_der_AO_prv(1, 1, i_xyz), ri_ao_ao_template, order=[1, 3, 2], move_data=.TRUE.)
+            CALL dbt_filter(ri_ao_ao_template, ri_data%filter_eps)
+            CALL get_tensor_occupancy(ri_ao_ao_template, nze, occ)
+            nze_tot = nze_tot + nze
+
+            CALL alloc_containers(t_3c_der_AO_comp(i_mem, i_xyz), 1)
+            CALL compress_tensor(ri_ao_ao_template, t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                 t_3c_der_AO_comp(i_mem, i_xyz), ri_data%filter_eps_storage, memory)
+            CALL dbt_clear(ri_ao_ao_template)
          END DO
       END DO
-      CALL dbt_clear(ao_ri_ao_template)
 
       CALL neighbor_list_3c_destroy(nl_3c)
-
       DO i_xyz = 1, 3
          CALL dbt_destroy(t_3c_der_RI_prv(1, 1, i_xyz))
          CALL dbt_destroy(t_3c_der_AO_prv(1, 1, i_xyz))
       END DO
+
+      CALL mp_sum(memory, para_env%group)
+      compression_factor = REAL(nze_tot, dp)*1.0E-06*8.0_dp/memory
+      IF (ri_data%unit_nr > 0) THEN
+         WRITE (UNIT=ri_data%unit_nr, FMT="((T3,A,T66,F11.2,A4))") &
+            "MEMORY_INFO| Memory for 3-center HFX derivatives (compressed):", memory, ' MiB'
+
+         WRITE (UNIT=ri_data%unit_nr, FMT="((T3,A,T60,F21.2))") &
+            "MEMORY_INFO| Compression factor:                  ", compression_factor
+      END IF
 
       !Deal with the 2-center derivatives
       CALL cp_dbcsr_dist2d_to_dist(dist_2d, dbcsr_dist)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -89,6 +89,7 @@ MODULE rpa_im_time_force_methods
                                               m_walltime
    USE mathconstants,                   ONLY: fourpi
    USE message_passing,                 ONLY: mp_cart_create,&
+                                              mp_sum,&
                                               mp_sync
    USE mp2_eri,                         ONLY: integrate_set_2c
    USE mp2_eri_gpw,                     ONLY: calc_potential_gpw,&
@@ -189,14 +190,16 @@ CONTAINS
 !> \param force_data ...
 !> \param fm_matrix_PQ ...
 !> \param t_3c_M the 3-center M tensor to be used as a template
+!> \param unit_nr ...
 !> \param mp2_env ...
 !> \param qs_env ...
 ! **************************************************************************************************
-   SUBROUTINE init_im_time_forces(force_data, fm_matrix_PQ, t_3c_M, mp2_env, qs_env)
+   SUBROUTINE init_im_time_forces(force_data, fm_matrix_PQ, t_3c_M, unit_nr, mp2_env, qs_env)
 
       TYPE(im_time_force_type), INTENT(INOUT)            :: force_data
       TYPE(cp_fm_type), POINTER                          :: fm_matrix_PQ
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M
+      INTEGER, INTENT(IN)                                :: unit_nr
       TYPE(mp2_type)                                     :: mp2_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
@@ -205,6 +208,7 @@ CONTAINS
       INTEGER                                            :: handle, i_mem, i_xyz, ispin, &
                                                             mp_comm_t3c, n_dependent, n_mem, &
                                                             natom, nkind, nspins
+      INTEGER(int_8)                                     :: nze, nze_tot
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist_AO_1, dist_AO_2, &
                                                             dist_RI, dummy_end, dummy_start, &
                                                             end_blocks, sizes_AO, sizes_RI, &
@@ -213,6 +217,7 @@ CONTAINS
       INTEGER, DIMENSION(3)                              :: nblks_total, pcoord, pdims, pdims_t3c
       INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       LOGICAL                                            :: do_periodic
+      REAL(dp)                                           :: compression_factor, memory, occ
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -244,7 +249,6 @@ CONTAINS
 
       CALL get_qs_env(qs_env, natom=natom, nkind=nkind, dft_control=dft_control, para_env=para_env, &
                       particle_set=particle_set, qs_kind_set=qs_kind_set, cell=cell)
-
       IF (dft_control%qs_control%gapw) THEN
          CPABORT("Low-scaling RPA/SOS-MP2 forces only available with GPW")
       END IF
@@ -303,6 +307,11 @@ CONTAINS
       CALL create_tensor_batches(sizes_AO, n_mem, dummy_start, dummy_end, start_blocks, end_blocks)
       DEALLOCATE (dummy_start, dummy_end)
 
+      ALLOCATE (force_data%t_3c_der_AO_comp(n_mem, 3), force_data%t_3c_der_RI_comp(n_mem, 3))
+      ALLOCATE (force_data%t_3c_der_AO_ind(n_mem, 3), force_data%t_3c_der_RI_ind(n_mem, 3))
+
+      memory = 0.0_dp
+      nze_tot = 0
       DO i_mem = 1, n_mem
          CALL build_3c_derivatives(t_3c_der_RI_prv, t_3c_der_AO_prv, mp2_env%ri_rpa_im_time%eps_filter, &
                                    qs_env, nl_3c, basis_set_ri_aux, basis_set_ao, basis_set_ao, &
@@ -310,13 +319,25 @@ CONTAINS
                                    bounds_j=[start_blocks(i_mem), end_blocks(i_mem)])
 
          DO i_xyz = 1, 3
-            CALL dbt_copy(t_3c_der_RI_prv(1, 1, i_xyz), force_data%t_3c_der_RI(i_xyz), &
-                          move_data=.TRUE., summation=.TRUE.)
+            CALL dbt_copy(t_3c_der_RI_prv(1, 1, i_xyz), force_data%t_3c_der_RI(i_xyz), move_data=.TRUE.)
             CALL dbt_filter(force_data%t_3c_der_RI(i_xyz), mp2_env%ri_rpa_im_time%eps_filter)
+            CALL get_tensor_occupancy(force_data%t_3c_der_RI(i_xyz), nze, occ)
+            nze_tot = nze_tot + nze
 
-            CALL dbt_copy(t_3c_der_AO_prv(1, 1, i_xyz), force_data%t_3c_der_AO(i_xyz), &
-                          move_data=.TRUE., summation=.TRUE.)
+            CALL alloc_containers(force_data%t_3c_der_RI_comp(i_mem, i_xyz), 1)
+            CALL compress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                 force_data%t_3c_der_RI_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress, memory)
+            CALL dbt_clear(force_data%t_3c_der_RI(i_xyz))
+
+            CALL dbt_copy(t_3c_der_AO_prv(1, 1, i_xyz), force_data%t_3c_der_AO(i_xyz), move_data=.TRUE.)
             CALL dbt_filter(force_data%t_3c_der_AO(i_xyz), mp2_env%ri_rpa_im_time%eps_filter)
+            CALL get_tensor_occupancy(force_data%t_3c_der_AO(i_xyz), nze, occ)
+            nze_tot = nze_tot + nze
+
+            CALL alloc_containers(force_data%t_3c_der_AO_comp(i_mem, i_xyz), 1)
+            CALL compress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                 force_data%t_3c_der_AO_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress, memory)
+            CALL dbt_clear(force_data%t_3c_der_AO(i_xyz))
          END DO
       END DO
       CALL neighbor_list_3c_destroy(nl_3c)
@@ -324,6 +345,16 @@ CONTAINS
          CALL dbt_destroy(t_3c_der_RI_prv(1, 1, i_xyz))
          CALL dbt_destroy(t_3c_der_AO_prv(1, 1, i_xyz))
       END DO
+
+      CALL mp_sum(memory, para_env%group)
+      compression_factor = REAL(nze_tot, dp)*1.0E-06*8.0_dp/memory
+      IF (unit_nr > 0) THEN
+         WRITE (UNIT=unit_nr, FMT="((T3,A,T66,F11.2,A4))") &
+            "MEMORY_INFO| Memory for 3-center derivatives (compressed):", memory, ' MiB'
+
+         WRITE (UNIT=unit_nr, FMT="((T3,A,T60,F21.2))") &
+            "MEMORY_INFO| Compression factor:                  ", compression_factor
+      END IF
 
       !Dealing with the 2-center derivatives
       CALL get_qs_env(qs_env, distribution_2d=dist_2d, blacs_env=blacs_env, matrix_s=matrix_s)
@@ -592,9 +623,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_laplace_loop_forces'
 
-      INTEGER                                            :: dummy_int, handle, handle2, i_xyz, &
-                                                            ispin, j_xyz, jquad, k_xyz, n_mem_RI, &
-                                                            natom, nspins, unit_nr_dbcsr
+      INTEGER                                            :: dummy_int, handle, handle2, i_mem, &
+                                                            i_xyz, ispin, j_xyz, jquad, k_xyz, &
+                                                            n_mem_RI, natom, nspins, unit_nr_dbcsr
       INTEGER(int_8)                                     :: flop, nze, nze_ddint, nze_der_AO, &
                                                             nze_der_RI, nze_KQK
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, batch_blk_end, &
@@ -670,22 +701,6 @@ CONTAINS
       mc_ranges_RI(n_mem_RI + 1) = batch_blk_end(n_mem_RI) + 1
       DEALLOCATE (batch_blk_start, batch_blk_end)
 
-      occ_der_AO = 0; nze_der_AO = 0
-      occ_der_RI = 0; nze_der_RI = 0
-      DO i_xyz = 1, 3
-         CALL get_tensor_occupancy(force_data%t_3c_der_AO(i_xyz), nze, occ)
-         occ_der_AO = occ_der_AO + occ
-         nze_der_AO = nze_der_AO + nze
-
-         CALL get_tensor_occupancy(force_data%t_3c_der_RI(i_xyz), nze, occ)
-         occ_der_RI = occ_der_RI + occ
-         nze_der_RI = nze_der_RI + nze
-      END DO
-      occ_der_RI = occ_der_RI/3.0_dp
-      occ_der_AO = occ_der_AO/3.0_dp
-      nze_der_RI = nze_der_RI/3
-      nze_der_AO = nze_der_AO/3
-
       !Pre-allocate all required tensors and matrices
       DO ispin = 1, nspins
          CALL dbt_create(t_2c_RI, t_P(ispin))
@@ -716,11 +731,30 @@ CONTAINS
       CALL dbt_create(t_3c_M, t_3c_work)
 
       !Pre-define the sparsity of t_3c_4 as a function of the derivatives
+      occ_der_AO = 0; nze_der_AO = 0
+      occ_der_RI = 0; nze_der_RI = 0
       DO i_xyz = 1, 3
-         CALL dbt_copy(force_data%t_3c_der_RI(i_xyz), t_3c_sparse, summation=.TRUE.)
-         CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, summation=.TRUE.)
-         CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, order=[1, 3, 2], summation=.TRUE.)
+         DO i_mem = 1, cut_memory
+            CALL decompress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                   force_data%t_3c_der_RI_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            CALL get_tensor_occupancy(force_data%t_3c_der_RI(i_xyz), nze, occ)
+            occ_der_RI = occ_der_RI + occ
+            nze_der_RI = nze_der_RI + nze
+            CALL dbt_copy(force_data%t_3c_der_RI(i_xyz), t_3c_sparse, summation=.TRUE., move_data=.TRUE.)
+
+            CALL decompress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                   force_data%t_3c_der_AO_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            CALL get_tensor_occupancy(force_data%t_3c_der_AO(i_xyz), nze, occ)
+            occ_der_AO = occ_der_AO + occ
+            nze_der_AO = nze_der_AO + nze
+            CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, order=[1, 3, 2], summation=.TRUE.)
+            CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, summation=.TRUE., move_data=.TRUE.)
+         END DO
       END DO
+      occ_der_RI = occ_der_RI/3.0_dp
+      occ_der_AO = occ_der_AO/3.0_dp
+      nze_der_RI = nze_der_RI/3
+      nze_der_AO = nze_der_AO/3
 
       CALL dbcsr_create(R_occ, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(R_virt, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
@@ -1095,9 +1129,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_rpa_loop_forces'
 
-      INTEGER                                            :: dummy_int, handle, handle2, i_xyz, &
-                                                            iquad, j_xyz, jquad, k_xyz, n_mem_RI, &
-                                                            natom, nspins, unit_nr_dbcsr
+      INTEGER                                            :: dummy_int, handle, handle2, i_mem, &
+                                                            i_xyz, iquad, j_xyz, jquad, k_xyz, &
+                                                            n_mem_RI, natom, nspins, unit_nr_dbcsr
       INTEGER(int_8)                                     :: flop, nze, nze_ddint, nze_der_AO, &
                                                             nze_der_RI, nze_KBK
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, batch_blk_end, &
@@ -1173,22 +1207,6 @@ CONTAINS
       mc_ranges_RI(1:n_mem_RI) = batch_blk_start(1:n_mem_RI)
       mc_ranges_RI(n_mem_RI + 1) = batch_blk_end(n_mem_RI) + 1
       DEALLOCATE (batch_blk_start, batch_blk_end)
-
-      occ_der_AO = 0; nze_der_AO = 0
-      occ_der_RI = 0; nze_der_RI = 0
-      DO i_xyz = 1, 3
-         CALL get_tensor_occupancy(force_data%t_3c_der_AO(i_xyz), nze, occ)
-         occ_der_AO = occ_der_AO + occ
-         nze_der_AO = nze_der_AO + nze
-
-         CALL get_tensor_occupancy(force_data%t_3c_der_RI(i_xyz), nze, occ)
-         occ_der_RI = occ_der_RI + occ
-         nze_der_RI = nze_der_RI + nze
-      END DO
-      occ_der_RI = occ_der_RI/3.0_dp
-      occ_der_AO = occ_der_AO/3.0_dp
-      nze_der_RI = nze_der_RI/3
-      nze_der_AO = nze_der_AO/3
 
       !Pre-allocate all required tensors and matrices
       CALL dbt_create(t_2c_RI, t_P)
@@ -1294,11 +1312,30 @@ CONTAINS
       CALL dbt_clear(t_2c_RI_2)
 
       !Pre-define the sparsity of t_3c_4 as a function of the derivatives
+      occ_der_AO = 0; nze_der_AO = 0
+      occ_der_RI = 0; nze_der_RI = 0
       DO i_xyz = 1, 3
-         CALL dbt_copy(force_data%t_3c_der_RI(i_xyz), t_3c_sparse, summation=.TRUE.)
-         CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, summation=.TRUE.)
-         CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, order=[1, 3, 2], summation=.TRUE.)
+         DO i_mem = 1, cut_memory
+            CALL decompress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                   force_data%t_3c_der_RI_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            CALL get_tensor_occupancy(force_data%t_3c_der_RI(i_xyz), nze, occ)
+            occ_der_RI = occ_der_RI + occ
+            nze_der_RI = nze_der_RI + nze
+            CALL dbt_copy(force_data%t_3c_der_RI(i_xyz), t_3c_sparse, summation=.TRUE., move_data=.TRUE.)
+
+            CALL decompress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                   force_data%t_3c_der_AO_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            CALL get_tensor_occupancy(force_data%t_3c_der_AO(i_xyz), nze, occ)
+            occ_der_AO = occ_der_AO + occ
+            nze_der_AO = nze_der_AO + nze
+            CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, order=[1, 3, 2], summation=.TRUE.)
+            CALL dbt_copy(force_data%t_3c_der_AO(i_xyz), t_3c_sparse, summation=.TRUE., move_data=.TRUE.)
+         END DO
       END DO
+      occ_der_RI = occ_der_RI/3.0_dp
+      occ_der_AO = occ_der_AO/3.0_dp
+      nze_der_RI = nze_der_RI/3
+      nze_der_AO = nze_der_AO/3
 
       CALL dbcsr_create(R_occ, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(R_virt, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
@@ -1799,7 +1836,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'perform_3c_ops'
 
       INTEGER                                            :: dummy_int, handle, handle2, i_mem, &
-                                                            j_mem, k_mem
+                                                            i_xyz, j_mem, k_mem
       INTEGER(int_8)                                     :: flop, nze
       INTEGER, DIMENSION(2, 1)                           :: ibounds, jbounds, kbounds
       INTEGER, DIMENSION(2, 2)                           :: bounds_2c
@@ -1959,21 +1996,51 @@ CONTAINS
 
       pref = 1.0_dp*fac
       IF (use_virial) THEN
-         CALL get_force_from_3c_trace(force, t_3c_help_1, force_data%t_3c_der_RI, atom_of_kind, kind_of, &
-                                      force_data%idx_to_at_RI, pref, work_virial, cell, particle_set, &
-                                      do_mp2=.TRUE., deriv_dim=1)
+         DO i_mem = 1, cut_memory
+            DO i_xyz = 1, 3
+               CALL dbt_clear(force_data%t_3c_der_RI(i_xyz))
+               CALL decompress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                      force_data%t_3c_der_RI_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            END DO
+            CALL get_force_from_3c_trace(force, t_3c_help_1, force_data%t_3c_der_RI, atom_of_kind, kind_of, &
+                                         force_data%idx_to_at_RI, pref, work_virial, cell, particle_set, &
+                                         do_mp2=.TRUE., deriv_dim=1)
+         END DO
+
          CALL dbt_copy(t_3c_help_1, t_3c_help_2)
          CALL dbt_copy(t_3c_help_1, t_3c_help_2, order=[1, 3, 2], move_data=.TRUE., summation=.TRUE.)
-         CALL get_force_from_3c_trace(force, t_3c_help_2, force_data%t_3c_der_AO, atom_of_kind, kind_of, &
-                                      force_data%idx_to_at_AO, pref, work_virial, cell, particle_set, &
-                                      do_mp2=.TRUE., deriv_dim=3)
+         DO i_mem = 1, cut_memory
+            DO i_xyz = 1, 3
+               CALL dbt_clear(force_data%t_3c_der_AO(i_xyz))
+               CALL decompress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                      force_data%t_3c_der_AO_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            END DO
+            CALL get_force_from_3c_trace(force, t_3c_help_2, force_data%t_3c_der_AO, atom_of_kind, kind_of, &
+                                         force_data%idx_to_at_AO, pref, work_virial, cell, particle_set, &
+                                         do_mp2=.TRUE., deriv_dim=3)
+         END DO
       ELSE
-         CALL get_force_from_3c_trace(force, t_3c_help_1, force_data%t_3c_der_RI, atom_of_kind, kind_of, &
-                                      force_data%idx_to_at_RI, pref, do_mp2=.TRUE., deriv_dim=1)
+         DO i_mem = 1, cut_memory
+            DO i_xyz = 1, 3
+               CALL dbt_clear(force_data%t_3c_der_RI(i_xyz))
+               CALL decompress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(i_mem, i_xyz)%ind, &
+                                      force_data%t_3c_der_RI_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            END DO
+            CALL get_force_from_3c_trace(force, t_3c_help_1, force_data%t_3c_der_RI, atom_of_kind, kind_of, &
+                                         force_data%idx_to_at_RI, pref, do_mp2=.TRUE., deriv_dim=1)
+         END DO
+
          CALL dbt_copy(t_3c_help_1, t_3c_help_2)
          CALL dbt_copy(t_3c_help_1, t_3c_help_2, order=[1, 3, 2], move_data=.TRUE., summation=.TRUE.)
-         CALL get_force_from_3c_trace(force, t_3c_help_2, force_data%t_3c_der_AO, atom_of_kind, kind_of, &
-                                      force_data%idx_to_at_AO, pref, do_mp2=.TRUE., deriv_dim=3)
+         DO i_mem = 1, cut_memory
+            DO i_xyz = 1, 3
+               CALL dbt_clear(force_data%t_3c_der_AO(i_xyz))
+               CALL decompress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(i_mem, i_xyz)%ind, &
+                                      force_data%t_3c_der_AO_comp(i_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            END DO
+            CALL get_force_from_3c_trace(force, t_3c_help_2, force_data%t_3c_der_AO, atom_of_kind, kind_of, &
+                                         force_data%idx_to_at_AO, pref, do_mp2=.TRUE., deriv_dim=3)
+         END DO
       END IF
       CALL dbt_clear(t_3c_help_2)
 

--- a/src/rpa_im_time_force_types.F
+++ b/src/rpa_im_time_force_types.F
@@ -16,6 +16,9 @@ MODULE rpa_im_time_force_types
                                               dbcsr_type
    USE dbt_api,                         ONLY: dbt_destroy,&
                                               dbt_type
+   USE hfx_types,                       ONLY: block_ind_type,&
+                                              dealloc_containers,&
+                                              hfx_compression_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -35,6 +38,10 @@ MODULE rpa_im_time_force_types
       !The 3-center integral derivatives (with the RI metric operator)
       TYPE(dbt_type), DIMENSION(3)  :: t_3c_der_AO, & ! (RI| AO deriv_AO)
                                        t_3c_der_RI    ! (deriv_RI| AO AO)
+
+      !The compressed 3-center derivatives
+      TYPE(hfx_compression_type), ALLOCATABLE, DIMENSION(:, :)   :: t_3c_der_AO_comp, t_3c_der_RI_comp
+      TYPE(block_ind_type), ALLOCATABLE, DIMENSION(:, :)         :: t_3c_der_AO_ind, t_3c_der_RI_ind
 
       !The RI related 2-center quantities
       TYPE(dbt_type) :: t_2c_pot_psqrt, t_2c_inv_metric, t_2c_K, t_2c_pot_msqrt
@@ -70,7 +77,7 @@ CONTAINS
 
       TYPE(im_time_force_type)                           :: force_data
 
-      INTEGER                                            :: i_xyz
+      INTEGER                                            :: dummy_int, i, i_xyz, j
 
       CALL dbt_destroy(force_data%t_2c_pot_psqrt)
       CALL dbt_destroy(force_data%t_2c_pot_msqrt)
@@ -96,6 +103,18 @@ CONTAINS
       DO i_xyz = 1, 3
          CALL dbt_destroy(force_data%t_2c_der_metric(i_xyz))
       END DO
+
+      DO i = 1, SIZE(force_data%t_3c_der_AO_comp, 1)
+         DO j = 1, SIZE(force_data%t_3c_der_AO_comp, 2)
+            CALL dealloc_containers(force_data%t_3c_der_AO_comp(i, j), dummy_int)
+         END DO
+      END DO
+      DO i = 1, SIZE(force_data%t_3c_der_RI_comp, 1)
+         DO j = 1, SIZE(force_data%t_3c_der_RI_comp, 2)
+            CALL dealloc_containers(force_data%t_3c_der_RI_comp(i, j), dummy_int)
+         END DO
+      END DO
+      DEALLOCATE (force_data%t_3c_der_AO_ind, force_data%t_3c_der_RI_ind)
 
    END SUBROUTINE im_time_force_release
 

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -1241,7 +1241,7 @@ CONTAINS
                             mat_SinvVSinv, mat_P_omega, mat_P_omega_kp, mat_work, mo_coeff, &
                             fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, homo, nmo)
 
-         IF (calc_forces) CALL init_im_time_forces(force_data, fm_matrix_PQ, t_3c_M, mp2_env, qs_env)
+         IF (calc_forces) CALL init_im_time_forces(force_data, fm_matrix_PQ, t_3c_M, unit_nr, mp2_env, qs_env)
 
          IF (my_do_gw) THEN
 


### PR DESCRIPTION
In RI-HFX and low-scaling RPA/SOS-MP2, the 3-center tensors containing the derivatives are now stored in a compressed form, the same way that integrals are. This should reduce the memory footprint of such calculations.