### PR TITLE
Enable toolchain build for target CPU

### DIFF
--- a/arch/Linux-gnu-aarch64-static.ssmp
+++ b/arch/Linux-gnu-aarch64-static.ssmp
@@ -16,7 +16,9 @@
       exit 1; \
    fi; \
    this_file=${BASH_SOURCE##*/}; \
-   ./install_cp2k_toolchain.sh --mpi-mode=no --no-arch-files --with-gcc=system --with-cmake=system; \
+   cd tools/toolchain; \
+   [[ -z "${target_cpu}" ]] && target_cpu="native"; \
+   ./install_cp2k_toolchain.sh --mpi-mode=no --no-arch-files --target-cpu=${target_cpu} --with-gcc=system --with-cmake=system; \
    source ./install/setup; \
    cd ../..; \
    echo; \
@@ -28,6 +30,7 @@
 
 # Set options
 DO_CHECKS      := no
+TARGET_CPU     := native
 USE_FFTW       := 3.3.10
 USE_LIBINT     := 2.6.0
 USE_LIBVORI    := 220621
@@ -44,7 +47,7 @@ FC             := gfortran
 LD             := gfortran
 AR             := ar -r
 
-CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=native
+CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)
 
 DFLAGS         += -D__MAX_CONTR=$(strip $(MAX_CONTR))
 

--- a/arch/Linux-gnu-aarch64.psmp
+++ b/arch/Linux-gnu-aarch64.psmp
@@ -20,7 +20,9 @@
    fi; \
    this_file=${BASH_SOURCE##*/}; \
    cd tools/toolchain; \
-   ./install_cp2k_toolchain.sh --install-all --no-arch-files --with-gcc --with-mpich; \
+   [[ -z "${mpi_implementation}" ]] && mpi_implementation="mpich"; \
+   [[ -z "${target_cpu}" ]] && target_cpu="native"; \
+   ./install_cp2k_toolchain.sh --install-all --no-arch-files --target-cpu=${target_cpu} --with-gcc --with-${mpi_implementation}; \
    source ./install/setup; \
    cd ../..; \
    echo; \
@@ -38,6 +40,7 @@
 # Set options
 DO_CHECKS      := no
 SHARED         := no
+TARGET_CPU     := native
 USE_COSMA      := 2.6.2
 USE_ELPA       := 2021.11.002
 USE_FFTW       := 3.3.10
@@ -69,7 +72,7 @@ FC             := mpif90
 LD             := mpif90
 AR             := ar -r
 
-CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=native
+CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__SCALAPACK

--- a/arch/Linux-gnu-x86_64-static.ssmp
+++ b/arch/Linux-gnu-x86_64-static.ssmp
@@ -6,7 +6,6 @@
 #              LIBXC 5.2.3, OpenBLAS 0.3.21, SPGLIB 1.16.2
 #
 # Usage: Source this arch file and then run make as instructed.
-#        Add "generic" as argument to compile for a generic x86_64 target.
 #
 # Author: Matthias Krack (30.09.2022)
 #
@@ -18,27 +17,20 @@
    fi; \
    this_file=${BASH_SOURCE##*/}; \
    cd tools/toolchain; \
-   if [[ "${1}" == "generic" ]]; then \
-      ./install_cp2k_toolchain.sh --generic --mpi-mode=no --no-arch-files --with-gcc=install; \
-   else \
-      ./install_cp2k_toolchain.sh --mpi-mode=no --no-arch-files --with-gcc=install; \
-   fi; \
+   [[ -z "${target_cpu}" ]] && target_cpu="native"; \
+   ./install_cp2k_toolchain.sh --mpi-mode=no --no-arch-files --target-cpu=${target_cpu} --with-gcc; \
    source ./install/setup; \
    cd ../..; \
    echo; \
    echo "Check the output above for error messages and consistency!"; \
    echo "If everything is OK, you can build a CP2K production binary with"; \
-   if [[ "${1}" == "generic" ]]; then \
-      echo "   make -j ARCH=${this_file%.*} VERSION=${this_file##*.} GENERIC=yes"; \
-   else \
-      echo "   make -j ARCH=${this_file%.*} VERSION=${this_file##*.}"; \
-   fi; \
-   echo "Further checks are performed, if DO_CHECKS=yes is added."; \
+   echo "   make -j ARCH=${this_file%.*} VERSION=${this_file##*.}"; \
+   echo "Further checks are performed, if DO_CHECKS=yes is added, but this disables static linking."; \
    return
 
 # Set options
 DO_CHECKS      := no
-GENERIC        := no
+TARGET_CPU     := native
 USE_FFTW       := 3.3.10
 USE_LIBINT     := 2.6.0
 USE_LIBVORI    := 220621
@@ -55,11 +47,7 @@ FC             := gfortran
 LD             := gfortran
 AR             := ar -r
 
-ifeq ($(GENERIC), yes)
-   CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=generic
-else
-   CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=native
-endif
+CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)
 
 DFLAGS         += -D__MAX_CONTR=$(strip $(MAX_CONTR))
 

--- a/arch/Linux-gnu-x86_64.psmp
+++ b/arch/Linux-gnu-x86_64.psmp
@@ -10,7 +10,7 @@
 #
 # Usage: Source this arch file and then run make as instructed.
 #        A full toolchain installation is performed as default.
-#        Optionally, GNU compiler and MPICH version can be specified as arguments.
+#        Optionally, GNU compiler and MPI implementation can be specified as arguments.
 #        Replace or adapt the "module add" commands below if needed.
 #
 # Author: Matthias Krack (30.09.2022)
@@ -24,18 +24,19 @@
    this_file=${BASH_SOURCE##*/}; \
    cd tools/toolchain; \
    [[ -z "${mpi_implementation}" ]] && mpi_implementation="mpich"; \
+   [[ -z "${target_cpu}" ]] && target_cpu="native"; \
    if [[ -n "${1}" ]]; then \
       module add ${1}; \
       if [[ -n "${2}" ]]; then \
          module add ${2}; \
          module list; \
-         ./install_cp2k_toolchain.sh --install-all --no-arch-files --with-gcc=system --with-${mpi_implementation}=system; \
+         ./install_cp2k_toolchain.sh --install-all --no-arch-files --target-cpu=${target_cpu} --with-gcc=system --with-${mpi_implementation}=system; \
       else \
          module list; \
-         ./install_cp2k_toolchain.sh --install-all --no-arch-files --with-gcc=system --with-${mpi_implementation}; \
+         ./install_cp2k_toolchain.sh --install-all --no-arch-files --target-cpu=${target_cpu} --with-gcc=system --with-${mpi_implementation}; \
       fi; \
    else \
-      ./install_cp2k_toolchain.sh --install-all --no-arch-files --with-gcc --with-${mpi_implementation}; \
+      ./install_cp2k_toolchain.sh --install-all --no-arch-files --target-cpu=${target_cpu} --with-gcc --with-${mpi_implementation}; \
    fi; \
    source ./install/setup; \
    cd ../..; \
@@ -54,6 +55,7 @@
 # Set options
 DO_CHECKS      := no
 SHARED         := no
+TARGET_CPU     := native
 USE_COSMA      := 2.6.2
 USE_ELPA       := 2021.11.002
 USE_FFTW       := 3.3.10
@@ -85,7 +87,7 @@ FC             := mpif90
 LD             := mpif90
 AR             := ar -r
 
-CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=native
+CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__SCALAPACK

--- a/arch/Linux-intel-x86_64.psmp
+++ b/arch/Linux-intel-x86_64.psmp
@@ -23,11 +23,12 @@
    fi; \
    this_file=${BASH_SOURCE##*/}; \
    cd tools/toolchain; \
+   [[ -z "${target_cpu}" ]] && target_cpu="native"; \
    if [[ -n "${1}" ]]; then \
       module add ${1}; \
       module list; \
    fi; \
-   ./install_cp2k_toolchain.sh --install-all --no-arch-files --with-intelmpi --with-mkl; \
+   ./install_cp2k_toolchain.sh --install-all --no-arch-files --target-cpu=${target_cpu} --with-intelmpi --with-mkl; \
    source ./install/setup; \
    cd ../..; \
    echo; \
@@ -45,6 +46,7 @@
 # Set options
 DO_CHECKS      := no
 SHARED         := no
+TARGET_CPU     := native
 USE_COSMA      := 2.6.2
 USE_ELPA       := 2021.11.002
 USE_LIBINT     := 2.6.0
@@ -72,7 +74,11 @@ FC             := mpiifort
 LD             := mpiifort
 AR             := ar -r
 
-CFLAGS         := -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost
+ifeq ($(strip $(TARGET_CPU)), native)
+   CFLAGS         := -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost
+else
+   CFLAGS         := -O2 -fopenmp -fp-model precise -funroll-loops -g -mtune=$(TARGET_CPU) -qopenmp-simd
+endif
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__SCALAPACK

--- a/tools/docker/Dockerfile.prod_generic_pdbg
+++ b/tools/docker/Dockerfile.prod_generic_pdbg
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.prod_generic_psmp
+++ b/tools/docker/Dockerfile.prod_generic_psmp
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.prod_generic_sdbg
+++ b/tools/docker/Dockerfile.prod_generic_sdbg
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.prod_generic_ssmp
+++ b/tools/docker/Dockerfile.prod_generic_ssmp
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.prod_pdbg
+++ b/tools/docker/Dockerfile.prod_pdbg
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.prod_psmp
+++ b/tools/docker/Dockerfile.prod_psmp
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.prod_sdbg
+++ b/tools/docker/Dockerfile.prod_sdbg
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.prod_ssmp
+++ b/tools/docker/Dockerfile.prod_ssmp
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_asan-ssmp
+++ b/tools/docker/Dockerfile.test_asan-ssmp
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_conventions
+++ b/tools/docker/Dockerfile.test_conventions
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_coverage-pdbg
+++ b/tools/docker/Dockerfile.test_coverage-pdbg
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_coverage-sdbg
+++ b/tools/docker/Dockerfile.test_coverage-sdbg
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_generic_pdbg
+++ b/tools/docker/Dockerfile.test_generic_pdbg
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_generic_sdbg
+++ b/tools/docker/Dockerfile.test_generic_sdbg
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_generic_ssmp
+++ b/tools/docker/Dockerfile.test_generic_ssmp
@@ -23,8 +23,8 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=generic \
     --with-gcc=system \
-    --generic \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_manual
+++ b/tools/docker/Dockerfile.test_manual
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=openmpi \
+    --target-cpu=native \
     --with-gcc=install \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_performance
+++ b/tools/docker/Dockerfile.test_performance
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
+    --target-cpu=native \
     --with-gcc=system \
     --dry-run
 

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -21,10 +21,10 @@ def main() -> None:
             f.write(toolchain_full() + production(version))
 
         with OutputFile(f"Dockerfile.test_generic_{version}", args.check) as f:
-            f.write(toolchain_full(generic=True) + regtest(version))
+            f.write(toolchain_full(target_cpu="generic") + regtest(version))
 
         with OutputFile(f"Dockerfile.prod_generic_{version}", args.check) as f:
-            f.write(toolchain_full(generic=True) + production(version))
+            f.write(toolchain_full(target_cpu="generic") + production(version))
 
     with OutputFile(f"Dockerfile.test_openmpi-psmp", args.check) as f:
         # Also testing --with-gcc=install here, see github.com/cp2k/cp2k/issues/2062 .
@@ -365,11 +365,9 @@ def toolchain_full(
     base_image: str = "ubuntu:22.04",
     mpi_mode: str = "mpich",
     gcc: str = "system",
-    generic: bool = False,
+    target_cpu: str = "native",
 ) -> str:
-    args = dict(install_all="", mpi_mode=mpi_mode, with_gcc=gcc)
-    if generic:
-        args["generic"] = ""
+    args = dict(install_all="", mpi_mode=mpi_mode, target_cpu=target_cpu, with_gcc=gcc)
     return f"\nFROM {base_image}\n\n" + install_toolchain(base_image=base_image, **args)
 
 

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -108,8 +108,8 @@ OPTIONS:
                           Default = 5
 --log-lines               Number of log file lines dumped in case of a non-zero exit code.
                           Default = 200
---generic                 Compile for a generic target system, i.e. do not optimize for
-                          the actual host system.
+--target-cpu              Compile for the specified target CPU (e.g. haswell or generic), i.e.
+                          do not optimize for the actual host system which is the default (native)
 --no-arch-files           Do not generate arch files
 --dry-run                 Write only config files, but don't actually build packages.
 
@@ -337,7 +337,6 @@ fi
 # default enable options
 dry_run="__FALSE__"
 no_arch_files="__FALSE__"
-export generic="__FALSE__"
 enable_tsan="__FALSE__"
 enable_gcc_master="__FALSE__"
 enable_libxsmm_master="__FALSE__"
@@ -345,6 +344,7 @@ enable_opencl="__FALSE__"
 enable_cuda="__FALSE__"
 enable_hip="__FALSE__"
 export GPUVER="no"
+export TARGET_CPU="native"
 
 # default for libint
 export LIBINT_LMAX="5"
@@ -452,6 +452,10 @@ while [ $# -ge 1 ]; do
           ;;
       esac
       ;;
+    --target-cpu=*)
+      user_input="${1#*=}"
+      export TARGET_CPU="${user_input}"
+      ;;
     --log-lines=*)
       user_input="${1#*=}"
       export LOG_LINES="${user_input}"
@@ -462,9 +466,6 @@ while [ $# -ge 1 ]; do
       ;;
     --no-arch-files)
       no_arch_files="__TRUE__"
-      ;;
-    --generic)
-      export generic="__TRUE__"
       ;;
     --dry-run)
       dry_run="__TRUE__"
@@ -897,7 +898,7 @@ fi
 # Installing tools required for building CP2K and associated libraries
 # ------------------------------------------------------------------------
 
-echo "Compiling with $(get_nprocs) processes."
+echo "Compiling with $(get_nprocs) processes for target ${TARGET_CPU}."
 
 # Select the correct compute number based on the GPU architecture
 case ${GPUVER} in

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -35,10 +35,8 @@ LD_arch="IF_MPI(${MPIFC}|${FC})"
 # we always want good line information and backtraces
 if [ "${with_intel}" != "__DONTUSE__" ]; then
   BASEFLAGS="-nofor-main -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost -wd279"
-elif [ "${generic}" = "__TRUE__" ]; then
-  BASEFLAGS="-fno-omit-frame-pointer -fopenmp -g -mtune=generic"
 else
-  BASEFLAGS="-fno-omit-frame-pointer -fopenmp -g -march=native -mtune=native IF_ASAN(-fsanitize=address|)"
+  BASEFLAGS="-fno-omit-frame-pointer -fopenmp -g -mtune=${TARGET_CPU} IF_ASAN(-fsanitize=address|)"
 fi
 
 OPT_FLAGS="-O3 -funroll-loops"

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -34,7 +34,13 @@ LD_arch="IF_MPI(${MPIFC}|${FC})"
 
 # we always want good line information and backtraces
 if [ "${with_intel}" != "__DONTUSE__" ]; then
-  BASEFLAGS="-nofor-main -O2 -fopenmp -fp-model precise -funroll-loops -g -qopenmp-simd -traceback -xHost -wd279"
+  if [ "${TARGET_CPU}" = "native" ]; then
+    BASEFLAGS="-fopenmp -fp-model precise -g -nofor-main -qopenmp-simd -traceback -wd279 -xHost"
+  elif [ "${TARGET_CPU}" = "generic" ]; then
+    BASEFLAGS="-fopenmp -fp-model precise -g -mtune=${TARGET_CPU} -nofor-main -qopenmp-simd -traceback -wd279"
+  else
+    BASEFLAGS="-fopenmp -fp-model precise -g -march=${TARGET_CPU} -mtune=${TARGET_CPU} -nofor-main -qopenmp-simd -traceback -wd279"
+  fi
 else
   BASEFLAGS="-fno-omit-frame-pointer -fopenmp -g -mtune=${TARGET_CPU} IF_ASAN(-fsanitize=address|)"
 fi

--- a/tools/toolchain/scripts/stage0/setup_buildtools.sh
+++ b/tools/toolchain/scripts/stage0/setup_buildtools.sh
@@ -21,10 +21,10 @@ done
 # ------------------------------------------------------------------------
 
 # setup compiler flags, leading to nice stack traces on crashes but still optimised
-if [ "${generic}" = "__TRUE__" ]; then
+if [ "${TARGET_CPU}" = "generic" ]; then
   CFLAGS="-O2 -fPIC -fno-omit-frame-pointer -fopenmp -g -mtune=generic ${TSANFLAGS}"
 else
-  CFLAGS="-O2 -fPIC -fno-omit-frame-pointer -fopenmp -g -march=native -mtune=native ${TSANFLAGS}"
+  CFLAGS="-O2 -fPIC -fno-omit-frame-pointer -fopenmp -g -march=${TARGET_CPU} -mtune=${TARGET_CPU} ${TSANFLAGS}"
 fi
 FFLAGS="${CFLAGS} -fbacktrace"
 CXXFLAGS="${CFLAGS}"

--- a/tools/toolchain/scripts/stage2/install_openblas.sh
+++ b/tools/toolchain/scripts/stage2/install_openblas.sh
@@ -53,7 +53,7 @@ case "${with_openblas}" in
       #                     for a good compromise between memory usage and scalability
       #
       # Unfortunately, NO_SHARED=1 breaks ScaLAPACK build.
-      if [ "${generic}" = "__TRUE__" ]; then
+      if [ "${TARGET_CPU}" = "generic" ]; then
         make -j $(get_nprocs) \
           MAKE_NB_JOBS=0 \
           TARGET=NEHALEM \

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -48,10 +48,12 @@ case "$with_fftw" in
       # fftw has mpi support but not compiled by default. so compile it if we build with mpi.
       # it will create a second library to link with if needed
       [ "${MPI_MODE}" != "no" ] && FFTW_FLAGS="--enable-mpi ${FFTW_FLAGS}"
-      if [ -f /proc/cpuinfo ]; then
-        grep '\bavx\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx"
-        grep '\bavx2\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx2"
-        grep '\bavx512f\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx512"
+      if [ "${TARGET_CPU}" = "native" ]; then
+        if [ -f /proc/cpuinfo ]; then
+          grep '\bavx\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx"
+          grep '\bavx2\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx2"
+          grep '\bavx512f\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx512"
+        fi
       fi
       ./configure --prefix=${pkg_install_dir} --libdir="${pkg_install_dir}/lib" ${FFTW_FLAGS} \
         > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -83,12 +83,12 @@ case "$with_elpa" in
       done
 
       # ELPA-2017xxxx enables AVX2 by default, switch off if machine doesn't support it.
+      AVX_flag=""
+      AVX512_flags=""
+      FMA_flag=""
+      SSE4_flag=""
+      config_flags="--disable-avx --disable-avx2 --disable-avx512 --disable-sse --disable-sse-assembly"
       if [ "${TARGET_CPU}" = "native" ]; then
-        AVX_flag=""
-        AVX512_flags=""
-        FMA_flag=""
-        SSE4_flag=""
-        config_flags="--disable-avx --disable-avx2 --disable-avx512 --disable-sse --disable-sse-assembly"
         if [ -f /proc/cpuinfo ] && [ "${OPENBLAS_ARCH}" = "x86_64" ]; then
           has_AVX=$(grep '\bavx\b' /proc/cpuinfo 1> /dev/null && echo 'yes' || echo 'no')
           [ "${has_AVX}" = "yes" ] && AVX_flag="-mavx" || AVX_flag=""

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -83,25 +83,27 @@ case "$with_elpa" in
       done
 
       # ELPA-2017xxxx enables AVX2 by default, switch off if machine doesn't support it.
-      AVX_flag=""
-      AVX512_flags=""
-      FMA_flag=""
-      SSE4_flag=""
-      config_flags="--disable-avx --disable-avx2 --disable-avx512 --disable-sse --disable-sse-assembly"
-      if [ -f /proc/cpuinfo ] && [ "${OPENBLAS_ARCH}" = "x86_64" ]; then
-        has_AVX=$(grep '\bavx\b' /proc/cpuinfo 1> /dev/null && echo 'yes' || echo 'no')
-        [ "${has_AVX}" = "yes" ] && AVX_flag="-mavx" || AVX_flag=""
-        has_AVX2=$(grep '\bavx2\b' /proc/cpuinfo 1> /dev/null && echo 'yes' || echo 'no')
-        [ "${has_AVX2}" = "yes" ] && AVX_flag="-mavx2"
-        has_AVX512=$(grep '\bavx512f\b' /proc/cpuinfo 1> /dev/null && echo 'yes' || echo 'no')
-        [ "${has_AVX512}" = "yes" ] && AVX512_flags="-mavx512f"
-        FMA_flag=$(grep '\bfma\b' /proc/cpuinfo 1> /dev/null && echo '-mfma' || echo '-mno-fma')
-        SSE4_flag=$(grep '\bsse4_1\b' /proc/cpuinfo 1> /dev/null && echo '-msse4' || echo '-mno-sse4')
-        grep '\bavx512dq\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512dq"
-        grep '\bavx512cd\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512cd"
-        grep '\bavx512bw\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512bw"
-        grep '\bavx512vl\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512vl"
-        config_flags="--enable-avx=${has_AVX} --enable-avx2=${has_AVX2} --enable-avx512=${has_AVX512}"
+      if [ "${TARGET_CPU}" = "native" ]; then
+        AVX_flag=""
+        AVX512_flags=""
+        FMA_flag=""
+        SSE4_flag=""
+        config_flags="--disable-avx --disable-avx2 --disable-avx512 --disable-sse --disable-sse-assembly"
+        if [ -f /proc/cpuinfo ] && [ "${OPENBLAS_ARCH}" = "x86_64" ]; then
+          has_AVX=$(grep '\bavx\b' /proc/cpuinfo 1> /dev/null && echo 'yes' || echo 'no')
+          [ "${has_AVX}" = "yes" ] && AVX_flag="-mavx" || AVX_flag=""
+          has_AVX2=$(grep '\bavx2\b' /proc/cpuinfo 1> /dev/null && echo 'yes' || echo 'no')
+          [ "${has_AVX2}" = "yes" ] && AVX_flag="-mavx2"
+          has_AVX512=$(grep '\bavx512f\b' /proc/cpuinfo 1> /dev/null && echo 'yes' || echo 'no')
+          [ "${has_AVX512}" = "yes" ] && AVX512_flags="-mavx512f"
+          FMA_flag=$(grep '\bfma\b' /proc/cpuinfo 1> /dev/null && echo '-mfma' || echo '-mno-fma')
+          SSE4_flag=$(grep '\bsse4_1\b' /proc/cpuinfo 1> /dev/null && echo '-msse4' || echo '-mno-sse4')
+          grep '\bavx512dq\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512dq"
+          grep '\bavx512cd\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512cd"
+          grep '\bavx512bw\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512bw"
+          grep '\bavx512vl\b' /proc/cpuinfo 1> /dev/null && AVX512_flags+=" -mavx512vl"
+          config_flags="--enable-avx=${has_AVX} --enable-avx2=${has_AVX2} --enable-avx512=${has_AVX512}"
+        fi
       fi
       for TARGET in "cpu" "nvidia"; do
         [ "$TARGET" = "nvidia" ] && [ "$ENABLE_CUDA" != "__TRUE__" ] && continue


### PR DESCRIPTION
- toolchain flag `--target-cpu=<cpu>` added to facilitate cross-compilation
- toolchain flag `--generic` removed, `--target-cpu=generic` can be used instead
- the default toolchain build is `--target-cpu=native` as before (host CPU)
- Docker and arch files updated correspondingly