### PR TITLE
Reduce runtime for performance tests

### DIFF
--- a/benchmarks/QS_mp2_rpa/32-H2O/RI-MP2.inp
+++ b/benchmarks/QS_mp2_rpa/32-H2O/RI-MP2.inp
@@ -25,17 +25,7 @@
     INPUT_FILE_NAME  H2O-32-HF-TZ.inp
     OUTPUT_FILE_NAME H2O-32-HF-TZ.inp.log
   &END JOB
-  # calculate RI-MP2 correlation energy (three times)
-  &JOB
-    DIRECTORY .
-    INPUT_FILE_NAME  H2O-32-RI-MP2-TZ.inp
-    OUTPUT_FILE_NAME result.log
-  &END JOB
-  &JOB
-    DIRECTORY .
-    INPUT_FILE_NAME  H2O-32-RI-MP2-TZ.inp
-    OUTPUT_FILE_NAME result.log
-  &END JOB
+  # calculate RI-MP2 correlation energy
   &JOB
     DIRECTORY .
     INPUT_FILE_NAME  H2O-32-RI-MP2-TZ.inp

--- a/benchmarks/QS_mp2_rpa/32-H2O/RI-RPA.inp
+++ b/benchmarks/QS_mp2_rpa/32-H2O/RI-RPA.inp
@@ -18,17 +18,7 @@
     INPUT_FILE_NAME  H2O-32-PBE-TZ.inp
     OUTPUT_FILE_NAME H2O-32-PBE-TZ.inp.log
   &END JOB
-  # calculate RI-RPA correlation energy (three times)
-  &JOB
-    DIRECTORY .
-    INPUT_FILE_NAME  H2O-32-RI-dRPA-TZ.inp
-    OUTPUT_FILE_NAME result.log
-  &END JOB
-  &JOB
-    DIRECTORY .
-    INPUT_FILE_NAME  H2O-32-RI-dRPA-TZ.inp
-    OUTPUT_FILE_NAME result.log
-  &END JOB
+  # calculate RI-RPA correlation energy
   &JOB
     DIRECTORY .
     INPUT_FILE_NAME  H2O-32-RI-dRPA-TZ.inp


### PR DESCRIPTION
The repeated runs for RI-RPA and RI-MP2 show only small variations