### PR TITLE
Docker: Fix and update Intel oneAPI test

### DIFF
--- a/tools/docker/Dockerfile.test_intel-psmp
+++ b/tools/docker/Dockerfile.test_intel-psmp
@@ -3,13 +3,12 @@
 # Usage: docker build -f ./Dockerfile.test_intel-psmp ../../
 #
 
-FROM intel/oneapi-hpckit:2021.4-devel-ubuntu18.04
+FROM intel/oneapi-hpckit:2022.2-devel-ubuntu20.04
 
-ENV PATH=/opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64:/opt/intel/oneapi/mpi/2021.4.0/bin:${PATH}
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/mpi/2021.4.0/lib/release:/opt/intel/oneapi/mpi/2021.4.0/lib:/opt/intel/oneapi/mpi/2021.4.0/libfabric/lib:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:${LD_LIBRARY_PATH}
-ENV MKLROOT=/opt/intel/oneapi/mkl/2021.4.0
-ENV I_MPI_ROOT=/opt/intel/oneapi/mpi/2021.4.0
-ENV FI_PROVIDER_PATH='/opt/intel/oneapi/mpi/2021.4.0/libfabric/lib/prov'
+# Without this cp2k segfaults right after startup.
+# See https://github.com/cp2k/cp2k/issues/1936
+ENV I_MPI_FABRICS='shm'
+
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
@@ -69,8 +68,6 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# TODO: Remove --mpiranks=1, see github.com/cp2k/cp2k/issues/2103
-
 # Install CP2K using local.psmp.
 WORKDIR /opt/cp2k
 COPY ./Makefile .
@@ -89,7 +86,7 @@ COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
 # Run regression tests.
-ARG TESTOPTS="--mpiranks=1"
+ARG TESTOPTS=""
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -o pipefail -c " \
     TESTOPTS="${TESTOPTS}" \


### PR DESCRIPTION
Fixes #2103 and #1936.

Turns out the solution was `export I_MPI_FABRICS='shm'`.

@hfp, is this worth a bug report?