### PR TITLE
Add interface to COSMA's pzgemm

### DIFF
--- a/src/emd/rt_delta_pulse.F
+++ b/src/emd/rt_delta_pulse.F
@@ -12,8 +12,7 @@
 MODULE rt_delta_pulse
    USE cell_types,                      ONLY: cell_type
    USE commutator_rpnl,                 ONLY: build_com_mom_nl
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_column_scale,&
-                                              cp_cfm_gemm
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_column_scale
    USE cp_cfm_diag,                     ONLY: cp_cfm_heevd
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_release,&
@@ -271,8 +270,8 @@ CONTAINS
          CALL cp_cfm_column_scale(oo_v, eigenvalues_sqrt)
          DEALLOCATE (eigenvalues)
          DEALLOCATE (eigenvalues_sqrt)
-         CALL cp_cfm_gemm('N', 'C', nmo, nmo, nmo, (1.0_dp, 0.0_dp), &
-                          oo_v, oo_vt, (0.0_dp, 0.0_dp), oo_c)
+         CALL parallel_gemm('N', 'C', nmo, nmo, nmo, (1.0_dp, 0.0_dp), &
+                            oo_v, oo_vt, (0.0_dp, 0.0_dp), oo_c)
          oo_1%local_data = REAL(oo_c%local_data, KIND=dp)
          oo_2%local_data = AIMAG(oo_c%local_data)
          CALL cp_cfm_release(oo_c)
@@ -422,8 +421,8 @@ CONTAINS
          CALL cp_cfm_column_scale(oo_v, eigenvalues_sqrt)
          DEALLOCATE (eigenvalues)
          DEALLOCATE (eigenvalues_sqrt)
-         CALL cp_cfm_gemm('N', 'C', nmo, nmo, nmo, (1.0_dp, 0.0_dp), &
-                          oo_v, oo_vt, (0.0_dp, 0.0_dp), oo_c)
+         CALL parallel_gemm('N', 'C', nmo, nmo, nmo, (1.0_dp, 0.0_dp), &
+                            oo_v, oo_vt, (0.0_dp, 0.0_dp), oo_c)
          oo_1%local_data = REAL(oo_c%local_data, KIND=dp)
          oo_2%local_data = AIMAG(oo_c%local_data)
          CALL cp_cfm_release(oo_c)

--- a/src/emd/rt_propagation_methods.F
+++ b/src/emd/rt_propagation_methods.F
@@ -14,7 +14,6 @@ MODULE rt_propagation_methods
                                               Kuhne2007,&
                                               cite_reference
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_cholesky_decompose,&
-                                              cp_cfm_gemm,&
                                               cp_cfm_triangular_multiply
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_release,&
@@ -56,6 +55,7 @@ MODULE rt_propagation_methods
    USE kinds,                           ONLY: dp
    USE ls_matrix_exp,                   ONLY: cp_complex_dbcsr_gemm_3
    USE mathlib,                         ONLY: binomial
+   USE parallel_gemm_api,               ONLY: parallel_gemm
    USE qs_energy_init,                  ONLY: qs_energies_init
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -763,7 +763,7 @@ CONTAINS
                cfm_tmp1%local_data(:, icol_local) = CMPLX(mos_new(2*i - 1)%matrix%local_data(:, icol_local), &
                                                           mos_new(2*i)%matrix%local_data(:, icol_local), dp)
             END DO
-            CALL cp_cfm_gemm('C', 'N', k, k, n, cone, cfm_tmp1, cfm_tmp, czero, csc)
+            CALL parallel_gemm('C', 'N', k, k, n, cone, cfm_tmp1, cfm_tmp, czero, csc)
             CALL cp_cfm_cholesky_decompose(csc)
             CALL cp_cfm_triangular_multiply(csc, cfm_tmp1, n_cols=k, side='R', invert_tr=.TRUE.)
             DO icol_local = 1, ncol_local

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -652,10 +652,9 @@ CONTAINS
 #endif
 
       CALL keyword_create(keyword, __LOCATION__, name="TYPE_OF_MATRIX_MULTIPLICATION", &
-                          description="Allows to switch between scalapack pdgemm and dbcsr_multiply. "// &
-                          "On normal systems pdgemm is recommended on system with GPU "// &
-                          "is optimized and can give better performance. NOTE: if DBCSR is employed "// &
-                          "FORCE_BLOCK_SIZE should be set. The performance on GPU's depends "// &
+                          description="Allows to switch between scalapack pxgemm and COSMA pxgemm. "// &
+                          "COSMA reduces the communication costs but increases the memory demands. "// &
+                          "The performance of Scalapack's pxgemm on GPU's depends "// &
                           "crucially on the BLOCK_SIZES. Make sure optimized kernels are available.", &
                           default_i_val=default_matmul, &
                           enum_i_vals=(/do_scalapack, do_scalapack, do_cosma/), &

--- a/src/matrix_exp.F
+++ b/src/matrix_exp.F
@@ -12,8 +12,7 @@
 
 MODULE matrix_exp
 
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm,&
-                                              cp_cfm_scale_and_add,&
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_scale_and_add,&
                                               cp_cfm_solve
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_p_type,&
@@ -210,8 +209,8 @@ CONTAINS
 
       DO i = 1, ntaylor
          tmp = tmp*REAL(i, dp)
-         CALL cp_cfm_gemm("N", "N", ndim, ndim, ndim, z_one, T1, T2, z_zero, &
-                          T3)
+         CALL parallel_gemm("N", "N", ndim, ndim, ndim, z_one, T1, T2, z_zero, &
+                            T3)
          Tfac = CMPLX(1._dp/tmp, 0.0_dp, kind=dp)
          CALL cp_cfm_scale_and_add(z_one, Tres, Tfac, T3)
          CALL cp_cfm_to_cfm(T3, T2)
@@ -219,8 +218,8 @@ CONTAINS
 
       IF (nsquare .GT. 0) THEN
          DO i = 1, nsquare
-            CALL cp_cfm_gemm("N", "N", ndim, ndim, ndim, z_one, Tres, Tres, z_zero, &
-                             T2)
+            CALL parallel_gemm("N", "N", ndim, ndim, ndim, z_one, Tres, Tres, z_zero, &
+                               T2)
             CALL cp_cfm_to_cfm(T2, Tres)
          END DO
       END IF
@@ -406,8 +405,8 @@ CONTAINS
          DO i = 2, npade
             IF (i .LE. p) scaleN = CMPLX(fac(p + q - i)*fac(p)/(fac(p + q)*fac(i)*fac(p - i)), 0.0_dp, kind=dp)
             scaleD = CMPLX((-1.0_dp)**i*fac(p + q - i)*fac(q)/(fac(p + q)*fac(i)*fac(q - i)), 0.0_dp, kind=dp)
-            CALL cp_cfm_gemm("N", "N", ndim, ndim, ndim, z_one, T1, mult_p(MOD(i, 2) + 1)%matrix, z_zero, &
-                             mult_p(MOD(i + 1, 2) + 1)%matrix)
+            CALL parallel_gemm("N", "N", ndim, ndim, ndim, z_one, T1, mult_p(MOD(i, 2) + 1)%matrix, z_zero, &
+                               mult_p(MOD(i + 1, 2) + 1)%matrix)
             IF (i .LE. p) CALL cp_cfm_scale_and_add(z_one, Npq, scaleN, mult_p(MOD(i + 1, 2) + 1)%matrix)
             IF (i .LE. q) CALL cp_cfm_scale_and_add(z_one, Dpq, scaleD, mult_p(MOD(i + 1, 2) + 1)%matrix)
          END DO
@@ -419,8 +418,8 @@ CONTAINS
       mult_p(1)%matrix => Tres
       IF (nsquare .GT. 0) THEN
          DO i = 1, nsquare
-           CALL cp_cfm_gemm("N", "N", ndim, ndim, ndim, z_one, mult_p(MOD(i, 2) + 1)%matrix, mult_p(MOD(i, 2) + 1)%matrix, z_zero, &
-                             mult_p(MOD(i + 1, 2) + 1)%matrix)
+         CALL parallel_gemm("N", "N", ndim, ndim, ndim, z_one, mult_p(MOD(i, 2) + 1)%matrix, mult_p(MOD(i, 2) + 1)%matrix, z_zero, &
+                               mult_p(MOD(i + 1, 2) + 1)%matrix)
             fin_p => mult_p(MOD(i + 1, 2) + 1)%matrix
          END DO
       ELSE
@@ -543,8 +542,8 @@ CONTAINS
       cmult_p(1)%matrix => T1
       IF (nsquare .GT. 0) THEN
          DO i = 1, nsquare
-         CALL cp_cfm_gemm("N", "N", ndim, ndim, ndim, z_one, cmult_p(MOD(i, 2) + 1)%matrix, cmult_p(MOD(i, 2) + 1)%matrix, z_zero, &
-                             cmult_p(MOD(i + 1, 2) + 1)%matrix)
+       CALL parallel_gemm("N", "N", ndim, ndim, ndim, z_one, cmult_p(MOD(i, 2) + 1)%matrix, cmult_p(MOD(i, 2) + 1)%matrix, z_zero, &
+                               cmult_p(MOD(i + 1, 2) + 1)%matrix)
             fin_p => cmult_p(MOD(i + 1, 2) + 1)%matrix
          END DO
       ELSE

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -23,8 +23,7 @@ MODULE mp2_ri_2c
    USE cp_blacs_env,                    ONLY: cp_blacs_env_create,&
                                               cp_blacs_env_release,&
                                               cp_blacs_env_type
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm,&
-                                              cp_cfm_scale_and_add_fm
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_scale_and_add_fm
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_release,&
                                               cp_cfm_to_fm,&
@@ -1508,25 +1507,25 @@ CONTAINS
          CALL cp_cfm_matrix_exponential(cfm_matrix_S_tmp, cfm_matrix_S_inv_tmp, threshold=eps_eigval_S, exponent=-0.5_dp)
 
          ! get S^(-1) = U^(-H)U^(-1)
-         CALL cp_cfm_gemm("C", "N", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_tmp, cfm_matrix_S_tmp, &
-                          czero, cfm_matrix_S_inv_tmp)
+         CALL parallel_gemm("C", "N", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_tmp, cfm_matrix_S_tmp, &
+                            czero, cfm_matrix_S_inv_tmp)
 
          CALL cp_cfm_matrix_exponential(cfm_matrix_L_tmp, cfm_matrix_S_tmp, threshold=0.0_dp, exponent=0.5_dp)
 
          ! get K = S^(-1)*L, where L is the Cholesky decomposition of V = L^T*L
-         CALL cp_cfm_gemm("N", "C", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_inv_tmp, cfm_matrix_L_tmp, &
-                          czero, cfm_matrix_K_tmp)
+         CALL parallel_gemm("N", "C", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_inv_tmp, cfm_matrix_L_tmp, &
+                            czero, cfm_matrix_K_tmp)
 
          ! move
          CALL cp_cfm_to_fm(cfm_matrix_K_tmp, fm_matrix_L_RI_metric(ikp, 1)%matrix, fm_matrix_L_RI_metric(ikp, 2)%matrix)
 
          ! S^(-1)*V_trunc
-         CALL cp_cfm_gemm("N", "C", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_Vtrunc_tmp, cfm_matrix_S_inv_tmp, &
-                          czero, cfm_matrix_K_tmp)
+         CALL parallel_gemm("N", "C", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_Vtrunc_tmp, cfm_matrix_S_inv_tmp, &
+                            czero, cfm_matrix_K_tmp)
 
          ! S^(-1)*V_trunc*S^{-1}
-         CALL cp_cfm_gemm("N", "N", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_inv_tmp, cfm_matrix_K_tmp, &
-                          czero, cfm_matrix_Vtrunc_tmp)
+         CALL parallel_gemm("N", "N", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_inv_tmp, cfm_matrix_K_tmp, &
+                            czero, cfm_matrix_Vtrunc_tmp)
 
          ! move
          CALL cp_cfm_to_fm(cfm_matrix_Vtrunc_tmp, fm_matrix_Sinv_Vtrunc_Sinv(ikp, 1)%matrix, &

--- a/src/negf_green_methods.F
+++ b/src/negf_green_methods.F
@@ -31,6 +31,7 @@ MODULE negf_green_methods
                                               z_mone,&
                                               z_one,&
                                               z_zero
+   USE parallel_gemm_api,               ONLY: parallel_gemm
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -185,21 +186,21 @@ CONTAINS
          CALL cp_cfm_lu_invert(work%a_inv)
 
          ! scratch <- A_n^-1 * B_n
-         CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, z_one, work%a_inv, work%b, z_zero, work%scratch)
+         CALL parallel_gemm('N', 'N', nrows, nrows, nrows, z_one, work%a_inv, work%b, z_zero, work%scratch)
          ! E_n = - C_n A_n^-1 B_n
          CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, z_mone, work%c, work%scratch, z_zero, work%e)
          ! g_surf <- B_{n+1} = B_n A_n^-1 B_n
          ! keep B_n, as we need it to compute the matrix product B_n A_n^-1 C_n
-         CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, z_one, work%b, work%scratch, z_zero, g_surf)
+         CALL parallel_gemm('N', 'N', nrows, nrows, nrows, z_one, work%b, work%scratch, z_zero, g_surf)
 
          ! scratch <- A_n^-1 * C_n
-         CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, z_one, work%a_inv, work%c, z_zero, work%scratch)
+         CALL parallel_gemm('N', 'N', nrows, nrows, nrows, z_one, work%a_inv, work%c, z_zero, work%scratch)
          ! D_n = - B_n A_n^-1 C_n
          CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, z_mone, work%b, work%scratch, z_zero, work%d)
          ! we do not need B_n any longer, so the matrix B now holds the B_{n+1} matrix
          CALL cp_cfm_to_cfm(g_surf, work%b)
          ! C_{n+1} = C_n A_n^-1 C_n
-         CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, z_one, work%c, work%scratch, z_zero, g_surf)
+         CALL parallel_gemm('N', 'N', nrows, nrows, nrows, z_one, work%c, work%scratch, z_zero, g_surf)
          CALL cp_cfm_to_cfm(g_surf, work%c)
 
          ! A0_{n+1} = A0_n + D_n = A0_n - B_n A_n^-1 C_n
@@ -255,16 +256,16 @@ CONTAINS
          CALL cp_fm_get_info(s_sc0, nrow_global=nao_contact, ncol_global=nao_scattering)
 
          ! zwork2 = g_surf_c * [omega * S_SC0^T - KS_SC0^T]
-         CALL cp_cfm_gemm('N', 'N', nao_contact, nao_scattering, nao_contact, z_one, g_surf_c, zwork1, z_zero, zwork2)
+         CALL parallel_gemm('N', 'N', nao_contact, nao_scattering, nao_contact, z_one, g_surf_c, zwork1, z_zero, zwork2)
          ! [omega * S_SC0^T - KS_SC0^T]^T * g_surf_c * [omega * S_SC0^T - KS_SC0^T]
-         CALL cp_cfm_gemm('T', 'N', nao_scattering, nao_scattering, nao_contact, z_one, zwork1, zwork2, z_zero, self_energy_c)
+         CALL parallel_gemm('T', 'N', nao_scattering, nao_scattering, nao_contact, z_one, zwork1, zwork2, z_zero, self_energy_c)
       ELSE
          CALL cp_fm_get_info(s_sc0, nrow_global=nao_scattering, ncol_global=nao_contact)
 
          ! zwork2 = [omega * S_SC0 - KS_SC0] * g_surf_c
-         CALL cp_cfm_gemm('N', 'N', nao_scattering, nao_contact, nao_contact, z_one, zwork1, g_surf_c, z_zero, zwork2)
+         CALL parallel_gemm('N', 'N', nao_scattering, nao_contact, nao_contact, z_one, zwork1, g_surf_c, z_zero, zwork2)
          ! [omega * S_SC0 - KS_SC0] * g_surf_c * [omega * S_SC0 - KS_SC0]^T
-         CALL cp_cfm_gemm('N', 'T', nao_scattering, nao_scattering, nao_contact, z_one, zwork2, zwork1, z_zero, self_energy_c)
+         CALL parallel_gemm('N', 'T', nao_scattering, nao_scattering, nao_contact, z_one, zwork2, zwork1, z_zero, self_energy_c)
       END IF
 
       CALL timestop(handle)

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -14,8 +14,7 @@ MODULE negf_methods
                                               Papior2017,&
                                               cite_reference
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm,&
-                                              cp_cfm_scale,&
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_scale,&
                                               cp_cfm_scale_and_add,&
                                               cp_cfm_trace
    USE cp_cfm_types,                    ONLY: &
@@ -104,6 +103,7 @@ MODULE negf_methods
    USE negf_subgroup_types,             ONLY: negf_sub_env_create,&
                                               negf_sub_env_release,&
                                               negf_subgroup_env_type
+   USE parallel_gemm_api,               ONLY: parallel_gemm
    USE physcon,                         ONLY: e_charge,&
                                               evolt,&
                                               kelvin,&
@@ -1634,14 +1634,14 @@ CONTAINS
                ! the array 'self_energy_contacts' as a set of work matrices
                DO icontact = 1, ncontacts
                   IF (ASSOCIATED(gret_gamma_gadv_group(icontact, ipoint)%matrix)) THEN
-                     CALL cp_cfm_gemm('N', 'C', nrows, nrows, nrows, &
-                                      z_one, gamma_contacts_group(icontact, ipoint)%matrix, &
-                                      g_ret_s_group(ipoint)%matrix, &
-                                      z_zero, self_energy_contacts(icontact)%matrix)
-                     CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, &
-                                      z_one, g_ret_s_group(ipoint)%matrix, &
-                                      self_energy_contacts(icontact)%matrix, &
-                                      z_zero, gret_gamma_gadv_group(icontact, ipoint)%matrix)
+                     CALL parallel_gemm('N', 'C', nrows, nrows, nrows, &
+                                        z_one, gamma_contacts_group(icontact, ipoint)%matrix, &
+                                        g_ret_s_group(ipoint)%matrix, &
+                                        z_zero, self_energy_contacts(icontact)%matrix)
+                     CALL parallel_gemm('N', 'N', nrows, nrows, nrows, &
+                                        z_one, g_ret_s_group(ipoint)%matrix, &
+                                        self_energy_contacts(icontact)%matrix, &
+                                        z_zero, gret_gamma_gadv_group(icontact, ipoint)%matrix)
                   END IF
                END DO
             END IF
@@ -1801,14 +1801,14 @@ CONTAINS
          DO ipoint = 1, npoints
             IF (ASSOCIATED(g_ret_s_group(ipoint)%matrix)) THEN
                ! gamma_1 * g_adv_s * gamma_2
-               CALL cp_cfm_gemm('N', 'C', nrows, nrows, nrows, &
-                                z_one, gamma_contacts_group(transm_contact1, ipoint)%matrix, &
-                                g_ret_s_group(ipoint)%matrix, &
-                                z_zero, self_energy_contacts(transm_contact1)%matrix)
-               CALL cp_cfm_gemm('N', 'N', nrows, nrows, nrows, &
-                                z_one, self_energy_contacts(transm_contact1)%matrix, &
-                                gamma_contacts_group(transm_contact2, ipoint)%matrix, &
-                                z_zero, self_energy_contacts(transm_contact2)%matrix)
+               CALL parallel_gemm('N', 'C', nrows, nrows, nrows, &
+                                  z_one, gamma_contacts_group(transm_contact1, ipoint)%matrix, &
+                                  g_ret_s_group(ipoint)%matrix, &
+                                  z_zero, self_energy_contacts(transm_contact1)%matrix)
+               CALL parallel_gemm('N', 'N', nrows, nrows, nrows, &
+                                  z_one, self_energy_contacts(transm_contact1)%matrix, &
+                                  gamma_contacts_group(transm_contact2, ipoint)%matrix, &
+                                  z_zero, self_energy_contacts(transm_contact2)%matrix)
 
                !  Trace[ g_ret_s * gamma_1 * g_adv_s * gamma_2 ]
                CALL cp_cfm_trace(g_ret_s_group(ipoint)%matrix, &

--- a/src/parallel_gemm_api.F
+++ b/src/parallel_gemm_api.F
@@ -17,6 +17,8 @@ MODULE parallel_gemm_api
                                               C_INT,&
                                               C_LOC,&
                                               C_PTR
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm
+   USE cp_cfm_types,                    ONLY: cp_cfm_type
    USE cp_fm_basic_linalg,              ONLY: cp_fm_gemm
    USE cp_fm_types,                     ONLY: cp_fm_get_mm_type,&
                                               cp_fm_type
@@ -32,6 +34,11 @@ MODULE parallel_gemm_api
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'parallel_gemm_api'
 
    PUBLIC :: parallel_gemm
+
+   INTERFACE parallel_gemm
+      MODULE PROCEDURE parallel_gemm_fm
+      MODULE PROCEDURE parallel_gemm_cfm
+   END INTERFACE parallel_gemm
 
 CONTAINS
 
@@ -54,9 +61,9 @@ CONTAINS
 !> \param c_first_col ...
 !> \param c_first_row ...
 ! **************************************************************************************************
-   SUBROUTINE parallel_gemm(transa, transb, m, n, k, alpha, matrix_a, matrix_b, beta, &
-                            matrix_c, a_first_col, a_first_row, b_first_col, b_first_row, &
-                            c_first_col, c_first_row)
+   SUBROUTINE parallel_gemm_fm(transa, transb, m, n, k, alpha, matrix_a, matrix_b, beta, &
+                               matrix_c, a_first_col, a_first_row, b_first_col, b_first_row, &
+                               c_first_col, c_first_row)
       CHARACTER(LEN=1), INTENT(IN)                       :: transa, transb
       INTEGER, INTENT(IN)                                :: m, n, k
       REAL(KIND=dp), INTENT(IN)                          :: alpha
@@ -66,7 +73,7 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: a_first_col, a_first_row, b_first_col, &
                                                             b_first_row, c_first_col, c_first_row
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'parallel_gemm'
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'parallel_gemm_fm'
 
       INTEGER                                            :: handle, handle1, my_multi
 
@@ -76,7 +83,7 @@ CONTAINS
 
       SELECT CASE (my_multi)
       CASE (do_scalapack)
-         CALL timeset(routineN//"_fm_gemm", handle1)
+         CALL timeset(routineN//"_gemm", handle1)
          CALL cp_fm_gemm(transa, transb, m, n, k, alpha, matrix_a, matrix_b, beta, matrix_c, &
                          a_first_col=a_first_col, &
                          a_first_row=a_first_row, &
@@ -104,7 +111,78 @@ CONTAINS
       END SELECT
       CALL timestop(handle)
 
-   END SUBROUTINE parallel_gemm
+   END SUBROUTINE parallel_gemm_fm
+
+! **************************************************************************************************
+!> \brief ...
+!> \param transa ...
+!> \param transb ...
+!> \param m ...
+!> \param n ...
+!> \param k ...
+!> \param alpha ...
+!> \param matrix_a ...
+!> \param matrix_b ...
+!> \param beta ...
+!> \param matrix_c ...
+!> \param a_first_col ...
+!> \param a_first_row ...
+!> \param b_first_col ...
+!> \param b_first_row ...
+!> \param c_first_col ...
+!> \param c_first_row ...
+! **************************************************************************************************
+   SUBROUTINE parallel_gemm_cfm(transa, transb, m, n, k, alpha, matrix_a, matrix_b, beta, &
+                                matrix_c, a_first_col, a_first_row, b_first_col, b_first_row, &
+                                c_first_col, c_first_row)
+      CHARACTER(LEN=1), INTENT(IN)                       :: transa, transb
+      INTEGER, INTENT(IN)                                :: m, n, k
+      COMPLEX(KIND=dp), INTENT(IN)                       :: alpha
+      TYPE(cp_cfm_type), POINTER                         :: matrix_a, matrix_b
+      COMPLEX(KIND=dp), INTENT(IN)                       :: beta
+      TYPE(cp_cfm_type), POINTER                         :: matrix_c
+      INTEGER, INTENT(IN), OPTIONAL                      :: a_first_col, a_first_row, b_first_col, &
+                                                            b_first_row, c_first_col, c_first_row
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'parallel_gemm_cfm'
+
+      INTEGER                                            :: handle, handle1, my_multi
+
+      CALL timeset(routineN, handle)
+
+      my_multi = cp_fm_get_mm_type()
+
+      SELECT CASE (my_multi)
+      CASE (do_scalapack)
+         CALL timeset(routineN//"_gemm", handle1)
+         CALL cp_cfm_gemm(transa, transb, m, n, k, alpha, matrix_a, matrix_b, beta, matrix_c, &
+                          a_first_col=a_first_col, &
+                          a_first_row=a_first_row, &
+                          b_first_col=b_first_col, &
+                          b_first_row=b_first_row, &
+                          c_first_col=c_first_col, &
+                          c_first_row=c_first_row)
+         CALL timestop(handle1)
+      CASE (do_cosma)
+#if defined(__COSMA)
+         CALL timeset(routineN//"_cosma", handle1)
+         CALL offload_activate_chosen_device()
+         CALL cosma_pzgemm(transa=transa, transb=transb, m=m, n=n, k=k, alpha=alpha, &
+                           matrix_a=matrix_a, matrix_b=matrix_b, beta=beta, matrix_c=matrix_c, &
+                           a_first_col=a_first_col, &
+                           a_first_row=a_first_row, &
+                           b_first_col=b_first_col, &
+                           b_first_row=b_first_row, &
+                           c_first_col=c_first_col, &
+                           c_first_row=c_first_row)
+         CALL timestop(handle1)
+#else
+         CPABORT("CP2K compiled without the COSMA library.")
+#endif
+      END SELECT
+      CALL timestop(handle)
+
+   END SUBROUTINE parallel_gemm_cfm
 
 #if defined(__COSMA)
 ! **************************************************************************************************
@@ -209,6 +287,115 @@ CONTAINS
                           descc=C_LOC(matrix_c%matrix_struct%descriptor(1)))
 
    END SUBROUTINE cosma_pdgemm
+
+! **************************************************************************************************
+!> \brief Fortran wrapper for cosma_pdgemm.
+!> \param transa ...
+!> \param transb ...
+!> \param m ...
+!> \param n ...
+!> \param k ...
+!> \param alpha ...
+!> \param matrix_a ...
+!> \param matrix_b ...
+!> \param beta ...
+!> \param matrix_c ...
+!> \param a_first_col ...
+!> \param a_first_row ...
+!> \param b_first_col ...
+!> \param b_first_row ...
+!> \param c_first_col ...
+!> \param c_first_row ...
+!> \author Ole Schuett
+! **************************************************************************************************
+   SUBROUTINE cosma_pzgemm(transa, transb, m, n, k, alpha, matrix_a, matrix_b, beta, matrix_c, &
+                           a_first_col, a_first_row, b_first_col, b_first_row, &
+                           c_first_col, c_first_row)
+      CHARACTER(LEN=1), INTENT(IN)                       :: transa, transb
+      INTEGER, INTENT(IN)                                :: m, n, k
+      COMPLEX(KIND=dp), INTENT(IN)                       :: alpha
+      TYPE(cp_cfm_type), POINTER                         :: matrix_a, matrix_b
+      COMPLEX(KIND=dp), INTENT(IN)                       :: beta
+      TYPE(cp_cfm_type), POINTER                         :: matrix_c
+      INTEGER, INTENT(IN), OPTIONAL                      :: a_first_col, a_first_row, b_first_col, &
+                                                            b_first_row, c_first_col, c_first_row
+
+      INTEGER                                            :: i_a, i_b, i_c, j_a, j_b, j_c
+      REAL(KIND=dp), DIMENSION(2), TARGET                :: alpha_t, beta_t
+      INTERFACE
+         SUBROUTINE cosma_pzgemm_c(transa, transb, m, n, k, alpha, a, ia, ja, desca, &
+                                   b, ib, jb, descb, beta, c, ic, jc, descc) &
+            BIND(C, name="cosma_pzgemm")
+            IMPORT :: C_PTR, C_INT, C_CHAR
+            CHARACTER(KIND=C_CHAR)                    :: transa
+            CHARACTER(KIND=C_CHAR)                    :: transb
+            INTEGER(KIND=C_INT)                       :: m
+            INTEGER(KIND=C_INT)                       :: n
+            INTEGER(KIND=C_INT)                       :: k
+            TYPE(C_PTR), VALUE                        :: alpha
+            TYPE(C_PTR), VALUE                        :: a
+            INTEGER(KIND=C_INT)                       :: ia
+            INTEGER(KIND=C_INT)                       :: ja
+            TYPE(C_PTR), VALUE                        :: desca
+            TYPE(C_PTR), VALUE                        :: b
+            INTEGER(KIND=C_INT)                       :: ib
+            INTEGER(KIND=C_INT)                       :: jb
+            TYPE(C_PTR), VALUE                        :: descb
+            TYPE(C_PTR), VALUE                        :: beta
+            TYPE(C_PTR), VALUE                        :: c
+            INTEGER(KIND=C_INT)                       :: ic
+            INTEGER(KIND=C_INT)                       :: jc
+            TYPE(C_PTR), VALUE                        :: descc
+         END SUBROUTINE cosma_pzgemm_c
+      END INTERFACE
+
+      IF (PRESENT(a_first_row)) THEN
+         i_a = a_first_row
+      ELSE
+         i_a = 1
+      END IF
+      IF (PRESENT(a_first_col)) THEN
+         j_a = a_first_col
+      ELSE
+         j_a = 1
+      END IF
+      IF (PRESENT(b_first_row)) THEN
+         i_b = b_first_row
+      ELSE
+         i_b = 1
+      END IF
+      IF (PRESENT(b_first_col)) THEN
+         j_b = b_first_col
+      ELSE
+         j_b = 1
+      END IF
+      IF (PRESENT(c_first_row)) THEN
+         i_c = c_first_row
+      ELSE
+         i_c = 1
+      END IF
+      IF (PRESENT(c_first_col)) THEN
+         j_c = c_first_col
+      ELSE
+         j_c = 1
+      END IF
+
+      alpha_t(1) = REAL(alpha, KIND=dp)
+      alpha_t(2) = REAL(AIMAG(alpha), KIND=dp)
+      beta_t(1) = REAL(beta, KIND=dp)
+      beta_t(2) = REAL(AIMAG(beta), KIND=dp)
+
+      CALL cosma_pzgemm_c(transa=transa, transb=transb, m=m, n=n, k=k, &
+                          alpha=C_LOC(alpha_t), &
+                          a=C_LOC(matrix_a%local_data(1, 1)), ia=i_a, ja=j_a, &
+                          desca=C_LOC(matrix_a%matrix_struct%descriptor(1)), &
+                          b=C_LOC(matrix_b%local_data(1, 1)), ib=i_b, jb=j_b, &
+                          descb=C_LOC(matrix_b%matrix_struct%descriptor(1)), &
+                          beta=C_LOC(beta_t), &
+                          c=C_LOC(matrix_c%local_data(1, 1)), ic=i_c, jc=j_c, &
+                          descc=C_LOC(matrix_c%matrix_struct%descriptor(1)))
+
+   END SUBROUTINE cosma_pzgemm
 #endif
 
 END MODULE parallel_gemm_api

--- a/src/qs_localization_methods.F
+++ b/src/qs_localization_methods.F
@@ -19,7 +19,6 @@ MODULE qs_localization_methods
    USE cell_types,                      ONLY: cell_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_column_scale,&
-                                              cp_cfm_gemm,&
                                               cp_cfm_scale,&
                                               cp_cfm_scale_and_add,&
                                               cp_cfm_schur_product,&
@@ -841,7 +840,7 @@ CONTAINS
                CALL cp_cfm_get_submatrix(V, tmp_cmat, nocc + 1, 1, northo, nstate)
                CALL cp_cfm_set_submatrix(VL, tmp_cmat, 1, 1, northo, nstate)
                DEALLOCATE (tmp_cmat)
-               CALL cp_cfm_gemm("C", "N", nextra, nstate, northo, cone, c_tilde, VL, czero, UL)
+               CALL parallel_gemm("C", "N", nextra, nstate, northo, cone, c_tilde, VL, czero, UL)
                ALLOCATE (tmp_cmat(nextra, nstate))
                CALL cp_cfm_get_submatrix(UL, tmp_cmat, 1, 1, nextra, nstate)
                CALL cp_cfm_set_submatrix(U, tmp_cmat, nocc + 1, 1, nextra, nstate)
@@ -862,7 +861,7 @@ CONTAINS
             CALL cp_cfm_get_submatrix(U, tmp_cmat, nocc + 1, 1, nextra, nstate)
             CALL cp_cfm_set_submatrix(UL, tmp_cmat, 1, 1, nextra, nstate)
             DEALLOCATE (tmp_cmat)
-            CALL cp_cfm_gemm("N", "N", northo, nstate, nextra, cone, c_tilde, UL, czero, VL)
+            CALL parallel_gemm("N", "N", northo, nstate, nextra, cone, c_tilde, UL, czero, VL)
             ALLOCATE (tmp_cmat(northo, nstate))
             CALL cp_cfm_get_submatrix(VL, tmp_cmat)
             CALL cp_cfm_set_submatrix(V, tmp_cmat, nocc + 1, 1, northo, nstate)
@@ -912,7 +911,7 @@ CONTAINS
             ELSE
                CALL jacobi_rot_para_1(weights, c_zij, para_env, 1, tmp_cfm_2, tol_out=tol)
             END IF
-            CALL cp_cfm_gemm('N', 'N', nstate, nstate, nstate, cone, U, tmp_cfm_2, czero, tmp_cfm)
+            CALL parallel_gemm('N', 'N', nstate, nstate, nstate, cone, U, tmp_cfm_2, czero, tmp_cfm)
             CALL cp_cfm_to_cfm(tmp_cfm, U)
             CALL cp_cfm_release(tmp_cfm)
             CALL cp_cfm_release(tmp_cfm_2)
@@ -935,7 +934,7 @@ CONTAINS
                CALL cp_cfm_get_submatrix(U, tmp_cmat, 1, 1, nocc, nstate)
                CALL cp_cfm_set_submatrix(V, tmp_cmat, 1, 1, nocc, nstate)
                DEALLOCATE (tmp_cmat)
-               CALL cp_cfm_gemm("N", "N", northo, nstate, nextra, cone, c_tilde, UL, czero, VL)
+               CALL parallel_gemm("N", "N", northo, nstate, nextra, cone, c_tilde, UL, czero, VL)
                ALLOCATE (tmp_cmat(northo, nstate))
                CALL cp_cfm_get_submatrix(VL, tmp_cmat)
                CALL cp_cfm_set_submatrix(V, tmp_cmat, nocc + 1, 1, northo, nstate)
@@ -962,11 +961,11 @@ CONTAINS
          ! update z_ij
          DO idim = 1, dim2
             ! 'tmp_cfm_1 = zij_0*tmp_cfm'
-            CALL cp_cfm_gemm("N", "N", ndummy, nstate, ndummy, cone, zij_0(idim)%matrix, &
-                             tmp_cfm, czero, tmp_cfm_1)
+            CALL parallel_gemm("N", "N", ndummy, nstate, ndummy, cone, zij_0(idim)%matrix, &
+                               tmp_cfm, czero, tmp_cfm_1)
             ! 'c_zij = tmp_cfm_dagg*tmp_cfm_1'
-            CALL cp_cfm_gemm("C", "N", nstate, nstate, ndummy, cone, tmp_cfm, tmp_cfm_1, &
-                             czero, c_zij(idim)%matrix)
+            CALL parallel_gemm("C", "N", nstate, nstate, ndummy, cone, tmp_cfm, tmp_cfm_1, &
+                               czero, c_zij(idim)%matrix)
          END DO
          CALL cp_cfm_release(tmp_cfm)
          CALL cp_cfm_release(tmp_cfm_1)
@@ -998,26 +997,26 @@ CONTAINS
                weight = weights(idim)
                arr_zii = matrix_zii(:, idim)
                ! tmp_cfm = zij_0*V
-               CALL cp_cfm_gemm("N", "N", nmo, nstate, nmo, cone, &
-                                zij_0(idim)%matrix, V, czero, tmp_cfm)
+               CALL parallel_gemm("N", "N", nmo, nstate, nmo, cone, &
+                                  zij_0(idim)%matrix, V, czero, tmp_cfm)
                ! tmp_cfm = tmp_cfm*diag_zij_dagg
                CALL cp_cfm_column_scale(tmp_cfm, CONJG(arr_zii))
                ! tmp_cfm_1 = tmp_cfm*U_dagg
-               CALL cp_cfm_gemm("N", "C", nmo, nstate, nstate, cone, tmp_cfm, &
-                                U, czero, tmp_cfm_1)
+               CALL parallel_gemm("N", "C", nmo, nstate, nstate, cone, tmp_cfm, &
+                                  U, czero, tmp_cfm_1)
                CALL cp_cfm_scale(weight, tmp_cfm_1)
                ! zdiag = zdiag + tmp_cfm_1'
                CALL cp_cfm_scale_and_add(cone, zdiag, cone, tmp_cfm_1)
 
                ! tmp_cfm = zij_0_dagg*V
-               CALL cp_cfm_gemm("C", "N", nmo, nstate, nmo, cone, &
-                                zij_0(idim)%matrix, V, czero, tmp_cfm)
+               CALL parallel_gemm("C", "N", nmo, nstate, nmo, cone, &
+                                  zij_0(idim)%matrix, V, czero, tmp_cfm)
 
                ! tmp_cfm = tmp_cfm*diag_zij
                CALL cp_cfm_column_scale(tmp_cfm, arr_zii)
                ! tmp_cfm_1 = tmp_cfm*U_dagg
-               CALL cp_cfm_gemm("N", "C", nmo, nstate, nstate, cone, tmp_cfm, &
-                                U, czero, tmp_cfm_1)
+               CALL parallel_gemm("N", "C", nmo, nstate, nstate, cone, tmp_cfm, &
+                                  U, czero, tmp_cfm_1)
                CALL cp_cfm_scale(weight, tmp_cfm_1)
                ! zdiag = zdiag + tmp_cfm_1'
                CALL cp_cfm_scale_and_add(cone, zdiag, cone, tmp_cfm_1)
@@ -1032,10 +1031,10 @@ CONTAINS
             CALL cp_cfm_set_submatrix(grad_ctilde, tmp_cmat)
             DEALLOCATE (tmp_cmat)
             ! ctrans_lambda = c_tilde_dagg*grad_ctilde
-            CALL cp_cfm_gemm("C", "N", nextra, nextra, northo, cone, c_tilde, grad_ctilde, czero, ctrans_lambda)
+            CALL parallel_gemm("C", "N", nextra, nextra, northo, cone, c_tilde, grad_ctilde, czero, ctrans_lambda)
             !WRITE(*,*) "norm(ctrans_lambda) = ", cp_cfm_norm(ctrans_lambda, "F")
             ! 'grad_ctilde = - c_tilde*ctrans_lambda + grad_ctilde'
-            CALL cp_cfm_gemm("N", "N", northo, nextra, nextra, -cone, c_tilde, ctrans_lambda, cone, grad_ctilde)
+            CALL parallel_gemm("N", "N", northo, nextra, nextra, -cone, c_tilde, ctrans_lambda, cone, grad_ctilde)
          END IF ! nextra > 0
 
          ! tolerance
@@ -1724,8 +1723,8 @@ CONTAINS
             evals_exp(:) = EXP((0.0_dp, -1.0_dp)*evals(:))
             CALL cp_cfm_to_cfm(cmat_R, cmat_t1)
             CALL cp_cfm_column_scale(cmat_t1, evals_exp)
-            CALL cp_cfm_gemm('N', 'C', nrow_global, nrow_global, nrow_global, cone, &
-                             cmat_t1, cmat_R, czero, cmat_A)
+            CALL parallel_gemm('N', 'C', nrow_global, nrow_global, nrow_global, cone, &
+                               cmat_t1, cmat_R, czero, cmat_A)
             mat_U%local_data = REAL(cmat_A%local_data, KIND=dp) ! U is a real matrix
          ELSE
             do_emd = .FALSE.
@@ -1892,13 +1891,13 @@ CONTAINS
          evals_exp(:) = EXP((0.0_dp, -1.0_dp)*evals(:))
          CALL cp_cfm_to_cfm(cmat_R, cmat_t1)
          CALL cp_cfm_column_scale(cmat_t1, evals_exp)
-         CALL cp_cfm_gemm('N', 'C', n, n, n, cone, cmat_t1, cmat_R, czero, cmat_U)
+         CALL parallel_gemm('N', 'C', n, n, n, cone, cmat_t1, cmat_R, czero, cmat_U)
          cmat_U%local_data = REAL(cmat_U%local_data, KIND=dp) ! enforce numerics, U is a real matrix
 
          IF (new_direction .AND. MOD(line_searches, 20) .EQ. 5) THEN ! reset with A .eq. 0
             DO idim = 1, ndim
-               CALL cp_cfm_gemm('N', 'N', n, n, n, cone, c_zij(idim)%matrix, cmat_U, czero, cmat_t1)
-               CALL cp_cfm_gemm('C', 'N', n, n, n, cone, cmat_U, cmat_t1, czero, c_zij(idim)%matrix)
+               CALL parallel_gemm('N', 'N', n, n, n, cone, c_zij(idim)%matrix, cmat_U, czero, cmat_t1)
+               CALL parallel_gemm('C', 'N', n, n, n, cone, cmat_U, cmat_t1, czero, c_zij(idim)%matrix)
             END DO
             ! collect rotation matrix
             matrix_H%local_data = REAL(cmat_U%local_data, KIND=dp)
@@ -1920,8 +1919,8 @@ CONTAINS
          CALL cp_cfm_set_all(cmat_M, czero)
          omega = 0.0_dp
          DO idim = 1, ndim
-            CALL cp_cfm_gemm('N', 'N', n, n, n, cone, c_zij(idim)%matrix, cmat_U, czero, cmat_t1) ! t1=ZU
-            CALL cp_cfm_gemm('C', 'N', n, n, n, cone, cmat_U, cmat_t1, czero, cmat_t2) ! t2=(U^T)ZU
+            CALL parallel_gemm('N', 'N', n, n, n, cone, c_zij(idim)%matrix, cmat_U, czero, cmat_t1) ! t1=ZU
+            CALL parallel_gemm('C', 'N', n, n, n, cone, cmat_U, cmat_t1, czero, cmat_t2) ! t2=(U^T)ZU
             DO i = 1, n
                CALL cp_cfm_get_element(cmat_t2, i, i, diag_z(i, idim))
                SELECT CASE (2) ! allows for selection of different spread functionals
@@ -1970,11 +1969,11 @@ CONTAINS
          END DO
          ! compute gradient matrix_G
 
-         CALL cp_cfm_gemm('C', 'N', n, n, n, cone, cmat_M, cmat_R, czero, cmat_t1) ! t1=(M^T)(R^T)
-         CALL cp_cfm_gemm('C', 'N', n, n, n, cone, cmat_R, cmat_t1, czero, cmat_t2) ! t2=(R)t1
+         CALL parallel_gemm('C', 'N', n, n, n, cone, cmat_M, cmat_R, czero, cmat_t1) ! t1=(M^T)(R^T)
+         CALL parallel_gemm('C', 'N', n, n, n, cone, cmat_R, cmat_t1, czero, cmat_t2) ! t2=(R)t1
          CALL cp_cfm_schur_product(cmat_t2, cmat_B, cmat_t1)
-         CALL cp_cfm_gemm('N', 'C', n, n, n, cone, cmat_t1, cmat_R, czero, cmat_t2)
-         CALL cp_cfm_gemm('N', 'N', n, n, n, cone, cmat_R, cmat_t2, czero, cmat_t1)
+         CALL parallel_gemm('N', 'C', n, n, n, cone, cmat_t1, cmat_R, czero, cmat_t2)
+         CALL parallel_gemm('N', 'N', n, n, n, cone, cmat_R, cmat_t2, czero, cmat_t1)
          matrix_G%local_data = REAL(cmat_t1%local_data, KIND=dp)
          CALL cp_fm_transpose(matrix_G, matrix_T)
          CALL cp_fm_scale_and_add(-1.0_dp, matrix_G, 1.0_dp, matrix_T)

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -15,7 +15,6 @@ MODULE rpa_gw
                                               gto_basis_set_type
    USE cell_types,                      ONLY: cell_type,&
                                               get_cell
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
                                               cp_cfm_p_type,&
@@ -5157,8 +5156,8 @@ CONTAINS
 !         CALL cp_cfm_scale_and_add(z_one, ks_mat_ao_ao, -z_one, ks_mat_no_xc_ao_ao)
 !         CALL cp_cfm_to_cfm(ks_mat_ao_ao, vxc_ao_ao)
 
-         CALL cp_cfm_gemm('N', 'N', nmo, nmo, nmo, z_one, vxc_ao_ao, cfm_mo_coeff, z_zero, vxc_ao_mo)
-         CALL cp_cfm_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mo_coeff, vxc_ao_mo, z_zero, vxc_mo_mo)
+         CALL parallel_gemm('N', 'N', nmo, nmo, nmo, z_one, vxc_ao_ao, cfm_mo_coeff, z_zero, vxc_ao_mo)
+         CALL parallel_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mo_coeff, vxc_ao_mo, z_zero, vxc_mo_mo)
 
          CALL cp_cfm_to_fm(vxc_mo_mo, fm_Sigma_x_minus_vxc_mo_mo)
 
@@ -5264,11 +5263,11 @@ CONTAINS
          CALL cp_fm_to_cfm(kpoints_Sigma%kp_env(ikp)%kpoint_env%mos(1, 1)%mo_set%mo_coeff, &
                            kpoints_Sigma%kp_env(ikp)%kpoint_env%mos(2, 1)%mo_set%mo_coeff, cfm_mo_coeff)
 
-         CALL cp_cfm_gemm('N', 'N', nmo, nmo, nmo, z_one, cfm_self_energy_ao_ao, cfm_mo_coeff, &
-                          z_zero, cfm_self_energy_ao_mo)
+         CALL parallel_gemm('N', 'N', nmo, nmo, nmo, z_one, cfm_self_energy_ao_ao, cfm_mo_coeff, &
+                            z_zero, cfm_self_energy_ao_mo)
 
-         CALL cp_cfm_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mo_coeff, cfm_self_energy_ao_mo, &
-                          z_zero, cfm_self_energy_mo_mo)
+         CALL parallel_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mo_coeff, cfm_self_energy_ao_mo, &
+                            z_zero, cfm_self_energy_mo_mo)
 
          CALL cp_cfm_to_fm(cfm_self_energy_mo_mo, fm_self_energy_mo_mo)
 

--- a/src/rpa_gw_kpoints_util.F
+++ b/src/rpa_gw_kpoints_util.F
@@ -20,7 +20,6 @@ MODULE rpa_gw_kpoints_util
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_cholesky_decompose,&
                                               cp_cfm_cholesky_invert,&
                                               cp_cfm_column_scale,&
-                                              cp_cfm_gemm,&
                                               cp_cfm_scale_and_add,&
                                               cp_cfm_scale_and_add_fm,&
                                               cp_cfm_transpose
@@ -77,6 +76,7 @@ MODULE rpa_gw_kpoints_util
    USE mathlib,                         ONLY: invmat
    USE message_passing,                 ONLY: mp_sum,&
                                               mp_sync
+   USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_types,                  ONLY: particle_type
    USE qs_band_structure,               ONLY: calculate_kpoints_for_bs
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -381,8 +381,8 @@ CONTAINS
       ! 2. Remove all negative eigenvalues from chi(k,iw)
       IF (make_chi_pos_definite) THEN
          CALL cp_cfm_matrix_exponential(cfm_mat_Q, cfm_mat_work, threshold=0.0_dp, exponent=0.5_dp)
-         CALL cp_cfm_gemm("C", "N", dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_Q, &
-                          z_zero, cfm_mat_work)
+         CALL parallel_gemm("C", "N", dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_Q, &
+                            z_zero, cfm_mat_work)
          CALL cp_cfm_to_cfm(cfm_mat_work, cfm_mat_Q)
 
       END IF
@@ -392,12 +392,12 @@ CONTAINS
       CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_L, gaussi, fm_mat_L_im)
 
       ! 4. work = P(iw,k)*L(k)
-      CALL cp_cfm_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
-                       z_zero, cfm_mat_work)
+      CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
+                         z_zero, cfm_mat_work)
 
       ! 5. Q(iw,k) = L^H(k)*work
-      CALL cp_cfm_gemm('C', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
-                       z_zero, cfm_mat_Q)
+      CALL parallel_gemm('C', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
+                         z_zero, cfm_mat_Q)
 
       CALL cp_cfm_release(cfm_mat_work)
       CALL cp_cfm_release(cfm_mat_L)
@@ -1130,12 +1130,12 @@ CONTAINS
          CALL timeset(routineN//"_3.1", handle2)
 
          ! work = epsilon(iw,k)*L^H(k)
-         CALL cp_cfm_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
-                          z_zero, cfm_mat_work)
+         CALL parallel_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
+                            z_zero, cfm_mat_work)
 
          ! W(iw,k) = L(k)*work
-         CALL cp_cfm_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
-                          z_zero, cfm_mat_work_2)
+         CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
+                            z_zero, cfm_mat_work_2)
 
          CALL timestop(handle2)
 
@@ -1150,8 +1150,8 @@ CONTAINS
          ELSE
 
             ! S^-1(k)V(k)S^-1(k) = L(k)*L(k)^H
-            CALL cp_cfm_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_L, &
-                             z_zero, cfm_mat_work_2)
+            CALL parallel_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_L, &
+                               z_zero, cfm_mat_work_2)
          END IF
 
       END IF
@@ -1405,12 +1405,12 @@ CONTAINS
       CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_L, gaussi, fm_mat_L_im)
 
       ! work = epsilon(iw,k)*L^H(k)
-      CALL cp_cfm_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
-                       z_zero, cfm_mat_work)
+      CALL parallel_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
+                         z_zero, cfm_mat_work)
 
       ! W(iw,k) = L(k)*work
-      CALL cp_cfm_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
-                       z_zero, cfm_mat_Q)
+      CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
+                         z_zero, cfm_mat_Q)
 
       DO iquad = 1, num_integ_points
          omega = tj(jquad)

--- a/src/rpa_gw_sigma_x.F
+++ b/src/rpa_gw_sigma_x.F
@@ -15,8 +15,7 @@ MODULE rpa_gw_sigma_x
    USE admm_methods,                    ONLY: admm_mo_merge_ks_matrix
    USE admm_types,                      ONLY: admm_type,&
                                               get_admm_env
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm,&
-                                              cp_cfm_scale_and_add_fm
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_scale_and_add_fm
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
                                               cp_cfm_release,&
@@ -65,6 +64,7 @@ MODULE rpa_gw_sigma_x
    USE mp2_integrals,                   ONLY: compute_kpoints
    USE mp2_ri_2c,                       ONLY: setup_abs_cutoffs_chi_and_trunc_coulomb_potential
    USE mp2_types,                       ONLY: mp2_type
+   USE parallel_gemm_api,               ONLY: parallel_gemm
    USE physcon,                         ONLY: evolt
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -860,12 +860,12 @@ CONTAINS
             CALL cp_cfm_scale_and_add_fm(z_one, cfm_mos, gaussi, mo_set_im%mo_coeff)
 
             ! tmp = V(k)*C(k)
-            CALL cp_cfm_gemm('N', 'N', nmo, nmo, nmo, z_one, cfm_sigma_x_minus_vxc, &
-                             cfm_mos, z_zero, cfm_tmp)
+            CALL parallel_gemm('N', 'N', nmo, nmo, nmo, z_one, cfm_sigma_x_minus_vxc, &
+                               cfm_mos, z_zero, cfm_tmp)
 
             ! V_n(k) = C^H(k)*tmp
-            CALL cp_cfm_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mos, cfm_tmp, &
-                             z_zero, cfm_sigma_x_minus_vxc_mo_basis)
+            CALL parallel_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mos, cfm_tmp, &
+                               z_zero, cfm_sigma_x_minus_vxc_mo_basis)
 
             DO jjB = 1, ncol_local
 

--- a/src/xas_tdp_utils.F
+++ b/src/xas_tdp_utils.F
@@ -12,7 +12,6 @@
 
 MODULE xas_tdp_utils
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_gemm
    USE cp_cfm_diag,                     ONLY: cp_cfm_heevd
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
@@ -2999,10 +2998,10 @@ CONTAINS
          CALL cp_fm_to_cfm(msourcer=amew_dip(i)%matrix, mtarget=work1_cfm)
 
          !compute amew_coeffs^dagger * amew_dip * amew_gs to get the transition moments
-         CALL cp_cfm_gemm('C', 'N', ntot, ntot, ntot, (1.0_dp, 0.0_dp), soc_evecs_cfm, work1_cfm, &
-                          (0.0_dp, 0.0_dp), work2_cfm)
-         CALL cp_cfm_gemm('N', 'N', ntot, 1, ntot, (1.0_dp, 0.0_dp), work2_cfm, soc_evecs_cfm, &
-                          (0.0_dp, 0.0_dp), dip_cfm)
+         CALL parallel_gemm('C', 'N', ntot, ntot, ntot, (1.0_dp, 0.0_dp), soc_evecs_cfm, work1_cfm, &
+                            (0.0_dp, 0.0_dp), work2_cfm)
+         CALL parallel_gemm('N', 'N', ntot, 1, ntot, (1.0_dp, 0.0_dp), work2_cfm, soc_evecs_cfm, &
+                            (0.0_dp, 0.0_dp), dip_cfm)
 
          CALL cp_cfm_get_submatrix(dip_cfm, transdip)
 
@@ -3110,10 +3109,10 @@ CONTAINS
          CALL cp_fm_to_cfm(msourcer=amew_quad(i)%matrix, mtarget=work1_cfm)
 
          !compute amew_coeffs^dagger * amew_quad * amew_gs to get the transition moments
-         CALL cp_cfm_gemm('C', 'N', ntot, ntot, ntot, (1.0_dp, 0.0_dp), soc_evecs_cfm, work1_cfm, &
-                          (0.0_dp, 0.0_dp), work2_cfm)
-         CALL cp_cfm_gemm('N', 'N', ntot, 1, ntot, (1.0_dp, 0.0_dp), work2_cfm, soc_evecs_cfm, &
-                          (0.0_dp, 0.0_dp), quad_cfm)
+         CALL parallel_gemm('C', 'N', ntot, ntot, ntot, (1.0_dp, 0.0_dp), soc_evecs_cfm, work1_cfm, &
+                            (0.0_dp, 0.0_dp), work2_cfm)
+         CALL parallel_gemm('N', 'N', ntot, 1, ntot, (1.0_dp, 0.0_dp), work2_cfm, soc_evecs_cfm, &
+                            (0.0_dp, 0.0_dp), quad_cfm)
 
          CALL cp_cfm_get_submatrix(quad_cfm, transquad)
 

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -167,6 +167,7 @@ EOF
 leak:cosma::communicator::communicator
 leak:cosma::cosma_context<double>::register_state
 leak:cosma::pxgemm<double>
+leak:cosma::cosma_context<std::complex<double> >::register_state
 EOF
 fi
 


### PR DESCRIPTION
This PR adds the call to COSMA's pzgemm version. It uses the same switch as for PDGEMM to enforce the use of either COSMA or Scalapack because COSMA's environment variables do not distinguish between the actual data types.