### PR TITLE
Refactoring of the fm module

### DIFF
--- a/src/common/cp_para_env.F
+++ b/src/common/cp_para_env.F
@@ -76,7 +76,7 @@ CONTAINS
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE cp_para_env_retain(para_env)
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
 
       CPASSERT(ASSOCIATED(para_env))
       CPASSERT(para_env%ref_count > 0)
@@ -171,9 +171,8 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE cp_cart_update(cart)
-      TYPE(cp_para_cart_type), POINTER                   :: cart
+      TYPE(cp_para_cart_type), INTENT(INOUT)             :: cart
 
-      CPASSERT(ASSOCIATED(cart))
       CPASSERT(cart%ref_count > 0)
       CALL mp_environ(cart%group, cart%ndims, cart%num_pe, task_coor=cart%mepos, &
                       periods=cart%periodic)

--- a/src/emd/rt_delta_pulse.F
+++ b/src/emd/rt_delta_pulse.F
@@ -95,9 +95,10 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: com_nl
       REAL(KIND=dp)                                      :: eps_ppnl, factor
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data
       REAL(KIND=dp), DIMENSION(3)                        :: kvec
       REAL(kind=dp), DIMENSION(:), POINTER               :: eigenvalues
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_cfm_type), POINTER                         :: oo_c, oo_v, oo_vt
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp

--- a/src/fm/cp_cfm_basic_linalg.F
+++ b/src/fm/cp_cfm_basic_linalg.F
@@ -68,7 +68,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_schur_product(matrix_a, matrix_b, matrix_c)
 
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a, matrix_b, matrix_c
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a, matrix_b, matrix_c
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_schur_product'
 
@@ -106,7 +106,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_schur_product_cc(matrix_a, matrix_b, matrix_c)
 
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a, matrix_b, matrix_c
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a, matrix_b, matrix_c
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_schur_product_cc'
 
@@ -155,9 +155,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_scale_and_add(alpha, matrix_a, beta, matrix_b)
       COMPLEX(kind=dp), INTENT(in)                       :: alpha
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a
       COMPLEX(kind=dp), INTENT(in), OPTIONAL             :: beta
-      TYPE(cp_cfm_type), OPTIONAL, POINTER               :: matrix_b
+      TYPE(cp_cfm_type), INTENT(IN), OPTIONAL            :: matrix_b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_scale_and_add'
 
@@ -172,8 +172,6 @@ CONTAINS
       IF (PRESENT(beta)) my_beta = beta
       NULLIFY (a, b)
 
-      CPASSERT(ASSOCIATED(matrix_a))
-      CPASSERT(matrix_a%ref_count > 0)
       ! to do: use dscal,dcopy,daxp
       myprow = matrix_a%matrix_struct%context%mepos(1)
       mypcol = matrix_a%matrix_struct%context%mepos(2)
@@ -196,8 +194,6 @@ CONTAINS
 
       ELSE
          CPASSERT(PRESENT(matrix_b))
-         CPASSERT(ASSOCIATED(matrix_b))
-         CPASSERT(matrix_b%ref_count > 0)
          IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
             CPABORT("matrixes must be in the same blacs context")
 
@@ -270,9 +266,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_scale_and_add_fm(alpha, matrix_a, beta, matrix_b)
       COMPLEX(kind=dp), INTENT(in)                       :: alpha
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a
       COMPLEX(kind=dp), INTENT(in)                       :: beta
-      TYPE(cp_fm_type), POINTER                          :: matrix_b
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix_b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_scale_and_add_fm'
 
@@ -285,7 +281,6 @@ CONTAINS
 
       NULLIFY (a, b)
 
-      CPASSERT(ASSOCIATED(matrix_a))
       myprow = matrix_a%matrix_struct%context%mepos(1)
       mypcol = matrix_a%matrix_struct%context%mepos(2)
 
@@ -306,7 +301,6 @@ CONTAINS
          END IF
 
       ELSE
-         CPASSERT(ASSOCIATED(matrix_b))
          IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
             CPABORT("matrices must be in the same blacs context")
 
@@ -378,7 +372,7 @@ CONTAINS
 !>    The original content of the matrix is destroyed.
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_lu_decompose(matrix_a, determinant)
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a
       COMPLEX(kind=dp), INTENT(out)                      :: determinant
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_lu_decompose'
@@ -486,9 +480,9 @@ CONTAINS
       CHARACTER(len=1), INTENT(in)                       :: transa, transb
       INTEGER, INTENT(in)                                :: m, n, k
       COMPLEX(kind=dp), INTENT(in)                       :: alpha
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a, matrix_b
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix_a, matrix_b
       COMPLEX(kind=dp), INTENT(in)                       :: beta
-      TYPE(cp_cfm_type), POINTER                         :: matrix_c
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_c
       INTEGER, INTENT(in), OPTIONAL                      :: a_first_col, a_first_row, b_first_col, &
                                                             b_first_row, c_first_col, c_first_row
 
@@ -565,7 +559,7 @@ CONTAINS
 !> \author Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_column_scale(matrix_a, scaling)
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a
       COMPLEX(kind=dp), DIMENSION(:), INTENT(in)         :: scaling
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_column_scale'
@@ -608,7 +602,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_dscale(alpha, matrix_a)
       REAL(kind=dp), INTENT(in)                          :: alpha
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_cfm_dscale'
 
@@ -618,9 +612,6 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (a)
-
-      CPASSERT(ASSOCIATED(matrix_a))
-      CPASSERT(matrix_a%ref_count > 0)
 
       a => matrix_a%local_data
 
@@ -639,7 +630,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_zscale(alpha, matrix_a)
       COMPLEX(kind=dp), INTENT(in)                       :: alpha
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_cfm_zscale'
 
@@ -649,9 +640,6 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (a)
-
-      CPASSERT(ASSOCIATED(matrix_a))
-      CPASSERT(matrix_a%ref_count > 0)
 
       a => matrix_a%local_data
 
@@ -670,7 +658,7 @@ CONTAINS
 !> \author Florian Schiffmann
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_solve(matrix_a, general_a, determinant)
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a, general_a
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix_a, general_a
       COMPLEX(kind=dp), OPTIONAL                         :: determinant
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_solve'
@@ -762,7 +750,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_lu_invert(matrix, info_out)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix
       INTEGER, INTENT(out), OPTIONAL                     :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_lu_invert'
@@ -848,7 +836,7 @@ CONTAINS
 !> \author Joost
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_cholesky_decompose(matrix, n, info_out)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix
       INTEGER, INTENT(in), OPTIONAL                      :: n
       INTEGER, INTENT(out), OPTIONAL                     :: info_out
 
@@ -904,7 +892,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_cholesky_invert(matrix, n, info_out)
-      TYPE(cp_cfm_type), POINTER                 :: matrix
+      TYPE(cp_cfm_type), INTENT(INOUT)           :: matrix
       INTEGER, INTENT(in), OPTIONAL              :: n
       INTEGER, INTENT(out), OPTIONAL             :: info_out
 
@@ -959,7 +947,7 @@ CONTAINS
 !>      Based on the subroutine cp_fm_trace(). Note the transposition of matrix_a!
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_trace(matrix_a, matrix_b, trace)
-      TYPE(cp_cfm_type), POINTER                         :: matrix_a, matrix_b
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix_a, matrix_b
       COMPLEX(kind=dp), INTENT(out)                      :: trace
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_cfm_trace'
@@ -1028,7 +1016,7 @@ CONTAINS
    SUBROUTINE cp_cfm_triangular_multiply(triangular_matrix, matrix_b, side, &
                                          transa_tr, invert_tr, uplo_tr, unit_diag_tr, n_rows, n_cols, &
                                          alpha)
-      TYPE(cp_cfm_type), POINTER                         :: triangular_matrix, matrix_b
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: triangular_matrix, matrix_b
       CHARACTER, INTENT(in), OPTIONAL                    :: side, transa_tr
       LOGICAL, INTENT(in), OPTIONAL                      :: invert_tr
       CHARACTER, INTENT(in), OPTIONAL                    :: uplo_tr
@@ -1110,7 +1098,7 @@ CONTAINS
 !> \author MI
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_triangular_invert(matrix_a, uplo, info_out)
-      TYPE(cp_cfm_type), POINTER               :: matrix_a
+      TYPE(cp_cfm_type), INTENT(INOUT)         :: matrix_a
       CHARACTER, INTENT(in), OPTIONAL          :: uplo
       INTEGER, INTENT(out), OPTIONAL           :: info_out
 
@@ -1160,9 +1148,9 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_transpose(matrix, trans, matrixt)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix
       CHARACTER, INTENT(in)                              :: trans
-      TYPE(cp_cfm_type), POINTER                         :: matrixt
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrixt
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_transpose'
 
@@ -1176,8 +1164,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CPASSERT(ASSOCIATED(matrix))
-      CPASSERT(ASSOCIATED(matrixt))
       nrow_global = matrix%matrix_struct%nrow_global
       ncol_global = matrix%matrix_struct%ncol_global
 
@@ -1235,7 +1221,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    FUNCTION cp_cfm_norm(matrix, mode) RESULT(res)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix
       CHARACTER, INTENT(IN)                              :: mode
       REAL(kind=dp)                                      :: res
 

--- a/src/fm/cp_cfm_types.F
+++ b/src/fm/cp_cfm_types.F
@@ -209,7 +209,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_set_all(matrix, alpha, beta)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix
       COMPLEX(kind=dp), INTENT(in)                       :: alpha
       COMPLEX(kind=dp), INTENT(in), OPTIONAL             :: beta
 
@@ -262,7 +262,7 @@ CONTAINS
 !>      always return the answer
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_get_element(matrix, irow_global, icol_global, alpha)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix
       INTEGER, INTENT(in)                                :: irow_global, icol_global
       COMPLEX(kind=dp), INTENT(out)                      :: alpha
 
@@ -309,7 +309,7 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_set_element(matrix, irow_global, icol_global, alpha)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix
       INTEGER, INTENT(in)                                :: irow_global, icol_global
       COMPLEX(kind=dp), INTENT(in)                       :: alpha
 
@@ -363,7 +363,7 @@ CONTAINS
 !>      Optimized for full column updates. The matrix target_m is replicated and valid on all CPUs.
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_get_submatrix(fm, target_m, start_row, start_col, n_rows, n_cols, transpose)
-      TYPE(cp_cfm_type), POINTER                         :: fm
+      TYPE(cp_cfm_type), INTENT(IN)                      :: fm
       COMPLEX(kind=dp), DIMENSION(:, :), INTENT(out)     :: target_m
       INTEGER, INTENT(in), OPTIONAL                      :: start_row, start_col, n_rows, n_cols
       LOGICAL, INTENT(in), OPTIONAL                      :: transpose
@@ -379,9 +379,6 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(fm))
-      CPASSERT(fm%ref_count .GT. 0)
 
       IF (SIZE(target_m) /= 0) THEN
 #if defined(__SCALAPACK)
@@ -503,7 +500,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_set_submatrix(matrix, new_values, start_row, &
                                    start_col, n_rows, n_cols, alpha, beta, transpose)
-      TYPE(cp_cfm_type), POINTER                         :: matrix
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix
       COMPLEX(kind=dp), DIMENSION(:, :), INTENT(in)      :: new_values
       INTEGER, INTENT(in), OPTIONAL                      :: start_row, start_col, n_rows, n_cols
       COMPLEX(kind=dp), INTENT(in), OPTIONAL             :: alpha, beta
@@ -520,9 +517,6 @@ CONTAINS
       LOGICAL                                            :: tr_a
 
       CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(matrix))
-      CPASSERT(matrix%ref_count > 0)
 
       al = z_one
       be = z_zero
@@ -643,7 +637,7 @@ CONTAINS
                               nrow_block, ncol_block, nrow_local, ncol_local, &
                               row_indices, col_indices, local_data, context, &
                               matrix_struct, para_env)
-      TYPE(cp_cfm_type), POINTER        :: matrix
+      TYPE(cp_cfm_type), INTENT(IN)           :: matrix
       CHARACTER(len=*), OPTIONAL, INTENT(OUT) :: name
       INTEGER, OPTIONAL, INTENT(OUT)          :: ncol_block, ncol_global, &
                                                  nrow_block, nrow_global, &
@@ -734,7 +728,7 @@ CONTAINS
 !> \author Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_to_cfm_matrix(source, destination)
-      TYPE(cp_cfm_type), POINTER                         :: source, destination
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: source, destination
 
       INTEGER                                            :: npcol, nprow
 
@@ -775,7 +769,7 @@ CONTAINS
    SUBROUTINE cp_cfm_to_cfm_columns(msource, mtarget, ncol, source_start, &
                                     target_start)
 
-      TYPE(cp_cfm_type), POINTER                         :: msource, mtarget
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: msource, mtarget
       INTEGER, INTENT(IN)                                :: ncol
       INTEGER, INTENT(IN), OPTIONAL                      :: source_start, target_start
 
@@ -822,7 +816,7 @@ CONTAINS
 !> \param uplo    'U' for upper triangular, 'L' for lower triangular
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_to_cfm_triangular(msource, mtarget, uplo)
-      TYPE(cp_cfm_type), POINTER                         :: msource, mtarget
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: msource, mtarget
       CHARACTER(len=*), INTENT(IN)                       :: uplo
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_to_cfm_triangular'
@@ -863,8 +857,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_to_fm(msource, mtargetr, mtargeti)
 
-      TYPE(cp_cfm_type), POINTER                         :: msource
-      TYPE(cp_fm_type), OPTIONAL, POINTER                :: mtargetr, mtargeti
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: msource
+      TYPE(cp_fm_type), INTENT(INOUT), OPTIONAL          :: mtargetr, mtargeti
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_cfm_to_fm'
 
@@ -914,8 +908,8 @@ CONTAINS
 !>        Matrix structures are assumed to be equivalent.
 ! **************************************************************************************************
    SUBROUTINE cp_fm_to_cfm(msourcer, msourcei, mtarget)
-      TYPE(cp_fm_type), OPTIONAL, POINTER                :: msourcer, msourcei
-      TYPE(cp_cfm_type), POINTER                         :: mtarget
+      TYPE(cp_fm_type), INTENT(IN), OPTIONAL             :: msourcer, msourcei
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: mtarget
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_to_cfm'
 

--- a/src/fm/cp_cfm_types.F
+++ b/src/fm/cp_cfm_types.F
@@ -75,7 +75,7 @@ MODULE cp_cfm_types
       CHARACTER(len=60) :: name
       INTEGER :: id_nr, ref_count, print_count
       TYPE(cp_fm_struct_type), POINTER :: matrix_struct
-      COMPLEX(kind=dp), DIMENSION(:, :), POINTER :: local_data
+      COMPLEX(kind=dp), DIMENSION(:, :), POINTER, CONTIGUOUS :: local_data
    END TYPE cp_cfm_type
 
 ! **************************************************************************************************
@@ -652,7 +652,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER, OPTIONAL :: para_env
       TYPE(cp_blacs_env_type), POINTER, OPTIONAL :: context
       TYPE(cp_fm_struct_type), POINTER, OPTIONAL :: matrix_struct
-      COMPLEX(kind=dp), DIMENSION(:, :), POINTER, OPTIONAL :: local_data
+      COMPLEX(kind=dp), DIMENSION(:, :), CONTIGUOUS, POINTER, OPTIONAL :: local_data
 
       INTEGER i, nprow, npcol, myprow, mypcol
       TYPE(cp_blacs_env_type), POINTER :: ctxt

--- a/src/fm/cp_fm_basic_linalg.F
+++ b/src/fm/cp_fm_basic_linalg.F
@@ -88,9 +88,9 @@ CONTAINS
    SUBROUTINE cp_fm_scale_and_add(alpha, matrix_a, beta, matrix_b)
 
       REAL(KIND=dp), INTENT(IN)                          :: alpha
-      TYPE(cp_fm_type), POINTER                          :: matrix_a
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix_a
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: beta
-      TYPE(cp_fm_type), OPTIONAL, POINTER                :: matrix_b
+      TYPE(cp_fm_type), INTENT(IN), OPTIONAL             :: matrix_b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_scale_and_add'
 
@@ -109,13 +109,8 @@ CONTAINS
       IF (PRESENT(beta)) my_beta = beta
       NULLIFY (a, b)
 
-      CPASSERT(ASSOCIATED(matrix_a))
-      CPASSERT(matrix_a%ref_count > 0)
-
       IF (PRESENT(beta)) THEN
          CPASSERT(PRESENT(matrix_b))
-         CPASSERT(ASSOCIATED(matrix_b))
-         CPASSERT(matrix_b%ref_count > 0)
          IF (matrix_a%id_nr == matrix_b%id_nr) THEN
             IF (matrix_a%id_nr == matrix_b%id_nr) &
                CPWARN("Bad use of routine. Call cp_fm_scale instead")
@@ -194,7 +189,7 @@ CONTAINS
    SUBROUTINE cp_fm_geadd(alpha, trans, matrix_a, beta, matrix_b)
       REAL(KIND=dp), INTENT(IN) :: alpha, beta
       CHARACTER, INTENT(IN) :: trans
-      TYPE(cp_fm_type), POINTER :: matrix_a, matrix_b
+      TYPE(cp_fm_type), INTENT(INOUT) :: matrix_a, matrix_b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_geadd'
 
@@ -208,8 +203,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CPASSERT(ASSOCIATED(matrix_a))
-      CPASSERT(ASSOCIATED(matrix_b))
       nrow_global = matrix_a%matrix_struct%nrow_global
       ncol_global = matrix_a%matrix_struct%ncol_global
       CPASSERT(nrow_global .EQ. matrix_b%matrix_struct%nrow_global)
@@ -273,7 +266,7 @@ CONTAINS
 !>      - Use cp_fm_get_diag instead of n times cp_fm_get_element (A. Bussy)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_lu_decompose(matrix_a, almost_determinant, correct_sign)
-      TYPE(cp_fm_type), POINTER                :: matrix_a
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_a
       REAL(KIND=dp), INTENT(OUT)               :: almost_determinant
       LOGICAL, INTENT(IN), OPTIONAL            :: correct_sign
 
@@ -364,9 +357,9 @@ CONTAINS
       CHARACTER(LEN=1), INTENT(IN)             :: transa, transb
       INTEGER, INTENT(IN)                      :: m, n, k
       REAL(KIND=dp), INTENT(IN)                :: alpha
-      TYPE(cp_fm_type), POINTER                :: matrix_a, matrix_b
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a, matrix_b
       REAL(KIND=dp), INTENT(IN)                :: beta
-      TYPE(cp_fm_type), POINTER                :: matrix_c
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_c
       INTEGER, INTENT(IN), OPTIONAL            :: a_first_col, a_first_row, &
                                                   b_first_col, b_first_row, &
                                                   c_first_col, c_first_row
@@ -500,9 +493,9 @@ CONTAINS
       CHARACTER(LEN=1), INTENT(IN)             :: side, uplo
       INTEGER, INTENT(IN)                      :: m, n
       REAL(KIND=dp), INTENT(IN)                :: alpha
-      TYPE(cp_fm_type), POINTER                :: matrix_a, matrix_b
+      TYPE(cp_fm_type), INTENT(IN)                :: matrix_a, matrix_b
       REAL(KIND=dp), INTENT(IN)                :: beta
-      TYPE(cp_fm_type), POINTER                :: matrix_c
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_c
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_symm'
 
@@ -548,8 +541,8 @@ CONTAINS
 !> \author VW
 ! **************************************************************************************************
    SUBROUTINE cp_fm_frobenius_norm(matrix_a, norm)
-      TYPE(cp_fm_type), POINTER                :: matrix_a
-      REAL(KIND=dp), INTENT(inout)             :: norm
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a
+      REAL(KIND=dp), INTENT(OUT)               :: norm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_frobenius_norm'
 
@@ -597,10 +590,10 @@ CONTAINS
       CHARACTER(LEN=1), INTENT(IN)             :: uplo, trans
       INTEGER, INTENT(IN)                      :: k
       REAL(KIND=dp), INTENT(IN)                :: alpha
-      TYPE(cp_fm_type), POINTER                :: matrix_a
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a
       INTEGER, INTENT(IN)                      :: ia, ja
       REAL(KIND=dp), INTENT(IN)                :: beta
-      TYPE(cp_fm_type), POINTER                :: matrix_c
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_c
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_syrk'
 
@@ -648,7 +641,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_schur_product(matrix_a, matrix_b, matrix_c)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix_a, matrix_b, matrix_c
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix_a, matrix_b, matrix_c
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_schur_product'
 
@@ -698,7 +691,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_trace_a0b0t0(matrix_a, matrix_b, trace)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix_a, matrix_b
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix_a, matrix_b
       REAL(KIND=dp), INTENT(OUT)                         :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a0b0t0'
@@ -769,7 +762,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_trace_a1b0t1(matrix_a, matrix_b, trace)
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: matrix_a
-      TYPE(cp_fm_type), POINTER                          :: matrix_b
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix_b
       REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b0t1'
@@ -1023,7 +1016,7 @@ CONTAINS
    SUBROUTINE cp_fm_triangular_multiply(triangular_matrix, matrix_b, side, &
                                         transpose_tr, invert_tr, uplo_tr, unit_diag_tr, n_rows, n_cols, &
                                         alpha)
-      TYPE(cp_fm_type), POINTER                          :: triangular_matrix, matrix_b
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: triangular_matrix, matrix_b
       CHARACTER, INTENT(in), OPTIONAL                    :: side
       LOGICAL, INTENT(in), OPTIONAL                      :: transpose_tr, invert_tr
       CHARACTER, INTENT(in), OPTIONAL                    :: uplo_tr
@@ -1112,7 +1105,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_scale(alpha, matrix_a)
       REAL(KIND=dp), INTENT(IN)                          :: alpha
-      TYPE(cp_fm_type), POINTER                          :: matrix_a
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix_a
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_scale'
 
@@ -1122,9 +1115,6 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (a)
-
-      CPASSERT(ASSOCIATED(matrix_a))
-      CPASSERT(matrix_a%ref_count > 0)
 
       a => matrix_a%local_data
       size_a = SIZE(a, 1)*SIZE(a, 2)
@@ -1144,7 +1134,7 @@ CONTAINS
 !>      all matrix elements are transposed (see cp_fm_upper_to_half to symmetrise a matrix)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_transpose(matrix, matrixt)
-      TYPE(cp_fm_type), POINTER                :: matrix, matrixt
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix, matrixt
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_transpose'
 
@@ -1157,8 +1147,6 @@ CONTAINS
       INTEGER                                  :: i, j
 #endif
 
-      CPASSERT(ASSOCIATED(matrix))
-      CPASSERT(ASSOCIATED(matrixt))
       nrow_global = matrix%matrix_struct%nrow_global
       ncol_global = matrix%matrix_struct%ncol_global
       nrow_globalt = matrixt%matrix_struct%nrow_global
@@ -1196,7 +1184,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_upper_to_full(matrix, work)
 
-      TYPE(cp_fm_type), POINTER                :: matrix, work
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix, work
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_upper_to_full'
 
@@ -1217,8 +1205,6 @@ CONTAINS
       REAL(KIND=sp), DIMENSION(:, :), POINTER   :: c_sp
 #endif
 
-      CPASSERT(ASSOCIATED(matrix))
-      CPASSERT(ASSOCIATED(work))
       nrow_global = matrix%matrix_struct%nrow_global
       ncol_global = matrix%matrix_struct%ncol_global
       CPASSERT(nrow_global == ncol_global)
@@ -1320,7 +1306,7 @@ CONTAINS
 !>      where every vector has a different prefactor
 ! **************************************************************************************************
    SUBROUTINE cp_fm_column_scale(matrixa, scaling)
-      TYPE(cp_fm_type), POINTER                :: matrixa
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrixa
       REAL(KIND=dp), DIMENSION(:), INTENT(in)  :: scaling
 
       INTEGER                                  :: k, mypcol, myprow, n, ncol_global, &
@@ -1383,7 +1369,7 @@ CONTAINS
 !> \note
 ! **************************************************************************************************
    SUBROUTINE cp_fm_row_scale(matrixa, scaling)
-      TYPE(cp_fm_type), POINTER                :: matrixa
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrixa
       REAL(KIND=dp), DIMENSION(:), INTENT(in)  :: scaling
 
       INTEGER                                  :: n, m, nrow_global, nrow_local, ncol_local
@@ -1454,7 +1440,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_invert(matrix_a, matrix_inverse, det_a, eps_svd, eigval)
 
-      TYPE(cp_fm_type), POINTER                :: matrix_a, matrix_inverse
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_a, matrix_inverse
       REAL(KIND=dp), INTENT(OUT), OPTIONAL     :: det_a
       REAL(KIND=dp), INTENT(IN), OPTIONAL      :: eps_svd
       REAL(KIND=dp), DIMENSION(:), POINTER, &
@@ -1631,7 +1617,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_triangular_invert(matrix_a, uplo_tr)
 
-      TYPE(cp_fm_type), POINTER                :: matrix_a
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_a
       CHARACTER, INTENT(IN), OPTIONAL          :: uplo_tr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_triangular_invert'
@@ -1679,7 +1665,7 @@ CONTAINS
 !> \author MI
 ! **************************************************************************************************
    SUBROUTINE cp_fm_qr_factorization(matrix_a, matrix_r, nrow_fact, ncol_fact, first_row, first_col)
-      TYPE(cp_fm_type), POINTER                :: matrix_a, matrix_r
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_a, matrix_r
       INTEGER, INTENT(IN), OPTIONAL            :: nrow_fact, ncol_fact, &
                                                   first_row, first_col
 
@@ -1761,7 +1747,7 @@ CONTAINS
 !> \author Florian Schiffmann
 ! **************************************************************************************************
    SUBROUTINE cp_fm_solve(matrix_a, general_a)
-      TYPE(cp_fm_type), POINTER                :: matrix_a, general_a
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix_a, general_a
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_solve'
 
@@ -1835,9 +1821,9 @@ CONTAINS
       CHARACTER(LEN=1), INTENT(IN)                       :: transa, transb
       INTEGER, INTENT(IN)                                :: m, n, k
       REAL(KIND=dp), INTENT(IN)                          :: alpha
-      TYPE(cp_fm_type), POINTER                          :: A_re, A_im, B_re, B_im
+      TYPE(cp_fm_type), INTENT(IN)                       :: A_re, A_im, B_re, B_im
       REAL(KIND=dp), INTENT(IN)                          :: beta
-      TYPE(cp_fm_type), POINTER                          :: C_re, C_im
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: C_re, C_im
       INTEGER, INTENT(IN), OPTIONAL                      :: a_first_col, a_first_row, b_first_col, &
                                                             b_first_row, c_first_col, c_first_row
 
@@ -1888,7 +1874,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    SUBROUTINE cp_fm_lu_invert(matrix, info_out)
-      TYPE(cp_fm_type), POINTER                :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix
       INTEGER, INTENT(OUT), OPTIONAL           :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_lu_invert'
@@ -2017,7 +2003,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    FUNCTION cp_fm_norm(matrix, mode) RESULT(res)
-      TYPE(cp_fm_type), POINTER :: matrix
+      TYPE(cp_fm_type), INTENT(IN) :: matrix
       CHARACTER, INTENT(IN) :: mode
       REAL(KIND=dp) :: res
 
@@ -2107,7 +2093,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    FUNCTION cp_fm_latra(matrix) RESULT(res)
-      TYPE(cp_fm_type), POINTER :: matrix
+      TYPE(cp_fm_type), INTENT(IN) :: matrix
       REAL(KIND=dp) :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_latra'
@@ -2168,10 +2154,9 @@ CONTAINS
 !> \param first_col ...
 !> \author MI
 ! **************************************************************************************************
-
    SUBROUTINE cp_fm_pdgeqpf(matrix, tau, nrow, ncol, first_row, first_col)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tau
       INTEGER, INTENT(IN)                                :: nrow, ncol, first_row, first_col
 
@@ -2237,10 +2222,9 @@ CONTAINS
 !> \param first_col ...
 !> \author MI
 ! **************************************************************************************************
-
    SUBROUTINE cp_fm_pdorgqr(matrix, tau, nrow, first_row, first_col)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tau
       INTEGER, INTENT(IN)                                :: nrow, first_row, first_col
 
@@ -2301,7 +2285,7 @@ CONTAINS
    SUBROUTINE cp_fm_Gram_Schmidt_orthonorm(matrix_a, B, nrows, ncols, start_row, start_col, &
                                            do_norm, do_print)
 
-      TYPE(cp_fm_type), INTENT(IN), POINTER              :: matrix_a
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix_a
       REAL(kind=dp), DIMENSION(:, :), INTENT(OUT)        :: B
       INTEGER, INTENT(IN), OPTIONAL                      :: nrows, ncols, start_row, start_col
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_norm, do_print
@@ -2318,8 +2302,6 @@ CONTAINS
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: a
 
       CALL timeset(routineN, handle)
-      CPASSERT(ASSOCIATED(matrix_a))
-      CPASSERT(matrix_a%ref_count .GT. 0)
 
       my_do_norm = .TRUE.
       IF (PRESENT(do_norm)) my_do_norm = do_norm

--- a/src/fm/cp_fm_cholesky.F
+++ b/src/fm/cp_fm_cholesky.F
@@ -44,7 +44,7 @@ CONTAINS
 !> \author Joost
 ! **************************************************************************************************
    SUBROUTINE cp_fm_cholesky_decompose(matrix, n, info_out)
-      TYPE(cp_fm_type), POINTER                :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix
       INTEGER, INTENT(in), OPTIONAL            :: n
       INTEGER, INTENT(out), OPTIONAL           :: info_out
 
@@ -110,7 +110,7 @@ CONTAINS
 !> \author Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE cp_fm_cholesky_invert(matrix, n, info_out)
-      TYPE(cp_fm_type), POINTER                 :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)           :: matrix
       INTEGER, INTENT(in), OPTIONAL             :: n
       INTEGER, INTENT(OUT), OPTIONAL            :: info_out
 
@@ -180,7 +180,7 @@ CONTAINS
 !> \author Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE cp_fm_cholesky_reduce(matrix, matrixb, itype)
-      TYPE(cp_fm_type), POINTER           :: matrix, matrixb
+      TYPE(cp_fm_type), INTENT(INOUT)     :: matrix, matrixb
       INTEGER, OPTIONAL                   :: itype
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_cholesky_reduce'
@@ -242,11 +242,11 @@ CONTAINS
 !> \param transa ...
 ! **************************************************************************************************
    SUBROUTINE cp_fm_cholesky_restore(matrix, neig, matrixb, matrixout, op, pos, transa)
-      TYPE(cp_fm_type), POINTER          :: matrix, matrixb, matrixout
-      INTEGER, INTENT(IN)                         :: neig
-      CHARACTER(LEN=*), INTENT(IN)        :: op
-      CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: pos
-      CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: transa
+      TYPE(cp_fm_type), INTENT(INOUT)         :: matrix, matrixb, matrixout
+      INTEGER, INTENT(IN)                     :: neig
+      CHARACTER(LEN=*), INTENT(IN)            :: op
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL  :: pos
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL  :: transa
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_cholesky_restore'
       REAL(KIND=dp), DIMENSION(:, :), POINTER         :: a, b, out

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -168,7 +168,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE choose_eigv_solver(matrix, eigenvectors, eigenvalues, info)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix, eigenvectors
+      TYPE(cp_fm_type), INTENT(INOUT), TARGET            :: matrix, eigenvectors
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
       INTEGER, INTENT(OUT), OPTIONAL                     :: info
 
@@ -209,7 +209,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE check_diag(matrix, eigenvectors, nvec)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix, eigenvectors
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix, eigenvectors
       INTEGER, INTENT(IN)                                :: nvec
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'check_diag'
@@ -347,7 +347,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_syevd(matrix, eigenvectors, eigenvalues, info)
 
-      TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
+      TYPE(cp_fm_type), INTENT(INOUT), TARGET  :: matrix, eigenvectors
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: eigenvalues
       INTEGER, INTENT(OUT), OPTIONAL           :: info
 
@@ -467,8 +467,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_syevd_base(matrix, eigenvectors, eigenvalues, info)
 
-      TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:)              :: eigenvalues
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix, eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: eigenvalues
       INTEGER, INTENT(OUT), OPTIONAL           :: info
 
       CHARACTER(LEN=*), PARAMETER              :: routineN = 'cp_fm_syevd_base'
@@ -593,8 +593,8 @@ CONTAINS
 
       ! Diagonalise the symmetric n by n matrix using the LAPACK library.
 
-      TYPE(cp_fm_type), POINTER                    :: matrix
-      TYPE(cp_fm_type), POINTER, OPTIONAL          :: eigenvectors
+      TYPE(cp_fm_type), INTENT(INOUT)              :: matrix
+      TYPE(cp_fm_type), OPTIONAL, INTENT(INOUT)    :: eigenvectors
       REAL(KIND=dp), OPTIONAL, INTENT(IN)          :: work_syevx
       INTEGER, INTENT(IN), OPTIONAL                :: neig
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)     :: eigenvalues
@@ -837,7 +837,7 @@ CONTAINS
       ! - Creation (29.03.1999, Matthias Krack)
       ! - Parallelised using BLACS and ScaLAPACK (06.06.2001,MK)
 
-      TYPE(cp_fm_type), POINTER                  :: matrix, work
+      TYPE(cp_fm_type), INTENT(INOUT)            :: matrix, work
       REAL(KIND=dp), INTENT(IN)                  :: exponent, threshold
       INTEGER, INTENT(OUT)                       :: n_dependent
       LOGICAL, INTENT(IN), OPTIONAL              :: verbose
@@ -1018,7 +1018,7 @@ CONTAINS
       ! - Creation (07.10.2002, Martin Fengler)
       ! - Cosmetics (05.04.06, MK)
 
-      TYPE(cp_fm_type), POINTER                 :: eigenvectors, matrix
+      TYPE(cp_fm_type), INTENT(INOUT)           :: eigenvectors, matrix
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)   :: eigval
       INTEGER, INTENT(IN)                       :: start_sec_block
       REAL(KIND=dp), INTENT(IN)                 :: thresh
@@ -1209,9 +1209,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_geeig(amatrix, bmatrix, eigenvectors, eigenvalues, work)
 
-      TYPE(cp_fm_type), POINTER                          :: amatrix, bmatrix, eigenvectors
+      TYPE(cp_fm_type), INTENT(INOUT), TARGET            :: amatrix, bmatrix, eigenvectors
       REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
-      TYPE(cp_fm_type), POINTER                          :: work
+      TYPE(cp_fm_type), INTENT(INOUT), TARGET            :: work
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_geeig'
 
@@ -1251,9 +1251,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_geeig_canon(amatrix, bmatrix, eigenvectors, eigenvalues, work, epseig)
 
-      TYPE(cp_fm_type), POINTER                          :: amatrix, bmatrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
-      TYPE(cp_fm_type), POINTER                          :: work
+      TYPE(cp_fm_type), INTENT(INOUT), TARGET            :: amatrix, bmatrix, eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+      TYPE(cp_fm_type), INTENT(INOUT), TARGET            :: work
       REAL(KIND=dp), INTENT(IN)                          :: epseig
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_geeig_canon'

--- a/src/fm/cp_fm_diag_utils.F
+++ b/src/fm/cp_fm_diag_utils.F
@@ -136,7 +136,7 @@ CONTAINS
 !> \author Nico Holmberg [01.2018]
 ! **************************************************************************************************
    SUBROUTINE cp_fm_redistribute_work_finalize(has_redistributed)
-      LOGICAL                                            :: has_redistributed
+      LOGICAL, INTENT(IN)                                :: has_redistributed
 
       IF (ASSOCIATED(work_redistribute%group_distribution)) THEN
          IF (has_redistributed) THEN
@@ -167,8 +167,8 @@ CONTAINS
 !> \author Nico Holmberg [01.2018]
 ! **************************************************************************************************
    SUBROUTINE cp_fm_redistribute_init(a, x, should_print, elpa_force_redistribute)
-      INTEGER                                            :: a, x
-      LOGICAL                                            :: should_print, elpa_force_redistribute
+      INTEGER, INTENT(IN)                                :: a, x
+      LOGICAL, INTENT(IN)                                :: should_print, elpa_force_redistribute
 
       work_redistribute%a = a
       work_redistribute%x = x
@@ -203,7 +203,7 @@ CONTAINS
 !> \author Nico Holmberg [01.2018]
 ! **************************************************************************************************
    FUNCTION cp_fm_max_ncpu_non_zero_column(matrix) RESULT(ncpu)
-      TYPE(cp_fm_type), INTENT(IN), POINTER              :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       INTEGER                                            :: ncpu
 
       INTEGER                                            :: gcd_max, ipe, jpe, ncol_block, &
@@ -284,8 +284,8 @@ CONTAINS
    SUBROUTINE cp_fm_redistribute_start(matrix, eigenvectors, matrix_new, eigenvectors_new, &
                                        caller_is_elpa, redist_info)
 
-      TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
-      TYPE(cp_fm_type), POINTER, INTENT(OUT)   :: matrix_new, eigenvectors_new
+      TYPE(cp_fm_type), INTENT(IN), TARGET     :: matrix, eigenvectors
+      TYPE(cp_fm_type), POINTER                :: matrix_new, eigenvectors_new
       LOGICAL, OPTIONAL, INTENT(IN)            :: caller_is_elpa
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_redistribute_start'
@@ -463,8 +463,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_redistribute_end(matrix, eigenvectors, eig, matrix_new, eigenvectors_new)
 
-      TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:)              :: eig
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix, eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)  :: eig
       TYPE(cp_fm_type), POINTER, INTENT(OUT)   :: matrix_new, eigenvectors_new
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_redistribute_end'

--- a/src/fm/cp_fm_elpa.F
+++ b/src/fm/cp_fm_elpa.F
@@ -275,8 +275,8 @@ CONTAINS
 !> \param eigenvalues eigenvalues of the input matrix
 ! **************************************************************************************************
    SUBROUTINE cp_fm_diag_elpa(matrix, eigenvectors, eigenvalues)
-      TYPE(cp_fm_type), POINTER                :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:)              :: eigenvalues
+      TYPE(cp_fm_type), INTENT(INOUT), TARGET  :: matrix, eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: eigenvalues
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_diag_elpa'
 
@@ -322,8 +322,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_diag_elpa_base(matrix, eigenvectors, eigenvalues, rdinfo)
 
-      TYPE(cp_fm_type), INTENT(INOUT), POINTER           :: matrix, eigenvectors
-      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: eigenvalues
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix, eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
       TYPE(cp_fm_redistribute_info), INTENT(IN)          :: rdinfo
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_diag_elpa_base'

--- a/src/fm/cp_fm_types.F
+++ b/src/fm/cp_fm_types.F
@@ -282,7 +282,7 @@ CONTAINS
 !>      the value of a_ij is independent of the number of cpus
 ! **************************************************************************************************
    SUBROUTINE cp_fm_init_random(matrix, ncol, start_col)
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix
       INTEGER, INTENT(IN), OPTIONAL                      :: ncol, start_col
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_init_random'
@@ -366,7 +366,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_set_all(matrix, alpha, beta)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix
       REAL(KIND=dp), INTENT(IN)                          :: alpha
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: beta
 
@@ -401,10 +401,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_get_diag(matrix, diag)
 
-      IMPLICIT NONE
-
       ! arguments
-      TYPE(cp_fm_type), POINTER                  :: matrix
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: diag
 
       ! locals
@@ -476,10 +474,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_get_element(matrix, irow_global, icol_global, alpha, local)
 
-      IMPLICIT NONE
-
       ! arguments
-      TYPE(cp_fm_type), POINTER          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)          :: matrix
       REAL(KIND=dp), INTENT(OUT)                     :: alpha
       INTEGER, INTENT(IN)                       :: icol_global, &
                                                    irow_global
@@ -534,7 +530,7 @@ CONTAINS
 !>      (otherwise one should use local_data tricks)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_set_element(matrix, irow_global, icol_global, alpha)
-      TYPE(cp_fm_type), POINTER                :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix
       INTEGER, INTENT(IN)                      :: irow_global, icol_global
       REAL(KIND=dp), INTENT(IN)                :: alpha
 
@@ -602,7 +598,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_set_submatrix(fm, new_values, start_row, &
                                   start_col, n_rows, n_cols, alpha, beta, transpose)
-      TYPE(cp_fm_type), POINTER                          :: fm
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: fm
       REAL(KIND=dp), DIMENSION(:, :), INTENT(in)         :: new_values
       INTEGER, INTENT(in), OPTIONAL                      :: start_row, start_col, n_rows, n_cols
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: alpha, beta
@@ -620,9 +616,6 @@ CONTAINS
       al = 1.0_dp; be = 0.0_dp; i0 = 1; j0 = 1; tr_a = .FALSE.
       ! can be called too many times, making it a bit useless
       ! CALL timeset(routineN//','//moduleN,handle)
-
-      CPASSERT(ASSOCIATED(fm))
-      CPASSERT(fm%ref_count > 0)
 
       CPASSERT(.NOT. fm%use_sp)
 
@@ -738,7 +731,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_get_submatrix(fm, target_m, start_row, &
                                   start_col, n_rows, n_cols, transpose)
-      TYPE(cp_fm_type), POINTER                          :: fm
+      TYPE(cp_fm_type), INTENT(IN)                       :: fm
       REAL(KIND=dp), DIMENSION(:, :), INTENT(out)        :: target_m
       INTEGER, INTENT(in), OPTIONAL                      :: start_row, start_col, n_rows, n_cols
       LOGICAL, INTENT(in), OPTIONAL                      :: transpose
@@ -756,9 +749,6 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       i0 = 1; j0 = 1; tr_a = .FALSE.
-
-      CPASSERT(ASSOCIATED(fm))
-      CPASSERT(fm%ref_count > 0)
 
       CPASSERT(.NOT. fm%use_sp)
 
@@ -857,7 +847,7 @@ CONTAINS
                              row_indices, col_indices, local_data, context, &
                              nrow_locals, ncol_locals, matrix_struct, para_env)
 
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       CHARACTER(LEN=*), INTENT(OUT), OPTIONAL            :: name
       INTEGER, INTENT(OUT), OPTIONAL                     :: nrow_global, ncol_global, nrow_block, &
                                                             ncol_block, nrow_local, ncol_local
@@ -901,7 +891,7 @@ CONTAINS
 !> \param io_unit the I/O unit to use for writing
 ! **************************************************************************************************
    SUBROUTINE cp_fm_write_info(matrix, io_unit)
-      TYPE(cp_fm_type), INTENT(IN), POINTER              :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       INTEGER, INTENT(IN)                                :: io_unit
 
       WRITE (io_unit, '(/,A,A12)') "CP_FM | Name:                           ", matrix%name
@@ -917,7 +907,7 @@ CONTAINS
 !> \param ic_max ...
 ! **************************************************************************************************
    SUBROUTINE cp_fm_maxabsval(matrix, a_max, ir_max, ic_max)
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       REAL(KIND=dp), INTENT(OUT)                         :: a_max
       INTEGER, INTENT(OUT), OPTIONAL                     :: ir_max, ic_max
 
@@ -1019,7 +1009,7 @@ CONTAINS
 !>      (but the bound is not so tight in the general case)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_maxabsrownorm(matrix, a_max)
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       REAL(KIND=dp), INTENT(OUT)                         :: a_max
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_maxabsrownorm'
@@ -1060,7 +1050,7 @@ CONTAINS
 !> \param norm_array ...
 ! **************************************************************************************************
    SUBROUTINE cp_fm_vectorsnorm(matrix, norm_array)
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: norm_array
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_vectorsnorm'
@@ -1105,7 +1095,7 @@ CONTAINS
 !>        added row variation
 ! **************************************************************************************************
    SUBROUTINE cp_fm_vectorssum(matrix, sum_array, dir)
-      TYPE(cp_fm_type), POINTER                          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: sum_array
       CHARACTER(LEN=1), INTENT(IN), OPTIONAL             :: dir
 
@@ -1166,7 +1156,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_to_fm_matrix(source, destination)
 
-      TYPE(cp_fm_type), POINTER                          :: source, destination
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: source, destination
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_to_fm_matrix'
 
@@ -1234,7 +1224,7 @@ CONTAINS
    SUBROUTINE cp_fm_to_fm_columns(msource, mtarget, ncol, source_start, &
                                   target_start)
 
-      TYPE(cp_fm_type), POINTER                :: msource, mtarget
+      TYPE(cp_fm_type), INTENT(INOUT)          :: msource, mtarget
       INTEGER, INTENT(IN)                      :: ncol
       INTEGER, INTENT(IN), OPTIONAL            :: source_start, target_start
 
@@ -1282,7 +1272,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_to_fm_triangular(msource, mtarget, uplo)
 
-      TYPE(cp_fm_type), POINTER                :: msource, mtarget
+      TYPE(cp_fm_type), INTENT(INOUT)          :: msource, mtarget
       CHARACTER(LEN=*), INTENT(IN)             :: uplo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_to_fm_triangular'
@@ -1327,7 +1317,7 @@ CONTAINS
 
    SUBROUTINE cp_fm_to_fm_submat(msource, mtarget, nrow, ncol, s_firstrow, s_firstcol, t_firstrow, t_firstcol)
 
-      TYPE(cp_fm_type), POINTER                :: msource, mtarget
+      TYPE(cp_fm_type), INTENT(INOUT)          :: msource, mtarget
       INTEGER, INTENT(IN)                      :: nrow, ncol, s_firstrow, &
                                                   s_firstcol, t_firstrow, &
                                                   t_firstcol
@@ -1905,7 +1895,7 @@ CONTAINS
                                          d_firstcol, &
                                          global_context)
 
-      TYPE(cp_fm_type), POINTER                :: source, destination
+      TYPE(cp_fm_type), POINTER, INTENT(IN)    :: source, destination
       INTEGER, INTENT(IN)                      :: nrows, ncols, &
                                                   s_firstrow, s_firstcol, &
                                                   d_firstrow, d_firstcol, &
@@ -2000,7 +1990,7 @@ CONTAINS
 
       ! - Creation (05.05.06,MK)
 
-      TYPE(cp_fm_type), POINTER                :: matrix
+      TYPE(cp_fm_type), INTENT(INOUT)          :: matrix
       INTEGER, INTENT(IN)                      :: irow_global, icol_global
       REAL(KIND=dp), INTENT(IN)                :: alpha
 
@@ -2012,8 +2002,6 @@ CONTAINS
                                                   irow_local
       INTEGER, DIMENSION(9)                    :: desca
 #endif
-
-      CPASSERT(ASSOCIATED(matrix))
 
       context => matrix%matrix_struct%context
 
@@ -2050,8 +2038,8 @@ CONTAINS
 !> \param unit ...
 ! **************************************************************************************************
    SUBROUTINE cp_fm_write_unformatted(fm, unit)
-      TYPE(cp_fm_type), POINTER                :: fm
-      INTEGER                                  :: unit
+      TYPE(cp_fm_type), INTENT(IN)             :: fm
+      INTEGER, INTENT(IN)                      :: unit
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_write_unformatted'
 
@@ -2152,9 +2140,9 @@ CONTAINS
 !> \param value_format ...
 ! **************************************************************************************************
    SUBROUTINE cp_fm_write_formatted(fm, unit, header, value_format)
-      TYPE(cp_fm_type), POINTER                :: fm
-      INTEGER                                  :: unit
-      CHARACTER(LEN=*), OPTIONAL               :: header, value_format
+      TYPE(cp_fm_type), INTENT(IN)             :: fm
+      INTEGER, INTENT(IN)                      :: unit
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL   :: header, value_format
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_write_formatted'
 
@@ -2279,8 +2267,8 @@ CONTAINS
 !> \param unit ...
 ! **************************************************************************************************
    SUBROUTINE cp_fm_read_unformatted(fm, unit)
-      TYPE(cp_fm_type), POINTER                :: fm
-      INTEGER                                  :: unit
+      TYPE(cp_fm_type), INTENT(INOUT)          :: fm
+      INTEGER, INTENT(IN)                      :: unit
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_read_unformatted'
 
@@ -2513,7 +2501,7 @@ CONTAINS
 !> \param mult_type ...
 ! **************************************************************************************************
    SUBROUTINE cp_fm_setup(mult_type)
-      INTEGER                                            :: mult_type
+      INTEGER, INTENT(IN)                                :: mult_type
 
       mm_type = mult_type
    END SUBROUTINE cp_fm_setup

--- a/src/fm/cp_fm_types.F
+++ b/src/fm/cp_fm_types.F
@@ -111,8 +111,8 @@ MODULE cp_fm_types
       INTEGER :: id_nr, ref_count, print_count
       LOGICAL :: use_sp
       TYPE(cp_fm_struct_type), POINTER :: matrix_struct
-      REAL(KIND=dp), DIMENSION(:, :), POINTER :: local_data
-      REAL(KIND=sp), DIMENSION(:, :), POINTER :: local_data_sp
+      REAL(KIND=dp), DIMENSION(:, :), POINTER, CONTIGUOUS :: local_data
+      REAL(KIND=sp), DIMENSION(:, :), POINTER, CONTIGUOUS :: local_data_sp
    END TYPE cp_fm_type
 
 ! **************************************************************************************************
@@ -291,9 +291,10 @@ CONTAINS
          ncol_local, nrow_global, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: buff
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data
       REAL(KIND=dp), DIMENSION(3, 2), SAVE :: &
          seed = RESHAPE((/1.0_dp, 2.0_dp, 3.0_dp, 4.0_dp, 5.0_dp, 6.0_dp/), (/3, 2/))
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
       TYPE(rng_stream_type)                              :: rng
 
       CALL timeset(routineN, handle)
@@ -861,7 +862,8 @@ CONTAINS
       INTEGER, INTENT(OUT), OPTIONAL                     :: nrow_global, ncol_global, nrow_block, &
                                                             ncol_block, nrow_local, ncol_local
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: row_indices, col_indices
-      REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         OPTIONAL, POINTER                               :: local_data
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: context
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: nrow_locals, ncol_locals
       TYPE(cp_fm_struct_type), OPTIONAL, POINTER         :: matrix_struct

--- a/src/matrix_exp.F
+++ b/src/matrix_exp.F
@@ -81,7 +81,8 @@ CONTAINS
 
       INTEGER                                            :: handle, i, ndim, nloop
       REAL(KIND=dp)                                      :: square_fac, Tfac, tmp
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data_im
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data_im
       TYPE(cp_fm_type), POINTER                          :: T1, T2, Tres_im, Tres_re
 
       CALL timeset(routineN, handle)
@@ -176,7 +177,8 @@ CONTAINS
       COMPLEX(KIND=dp)                                   :: Tfac
       INTEGER                                            :: handle, i, ndim
       REAL(KIND=dp)                                      :: square_fac, tmp
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data_im, local_data_re
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data_im, local_data_re
       TYPE(cp_cfm_type), POINTER                         :: T1, T2, T3, Tres
 
       CALL timeset(routineN, handle)
@@ -352,7 +354,8 @@ CONTAINS
       COMPLEX(KIND=dp)                                   :: scaleD, scaleN
       INTEGER                                            :: handle, i, ldim, ndim, p, q
       REAL(KIND=dp)                                      :: square_fac, tmp
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data_im, local_data_re
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data_im, local_data_re
       TYPE(cp_cfm_p_type), DIMENSION(:), POINTER         :: mult_p
       TYPE(cp_cfm_type), POINTER                         :: Dpq, fin_p, Npq, T1, T2, Tres
 
@@ -459,7 +462,8 @@ CONTAINS
       COMPLEX(KIND=dp)                                   :: scaleD, scaleN
       INTEGER                                            :: handle, i, j, k, ldim, ndim, p, q
       REAL(KIND=dp)                                      :: my_fac, square_fac
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data_im
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data_im
       TYPE(cp_cfm_p_type), DIMENSION(:), POINTER         :: cmult_p
       TYPE(cp_cfm_type), POINTER                         :: Dpq, fin_p, Npq, T1
       TYPE(cp_fm_type), POINTER                          :: T2, Tres
@@ -581,7 +585,8 @@ CONTAINS
 
       INTEGER                                            :: handle, i, j, k, ldim, ndim, p, q
       REAL(KIND=dp)                                      :: my_fac, scaleD, scaleN, square_fac
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mult_p
       TYPE(cp_fm_type), POINTER                          :: Dpq, fin_p, Npq, T1, T2, Tres
 

--- a/src/motion/bfgs_optimizer.F
+++ b/src/motion/bfgs_optimizer.F
@@ -478,7 +478,7 @@ CONTAINS
       LOGICAL                                            :: bisec, fail, set
       REAL(KIND=dp)                                      :: fun, fun1, fun2, fun3, fung, lam1, lam2, &
                                                             ln, lp, ssize, step, stol
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER            :: local_data
 
       CALL timeset(routineN, handle)
 
@@ -644,7 +644,7 @@ CONTAINS
                                                             nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: DDOT, dxw, gdx
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_hes
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER            :: local_hes
 
       CALL timeset(routineN, handle)
 
@@ -755,7 +755,7 @@ CONTAINS
 
       INTEGER                                            :: i, indf, j, k, l, ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER            :: local_data
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
       TYPE(cp_fm_type), POINTER                          :: tmp
 
@@ -864,7 +864,7 @@ CONTAINS
                                                             nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: DDOT, ener1, ener2
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER            :: local_data
 
       CALL timeset(routineN, handle)
 
@@ -1019,7 +1019,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: d_ij, rho_ij
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: r_ij
       REAL(KIND=dp), DIMENSION(3, 3)                     :: alpha, r0
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: fixed, local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER            :: fixed, local_data
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(particle_list_type), POINTER                  :: particles

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -682,7 +682,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, col_indices_rec, &
                                                             row_indices, row_indices_rec
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: C, Cgw, Cocc, Cvirt, rec_C
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_C, local_C_internal
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_C, local_C_internal
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_coeff
       TYPE(group_dist_d1_type)                           :: gd_array
 

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -1721,7 +1721,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, col_indices_rec, &
                                                             row_indices, row_indices_rec
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: local_L, rec_L
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_L_internal
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_L_internal
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CALL timeset(routineN, handle)

--- a/src/negf_integr_cc.F
+++ b/src/negf_integr_cc.F
@@ -122,7 +122,8 @@ CONTAINS
 
       INTEGER                                            :: handle, icol, ipoint, irow, ncols, &
                                                             nnodes_half, nrows
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: w_data, w_data_my
+      REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: w_data, w_data_my
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
 
       CALL timeset(routineN, handle)

--- a/src/negf_integr_simpson.F
+++ b/src/negf_integr_simpson.F
@@ -133,7 +133,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'simpsonrule_init'
 
       INTEGER                                            :: handle, icol, irow, ncols, nrows
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: w_data, w_data_my
+      REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: w_data, w_data_my
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
 
       CALL timeset(routineN, handle)
@@ -317,13 +318,15 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'simpsonrule_refine_integral'
 
       COMPLEX(kind=dp), ALLOCATABLE, DIMENSION(:)        :: zscale
-      COMPLEX(kind=dp), DIMENSION(:, :), POINTER         :: error_zdata
+      COMPLEX(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: error_zdata
       INTEGER                                            :: handle, interval, ipoint, nintervals, &
                                                             nintervals_exist, npoints
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: inds
       REAL(kind=dp)                                      :: rscale
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: errors
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: error_rdata
+      REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: error_rdata
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(simpsonrule_subinterval_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: subintervals

--- a/src/preconditioner_apply.F
+++ b/src/preconditioner_apply.F
@@ -225,7 +225,8 @@ CONTAINS
                                                             nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: dum
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data
       TYPE(cp_fm_type), POINTER                          :: matrix_tmp
 
       CALL timeset(routineN, handle)

--- a/src/qs_scf_methods.F
+++ b/src/qs_scf_methods.F
@@ -558,7 +558,8 @@ CONTAINS
                                                             ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: compatible_matrices
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: fa, fb
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: fa, fb
       TYPE(cp_fm_struct_type), POINTER                   :: ksa_struct, ksb_struct
 
 ! -------------------------------------------------------------------------
@@ -635,7 +636,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: compatible_matrices
       REAL(KIND=dp)                                      :: beta, t1, t2, ta, tb
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: fa, fb
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: fa, fb
       TYPE(cp_fm_struct_type), POINTER                   :: ksa_struct, ksb_struct
 
 ! -------------------------------------------------------------------------

--- a/src/qs_tddfpt2_eigensolver.F
+++ b/src/qs_tddfpt2_eigensolver.F
@@ -555,7 +555,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices_local, row_indices_local
       INTEGER, DIMENSION(maxspins)                       :: nactive, nmo_virt
       REAL(kind=dp)                                      :: e_occ_plus_lambda, eref, lambda
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: weights_ldata
+      REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: weights_ldata
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: awork, vomat
       TYPE(cp_fm_struct_type), POINTER                   :: ao_mo_struct, virt_mo_struct
 

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -172,8 +172,9 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       INTEGER, DIMENSION(maxspins)                       :: nmo_occ, nmo_virt
       REAL(kind=dp)                                      :: eval_occ
+      REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data_ediff, local_data_wfm
       REAL(kind=dp), DIMENSION(3)                        :: kvec, reference_point
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: local_data_ediff, local_data_wfm
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_cfm_p_type), ALLOCATABLE, DIMENSION(:)     :: gamma_00, gamma_inv_00
@@ -689,7 +690,8 @@ CONTAINS
       LOGICAL                                            :: do_exc_analysis
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: weights_local, weights_neg_abs_recv, &
                                                             weights_recv
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: S_mos_virt, weights_fm
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct

--- a/src/qs_tddfpt2_stda_utils.F
+++ b/src/qs_tddfpt2_stda_utils.F
@@ -332,7 +332,8 @@ CONTAINS
       LOGICAL                                            :: converged
       REAL(KIND=dp)                                      :: eps_lanczos, sij, threshold
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: slam
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct
       TYPE(cp_fm_type), POINTER                          :: fm_s_half, fm_work1
       TYPE(cp_logger_type), POINTER                      :: logger

--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -249,9 +249,10 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: do_eigen
       REAL(kind=dp)                                      :: element, maxocc
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: my_block
       REAL(kind=dp), DIMENSION(:), POINTER               :: mo_evals_extended, mo_occ_extended, &
                                                             mo_occ_scf
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: my_block
       TYPE(cp_fm_pool_type), POINTER                     :: wfn_fm_pool
       TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_fm_struct, ao_mo_occ_fm_struct, &
                                                             ao_mo_virt_fm_struct, wfn_fm_struct

--- a/src/s_square_methods.F
+++ b/src/s_square_methods.F
@@ -81,7 +81,8 @@ CONTAINS
       LOGICAL                                            :: has_uniform_occupation_alpha, &
                                                             has_uniform_occupation_beta
       REAL(KIND=dp)                                      :: s2
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: local_data
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data
       TYPE(cp_blacs_env_type), POINTER                   :: context
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
       TYPE(cp_fm_type), POINTER                          :: c_alpha, c_beta, catscb, sca, scb


### PR DESCRIPTION
This PR makes the local_data component of the cp_fm_type and cp_cfm_type CONTIGUOUS which prevents accidental deallocations or reassociation to non-contiguous data. Contiguity is required for the underlying libraries. Further, some POINTER attributes are removed in the fm directory where possible.