### PR TITLE
Refactor the PW package

### DIFF
--- a/src/admm_dm_methods.F
+++ b/src/admm_dm_methods.F
@@ -258,8 +258,8 @@ CONTAINS
       DO ispin = 1, dft_control%nspins
          CALL calculate_rho_elec(ks_env=ks_env, &
                                  matrix_p=rho_ao_aux(ispin)%matrix, &
-                                 rho=rho_r_aux(ispin), &
-                                 rho_gspace=rho_g_aux(ispin), &
+                                 rho=rho_r_aux(ispin)%pw, &
+                                 rho_gspace=rho_g_aux(ispin)%pw, &
                                  total_rho=tot_rho_r_aux(ispin), &
                                  soft_valid=.FALSE., &
                                  basis_type="AUX_FIT", &

--- a/src/admm_methods.F
+++ b/src/admm_methods.F
@@ -217,8 +217,8 @@ CONTAINS
 
          CALL calculate_rho_elec(ks_env=ks_env, &
                                  matrix_p=rho_ao_aux(ispin)%matrix, &
-                                 rho=rho_r_aux(ispin), &
-                                 rho_gspace=rho_g_aux(ispin), &
+                                 rho=rho_r_aux(ispin)%pw, &
+                                 rho_gspace=rho_g_aux(ispin)%pw, &
                                  total_rho=tot_rho_r_aux(ispin), &
                                  soft_valid=.FALSE., &
                                  basis_type=basis_type, &
@@ -1559,8 +1559,8 @@ CONTAINS
 
          CALL calculate_rho_elec(ks_env=ks_env, &
                                  matrix_p=rho_ao_aux_buffer(myspin)%matrix, &
-                                 rho=rho_r(myspin), &
-                                 rho_gspace=rho_g(myspin), &
+                                 rho=rho_r(myspin)%pw, &
+                                 rho_gspace=rho_g(myspin)%pw, &
                                  total_rho=tot_rho_r(myspin), &
                                  soft_valid=.FALSE., &
                                  basis_type="AUX_FIT", &

--- a/src/cp_ddapc.F
+++ b/src/cp_ddapc.F
@@ -140,6 +140,7 @@ CONTAINS
       dft_control%qs_control%ddapc_explicit_potential = explicit_potential
       dft_control%qs_control%ddapc_restraint_is_spin = ddapc_restraint_is_spin
       IF (explicit_potential) THEN
+         ALLOCATE (v_spin_ddapc_rest_g%pw, v_spin_ddapc_rest_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_spin_ddapc_rest_g%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_zero(v_spin_ddapc_rest_g%pw)

--- a/src/cp_ddapc.F
+++ b/src/cp_ddapc.F
@@ -181,7 +181,7 @@ CONTAINS
                      CALL dbcsr_copy(qs_env%et_coupling%rest_mat(1)%matrix, ks_matrix(1, 1)%matrix, &
                                      name="ET_RESTRAINT_MATRIX_B")
                      CALL dbcsr_set(qs_env%et_coupling%rest_mat(1)%matrix, 0.0_dp)
-                     CALL integrate_v_rspace(v_spin_ddapc_rest_r, &
+                     CALL integrate_v_rspace(v_spin_ddapc_rest_r%pw, &
                                              hmat=qs_env%et_coupling%rest_mat(1), &
                                              qs_env=qs_env, calculate_forces=.FALSE.)
                      qs_env%et_coupling%order_p = &
@@ -194,7 +194,7 @@ CONTAINS
                      CALL dbcsr_copy(qs_env%et_coupling%rest_mat(2)%matrix, ks_matrix(1, 1)%matrix, &
                                      name="ET_RESTRAINT_MATRIX_B")
                      CALL dbcsr_set(qs_env%et_coupling%rest_mat(2)%matrix, 0.0_dp)
-                     CALL integrate_v_rspace(v_spin_ddapc_rest_r, &
+                     CALL integrate_v_rspace(v_spin_ddapc_rest_r%pw, &
                                              hmat=qs_env%et_coupling%rest_mat(2), &
                                              qs_env=qs_env, calculate_forces=.FALSE.)
                   END IF

--- a/src/cp_ddapc.F
+++ b/src/cp_ddapc.F
@@ -205,6 +205,7 @@ CONTAINS
 
       IF (explicit_potential) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_g%pw)
+         DEALLOCATE (v_spin_ddapc_rest_g%pw)
       END IF
       CALL timestop(handle)
 

--- a/src/cp_ddapc_types.F
+++ b/src/cp_ddapc_types.F
@@ -435,9 +435,11 @@ CONTAINS
       IF (ASSOCIATED(cp_ddapc_ewald)) THEN
          IF (ASSOCIATED(cp_ddapc_ewald%coeff_qm)) THEN
             CALL pw_pool_give_back_pw(cp_ddapc_ewald%pw_pool_qm, cp_ddapc_ewald%coeff_qm)
+            DEALLOCATE (cp_ddapc_ewald%coeff_qm)
          END IF
          IF (ASSOCIATED(cp_ddapc_ewald%coeff_mm)) THEN
             CALL pw_pool_give_back_pw(cp_ddapc_ewald%pw_pool_mm, cp_ddapc_ewald%coeff_mm)
+            DEALLOCATE (cp_ddapc_ewald%coeff_mm)
          END IF
          IF (ASSOCIATED(cp_ddapc_ewald%pw_pool_qm)) THEN
             CALL pw_pool_release(cp_ddapc_ewald%pw_pool_qm)

--- a/src/cp_ddapc_util.F
+++ b/src/cp_ddapc_util.F
@@ -96,7 +96,6 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core
       TYPE(pw_pool_type), POINTER                        :: auxbas_pool
       TYPE(pw_type), POINTER                             :: rho_tot_g
       TYPE(qs_charges_type), POINTER                     :: qs_charges
@@ -105,7 +104,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
-      NULLIFY (dft_control, rho, rho_tot_g, rho_core, rho0_s_gs, pw_env, &
+      NULLIFY (dft_control, rho, rho_tot_g, pw_env, &
                radii, inp_radii, particle_set, qs_charges, para_env)
 
       CALL get_qs_env(qs_env, dft_control=dft_control)
@@ -126,8 +125,6 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, &
                          dft_control=dft_control, &
                          rho=rho, &
-                         rho_core=rho_core, &
-                         rho0_s_gs=rho0_s_gs, &
                          pw_env=pw_env, &
                          qs_charges=qs_charges, &
                          particle_set=particle_set, &
@@ -243,9 +240,8 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
-      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core
       TYPE(pw_pool_type), POINTER                        :: auxbas_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), POINTER                             :: rho0_s_gs, rho_core, rho_tot_g
       TYPE(qs_charges_type), POINTER                     :: qs_charges
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -303,9 +299,9 @@ CONTAINS
          CASE (do_full_density)
             ! Otherwise build the total QS density (electron+nuclei) in G-space
             IF (dft_control%qs_control%gapw) THEN
-               CALL pw_transfer(rho0_s_gs%pw, rho_tot_g)
+               CALL pw_transfer(rho0_s_gs, rho_tot_g)
             ELSE
-               CALL pw_transfer(rho_core%pw, rho_tot_g)
+               CALL pw_transfer(rho_core, rho_tot_g)
             END IF
             DO ispin = 1, SIZE(rho_g)
                CALL pw_axpy(rho_g(ispin)%pw, rho_tot_g)

--- a/src/cp_ddapc_util.F
+++ b/src/cp_ddapc_util.F
@@ -185,8 +185,7 @@ CONTAINS
          CALL cp_print_key_finished_output(iw2, logger, density_fit_section, &
                                            "PROGRAM_RUN_INFO/CONDITION_NUMBER")
          DEALLOCATE (radii)
-         CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g, &
-                                   accept_non_compatible=.TRUE.)
+         CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
       END IF
       CALL timestop(handle)
    END SUBROUTINE cp_ddapc_init
@@ -525,8 +524,7 @@ CONTAINS
          CALL cp_print_key_finished_output(iw, logger, density_fit_section, &
                                            "PROGRAM_RUN_INFO")
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g, &
-                                accept_non_compatible=.TRUE.)
+      CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
       CALL timestop(handle)
    END SUBROUTINE get_ddapc
 

--- a/src/cp_ddapc_util.F
+++ b/src/cp_ddapc_util.F
@@ -141,6 +141,8 @@ CONTAINS
             WRITE (iw, '(/,A)') " Initializing the DDAPC Environment"
          END IF
          CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pool)
+         NULLIFY (rho_tot_g)
+         ALLOCATE (rho_tot_g)
          CALL pw_pool_create_pw(auxbas_pool, rho_tot_g, in_space=RECIPROCALSPACE, &
                                 use_data=COMPLEXDATA1D)
          Vol = rho_tot_g%pw_grid%vol
@@ -282,6 +284,8 @@ CONTAINS
       END IF
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pool)
+      NULLIFY (rho_tot_g)
+      ALLOCATE (rho_tot_g)
       CALL pw_pool_create_pw(auxbas_pool, rho_tot_g, in_space=RECIPROCALSPACE, &
                              use_data=COMPLEXDATA1D)
       IF (PRESENT(ext_rho_tot_g)) THEN

--- a/src/cp_ddapc_util.F
+++ b/src/cp_ddapc_util.F
@@ -186,6 +186,7 @@ CONTAINS
                                            "PROGRAM_RUN_INFO/CONDITION_NUMBER")
          DEALLOCATE (radii)
          CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
+         DEALLOCATE (rho_tot_g)
       END IF
       CALL timestop(handle)
    END SUBROUTINE cp_ddapc_init
@@ -525,6 +526,7 @@ CONTAINS
                                            "PROGRAM_RUN_INFO")
       END IF
       CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
+      DEALLOCATE (rho_tot_g)
       CALL timestop(handle)
    END SUBROUTINE get_ddapc
 

--- a/src/cp_realspace_grid_cube.F
+++ b/src/cp_realspace_grid_cube.F
@@ -42,7 +42,7 @@ CONTAINS
 !> \param mpi_io True if cube should be written in parallel using MPI
 ! **************************************************************************************************
    SUBROUTINE cp_pw_to_cube(pw, unit_nr, title, particles, stride, zero_tails, silent, mpi_io)
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: unit_nr
       CHARACTER(*), INTENT(IN), OPTIONAL                 :: title
       TYPE(particle_list_type), POINTER                  :: particles
@@ -87,7 +87,7 @@ CONTAINS
 !>      Created [Vladimir Rybkin] (08.2017)
 ! **************************************************************************************************
    SUBROUTINE cp_pw_to_simple_volumetric(pw, unit_nr, stride, pw2)
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: unit_nr
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: stride
       TYPE(pw_type), OPTIONAL, POINTER                   :: pw2
@@ -110,7 +110,7 @@ CONTAINS
 !>      Created [Nico Holmberg] (09.2018)
 ! **************************************************************************************************
    SUBROUTINE cp_cube_to_pw(grid, filename, scaling, silent)
-      TYPE(pw_type), POINTER                             :: grid
+      TYPE(pw_type), INTENT(IN)                          :: grid
       CHARACTER(len=*), INTENT(in)                       :: filename
       REAL(kind=dp), INTENT(in)                          :: scaling
       LOGICAL, INTENT(in), OPTIONAL                      :: silent

--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -709,6 +709,7 @@ CONTAINS
       !free memory
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+      DEALLOCATE (wf_r%pw, wf_g%pw)
       CALL dbcsr_release(matrix_p_qs)
       DEALLOCATE (matrix_p_qs)
 

--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -697,8 +697,8 @@ CONTAINS
                              in_space=RECIPROCALSPACE)
       CALL pw_zero(wf_g%pw)
       CALL calculate_rho_elec(matrix_p=matrix_p_qs, &
-                              rho=wf_r, &
-                              rho_gspace=wf_g, &
+                              rho=wf_r%pw, &
+                              rho_gspace=wf_g%pw, &
                               ks_env=ks_env)
 
       ! write this to a cube

--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -686,6 +686,7 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
+      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                              pw=wf_r%pw, &
                              use_data=REALDATA3D, &

--- a/src/ec_env_types.F
+++ b/src/ec_env_types.F
@@ -169,23 +169,27 @@ CONTAINS
          ! potential
          IF (ASSOCIATED(ec_env%vh_rspace)) THEN
             CALL pw_release(ec_env%vh_rspace%pw)
+            DEALLOCATE (ec_env%vh_rspace%pw)
             DEALLOCATE (ec_env%vh_rspace)
          END IF
          IF (ASSOCIATED(ec_env%vxc_rspace)) THEN
             DO iab = 1, SIZE(ec_env%vxc_rspace)
                CALL pw_release(ec_env%vxc_rspace(iab)%pw)
+               DEALLOCATE (ec_env%vxc_rspace(iab)%pw)
             END DO
             DEALLOCATE (ec_env%vxc_rspace)
          END IF
          IF (ASSOCIATED(ec_env%vtau_rspace)) THEN
             DO iab = 1, SIZE(ec_env%vtau_rspace)
                CALL pw_release(ec_env%vtau_rspace(iab)%pw)
+               DEALLOCATE (ec_env%vtau_rspace(iab)%pw)
             END DO
             DEALLOCATE (ec_env%vtau_rspace)
          END IF
          IF (ASSOCIATED(ec_env%vadmm_rspace)) THEN
             DO iab = 1, SIZE(ec_env%vadmm_rspace)
                CALL pw_release(ec_env%vadmm_rspace(iab)%pw)
+               DEALLOCATE (ec_env%vadmm_rspace(iab)%pw)
             END DO
             DEALLOCATE (ec_env%vadmm_rspace)
          END IF

--- a/src/ec_orth_solver.F
+++ b/src/ec_orth_solver.F
@@ -1290,13 +1290,16 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, rho_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+         DEALLOCATE (v_xc(ispin)%pw)
       END DO
       DEALLOCATE (v_xc)
       IF (ASSOCIATED(v_xc_tau)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+            DEALLOCATE (v_xc_tau(ispin)%pw)
          END DO
          DEALLOCATE (v_xc_tau)
       END IF

--- a/src/ec_orth_solver.F
+++ b/src/ec_orth_solver.F
@@ -1169,6 +1169,7 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the NSC Hartree potential
+      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                              pw=v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, &

--- a/src/ec_orth_solver.F
+++ b/src/ec_orth_solver.F
@@ -1241,7 +1241,7 @@ CONTAINS
                          name="MATRIX Kernel")
 
          ! Integrate with ground-state density matrix, in non-orthogonal basis
-         CALL integrate_v_rspace(v_rspace=v_xc(ispin), &
+         CALL integrate_v_rspace(v_rspace=v_xc(ispin)%pw, &
                                  pmat=rho_ao(ispin), &
                                  hmat=matrix_G(ispin), &
                                  qs_env=qs_env, &
@@ -1249,7 +1249,7 @@ CONTAINS
                                  basis_type="ORB")
 
          IF (ASSOCIATED(v_xc_tau)) THEN
-            CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), &
+            CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, &
                                     pmat=rho_ao(ispin), &
                                     hmat=matrix_G(ispin), &
                                     qs_env=qs_env, &

--- a/src/emd/rt_propagation_output.F
+++ b/src/emd/rt_propagation_output.F
@@ -66,7 +66,7 @@ MODULE rt_propagation_output
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_kind_types,                   ONLY: get_qs_kind_set,&
@@ -685,8 +685,8 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: tmp, zero
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: gs, rs
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: gs, rs
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
       CALL timeset(routineN, handle)
@@ -696,9 +696,7 @@ CONTAINS
       CALL qs_subsys_get(subsys, particles=particles)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
-      NULLIFY (zero, rs, gs, tmp)
-      ALLOCATE (rs, gs)
-      NULLIFY (rs%pw, gs%pw)
+      NULLIFY (zero, tmp)
       ALLOCATE (zero, tmp)
       CALL dbcsr_create(zero, template=P_im)
       CALL dbcsr_copy(zero, P_im)
@@ -710,17 +708,16 @@ CONTAINS
       END IF
       current_env%gauge = -1
       current_env%gauge_init = .FALSE.
-      ALLOCATE (rs%pw, gs%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rs%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, gs%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rs, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       NULLIFY (stride)
       ALLOCATE (stride(3))
 
       DO dir = 1, 3
 
-         CALL pw_zero(rs%pw)
-         CALL pw_zero(gs%pw)
+         CALL pw_zero(rs)
+         CALL pw_zero(gs)
 
          CALL calculate_jrho_resp(zero, tmp, zero, zero, dir, dir, rs, gs, qs_env, current_env, retain_rsgrid=.TRUE.)
 
@@ -741,7 +738,7 @@ CONTAINS
                                            extension=ext, file_status="REPLACE", file_action="WRITE", &
                                            log_filename=.FALSE., mpi_io=mpi_io)
 
-         CALL cp_pw_to_cube(rs%pw, print_unit, "EMD current", particles=particles, stride=stride, &
+         CALL cp_pw_to_cube(rs, print_unit, "EMD current", particles=particles, stride=stride, &
                             mpi_io=mpi_io)
 
          CALL cp_print_key_finished_output(print_unit, logger, dft_section, "REAL_TIME_PROPAGATION%PRINT%CURRENT", &
@@ -749,12 +746,8 @@ CONTAINS
 
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rs%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, gs%pw)
-      DEALLOCATE (rs%pw, gs%pw)
-
-      DEALLOCATE (rs)
-      DEALLOCATE (gs)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rs)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, gs)
 
       CALL dbcsr_deallocate_matrix(zero)
       CALL dbcsr_deallocate_matrix(tmp)

--- a/src/emd/rt_propagation_output.F
+++ b/src/emd/rt_propagation_output.F
@@ -751,6 +751,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rs%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, gs%pw)
+      DEALLOCATE (rs%pw, gs%pw)
 
       DEALLOCATE (rs)
       DEALLOCATE (gs)

--- a/src/emd/rt_propagation_output.F
+++ b/src/emd/rt_propagation_output.F
@@ -710,6 +710,7 @@ CONTAINS
       END IF
       current_env%gauge = -1
       current_env%gauge_init = .FALSE.
+      ALLOCATE (rs%pw, gs%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rs%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, gs%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -961,10 +961,9 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rhoout_g, rhoout_r, tau_r, &
                                                             tauout_g, tauout_r, v_rspace, &
                                                             v_tau_rspace, v_xc, v_xc_tau
-      TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_gspace
+      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -1096,7 +1095,7 @@ CONTAINS
 
          ! make rho_tot_gspace with output density
          CALL get_qs_env(qs_env=qs_env, rho_core=rho_core)
-         CALL pw_copy(rho_core%pw, rhodn_tot_gspace%pw)
+         CALL pw_copy(rho_core, rhodn_tot_gspace%pw)
          DO ispin = 1, dft_control%nspins
             CALL pw_axpy(rhoout_g(ispin)%pw, rhodn_tot_gspace%pw)
          END DO

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -399,7 +399,7 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ALLOCATE (ec_env%rhoz_r(nspins))
          DO ispin = 1, nspins
-            NULLIFY (ec_env%rhoz_r(nspins)%pw)
+            ALLOCATE (ec_env%rhoz_r(nspins)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, ec_env%rhoz_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
          END DO
@@ -646,7 +646,7 @@ CONTAINS
       IF (.NOT. ASSOCIATED(v_rspace)) THEN
          ALLOCATE (v_rspace(nspins))
          DO ispin = 1, nspins
-            NULLIFY (v_rspace(ispin)%pw)
+            ALLOCATE (v_rspace(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin)%pw)
@@ -1008,7 +1008,7 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      NULLIFY (v_hartree_gspace%pw, rhodn_tot_gspace%pw, v_hartree_rspace%pw)
+      ALLOCATE (v_hartree_gspace%pw, rhodn_tot_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhodn_tot_gspace%pw, &
@@ -1026,12 +1026,13 @@ CONTAINS
       NULLIFY (rhoout_r, rhoout_g)
       ALLOCATE (rhoout_r(nspins), rhoout_g(nspins))
       DO ispin = 1, nspins
-         NULLIFY (rhoout_r(ispin)%pw, rhoout_g(ispin)%pw)
+         ALLOCATE (rhoout_r(ispin)%pw, rhoout_g(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoout_r(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoout_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
+      ALLOCATE (dv_hartree_rspace%pw, vtot_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, dv_hartree_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, vtot_rspace%pw, &
@@ -1049,7 +1050,7 @@ CONTAINS
       ! Save Harris on real space grid for use in properties
       ALLOCATE (ec_env%rhoout_r(nspins))
       DO ispin = 1, nspins
-         NULLIFY (ec_env%rhoout_r(ispin)%pw)
+         ALLOCATE (ec_env%rhoout_r(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, ec_env%rhoout_r(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_copy(rhoout_r(ispin)%pw, ec_env%rhoout_r(ispin)%pw)
@@ -1062,7 +1063,7 @@ CONTAINS
                           "tau-dependent functionals not implemented!")
          ALLOCATE (tauout_r(nspins), tauout_g(nspins))
          DO ispin = 1, nspins
-            NULLIFY (tauout_r(ispin)%pw, tauout_g(ispin)%pw)
+            ALLOCATE (tauout_r(ispin)%pw, tauout_g(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, tauout_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(auxbas_pw_pool, tauout_g(ispin)%pw, &
@@ -1083,6 +1084,7 @@ CONTAINS
 
          ! Calculate the Hartree potential
          NULLIFY (rho_tot_gspace)
+         ALLOCATE (rho_tot_gspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1160,7 +1162,7 @@ CONTAINS
       IF (use_virial) THEN
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-         NULLIFY (v_hartree_gspace%pw)
+         ALLOCATE (v_hartree_gspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1344,7 +1346,7 @@ CONTAINS
       IF (.NOT. ASSOCIATED(v_rspace)) THEN
          ALLOCATE (v_rspace(nspins))
          DO ispin = 1, nspins
-            NULLIFY (v_rspace(ispin)%pw)
+            ALLOCATE (v_rspace(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin)%pw)
@@ -2278,6 +2280,7 @@ CONTAINS
          CALL pw_env_get(pw_env=pw_env, &
                          auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
+         ALLOCATE (rho_elec_rspace%pw)
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                 pw=rho_elec_rspace%pw, &
                                 use_data=REALDATA3D, &

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -952,15 +952,16 @@ CONTAINS
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: dv_hartree_rspace, rho_tot_gspace, &
-                                                            rhodn_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace, vtot_rspace
+      TYPE(pw_p_type)                                    :: dv_hartree_rspace, rhodn_tot_gspace, &
+                                                            v_hartree_gspace, v_hartree_rspace, &
+                                                            vtot_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rhoout_g, rhoout_r, tau_r, &
                                                             tauout_g, tauout_r, v_rspace, &
                                                             v_tau_rspace, v_xc, v_xc_tau
       TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rho_tot_gspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -1039,8 +1040,8 @@ CONTAINS
       CALL pw_zero(rhodn_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=ec_env%matrix_p(ispin, 1)%matrix, &
-                                 rho=rhoout_r(ispin), &
-                                 rho_gspace=rhoout_g(ispin), &
+                                 rho=rhoout_r(ispin)%pw, &
+                                 rho_gspace=rhoout_g(ispin)%pw, &
                                  basis_type="HARRIS", &
                                  task_list_external=ec_env%task_list)
       END DO
@@ -1070,8 +1071,8 @@ CONTAINS
 
          DO ispin = 1, nspins
             CALL calculate_rho_elec(ks_env=ks_env, matrix_p=ec_env%matrix_p(ispin, 1)%matrix, &
-                                    rho=tauout_r(ispin), &
-                                    rho_gspace=tauout_g(ispin), &
+                                    rho=tauout_r(ispin)%pw, &
+                                    rho_gspace=tauout_g(ispin)%pw, &
                                     compute_tau=.TRUE., &
                                     basis_type="HARRIS", &
                                     task_list_external=ec_env%task_list)
@@ -1081,8 +1082,8 @@ CONTAINS
       IF (use_virial) THEN
 
          ! Calculate the Hartree potential
-         NULLIFY (rho_tot_gspace%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
+         NULLIFY (rho_tot_gspace)
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
          ! Get the total input density in g-space [ions + electrons]
@@ -1098,7 +1099,7 @@ CONTAINS
          ! Volume and Green function terms
          h_stress(:, :) = 0.0_dp
          CALL pw_poisson_solve(poisson_env, &
-                               density=rho_tot_gspace%pw, &  ! n_in
+                               density=rho_tot_gspace, &  ! n_in
                                ehartree=ehartree, &
                                vhartree=v_hartree_gspace%pw, & ! v_H[n_in]
                                h_stress=h_stress, &
@@ -1170,9 +1171,9 @@ CONTAINS
                                ehartree=dehartree, &
                                vhartree=v_hartree_gspace%pw, & ! v_H[delta_n]
                                h_stress=h_stress, &
-                               aux_density=rho_tot_gspace%pw)  ! n_in
+                               aux_density=rho_tot_gspace)  ! n_in
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
 
          virial%pv_ehartree = virial%pv_ehartree + h_stress/REAL(para_env%num_pe, dp)
          virial%pv_virial = virial%pv_virial + h_stress/REAL(para_env%num_pe, dp)

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -364,7 +364,9 @@ CONTAINS
          CALL ec_build_neighborlist(qs_env, ec_env)
          !
          CALL ec_build_core_hamiltonian(qs_env, ec_env)
-         CALL ks_ref_potential(qs_env, ec_env%vh_rspace, ec_env%vxc_rspace, ec_env%vtau_rspace, ec_env%vadmm_rspace, &
+         IF (.NOT. ASSOCIATED(ec_env%vh_rspace)) ALLOCATE (ec_env%vh_rspace)
+         IF (.NOT. ASSOCIATED(ec_env%vh_rspace%pw)) ALLOCATE (ec_env%vh_rspace%pw)
+         CALL ks_ref_potential(qs_env, ec_env%vh_rspace%pw, ec_env%vxc_rspace, ec_env%vtau_rspace, ec_env%vadmm_rspace, &
                                ec_env%ehartree, exc)
          CALL ec_build_ks_matrix(qs_env, ec_env)
          !
@@ -405,7 +407,7 @@ CONTAINS
          END DO
 
          CALL response_force(qs_env, &
-                             vh_rspace=ec_env%vh_rspace, &
+                             vh_rspace=ec_env%vh_rspace%pw, &
                              vxc_rspace=ec_env%vxc_rspace, &
                              vtau_rspace=ec_env%vtau_rspace, &
                              vadmm_rspace=ec_env%vadmm_rspace, &
@@ -955,15 +957,15 @@ CONTAINS
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: dv_hartree_rspace, rhodn_tot_gspace, &
-                                                            v_hartree_gspace, v_hartree_rspace, &
-                                                            vtot_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rhoout_g, rhoout_r, tau_r, &
                                                             tauout_g, tauout_r, v_rspace, &
                                                             v_tau_rspace, v_xc, v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace
+      TYPE(pw_type)                                      :: dv_hartree_rspace, rho_tot_gspace, &
+                                                            rhodn_tot_gspace, v_hartree_gspace, &
+                                                            v_hartree_rspace, vtot_rspace
+      TYPE(pw_type), POINTER                             :: rho_core
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -1010,15 +1012,14 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      ALLOCATE (v_hartree_gspace%pw, rhodn_tot_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhodn_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhodn_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL pw_transfer(ec_env%vh_rspace%pw, v_hartree_rspace%pw)
+      CALL pw_transfer(ec_env%vh_rspace%pw, v_hartree_rspace)
 
       CALL get_qs_env(qs_env=qs_env, force=force)
       ! calculate output density on grid
@@ -1034,13 +1035,12 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoout_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      ALLOCATE (dv_hartree_rspace%pw, vtot_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, dv_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, dv_hartree_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vtot_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, vtot_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL pw_zero(rhodn_tot_gspace%pw)
+      CALL pw_zero(rhodn_tot_gspace)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=ec_env%matrix_p(ispin, 1)%matrix, &
                                  rho=rhoout_r(ispin)%pw, &
@@ -1085,8 +1085,6 @@ CONTAINS
       IF (use_virial) THEN
 
          ! Calculate the Hartree potential
-         NULLIFY (rho_tot_gspace)
-         ALLOCATE (rho_tot_gspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1095,9 +1093,9 @@ CONTAINS
 
          ! make rho_tot_gspace with output density
          CALL get_qs_env(qs_env=qs_env, rho_core=rho_core)
-         CALL pw_copy(rho_core, rhodn_tot_gspace%pw)
+         CALL pw_copy(rho_core, rhodn_tot_gspace)
          DO ispin = 1, dft_control%nspins
-            CALL pw_axpy(rhoout_g(ispin)%pw, rhodn_tot_gspace%pw)
+            CALL pw_axpy(rhoout_g(ispin)%pw, rhodn_tot_gspace)
          END DO
 
          ! Volume and Green function terms
@@ -1105,9 +1103,9 @@ CONTAINS
          CALL pw_poisson_solve(poisson_env, &
                                density=rho_tot_gspace, &  ! n_in
                                ehartree=ehartree, &
-                               vhartree=v_hartree_gspace%pw, & ! v_H[n_in]
+                               vhartree=v_hartree_gspace, & ! v_H[n_in]
                                h_stress=h_stress, &
-                               aux_density=rhodn_tot_gspace%pw) ! n_out
+                               aux_density=rhodn_tot_gspace) ! n_out
 
          virial%pv_ehartree = virial%pv_ehartree + h_stress/REAL(para_env%num_pe, dp)
          virial%pv_virial = virial%pv_virial + h_stress/REAL(para_env%num_pe, dp)
@@ -1151,7 +1149,7 @@ CONTAINS
             END DO
             DEALLOCATE (v_tau_rspace)
          END IF
-         CALL pw_zero(rhodn_tot_gspace%pw)
+         CALL pw_zero(rhodn_tot_gspace)
 
       END IF
 
@@ -1159,30 +1157,22 @@ CONTAINS
       DO ispin = 1, nspins
          CALL pw_axpy(rho_r(ispin)%pw, rhoout_r(ispin)%pw, -1.0_dp)
          CALL pw_axpy(rho_g(ispin)%pw, rhoout_g(ispin)%pw, -1.0_dp)
-         CALL pw_axpy(rhoout_g(ispin)%pw, rhodn_tot_gspace%pw)
+         CALL pw_axpy(rhoout_g(ispin)%pw, rhodn_tot_gspace)
          IF (dft_control%use_kinetic_energy_density) CALL pw_axpy(tau_r(ispin)%pw, tauout_r(ispin)%pw, -1.0_dp)
       END DO
       ! calculate associated hartree potential
       IF (use_virial) THEN
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-         DEALLOCATE (v_hartree_gspace%pw)
-         NULLIFY (v_hartree_gspace%pw)
-         ALLOCATE (v_hartree_gspace%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-
          ! Stress tensor - 2nd derivative Volume and Green function contribution
          h_stress(:, :) = 0.0_dp
          CALL pw_poisson_solve(poisson_env, &
-                               density=rhodn_tot_gspace%pw, &  ! delta_n
+                               density=rhodn_tot_gspace, &  ! delta_n
                                ehartree=dehartree, &
-                               vhartree=v_hartree_gspace%pw, & ! v_H[delta_n]
+                               vhartree=v_hartree_gspace, & ! v_H[delta_n]
                                h_stress=h_stress, &
                                aux_density=rho_tot_gspace)  ! n_in
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-         DEALLOCATE (rho_tot_gspace)
 
          virial%pv_ehartree = virial%pv_ehartree + h_stress/REAL(para_env%num_pe, dp)
          virial%pv_virial = virial%pv_virial + h_stress/REAL(para_env%num_pe, dp)
@@ -1196,19 +1186,19 @@ CONTAINS
 
       ELSE
          ! v_H[dn]
-         CALL pw_poisson_solve(poisson_env, rhodn_tot_gspace%pw, dehartree, &
-                               v_hartree_gspace%pw)
+         CALL pw_poisson_solve(poisson_env, rhodn_tot_gspace, dehartree, &
+                               v_hartree_gspace)
       END IF
 
-      CALL pw_transfer(v_hartree_gspace%pw, dv_hartree_rspace%pw)
-      CALL pw_scale(dv_hartree_rspace%pw, dv_hartree_rspace%pw%pw_grid%dvol)
+      CALL pw_transfer(v_hartree_gspace, dv_hartree_rspace)
+      CALL pw_scale(dv_hartree_rspace, dv_hartree_rspace%pw_grid%dvol)
       ! Getting nuclear force contribution from the core charge density
       ! Vh(rho_in + rho_c) + Vh(rho_out - rho_in)
-      CALL pw_transfer(v_hartree_rspace%pw, vtot_rspace%pw)
-      CALL pw_axpy(dv_hartree_rspace%pw, vtot_rspace%pw)
+      CALL pw_transfer(v_hartree_rspace, vtot_rspace)
+      CALL pw_axpy(dv_hartree_rspace, vtot_rspace)
       IF (debug_forces) fodeb(1:3) = force(1)%rho_core(1:3, 1)
       IF (debug_stress .AND. use_virial) stdeb = virial%pv_ehartree
-      CALL integrate_v_core_rspace(vtot_rspace%pw, qs_env)
+      CALL integrate_v_core_rspace(vtot_rspace, qs_env)
       IF (debug_forces) THEN
          fodeb(1:3) = force(1)%rho_core(1:3, 1) - fodeb(1:3)
          CALL mp_sum(fodeb, para_env%group)
@@ -1273,7 +1263,7 @@ CONTAINS
 
       DO ispin = 1, nspins
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
-         CALL pw_axpy(dv_hartree_rspace%pw, v_xc(ispin)%pw)
+         CALL pw_axpy(dv_hartree_rspace, v_xc(ispin)%pw)
          CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin)%pw, &
                                  hmat=ec_env%matrix_hz(ispin), &
                                  pmat=matrix_p(ispin, 1), &
@@ -1371,7 +1361,7 @@ CONTAINS
       DO ispin = 1, nspins
          ! Add v_hartree + v_xc = v_rspace
          CALL pw_scale(v_rspace(ispin)%pw, v_rspace(ispin)%pw%pw_grid%dvol)
-         CALL pw_axpy(v_hartree_rspace%pw, v_rspace(ispin)%pw)
+         CALL pw_axpy(v_hartree_rspace, v_rspace(ispin)%pw)
          ! integrate over potential <a|V|b>
          CALL integrate_v_rspace(v_rspace=v_rspace(ispin)%pw, &
                                  hmat=scrm, &
@@ -1414,8 +1404,7 @@ CONTAINS
       DEALLOCATE (scrm%matrix)
 
       ! return pw grids
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      DEALLOCATE (v_hartree_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin)%pw)
          DEALLOCATE (v_rspace(ispin)%pw)
@@ -1454,9 +1443,8 @@ CONTAINS
 
       DEALLOCATE (v_rspace)
       !
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, dv_hartree_rspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vtot_rspace%pw)
-      DEALLOCATE (dv_hartree_rspace%pw, vtot_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, dv_hartree_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vtot_rspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoout_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoout_g(ispin)%pw)
@@ -1479,9 +1467,8 @@ CONTAINS
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhodn_tot_gspace%pw)
-      DEALLOCATE (v_hartree_gspace%pw, rhodn_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhodn_tot_gspace)
 
       ! Stress tensor - volume terms need to be stored,
       ! for a sign correction in QS at the end of qs_force
@@ -2139,10 +2126,9 @@ CONTAINS
       TYPE(distribution_1d_type), POINTER                :: local_particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_elec_rspace
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: mb_rho
+      TYPE(pw_type)                                      :: rho_elec_rspace
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(section_vals_type), POINTER                   :: ec_section, print_key, print_key_bqb, &
                                                             print_key_voro
@@ -2295,29 +2281,24 @@ CONTAINS
          CALL pw_env_get(pw_env=pw_env, &
                          auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         ALLOCATE (rho_elec_rspace%pw)
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                pw=rho_elec_rspace%pw, &
+                                pw=rho_elec_rspace, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
 
          IF (dft_control%nspins > 1) THEN
 
             ! add Pout and Pz
-            CALL pw_copy(ec_env%rhoout_r(1)%pw, rho_elec_rspace%pw)
-            CALL pw_axpy(ec_env%rhoout_r(2)%pw, rho_elec_rspace%pw)
+            CALL pw_copy(ec_env%rhoout_r(1)%pw, rho_elec_rspace)
+            CALL pw_axpy(ec_env%rhoout_r(2)%pw, rho_elec_rspace)
 
-            CALL pw_axpy(ec_env%rhoz_r(1)%pw, rho_elec_rspace%pw)
-            CALL pw_axpy(ec_env%rhoz_r(2)%pw, rho_elec_rspace%pw)
-
-            mb_rho => rho_elec_rspace%pw
+            CALL pw_axpy(ec_env%rhoz_r(1)%pw, rho_elec_rspace)
+            CALL pw_axpy(ec_env%rhoz_r(2)%pw, rho_elec_rspace)
          ELSE
 
             ! add Pout and Pz
-            CALL pw_copy(ec_env%rhoout_r(1)%pw, rho_elec_rspace%pw)
-            CALL pw_axpy(ec_env%rhoz_r(1)%pw, rho_elec_rspace%pw)
-
-            mb_rho => rho_elec_rspace%pw
+            CALL pw_copy(ec_env%rhoout_r(1)%pw, rho_elec_rspace)
+            CALL pw_axpy(ec_env%rhoz_r(1)%pw, rho_elec_rspace)
          END IF ! nspins
 
          IF (should_print_voro /= 0) THEN
@@ -2338,10 +2319,9 @@ CONTAINS
          END IF
 
          CALL entry_voronoi_or_bqb(should_print_voro, should_print_bqb, print_key_voro, print_key_bqb, &
-                                   unit_nr_voro, qs_env, mb_rho)
+                                   unit_nr_voro, qs_env, rho_elec_rspace)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
-         DEALLOCATE (rho_elec_rspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
 
          IF (unit_nr_voro > 0) THEN
             CALL cp_print_key_finished_output(unit_nr_voro, logger, ec_section, "PRINT%VORONOI")

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -424,6 +424,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, ec_env%rhoout_r(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, ec_env%rhoz_r(ispin)%pw)
+            DEALLOCATE (ec_env%rhoout_r(ispin)%pw, ec_env%rhoz_r(ispin)%pw)
          END DO
          DEALLOCATE (ec_env%rhoout_r, ec_env%rhoz_r)
 
@@ -692,8 +693,10 @@ CONTAINS
       ! return pw grids
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin)%pw)
+         DEALLOCATE (v_rspace(ispin)%pw)
          IF (ASSOCIATED(v_tau_rspace)) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
+            DEALLOCATE (v_tau_rspace(ispin)%pw)
          END IF
       END DO
       DEALLOCATE (v_rspace)
@@ -1138,12 +1141,14 @@ CONTAINS
          IF (ASSOCIATED(v_rspace)) THEN
             DO ispin = 1, nspins
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin)%pw)
+               DEALLOCATE (v_rspace(ispin)%pw)
             END DO
             DEALLOCATE (v_rspace)
          END IF
          IF (ASSOCIATED(v_tau_rspace)) THEN
             DO ispin = 1, nspins
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
+               DEALLOCATE (v_tau_rspace(ispin)%pw)
             END DO
             DEALLOCATE (v_tau_rspace)
          END IF
@@ -1162,6 +1167,8 @@ CONTAINS
       IF (use_virial) THEN
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+         DEALLOCATE (v_hartree_gspace%pw)
+         NULLIFY (v_hartree_gspace%pw)
          ALLOCATE (v_hartree_gspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
@@ -1176,6 +1183,7 @@ CONTAINS
                                aux_density=rho_tot_gspace)  ! n_in
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+         DEALLOCATE (rho_tot_gspace)
 
          virial%pv_ehartree = virial%pv_ehartree + h_stress/REAL(para_env%num_pe, dp)
          virial%pv_virial = virial%pv_virial + h_stress/REAL(para_env%num_pe, dp)
@@ -1408,10 +1416,13 @@ CONTAINS
 
       ! return pw grids
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
+      DEALLOCATE (v_hartree_rspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin)%pw)
+         DEALLOCATE (v_rspace(ispin)%pw)
          IF (ASSOCIATED(v_tau_rspace)) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
+            DEALLOCATE (v_tau_rspace(ispin)%pw)
          END IF
       END DO
       IF (ASSOCIATED(v_tau_rspace)) DEALLOCATE (v_tau_rspace)
@@ -1446,27 +1457,32 @@ CONTAINS
       !
       CALL pw_pool_give_back_pw(auxbas_pw_pool, dv_hartree_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vtot_rspace%pw)
+      DEALLOCATE (dv_hartree_rspace%pw, vtot_rspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoout_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoout_g(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+         DEALLOCATE (rhoout_r(ispin)%pw, rhoout_g(ispin)%pw, v_xc(ispin)%pw)
       END DO
       DEALLOCATE (rhoout_r, rhoout_g, v_xc)
       IF (ASSOCIATED(tauout_r)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, tauout_r(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, tauout_g(ispin)%pw)
+            DEALLOCATE (tauout_r(ispin)%pw, tauout_g(ispin)%pw)
          END DO
          DEALLOCATE (tauout_r, tauout_g)
       END IF
       IF (ASSOCIATED(v_xc_tau)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+            DEALLOCATE (v_xc_tau(ispin)%pw)
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhodn_tot_gspace%pw)
+      DEALLOCATE (v_hartree_gspace%pw, rhodn_tot_gspace%pw)
 
       ! Stress tensor - volume terms need to be stored,
       ! for a sign correction in QS at the end of qs_force
@@ -2326,6 +2342,7 @@ CONTAINS
                                    unit_nr_voro, qs_env, mb_rho)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
+         DEALLOCATE (rho_elec_rspace%pw)
 
          IF (unit_nr_voro > 0) THEN
             CALL cp_print_key_finished_output(unit_nr_voro, logger, ec_section, "PRINT%VORONOI")

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -664,7 +664,7 @@ CONTAINS
          CALL pw_scale(v_rspace(ispin)%pw, v_rspace(ispin)%pw%pw_grid%dvol)
          CALL pw_axpy(ec_env%vh_rspace%pw, v_rspace(ispin)%pw)
          ! integrate over potential <a|V|b>
-         CALL integrate_v_rspace(v_rspace=v_rspace(ispin), &
+         CALL integrate_v_rspace(v_rspace=v_rspace(ispin)%pw, &
                                  hmat=ec_env%matrix_ks(ispin, 1), &
                                  qs_env=qs_env, &
                                  calculate_forces=.FALSE., &
@@ -674,7 +674,7 @@ CONTAINS
          IF (ASSOCIATED(v_tau_rspace)) THEN
             ! integrate over Tau-potential <nabla.a|V|nabla.b>
             CALL pw_scale(v_tau_rspace(ispin)%pw, v_tau_rspace(ispin)%pw%pw_grid%dvol)
-            CALL integrate_v_rspace(v_rspace=v_tau_rspace(ispin), hmat=ec_env%matrix_ks(ispin, 1), &
+            CALL integrate_v_rspace(v_rspace=v_tau_rspace(ispin)%pw, hmat=ec_env%matrix_ks(ispin, 1), &
                                     qs_env=qs_env, calculate_forces=.FALSE., compute_tau=.TRUE., &
                                     basis_type="HARRIS", &
                                     task_list_external=ec_env%task_list)
@@ -1209,7 +1209,7 @@ CONTAINS
       CALL pw_axpy(dv_hartree_rspace%pw, vtot_rspace%pw)
       IF (debug_forces) fodeb(1:3) = force(1)%rho_core(1:3, 1)
       IF (debug_stress .AND. use_virial) stdeb = virial%pv_ehartree
-      CALL integrate_v_core_rspace(vtot_rspace, qs_env)
+      CALL integrate_v_core_rspace(vtot_rspace%pw, qs_env)
       IF (debug_forces) THEN
          fodeb(1:3) = force(1)%rho_core(1:3, 1) - fodeb(1:3)
          CALL mp_sum(fodeb, para_env%group)
@@ -1275,7 +1275,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
          CALL pw_axpy(dv_hartree_rspace%pw, v_xc(ispin)%pw)
-         CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin), &
+         CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin)%pw, &
                                  hmat=ec_env%matrix_hz(ispin), &
                                  pmat=matrix_p(ispin, 1), &
                                  calculate_forces=.TRUE.)
@@ -1299,7 +1299,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
-            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc_tau(ispin), &
+            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc_tau(ispin)%pw, &
                                     hmat=ec_env%matrix_hz(ispin), &
                                     pmat=matrix_p(ispin, 1), &
                                     compute_tau=.TRUE., &
@@ -1374,7 +1374,7 @@ CONTAINS
          CALL pw_scale(v_rspace(ispin)%pw, v_rspace(ispin)%pw%pw_grid%dvol)
          CALL pw_axpy(v_hartree_rspace%pw, v_rspace(ispin)%pw)
          ! integrate over potential <a|V|b>
-         CALL integrate_v_rspace(v_rspace=v_rspace(ispin), &
+         CALL integrate_v_rspace(v_rspace=v_rspace(ispin)%pw, &
                                  hmat=scrm, &
                                  pmat=ec_env%matrix_p(ispin, 1), &
                                  qs_env=qs_env, &
@@ -1385,7 +1385,7 @@ CONTAINS
          IF (ASSOCIATED(v_tau_rspace)) THEN
             ! integrate over Tau-potential <nabla.a|V|nabla.b>
             CALL pw_scale(v_tau_rspace(ispin)%pw, v_tau_rspace(ispin)%pw%pw_grid%dvol)
-            CALL integrate_v_rspace(v_rspace=v_tau_rspace(ispin), hmat=scrm, &
+            CALL integrate_v_rspace(v_rspace=v_tau_rspace(ispin)%pw, hmat=scrm, &
                                     pmat=ec_env%matrix_p(ispin, 1), &
                                     qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.TRUE., &
                                     basis_type="HARRIS", &

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -1648,6 +1648,7 @@ CONTAINS
       ! Clean memory
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+      DEALLOCATE (wf_r%pw, wf_g%pw)
 
    END SUBROUTINE save_mo_cube
 

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -1637,7 +1637,7 @@ CONTAINS
       ! Calculate the grid values
       CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
                       cell=cell, dft_control=dft_control, particle_set=particle_set)
-      CALL calculate_wavefunction(mo%mo_coeff, im, wf_r, wf_g, atomic_kind_set, &
+      CALL calculate_wavefunction(mo%mo_coeff, im, wf_r%pw, wf_g%pw, atomic_kind_set, &
                                   qs_kind_set, cell, dft_control, particle_set, pw_env)
       CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
                          stride=section_get_ivals(input, 'MO_CUBES%STRIDE'))

--- a/src/ewald_methods_tb.F
+++ b/src/ewald_methods_tb.F
@@ -252,16 +252,19 @@ CONTAINS
                END DO
             END DO
             CALL pw_pool_give_back_pw(pw_pool, phib_g)
+            DEALLOCATE (phib_g)
 
          END IF
       END IF
 
       CALL pw_pool_give_back_pw(pw_pool, rhob_g)
+      DEALLOCATE (rhob_g)
 
       CALL rs_grid_zero(rpot)
       phi_g%cc = phi_g%cc*green%p3m_charge%cr
       CALL pw_transfer(phi_g, rhob_r)
       CALL pw_pool_give_back_pw(pw_pool, phi_g)
+      DEALLOCATE (phi_g)
       CALL rs_pw_transfer(rpot, rhob_r, pw2rs)
 
       !---------- END OF ELECTROSTATIC CALCULATION --------
@@ -291,14 +294,17 @@ CONTAINS
             dphi_g(i)%pw%cc = dphi_g(i)%pw%cc*green%p3m_charge%cr
             CALL pw_transfer(dphi_g(i)%pw, rhob_r)
             CALL pw_pool_give_back_pw(pw_pool, dphi_g(i)%pw)
+            DEALLOCATE (dphi_g(i)%pw)
             CALL rs_pw_transfer(drpot(i)%rs_grid, rhob_r, pw2rs)
          END DO
       ELSE
          DO i = 1, 3
             CALL pw_pool_give_back_pw(pw_pool, dphi_g(i)%pw)
+            DEALLOCATE (dphi_g(i)%pw)
          END DO
       END IF
       CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      DEALLOCATE (rhob_r)
 
       !----------------- FORCE CALCULATION ----------------
 
@@ -529,11 +535,13 @@ CONTAINS
       CALL rs_grid_set_box(grid_spme, rs=rpot)
 
       CALL pw_pool_give_back_pw(pw_pool, rhob_g)
+      DEALLOCATE (rhob_g)
 
       CALL rs_grid_zero(rpot)
       phi_g%cc = phi_g%cc*green%p3m_charge%cr
       CALL pw_transfer(phi_g, rhob_r)
       CALL pw_pool_give_back_pw(pw_pool, phi_g)
+      DEALLOCATE (phi_g)
       CALL rs_pw_transfer(rpot, rhob_r, pw2rs)
 
       !---------- END OF ELECTROSTATIC CALCULATION --------
@@ -547,9 +555,11 @@ CONTAINS
          dphi_g(i)%pw%cc = dphi_g(i)%pw%cc*green%p3m_charge%cr
          CALL pw_transfer(dphi_g(i)%pw, rhob_r)
          CALL pw_pool_give_back_pw(pw_pool, dphi_g(i)%pw)
+         DEALLOCATE (dphi_g(i)%pw)
          CALL rs_pw_transfer(drpot(i)%rs_grid, rhob_r, pw2rs)
       END DO
       CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      DEALLOCATE (rhob_r)
 
       !----------------- FORCE CALCULATION ----------------
 

--- a/src/ewald_methods_tb.F
+++ b/src/ewald_methods_tb.F
@@ -157,12 +157,16 @@ CONTAINS
          CALL dg_sum_patch(rden, rhos, center(:, p1))
       END DO
 
+      NULLIFY (rhob_r)
+      ALLOCATE (rhob_r)
       CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       CALL rs_pw_transfer(rden, rhob_r, rs2pw)
 
       ! transform density to G space and add charge function
+      NULLIFY (rhob_g)
+      ALLOCATE (rhob_g)
       CALL pw_pool_create_pw(pw_pool, rhob_g, use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
@@ -173,10 +177,12 @@ CONTAINS
 
       ! allocate intermediate arrays
       DO i = 1, 3
-         NULLIFY (dphi_g(i)%pw)
+         ALLOCATE (dphi_g(i)%pw)
          CALL pw_pool_create_pw(pw_pool, dphi_g(i)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
+      NULLIFY (phi_g)
+      ALLOCATE (phi_g)
       CALL pw_pool_create_pw(pw_pool, phi_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       IF (use_virial) THEN
@@ -209,6 +215,8 @@ CONTAINS
                atprop%atstress(3, 3, p1) = atprop%atstress(3, 3, p1) + 0.5_dp*mcharge(p1)*fint*dvols
             END DO
 
+            NULLIFY (phib_g)
+            ALLOCATE (phib_g)
             CALL pw_pool_create_pw(pw_pool, phib_g, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             ffa = (0.5_dp/alpha)**2
@@ -487,12 +495,16 @@ CONTAINS
          CALL dg_sum_patch(rden, rhos, center(:, p1))
       END DO
 
+      NULLIFY (rhob_r)
+      ALLOCATE (rhob_r)
       CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       CALL rs_pw_transfer(rden, rhob_r, rs2pw)
 
       ! transform density to G space and add charge function
+      NULLIFY (rhob_g)
+      ALLOCATE (rhob_g)
       CALL pw_pool_create_pw(pw_pool, rhob_g, use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
@@ -503,10 +515,12 @@ CONTAINS
 
       ! allocate intermediate arrays
       DO i = 1, 3
-         NULLIFY (dphi_g(i)%pw)
+         ALLOCATE (dphi_g(i)%pw)
          CALL pw_pool_create_pw(pw_pool, dphi_g(i)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
+      NULLIFY (phi_g)
+      ALLOCATE (phi_g)
       CALL pw_pool_create_pw(pw_pool, phi_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_poisson_solve(poisson_env, rhob_g, vgc, phi_g, dphi_g)

--- a/src/ewald_spline_util.F
+++ b/src/ewald_spline_util.F
@@ -120,6 +120,7 @@ CONTAINS
       CALL eval_pw_TabLR(pw, pw_pool, coeff, Lg, gx, gy, gz, hmat_mm=hmat, &
                          param_section=param_section, tag=tag)
       CALL pw_pool_give_back_pw(pw_pool, pw)
+      DEALLOCATE (pw)
       CALL cell_release(cell)
 
    END SUBROUTINE Setup_Ewald_Spline

--- a/src/ewald_spline_util.F
+++ b/src/ewald_spline_util.F
@@ -113,6 +113,7 @@ CONTAINS
                                         "")
       ! pw_pool initialized
       CALL pw_pool_create(pw_pool, pw_grid=pw_grid)
+      ALLOCATE (pw, coeff)
       CALL pw_pool_create_pw(pw_pool, pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, coeff, use_data=REALDATA3D, in_space=REALSPACE)
       ! Evaluate function on grid

--- a/src/ewald_spline_util.F
+++ b/src/ewald_spline_util.F
@@ -165,7 +165,7 @@ CONTAINS
                                                             cos_gz(:, :), lhs(:, :), rhs(:, :), &
                                                             sin_gx(:, :), sin_gy(:, :), &
                                                             sin_gz(:, :)
-      TYPE(pw_spline_precond_type), POINTER              :: precond
+      TYPE(pw_spline_precond_type)                       :: precond
       TYPE(section_vals_type), POINTER                   :: interp_section
 
 !NB pull expensive Cos() out of inner looop

--- a/src/excited_states.F
+++ b/src/excited_states.F
@@ -118,7 +118,7 @@ CONTAINS
                CALL response_force_xtb(qs_env, p_env, ex_env%matrix_hz, ex_env)
             ELSE
                ! KS-DFT
-               CALL response_force(qs_env=qs_env, vh_rspace=ex_env%vh_rspace, &
+               CALL response_force(qs_env=qs_env, vh_rspace=ex_env%vh_rspace%pw, &
                                    vxc_rspace=ex_env%vxc_rspace, vtau_rspace=ex_env%vtau_rspace, &
                                    vadmm_rspace=ex_env%vadmm_rspace, matrix_hz=ex_env%matrix_hz, &
                                    matrix_pz=ex_env%matrix_px1, matrix_pz_admm=p_env%p1_admm, &

--- a/src/exstates_types.F
+++ b/src/exstates_types.F
@@ -107,23 +107,27 @@ CONTAINS
          !
          IF (ASSOCIATED(ex_env%vh_rspace)) THEN
             CALL pw_release(ex_env%vh_rspace%pw)
+            DEALLOCATE (ex_env%vh_rspace%pw)
             DEALLOCATE (ex_env%vh_rspace)
          END IF
          IF (ASSOCIATED(ex_env%vxc_rspace)) THEN
             DO iab = 1, SIZE(ex_env%vxc_rspace)
                CALL pw_release(ex_env%vxc_rspace(iab)%pw)
+               DEALLOCATE (ex_env%vxc_rspace(iab)%pw)
             END DO
             DEALLOCATE (ex_env%vxc_rspace)
          END IF
          IF (ASSOCIATED(ex_env%vtau_rspace)) THEN
             DO iab = 1, SIZE(ex_env%vtau_rspace)
                CALL pw_release(ex_env%vtau_rspace(iab)%pw)
+               DEALLOCATE (ex_env%vtau_rspace(iab)%pw)
             END DO
             DEALLOCATE (ex_env%vtau_rspace)
          END IF
          IF (ASSOCIATED(ex_env%vadmm_rspace)) THEN
             DO iab = 1, SIZE(ex_env%vadmm_rspace)
                CALL pw_release(ex_env%vadmm_rspace(iab)%pw)
+               DEALLOCATE (ex_env%vadmm_rspace(iab)%pw)
             END DO
             DEALLOCATE (ex_env%vadmm_rspace)
          END IF

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -1510,14 +1510,22 @@ CONTAINS
                                embed_pot=embed_pot, spin_embed_pot=spin_embed_pot, pw_env=pw_env)
                CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, embed_pot%pw)
-               CALL pw_release(embed_pot%pw)
-               DEALLOCATE (embed_pot%pw)
+               IF (ASSOCIATED(embed_pot)) THEN
+               IF (ASSOCIATED(embed_pot%pw)) THEN
+                  CALL pw_release(embed_pot%pw)
+                  DEALLOCATE (embed_pot%pw)
+               END IF
                DEALLOCATE (embed_pot)
+               END IF
                IF (ASSOCIATED(spin_embed_pot)) THEN
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, spin_embed_pot%pw)
-                  CALL pw_release(spin_embed_pot%pw)
-                  DEALLOCATE (spin_embed_pot%pw)
+                  IF (ASSOCIATED(spin_embed_pot)) THEN
+                  IF (ASSOCIATED(spin_embed_pot%pw)) THEN
+                     CALL pw_release(spin_embed_pot%pw)
+                     DEALLOCATE (spin_embed_pot%pw)
+                  END IF
                   DEALLOCATE (spin_embed_pot)
+                  END IF
                END IF
             END IF
          END IF

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -1510,6 +1510,7 @@ CONTAINS
                                embed_pot=embed_pot, spin_embed_pot=spin_embed_pot, pw_env=pw_env)
                CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, embed_pot%pw)
+               DEALLOCATE (embed_pot%pw)
                IF (ASSOCIATED(embed_pot)) THEN
                IF (ASSOCIATED(embed_pot%pw)) THEN
                   CALL pw_release(embed_pot%pw)
@@ -1519,6 +1520,7 @@ CONTAINS
                END IF
                IF (ASSOCIATED(spin_embed_pot)) THEN
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, spin_embed_pot%pw)
+                  DEALLOCATE (spin_embed_pot%pw)
                   IF (ASSOCIATED(spin_embed_pot)) THEN
                   IF (ASSOCIATED(spin_embed_pot%pw)) THEN
                      CALL pw_release(spin_embed_pot%pw)

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -1694,7 +1694,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
       NULLIFY (diff_rho_r)
       ALLOCATE (diff_rho_r)
-      NULLIFY (diff_rho_r%pw)
+      ALLOCATE (diff_rho_r%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -1702,7 +1702,7 @@ CONTAINS
       IF (opt_embed%open_shell_embed) THEN
          NULLIFY (diff_rho_spin)
          ALLOCATE (diff_rho_spin)
-         NULLIFY (diff_rho_spin%pw)
+         ALLOCATE (diff_rho_spin%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_spin%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -1511,10 +1511,12 @@ CONTAINS
                CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, embed_pot%pw)
                CALL pw_release(embed_pot%pw)
+               DEALLOCATE (embed_pot%pw)
                DEALLOCATE (embed_pot)
                IF (ASSOCIATED(spin_embed_pot)) THEN
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, spin_embed_pot%pw)
                   CALL pw_release(spin_embed_pot%pw)
+                  DEALLOCATE (spin_embed_pot%pw)
                   DEALLOCATE (spin_embed_pot)
                END IF
             END IF
@@ -1870,9 +1872,11 @@ CONTAINS
 
             ! Release embedding potential for subsystem
             CALL pw_release(embed_pot_subsys%pw)
+            DEALLOCATE (embed_pot_subsys%pw)
             DEALLOCATE (embed_pot_subsys)
             IF (opt_embed%open_shell_embed) THEN
                CALL pw_release(spin_embed_pot_subsys%pw)
+               DEALLOCATE (spin_embed_pot_subsys%pw)
                DEALLOCATE (spin_embed_pot_subsys)
             END IF
 
@@ -1943,9 +1947,11 @@ CONTAINS
 
       ! Give away plane waves pools
       CALL pw_release(diff_rho_r%pw)
+      DEALLOCATE (diff_rho_r%pw)
       DEALLOCATE (diff_rho_r)
       IF (opt_embed%open_shell_embed) THEN
          CALL pw_release(diff_rho_spin%pw)
+         DEALLOCATE (diff_rho_spin%pw)
          DEALLOCATE (diff_rho_spin)
       END IF
 
@@ -1985,9 +1991,11 @@ CONTAINS
 
       ! Deallocate embedding potential
       CALL pw_release(embed_pot%pw)
+      DEALLOCATE (embed_pot%pw)
       DEALLOCATE (embed_pot)
       IF (opt_embed%open_shell_embed) THEN
          CALL pw_release(spin_embed_pot%pw)
+         DEALLOCATE (spin_embed_pot%pw)
          DEALLOCATE (spin_embed_pot)
       END IF
 

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -214,7 +214,7 @@ CONTAINS
                DO iorb = iorb_block, MIN(iorb_block + blocksize - 1, norb)
 
                   iloc = iorb - iorb_block + 1
-                  CALL calculate_wavefunction(mo_coeff, iorb, rho_i(iloc), rho_g, &
+                  CALL calculate_wavefunction(mo_coeff, iorb, rho_i(iloc)%pw, rho_g%pw, &
                                               atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                               pw_env)
 
@@ -225,7 +225,7 @@ CONTAINS
                   DO jorb = jorb_block, MIN(jorb_block + blocksize - 1, norb)
 
                      jloc = jorb - jorb_block + 1
-                     CALL calculate_wavefunction(mo_coeff, jorb, rho_j(jloc), rho_g, &
+                     CALL calculate_wavefunction(mo_coeff, jorb, rho_j(jloc)%pw, rho_g%pw, &
                                                  atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                                  pw_env)
 

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -262,6 +262,7 @@ CONTAINS
          DO iorb_block = 1, blocksize
             CALL pw_release(rho_i(iorb_block)%pw)
             CALL pw_release(rho_j(iorb_block)%pw)
+            DEALLOCATE (rho_i(iorb_block)%pw, rho_j(iorb_block)%pw)
          END DO
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r%pw)

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -136,6 +136,7 @@ CONTAINS
          CALL cp_fm_get_info(mo_coeff, ncol_global=norb)
          blocksize = MAX(1, MIN(blocksize, norb))
 
+         ALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -150,6 +151,7 @@ CONTAINS
          ALLOCATE (rho_j(blocksize))
 
          NULLIFY (greenfn)
+         ALLOCATE (greenfn)
          CALL pw_pool_create_pw(auxbas_pw_pool, greenfn, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -188,11 +188,11 @@ CONTAINS
          END IF
 
          DO iorb_block = 1, blocksize
-            NULLIFY (rho_i(iorb_block)%pw)
+            ALLOCATE (rho_i(iorb_block)%pw)
             CALL pw_create(rho_i(iorb_block)%pw, rho_r%pw%pw_grid, &
                            use_data=REALDATA3D, &
                            in_space=REALSPACE)
-            NULLIFY (rho_j(iorb_block)%pw)
+            ALLOCATE (rho_j(iorb_block)%pw)
             CALL pw_create(rho_j(iorb_block)%pw, rho_r%pw%pw_grid, &
                            use_data=REALDATA3D, &
                            in_space=REALSPACE)

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -271,6 +271,7 @@ CONTAINS
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, greenfn)
+         DEALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw, greenfn)
 
          iw = cp_print_key_unit_nr(logger, hfx_section, "HF_INFO", &
                                    extension=".scfLog")

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -534,6 +534,7 @@ CONTAINS
       CALL get_hirshfeld_info(hirshfeld_env, fnorm=fnorm)
       IF (ASSOCIATED(fnorm)) THEN
          CALL pw_release(fnorm%pw)
+         DEALLOCATE (fnorm%pw)
          DEALLOCATE (fnorm)
       END IF
       ALLOCATE (fnorm)

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -315,6 +315,7 @@ CONTAINS
          charges(:, is) = charges(:, is)*hirshfeld_env%charges(:)
       END DO
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm%pw)
+      DEALLOCATE (rhonorm%pw)
       !
       DEALLOCATE (rhonorm)
 
@@ -435,6 +436,7 @@ CONTAINS
       END DO
       !
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm%pw)
+      DEALLOCATE (rhonorm%pw)
       !
       DEALLOCATE (rhonorm)
 

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -301,6 +301,7 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
+      ALLOCATE (rhonorm%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm%pw, use_data=REALDATA3D)
       ! loop over spins
       DO is = 1, SIZE(rho_r)
@@ -393,6 +394,7 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
+      ALLOCATE (rhonorm%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm%pw, use_data=REALDATA3D)
       !
       DO iloop = 1, maxloop
@@ -538,6 +540,7 @@ CONTAINS
          DEALLOCATE (fnorm)
       END IF
       ALLOCATE (fnorm)
+      ALLOCATE (fnorm%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, fnorm%pw, use_data=REALDATA3D)
       fnorm%pw%in_space = REALSPACE
       CALL set_hirshfeld_info(hirshfeld_env, fnorm=fnorm)

--- a/src/hirshfeld_types.F
+++ b/src/hirshfeld_types.F
@@ -113,6 +113,7 @@ CONTAINS
 
          IF (ASSOCIATED(hirshfeld_env%fnorm)) THEN
             CALL pw_release(hirshfeld_env%fnorm%pw)
+            DEALLOCATE (hirshfeld_env%fnorm%pw)
             DEALLOCATE (hirshfeld_env%fnorm)
          END IF
 

--- a/src/kg_correction.F
+++ b/src/kg_correction.F
@@ -262,6 +262,7 @@ CONTAINS
                                  pmat=density_matrix(ispin), hmat=ks_matrix(ispin), &
                                  qs_env=qs_env, calculate_forces=calc_force)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
+         DEALLOCATE (vxc_rho(ispin)%pw)
       END DO
       DEALLOCATE (vxc_rho)
       ekin_mol = -ekin_imol
@@ -336,6 +337,7 @@ CONTAINS
                                     task_list_external=kg_env%subset(isub)%task_list)
             ! clean up vxc_rho
             CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
+            DEALLOCATE (vxc_rho(ispin)%pw)
             IF (ASSOCIATED(vxc_tau)) THEN
                CALL pw_scale(vxc_tau(ispin)%pw, -alpha*vxc_tau(ispin)%pw%pw_grid%dvol)
                CALL integrate_v_rspace(v_rspace=vxc_tau(ispin), &
@@ -347,6 +349,7 @@ CONTAINS
                                        task_list_external=kg_env%subset(isub)%task_list)
                ! clean up vxc_rho
                CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_tau(ispin)%pw)
+               DEALLOCATE (vxc_tau(ispin)%pw)
             END IF
          END DO
          DEALLOCATE (vxc_rho)
@@ -473,6 +476,7 @@ CONTAINS
          lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
          CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, lri_v_int, calc_force, "LRI_AUX")
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
+         DEALLOCATE (vxc_rho(ispin)%pw)
       END DO
       DEALLOCATE (vxc_rho)
       ekin_mol = -ekin_imol
@@ -503,6 +507,7 @@ CONTAINS
                                                "LRI_AUX", atomlist=atomlist)
             ! clean up vxc_rho
             CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
+            DEALLOCATE (vxc_rho(ispin)%pw)
          END DO
          DEALLOCATE (vxc_rho)
 
@@ -713,6 +718,7 @@ CONTAINS
          END IF
          CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, lri_v_int, calc_force, "LRI_AUX")
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
+         DEALLOCATE (vxc_rho(ispin)%pw)
       END DO
 
       DEALLOCATE (vxc_rho)
@@ -782,6 +788,7 @@ CONTAINS
                                                "LRI_AUX", atomlist=atomlist)
             ! clean up vxc_rho
             CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
+            DEALLOCATE (vxc_rho(ispin)%pw)
          END DO
          DEALLOCATE (vxc_rho)
 

--- a/src/kg_correction.F
+++ b/src/kg_correction.F
@@ -258,7 +258,7 @@ CONTAINS
       END DO
 
       DO ispin = 1, nspins
-         CALL integrate_v_rspace(v_rspace=vxc_rho(ispin), &
+         CALL integrate_v_rspace(v_rspace=vxc_rho(ispin)%pw, &
                                  pmat=density_matrix(ispin), hmat=ks_matrix(ispin), &
                                  qs_env=qs_env, calculate_forces=calc_force)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
@@ -329,7 +329,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_scale(vxc_rho(ispin)%pw, -alpha*vxc_rho(ispin)%pw%pw_grid%dvol)
 
-            CALL integrate_v_rspace(v_rspace=vxc_rho(ispin), &
+            CALL integrate_v_rspace(v_rspace=vxc_rho(ispin)%pw, &
                                     pmat=density_matrix(ispin), &
                                     hmat=ks_matrix(ispin), &
                                     qs_env=qs_env, &
@@ -340,7 +340,7 @@ CONTAINS
             DEALLOCATE (vxc_rho(ispin)%pw)
             IF (ASSOCIATED(vxc_tau)) THEN
                CALL pw_scale(vxc_tau(ispin)%pw, -alpha*vxc_tau(ispin)%pw%pw_grid%dvol)
-               CALL integrate_v_rspace(v_rspace=vxc_tau(ispin), &
+               CALL integrate_v_rspace(v_rspace=vxc_tau(ispin)%pw, &
                                        pmat=density_matrix(ispin), &
                                        hmat=ks_matrix(ispin), &
                                        qs_env=qs_env, &
@@ -474,7 +474,7 @@ CONTAINS
       DO ispin = 1, nspins
          vxc_rho(ispin)%pw%cr3d = vxc_rho(ispin)%pw%cr3d*vxc_rho(ispin)%pw%pw_grid%dvol
          lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
-         CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, lri_v_int, calc_force, "LRI_AUX")
+         CALL integrate_v_rspace_one_center(vxc_rho(ispin)%pw, qs_env, lri_v_int, calc_force, "LRI_AUX")
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
          DEALLOCATE (vxc_rho(ispin)%pw)
       END DO
@@ -502,7 +502,7 @@ CONTAINS
          DO ispin = 1, nspins
             vxc_rho(ispin)%pw%cr3d = -vxc_rho(ispin)%pw%cr3d*vxc_rho(ispin)%pw%pw_grid%dvol
             lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
-            CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, &
+            CALL integrate_v_rspace_one_center(vxc_rho(ispin)%pw, qs_env, &
                                                lri_v_int, calc_force, &
                                                "LRI_AUX", atomlist=atomlist)
             ! clean up vxc_rho
@@ -716,7 +716,7 @@ CONTAINS
             ! int w/ rho_ao
             lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
          END IF
-         CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, lri_v_int, calc_force, "LRI_AUX")
+         CALL integrate_v_rspace_one_center(vxc_rho(ispin)%pw, qs_env, lri_v_int, calc_force, "LRI_AUX")
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin)%pw)
          DEALLOCATE (vxc_rho(ispin)%pw)
       END DO
@@ -783,7 +783,7 @@ CONTAINS
                lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
             END IF
 
-            CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, &
+            CALL integrate_v_rspace_one_center(vxc_rho(ispin)%pw, qs_env, &
                                                lri_v_int, calc_force, &
                                                "LRI_AUX", atomlist=atomlist)
             ! clean up vxc_rho

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -97,8 +97,8 @@ MODULE library_tests
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_create,&
-                                              pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE realspace_grid_types,            ONLY: &
         pw2rs, realspace_grid_desc_type, realspace_grid_input_type, realspace_grid_type, rs2pw, &
         rs_grid_create, rs_grid_create_descriptor, rs_grid_print, rs_grid_release, &
@@ -719,7 +719,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: tend, tstart
       TYPE(cell_type), POINTER                           :: box
       TYPE(pw_grid_type), POINTER                        :: grid
-      TYPE(pw_p_type)                                    :: ca
+      TYPE(pw_type)                                      :: ca
       TYPE(realspace_grid_desc_type), POINTER            :: rs_desc
       TYPE(realspace_grid_input_type)                    :: input_settings
       TYPE(realspace_grid_type), POINTER                 :: rs_grid
@@ -748,10 +748,9 @@ CONTAINS
       CALL pw_grid_setup(box%hmat, grid, grid_span=FULLSPACE, npts=np, fft_usage=.TRUE., iounit=iw)
       no = grid%npts
 
-      NULLIFY (ca%pw)
-      CALL pw_create(ca%pw, grid, REALDATA3D)
-      ca%pw%in_space = REALSPACE
-      CALL pw_zero(ca%pw)
+      CALL pw_create(ca, grid, REALDATA3D)
+      ca%in_space = REALSPACE
+      CALL pw_zero(ca)
 
       ! .. rs input setting type
       CALL section_vals_val_get(rs_pw_transfer_section, "HALO_SIZE", i_val=halo_size)
@@ -788,7 +787,7 @@ CONTAINS
       DO i_loop = 1, N_loop
          CALL mp_sync(para_env%group)
          tstart = m_walltime()
-         CALL rs_pw_transfer(rs_grid, ca%pw, dir)
+         CALL rs_pw_transfer(rs_grid, ca, dir)
          CALL mp_sync(para_env%group)
          tend = m_walltime()
          IF (para_env%ionode) THEN
@@ -799,7 +798,7 @@ CONTAINS
       !cleanup
       CALL rs_grid_release(rs_grid)
       CALL rs_grid_release_descriptor(rs_desc)
-      CALL pw_release(ca%pw)
+      CALL pw_release(ca)
       CALL pw_grid_release(grid)
       CALL cell_release(box)
       CALL finalize_fft(para_env, wisdom_file=globenv%fftw_wisdom_file_name)
@@ -841,7 +840,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: t_end, t_start
       TYPE(cell_type), POINTER                           :: box
       TYPE(pw_grid_type), POINTER                        :: grid
-      TYPE(pw_p_type)                                    :: ca, cb, cc
+      TYPE(pw_type)                                      :: ca, cb, cc
 
 !..set fft lib
 
@@ -948,23 +947,19 @@ CONTAINS
             ! note that the number of grid points might be different from what the user requested (fft-able needed)
             no = grid%npts
 
-            NULLIFY (ca%pw)
-            NULLIFY (cb%pw)
-            NULLIFY (cc%pw)
-
-            CALL pw_create(ca%pw, grid, COMPLEXDATA1D)
-            CALL pw_create(cb%pw, grid, COMPLEXDATA3D)
-            CALL pw_create(cc%pw, grid, COMPLEXDATA1D)
+            CALL pw_create(ca, grid, COMPLEXDATA1D)
+            CALL pw_create(cb, grid, COMPLEXDATA3D)
+            CALL pw_create(cc, grid, COMPLEXDATA1D)
 
             ! initialize data
-            CALL pw_zero(ca%pw)
-            CALL pw_zero(cb%pw)
-            CALL pw_zero(cc%pw)
-            ca%pw%in_space = RECIPROCALSPACE
-            nn = SIZE(ca%pw%cc)
+            CALL pw_zero(ca)
+            CALL pw_zero(cb)
+            CALL pw_zero(cc)
+            ca%in_space = RECIPROCALSPACE
+            nn = SIZE(ca%cc)
             DO ig = 1, nn
                gsq = grid%gsq(ig)
-               ca%pw%cc(ig) = EXP(-gsq)
+               ca%cc(ig) = EXP(-gsq)
             END DO
 
             flops = PRODUCT(no)*30.0_dp*LOG(REAL(MAXVAL(no), KIND=dp))
@@ -972,8 +967,8 @@ CONTAINS
             DO ip = 1, n_loop
                CALL mp_sync(para_env%group)
                t_start(ip) = m_walltime()
-               CALL pw_transfer(ca%pw, cb%pw, debug)
-               CALL pw_transfer(cb%pw, cc%pw, debug)
+               CALL pw_transfer(ca, cb, debug)
+               CALL pw_transfer(cb, cc, debug)
                CALL mp_sync(para_env%group)
                t_end(ip) = m_walltime()
             END DO
@@ -985,9 +980,9 @@ CONTAINS
                perf = 0.0_dp
             END IF
 
-            em = MAXVAL(ABS(ca%pw%cc(:) - cc%pw%cc(:)))
+            em = MAXVAL(ABS(ca%cc(:) - cc%cc(:)))
             CALL mp_max(em, para_env%group)
-            et = SUM(ABS(ca%pw%cc(:) - cc%pw%cc(:)))
+            et = SUM(ABS(ca%cc(:) - cc%cc(:)))
             CALL mp_sum(et, para_env%group)
             t_min = MINVAL(t_end - t_start)
             t_max = MAXVAL(t_end - t_start)
@@ -1006,14 +1001,14 @@ CONTAINS
             ! need debugging ???
             IF (em > toler .OR. et > toler) THEN
                CPWARN("The FFT results are not accurate ... starting debug pw_transfer")
-               CALL pw_transfer(ca%pw, cb%pw, .TRUE.)
-               CALL pw_transfer(cb%pw, cc%pw, .TRUE.)
+               CALL pw_transfer(ca, cb, .TRUE.)
+               CALL pw_transfer(cb, cc, .TRUE.)
             END IF
 
             ! done with these grids
-            CALL pw_release(ca%pw)
-            CALL pw_release(cb%pw)
-            CALL pw_release(cc%pw)
+            CALL pw_release(ca)
+            CALL pw_release(cb)
+            CALL pw_release(cc)
             CALL pw_grid_release(grid)
 
          END DO

--- a/src/localization_tb.F
+++ b/src/localization_tb.F
@@ -182,6 +182,7 @@ CONTAINS
 
             CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
+            ALLOCATE (wf_r%pw, wf_g%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)

--- a/src/localization_tb.F
+++ b/src/localization_tb.F
@@ -216,6 +216,7 @@ CONTAINS
             END IF
             CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
+            DEALLOCATE (wf_g%pw, wf_r%pw)
             CALL qs_loc_env_destroy(qs_loc_env_homo)
             IF (ASSOCIATED(marked_states)) THEN
                DEALLOCATE (marked_states)

--- a/src/lri_environment_methods.F
+++ b/src/lri_environment_methods.F
@@ -368,7 +368,7 @@ CONTAINS
       CPASSERT(.NOT. lri_env%exact_1c_terms)
 
       DO ispin = 1, nspins
-         CALL calculate_lri_rho_elec(rho_g(ispin), rho_r(ispin), qs_env, &
+         CALL calculate_lri_rho_elec(rho_g(ispin)%pw, rho_r(ispin)%pw, qs_env, &
                                      lri_density%lri_coefs(ispin)%lri_kinds, tot_rho_r(ispin), &
                                      "LRI_AUX", lri_env%exact_1c_terms, pmat=pmat_diag, atomlist=atomlist)
       END DO
@@ -954,13 +954,13 @@ CONTAINS
             END IF
             !
             IF (.NOT. response_density) THEN
-               CALL calculate_lri_rho_elec(rho_g(ispin), &
-                                           rho_r(ispin), qs_env, &
+               CALL calculate_lri_rho_elec(rho_g(ispin)%pw, &
+                                           rho_r(ispin)%pw, qs_env, &
                                            lri_density%lri_coefs(ispin)%lri_kinds, tot_rho_r(ispin), &
                                            "LRI_AUX", lri_env%exact_1c_terms, pmat=pmat_diag)
             ELSE
-               CALL calculate_lri_rho_elec(rho_g(ispin), &
-                                           rho_r(ispin), qs_env, &
+               CALL calculate_lri_rho_elec(rho_g(ispin)%pw, &
+                                           rho_r(ispin)%pw, qs_env, &
                                            lri_density%lri_coefs(ispin)%lri_kinds, tot_rho_r(ispin), &
                                            "P_LRI_AUX", lri_env%exact_1c_terms, pmat=pmat_diag)
             END IF

--- a/src/maxwell_solver_interface.F
+++ b/src/maxwell_solver_interface.F
@@ -17,7 +17,7 @@ MODULE maxwell_solver_interface
                               cp_logger_get_default_io_unit, &
                               cp_logger_type
    USE kinds, ONLY: dp
-   USE pw_types, ONLY: pw_p_type
+   USE pw_types, ONLY: pw_type
    USE message_passing, ONLY: &
       file_amode_rdonly, file_offset, mp_bcast, mp_file_close, mp_file_descriptor_type, &
       mp_file_get_position, mp_file_open, mp_file_read_all_chv, mp_file_type_free, &
@@ -79,7 +79,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE maxwell_solver(maxwell_control, v_ee, sim_step, sim_time, scaling_factor)
       TYPE(maxwell_control_type), INTENT(IN)             :: maxwell_control
-      TYPE(pw_p_type), POINTER                           :: v_ee
+      TYPE(pw_type), POINTER                           :: v_ee
       INTEGER, INTENT(IN)                                :: sim_step
       REAL(KIND=dp), INTENT(IN)                          :: sim_time
       REAL(KIND=dp), INTENT(IN)                          :: scaling_factor
@@ -106,18 +106,18 @@ CONTAINS
       logger => cp_get_default_logger()
       iounit = cp_logger_get_default_io_unit(logger)
 
-      my_rank = v_ee%pw%pw_grid%para%my_pos
-      num_pe = v_ee%pw%pw_grid%para%group_size
-      gid = v_ee%pw%pw_grid%para%group
+      my_rank = v_ee%pw_grid%para%my_pos
+      num_pe = v_ee%pw_grid%para%group_size
+      gid = v_ee%pw_grid%para%group
       tag = 1
 
-      lbounds = v_ee%pw%pw_grid%bounds(1, :)
-      ubounds = v_ee%pw%pw_grid%bounds(2, :)
-      npoints = v_ee%pw%pw_grid%npts
+      lbounds = v_ee%pw_grid%bounds(1, :)
+      ubounds = v_ee%pw_grid%bounds(2, :)
+      npoints = v_ee%pw_grid%npts
 
-      lbounds_local = v_ee%pw%pw_grid%bounds_local(1, :)
-      ubounds_local = v_ee%pw%pw_grid%bounds_local(2, :)
-      npoints_local = v_ee%pw%pw_grid%npts_local
+      lbounds_local = v_ee%pw_grid%bounds_local(1, :)
+      ubounds_local = v_ee%pw_grid%bounds_local(2, :)
+      npoints_local = v_ee%pw_grid%npts_local
 
       ALLOCATE (buffer(lbounds(3):ubounds(3)))
 
@@ -132,15 +132,15 @@ CONTAINS
                ubounds(1) - lbounds(1) + 1, &
                ubounds(2) - lbounds(2) + 1, &
                ubounds(3) - lbounds(3) + 1, &
-               v_ee%pw%pw_grid%dh(1, 1)*(ubounds(1) - lbounds(1) + 1), &
-               v_ee%pw%pw_grid%dh(2, 1)*(ubounds(1) - lbounds(1) + 1), &
-               v_ee%pw%pw_grid%dh(3, 1)*(ubounds(1) - lbounds(1) + 1), &
-               v_ee%pw%pw_grid%dh(1, 2)*(ubounds(2) - lbounds(2) + 1), &
-               v_ee%pw%pw_grid%dh(2, 2)*(ubounds(2) - lbounds(2) + 1), &
-               v_ee%pw%pw_grid%dh(3, 2)*(ubounds(2) - lbounds(2) + 1), &
-               v_ee%pw%pw_grid%dh(1, 3)*(ubounds(3) - lbounds(3) + 1), &
-               v_ee%pw%pw_grid%dh(2, 3)*(ubounds(3) - lbounds(3) + 1), &
-               v_ee%pw%pw_grid%dh(3, 3)*(ubounds(3) - lbounds(3) + 1) &
+               v_ee%pw_grid%dh(1, 1)*(ubounds(1) - lbounds(1) + 1), &
+               v_ee%pw_grid%dh(2, 1)*(ubounds(1) - lbounds(1) + 1), &
+               v_ee%pw_grid%dh(3, 1)*(ubounds(1) - lbounds(1) + 1), &
+               v_ee%pw_grid%dh(1, 2)*(ubounds(2) - lbounds(2) + 1), &
+               v_ee%pw_grid%dh(2, 2)*(ubounds(2) - lbounds(2) + 1), &
+               v_ee%pw_grid%dh(3, 2)*(ubounds(2) - lbounds(2) + 1), &
+               v_ee%pw_grid%dh(1, 3)*(ubounds(3) - lbounds(3) + 1), &
+               v_ee%pw_grid%dh(2, 3)*(ubounds(3) - lbounds(3) + 1), &
+               v_ee%pw_grid%dh(3, 3)*(ubounds(3) - lbounds(3) + 1) &
                )
 
          res = libcp2kmw_step(sim_step, sim_time)
@@ -179,7 +179,7 @@ CONTAINS
             IF ((lbounds_local(1) <= i) .AND. (i <= ubounds_local(1)) .AND. &
                 (lbounds_local(2) <= j) .AND. (j <= ubounds_local(2))) THEN
                !allow scaling of external potential values by factor 'scaling' (SCALING_FACTOR in input file)
-               v_ee%pw%cr3d(i, j, lbounds(3):ubounds(3)) = buffer(lbounds(3):ubounds(3))*scaling_factor
+               v_ee%cr3d(i, j, lbounds(3):ubounds(3)) = buffer(lbounds(3):ubounds(3))*scaling_factor
             END IF
 
          END DO

--- a/src/minbas_wfn_analysis.F
+++ b/src/minbas_wfn_analysis.F
@@ -527,6 +527,7 @@ CONTAINS
       END DO
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 

--- a/src/minbas_wfn_analysis.F
+++ b/src/minbas_wfn_analysis.F
@@ -571,6 +571,7 @@ CONTAINS
       DEALLOCATE (blk_sizes, first_bas)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+      DEALLOCATE (wf_r%pw, wf_g%pw)
 
    END SUBROUTINE post_minbas_cubes
 

--- a/src/minbas_wfn_analysis.F
+++ b/src/minbas_wfn_analysis.F
@@ -541,7 +541,7 @@ CONTAINS
                iw = cp_print_key_unit_nr(logger, print_section, "MINBAS_CUBE", extension=".cube", &
                                          middle_name=TRIM(filename), file_position="REWIND", log_filename=.FALSE., &
                                          mpi_io=mpi_io)
-               CALL calculate_wavefunction(minbas_coeff, ivec, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
+               CALL calculate_wavefunction(minbas_coeff, ivec, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
                                            cell, dft_control, particle_set, pw_env)
                CALL cp_pw_to_cube(wf_r%pw, iw, title, particles=particles, stride=stride, mpi_io=mpi_io)
                CALL cp_print_key_finished_output(iw, logger, print_section, "MINBAS_CUBE", mpi_io=mpi_io)
@@ -559,7 +559,7 @@ CONTAINS
                   iw = cp_print_key_unit_nr(logger, print_section, "MINBAS_CUBE", extension=".cube", &
                                             middle_name=TRIM(filename), file_position="REWIND", log_filename=.FALSE., &
                                             mpi_io=mpi_io)
-                  CALL calculate_wavefunction(minbas_coeff, ivec, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
+                  CALL calculate_wavefunction(minbas_coeff, ivec, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
                                               cell, dft_control, particle_set, pw_env)
                   CALL cp_pw_to_cube(wf_r%pw, iw, title, particles=particles, stride=stride, mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(iw, logger, print_section, "MINBAS_CUBE", mpi_io=mpi_io)

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -661,6 +661,7 @@ CONTAINS
       END IF
       ! In principle, we could reduce the memory footprint of becke_pot by only transferring the nonzero portion
       ! of the potential, but this would require a custom integrate_v_rspace
+      ALLOCATE (cdft_control_target%group(1)%weight%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control_target%group(1)%weight%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       cdft_control_target%group(1)%weight%pw%cr3d = 0.0_dp
@@ -956,6 +957,7 @@ CONTAINS
          IF (mixed_cdft%identical_constraints) THEN
             ! Weight function
             DO igroup = 1, SIZE(cdft_control_target%group)
+               ALLOCATE (cdft_control_target%group(igroup)%weight%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool_target, &
                                       cdft_control_target%group(igroup)%weight%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
@@ -966,6 +968,7 @@ CONTAINS
             ! Cavity
             IF (cdft_control_source%type == outer_scf_becke_constraint) THEN
                IF (cdft_control_source%becke_control%cavity_confine) THEN
+                  ALLOCATE (cdft_control_target%becke_control%cavity%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool_target, cdft_control_target%becke_control%cavity%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   cdft_control_target%becke_control%cavity%pw%cr3d(:, :, :) = &
@@ -996,6 +999,7 @@ CONTAINS
                IF (.NOT. ASSOCIATED(cdft_control_target%charge)) &
                   ALLOCATE (cdft_control_target%charge(cdft_control_target%natoms))
                DO iatom = 1, cdft_control_target%natoms
+                  ALLOCATE (cdft_control_target%charge(iatom)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool_target, &
                                          cdft_control_target%charge(iatom)%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
@@ -2605,6 +2609,7 @@ CONTAINS
             DEALLOCATE (cores)
          END DO
          DEALLOCATE (pab)
+         ALLOCATE (cdft_control%becke_control%cavity%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%becke_control%cavity%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL rs_pw_transfer(rs_cavity, cdft_control%becke_control%cavity%pw, rs2pw)

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -964,6 +964,7 @@ CONTAINS
                ! We have ensured that the grids are consistent => no danger in using explicit copy
                cdft_control_target%group(igroup)%weight%pw%cr3d = cdft_control_source%group(igroup)%weight%pw%cr3d
                CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%group(igroup)%weight%pw)
+               DEALLOCATE (cdft_control_source%group(igroup)%weight%pw)
             END DO
             ! Cavity
             IF (cdft_control_source%type == outer_scf_becke_constraint) THEN
@@ -974,6 +975,7 @@ CONTAINS
                   cdft_control_target%becke_control%cavity%pw%cr3d(:, :, :) = &
                      cdft_control_source%becke_control%cavity%pw%cr3d
                   CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%becke_control%cavity%pw)
+                  DEALLOCATE (cdft_control_source%becke_control%cavity%pw)
                END IF
             END IF
             ! Gradients
@@ -1005,6 +1007,7 @@ CONTAINS
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   cdft_control_target%charge(iatom)%pw%cr3d = cdft_control_source%charge(iatom)%pw%cr3d
                   CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%charge(iatom)%pw)
+                  DEALLOCATE (cdft_control_source%charge(iatom)%pw)
                END DO
             END IF
             ! Set some flags so the weight is not rebuilt during SCF
@@ -2699,6 +2702,7 @@ CONTAINS
                                                                           bo_conf(1, 3):bo_conf(2, 3))
          END IF
          CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%becke_control%cavity%pw)
+         DEALLOCATE (cdft_control%becke_control%cavity%pw)
       END IF
       IF (mixed_cdft%is_special) THEN
          DO i = 1, SIZE(mixed_cdft%dest_list)

--- a/src/molecular_states.F
+++ b/src/molecular_states.F
@@ -322,8 +322,8 @@ CONTAINS
             DO i = 1, ns
                IF (evals(i) < eval_range(1) .OR. evals(i) > eval_range(2)) CYCLE
 
-               CALL calculate_wavefunction(rot_e_vectors, i, wf_r, &
-                                           wf_g, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
+               CALL calculate_wavefunction(rot_e_vectors, i, wf_r%pw, &
+                                           wf_g%pw, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                            pw_env)
 
                WRITE (filename, '(a9,I4.4,a1,I5.5,a4)') "MOLECULE_", imol, "_", i, tag

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -1560,16 +1560,16 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
             CALL dbcsr_add(rho_ao(ispin)%matrix, matrix_p_mp2(ispin)%matrix, 1.0_dp, -1.0_dp)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
                                     hmat=matrix_ks(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             CALL dbcsr_add(rho_ao(ispin)%matrix, matrix_p_mp2(ispin)%matrix, 1.0_dp, 1.0_dp)
             CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
                                     hmat=matrix_ks(ispin), pmat=matrix_p_mp2(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (ASSOCIATED(vtau_rspace)) THEN
-               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin), &
+               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin)%pw, &
                                        hmat=matrix_ks(ispin), pmat=matrix_p_mp2(ispin), &
                                        qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.TRUE.)
             END IF
@@ -1578,11 +1578,11 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
             CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
                                     hmat=matrix_ks(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (ASSOCIATED(vtau_rspace)) THEN
-               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin), &
+               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin)%pw, &
                                        hmat=matrix_ks(ispin), pmat=rho_ao(ispin), &
                                        qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.TRUE.)
             END IF
@@ -1676,7 +1676,7 @@ CONTAINS
       CALL pw_axpy(pot_r%pw, vh_rspace%pw)
 
       ! calculate core forces
-      CALL integrate_v_core_rspace(vh_rspace, qs_env)
+      CALL integrate_v_core_rspace(vh_rspace%pw, qs_env)
       IF (debug_forces) THEN
          deb(:) = force(1)%rho_core(:, 1)
          CALL mp_sum(deb, para_env%group)
@@ -1929,11 +1929,11 @@ CONTAINS
                END IF
                DO ispin = 1, nspins
                   IF (do_exx) THEN
-                     CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin), hmat=matrix_ks_aux(ispin), qs_env=qs_env, &
+                     CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin)%pw, hmat=matrix_ks_aux(ispin), qs_env=qs_env, &
                                              calculate_forces=.TRUE., basis_type="AUX_FIT", &
                                              task_list_external=task_list_aux_fit, pmat=matrix_p_mp2_admm(ispin))
                   ELSE
-                     CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin), hmat=matrix_ks_aux(ispin), qs_env=qs_env, &
+                     CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin)%pw, hmat=matrix_ks_aux(ispin), qs_env=qs_env, &
                                              calculate_forces=.TRUE., basis_type="AUX_FIT", &
                                              task_list_external=task_list_aux_fit, pmat=rho_ao_aux(ispin))
                   END IF

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -1376,14 +1376,13 @@ CONTAINS
          POINTER                                         :: sab_orb, sac_ppl, sap_ppnl
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: pot_g, pot_r, rho_tot_g, temp_pw_g, &
-                                                            vhxc_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: dvg, rho_g, rho_mp2_g, rho_mp2_r, &
                                                             rho_mp2_r_aux, rho_r, tau_mp2_r, &
                                                             vadmm_rspace, vtau_rspace, vxc_rspace
-      TYPE(pw_p_type), POINTER                           :: vh_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_g, pot_r, rho_tot_g, temp_pw_g, &
+                                                            vh_rspace, vhxc_rspace
       TYPE(pw_type), POINTER                             :: rho_core
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
       TYPE(qs_energy_type), POINTER                      :: energy
@@ -1524,7 +1523,7 @@ CONTAINS
       END IF
 
       ! Get the different components of the KS potential
-      NULLIFY (vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace)
+      NULLIFY (vxc_rspace, vtau_rspace, vadmm_rspace)
       IF (use_virial) THEN
          h_stress = 0.0_dp
          CALL ks_ref_potential(qs_env, vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace, ehartree, exc, h_stress)
@@ -1550,8 +1549,7 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      ALLOCATE (vhxc_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       IF (use_virial) h_stress = virial%pv_virial
       IF (debug_forces) THEN
@@ -1560,14 +1558,14 @@ CONTAINS
       END IF
       IF (do_exx) THEN
          DO ispin = 1, nspins
-            CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
+            CALL pw_transfer(vh_rspace, vhxc_rspace)
             CALL dbcsr_add(rho_ao(ispin)%matrix, matrix_p_mp2(ispin)%matrix, 1.0_dp, -1.0_dp)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
                                     hmat=matrix_ks(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             CALL dbcsr_add(rho_ao(ispin)%matrix, matrix_p_mp2(ispin)%matrix, 1.0_dp, 1.0_dp)
-            CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
+            CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace)
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
                                     hmat=matrix_ks(ispin), pmat=matrix_p_mp2(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (ASSOCIATED(vtau_rspace)) THEN
@@ -1578,9 +1576,9 @@ CONTAINS
          END DO
       ELSE
          DO ispin = 1, nspins
-            CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
-            CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
+            CALL pw_transfer(vh_rspace, vhxc_rspace)
+            CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace)
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
                                     hmat=matrix_ks(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (ASSOCIATED(vtau_rspace)) THEN
@@ -1627,9 +1625,8 @@ CONTAINS
             DEALLOCATE (vtau_rspace(ispin)%pw)
          END IF
       END DO
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace%pw)
-      DEALLOCATE (vhxc_rspace%pw)
       DEALLOCATE (vxc_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace)
       IF (ASSOCIATED(vtau_rspace)) DEALLOCATE (vtau_rspace)
 
       DO ispin = 1, nspins
@@ -1642,22 +1639,21 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! get some of the grids ready
-      ALLOCATE (pot_r%pw, pot_g%pw, rho_tot_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, pot_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      CALL pw_zero(rho_tot_g%pw)
+      CALL pw_zero(rho_tot_g)
 
       CALL qs_rho_get(p_env%rho1, rho_r=rho_mp2_r, rho_g=rho_mp2_g)
       DO ispin = 1, nspins
-         CALL pw_axpy(rho_mp2_g(ispin)%pw, rho_tot_g%pw)
+         CALL pw_axpy(rho_mp2_g(ispin)%pw, rho_tot_g)
       END DO
 
       NULLIFY (dvg)
@@ -1672,13 +1668,13 @@ CONTAINS
       END IF
 
       ! calculate the MP2 potential
-      CALL pw_poisson_solve(poisson_env, rho_tot_g%pw, vhartree=pot_g%pw, dvhartree=dvg)
-      CALL pw_transfer(pot_g%pw, pot_r%pw)
-      CALL pw_scale(pot_r%pw, pot_r%pw%pw_grid%dvol)
-      CALL pw_axpy(pot_r%pw, vh_rspace%pw)
+      CALL pw_poisson_solve(poisson_env, rho_tot_g, vhartree=pot_g, dvhartree=dvg)
+      CALL pw_transfer(pot_g, pot_r)
+      CALL pw_scale(pot_r, pot_r%pw_grid%dvol)
+      CALL pw_axpy(pot_r, vh_rspace)
 
       ! calculate core forces
-      CALL integrate_v_core_rspace(vh_rspace%pw, qs_env)
+      CALL integrate_v_core_rspace(vh_rspace, qs_env)
       IF (debug_forces) THEN
          deb(:) = force(1)%rho_core(:, 1)
          CALL mp_sum(deb, para_env%group)
@@ -1689,49 +1685,45 @@ CONTAINS
             IF (iounit > 0) WRITE (iounit, "(T3,A,T33,F16.8)") "DEBUG VIRIAL:: core      ", e_dummy
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace%pw)
-      DEALLOCATE (vh_rspace%pw)
-      DEALLOCATE (vh_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace)
 
       IF (use_virial) THEN
          ! update virial if necessary with the volume term
          ! first create pw auxiliary stuff
-         ALLOCATE (temp_pw_g%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, temp_pw_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, temp_pw_g, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
 
          ! make a copy of the MP2 density in G space
-         CALL pw_copy(rho_tot_g%pw, temp_pw_g%pw)
+         CALL pw_copy(rho_tot_g, temp_pw_g)
 
          ! calculate total SCF density and potential
-         CALL pw_copy(rho_g(1)%pw, rho_tot_g%pw)
-         IF (nspins == 2) CALL pw_axpy(rho_g(2)%pw, rho_tot_g%pw)
-         CALL pw_axpy(rho_core, rho_tot_g%pw)
-         CALL pw_poisson_solve(poisson_env, rho_tot_g%pw, vhartree=pot_g%pw)
+         CALL pw_copy(rho_g(1)%pw, rho_tot_g)
+         IF (nspins == 2) CALL pw_axpy(rho_g(2)%pw, rho_tot_g)
+         CALL pw_axpy(rho_core, rho_tot_g)
+         CALL pw_poisson_solve(poisson_env, rho_tot_g, vhartree=pot_g)
 
          ! finally update virial with the volume contribution
-         e_hartree = pw_integral_ab(temp_pw_g%pw, pot_g%pw)
+         e_hartree = pw_integral_ab(temp_pw_g, pot_g)
          IF (debug_forces .AND. iounit > 0) WRITE (iounit, "(T3,A,T33,F16.8)") "DEBUG VIRIAL:: vh1*d0   ", e_hartree
 
          h_stress = 0.0_dp
          DO alpha = 1, 3
             comp = 0
             comp(alpha) = 1
-            CALL pw_copy(pot_g%pw, rho_tot_g%pw)
-            CALL pw_derive(rho_tot_g%pw, comp)
+            CALL pw_copy(pot_g, rho_tot_g)
+            CALL pw_derive(rho_tot_g, comp)
             h_stress(alpha, alpha) = -e_hartree
             DO beta = alpha, 3
                h_stress(alpha, beta) = h_stress(alpha, beta) &
-                                       - 2.0_dp*pw_integral_ab(rho_tot_g%pw, dvg(beta)%pw)/fourpi
+                                       - 2.0_dp*pw_integral_ab(rho_tot_g, dvg(beta)%pw)/fourpi
                h_stress(beta, alpha) = h_stress(alpha, beta)
             END DO
          END DO
          IF (debug_forces .AND. iounit > 0) WRITE (iounit, "(T3,A,T33,F16.8)") "DEBUG VIRIAL:: Hartree  ", third_tr(h_stress)
 
          ! free stuff
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, temp_pw_g%pw)
-         DEALLOCATE (temp_pw_g%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, temp_pw_g)
          DO idir = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(idir)%pw)
             DEALLOCATE (dvg(idir)%pw)
@@ -1801,14 +1793,8 @@ CONTAINS
             IF (dft_control%do_admm) THEN
                CALL get_admm_env(qs_env%admm_env, rho_aux_fit=rho_aux)
                CALL qs_rho_get(rho_aux, rho_ao=rho_ao_aux, rho_ao_kp=rho_ao_kp)
-               DO ispin = 1, nspins
-!                  CALL dbcsr_add(rho_ao_aux(ispin)%matrix, p_env%p1_admm(ispin)%matrix, 1.0_dp, 1.0_dp)
-               END DO
                rho1 => p_env%p1_admm
             ELSE
-               DO ispin = 1, nspins
-                  !         CALL dbcsr_add(rho_ao(ispin)%matrix, p_env%p1(ispin)%matrix, 1.0_dp, 1.0_dp)
-               END DO
                rho1 => p_env%p1
             END IF
          ELSE
@@ -2027,10 +2013,9 @@ CONTAINS
          END IF
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_g%pw)
-      DEALLOCATE (pot_r%pw, pot_g%pw, rho_tot_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_g)
 
       ! Release linres stuff
       CALL p_env_release(p_env)

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -93,7 +93,8 @@ MODULE mp2_cphf
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_2nd_kernel_ao,                ONLY: apply_2nd_order_kernel
    USE qs_density_matrices,             ONLY: calculate_whz_matrix
    USE qs_dispersion_pairpot,           ONLY: calculate_dispersion_pairpot
@@ -1380,9 +1381,10 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: dvg, rho_g, rho_mp2_g, rho_mp2_r, &
                                                             rho_mp2_r_aux, rho_r, tau_mp2_r, &
                                                             vadmm_rspace, vtau_rspace, vxc_rspace
-      TYPE(pw_p_type), POINTER                           :: rho_core, vh_rspace
+      TYPE(pw_p_type), POINTER                           :: vh_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rho_core
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
@@ -1705,7 +1707,7 @@ CONTAINS
          ! calculate total SCF density and potential
          CALL pw_copy(rho_g(1)%pw, rho_tot_g%pw)
          IF (nspins == 2) CALL pw_axpy(rho_g(2)%pw, rho_tot_g%pw)
-         CALL pw_axpy(rho_core%pw, rho_tot_g%pw)
+         CALL pw_axpy(rho_core, rho_tot_g%pw)
          CALL pw_poisson_solve(poisson_env, rho_tot_g%pw, vhartree=pot_g%pw)
 
          ! finally update virial with the volume contribution

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -1548,7 +1548,7 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      NULLIFY (vhxc_rspace%pw)
+      ALLOCATE (vhxc_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       IF (use_virial) h_stress = virial%pv_virial
@@ -1635,7 +1635,7 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! get some of the grids ready
-      NULLIFY (pot_r%pw, pot_g%pw, rho_tot_g%pw)
+      ALLOCATE (pot_r%pw, pot_g%pw, rho_tot_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, pot_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -1657,7 +1657,7 @@ CONTAINS
       IF (use_virial) THEN
          ALLOCATE (dvg(3))
          DO idir = 1, 3
-            NULLIFY (dvg(idir)%pw)
+            ALLOCATE (dvg(idir)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, dvg(idir)%pw, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
@@ -1688,7 +1688,7 @@ CONTAINS
       IF (use_virial) THEN
          ! update virial if necessary with the volume term
          ! first create pw auxiliary stuff
-         NULLIFY (temp_pw_g%pw)
+         ALLOCATE (temp_pw_g%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, temp_pw_g%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -1619,9 +1619,14 @@ CONTAINS
       END IF
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin)%pw)
-         IF (ASSOCIATED(vtau_rspace)) CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin)%pw)
+         DEALLOCATE (vxc_rspace(ispin)%pw)
+         IF (ASSOCIATED(vtau_rspace)) THEN
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin)%pw)
+            DEALLOCATE (vtau_rspace(ispin)%pw)
+         END IF
       END DO
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace%pw)
+      DEALLOCATE (vhxc_rspace%pw)
       DEALLOCATE (vxc_rspace)
       IF (ASSOCIATED(vtau_rspace)) DEALLOCATE (vtau_rspace)
 
@@ -1683,6 +1688,7 @@ CONTAINS
          END IF
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace%pw)
+      DEALLOCATE (vh_rspace%pw)
       DEALLOCATE (vh_rspace)
 
       IF (use_virial) THEN
@@ -1723,8 +1729,10 @@ CONTAINS
 
          ! free stuff
          CALL pw_pool_give_back_pw(auxbas_pw_pool, temp_pw_g%pw)
+         DEALLOCATE (temp_pw_g%pw)
          DO idir = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(idir)%pw)
+            DEALLOCATE (dvg(idir)%pw)
          END DO
          DEALLOCATE (dvg)
 
@@ -1930,6 +1938,7 @@ CONTAINS
                                              task_list_external=task_list_aux_fit, pmat=rho_ao_aux(ispin))
                   END IF
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin)%pw)
+                  DEALLOCATE (vadmm_rspace(ispin)%pw)
                END DO
                IF (use_virial) virial%pv_ehartree = virial%pv_ehartree + (virial%pv_virial - h_stress)
                DEALLOCATE (vadmm_rspace)
@@ -2019,6 +2028,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_g%pw)
+      DEALLOCATE (pot_r%pw, pot_g%pw, rho_tot_g%pw)
 
       ! Release linres stuff
       CALL p_env_release(p_env)

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -142,7 +142,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       ! pseudo psi_L
-      CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
+      CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                   qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
                                   basis_type="RI_AUX", &
                                   external_vector=external_vector)
@@ -226,7 +226,7 @@ CONTAINS
          i_counter = i_counter + 1
 
          ! pseudo psi_L
-         CALL collocate_single_gaussian(psi_L, rho_g, atomic_kind_set, &
+         CALL collocate_single_gaussian(psi_L%pw, rho_g%pw, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
                                         required_function=LLL, basis_type="RI_AUX")
 
@@ -431,7 +431,7 @@ CONTAINS
       ! pseudo psi_L
       CALL pw_zero(rho_r%pw)
       CALL pw_zero(rho_g%pw)
-      CALL collocate_single_gaussian(rho_r, rho_g, atomic_kind_set, &
+      CALL collocate_single_gaussian(rho_r%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, &
                                      pw_env_sub, required_function=LLL, basis_type='RI_AUX')
       IF (use_virial) THEN
@@ -451,7 +451,7 @@ CONTAINS
          ! hartree potential derivatives
          CALL pw_zero(psi_L%pw)
          CALL pw_zero(rho_g%pw)
-         CALL calculate_wavefunction(matrix, 1, psi_L, rho_g, atomic_kind_set, &
+         CALL calculate_wavefunction(matrix, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
                                      basis_type="RI_AUX", &
                                      external_vector=0.5_dp*factor*G_PQ_local)

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -240,7 +240,7 @@ CONTAINS
          DO i = 1, SIZE(rs_v)
             CALL rs_grid_retain(rs_v(i)%rs_grid)
          END DO
-         CALL potential_pw2rs(rs_v, rho_r, pw_env_sub)
+         CALL potential_pw2rs(rs_v, rho_r%pw, pw_env_sub)
 
          CALL timestop(handle2)
 
@@ -586,8 +586,8 @@ CONTAINS
       CALL pw_zero(rho_r%pw)
       CALL pw_zero(rho_g%pw)
       CALL calculate_rho_elec(matrix_p=matrix_P_munu%matrix, &
-                              rho=rho_r, &
-                              rho_gspace=rho_g, &
+                              rho=rho_r%pw, &
+                              rho_gspace=rho_g%pw, &
                               task_list_external=task_list_sub, &
                               pw_env_external=pw_env_sub, &
                               ks_env=ks_env)
@@ -605,7 +605,7 @@ CONTAINS
       DO i = 1, SIZE(rs_v)
          CALL rs_grid_retain(rs_v(i)%rs_grid)
       END DO
-      CALL potential_pw2rs(rs_v, rho_r, pw_env_sub)
+      CALL potential_pw2rs(rs_v, rho_r%pw, pw_env_sub)
 
       offset = 0
       DO iatom = 1, SIZE(kind_of)
@@ -899,7 +899,7 @@ CONTAINS
       DO i = 1, SIZE(rs_v)
          CALL rs_grid_retain(rs_v(i)%rs_grid)
       END DO
-      CALL potential_pw2rs(rs_v, pot_r, pw_env_sub)
+      CALL potential_pw2rs(rs_v, pot_r%pw, pw_env_sub)
 
       offset = 0
       DO iatom = 1, SIZE(kind_of)

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -151,7 +151,7 @@ CONTAINS
 
       ! and finally (K|mu nu)
       CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-      CALL integrate_v_rspace(rho_r, hmat=mat_munu, qs_env=qs_env, &
+      CALL integrate_v_rspace(rho_r%pw, hmat=mat_munu, qs_env=qs_env, &
                               calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE., &
                               pw_env_external=pw_env_sub, task_list_external=task_list_sub)
 
@@ -498,7 +498,7 @@ CONTAINS
       ! integrate the potential of the single gaussian and update
       ! 3-center forces
       CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-      CALL integrate_v_rspace(rho_r, hmat=mat_munu, pmat=matrix_P_munu, &
+      CALL integrate_v_rspace(rho_r%pw, hmat=mat_munu, pmat=matrix_P_munu, &
                               qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.FALSE., gapw=.FALSE., &
                               pw_env_external=pw_env_sub, &
                               task_list_external=task_list_sub)

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -1087,7 +1087,7 @@ CONTAINS
                                  pw_env_external=pw_env_sub, sab_orb_external=sab_orb_sub)
 
       ! get some of the grids ready
-      NULLIFY (rho_r%pw, rho_g%pw, pot_g%pw, psi_L%pw)
+      ALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw, psi_L%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -1148,6 +1148,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L%pw)
+      DEALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw, psi_L%pw)
 
       CALL deallocate_task_list(task_list_sub)
       CALL pw_env_release(pw_env_sub, para_env=para_env_sub)

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -394,7 +394,7 @@ CONTAINS
 
       ALLOCATE (psi_i(my_I_occupied_start:my_I_occupied_end))
       DO i = my_I_occupied_start, my_I_occupied_end
-         NULLIFY (psi_i(i)%pw)
+         ALLOCATE (psi_i(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, psi_i(i)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -583,6 +583,7 @@ CONTAINS
 
       DO i = my_I_occupied_start, my_I_occupied_end
          CALL pw_release(psi_i(i)%pw)
+         DEALLOCATE (psi_i(i)%pw)
       END DO
       DEALLOCATE (psi_i)
 

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -398,7 +398,7 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, psi_i(i)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL calculate_wavefunction(mo_coeff, i, psi_i(i), rho_g, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, i, psi_i(i)%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, &
                                      pw_env_sub, external_vector=my_Cocc(:, i - my_I_occupied_start + 1))
       END DO
@@ -417,7 +417,7 @@ CONTAINS
          IF (calc_ex) BIb_C = 0.0_dp
 
          ! psi_a
-         CALL calculate_wavefunction(mo_coeff, a, psi_a, rho_g, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, a, psi_a%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, &
                                      pw_env_sub, external_vector=my_Cvirt(:, a - (homo + my_A_virtual_start) + 1))
          i_counter = 0

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -432,7 +432,7 @@ CONTAINS
             ! and finally (ia|munu)
             CALL timeset(routineN//"_int", handle3)
             CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-            CALL integrate_v_rspace(rho_r, hmat=mat_munu, qs_env=qs_env, &
+            CALL integrate_v_rspace(rho_r%pw, hmat=mat_munu, qs_env=qs_env, &
                                     calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE., &
                                     pw_env_external=pw_env_sub, task_list_external=task_list_sub)
             CALL timestop(handle3)

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -417,8 +417,10 @@ CONTAINS
 
          IF (use_virial) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy%pw)
+            DEALLOCATE (rho_g_copy%pw)
             DO i = 1, 3
                CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(i)%pw)
+               DEALLOCATE (dvg(i)%pw)
             END DO
          END IF
 

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -350,12 +350,12 @@ CONTAINS
          ! for calculate the MP2-volume contribution to the virial
          ! (hartree potential derivatives)
          IF (use_virial) THEN
-            NULLIFY (rho_g_copy%pw)
+            ALLOCATE (rho_g_copy%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy%pw, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
             DO i = 1, 3
-               NULLIFY (dvg(i)%pw)
+               ALLOCATE (dvg(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, dvg(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -815,7 +815,7 @@ CONTAINS
          CALL pw_pool_create_pw(pw_pool, v_hartree%pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL negf_env_init_v_hartree(v_hartree%pw, negf_env%contacts, negf_control%contacts)
 
-         CALL integrate_v_rspace(v_rspace=v_hartree, hmat=hmat, qs_env=qs_env, &
+         CALL integrate_v_rspace(v_rspace=v_hartree%pw, hmat=hmat, qs_env=qs_env, &
                                  calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE.)
 
          CALL pw_pool_give_back_pw(pw_pool, v_hartree%pw)

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -819,6 +819,7 @@ CONTAINS
                                  calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE.)
 
          CALL pw_pool_give_back_pw(pw_pool, v_hartree%pw)
+         DEALLOCATE (v_hartree%pw)
 
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=hmat%matrix, &
                                                fm=negf_env%v_hartree_s, &

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -811,7 +811,7 @@ CONTAINS
          CALL dbcsr_copy(matrix_b=hmat%matrix, matrix_a=matrix_s_kp(1, 1)%matrix)
          CALL dbcsr_set(hmat%matrix, 0.0_dp)
 
-         NULLIFY (v_hartree%pw)
+         ALLOCATE (v_hartree%pw)
          CALL pw_pool_create_pw(pw_pool, v_hartree%pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL negf_env_init_v_hartree(v_hartree%pw, negf_env%contacts, negf_control%contacts)
 

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -1048,7 +1048,7 @@ CONTAINS
 
       ! Calculate charge density
       CALL pw_zero(rho_resp%pw)
-      CALL calculate_rho_resp_all(rho_resp, rhs_subsys, natom, eta, qs_env)
+      CALL calculate_rho_resp_all(rho_resp%pw, rhs_subsys, natom, eta, qs_env)
 
       ! Calculate potential
       CALL pw_zero(v_resp_gspace%pw)
@@ -1884,7 +1884,7 @@ CONTAINS
          CALL mp_sum(wf_vector, para_env%group)
 
          ! Calculate the variable part of the embedding potential
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env, &
                                      basis_type="RI_AUX", &
                                      external_vector=wf_vector)
@@ -1911,7 +1911,7 @@ CONTAINS
          CALL mp_sum(wf_vector, para_env%group)
 
          ! Calculate the variable part of the embedding potential
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env, &
                                      basis_type="RI_AUX", &
                                      external_vector=wf_vector)
@@ -1933,10 +1933,10 @@ CONTAINS
          CALL mp_sum(wf_vector, para_env%group)
 
          ! Calculate the variable part of the embedding potential
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env)
 
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env, &
                                      basis_type="RI_AUX", &
                                      external_vector=wf_vector)

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -1529,9 +1529,11 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, grid_reg)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, grid_reg_g)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, square_norm_dpot)
+      DEALLOCATE (potential_g, dr2_pot, grid_reg, grid_reg_g, square_norm_dpot)
       DO i = 1, 3
          CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot(i)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot_g(i)%pw)
+         DEALLOCATE (dpot(i)%pw, dpot_g(i)%pw)
       END DO
 
    END SUBROUTINE grid_regularize
@@ -1946,6 +1948,7 @@ CONTAINS
       DEALLOCATE (wf_vector)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
+      DEALLOCATE (psi_L%pw, rho_g%pw)
 
       IF (open_shell_embed) THEN
          CALL cp_fm_release(embed_pot_coef_spin)

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -948,6 +948,7 @@ CONTAINS
 
       DO i_dens = 1, SIZE(opt_embed%prev_subsys_dens)
          CALL pw_release(opt_embed%prev_subsys_dens(i_dens)%pw)
+         DEALLOCATE (opt_embed%prev_subsys_dens(i_dens)%pw)
       END DO
       DEALLOCATE (opt_embed%prev_subsys_dens)
       DEALLOCATE (opt_embed%max_subsys_dens_diff)
@@ -956,23 +957,28 @@ CONTAINS
 
       IF (opt_embed%add_const_pot .AND. (.NOT. opt_embed%grid_opt)) THEN
          CALL pw_release(opt_embed%const_pot%pw)
+         DEALLOCATE (opt_embed%const_pot%pw)
          DEALLOCATE (opt_embed%const_pot)
       END IF
 
       IF (opt_embed%Coulomb_guess) THEN
          CALL pw_release(opt_embed%pot_diff%pw)
+         DEALLOCATE (opt_embed%pot_diff%pw)
          DEALLOCATE (opt_embed%pot_diff)
       END IF
 
       IF (opt_embed%fab) THEN
          CALL pw_release(opt_embed%prev_embed_pot%pw)
+         DEALLOCATE (opt_embed%prev_embed_pot%pw)
          DEALLOCATE (opt_embed%prev_embed_pot)
          IF (opt_embed%open_shell_embed) THEN
             CALL pw_release(opt_embed%prev_spin_embed_pot%pw)
+            DEALLOCATE (opt_embed%prev_spin_embed_pot%pw)
             DEALLOCATE (opt_embed%prev_spin_embed_pot)
          END IF
          DO i_spin = 1, SIZE(opt_embed%v_w)
             CALL pw_release(opt_embed%v_w(i_spin)%pw)
+            DEALLOCATE (opt_embed%v_w(i_spin)%pw)
          END DO
          DEALLOCATE (opt_embed%v_w)
       END IF
@@ -1069,6 +1075,7 @@ CONTAINS
       CALL pw_release(v_resp_gspace%pw)
       CALL pw_release(v_resp_rspace%pw)
       CALL pw_release(rho_resp%pw)
+      DEALLOCATE (v_resp_gspace%pw, v_resp_rspace%pw, rho_resp%pw)
 
       ! Deallocate map_index array
       DEALLOCATE (map_index)
@@ -2711,6 +2718,7 @@ CONTAINS
          DO i_spin = 1, nspins
             CALL pw_release(rho_n_1(i_spin)%pw)
             CALL pw_release(temp_embed_pot(i_spin)%pw)
+            DEALLOCATE (rho_n_1(i_spin)%pw, temp_embed_pot(i_spin)%pw)
          END DO
          DEALLOCATE (rho_n_1)
          DEALLOCATE (temp_embed_pot)
@@ -2718,6 +2726,7 @@ CONTAINS
 
       DO i_spin = 1, nspins
          CALL pw_release(new_embed_pot(i_spin)%pw)
+         DEALLOCATE (new_embed_pot(i_spin)%pw)
       END DO
 
       DEALLOCATE (new_embed_pot)
@@ -2911,6 +2920,7 @@ CONTAINS
 
             DO i_spin = 1, nspins
                CALL pw_release(temp_embed_pot(i_spin)%pw)
+               DEALLOCATE (temp_embed_pot(i_spin)%pw)
             END DO
             DEALLOCATE (temp_embed_pot)
 
@@ -2920,6 +2930,7 @@ CONTAINS
             CALL pw_release(curr_rho(i_spin)%pw)
             CALL pw_release(new_embed_pot(i_spin)%pw)
             CALL pw_release(v_w(i_spin)%pw)
+            DEALLOCATE (curr_rho(i_spin)%pw, new_embed_pot(i_spin)%pw, v_w(i_spin)%pw)
          END DO
 
          DEALLOCATE (new_embed_pot)
@@ -3078,6 +3089,7 @@ CONTAINS
 
       DO i_spin = 1, nspins
          CALL pw_release(rho_g(i_spin)%pw)
+         DEALLOCATE (rho_g(i_spin)%pw)
       END DO
       DEALLOCATE (rho_g)
 
@@ -3423,9 +3435,11 @@ CONTAINS
                                            "DFT%QS%OPT_EMBED%WRITE_SIMPLE_GRID")
          ! Release structures
          CALL pw_release(pot_alpha%pw)
+         DEALLOCATE (pot_alpha%pw)
          DEALLOCATE (pot_alpha)
          IF (open_shell_embed) THEN
             CALL pw_release(pot_beta%pw)
+            DEALLOCATE (pot_beta%pw)
             DEALLOCATE (pot_beta)
          END IF
 

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -1310,7 +1310,7 @@ CONTAINS
          lri(ikind)%v_int = 0.0_dp
       END DO
 
-      CALL integrate_v_rspace_one_center(rho_r, qs_env, lri, &
+      CALL integrate_v_rspace_one_center(rho_r%pw, qs_env, lri, &
                                          .FALSE., "RI_AUX")
       DO ikind = 1, SIZE(lri)
          CALL mp_sum(lri(ikind)%v_int, para_env%group)
@@ -1332,7 +1332,7 @@ CONTAINS
             lri(ikind)%v_int = 0.0_dp
          END DO
 
-         CALL integrate_v_rspace_one_center(rho_spin, qs_env, lri, &
+         CALL integrate_v_rspace_one_center(rho_spin%pw, qs_env, lri, &
                                             .FALSE., "RI_AUX")
          DO ikind = 1, SIZE(lri)
             CALL mp_sum(lri(ikind)%v_int, para_env%group)

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -239,7 +239,7 @@ CONTAINS
       ! Create embedding potential and set to zero
       NULLIFY (embed_pot)
       ALLOCATE (embed_pot)
-      NULLIFY (embed_pot%pw)
+      ALLOCATE (embed_pot%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -249,7 +249,7 @@ CONTAINS
       IF (open_shell_embed) THEN
          NULLIFY (spin_embed_pot)
          ALLOCATE (spin_embed_pot)
-         NULLIFY (spin_embed_pot%pw)
+         ALLOCATE (spin_embed_pot%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -260,7 +260,7 @@ CONTAINS
       IF (Coulomb_guess) THEN
          NULLIFY (pot_diff)
          ALLOCATE (pot_diff)
-         NULLIFY (pot_diff%pw)
+         ALLOCATE (pot_diff%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, pot_diff%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -272,8 +272,7 @@ CONTAINS
          ! Now the constant potential is the Coulomb one
          NULLIFY (const_pot)
          ALLOCATE (const_pot)
-         NULLIFY (const_pot%pw)
-
+         ALLOCATE (const_pot%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, const_pot%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -401,26 +400,6 @@ CONTAINS
          ! Release blacs environment
          CALL cp_blacs_env_release(blacs_env)
 
-         ! ELSE ! Grid-based optimization
-         !my_spins = 1
-         !IF (opt_embed%open_shell_embed) my_spins = 2
-         !CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
-         !CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         !NULLIFY (opt_embed%prev_grid_grad, opt_embed%prev_grid_pot)
-         !ALLOCATE (opt_embed%prev_grid_grad(my_spins))
-         !ALLOCATE (opt_embed%prev_grid_pot(my_spins))
-         !DO i_spin = 1, my_spins
-         !   ALLOCATE (opt_embed%prev_grid_grad(i_spin))
-         !   CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_grid_grad(i_spin)%pw, &
-         !                          use_data=REALDATA3D, &
-         !                          in_space=REALSPACE)
-         !   CALL pw_zero(opt_embed%prev_grid_grad(i_spin)%pw)
-         !   ALLOCATE (opt_embed%prev_grid_pot(i_spin))
-         !   CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_grid_pot(i_spin)%pw, &
-         !                          use_data=REALDATA3D, &
-         !                          in_space=REALSPACE)
-         !   CALL pw_zero(opt_embed%prev_grid_pot(i_spin)%pw)
-         !ENDDO
       END IF
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
@@ -429,6 +408,7 @@ CONTAINS
       size_prev_dens = SUM(opt_embed%all_nspins(1:(SIZE(opt_embed%all_nspins) - 1)))
       ALLOCATE (opt_embed%prev_subsys_dens(size_prev_dens))
       DO i_dens = 1, size_prev_dens
+         ALLOCATE (opt_embed%prev_subsys_dens(i_dens)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_subsys_dens(i_dens)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -451,7 +431,7 @@ CONTAINS
       IF (opt_embed%fab) THEN
          NULLIFY (opt_embed%prev_embed_pot)
          ALLOCATE (opt_embed%prev_embed_pot)
-         NULLIFY (opt_embed%prev_embed_pot%pw)
+         ALLOCATE (opt_embed%prev_embed_pot%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_embed_pot%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -459,7 +439,7 @@ CONTAINS
          IF (opt_embed%open_shell_embed) THEN
             NULLIFY (opt_embed%prev_spin_embed_pot)
             ALLOCATE (opt_embed%prev_spin_embed_pot)
-            NULLIFY (opt_embed%prev_spin_embed_pot%pw)
+            ALLOCATE (opt_embed%prev_spin_embed_pot%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_spin_embed_pot%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -690,16 +670,14 @@ CONTAINS
       !CALL get_qs_env(qs_env=qs_env, &
       !                embed_pot=embed_pot)
       ALLOCATE (embed_pot)
-      NULLIFY (embed_pot%pw)
+      ALLOCATE (embed_pot%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
       IF (open_shell_embed) THEN
          ! Create spin embedding potential
-         !  CALL get_qs_env(qs_env=qs_env, &
-         !               spin_embed_pot=spin_embed_pot)
          ALLOCATE (spin_embed_pot)
-         NULLIFY (spin_embed_pot%pw)
+         ALLOCATE (spin_embed_pot%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -1038,6 +1016,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
+      ALLOCATE (v_resp_gspace%pw, v_resp_rspace%pw, rho_resp%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              v_resp_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -1115,7 +1094,7 @@ CONTAINS
       ! Create embedding potential and set to zero
       NULLIFY (embed_pot_subsys)
       ALLOCATE (embed_pot_subsys)
-      NULLIFY (embed_pot_subsys%pw)
+      ALLOCATE (embed_pot_subsys%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot_subsys%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -1126,7 +1105,7 @@ CONTAINS
       IF (open_shell_embed) THEN
          NULLIFY (spin_embed_pot_subsys)
          ALLOCATE (spin_embed_pot_subsys)
-         NULLIFY (spin_embed_pot_subsys%pw)
+         ALLOCATE (spin_embed_pot_subsys%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot_subsys%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -1457,21 +1436,25 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
       NULLIFY (potential_g)
+      ALLOCATE (potential_g)
       CALL pw_pool_create_pw(auxbas_pw_pool, potential_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       NULLIFY (dr2_pot)
+      ALLOCATE (dr2_pot)
       CALL pw_pool_create_pw(auxbas_pw_pool, dr2_pot, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       NULLIFY (grid_reg)
+      ALLOCATE (grid_reg)
       CALL pw_pool_create_pw(auxbas_pw_pool, grid_reg, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       NULLIFY (grid_reg_g)
+      ALLOCATE (grid_reg_g)
       CALL pw_pool_create_pw(auxbas_pw_pool, grid_reg_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -1495,17 +1478,18 @@ CONTAINS
       ! Second, the contribution to the functional
       !
       DO i = 1, 3
-         NULLIFY (dpot(i)%pw)
+         ALLOCATE (dpot(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, dpot(i)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         NULLIFY (dpot_g(i)%pw)
+         ALLOCATE (dpot_g(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, dpot_g(i)%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
 
       NULLIFY (square_norm_dpot)
+      ALLOCATE (square_norm_dpot)
       CALL pw_pool_create_pw(auxbas_pw_pool, square_norm_dpot, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -1840,12 +1824,12 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
       ! get some of the grids ready
-      NULLIFY (rho_g%pw)
+      ALLOCATE (rho_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      NULLIFY (psi_L%pw)
+      ALLOCATE (psi_L%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, psi_L%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -2594,7 +2578,7 @@ CONTAINS
       NULLIFY (new_embed_pot)
       ALLOCATE (new_embed_pot(nspins))
       DO i_spin = 1, nspins
-         NULLIFY (new_embed_pot(i_spin)%pw)
+         ALLOCATE (new_embed_pot(i_spin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, new_embed_pot(i_spin)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -2631,12 +2615,12 @@ CONTAINS
          NULLIFY (temp_embed_pot)
          ALLOCATE (temp_embed_pot(nspins))
          DO i_spin = 1, nspins
-            NULLIFY (rho_n_1(i_spin)%pw)
+            ALLOCATE (rho_n_1(i_spin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_n_1(i_spin)%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
             CALL pw_zero(rho_n_1(i_spin)%pw)
-            NULLIFY (temp_embed_pot(i_spin)%pw)
+            ALLOCATE (temp_embed_pot(i_spin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, temp_embed_pot(i_spin)%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -2790,7 +2774,7 @@ CONTAINS
          NULLIFY (v_w_ref)
          ALLOCATE (v_w_ref(nspins))
          DO i_spin = 1, nspins
-            NULLIFY (v_w_ref(i_spin)%pw)
+            ALLOCATE (v_w_ref(i_spin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, v_w_ref(i_spin)%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -2817,19 +2801,19 @@ CONTAINS
          NULLIFY (curr_rho)
          ALLOCATE (curr_rho(nspins))
          DO i_spin = 1, nspins
-            NULLIFY (new_embed_pot(i_spin)%pw)
+            ALLOCATE (new_embed_pot(i_spin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, new_embed_pot(i_spin)%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
             CALL pw_zero(new_embed_pot(i_spin)%pw)
 
-            NULLIFY (v_w(i_spin)%pw)
+            ALLOCATE (v_w(i_spin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, v_w(i_spin)%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
             CALL pw_zero(v_w(i_spin)%pw)
 
-            NULLIFY (curr_rho(i_spin)%pw)
+            ALLOCATE (curr_rho(i_spin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, curr_rho(i_spin)%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -2877,7 +2861,7 @@ CONTAINS
             NULLIFY (temp_embed_pot)
             ALLOCATE (temp_embed_pot(nspins))
             DO i_spin = 1, nspins
-               NULLIFY (temp_embed_pot(i_spin)%pw)
+               ALLOCATE (temp_embed_pot(i_spin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, temp_embed_pot(i_spin)%pw, &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
@@ -2987,7 +2971,7 @@ CONTAINS
       NULLIFY (rho_g)
       ALLOCATE (rho_g(nspins))
       DO i_spin = 1, nspins
-         NULLIFY (rho_g(i_spin)%pw)
+         ALLOCATE (rho_g(i_spin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(i_spin)%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
@@ -3393,7 +3377,7 @@ CONTAINS
          ! Create embedding potential and set to zero
          NULLIFY (pot_alpha)
          ALLOCATE (pot_alpha)
-         NULLIFY (pot_alpha%pw)
+         ALLOCATE (pot_alpha%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, pot_alpha%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -3404,7 +3388,7 @@ CONTAINS
          IF (open_shell_embed) THEN
             NULLIFY (pot_beta)
             ALLOCATE (pot_beta)
-            NULLIFY (pot_beta%pw)
+            ALLOCATE (pot_beta%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, pot_beta%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)

--- a/src/pme.F
+++ b/src/pme.F
@@ -161,6 +161,7 @@ CONTAINS
                                         allocate_centre=.TRUE.)
       END IF
 
+      ALLOCATE (rhos1%pw, rhos2%pw)
       CALL pw_pool_create_pw(pw_small_pool, rhos1%pw, &
                              use_data=REALDATA3D)
       CALL pw_pool_create_pw(pw_small_pool, rhos2%pw, &
@@ -235,6 +236,7 @@ CONTAINS
          END DO
       END IF
 
+      ALLOCATE (rhob_r)
       CALL pw_pool_create_pw(pw_big_pool, rhob_r, use_data=REALDATA3D, in_space=REALSPACE)
       CALL rs_pw_transfer(rden, rhob_r, rs2pw)
 
@@ -242,11 +244,13 @@ CONTAINS
 
       ! allocate intermediate arrays
       DO i = 1, 3
-         NULLIFY (dphi_g(i)%pw)
+         ALLOCATE (dphi_g(i)%pw)
          CALL pw_pool_create_pw(pw_big_pool, dphi_g(i)%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
+      NULLIFY (phi_r)
+      ALLOCATE (phi_r)
       CALL pw_pool_create_pw(pw_big_pool, phi_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -289,6 +293,8 @@ CONTAINS
             END IF
          END DO
          IF (atprop%stress) THEN
+            NULLIFY (phi_g, rhob_g)
+            ALLOCATE (phi_g, rhob_g)
             CALL pw_pool_create_pw(pw_big_pool, phi_g, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)

--- a/src/pme.F
+++ b/src/pme.F
@@ -203,21 +203,21 @@ CONTAINS
 
             ! add boxes to real space grid (big box)
             IF (is1_core) THEN
-               CALL dg_sum_patch(rden, rhos1, exp_igr%core_centre(:, particle_set(p1)%shell_index))
+               CALL dg_sum_patch(rden, rhos1%pw, exp_igr%core_centre(:, particle_set(p1)%shell_index))
             ELSE
-               CALL dg_sum_patch(rden, rhos1, exp_igr%centre(:, p1))
+               CALL dg_sum_patch(rden, rhos1%pw, exp_igr%centre(:, p1))
             END IF
             IF (p2 /= 0 .AND. is2_core) THEN
-               CALL dg_sum_patch(rden, rhos2, exp_igr%core_centre(:, particle_set(p2)%shell_index))
+               CALL dg_sum_patch(rden, rhos2%pw, exp_igr%core_centre(:, particle_set(p2)%shell_index))
             ELSE IF (p2 /= 0) THEN
-               CALL dg_sum_patch(rden, rhos2, exp_igr%centre(:, p2))
+               CALL dg_sum_patch(rden, rhos2%pw, exp_igr%centre(:, p2))
             END IF
          ELSE
             CALL get_patch(dg, particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                            rhos1, rhos2, charges=charges)
             ! add boxes to real space grid (big box)
-            CALL dg_sum_patch(rden, rhos1, exp_igr%centre(:, p1))
-            IF (p2 /= 0) CALL dg_sum_patch(rden, rhos2, exp_igr%centre(:, p2))
+            CALL dg_sum_patch(rden, rhos1%pw, exp_igr%centre(:, p1))
+            IF (p2 /= 0) CALL dg_sum_patch(rden, rhos2%pw, exp_igr%centre(:, p2))
          END IF
 
       END DO
@@ -231,8 +231,8 @@ CONTAINS
             CALL get_patch(dg, shell_particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                            rhos1, rhos2, is1_shell=.TRUE., is2_shell=.TRUE., charges=charges)
             ! add boxes to real space grid (big box)
-            CALL dg_sum_patch(rpot, rhos1, exp_igr%shell_centre(:, p1))
-            IF (p2 /= 0) CALL dg_sum_patch(rpot, rhos2, exp_igr%shell_centre(:, p2))
+            CALL dg_sum_patch(rpot, rhos1%pw, exp_igr%shell_centre(:, p1))
+            IF (p2 /= 0) CALL dg_sum_patch(rpot, rhos2%pw, exp_igr%shell_centre(:, p2))
          END DO
       END IF
 
@@ -271,7 +271,7 @@ CONTAINS
             CALL get_patch(dg, particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                            rhos1, rhos2, charges=charges)
             ! add boxes to real space grid (big box)
-            CALL dg_sum_patch_force_1d(rpot, rhos1, exp_igr%centre(:, p1), fat1)
+            CALL dg_sum_patch_force_1d(rpot, rhos1%pw, exp_igr%centre(:, p1), fat1)
             IF (atprop%energy) THEN
                atprop%atener(p1) = atprop%atener(p1) + 0.5_dp*fat1*dvols
             END IF
@@ -281,7 +281,7 @@ CONTAINS
                atprop%atstress(3, 3, p1) = atprop%atstress(3, 3, p1) + 0.5_dp*fat1*dvols
             END IF
             IF (p2 /= 0) THEN
-               CALL dg_sum_patch_force_1d(rpot, rhos2, exp_igr%centre(:, p2), fat1)
+               CALL dg_sum_patch_force_1d(rpot, rhos2%pw, exp_igr%centre(:, p2), fat1)
                IF (atprop%energy) THEN
                   atprop%atener(p2) = atprop%atener(p2) + 0.5_dp*fat1*dvols
                END IF
@@ -326,11 +326,11 @@ CONTAINS
                      CALL get_patch(dg, particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                                     rhos1, rhos2, charges=charges)
                      ! add boxes to real space grid (big box)
-                     CALL dg_sum_patch_force_1d(rpot, rhos1, exp_igr%centre(:, p1), fat1)
+                     CALL dg_sum_patch_force_1d(rpot, rhos1%pw, exp_igr%centre(:, p1), fat1)
                      atprop%atstress(i, j, p1) = atprop%atstress(i, j, p1) + fat1*dvols
                      IF (i /= j) atprop%atstress(j, i, p1) = atprop%atstress(j, i, p1) + fat1*dvols
                      IF (p2 /= 0) THEN
-                        CALL dg_sum_patch_force_1d(rpot, rhos2, exp_igr%centre(:, p2), fat1)
+                        CALL dg_sum_patch_force_1d(rpot, rhos2%pw, exp_igr%centre(:, p2), fat1)
                         atprop%atstress(i, j, p2) = atprop%atstress(i, j, p2) + fat1*dvols
                         IF (i /= j) atprop%atstress(j, i, p2) = atprop%atstress(j, i, p2) + fat1*dvols
                      END IF
@@ -406,7 +406,7 @@ CONTAINS
 
             ! sum boxes on real space grids (big box)
             IF (is1_core) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos1, &
+               CALL dg_sum_patch_force_3d(drpot, rhos1%pw, &
                                           exp_igr%core_centre(:, particle_set(p1)%shell_index), fat)
                fgcore_coulomb(1, particle_set(p1)%shell_index) = &
                   fgcore_coulomb(1, particle_set(p1)%shell_index) - fat(1)*dvols
@@ -415,13 +415,13 @@ CONTAINS
                fgcore_coulomb(3, particle_set(p1)%shell_index) = &
                   fgcore_coulomb(3, particle_set(p1)%shell_index) - fat(3)*dvols
             ELSE
-               CALL dg_sum_patch_force_3d(drpot, rhos1, exp_igr%centre(:, p1), fat)
+               CALL dg_sum_patch_force_3d(drpot, rhos1%pw, exp_igr%centre(:, p1), fat)
                fg_coulomb(1, p1) = fg_coulomb(1, p1) - fat(1)*dvols
                fg_coulomb(2, p1) = fg_coulomb(2, p1) - fat(2)*dvols
                fg_coulomb(3, p1) = fg_coulomb(3, p1) - fat(3)*dvols
             END IF
             IF (p2 /= 0 .AND. is2_core) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos1, &
+               CALL dg_sum_patch_force_3d(drpot, rhos1%pw, &
                                           exp_igr%core_centre(:, particle_set(p2)%shell_index), fat)
                fgcore_coulomb(1, particle_set(p2)%shell_index) = &
                   fgcore_coulomb(1, particle_set(p2)%shell_index) - fat(1)*dvols
@@ -430,7 +430,7 @@ CONTAINS
                fgcore_coulomb(3, particle_set(p2)%shell_index) = &
                   fgcore_coulomb(3, particle_set(p2)%shell_index) - fat(3)*dvols
             ELSEIF (p2 /= 0) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos2, exp_igr%centre(:, p2), fat)
+               CALL dg_sum_patch_force_3d(drpot, rhos2%pw, exp_igr%centre(:, p2), fat)
                fg_coulomb(1, p2) = fg_coulomb(1, p2) - fat(1)*dvols
                fg_coulomb(2, p2) = fg_coulomb(2, p2) - fat(2)*dvols
                fg_coulomb(3, p2) = fg_coulomb(3, p2) - fat(3)*dvols
@@ -453,12 +453,12 @@ CONTAINS
                                  is1_shell=.TRUE., is2_shell=.TRUE., charges=charges)
 
             ! sum boxes on real space grids (big box)
-            CALL dg_sum_patch_force_3d(drpot, rhos1, exp_igr%shell_centre(:, p1), fat)
+            CALL dg_sum_patch_force_3d(drpot, rhos1%pw, exp_igr%shell_centre(:, p1), fat)
             fgshell_coulomb(1, p1) = fgshell_coulomb(1, p1) - fat(1)*dvols
             fgshell_coulomb(2, p1) = fgshell_coulomb(2, p1) - fat(2)*dvols
             fgshell_coulomb(3, p1) = fgshell_coulomb(3, p1) - fat(3)*dvols
             IF (p2 /= 0) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos2, exp_igr%shell_centre(:, p2), fat)
+               CALL dg_sum_patch_force_3d(drpot, rhos2%pw, exp_igr%shell_centre(:, p2), fat)
                fgshell_coulomb(1, p2) = fgshell_coulomb(1, p2) - fat(1)*dvols
                fgshell_coulomb(2, p2) = fgshell_coulomb(2, p2) - fat(2)*dvols
                fgshell_coulomb(3, p2) = fgshell_coulomb(3, p2) - fat(3)*dvols
@@ -633,9 +633,9 @@ CONTAINS
       END IF
 
       IF (p2 == 0) THEN
-         CALL dg_get_patch(rho0, rhos1, q1, ex1, ey1, ez1)
+         CALL dg_get_patch(rho0%pw, rhos1%pw, q1, ex1, ey1, ez1)
       ELSE
-         CALL dg_get_patch(rho0, rhos1, rhos2, q1, q2, ex1, ey1, ez1, ex2, ey2, ez2)
+         CALL dg_get_patch(rho0%pw, rhos1%pw, rhos2%pw, q1, q2, ex1, ey1, ez1, ex2, ey2, ez2)
       END IF
 
    END SUBROUTINE get_patch
@@ -743,9 +743,9 @@ CONTAINS
       END IF
 
       IF (p2 == 0) THEN
-         CALL dg_get_patch(rho0, rhos1, q1, ex1, ey1, ez1)
+         CALL dg_get_patch(rho0%pw, rhos1%pw, q1, ex1, ey1, ez1)
       ELSE
-         CALL dg_get_patch(rho0, rhos1, rhos2, q1, q2, &
+         CALL dg_get_patch(rho0%pw, rhos1%pw, rhos2%pw, q1, q2, &
                            ex1, ey1, ez1, ex2, ey2, ez2)
       END IF
 

--- a/src/pme.F
+++ b/src/pme.F
@@ -339,11 +339,13 @@ CONTAINS
             END DO
             CALL pw_pool_give_back_pw(pw_big_pool, phi_g)
             CALL pw_pool_give_back_pw(pw_big_pool, rhob_g)
+            DEALLOCATE (phi_g, rhob_g)
          END IF
          CALL rs_grid_release(rpot)
       END IF
 
       CALL pw_pool_give_back_pw(pw_big_pool, phi_r)
+      DEALLOCATE (phi_r)
 
       !---------- END OF ELECTROSTATIC CALCULATION --------
 
@@ -369,10 +371,12 @@ CONTAINS
          CALL rs_grid_set_box(grid_b, rs=drpot(i)%rs_grid)
          CALL pw_transfer(dphi_g(i)%pw, rhob_r)
          CALL pw_pool_give_back_pw(pw_big_pool, dphi_g(i)%pw)
+         DEALLOCATE (dphi_g(i)%pw)
          CALL rs_pw_transfer(drpot(i)%rs_grid, rhob_r, pw2rs)
       END DO
 
       CALL pw_pool_give_back_pw(pw_big_pool, rhob_r)
+      DEALLOCATE (rhob_r)
 
       !----------------- FORCE CALCULATION ----------------
 
@@ -476,6 +480,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(pw_small_pool, rhos1%pw)
       CALL pw_pool_give_back_pw(pw_small_pool, rhos2%pw)
+      DEALLOCATE (rhos1%pw, rhos2%pw)
       CALL structure_factor_deallocate(exp_igr)
 
       CALL timestop(handle)

--- a/src/pw/dct.F
+++ b/src/pw/dct.F
@@ -526,8 +526,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :), INTENT(IN), POINTER   :: recv_msgs_bnds
       INTEGER, DIMENSION(:), INTENT(IN), POINTER         :: dests_expand, srcs_expand, flipg_stat
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds_shftd
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw_in
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw_expanded
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_expanded
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'pw_expand'
 
@@ -711,8 +710,7 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN), POINTER         :: dests_shrink
       INTEGER, INTENT(IN)                                :: srcs_shrink
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds_local_shftd
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw_in
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw_shrinked
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_shrinked
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'pw_shrink'
 
@@ -1215,16 +1213,12 @@ CONTAINS
 !>       07.2014 created [Hossein Bani-Hashemian]
 !> \author Mohammad Hossein Bani-Hashemian
 ! **************************************************************************************************
-   FUNCTION flipud_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
+   PURE FUNCTION flipud_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
 
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bndsl_in, bounds
       INTEGER, DIMENSION(2, 3)                           :: bndsl_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'flipud_bounds_local'
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
 
       bndsl_out(1, 1) = 2*(bounds(2, 1) + 1) - bndsl_in(2, 1)
       bndsl_out(2, 1) = 2*(bounds(2, 1) + 1) - bndsl_in(1, 1)
@@ -1236,8 +1230,6 @@ CONTAINS
 
       bndsl_out(1, 3) = bndsl_in(1, 3)
       bndsl_out(2, 3) = bndsl_in(2, 3)
-
-      CALL timestop(handle)
 
    END FUNCTION flipud_bounds_local
 
@@ -1250,16 +1242,12 @@ CONTAINS
 !>       07.2014 created [Hossein Bani-Hashemian]
 !> \author Mohammad Hossein Bani-Hashemian
 ! **************************************************************************************************
-   FUNCTION fliplr_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
+   PURE FUNCTION fliplr_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
 
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bndsl_in, bounds
       INTEGER, DIMENSION(2, 3)                           :: bndsl_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fliplr_bounds_local'
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
 
       bndsl_out(1, 1) = bndsl_in(1, 1)
       bndsl_out(2, 1) = bndsl_in(2, 1)
@@ -1272,8 +1260,6 @@ CONTAINS
       bndsl_out(1, 3) = bndsl_in(1, 3)
       bndsl_out(2, 3) = bndsl_in(2, 3)
 
-      CALL timestop(handle)
-
    END FUNCTION fliplr_bounds_local
 
 ! **************************************************************************************************
@@ -1285,16 +1271,12 @@ CONTAINS
 !>       07.2014 created [Hossein Bani-Hashemian]
 !> \author Mohammad Hossein Bani-Hashemian
 ! **************************************************************************************************
-   FUNCTION flipbf_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
+   PURE FUNCTION flipbf_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
 
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bndsl_in, bounds
       INTEGER, DIMENSION(2, 3)                           :: bndsl_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'flipbf_bounds_local'
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
 
       bndsl_out(1, 1) = bndsl_in(1, 1)
       bndsl_out(2, 1) = bndsl_in(2, 1)
@@ -1307,8 +1289,6 @@ CONTAINS
       IF (bndsl_out(1, 3) .EQ. bounds(2, 3) + 2) bndsl_out(1, 3) = bndsl_out(1, 3) - 1
       IF (bndsl_out(2, 3) .EQ. 2*(bounds(2, 3) + 1) - bounds(1, 3)) bndsl_out(2, 3) = bndsl_out(2, 3) - 1
 
-      CALL timestop(handle)
-
    END FUNCTION flipbf_bounds_local
 
 ! **************************************************************************************************
@@ -1320,16 +1300,12 @@ CONTAINS
 !>       07.2014 created [Hossein Bani-Hashemian]
 !> \author Mohammad Hossein Bani-Hashemian
 ! **************************************************************************************************
-   FUNCTION rot180_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
+   PURE FUNCTION rot180_bounds_local(bndsl_in, bounds) RESULT(bndsl_out)
 
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bndsl_in, bounds
       INTEGER, DIMENSION(2, 3)                           :: bndsl_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rot180_bounds_local'
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
 
       bndsl_out(1, 1) = 2*(bounds(2, 1) + 1) - bndsl_in(2, 1)
       bndsl_out(2, 1) = 2*(bounds(2, 1) + 1) - bndsl_in(1, 1)
@@ -1343,8 +1319,6 @@ CONTAINS
 
       bndsl_out(1, 3) = bndsl_in(1, 3)
       bndsl_out(2, 3) = bndsl_in(2, 3)
-
-      CALL timestop(handle)
 
    END FUNCTION rot180_bounds_local
 

--- a/src/pw/dg_rho0_types.F
+++ b/src/pw/dg_rho0_types.F
@@ -21,7 +21,8 @@ MODULE dg_rho0_types
    USE pw_types,                        ONLY: REALDATA3D,&
                                               pw_create,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -204,11 +205,11 @@ CONTAINS
       CASE (do_ewald_ewald)
          ALLOCATE (dg_rho0%density%pw)
          CALL pw_create(dg_rho0%density%pw, pw_grid, REALDATA3D)
-         CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
+         CALL dg_rho0_pme_gauss(dg_rho0%density%pw, dg_rho0%zet(1))
       CASE (do_ewald_pme)
          ALLOCATE (dg_rho0%density%pw)
          CALL pw_create(dg_rho0%density%pw, pw_grid, REALDATA3D)
-         CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
+         CALL dg_rho0_pme_gauss(dg_rho0%density%pw, dg_rho0%zet(1))
       CASE (do_ewald_spme)
          CPABORT('SPME type not implemented')
       END SELECT
@@ -222,7 +223,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dg_rho0_pme_gauss(dg_rho0, alpha)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: dg_rho0
+      TYPE(pw_type), INTENT(INOUT)                       :: dg_rho0
       REAL(KIND=dp), INTENT(IN)                          :: alpha
 
       INTEGER, PARAMETER                                 :: IMPOSSIBLE = 10000
@@ -236,7 +237,7 @@ CONTAINS
 
       const = 1.0_dp/(8.0_dp*alpha**2)
 
-      pw_grid => dg_rho0%pw%pw_grid
+      pw_grid => dg_rho0%pw_grid
       bds => pw_grid%bounds
 
       IF (-bds(1, 1) == bds(2, 1)) THEN
@@ -257,9 +258,9 @@ CONTAINS
          n0 = bds(1, 3)
       END IF
 
-      CALL pw_zero(dg_rho0%pw)
+      CALL pw_zero(dg_rho0)
 
-      rho0 => dg_rho0%pw%cr3d
+      rho0 => dg_rho0%cr3d
 
       DO gpt = 1, pw_grid%ngpts_cut_local
          ghat => pw_grid%g_hat(:, gpt)

--- a/src/pw/dg_rho0_types.F
+++ b/src/pw/dg_rho0_types.F
@@ -176,6 +176,7 @@ CONTAINS
                DEALLOCATE (dg_rho0%zet)
             END IF
             CALL pw_release(dg_rho0%density%pw)
+            DEALLOCATE (dg_rho0%density%pw)
             NULLIFY (dg_rho0%gcc)
             NULLIFY (dg_rho0%zet)
             DEALLOCATE (dg_rho0)
@@ -194,6 +195,7 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
       CALL pw_release(dg_rho0%density%pw)
+      DEALLOCATE (dg_rho0%density%pw)
       SELECT CASE (dg_rho0%type)
       CASE (do_ewald_ewald)
          CALL pw_create(dg_rho0%density%pw, pw_grid, REALDATA3D)

--- a/src/pw/dg_rho0_types.F
+++ b/src/pw/dg_rho0_types.F
@@ -175,8 +175,10 @@ CONTAINS
             IF (ASSOCIATED(dg_rho0%zet)) THEN
                DEALLOCATE (dg_rho0%zet)
             END IF
-            CALL pw_release(dg_rho0%density%pw)
-            DEALLOCATE (dg_rho0%density%pw)
+            IF (ASSOCIATED(dg_rho0%density%pw)) THEN
+               CALL pw_release(dg_rho0%density%pw)
+               DEALLOCATE (dg_rho0%density%pw)
+            END IF
             NULLIFY (dg_rho0%gcc)
             NULLIFY (dg_rho0%zet)
             DEALLOCATE (dg_rho0)
@@ -194,13 +196,17 @@ CONTAINS
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
-      CALL pw_release(dg_rho0%density%pw)
-      DEALLOCATE (dg_rho0%density%pw)
+      IF (ASSOCIATED(dg_rho0%density%pw)) THEN
+         CALL pw_release(dg_rho0%density%pw)
+         DEALLOCATE (dg_rho0%density%pw)
+      END IF
       SELECT CASE (dg_rho0%type)
       CASE (do_ewald_ewald)
+         ALLOCATE (dg_rho0%density%pw)
          CALL pw_create(dg_rho0%density%pw, pw_grid, REALDATA3D)
          CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_pme)
+         ALLOCATE (dg_rho0%density%pw)
          CALL pw_create(dg_rho0%density%pw, pw_grid, REALDATA3D)
          CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_spme)

--- a/src/pw/dgs.F
+++ b/src/pw/dgs.F
@@ -32,7 +32,7 @@ MODULE dgs
                                               pw_grid_setup
    USE pw_types,                        ONLY: COMPLEXDATA3D,&
                                               REALDATA3D,&
-                                              pw_p_type
+                                              pw_type
    USE realspace_grid_types,            ONLY: realspace_grid_p_type,&
                                               realspace_grid_type
    USE structure_factors,               ONLY: structure_factor_evaluate
@@ -135,7 +135,7 @@ CONTAINS
 !> \par History 01.2014 copied from cell_types::get_cell()
 !> \author Ole Schuett
 ! **************************************************************************************************
-   FUNCTION get_cell_lengths(cell_hmat) RESULT(abc)
+   PURE FUNCTION get_cell_lengths(cell_hmat) RESULT(abc)
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: cell_hmat
       REAL(KIND=dp), DIMENSION(3)                        :: abc
 
@@ -284,7 +284,7 @@ CONTAINS
 !> \param cell_hmat ...
 !> \param unit_cell_hmat ...
 ! **************************************************************************************************
-   SUBROUTINE dg_find_basis(npts, cell_hmat, unit_cell_hmat)
+   PURE SUBROUTINE dg_find_basis(npts, cell_hmat, unit_cell_hmat)
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: cell_hmat
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: unit_cell_hmat
@@ -305,7 +305,7 @@ CONTAINS
 !> \param unit_cell_hmat ...
 !> \param cell_hmat ...
 ! **************************************************************************************************
-   SUBROUTINE dg_set_cell(npts, unit_cell_hmat, cell_hmat)
+   PURE SUBROUTINE dg_set_cell(npts, unit_cell_hmat, cell_hmat)
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: unit_cell_hmat
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: cell_hmat
@@ -402,10 +402,10 @@ CONTAINS
 !> \param rhos ...
 !> \param center ...
 ! **************************************************************************************************
-   SUBROUTINE dg_sum_patch_coef(rs, rhos, center)
+   PURE SUBROUTINE dg_sum_patch_coef(rs, rhos, center)
 
       TYPE(realspace_grid_type), POINTER                 :: rs
-      TYPE(pw_p_type), INTENT(IN)                        :: rhos
+      TYPE(pw_type), INTENT(IN)                          :: rhos
       INTEGER, DIMENSION(3), INTENT(IN)                  :: center
 
       INTEGER                                            :: i, ia, ii
@@ -414,8 +414,8 @@ CONTAINS
 
       folded = .FALSE.
 
-      DO i = rhos%pw%pw_grid%bounds(1, 1), rhos%pw%pw_grid%bounds(2, 1)
-         ia = i - rhos%pw%pw_grid%bounds(1, 1) + 1
+      DO i = rhos%pw_grid%bounds(1, 1), rhos%pw_grid%bounds(2, 1)
+         ia = i - rhos%pw_grid%bounds(1, 1) + 1
          ii = center(1) + i - rs%lb_local(1)
          IF (ii < 0) THEN
             rs%px(ia) = ii + rs%npts_local(1) + 1
@@ -427,8 +427,8 @@ CONTAINS
             rs%px(ia) = ii + 1
          END IF
       END DO
-      DO i = rhos%pw%pw_grid%bounds(1, 2), rhos%pw%pw_grid%bounds(2, 2)
-         ia = i - rhos%pw%pw_grid%bounds(1, 2) + 1
+      DO i = rhos%pw_grid%bounds(1, 2), rhos%pw_grid%bounds(2, 2)
+         ia = i - rhos%pw_grid%bounds(1, 2) + 1
          ii = center(2) + i - rs%lb_local(2)
          IF (ii < 0) THEN
             rs%py(ia) = ii + rs%npts_local(2) + 1
@@ -440,8 +440,8 @@ CONTAINS
             rs%py(ia) = ii + 1
          END IF
       END DO
-      DO i = rhos%pw%pw_grid%bounds(1, 3), rhos%pw%pw_grid%bounds(2, 3)
-         ia = i - rhos%pw%pw_grid%bounds(1, 3) + 1
+      DO i = rhos%pw_grid%bounds(1, 3), rhos%pw_grid%bounds(2, 3)
+         ia = i - rhos%pw_grid%bounds(1, 3) + 1
          ii = center(3) + i - rs%lb_local(3)
          IF (ii < 0) THEN
             rs%pz(ia) = ii + rs%npts_local(3) + 1
@@ -455,13 +455,13 @@ CONTAINS
       END DO
 
       IF (folded) THEN
-         CALL dg_add_patch(rs%r, rhos%pw%cr3d, rhos%pw%pw_grid%npts, &
+         CALL dg_add_patch(rs%r, rhos%cr3d, rhos%pw_grid%npts, &
                            rs%px, rs%py, rs%pz)
       ELSE
          nc(1) = rs%px(1) - 1
          nc(2) = rs%py(1) - 1
          nc(3) = rs%pz(1) - 1
-         CALL dg_add_patch(rs%r, rhos%pw%cr3d, rhos%pw%pw_grid%npts, nc)
+         CALL dg_add_patch(rs%r, rhos%cr3d, rhos%pw_grid%npts, nc)
       END IF
 
    END SUBROUTINE dg_sum_patch_coef
@@ -472,7 +472,7 @@ CONTAINS
 !> \param rhos ...
 !> \param center ...
 ! **************************************************************************************************
-   SUBROUTINE dg_sum_patch_arr(rs, rhos, center)
+   PURE SUBROUTINE dg_sum_patch_arr(rs, rhos, center)
 
       TYPE(realspace_grid_type), POINTER                 :: rs
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rhos
@@ -547,7 +547,7 @@ CONTAINS
 !> \param center ...
 !> \param force ...
 ! **************************************************************************************************
-   SUBROUTINE dg_sum_patch_force_arr_3d(drpot, rhos, center, force)
+   PURE SUBROUTINE dg_sum_patch_force_arr_3d(drpot, rhos, center, force)
 
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: drpot
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rhos
@@ -626,7 +626,7 @@ CONTAINS
 !> \param center ...
 !> \param force ...
 ! **************************************************************************************************
-   SUBROUTINE dg_sum_patch_force_arr_1d(drpot, rhos, center, force)
+   PURE SUBROUTINE dg_sum_patch_force_arr_1d(drpot, rhos, center, force)
 
       TYPE(realspace_grid_type), POINTER                 :: drpot
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rhos
@@ -703,10 +703,10 @@ CONTAINS
 !> \param center ...
 !> \param force ...
 ! **************************************************************************************************
-   SUBROUTINE dg_sum_patch_force_coef_3d(drpot, rhos, center, force)
+   PURE SUBROUTINE dg_sum_patch_force_coef_3d(drpot, rhos, center, force)
 
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: drpot
-      TYPE(pw_p_type), INTENT(IN)                        :: rhos
+      TYPE(pw_type), INTENT(IN)                          :: rhos
       INTEGER, DIMENSION(3), INTENT(IN)                  :: center
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: force
 
@@ -716,8 +716,8 @@ CONTAINS
 
       folded = .FALSE.
 
-      DO i = rhos%pw%pw_grid%bounds(1, 1), rhos%pw%pw_grid%bounds(2, 1)
-         ia = i - rhos%pw%pw_grid%bounds(1, 1) + 1
+      DO i = rhos%pw_grid%bounds(1, 1), rhos%pw_grid%bounds(2, 1)
+         ia = i - rhos%pw_grid%bounds(1, 1) + 1
          ii = center(1) + i - drpot(1)%rs_grid%lb_local(1)
          IF (ii < 0) THEN
             drpot(1)%rs_grid%px(ia) = ii + drpot(1)%rs_grid%desc%npts(1) + 1
@@ -729,8 +729,8 @@ CONTAINS
             drpot(1)%rs_grid%px(ia) = ii + 1
          END IF
       END DO
-      DO i = rhos%pw%pw_grid%bounds(1, 2), rhos%pw%pw_grid%bounds(2, 2)
-         ia = i - rhos%pw%pw_grid%bounds(1, 2) + 1
+      DO i = rhos%pw_grid%bounds(1, 2), rhos%pw_grid%bounds(2, 2)
+         ia = i - rhos%pw_grid%bounds(1, 2) + 1
          ii = center(2) + i - drpot(1)%rs_grid%lb_local(2)
          IF (ii < 0) THEN
             drpot(1)%rs_grid%py(ia) = ii + drpot(1)%rs_grid%desc%npts(2) + 1
@@ -742,8 +742,8 @@ CONTAINS
             drpot(1)%rs_grid%py(ia) = ii + 1
          END IF
       END DO
-      DO i = rhos%pw%pw_grid%bounds(1, 3), rhos%pw%pw_grid%bounds(2, 3)
-         ia = i - rhos%pw%pw_grid%bounds(1, 3) + 1
+      DO i = rhos%pw_grid%bounds(1, 3), rhos%pw_grid%bounds(2, 3)
+         ia = i - rhos%pw_grid%bounds(1, 3) + 1
          ii = center(3) + i - drpot(1)%rs_grid%lb_local(3)
          IF (ii < 0) THEN
             drpot(1)%rs_grid%pz(ia) = ii + drpot(1)%rs_grid%desc%npts(3) + 1
@@ -758,14 +758,14 @@ CONTAINS
 
       IF (folded) THEN
          CALL dg_int_patch_3d(drpot(1)%rs_grid%r, drpot(2)%rs_grid%r, &
-                              drpot(3)%rs_grid%r, rhos%pw%cr3d, force, rhos%pw%pw_grid%npts, &
+                              drpot(3)%rs_grid%r, rhos%cr3d, force, rhos%pw_grid%npts, &
                               drpot(1)%rs_grid%px, drpot(1)%rs_grid%py, drpot(1)%rs_grid%pz)
       ELSE
          nc(1) = drpot(1)%rs_grid%px(1) - 1
          nc(2) = drpot(1)%rs_grid%py(1) - 1
          nc(3) = drpot(1)%rs_grid%pz(1) - 1
          CALL dg_int_patch_3d(drpot(1)%rs_grid%r, drpot(2)%rs_grid%r, &
-                              drpot(3)%rs_grid%r, rhos%pw%cr3d, force, rhos%pw%pw_grid%npts, nc)
+                              drpot(3)%rs_grid%r, rhos%cr3d, force, rhos%pw_grid%npts, nc)
       END IF
 
    END SUBROUTINE dg_sum_patch_force_coef_3d
@@ -777,10 +777,10 @@ CONTAINS
 !> \param center ...
 !> \param force ...
 ! **************************************************************************************************
-   SUBROUTINE dg_sum_patch_force_coef_1d(drpot, rhos, center, force)
+   PURE SUBROUTINE dg_sum_patch_force_coef_1d(drpot, rhos, center, force)
 
       TYPE(realspace_grid_type), POINTER                 :: drpot
-      TYPE(pw_p_type), INTENT(IN)                        :: rhos
+      TYPE(pw_type), INTENT(IN)                          :: rhos
       INTEGER, DIMENSION(3), INTENT(IN)                  :: center
       REAL(KIND=dp), INTENT(OUT)                         :: force
 
@@ -790,8 +790,8 @@ CONTAINS
 
       folded = .FALSE.
 
-      DO i = rhos%pw%pw_grid%bounds(1, 1), rhos%pw%pw_grid%bounds(2, 1)
-         ia = i - rhos%pw%pw_grid%bounds(1, 1) + 1
+      DO i = rhos%pw_grid%bounds(1, 1), rhos%pw_grid%bounds(2, 1)
+         ia = i - rhos%pw_grid%bounds(1, 1) + 1
          ii = center(1) + i - drpot%lb_local(1)
          IF (ii < 0) THEN
             drpot%px(ia) = ii + drpot%desc%npts(1) + 1
@@ -803,8 +803,8 @@ CONTAINS
             drpot%px(ia) = ii + 1
          END IF
       END DO
-      DO i = rhos%pw%pw_grid%bounds(1, 2), rhos%pw%pw_grid%bounds(2, 2)
-         ia = i - rhos%pw%pw_grid%bounds(1, 2) + 1
+      DO i = rhos%pw_grid%bounds(1, 2), rhos%pw_grid%bounds(2, 2)
+         ia = i - rhos%pw_grid%bounds(1, 2) + 1
          ii = center(2) + i - drpot%lb_local(2)
          IF (ii < 0) THEN
             drpot%py(ia) = ii + drpot%desc%npts(2) + 1
@@ -816,8 +816,8 @@ CONTAINS
             drpot%py(ia) = ii + 1
          END IF
       END DO
-      DO i = rhos%pw%pw_grid%bounds(1, 3), rhos%pw%pw_grid%bounds(2, 3)
-         ia = i - rhos%pw%pw_grid%bounds(1, 3) + 1
+      DO i = rhos%pw_grid%bounds(1, 3), rhos%pw_grid%bounds(2, 3)
+         ia = i - rhos%pw_grid%bounds(1, 3) + 1
          ii = center(3) + i - drpot%lb_local(3)
          IF (ii < 0) THEN
             drpot%pz(ia) = ii + drpot%desc%npts(3) + 1
@@ -831,13 +831,13 @@ CONTAINS
       END DO
 
       IF (folded) THEN
-         CALL dg_int_patch_1d(drpot%r, rhos%pw%cr3d, force, &
-                              rhos%pw%pw_grid%npts, drpot%px, drpot%py, drpot%pz)
+         CALL dg_int_patch_1d(drpot%r, rhos%cr3d, force, &
+                              rhos%pw_grid%npts, drpot%px, drpot%py, drpot%pz)
       ELSE
          nc(1) = drpot%px(1) - 1
          nc(2) = drpot%py(1) - 1
          nc(3) = drpot%pz(1) - 1
-         CALL dg_int_patch_1d(drpot%r, rhos%pw%cr3d, force, rhos%pw%pw_grid%npts, nc)
+         CALL dg_int_patch_1d(drpot%r, rhos%cr3d, force, rhos%pw_grid%npts, nc)
       END IF
 
    END SUBROUTINE dg_sum_patch_force_coef_1d
@@ -853,18 +853,17 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dg_get_patch_1(rho0, rhos1, charge1, ex1, ey1, ez1)
 
-      TYPE(pw_p_type), INTENT(IN)                        :: rho0
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rhos1
+      TYPE(pw_type), INTENT(IN)                          :: rho0
+      TYPE(pw_type), INTENT(INOUT)                       :: rhos1
       REAL(KIND=dp), INTENT(IN)                          :: charge1
       COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: ex1, ey1, ez1
 
       COMPLEX(KIND=dp)                                   :: za, zb
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: zs
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: cd
-      INTEGER                                            :: n, nd(3)
+      INTEGER                                            :: nd(3)
 
-      nd = rhos1%pw%pw_grid%npts
-      n = PRODUCT(nd)
+      nd = rhos1%pw_grid%npts
 
       ALLOCATE (zs(nd(1)*nd(2)))
       zs = 0.0_dp
@@ -874,12 +873,12 @@ CONTAINS
       za = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
       zb = CMPLX(charge1, 0.0_dp, KIND=dp)
       CALL rankup(nd, za, cd, zb, ex1, ey1, ez1, zs)
-      IF (rho0%pw%in_use == REALDATA3D) &
-         CALL vr_x_vc(rho0%pw%cr3d, cd)
-      IF (rho0%pw%in_use == COMPLEXDATA3D) &
-         CALL vc_x_vc(rho0%pw%cc3d, cd)
+      IF (rho0%in_use == REALDATA3D) &
+         CALL vr_x_vc(rho0%cr3d, cd)
+      IF (rho0%in_use == COMPLEXDATA3D) &
+         CALL vc_x_vc(rho0%cc3d, cd)
       CALL fft3d(BWFFT, nd, cd)
-      CALL copy_cr(cd, rhos1%pw%cr3d)
+      CALL copy_cr(cd, rhos1%cr3d)
 
       DEALLOCATE (zs)
       DEALLOCATE (cd)
@@ -903,18 +902,17 @@ CONTAINS
    SUBROUTINE dg_get_patch_2(rho0, rhos1, rhos2, charge1, charge2, &
                              ex1, ey1, ez1, ex2, ey2, ez2)
 
-      TYPE(pw_p_type), INTENT(IN)                        :: rho0
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rhos1, rhos2
+      TYPE(pw_type), INTENT(IN)                          :: rho0
+      TYPE(pw_type), INTENT(INOUT)                       :: rhos1, rhos2
       REAL(KIND=dp), INTENT(IN)                          :: charge1, charge2
       COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: ex1, ey1, ez1, ex2, ey2, ez2
 
       COMPLEX(KIND=dp)                                   :: za, zb
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: zs
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: cd
-      INTEGER                                            :: n, nd(3)
+      INTEGER                                            :: nd(3)
 
-      nd = rhos1%pw%pw_grid%npts
-      n = PRODUCT(nd)
+      nd = rhos1%pw_grid%npts
 
       ALLOCATE (zs(nd(1)*nd(2)))
       zs = 0.0_dp
@@ -927,12 +925,12 @@ CONTAINS
       za = CMPLX(0.0_dp, 1.0_dp, KIND=dp)
       zb = CMPLX(charge1, 0.0_dp, KIND=dp)
       CALL rankup(nd, za, cd, zb, ex1, ey1, ez1, zs)
-      IF (rho0%pw%in_use == REALDATA3D) &
-         CALL vr_x_vc(rho0%pw%cr3d, cd)
-      IF (rho0%pw%in_use == COMPLEXDATA3D) &
-         CALL vc_x_vc(rho0%pw%cc3d, cd)
+      IF (rho0%in_use == REALDATA3D) &
+         CALL vr_x_vc(rho0%cr3d, cd)
+      IF (rho0%in_use == COMPLEXDATA3D) &
+         CALL vc_x_vc(rho0%cc3d, cd)
       CALL fft3d(BWFFT, nd, cd)
-      CALL copy_cri(cd, rhos1%pw%cr3d, rhos2%pw%cr3d)
+      CALL copy_cri(cd, rhos1%cr3d, rhos2%cr3d)
 
       DEALLOCATE (zs)
       DEALLOCATE (cd)
@@ -946,7 +944,7 @@ CONTAINS
 !> \param ns ...
 !> \param nc ...
 ! **************************************************************************************************
-   SUBROUTINE dg_add_patch_simple(rb, rs, ns, nc)
+   PURE SUBROUTINE dg_add_patch_simple(rb, rs, ns, nc)
 
       REAL(KIND=dp), INTENT(INOUT)                       :: rb(:, :, :)
       REAL(KIND=dp), INTENT(IN)                          :: rs(:, :, :)
@@ -976,7 +974,7 @@ CONTAINS
 !> \param py ...
 !> \param pz ...
 ! **************************************************************************************************
-   SUBROUTINE dg_add_patch_folded(rb, rs, ns, px, py, pz)
+   PURE SUBROUTINE dg_add_patch_folded(rb, rs, ns, px, py, pz)
 
       REAL(KIND=dp), INTENT(INOUT)                       :: rb(:, :, :)
       REAL(KIND=dp), INTENT(IN)                          :: rs(:, :, :)
@@ -1008,7 +1006,7 @@ CONTAINS
 !> \param ns ...
 !> \param nc ...
 ! **************************************************************************************************
-   SUBROUTINE dg_int_patch_simple_3d(rbx, rby, rbz, rs, f, ns, nc)
+   PURE SUBROUTINE dg_int_patch_simple_3d(rbx, rby, rbz, rs, f, ns, nc)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rbx, rby, rbz, rs
       REAL(KIND=dp), DIMENSION(3), INTENT(OUT)           :: f
@@ -1042,7 +1040,7 @@ CONTAINS
 !> \param ns ...
 !> \param nc ...
 ! **************************************************************************************************
-   SUBROUTINE dg_int_patch_simple_1d(rb, rs, f, ns, nc)
+   PURE SUBROUTINE dg_int_patch_simple_1d(rb, rs, f, ns, nc)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rb, rs
       REAL(KIND=dp), INTENT(OUT)                         :: f
@@ -1078,7 +1076,7 @@ CONTAINS
 !> \param py ...
 !> \param pz ...
 ! **************************************************************************************************
-   SUBROUTINE dg_int_patch_folded_3d(rbx, rby, rbz, rs, f, ns, px, py, pz)
+   PURE SUBROUTINE dg_int_patch_folded_3d(rbx, rby, rbz, rs, f, ns, px, py, pz)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rbx, rby, rbz, rs
       REAL(KIND=dp), DIMENSION(3), INTENT(INOUT)         :: f
@@ -1115,7 +1113,7 @@ CONTAINS
 !> \param py ...
 !> \param pz ...
 ! **************************************************************************************************
-   SUBROUTINE dg_int_patch_folded_1d(rb, rs, f, ns, px, py, pz)
+   PURE SUBROUTINE dg_int_patch_folded_1d(rb, rs, f, ns, px, py, pz)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: rb, rs
       REAL(KIND=dp), INTENT(INOUT)                       :: f

--- a/src/pw/dielectric_methods.F
+++ b/src/pw/dielectric_methods.F
@@ -35,7 +35,6 @@ MODULE dielectric_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_type
    USE realspace_grid_types,            ONLY: realspace_grid_type
    USE rs_methods,                      ONLY: derive_fdm_cd3,&
@@ -49,7 +48,7 @@ MODULE dielectric_methods
    PRIVATE
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'dielectric_methods'
 
-   PUBLIC dielectric_create, dielectric_compute
+   PUBLIC dielectric_create, dielectric_compute, derive_fft
 
    INTERFACE dielectric_compute
       MODULE PROCEDURE dielectric_compute_periodic, &
@@ -90,10 +89,9 @@ CONTAINS
          dielectric%eps%cr3d = 1.0_dp
          CALL pw_zero(dielectric%deps_drho)
          DO i = 1, 3
-            ALLOCATE (dielectric%dln_eps(i)%pw)
-            CALL pw_pool_create_pw(pw_pool, dielectric%dln_eps(i)%pw, &
+            CALL pw_pool_create_pw(pw_pool, dielectric%dln_eps(i), &
                                    use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_zero(dielectric%dln_eps(i)%pw)
+            CALL pw_zero(dielectric%dln_eps(i))
          END DO
          dielectric%params = dielectric_params
          dielectric%params%times_called = 0
@@ -121,7 +119,7 @@ CONTAINS
       TYPE(dielectric_type), INTENT(INOUT), POINTER      :: dielectric
       TYPE(realspace_grid_type), POINTER                 :: diel_rs_grid
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
-      TYPE(pw_type), INTENT(IN), POINTER                 :: rho
+      TYPE(pw_type), INTENT(IN)                          :: rho
       TYPE(pw_type), INTENT(IN), OPTIONAL                :: rho_core
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dielectric_compute_periodic'
@@ -131,8 +129,8 @@ CONTAINS
                                                             handle, i, idir, j, k, times_called
       INTEGER, DIMENSION(3)                              :: lb, ub
       REAL(dp)                                           :: eps0, rho_max, rho_min
-      TYPE(pw_p_type), DIMENSION(3)                      :: deps, drho
-      TYPE(pw_type), POINTER                             :: ln_eps, rho_core_rs, rho_elec_rs
+      TYPE(pw_type)                                      :: ln_eps, rho_core_rs, rho_elec_rs
+      TYPE(pw_type), DIMENSION(3)                        :: deps, drho
 
       CALL timeset(routineN, handle)
 
@@ -151,8 +149,6 @@ CONTAINS
                        "the dielectric constant function.")
       END IF
 
-      NULLIFY (rho_elec_rs)
-      ALLOCATE (rho_elec_rs)
       CALL pw_pool_create_pw(pw_pool, rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! for evaluating epsilon make sure rho is in the real space
@@ -160,8 +156,6 @@ CONTAINS
 
       IF (PRESENT(rho_core)) THEN
          ! make sure rho_core is in the real space
-         NULLIFY (rho_core_rs)
-         ALLOCATE (rho_core_rs)
          CALL pw_pool_create_pw(pw_pool, rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(rho_core, rho_core_rs)
          IF (dielectric%params%dielec_core_correction) THEN
@@ -172,7 +166,6 @@ CONTAINS
             CALL pw_axpy(rho_core_rs, rho_elec_rs, -1.0_dp)
          END IF
          CALL pw_pool_give_back_pw(pw_pool, rho_core_rs)
-         DEALLOCATE (rho_core_rs)
       ELSE
          CPABORT("For dielectric constant larger than 1, rho_core has to be present.")
       END IF
@@ -197,23 +190,19 @@ CONTAINS
           ((dielec_functiontype .EQ. spatially_dependent) .AND. times_called .EQ. 0)) THEN
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
-            NULLIFY (ln_eps)
-            ALLOCATE (ln_eps)
             CALL pw_pool_create_pw(pw_pool, ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
             ln_eps%cr3d = LOG(dielectric%eps%cr3d)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               ALLOCATE (deps(i)%pw)
-               CALL pw_pool_create_pw(pw_pool, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_zero(deps(i)%pw)
+               CALL pw_pool_create_pw(pw_pool, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_zero(deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               ALLOCATE (deps(i)%pw, drho(i)%pw)
-               CALL pw_pool_create_pw(pw_pool, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(pw_pool, drho(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_zero(deps(i)%pw)
-               CALL pw_zero(drho(i)%pw)
+               CALL pw_pool_create_pw(pw_pool, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_create_pw(pw_pool, drho(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_zero(deps(i))
+               CALL pw_zero(drho(i))
             END DO
          END SELECT
 
@@ -239,43 +228,39 @@ CONTAINS
                   DO j = lb(2), ub(2)
                      DO i = lb(1), ub(1)
                         IF (ABS(dielectric%deps_drho%cr3d(i, j, k)) .LE. small_value) THEN
-                           deps(idir)%pw%cr3d(i, j, k) = 0.0_dp
+                           deps(idir)%cr3d(i, j, k) = 0.0_dp
                         END IF
                      END DO
                   END DO
                END DO
-               dielectric%dln_eps(idir)%pw%cr3d = deps(idir)%pw%cr3d/dielectric%eps%cr3d
+               dielectric%dln_eps(idir)%cr3d = deps(idir)%cr3d/dielectric%eps%cr3d
             END DO
          CASE (derivative_fft_use_drho)
             ! \Nabla \eps = \Nabla \rho \cdot \frac{\partial \eps}{\partial \rho}
             ! \Nabla ln(\eps) = \frac{\Nabla \eps}{\eps}
             CALL derive_fft(rho_elec_rs, drho, pw_pool)
             DO i = 1, 3
-               deps(i)%pw%cr3d = drho(i)%pw%cr3d*dielectric%deps_drho%cr3d
-               dielectric%dln_eps(i)%pw%cr3d = deps(i)%pw%cr3d/dielectric%eps%cr3d
+               deps(i)%cr3d = drho(i)%cr3d*dielectric%deps_drho%cr3d
+               dielectric%dln_eps(i)%cr3d = deps(i)%cr3d/dielectric%eps%cr3d
             END DO
          END SELECT
 
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
             CALL pw_pool_give_back_pw(pw_pool, ln_eps)
-            DEALLOCATE (ln_eps)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, deps(i)%pw)
-               DEALLOCATE (deps(i)%pw)
+               CALL pw_pool_give_back_pw(pw_pool, deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, drho(i)%pw)
-               CALL pw_pool_give_back_pw(pw_pool, deps(i)%pw)
-               DEALLOCATE (drho(i)%pw, deps(i)%pw)
+               CALL pw_pool_give_back_pw(pw_pool, drho(i))
+               CALL pw_pool_give_back_pw(pw_pool, deps(i))
             END DO
          END SELECT
       END IF
 
       CALL pw_pool_give_back_pw(pw_pool, rho_elec_rs)
-      DEALLOCATE (rho_elec_rs)
 
       dielectric%params%times_called = dielectric%params%times_called + 1
 
@@ -315,8 +300,8 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :), INTENT(IN), POINTER   :: recv_msgs_bnds
       INTEGER, DIMENSION(:), INTENT(IN), POINTER         :: dests_expand, srcs_expand, flipg_stat
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds_shftd
-      TYPE(pw_type), INTENT(IN), POINTER                 :: rho
-      TYPE(pw_type), INTENT(IN), OPTIONAL, POINTER       :: rho_core
+      TYPE(pw_type), INTENT(IN)                          :: rho
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: rho_core
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dielectric_compute_neumann'
       REAL(dp), PARAMETER                                :: small_value = EPSILON(1.0_dp)
@@ -325,10 +310,10 @@ CONTAINS
                                                             handle, i, idir, j, k, times_called
       INTEGER, DIMENSION(3)                              :: lb, ub
       REAL(dp)                                           :: eps0, rho_max, rho_min
-      TYPE(pw_p_type), DIMENSION(3)                      :: deps, drho
       TYPE(pw_pool_type), POINTER                        :: pw_pool_xpndd
-      TYPE(pw_type), POINTER                             :: ln_eps, rho_core_rs, rho_core_rs_xpndd, &
+      TYPE(pw_type)                                      :: ln_eps, rho_core_rs, rho_core_rs_xpndd, &
                                                             rho_elec_rs, rho_elec_rs_xpndd
+      TYPE(pw_type), DIMENSION(3)                        :: deps, drho
 
       CALL timeset(routineN, handle)
 
@@ -349,27 +334,19 @@ CONTAINS
 
       CALL pw_pool_create(pw_pool_xpndd, pw_grid=dct_pw_grid)
 
-      NULLIFY (rho_elec_rs)
       ! make sure rho is in the real space
-      ALLOCATE (rho_elec_rs)
       CALL pw_pool_create_pw(pw_pool_orig, rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_transfer(rho, rho_elec_rs)
       ! expand rho_elec
-      NULLIFY (rho_elec_rs_xpndd)
-      ALLOCATE (rho_elec_rs_xpndd)
       CALL pw_pool_create_pw(pw_pool_xpndd, rho_elec_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_expand(neumann_directions, recv_msgs_bnds, dests_expand, srcs_expand, flipg_stat, bounds_shftd, &
                      rho_elec_rs, rho_elec_rs_xpndd)
 
       IF (PRESENT(rho_core)) THEN
          ! make sure rho_core is in the real space
-         NULLIFY (rho_core_rs)
-         ALLOCATE (rho_core_rs)
          CALL pw_pool_create_pw(pw_pool_orig, rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(rho_core, rho_core_rs)
          ! expand rho_core
-         NULLIFY (rho_core_rs_xpndd)
-         ALLOCATE (rho_core_rs_xpndd)
          CALL pw_pool_create_pw(pw_pool_xpndd, rho_core_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_expand(neumann_directions, recv_msgs_bnds, dests_expand, srcs_expand, flipg_stat, bounds_shftd, &
                         rho_core_rs, rho_core_rs_xpndd)
@@ -382,7 +359,6 @@ CONTAINS
          END IF
          CALL pw_pool_give_back_pw(pw_pool_orig, rho_core_rs)
          CALL pw_pool_give_back_pw(pw_pool_xpndd, rho_core_rs_xpndd)
-         DEALLOCATE (rho_core_rs, rho_core_rs_xpndd)
       ELSE
          CPABORT("For dielectric constant larger than 1, rho_core has to be present.")
       END IF
@@ -407,23 +383,19 @@ CONTAINS
           ((dielec_functiontype .EQ. spatially_dependent) .AND. times_called .EQ. 0)) THEN
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
-            NULLIFY (ln_eps)
-            ALLOCATE (ln_eps)
             CALL pw_pool_create_pw(pw_pool_xpndd, ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
             ln_eps%cr3d = LOG(dielectric%eps%cr3d)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               ALLOCATE (deps(i)%pw)
-               CALL pw_pool_create_pw(pw_pool_xpndd, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_zero(deps(i)%pw)
+               CALL pw_pool_create_pw(pw_pool_xpndd, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_zero(deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               ALLOCATE (deps(i)%pw, drho(i)%pw)
-               CALL pw_pool_create_pw(pw_pool_xpndd, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(pw_pool_xpndd, drho(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_zero(deps(i)%pw)
-               CALL pw_zero(drho(i)%pw)
+               CALL pw_pool_create_pw(pw_pool_xpndd, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_create_pw(pw_pool_xpndd, drho(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_zero(deps(i))
+               CALL pw_zero(drho(i))
             END DO
          END SELECT
 
@@ -449,44 +421,40 @@ CONTAINS
                   DO j = lb(2), ub(2)
                      DO i = lb(1), ub(1)
                         IF (ABS(dielectric%deps_drho%cr3d(i, j, k)) .LE. small_value) THEN
-                           deps(idir)%pw%cr3d(i, j, k) = 0.0_dp
+                           deps(idir)%cr3d(i, j, k) = 0.0_dp
                         END IF
                      END DO
                   END DO
                END DO
-               dielectric%dln_eps(idir)%pw%cr3d = deps(idir)%pw%cr3d/dielectric%eps%cr3d
+               dielectric%dln_eps(idir)%cr3d = deps(idir)%cr3d/dielectric%eps%cr3d
             END DO
          CASE (derivative_fft_use_drho)
             ! \Nabla \eps = \Nabla \rho \cdot \frac{\partial \eps}{\partial \rho}
             ! \Nabla ln(\eps) = \frac{\Nabla \eps}{\eps}
             CALL derive_fft(rho_elec_rs_xpndd, drho, pw_pool_xpndd)
             DO i = 1, 3
-               deps(i)%pw%cr3d = drho(i)%pw%cr3d*dielectric%deps_drho%cr3d
-               dielectric%dln_eps(i)%pw%cr3d = deps(i)%pw%cr3d/dielectric%eps%cr3d
+               deps(i)%cr3d = drho(i)%cr3d*dielectric%deps_drho%cr3d
+               dielectric%dln_eps(i)%cr3d = deps(i)%cr3d/dielectric%eps%cr3d
             END DO
          END SELECT
 
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
             CALL pw_pool_give_back_pw(pw_pool_xpndd, ln_eps)
-            DEALLOCATE (ln_eps)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i)%pw)
-               DEALLOCATE (deps(i)%pw)
+               CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, drho(i)%pw)
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i)%pw)
-               DEALLOCATE (drho(i)%pw, deps(i)%pw)
+               CALL pw_pool_give_back_pw(pw_pool_xpndd, drho(i))
+               CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i))
             END DO
          END SELECT
       END IF
 
       CALL pw_pool_give_back_pw(pw_pool_orig, rho_elec_rs)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, rho_elec_rs_xpndd)
-      DEALLOCATE (rho_elec_rs, rho_elec_rs_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       dielectric%params%times_called = dielectric%params%times_called + 1
@@ -510,7 +478,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dielectric_constant_sccs(rho, eps, deps_drho, eps0, rho_max, rho_min)
 
-      TYPE(pw_type), POINTER                             :: rho, eps, deps_drho
+      TYPE(pw_type), INTENT(IN)                          :: rho, eps, deps_drho
       REAL(KIND=dp), INTENT(IN)                          :: eps0, rho_max, rho_min
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dielectric_constant_sccs'
@@ -578,7 +546,7 @@ CONTAINS
                                               x_glbl, y_glbl, z_glbl, &
                                               x_locl, y_locl, z_locl)
 
-      TYPE(pw_type), POINTER                             :: eps
+      TYPE(pw_type), INTENT(INOUT)                       :: eps
       REAL(KIND=dp), INTENT(IN)                          :: dielec_const
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       REAL(KIND=dp), INTENT(IN)                          :: zeta
@@ -596,7 +564,7 @@ CONTAINS
                                                             forb_xtnt4, forb_xtnt5, forb_xtnt6
       REAL(KIND=dp)                                      :: dx, dy, dz
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: eps_tmp
+      TYPE(pw_type)                                      :: eps_tmp
 
       CALL timeset(routineN, handle)
 
@@ -622,8 +590,6 @@ CONTAINS
                        "the simulation cell.")
       END IF
 
-      NULLIFY (eps_tmp)
-      ALLOCATE (eps_tmp)
       CALL pw_pool_create_pw(pw_pool, eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_copy(eps, eps_tmp)
 
@@ -646,7 +612,6 @@ CONTAINS
 
       CALL pw_mollifier(pw_pool, zeta, x_glbl, y_glbl, z_glbl, eps_tmp, eps)
       CALL pw_pool_give_back_pw(pw_pool, eps_tmp)
-      DEALLOCATE (eps_tmp)
 
       CALL timestop(handle)
 
@@ -676,7 +641,7 @@ CONTAINS
                                               x_glbl, y_glbl, z_glbl, &
                                               x_locl, y_locl, z_locl)
 
-      TYPE(pw_type), POINTER                             :: eps
+      TYPE(pw_type), INTENT(INOUT)                       :: eps
       REAL(KIND=dp), INTENT(IN)                          :: dielec_const
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       REAL(dp), INTENT(IN)                               :: zeta
@@ -694,7 +659,7 @@ CONTAINS
                                                             forb_xtnt4, forb_xtnt5, forb_xtnt6
       REAL(KIND=dp)                                      :: bctry, bctrz, distsq, dx, dy, dz
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: eps_tmp
+      TYPE(pw_type)                                      :: eps_tmp
 
       CALL timeset(routineN, handle)
 
@@ -721,8 +686,6 @@ CONTAINS
                        "the simulation cell.")
       END IF
 
-      NULLIFY (eps_tmp)
-      ALLOCATE (eps_tmp)
       CALL pw_pool_create_pw(pw_pool, eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_copy(eps, eps_tmp)
 
@@ -745,7 +708,6 @@ CONTAINS
 
       CALL pw_mollifier(pw_pool, zeta, x_glbl, y_glbl, z_glbl, eps_tmp, eps)
       CALL pw_pool_give_back_pw(pw_pool, eps_tmp)
-      DEALLOCATE (eps_tmp)
 
       CALL timestop(handle)
 
@@ -762,7 +724,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dielectric_constant_spatially_dependent(eps, pw_pool, dielectric_params)
 
-      TYPE(pw_type), POINTER                             :: eps
+      TYPE(pw_type), INTENT(INOUT)                       :: eps
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(dielectric_parameters), INTENT(IN)            :: dielectric_params
 
@@ -835,14 +797,14 @@ CONTAINS
    SUBROUTINE dielectric_constant_spatially_rho_dependent(rho, eps, deps_drho, &
                                                           pw_pool, dielectric_params)
 
-      TYPE(pw_type), POINTER                             :: rho, eps, deps_drho
+      TYPE(pw_type), INTENT(IN)                          :: rho, eps, deps_drho
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(dielectric_parameters), INTENT(IN)            :: dielectric_params
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dielectric_constant_spatially_rho_dependent'
 
       INTEGER                                            :: handle
-      TYPE(pw_type), POINTER                             :: dswch_func_drho, eps_sptldep, swch_func
+      TYPE(pw_type)                                      :: dswch_func_drho, eps_sptldep, swch_func
 
       CALL timeset(routineN, handle)
 
@@ -850,8 +812,6 @@ CONTAINS
          CPABORT("The dielectric constant has to be greater than or equal to 1.")
       END IF
 
-      NULLIFY (eps_sptldep, swch_func, dswch_func_drho)
-      ALLOCATE (eps_sptldep, swch_func, dswch_func_drho)
       CALL pw_pool_create_pw(pw_pool, eps_sptldep, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, swch_func, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, dswch_func_drho, use_data=REALDATA3D, in_space=REALSPACE)
@@ -869,7 +829,6 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, dswch_func_drho)
       CALL pw_pool_give_back_pw(pw_pool, swch_func)
       CALL pw_pool_give_back_pw(pw_pool, eps_sptldep)
-      DEALLOCATE (dswch_func_drho, swch_func, eps_sptldep)
 
       CALL timestop(handle)
 
@@ -883,36 +842,34 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE derive_fft(f, df, pw_pool)
 
-      TYPE(pw_type), POINTER                             :: f
-      TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
+      TYPE(pw_type), INTENT(IN)                          :: f
+      TYPE(pw_type), DIMENSION(3), INTENT(INOUT)         :: df
       TYPE(pw_pool_type), POINTER                        :: pw_pool
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fft'
 
       INTEGER                                            :: handle, i
       INTEGER, DIMENSION(3)                              :: nd
-      TYPE(pw_p_type), DIMENSION(2)                      :: work_gs
+      TYPE(pw_type), DIMENSION(2)                        :: work_gs
 
       CALL timeset(routineN, handle)
 
       DO i = 1, 2
-         ALLOCATE (work_gs(i)%pw)
-         CALL pw_pool_create_pw(pw_pool, work_gs(i)%pw, &
+         CALL pw_pool_create_pw(pw_pool, work_gs(i), &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
 
-      CALL pw_transfer(f, work_gs(1)%pw)
+      CALL pw_transfer(f, work_gs(1))
       DO i = 1, 3
          nd(:) = 0
          nd(i) = 1
-         CALL pw_copy(work_gs(1)%pw, work_gs(2)%pw)
-         CALL pw_derive(work_gs(2)%pw, nd(:))
-         CALL pw_transfer(work_gs(2)%pw, df(i)%pw)
+         CALL pw_copy(work_gs(1), work_gs(2))
+         CALL pw_derive(work_gs(2), nd(:))
+         CALL pw_transfer(work_gs(2), df(i))
       END DO
 
       DO i = 1, 2
-         CALL pw_pool_give_back_pw(pw_pool, work_gs(i)%pw)
-         DEALLOCATE (work_gs(i)%pw)
+         CALL pw_pool_give_back_pw(pw_pool, work_gs(i))
       END DO
 
       CALL timestop(handle)

--- a/src/pw/dielectric_methods.F
+++ b/src/pw/dielectric_methods.F
@@ -172,6 +172,7 @@ CONTAINS
             CALL pw_axpy(rho_core_rs, rho_elec_rs, -1.0_dp)
          END IF
          CALL pw_pool_give_back_pw(pw_pool, rho_core_rs)
+         DEALLOCATE (rho_core_rs)
       ELSE
          CPABORT("For dielectric constant larger than 1, rho_core has to be present.")
       END IF
@@ -258,19 +259,23 @@ CONTAINS
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
             CALL pw_pool_give_back_pw(pw_pool, ln_eps)
+            DEALLOCATE (ln_eps)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
                CALL pw_pool_give_back_pw(pw_pool, deps(i)%pw)
+               DEALLOCATE (deps(i)%pw)
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
                CALL pw_pool_give_back_pw(pw_pool, drho(i)%pw)
                CALL pw_pool_give_back_pw(pw_pool, deps(i)%pw)
+               DEALLOCATE (drho(i)%pw, deps(i)%pw)
             END DO
          END SELECT
       END IF
 
       CALL pw_pool_give_back_pw(pw_pool, rho_elec_rs)
+      DEALLOCATE (rho_elec_rs)
 
       dielectric%params%times_called = dielectric%params%times_called + 1
 
@@ -377,6 +382,7 @@ CONTAINS
          END IF
          CALL pw_pool_give_back_pw(pw_pool_orig, rho_core_rs)
          CALL pw_pool_give_back_pw(pw_pool_xpndd, rho_core_rs_xpndd)
+         DEALLOCATE (rho_core_rs, rho_core_rs_xpndd)
       ELSE
          CPABORT("For dielectric constant larger than 1, rho_core has to be present.")
       END IF
@@ -463,20 +469,24 @@ CONTAINS
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
             CALL pw_pool_give_back_pw(pw_pool_xpndd, ln_eps)
+            DEALLOCATE (ln_eps)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
                CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i)%pw)
+               DEALLOCATE (deps(i)%pw)
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
                CALL pw_pool_give_back_pw(pw_pool_xpndd, drho(i)%pw)
                CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i)%pw)
+               DEALLOCATE (drho(i)%pw, deps(i)%pw)
             END DO
          END SELECT
       END IF
 
       CALL pw_pool_give_back_pw(pw_pool_orig, rho_elec_rs)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, rho_elec_rs_xpndd)
+      DEALLOCATE (rho_elec_rs, rho_elec_rs_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       dielectric%params%times_called = dielectric%params%times_called + 1
@@ -636,6 +646,7 @@ CONTAINS
 
       CALL pw_mollifier(pw_pool, zeta, x_glbl, y_glbl, z_glbl, eps_tmp, eps)
       CALL pw_pool_give_back_pw(pw_pool, eps_tmp)
+      DEALLOCATE (eps_tmp)
 
       CALL timestop(handle)
 
@@ -734,6 +745,7 @@ CONTAINS
 
       CALL pw_mollifier(pw_pool, zeta, x_glbl, y_glbl, z_glbl, eps_tmp, eps)
       CALL pw_pool_give_back_pw(pw_pool, eps_tmp)
+      DEALLOCATE (eps_tmp)
 
       CALL timestop(handle)
 
@@ -857,6 +869,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, dswch_func_drho)
       CALL pw_pool_give_back_pw(pw_pool, swch_func)
       CALL pw_pool_give_back_pw(pw_pool, eps_sptldep)
+      DEALLOCATE (dswch_func_drho, swch_func, eps_sptldep)
 
       CALL timestop(handle)
 
@@ -899,6 +912,7 @@ CONTAINS
 
       DO i = 1, 2
          CALL pw_pool_give_back_pw(pw_pool, work_gs(i)%pw)
+         DEALLOCATE (work_gs(i)%pw)
       END DO
 
       CALL timestop(handle)

--- a/src/pw/dielectric_methods.F
+++ b/src/pw/dielectric_methods.F
@@ -82,6 +82,7 @@ CONTAINS
          ALLOCATE (dielectric)
          NULLIFY (dielectric%eps)
          NULLIFY (dielectric%deps_drho)
+         ALLOCATE (dielectric%eps, dielectric%deps_drho)
          CALL pw_pool_create_pw(pw_pool, dielectric%eps, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(pw_pool, dielectric%deps_drho, &
@@ -89,7 +90,7 @@ CONTAINS
          dielectric%eps%cr3d = 1.0_dp
          CALL pw_zero(dielectric%deps_drho)
          DO i = 1, 3
-            NULLIFY (dielectric%dln_eps(i)%pw)
+            ALLOCATE (dielectric%dln_eps(i)%pw)
             CALL pw_pool_create_pw(pw_pool, dielectric%dln_eps(i)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dielectric%dln_eps(i)%pw)
@@ -151,6 +152,7 @@ CONTAINS
       END IF
 
       NULLIFY (rho_elec_rs)
+      ALLOCATE (rho_elec_rs)
       CALL pw_pool_create_pw(pw_pool, rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! for evaluating epsilon make sure rho is in the real space
@@ -158,6 +160,8 @@ CONTAINS
 
       IF (PRESENT(rho_core)) THEN
          ! make sure rho_core is in the real space
+         NULLIFY (rho_core_rs)
+         ALLOCATE (rho_core_rs)
          CALL pw_pool_create_pw(pw_pool, rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(rho_core, rho_core_rs)
          IF (dielectric%params%dielec_core_correction) THEN
@@ -193,17 +197,18 @@ CONTAINS
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
             NULLIFY (ln_eps)
+            ALLOCATE (ln_eps)
             CALL pw_pool_create_pw(pw_pool, ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
             ln_eps%cr3d = LOG(dielectric%eps%cr3d)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               NULLIFY (deps(i)%pw)
+               ALLOCATE (deps(i)%pw)
                CALL pw_pool_create_pw(pw_pool, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i)%pw)
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               NULLIFY (deps(i)%pw, drho(i)%pw)
+               ALLOCATE (deps(i)%pw, drho(i)%pw)
                CALL pw_pool_create_pw(pw_pool, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_pool_create_pw(pw_pool, drho(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i)%pw)
@@ -341,20 +346,25 @@ CONTAINS
 
       NULLIFY (rho_elec_rs)
       ! make sure rho is in the real space
+      ALLOCATE (rho_elec_rs)
       CALL pw_pool_create_pw(pw_pool_orig, rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_transfer(rho, rho_elec_rs)
       ! expand rho_elec
       NULLIFY (rho_elec_rs_xpndd)
+      ALLOCATE (rho_elec_rs_xpndd)
       CALL pw_pool_create_pw(pw_pool_xpndd, rho_elec_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_expand(neumann_directions, recv_msgs_bnds, dests_expand, srcs_expand, flipg_stat, bounds_shftd, &
                      rho_elec_rs, rho_elec_rs_xpndd)
 
       IF (PRESENT(rho_core)) THEN
          ! make sure rho_core is in the real space
+         NULLIFY (rho_core_rs)
+         ALLOCATE (rho_core_rs)
          CALL pw_pool_create_pw(pw_pool_orig, rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(rho_core, rho_core_rs)
          ! expand rho_core
          NULLIFY (rho_core_rs_xpndd)
+         ALLOCATE (rho_core_rs_xpndd)
          CALL pw_pool_create_pw(pw_pool_xpndd, rho_core_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_expand(neumann_directions, recv_msgs_bnds, dests_expand, srcs_expand, flipg_stat, bounds_shftd, &
                         rho_core_rs, rho_core_rs_xpndd)
@@ -392,17 +402,18 @@ CONTAINS
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
             NULLIFY (ln_eps)
+            ALLOCATE (ln_eps)
             CALL pw_pool_create_pw(pw_pool_xpndd, ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
             ln_eps%cr3d = LOG(dielectric%eps%cr3d)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               NULLIFY (deps(i)%pw)
+               ALLOCATE (deps(i)%pw)
                CALL pw_pool_create_pw(pw_pool_xpndd, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i)%pw)
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               NULLIFY (deps(i)%pw, drho(i)%pw)
+               ALLOCATE (deps(i)%pw, drho(i)%pw)
                CALL pw_pool_create_pw(pw_pool_xpndd, deps(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_pool_create_pw(pw_pool_xpndd, drho(i)%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i)%pw)
@@ -601,6 +612,8 @@ CONTAINS
                        "the simulation cell.")
       END IF
 
+      NULLIFY (eps_tmp)
+      ALLOCATE (eps_tmp)
       CALL pw_pool_create_pw(pw_pool, eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_copy(eps, eps_tmp)
 
@@ -697,6 +710,8 @@ CONTAINS
                        "the simulation cell.")
       END IF
 
+      NULLIFY (eps_tmp)
+      ALLOCATE (eps_tmp)
       CALL pw_pool_create_pw(pw_pool, eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_copy(eps, eps_tmp)
 
@@ -823,6 +838,8 @@ CONTAINS
          CPABORT("The dielectric constant has to be greater than or equal to 1.")
       END IF
 
+      NULLIFY (eps_sptldep, swch_func, dswch_func_drho)
+      ALLOCATE (eps_sptldep, swch_func, dswch_func_drho)
       CALL pw_pool_create_pw(pw_pool, eps_sptldep, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, swch_func, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, dswch_func_drho, use_data=REALDATA3D, in_space=REALSPACE)
@@ -866,7 +883,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       DO i = 1, 2
-         NULLIFY (work_gs(i)%pw)
+         ALLOCATE (work_gs(i)%pw)
          CALL pw_pool_create_pw(pw_pool, work_gs(i)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO

--- a/src/pw/dielectric_methods.F
+++ b/src/pw/dielectric_methods.F
@@ -122,7 +122,7 @@ CONTAINS
       TYPE(realspace_grid_type), POINTER                 :: diel_rs_grid
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(pw_type), INTENT(IN), POINTER                 :: rho
-      TYPE(pw_type), INTENT(IN), OPTIONAL, POINTER       :: rho_core
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: rho_core
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dielectric_compute_periodic'
       REAL(dp), PARAMETER                                :: small_value = EPSILON(1.0_dp)

--- a/src/pw/dielectric_types.F
+++ b/src/pw/dielectric_types.F
@@ -106,8 +106,10 @@ CONTAINS
          ELSE
             CALL pw_release(dielectric%eps)
             CALL pw_release(dielectric%deps_drho)
+            DEALLOCATE (dielectric%eps, dielectric%deps_drho)
             DO i = 1, 3
                CALL pw_release(dielectric%dln_eps(i)%pw)
+               DEALLOCATE (dielectric%dln_eps(i)%pw)
             END DO
          END IF
          CALL dielectric_parameters_dealloc(dielectric%params)

--- a/src/pw/dielectric_types.F
+++ b/src/pw/dielectric_types.F
@@ -99,9 +99,11 @@ CONTAINS
                                       accept_non_compatible=.TRUE.)
             CALL pw_pool_give_back_pw(pw_pool, dielectric%deps_drho, &
                                       accept_non_compatible=.TRUE.)
+            DEALLOCATE (dielectric%eps, dielectric%deps_drho)
             DO i = 1, 3
                CALL pw_pool_give_back_pw(pw_pool, dielectric%dln_eps(i)%pw, &
                                          accept_non_compatible=.TRUE.)
+               DEALLOCATE (dielectric%dln_eps(i)%pw)
             END DO
          ELSE
             CALL pw_release(dielectric%eps)

--- a/src/pw/dielectric_types.F
+++ b/src/pw/dielectric_types.F
@@ -16,8 +16,7 @@ MODULE dielectric_types
    USE kinds,                           ONLY: dp
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release,&
+   USE pw_types,                        ONLY: pw_release,&
                                               pw_type
 #include "../base/base_uses.f90"
 
@@ -55,7 +54,7 @@ MODULE dielectric_types
       TYPE(dielectric_parameters)       :: params
       TYPE(pw_type), POINTER            :: eps
       TYPE(pw_type), POINTER            :: deps_drho
-      TYPE(pw_p_type), DIMENSION(3)     :: dln_eps
+      TYPE(pw_type), DIMENSION(3)     :: dln_eps
    END TYPE dielectric_type
 
    PUBLIC :: dielectric_type, dielectric_parameters
@@ -99,16 +98,14 @@ CONTAINS
             CALL pw_pool_give_back_pw(pw_pool, dielectric%deps_drho)
             DEALLOCATE (dielectric%eps, dielectric%deps_drho)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, dielectric%dln_eps(i)%pw)
-               DEALLOCATE (dielectric%dln_eps(i)%pw)
+               CALL pw_pool_give_back_pw(pw_pool, dielectric%dln_eps(i))
             END DO
          ELSE
             CALL pw_release(dielectric%eps)
             CALL pw_release(dielectric%deps_drho)
             DEALLOCATE (dielectric%eps, dielectric%deps_drho)
             DO i = 1, 3
-               CALL pw_release(dielectric%dln_eps(i)%pw)
-               DEALLOCATE (dielectric%dln_eps(i)%pw)
+               CALL pw_release(dielectric%dln_eps(i))
             END DO
          END IF
          CALL dielectric_parameters_dealloc(dielectric%params)

--- a/src/pw/dielectric_types.F
+++ b/src/pw/dielectric_types.F
@@ -95,14 +95,11 @@ CONTAINS
          can_give_back = PRESENT(pw_pool)
          IF (can_give_back) can_give_back = ASSOCIATED(pw_pool)
          IF (can_give_back) THEN
-            CALL pw_pool_give_back_pw(pw_pool, dielectric%eps, &
-                                      accept_non_compatible=.TRUE.)
-            CALL pw_pool_give_back_pw(pw_pool, dielectric%deps_drho, &
-                                      accept_non_compatible=.TRUE.)
+            CALL pw_pool_give_back_pw(pw_pool, dielectric%eps)
+            CALL pw_pool_give_back_pw(pw_pool, dielectric%deps_drho)
             DEALLOCATE (dielectric%eps, dielectric%deps_drho)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, dielectric%dln_eps(i)%pw, &
-                                         accept_non_compatible=.TRUE.)
+               CALL pw_pool_give_back_pw(pw_pool, dielectric%dln_eps(i)%pw)
                DEALLOCATE (dielectric%dln_eps(i)%pw)
             END DO
          ELSE

--- a/src/pw/dirichlet_bc_methods.F
+++ b/src/pw/dirichlet_bc_methods.F
@@ -322,6 +322,7 @@ CONTAINS
          ALLOCATE (tile_maxvals(n_tiles))
          tile_maxvals = 0.0_dp
          DO k = 1, n_tiles
+            ALLOCATE (dirichlet_bc%tiles(k)%tile%tile_pw)
             CALL pw_pool_create_pw(pw_pool, dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_bc%tiles(k)%tile%tile_pw)
 
@@ -353,10 +354,13 @@ CONTAINS
          dirichlet_bc%tiles = tiles
          IF ((unit_nr .GT. 0) .AND. verbose) WRITE (unit_nr, '(T7,A,I5)') "number of partitions : ", n_tiles
 
+         NULLIFY (cylinder_pw)
+         ALLOCATE (cylinder_pw)
          CALL pw_pool_create_pw(pw_pool, cylinder_pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(cylinder_pw)
 
          DO k = 1, n_tiles
+            ALLOCATE (dirichlet_bc%tiles(k)%tile%tile_pw)
             CALL pw_pool_create_pw(pw_pool, dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_bc%tiles(k)%tile%tile_pw)
 
@@ -401,6 +405,7 @@ CONTAINS
          IF ((unit_nr .GT. 0) .AND. verbose) WRITE (unit_nr, '(T7,A,I5)') "number of partitions : ", n_tiles
 
          DO k = 1, n_tiles
+            ALLOCATE (dirichlet_bc%tiles(k)%tile%tile_pw)
             CALL pw_pool_create_pw(pw_pool, dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_bc%tiles(k)%tile%tile_pw)
 

--- a/src/pw/dirichlet_bc_methods.F
+++ b/src/pw/dirichlet_bc_methods.F
@@ -390,6 +390,7 @@ CONTAINS
          END IF
 
          CALL pw_pool_give_back_pw(pw_pool, cylinder_pw)
+         DEALLOCATE (cylinder_pw)
 
          IF ((unit_nr .GT. 0) .AND. verbose) WRITE (unit_nr, '(T3,A)') REPEAT('=', 78)
 

--- a/src/pw/dirichlet_bc_types.F
+++ b/src/pw/dirichlet_bc_types.F
@@ -214,6 +214,7 @@ CONTAINS
       ELSE
          DO k = 1, n_tiles
             CALL pw_release(dbc%tiles(k)%tile%tile_pw)
+            DEALLOCATE (dbc%tiles(k)%tile%tile_pw)
             DEALLOCATE (dbc%tiles(k)%tile)
          END DO
          DEALLOCATE (dbc%tiles)

--- a/src/pw/dirichlet_bc_types.F
+++ b/src/pw/dirichlet_bc_types.F
@@ -208,6 +208,7 @@ CONTAINS
       IF (PRESENT(pw_pool)) THEN
          DO k = 1, n_tiles
             CALL pw_pool_give_back_pw(pw_pool, dbc%tiles(k)%tile%tile_pw)
+            DEALLOCATE (dbc%tiles(k)%tile%tile_pw)
             DEALLOCATE (dbc%tiles(k)%tile)
          END DO
          DEALLOCATE (dbc%tiles)

--- a/src/pw/mt_util.F
+++ b/src/pw/mt_util.F
@@ -79,11 +79,15 @@ CONTAINS
       IF (ASSOCIATED(super_ref_pw_grid)) THEN
          CALL pw_pool_create(pw_pool_aux, pw_grid=super_ref_pw_grid)
       END IF
+      NULLIFY (screen_function)
+      ALLOCATE (screen_function)
       CALL pw_pool_create_pw(pw_pool, screen_function, use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_zero(screen_function)
       SELECT CASE (method)
       CASE (MT0D)
+         NULLIFY (Vloc, Vlocg)
+         ALLOCATE (Vloc, Vlocg)
          IF (ASSOCIATED(pw_pool_aux)) THEN
             CALL pw_pool_create_pw(pw_pool_aux, Vloc, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(pw_pool_aux, Vlocg, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)

--- a/src/pw/mt_util.F
+++ b/src/pw/mt_util.F
@@ -105,6 +105,7 @@ CONTAINS
             CALL pw_pool_give_back_pw(pw_pool, Vloc)
             CALL pw_pool_give_back_pw(pw_pool, Vlocg)
          END IF
+         DEALLOCATE (Vloc, Vlocg)
          !
          ! Get rid of the analytical FT of the erf(a*r)/r
          !

--- a/src/pw/ps_implicit_methods.F
+++ b/src/pw/ps_implicit_methods.F
@@ -132,6 +132,7 @@ CONTAINS
 
 ! v_eps
          NULLIFY (ps_implicit_env%v_eps)
+         ALLOCATE (ps_implicit_env%v_eps)
          CALL pw_pool_create_pw(pw_pool, ps_implicit_env%v_eps, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(ps_implicit_env%v_eps)
 
@@ -139,10 +140,12 @@ CONTAINS
          NULLIFY (ps_implicit_env%cstr_charge)
          SELECT CASE (boundary_condition)
          CASE (MIXED_PERIODIC_BC)
+            ALLOCATE (ps_implicit_env%cstr_charge)
             CALL pw_pool_create_pw(pw_pool, ps_implicit_env%cstr_charge, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(ps_implicit_env%cstr_charge)
          CASE (MIXED_BC)
             CALL pw_pool_create(pw_pool_xpndd, pw_grid=dct_pw_grid)
+            ALLOCATE (ps_implicit_env%cstr_charge)
             CALL pw_pool_create_pw(pw_pool_xpndd, ps_implicit_env%cstr_charge, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(ps_implicit_env%cstr_charge)
             CALL pw_pool_release(pw_pool_xpndd)
@@ -224,6 +227,8 @@ CONTAINS
 ! check if this is the first scf iteration
       IF (times_called .EQ. 0) CALL ps_implicit_initial_guess_create(ps_implicit_env, pw_pool)
 
+      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres)
+      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres)
       CALL pw_pool_create_pw(pw_pool, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -374,6 +379,8 @@ CONTAINS
 ! check if this is the first scf iteration
       IF (times_called .EQ. 0) CALL ps_implicit_initial_guess_create(ps_implicit_env, pw_pool_xpndd)
 
+      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, density_xpndd, v_new_xpndd, v_eps_xpndd)
+      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_create_pw(pw_pool_xpndd, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -584,6 +591,8 @@ CONTAINS
       ALLOCATE (v_new1D(data_size))
       ALLOCATE (Bxv_new(n_tiles_tot))
 
+      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar)
+      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar)
       CALL pw_pool_create_pw(pw_pool, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -859,6 +868,8 @@ CONTAINS
       ALLOCATE (v_new1D(data_size))
       ALLOCATE (Bxv_new(n_tiles_tot))
 
+      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar, density_xpndd, v_new_xpndd, v_eps_xpndd)
+      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_create_pw(pw_pool_xpndd, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -1051,6 +1062,8 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       n_tiles_tot = SIZE(ps_implicit_env%v_D)
+      NULLIFY (ps_implicit_env%initial_guess)
+      ALLOCATE (ps_implicit_env%initial_guess)
       CALL pw_pool_create_pw(pw_pool, ps_implicit_env%initial_guess, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_zero(ps_implicit_env%initial_guess)
@@ -1190,6 +1203,8 @@ CONTAINS
             DO i = 1, n_tiles
                tile_pw => ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw
 
+               NULLIFY (pw_in)
+               ALLOCATE (pw_in)
                CALL pw_pool_create_pw(pw_pool_xpndd, pw_in, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_expand(neumann_directions, &
                               dct_env%recv_msgs_bnds, dct_env%dests_expand, dct_env%srcs_expand, &
@@ -1199,6 +1214,8 @@ CONTAINS
                CALL pw_scale(pw_in, 1.0_dp/(vol_scfac*tile_volume)) ! normalize tile_pw
                ps_implicit_env%Bt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_in%cr3d, (/data_size/))
 
+               NULLIFY (pw_out)
+               ALLOCATE (pw_out)
                CALL pw_pool_create_pw(pw_pool_xpndd, pw_out, use_data=REALDATA3D, in_space=REALSPACE)
                CALL apply_inv_laplace_operator_dct(pw_pool_xpndd, green, pw_in, pw_out)
                QAinvxBt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_out%cr3d, (/data_size/))
@@ -1316,6 +1333,8 @@ CONTAINS
             DO i = 1, n_tiles
                tile_pw => ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw
 
+               NULLIFY (pw_in)
+               ALLOCATE (pw_in)
                CALL pw_pool_create_pw(pw_pool_orig, pw_in, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(tile_pw, pw_in)
 
@@ -1323,6 +1342,8 @@ CONTAINS
                CALL pw_scale(pw_in, 1.0_dp/tile_volume) ! normalize tile_pw
                ps_implicit_env%Bt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_in%cr3d, (/data_size/))
 
+               NULLIFY (pw_out)
+               ALLOCATE (pw_out)
                CALL pw_pool_create_pw(pw_pool_orig, pw_out, use_data=REALDATA3D, in_space=REALSPACE)
                CALL apply_inv_laplace_operator_fft(pw_pool_orig, green, pw_in, pw_out)
                QAinvxBt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_out%cr3d, (/data_size/))
@@ -1430,6 +1451,7 @@ CONTAINS
 
       dln_eps = dielectric%dln_eps
       DO i = 1, 3
+         ALLOCATE (dv(i)%pw)
          CALL pw_pool_create_pw(pw_pool, dv(i)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
       END DO
@@ -1479,6 +1501,8 @@ CONTAINS
       pw_grid => pw_pool%pw_grid
       ng = SIZE(pw_grid%gsq)
 
+      NULLIFY (pw_in_gs)
+      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1528,6 +1552,8 @@ CONTAINS
       pw_grid => pw_pool%pw_grid
       ng = SIZE(pw_grid%gsq)
 
+      NULLIFY (pw_in_gs)
+      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1577,6 +1603,8 @@ CONTAINS
       ng = SIZE(pw_in%pw_grid%gsq)
       have_g0 = green%influence_fn%pw_grid%have_g0
 
+      NULLIFY (pw_in_gs)
+      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1633,6 +1661,8 @@ CONTAINS
       ng = SIZE(pw_in%pw_grid%gsq)
       have_g0 = green%dct_influence_fn%pw_grid%have_g0
 
+      NULLIFY (pw_in_gs)
+      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1680,6 +1710,8 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
+      NULLIFY (Pxv)
+      ALLOCATE (Pxv)
       CALL pw_pool_create_pw(pw_pool, Pxv, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1721,6 +1753,8 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
+      NULLIFY (Pxv)
+      ALLOCATE (Pxv)
       CALL pw_pool_create_pw(pw_pool, Pxv, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1767,9 +1801,12 @@ CONTAINS
       eightpi = 2*fourpi
       deps_drho => dielectric%deps_drho
 
+      NULLIFY (dv2)
+      ALLOCATE (dv2)
       CALL pw_pool_create_pw(pw_pool, dv2, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       DO i = 1, 3
+         ALLOCATE (dv(i)%pw)
          CALL pw_pool_create_pw(pw_pool, dv(i)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
       END DO
@@ -2110,7 +2147,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       DO i = 1, 2
-         NULLIFY (work_gs(i)%pw)
+         ALLOCATE (work_gs(i)%pw)
          CALL pw_pool_create_pw(pw_pool, work_gs(i)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO

--- a/src/pw/ps_implicit_methods.F
+++ b/src/pw/ps_implicit_methods.F
@@ -308,6 +308,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, res_new)
       CALL pw_pool_give_back_pw(pw_pool, QAinvxres)
       CALL pw_pool_give_back_pw(pw_pool, PxQAinvxres)
+      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres)
 
       CALL timestop(handle)
 
@@ -479,6 +480,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool_xpndd, density_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_new_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_eps_xpndd)
+      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       CALL timestop(handle)
@@ -740,6 +742,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, QAinvxres)
       CALL pw_pool_give_back_pw(pw_pool, PxQAinvxres)
       CALL pw_pool_give_back_pw(pw_pool, Axvbar)
+      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar)
 
       CALL timestop(handle)
 
@@ -1036,6 +1039,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool_xpndd, density_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_new_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_eps_xpndd)
+      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       CALL timestop(handle)
@@ -1227,6 +1231,7 @@ CONTAINS
 
                CALL pw_pool_give_back_pw(pw_pool_xpndd, pw_in)
                CALL pw_pool_give_back_pw(pw_pool_xpndd, pw_out)
+               DEALLOCATE (pw_in, pw_out)
             END DO
             indx1 = indx2 + 1
          END DO
@@ -1355,6 +1360,7 @@ CONTAINS
 
                CALL pw_pool_give_back_pw(pw_pool_orig, pw_in)
                CALL pw_pool_give_back_pw(pw_pool_orig, pw_out)
+               DEALLOCATE (pw_in, pw_out)
             END DO
             indx1 = indx2 + 1
          END DO
@@ -1463,6 +1469,7 @@ CONTAINS
 
       DO i = 1, 3
          CALL pw_pool_give_back_pw(pw_pool, dv(i)%pw)
+         DEALLOCATE (dv(i)%pw)
       END DO
 
       CALL timestop(handle)
@@ -1513,6 +1520,7 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1564,6 +1572,7 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1621,6 +1630,7 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1679,6 +1689,7 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1720,6 +1731,7 @@ CONTAINS
       CALL pw_axpy(Pxv, density)
 
       CALL pw_pool_give_back_pw(pw_pool, Pxv)
+      DEALLOCATE (Pxv)
 
       CALL timestop(handle)
 
@@ -1763,6 +1775,7 @@ CONTAINS
       CALL pw_axpy(Pxv, density)
 
       CALL pw_pool_give_back_pw(pw_pool, Pxv)
+      DEALLOCATE (Pxv)
 
       CALL timestop(handle)
 
@@ -1819,8 +1832,10 @@ CONTAINS
       v_eps%cr3d = -(1.0_dp/eightpi)*(dv2%cr3d*deps_drho%cr3d)
 
       CALL pw_pool_give_back_pw(pw_pool, dv2)
+      DEALLOCATE (dv2)
       DO i = 1, 3
          CALL pw_pool_give_back_pw(pw_pool, dv(i)%pw)
+         DEALLOCATE (dv(i)%pw)
       END DO
 
       CALL timestop(handle)
@@ -2163,6 +2178,7 @@ CONTAINS
 
       DO i = 1, 2
          CALL pw_pool_give_back_pw(pw_pool, work_gs(i)%pw)
+         DEALLOCATE (work_gs(i)%pw)
       END DO
 
       CALL timestop(handle)

--- a/src/pw/ps_implicit_methods.F
+++ b/src/pw/ps_implicit_methods.F
@@ -22,7 +22,8 @@ MODULE ps_implicit_methods
    USE dct,                             ONLY: &
         dct_type, dct_type_init, neumannX, neumannXY, neumannXYZ, neumannXZ, neumannY, neumannYZ, &
         neumannZ, pw_expand, pw_shrink
-   USE dielectric_methods,              ONLY: dielectric_create
+   USE dielectric_methods,              ONLY: derive_fft,&
+                                              dielectric_create
    USE dielectric_types,                ONLY: dielectric_type
    USE dirichlet_bc_methods,            ONLY: dirichlet_boundary_region_setup
    USE dirichlet_bc_types,              ONLY: dbc_tile_release
@@ -40,7 +41,6 @@ MODULE ps_implicit_methods
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_copy,&
-                                              pw_derive,&
                                               pw_integral_ab,&
                                               pw_scale,&
                                               pw_transfer,&
@@ -57,7 +57,6 @@ MODULE ps_implicit_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_type
 #include "../base/base_uses.f90"
 
@@ -193,8 +192,8 @@ CONTAINS
    SUBROUTINE implicit_poisson_solver_periodic(poisson_env, density, v_new, ehartree)
 
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
-      TYPE(pw_type), INTENT(IN), POINTER                 :: density
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
+      TYPE(pw_type), INTENT(IN)                          :: density
+      TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: ehartree
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_periodic'
@@ -208,7 +207,7 @@ CONTAINS
       TYPE(greens_fn_type), POINTER                      :: green
       TYPE(ps_implicit_type), POINTER                    :: ps_implicit_env
       TYPE(pw_pool_type), POINTER                        :: pw_pool
-      TYPE(pw_type), POINTER                             :: g, PxQAinvxres, QAinvxres, res_new, &
+      TYPE(pw_type)                                      :: g, PxQAinvxres, QAinvxres, res_new, &
                                                             res_old, v_old
 
       CALL timeset(routineN, handle)
@@ -227,8 +226,6 @@ CONTAINS
 ! check if this is the first scf iteration
       IF (times_called .EQ. 0) CALL ps_implicit_initial_guess_create(ps_implicit_env, pw_pool)
 
-      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres)
-      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres)
       CALL pw_pool_create_pw(pw_pool, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -308,7 +305,6 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, res_new)
       CALL pw_pool_give_back_pw(pw_pool, QAinvxres)
       CALL pw_pool_give_back_pw(pw_pool, PxQAinvxres)
-      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres)
 
       CALL timestop(handle)
 
@@ -329,8 +325,8 @@ CONTAINS
    SUBROUTINE implicit_poisson_solver_neumann(poisson_env, density, v_new, ehartree)
 
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
-      TYPE(pw_type), INTENT(IN), POINTER                 :: density
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
+      TYPE(pw_type), INTENT(IN)                          :: density
+      TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: ehartree
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_neumann'
@@ -347,7 +343,7 @@ CONTAINS
       TYPE(greens_fn_type), POINTER                      :: green
       TYPE(ps_implicit_type), POINTER                    :: ps_implicit_env
       TYPE(pw_pool_type), POINTER                        :: pw_pool, pw_pool_xpndd
-      TYPE(pw_type), POINTER                             :: density_xpndd, g, PxQAinvxres, &
+      TYPE(pw_type)                                      :: density_xpndd, g, PxQAinvxres, &
                                                             QAinvxres, res_new, res_old, &
                                                             v_eps_xpndd, v_new_xpndd, v_old
 
@@ -380,8 +376,6 @@ CONTAINS
 ! check if this is the first scf iteration
       IF (times_called .EQ. 0) CALL ps_implicit_initial_guess_create(ps_implicit_env, pw_pool_xpndd)
 
-      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, density_xpndd, v_new_xpndd, v_eps_xpndd)
-      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_create_pw(pw_pool_xpndd, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -480,7 +474,6 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool_xpndd, density_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_new_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_eps_xpndd)
-      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       CALL timestop(handle)
@@ -500,8 +493,8 @@ CONTAINS
    SUBROUTINE implicit_poisson_solver_mixed_periodic(poisson_env, density, v_new, electric_enthalpy)
 
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
-      TYPE(pw_type), INTENT(IN), POINTER                 :: density
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
+      TYPE(pw_type), INTENT(IN)                          :: density
+      TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: electric_enthalpy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_mixed_periodic'
@@ -526,7 +519,7 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       TYPE(pw_poisson_parameter_type), POINTER           :: poisson_params
       TYPE(pw_pool_type), POINTER                        :: pw_pool
-      TYPE(pw_type), POINTER                             :: Axvbar, g, PxQAinvxres, QAinvxres, &
+      TYPE(pw_type)                                      :: Axvbar, g, PxQAinvxres, QAinvxres, &
                                                             res_new, res_old, v_old
 
       CALL timeset(routineN, handle)
@@ -593,8 +586,6 @@ CONTAINS
       ALLOCATE (v_new1D(data_size))
       ALLOCATE (Bxv_new(n_tiles_tot))
 
-      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar)
-      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar)
       CALL pw_pool_create_pw(pw_pool, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -742,7 +733,6 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, QAinvxres)
       CALL pw_pool_give_back_pw(pw_pool, PxQAinvxres)
       CALL pw_pool_give_back_pw(pw_pool, Axvbar)
-      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar)
 
       CALL timestop(handle)
 
@@ -762,8 +752,8 @@ CONTAINS
    SUBROUTINE implicit_poisson_solver_mixed(poisson_env, density, v_new, electric_enthalpy)
 
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
-      TYPE(pw_type), INTENT(IN), POINTER                 :: density
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: v_new
+      TYPE(pw_type), INTENT(IN)                          :: density
+      TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: electric_enthalpy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'implicit_poisson_solver_mixed'
@@ -789,7 +779,7 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: dct_pw_grid, pw_grid
       TYPE(pw_poisson_parameter_type), POINTER           :: poisson_params
       TYPE(pw_pool_type), POINTER                        :: pw_pool, pw_pool_xpndd
-      TYPE(pw_type), POINTER                             :: Axvbar, density_xpndd, g, PxQAinvxres, &
+      TYPE(pw_type)                                      :: Axvbar, density_xpndd, g, PxQAinvxres, &
                                                             QAinvxres, res_new, res_old, &
                                                             v_eps_xpndd, v_new_xpndd, v_old
 
@@ -871,8 +861,6 @@ CONTAINS
       ALLOCATE (v_new1D(data_size))
       ALLOCATE (Bxv_new(n_tiles_tot))
 
-      NULLIFY (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar, density_xpndd, v_new_xpndd, v_eps_xpndd)
-      ALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_create_pw(pw_pool_xpndd, g, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, v_old, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool_xpndd, res_old, use_data=REALDATA3D, in_space=REALSPACE)
@@ -1039,7 +1027,6 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool_xpndd, density_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_new_xpndd)
       CALL pw_pool_give_back_pw(pw_pool_xpndd, v_eps_xpndd)
-      DEALLOCATE (g, v_old, res_old, res_new, QAinvxres, PxQAinvxres, Axvbar, density_xpndd, v_new_xpndd, v_eps_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       CALL timestop(handle)
@@ -1114,7 +1101,7 @@ CONTAINS
       TYPE(dct_type), POINTER                            :: dct_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid_orig
       TYPE(pw_pool_type), POINTER                        :: pw_pool_xpndd
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out, tile_pw
+      TYPE(pw_type)                                      :: pw_in, pw_out
 
       CALL timeset(routineN, handle)
 
@@ -1205,21 +1192,17 @@ CONTAINS
             n_tiles = ps_implicit_env%contacts(j)%dirichlet_bc%n_tiles
             indx2 = indx1 + n_tiles - 1
             DO i = 1, n_tiles
-               tile_pw => ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw
 
-               NULLIFY (pw_in)
-               ALLOCATE (pw_in)
                CALL pw_pool_create_pw(pw_pool_xpndd, pw_in, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_expand(neumann_directions, &
                               dct_env%recv_msgs_bnds, dct_env%dests_expand, dct_env%srcs_expand, &
-                              dct_env%flipg_stat, dct_env%bounds_shftd, tile_pw, pw_in)
+                              dct_env%flipg_stat, dct_env%bounds_shftd, &
+                              ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, pw_in)
 
                tile_volume = ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%volume
                CALL pw_scale(pw_in, 1.0_dp/(vol_scfac*tile_volume)) ! normalize tile_pw
                ps_implicit_env%Bt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_in%cr3d, (/data_size/))
 
-               NULLIFY (pw_out)
-               ALLOCATE (pw_out)
                CALL pw_pool_create_pw(pw_pool_xpndd, pw_out, use_data=REALDATA3D, in_space=REALSPACE)
                CALL apply_inv_laplace_operator_dct(pw_pool_xpndd, green, pw_in, pw_out)
                QAinvxBt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_out%cr3d, (/data_size/))
@@ -1231,7 +1214,6 @@ CONTAINS
 
                CALL pw_pool_give_back_pw(pw_pool_xpndd, pw_in)
                CALL pw_pool_give_back_pw(pw_pool_xpndd, pw_out)
-               DEALLOCATE (pw_in, pw_out)
             END DO
             indx1 = indx2 + 1
          END DO
@@ -1336,19 +1318,13 @@ CONTAINS
             n_tiles = ps_implicit_env%contacts(j)%dirichlet_bc%n_tiles
             indx2 = indx1 + n_tiles - 1
             DO i = 1, n_tiles
-               tile_pw => ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw
-
-               NULLIFY (pw_in)
-               ALLOCATE (pw_in)
                CALL pw_pool_create_pw(pw_pool_orig, pw_in, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_copy(tile_pw, pw_in)
+               CALL pw_copy(ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, pw_in)
 
                tile_volume = ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%volume
                CALL pw_scale(pw_in, 1.0_dp/tile_volume) ! normalize tile_pw
                ps_implicit_env%Bt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_in%cr3d, (/data_size/))
 
-               NULLIFY (pw_out)
-               ALLOCATE (pw_out)
                CALL pw_pool_create_pw(pw_pool_orig, pw_out, use_data=REALDATA3D, in_space=REALSPACE)
                CALL apply_inv_laplace_operator_fft(pw_pool_orig, green, pw_in, pw_out)
                QAinvxBt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_out%cr3d, (/data_size/))
@@ -1360,7 +1336,6 @@ CONTAINS
 
                CALL pw_pool_give_back_pw(pw_pool_orig, pw_in)
                CALL pw_pool_give_back_pw(pw_pool_orig, pw_out)
-               DEALLOCATE (pw_in, pw_out)
             END DO
             indx1 = indx2 + 1
          END DO
@@ -1445,31 +1420,30 @@ CONTAINS
 
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(dielectric_type), INTENT(IN), POINTER         :: dielectric
-      TYPE(pw_type), INTENT(IN), POINTER                 :: v
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: Pxv
+      TYPE(pw_type), INTENT(IN)                          :: v
+      TYPE(pw_type), INTENT(INOUT)                       :: Pxv
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'apply_P_operator'
 
       INTEGER                                            :: handle, i
-      TYPE(pw_p_type), DIMENSION(3)                      :: dln_eps, dv
+      TYPE(pw_type), DIMENSION(3)                        :: dv
 
       CALL timeset(routineN, handle)
 
-      dln_eps = dielectric%dln_eps
       DO i = 1, 3
-         ALLOCATE (dv(i)%pw)
-         CALL pw_pool_create_pw(pw_pool, dv(i)%pw, &
+         CALL pw_pool_create_pw(pw_pool, dv(i), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
       END DO
 
       CALL derive_fft(v, dv, pw_pool)
-      Pxv%cr3d = -(dv(1)%pw%cr3d*dln_eps(1)%pw%cr3d + &
-                   dv(2)%pw%cr3d*dln_eps(2)%pw%cr3d + &
-                   dv(3)%pw%cr3d*dln_eps(3)%pw%cr3d)
+      ASSOCIATE (dln_eps => dielectric%dln_eps)
+         Pxv%cr3d = -(dv(1)%cr3d*dln_eps(1)%cr3d + &
+                      dv(2)%cr3d*dln_eps(2)%cr3d + &
+                      dv(3)%cr3d*dln_eps(3)%cr3d)
+      END ASSOCIATE
 
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(pw_pool, dv(i)%pw)
-         DEALLOCATE (dv(i)%pw)
+         CALL pw_pool_give_back_pw(pw_pool, dv(i))
       END DO
 
       CALL timestop(handle)
@@ -1490,15 +1464,15 @@ CONTAINS
 
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw_in
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in
+      TYPE(pw_type), INTENT(INOUT)                       :: pw_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_inv_laplace_operator_fft'
 
       INTEGER                                            :: handle, ig, ng
       REAL(dp)                                           :: prefactor
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: pw_in_gs
+      TYPE(pw_type)                                      :: pw_in_gs
 
       CALL timeset(routineN, handle)
 
@@ -1508,8 +1482,6 @@ CONTAINS
       pw_grid => pw_pool%pw_grid
       ng = SIZE(pw_grid%gsq)
 
-      NULLIFY (pw_in_gs)
-      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1520,7 +1492,6 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
-      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1542,15 +1513,15 @@ CONTAINS
 
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw_in
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in
+      TYPE(pw_type), INTENT(INOUT)                       :: pw_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_inv_laplace_operator_dct'
 
       INTEGER                                            :: handle, ig, ng
       REAL(dp)                                           :: prefactor
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: pw_in_gs
+      TYPE(pw_type)                                      :: pw_in_gs
 
       CALL timeset(routineN, handle)
 
@@ -1560,8 +1531,6 @@ CONTAINS
       pw_grid => pw_pool%pw_grid
       ng = SIZE(pw_grid%gsq)
 
-      NULLIFY (pw_in_gs)
-      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1572,7 +1541,6 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
-      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1592,8 +1560,8 @@ CONTAINS
 
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw_in
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in
+      TYPE(pw_type), INTENT(INOUT)                       :: pw_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_laplace_operator_fft'
 
@@ -1601,7 +1569,7 @@ CONTAINS
       LOGICAL                                            :: have_g0
       REAL(dp)                                           :: prefactor
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: pw_in_gs
+      TYPE(pw_type)                                      :: pw_in_gs
 
       CALL timeset(routineN, handle)
 
@@ -1612,8 +1580,6 @@ CONTAINS
       ng = SIZE(pw_in%pw_grid%gsq)
       have_g0 = green%influence_fn%pw_grid%have_g0
 
-      NULLIFY (pw_in_gs)
-      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1630,7 +1596,6 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
-      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1651,8 +1616,8 @@ CONTAINS
 
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw_in
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in
+      TYPE(pw_type), INTENT(INOUT)                       :: pw_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_laplace_operator_dct'
 
@@ -1660,7 +1625,7 @@ CONTAINS
       LOGICAL                                            :: have_g0
       REAL(dp)                                           :: prefactor
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: pw_in_gs
+      TYPE(pw_type)                                      :: pw_in_gs
 
       CALL timeset(routineN, handle)
 
@@ -1671,8 +1636,6 @@ CONTAINS
       ng = SIZE(pw_in%pw_grid%gsq)
       have_g0 = green%dct_influence_fn%pw_grid%have_g0
 
-      NULLIFY (pw_in_gs)
-      ALLOCATE (pw_in_gs)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1689,7 +1652,6 @@ CONTAINS
       CALL pw_transfer(pw_in_gs, pw_out)
 
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
-      DEALLOCATE (pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1711,18 +1673,16 @@ CONTAINS
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
       TYPE(dielectric_type), INTENT(IN), POINTER         :: dielectric
-      TYPE(pw_type), INTENT(IN), POINTER                 :: v
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: density
+      TYPE(pw_type), INTENT(IN)                          :: v
+      TYPE(pw_type), INTENT(INOUT)                       :: density
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_poisson_operator_fft'
 
       INTEGER                                            :: handle
-      TYPE(pw_type), POINTER                             :: Pxv
+      TYPE(pw_type)                                      :: Pxv
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (Pxv)
-      ALLOCATE (Pxv)
       CALL pw_pool_create_pw(pw_pool, Pxv, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1731,7 +1691,6 @@ CONTAINS
       CALL pw_axpy(Pxv, density)
 
       CALL pw_pool_give_back_pw(pw_pool, Pxv)
-      DEALLOCATE (Pxv)
 
       CALL timestop(handle)
 
@@ -1755,18 +1714,16 @@ CONTAINS
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
       TYPE(dielectric_type), INTENT(IN), POINTER         :: dielectric
-      TYPE(pw_type), INTENT(IN), POINTER                 :: v
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: density
+      TYPE(pw_type), INTENT(IN)                          :: v
+      TYPE(pw_type), INTENT(INOUT)                       :: density
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'apply_poisson_operator_dct'
 
       INTEGER                                            :: handle
-      TYPE(pw_type), POINTER                             :: Pxv
+      TYPE(pw_type)                                      :: Pxv
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (Pxv)
-      ALLOCATE (Pxv)
       CALL pw_pool_create_pw(pw_pool, Pxv, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1775,7 +1732,6 @@ CONTAINS
       CALL pw_axpy(Pxv, density)
 
       CALL pw_pool_give_back_pw(pw_pool, Pxv)
-      DEALLOCATE (Pxv)
 
       CALL timestop(handle)
 
@@ -1799,43 +1755,37 @@ CONTAINS
 
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(dielectric_type), INTENT(IN), POINTER         :: dielectric
-      TYPE(pw_type), INTENT(IN), POINTER                 :: v
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: v_eps
+      TYPE(pw_type), INTENT(IN)                          :: v
+      TYPE(pw_type), INTENT(INOUT)                       :: v_eps
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ps_implicit_compute_veps'
 
       INTEGER                                            :: handle, i
       REAL(dp)                                           :: eightpi
-      TYPE(pw_p_type), DIMENSION(3)                      :: dv
-      TYPE(pw_type), POINTER                             :: deps_drho, dv2
+      TYPE(pw_type)                                      :: dv2
+      TYPE(pw_type), DIMENSION(3)                        :: dv
 
       CALL timeset(routineN, handle)
 
       eightpi = 2*fourpi
-      deps_drho => dielectric%deps_drho
 
-      NULLIFY (dv2)
-      ALLOCATE (dv2)
       CALL pw_pool_create_pw(pw_pool, dv2, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       DO i = 1, 3
-         ALLOCATE (dv(i)%pw)
-         CALL pw_pool_create_pw(pw_pool, dv(i)%pw, &
+         CALL pw_pool_create_pw(pw_pool, dv(i), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
       END DO
 
       CALL derive_fft(v, dv, pw_pool)
 
 ! evaluate |\nabla_r(v)|^2
-      dv2%cr3d = dv(1)%pw%cr3d**2 + dv(2)%pw%cr3d**2 + dv(3)%pw%cr3d**2
+      dv2%cr3d = dv(1)%cr3d**2 + dv(2)%cr3d**2 + dv(3)%cr3d**2
 
-      v_eps%cr3d = -(1.0_dp/eightpi)*(dv2%cr3d*deps_drho%cr3d)
+      v_eps%cr3d = -(1.0_dp/eightpi)*(dv2%cr3d*dielectric%deps_drho%cr3d)
 
       CALL pw_pool_give_back_pw(pw_pool, dv2)
-      DEALLOCATE (dv2)
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(pw_pool, dv(i)%pw)
-         DEALLOCATE (dv(i)%pw)
+         CALL pw_pool_give_back_pw(pw_pool, dv(i))
       END DO
 
       CALL timestop(handle)
@@ -1853,7 +1803,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE compute_ehartree_periodic_bc(density, v, ehartree)
 
-      TYPE(pw_type), INTENT(IN), POINTER                 :: density, v
+      TYPE(pw_type), INTENT(IN)                          :: density, v
       REAL(dp), INTENT(OUT)                              :: ehartree
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_ehartree_periodic_bc'
@@ -1885,10 +1835,10 @@ CONTAINS
    SUBROUTINE compute_ehartree_mixed_bc(dielectric, density, Btxlambda, v, ehartree, electric_enthalpy)
 
       TYPE(dielectric_type), INTENT(IN), POINTER         :: dielectric
-      TYPE(pw_type), INTENT(IN), POINTER                 :: density
+      TYPE(pw_type), INTENT(IN)                          :: density
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(IN)                                      :: Btxlambda
-      TYPE(pw_type), INTENT(IN), POINTER                 :: v
+      TYPE(pw_type), INTENT(IN)                          :: v
       REAL(dp), INTENT(OUT)                              :: ehartree, electric_enthalpy
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_ehartree_mixed_bc'
@@ -1896,12 +1846,10 @@ CONTAINS
       INTEGER                                            :: handle
       REAL(dp)                                           :: dvol, ehartree_rho, ehartree_rho_cstr
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: eps
 
       CALL timeset(routineN, handle)
 
       pw_grid => v%pw_grid
-      eps => dielectric%eps
 
       dvol = pw_grid%dvol
 
@@ -1909,7 +1857,7 @@ CONTAINS
 ! the sign of the second term depends on the sign chosen for the Lagrange multiplier
 ! term in the variational form
       ehartree_rho = accurate_sum(density%cr3d*v%cr3d)
-      ehartree_rho_cstr = accurate_sum(eps%cr3d*Btxlambda*v%cr3d/fourpi)
+      ehartree_rho_cstr = accurate_sum(dielectric%eps%cr3d*Btxlambda*v%cr3d/fourpi)
       ehartree_rho = 0.5_dp*ehartree_rho*dvol
       ehartree_rho_cstr = 0.5_dp*ehartree_rho_cstr*dvol
       CALL mp_sum(ehartree_rho, pw_grid%para%group)
@@ -1941,8 +1889,8 @@ CONTAINS
 
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
-      TYPE(pw_type), INTENT(IN), POINTER                 :: res_new, v_old, v_new
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: QAinvxres_new
+      TYPE(pw_type), INTENT(IN)                          :: res_new, v_old, v_new
+      TYPE(pw_type), INTENT(INOUT)                       :: QAinvxres_new
       REAL(dp), INTENT(OUT)                              :: pres_error, nabs_error
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ps_implicit_compute_error_fft'
@@ -1992,8 +1940,8 @@ CONTAINS
 
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       TYPE(greens_fn_type), INTENT(IN), POINTER          :: green
-      TYPE(pw_type), INTENT(IN), POINTER                 :: res_new, v_old, v_new
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: QAinvxres_new
+      TYPE(pw_type), INTENT(IN)                          :: res_new, v_old, v_new
+      TYPE(pw_type), INTENT(INOUT)                       :: QAinvxres_new
       REAL(dp), INTENT(OUT)                              :: pres_error, nabs_error
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'ps_implicit_compute_error_dct'
@@ -2140,50 +2088,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE ps_implicit_print_convergence_msg
-
-! **************************************************************************************************
-!> \brief  computes the derivative of a function using FFT
-!> \param f  input funcition
-!> \param df derivative of f
-!> \param pw_pool pool of plane-wave grid
-! **************************************************************************************************
-   SUBROUTINE derive_fft(f, df, pw_pool)
-
-      TYPE(pw_type), POINTER                             :: f
-      TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
-      TYPE(pw_pool_type), POINTER                        :: pw_pool
-
-      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fft'
-
-      INTEGER                                            :: handle, i
-      INTEGER, DIMENSION(3)                              :: nd
-      TYPE(pw_p_type), DIMENSION(2)                      :: work_gs
-
-      CALL timeset(routineN, handle)
-
-      DO i = 1, 2
-         ALLOCATE (work_gs(i)%pw)
-         CALL pw_pool_create_pw(pw_pool, work_gs(i)%pw, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      END DO
-
-      CALL pw_transfer(f, work_gs(1)%pw)
-      DO i = 1, 3
-         nd(:) = 0
-         nd(i) = 1
-         CALL pw_copy(work_gs(1)%pw, work_gs(2)%pw)
-         CALL pw_derive(work_gs(2)%pw, nd(:))
-         CALL pw_transfer(work_gs(2)%pw, df(i)%pw)
-      END DO
-
-      DO i = 1, 2
-         CALL pw_pool_give_back_pw(pw_pool, work_gs(i)%pw)
-         DEALLOCATE (work_gs(i)%pw)
-      END DO
-
-      CALL timestop(handle)
-
-   END SUBROUTINE derive_fft
 
 ! **************************************************************************************************
 !> \brief  converts a 1D array to a 3D array (contiguous layout)

--- a/src/pw/ps_implicit_types.F
+++ b/src/pw/ps_implicit_types.F
@@ -100,12 +100,9 @@ CONTAINS
          do_dbc_cube = ps_implicit_env%do_dbc_cube
 
          IF (can_give_back) THEN
-            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%initial_guess, &
-                                      accept_non_compatible=.TRUE.)
-            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%v_eps, &
-                                      accept_non_compatible=.TRUE.)
-            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%cstr_charge, &
-                                      accept_non_compatible=.TRUE.)
+            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%initial_guess)
+            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%v_eps)
+            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%cstr_charge)
             DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps, ps_implicit_env%cstr_charge)
             CALL dbc_release(ps_implicit_env%contacts, do_dbc_cube, pw_pool=pw_pool)
          ELSE

--- a/src/pw/ps_implicit_types.F
+++ b/src/pw/ps_implicit_types.F
@@ -106,6 +106,7 @@ CONTAINS
                                       accept_non_compatible=.TRUE.)
             CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%cstr_charge, &
                                       accept_non_compatible=.TRUE.)
+            DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps, ps_implicit_env%cstr_charge)
             CALL dbc_release(ps_implicit_env%contacts, do_dbc_cube, pw_pool=pw_pool)
          ELSE
             CALL pw_release(ps_implicit_env%initial_guess)

--- a/src/pw/ps_implicit_types.F
+++ b/src/pw/ps_implicit_types.F
@@ -110,8 +110,11 @@ CONTAINS
          ELSE
             CALL pw_release(ps_implicit_env%initial_guess)
             CALL pw_release(ps_implicit_env%v_eps)
-            CALL pw_release(ps_implicit_env%cstr_charge)
-            DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps, ps_implicit_env%cstr_charge)
+            IF (ASSOCIATED(ps_implicit_env%cstr_charge)) THEN
+               CALL pw_release(ps_implicit_env%cstr_charge)
+               DEALLOCATE (ps_implicit_env%cstr_charge)
+            END IF
+            DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps)
             CALL dbc_release(ps_implicit_env%contacts, do_dbc_cube)
          END IF
 

--- a/src/pw/ps_implicit_types.F
+++ b/src/pw/ps_implicit_types.F
@@ -111,6 +111,7 @@ CONTAINS
             CALL pw_release(ps_implicit_env%initial_guess)
             CALL pw_release(ps_implicit_env%v_eps)
             CALL pw_release(ps_implicit_env%cstr_charge)
+            DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps, ps_implicit_env%cstr_charge)
             CALL dbc_release(ps_implicit_env%contacts, do_dbc_cube)
          END IF
 

--- a/src/pw/ps_wavelet_methods.F
+++ b/src/pw/ps_wavelet_methods.F
@@ -170,7 +170,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp2k_distribution_to_z_slices(density, wavelet, pw_grid)
 
-      TYPE(pw_type), POINTER                             :: density
+      TYPE(pw_type), INTENT(IN)                          :: density
       TYPE(ps_wavelet_type), POINTER                     :: wavelet
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
@@ -330,7 +330,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE z_slices_to_cp2k_distribution(density, wavelet, pw_grid)
 
-      TYPE(pw_type), POINTER                             :: density
+      TYPE(pw_type), INTENT(IN)                          :: density
       TYPE(ps_wavelet_type), POINTER                     :: wavelet
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 

--- a/src/pw/pw_gpu.F
+++ b/src/pw/pw_gpu.F
@@ -103,9 +103,9 @@ CONTAINS
 !> \author Benjamin G Levine
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_r3dc1d_3d(pw1, pw2, scale)
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
-      REAL(KIND=dp)                                      :: scale
+      TYPE(pw_type), INTENT(IN)                          :: pw1
+      TYPE(pw_type), INTENT(INOUT)                       :: pw2
+      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_r3dc1d_3d'
 
@@ -163,9 +163,9 @@ CONTAINS
 !> \author Benjamin G Levine
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_c1dr3d_3d(pw1, pw2, scale)
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
-      REAL(KIND=dp)                                      :: scale
+      TYPE(pw_type), INTENT(IN)                          :: pw1
+      TYPE(pw_type), INTENT(INOUT)                       :: pw2
+      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_c1dr3d_3d'
 
@@ -223,9 +223,9 @@ CONTAINS
 !> \author Andreas Gloess
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_r3dc1d_3d_ps(pw1, pw2, scale)
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
-      REAL(KIND=dp)                                      :: scale
+      TYPE(pw_type), INTENT(IN)                          :: pw1
+      TYPE(pw_type), INTENT(INOUT)                       :: pw2
+      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_gpu_r3dc1d_3d_ps'
 
@@ -403,9 +403,9 @@ CONTAINS
 !> \author Andreas Gloess
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_c1dr3d_3d_ps(pw1, pw2, scale)
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
-      REAL(KIND=dp)                                      :: scale
+      TYPE(pw_type), INTENT(IN)                          :: pw1
+      TYPE(pw_type), INTENT(INOUT)                       :: pw2
+      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_gpu_c1dr3d_3d_ps'
 
@@ -586,9 +586,9 @@ CONTAINS
 !> \author Andreas Gloess
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_cff(pw1, pwbuf)
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
+      TYPE(pw_type), INTENT(IN)                          :: pw1
       COMPLEX(KIND=dp), DIMENSION(:, :, :), &
-         INTENT(INOUT), POINTER                          :: pwbuf
+         INTENT(INOUT), TARGET                           :: pwbuf
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_cff'
 
@@ -635,8 +635,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_ffc(pwbuf, pw2)
       COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(IN), &
-         POINTER                                         :: pwbuf
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
+         TARGET                                          :: pwbuf
+      TYPE(pw_type), INTENT(IN)                          :: pw2
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_ffc'
 
@@ -682,9 +682,9 @@ CONTAINS
 !> \author Andreas Gloess
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_cf(pw1, pwbuf)
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
+      TYPE(pw_type), INTENT(IN)                          :: pw1
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
-         POINTER                                         :: pwbuf
+         TARGET                                          :: pwbuf
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_cf'
 
@@ -730,8 +730,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_fc(pwbuf, pw2)
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN), &
-         POINTER                                         :: pwbuf
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
+         TARGET                                          :: pwbuf
+      TYPE(pw_type), INTENT(IN)                          :: pw2
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_fc'
 
@@ -780,9 +780,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_f(pwbuf1, pwbuf2, dir, n, m)
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN), &
-         POINTER                                         :: pwbuf1
+         TARGET                                          :: pwbuf1
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
-         POINTER                                         :: pwbuf2
+         TARGET                                          :: pwbuf2
       INTEGER, INTENT(IN)                                :: dir, n, m
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_f'
@@ -825,8 +825,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_fg(pwbuf, pw2, scale)
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN), &
-         POINTER                                         :: pwbuf
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
+         TARGET                                          :: pwbuf
+      TYPE(pw_type), INTENT(IN)                          :: pw2
       REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_fg'
@@ -884,9 +884,9 @@ CONTAINS
 !> \author Andreas Gloess
 ! **************************************************************************************************
    SUBROUTINE pw_gpu_sf(pw1, pwbuf, scale)
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
+      TYPE(pw_type), INTENT(IN)                          :: pw1
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
-         POINTER                                         :: pwbuf
+         TARGET                                          :: pwbuf
       REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_sf'

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -103,7 +103,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: zr
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
       IF (pw%in_use == REALDATA1D) THEN
          ns = SIZE(pw%cr)
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw)
@@ -157,8 +156,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       out_unit = cp_logger_get_default_io_unit()
-      CPASSERT(pw1%ref_count > 0)
-      CPASSERT(pw2%ref_count > 0)
       IF (pw1%pw_grid%id_nr /= pw2%pw_grid%id_nr) THEN
 
          IF (pw1%pw_grid%spherical .AND. pw2%pw_grid%spherical) THEN
@@ -335,7 +332,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       SELECT CASE (pw%in_use)
       CASE (REALDATA1D)
@@ -392,7 +388,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop, omega_2
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
       CPASSERT(omega >= 0)
 
       flop = 0.0_dp
@@ -448,7 +443,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop, omega_2, tmp
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
       CPASSERT(omega >= 0)
 
       flop = 0.0_dp
@@ -511,7 +505,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop, omega_2
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
       CPASSERT(omega >= 0)
 
       flop = 0.0_dp
@@ -567,7 +560,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop, tmp
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
       CPASSERT(rcutoff >= 0)
 
       flop = 0.0_dp
@@ -626,7 +618,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
       CPASSERT(ALL(n >= 0))
 
       m = SUM(n)
@@ -713,7 +704,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       flop = 0.0_dp
 
@@ -762,7 +752,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop, gg, o3
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       flop = 0.0_dp
       o3 = 1._dp/3._dp
@@ -823,7 +812,6 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_dr2_gg'
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       flop = 0.0_dp
       o3 = 1._dp/3._dp
@@ -885,7 +873,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: arg, f, flop
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       flop = 0.0_dp
 
@@ -937,9 +924,6 @@ CONTAINS
       CALL timeset(routineN, handle)
       !sample peak memory
       CALL m_memory()
-
-      CPASSERT(pw1%ref_count > 0)
-      CPASSERT(pw2%ref_count > 0)
 
       IF (pw1%in_space == REALSPACE .AND. pw2%in_space == REALSPACE) THEN
 
@@ -1005,9 +989,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       out_unit = cp_logger_get_default_io_unit()
-
-      CPASSERT(pw1%ref_count > 0)
-      CPASSERT(pw2%ref_count > 0)
 
       my_alpha = 1.0_dp
       IF (PRESENT(alpha)) my_alpha = alpha
@@ -1221,10 +1202,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CPASSERT(pw_out%ref_count > 0)
-      CPASSERT(pw1%ref_count > 0)
-      CPASSERT(pw2%ref_count > 0)
-
       my_alpha = 1.0_dp
       IF (PRESENT(alpha)) my_alpha = alpha
 
@@ -1321,7 +1298,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: cpy
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       IF (pw%in_use /= COMPLEXDATA1D) THEN
          CPABORT("Data field has to be COMPLEXDATA1D")
@@ -1389,7 +1365,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: cpy
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       IF (pw%in_use /= COMPLEXDATA1D) THEN
          CPABORT("Data field has to be COMPLEXDATA1D")
@@ -1470,7 +1445,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: cpy
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       IF (pw%in_use /= COMPLEXDATA1D) THEN
          CPABORT("Data field has to be COMPLEXDATA1D")
@@ -1576,7 +1550,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: cpy
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
 
       IF (pw%in_use /= COMPLEXDATA1D) THEN
          CPABORT("Data field has to be COMPLEXDATA1D")
@@ -1713,8 +1686,6 @@ CONTAINS
       CALL timeset(routineN//"_"//TRIM(ADJUSTL(cp_to_string( &
                                                CEILING(pw1%pw_grid%cutoff/10)*10))), handle)
 
-      CPASSERT(pw1%ref_count > 0)
-      CPASSERT(pw2%ref_count > 0)
       NULLIFY (c_in)
       NULLIFY (c_out)
 
@@ -2379,7 +2350,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: arg, flop
 
       CALL timeset(routineN, handle)
-      CPASSERT(sf%ref_count > 0)
       flop = 0.0_dp
 
       IF (sf%in_space == RECIPROCALSPACE .AND. &
@@ -2484,7 +2454,6 @@ CONTAINS
       LOGICAL                                            :: is_match
 
       CALL timeset(routineN, handle)
-      CPASSERT(pw%ref_count > 0)
       IF (pw%in_use == REALDATA3D) THEN
          is_match = .TRUE.
          is_match = is_match .AND. (LBOUND(values, 1) .GE. LBOUND(pw%cr3d, 1))

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -95,7 +95,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_zero(pw)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_zero'
 
@@ -323,7 +323,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_scale(pw, a)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp), INTENT(IN)                          :: a
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_scale'
@@ -379,7 +379,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_gauss_damp(pw, omega)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp), INTENT(IN)                          :: omega
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gauss_damp'
@@ -434,7 +434,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_compl_gauss_damp(pw, omega)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp), INTENT(IN)                          :: omega
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_compl_gauss_damp'
@@ -443,7 +443,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop, omega_2, tmp
 
       CALL timeset(routineN, handle)
-      CPASSERT(omega >= 0)
 
       flop = 0.0_dp
       n_exp = 0
@@ -496,7 +495,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_gauss_damp_mix(pw, omega, scale_coul, scale_long)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp), INTENT(IN)                          :: omega, scale_coul, scale_long
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gauss_damp_mix'
@@ -505,7 +504,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: flop, omega_2
 
       CALL timeset(routineN, handle)
-      CPASSERT(omega >= 0)
 
       flop = 0.0_dp
       n_exp = 0
@@ -551,7 +549,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_truncated(pw, rcutoff)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp), INTENT(IN)                          :: rcutoff
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_truncated'
@@ -608,7 +606,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_derive(pw, n)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, DIMENSION(3), INTENT(IN)                  :: n
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_derive'
@@ -696,7 +694,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_laplace(pw)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_laplace'
 
@@ -742,8 +740,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_dr2(pw, pwdr2, i, j)
 
-      TYPE(pw_type), INTENT(IN)                          :: pw
-      TYPE(pw_type), INTENT(INOUT)                       :: pwdr2
+      TYPE(pw_type), INTENT(IN)                          :: pw, pwdr2
       INTEGER, INTENT(IN)                                :: i, j
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_dr2'
@@ -803,8 +800,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_dr2_gg(pw, pwdr2_gg, i, j)
 
-      TYPE(pw_type), INTENT(IN)                          :: pw
-      TYPE(pw_type), INTENT(INOUT)                       :: pwdr2_gg
+      TYPE(pw_type), INTENT(IN)                          :: pw, pwdr2_gg
       INTEGER, INTENT(IN)                                :: i, j
 
       INTEGER                                            :: cnt, handle, ig
@@ -864,7 +860,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_smoothing(pw, ecut, sigma)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp), INTENT(IN)                          :: ecut, sigma
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_smoothing'
@@ -913,8 +909,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_transfer(pw1, pw2, debug)
 
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
+      TYPE(pw_type), INTENT(IN)                          :: pw1
+      TYPE(pw_type), INTENT(INOUT)                       :: pw2
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_transfer'
@@ -978,8 +974,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_axpy(pw1, pw2, alpha)
 
-      TYPE(pw_type), INTENT(IN)                          :: pw1
-      TYPE(pw_type), INTENT(INOUT)                       :: pw2
+      TYPE(pw_type), INTENT(IN)                          :: pw1, pw2
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: alpha
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_axpy'
@@ -1191,8 +1186,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_multiply(pw_out, pw1, pw2, alpha)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw_out
-      TYPE(pw_type), INTENT(IN)                          :: pw1, pw2
+      TYPE(pw_type), INTENT(IN)                          :: pw_out, pw1, pw2
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: alpha
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_multiply'
@@ -1353,7 +1347,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_gather_p(pw, c, scale)
 
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw
+      TYPE(pw_type), INTENT(INOUT)                       :: pw
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: c
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
 
@@ -1538,7 +1532,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_scatter_p(pw, c, scale)
 
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: c
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
 
@@ -1662,8 +1656,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fft_wrap_pw1pw2(pw1, pw2, debug)
 
-      TYPE(pw_type), INTENT(IN), TARGET                  :: pw1
-      TYPE(pw_type), INTENT(INOUT), TARGET               :: pw2
+      TYPE(pw_type), INTENT(IN)                  :: pw1
+      TYPE(pw_type), INTENT(INOUT)               :: pw2
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'fft_wrap_pw1pw2'
@@ -2341,7 +2335,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_structure_factor(sf, r)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: sf
+      TYPE(pw_type), INTENT(IN)                          :: sf
       REAL(KIND=dp), DIMENSION(:), INTENT(in)            :: r
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_structure_factor'
@@ -2444,7 +2438,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_set(pw, values)
 
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN), &
          POINTER                                         :: values
 

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -173,7 +173,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_poisson_rebuild(poisson_env, density)
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
-      TYPE(pw_type), OPTIONAL, POINTER                   :: density
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: density
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_poisson_rebuild'
 
@@ -240,13 +240,13 @@ CONTAINS
                                dvhartree, h_stress, rho_core, greenfn, aux_density)
 
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
-      TYPE(pw_type), POINTER                             :: density
+      TYPE(pw_type), INTENT(IN)                          :: density
       REAL(kind=dp), INTENT(out), OPTIONAL               :: ehartree
-      TYPE(pw_type), OPTIONAL, POINTER                   :: vhartree
+      TYPE(pw_type), INTENT(INOUT), OPTIONAL             :: vhartree
       TYPE(pw_p_type), DIMENSION(3), OPTIONAL            :: dvhartree
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
          OPTIONAL                                        :: h_stress
-      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core, greenfn, aux_density
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: rho_core, greenfn, aux_density
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_poisson_solve'
 
@@ -255,11 +255,10 @@ CONTAINS
       LOGICAL                                            :: has_dielectric
       REAL(KIND=dp)                                      :: ffa
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_p_type)                                    :: dvg(3), dvg_aux(3)
       TYPE(pw_poisson_parameter_type), POINTER           :: poisson_params
       TYPE(pw_pool_type), POINTER                        :: pw_pool
-      TYPE(pw_type), POINTER                             :: influence_fn, rhog, rhog_aux, rhor, &
-                                                            tmpg, vhartree_rs
+      TYPE(pw_type)                                      :: dvg(3), dvg_aux(3), influence_fn, rhog, &
+                                                            rhog_aux, rhor, tmpg, vhartree_rs
 
       CALL timeset(routineN, handle)
 
@@ -274,17 +273,12 @@ CONTAINS
       pw_pool => poisson_env%pw_pools(poisson_env%pw_level)%pool
       pw_grid => pw_pool%pw_grid
       IF (PRESENT(vhartree)) THEN
-         CPASSERT(ASSOCIATED(vhartree))
          IF (.NOT. pw_grid_compare(pw_pool%pw_grid, vhartree%pw_grid)) &
             CPABORT("vhartree has a different grid than the poisson solver")
       END IF
       ! density in G space
-      NULLIFY (rhog)
-      ALLOCATE (rhog)
       CALL pw_pool_create_pw(pw_pool, rhog, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       IF (PRESENT(aux_density)) THEN
-         NULLIFY (rhog_aux)
-         ALLOCATE (rhog_aux)
          CALL pw_pool_create_pw(pw_pool, rhog_aux, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END IF
 
@@ -299,16 +293,14 @@ CONTAINS
                CALL pw_transfer(aux_density, rhog_aux)
             END IF
             IF (PRESENT(ehartree) .AND. (.NOT. PRESENT(vhartree))) THEN
-               NULLIFY (tmpg)
-               ALLOCATE (tmpg)
                CALL pw_pool_create_pw(pw_pool, tmpg, use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
                CALL pw_copy(rhog, tmpg)
             END IF
             IF (PRESENT(greenfn)) THEN
-               influence_fn => greenfn
+               influence_fn = greenfn
             ELSE
-               influence_fn => poisson_env%green_fft%influence_fn
+               influence_fn = poisson_env%green_fft%influence_fn
             END IF
             rhog%cc(:) = rhog%cc(:)*influence_fn%cc(:)
             IF (PRESENT(aux_density)) THEN
@@ -326,7 +318,6 @@ CONTAINS
             ELSE IF (PRESENT(ehartree)) THEN
                ehartree = 0.5_dp*pw_integral_ab(rhog, tmpg)
                CALL pw_pool_give_back_pw(pw_pool, tmpg)
-               DEALLOCATE (tmpg)
             END IF
 
          CASE (PS_IMPLICIT)
@@ -353,8 +344,6 @@ CONTAINS
                END SELECT
             END IF
 
-            NULLIFY (rhor, vhartree_rs)
-            ALLOCATE (rhor, vhartree_rs)
             CALL pw_pool_create_pw(pw_pool, rhor, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(pw_pool, vhartree_rs, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(density, rhor)
@@ -382,7 +371,6 @@ CONTAINS
 
             CALL pw_pool_give_back_pw(pw_pool, rhor)
             CALL pw_pool_give_back_pw(pw_pool, vhartree_rs)
-            DEALLOCATE (rhor, vhartree_rs)
 
          CASE DEFAULT
             CALL cp_abort(__LOCATION__, &
@@ -392,8 +380,6 @@ CONTAINS
 
       CASE (use_rs_grid)
 
-         NULLIFY (rhor)
-         ALLOCATE (rhor)
          CALL pw_pool_create_pw(pw_pool, rhor, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(density, rhor)
          CALL cp2k_distribution_to_z_slices(rhor, poisson_env%wavelet, rhor%pw_grid)
@@ -411,32 +397,29 @@ CONTAINS
             CALL pw_transfer(rhor, rhog)
          END IF
          CALL pw_pool_give_back_pw(pw_pool, rhor)
-         DEALLOCATE (rhor)
 
       END SELECT
 
       ! do we need to calculate the derivative of the potential?
       IF (PRESENT(h_stress) .OR. PRESENT(dvhartree)) THEN
          DO i = 1, 3
-            ALLOCATE (dvg(i)%pw)
-            CALL pw_pool_create_pw(pw_pool, dvg(i)%pw, use_data=COMPLEXDATA1D, &
+            CALL pw_pool_create_pw(pw_pool, dvg(i), use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
             n = 0
             n(i) = 1
-            CALL pw_copy(rhog, dvg(i)%pw)
-            CALL pw_derive(dvg(i)%pw, n)
+            CALL pw_copy(rhog, dvg(i))
+            CALL pw_derive(dvg(i), n)
             IF (PRESENT(aux_density)) THEN
-               ALLOCATE (dvg_aux(i)%pw)
-               CALL pw_pool_create_pw(pw_pool, dvg_aux(i)%pw, use_data=COMPLEXDATA1D, &
+               CALL pw_pool_create_pw(pw_pool, dvg_aux(i), use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
-               CALL pw_copy(rhog_aux, dvg_aux(i)%pw)
-               CALL pw_derive(dvg_aux(i)%pw, n)
+               CALL pw_copy(rhog_aux, dvg_aux(i))
+               CALL pw_derive(dvg_aux(i), n)
             END IF
          END DO
          ! save the derivatives
          IF (PRESENT(dvhartree)) THEN
             DO i = 1, 3
-               CALL pw_transfer(dvg(i)%pw, dvhartree(i)%pw)
+               CALL pw_transfer(dvg(i), dvhartree(i)%pw)
             END DO
          END IF
          ! Calculate the contribution to the stress tensor this is only the contribution from
@@ -449,13 +432,13 @@ CONTAINS
                IF (PRESENT(aux_density)) THEN
                   DO beta = alpha, 3
                      h_stress(alpha, beta) = h_stress(alpha, beta) &
-                                             + ffa*pw_integral_ab(dvg_aux(alpha)%pw, dvg(beta)%pw)
+                                             + ffa*pw_integral_ab(dvg_aux(alpha), dvg(beta))
                      h_stress(beta, alpha) = h_stress(alpha, beta)
                   END DO
                ELSE
                   DO beta = alpha, 3
                      h_stress(alpha, beta) = h_stress(alpha, beta) &
-                                             + ffa*pw_integral_ab(dvg(alpha)%pw, dvg(beta)%pw)
+                                             + ffa*pw_integral_ab(dvg(alpha), dvg(beta))
                      h_stress(beta, alpha) = h_stress(alpha, beta)
                   END DO
                END IF
@@ -520,20 +503,16 @@ CONTAINS
          END IF
 
          DO i = 1, 3
-            CALL pw_pool_give_back_pw(pw_pool, dvg(i)%pw)
-            DEALLOCATE (dvg(i)%pw)
+            CALL pw_pool_give_back_pw(pw_pool, dvg(i))
             IF (PRESENT(aux_density)) THEN
-               CALL pw_pool_give_back_pw(pw_pool, dvg_aux(i)%pw)
-               DEALLOCATE (dvg_aux(i)%pw)
+               CALL pw_pool_give_back_pw(pw_pool, dvg_aux(i))
             END IF
          END DO
 
       END IF
       CALL pw_pool_give_back_pw(pw_pool, rhog)
-      DEALLOCATE (rhog)
       IF (PRESENT(aux_density)) THEN
          CALL pw_pool_give_back_pw(pw_pool, rhog_aux)
-         DEALLOCATE (rhog_aux)
       END IF
 
       CALL timestop(handle)

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -327,6 +327,7 @@ CONTAINS
             ELSE IF (PRESENT(ehartree)) THEN
                ehartree = 0.5_dp*pw_integral_ab(rhog, tmpg)
                CALL pw_pool_give_back_pw(pw_pool, tmpg)
+               DEALLOCATE (tmpg)
             END IF
 
          CASE (PS_IMPLICIT)
@@ -382,6 +383,7 @@ CONTAINS
 
             CALL pw_pool_give_back_pw(pw_pool, rhor)
             CALL pw_pool_give_back_pw(pw_pool, vhartree_rs)
+            DEALLOCATE (rhor, vhartree_rs)
 
          CASE DEFAULT
             CALL cp_abort(__LOCATION__, &
@@ -410,6 +412,7 @@ CONTAINS
             CALL pw_transfer(rhor, rhog)
          END IF
          CALL pw_pool_give_back_pw(pw_pool, rhor)
+         DEALLOCATE (rhor)
 
       END SELECT
 
@@ -519,15 +522,19 @@ CONTAINS
 
          DO i = 1, 3
             CALL pw_pool_give_back_pw(pw_pool, dvg(i)%pw)
+            DEALLOCATE (dvg(i)%pw)
             IF (PRESENT(aux_density)) THEN
                CALL pw_pool_give_back_pw(pw_pool, dvg_aux(i)%pw)
+               DEALLOCATE (dvg_aux(i)%pw)
             END IF
          END DO
 
       END IF
       CALL pw_pool_give_back_pw(pw_pool, rhog)
+      DEALLOCATE (rhog)
       IF (PRESENT(aux_density)) THEN
          CALL pw_pool_give_back_pw(pw_pool, rhog_aux)
+         DEALLOCATE (rhog_aux)
       END IF
 
       CALL timestop(handle)

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -281,9 +281,11 @@ CONTAINS
       END IF
       ! density in G space
       NULLIFY (rhog)
+      ALLOCATE (rhog)
       CALL pw_pool_create_pw(pw_pool, rhog, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       IF (PRESENT(aux_density)) THEN
          NULLIFY (rhog_aux)
+         ALLOCATE (rhog_aux)
          CALL pw_pool_create_pw(pw_pool, rhog_aux, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END IF
 
@@ -298,6 +300,8 @@ CONTAINS
                CALL pw_transfer(aux_density, rhog_aux)
             END IF
             IF (PRESENT(ehartree) .AND. (.NOT. PRESENT(vhartree))) THEN
+               NULLIFY (tmpg)
+               ALLOCATE (tmpg)
                CALL pw_pool_create_pw(pw_pool, tmpg, use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
                CALL pw_copy(rhog, tmpg)
@@ -349,6 +353,8 @@ CONTAINS
                END SELECT
             END IF
 
+            NULLIFY (rhor, vhartree_rs)
+            ALLOCATE (rhor, vhartree_rs)
             CALL pw_pool_create_pw(pw_pool, rhor, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(pw_pool, vhartree_rs, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(density, rhor)
@@ -385,6 +391,8 @@ CONTAINS
 
       CASE (use_rs_grid)
 
+         NULLIFY (rhor)
+         ALLOCATE (rhor)
          CALL pw_pool_create_pw(pw_pool, rhor, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(density, rhor)
          CALL cp2k_distribution_to_z_slices(rhor, poisson_env%wavelet, rhor%pw_grid)
@@ -408,7 +416,7 @@ CONTAINS
       ! do we need to calculate the derivative of the potential?
       IF (PRESENT(h_stress) .OR. PRESENT(dvhartree)) THEN
          DO i = 1, 3
-            NULLIFY (dvg(i)%pw)
+            ALLOCATE (dvg(i)%pw)
             CALL pw_pool_create_pw(pw_pool, dvg(i)%pw, use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
             n = 0
@@ -416,7 +424,7 @@ CONTAINS
             CALL pw_copy(rhog, dvg(i)%pw)
             CALL pw_derive(dvg(i)%pw, n)
             IF (PRESENT(aux_density)) THEN
-               NULLIFY (dvg_aux(i)%pw)
+               ALLOCATE (dvg_aux(i)%pw)
                CALL pw_pool_create_pw(pw_pool, dvg_aux(i)%pw, use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
                CALL pw_copy(rhog_aux, dvg_aux(i)%pw)

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -246,8 +246,7 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(3), OPTIONAL            :: dvhartree
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
          OPTIONAL                                        :: h_stress
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_core
-      TYPE(pw_type), OPTIONAL, POINTER                   :: greenfn, aux_density
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core, greenfn, aux_density
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_poisson_solve'
 
@@ -338,7 +337,7 @@ CONTAINS
                   CALL dielectric_compute(poisson_env%implicit_env%dielectric, &
                                           poisson_env%diel_rs_grid, &
                                           poisson_env%pw_pools(poisson_env%pw_level)%pool, &
-                                          density, rho_core=rho_core%pw)
+                                          density, rho_core=rho_core)
                CASE (NEUMANN_BC, MIXED_BC)
                   CALL dielectric_compute(poisson_env%implicit_env%dielectric, &
                                           poisson_env%diel_rs_grid, &
@@ -350,7 +349,7 @@ CONTAINS
                                           poisson_env%implicit_env%dct_env%srcs_expand, &
                                           poisson_env%implicit_env%dct_env%flipg_stat, &
                                           poisson_env%implicit_env%dct_env%bounds_shftd, &
-                                          density, rho_core=rho_core%pw)
+                                          density, rho_core=rho_core)
                END SELECT
             END IF
 

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -302,6 +302,8 @@ CONTAINS
       ! allocate influence function,...
       SELECT CASE (green%method)
       CASE (PERIODIC3D, ANALYTIC2D, ANALYTIC1D, ANALYTIC0D, MT2D, MT1D, MT0D, MULTIPOLE0D, PS_IMPLICIT)
+         NULLIFY (green%influence_fn)
+         ALLOCATE (green%influence_fn)
          CALL pw_pool_create_pw(pw_pool, green%influence_fn, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -312,6 +314,8 @@ CONTAINS
             n = green%p3m_order
             ALLOCATE (green%p3m_coeff(-(n - 1):n - 1, 0:n - 1))
             CALL spme_coeff_calculate(n, green%p3m_coeff)
+            NULLIFY (green%p3m_charge)
+            ALLOCATE (green%p3m_charge)
             CALL pw_pool_create_pw(pw_pool, green%p3m_charge, use_data=REALDATA1D, &
                                    in_space=RECIPROCALSPACE)
             CALL influence_factor(green)
@@ -330,6 +334,8 @@ CONTAINS
             IF ((poisson_params%ps_implicit_params%boundary_condition .EQ. MIXED_BC) .OR. &
                 (poisson_params%ps_implicit_params%boundary_condition .EQ. NEUMANN_BC)) THEN
                CALL pw_pool_create(pw_pool_xpndd, pw_grid=dct_pw_grid)
+               NULLIFY (green%dct_influence_fn)
+               ALLOCATE (green%dct_influence_fn)
                CALL pw_pool_create_pw(pw_pool_xpndd, green%dct_influence_fn, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                CALL pw_pool_release(pw_pool_xpndd)

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -478,14 +478,26 @@ CONTAINS
             can_give_back = PRESENT(pw_pool)
             IF (can_give_back) can_give_back = ASSOCIATED(pw_pool)
             IF (can_give_back) THEN
-               CALL pw_pool_give_back_pw(pw_pool, gftype%influence_fn, &
-                                         accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_pw(pw_pool, gftype%dct_influence_fn, &
-                                         accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_pw(pw_pool, gftype%screen_fn, &
-                                         accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_pw(pw_pool, gftype%p3m_charge, &
-                                         accept_non_compatible=.TRUE.)
+               IF (ASSOCIATED(gftype%influence_fn)) THEN
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%influence_fn, &
+                                            accept_non_compatible=.TRUE.)
+                  DEALLOCATE (gftype%influence_fn)
+               END IF
+               IF (ASSOCIATED(gftype%dct_influence_fn)) THEN
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%dct_influence_fn, &
+                                            accept_non_compatible=.TRUE.)
+                  DEALLOCATE (gftype%dct_influence_fn)
+               END IF
+               IF (ASSOCIATED(gftype%screen_fn)) THEN
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%screen_fn, &
+                                            accept_non_compatible=.TRUE.)
+                  DEALLOCATE (gftype%screen_fn)
+               END IF
+               IF (ASSOCIATED(gftype%p3m_charge)) THEN
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%p3m_charge, &
+                                            accept_non_compatible=.TRUE.)
+                  DEALLOCATE (gftype%p3m_charge)
+               END IF
             ELSE
                IF (ASSOCIATED(gftype%influence_fn)) THEN
                   CALL pw_release(gftype%influence_fn)

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -505,7 +505,7 @@ CONTAINS
 !> \author DH (29-Mar-2001)
 ! **************************************************************************************************
    SUBROUTINE influence_factor(gftype)
-      TYPE(greens_fn_type), POINTER                      :: gftype
+      TYPE(greens_fn_type), INTENT(INOUT)                :: gftype
 
       COMPLEX(KIND=dp)                                   :: b_m, exp_m, sum_m
       INTEGER                                            :: dim, j, k, l, n, pt
@@ -514,7 +514,6 @@ CONTAINS
       REAL(KIND=dp)                                      :: l_arg, prod_arg, val
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: m_assign
 
-      CPASSERT(ASSOCIATED(gftype))
       CPASSERT(gftype%ref_count > 0)
       n = gftype%p3m_order
 
@@ -568,7 +567,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calc_p3m_charge(gf)
 
-      TYPE(greens_fn_type), POINTER                      :: gf
+      TYPE(greens_fn_type), INTENT(IN)                   :: gf
 
       INTEGER                                            :: ig, l, m, n
       REAL(KIND=dp)                                      :: arg, novol

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -481,11 +481,22 @@ CONTAINS
                CALL pw_pool_give_back_pw(pw_pool, gftype%p3m_charge, &
                                          accept_non_compatible=.TRUE.)
             ELSE
-               CALL pw_release(gftype%influence_fn)
-               CALL pw_release(gftype%dct_influence_fn)
-               CALL pw_release(gftype%screen_fn)
-               CALL pw_release(gftype%p3m_charge)
-               DEALLOCATE (gftype%influence_fn, gftype%dct_influence_fn, gftype%screen_fn, gftype%p3m_charge)
+               IF (ASSOCIATED(gftype%influence_fn)) THEN
+                  CALL pw_release(gftype%influence_fn)
+                  DEALLOCATE (gftype%influence_fn)
+               END IF
+               IF (ASSOCIATED(gftype%dct_influence_fn)) THEN
+                  CALL pw_release(gftype%dct_influence_fn)
+                  DEALLOCATE (gftype%dct_influence_fn)
+               END IF
+               IF (ASSOCIATED(gftype%screen_fn)) THEN
+                  CALL pw_release(gftype%screen_fn)
+                  DEALLOCATE (gftype%screen_fn)
+               END IF
+               IF (ASSOCIATED(gftype%p3m_charge)) THEN
+                  CALL pw_release(gftype%p3m_charge)
+                  DEALLOCATE (gftype%p3m_charge)
+               END IF
             END IF
             IF (ASSOCIATED(gftype%p3m_bm2)) &
                DEALLOCATE (gftype%p3m_bm2)

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -167,7 +167,7 @@ MODULE pw_poisson_types
       LOGICAL :: sr_screening
       REAL(KIND=dp) :: sr_alpha
       REAL(KIND=dp) :: sr_rc
-      TYPE(pw_type), POINTER :: influence_fn
+      TYPE(pw_type) :: influence_fn
       TYPE(pw_type), POINTER :: dct_influence_fn
       TYPE(pw_type), POINTER :: screen_fn
       TYPE(pw_type), POINTER :: p3m_charge
@@ -198,9 +198,9 @@ CONTAINS
       REAL(KIND=dp)                                      :: g2, g3d, gg, gxy, gz, j0g, j1g, k0g, &
                                                             k1g, rlength, zlength
       REAL(KIND=dp), DIMENSION(3)                        :: abc
-      TYPE(pw_grid_type), POINTER                        :: dct_grid, grid
+      TYPE(pw_grid_type), POINTER                        :: dct_grid
       TYPE(pw_pool_type), POINTER                        :: pw_pool_xpndd
-      TYPE(pw_type), POINTER                             :: dct_gf, gf
+      TYPE(pw_type), POINTER                             :: dct_gf
 
       CPASSERT(.NOT. (ASSOCIATED(green)))
       ALLOCATE (green)
@@ -222,7 +222,7 @@ CONTAINS
       green%sr_alpha = 1.0_dp
       green%sr_rc = 0.0_dp
 
-      NULLIFY (green%influence_fn, green%p3m_charge)
+      NULLIFY (green%p3m_charge)
       NULLIFY (green%p3m_coeff, green%p3m_bm2)
       NULLIFY (green%dct_influence_fn)
       NULLIFY (green%screen_fn)
@@ -302,8 +302,6 @@ CONTAINS
       ! allocate influence function,...
       SELECT CASE (green%method)
       CASE (PERIODIC3D, ANALYTIC2D, ANALYTIC1D, ANALYTIC0D, MT2D, MT1D, MT0D, MULTIPOLE0D, PS_IMPLICIT)
-         NULLIFY (green%influence_fn)
-         ALLOCATE (green%influence_fn)
          CALL pw_pool_create_pw(pw_pool, green%influence_fn, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -347,99 +345,99 @@ CONTAINS
       END SELECT
 
       ! initialize influence function
-      gf => green%influence_fn
-      grid => green%influence_fn%pw_grid
-      SELECT CASE (green%method)
-      CASE (PERIODIC3D, MULTIPOLE0D)
+      ASSOCIATE (gf => green%influence_fn, grid => green%influence_fn%pw_grid)
+         SELECT CASE (green%method)
+         CASE (PERIODIC3D, MULTIPOLE0D)
 
-         DO ig = grid%first_gne0, grid%ngpts_cut_local
-            g2 = grid%gsq(ig)
-            gf%cc(ig) = fourpi/g2
-         END DO
-         IF (grid%have_g0) gf%cc(1) = 0.0_dp
-
-      CASE (ANALYTIC2D)
-
-         iz = green%special_dimension ! iz is the direction with NO PBC
-         zlength = green%slab_size ! zlength is the thickness of the cell
-         DO ig = grid%first_gne0, grid%ngpts_cut_local
-            nz = grid%g_hat(iz, ig)
-            g2 = grid%gsq(ig)
-            g3d = fourpi/g2
-            gg = 0.5_dp*SQRT(g2)
-            gf%cc(ig) = g3d*(1.0_dp - (-1.0_dp)**nz*EXP(-gg*zlength))
-         END DO
-         IF (grid%have_g0) gf%cc(1) = 0.0_dp
-
-      CASE (ANALYTIC1D)
-         ! see 'ab initio molecular dynamics' table 3.1
-         ! iz is the direction of the PBC ( can be 1,2,3 -> x,y,z )
-         iz = green%special_dimension
-         ! rlength is the radius of the tube
-         rlength = green%radius
-         DO ig = grid%first_gne0, grid%ngpts_cut_local
-            g2 = grid%gsq(ig)
-            g3d = fourpi/g2
-            gxy = SQRT(MAX(0.0_dp, g2 - grid%g(iz, ig)*grid%g(iz, ig)))
-            gz = ABS(grid%g(iz, ig))
-            j0g = BESSEL_J0(rlength*gxy)
-            j1g = BESSEL_J1(rlength*gxy)
-            IF (gz > 0) THEN
-               k0g = bessk0(rlength*gz)
-               k1g = bessk1(rlength*gz)
-            ELSE
-               k0g = 0
-               k1g = 0
-            END IF
-            gf%cc(ig) = g3d*(1.0_dp + rlength* &
-                             (gxy*j1g*k0g - gz*j0g*k1g))
-         END DO
-         IF (grid%have_g0) gf%cc(1) = 0.0_dp
-
-      CASE (ANALYTIC0D)
-
-         rlength = green%radius ! rlength is the radius of the sphere
-         DO ig = grid%first_gne0, grid%ngpts_cut_local
-            g2 = grid%gsq(ig)
-            gg = SQRT(g2)
-            g3d = fourpi/g2
-            gf%cc(ig) = g3d*(1.0_dp - COS(rlength*gg))
-         END DO
-         IF (grid%have_g0) &
-            gf%cc(1) = 0.5_dp*fourpi*rlength*rlength
-
-      CASE (MT2D, MT1D, MT0D)
-
-         DO ig = grid%first_gne0, grid%ngpts_cut_local
-            g2 = grid%gsq(ig)
-            g3d = fourpi/g2
-            gf%cc(ig) = g3d + green%screen_fn%cc(ig)
-         END DO
-         IF (grid%have_g0) &
-            gf%cc(1) = green%screen_fn%cc(1)
-
-      CASE (PS_IMPLICIT)
-
-         DO ig = grid%first_gne0, grid%ngpts_cut_local
-            g2 = grid%gsq(ig)
-            gf%cc(ig) = fourpi/g2
-         END DO
-         IF (grid%have_g0) gf%cc(1) = 0.0_dp
-
-         IF (ASSOCIATED(green%dct_influence_fn)) THEN
-            dct_gf => green%dct_influence_fn
-            dct_grid => green%dct_influence_fn%pw_grid
-
-            DO ig = dct_grid%first_gne0, dct_grid%ngpts_cut_local
-               g2 = dct_grid%gsq(ig)
-               dct_gf%cc(ig) = fourpi/g2
+            DO ig = grid%first_gne0, grid%ngpts_cut_local
+               g2 = grid%gsq(ig)
+               gf%cc(ig) = fourpi/g2
             END DO
-            IF (dct_grid%have_g0) dct_gf%cc(1) = 0.0_dp
-         END IF
+            IF (grid%have_g0) gf%cc(1) = 0.0_dp
 
-      CASE DEFAULT
-         CPABORT("")
-      END SELECT
+         CASE (ANALYTIC2D)
+
+            iz = green%special_dimension ! iz is the direction with NO PBC
+            zlength = green%slab_size ! zlength is the thickness of the cell
+            DO ig = grid%first_gne0, grid%ngpts_cut_local
+               nz = grid%g_hat(iz, ig)
+               g2 = grid%gsq(ig)
+               g3d = fourpi/g2
+               gg = 0.5_dp*SQRT(g2)
+               gf%cc(ig) = g3d*(1.0_dp - (-1.0_dp)**nz*EXP(-gg*zlength))
+            END DO
+            IF (grid%have_g0) gf%cc(1) = 0.0_dp
+
+         CASE (ANALYTIC1D)
+            ! see 'ab initio molecular dynamics' table 3.1
+            ! iz is the direction of the PBC ( can be 1,2,3 -> x,y,z )
+            iz = green%special_dimension
+            ! rlength is the radius of the tube
+            rlength = green%radius
+            DO ig = grid%first_gne0, grid%ngpts_cut_local
+               g2 = grid%gsq(ig)
+               g3d = fourpi/g2
+               gxy = SQRT(MAX(0.0_dp, g2 - grid%g(iz, ig)*grid%g(iz, ig)))
+               gz = ABS(grid%g(iz, ig))
+               j0g = BESSEL_J0(rlength*gxy)
+               j1g = BESSEL_J1(rlength*gxy)
+               IF (gz > 0) THEN
+                  k0g = bessk0(rlength*gz)
+                  k1g = bessk1(rlength*gz)
+               ELSE
+                  k0g = 0
+                  k1g = 0
+               END IF
+               gf%cc(ig) = g3d*(1.0_dp + rlength* &
+                                (gxy*j1g*k0g - gz*j0g*k1g))
+            END DO
+            IF (grid%have_g0) gf%cc(1) = 0.0_dp
+
+         CASE (ANALYTIC0D)
+
+            rlength = green%radius ! rlength is the radius of the sphere
+            DO ig = grid%first_gne0, grid%ngpts_cut_local
+               g2 = grid%gsq(ig)
+               gg = SQRT(g2)
+               g3d = fourpi/g2
+               gf%cc(ig) = g3d*(1.0_dp - COS(rlength*gg))
+            END DO
+            IF (grid%have_g0) &
+               gf%cc(1) = 0.5_dp*fourpi*rlength*rlength
+
+         CASE (MT2D, MT1D, MT0D)
+
+            DO ig = grid%first_gne0, grid%ngpts_cut_local
+               g2 = grid%gsq(ig)
+               g3d = fourpi/g2
+               gf%cc(ig) = g3d + green%screen_fn%cc(ig)
+            END DO
+            IF (grid%have_g0) &
+               gf%cc(1) = green%screen_fn%cc(1)
+
+         CASE (PS_IMPLICIT)
+
+            DO ig = grid%first_gne0, grid%ngpts_cut_local
+               g2 = grid%gsq(ig)
+               gf%cc(ig) = fourpi/g2
+            END DO
+            IF (grid%have_g0) gf%cc(1) = 0.0_dp
+
+            IF (ASSOCIATED(green%dct_influence_fn)) THEN
+               dct_gf => green%dct_influence_fn
+               dct_grid => green%dct_influence_fn%pw_grid
+
+               DO ig = dct_grid%first_gne0, dct_grid%ngpts_cut_local
+                  g2 = dct_grid%gsq(ig)
+                  dct_gf%cc(ig) = fourpi/g2
+               END DO
+               IF (dct_grid%have_g0) dct_gf%cc(1) = 0.0_dp
+            END IF
+
+         CASE DEFAULT
+            CPABORT("")
+         END SELECT
+      END ASSOCIATE
 
    END SUBROUTINE pw_green_create
 
@@ -478,10 +476,7 @@ CONTAINS
             can_give_back = PRESENT(pw_pool)
             IF (can_give_back) can_give_back = ASSOCIATED(pw_pool)
             IF (can_give_back) THEN
-               IF (ASSOCIATED(gftype%influence_fn)) THEN
-                  CALL pw_pool_give_back_pw(pw_pool, gftype%influence_fn)
-                  DEALLOCATE (gftype%influence_fn)
-               END IF
+               CALL pw_pool_give_back_pw(pw_pool, gftype%influence_fn)
                IF (ASSOCIATED(gftype%dct_influence_fn)) THEN
                   CALL pw_pool_give_back_pw(pw_pool, gftype%dct_influence_fn)
                   DEALLOCATE (gftype%dct_influence_fn)
@@ -495,10 +490,7 @@ CONTAINS
                   DEALLOCATE (gftype%p3m_charge)
                END IF
             ELSE
-               IF (ASSOCIATED(gftype%influence_fn)) THEN
-                  CALL pw_release(gftype%influence_fn)
-                  DEALLOCATE (gftype%influence_fn)
-               END IF
+               CALL pw_release(gftype%influence_fn)
                IF (ASSOCIATED(gftype%dct_influence_fn)) THEN
                   CALL pw_release(gftype%dct_influence_fn)
                   DEALLOCATE (gftype%dct_influence_fn)

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -485,6 +485,7 @@ CONTAINS
                CALL pw_release(gftype%dct_influence_fn)
                CALL pw_release(gftype%screen_fn)
                CALL pw_release(gftype%p3m_charge)
+               DEALLOCATE (gftype%influence_fn, gftype%dct_influence_fn, gftype%screen_fn, gftype%p3m_charge)
             END IF
             IF (ASSOCIATED(gftype%p3m_bm2)) &
                DEALLOCATE (gftype%p3m_bm2)

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -479,23 +479,19 @@ CONTAINS
             IF (can_give_back) can_give_back = ASSOCIATED(pw_pool)
             IF (can_give_back) THEN
                IF (ASSOCIATED(gftype%influence_fn)) THEN
-                  CALL pw_pool_give_back_pw(pw_pool, gftype%influence_fn, &
-                                            accept_non_compatible=.TRUE.)
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%influence_fn)
                   DEALLOCATE (gftype%influence_fn)
                END IF
                IF (ASSOCIATED(gftype%dct_influence_fn)) THEN
-                  CALL pw_pool_give_back_pw(pw_pool, gftype%dct_influence_fn, &
-                                            accept_non_compatible=.TRUE.)
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%dct_influence_fn)
                   DEALLOCATE (gftype%dct_influence_fn)
                END IF
                IF (ASSOCIATED(gftype%screen_fn)) THEN
-                  CALL pw_pool_give_back_pw(pw_pool, gftype%screen_fn, &
-                                            accept_non_compatible=.TRUE.)
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%screen_fn)
                   DEALLOCATE (gftype%screen_fn)
                END IF
                IF (ASSOCIATED(gftype%p3m_charge)) THEN
-                  CALL pw_pool_give_back_pw(pw_pool, gftype%p3m_charge, &
-                                            accept_non_compatible=.TRUE.)
+                  CALL pw_pool_give_back_pw(pw_pool, gftype%p3m_charge)
                   DEALLOCATE (gftype%p3m_charge)
                END IF
             ELSE

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -190,6 +190,7 @@ CONTAINS
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
          CALL pw_release(pw_el)
+         DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%real1d_pw)
 
@@ -197,6 +198,7 @@ CONTAINS
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
          CALL pw_release(pw_el)
+         DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%real3d_pw)
 
@@ -204,6 +206,7 @@ CONTAINS
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
          CALL pw_release(pw_el)
+         DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%complex1d_pw)
 
@@ -211,6 +214,7 @@ CONTAINS
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
          CALL pw_release(pw_el)
+         DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%complex3d_pw)
 
@@ -418,6 +422,7 @@ CONTAINS
             IF (.NOT. my_accept_non_compatible) &
                CPABORT("pool cannot reuse pw of another grid")
             CALL pw_release(pw)
+            DEALLOCATE (pw)
             failure = .TRUE.
          END IF
       END IF
@@ -439,6 +444,7 @@ CONTAINS
                IF (max_max_cache >= 0) &
                   CPWARN("hit max_cache")
                CALL pw_release(pw)
+               DEALLOCATE (pw)
             END IF
          CASE (REALDATA3D)
             IF (ASSOCIATED(pw%cr3d)) THEN
@@ -448,6 +454,7 @@ CONTAINS
                   IF (max_max_cache >= 0) &
                      CPWARN("hit max_cache")
                   CALL pw_release(pw)
+                  DEALLOCATE (pw)
                END IF
             ELSE
                IF (debug_this_module) THEN
@@ -458,6 +465,7 @@ CONTAINS
                END IF
                CPASSERT(my_accept_non_compatible)
                CALL pw_release(pw)
+               DEALLOCATE (pw)
             END IF
          CASE (COMPLEXDATA1D)
             IF (cp_sll_pw_get_length(pool%complex1d_pw) < pool%max_cache) THEN
@@ -466,6 +474,7 @@ CONTAINS
                IF (max_max_cache >= 0) &
                   CPWARN("hit max_cache")
                CALL pw_release(pw)
+               DEALLOCATE (pw)
             END IF
          CASE (COMPLEXDATA3D)
             IF (cp_sll_pw_get_length(pool%complex3d_pw) < pool%max_cache) THEN
@@ -474,6 +483,7 @@ CONTAINS
                IF (max_max_cache >= 0) &
                   CPWARN("hit max_cache")
                CALL pw_release(pw)
+               DEALLOCATE (pw)
             END IF
          CASE default
             ! unknown in_use
@@ -517,6 +527,7 @@ CONTAINS
             cr3d => pw%cr3d
             NULLIFY (pw%cr3d)
             CALL pw_release(pw)
+            DEALLOCATE (pw)
          END IF
       END IF
       IF (.NOT. ASSOCIATED(cr3d)) THEN

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -379,30 +379,21 @@ CONTAINS
 !> \brief returns the pw to the pool
 !> \param pool the pool where to reintegrate the pw
 !> \param pw the pw to give back
-!> \param accept_non_compatible if non compatible pw should be accepted
-!>        (they will be destroied). Defaults to false (and thus stops with
-!>        an error)
 !> \par History
 !>      08.2002 created [fawzi]
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
-   SUBROUTINE pw_pool_give_back_pw(pool, pw, accept_non_compatible)
+   SUBROUTINE pw_pool_give_back_pw(pool, pw)
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pool
       TYPE(pw_type), INTENT(INOUT)                       :: pw
-      LOGICAL, INTENT(in), OPTIONAL                      :: accept_non_compatible
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_pool_give_back_pw'
 
       INTEGER                                            :: handle
-      LOGICAL                                            :: failure, my_accept_non_compatible
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(pw_type), POINTER                             :: el
 
-      failure = .FALSE.
-
-      my_accept_non_compatible = .FALSE.
       logger => cp_get_default_logger()
-      IF (PRESENT(accept_non_compatible)) my_accept_non_compatible = accept_non_compatible
 
       CALL timeset(routineN, handle)
       CPASSERT(ASSOCIATED(pool))
@@ -418,12 +409,8 @@ CONTAINS
                CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
             END IF
 
-            IF (.NOT. my_accept_non_compatible) &
-               CPABORT("pool cannot reuse pw of another grid")
             CALL pw_release(pw)
-            failure = .TRUE.
-         END IF
-         IF (.NOT. failure) THEN
+         ELSE
             IF (debug_this_module) THEN
                WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
                       fmt="(' *** pw_pool ',i4,' giving back pw ',i4)") &
@@ -464,7 +451,6 @@ CONTAINS
                         pool%id_nr, el%id_nr
                      CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
                   END IF
-                  CPASSERT(my_accept_non_compatible)
                   CALL pw_release(el)
                   DEALLOCATE (el)
                END IF
@@ -499,7 +485,7 @@ CONTAINS
          IF (ASSOCIATED(pw%cr)) DEALLOCATE (pw%cr)
          IF (ASSOCIATED(pw%cr3d)) DEALLOCATE (pw%cr3d)
       END IF
-      NULLIFY (pw%cc, pw%cc3d, pw%cr, pw%cr3d)
+      NULLIFY (pw%cc, pw%cc3d, pw%cr, pw%cr3d, pw%pw_grid)
       CALL timestop(handle)
    END SUBROUTINE pw_pool_give_back_pw
 

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -298,7 +298,7 @@ CONTAINS
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE pw_pool_create_pw(pool, pw, use_data, in_space)
-      TYPE(pw_pool_type), POINTER                        :: pool
+      TYPE(pw_pool_type), INTENT(IN), POINTER            :: pool
       TYPE(pw_type), INTENT(OUT)                         :: pw
       INTEGER, INTENT(in)                                :: use_data
       INTEGER, INTENT(in), OPTIONAL                      :: in_space
@@ -387,8 +387,8 @@ CONTAINS
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE pw_pool_give_back_pw(pool, pw, accept_non_compatible)
-      TYPE(pw_pool_type), POINTER                        :: pool
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_pool_type), INTENT(IN), POINTER            :: pool
+      TYPE(pw_type), INTENT(INOUT)                       :: pw
       LOGICAL, INTENT(in), OPTIONAL                      :: accept_non_compatible
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_pool_give_back_pw'
@@ -407,7 +407,8 @@ CONTAINS
       CALL timeset(routineN, handle)
       CPASSERT(ASSOCIATED(pool))
       CPASSERT(pool%ref_count > 0)
-      IF (.NOT. ASSOCIATED(pw)) THEN
+      IF (ASSOCIATED(pw%pw_grid)) THEN
+      IF (.NOT. (ASSOCIATED(pw%cc) .OR. ASSOCIATED(pw%cc3d) .OR. ASSOCIATED(pw%cr) .OR. ASSOCIATED(pw%cr3d))) THEN
          CPASSERT(my_accept_non_compatible)
          failure = .TRUE.
       END IF
@@ -441,6 +442,7 @@ CONTAINS
          NULLIFY (el)
          ALLOCATE (el)
          el = pw
+         NULLIFY (pw%cc, pw%cc3d, pw%cr, pw%cr3d)
 
          SELECT CASE (el%in_use)
          CASE (REALDATA1D)
@@ -498,8 +500,8 @@ CONTAINS
          !FM so that if someone tries to use a pw that is in the pool
          !FM (s)he gets problems
       END IF
-      IF (ASSOCIATED(pw)) DEALLOCATE (pw)
-      NULLIFY (pw)
+      NULLIFY (pw%pw_grid)
+      END IF
       CALL timestop(handle)
    END SUBROUTINE pw_pool_give_back_pw
 
@@ -667,6 +669,7 @@ CONTAINS
       CPASSERT(SIZE(pws) == SIZE(pools))
       DO i = 1, SIZE(pools)
          CALL pw_pool_give_back_pw(pools(i)%pool, pws(i)%pw)
+         DEALLOCATE (pws(i)%pw)
       END DO
       DEALLOCATE (pws)
    END SUBROUTINE pw_pools_give_back_pws

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -337,8 +337,8 @@ CONTAINS
          CPABORT("")
       END SELECT
 
+      ALLOCATE (pw)
       IF (.NOT. ASSOCIATED(el)) THEN
-         ALLOCATE (pw)
          CALL pw_create(pw, pool%pw_grid, use_data=use_data, &
                         cr3d_ptr=cr3d_ptr)
          IF (debug_this_module) THEN
@@ -357,6 +357,7 @@ CONTAINS
             CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
          END IF
       ELSE
+         pw = el
          IF (debug_this_module) THEN
             WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
                    fmt="(' *** pw_pool ',i4,' created pw reusing old ',i4)") &
@@ -366,7 +367,7 @@ CONTAINS
                pw=pw)
             CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
          END IF
-         pw => el
+         DEALLOCATE (el)
       END IF
 
       pw%in_space = 0

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -408,11 +408,6 @@ CONTAINS
       CPASSERT(ASSOCIATED(pool))
       CPASSERT(pool%ref_count > 0)
       IF (ASSOCIATED(pw%pw_grid)) THEN
-      IF (.NOT. (ASSOCIATED(pw%cc) .OR. ASSOCIATED(pw%cc3d) .OR. ASSOCIATED(pw%cr) .OR. ASSOCIATED(pw%cr3d))) THEN
-         CPASSERT(my_accept_non_compatible)
-         failure = .TRUE.
-      END IF
-      IF (.NOT. failure) THEN
          IF (.NOT. pw_grid_compare(pw%pw_grid, pool%pw_grid)) THEN
             IF (debug_this_module) THEN
                WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
@@ -428,80 +423,83 @@ CONTAINS
             CALL pw_release(pw)
             failure = .TRUE.
          END IF
-      END IF
-      IF (.NOT. failure) THEN
-         IF (debug_this_module) THEN
-            WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
-                   fmt="(' *** pw_pool ',i4,' giving back pw ',i4)") &
-               pool%id_nr, pw%id_nr
-            CALL pw_write(unit_nr=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
-                          pw=pw)
-            CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
-         END IF
-
-         NULLIFY (el)
-         ALLOCATE (el)
-         el = pw
-         NULLIFY (pw%cc, pw%cc3d, pw%cr, pw%cr3d)
-
-         SELECT CASE (el%in_use)
-         CASE (REALDATA1D)
-            IF (cp_sll_pw_get_length(pool%real1d_pw) < pool%max_cache) THEN
-               CALL cp_sll_pw_insert_el(pool%real1d_pw, el=el)
-            ELSE
-               IF (max_max_cache >= 0) &
-                  CPWARN("hit max_cache")
-               CALL pw_release(el)
-               DEALLOCATE (el)
+         IF (.NOT. failure) THEN
+            IF (debug_this_module) THEN
+               WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
+                      fmt="(' *** pw_pool ',i4,' giving back pw ',i4)") &
+                  pool%id_nr, pw%id_nr
+               CALL pw_write(unit_nr=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
+                             pw=pw)
+               CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
             END IF
-         CASE (REALDATA3D)
-            IF (ASSOCIATED(el%cr3d)) THEN
-               IF (cp_sll_pw_get_length(pool%real3d_pw) < pool%max_cache) THEN
-                  CALL cp_sll_pw_insert_el(pool%real3d_pw, el=el)
+
+            NULLIFY (el)
+            ALLOCATE (el)
+            el = pw
+
+            SELECT CASE (el%in_use)
+            CASE (REALDATA1D)
+               IF (cp_sll_pw_get_length(pool%real1d_pw) < pool%max_cache) THEN
+                  CALL cp_sll_pw_insert_el(pool%real1d_pw, el=el)
                ELSE
                   IF (max_max_cache >= 0) &
                      CPWARN("hit max_cache")
                   CALL pw_release(el)
                   DEALLOCATE (el)
                END IF
-            ELSE
-               IF (debug_this_module) THEN
-                  WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
-                         fmt="(' *** pw_pool ',i4,' el ',i4,' cr3d is not associated, discarding')") &
-                     pool%id_nr, el%id_nr
-                  CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
+            CASE (REALDATA3D)
+               IF (ASSOCIATED(el%cr3d)) THEN
+                  IF (cp_sll_pw_get_length(pool%real3d_pw) < pool%max_cache) THEN
+                     CALL cp_sll_pw_insert_el(pool%real3d_pw, el=el)
+                  ELSE
+                     IF (max_max_cache >= 0) &
+                        CPWARN("hit max_cache")
+                     CALL pw_release(el)
+                     DEALLOCATE (el)
+                  END IF
+               ELSE
+                  IF (debug_this_module) THEN
+                     WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
+                            fmt="(' *** pw_pool ',i4,' el ',i4,' cr3d is not associated, discarding')") &
+                        pool%id_nr, el%id_nr
+                     CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
+                  END IF
+                  CPASSERT(my_accept_non_compatible)
+                  CALL pw_release(el)
+                  DEALLOCATE (el)
                END IF
-               CPASSERT(my_accept_non_compatible)
-               CALL pw_release(el)
-               DEALLOCATE (el)
-            END IF
-         CASE (COMPLEXDATA1D)
-            IF (cp_sll_pw_get_length(pool%complex1d_pw) < pool%max_cache) THEN
-               CALL cp_sll_pw_insert_el(pool%complex1d_pw, el=el)
-            ELSE
-               IF (max_max_cache >= 0) &
-                  CPWARN("hit max_cache")
-               CALL pw_release(el)
-               DEALLOCATE (el)
-            END IF
-         CASE (COMPLEXDATA3D)
-            IF (cp_sll_pw_get_length(pool%complex3d_pw) < pool%max_cache) THEN
-               CALL cp_sll_pw_insert_el(pool%complex3d_pw, el=el)
-            ELSE
-               IF (max_max_cache >= 0) &
-                  CPWARN("hit max_cache")
-               CALL pw_release(el)
-               DEALLOCATE (el)
-            END IF
-         CASE default
-            ! unknown in_use
-            CPABORT("")
-         END SELECT
-         !FM so that if someone tries to use a pw that is in the pool
-         !FM (s)he gets problems
+            CASE (COMPLEXDATA1D)
+               IF (cp_sll_pw_get_length(pool%complex1d_pw) < pool%max_cache) THEN
+                  CALL cp_sll_pw_insert_el(pool%complex1d_pw, el=el)
+               ELSE
+                  IF (max_max_cache >= 0) &
+                     CPWARN("hit max_cache")
+                  CALL pw_release(el)
+                  DEALLOCATE (el)
+               END IF
+            CASE (COMPLEXDATA3D)
+               IF (cp_sll_pw_get_length(pool%complex3d_pw) < pool%max_cache) THEN
+                  CALL cp_sll_pw_insert_el(pool%complex3d_pw, el=el)
+               ELSE
+                  IF (max_max_cache >= 0) &
+                     CPWARN("hit max_cache")
+                  CALL pw_release(el)
+                  DEALLOCATE (el)
+               END IF
+            CASE default
+               ! unknown in_use
+               CPABORT("")
+            END SELECT
+            !FM so that if someone tries to use a pw that is in the pool
+            !FM (s)he gets problems
+         END IF
+      ELSE
+         IF (ASSOCIATED(pw%cc)) DEALLOCATE (pw%cc)
+         IF (ASSOCIATED(pw%cc3d)) DEALLOCATE (pw%cc3d)
+         IF (ASSOCIATED(pw%cr)) DEALLOCATE (pw%cr)
+         IF (ASSOCIATED(pw%cr3d)) DEALLOCATE (pw%cr3d)
       END IF
-      NULLIFY (pw%pw_grid)
-      END IF
+      NULLIFY (pw%cc, pw%cc3d, pw%cr, pw%cr3d)
       CALL timestop(handle)
    END SUBROUTINE pw_pool_give_back_pw
 

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -396,6 +396,7 @@ CONTAINS
       INTEGER                                            :: handle
       LOGICAL                                            :: failure, my_accept_non_compatible
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(pw_type), POINTER                             :: el
 
       failure = .FALSE.
 
@@ -424,7 +425,6 @@ CONTAINS
             IF (.NOT. my_accept_non_compatible) &
                CPABORT("pool cannot reuse pw of another grid")
             CALL pw_release(pw)
-            DEALLOCATE (pw)
             failure = .TRUE.
          END IF
       END IF
@@ -438,54 +438,58 @@ CONTAINS
             CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
          END IF
 
-         SELECT CASE (pw%in_use)
+         NULLIFY (el)
+         ALLOCATE (el)
+         el = pw
+
+         SELECT CASE (el%in_use)
          CASE (REALDATA1D)
             IF (cp_sll_pw_get_length(pool%real1d_pw) < pool%max_cache) THEN
-               CALL cp_sll_pw_insert_el(pool%real1d_pw, el=pw)
+               CALL cp_sll_pw_insert_el(pool%real1d_pw, el=el)
             ELSE
                IF (max_max_cache >= 0) &
                   CPWARN("hit max_cache")
-               CALL pw_release(pw)
-               DEALLOCATE (pw)
+               CALL pw_release(el)
+               DEALLOCATE (el)
             END IF
          CASE (REALDATA3D)
-            IF (ASSOCIATED(pw%cr3d)) THEN
+            IF (ASSOCIATED(el%cr3d)) THEN
                IF (cp_sll_pw_get_length(pool%real3d_pw) < pool%max_cache) THEN
-                  CALL cp_sll_pw_insert_el(pool%real3d_pw, el=pw)
+                  CALL cp_sll_pw_insert_el(pool%real3d_pw, el=el)
                ELSE
                   IF (max_max_cache >= 0) &
                      CPWARN("hit max_cache")
-                  CALL pw_release(pw)
-                  DEALLOCATE (pw)
+                  CALL pw_release(el)
+                  DEALLOCATE (el)
                END IF
             ELSE
                IF (debug_this_module) THEN
                   WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
-                         fmt="(' *** pw_pool ',i4,' pw ',i4,' cr3d is not associated, discarding')") &
-                     pool%id_nr, pw%id_nr
+                         fmt="(' *** pw_pool ',i4,' el ',i4,' cr3d is not associated, discarding')") &
+                     pool%id_nr, el%id_nr
                   CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
                END IF
                CPASSERT(my_accept_non_compatible)
-               CALL pw_release(pw)
-               DEALLOCATE (pw)
+               CALL pw_release(el)
+               DEALLOCATE (el)
             END IF
          CASE (COMPLEXDATA1D)
             IF (cp_sll_pw_get_length(pool%complex1d_pw) < pool%max_cache) THEN
-               CALL cp_sll_pw_insert_el(pool%complex1d_pw, el=pw)
+               CALL cp_sll_pw_insert_el(pool%complex1d_pw, el=el)
             ELSE
                IF (max_max_cache >= 0) &
                   CPWARN("hit max_cache")
-               CALL pw_release(pw)
-               DEALLOCATE (pw)
+               CALL pw_release(el)
+               DEALLOCATE (el)
             END IF
          CASE (COMPLEXDATA3D)
             IF (cp_sll_pw_get_length(pool%complex3d_pw) < pool%max_cache) THEN
-               CALL cp_sll_pw_insert_el(pool%complex3d_pw, el=pw)
+               CALL cp_sll_pw_insert_el(pool%complex3d_pw, el=el)
             ELSE
                IF (max_max_cache >= 0) &
                   CPWARN("hit max_cache")
-               CALL pw_release(pw)
-               DEALLOCATE (pw)
+               CALL pw_release(el)
+               DEALLOCATE (el)
             END IF
          CASE default
             ! unknown in_use
@@ -494,6 +498,7 @@ CONTAINS
          !FM so that if someone tries to use a pw that is in the pool
          !FM (s)he gets problems
       END IF
+      IF (ASSOCIATED(pw)) DEALLOCATE (pw)
       NULLIFY (pw)
       CALL timestop(handle)
    END SUBROUTINE pw_pool_give_back_pw

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -337,6 +337,7 @@ CONTAINS
       END SELECT
 
       IF (.NOT. ASSOCIATED(pw)) THEN
+         ALLOCATE (pw)
          CALL pw_create(pw, pool%pw_grid, use_data=use_data, &
                         cr3d_ptr=cr3d_ptr)
          IF (debug_this_module) THEN

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -308,6 +308,7 @@ CONTAINS
       INTEGER                                            :: handle
       REAL(kind=dp), DIMENSION(:, :, :), POINTER         :: cr3d_ptr
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(pw_type), POINTER                             :: el
 
       CALL timeset(routineN, handle)
       NULLIFY (pw)
@@ -318,25 +319,25 @@ CONTAINS
 
       SELECT CASE (use_data)
       CASE (REALDATA1D)
-         pw => try_pop(pool%real1d_pw)
+         el => try_pop(pool%real1d_pw)
       CASE (REALDATA3D)
-         pw => try_pop(pool%real3d_pw)
-         IF (.NOT. ASSOCIATED(pw)) THEN
+         el => try_pop(pool%real3d_pw)
+         IF (.NOT. ASSOCIATED(el)) THEN
             IF (ASSOCIATED(pool%real3d_array)) THEN
                cr3d_ptr => cp_sll_3d_r_get_first_el(pool%real3d_array)
                CALL cp_sll_3d_r_rm_first_el(pool%real3d_array)
             END IF
          END IF
       CASE (COMPLEXDATA1D)
-         pw => try_pop(pool%complex1d_pw)
+         el => try_pop(pool%complex1d_pw)
       CASE (COMPLEXDATA3D)
-         pw => try_pop(pool%complex3d_pw)
+         el => try_pop(pool%complex3d_pw)
       CASE default
 ! unknown use_data
          CPABORT("")
       END SELECT
 
-      IF (.NOT. ASSOCIATED(pw)) THEN
+      IF (.NOT. ASSOCIATED(el)) THEN
          ALLOCATE (pw)
          CALL pw_create(pw, pool%pw_grid, use_data=use_data, &
                         cr3d_ptr=cr3d_ptr)
@@ -365,6 +366,7 @@ CONTAINS
                pw=pw)
             CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
          END IF
+         pw => el
       END IF
 
       pw%in_space = 0

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -299,7 +299,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_pool_create_pw(pool, pw, use_data, in_space)
       TYPE(pw_pool_type), POINTER                        :: pool
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(OUT)                         :: pw
       INTEGER, INTENT(in)                                :: use_data
       INTEGER, INTENT(in), OPTIONAL                      :: in_space
 
@@ -311,7 +311,6 @@ CONTAINS
       TYPE(pw_type), POINTER                             :: el
 
       CALL timeset(routineN, handle)
-      NULLIFY (pw)
       NULLIFY (cr3d_ptr)
       logger => cp_get_default_logger()
       CPASSERT(ASSOCIATED(pool))
@@ -337,7 +336,6 @@ CONTAINS
          CPABORT("")
       END SELECT
 
-      ALLOCATE (pw)
       IF (.NOT. ASSOCIATED(el)) THEN
          CALL pw_create(pw, pool%pw_grid, use_data=use_data, &
                         cr3d_ptr=cr3d_ptr)
@@ -639,7 +637,7 @@ CONTAINS
       CPASSERT(ASSOCIATED(pools))
       ALLOCATE (pws(SIZE(pools)))
       DO i = 1, SIZE(pools)
-         NULLIFY (pws(i)%pw)
+         ALLOCATE (pws(i)%pw)
          CALL pw_pool_create_pw(pools(i)%pool, pws(i)%pw, use_data, &
                                 in_space=in_space)
       END DO

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -189,8 +189,6 @@ CONTAINS
       iterator => pool%real1d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CPASSERT(pw_el%ref_count == 0)
-         pw_el%ref_count = 1
          CALL pw_release(pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%real1d_pw)
@@ -198,8 +196,6 @@ CONTAINS
       iterator => pool%real3d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CPASSERT(pw_el%ref_count == 0)
-         pw_el%ref_count = 1
          CALL pw_release(pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%real3d_pw)
@@ -207,8 +203,6 @@ CONTAINS
       iterator => pool%complex1d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CPASSERT(pw_el%ref_count == 0)
-         pw_el%ref_count = 1
          CALL pw_release(pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%complex1d_pw)
@@ -216,8 +210,6 @@ CONTAINS
       iterator => pool%complex3d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CPASSERT(pw_el%ref_count == 0)
-         pw_el%ref_count = 1
          CALL pw_release(pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%complex3d_pw)
@@ -359,8 +351,6 @@ CONTAINS
             CALL print_stack(cp_logger_get_default_unit_nr(logger, local=.TRUE.))
          END IF
       ELSE
-         CPASSERT(pw%ref_count == 0)
-         pw%ref_count = 1
          IF (debug_this_module) THEN
             WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
                    fmt="(' *** pw_pool ',i4,' created pw reusing old ',i4)") &
@@ -415,7 +405,6 @@ CONTAINS
          failure = .TRUE.
       END IF
       IF (.NOT. failure) THEN
-         CPASSERT(pw%ref_count == 1)
          IF (.NOT. pw_grid_compare(pw%pw_grid, pool%pw_grid)) THEN
             IF (debug_this_module) THEN
                WRITE (unit=cp_logger_get_default_unit_nr(logger, local=.TRUE.), &
@@ -490,7 +479,6 @@ CONTAINS
             ! unknown in_use
             CPABORT("")
          END SELECT
-         IF (ASSOCIATED(pw)) pw%ref_count = 0
          !FM so that if someone tries to use a pw that is in the pool
          !FM (s)he gets problems
       END IF
@@ -519,7 +507,6 @@ CONTAINS
       logger => cp_get_default_logger()
 
       CPASSERT(ASSOCIATED(pw_pool))
-      CPASSERT(pw_pool%ref_count > 0)
       CPASSERT(.NOT. ASSOCIATED(cr3d))
       IF (ASSOCIATED(pw_pool%real3d_array)) THEN
          cr3d => cp_sll_3d_r_get_first_el(pw_pool%real3d_array)
@@ -527,8 +514,6 @@ CONTAINS
       ELSE
          pw => try_pop(pw_pool%real3d_pw)
          IF (ASSOCIATED(pw)) THEN
-            CPASSERT(pw%ref_count == 0)
-            pw%ref_count = 1
             cr3d => pw%cr3d
             NULLIFY (pw%cr3d)
             CALL pw_release(pw)

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -116,7 +116,7 @@ MODULE pw_spline_utils
 !> \author fawzi
 ! **************************************************************************************************
    TYPE pw_spline_precond_type
-      INTEGER :: ref_count, id_nr, kind
+      INTEGER :: kind
       REAL(kind=dp), DIMENSION(4) :: coeffs
       REAL(kind=dp), DIMENSION(3) :: coeffs_1d
       LOGICAL :: sharpen, normalize, pbc, transpose
@@ -2506,9 +2506,6 @@ CONTAINS
       LOGICAL, INTENT(in)                                :: pbc, transpose
 
       ALLOCATE (preconditioner)
-      last_precond_id = last_precond_id + 1
-      preconditioner%id_nr = last_precond_id
-      preconditioner%ref_count = 1
       preconditioner%kind = no_precond
       preconditioner%pool => pool
       preconditioner%pbc = pbc
@@ -2535,7 +2532,6 @@ CONTAINS
       REAL(kind=dp)                                      :: s
 
       CPASSERT(ASSOCIATED(preconditioner))
-      CPASSERT(preconditioner%ref_count > 0)
       IF (PRESENT(transpose)) preconditioner%transpose = transpose
       do_3d_coeff = .FALSE.
       preconditioner%kind = precond_kind
@@ -2607,19 +2603,6 @@ CONTAINS
    END SUBROUTINE pw_spline_precond_set_kind
 
 ! **************************************************************************************************
-!> \brief retains the preconditioner
-!> \param preconditioner the preconditioner to retain
-!> \author fawzi
-! **************************************************************************************************
-   SUBROUTINE pw_spline_precond_retain(preconditioner)
-      TYPE(pw_spline_precond_type), POINTER              :: preconditioner
-
-      CPASSERT(ASSOCIATED(preconditioner))
-      CPASSERT(preconditioner%ref_count > 1)
-      preconditioner%ref_count = preconditioner%ref_count + 1
-   END SUBROUTINE pw_spline_precond_retain
-
-! **************************************************************************************************
 !> \brief releases the preconditioner
 !> \param preconditioner the preconditioner to release
 !> \author fawzi
@@ -2628,12 +2611,8 @@ CONTAINS
       TYPE(pw_spline_precond_type), POINTER              :: preconditioner
 
       IF (ASSOCIATED(preconditioner)) THEN
-         CPASSERT(preconditioner%ref_count > 0)
-         preconditioner%ref_count = preconditioner%ref_count - 1
-         IF (preconditioner%ref_count == 0) THEN
-            CALL pw_pool_release(preconditioner%pool)
-            DEALLOCATE (preconditioner)
-         END IF
+         CALL pw_pool_release(preconditioner%pool)
+         DEALLOCATE (preconditioner)
       END IF
    END SUBROUTINE pw_spline_precond_release
 
@@ -2649,7 +2628,6 @@ CONTAINS
       TYPE(pw_spline_precond_type), INTENT(IN)           :: preconditioner
       TYPE(pw_type), POINTER                             :: in_v, out_v
 
-      CPASSERT(preconditioner%ref_count > 0)
       SELECT CASE (preconditioner%kind)
       CASE (no_precond)
          CALL pw_copy(in_v, out_v)

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -2500,12 +2500,11 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_spline_precond_create(preconditioner, precond_kind, &
                                        pool, pbc, transpose)
-      TYPE(pw_spline_precond_type), POINTER              :: preconditioner
+      TYPE(pw_spline_precond_type), INTENT(OUT)          :: preconditioner
       INTEGER, INTENT(in)                                :: precond_kind
-      TYPE(pw_pool_type), POINTER                        :: pool
+      TYPE(pw_pool_type), INTENT(IN), POINTER            :: pool
       LOGICAL, INTENT(in)                                :: pbc, transpose
 
-      ALLOCATE (preconditioner)
       preconditioner%kind = no_precond
       preconditioner%pool => pool
       preconditioner%pbc = pbc
@@ -2524,14 +2523,13 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_spline_precond_set_kind(preconditioner, precond_kind, pbc, &
                                          transpose)
-      TYPE(pw_spline_precond_type), POINTER              :: preconditioner
+      TYPE(pw_spline_precond_type), INTENT(INOUT)        :: preconditioner
       INTEGER, INTENT(in)                                :: precond_kind
       LOGICAL, INTENT(in), OPTIONAL                      :: pbc, transpose
 
       LOGICAL                                            :: do_3d_coeff
       REAL(kind=dp)                                      :: s
 
-      CPASSERT(ASSOCIATED(preconditioner))
       IF (PRESENT(transpose)) preconditioner%transpose = transpose
       do_3d_coeff = .FALSE.
       preconditioner%kind = precond_kind
@@ -2608,12 +2606,9 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_spline_precond_release(preconditioner)
-      TYPE(pw_spline_precond_type), POINTER              :: preconditioner
+      TYPE(pw_spline_precond_type), INTENT(INOUT)        :: preconditioner
 
-      IF (ASSOCIATED(preconditioner)) THEN
-         CALL pw_pool_release(preconditioner%pool)
-         DEALLOCATE (preconditioner)
-      END IF
+      CALL pw_pool_release(preconditioner%pool)
    END SUBROUTINE pw_spline_precond_release
 
 ! **************************************************************************************************
@@ -2626,7 +2621,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_spline_do_precond(preconditioner, in_v, out_v)
       TYPE(pw_spline_precond_type), INTENT(IN)           :: preconditioner
-      TYPE(pw_type), POINTER                             :: in_v, out_v
+      TYPE(pw_type), INTENT(IN)                          :: in_v
+      TYPE(pw_type), INTENT(INOUT)                       :: out_v
 
       SELECT CASE (preconditioner%kind)
       CASE (no_precond)
@@ -2686,7 +2682,7 @@ CONTAINS
             TYPE(pw_type), INTENT(IN) :: pw_in, pw_out
          END SUBROUTINE linOp
       END INTERFACE
-      TYPE(pw_spline_precond_type), POINTER              :: preconditioner
+      TYPE(pw_spline_precond_type), INTENT(IN)           :: preconditioner
       TYPE(pw_pool_type), POINTER                        :: pool
       REAL(kind=dp), INTENT(in)                          :: eps_r, eps_x
       INTEGER, INTENT(in)                                :: max_iter
@@ -2699,14 +2695,12 @@ CONTAINS
       REAL(kind=dp)                                      :: alpha, beta, eps_r_att, eps_x_att, r_z, &
                                                             r_z_new
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(pw_type), POINTER                             :: Ap, p, r, z
+      TYPE(pw_type)                                      :: Ap, p, r, z
 
       last = .FALSE.
 
       res = .FALSE.
       logger => cp_get_default_logger()
-      NULLIFY (r, z, p, Ap)
-      ALLOCATE (r, z, p, Ap)
       CALL pw_pool_create_pw(pool, r, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pool, z, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pool, p, use_data=REALDATA3D, in_space=REALSPACE)
@@ -2768,7 +2762,6 @@ CONTAINS
       CALL pw_pool_give_back_pw(pool, z)
       CALL pw_pool_give_back_pw(pool, p)
       CALL pw_pool_give_back_pw(pool, Ap)
-      DEALLOCATE (r, z, p, Ap)
    END FUNCTION find_coeffs
 
 ! **************************************************************************************************

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -2727,6 +2727,8 @@ CONTAINS
 
       res = .FALSE.
       logger => cp_get_default_logger()
+      NULLIFY (r, z, p, Ap)
+      ALLOCATE (r, z, p, Ap)
       CALL pw_pool_create_pw(pool, r, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pool, z, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pool, p, use_data=REALDATA3D, in_space=REALSPACE)

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -2790,6 +2790,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pool, z)
       CALL pw_pool_give_back_pw(pool, p)
       CALL pw_pool_give_back_pw(pool, Ap)
+      DEALLOCATE (r, z, p, Ap)
    END FUNCTION find_coeffs
 
 ! **************************************************************************************************

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -137,7 +137,7 @@ CONTAINS
 !>      does not work with spherical cutoff
 ! **************************************************************************************************
    SUBROUTINE pw_spline2_interpolate_values_g(spline_g)
-      TYPE(pw_type), POINTER                             :: spline_g
+      TYPE(pw_type), INTENT(IN)                          :: spline_g
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_spline2_interpolate_values_g'
 
@@ -152,7 +152,6 @@ CONTAINS
       n_tot(1:3) = spline_g%pw_grid%npts(1:3)
       gbo = spline_g%pw_grid%bounds
 
-      CPASSERT(ASSOCIATED(spline_g))
       CPASSERT(spline_g%in_use == COMPLEXDATA1D)
       CPASSERT(spline_g%in_space == RECIPROCALSPACE)
       CPASSERT(.NOT. spline_g%pw_grid%spherical)
@@ -211,7 +210,7 @@ CONTAINS
 !>      needed cos, and avoid the mp_sum
 ! **************************************************************************************************
    SUBROUTINE pw_spline3_interpolate_values_g(spline_g)
-      TYPE(pw_type), POINTER                             :: spline_g
+      TYPE(pw_type), INTENT(IN)                          :: spline_g
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_spline3_interpolate_values_g'
 
@@ -226,7 +225,6 @@ CONTAINS
       n_tot(1:3) = spline_g%pw_grid%npts(1:3)
       gbo = spline_g%pw_grid%bounds
 
-      CPASSERT(ASSOCIATED(spline_g))
       CPASSERT(spline_g%in_use == COMPLEXDATA1D)
       CPASSERT(spline_g%in_space == RECIPROCALSPACE)
       CPASSERT(.NOT. spline_g%pw_grid%spherical)
@@ -380,7 +378,7 @@ CONTAINS
 !>      the distance between gridpoints is assumed to be 1
 ! **************************************************************************************************
    SUBROUTINE pw_spline3_deriv_g(spline_g, idir)
-      TYPE(pw_type), POINTER                             :: spline_g
+      TYPE(pw_type), INTENT(IN)                          :: spline_g
       INTEGER, INTENT(in)                                :: idir
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_spline3_deriv_g'
@@ -399,7 +397,6 @@ CONTAINS
       bo = spline_g%pw_grid%bounds_local
       gbo = spline_g%pw_grid%bounds
 
-      CPASSERT(ASSOCIATED(spline_g))
       CPASSERT(spline_g%in_use == COMPLEXDATA1D)
       CPASSERT(spline_g%in_space == RECIPROCALSPACE)
       CPASSERT(.NOT. spline_g%pw_grid%spherical)
@@ -518,7 +515,7 @@ CONTAINS
 !>      the distance between gridpoints is assumed to be 1
 ! **************************************************************************************************
    SUBROUTINE pw_spline2_deriv_g(spline_g, idir)
-      TYPE(pw_type), POINTER                             :: spline_g
+      TYPE(pw_type), INTENT(IN)                          :: spline_g
       INTEGER, INTENT(in)                                :: idir
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_spline2_deriv_g'
@@ -536,7 +533,6 @@ CONTAINS
       n_tot(1:3) = spline_g%pw_grid%npts(1:3)
       bo = spline_g%pw_grid%bounds
 
-      CPASSERT(ASSOCIATED(spline_g))
       CPASSERT(spline_g%in_use == COMPLEXDATA1D)
       CPASSERT(spline_g%in_space == RECIPROCALSPACE)
       CPASSERT(.NOT. spline_g%pw_grid%spherical)
@@ -762,7 +758,7 @@ CONTAINS
    SUBROUTINE pw_nn_compose_r_work(weights, in_val, out_val, pw_in, bo)
       REAL(kind=dp), DIMENSION(0:2, 0:2, 0:2)            :: weights
       INTEGER, DIMENSION(2, 3)                           :: bo
-      TYPE(pw_type), POINTER                             :: pw_in
+      TYPE(pw_type), INTENT(IN)                          :: pw_in
       REAL(kind=dp), DIMENSION(bo(1, 1):bo(2, 1), bo(1, &
          2):bo(2, 2), bo(1, 3):bo(2, 3)), INTENT(inout)  :: out_val
       REAL(kind=dp), DIMENSION(bo(1, 1):bo(2, 1), bo(1, &
@@ -846,17 +842,15 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_nn_compose_r(weights, pw_in, pw_out)
       REAL(kind=dp), DIMENSION(0:2, 0:2, 0:2)            :: weights
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_out
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_nn_compose_r'
 
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
-      CPASSERT(ASSOCIATED(pw_in))
       CPASSERT(pw_in%in_space == REALSPACE)
       CPASSERT(pw_in%in_use == REALDATA3D)
-      CPASSERT(ASSOCIATED(pw_out))
       CPASSERT(pw_out%in_space == REALSPACE)
       CPASSERT(pw_out%in_use == REALDATA3D)
       IF (.NOT. ALL(pw_in%pw_grid%bounds_local(:, 2:3) == pw_in%pw_grid%bounds(:, 2:3))) THEN
@@ -884,7 +878,7 @@ CONTAINS
 !>      coeff=(/ 27._dp/64._dp, 9._dp/128._dp, 3._dp/256._dp, 1._dp/512._dp /)
 ! **************************************************************************************************
    SUBROUTINE pw_nn_smear_r(pw_in, pw_out, coeffs)
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_out
       REAL(KIND=dp), DIMENSION(4), INTENT(in)            :: coeffs
 
       INTEGER                                            :: i, j, k
@@ -927,7 +921,7 @@ CONTAINS
 !>      coeff=(/ 25._dp/72._dp, 5._dp/144, 1._dp/288._dp /)
 ! **************************************************************************************************
    SUBROUTINE pw_nn_deriv_r(pw_in, pw_out, coeffs, idir)
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_out
       REAL(KIND=dp), DIMENSION(3), INTENT(in)            :: coeffs
       INTEGER                                            :: idir
 
@@ -1005,7 +999,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE add_coarse2fine(coarse_coeffs_pw, fine_values_pw, &
                               weights_1d, w_border0, w_border1, pbc, safe_computation)
-      TYPE(pw_type), POINTER                             :: coarse_coeffs_pw, fine_values_pw
+      TYPE(pw_type), INTENT(IN)                          :: coarse_coeffs_pw, fine_values_pw
       REAL(kind=dp), DIMENSION(4), INTENT(in)            :: weights_1d
       REAL(kind=dp), INTENT(in)                          :: w_border0
       REAL(kind=dp), DIMENSION(3), INTENT(in)            :: w_border1
@@ -1802,7 +1796,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE add_fine2coarse(fine_values_pw, coarse_coeffs_pw, &
                               weights_1d, w_border0, w_border1, pbc, safe_computation)
-      TYPE(pw_type), POINTER                             :: fine_values_pw, coarse_coeffs_pw
+      TYPE(pw_type), INTENT(IN)                          :: fine_values_pw, coarse_coeffs_pw
       REAL(kind=dp), DIMENSION(4), INTENT(in)            :: weights_1d
       REAL(kind=dp), INTENT(in)                          :: w_border0
       REAL(kind=dp), DIMENSION(3), INTENT(in)            :: w_border1
@@ -2652,10 +2646,9 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_spline_do_precond(preconditioner, in_v, out_v)
-      TYPE(pw_spline_precond_type), POINTER              :: preconditioner
+      TYPE(pw_spline_precond_type), INTENT(IN)           :: preconditioner
       TYPE(pw_type), POINTER                             :: in_v, out_v
 
-      CPASSERT(ASSOCIATED(preconditioner))
       CPASSERT(preconditioner%ref_count > 0)
       SELECT CASE (preconditioner%kind)
       CASE (no_precond)
@@ -2707,12 +2700,12 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION find_coeffs(values, coeffs, linOp, preconditioner, pool, &
                         eps_r, eps_x, max_iter, sumtype) RESULT(res)
-      TYPE(pw_type), POINTER                             :: values, coeffs
+      TYPE(pw_type), INTENT(IN)                          :: values, coeffs
       INTERFACE
 ! **************************************************************************************************
          SUBROUTINE linOp(pw_in, pw_out)
             USE pw_types, ONLY: pw_type
-            TYPE(pw_type), POINTER :: pw_in, pw_out
+            TYPE(pw_type), INTENT(IN) :: pw_in, pw_out
          END SUBROUTINE linOp
       END INTERFACE
       TYPE(pw_spline_precond_type), POINTER              :: preconditioner
@@ -2814,7 +2807,7 @@ CONTAINS
    SUBROUTINE pw_nn_compose_r_no_pbc(weights_1d, pw_in, pw_out, &
                                      sharpen, normalize, transpose, smooth_boundary)
       REAL(kind=dp), DIMENSION(-1:1)                     :: weights_1d
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_out
       LOGICAL, INTENT(in), OPTIONAL                      :: sharpen, normalize, transpose, &
                                                             smooth_boundary
 
@@ -3154,7 +3147,7 @@ CONTAINS
 !> \param pw_out ...
 ! **************************************************************************************************
    SUBROUTINE spl3_nopbc(pw_in, pw_out)
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_out
 
       CALL pw_zero(pw_out)
       CALL pw_nn_compose_r_no_pbc(weights_1d=spl3_1d_coeffs0, pw_in=pw_in, &
@@ -3167,7 +3160,7 @@ CONTAINS
 !> \param pw_out ...
 ! **************************************************************************************************
    SUBROUTINE spl3_nopbct(pw_in, pw_out)
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_out
 
       CALL pw_zero(pw_out)
       CALL pw_nn_compose_r_no_pbc(weights_1d=spl3_1d_coeffs0, pw_in=pw_in, &
@@ -3180,7 +3173,7 @@ CONTAINS
 !> \param pw_out ...
 ! **************************************************************************************************
    SUBROUTINE spl3_pbc(pw_in, pw_out)
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in, pw_out
 
       CALL pw_zero(pw_out)
       CALL pw_nn_smear_r(pw_in, pw_out, coeffs=spline3_coeffs)
@@ -3200,7 +3193,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION Eval_Interp_Spl3_pbc(vec, pw) RESULT(val)
       REAL(KIND=dp), DIMENSION(3), INTENT(in)            :: vec
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp)                                      :: val
 
       INTEGER                                            :: i, ivec(3), j, k, npts(3)
@@ -3349,7 +3342,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION Eval_d_Interp_Spl3_pbc(vec, pw) RESULT(val)
       REAL(KIND=dp), DIMENSION(3), INTENT(in)            :: vec
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       REAL(KIND=dp)                                      :: val(3)
 
       INTEGER                                            :: i, ivec(3), j, k, npts(3)

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -152,14 +152,11 @@ CONTAINS
 
       last_pw_id_nr = last_pw_id_nr + 1
       pw%id_nr = last_pw_id_nr
-      NULLIFY (pw%pw_grid)
       pw%in_use = use_data
       pw%pw_grid => pw_grid
       CALL pw_grid_retain(pw%pw_grid)
       pw%in_space = NOSPACE
       bounds => pw%pw_grid%bounds_local
-
-      NULLIFY (pw%cr, pw%cc, pw%cr3d, pw%cc3d)
 
       SELECT CASE (use_data)
       CASE (REALDATA1D)

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -61,7 +61,6 @@ MODULE pw_types
       INTEGER :: in_use = NODATA ! Which data is used [r1d/c1d/r3d/c3d]
       INTEGER :: in_space = NOSPACE ! Real/Reciprocal space
       INTEGER :: id_nr = -1 ! unique identifier
-      INTEGER :: ref_count = 0 ! reference count
 
       TYPE(pw_grid_type), POINTER :: pw_grid => NULL()
    END TYPE pw_type
@@ -89,31 +88,24 @@ CONTAINS
       TYPE(pw_type), POINTER                             :: pw
 
       IF (ASSOCIATED(pw)) THEN
-         CPASSERT(pw%ref_count > 0)
-         pw%ref_count = pw%ref_count - 1
-         IF (pw%ref_count == 0) THEN
-            pw%ref_count = 1
-
-            SELECT CASE (pw%in_use)
-            CASE (REALDATA1D)
-               DEALLOCATE (pw%cr)
-            CASE (COMPLEXDATA1D)
-               DEALLOCATE (pw%cc)
-            CASE (REALDATA3D)
-               IF (ASSOCIATED(pw%cr3d)) THEN
-                  !FM optimizations of pools might have removed the 3d field to cache it
-                  DEALLOCATE (pw%cr3d)
-               END IF
-            CASE (COMPLEXDATA3D)
-               DEALLOCATE (pw%cc3d)
-            CASE (NODATA)
-            CASE default
-               CPABORT("unknown data type "//cp_to_string(pw%in_use))
-            END SELECT
-            CALL pw_grid_release(pw%pw_grid)
-            pw%ref_count = 0
-            DEALLOCATE (pw)
-         END IF
+         SELECT CASE (pw%in_use)
+         CASE (REALDATA1D)
+            DEALLOCATE (pw%cr)
+         CASE (COMPLEXDATA1D)
+            DEALLOCATE (pw%cc)
+         CASE (REALDATA3D)
+            IF (ASSOCIATED(pw%cr3d)) THEN
+               !FM optimizations of pools might have removed the 3d field to cache it
+               DEALLOCATE (pw%cr3d)
+            END IF
+         CASE (COMPLEXDATA3D)
+            DEALLOCATE (pw%cc3d)
+         CASE (NODATA)
+         CASE default
+            CPABORT("unknown data type "//cp_to_string(pw%in_use))
+         END SELECT
+         CALL pw_grid_release(pw%pw_grid)
+         DEALLOCATE (pw)
       END IF
       NULLIFY (pw)
    END SUBROUTINE pw_release
@@ -166,7 +158,6 @@ CONTAINS
 
       last_pw_id_nr = last_pw_id_nr + 1
       pw%id_nr = last_pw_id_nr
-      pw%ref_count = 1
       NULLIFY (pw%pw_grid)
       pw%in_use = use_data
       pw%pw_grid => pw_grid

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -85,29 +85,25 @@ CONTAINS
 !>      see doc/ReferenceCounting.html
 ! **************************************************************************************************
    SUBROUTINE pw_release(pw)
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(INOUT)                       :: pw
 
-      IF (ASSOCIATED(pw)) THEN
-         SELECT CASE (pw%in_use)
-         CASE (REALDATA1D)
-            DEALLOCATE (pw%cr)
-         CASE (COMPLEXDATA1D)
-            DEALLOCATE (pw%cc)
-         CASE (REALDATA3D)
-            IF (ASSOCIATED(pw%cr3d)) THEN
-               !FM optimizations of pools might have removed the 3d field to cache it
-               DEALLOCATE (pw%cr3d)
-            END IF
-         CASE (COMPLEXDATA3D)
-            DEALLOCATE (pw%cc3d)
-         CASE (NODATA)
-         CASE default
-            CPABORT("unknown data type "//cp_to_string(pw%in_use))
-         END SELECT
-         CALL pw_grid_release(pw%pw_grid)
-         DEALLOCATE (pw)
-      END IF
-      NULLIFY (pw)
+      SELECT CASE (pw%in_use)
+      CASE (REALDATA1D)
+         DEALLOCATE (pw%cr)
+      CASE (COMPLEXDATA1D)
+         DEALLOCATE (pw%cc)
+      CASE (REALDATA3D)
+         IF (ASSOCIATED(pw%cr3d)) THEN
+            !FM optimizations of pools might have removed the 3d field to cache it
+            DEALLOCATE (pw%cr3d)
+         END IF
+      CASE (COMPLEXDATA3D)
+         DEALLOCATE (pw%cc3d)
+      CASE (NODATA)
+      CASE default
+         CPABORT("unknown data type "//cp_to_string(pw%in_use))
+      END SELECT
+      CALL pw_grid_release(pw%pw_grid)
    END SUBROUTINE pw_release
 
 ! **************************************************************************************************
@@ -123,12 +119,12 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_create(pw, pw_grid, use_data, in_space, cr3d_ptr)
-      TYPE(pw_type), POINTER                             :: pw
-      TYPE(pw_grid_type), POINTER                        :: pw_grid
+      TYPE(pw_type), INTENT(OUT)                         :: pw
+      TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
       INTEGER, INTENT(in)                                :: use_data
       INTEGER, INTENT(in), OPTIONAL                      :: in_space
-      REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
-         POINTER                                         :: cr3d_ptr
+      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN), &
+         OPTIONAL, POINTER                               :: cr3d_ptr
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_create'
 
@@ -137,8 +133,6 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
 
       CALL timeset(routineN, handle)
-      CPASSERT(.NOT. ASSOCIATED(pw))
-      ALLOCATE (pw)
       logger => cp_get_default_logger()
       IF (debug_this_module) THEN
          WRITE (cp_logger_get_default_unit_nr(logger), "('*** allocated pw ***')")

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -38,7 +38,7 @@ MODULE pw_types
 
    PRIVATE
    PUBLIC :: pw_type, pw_p_type
-   PUBLIC :: pw_retain, pw_release, pw_create
+   PUBLIC :: pw_release, pw_create
 
    ! Flags for the structure member 'in_use'
    INTEGER, PARAMETER, PUBLIC :: REALDATA1D = 301, COMPLEXDATA1D = 302
@@ -75,23 +75,6 @@ MODULE pw_types
    LOGICAL, PARAMETER, PRIVATE :: debug_this_module = .FALSE.
 
 CONTAINS
-
-! **************************************************************************************************
-!> \brief retains a pw type
-!> \param pw the pw to retain
-!> \par History
-!>      03.2003 created [fawzi]
-!> \author fawzi
-!> \note
-!>      see doc/ReferenceCounting.html
-! **************************************************************************************************
-   SUBROUTINE pw_retain(pw)
-      TYPE(pw_type), POINTER                             :: pw
-
-      CPASSERT(ASSOCIATED(pw))
-      CPASSERT(pw%ref_count > 0)
-      pw%ref_count = pw%ref_count + 1
-   END SUBROUTINE pw_retain
 
 ! **************************************************************************************************
 !> \brief releases the given pw

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -40,26 +40,6 @@ MODULE pw_types
    PUBLIC :: pw_type, pw_p_type
    PUBLIC :: pw_retain, pw_release, pw_create
 
-! **************************************************************************************************
-   TYPE pw_type
-      REAL(KIND=dp), DIMENSION(:), POINTER :: cr
-      REAL(KIND=dp), DIMENSION(:, :, :), POINTER :: cr3d
-      COMPLEX(KIND=dp), DIMENSION(:), POINTER :: cc
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER :: cc3d
-
-      INTEGER :: in_use ! Which data is used [r1d/c1d/r3d/c3d]
-      INTEGER :: in_space ! Real/Reciprocal space
-      INTEGER :: id_nr ! unique identifier
-      INTEGER :: ref_count ! reference count
-
-      TYPE(pw_grid_type), POINTER :: pw_grid
-   END TYPE pw_type
-
-! **************************************************************************************************
-   TYPE pw_p_type
-      TYPE(pw_type), POINTER :: pw
-   END TYPE pw_p_type
-
    ! Flags for the structure member 'in_use'
    INTEGER, PARAMETER, PUBLIC :: REALDATA1D = 301, COMPLEXDATA1D = 302
    INTEGER, PARAMETER, PUBLIC :: REALDATA3D = 303, COMPLEXDATA3D = 304, NODATA = 305
@@ -71,6 +51,26 @@ MODULE pw_types
    ! to generate unique id_nr
    INTEGER, SAVE, PRIVATE :: last_pw_id_nr = 0
    INTEGER, SAVE, PRIVATE :: allocated_pw_count = 0
+
+! **************************************************************************************************
+   TYPE pw_type
+      REAL(KIND=dp), DIMENSION(:), CONTIGUOUS, POINTER :: cr => NULL()
+      REAL(KIND=dp), DIMENSION(:, :, :), CONTIGUOUS, POINTER :: cr3d => NULL()
+      COMPLEX(KIND=dp), DIMENSION(:), CONTIGUOUS, POINTER :: cc => NULL()
+      COMPLEX(KIND=dp), DIMENSION(:, :, :), CONTIGUOUS, POINTER :: cc3d => NULL()
+
+      INTEGER :: in_use = NODATA ! Which data is used [r1d/c1d/r3d/c3d]
+      INTEGER :: in_space = NOSPACE ! Real/Reciprocal space
+      INTEGER :: id_nr = -1 ! unique identifier
+      INTEGER :: ref_count = 0 ! reference count
+
+      TYPE(pw_grid_type), POINTER :: pw_grid => NULL()
+   END TYPE pw_type
+
+! **************************************************************************************************
+   TYPE pw_p_type
+      TYPE(pw_type), POINTER :: pw => NULL()
+   END TYPE pw_p_type
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'pw_types'
    LOGICAL, PARAMETER, PRIVATE :: debug_this_module = .FALSE.

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -50,7 +50,6 @@ MODULE pw_types
 
    ! to generate unique id_nr
    INTEGER, SAVE, PRIVATE :: last_pw_id_nr = 0
-   INTEGER, SAVE, PRIVATE :: allocated_pw_count = 0
 
 ! **************************************************************************************************
    TYPE pw_type
@@ -112,7 +111,6 @@ CONTAINS
          IF (pw%ref_count == 0) THEN
             pw%ref_count = 1
 
-            allocated_pw_count = allocated_pw_count - 1
             SELECT CASE (pw%in_use)
             CASE (REALDATA1D)
                DEALLOCATE (pw%cr)
@@ -192,8 +190,6 @@ CONTAINS
       CALL pw_grid_retain(pw%pw_grid)
       pw%in_space = NOSPACE
       bounds => pw%pw_grid%bounds_local
-
-      allocated_pw_count = allocated_pw_count + 1
 
       NULLIFY (pw%cr, pw%cc, pw%cr3d, pw%cc3d)
 

--- a/src/pw/realspace_grid_cube.F
+++ b/src/pw/realspace_grid_cube.F
@@ -49,7 +49,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_to_cube(pw, unit_nr, title, particles_r, particles_z, stride, zero_tails, &
                          silent, mpi_io)
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: unit_nr
       CHARACTER(*), INTENT(IN), OPTIONAL                 :: title
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
@@ -234,7 +234,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_to_pw(grid, filename, scaling, parallel_read, silent)
 
-      TYPE(pw_type), POINTER                             :: grid
+      TYPE(pw_type), INTENT(IN)                          :: grid
       CHARACTER(len=*), INTENT(in)                       :: filename
       REAL(kind=dp), INTENT(in)                          :: scaling
       LOGICAL, INTENT(in)                                :: parallel_read
@@ -374,7 +374,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_to_pw_parallel(grid, filename, scaling, msglen, silent)
 
-      TYPE(pw_type), POINTER                             :: grid
+      TYPE(pw_type), INTENT(IN)                          :: grid
       CHARACTER(len=*), INTENT(in)                       :: filename
       REAL(kind=dp), INTENT(in)                          :: scaling
       INTEGER, INTENT(in)                                :: msglen
@@ -635,7 +635,7 @@ CONTAINS
    SUBROUTINE pw_to_cube_parallel(grid, unit_nr, title, particles_r, particles_z, stride, zero_tails, &
                                   msglen)
 
-      TYPE(pw_type), POINTER                             :: grid
+      TYPE(pw_type), INTENT(IN)                          :: grid
       INTEGER, INTENT(IN)                                :: unit_nr
       CHARACTER(*), INTENT(IN), OPTIONAL                 :: title
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
@@ -827,10 +827,10 @@ CONTAINS
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
    SUBROUTINE pw_to_simple_volumetric(pw, unit_nr, stride, pw2)
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: unit_nr
-      INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: stride
-      TYPE(pw_type), OPTIONAL, POINTER                   :: pw2
+      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: stride
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: pw2
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_to_simple_volumetric'
 

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -180,7 +180,7 @@ CONTAINS
 !> \return ...
 ! **************************************************************************************************
    FUNCTION rs_grid_locate_rank(rs_desc, rank_in, shift) RESULT(rank_out)
-      TYPE(realspace_grid_desc_type), POINTER            :: rs_desc
+      TYPE(realspace_grid_desc_type), INTENT(IN)         :: rs_desc
       INTEGER, INTENT(IN)                                :: rank_in
       INTEGER, DIMENSION(3), INTENT(IN)                  :: shift
       INTEGER                                            :: rank_out
@@ -686,8 +686,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE rs_pw_transfer(rs, pw, dir)
 
-      TYPE(realspace_grid_type), POINTER                 :: rs
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: dir
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'rs_pw_transfer'
@@ -838,8 +838,8 @@ CONTAINS
 !>      pw2rs will scatter all pw data to the rs grids
 ! **************************************************************************************************
    SUBROUTINE rs_pw_transfer_replicated(rs, pw, dir)
-      TYPE(realspace_grid_type), POINTER                 :: rs
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: dir
 
       INTEGER                                            :: dest, group, i, ii, im, ip, ix, iy, iz, &
@@ -1019,8 +1019,8 @@ CONTAINS
 !>       with the central domain of several CPUs (i.e. next nearest neighbors)
 ! **************************************************************************************************
    SUBROUTINE rs_pw_transfer_distributed(rs, pw, dir)
-      TYPE(realspace_grid_type), POINTER                 :: rs
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs
+      TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: dir
 
       CHARACTER(LEN=200)                                 :: error_string
@@ -1935,7 +1935,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE rs_grid_zero(rs)
 
-      TYPE(realspace_grid_type), POINTER                 :: rs
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'rs_grid_zero'
 
@@ -1971,7 +1971,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE rs_grid_mult_and_add(rs1, rs2, rs3, scalar)
 
-      TYPE(realspace_grid_type), POINTER                 :: rs1, rs2, rs3
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs1, rs2, rs3
       REAL(dp), INTENT(IN)                               :: scalar
 
       CHARACTER(len=*), PARAMETER :: routineN = 'rs_grid_mult_and_add'
@@ -2133,9 +2133,9 @@ CONTAINS
 !>      04.2009 created [Iain Bethune]
 !>        (c) The Numerical Algorithms Group (NAG) Ltd, 2009 on behalf of the HECToR project
 ! **************************************************************************************************
-   SUBROUTINE cart_shift(rs_grid, dir, disp, source, dest)
+   PURE SUBROUTINE cart_shift(rs_grid, dir, disp, source, dest)
 
-      TYPE(realspace_grid_type), POINTER                 :: rs_grid
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
       INTEGER, INTENT(IN)                                :: dir, disp
       INTEGER, INTENT(OUT)                               :: source, dest
 
@@ -2159,7 +2159,7 @@ CONTAINS
 !>      10.2011 created [Iain Bethune]
 ! **************************************************************************************************
    FUNCTION rs_grid_max_ngpts(desc) RESULT(max_ngpts)
-      TYPE(realspace_grid_desc_type), POINTER            :: desc
+      TYPE(realspace_grid_desc_type), INTENT(IN)         :: desc
       INTEGER                                            :: max_ngpts
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'rs_grid_max_ngpts'

--- a/src/pw/rs_methods.F
+++ b/src/pw/rs_methods.F
@@ -457,6 +457,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, G_gs)
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
       CALL pw_pool_give_back_pw(pw_pool, pw_out_gs)
+      DEALLOCATE (G, G_gs, pw_in_gs, pw_out_gs)
       CALL timestop(handle)
 
    CONTAINS

--- a/src/pw/rs_methods.F
+++ b/src/pw/rs_methods.F
@@ -395,6 +395,8 @@ CONTAINS
       lb2 = bounds_local(1, 2); ub2 = bounds_local(2, 2)
       lb3 = bounds_local(1, 3); ub3 = bounds_local(2, 3)
 
+      NULLIFY (G, G_gs, pw_in_gs, pw_out_gs)
+      ALLOCATE (G, G_gs, pw_in_gs, pw_out_gs)
       CALL pw_pool_create_pw(pw_pool, G, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, G_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)

--- a/src/pw/rs_methods.F
+++ b/src/pw/rs_methods.F
@@ -60,9 +60,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE derive_fdm_cd3(f, df, rs_grid)
 
-      TYPE(pw_type), POINTER                             :: f
+      TYPE(pw_type), INTENT(IN)                          :: f
       TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
-      TYPE(realspace_grid_type), POINTER                 :: rs_grid
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fdm_cd3'
 
@@ -74,8 +74,6 @@ CONTAINS
       TYPE(realspace_grid_p_type), DIMENSION(3)          :: drs_grid
 
       CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(f))
 
       ! Setup
       rs_desc => rs_grid%desc
@@ -131,9 +129,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE derive_fdm_cd5(f, df, rs_grid)
 
-      TYPE(pw_type), POINTER                             :: f
+      TYPE(pw_type), INTENT(IN)                          :: f
       TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
-      TYPE(realspace_grid_type), POINTER                 :: rs_grid
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fdm_cd5'
 
@@ -145,8 +143,6 @@ CONTAINS
       TYPE(realspace_grid_p_type), DIMENSION(3)          :: drs_grid
 
       CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(f))
 
       ! Setup
       rs_desc => rs_grid%desc
@@ -202,9 +198,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE derive_fdm_cd7(f, df, rs_grid)
 
-      TYPE(pw_type), POINTER                             :: f
+      TYPE(pw_type), INTENT(IN)                          :: f
       TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
-      TYPE(realspace_grid_type), POINTER                 :: rs_grid
+      TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fdm_cd7'
 
@@ -216,8 +212,6 @@ CONTAINS
       TYPE(realspace_grid_p_type), DIMENSION(3)          :: drs_grid
 
       CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(f))
 
       ! Setup
       rs_desc => rs_grid%desc
@@ -280,7 +274,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE setup_grid_axes(pw_grid, x_glbl, y_glbl, z_glbl, x_locl, y_locl, z_locl)
 
-      TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
+      TYPE(pw_grid_type), INTENT(IN)                     :: pw_grid
       REAL(dp), ALLOCATABLE, DIMENSION(:), INTENT(OUT)   :: x_glbl, y_glbl, z_glbl, x_locl, y_locl, &
                                                             z_locl
 
@@ -376,8 +370,8 @@ CONTAINS
       REAL(dp), INTENT(IN)                     :: zeta
       REAL(dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                             :: x_glbl, y_glbl, z_glbl
-      TYPE(pw_type), INTENT(IN), POINTER       :: pw_in
-      TYPE(pw_type), INTENT(INOUT), POINTER    :: pw_out
+      TYPE(pw_type), INTENT(IN)       :: pw_in
+      TYPE(pw_type), INTENT(INOUT)   :: pw_out
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'pw_mollifier'
 

--- a/src/pw/rs_methods.F
+++ b/src/pw/rs_methods.F
@@ -26,7 +26,6 @@ MODULE rs_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_type
    USE realspace_grid_types,            ONLY: &
         pw2rs, realspace_grid_desc_type, realspace_grid_p_type, realspace_grid_type, rs2pw, &
@@ -61,7 +60,7 @@ CONTAINS
    SUBROUTINE derive_fdm_cd3(f, df, rs_grid)
 
       TYPE(pw_type), INTENT(IN)                          :: f
-      TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
+      TYPE(pw_type), DIMENSION(3), INTENT(INOUT)         :: df
       TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fdm_cd3'
@@ -108,7 +107,7 @@ CONTAINS
 
       ! Cleanup
       DO i = 1, 3
-         CALL rs_pw_transfer(drs_grid(i)%rs_grid, df(i)%pw, rs2pw)
+         CALL rs_pw_transfer(drs_grid(i)%rs_grid, df(i), rs2pw)
          CALL rs_grid_release(drs_grid(i)%rs_grid)
       END DO
 
@@ -130,7 +129,7 @@ CONTAINS
    SUBROUTINE derive_fdm_cd5(f, df, rs_grid)
 
       TYPE(pw_type), INTENT(IN)                          :: f
-      TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
+      TYPE(pw_type), DIMENSION(3), INTENT(INOUT)         :: df
       TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fdm_cd5'
@@ -177,7 +176,7 @@ CONTAINS
 
       ! Cleanup
       DO i = 1, 3
-         CALL rs_pw_transfer(drs_grid(i)%rs_grid, df(i)%pw, rs2pw)
+         CALL rs_pw_transfer(drs_grid(i)%rs_grid, df(i), rs2pw)
          CALL rs_grid_release(drs_grid(i)%rs_grid)
       END DO
 
@@ -199,7 +198,7 @@ CONTAINS
    SUBROUTINE derive_fdm_cd7(f, df, rs_grid)
 
       TYPE(pw_type), INTENT(IN)                          :: f
-      TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
+      TYPE(pw_type), DIMENSION(3), INTENT(INOUT)         :: df
       TYPE(realspace_grid_type), INTENT(IN)              :: rs_grid
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive_fdm_cd7'
@@ -249,7 +248,7 @@ CONTAINS
 
       ! Cleanup
       DO i = 1, 3
-         CALL rs_pw_transfer(drs_grid(i)%rs_grid, df(i)%pw, rs2pw)
+         CALL rs_pw_transfer(drs_grid(i)%rs_grid, df(i), rs2pw)
          CALL rs_grid_release(drs_grid(i)%rs_grid)
       END DO
 
@@ -366,23 +365,22 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_mollifier(pw_pool, zeta, x_glbl, y_glbl, z_glbl, pw_in, pw_out)
 
-      TYPE(pw_pool_type), INTENT(IN), POINTER  :: pw_pool
-      REAL(dp), INTENT(IN)                     :: zeta
-      REAL(dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(IN)                             :: x_glbl, y_glbl, z_glbl
-      TYPE(pw_type), INTENT(IN)       :: pw_in
-      TYPE(pw_type), INTENT(INOUT)   :: pw_out
+      TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
+      REAL(dp), INTENT(IN)                               :: zeta
+      REAL(dp), ALLOCATABLE, DIMENSION(:), INTENT(IN)    :: x_glbl, y_glbl, z_glbl
+      TYPE(pw_type), INTENT(IN)                          :: pw_in
+      TYPE(pw_type), INTENT(INOUT)                       :: pw_out
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'pw_mollifier'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'pw_mollifier'
 
-      INTEGER                                  :: handle, i, j, k, lb1, lb2, &
-                                                  lb3, ub1, ub2, ub3
-      INTEGER, DIMENSION(2, 3)                 :: bounds, bounds_local
-      REAL(dp)                                 :: normfact, xi, xmax, xmin, yj, &
-                                                  ymax, ymin, zk, zmax, zmin
-      REAL(dp), DIMENSION(3, 3)                :: dh
-      TYPE(pw_grid_type), POINTER              :: pw_grid
-      TYPE(pw_type), POINTER                   :: G, G_gs, pw_in_gs, pw_out_gs
+      INTEGER                                            :: handle, i, j, k, lb1, lb2, lb3, ub1, &
+                                                            ub2, ub3
+      INTEGER, DIMENSION(2, 3)                           :: bounds, bounds_local
+      REAL(dp)                                           :: normfact, xi, xmax, xmin, yj, ymax, &
+                                                            ymin, zk, zmax, zmin
+      REAL(dp), DIMENSION(3, 3)                          :: dh
+      TYPE(pw_grid_type), POINTER                        :: pw_grid
+      TYPE(pw_type)                                      :: G, G_gs, pw_in_gs, pw_out_gs
 
       CALL timeset(routineN, handle)
 
@@ -395,8 +393,6 @@ CONTAINS
       lb2 = bounds_local(1, 2); ub2 = bounds_local(2, 2)
       lb3 = bounds_local(1, 3); ub3 = bounds_local(2, 3)
 
-      NULLIFY (G, G_gs, pw_in_gs, pw_out_gs)
-      ALLOCATE (G, G_gs, pw_in_gs, pw_out_gs)
       CALL pw_pool_create_pw(pw_pool, G, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_pool, G_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(pw_pool, pw_in_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
@@ -411,22 +407,22 @@ CONTAINS
          DO j = lb2, ub2
             DO i = lb1, ub1
                xi = x_glbl(i); yj = y_glbl(j); zk = z_glbl(k)
-               IF (vec_norm2((/(xi - xmin), (yj - ymin), (zk - zmin)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmin), (yj - ymin), (zk - zmin)/)/zeta)**2 - 1))
-               ELSE IF (vec_norm2((/(xi - xmax), (yj - ymax), (zk - zmax)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmax), (yj - ymax), (zk - zmax)/)/zeta)**2 - 1))
-               ELSE IF (vec_norm2((/(xi - xmin), (yj - ymax), (zk - zmax)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmin), (yj - ymax), (zk - zmax)/)/zeta)**2 - 1))
-               ELSE IF (vec_norm2((/(xi - xmax), (yj - ymin), (zk - zmax)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmax), (yj - ymin), (zk - zmax)/)/zeta)**2 - 1))
-               ELSE IF (vec_norm2((/(xi - xmax), (yj - ymax), (zk - zmin)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmax), (yj - ymax), (zk - zmin)/)/zeta)**2 - 1))
-               ELSE IF (vec_norm2((/(xi - xmin), (yj - ymin), (zk - zmax)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmin), (yj - ymin), (zk - zmax)/)/zeta)**2 - 1))
-               ELSE IF (vec_norm2((/(xi - xmin), (yj - ymax), (zk - zmin)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmin), (yj - ymax), (zk - zmin)/)/zeta)**2 - 1))
-               ELSE IF (vec_norm2((/(xi - xmax), (yj - ymin), (zk - zmin)/)) .LT. zeta - small_value) THEN
-                  G%cr3d(i, j, k) = EXP(1.0_dp/(vec_norm2((/(xi - xmax), (yj - ymin), (zk - zmin)/)/zeta)**2 - 1))
+               IF (norm2((/(xi - xmin), (yj - ymin), (zk - zmin)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmin), (yj - ymin), (zk - zmin)/)/zeta)**2 - 1))
+               ELSE IF (norm2((/(xi - xmax), (yj - ymax), (zk - zmax)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmax), (yj - ymax), (zk - zmax)/)/zeta)**2 - 1))
+               ELSE IF (norm2((/(xi - xmin), (yj - ymax), (zk - zmax)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmin), (yj - ymax), (zk - zmax)/)/zeta)**2 - 1))
+               ELSE IF (norm2((/(xi - xmax), (yj - ymin), (zk - zmax)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmax), (yj - ymin), (zk - zmax)/)/zeta)**2 - 1))
+               ELSE IF (norm2((/(xi - xmax), (yj - ymax), (zk - zmin)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmax), (yj - ymax), (zk - zmin)/)/zeta)**2 - 1))
+               ELSE IF (norm2((/(xi - xmin), (yj - ymin), (zk - zmax)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmin), (yj - ymin), (zk - zmax)/)/zeta)**2 - 1))
+               ELSE IF (norm2((/(xi - xmin), (yj - ymax), (zk - zmin)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmin), (yj - ymax), (zk - zmin)/)/zeta)**2 - 1))
+               ELSE IF (norm2((/(xi - xmax), (yj - ymin), (zk - zmin)/)) .LT. zeta - small_value) THEN
+                  G%cr3d(i, j, k) = EXP(1.0_dp/(norm2((/(xi - xmax), (yj - ymin), (zk - zmin)/)/zeta)**2 - 1))
                END IF
             END DO
          END DO
@@ -457,21 +453,8 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, G_gs)
       CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
       CALL pw_pool_give_back_pw(pw_pool, pw_out_gs)
-      DEALLOCATE (G, G_gs, pw_in_gs, pw_out_gs)
       CALL timestop(handle)
 
-   CONTAINS
-! **************************************************************************************************
-!> \brief computes the norm 2 of a vector in the three-dimensional real space
-!> \param vec input vector
-!> \return ...
-! **************************************************************************************************
-      PURE FUNCTION vec_norm2(vec)
-      REAL(dp), DIMENSION(3), INTENT(IN)                 :: vec
-      REAL(dp)                                           :: vec_norm2
-
-         vec_norm2 = SQRT(SUM(vec**2))
-      END FUNCTION vec_norm2
    END SUBROUTINE pw_mollifier
 
 END MODULE rs_methods

--- a/src/pw_env/cp_spline_utils.F
+++ b/src/pw_env/cp_spline_utils.F
@@ -92,19 +92,10 @@ CONTAINS
       CPASSERT(pbc .OR. interp_kind == spline3_nopbc_interp)
       bo = pw_coarse_out%pw_grid%bounds_local
       NULLIFY (values, coeffs)
+      ALLOCATE (values)
       CALL pw_pool_create_pw(coarse_pool, values, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL pw_zero(values)
-
-!FM       nullify(tst_pw)
-!FM       CALL pw_pool_create_pw(coarse_pool,tst_pw, use_data=REALDATA3D,&
-!FM            in_space=REALSPACE)
-!FM       call pw_copy(values,tst_pw)
-!FM       call add_fine2coarse(fine_values_pw=pw_fine_in,&
-!FM            coarse_coeffs_pw=tst_pw,&
-!FM            weights_1d=spl3_1d_transf_coeffs/2._dp, w_border0=0.5_dp,&
-!FM            w_border1=spl3_1d_transf_border1/2._dp,pbc=pbc,&
-!FM            safe_computation=.false.)
 
       CALL add_fine2coarse(fine_values_pw=pw_fine_in, &
                            coarse_coeffs_pw=values, &
@@ -112,10 +103,7 @@ CONTAINS
                            w_border1=spl3_1d_transf_border1/2._dp, pbc=pbc, &
                            safe_computation=safe_computation)
 
-!FM       CALL pw_compare_debug(tst_pw,values,max_diff)
-!FM       WRITE(cp_logger_get_default_unit_nr(logger,.TRUE.),*)"f2cmax_diff=",max_diff
-!FM       CALL pw_pool_give_back_pw(coarse_pool,tst_pw)
-
+      ALLOCATE (coeffs)
       CALL pw_pool_create_pw(coarse_pool, coeffs, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       NULLIFY (precond)
@@ -172,6 +160,7 @@ CONTAINS
       ifile = ifile + 1
       CALL timeset(routineN, handle)
       NULLIFY (coeffs)
+      ALLOCATE (coeffs)
       CALL pw_pool_create_pw(coarse_pool, coeffs, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       bo = pw_coarse_in%pw_grid%bounds_local

--- a/src/pw_env/cp_spline_utils.F
+++ b/src/pw_env/cp_spline_utils.F
@@ -211,28 +211,12 @@ CONTAINS
       CPASSERT(success)
       CALL pw_spline_precond_release(precond)
 
-!FM       nullify(tst_pw)
-!FM       call pw_create(tst_pw, pw_fine_out%pw_grid, use_data=REALDATA3D,&
-!FM            in_space=REALSPACE)
-!FM       call pw_copy(pw_fine_out,tst_pw)
-!FM       CALL add_coarse2fine(coarse_coeffs_pw=coeffs,&
-!FM            fine_values_pw=tst_pw,&
-!FM            weights_1d=spl3_1d_transf_coeffs,&
-!FM            w_border0=1._dp,&
-!FM            w_border1=spl3_1d_transf_border1,&
-!FM            pbc=pbc,safe_computation=.false.,&
-!FM
-
       CALL add_coarse2fine(coarse_coeffs_pw=coeffs, &
                            fine_values_pw=pw_fine_out, &
                            weights_1d=spl3_1d_transf_coeffs, &
                            w_border0=1._dp, &
                            w_border1=spl3_1d_transf_border1, &
                            pbc=pbc, safe_computation=safe_computation)
-
-!FM       CALL pw_compare_debug(tst_pw,pw_fine_out,max_diff)
-!FM       WRITE(cp_logger_get_default_unit_nr(logger,.TRUE.),*)"c2fmax_diff=",max_diff
-!FM       CALL pw_release(tst_pw)
 
       CALL pw_pool_give_back_pw(coarse_pool, coeffs)
 

--- a/src/pw_env/cp_spline_utils.F
+++ b/src/pw_env/cp_spline_utils.F
@@ -127,6 +127,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(coarse_pool, values)
       CALL pw_pool_give_back_pw(coarse_pool, coeffs)
+      DEALLOCATE (values, coeffs)
       CALL timestop(handle)
    END SUBROUTINE pw_restrict_s3
 
@@ -208,6 +209,7 @@ CONTAINS
                            pbc=pbc, safe_computation=safe_computation)
 
       CALL pw_pool_give_back_pw(coarse_pool, coeffs)
+      DEALLOCATE (coeffs)
 
       CALL timestop(handle)
    END SUBROUTINE pw_prolongate_s3

--- a/src/pw_env/cp_spline_utils.F
+++ b/src/pw_env/cp_spline_utils.F
@@ -56,7 +56,7 @@ CONTAINS
 !>      extremely slow (but correct) version
 ! **************************************************************************************************
    SUBROUTINE pw_restrict_s3(pw_fine_in, pw_coarse_out, coarse_pool, param_section)
-      TYPE(pw_type), POINTER                             :: pw_fine_in, pw_coarse_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_fine_in, pw_coarse_out
       TYPE(pw_pool_type), POINTER                        :: coarse_pool
       TYPE(section_vals_type), POINTER                   :: param_section
 
@@ -68,8 +68,8 @@ CONTAINS
       INTEGER, SAVE                                      :: ifile = 0
       LOGICAL                                            :: pbc, safe_computation, success
       REAL(kind=dp)                                      :: eps_r, eps_x
-      TYPE(pw_spline_precond_type), POINTER              :: precond
-      TYPE(pw_type), POINTER                             :: coeffs, values
+      TYPE(pw_spline_precond_type)                       :: precond
+      TYPE(pw_type)                                      :: coeffs, values
 
       ifile = ifile + 1
       CALL timeset(routineN, handle)
@@ -91,8 +91,6 @@ CONTAINS
       pbc = (interp_kind == spline3_pbc_interp)
       CPASSERT(pbc .OR. interp_kind == spline3_nopbc_interp)
       bo = pw_coarse_out%pw_grid%bounds_local
-      NULLIFY (values, coeffs)
-      ALLOCATE (values)
       CALL pw_pool_create_pw(coarse_pool, values, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL pw_zero(values)
@@ -103,10 +101,8 @@ CONTAINS
                            w_border1=spl3_1d_transf_border1/2._dp, pbc=pbc, &
                            safe_computation=safe_computation)
 
-      ALLOCATE (coeffs)
       CALL pw_pool_create_pw(coarse_pool, coeffs, use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      NULLIFY (precond)
       CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                     pool=coarse_pool, pbc=pbc, transpose=.TRUE.)
       CALL pw_spline_do_precond(precond, values, coeffs)
@@ -127,7 +123,6 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(coarse_pool, values)
       CALL pw_pool_give_back_pw(coarse_pool, coeffs)
-      DEALLOCATE (values, coeffs)
       CALL timestop(handle)
    END SUBROUTINE pw_restrict_s3
 
@@ -143,7 +138,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_prolongate_s3(pw_coarse_in, pw_fine_out, coarse_pool, &
                                param_section)
-      TYPE(pw_type), POINTER                             :: pw_coarse_in, pw_fine_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_coarse_in, pw_fine_out
       TYPE(pw_pool_type), POINTER                        :: coarse_pool
       TYPE(section_vals_type), POINTER                   :: param_section
 
@@ -155,13 +150,11 @@ CONTAINS
       INTEGER, SAVE                                      :: ifile = 0
       LOGICAL                                            :: pbc, safe_computation, success
       REAL(kind=dp)                                      :: eps_r, eps_x
-      TYPE(pw_spline_precond_type), POINTER              :: precond
-      TYPE(pw_type), POINTER                             :: coeffs
+      TYPE(pw_spline_precond_type)                       :: precond
+      TYPE(pw_type)                                      :: coeffs
 
       ifile = ifile + 1
       CALL timeset(routineN, handle)
-      NULLIFY (coeffs)
-      ALLOCATE (coeffs)
       CALL pw_pool_create_pw(coarse_pool, coeffs, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       bo = pw_coarse_in%pw_grid%bounds_local
@@ -182,7 +175,6 @@ CONTAINS
 
       pbc = (interp_kind == spline3_pbc_interp)
       CPASSERT(pbc .OR. interp_kind == spline3_nopbc_interp)
-      NULLIFY (precond)
       CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                     pool=coarse_pool, pbc=pbc, transpose=.FALSE.)
       CALL pw_spline_do_precond(precond, pw_coarse_in, coeffs)
@@ -209,7 +201,6 @@ CONTAINS
                            pbc=pbc, safe_computation=safe_computation)
 
       CALL pw_pool_give_back_pw(coarse_pool, coeffs)
-      DEALLOCATE (coeffs)
 
       CALL timestop(handle)
    END SUBROUTINE pw_prolongate_s3

--- a/src/pw_env/rs_pw_interface.F
+++ b/src/pw_env/rs_pw_interface.F
@@ -33,7 +33,8 @@ MODULE rs_pw_interface
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE realspace_grid_types,            ONLY: pw2rs,&
                                               realspace_grid_desc_p_type,&
                                               realspace_grid_p_type,&
@@ -71,7 +72,7 @@ CONTAINS
 
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: rs_rho
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: rho, rho_gspace
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'density_rs2pw'
 
@@ -100,11 +101,11 @@ CONTAINS
                                in_space=RECIPROCALSPACE)
 
       IF (gridlevel_info%ngrid_levels == 1) THEN
-         CALL rs_pw_transfer(rs_rho(1)%rs_grid, rho%pw, rs2pw)
+         CALL rs_pw_transfer(rs_rho(1)%rs_grid, rho, rs2pw)
          CALL rs_grid_release(rs_rho(1)%rs_grid)
-         CALL pw_transfer(rho%pw, rho_gspace%pw)
-         IF (rho%pw%pw_grid%spherical) THEN ! rho_gspace = rho
-            CALL pw_transfer(rho_gspace%pw, rho%pw)
+         CALL pw_transfer(rho, rho_gspace)
+         IF (rho%pw_grid%spherical) THEN ! rho_gspace = rho
+            CALL pw_transfer(rho_gspace, rho)
          END IF
       ELSE
          DO igrid_level = 1, gridlevel_info%ngrid_levels
@@ -116,21 +117,21 @@ CONTAINS
          ! we want both rho and rho_gspace, the latter for Hartree and co-workers.
          SELECT CASE (interp_kind)
          CASE (pw_interp)
-            CALL pw_zero(rho_gspace%pw)
+            CALL pw_zero(rho_gspace)
             DO igrid_level = 1, gridlevel_info%ngrid_levels
                CALL pw_transfer(mgrid_rspace(igrid_level)%pw, &
                                 mgrid_gspace(igrid_level)%pw)
-               CALL pw_axpy(mgrid_gspace(igrid_level)%pw, rho_gspace%pw)
+               CALL pw_axpy(mgrid_gspace(igrid_level)%pw, rho_gspace)
             END DO
-            CALL pw_transfer(rho_gspace%pw, rho%pw)
+            CALL pw_transfer(rho_gspace, rho)
          CASE (spline3_pbc_interp)
             DO igrid_level = gridlevel_info%ngrid_levels, 2, -1
                CALL pw_prolongate_s3(mgrid_rspace(igrid_level)%pw, &
                                      mgrid_rspace(igrid_level - 1)%pw, pw_pools(igrid_level)%pool, &
                                      pw_env%interp_section)
             END DO
-            CALL pw_copy(mgrid_rspace(1)%pw, rho%pw)
-            CALL pw_transfer(rho%pw, rho_gspace%pw)
+            CALL pw_copy(mgrid_rspace(1)%pw, rho)
+            CALL pw_transfer(rho, rho_gspace)
          CASE default
             CALL cp_abort(__LOCATION__, &
                           "interpolator "// &
@@ -160,7 +161,7 @@ CONTAINS
 
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: rs_rho
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: rho, rho_gspace
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_rs2pw_basic'
 
@@ -189,8 +190,8 @@ CONTAINS
                                in_space=RECIPROCALSPACE)
 
       IF (gridlevel_info%ngrid_levels == 1) THEN
-         CALL rs_pw_transfer(rs_rho(1)%rs_grid, rho%pw, rs2pw)
-         CALL pw_transfer(rho%pw, rho_gspace%pw)
+         CALL rs_pw_transfer(rs_rho(1)%rs_grid, rho, rs2pw)
+         CALL pw_transfer(rho, rho_gspace)
       ELSE
          DO igrid_level = 1, gridlevel_info%ngrid_levels
             CALL rs_pw_transfer(rs_rho(igrid_level)%rs_grid, &
@@ -207,16 +208,16 @@ CONTAINS
                   CALL pw_axpy(mgrid_gspace(igrid_level)%pw, mgrid_gspace(1)%pw)
                END IF
             END DO
-            CALL pw_transfer(mgrid_gspace(1)%pw, rho%pw)
-            CALL pw_transfer(mgrid_rspace(1)%pw, rho_gspace%pw)
+            CALL pw_transfer(mgrid_gspace(1)%pw, rho)
+            CALL pw_transfer(mgrid_rspace(1)%pw, rho_gspace)
          CASE (spline3_pbc_interp)
             DO igrid_level = gridlevel_info%ngrid_levels, 2, -1
                CALL pw_prolongate_s3(mgrid_rspace(igrid_level)%pw, &
                                      mgrid_rspace(igrid_level - 1)%pw, pw_pools(igrid_level)%pool, &
                                      pw_env%interp_section)
             END DO
-            CALL pw_copy(mgrid_rspace(1)%pw, rho%pw)
-            CALL pw_transfer(rho%pw, rho_gspace%pw)
+            CALL pw_copy(mgrid_rspace(1)%pw, rho)
+            CALL pw_transfer(rho, rho_gspace)
          CASE default
             CALL cp_abort(__LOCATION__, &
                           "interpolator "// &
@@ -247,7 +248,7 @@ CONTAINS
    SUBROUTINE potential_pw2rs(rs_v, v_rspace, pw_env)
 
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: rs_v
-      TYPE(pw_p_type), INTENT(IN)                        :: v_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_rspace
       TYPE(pw_env_type), POINTER                         :: pw_env
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'potential_pw2rs'
@@ -276,7 +277,7 @@ CONTAINS
          CALL pw_pools_create_pws(pw_pools, mgrid_gspace, &
                                   use_data=COMPLEXDATA1D, &
                                   in_space=RECIPROCALSPACE)
-         CALL pw_transfer(v_rspace%pw, mgrid_gspace(auxbas_grid)%pw)
+         CALL pw_transfer(v_rspace, mgrid_gspace(auxbas_grid)%pw)
          DO igrid_level = 1, gridlevel_info%ngrid_levels
             IF (igrid_level /= auxbas_grid) THEN
                CALL pw_copy(mgrid_gspace(auxbas_grid)%pw, mgrid_gspace(igrid_level)%pw)
@@ -285,7 +286,7 @@ CONTAINS
                IF (mgrid_gspace(auxbas_grid)%pw%pw_grid%spherical) THEN
                   CALL pw_transfer(mgrid_gspace(auxbas_grid)%pw, mgrid_rspace(auxbas_grid)%pw)
                ELSE ! fft forward + backward should be identical
-                  CALL pw_copy(v_rspace%pw, mgrid_rspace(auxbas_grid)%pw)
+                  CALL pw_copy(v_rspace, mgrid_rspace(auxbas_grid)%pw)
                END IF
             END IF
             ! *** Multiply by the grid volume element ratio ***
@@ -298,7 +299,7 @@ CONTAINS
          END DO
          CALL pw_pools_give_back_pws(pw_pools, mgrid_gspace)
       CASE (spline3_pbc_interp)
-         CALL pw_copy(v_rspace%pw, mgrid_rspace(1)%pw)
+         CALL pw_copy(v_rspace, mgrid_rspace(1)%pw)
          DO igrid_level = 1, gridlevel_info%ngrid_levels - 1
             CALL pw_zero(mgrid_rspace(igrid_level + 1)%pw)
             CALL pw_restrict_s3(mgrid_rspace(igrid_level)%pw, &

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -121,10 +121,10 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
-      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_r, rho_tot_r2
+      TYPE(pw_type), POINTER                             :: rho0_s_gs, rho_core, rho_tot_r, &
+                                                            rho_tot_r2
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_qmmm_env_type), POINTER                 :: ks_qmmm_env_loc
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -217,26 +217,26 @@ CONTAINS
          ! IF GAPW the core charge is replaced by the compensation charge
          IF (gapw) THEN
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
-               CALL pw_transfer(rho_core%pw, rho_tot_r)
+               CALL pw_transfer(rho_core, rho_tot_r)
                energy%qmmm_nu = pw_integral_ab(rho_tot_r, ks_qmmm_env_loc%v_qmmm_rspace%pw)
                NULLIFY (rho_tot_r2)
                ALLOCATE (rho_tot_r2)
                CALL pw_pool_create_pw(auxbas_pool, rho_tot_r2, &
                                       in_space=REALSPACE, &
                                       use_data=REALDATA3D)
-               CALL pw_transfer(rho0_s_gs%pw, rho_tot_r2)
+               CALL pw_transfer(rho0_s_gs, rho_tot_r2)
                CALL pw_axpy(rho_tot_r2, rho_tot_r)
                CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r2)
                DEALLOCATE (rho_tot_r2)
             ELSE
-               CALL pw_transfer(rho0_s_gs%pw, rho_tot_r)
+               CALL pw_transfer(rho0_s_gs, rho_tot_r)
                !
                ! QM/MM Nuclear Electrostatic Potential already included through rho0
                !
                energy%qmmm_nu = 0.0_dp
             END IF
          ELSE
-            CALL pw_transfer(rho_core%pw, rho_tot_r)
+            CALL pw_transfer(rho_core, rho_tot_r)
             !
             ! Computes the QM/MM Nuclear Electrostatic Potential
             !

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -227,6 +227,7 @@ CONTAINS
                CALL pw_transfer(rho0_s_gs%pw, rho_tot_r2)
                CALL pw_axpy(rho_tot_r2, rho_tot_r)
                CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r2)
+               DEALLOCATE (rho_tot_r2)
             ELSE
                CALL pw_transfer(rho0_s_gs%pw, rho_tot_r)
                !
@@ -320,6 +321,7 @@ CONTAINS
       IF ((.NOT. dft_control%qs_control%semi_empirical) .AND. &
           (.NOT. dft_control%qs_control%dftb) .AND. (.NOT. dft_control%qs_control%xtb)) THEN
          CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r)
+         DEALLOCATE (rho_tot_r)
       END IF
       IF (iw > 0) THEN
          IF (.NOT. gapw) WRITE (iw, '(T2,"QMMM|",1X,A,T66,F15.9)') &
@@ -1447,6 +1449,7 @@ CONTAINS
       CALL cp_print_key_finished_output(iw, logger, print_section, "PROGRAM_RUN_INFO")
 
       CALL pw_pool_give_back_pw(pw_pools(1)%pool, v_qmmm_rspace%pw)
+      DEALLOCATE (v_qmmm_rspace%pw)
       DEALLOCATE (Num_Forces)
       CALL timestop(handle)
 100   FORMAT(I5, 2F15.9, " ( ", F7.2, " ) ", 2F15.9, " ( ", F7.2, " ) ", 2F15.9, " ( ", F7.2, " ) ")

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -226,7 +226,7 @@ CONTAINS
                                       use_data=REALDATA3D)
                CALL pw_transfer(rho0_s_gs%pw, rho_tot_r2)
                CALL pw_axpy(rho_tot_r2, rho_tot_r)
-               CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r2, accept_non_compatible=.TRUE.)
+               CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r2)
             ELSE
                CALL pw_transfer(rho0_s_gs%pw, rho_tot_r)
                !
@@ -319,7 +319,7 @@ CONTAINS
       ! Give back rho_tot_t to auxbas_pool only for GPW/GAPW
       IF ((.NOT. dft_control%qs_control%semi_empirical) .AND. &
           (.NOT. dft_control%qs_control%dftb) .AND. (.NOT. dft_control%qs_control%xtb)) THEN
-         CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r, accept_non_compatible=.TRUE.)
+         CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r)
       END IF
       IF (iw > 0) THEN
          IF (.NOT. gapw) WRITE (iw, '(T2,"QMMM|",1X,A,T66,F15.9)') &

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -209,6 +209,8 @@ CONTAINS
          CALL pw_env_get(pw_env=pw_env, &
                          pw_pools=pw_pools, &
                          auxbas_pw_pool=auxbas_pool)
+         NULLIFY (rho_tot_r)
+         ALLOCATE (rho_tot_r)
          CALL pw_pool_create_pw(auxbas_pool, rho_tot_r, &
                                 in_space=REALSPACE, &
                                 use_data=REALDATA3D)
@@ -217,6 +219,8 @@ CONTAINS
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
                CALL pw_transfer(rho_core%pw, rho_tot_r)
                energy%qmmm_nu = pw_integral_ab(rho_tot_r, ks_qmmm_env_loc%v_qmmm_rspace%pw)
+               NULLIFY (rho_tot_r2)
+               ALLOCATE (rho_tot_r2)
                CALL pw_pool_create_pw(auxbas_pool, rho_tot_r2, &
                                       in_space=REALSPACE, &
                                       use_data=REALDATA3D)
@@ -1362,6 +1366,7 @@ CONTAINS
       logger => cp_get_default_logger()
       iw = cp_print_key_unit_nr(logger, print_section, "PROGRAM_RUN_INFO", extension=".qmmmLog")
       CALL pw_env_get(pw_env=pw_env, pw_pools=pw_pools)
+      ALLOCATE (v_qmmm_rspace%pw)
       CALL pw_pool_create_pw(pw_pools(1)%pool, v_qmmm_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       ALLOCATE (Num_Forces(3, num_mm_atoms))

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -749,7 +749,7 @@ CONTAINS
       iatom_ref = 1 !
       !collocate gaussian of reference MM atom on grid
       CALL pw_zero(rho_gb%pw)
-      CALL calculate_rho_single_gaussian(rho_gb, qs_env, iatom_ref)
+      CALL calculate_rho_single_gaussian(rho_gb%pw, qs_env, iatom_ref)
       !calculate potential vb like hartree potential
       CALL pw_zero(vb_gspace%pw)
       CALL pw_poisson_solve(poisson_env, rho_gb%pw, vhartree=vb_gspace%pw)
@@ -920,7 +920,7 @@ CONTAINS
                              in_space=REALSPACE)
 
       CALL pw_zero(rho_metal%pw)
-      CALL calculate_rho_metal(rho_metal, coeff, total_rho_metal=total_rho_metal, &
+      CALL calculate_rho_metal(rho_metal%pw, coeff, total_rho_metal=total_rho_metal, &
                                qs_env=qs_env)
 
       CALL pw_zero(v_metal_gspace%pw)

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -735,6 +735,7 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
+      ALLOCATE (rho_gb%pw, vb_gspace%pw, vb_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              rho_gb%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -908,6 +909,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
+      ALLOCATE (rho_metal%pw, v_metal_gspace%pw, v_metal_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              rho_metal%pw, &
                              use_data=COMPLEXDATA1D, &

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -58,7 +58,8 @@ MODULE qmmm_image_charge
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type
    USE qs_collocate_density,            ONLY: calculate_rho_metal,&
                                               calculate_rho_single_gaussian
@@ -463,7 +464,7 @@ CONTAINS
    SUBROUTINE integrate_potential_devga_rspace(potential, coeff, forces, qmmm_env, &
                                                qs_env)
 
-      TYPE(pw_p_type), INTENT(IN)                        :: potential
+      TYPE(pw_type), INTENT(IN)                          :: potential
       REAL(KIND=dp), DIMENSION(:), POINTER               :: coeff
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: forces
       TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
@@ -498,7 +499,7 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, auxbas_rs_desc=auxbas_rs_desc, &
                       auxbas_rs_grid=rs_v)
       CALL rs_grid_retain(rs_v)
-      CALL rs_pw_transfer(rs_v, potential%pw, pw2rs)
+      CALL rs_pw_transfer(rs_v, potential, pw2rs)
 
       CALL get_qs_env(qs_env=qs_env, &
                       cell=cell, &

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -293,11 +293,13 @@ CONTAINS
          ! SQRT(rsnew) < 1.0E-08
          IF (rsnew < 1.0E-16) THEN
             CALL pw_release(auxpot_Ad_rspace%pw)
+            DEALLOCATE (auxpot_Ad_rspace%pw)
             EXIT
          END IF
          d = z + rsnew/rsold*d
          rsold = rsnew
          CALL pw_release(auxpot_Ad_rspace%pw)
+         DEALLOCATE (auxpot_Ad_rspace%pw)
       END DO
 
       ! print iteration info
@@ -318,6 +320,7 @@ CONTAINS
       END IF
 
       CALL pw_release(v_metal_rspace_guess%pw)
+      DEALLOCATE (v_metal_rspace_guess%pw)
       DEALLOCATE (pot_const)
       DEALLOCATE (vmetal_const)
       DEALLOCATE (r)
@@ -770,6 +773,7 @@ CONTAINS
       CALL pw_release(vb_gspace%pw)
       CALL pw_release(vb_rspace%pw)
       CALL pw_release(rho_gb%pw)
+      DEALLOCATE (vb_gspace%pw, vb_rspace%pw, rho_gb%pw)
 
       DEALLOCATE (int_res)
 
@@ -941,6 +945,7 @@ CONTAINS
       CALL pw_scale(v_metal_rspace%pw, v_metal_rspace%pw%pw_grid%dvol)
       CALL pw_release(v_metal_gspace%pw)
       CALL pw_release(rho_metal%pw)
+      DEALLOCATE (v_metal_gspace%pw, rho_metal%pw)
 
       CALL timestop(handle)
 

--- a/src/qmmm_types_low.F
+++ b/src/qmmm_types_low.F
@@ -580,6 +580,7 @@ CONTAINS
             END IF
             IF (ASSOCIATED(Per_Potentials(I)%Pot%TabLR)) THEN
                CALL pw_pool_give_back_pw(Per_Potentials(I)%Pot%pw_pool, Per_Potentials(I)%Pot%TabLR)
+               DEALLOCATE (Per_Potentials(I)%Pot%TabLR)
             END IF
             IF (ASSOCIATED(Per_Potentials(I)%Pot%pw_pool)) THEN
                CALL pw_pool_release(Per_Potentials(I)%Pot%pw_pool)

--- a/src/qs_2nd_kernel_ao.F
+++ b/src/qs_2nd_kernel_ao.F
@@ -346,12 +346,12 @@ CONTAINS
          DO ispin = 1, nspins
             v_xc(ispin)%pw%cr3d = v_xc(ispin)%pw%cr3d*v_xc(ispin)%pw%pw_grid%dvol
             CALL dbcsr_set(work_hmat%matrix, 0.0_dp)
-            CALL integrate_v_rspace(v_rspace=v_xc(ispin), hmat=work_hmat, qs_env=qs_env, &
+            CALL integrate_v_rspace(v_rspace=v_xc(ispin)%pw, hmat=work_hmat, qs_env=qs_env, &
                                     calculate_forces=my_calc_forces, basis_type="AUX_FIT", &
                                     task_list_external=task_list_aux_fit, pmat=rho_ao_aux(ispin))
             IF (ASSOCIATED(v_xc_tau)) THEN
                v_xc_tau(ispin)%pw%cr3d = v_xc_tau(ispin)%pw%cr3d*v_xc_tau(ispin)%pw%pw_grid%dvol
-               CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), hmat=work_hmat, qs_env=qs_env, &
+               CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, hmat=work_hmat, qs_env=qs_env, &
                                        compute_tau=.TRUE., &
                                        calculate_forces=my_calc_forces, basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit, pmat=rho_ao_aux(ispin))

--- a/src/qs_2nd_kernel_ao.F
+++ b/src/qs_2nd_kernel_ao.F
@@ -365,6 +365,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+            DEALLOCATE (v_xc(ispin)%pw)
          END DO
          DEALLOCATE (v_xc)
 

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -71,7 +71,6 @@ MODULE qs_active_space_methods
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_release,&
                                               pw_env_type
-   USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_methods,                      ONLY: pw_integrate_function,&
                                               pw_transfer
    USE pw_poisson_methods,              ONLY: pw_poisson_rebuild,&
@@ -90,8 +89,7 @@ MODULE qs_active_space_methods
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type,&
-                                              pw_release,&
-                                              pw_type
+                                              pw_release
    USE qs_active_space_types,           ONLY: active_space_type,&
                                               create_active_space_type,&
                                               csr_idx_from_combined,&
@@ -1249,104 +1247,102 @@ CONTAINS
 
       INTEGER                                            :: ig
       REAL(KIND=dp)                                      :: a, ea, g2, g3d, ga, gg, rg, rlength
-      TYPE(pw_grid_type), POINTER                        :: grid
-      TYPE(pw_type), POINTER                             :: gf
 
       ! initialize influence function
-      gf => green%influence_fn
-      grid => green%influence_fn%pw_grid
-      SELECT CASE (green%method)
-      CASE (PERIODIC3D)
+      ASSOCIATE (gf => green%influence_fn, grid => green%influence_fn%pw_grid)
+         SELECT CASE (green%method)
+         CASE (PERIODIC3D)
 
-         SELECT CASE (eri_env%operator)
-         CASE (eri_operator_coulomb)
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               gf%cc(ig) = fourpi/g2
-            END DO
-            IF (grid%have_g0) gf%cc(1) = 0.0_dp
-         CASE (eri_operator_yukawa)
-            a = eri_env%operator_parameter**2
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               gf%cc(ig) = fourpi/(a + g2)
-            END DO
-            IF (grid%have_g0) gf%cc(1) = fourpi/a
-         CASE (eri_operator_erf)
-            a = eri_env%operator_parameter**2
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               ga = -0.25_dp*g2/a
-               gf%cc(ig) = fourpi/g2*EXP(ga)
-            END DO
-            IF (grid%have_g0) gf%cc(1) = 0.0_dp
-         CASE (eri_operator_erfc)
-            a = eri_env%operator_parameter**2
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               ga = -0.25_dp*g2/a
-               gf%cc(ig) = fourpi/g2*(1._dp - EXP(ga))
-            END DO
-            IF (grid%have_g0) gf%cc(1) = 0.25_dp*fourpi/a
-         CASE (eri_operator_gaussian)
-            CPABORT("")
+            SELECT CASE (eri_env%operator)
+            CASE (eri_operator_coulomb)
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  gf%cc(ig) = fourpi/g2
+               END DO
+               IF (grid%have_g0) gf%cc(1) = 0.0_dp
+            CASE (eri_operator_yukawa)
+               a = eri_env%operator_parameter**2
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  gf%cc(ig) = fourpi/(a + g2)
+               END DO
+               IF (grid%have_g0) gf%cc(1) = fourpi/a
+            CASE (eri_operator_erf)
+               a = eri_env%operator_parameter**2
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  ga = -0.25_dp*g2/a
+                  gf%cc(ig) = fourpi/g2*EXP(ga)
+               END DO
+               IF (grid%have_g0) gf%cc(1) = 0.0_dp
+            CASE (eri_operator_erfc)
+               a = eri_env%operator_parameter**2
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  ga = -0.25_dp*g2/a
+                  gf%cc(ig) = fourpi/g2*(1._dp - EXP(ga))
+               END DO
+               IF (grid%have_g0) gf%cc(1) = 0.25_dp*fourpi/a
+            CASE (eri_operator_gaussian)
+               CPABORT("")
+            CASE DEFAULT
+               CPABORT("")
+            END SELECT
+
+         CASE (ANALYTIC0D)
+
+            SELECT CASE (eri_env%operator)
+            CASE (eri_operator_coulomb)
+               rlength = green%radius
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  gg = SQRT(g2)
+                  g3d = fourpi/g2
+                  gf%cc(ig) = g3d*(1.0_dp - COS(rlength*gg))
+               END DO
+               IF (grid%have_g0) gf%cc(1) = 0.5_dp*fourpi*rlength*rlength
+            CASE (eri_operator_yukawa)
+               rlength = green%radius
+               a = eri_env%operator_parameter
+               ea = EXP(-a*rlength)
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  gg = SQRT(g2)
+                  g3d = fourpi/(a*a + g2)
+                  rg = rlength*gg
+                  gf%cc(ig) = g3d*(1.0_dp - ea*(COS(rg) + a/gg*SIN(rg)))
+               END DO
+               IF (grid%have_g0) gf%cc(1) = fourpi/(a*a)*(1.0_dp - ea*(1._dp + a*rlength))
+            CASE (eri_operator_erf)
+               rlength = green%radius
+               a = eri_env%operator_parameter**2
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  gg = SQRT(g2)
+                  ga = -0.25_dp*g2/a
+                  gf%cc(ig) = fourpi/g2*EXP(ga)*(1.0_dp - COS(rlength*gg))
+               END DO
+               IF (grid%have_g0) gf%cc(1) = 0.5_dp*fourpi*rlength*rlength
+            CASE (eri_operator_erfc)
+               rlength = green%radius
+               a = eri_env%operator_parameter**2
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  gg = SQRT(g2)
+                  ga = -0.25_dp*g2/a
+                  gf%cc(ig) = fourpi/g2*(1._dp - EXP(ga))*(1.0_dp - COS(rlength*gg))
+               END DO
+               IF (grid%have_g0) gf%cc(1) = 0._dp
+            CASE (eri_operator_gaussian)
+               CPABORT("")
+            CASE DEFAULT
+               CPABORT("")
+            END SELECT
+
          CASE DEFAULT
             CPABORT("")
          END SELECT
-
-      CASE (ANALYTIC0D)
-
-         SELECT CASE (eri_env%operator)
-         CASE (eri_operator_coulomb)
-            rlength = green%radius
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               gg = SQRT(g2)
-               g3d = fourpi/g2
-               gf%cc(ig) = g3d*(1.0_dp - COS(rlength*gg))
-            END DO
-            IF (grid%have_g0) gf%cc(1) = 0.5_dp*fourpi*rlength*rlength
-         CASE (eri_operator_yukawa)
-            rlength = green%radius
-            a = eri_env%operator_parameter
-            ea = EXP(-a*rlength)
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               gg = SQRT(g2)
-               g3d = fourpi/(a*a + g2)
-               rg = rlength*gg
-               gf%cc(ig) = g3d*(1.0_dp - ea*(COS(rg) + a/gg*SIN(rg)))
-            END DO
-            IF (grid%have_g0) gf%cc(1) = fourpi/(a*a)*(1.0_dp - ea*(1._dp + a*rlength))
-         CASE (eri_operator_erf)
-            rlength = green%radius
-            a = eri_env%operator_parameter**2
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               gg = SQRT(g2)
-               ga = -0.25_dp*g2/a
-               gf%cc(ig) = fourpi/g2*EXP(ga)*(1.0_dp - COS(rlength*gg))
-            END DO
-            IF (grid%have_g0) gf%cc(1) = 0.5_dp*fourpi*rlength*rlength
-         CASE (eri_operator_erfc)
-            rlength = green%radius
-            a = eri_env%operator_parameter**2
-            DO ig = grid%first_gne0, grid%ngpts_cut_local
-               g2 = grid%gsq(ig)
-               gg = SQRT(g2)
-               ga = -0.25_dp*g2/a
-               gf%cc(ig) = fourpi/g2*(1._dp - EXP(ga))*(1.0_dp - COS(rlength*gg))
-            END DO
-            IF (grid%have_g0) gf%cc(1) = 0._dp
-         CASE (eri_operator_gaussian)
-            CPABORT("")
-         CASE DEFAULT
-            CPABORT("")
-         END SELECT
-
-      CASE DEFAULT
-         CPABORT("")
-      END SELECT
+      END ASSOCIATE
 
    END SUBROUTINE pw_eri_green_create
 

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1066,7 +1066,7 @@ CONTAINS
                                     pw_env_external=pw_env_sub, sab_orb_external=sab_orb_sub)
       END IF
 
-      NULLIFY (wfn_r%pw, rho_g%pw)
+      ALLOCATE (wfn_r%pw, rho_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wfn_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL get_qs_env(qs_env, qs_kind_set=qs_kind_set, cell=cell, &
@@ -1090,7 +1090,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL get_mo_set(mo_set=mos(ispin)%mo_set, mo_coeff=mo_coeff, nmo=nmo)
             DO iwfn = 1, nmo
-               NULLIFY (wfn_a(iwfn, ispin)%pw)
+               ALLOCATE (wfn_a(iwfn, ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, wfn_a(iwfn, ispin)%pw, &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
@@ -1104,7 +1104,7 @@ CONTAINS
       END IF
 
       ! get some of the grids ready
-      NULLIFY (rho_r%pw, pot_g%pw)
+      ALLOCATE (rho_r%pw, pot_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, pot_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1450,6 +1450,7 @@ CONTAINS
       CALL qs_subsys_get(subsys, particles=particles)
       !
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       !

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1094,7 +1094,7 @@ CONTAINS
                CALL pw_pool_create_pw(auxbas_pw_pool, wfn_a(iwfn, ispin)%pw, &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
-               CALL calculate_wavefunction(mo_coeff, iwfn, wfn_a(iwfn, ispin), rho_g, atomic_kind_set, &
+               CALL calculate_wavefunction(mo_coeff, iwfn, wfn_a(iwfn, ispin)%pw, rho_g%pw, atomic_kind_set, &
                                            qs_kind_set, cell, dft_control, particle_set, pw_env_sub)
                IF (print2 .AND. iw > 0) THEN
                   WRITE (iw, "(T4,'ERI_GPW|',' Orbital stored ',I4,'  Spin ',i1)") iwfn, ispin
@@ -1477,7 +1477,7 @@ CONTAINS
                do_mo = .TRUE.
             END IF
             IF (.NOT. do_mo) CYCLE
-            CALL calculate_wavefunction(mo_coeff, imo, wf_r, wf_g, atomic_kind_set, &
+            CALL calculate_wavefunction(mo_coeff, imo, wf_r%pw, wf_g%pw, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env)
             IF (para_env%ionode) THEN
                WRITE (filename, '(A,A1,I4.4,A1,I1.1,A)') TRIM(filebody), "_", imo, "_", isp, ".cube"

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1210,6 +1210,7 @@ CONTAINS
             CALL get_mo_set(mo_set=mos(ispin)%mo_set, nmo=nmo)
             DO iwfn = 1, nmo
                CALL pw_release(wfn_a(iwfn, ispin)%pw)
+               DEALLOCATE (wfn_a(iwfn, ispin)%pw)
             END DO
          END DO
          DEALLOCATE (wfn_a)

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1219,6 +1219,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
+      DEALLOCATE (wfn_r%pw, rho_g%pw, rho_r%pw, pot_g%pw)
 
       IF (eri_env%method == eri_method_gpw_ht) THEN
          CALL deallocate_task_list(task_list_sub)
@@ -1497,6 +1498,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+      DEALLOCATE (wf_r%pw, wf_g%pw)
 
    END SUBROUTINE print_orbital_cubes
 

--- a/src/qs_cdft_methods.F
+++ b/src/qs_cdft_methods.F
@@ -753,17 +753,20 @@ CONTAINS
          ! Setup pw
          cdft_control%group(igroup)%weight%pw%cr3d = 0.0_dp
 
+         ALLOCATE (cdft_control%group(igroup)%hw_rho_total_constraint%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          cdft_control%group(igroup)%hw_rho_total_constraint%pw%cr3d = 1.0_dp
 
          IF (igroup == 1) THEN
+            ALLOCATE (cdft_control%group(igroup)%hw_rho_total%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             cdft_control%group(igroup)%hw_rho_total%pw%cr3d = 1.0_dp
 
             IF (hirshfeld_control%print_density) THEN
                DO iatom = 1, cdft_control%natoms
+                  ALLOCATE (cdft_control%group(igroup)%hw_rho_atomic(iatom)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic(iatom)%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   cdft_control%group(igroup)%hw_rho_atomic(iatom)%pw%cr3d = 1.0_dp
@@ -785,6 +788,7 @@ CONTAINS
             END DO
 
             DO iatom = 1, cdft_control%natoms
+               ALLOCATE (cdft_control%group(igroup)%hw_rho_atomic_charge(iatom)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic_charge(iatom)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                cdft_control%group(igroup)%hw_rho_atomic_charge(iatom)%pw%cr3d = 1.0_dp
@@ -974,6 +978,7 @@ CONTAINS
                ALLOCATE (rs_single_dr(num_species))
 
                DO i = 1, num_species
+                  ALLOCATE (pw_single_dr(i)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, pw_single_dr(i)%pw, use_data=REALDATA3D, &
                                          in_space=REALSPACE)
                   pw_single_dr(i)%pw%cr3d(:, :, :) = 0.0_dp
@@ -1681,20 +1686,24 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
       ! Total density (rho_alpha + rho_beta)
+      ALLOCATE (cdft_control%fragments(1, 1)%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(1, 1)%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL cp_cube_to_pw(cdft_control%fragments(1, 1)%pw, &
                          cdft_control%fragment_a_fname, 1.0_dp)
+      ALLOCATE (cdft_control%fragments(1, 2)%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(1, 2)%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL cp_cube_to_pw(cdft_control%fragments(1, 2)%pw, &
                          cdft_control%fragment_b_fname, 1.0_dp)
       ! Spin difference density (rho_alpha - rho_beta) if needed
       IF (needs_spin_density) THEN
+         ALLOCATE (cdft_control%fragments(2, 1)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(2, 1)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL cp_cube_to_pw(cdft_control%fragments(2, 1)%pw, &
                             cdft_control%fragment_a_spin_fname, multiplier(1))
+         ALLOCATE (cdft_control%fragments(2, 2)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(2, 2)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL cp_cube_to_pw(cdft_control%fragments(2, 2)%pw, &
@@ -1702,6 +1711,7 @@ CONTAINS
       END IF
       ! Sum up fragments
       DO i = 1, nfrag_spins
+         ALLOCATE (rho_frag(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_frag(i)%pw, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          CALL pw_copy(cdft_control%fragments(i, 1)%pw, rho_frag(i)%pw)

--- a/src/qs_cdft_methods.F
+++ b/src/qs_cdft_methods.F
@@ -927,15 +927,18 @@ CONTAINS
       DO igroup = 1, SIZE(cdft_control%group)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint%pw)
+         DEALLOCATE (cdft_control%group(igroup)%hw_rho_total_constraint%pw)
 
          IF (.NOT. cdft_control%in_memory .AND. igroup == 1) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total%pw)
+            DEALLOCATE (cdft_control%group(1)%hw_rho_total%pw)
          END IF
 
          IF (hirshfeld_control%print_density .AND. igroup == 1) THEN
             DO i = 1, cdft_control%natoms
                CALL rs_grid_release(rs_single(i)%rs_grid)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic(i)%pw)
+               DEALLOCATE (cdft_control%group(igroup)%hw_rho_atomic(i)%pw)
             END DO
             DEALLOCATE (rs_single)
             DEALLOCATE (cdft_control%group(igroup)%hw_rho_atomic)
@@ -945,6 +948,7 @@ CONTAINS
             DO i = 1, cdft_control%natoms
                CALL rs_grid_release(rs_single_charge(i)%rs_grid)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic_charge(i)%pw)
+               DEALLOCATE (cdft_control%group(igroup)%hw_rho_atomic_charge(i)%pw)
             END DO
             DEALLOCATE (rs_single_charge)
             DEALLOCATE (compute_charge)
@@ -1069,6 +1073,7 @@ CONTAINS
                   atom_a = atom_list(iatom)
                   cdft_control%group(igroup)%gradients_x(atom_a, :, :, :) = pw_single_dr(iatom)%pw%cr3d(:, :, :)
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_single_dr(iatom)%pw)
+                  DEALLOCATE (pw_single_dr(iatom)%pw)
                END DO
 
                DEALLOCATE (rs_single_dr)
@@ -1133,6 +1138,7 @@ CONTAINS
 
             IF (igroup == 1) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total%pw)
+               DEALLOCATE (cdft_control%group(1)%hw_rho_total%pw)
             END IF
             CALL rs_grid_release(rs_rho_all)
          END DO
@@ -1718,6 +1724,7 @@ CONTAINS
          CALL pw_axpy(cdft_control%fragments(i, 2)%pw, rho_frag(i)%pw, 1.0_dp)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%fragments(i, 1)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%fragments(i, 2)%pw)
+         DEALLOCATE (cdft_control%fragments(i, 1)%pw, cdft_control%fragments(i, 2)%pw)
       END DO
       DEALLOCATE (cdft_control%fragments)
       ! Check that the number of electrons is consistent
@@ -1759,6 +1766,7 @@ CONTAINS
       END IF
       DO i = 1, nfrag_spins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_frag(i)%pw)
+         DEALLOCATE (rho_frag(i)%pw)
       END DO
       DEALLOCATE (rho_frag)
       cdft_control%fragments_integrated = .TRUE.

--- a/src/qs_cdft_utils.F
+++ b/src/qs_cdft_utils.F
@@ -394,6 +394,8 @@ CONTAINS
             DEALLOCATE (cores)
          END DO
          DEALLOCATE (pab)
+         NULLIFY (becke_control%cavity%pw)
+         ALLOCATE (becke_control%cavity%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, becke_control%cavity%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL rs_pw_transfer(rs_cavity, becke_control%cavity%pw, rs2pw)

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -815,7 +815,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rhoc_r
+      TYPE(pw_type)                                      :: rhoc_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
@@ -899,8 +899,6 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
-      NULLIFY (rhoc_r)
-      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -912,7 +910,6 @@ CONTAINS
       CALL pw_transfer(rhoc_r, rho_core)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
-      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -949,7 +946,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rhoc_r
+      TYPE(pw_type)                                      :: rhoc_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
@@ -1040,8 +1037,6 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
-      NULLIFY (rhoc_r)
-      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1051,7 +1046,6 @@ CONTAINS
       CALL pw_transfer(rhoc_r, drho_core)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
-      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1083,7 +1077,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rhoc_r
+      TYPE(pw_type)                                      :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1134,8 +1128,6 @@ CONTAINS
 
       DEALLOCATE (pab)
 
-      NULLIFY (rhoc_r)
-      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1145,7 +1137,6 @@ CONTAINS
       CALL pw_transfer(rhoc_r, rho_gb)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
-      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1181,7 +1172,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rhoc_r
+      TYPE(pw_type)                                      :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1244,8 +1235,6 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
-      NULLIFY (rhoc_r)
-      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1258,7 +1247,6 @@ CONTAINS
 
       CALL pw_transfer(rhoc_r, rho_metal)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
-      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1292,7 +1280,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rhoc_r
+      TYPE(pw_type)                                      :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1343,8 +1331,6 @@ CONTAINS
 
       DEALLOCATE (pab)
 
-      NULLIFY (rhoc_r)
-      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1354,7 +1340,6 @@ CONTAINS
       CALL pw_transfer(rhoc_r, rho_gb)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
-      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1392,7 +1377,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rhoc_r
+      TYPE(pw_type)                                      :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1453,8 +1438,6 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
-      NULLIFY (rhoc_r)
-      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1463,7 +1446,6 @@ CONTAINS
 
       CALL pw_transfer(rhoc_r, rho_resp)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
-      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -1483,7 +1483,7 @@ CONTAINS
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_p
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: rho, rho_gspace
       REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: total_rho
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: soft_valid, compute_tau, compute_grad
@@ -1626,7 +1626,7 @@ CONTAINS
 
       ! Merge realspace multi-grids into single planewave grid.
       CALL density_rs2pw(pw_env, rs_rho, rho, rho_gspace)
-      IF (PRESENT(total_rho)) total_rho = pw_integrate_function(rho%pw, isign=-1)
+      IF (PRESENT(total_rho)) total_rho = pw_integrate_function(rho, isign=-1)
 
       CALL timestop(handle)
 
@@ -1650,7 +1650,7 @@ CONTAINS
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_p
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
-      TYPE(pw_p_type), DIMENSION(:), INTENT(INOUT)       :: drho, drho_gspace
+      TYPE(pw_p_type), DIMENSION(3), INTENT(IN)          :: drho, drho_gspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: soft_valid
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: basis_type
@@ -1986,7 +1986,7 @@ CONTAINS
 
          END DO loop_tasks
 
-         CALL density_rs2pw_basic(pw_env, rs_rho, drho(idir), drho_gspace(idir))
+         CALL density_rs2pw_basic(pw_env, rs_rho, drho(idir)%pw, drho_gspace(idir)%pw)
 
       END DO loop_xyz
 
@@ -2033,7 +2033,7 @@ CONTAINS
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_p
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
-      TYPE(pw_p_type), INTENT(INOUT)                     :: drho, drho_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: drho, drho_gspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: soft_valid
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: basis_type

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -1650,7 +1650,7 @@ CONTAINS
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_p
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
-      TYPE(pw_p_type), DIMENSION(3), INTENT(IN)          :: drho, drho_gspace
+      TYPE(pw_type), DIMENSION(3), INTENT(INOUT)         :: drho, drho_gspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: soft_valid
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: basis_type
@@ -1986,7 +1986,7 @@ CONTAINS
 
          END DO loop_tasks
 
-         CALL density_rs2pw_basic(pw_env, rs_rho, drho(idir)%pw, drho_gspace(idir)%pw)
+         CALL density_rs2pw_basic(pw_env, rs_rho, drho(idir), drho_gspace(idir))
 
       END DO loop_xyz
 

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -899,6 +899,8 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
+      NULLIFY (rhoc_r)
+      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1037,6 +1039,8 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
+      NULLIFY (rhoc_r)
+      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1128,6 +1132,8 @@ CONTAINS
 
       DEALLOCATE (pab)
 
+      NULLIFY (rhoc_r)
+      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1235,6 +1241,8 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
+      NULLIFY (rhoc_r)
+      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1331,6 +1339,8 @@ CONTAINS
 
       DEALLOCATE (pab)
 
+      NULLIFY (rhoc_r)
+      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1438,6 +1448,8 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
+      NULLIFY (rhoc_r)
+      ALLOCATE (rhoc_r)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -912,6 +912,7 @@ CONTAINS
       CALL pw_transfer(rhoc_r, rho_core)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1050,6 +1051,7 @@ CONTAINS
       CALL pw_transfer(rhoc_r, drho_core)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1143,6 +1145,7 @@ CONTAINS
       CALL pw_transfer(rhoc_r, rho_gb)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1255,6 +1258,7 @@ CONTAINS
 
       CALL pw_transfer(rhoc_r, rho_metal)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1350,6 +1354,7 @@ CONTAINS
       CALL pw_transfer(rhoc_r, rho_gb)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 
@@ -1458,6 +1463,7 @@ CONTAINS
 
       CALL pw_transfer(rhoc_r, rho_resp)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      DEALLOCATE (rhoc_r)
 
       CALL timestop(handle)
 

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -89,7 +89,8 @@ MODULE qs_collocate_density
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_kind_types,                   ONLY: get_qs_kind,&
@@ -145,7 +146,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_rho_nlcc(rho_nlcc, qs_env)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_nlcc
+      TYPE(pw_type), INTENT(IN)                          :: rho_nlcc
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_rho_nlcc'
@@ -312,7 +313,7 @@ CONTAINS
          DEALLOCATE (cores)
       END IF
 
-      CALL rs_pw_transfer(rs_rho, rho_nlcc%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, rho_nlcc, rs2pw)
       CALL rs_grid_release(rs_rho)
 
       CALL timestop(handle)
@@ -326,7 +327,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_ppl_grid(vppl, qs_env)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: vppl
+      TYPE(pw_type), INTENT(IN)                          :: vppl
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_ppl_grid'
@@ -487,7 +488,7 @@ CONTAINS
          DEALLOCATE (cores)
       END IF
 
-      CALL rs_pw_transfer(rs_rho, vppl%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, vppl, rs2pw)
       CALL rs_grid_release(rs_rho)
 
       CALL timestop(handle)
@@ -512,7 +513,8 @@ CONTAINS
    SUBROUTINE calculate_lri_rho_elec(lri_rho_g, lri_rho_r, qs_env, &
                                      lri_coef, total_rho, basis_type, exact_1c_terms, pmat, atomlist)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: lri_rho_g, lri_rho_r
+      TYPE(pw_type), INTENT(IN)                          :: lri_rho_g
+      TYPE(pw_type), INTENT(INOUT)                       :: lri_rho_r
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri_coef
       REAL(KIND=dp), INTENT(OUT)                         :: total_rho
@@ -756,8 +758,8 @@ CONTAINS
          DEALLOCATE (pab, work)
       END IF
 
-      CALL pw_zero(lri_rho_g%pw)
-      CALL pw_zero(lri_rho_r%pw)
+      CALL pw_zero(lri_rho_g)
+      CALL pw_zero(lri_rho_r)
 
       DO igrid_level = 1, gridlevel_info%ngrid_levels
          CALL pw_zero(mgrid_rspace(igrid_level)%pw)
@@ -770,10 +772,10 @@ CONTAINS
          CALL pw_zero(mgrid_gspace(igrid_level)%pw)
          CALL pw_transfer(mgrid_rspace(igrid_level)%pw, &
                           mgrid_gspace(igrid_level)%pw)
-         CALL pw_axpy(mgrid_gspace(igrid_level)%pw, lri_rho_g%pw)
+         CALL pw_axpy(mgrid_gspace(igrid_level)%pw, lri_rho_g)
       END DO
-      CALL pw_transfer(lri_rho_g%pw, lri_rho_r%pw)
-      total_rho = pw_integrate_function(lri_rho_r%pw, isign=-1)
+      CALL pw_transfer(lri_rho_g, lri_rho_r)
+      total_rho = pw_integrate_function(lri_rho_r, isign=-1)
 
       ! *** give back the multi-grids *** !
       CALL pw_pools_give_back_pws(pw_pools, mgrid_gspace)
@@ -792,7 +794,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_rho_core(rho_core, total_rho, qs_env, only_nopaw)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_core
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_core
       REAL(KIND=dp), INTENT(OUT)                         :: total_rho
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: only_nopaw
@@ -812,8 +814,8 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoc_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rhoc_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
@@ -897,17 +899,17 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL rs_pw_transfer(rs_rho, rhoc_r%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, rhoc_r, rs2pw)
       CALL rs_grid_release(rs_rho)
 
-      total_rho = pw_integrate_function(rhoc_r%pw, isign=-1)
+      total_rho = pw_integrate_function(rhoc_r, isign=-1)
 
-      CALL pw_transfer(rhoc_r%pw, rho_core%pw)
+      CALL pw_transfer(rhoc_r, rho_core)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
 
       CALL timestop(handle)
 
@@ -924,7 +926,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_drho_core(drho_core, qs_env, beta, lambda)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: drho_core
+      TYPE(pw_type), INTENT(INOUT)                       :: drho_core
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: beta, lambda
 
@@ -943,8 +945,8 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoc_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rhoc_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
@@ -1035,15 +1037,15 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL rs_pw_transfer(rs_rho, rhoc_r%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, rhoc_r, rs2pw)
       CALL rs_grid_release(rs_rho)
 
-      CALL pw_transfer(rhoc_r%pw, drho_core%pw)
+      CALL pw_transfer(rhoc_r, drho_core)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
 
       CALL timestop(handle)
 
@@ -1060,7 +1062,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_rho_single_gaussian(rho_gb, qs_env, iatom_in)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_gb
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_gb
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: iatom_in
 
@@ -1074,8 +1076,8 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoc_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1126,15 +1128,15 @@ CONTAINS
 
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL rs_pw_transfer(rs_rho, rhoc_r%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, rhoc_r, rs2pw)
       CALL rs_grid_release(rs_rho)
 
-      CALL pw_transfer(rhoc_r%pw, rho_gb%pw)
+      CALL pw_transfer(rhoc_r, rho_gb)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
 
       CALL timestop(handle)
 
@@ -1153,7 +1155,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_rho_metal(rho_metal, coeff, total_rho_metal, qs_env)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_metal
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_metal
       REAL(KIND=dp), DIMENSION(:), POINTER               :: coeff
       REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: total_rho_metal
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -1169,8 +1171,8 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoc_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1233,18 +1235,18 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL rs_pw_transfer(rs_rho, rhoc_r%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, rhoc_r, rs2pw)
       CALL rs_grid_release(rs_rho)
 
       IF (PRESENT(total_rho_metal)) &
          !minus sign: account for the fact that rho_metal has opposite sign
-         total_rho_metal = pw_integrate_function(rhoc_r%pw, isign=-1)
+         total_rho_metal = pw_integrate_function(rhoc_r, isign=-1)
 
-      CALL pw_transfer(rhoc_r%pw, rho_metal%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r%pw)
+      CALL pw_transfer(rhoc_r, rho_metal)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
 
       CALL timestop(handle)
 
@@ -1262,7 +1264,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_rho_resp_single(rho_gb, qs_env, eta, iatom_in)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_gb
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_gb
       TYPE(qs_environment_type), POINTER                 :: qs_env
       REAL(KIND=dp), INTENT(IN)                          :: eta
       INTEGER, INTENT(IN)                                :: iatom_in
@@ -1277,8 +1279,8 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoc_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1329,15 +1331,15 @@ CONTAINS
 
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL rs_pw_transfer(rs_rho, rhoc_r%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, rhoc_r, rs2pw)
       CALL rs_grid_release(rs_rho)
 
-      CALL pw_transfer(rhoc_r%pw, rho_gb%pw)
+      CALL pw_transfer(rhoc_r, rho_gb)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
 
       CALL timestop(handle)
 
@@ -1357,7 +1359,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_rho_resp_all(rho_resp, coeff, natom, eta, qs_env)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_resp
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_resp
       REAL(KIND=dp), DIMENSION(:), POINTER               :: coeff
       INTEGER, INTENT(IN)                                :: natom
       REAL(KIND=dp), INTENT(IN)                          :: eta
@@ -1374,8 +1376,8 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoc_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rhoc_r
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
       CALL timeset(routineN, handle)
@@ -1436,14 +1438,14 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL rs_pw_transfer(rs_rho, rhoc_r%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, rhoc_r, rs2pw)
       CALL rs_grid_release(rs_rho)
 
-      CALL pw_transfer(rhoc_r%pw, rho_resp%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r%pw)
+      CALL pw_transfer(rhoc_r, rho_resp)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
 
       CALL timestop(handle)
 
@@ -2431,7 +2433,8 @@ CONTAINS
                                         atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                         pw_env, required_function, basis_type)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: rho
+      TYPE(pw_type), INTENT(IN)                          :: rho_gspace
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(cell_type), POINTER                           :: cell
@@ -2575,14 +2578,14 @@ CONTAINS
          CALL rs_grid_release(rs_rho(igrid_level)%rs_grid)
       END DO
 
-      CALL pw_zero(rho_gspace%pw)
+      CALL pw_zero(rho_gspace)
       DO igrid_level = 1, gridlevel_info%ngrid_levels
          CALL pw_transfer(mgrid_rspace(igrid_level)%pw, &
                           mgrid_gspace(igrid_level)%pw)
-         CALL pw_axpy(mgrid_gspace(igrid_level)%pw, rho_gspace%pw)
+         CALL pw_axpy(mgrid_gspace(igrid_level)%pw, rho_gspace)
       END DO
 
-      CALL pw_transfer(rho_gspace%pw, rho%pw)
+      CALL pw_transfer(rho_gspace, rho)
 
       ! Release work storage
       DEALLOCATE (pab)
@@ -2626,7 +2629,8 @@ CONTAINS
 
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_vectors
       INTEGER, INTENT(IN)                                :: ivector
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho, rho_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: rho
+      TYPE(pw_type), INTENT(IN)                          :: rho_gspace
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(cell_type), POINTER                           :: cell
@@ -2778,14 +2782,14 @@ CONTAINS
          CALL rs_grid_release(rs_rho(igrid_level)%rs_grid)
       END DO
 
-      CALL pw_zero(rho_gspace%pw)
+      CALL pw_zero(rho_gspace)
       DO igrid_level = 1, gridlevel_info%ngrid_levels
          CALL pw_transfer(mgrid_rspace(igrid_level)%pw, &
                           mgrid_gspace(igrid_level)%pw)
-         CALL pw_axpy(mgrid_gspace(igrid_level)%pw, rho_gspace%pw)
+         CALL pw_axpy(mgrid_gspace(igrid_level)%pw, rho_gspace)
       END DO
 
-      CALL pw_transfer(rho_gspace%pw, rho%pw)
+      CALL pw_transfer(rho_gspace, rho)
 
       ! Release work storage
       DEALLOCATE (eigenvector)

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -55,7 +55,8 @@ MODULE qs_dcdr_ao
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_drho_core,&
                                               calculate_drho_elec_dR
    USE qs_energy_types,                 ONLY: qs_energy_type
@@ -501,11 +502,11 @@ CONTAINS
       INTEGER                                            :: handle, idir
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: drho_g, drho_r, rho_r, v_xc, v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: v_hartree_gspace, v_hartree_rspace
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: input, xc_section
       TYPE(xc_derivative_set_type)                       :: my_deriv_set
@@ -527,11 +528,10 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools, poisson_env=poisson_env)
-      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -541,8 +541,8 @@ CONTAINS
       CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(1)%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       DO idir = 1, 3
-         CALL pw_zero(v_hartree_gspace%pw)
-         CALL pw_zero(v_hartree_rspace%pw)
+         CALL pw_zero(v_hartree_gspace)
+         CALL pw_zero(v_hartree_rspace)
          CALL pw_zero(drho_r(1)%pw)
          CALL pw_zero(drho_g(1)%pw)
 
@@ -555,8 +555,8 @@ CONTAINS
 
          ! Get the Hartree potential corresponding to the perturbed density
          CALL pw_poisson_solve(poisson_env, drho_g(1)%pw, &
-                               vhartree=v_hartree_gspace%pw)
-         CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
+                               vhartree=v_hartree_gspace)
+         CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
 
          ! Get the XC potential corresponding to the perturbed density
          CALL xc_prep_2nd_deriv(my_deriv_set, my_rho_set, &
@@ -575,7 +575,7 @@ CONTAINS
          !-------------------------------!
          ! Can the dvol be different?
          CALL pw_scale(v_xc(1)%pw, v_xc(1)%pw%pw_grid%dvol)
-         CALL pw_axpy(v_hartree_rspace%pw, v_xc(1)%pw, v_hartree_rspace%pw%pw_grid%dvol)
+         CALL pw_axpy(v_hartree_rspace, v_xc(1)%pw, v_hartree_rspace%pw_grid%dvol)
 
          CALL integrate_v_rspace(v_rspace=v_xc(1)%pw, &
                                  hmat=dcdr_env%matrix_d_vhxc_dR(idir), &
@@ -588,11 +588,11 @@ CONTAINS
          DEALLOCATE (v_xc)
       END DO ! idir
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(1)%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(1)%pw)
-      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, drho_g(1)%pw, drho_r(1)%pw)
+      DEALLOCATE (drho_g(1)%pw, drho_r(1)%pw)
 
       DEALLOCATE (drho_g)
       DEALLOCATE (drho_r)
@@ -619,9 +619,9 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_vhxc_dbasis
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_p
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_hartree_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_hxc_r, v_tau_rspace
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: v_hartree_r
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
@@ -636,7 +636,7 @@ CONTAINS
                       input=input, &
                       ks_env=ks_env, &
                       pw_env=pw_env, &
-                      v_hartree_rspace=v_hartree_r%pw)
+                      v_hartree_rspace=v_hartree_r)
       CALL qs_rho_get(rho_struct, rho_ao_kp=matrix_p)
       xc_section => section_vals_get_subs_vals(input, "DFT%XC")
 
@@ -653,7 +653,7 @@ CONTAINS
       CALL pw_scale(v_hxc_r(1)%pw, v_hxc_r(1)%pw%pw_grid%dvol)
 
       ! sum up potentials and integrate
-      CALL pw_axpy(v_hartree_r%pw, v_hxc_r(1)%pw, 1._dp)
+      CALL pw_axpy(v_hartree_r, v_hxc_r(1)%pw, 1._dp)
 
       matrix_vhxc_dbasis => dcdr_env%matrix_vhxc_perturbed_basis(1, :)
       CALL integrate_v_dbasis(v_rspace=v_hxc_r(1)%pw, &

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -367,7 +367,7 @@ CONTAINS
          CALL pw_zero(drho_g%pw)
 
          ! Calculate the Hartree potential on the perturbed density and Poisson solve it
-         CALL calculate_drho_core(drho_core=drho_g, qs_env=qs_env, &
+         CALL calculate_drho_core(drho_core=drho_g%pw, qs_env=qs_env, &
                                   beta=beta, lambda=dcdr_env%lambda)
          CALL pw_poisson_solve(poisson_env, drho_g%pw, &
                                vhartree=v_hartree_gspace%pw)

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -281,7 +281,7 @@ CONTAINS
       CALL pw_axpy(v_hartree_rspace%pw, v_rspace_new(1)%pw, 1._dp)
 
       CALL dbcsr_set(dcdr_env%matrix_apply_op_constant(1)%matrix, 0.0_dp)
-      CALL integrate_v_rspace(v_rspace=v_rspace_new(1), &
+      CALL integrate_v_rspace(v_rspace=v_rspace_new(1)%pw, &
                               hmat=dcdr_env%matrix_apply_op_constant(1), &
                               qs_env=qs_env, &
                               calculate_forces=.FALSE.)
@@ -294,7 +294,7 @@ CONTAINS
 
       IF (ASSOCIATED(v_xc_tau)) THEN
          CALL pw_scale(v_xc_tau(1)%pw, 2._dp*v_xc_tau(1)%pw%pw_grid%dvol)
-         CALL integrate_v_rspace(v_rspace=v_xc_tau(1), &
+         CALL integrate_v_rspace(v_rspace=v_xc_tau(1)%pw, &
                                  hmat=dcdr_env%matrix_apply_op_constant(1), &
                                  qs_env=qs_env, &
                                  compute_tau=.TRUE., &
@@ -382,7 +382,7 @@ CONTAINS
          CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
 
          ! Calculate the integrals
-         CALL integrate_v_rspace(v_rspace=v_hartree_rspace, &
+         CALL integrate_v_rspace(v_rspace=v_hartree_rspace%pw, &
                                  hmat=dcdr_env%matrix_core_charge_1(beta), &
                                  qs_env=qs_env, &
                                  calculate_forces=.FALSE.)
@@ -577,7 +577,7 @@ CONTAINS
          CALL pw_scale(v_xc(1)%pw, v_xc(1)%pw%pw_grid%dvol)
          CALL pw_axpy(v_hartree_rspace%pw, v_xc(1)%pw, v_hartree_rspace%pw%pw_grid%dvol)
 
-         CALL integrate_v_rspace(v_rspace=v_xc(1), &
+         CALL integrate_v_rspace(v_rspace=v_xc(1)%pw, &
                                  hmat=dcdr_env%matrix_d_vhxc_dR(idir), &
                                  qs_env=qs_env, &
                                  calculate_forces=.FALSE.)
@@ -656,7 +656,7 @@ CONTAINS
       CALL pw_axpy(v_hartree_r%pw, v_hxc_r(1)%pw, 1._dp)
 
       matrix_vhxc_dbasis => dcdr_env%matrix_vhxc_perturbed_basis(1, :)
-      CALL integrate_v_dbasis(v_rspace=v_hxc_r(1), &
+      CALL integrate_v_dbasis(v_rspace=v_hxc_r(1)%pw, &
                               matrix_p=matrix_p(1, 1)%matrix, &
                               matrix_vhxc_dbasis=matrix_vhxc_dbasis, &
                               qs_env=qs_env, &

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -538,8 +538,8 @@ CONTAINS
 
          ! Get the density
          CALL calculate_drho_elec_dR(matrix_p=rho_ao(1)%matrix, &
-                                     drho=drho_r(1), &
-                                     drho_gspace=drho_g(1), &
+                                     drho=drho_r(1)%pw, &
+                                     drho_gspace=drho_g(1)%pw, &
                                      qs_env=qs_env, &
                                      beta=idir, lambda=dcdr_env%lambda)
 

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -237,6 +237,7 @@ CONTAINS
       ! Done with deriv_set and rho_set
 
       ALLOCATE (v_rspace_new(1))
+      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -245,6 +246,7 @@ CONTAINS
                              in_space=REALSPACE)
 
       ! Calculate the Hartree potential on the total density
+      ALLOCATE (rho1_tot_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -349,6 +351,7 @@ CONTAINS
                       pw_pools=pw_pools)
 
       ! Create the Hartree potential grids in real and reciprocal space.
+      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -358,6 +361,7 @@ CONTAINS
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
       ! Create the grid for the derivative of the core potential
+      ALLOCATE (drho_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, drho_g%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -519,6 +523,7 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools, poisson_env=poisson_env)
+      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -526,6 +531,7 @@ CONTAINS
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
+      ALLOCATE (drho_r(1)%pw, drho_g(1)%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(1)%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(1)%pw, &

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -260,6 +260,7 @@ CONTAINS
       CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace%pw)
+      DEALLOCATE (rho1_tot_gspace%pw)
 
       ! Calculate the second derivative of the exchange-correlation potential
       CALL xc_calc_2nd_deriv(v_xc, v_xc_tau, deriv_set, rho_set, &
@@ -288,6 +289,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(1)%pw)
+      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, v_rspace_new(1)%pw)
       DEALLOCATE (v_rspace_new)
 
       IF (ASSOCIATED(v_xc_tau)) THEN
@@ -299,6 +301,7 @@ CONTAINS
                                  calculate_forces=.FALSE.)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(1)%pw)
+         DEALLOCATE (v_xc_tau(1)%pw)
          DEALLOCATE (v_xc_tau)
       END IF
 
@@ -388,6 +391,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+      DEALLOCATE (drho_g%pw, v_hartree_rspace%pw, v_hartree_gspace%pw)
 
       CALL timestop(handle)
    END SUBROUTINE d_core_charge_density_dR
@@ -580,6 +584,7 @@ CONTAINS
 
          ! v_xc gets allocated again in xc_calc_2nd_deriv
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(1)%pw)
+         DEALLOCATE (v_xc(1)%pw)
          DEALLOCATE (v_xc)
       END DO ! idir
 
@@ -587,6 +592,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(1)%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(1)%pw)
+      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, drho_g(1)%pw, drho_r(1)%pw)
 
       DEALLOCATE (drho_g)
       DEALLOCATE (drho_r)
@@ -657,6 +663,7 @@ CONTAINS
                               lambda=dcdr_env%lambda)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hxc_r(1)%pw)
+      DEALLOCATE (v_hxc_r(1)%pw)
 
       DEALLOCATE (v_hxc_r)
 

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -540,6 +540,8 @@ CONTAINS
          END DO
          CALL pw_transfer(vxc_r, tmp_g)
          CALL pw_pool_give_back_pw(pw_pool, vxc_r)
+         DEALLOCATE (vxc_r)
+         NULLIFY (vxc_r)
          ALLOCATE (vxc_r, vxc_g)
          CALL pw_pool_create_pw(xc_pw_pool, vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(xc_pw_pool, vxc_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
@@ -550,6 +552,7 @@ CONTAINS
          END DO
          CALL pw_pool_give_back_pw(xc_pw_pool, vxc_r)
          CALL pw_pool_give_back_pw(xc_pw_pool, vxc_g)
+         DEALLOCATE (vxc_r, vxc_g)
          DEALLOCATE (q0, dq0_drho, dq0_dgradrho)
       END IF
 
@@ -557,14 +560,17 @@ CONTAINS
 
       DO i = 1, dispersion_env%nqs
          CALL pw_pool_give_back_pw(pw_pool, thetas_g(i)%pw)
+         DEALLOCATE (thetas_g(i)%pw)
       END DO
       DO ispin = 1, nspin
          DO idir = 1, 3
             CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin)%pw)
+            DEALLOCATE (drho_r(idir, ispin)%pw)
          END DO
       END DO
       CALL pw_pool_give_back_pw(pw_pool, tmp_r)
       CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+      DEALLOCATE (tmp_r, tmp_g)
 
       DEALLOCATE (rho, drho, drho_r, thetas_g)
 

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -220,6 +220,8 @@ CONTAINS
       const = 1.0_dp/(3.0_dp*SQRT(pi)*b_value**1.5_dp)/(pi**0.75_dp)
 
       ! temporary arrays for FFT
+      NULLIFY (tmp_g, tmp_r)
+      ALLOCATE (tmp_g, tmp_r)
       CALL pw_pool_create_pw(pw_pool, tmp_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(pw_pool, tmp_r, use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -227,7 +229,7 @@ CONTAINS
       ALLOCATE (drho_r(3, nspin))
       DO ispin = 1, nspin
          DO idir = 1, 3
-            NULLIFY (drho_r(idir, ispin)%pw)
+            ALLOCATE (drho_r(idir, ispin)%pw)
             CALL pw_pool_create_pw(pw_pool, drho_r(idir, ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(rho_g(ispin)%pw, tmp_g)
@@ -398,7 +400,7 @@ CONTAINS
             END DO
          END DO
 !$OMP END PARALLEL DO
-         NULLIFY (thetas_g(i)%pw)
+         ALLOCATE (thetas_g(i)%pw)
          CALL pw_pool_create_pw(pw_pool, thetas_g(i)%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_transfer(tmp_r, thetas_g(i)%pw)
       END DO
@@ -480,6 +482,8 @@ CONTAINS
             potential(:) = (0.5_dp*potential(:) + beta)*dispersion_env%scale_rvv10
             hpot(:) = 0.5_dp*dispersion_env%scale_rvv10*hpot(:)
          END SELECT
+         NULLIFY (vxc_r)
+         ALLOCATE (vxc_r)
          CALL pw_pool_create_pw(pw_pool, vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
          DO i = 1, 3
             lo(i) = LBOUND(vxc_r%cr3d, i)
@@ -536,6 +540,7 @@ CONTAINS
          END DO
          CALL pw_transfer(vxc_r, tmp_g)
          CALL pw_pool_give_back_pw(pw_pool, vxc_r)
+         ALLOCATE (vxc_r, vxc_g)
          CALL pw_pool_create_pw(xc_pw_pool, vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(xc_pw_pool, vxc_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_transfer(tmp_g, vxc_g)

--- a/src/qs_electric_field_gradient.F
+++ b/src/qs_electric_field_gradient.F
@@ -169,6 +169,7 @@ CONTAINS
          ecut = 2._dp*dvr2rs%pw%pw_grid%cutoff*0.875_dp
          sigma = 2._dp*dvr2rs%pw%pw_grid%cutoff*0.125_dp
          CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs%pw)
+         DEALLOCATE (dvr2rs%pw)
       ELSE
          smoothing = .TRUE.
       END IF
@@ -235,6 +236,7 @@ CONTAINS
       IF (smoothing) CALL pw_smoothing(v_hartree_gspace%pw, ecut, sigma)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      DEALLOCATE (rho_tot_gspace)
 
       DO i = 1, 3
          DO j = 1, i
@@ -280,8 +282,10 @@ CONTAINS
             CPASSERT(success)
             CALL pw_spline_precond_release(precond)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i)%pw)
+            DEALLOCATE (dvr2(i)%pw)
          END DO
          CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs%pw)
+         DEALLOCATE (dvr2rs%pw)
       END IF
 
       nkind = SIZE(qs_kind_set)
@@ -391,14 +395,18 @@ CONTAINS
       END DO
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+      DEALLOCATE (v_hartree_gspace%pw)
       IF (.NOT. efg_interpolation) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, structure_factor%pw)
+         DEALLOCATE (structure_factor%pw)
          DO i = 1, 6
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i)%pw)
+            DEALLOCATE (dvr2(i)%pw)
          END DO
       ELSE
          DO i = 1, 6
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dvspl(i)%pw)
+            DEALLOCATE (dvspl(i)%pw)
          END DO
       END IF
 

--- a/src/qs_electric_field_gradient.F
+++ b/src/qs_electric_field_gradient.F
@@ -119,7 +119,7 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: dvr2, dvspl
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_spline_precond_type), POINTER              :: precond
+      TYPE(pw_spline_precond_type)                       :: precond
       TYPE(pw_type), POINTER                             :: rho_tot_gspace
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho

--- a/src/qs_electric_field_gradient.F
+++ b/src/qs_electric_field_gradient.F
@@ -59,7 +59,8 @@ MODULE qs_electric_field_gradient
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_gapw_densities,               ONLY: prepare_gapw_den
@@ -113,12 +114,13 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: dvr2rs, rho_tot_gspace, &
-                                                            structure_factor, v_hartree_gspace
+      TYPE(pw_p_type)                                    :: dvr2rs, structure_factor, &
+                                                            v_hartree_gspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: dvr2, dvspl
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_spline_precond_type), POINTER              :: precond
+      TYPE(pw_type), POINTER                             :: rho_tot_gspace
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set
@@ -220,17 +222,17 @@ CONTAINS
       !calculate electrostatic potential
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
-      CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, ehartree, &
+      CALL pw_poisson_solve(poisson_env, rho_tot_gspace, ehartree, &
                             v_hartree_gspace%pw)
 
       ! smoothing of potential
       IF (smoothing) CALL pw_smoothing(v_hartree_gspace%pw, ecut, sigma)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
 
       DO i = 1, 3
          DO j = 1, i

--- a/src/qs_electric_field_gradient.F
+++ b/src/qs_electric_field_gradient.F
@@ -163,6 +163,7 @@ CONTAINS
       ELSEIF (ecut == -1._dp .AND. sigma == -1._dp) THEN
          smoothing = .TRUE.
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (dvr2rs%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          ecut = 2._dp*dvr2rs%pw%pw_grid%cutoff*0.875_dp
@@ -220,6 +221,7 @@ CONTAINS
       IF (gapw) CALL prepare_gapw_den(qs_env, do_rho0=.TRUE.)
 
       !calculate electrostatic potential
+      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
@@ -237,6 +239,7 @@ CONTAINS
       DO i = 1, 3
          DO j = 1, i
             ij = (i*(i - 1))/2 + j
+            ALLOCATE (dvr2(ij)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, dvr2(ij)%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL pw_dr2(v_hartree_gspace%pw, dvr2(ij)%pw, i, j)
@@ -244,6 +247,7 @@ CONTAINS
       END DO
 
       IF (.NOT. efg_interpolation) THEN
+         ALLOCATE (structure_factor%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, structure_factor%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       ELSE
@@ -257,9 +261,11 @@ CONTAINS
          CALL section_vals_val_get(interp_section, "eps_r", r_val=eps_r)
          CALL section_vals_val_get(interp_section, "eps_x", r_val=eps_x)
 
+         ALLOCATE (dvr2rs%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          DO i = 1, 6
+            ALLOCATE (dvspl(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, dvspl(i)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(dvr2(i)%pw, dvr2rs%pw)

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -192,17 +192,21 @@ CONTAINS
          IF (.NOT. tau_r_valid) THEN
             CALL pw_pool_give_back_pw(auxbas_pw_pool, tau_r(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, tau_g(ispin)%pw)
+            DEALLOCATE (tau_r(ispin)%pw, tau_g(ispin)%pw)
          END IF
          IF (.NOT. drho_r_valid) THEN
             IF (deriv_pw) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g)
+               DEALLOCATE (tmp_g)
                DO idir = 1, 3
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw)
+                  DEALLOCATE (drho_r(3*(ispin - 1) + idir)%pw)
                END DO
             ELSE
                DO idir = 1, 3
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw)
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(3*(ispin - 1) + idir)%pw)
+                  DEALLOCATE (drho_r(3*(ispin - 1) + idir)%pw, drho_g(3*(ispin - 1) + idir)%pw)
                END DO
             END IF
          END IF

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -76,9 +76,9 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_struct_ao
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: drho_g, drho_r, drho_struct_r, rho_r, &
-                                                            rho_struct_r, tau_g, tau_r, &
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, rho_struct_r, tau_g, tau_r, &
                                                             tau_struct_r
+      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g, drho_r, drho_struct_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_type), POINTER                             :: tmp_g
@@ -109,8 +109,8 @@ CONTAINS
       ALLOCATE (rho_r(nspin))
       ALLOCATE (tau_r(nspin))
       ALLOCATE (tau_g(nspin))
-      ALLOCATE (drho_r(3*nspin))
-      ALLOCATE (drho_g(3*nspin))
+      ALLOCATE (drho_r(3, nspin))
+      ALLOCATE (drho_g(3, nspin))
 
       DO ispin = 1, nspin
          rho_r(ispin)%pw => rho_struct_r(ispin)%pw
@@ -132,7 +132,7 @@ CONTAINS
 
          IF (drho_r_valid) THEN
             DO idir = 1, 3
-               drho_r(3*(ispin - 1) + idir)%pw => drho_struct_r(3*(ispin - 1) + idir)%pw
+               drho_r(idir, ispin)%pw => drho_struct_r(idir, ispin)%pw
             END DO
          ELSE
             deriv_pw = .FALSE.
@@ -144,25 +144,25 @@ CONTAINS
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                udvol = 1.0_dp/rho_struct_r(ispin)%pw%pw_grid%dvol
                DO idir = 1, 3
-                  ALLOCATE (drho_r(3*(ispin - 1) + idir)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw, &
+                  ALLOCATE (drho_r(idir, ispin)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_transfer(rho_struct_r(ispin)%pw, tmp_g)
                   CALL pw_derive(tmp_g, nd(:, idir))
-                  CALL pw_transfer(tmp_g, drho_r(3*(ispin - 1) + idir)%pw)
+                  CALL pw_transfer(tmp_g, drho_r(idir, ispin)%pw)
                END DO
 
             ELSE
                DO idir = 1, 3
-                  ALLOCATE (drho_r(3*(ispin - 1) + idir)%pw, drho_g(3*(ispin - 1) + idir)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw, &
+                  ALLOCATE (drho_r(idir, ispin)%pw, drho_g(idir, ispin)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(3*(ispin - 1) + idir)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(idir, ispin)%pw, &
                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                   rho_ao => rho_struct_ao(ispin, :)
                   CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                          rho=drho_r(3*(ispin - 1) + idir)%pw, &
-                                          rho_gspace=drho_g(3*(ispin - 1) + idir)%pw, &
+                                          rho=drho_r(idir, ispin)%pw, &
+                                          rho_gspace=drho_g(idir, ispin)%pw, &
                                           ks_env=ks_env, soft_valid=.FALSE., &
                                           compute_tau=.FALSE., compute_grad=.TRUE., idir=idir)
 
@@ -176,9 +176,9 @@ CONTAINS
          DO k = bo(1, 3), bo(2, 3)
             DO j = bo(1, 2), bo(2, 2)
                DO i = bo(1, 1), bo(2, 1)
-                  norm_drho = drho_r(3*(ispin - 1) + 1)%pw%cr3d(i, j, k)**2 + &
-                              drho_r(3*(ispin - 1) + 2)%pw%cr3d(i, j, k)**2 + &
-                              drho_r(3*(ispin - 1) + 3)%pw%cr3d(i, j, k)**2
+                  norm_drho = drho_r(1, ispin)%pw%cr3d(i, j, k)**2 + &
+                              drho_r(2, ispin)%pw%cr3d(i, j, k)**2 + &
+                              drho_r(3, ispin)%pw%cr3d(i, j, k)**2
                   norm_drho = norm_drho/MAX(rho_r(ispin)%pw%cr3d(i, j, k), rho_cutoff)
                   rho_53 = cfermi*MAX(rho_r(ispin)%pw%cr3d(i, j, k), rho_cutoff)**f53
                   elf_kernel = (tau_r(ispin)%pw%cr3d(i, j, k) - f18*norm_drho) + 2.87E-5_dp
@@ -199,14 +199,14 @@ CONTAINS
                CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g)
                DEALLOCATE (tmp_g)
                DO idir = 1, 3
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw)
-                  DEALLOCATE (drho_r(3*(ispin - 1) + idir)%pw)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw)
+                  DEALLOCATE (drho_r(idir, ispin)%pw)
                END DO
             ELSE
                DO idir = 1, 3
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(3*(ispin - 1) + idir)%pw)
-                  DEALLOCATE (drho_r(3*(ispin - 1) + idir)%pw, drho_g(3*(ispin - 1) + idir)%pw)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(idir, ispin)%pw)
+                  DEALLOCATE (drho_r(idir, ispin)%pw, drho_g(idir, ispin)%pw)
                END DO
             END IF
          END IF

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -123,8 +123,8 @@ CONTAINS
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             rho_ao => rho_struct_ao(ispin, :)
             CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                    rho=tau_r(ispin), &
-                                    rho_gspace=tau_g(ispin), &
+                                    rho=tau_r(ispin)%pw, &
+                                    rho_gspace=tau_g(ispin)%pw, &
                                     ks_env=ks_env, soft_valid=.FALSE., &
                                     compute_tau=.TRUE.)
          END IF
@@ -157,8 +157,8 @@ CONTAINS
                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                   rho_ao => rho_struct_ao(ispin, :)
                   CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                          rho=drho_r(3*(ispin - 1) + idir), &
-                                          rho_gspace=drho_g(3*(ispin - 1) + idir), &
+                                          rho=drho_r(3*(ispin - 1) + idir)%pw, &
+                                          rho_gspace=drho_g(3*(ispin - 1) + idir)%pw, &
                                           ks_env=ks_env, soft_valid=.FALSE., &
                                           compute_tau=.FALSE., compute_grad=.TRUE., idir=idir)
 

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -62,6 +62,7 @@ CONTAINS
       REAL(kind=dp), INTENT(IN)                          :: rho_cutoff
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'qs_elf_calc'
+      INTEGER, DIMENSION(3, 3), PARAMETER :: nd = RESHAPE((/1, 0, 0, 0, 1, 0, 0, 0, 1/), (/3, 3/))
       REAL(KIND=dp), PARAMETER                           :: ELFCUT = 0.0001_dp, &
                                                             f18 = (1.0_dp/8.0_dp), &
                                                             f23 = (2.0_dp/3.0_dp), &
@@ -69,7 +70,6 @@ CONTAINS
 
       INTEGER                                            :: handle, i, idir, ispin, j, k, nspin
       INTEGER, DIMENSION(2, 3)                           :: bo
-      INTEGER, DIMENSION(3, 3)                           :: nd
       LOGICAL                                            :: deriv_pw, drho_r_valid, tau_r_valid
       REAL(kind=dp)                                      :: cfermi, elf_kernel, norm_drho, rho_53, &
                                                             udvol
@@ -78,16 +78,17 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, rho_struct_r, tau_g, tau_r, &
                                                             tau_struct_r
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g, drho_r, drho_struct_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: tmp_g
+      TYPE(pw_type)                                      :: tmp_g
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:, :)        :: drho_g, drho_r
+      TYPE(pw_type), DIMENSION(:, :), POINTER            :: drho_struct_r
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (rho_struct, rho_r, drho_g, drho_r, tau_r, tau_g, pw_env, auxbas_pw_pool, pw_pools, tmp_g, ks_env)
+      NULLIFY (rho_struct, rho_r, tau_r, tau_g, pw_env, auxbas_pw_pool, pw_pools, ks_env)
       NULLIFY (rho_struct_ao, rho_struct_r, tau_struct_r, drho_struct_r)
 
       CALL get_qs_env(qs_env, ks_env=ks_env, pw_env=pw_env, rho=rho_struct)
@@ -131,38 +132,32 @@ CONTAINS
          END IF
 
          IF (drho_r_valid) THEN
-            DO idir = 1, 3
-               drho_r(idir, ispin)%pw => drho_struct_r(idir, ispin)%pw
-            END DO
+            drho_r(:, ispin) = drho_struct_r(:, ispin)
          ELSE
             deriv_pw = .FALSE.
             !        deriv_pw = .TRUE.
             IF (deriv_pw) THEN
-               nd = RESHAPE((/1, 0, 0, 0, 1, 0, 0, 0, 1/), (/3, 3/))
-               ALLOCATE (tmp_g)
                CALL pw_pool_create_pw(auxbas_pw_pool, tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                udvol = 1.0_dp/rho_struct_r(ispin)%pw%pw_grid%dvol
                DO idir = 1, 3
-                  ALLOCATE (drho_r(idir, ispin)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(idir, ispin), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_transfer(rho_struct_r(ispin)%pw, tmp_g)
                   CALL pw_derive(tmp_g, nd(:, idir))
-                  CALL pw_transfer(tmp_g, drho_r(idir, ispin)%pw)
+                  CALL pw_transfer(tmp_g, drho_r(idir, ispin))
                END DO
 
             ELSE
                DO idir = 1, 3
-                  ALLOCATE (drho_r(idir, ispin)%pw, drho_g(idir, ispin)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(idir, ispin), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(idir, ispin)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(idir, ispin), &
                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                   rho_ao => rho_struct_ao(ispin, :)
                   CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                          rho=drho_r(idir, ispin)%pw, &
-                                          rho_gspace=drho_g(idir, ispin)%pw, &
+                                          rho=drho_r(idir, ispin), &
+                                          rho_gspace=drho_g(idir, ispin), &
                                           ks_env=ks_env, soft_valid=.FALSE., &
                                           compute_tau=.FALSE., compute_grad=.TRUE., idir=idir)
 
@@ -176,9 +171,9 @@ CONTAINS
          DO k = bo(1, 3), bo(2, 3)
             DO j = bo(1, 2), bo(2, 2)
                DO i = bo(1, 1), bo(2, 1)
-                  norm_drho = drho_r(1, ispin)%pw%cr3d(i, j, k)**2 + &
-                              drho_r(2, ispin)%pw%cr3d(i, j, k)**2 + &
-                              drho_r(3, ispin)%pw%cr3d(i, j, k)**2
+                  norm_drho = drho_r(1, ispin)%cr3d(i, j, k)**2 + &
+                              drho_r(2, ispin)%cr3d(i, j, k)**2 + &
+                              drho_r(3, ispin)%cr3d(i, j, k)**2
                   norm_drho = norm_drho/MAX(rho_r(ispin)%pw%cr3d(i, j, k), rho_cutoff)
                   rho_53 = cfermi*MAX(rho_r(ispin)%pw%cr3d(i, j, k), rho_cutoff)**f53
                   elf_kernel = (tau_r(ispin)%pw%cr3d(i, j, k) - f18*norm_drho) + 2.87E-5_dp
@@ -197,16 +192,13 @@ CONTAINS
          IF (.NOT. drho_r_valid) THEN
             IF (deriv_pw) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g)
-               DEALLOCATE (tmp_g)
                DO idir = 1, 3
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw)
-                  DEALLOCATE (drho_r(idir, ispin)%pw)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(idir, ispin))
                END DO
             ELSE
                DO idir = 1, 3
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(idir, ispin)%pw)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(idir, ispin)%pw)
-                  DEALLOCATE (drho_r(idir, ispin)%pw, drho_g(idir, ispin)%pw)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(idir, ispin))
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(idir, ispin))
                END DO
             END IF
          END IF

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -117,6 +117,7 @@ CONTAINS
          IF (tau_r_valid) THEN
             tau_r(ispin)%pw => tau_struct_r(ispin)%pw
          ELSE
+            ALLOCATE (tau_r(ispin)%pw, tau_g(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, tau_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(auxbas_pw_pool, tau_g(ispin)%pw, &
@@ -138,10 +139,12 @@ CONTAINS
             !        deriv_pw = .TRUE.
             IF (deriv_pw) THEN
                nd = RESHAPE((/1, 0, 0, 0, 1, 0, 0, 0, 1/), (/3, 3/))
+               ALLOCATE (tmp_g)
                CALL pw_pool_create_pw(auxbas_pw_pool, tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                udvol = 1.0_dp/rho_struct_r(ispin)%pw%pw_grid%dvol
                DO idir = 1, 3
+                  ALLOCATE (drho_r(3*(ispin - 1) + idir)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_transfer(rho_struct_r(ispin)%pw, tmp_g)
@@ -151,6 +154,7 @@ CONTAINS
 
             ELSE
                DO idir = 1, 3
+                  ALLOCATE (drho_r(3*(ispin - 1) + idir)%pw, drho_g(3*(ispin - 1) + idir)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(3*(ispin - 1) + idir)%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(3*(ispin - 1) + idir)%pw, &

--- a/src/qs_energy_utils.F
+++ b/src/qs_energy_utils.F
@@ -241,7 +241,7 @@ CONTAINS
              .NOT. dft_control%qs_control%xtb .AND. &
              .NOT. dft_control%qs_control%dftb) THEN
             ! Nuclear charge correction
-            CALL integrate_v_core_rspace(v_hartree_rspace, qs_env)
+            CALL integrate_v_core_rspace(v_hartree_rspace%pw, qs_env)
             ! Kohn-Sham Functional corrections
          END IF
          CALL atprop_array_add(atprop%atener, atprop%ateb)

--- a/src/qs_energy_window.F
+++ b/src/qs_energy_window.F
@@ -322,6 +322,7 @@ CONTAINS
       CALL cp_fm_release(S_minus_half_fm)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
+      DEALLOCATE (rho_r%pw, rho_g%pw)
       DEALLOCATE (rho_r, rho_g)
       DEALLOCATE (eigenvalues)
       DEALLOCATE (STRIDE)

--- a/src/qs_energy_window.F
+++ b/src/qs_energy_window.F
@@ -212,8 +212,8 @@ CONTAINS
          CALL dbcsr_copy(window, matrix_ks(1)%matrix)
          CALL dbcsr_copy_into_existing(window, tmp)
          CALL calculate_rho_elec(matrix_p=window, &
-                                 rho=rho_r, &
-                                 rho_gspace=rho_g, &
+                                 rho=rho_r%pw, &
+                                 rho_gspace=rho_g%pw, &
                                  ks_env=ks_env)
          density_total = pw_integrate_function(rho_r%pw)
          IF (unit_nr > 0) WRITE (unit_nr, *) " Ground-state density: ", density_total
@@ -279,8 +279,8 @@ CONTAINS
             CALL dbcsr_copy(window, matrix_ks(1)%matrix)
             CALL dbcsr_copy_into_existing(window, tmp)
             CALL calculate_rho_elec(matrix_p=window, &
-                                    rho=rho_r, &
-                                    rho_gspace=rho_g, &
+                                    rho=rho_r%pw, &
+                                    rho_gspace=rho_g%pw, &
                                     ks_env=ks_env)
             WRITE (ext, "(A14,I5.5,A)") "-ENERGY-WINDOW", i, TRIM(cp_iter_string(logger%iter_info))//".cube"
             mpi_io = .TRUE.

--- a/src/qs_energy_window.F
+++ b/src/qs_energy_window.F
@@ -162,7 +162,7 @@ CONTAINS
       CALL cp_fm_create(eigenvectors_nonorth, ao_ao_fmstruct)
       NULLIFY (rho_r, rho_g)
       ALLOCATE (rho_r, rho_g)
-      NULLIFY (rho_r%pw, rho_g%pw)
+      ALLOCATE (rho_r%pw, rho_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -245,6 +245,7 @@ CONTAINS
          IF (dft_control%qs_control%gapw) THEN
             IF (ASSOCIATED(rho_core)) THEN
                CALL pw_release(rho_core%pw)
+               DEALLOCATE (rho_core%pw)
                DEALLOCATE (rho_core)
             END IF
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
@@ -279,6 +280,7 @@ CONTAINS
          ELSE
             IF (ASSOCIATED(rho_core)) THEN
                CALL pw_release(rho_core%pw)
+               DEALLOCATE (rho_core%pw)
                DEALLOCATE (rho_core)
             END IF
             ALLOCATE (rho_core)
@@ -295,6 +297,7 @@ CONTAINS
             CALL get_qs_env(qs_env, pw_env=new_pw_env, vppl=vppl)
             IF (ASSOCIATED(vppl)) THEN
                CALL pw_release(vppl%pw)
+               DEALLOCATE (vppl%pw)
                DEALLOCATE (vppl)
             END IF
             ALLOCATE (vppl)
@@ -313,6 +316,7 @@ CONTAINS
             CALL get_qs_env(qs_env, pw_env=new_pw_env, rho_nlcc=rho_nlcc)
             IF (ASSOCIATED(rho_nlcc)) THEN
                CALL pw_release(rho_nlcc%pw)
+               DEALLOCATE (rho_nlcc%pw)
                DEALLOCATE (rho_nlcc)
             END IF
             ALLOCATE (rho_nlcc)
@@ -325,6 +329,7 @@ CONTAINS
             CALL get_qs_env(qs_env, pw_env=new_pw_env, rho_nlcc_g=rho_nlcc_g)
             IF (ASSOCIATED(rho_nlcc_g)) THEN
                CALL pw_release(rho_nlcc_g%pw)
+               DEALLOCATE (rho_nlcc_g%pw)
                DEALLOCATE (rho_nlcc_g)
             END IF
             ALLOCATE (rho_nlcc_g)
@@ -340,6 +345,7 @@ CONTAINS
             CALL get_qs_env(qs_env, pw_env=new_pw_env, vee=vee)
             IF (ASSOCIATED(vee)) THEN
                CALL pw_release(vee%pw)
+               DEALLOCATE (vee%pw)
                DEALLOCATE (vee)
             END IF
             ALLOCATE (vee)
@@ -356,6 +362,7 @@ CONTAINS
             CALL get_qs_env(qs_env, pw_env=new_pw_env, external_vxc=external_vxc)
             IF (ASSOCIATED(external_vxc)) THEN
                CALL pw_release(external_vxc%pw)
+               DEALLOCATE (external_vxc%pw)
                DEALLOCATE (external_vxc)
             END IF
             ALLOCATE (external_vxc)
@@ -372,6 +379,7 @@ CONTAINS
             CALL get_qs_env(qs_env, pw_env=new_pw_env, embed_pot=embed_pot)
             IF (ASSOCIATED(embed_pot)) THEN
                CALL pw_release(embed_pot%pw)
+               DEALLOCATE (embed_pot%pw)
                DEALLOCATE (embed_pot)
             END IF
             ALLOCATE (embed_pot)
@@ -384,6 +392,7 @@ CONTAINS
             CALL get_qs_env(qs_env, pw_env=new_pw_env, spin_embed_pot=spin_embed_pot)
             IF (ASSOCIATED(spin_embed_pot)) THEN
                CALL pw_release(spin_embed_pot%pw)
+               DEALLOCATE (spin_embed_pot%pw)
                DEALLOCATE (spin_embed_pot)
             END IF
             ALLOCATE (spin_embed_pot)
@@ -394,8 +403,10 @@ CONTAINS
          END IF
 
          CALL get_ks_env(ks_env, v_hartree_rspace=v_hartree_rspace)
-         IF (ASSOCIATED(v_hartree_rspace)) &
+         IF (ASSOCIATED(v_hartree_rspace)) THEN
             CALL pw_release(v_hartree_rspace)
+            DEALLOCATE (v_hartree_rspace)
+         END IF
          CALL get_qs_env(qs_env, pw_env=new_pw_env)
          CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -208,11 +208,10 @@ CONTAINS
       TYPE(ewald_environment_type), POINTER              :: ewald_env
       TYPE(ewald_pw_type), POINTER                       :: ewald_pw
       TYPE(pw_env_type), POINTER                         :: new_pw_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, external_vxc, rho_core, &
-                                                            rho_nlcc, rho_nlcc_g, spin_embed_pot, &
-                                                            vppl
+      TYPE(pw_p_type), POINTER                           :: embed_pot, external_vxc, rho_nlcc, &
+                                                            rho_nlcc_g, spin_embed_pot, vppl
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: v_hartree_rspace, vee
+      TYPE(pw_type), POINTER                             :: rho_core, v_hartree_rspace, vee
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(rho0_mpole_type), POINTER                     :: rho0_mpole
@@ -244,17 +243,15 @@ CONTAINS
          CPASSERT(ASSOCIATED(new_pw_env))
          IF (dft_control%qs_control%gapw) THEN
             IF (ASSOCIATED(rho_core)) THEN
-               CALL pw_release(rho_core%pw)
-               DEALLOCATE (rho_core%pw)
+               CALL pw_release(rho_core)
                DEALLOCATE (rho_core)
             END IF
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
                ALLOCATE (rho_core)
                CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-               ALLOCATE (rho_core%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, rho_core%pw, &
+               CALL pw_pool_create_pw(auxbas_pw_pool, rho_core, &
                                       use_data=COMPLEXDATA1D)
-               rho_core%pw%in_space = RECIPROCALSPACE
+               rho_core%in_space = RECIPROCALSPACE
                CALL set_ks_env(ks_env, rho_core=rho_core)
             END IF
             CALL get_qs_env(qs_env=qs_env, rho0_mpole=rho0_mpole)
@@ -280,16 +277,14 @@ CONTAINS
             END IF
          ELSE
             IF (ASSOCIATED(rho_core)) THEN
-               CALL pw_release(rho_core%pw)
-               DEALLOCATE (rho_core%pw)
+               CALL pw_release(rho_core)
                DEALLOCATE (rho_core)
             END IF
             ALLOCATE (rho_core)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (rho_core%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_core%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_core, &
                                    use_data=COMPLEXDATA1D)
-            rho_core%pw%in_space = RECIPROCALSPACE
+            rho_core%in_space = RECIPROCALSPACE
             CALL set_ks_env(ks_env, rho_core=rho_core)
          END IF
 

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -210,9 +210,9 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: new_pw_env
       TYPE(pw_p_type), POINTER                           :: embed_pot, external_vxc, rho_core, &
                                                             rho_nlcc, rho_nlcc_g, spin_embed_pot, &
-                                                            vee, vppl
+                                                            vppl
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: v_hartree_rspace
+      TYPE(pw_type), POINTER                             :: v_hartree_rspace, vee
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(rho0_mpole_type), POINTER                     :: rho0_mpole
@@ -349,15 +349,13 @@ CONTAINS
             NULLIFY (vee)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, vee=vee)
             IF (ASSOCIATED(vee)) THEN
-               CALL pw_release(vee%pw)
-               DEALLOCATE (vee%pw)
+               CALL pw_release(vee)
                DEALLOCATE (vee)
             END IF
             ALLOCATE (vee)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (vee%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, vee%pw, use_data=REALDATA3D)
-            vee%pw%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, vee, use_data=REALDATA3D)
+            vee%in_space = REALSPACE
             CALL set_ks_env(ks_env, vee=vee)
             dft_control%eval_external_potential = .TRUE.
          END IF

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -251,6 +251,7 @@ CONTAINS
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
                ALLOCATE (rho_core)
                CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+               ALLOCATE (rho_core%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_core%pw, &
                                       use_data=COMPLEXDATA1D)
                rho_core%pw%in_space = RECIPROCALSPACE
@@ -285,6 +286,7 @@ CONTAINS
             END IF
             ALLOCATE (rho_core)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (rho_core%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_core%pw, &
                                    use_data=COMPLEXDATA1D)
             rho_core%pw%in_space = RECIPROCALSPACE
@@ -302,6 +304,7 @@ CONTAINS
             END IF
             ALLOCATE (vppl)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (vppl%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, vppl%pw, use_data=REALDATA3D)
             vppl%pw%in_space = REALSPACE
             CALL set_ks_env(ks_env, vppl=vppl)
@@ -321,6 +324,7 @@ CONTAINS
             END IF
             ALLOCATE (rho_nlcc)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (rho_nlcc%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc%pw, use_data=REALDATA3D)
             rho_nlcc%pw%in_space = REALSPACE
             CALL set_ks_env(ks_env, rho_nlcc=rho_nlcc)
@@ -334,6 +338,7 @@ CONTAINS
             END IF
             ALLOCATE (rho_nlcc_g)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (rho_nlcc_g%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc_g%pw, use_data=COMPLEXDATA1D)
             rho_nlcc_g%pw%in_space = RECIPROCALSPACE
             CALL set_ks_env(ks_env, rho_nlcc_g=rho_nlcc_g)
@@ -350,6 +355,7 @@ CONTAINS
             END IF
             ALLOCATE (vee)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (vee%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, vee%pw, use_data=REALDATA3D)
             vee%pw%in_space = REALSPACE
             CALL set_ks_env(ks_env, vee=vee)
@@ -367,6 +373,7 @@ CONTAINS
             END IF
             ALLOCATE (external_vxc)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (external_vxc%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, external_vxc%pw, use_data=REALDATA3D)
             external_vxc%pw%in_space = REALSPACE
             CALL set_qs_env(qs_env, external_vxc=external_vxc)
@@ -384,6 +391,7 @@ CONTAINS
             END IF
             ALLOCATE (embed_pot)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (embed_pot%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot%pw, use_data=REALDATA3D)
             embed_pot%pw%in_space = REALSPACE
             CALL set_qs_env(qs_env, embed_pot=embed_pot)
@@ -397,6 +405,7 @@ CONTAINS
             END IF
             ALLOCATE (spin_embed_pot)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (spin_embed_pot%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot%pw, use_data=REALDATA3D)
             spin_embed_pot%pw%in_space = REALSPACE
             CALL set_qs_env(qs_env, spin_embed_pot=spin_embed_pot)
@@ -409,6 +418,7 @@ CONTAINS
          END IF
          CALL get_qs_env(qs_env, pw_env=new_pw_env)
          CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (v_hartree_rspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL set_ks_env(ks_env, v_hartree_rspace=v_hartree_rspace)

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -629,7 +629,7 @@ CONTAINS
       TYPE(energy_correction_type), OPTIONAL, POINTER    :: ec_env
       TYPE(qs_dispersion_type), OPTIONAL, POINTER        :: dispersion_env
       TYPE(qs_gcp_type), OPTIONAL, POINTER               :: gcp_env
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vee
+      TYPE(pw_type), OPTIONAL, POINTER                   :: vee
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_external
       TYPE(pw_p_type), OPTIONAL, POINTER                 :: external_vxc, mask
       TYPE(mp2_type), OPTIONAL, POINTER                  :: mp2_env

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -1443,10 +1443,12 @@ CONTAINS
             END IF
             IF (ASSOCIATED(qs_env%external_vxc)) THEN
                CALL pw_release(qs_env%external_vxc%pw)
+               DEALLOCATE (qs_env%external_vxc%pw)
                DEALLOCATE (qs_env%external_vxc)
             END IF
             IF (ASSOCIATED(qs_env%mask)) THEN
                CALL pw_release(qs_env%mask%pw)
+               DEALLOCATE (qs_env%mask%pw)
                DEALLOCATE (qs_env%mask)
             END IF
             IF (ASSOCIATED(qs_env%active_space)) THEN
@@ -1455,9 +1457,11 @@ CONTAINS
             ! Embedding potentials if provided as input
             IF (qs_env%given_embed_pot) THEN
                CALL pw_release(qs_env%embed_pot%pw)
+               DEALLOCATE (qs_env%embed_pot%pw)
                DEALLOCATE (qs_env%embed_pot)
                IF (ASSOCIATED(qs_env%spin_embed_pot)) THEN
                   CALL pw_release(qs_env%spin_embed_pot%pw)
+                  DEALLOCATE (qs_env%spin_embed_pot%pw)
                   DEALLOCATE (qs_env%spin_embed_pot)
                END IF
             END IF
@@ -1639,10 +1643,12 @@ CONTAINS
             END IF
             IF (ASSOCIATED(qs_env%external_vxc)) THEN
                CALL pw_release(qs_env%external_vxc%pw)
+               DEALLOCATE (qs_env%external_vxc%pw)
                DEALLOCATE (qs_env%external_vxc)
             END IF
             IF (ASSOCIATED(qs_env%mask)) THEN
                CALL pw_release(qs_env%mask%pw)
+               DEALLOCATE (qs_env%mask%pw)
                DEALLOCATE (qs_env%mask)
             END IF
             IF (ASSOCIATED(qs_env%active_space)) THEN
@@ -1651,9 +1657,11 @@ CONTAINS
             ! Embedding potentials if provided as input
             IF (qs_env%given_embed_pot) THEN
                CALL pw_release(qs_env%embed_pot%pw)
+               DEALLOCATE (qs_env%embed_pot%pw)
                DEALLOCATE (qs_env%embed_pot)
                IF (ASSOCIATED(qs_env%spin_embed_pot)) THEN
                   CALL pw_release(qs_env%spin_embed_pot%pw)
+                  DEALLOCATE (qs_env%spin_embed_pot%pw)
                   DEALLOCATE (qs_env%spin_embed_pot)
                END IF
             END IF

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -569,7 +569,9 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: kinetic
       TYPE(qs_charges_type), OPTIONAL, POINTER           :: qs_charges
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_nlcc, rho_nlcc_g
       TYPE(qs_ks_env_type), OPTIONAL, POINTER            :: ks_env
       TYPE(qs_ks_qmmm_env_type), OPTIONAL, POINTER       :: ks_qmmm_env
       TYPE(qs_wf_history_type), OPTIONAL, POINTER        :: wf_history
@@ -595,7 +597,7 @@ CONTAINS
       TYPE(rhoz_type), DIMENSION(:), OPTIONAL, POINTER   :: rhoz_set
       TYPE(ecoul_1center_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: ecoul_1c
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho0_s_rs, rho0_s_gs
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho0_s_rs, rho0_s_gs
       LOGICAL, OPTIONAL                                  :: do_kpoints, has_unit_metric, &
                                                             requires_mo_derivs
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &

--- a/src/qs_epr_hyp.F
+++ b/src/qs_epr_hyp.F
@@ -331,9 +331,11 @@ CONTAINS
       END DO ! idir1
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhototspin_elec_gspace%pw)
+      DEALLOCATE (rhototspin_elec_gspace%pw)
       DEALLOCATE (rhototspin_elec_gspace)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, hypaniso_gspace%pw)
+      DEALLOCATE (hypaniso_gspace%pw)
       DEALLOCATE (hypaniso_gspace)
 
       ! Multiply hyperfine matrices with constant*gyromagnetic ratio's

--- a/src/qs_epr_hyp.F
+++ b/src/qs_epr_hyp.F
@@ -288,6 +288,7 @@ CONTAINS
                       auxbas_pw_pool=auxbas_pw_pool)
 
       ALLOCATE (rhototspin_elec_gspace)
+      ALLOCATE (rhototspin_elec_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              rhototspin_elec_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -303,6 +304,7 @@ CONTAINS
       CALL pw_axpy(rho_g(2)%pw, rhototspin_elec_gspace%pw, alpha=-1._dp)
       ! grid to assemble anisotropic hyperfine terms
       ALLOCATE (hypaniso_gspace)
+      ALLOCATE (hypaniso_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              hypaniso_gspace%pw, &
                              use_data=COMPLEXDATA1D, &

--- a/src/qs_external_density.F
+++ b/src/qs_external_density.F
@@ -196,7 +196,7 @@ CONTAINS
             IF (my_rank == 0) CALL close_file(unit_number=extunit)
          END IF
 
-         CALL density_rs2pw(pw_env, rs_rho_ext, rho=rho_ext_r(1), rho_gspace=rho_ext_g(1))
+         CALL density_rs2pw(pw_env, rs_rho_ext, rho=rho_ext_r(1)%pw, rho_gspace=rho_ext_g(1)%pw)
          tot_rho_r_ext(1) = pw_integrate_function(rho_ext_r(1)%pw, isign=1)
          IF (my_rank == 0) THEN
             WRITE (*, FMT="(T3,A,T61,F20.10)") "ZMP| Total external charge:                    ", &

--- a/src/qs_external_potential.F
+++ b/src/qs_external_potential.F
@@ -33,8 +33,7 @@ MODULE qs_external_potential
    USE message_passing,                 ONLY: mp_bcast
    USE particle_types,                  ONLY: particle_type
    USE pw_grid_types,                   ONLY: PW_MODE_LOCAL
-   USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -73,7 +72,7 @@ CONTAINS
       REAL(kind=dp)                                      :: dvol, efunc, scaling_factor
       REAL(kind=dp), DIMENSION(3)                        :: dr, grid_p
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(pw_p_type), POINTER                           :: v_ee
+      TYPE(pw_type), POINTER                             :: v_ee
       TYPE(section_vals_type), POINTER                   :: ext_pot_section, input
 
       CALL timeset(routineN, handle)
@@ -89,18 +88,18 @@ CONTAINS
                dft_control%eval_external_potential = .FALSE.
             ELSEIF (dft_control%expot_control%read_from_cube) THEN
                scaling_factor = dft_control%expot_control%scaling_factor
-               CALL cp_cube_to_pw(v_ee%pw, 'pot.cube', scaling_factor)
+               CALL cp_cube_to_pw(v_ee, 'pot.cube', scaling_factor)
                dft_control%eval_external_potential = .FALSE.
             ELSE
                CALL get_qs_env(qs_env, input=input)
                ext_pot_section => section_vals_get_subs_vals(input, "DFT%EXTERNAL_POTENTIAL")
 
-               dr = v_ee%pw%pw_grid%dr
-               dvol = v_ee%pw%pw_grid%dvol
-               v_ee%pw%cr3d = 0.0_dp
+               dr = v_ee%pw_grid%dr
+               dvol = v_ee%pw_grid%dvol
+               v_ee%cr3d = 0.0_dp
 
-               bo_local = v_ee%pw%pw_grid%bounds_local
-               bo_global = v_ee%pw%pw_grid%bounds
+               bo_local = v_ee%pw_grid%bounds_local
+               bo_global = v_ee%pw_grid%bounds
 
                DO k = bo_local(1, 3), bo_local(2, 3)
                   DO j = bo_local(1, 2), bo_local(2, 2)
@@ -109,7 +108,7 @@ CONTAINS
                         grid_p(2) = (j - bo_global(1, 2))*dr(2)
                         grid_p(3) = (k - bo_global(1, 3))*dr(3)
                         CALL get_external_potential(grid_p, ext_pot_section, func=efunc)
-                        v_ee%pw%cr3d(i, j, k) = v_ee%pw%cr3d(i, j, k) + efunc
+                        v_ee%cr3d(i, j, k) = v_ee%cr3d(i, j, k) + efunc
                      END DO
                   END DO
                END DO
@@ -144,7 +143,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      TYPE(pw_p_type), POINTER                           :: v_ee
+      TYPE(pw_type), POINTER                             :: v_ee
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -198,7 +197,7 @@ CONTAINS
                !if potential is on grid, interpolate the value at r,
                !otherwise evaluate the given function
                IF (pot_on_grid) THEN
-                  CALL interpolate_external_potential(r, v_ee%pw, func=efunc, &
+                  CALL interpolate_external_potential(r, v_ee, func=efunc, &
                                                       dfunc=dfunc, calc_derivatives=my_force)
                ELSE
                   CALL get_external_potential(r, ext_pot_section, func=efunc, &

--- a/src/qs_fxc.F
+++ b/src/qs_fxc.F
@@ -219,6 +219,7 @@ CONTAINS
             IF (.NOT. ASSOCIATED(fxc_rho)) THEN
                ALLOCATE (fxc_rho(nspins))
                DO ispin = 1, nspins
+                  ALLOCATE (fxc_rho(ispin)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, fxc_rho(ispin)%pw, &
                                          in_space=REALSPACE, use_data=REALDATA3D)
                   CALL pw_zero(fxc_rho(ispin)%pw)
@@ -235,6 +236,7 @@ CONTAINS
                IF (.NOT. ASSOCIATED(fxc_tau)) THEN
                   ALLOCATE (fxc_tau(nspins))
                   DO ispin = 1, nspins
+                     ALLOCATE (fxc_tau(ispin)%pw)
                      CALL pw_pool_create_pw(auxbas_pw_pool, fxc_tau(ispin)%pw, &
                                             in_space=REALSPACE, use_data=REALDATA3D)
                      CALL pw_zero(fxc_tau(ispin)%pw)
@@ -359,6 +361,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(fxc_rho)) THEN
             ALLOCATE (fxc_rho(nspins))
             DO ispin = 1, nspins
+               ALLOCATE (fxc_rho(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, fxc_rho(ispin)%pw, &
                                       in_space=REALSPACE, use_data=REALDATA3D)
                CALL pw_zero(fxc_rho(ispin)%pw)
@@ -367,6 +370,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(gxc_rho)) THEN
             ALLOCATE (gxc_rho(nspins))
             DO ispin = 1, nspins
+               ALLOCATE (gxc_rho(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, gxc_rho(ispin)%pw, &
                                       in_space=REALSPACE, use_data=REALDATA3D)
                CALL pw_zero(gxc_rho(ispin)%pw)

--- a/src/qs_fxc.F
+++ b/src/qs_fxc.F
@@ -230,6 +230,7 @@ CONTAINS
             END DO
             DO ispin = 1, SIZE(vxc00)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc00(ispin)%pw)
+               DEALLOCATE (vxc00(ispin)%pw)
             END DO
             DEALLOCATE (vxc00)
             IF (ASSOCIATED(v_tau_rspace)) THEN
@@ -247,6 +248,7 @@ CONTAINS
                END DO
                DO ispin = 1, SIZE(v_tau_rspace)
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
+                  DEALLOCATE (v_tau_rspace(ispin)%pw)
                END DO
                DEALLOCATE (v_tau_rspace)
             END IF
@@ -387,6 +389,7 @@ CONTAINS
          END DO
          DO ispin = 1, SIZE(vxc00)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc00(ispin)%pw)
+            DEALLOCATE (vxc00(ispin)%pw)
          END DO
          DEALLOCATE (vxc00)
 
@@ -429,24 +432,28 @@ CONTAINS
       IF (ASSOCIATED(fxc_rho)) THEN
          DO ispin = 1, SIZE(fxc_rho)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, fxc_rho(ispin)%pw)
+            DEALLOCATE (fxc_rho(ispin)%pw)
          END DO
          DEALLOCATE (fxc_rho)
       END IF
       IF (ASSOCIATED(fxc_tau)) THEN
          DO ispin = 1, SIZE(fxc_tau)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, fxc_tau(ispin)%pw)
+            DEALLOCATE (fxc_tau(ispin)%pw)
          END DO
          DEALLOCATE (fxc_tau)
       END IF
       IF (ASSOCIATED(gxc_rho)) THEN
          DO ispin = 1, SIZE(gxc_rho)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, gxc_rho(ispin)%pw)
+            DEALLOCATE (gxc_rho(ispin)%pw)
          END DO
          DEALLOCATE (gxc_rho)
       END IF
       IF (ASSOCIATED(gxc_tau)) THEN
          DO ispin = 1, SIZE(gxc_tau)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, gxc_tau(ispin)%pw)
+            DEALLOCATE (gxc_tau(ispin)%pw)
          END DO
          DEALLOCATE (gxc_tau)
       END IF

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -147,6 +147,7 @@ CONTAINS
                CALL pw_axpy(rho_g(1)%pw, rho_g(2)%pw, -1.0_dp)
                CALL pw_scale(rho_g(2)%pw, -1.0_dp)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp%pw)
+               DEALLOCATE (rho_tmp%pw)
             END IF
             CALL timestop(handle)
             RETURN
@@ -180,6 +181,7 @@ CONTAINS
             CALL pw_axpy(rho_g(1)%pw, rho_g(2)%pw, -1.0_dp)
             CALL pw_scale(rho_g(2)%pw, -1.0_dp)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp%pw)
+            DEALLOCATE (rho_tmp%pw)
          END IF
 
          DO ispin = 1, nspin

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -108,6 +108,7 @@ CONTAINS
 
          IF (nspin == 2) THEN
             CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (rho_tmp%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
                                    rho_tmp%pw, &
                                    use_data=COMPLEXDATA1D, &

--- a/src/qs_integrate_potential_product.F
+++ b/src/qs_integrate_potential_product.F
@@ -55,7 +55,7 @@ MODULE qs_integrate_potential_product
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_force_types,                  ONLY: qs_force_type
@@ -109,7 +109,7 @@ CONTAINS
 !> \param lambda The atom index.
 ! **************************************************************************************************
    SUBROUTINE integrate_v_dbasis(v_rspace, matrix_vhxc_dbasis, matrix_p, qs_env, lambda)
-      TYPE(pw_p_type)                                    :: v_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_rspace
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_vhxc_dbasis
       TYPE(dbcsr_type), POINTER                          :: matrix_p
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -193,7 +193,7 @@ CONTAINS
       group = rs_rho(1)%rs_grid%desc%group
 
       ! transform the potential on the rs_multigrids
-      CALL potential_pw2rs(rs_rho, v_rspace%pw, pw_env)
+      CALL potential_pw2rs(rs_rho, v_rspace, pw_env)
 
       nkind = SIZE(qs_kind_set)
 
@@ -587,7 +587,7 @@ CONTAINS
                                  qs_env, calculate_forces, force_adm, ispin, &
                                  compute_tau, gapw, basis_type, pw_env_external, task_list_external)
 
-      TYPE(pw_p_type)                                    :: v_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_rspace
       TYPE(dbcsr_p_type), INTENT(INOUT), OPTIONAL        :: hmat
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: hmat_kp
@@ -720,7 +720,7 @@ CONTAINS
       gridlevel_info => pw_env%gridlevel_info
 
       ! transform the potential on the rs_multigrids
-      CALL potential_pw2rs(rs_v, v_rspace%pw, pw_env)
+      CALL potential_pw2rs(rs_v, v_rspace, pw_env)
 
       nimages = dft_control%nimages
       IF (nimages > 1) THEN

--- a/src/qs_integrate_potential_product.F
+++ b/src/qs_integrate_potential_product.F
@@ -193,7 +193,7 @@ CONTAINS
       group = rs_rho(1)%rs_grid%desc%group
 
       ! transform the potential on the rs_multigrids
-      CALL potential_pw2rs(rs_rho, v_rspace, pw_env)
+      CALL potential_pw2rs(rs_rho, v_rspace%pw, pw_env)
 
       nkind = SIZE(qs_kind_set)
 
@@ -720,7 +720,7 @@ CONTAINS
       gridlevel_info => pw_env%gridlevel_info
 
       ! transform the potential on the rs_multigrids
-      CALL potential_pw2rs(rs_v, v_rspace, pw_env)
+      CALL potential_pw2rs(rs_v, v_rspace%pw, pw_env)
 
       nimages = dft_control%nimages
       IF (nimages > 1) THEN

--- a/src/qs_integrate_potential_single.F
+++ b/src/qs_integrate_potential_single.F
@@ -706,7 +706,7 @@ CONTAINS
 
       gridlevel_info => pw_env%gridlevel_info
 
-      CALL potential_pw2rs(rs_v, v_rspace, pw_env)
+      CALL potential_pw2rs(rs_v, v_rspace%pw, pw_env)
 
       CALL get_qs_env(qs_env=qs_env, &
                       atomic_kind_set=atomic_kind_set, &
@@ -912,7 +912,7 @@ CONTAINS
       DO i = 1, SIZE(rs_v)
          CALL rs_grid_retain(rs_v(i)%rs_grid)
       END DO
-      CALL potential_pw2rs(rs_v, v_rspace, pw_env)
+      CALL potential_pw2rs(rs_v, v_rspace%pw, pw_env)
 
       gridlevel_info => pw_env%gridlevel_info
 

--- a/src/qs_integrate_potential_single.F
+++ b/src/qs_integrate_potential_single.F
@@ -55,7 +55,7 @@ MODULE qs_integrate_potential_single
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_force_types,                  ONLY: qs_force_type
@@ -99,7 +99,7 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE integrate_ppl_rspace(rho_rspace, qs_env)
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_rspace
+      TYPE(pw_type), INTENT(IN)                          :: rho_rspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_ppl_rspace'
@@ -132,7 +132,7 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, auxbas_rs_grid=rs_v)
       CALL rs_grid_retain(rs_v)
 
-      CALL rs_pw_transfer(rs_v, rho_rspace%pw, pw2rs)
+      CALL rs_pw_transfer(rs_v, rho_rspace, pw2rs)
 
       CALL get_qs_env(qs_env=qs_env, &
                       atomic_kind_set=atomic_kind_set, &
@@ -260,11 +260,11 @@ CONTAINS
                                        my_virial_b=my_virial_b, use_subpatch=.TRUE., subpatch_pattern=0)
 
             force(ikind)%gth_ppl(:, iatom) = &
-               force(ikind)%gth_ppl(:, iatom) + force_a(:)*rho_rspace%pw%pw_grid%dvol
+               force(ikind)%gth_ppl(:, iatom) + force_a(:)*rho_rspace%pw_grid%dvol
 
             IF (use_virial) THEN
-               virial%pv_ppl = virial%pv_ppl + my_virial_a*rho_rspace%pw%pw_grid%dvol
-               virial%pv_virial = virial%pv_virial + my_virial_a*rho_rspace%pw%pw_grid%dvol
+               virial%pv_ppl = virial%pv_ppl + my_virial_a*rho_rspace%pw_grid%dvol
+               virial%pv_virial = virial%pv_virial + my_virial_a*rho_rspace%pw_grid%dvol
                CPABORT("Virial not debuged for CORE_PPL")
             END IF
          END DO
@@ -287,7 +287,7 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE integrate_rho_nlcc(rho_rspace, qs_env)
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_rspace
+      TYPE(pw_type), INTENT(IN)                          :: rho_rspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_rho_nlcc'
@@ -321,7 +321,7 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, auxbas_rs_grid=rs_v)
       CALL rs_grid_retain(rs_v)
 
-      CALL rs_pw_transfer(rs_v, rho_rspace%pw, pw2rs)
+      CALL rs_pw_transfer(rs_v, rho_rspace, pw2rs)
 
       CALL get_qs_env(qs_env=qs_env, &
                       atomic_kind_set=atomic_kind_set, &
@@ -460,11 +460,11 @@ CONTAINS
                                           my_virial_b=my_virial_b, use_subpatch=.TRUE., subpatch_pattern=0)
 
                force(ikind)%gth_nlcc(:, iatom) = &
-                  force(ikind)%gth_nlcc(:, iatom) + force_a(:)*rho_rspace%pw%pw_grid%dvol
+                  force(ikind)%gth_nlcc(:, iatom) + force_a(:)*rho_rspace%pw_grid%dvol
 
                IF (use_virial) THEN
-                  virial%pv_nlcc = virial%pv_nlcc + my_virial_a*rho_rspace%pw%pw_grid%dvol
-                  virial%pv_virial = virial%pv_virial + my_virial_a*rho_rspace%pw%pw_grid%dvol
+                  virial%pv_nlcc = virial%pv_nlcc + my_virial_a*rho_rspace%pw_grid%dvol
+                  virial%pv_virial = virial%pv_virial + my_virial_a*rho_rspace%pw_grid%dvol
                END IF
             END DO
 
@@ -489,7 +489,7 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE integrate_v_core_rspace(v_rspace, qs_env)
-      TYPE(pw_p_type), INTENT(INOUT)                     :: v_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_rspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_v_core_rspace'
@@ -535,7 +535,7 @@ CONTAINS
          CALL pw_env_get(pw_env=pw_env, auxbas_rs_grid=rs_v)
          CALL rs_grid_retain(rs_v)
 
-         CALL rs_pw_transfer(rs_v, v_rspace%pw, pw2rs)
+         CALL rs_pw_transfer(rs_v, v_rspace, pw2rs)
 
          CALL get_qs_env(qs_env=qs_env, &
                          atomic_kind_set=atomic_kind_set, &
@@ -654,7 +654,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE integrate_v_rspace_one_center(v_rspace, qs_env, int_res, &
                                             calculate_forces, basis_type, atomlist)
-      TYPE(pw_p_type), INTENT(IN)                        :: v_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_rspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: int_res
       LOGICAL, INTENT(IN)                                :: calculate_forces
@@ -706,7 +706,7 @@ CONTAINS
 
       gridlevel_info => pw_env%gridlevel_info
 
-      CALL potential_pw2rs(rs_v, v_rspace%pw, pw_env)
+      CALL potential_pw2rs(rs_v, v_rspace, pw_env)
 
       CALL get_qs_env(qs_env=qs_env, &
                       atomic_kind_set=atomic_kind_set, &
@@ -723,8 +723,8 @@ CONTAINS
       eps_rho_rspace = dft_control%qs_control%eps_rho_rspace
 
       offset = 0
-      my_pos = v_rspace%pw%pw_grid%para%my_pos
-      group_size = v_rspace%pw%pw_grid%para%group_size
+      my_pos = v_rspace%pw_grid%para%my_pos
+      group_size = v_rspace%pw_grid%para%group_size
 
       DO ikind = 1, nkind
 
@@ -869,7 +869,7 @@ CONTAINS
 !> \author JGH
 ! **************************************************************************************************
    SUBROUTINE integrate_v_rspace_diagonal(v_rspace, ksmat, pmat, qs_env, calculate_forces, basis_type)
-      TYPE(pw_p_type), INTENT(IN)                        :: v_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_rspace
       TYPE(dbcsr_type), INTENT(INOUT)                    :: ksmat, pmat
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN)                                :: calculate_forces
@@ -912,7 +912,7 @@ CONTAINS
       DO i = 1, SIZE(rs_v)
          CALL rs_grid_retain(rs_v(i)%rs_grid)
       END DO
-      CALL potential_pw2rs(rs_v, v_rspace%pw, pw_env)
+      CALL potential_pw2rs(rs_v, v_rspace, pw_env)
 
       gridlevel_info => pw_env%gridlevel_info
 
@@ -931,8 +931,8 @@ CONTAINS
       use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
 
       offset = 0
-      my_pos = v_rspace%pw%pw_grid%para%my_pos
-      group_size = v_rspace%pw%pw_grid%para%group_size
+      my_pos = v_rspace%pw_grid%para%my_pos
+      group_size = v_rspace%pw_grid%para%group_size
 
       DO ikind = 1, nkind
 

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -438,14 +438,14 @@ CONTAINS
          IF (gapw_xc) THEN
 
             IF (do_excitations .AND. nspins == 1) THEN
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=p_env%kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
                                        calculate_forces=my_calc_forces, gapw=gapw_xc)
 
                IF (ASSOCIATED(v_xc_tau)) THEN
-                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
                                           hmat=p_env%kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
@@ -457,21 +457,21 @@ CONTAINS
                IF (.NOT. do_triplet) THEN
                   v_rspace_new(1)%pw%cr3d = v_hartree_rspace%pw%cr3d
 
-                  CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
                                           hmat=p_env%kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
                                           calculate_forces=my_calc_forces, gapw=gapw)
                END IF
             ELSE
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=p_env%kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
                                        calculate_forces=my_calc_forces, gapw=gapw_xc)
 
                IF (ASSOCIATED(v_xc_tau)) THEN
-                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
                                           hmat=p_env%kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
@@ -480,7 +480,7 @@ CONTAINS
                END IF
 
                v_rspace_new(ispin)%pw%cr3d = v_hartree_rspace%pw%cr3d
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=p_env%kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
@@ -509,7 +509,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace_new(ispin), qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace_new(ispin)%pw, qs_env, &
                                                   lri_v_int, .FALSE., "LRI_AUX")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -517,20 +517,20 @@ CONTAINS
                ALLOCATE (k1mat(1))
                k1mat(1)%matrix => p_env%kpp1_env%v_ao(ispin)%matrix
                IF (lri_env%exact_1c_terms) THEN
-                  CALL integrate_v_rspace_diagonal(v_rspace_new(ispin), k1mat(1)%matrix, &
+                  CALL integrate_v_rspace_diagonal(v_rspace_new(ispin)%pw, k1mat(1)%matrix, &
                                                    rho_ao(ispin)%matrix, qs_env, my_calc_forces, "ORB")
                END IF
                CALL calculate_lri_ks_matrix(lri_env, lri_v_int, k1mat, atomic_kind_set)
                DEALLOCATE (k1mat)
             ELSE
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=p_env%kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
                                        calculate_forces=my_calc_forces, gapw=gapw)
 
                IF (ASSOCIATED(v_xc_tau)) THEN
-                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
                                           hmat=p_env%kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
@@ -549,7 +549,7 @@ CONTAINS
                                     p_env%hartree_local%ecoul_1c, &
                                     p_env%local_rho_set, &
                                     para_env, tddft=.TRUE.)
-            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace, para_env, &
+            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace%pw, para_env, &
                                        calculate_forces=my_calc_forces, &
                                        local_rho_set=p_env%local_rho_set)
          END IF

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -282,6 +282,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
       ALLOCATE (v_rspace_new(nspins))
+      ALLOCATE (v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -290,6 +291,7 @@ CONTAINS
          CALL prepare_gapw_den(qs_env, p_env%local_rho_set, do_rho0=(.NOT. gapw_xc))
 
       ! *** calculate the hartree potential on the total density ***
+      ALLOCATE (rho1_tot_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -312,6 +314,7 @@ CONTAINS
       END IF
 
       IF (.NOT. (nspins == 1 .AND. do_excitations .AND. do_triplet)) THEN
+         ALLOCATE (v_hartree_gspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
@@ -727,6 +730,7 @@ CONTAINS
                                 (lsd_singlets .OR. do_triplet))) THEN
             ALLOCATE (my_rho_r(2))
             DO ispin = 1, 2
+               ALLOCATE (my_rho_r(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, my_rho_r(ispin)%pw, &
                                       use_data=rho_r(1)%pw%in_use, in_space=rho_r(1)%pw%in_space)
                my_rho_r(ispin)%pw%cr3d = 0.5_dp*rho_r(1)%pw%cr3d
@@ -734,6 +738,7 @@ CONTAINS
             IF (dft_control%use_kinetic_energy_density) THEN
                ALLOCATE (my_tau_r(2))
                DO ispin = 1, 2
+                  ALLOCATE (my_tau_r(ispin)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, my_tau_r(ispin)%pw, &
                                          use_data=tau_r(1)%pw%in_use, in_space=tau_r(1)%pw%in_space)
                   my_tau_r(ispin)%pw%cr3d = 0.5_dp*tau_r(1)%pw%cr3d

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -399,10 +399,14 @@ CONTAINS
           (lsd_singlets .OR. do_triplet)) THEN
          DO ispin = 1, SIZE(rho1_r_pw)
             CALL pw_release(rho1_r_pw(ispin)%pw)
+            DEALLOCATE (rho1_r_pw(ispin)%pw)
          END DO
          IF (ASSOCIATED(tau1_r_pw)) THEN
          DO ispin = 1, SIZE(tau1_r_pw)
-            IF (ASSOCIATED(tau1_r_pw(ispin)%pw)) CALL pw_release(tau1_r_pw(ispin)%pw)
+            IF (ASSOCIATED(tau1_r_pw(ispin)%pw)) THEN
+               CALL pw_release(tau1_r_pw(ispin)%pw)
+               DEALLOCATE (tau1_r_pw(ispin)%pw)
+            END IF
          END DO
          END IF
       END IF
@@ -763,10 +767,12 @@ CONTAINS
                                 (lsd_singlets .OR. do_triplet))) THEN
          DO ispin = 1, SIZE(my_rho_r)
             CALL pw_release(my_rho_r(ispin)%pw)
+            DEALLOCATE (my_rho_r(ispin)%pw)
          END DO
          IF (ASSOCIATED(my_tau_r)) THEN
             DO ispin = 1, SIZE(my_tau_r)
                CALL pw_release(my_tau_r(ispin)%pw)
+               DEALLOCATE (my_tau_r(ispin)%pw)
             END DO
          END IF
          END IF

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -67,8 +67,7 @@ MODULE qs_kpp1_env_methods
                                               RECIPROCALSPACE,&
                                               pw_create,&
                                               pw_p_type,&
-                                              pw_release,&
-                                              pw_retain
+                                              pw_release
    USE qs_energy_types,                 ONLY: allocate_qs_energy,&
                                               deallocate_qs_energy,&
                                               qs_energy_type
@@ -360,14 +359,12 @@ CONTAINS
          ALLOCATE (rho1_r_pw(nspins))
          DO ispin = 1, nspins
             rho1_r_pw(ispin)%pw => rho1_r(ispin)%pw
-            CALL pw_retain(rho1_r_pw(ispin)%pw)
          END DO
 
          IF (ASSOCIATED(tau1_r)) THEN
             ALLOCATE (tau1_r_pw(nspins))
             DO ispin = 1, nspins
                tau1_r_pw(ispin)%pw => tau1_r(ispin)%pw
-               CALL pw_retain(tau1_r_pw(ispin)%pw)
             END DO
          END IF
 
@@ -398,16 +395,19 @@ CONTAINS
                                           do_tddft=do_tddft, do_triplet=do_triplet)
       END IF
 
-      DO ispin = 1, SIZE(rho1_r_pw)
-         CALL pw_release(rho1_r_pw(ispin)%pw)
-      END DO
-      DEALLOCATE (rho1_r_pw)
-      IF (ASSOCIATED(tau1_r_pw)) THEN
-      DO ispin = 1, SIZE(tau1_r_pw)
-         IF (ASSOCIATED(tau1_r_pw(ispin)%pw)) CALL pw_release(tau1_r_pw(ispin)%pw)
-      END DO
-      DEALLOCATE (tau1_r_pw)
+      IF (nspins == 1 .AND. do_excitations .AND. &
+          (lsd_singlets .OR. do_triplet)) THEN
+         DO ispin = 1, SIZE(rho1_r_pw)
+            CALL pw_release(rho1_r_pw(ispin)%pw)
+         END DO
+         IF (ASSOCIATED(tau1_r_pw)) THEN
+         DO ispin = 1, SIZE(tau1_r_pw)
+            IF (ASSOCIATED(tau1_r_pw(ispin)%pw)) CALL pw_release(tau1_r_pw(ispin)%pw)
+         END DO
+         END IF
       END IF
+      DEALLOCATE (rho1_r_pw)
+      IF (ASSOCIATED(tau1_r_pw)) DEALLOCATE (tau1_r_pw)
 
       alpha = 1.0_dp
       IF (do_excitations .AND. nspins == 1) alpha = 2.0_dp
@@ -739,13 +739,11 @@ CONTAINS
             ALLOCATE (my_rho_r(SIZE(rho_r)))
             DO ispin = 1, SIZE(rho_r)
                my_rho_r(ispin)%pw => rho_r(ispin)%pw
-               CALL pw_retain(my_rho_r(ispin)%pw)
             END DO
             IF (dft_control%use_kinetic_energy_density) THEN
                ALLOCATE (my_tau_r(SIZE(tau_r)))
                DO ispin = 1, SIZE(tau_r)
                   my_tau_r(ispin)%pw => tau_r(ispin)%pw
-                  CALL pw_retain(my_tau_r(ispin)%pw)
                END DO
             END IF
          END IF
@@ -761,16 +759,19 @@ CONTAINS
                                 my_rho_r, auxbas_pw_pool, &
                                 xc_section=xc_section, tau_r=my_tau_r)
 
+         IF (nspins == 1 .AND. (do_excitations .AND. &
+                                (lsd_singlets .OR. do_triplet))) THEN
          DO ispin = 1, SIZE(my_rho_r)
             CALL pw_release(my_rho_r(ispin)%pw)
          END DO
-         DEALLOCATE (my_rho_r)
-         IF (dft_control%use_kinetic_energy_density) THEN
+         IF (ASSOCIATED(my_tau_r)) THEN
             DO ispin = 1, SIZE(my_tau_r)
                CALL pw_release(my_tau_r(ispin)%pw)
             END DO
-            DEALLOCATE (my_tau_r)
          END IF
+         END IF
+         DEALLOCATE (my_rho_r)
+         IF (ASSOCIATED(my_tau_r)) DEALLOCATE (my_tau_r)
       END IF
 
       ! ADMM Correction

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -323,10 +323,12 @@ CONTAINS
                                v_hartree_gspace%pw)
          CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+         DEALLOCATE (v_hartree_gspace%pw)
          CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace%pw)
+      DEALLOCATE (rho1_tot_gspace%pw)
 
       ! *** calculate the xc potential ***
       IF (gapw_xc) THEN
@@ -382,13 +384,19 @@ CONTAINS
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
          v_rspace_new(ispin)%pw => v_xc(ispin)%pw
       END DO
-      IF (SIZE(v_xc) /= nspins) CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(2)%pw)
+      IF (SIZE(v_xc) /= nspins) THEN
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(2)%pw)
+         DEALLOCATE (v_xc(2)%pw)
+      END IF
       DEALLOCATE (v_xc)
       IF (ASSOCIATED(v_xc_tau)) THEN
       DO ispin = 1, nspins
          CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
       END DO
-      IF (SIZE(v_xc_tau) /= nspins) CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(2)%pw)
+      IF (SIZE(v_xc_tau) /= nspins) THEN
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(2)%pw)
+         DEALLOCATE (v_xc_tau(2)%pw)
+      END IF
       END IF
 
       IF (gapw .OR. gapw_xc) THEN
@@ -563,13 +571,16 @@ CONTAINS
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
+      DEALLOCATE (v_hartree_rspace%pw)
       DO ispin = 1, SIZE(v_rspace_new)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin)%pw)
+         DEALLOCATE (v_rspace_new(ispin)%pw)
       END DO
       DEALLOCATE (v_rspace_new)
       IF (ASSOCIATED(v_xc_tau)) THEN
       DO ispin = 1, SIZE(v_xc_tau)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+         DEALLOCATE (v_xc_tau(ispin)%pw)
       END DO
       DEALLOCATE (v_xc_tau)
       END IF

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -301,7 +301,7 @@ CONTAINS
          CALL pw_axpy(rho1_g(ispin)%pw, rho1_tot_gspace%pw)
       END DO
       IF (gapw) &
-         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs%pw, rho1_tot_gspace%pw)
+         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs, rho1_tot_gspace%pw)
 
       scf_section => section_vals_get_subs_vals(input, "DFT%SCF")
       IF (cp_print_key_should_output(logger%iter_info, scf_section, "PRINT%TOTAL_DENSITIES") &

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -338,7 +338,7 @@ CONTAINS
          lsd = .TRUE.
          ALLOCATE (rho1_r_pw(2))
          DO ispin = 1, 2
-            NULLIFY (rho1_r_pw(ispin)%pw)
+            ALLOCATE (rho1_r_pw(ispin)%pw)
             CALL pw_create(rho1_r_pw(ispin)%pw, rho1_r(1)%pw%pw_grid, &
                            rho1_r(1)%pw%in_use, rho1_r(1)%pw%in_space)
             CALL pw_transfer(rho1_r(1)%pw, rho1_r_pw(ispin)%pw)
@@ -347,7 +347,7 @@ CONTAINS
          IF (ASSOCIATED(tau1_r)) THEN
             ALLOCATE (tau1_r_pw(2))
             DO ispin = 1, 2
-               NULLIFY (tau1_r_pw(ispin)%pw)
+               ALLOCATE (tau1_r_pw(ispin)%pw)
                CALL pw_create(tau1_r_pw(ispin)%pw, tau1_r(1)%pw%pw_grid, &
                               tau1_r(1)%pw%in_use, tau1_r(1)%pw%in_space)
                CALL pw_transfer(tau1_r(1)%pw, tau1_r_pw(ispin)%pw)

--- a/src/qs_ks_apply_restraints.F
+++ b/src/qs_ks_apply_restraints.F
@@ -83,6 +83,7 @@ CONTAINS
             IF (cdft_control%need_pot) THEN
                ! First SCF iteraration => allocate storage
                DO igroup = 1, SIZE(cdft_control%group)
+                  ALLOCATE (cdft_control%group(igroup)%weight%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%weight%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   ! Sanity check
@@ -95,6 +96,7 @@ CONTAINS
                   IF (.NOT. ASSOCIATED(cdft_control%charge)) &
                      ALLOCATE (cdft_control%charge(cdft_control%natoms))
                   DO iatom = 1, cdft_control%natoms
+                     ALLOCATE (cdft_control%charge(iatom)%pw)
                      CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%charge(iatom)%pw, &
                                             use_data=REALDATA3D, in_space=REALSPACE)
                   END DO

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -491,7 +491,7 @@ CONTAINS
                                                  qs_env=qs_env)
                IF (calculate_forces) THEN
                   CALL integrate_potential_devga_rspace( &
-                     potential=v_hartree_rspace, coeff=qs_env%image_coeff, &
+                     potential=v_hartree_rspace%pw, coeff=qs_env%image_coeff, &
                      forces=qs_env%qmmm_env_qm%image_charge_pot%image_forcesMM, &
                      qmmm_env=qs_env%qmmm_env_qm, qs_env=qs_env)
                END IF
@@ -616,14 +616,14 @@ CONTAINS
       IF (do_ppl .AND. calculate_forces) THEN
          CPASSERT(.NOT. gapw)
          DO ispin = 1, nspins
-            CALL integrate_ppl_rspace(rho_r(ispin), qs_env)
+            CALL integrate_ppl_rspace(rho_r(ispin)%pw, qs_env)
          END DO
       END IF
 
       IF (ASSOCIATED(rho_nlcc) .AND. calculate_forces) THEN
          DO ispin = 1, nspins
-            CALL integrate_rho_nlcc(v_rspace_new(ispin), qs_env)
-            IF (dft_control%do_admm) CALL integrate_rho_nlcc(v_rspace_new_aux_fit(ispin), qs_env)
+            CALL integrate_rho_nlcc(v_rspace_new(ispin)%pw, qs_env)
+            IF (dft_control%do_admm) CALL integrate_rho_nlcc(v_rspace_new_aux_fit(ispin)%pw, qs_env)
          END DO
       END IF
 
@@ -650,11 +650,11 @@ CONTAINS
                CALL pw_pool_create_pw(auxbas_pw_pool, v_minus_veps%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(v_hartree_rspace%pw, v_minus_veps%pw)
                CALL pw_axpy(poisson_env%implicit_env%v_eps, v_minus_veps%pw, -v_hartree_rspace%pw%pw_grid%dvol)
-               CALL integrate_v_core_rspace(v_minus_veps, qs_env)
+               CALL integrate_v_core_rspace(v_minus_veps%pw, qs_env)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_minus_veps%pw)
                DEALLOCATE (v_minus_veps%pw)
             ELSE
-               CALL integrate_v_core_rspace(v_hartree_rspace, qs_env)
+               CALL integrate_v_core_rspace(v_hartree_rspace%pw, qs_env)
             END IF
          END IF
 
@@ -773,7 +773,7 @@ CONTAINS
             CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace, &
                                          v_qmmm=vee, scale=-1.0_dp)
          END IF
-         CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace, para_env, calculate_forces)
+         CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace%pw, para_env, calculate_forces)
       END IF
 
       IF (gapw .OR. gapw_xc) THEN

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -342,6 +342,7 @@ CONTAINS
       END IF
 
       ! Calculate the Hartree potential
+      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -374,6 +375,7 @@ CONTAINS
 
       IF (dft_control%do_sccs) THEN
          ! Self-consistent continuum solvation (SCCS) model
+         ALLOCATE (v_sccs_rspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
                                 v_sccs_rspace%pw, &
                                 use_data=REALDATA3D, &
@@ -423,6 +425,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
 
       IF (dft_control%apply_efield_field) THEN
+         ALLOCATE (v_efield_rspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
                                 v_efield_rspace%pw, &
                                 use_data=REALDATA3D, &
@@ -641,6 +644,7 @@ CONTAINS
             ! Getting nuclear force contribution from the core charge density
             IF ((poisson_env%parameters%solver .EQ. pw_poisson_implicit) .AND. &
                 (poisson_env%parameters%dielectric_params%dielec_core_correction)) THEN
+               ALLOCATE (v_minus_veps%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, v_minus_veps%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(v_hartree_rspace%pw, v_minus_veps%pw)
                CALL pw_axpy(poisson_env%implicit_env%v_eps, v_minus_veps%pw, -v_hartree_rspace%pw%pw_grid%dvol)

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -493,6 +493,7 @@ CONTAINS
                END IF
             END IF
             CALL pw_release(qs_env%ks_qmmm_env%v_metal_rspace%pw)
+            DEALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace%pw)
          END IF
          IF (.NOT. just_energy) THEN
             CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace, &

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -209,10 +209,11 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, v_rspace_embed, v_rspace_new, &
                                                             v_rspace_new_aux_fit, v_tau_rspace, &
                                                             v_tau_rspace_aux_fit
-      TYPE(pw_p_type), POINTER                           :: rho0_s_rs, rho_core, rho_nlcc, vee, &
+      TYPE(pw_p_type), POINTER                           :: rho0_s_rs, rho_core, rho_nlcc, &
                                                             vppl_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: vee
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_struct, rho_xc
@@ -459,14 +460,14 @@ CONTAINS
          ! Compute the energy due to the external potential
          ee_ener = 0.0_dp
          DO ispin = 1, nspins
-            ee_ener = ee_ener + pw_integral_ab(rho_r(ispin)%pw, vee%pw)
+            ee_ener = ee_ener + pw_integral_ab(rho_r(ispin)%pw, vee)
          END DO
          IF (.NOT. just_energy) THEN
             IF (gapw) THEN
                CALL get_qs_env(qs_env=qs_env, &
                                rho0_s_rs=rho0_s_rs)
                CPASSERT(ASSOCIATED(rho0_s_rs))
-               ee_ener = ee_ener + pw_integral_ab(rho0_s_rs%pw, vee%pw)
+               ee_ener = ee_ener + pw_integral_ab(rho0_s_rs%pw, vee)
             END IF
          END IF
          ! the sign accounts for the charge of the electrons
@@ -500,8 +501,8 @@ CONTAINS
             DEALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace%pw)
          END IF
          IF (.NOT. just_energy) THEN
-            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace, &
-                                         v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace, scale=1.0_dp)
+            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace%pw, &
+                                         v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace%pw, scale=1.0_dp)
          END IF
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
@@ -770,7 +771,7 @@ CONTAINS
       IF (gapw) THEN
          IF (dft_control%apply_external_potential) THEN
             ! Integrals of the Hartree potential with g0_soft
-            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace, &
+            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace%pw, &
                                          v_qmmm=vee, scale=-1.0_dp)
          END IF
          CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace%pw, para_env, calculate_forces)

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -423,6 +423,7 @@ CONTAINS
          END IF
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+      DEALLOCATE (v_hartree_gspace%pw)
 
       IF (dft_control%apply_efield_field) THEN
          ALLOCATE (v_efield_rspace%pw)
@@ -504,6 +505,7 @@ CONTAINS
          END IF
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+      DEALLOCATE (rho_tot_gspace%pw)
 
       ! calculate the density matrix for the fitted mo_coeffs
       IF (dft_control%do_admm) THEN
@@ -650,6 +652,7 @@ CONTAINS
                CALL pw_axpy(poisson_env%implicit_env%v_eps, v_minus_veps%pw, -v_hartree_rspace%pw%pw_grid%dvol)
                CALL integrate_v_core_rspace(v_minus_veps, qs_env)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_minus_veps%pw)
+               DEALLOCATE (v_minus_veps%pw)
             ELSE
                CALL integrate_v_core_rspace(v_hartree_rspace, qs_env)
             END IF
@@ -717,20 +720,24 @@ CONTAINS
 
       IF (dft_control%qs_control%ddapc_explicit_potential) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_r%pw)
+         DEALLOCATE (v_spin_ddapc_rest_r%pw)
       END IF
 
       IF (dft_control%apply_efield_field) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_efield_rspace%pw)
+         DEALLOCATE (v_efield_rspace%pw)
       END IF
 
       IF (calculate_forces .AND. dft_control%qs_control%cdft) THEN
          IF (.NOT. cdft_control%transfer_pot) THEN
             DO iatom = 1, SIZE(cdft_control%group)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight%pw)
+               DEALLOCATE (cdft_control%group(iatom)%weight%pw)
             END DO
             IF (cdft_control%atomic_charges) THEN
                DO iatom = 1, cdft_control%natoms
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%charge(iatom)%pw)
+                  DEALLOCATE (cdft_control%charge(iatom)%pw)
                END DO
                DEALLOCATE (cdft_control%charge)
             END IF
@@ -738,12 +745,15 @@ CONTAINS
                 cdft_control%becke_control%cavity_confine) THEN
                IF (.NOT. ASSOCIATED(cdft_control%becke_control%cavity_mat)) THEN
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%becke_control%cavity%pw)
+                  DEALLOCATE (cdft_control%becke_control%cavity%pw)
                ELSE
                   DEALLOCATE (cdft_control%becke_control%cavity_mat)
                END IF
             ELSE IF (cdft_control%type == outer_scf_hirshfeld_constraint) THEN
-               IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) &
+               IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) THEN
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
+                  DEALLOCATE (cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
+               END IF
             END IF
             IF (ASSOCIATED(cdft_control%charges_fragment)) DEALLOCATE (cdft_control%charges_fragment)
             cdft_control%save_pot = .FALSE.
@@ -754,6 +764,7 @@ CONTAINS
 
       IF (dft_control%do_sccs) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sccs_rspace%pw)
+         DEALLOCATE (v_sccs_rspace%pw)
       END IF
 
       IF (gapw) THEN

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -209,11 +209,10 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, v_rspace_embed, v_rspace_new, &
                                                             v_rspace_new_aux_fit, v_tau_rspace, &
                                                             v_tau_rspace_aux_fit
-      TYPE(pw_p_type), POINTER                           :: rho0_s_rs, rho_core, rho_nlcc, &
-                                                            vppl_rspace
+      TYPE(pw_p_type), POINTER                           :: rho_nlcc, vppl_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: vee
+      TYPE(pw_type), POINTER                             :: rho0_s_rs, rho_core, vee
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_struct, rho_xc
@@ -467,7 +466,7 @@ CONTAINS
                CALL get_qs_env(qs_env=qs_env, &
                                rho0_s_rs=rho0_s_rs)
                CPASSERT(ASSOCIATED(rho0_s_rs))
-               ee_ener = ee_ener + pw_integral_ab(rho0_s_rs%pw, vee)
+               ee_ener = ee_ener + pw_integral_ab(rho0_s_rs, vee)
             END IF
          END IF
          ! the sign accounts for the charge of the electrons
@@ -920,7 +919,7 @@ CONTAINS
       LOGICAL                                            :: my_skip
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g
-      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core
+      TYPE(pw_type), POINTER                             :: rho0_s_gs, rho_core
       TYPE(qs_charges_type), POINTER                     :: qs_charges
 
       my_skip = .FALSE.
@@ -936,12 +935,12 @@ CONTAINS
             NULLIFY (rho0_s_gs)
             CALL get_qs_env(qs_env=qs_env, rho0_s_gs=rho0_s_gs)
             CPASSERT(ASSOCIATED(rho0_s_gs))
-            CALL pw_copy(rho0_s_gs%pw, rho_tot_gspace)
+            CALL pw_copy(rho0_s_gs, rho_tot_gspace)
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
-               CALL pw_axpy(rho_core%pw, rho_tot_gspace)
+               CALL pw_axpy(rho_core, rho_tot_gspace)
             END IF
          ELSE
-            CALL pw_copy(rho_core%pw, rho_tot_gspace)
+            CALL pw_copy(rho_core, rho_tot_gspace)
          END IF
          DO ispin = 1, dft_control%nspins
             CALL pw_axpy(rho_g(ispin)%pw, rho_tot_gspace)

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -87,7 +87,8 @@ MODULE qs_ks_methods
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qmmm_image_charge,               ONLY: add_image_pot_to_hartree_pot,&
                                               calculate_image_pot,&
                                               integrate_potential_devga_rspace
@@ -357,7 +358,7 @@ CONTAINS
           (.NOT. gapw) .AND. (.NOT. gapw_xc) .AND. &
           (.NOT. (poisson_env%parameters%solver .EQ. pw_poisson_implicit))) THEN
          CALL pw_zero(rho_tot_gspace%pw)
-         CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho, skip_nuclear_density=.TRUE.)
+         CALL calc_rho_tot_gspace(rho_tot_gspace%pw, qs_env, rho, skip_nuclear_density=.TRUE.)
          CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, energy%e_hartree, &
                                v_hartree_gspace%pw)
          CALL pw_zero(rho_tot_gspace%pw)
@@ -365,7 +366,7 @@ CONTAINS
       END IF
 
       ! Get the total density in g-space [ions + electrons]
-      CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
+      CALL calc_rho_tot_gspace(rho_tot_gspace%pw, qs_env, rho)
 
       IF (my_print) THEN
          CALL print_densities(qs_env, rho)
@@ -893,7 +894,7 @@ CONTAINS
 !> \param skip_nuclear_density ...
 ! **************************************************************************************************
    SUBROUTINE calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho, skip_nuclear_density)
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_tot_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_tot_gspace
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_rho_type), POINTER                         :: rho
       LOGICAL, INTENT(IN), OPTIONAL                      :: skip_nuclear_density
@@ -918,21 +919,21 @@ CONTAINS
             NULLIFY (rho0_s_gs)
             CALL get_qs_env(qs_env=qs_env, rho0_s_gs=rho0_s_gs)
             CPASSERT(ASSOCIATED(rho0_s_gs))
-            CALL pw_copy(rho0_s_gs%pw, rho_tot_gspace%pw)
+            CALL pw_copy(rho0_s_gs%pw, rho_tot_gspace)
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
-               CALL pw_axpy(rho_core%pw, rho_tot_gspace%pw)
+               CALL pw_axpy(rho_core%pw, rho_tot_gspace)
             END IF
          ELSE
-            CALL pw_copy(rho_core%pw, rho_tot_gspace%pw)
+            CALL pw_copy(rho_core%pw, rho_tot_gspace)
          END IF
          DO ispin = 1, dft_control%nspins
-            CALL pw_axpy(rho_g(ispin)%pw, rho_tot_gspace%pw)
+            CALL pw_axpy(rho_g(ispin)%pw, rho_tot_gspace)
          END DO
          CALL get_qs_env(qs_env=qs_env, qs_charges=qs_charges)
-         qs_charges%total_rho_gspace = pw_integrate_function(rho_tot_gspace%pw, isign=-1)
+         qs_charges%total_rho_gspace = pw_integrate_function(rho_tot_gspace, isign=-1)
       ELSE
          DO ispin = 1, dft_control%nspins
-            CALL pw_axpy(rho_g(ispin)%pw, rho_tot_gspace%pw)
+            CALL pw_axpy(rho_g(ispin)%pw, rho_tot_gspace)
          END DO
       END IF
 

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -117,6 +117,7 @@ CONTAINS
       last_ks_qmmm_nr = last_ks_qmmm_nr + 1
       ks_qmmm_env%id_nr = last_ks_qmmm_nr
 
+      ALLOCATE (ks_qmmm_env%v_qmmm_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, ks_qmmm_env%v_qmmm_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -29,7 +29,8 @@ MODULE qs_ks_qmmm_methods
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
@@ -208,8 +209,7 @@ CONTAINS
 !> \author Teodoro Laino
 ! **************************************************************************************************
    SUBROUTINE qmmm_modify_hartree_pot(v_hartree, v_qmmm, scale)
-      TYPE(pw_p_type), INTENT(INOUT)                     :: v_hartree
-      TYPE(pw_p_type), INTENT(IN)                        :: v_qmmm
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree, v_qmmm
       REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qmmm_modify_hartree_pot'
@@ -219,8 +219,8 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      fac = v_qmmm%pw%pw_grid%dvol*scale
-      v_hartree%pw%cr3d = v_hartree%pw%cr3d + fac*v_qmmm%pw%cr3d
+      fac = v_qmmm%pw_grid%dvol*scale
+      v_hartree%cr3d = v_hartree%cr3d + fac*v_qmmm%cr3d
 
       CALL timestop(handle)
    END SUBROUTINE qmmm_modify_hartree_pot

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -165,7 +165,7 @@ CONTAINS
       INTEGER                                            :: handle, ispin, output_unit
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(pw_p_type), POINTER                           :: rho0_s_rs
+      TYPE(pw_type), POINTER                             :: rho0_s_rs
       TYPE(section_vals_type), POINTER                   :: input
 
       CALL timeset(routineN, handle)
@@ -190,7 +190,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, &
                          rho0_s_rs=rho0_s_rs)
          CPASSERT(ASSOCIATED(rho0_s_rs))
-         qmmm_energy = qmmm_energy + pw_integral_ab(rho0_s_rs%pw, v_qmmm%pw)
+         qmmm_energy = qmmm_energy + pw_integral_ab(rho0_s_rs, v_qmmm%pw)
       END IF
 
       CALL cp_print_key_finished_output(output_unit, logger, input, &

--- a/src/qs_ks_qmmm_types.F
+++ b/src/qs_ks_qmmm_types.F
@@ -89,6 +89,7 @@ CONTAINS
          IF (ks_qmmm_env%ref_count < 1) THEN
             CALL pw_env_get(ks_qmmm_env%pw_env, auxbas_pw_pool=pool)
             CALL pw_pool_give_back_pw(pool, ks_qmmm_env%v_qmmm_rspace%pw)
+            DEALLOCATE (ks_qmmm_env%v_qmmm_rspace%pw)
             CALL pw_env_release(ks_qmmm_env%pw_env)
             IF (ASSOCIATED(ks_qmmm_env%cube_info)) THEN
                DO i = 1, SIZE(ks_qmmm_env%cube_info)

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -707,8 +707,10 @@ CONTAINS
          ks_env%ref_count = ks_env%ref_count - 1
 
          IF (ks_env%ref_count < 1) THEN
-            IF (ASSOCIATED(ks_env%v_hartree_rspace)) &
+            IF (ASSOCIATED(ks_env%v_hartree_rspace)) THEN
                CALL pw_release(ks_env%v_hartree_rspace)
+               DEALLOCATE (ks_env%v_hartree_rspace)
+            END IF
             IF (ASSOCIATED(ks_env%matrix_ks_im)) &
                CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_im)
 
@@ -739,22 +741,27 @@ CONTAINS
 
             IF (ASSOCIATED(ks_env%rho_nlcc_g)) THEN
                CALL pw_release(ks_env%rho_nlcc_g%pw)
+               DEALLOCATE (ks_env%rho_nlcc_g%pw)
                DEALLOCATE (ks_env%rho_nlcc_g)
             END IF
             IF (ASSOCIATED(ks_env%rho_nlcc)) THEN
                CALL pw_release(ks_env%rho_nlcc%pw)
+               DEALLOCATE (ks_env%rho_nlcc%pw)
                DEALLOCATE (ks_env%rho_nlcc)
             END IF
             IF (ASSOCIATED(ks_env%rho_core)) THEN
                CALL pw_release(ks_env%rho_core%pw)
+               DEALLOCATE (ks_env%rho_core%pw)
                DEALLOCATE (ks_env%rho_core)
             END IF
             IF (ASSOCIATED(ks_env%vppl)) THEN
                CALL pw_release(ks_env%vppl%pw)
+               DEALLOCATE (ks_env%vppl%pw)
                DEALLOCATE (ks_env%vppl)
             END IF
             IF (ASSOCIATED(ks_env%vee)) THEN
                CALL pw_release(ks_env%vee%pw)
+               DEALLOCATE (ks_env%vee%pw)
                DEALLOCATE (ks_env%vee)
             END IF
             IF (ASSOCIATED(ks_env%dbcsr_dist)) THEN
@@ -806,8 +813,10 @@ CONTAINS
          CPASSERT(ks_env%ref_count > 0)
 
          IF (ks_env%ref_count == 1) THEN
-            IF (ASSOCIATED(ks_env%v_hartree_rspace)) &
+            IF (ASSOCIATED(ks_env%v_hartree_rspace)) THEN
                CALL pw_release(ks_env%v_hartree_rspace)
+               DEALLOCATE (ks_env%v_hartree_rspace)
+            END IF
             IF (ASSOCIATED(ks_env%matrix_ks_im)) &
                CALL dbcsr_deallocate_matrix_set(ks_env%matrix_ks_im)
 
@@ -834,22 +843,27 @@ CONTAINS
 
             IF (ASSOCIATED(ks_env%rho_nlcc_g)) THEN
                CALL pw_release(ks_env%rho_nlcc_g%pw)
+               DEALLOCATE (ks_env%rho_nlcc_g%pw)
                DEALLOCATE (ks_env%rho_nlcc_g)
             END IF
             IF (ASSOCIATED(ks_env%rho_nlcc)) THEN
                CALL pw_release(ks_env%rho_nlcc%pw)
+               DEALLOCATE (ks_env%rho_nlcc%pw)
                DEALLOCATE (ks_env%rho_nlcc)
             END IF
             IF (ASSOCIATED(ks_env%rho_core)) THEN
                CALL pw_release(ks_env%rho_core%pw)
+               DEALLOCATE (ks_env%rho_core%pw)
                DEALLOCATE (ks_env%rho_core)
             END IF
             IF (ASSOCIATED(ks_env%vppl)) THEN
                CALL pw_release(ks_env%vppl%pw)
+               DEALLOCATE (ks_env%vppl%pw)
                DEALLOCATE (ks_env%vppl)
             END IF
             IF (ASSOCIATED(ks_env%vee)) THEN
                CALL pw_release(ks_env%vee%pw)
+               DEALLOCATE (ks_env%vee%pw)
                DEALLOCATE (ks_env%vee)
             END IF
 

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -169,8 +169,9 @@ MODULE qs_ks_types
       TYPE(pw_p_type), POINTER                              :: rho_core => Null(), &
                                                                vppl => Null(), &
                                                                rho_nlcc => Null(), &
-                                                               rho_nlcc_g => Null(), &
-                                                               vee => Null()
+                                                               rho_nlcc_g => Null()
+
+      TYPE(pw_type), POINTER :: vee => NULL()
 
       INTEGER                                               :: neighbor_list_id = -1
       TYPE(neighbor_list_set_p_type), DIMENSION(:), POINTER :: sab_orb => Null(), &
@@ -351,7 +352,8 @@ CONTAINS
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho, rho_buffer, rho_xc
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g, vee
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g
+      TYPE(pw_type), OPTIONAL, POINTER                   :: vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
          sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, sab_se, sab_xtbe, sab_tbe, sab_core, &
@@ -574,7 +576,8 @@ CONTAINS
                                                             matrix_vxc_kp, kinetic_kp, &
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g, vee
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g
+      TYPE(pw_type), OPTIONAL, POINTER                   :: vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
@@ -760,8 +763,7 @@ CONTAINS
                DEALLOCATE (ks_env%vppl)
             END IF
             IF (ASSOCIATED(ks_env%vee)) THEN
-               CALL pw_release(ks_env%vee%pw)
-               DEALLOCATE (ks_env%vee%pw)
+               CALL pw_release(ks_env%vee)
                DEALLOCATE (ks_env%vee)
             END IF
             IF (ASSOCIATED(ks_env%dbcsr_dist)) THEN
@@ -862,8 +864,7 @@ CONTAINS
                DEALLOCATE (ks_env%vppl)
             END IF
             IF (ASSOCIATED(ks_env%vee)) THEN
-               CALL pw_release(ks_env%vee%pw)
-               DEALLOCATE (ks_env%vee%pw)
+               CALL pw_release(ks_env%vee)
                DEALLOCATE (ks_env%vee)
             END IF
 

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -166,12 +166,12 @@ MODULE qs_ks_types
                                                                rho_buffer => Null(), &
                                                                rho_xc => Null()
 
-      TYPE(pw_p_type), POINTER                              :: rho_core => Null(), &
-                                                               vppl => Null(), &
+      TYPE(pw_p_type), POINTER                              :: vppl => Null(), &
                                                                rho_nlcc => Null(), &
                                                                rho_nlcc_g => Null()
 
-      TYPE(pw_type), POINTER :: vee => NULL()
+      TYPE(pw_type), POINTER :: rho_core => NULL(), &
+                                vee => NULL()
 
       INTEGER                                               :: neighbor_list_id = -1
       TYPE(neighbor_list_set_p_type), DIMENSION(:), POINTER :: sab_orb => Null(), &
@@ -352,7 +352,9 @@ CONTAINS
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho, rho_buffer, rho_xc
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_nlcc, rho_nlcc_g
       TYPE(pw_type), OPTIONAL, POINTER                   :: vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
@@ -576,7 +578,9 @@ CONTAINS
                                                             matrix_vxc_kp, kinetic_kp, &
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl, rho_core, rho_nlcc, rho_nlcc_g
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core
+      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_nlcc, rho_nlcc_g
       TYPE(pw_type), OPTIONAL, POINTER                   :: vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
@@ -753,8 +757,7 @@ CONTAINS
                DEALLOCATE (ks_env%rho_nlcc)
             END IF
             IF (ASSOCIATED(ks_env%rho_core)) THEN
-               CALL pw_release(ks_env%rho_core%pw)
-               DEALLOCATE (ks_env%rho_core%pw)
+               CALL pw_release(ks_env%rho_core)
                DEALLOCATE (ks_env%rho_core)
             END IF
             IF (ASSOCIATED(ks_env%vppl)) THEN
@@ -854,8 +857,7 @@ CONTAINS
                DEALLOCATE (ks_env%rho_nlcc)
             END IF
             IF (ASSOCIATED(ks_env%rho_core)) THEN
-               CALL pw_release(ks_env%rho_core%pw)
-               DEALLOCATE (ks_env%rho_core%pw)
+               CALL pw_release(ks_env%rho_core)
                DEALLOCATE (ks_env%rho_core)
             END IF
             IF (ASSOCIATED(ks_env%vppl)) THEN

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -340,7 +340,7 @@ CONTAINS
                                        vxc(ispin)%pw%cr3d
                ! zero first ?!
                CALL dbcsr_set(matrix_h(ispin)%matrix, 0.0_dp)
-               CALL integrate_v_rspace(v_rspace=work_v_rspace, pmat=matrix_p(ispin), hmat=matrix_h(ispin), &
+               CALL integrate_v_rspace(v_rspace=work_v_rspace%pw, pmat=matrix_p(ispin), hmat=matrix_h(ispin), &
                                        qs_env=qs_env, calculate_forces=calculate_forces)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc(ispin)%pw)
                DEALLOCATE (vxc(ispin)%pw)
@@ -646,7 +646,7 @@ CONTAINS
 
          IF (.NOT. just_energy) THEN
             ! note, orb_h (which is being pointed to with orb_h_p) is zeroed above
-            CALL integrate_v_rspace(v_rspace=work_v_rspace, pmat=orb_density_matrix_p, hmat=orb_h_p, &
+            CALL integrate_v_rspace(v_rspace=work_v_rspace%pw, pmat=orb_density_matrix_p, hmat=orb_h_p, &
                                     qs_env=qs_env, calculate_forces=calculate_forces)
 
             ! add this to the mo_derivs
@@ -1161,7 +1161,7 @@ CONTAINS
       CALL get_qs_env(qs_env, dft_control=dft_control)
       gapw = dft_control%qs_control%gapw .OR. dft_control%qs_control%gapw_xc
       DO ispin = 1, SIZE(matrix_ks)
-         CALL integrate_v_rspace(v_rspace=v_rspace(ispin), &
+         CALL integrate_v_rspace(v_rspace=v_rspace(ispin)%pw, &
                                  hmat=matrix_vxc(ispin), &
                                  qs_env=qs_env, &
                                  calculate_forces=.FALSE., &
@@ -1292,7 +1292,7 @@ CONTAINS
                ! add the xc  part due to v_rspace soft
                rho_ao => rho_ao_kp(ispin, :)
                ksmat => ks_matrix(ispin, :)
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat_kp=rho_ao, hmat_kp=ksmat, &
                                        qs_env=qs_env, &
                                        calculate_forces=calculate_forces, &
@@ -1405,7 +1405,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace_new(ispin), qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace_new(ispin)%pw, qs_env, &
                                                   lri_v_int, calculate_forces, "LRI_AUX")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -1413,7 +1413,7 @@ CONTAINS
                IF (lri_env%exact_1c_terms) THEN
                   rho_ao => my_rho(ispin, :)
                   ksmat => ks_matrix(ispin, :)
-                  CALL integrate_v_rspace_diagonal(v_rspace_new(ispin), ksmat(1)%matrix, &
+                  CALL integrate_v_rspace_diagonal(v_rspace_new(ispin)%pw, ksmat(1)%matrix, &
                                                    rho_ao(1)%matrix, qs_env, &
                                                    calculate_forces, "ORB")
                END IF
@@ -1426,7 +1426,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace_new(ispin), qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace_new(ispin)%pw, qs_env, &
                                                   lri_v_int, calculate_forces, "RI_HXC")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -1434,7 +1434,7 @@ CONTAINS
             ELSE
                rho_ao => my_rho(ispin, :)
                ksmat => ks_matrix(ispin, :)
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat_kp=rho_ao, hmat_kp=ksmat, &
                                        qs_env=qs_env, &
                                        calculate_forces=calculate_forces, &
@@ -1484,7 +1484,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace, qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace%pw, qs_env, &
                                                   lri_v_int, calculate_forces, "LRI_AUX")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -1492,7 +1492,7 @@ CONTAINS
                IF (lri_env%exact_1c_terms) THEN
                   rho_ao => my_rho(ispin, :)
                   ksmat => ks_matrix(ispin, :)
-                  CALL integrate_v_rspace_diagonal(v_rspace, ksmat(1)%matrix, &
+                  CALL integrate_v_rspace_diagonal(v_rspace%pw, ksmat(1)%matrix, &
                                                    rho_ao(1)%matrix, qs_env, &
                                                    calculate_forces, "ORB")
                END IF
@@ -1505,7 +1505,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace, qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace%pw, qs_env, &
                                                   lri_v_int, calculate_forces, "RI_HXC")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -1513,7 +1513,7 @@ CONTAINS
             ELSE
                rho_ao => my_rho(ispin, :)
                ksmat => ks_matrix(ispin, :)
-               CALL integrate_v_rspace(v_rspace=v_rspace, &
+               CALL integrate_v_rspace(v_rspace=v_rspace%pw, &
                                        pmat_kp=rho_ao, &
                                        hmat_kp=ksmat, &
                                        qs_env=qs_env, &
@@ -1559,7 +1559,7 @@ CONTAINS
 
             rho_ao => rho_ao_kp(ispin, :)
             ksmat => ks_matrix(ispin, :)
-            CALL integrate_v_rspace(v_rspace=v_tau_rspace(ispin), &
+            CALL integrate_v_rspace(v_rspace=v_tau_rspace(ispin)%pw, &
                                     pmat_kp=rho_ao, hmat_kp=ksmat, &
                                     qs_env=qs_env, &
                                     calculate_forces=calculate_forces, compute_tau=.TRUE., &
@@ -1599,7 +1599,7 @@ CONTAINS
                      basis_type = "AUX_FIT_SOFT"
                   END IF
 
-                  CALL integrate_v_rspace(v_rspace=v_rspace_new_aux_fit(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_rspace_new_aux_fit(ispin)%pw, &
                                           pmat=rho_ao_aux(ispin), &
                                           hmat=matrix_ks_aux_fit(ispin), &
                                           qs_env=qs_env, &

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -276,6 +276,7 @@ CONTAINS
       ALLOCATE (rho_r(Nspin))
       ALLOCATE (rho_g(Nspin))
       DO ispin = 1, Nspin
+         ALLOCATE (rho_r(ispin)%pw, rho_g(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(ispin)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -283,6 +284,7 @@ CONTAINS
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
+      ALLOCATE (work_v_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, work_v_rspace%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -540,6 +542,7 @@ CONTAINS
       END SELECT
 
       ! data needed for each of the orbs
+      ALLOCATE (orb_rho_r%pw, tmp_r%pw, orb_rho_g%pw, tmp_g%pw, work_v_gspace%pw, work_v_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, orb_rho_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -597,13 +600,6 @@ CONTAINS
       CALL pw_zero(tmp_g%pw)
 
       NULLIFY (vxc)
-      ! ALLOCATE(vxc(2),stat=stat)
-      ! CPPostcondition(stat==0,cp_failure_level,routineP,failure)
-      ! CALL pw_pool_create_pw(xc_pw_pool,vxc(1)%pw,&
-      !         in_space=REALSPACE, use_data=REALDATA3D)
-      ! CALL pw_pool_create_pw(xc_pw_pool,vxc(2)%pw,&
-      !         in_space=REALSPACE, use_data=REALDATA3D)
-
       ! now apply to SIC correction to each selected orbital
       DO iorb = 1, Norb
          ! extract the proper orbital from the mo_coeff
@@ -738,6 +734,7 @@ CONTAINS
       ! OK, right now we like two spins to do sic, could be relaxed for AD
       CPASSERT(dft_control%nspins == 2)
 
+      ALLOCATE (work_rho%pw, work_v%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, work_rho%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -813,6 +810,7 @@ CONTAINS
       END IF
 
       IF (.NOT. just_energy) THEN
+         ALLOCATE (v_sic_rspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_sic_rspace%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(work_v%pw, v_sic_rspace%pw)
@@ -1647,7 +1645,7 @@ CONTAINS
 
       CHARACTER(*), PARAMETER :: routineN = 'calculate_zmp_potential'
 
-      INTEGER                                            :: handle, my_val, nelectron, nspins, stat
+      INTEGER                                            :: handle, my_val, nelectron, nspins
       INTEGER, DIMENSION(2)                              :: nelectron_spin
       LOGICAL                                            :: do_zmp_read, fermi_amaldi
       REAL(KIND=dp)                                      :: factor, lambda
@@ -1682,8 +1680,8 @@ CONTAINS
                       poisson_env=poisson_env)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_g=rho_g)
       nspins = 1
-      ALLOCATE (v_rspace_new(nspins), stat=stat)
-      CPASSERT(stat == 0)
+      ALLOCATE (v_rspace_new(nspins))
+      ALLOCATE (v_rspace_new(1)%pw, v_xc_rspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_rspace_new(1)%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_xc_rspace%pw, &
@@ -1697,6 +1695,7 @@ CONTAINS
          exc = accurate_dot_product(v_rspace_new(1)%pw%cr3d, rho_r(1)%pw%cr3d)* &
                v_rspace_new(1)%pw%pw_grid%dvol
       ELSE
+         ALLOCATE (rho_eff_gspace%pw, v_xc_gspace%pw)
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                 pw=rho_eff_gspace%pw, &
                                 use_data=COMPLEXDATA1D, &
@@ -1796,6 +1795,7 @@ CONTAINS
       embed_corr = 0.0_dp
 
       DO ispin = 1, dft_control%nspins
+         ALLOCATE (v_rspace_embed(ispin)%pw)
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_rspace_embed(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(v_rspace_embed(ispin)%pw)

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -343,6 +343,7 @@ CONTAINS
                CALL integrate_v_rspace(v_rspace=work_v_rspace, pmat=matrix_p(ispin), hmat=matrix_h(ispin), &
                                        qs_env=qs_env, calculate_forces=calculate_forces)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc(ispin)%pw)
+               DEALLOCATE (vxc(ispin)%pw)
             END DO
             DEALLOCATE (vxc)
 
@@ -365,12 +366,14 @@ CONTAINS
       DO ispin = 1, Nspin
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g(ispin)%pw)
+         DEALLOCATE (rho_r(ispin)%pw, rho_g(ispin)%pw)
       END DO
       DEALLOCATE (rho_r, rho_g)
       CALL dbcsr_deallocate_matrix_set(matrix_p)
       CALL dbcsr_deallocate_matrix_set(matrix_h)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace%pw)
+      DEALLOCATE (work_v_rspace%pw)
 
       CALL dbcsr_release_p(fm_deriv)
       CALL dbcsr_release_p(fm_scaled)
@@ -659,6 +662,7 @@ CONTAINS
             ! need to deallocate vxc
             CALL pw_pool_give_back_pw(xc_pw_pool, vxc(1)%pw)
             CALL pw_pool_give_back_pw(xc_pw_pool, vxc(2)%pw)
+            DEALLOCATE (vxc(1)%pw, vxc(2)%pw)
             DEALLOCATE (vxc)
 
          END IF
@@ -671,6 +675,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace%pw)
+      DEALLOCATE (orb_rho_r%pw, tmp_r%pw, orb_rho_g%pw, tmp_g%pw, work_v_gspace%pw, work_v_rspace%pw)
 
       CALL dbcsr_deallocate_matrix(orb_density_matrix)
       CALL dbcsr_deallocate_matrix(orb_h)
@@ -821,6 +826,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, work_rho%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v%pw)
+      DEALLOCATE (work_rho%pw, work_v%pw)
 
    END SUBROUTINE calc_v_sic_rspace
 
@@ -1391,6 +1397,7 @@ CONTAINS
                                              v_rspace_embed(ispin)%pw%pw_grid%dvol* &
                                              v_rspace_embed(ispin)%pw%cr3d
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin)%pw)
+               DEALLOCATE (v_rspace_embed(ispin)%pw)
             END IF
             IF (lrigpw) THEN
                lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
@@ -1434,12 +1441,14 @@ CONTAINS
                                        gapw=gapw)
             END IF
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin)%pw)
+            DEALLOCATE (v_rspace_new(ispin)%pw)
          END DO ! ispin
 
          SELECT CASE (dft_control%sic_method_id)
          CASE (sic_none)
          CASE (sic_mauri_us, sic_mauri_spz, sic_ad)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sic_rspace%pw)
+            DEALLOCATE (v_sic_rspace%pw)
          END SELECT
          DEALLOCATE (v_rspace_new)
 
@@ -1467,6 +1476,7 @@ CONTAINS
                                   v_rspace_embed(ispin)%pw%pw_grid%dvol* &
                                   v_rspace_embed(ispin)%pw%cr3d
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin)%pw)
+               DEALLOCATE (v_rspace_embed(ispin)%pw)
             END IF
             IF (lrigpw) THEN
                lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
@@ -1555,6 +1565,7 @@ CONTAINS
                                     calculate_forces=calculate_forces, compute_tau=.TRUE., &
                                     gapw=gapw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
+            DEALLOCATE (v_tau_rspace(ispin)%pw)
          END DO
          DEALLOCATE (v_tau_rspace)
       END IF
@@ -1605,6 +1616,7 @@ CONTAINS
                               matrix_ks_aux_fit(ispin)%matrix, 1.0_dp, -1.0_dp)
 
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new_aux_fit(ispin)%pw)
+               DEALLOCATE (v_rspace_new_aux_fit(ispin)%pw)
             END DO
             DEALLOCATE (v_rspace_new_aux_fit)
          END IF
@@ -1612,6 +1624,7 @@ CONTAINS
          IF (ASSOCIATED(v_tau_rspace_aux_fit)) THEN
             DO ispin = 1, nspins
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace_aux_fit(ispin)%pw)
+               DEALLOCATE (v_tau_rspace_aux_fit(ispin)%pw)
             END DO
             DEALLOCATE (v_tau_rspace_aux_fit)
          END IF
@@ -1745,9 +1758,11 @@ CONTAINS
                                    rho_eff_gspace%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, &
                                    v_xc_gspace%pw)
+         DEALLOCATE (rho_eff_gspace%pw, v_xc_gspace%pw)
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rspace%pw)
+      DEALLOCATE (v_xc_rspace%pw)
 
       CALL timestop(handle)
 
@@ -1831,6 +1846,7 @@ CONTAINS
       IF (just_energy) THEN
          DO ispin = 1, dft_control%nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin)%pw)
+            DEALLOCATE (v_rspace_embed(ispin)%pw)
          END DO
          DEALLOCATE (v_rspace_embed)
       END IF

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -312,7 +312,7 @@ CONTAINS
                                 0.0_dp, matrix_p(ispin)%matrix, retain_sparsity=.TRUE.)
             ! compute the densities on the grid
             CALL calculate_rho_elec(matrix_p=matrix_p(ispin)%matrix, &
-                                    rho=rho_r(ispin), rho_gspace=rho_g(ispin), &
+                                    rho=rho_r(ispin)%pw, rho_gspace=rho_g(ispin)%pw, &
                                     ks_env=ks_env)
          END DO
 
@@ -616,7 +616,7 @@ CONTAINS
                                     alpha=1.0_dp)
 
          CALL calculate_rho_elec(matrix_p=orb_density_matrix, &
-                                 rho=orb_rho_r, rho_gspace=orb_rho_g, &
+                                 rho=orb_rho_r%pw, rho_gspace=orb_rho_g%pw, &
                                  ks_env=ks_env)
 
          ! compute the energy functional for this orbital and its derivative

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -99,7 +99,8 @@ MODULE qs_ks_utils
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_cdft_types,                   ONLY: cdft_control_type
    USE qs_charges_types,                ONLY: qs_charges_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
@@ -1131,7 +1132,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE compute_matrix_vxc(qs_env, v_rspace, matrix_vxc)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_rspace
+      TYPE(pw_p_type), DIMENSION(:), INTENT(IN)          :: v_rspace
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_vxc
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_matrix_vxc'
@@ -1240,10 +1241,9 @@ CONTAINS
       TYPE(lri_environment_type), POINTER                :: lri_env
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri_v_int
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_rspace
-      TYPE(pw_p_type), POINTER                           :: vee
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: v_rspace, vee
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_aux_fit
       TYPE(task_list_type), POINTER                      :: task_list
@@ -1251,14 +1251,14 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (auxbas_pw_pool, dft_control, pw_env, matrix_ks_aux_fit, &
-               v_rspace%pw, rho_aux_fit, vee, rho_ao, rho_ao_kp, rho_ao_aux, &
+               v_rspace, rho_aux_fit, vee, rho_ao, rho_ao_kp, rho_ao_aux, &
                ksmat, matrix_ks_aux_fit_dft, lri_env, lri_density, atomic_kind_set, &
                rho_ao_nokp, ks_env, admm_env, task_list)
 
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
                       pw_env=pw_env, &
-                      v_hartree_rspace=v_rspace%pw, &
+                      v_hartree_rspace=v_rspace, &
                       vee=vee)
 
       CALL qs_rho_get(rho, rho_ao_kp=rho_ao_kp)
@@ -1299,12 +1299,12 @@ CONTAINS
                                        gapw=gapw_xc)
 
                ! Now the Hartree potential to be integrated with the full basis
-               v_rspace_new(ispin)%pw%cr3d = v_rspace%pw%cr3d
+               v_rspace_new(ispin)%pw%cr3d = v_rspace%cr3d
             ELSE
                ! Add v_hartree + v_xc = v_rspace_new
                v_rspace_new(ispin)%pw%cr3d = &
                   v_rspace_new(ispin)%pw%pw_grid%dvol* &
-                  v_rspace_new(ispin)%pw%cr3d + v_rspace%pw%cr3d
+                  v_rspace_new(ispin)%pw%cr3d + v_rspace%cr3d
             END IF ! gapw_xc
             IF (dft_control%qs_control%ddapc_explicit_potential) THEN
                IF (dft_control%qs_control%ddapc_restraint_is_spin) THEN
@@ -1366,7 +1366,7 @@ CONTAINS
             END IF
             ! External electrostatic potential
             IF (dft_control%apply_external_potential) THEN
-               CALL qmmm_modify_hartree_pot(v_hartree=v_rspace_new(ispin), &
+               CALL qmmm_modify_hartree_pot(v_hartree=v_rspace_new(ispin)%pw, &
                                             v_qmmm=vee, scale=-1.0_dp)
             END IF
             IF (do_ppl) THEN
@@ -1459,22 +1459,22 @@ CONTAINS
          DO ispin = 1, nspins
             ! the efield contribution
             IF (dft_control%apply_efield_field) THEN
-               v_rspace%pw%cr3d = v_rspace%pw%cr3d + v_efield_rspace%pw%cr3d
+               v_rspace%cr3d = v_rspace%cr3d + v_efield_rspace%pw%cr3d
             END IF
             ! extra contribution attributed to the dependency of the dielectric constant to the charge density
             IF (poisson_env%parameters%solver .EQ. pw_poisson_implicit) THEN
                dvol = poisson_env%implicit_env%v_eps%pw_grid%dvol
-               v_rspace%pw%cr3d = v_rspace%pw%cr3d + poisson_env%implicit_env%v_eps%cr3d*dvol
+               v_rspace%cr3d = v_rspace%cr3d + poisson_env%implicit_env%v_eps%cr3d*dvol
             END IF
             ! Add SCCS contribution
             IF (dft_control%do_sccs) THEN
-               v_rspace%pw%cr3d = v_rspace%pw%cr3d + v_sccs_rspace%pw%cr3d
+               v_rspace%cr3d = v_rspace%cr3d + v_sccs_rspace%pw%cr3d
             END IF
             ! DFT embedding
             IF (dft_control%apply_embed_pot) THEN
-               v_rspace%pw%cr3d = v_rspace%pw%cr3d + &
-                                  v_rspace_embed(ispin)%pw%pw_grid%dvol* &
-                                  v_rspace_embed(ispin)%pw%cr3d
+               v_rspace%cr3d = v_rspace%cr3d + &
+                               v_rspace_embed(ispin)%pw%pw_grid%dvol* &
+                               v_rspace_embed(ispin)%pw%cr3d
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin)%pw)
                DEALLOCATE (v_rspace_embed(ispin)%pw)
             END IF
@@ -1484,7 +1484,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace%pw, qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace, qs_env, &
                                                   lri_v_int, calculate_forces, "LRI_AUX")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -1492,7 +1492,7 @@ CONTAINS
                IF (lri_env%exact_1c_terms) THEN
                   rho_ao => my_rho(ispin, :)
                   ksmat => ks_matrix(ispin, :)
-                  CALL integrate_v_rspace_diagonal(v_rspace%pw, ksmat(1)%matrix, &
+                  CALL integrate_v_rspace_diagonal(v_rspace, ksmat(1)%matrix, &
                                                    rho_ao(1)%matrix, qs_env, &
                                                    calculate_forces, "ORB")
                END IF
@@ -1505,7 +1505,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace%pw, qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace, qs_env, &
                                                   lri_v_int, calculate_forces, "RI_HXC")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -1513,7 +1513,7 @@ CONTAINS
             ELSE
                rho_ao => my_rho(ispin, :)
                ksmat => ks_matrix(ispin, :)
-               CALL integrate_v_rspace(v_rspace=v_rspace%pw, &
+               CALL integrate_v_rspace(v_rspace=v_rspace, &
                                        pmat_kp=rho_ao, &
                                        hmat_kp=ksmat, &
                                        qs_env=qs_env, &

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -514,6 +514,7 @@ CONTAINS
          END DO
          !
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
+         DEALLOCATE (wf_r%pw)
       END IF ! current cube
       !
       ! Integrated current response checksum

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -1238,7 +1238,7 @@ CONTAINS
       IF (ASSOCIATED(atom_pair_send)) DEALLOCATE (atom_pair_send)
       IF (ASSOCIATED(atom_pair_recv)) DEALLOCATE (atom_pair_recv)
 
-      CALL density_rs2pw(pw_env, rs_current, current_rs, current_gs)
+      CALL density_rs2pw(pw_env, rs_current, current_rs%pw, current_gs%pw)
 
       IF (ASSOCIATED(rs_rho) .AND. .NOT. my_retain_rsgrid) THEN
          DO i = 1, SIZE(rs_rho)

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -88,7 +88,8 @@ MODULE qs_linres_current
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_kind_types,                   ONLY: get_qs_kind,&
@@ -213,10 +214,9 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: jrho1_g, jrho1_r
-      TYPE(pw_p_type), POINTER                           :: jrho_gspace, jrho_rspace
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_matrix_pools_type), POINTER                :: mpools
       TYPE(qs_subsys_type), POINTER                      :: subsys
@@ -225,7 +225,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       !
-      NULLIFY (jrho_rspace, jrho_gspace, logger, current_section, density_matrix0, density_matrix_a, &
+      NULLIFY (logger, current_section, density_matrix0, density_matrix_a, &
                density_matrix_ii, density_matrix_iii, cell, dft_control, mos, &
                particle_set, pw_env, auxbas_rs_desc, auxbas_pw_pool, &
                para_env, center_list, mo_coeff, psi_a_iB, jrho1_r, jrho1_g, &
@@ -412,23 +412,23 @@ CONTAINS
             ! Use the qs_rho_type already  used for rho during the scf
             CALL qs_rho_get(current_env%jrho1_set(idir)%rho, rho_r=jrho1_r)
             CALL qs_rho_get(current_env%jrho1_set(idir)%rho, rho_g=jrho1_g)
-            jrho_rspace => jrho1_r(ispin)
-            jrho_gspace => jrho1_g(ispin)
-            CALL pw_zero(jrho_rspace%pw)
-            CALL pw_zero(jrho_gspace%pw)
-            CALL calculate_jrho_resp(density_matrix0(ispin)%matrix, &
-                                     density_matrix_a(ispin)%matrix, &
-                                     density_matrix_ii(ispin)%matrix, &
-                                     density_matrix_iii(ispin)%matrix, &
-                                     iB, idir, jrho_rspace, jrho_gspace, qs_env, &
-                                     current_env, gapw)
+            ASSOCIATE (jrho_rspace => jrho1_r(ispin), jrho_gspace => jrho1_g(ispin))
+               CALL pw_zero(jrho_rspace%pw)
+               CALL pw_zero(jrho_gspace%pw)
+               CALL calculate_jrho_resp(density_matrix0(ispin)%matrix, &
+                                        density_matrix_a(ispin)%matrix, &
+                                        density_matrix_ii(ispin)%matrix, &
+                                        density_matrix_iii(ispin)%matrix, &
+                                        iB, idir, jrho_rspace%pw, jrho_gspace%pw, qs_env, &
+                                        current_env, gapw)
 
-            scale_fac = cell%deth/twopi
-            CALL pw_scale(jrho_rspace%pw, scale_fac)
-            CALL pw_scale(jrho_gspace%pw, scale_fac)
+               scale_fac = cell%deth/twopi
+               CALL pw_scale(jrho_rspace%pw, scale_fac)
+               CALL pw_scale(jrho_gspace%pw, scale_fac)
 
-            jrho_tot_G(idir, iB) = pw_integrate_function(jrho_gspace%pw, isign=-1)
-            jrho_tot_R(idir, iB) = pw_integrate_function(jrho_rspace%pw, isign=-1)
+               jrho_tot_G(idir, iB) = pw_integrate_function(jrho_gspace%pw, isign=-1)
+               jrho_tot_R(idir, iB) = pw_integrate_function(jrho_rspace%pw, isign=-1)
+            END ASSOCIATE
 
             IF (output_unit > 0) THEN
                WRITE (output_unit, '(T2,2(A,E24.16))') 'Integrated j_'&
@@ -479,15 +479,14 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_rs_desc=auxbas_rs_desc, &
                          auxbas_pw_pool=auxbas_pw_pool)
          !
-         ALLOCATE (wf_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, use_data=REALDATA3D, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          !
          DO idir = 1, 3
-            CALL pw_zero(wf_r%pw)
+            CALL pw_zero(wf_r)
             CALL qs_rho_get(current_env%jrho1_set(idir)%rho, rho_r=jrho1_r)
             DO ispin = 1, nspins
-               CALL pw_axpy(jrho1_r(ispin)%pw, wf_r%pw, 1.0_dp)
+               CALL pw_axpy(jrho1_r(ispin)%pw, wf_r, 1.0_dp)
             END DO
             !
             IF (gapw) THEN
@@ -505,7 +504,7 @@ CONTAINS
                                            log_filename=.FALSE., file_position=my_pos, &
                                            mpi_io=mpi_io)
 
-            CALL cp_pw_to_cube(wf_r%pw, unit_nr, "RESPONSE CURRENT DENSITY ", &
+            CALL cp_pw_to_cube(wf_r, unit_nr, "RESPONSE CURRENT DENSITY ", &
                                particles=particles, &
                                stride=section_get_ivals(current_section, "PRINT%CURRENT_CUBES%STRIDE"), &
                                mpi_io=mpi_io)
@@ -513,8 +512,7 @@ CONTAINS
                  &                            "PRINT%CURRENT_CUBES", mpi_io=mpi_io)
          END DO
          !
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-         DEALLOCATE (wf_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
       END IF ! current cube
       !
       ! Integrated current response checksum
@@ -586,7 +584,7 @@ CONTAINS
 
       TYPE(dbcsr_type), POINTER                          :: mat_d0, mat_jp, mat_jp_rii, mat_jp_riii
       INTEGER, INTENT(IN)                                :: iB, idir
-      TYPE(pw_p_type), INTENT(INOUT)                     :: current_rs, current_gs
+      TYPE(pw_type), INTENT(INOUT)                       :: current_rs, current_gs
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(current_env_type)                             :: current_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: soft_valid, retain_rsgrid
@@ -1240,7 +1238,7 @@ CONTAINS
       IF (ASSOCIATED(atom_pair_send)) DEALLOCATE (atom_pair_send)
       IF (ASSOCIATED(atom_pair_recv)) DEALLOCATE (atom_pair_recv)
 
-      CALL density_rs2pw(pw_env, rs_current, current_rs%pw, current_gs%pw)
+      CALL density_rs2pw(pw_env, rs_current, current_rs, current_gs)
 
       IF (ASSOCIATED(rs_rho) .AND. .NOT. my_retain_rsgrid) THEN
          DO i = 1, SIZE(rs_rho)

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -479,6 +479,7 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_rs_desc=auxbas_rs_desc, &
                          auxbas_pw_pool=auxbas_pw_pool)
          !
+         ALLOCATE (wf_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          !

--- a/src/qs_linres_current_utils.F
+++ b/src/qs_linres_current_utils.F
@@ -1290,6 +1290,7 @@ CONTAINS
          NULLIFY (rho_r, rho_g)
          ALLOCATE (rho_r(nspins), rho_g(nspins))
          DO ispin = 1, nspins
+            ALLOCATE (rho_r(ispin)%pw, rho_g(ispin)%pw,)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(rho_r(ispin)%pw)

--- a/src/qs_linres_epr_nablavks.F
+++ b/src/qs_linres_epr_nablavks.F
@@ -465,6 +465,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gtemp%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rtemp%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      DEALLOCATE (v_hartree_gspace%pw, v_hartree_gtemp%pw, v_hartree_rtemp%pw, rho_tot_gspace)
 
       DEALLOCATE (v_hartree_gspace)
       DEALLOCATE (v_hartree_gtemp)
@@ -623,6 +624,7 @@ CONTAINS
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gspace%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gtemp%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_rtemp%pw)
+               DEALLOCATE (v_coulomb_gspace%pw, v_coulomb_gtemp%pw, v_coulomb_rtemp%pw)
 
                DEALLOCATE (v_coulomb_gspace)
                DEALLOCATE (v_coulomb_gtemp)
@@ -912,6 +914,7 @@ CONTAINS
             CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
 
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin)%pw)
+            DEALLOCATE (v_rspace_new(ispin)%pw)
 
          END DO
 
@@ -941,6 +944,7 @@ CONTAINS
             CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
 
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
+            DEALLOCATE (v_tau_rspace(ispin)%pw)
 
          END DO
 
@@ -949,6 +953,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_gtemp%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rtemp%pw)
+      DEALLOCATE (v_xc_gtemp%pw, v_xc_rtemp%pw)
 
       DEALLOCATE (v_xc_gtemp)
       DEALLOCATE (v_xc_rtemp)
@@ -989,6 +994,7 @@ CONTAINS
                                               "EPR%PRINT%NABLAVKS_CUBES", mpi_io=mpi_io)
          END DO
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
+         DEALLOCATE (wf_r%pw)
          DEALLOCATE (wf_r)
       END IF
 

--- a/src/qs_linres_epr_nablavks.F
+++ b/src/qs_linres_epr_nablavks.F
@@ -287,6 +287,7 @@ CONTAINS
       ALLOCATE (v_hartree_gtemp)
       ALLOCATE (v_hartree_rtemp)
 
+      ALLOCATE (v_hartree_gspace%pw, v_hartree_gtemp%pw, v_hartree_rtemp%pw, rho_tot_gspace)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gtemp%pw, &
@@ -517,6 +518,7 @@ CONTAINS
                ALLOCATE (v_coulomb_gtemp)
                ALLOCATE (v_coulomb_rtemp)
 
+               ALLOCATE (v_coulomb_gspace%pw, v_coulomb_gtemp%pw, v_coulomb_rtemp%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gspace%pw, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gtemp%pw, &
@@ -870,6 +872,7 @@ CONTAINS
       ALLOCATE (v_xc_gtemp)
       ALLOCATE (v_xc_rtemp)
 
+      ALLOCATE (v_xc_gtemp%pw, v_xc_rtemp%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_gtemp%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_rtemp%pw, &
@@ -962,6 +965,7 @@ CONTAINS
       IF (BTEST(cp_print_key_should_output(logger%iter_info, lr_section, &
                                            "EPR%PRINT%NABLAVKS_CUBES"), cp_p_file)) THEN
          ALLOCATE (wf_r)
+         ALLOCATE (wf_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)

--- a/src/qs_linres_epr_nablavks.F
+++ b/src/qs_linres_epr_nablavks.F
@@ -147,12 +147,11 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho1_r, rho2_r, rho_r, v_rspace_new, &
                                                             v_tau_rspace
-      TYPE(pw_p_type), POINTER :: rho_tot_gspace, v_coulomb_gspace, v_coulomb_gtemp, &
-         v_coulomb_rtemp, v_hartree_gspace, v_hartree_gtemp, v_hartree_rtemp, v_xc_gtemp, &
-         v_xc_rtemp, wf_r
+      TYPE(pw_p_type), POINTER :: v_coulomb_gspace, v_coulomb_gtemp, v_coulomb_rtemp, &
+         v_hartree_gspace, v_hartree_gtemp, v_hartree_rtemp, v_xc_gtemp, v_xc_rtemp, wf_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: pwx, pwy, pwz
+      TYPE(pw_type), POINTER                             :: pwx, pwy, pwz, rho_tot_gspace
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_p_type), DIMENSION(:, :), POINTER      :: nablavks_set
@@ -287,7 +286,6 @@ CONTAINS
       ALLOCATE (v_hartree_gspace)
       ALLOCATE (v_hartree_gtemp)
       ALLOCATE (v_hartree_rtemp)
-      ALLOCATE (rho_tot_gspace)
 
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
@@ -295,7 +293,7 @@ CONTAINS
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rtemp%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       IF (gapw) THEN
@@ -306,12 +304,12 @@ CONTAINS
          CALL prepare_gapw_den(qs_env, do_rho0=.TRUE.)
       END IF
 
-      CALL pw_zero(rho_tot_gspace%pw)
+      CALL pw_zero(rho_tot_gspace)
 
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho, &
                                skip_nuclear_density=.NOT. gapw)
 
-      CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, ehartree, &
+      CALL pw_poisson_solve(poisson_env, rho_tot_gspace, ehartree, &
                             v_hartree_gspace%pw)
 
       !   -------------------------------------
@@ -465,12 +463,11 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gtemp%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rtemp%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
 
       DEALLOCATE (v_hartree_gspace)
       DEALLOCATE (v_hartree_gtemp)
       DEALLOCATE (v_hartree_rtemp)
-      DEALLOCATE (rho_tot_gspace)
 
 !   -------------------------------------
 !   Add Coulomb potential

--- a/src/qs_linres_epr_ownutils.F
+++ b/src/qs_linres_epr_ownutils.F
@@ -313,7 +313,7 @@ CONTAINS
                                                             nrho3_r
       TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: vks_pw_spline
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_spline_precond_type), POINTER              :: precond
+      TYPE(pw_spline_precond_type)                       :: precond
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_p_type), DIMENSION(:), POINTER         :: jrho1_set
       TYPE(qs_rho_p_type), DIMENSION(:, :), POINTER      :: nablavks_set
@@ -578,7 +578,7 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: brho1_r, rho_r
       TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: bind_pw_spline
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_spline_precond_type), POINTER              :: precond
+      TYPE(pw_spline_precond_type)                       :: precond
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_p_type), DIMENSION(:, :), POINTER      :: bind_set
       TYPE(qs_rho_type), POINTER                         :: rho

--- a/src/qs_linres_epr_ownutils.F
+++ b/src/qs_linres_epr_ownutils.F
@@ -522,6 +522,7 @@ CONTAINS
          DO ispin = 1, nspins
             DO idir1 = 1, 3
                CALL pw_pool_give_back_pw(auxbas_pw_pool, vks_pw_spline(idir1, ispin)%pw)
+               DEALLOCATE (vks_pw_spline(idir1, ispin)%pw)
             END DO
          END DO
 
@@ -751,6 +752,7 @@ CONTAINS
 
          DO idir1 = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, bind_pw_spline(idir1, iB)%pw)
+            DEALLOCATE (bind_pw_spline(idir1, iB)%pw)
          END DO
 
          DEALLOCATE (bind_pw_spline)
@@ -878,13 +880,16 @@ CONTAINS
       !
       ! Dellocate grids for the calculation of jrho and the shift
       CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work%pw)
+      DEALLOCATE (pw_gspace_work%pw)
       DO ispin = 1, dft_control%nspins
          DO idir = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw)
+            DEALLOCATE (shift_pw_gspace(idir, ispin)%pw)
          END DO
       END DO
       DEALLOCATE (shift_pw_gspace)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace%pw)
+      DEALLOCATE (shift_pw_rspace%pw)
       !
       ! Finalize
       CALL timestop(handle)

--- a/src/qs_linres_epr_ownutils.F
+++ b/src/qs_linres_epr_ownutils.F
@@ -385,6 +385,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             DO idir1 = 1, 3
+               ALLOCATE (vks_pw_spline(idir1, ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, &
                                       vks_pw_spline(idir1, ispin)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
@@ -656,6 +657,7 @@ CONTAINS
          CALL section_vals_val_get(interp_section, "eps_x", r_val=eps_x)
 
          DO idir1 = 1, 3
+            ALLOCATE (bind_pw_spline(idir1, iB)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
                                    bind_pw_spline(idir1, iB)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
@@ -819,19 +821,21 @@ CONTAINS
       ALLOCATE (shift_pw_gspace(3, nspins))
       DO ispin = 1, nspins
          DO idir = 1, 3
+            ALLOCATE (shift_pw_gspace(idir, ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
             CALL pw_zero(shift_pw_gspace(idir, ispin)%pw)
          END DO
       END DO
+      ALLOCATE (shift_pw_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_zero(shift_pw_rspace%pw)
+      ALLOCATE (pw_gspace_work%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-
       CALL pw_zero(pw_gspace_work%pw)
       !
       CALL set_vecp(iB, iiB, iiiB)
@@ -850,7 +854,7 @@ CONTAINS
             DO idir2 = 1, 3
                IF (idir /= idir2) THEN
                   ! in reciprocal space multiply (G_idir2(i)/G(i)^2)J_(idir)(G(i))
-                  CALL mult_G_ov_G2_grid(cell, auxbas_pw_pool, rho_gspace, &
+                  CALL mult_G_ov_G2_grid(auxbas_pw_pool, rho_gspace, &
                                          pw_gspace_work, idir2, 0.0_dp)
                   !
                   ! scale and add to the correct component of the shift column

--- a/src/qs_linres_epr_utils.F
+++ b/src/qs_linres_epr_utils.F
@@ -191,6 +191,7 @@ CONTAINS
             NULLIFY (epr_env%bind_set(idir, i_B)%rho, rho_r, rho_g)
             CALL qs_rho_create(epr_env%bind_set(idir, i_B)%rho)
             ALLOCATE (rho_r(1), rho_g(1))
+            ALLOCATE (rho_r(1)%pw, rho_g(1)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(1)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(1)%pw, &
@@ -206,6 +207,7 @@ CONTAINS
             NULLIFY (epr_env%nablavks_set(idir, ispin)%rho, rho_r, rho_g)
             CALL qs_rho_create(epr_env%nablavks_set(idir, ispin)%rho)
             ALLOCATE (rho_r(1), rho_g(1))
+            ALLOCATE (rho_r(1)%pw, rho_g(1)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(1)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(1)%pw, &

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -274,6 +274,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
       ALLOCATE (v_rspace_new(nspins))
+      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -285,6 +286,7 @@ CONTAINS
          CALL prepare_gapw_den(qs_env, p_env%local_rho_set, do_rho0=(.NOT. gapw_xc))
 
       ! *** calculate the hartree potential on the total density ***
+      ALLOCATE (rho1_tot_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -307,6 +307,7 @@ CONTAINS
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace%pw)
+      DEALLOCATE (rho1_tot_gspace%pw)
 
       ! *** calculate the xc potential ***
       NULLIFY (rho1a)
@@ -538,13 +539,16 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
+      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin)%pw)
+         DEALLOCATE (v_rspace_new(ispin)%pw)
       END DO
       DEALLOCATE (v_rspace_new)
       IF (ASSOCIATED(v_xc_tau)) THEN
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+         DEALLOCATE (v_xc_tau(ispin)%pw)
       END DO
       DEALLOCATE (v_xc_tau)
       END IF
@@ -946,6 +950,7 @@ CONTAINS
 
             DO ispin = 1, nspins
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+               DEALLOCATE (v_xc(ispin)%pw)
             END DO
             DEALLOCATE (v_xc)
             CALL dbcsr_deallocate_matrix(xcmat%matrix)

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -297,7 +297,7 @@ CONTAINS
          CALL pw_axpy(rho1_g(ispin)%pw, rho1_tot_gspace%pw)
       END DO
       IF (gapw) &
-         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs%pw, rho1_tot_gspace%pw)
+         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs, rho1_tot_gspace%pw)
 
       IF (.NOT. (nspins == 1 .AND. lr_triplet)) THEN
          CALL pw_poisson_solve(poisson_env, rho1_tot_gspace%pw, &

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -378,14 +378,14 @@ CONTAINS
                END IF
                CALL qs_rho_get(rho1, rho_ao=rho1_ao)
                ! remove kpp1_env%v_ao and work directly on k_p_p1 ?
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho1_ao(ispin), &
                                        hmat=kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
                                        calculate_forces=.FALSE., gapw=gapw_xc)
 
                IF (ASSOCIATED(v_xc_tau)) THEN
-                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, &
                                           pmat=rho1_ao(ispin), &
                                           hmat=kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
@@ -397,7 +397,7 @@ CONTAINS
                IF (.NOT. lr_triplet) THEN
                   v_rspace_new(1)%pw%cr3d = 2.0_dp*v_hartree_rspace%pw%cr3d
 
-                  CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
                                           hmat=kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
@@ -405,14 +405,14 @@ CONTAINS
                END IF
             ELSE
                ! remove kpp1_env%v_ao and work directly on k_p_p1 ?
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
                                        calculate_forces=.FALSE., gapw=gapw_xc)
 
                IF (ASSOCIATED(v_xc_tau)) THEN
-                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
                                           hmat=kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
@@ -421,7 +421,7 @@ CONTAINS
                END IF
 
                v_rspace_new(ispin)%pw%cr3d = v_hartree_rspace%pw%cr3d
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
@@ -455,7 +455,7 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(v_rspace_new(ispin), qs_env, &
+               CALL integrate_v_rspace_one_center(v_rspace_new(ispin)%pw, qs_env, &
                                                   lri_v_int, .FALSE., "LRI_AUX")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
@@ -463,20 +463,20 @@ CONTAINS
                ALLOCATE (k1mat(1))
                k1mat(1)%matrix => kpp1_env%v_ao(ispin)%matrix
                IF (lri_env%exact_1c_terms) THEN
-                  CALL integrate_v_rspace_diagonal(v_rspace_new(ispin), k1mat(1)%matrix, &
+                  CALL integrate_v_rspace_diagonal(v_rspace_new(ispin)%pw, k1mat(1)%matrix, &
                                                    rho_ao(ispin)%matrix, qs_env, .FALSE., "ORB")
                END IF
                CALL calculate_lri_ks_matrix(lri_env, lri_v_int, k1mat, atomic_kind_set)
                DEALLOCATE (k1mat)
             ELSE
-               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
+               CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=kpp1_env%v_ao(ispin), &
                                        qs_env=qs_env, &
                                        calculate_forces=.FALSE., gapw=gapw)
 
                IF (ASSOCIATED(v_xc_tau)) THEN
-                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), &
+                  CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
                                           hmat=kpp1_env%v_ao(ispin), &
                                           qs_env=qs_env, &
@@ -497,7 +497,7 @@ CONTAINS
                                     p_env%local_rho_set, &
                                     para_env, tddft=.TRUE.)
 
-            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace, para_env, &
+            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace%pw, para_env, &
                                        calculate_forces=.FALSE., &
                                        local_rho_set=p_env%local_rho_set)
          END IF
@@ -930,7 +930,7 @@ CONTAINS
                v_xc(ispin)%pw%cr3d = v_xc(ispin)%pw%cr3d*v_xc(ispin)%pw%pw_grid%dvol
                CALL dbcsr_copy(xcmat%matrix, matrix_s(1)%matrix)
                CALL dbcsr_set(xcmat%matrix, 0.0_dp)
-               CALL integrate_v_rspace(v_rspace=v_xc(ispin), hmat=xcmat, qs_env=qs_env, &
+               CALL integrate_v_rspace(v_rspace=v_xc(ispin)%pw, hmat=xcmat, qs_env=qs_env, &
                                        calculate_forces=.FALSE., basis_type="AUX_FIT", &
                                        task_list_external=task_list)
                CALL dbcsr_add(p_env%kpp1_admm(ispin)%matrix, xcmat%matrix, 1.0_dp, alpha)

--- a/src/qs_linres_nmr_epr_common_utils.F
+++ b/src/qs_linres_nmr_epr_common_utils.F
@@ -15,7 +15,6 @@
 !> \author MI
 ! **************************************************************************************************
 MODULE qs_linres_nmr_epr_common_utils
-   USE cell_types,                      ONLY: cell_type
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: gaussi
    USE pw_grid_types,                   ONLY: pw_grid_type
@@ -46,7 +45,6 @@ CONTAINS
 !>         \int_{r}[ ((r-r') x j(r))/|r-r'|^3 ] = Bind(r')
 !>       which in reciprcal space reads  (for G/=0)
 !>          i G/|G|^2 x J(G)
-!> \param cell ...
 !> \param pw_pool ...
 !> \param rho_gspace ...
 !> \param funcG_times_rho ...
@@ -60,9 +58,8 @@ CONTAINS
 !>      This method would not work for a non periodic system
 !>      It should be generalized like the calculation of Hartree
 ! **************************************************************************************************
-   SUBROUTINE mult_G_ov_G2_grid(cell, pw_pool, rho_gspace, funcG_times_rho, idir, my_chi)
+   SUBROUTINE mult_G_ov_G2_grid(pw_pool, rho_gspace, funcG_times_rho, idir, my_chi)
 
-      TYPE(cell_type), POINTER                           :: cell
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(pw_p_type), POINTER                           :: rho_gspace
       TYPE(pw_p_type)                                    :: funcG_times_rho
@@ -78,9 +75,8 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CPASSERT(ASSOCIATED(cell))
-      MARK_USED(cell)
-
+      NULLIFY (influence_fn)
+      ALLOCATE (influence_fn)
       CALL pw_pool_create_pw(pw_pool, influence_fn, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 

--- a/src/qs_linres_nmr_epr_common_utils.F
+++ b/src/qs_linres_nmr_epr_common_utils.F
@@ -71,12 +71,10 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: grid
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mult_G_ov_G2_grid'
 
-      TYPE(pw_type), POINTER                             :: frho, influence_fn
+      TYPE(pw_type)                                      :: influence_fn
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (influence_fn)
-      ALLOCATE (influence_fn)
       CALL pw_pool_create_pw(pw_pool, influence_fn, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -87,12 +85,11 @@ CONTAINS
       END DO ! ig
       IF (grid%have_g0) influence_fn%cc(1) = 0.0_dp
 
-      frho => funcG_times_rho%pw
-      CALL pw_transfer(rho_gspace%pw, frho)
+      CALL pw_transfer(rho_gspace%pw, funcG_times_rho%pw)
 
       ng = SIZE(grid%gsq)
-      frho%cc(1:ng) = frho%cc(1:ng)*influence_fn%cc(1:ng)
-      IF (grid%have_g0) frho%cc(1) = my_chi
+      funcG_times_rho%pw%cc(1:ng) = funcG_times_rho%pw%cc(1:ng)*influence_fn%cc(1:ng)
+      IF (grid%have_g0) funcG_times_rho%pw%cc(1) = my_chi
 
       CALL pw_pool_give_back_pw(pw_pool, influence_fn)
 

--- a/src/qs_linres_nmr_epr_common_utils.F
+++ b/src/qs_linres_nmr_epr_common_utils.F
@@ -94,8 +94,7 @@ CONTAINS
       frho%cc(1:ng) = frho%cc(1:ng)*influence_fn%cc(1:ng)
       IF (grid%have_g0) frho%cc(1) = my_chi
 
-      CALL pw_pool_give_back_pw(pw_pool, influence_fn, &
-                                accept_non_compatible=.TRUE.)
+      CALL pw_pool_give_back_pw(pw_pool, influence_fn)
 
       CALL timestop(handle)
 

--- a/src/qs_linres_nmr_shift.F
+++ b/src/qs_linres_nmr_shift.F
@@ -200,6 +200,7 @@ CONTAINS
       END DO ! ispin
       !
       CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work%pw)
+      DEALLOCATE (pw_gspace_work%pw)
       !
       ! compute shildings
       IF (interpolate_shift) THEN
@@ -217,6 +218,7 @@ CONTAINS
             END DO
          END DO
          CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace%pw)
+         DEALLOCATE (shift_pw_rspace%pw)
       ELSE
          DO ispin = 1, nspins
             DO idir = 1, 3
@@ -240,6 +242,7 @@ CONTAINS
       DO ispin = 1, nspins
          DO idir = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw)
+            DEALLOCATE (shift_pw_gspace(idir, ispin)%pw)
          END DO
       END DO
       DEALLOCATE (shift_pw_gspace)
@@ -599,6 +602,7 @@ CONTAINS
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, shiftspl%pw)
+      DEALLOCATE (shiftspl%pw)
 
       !
       CALL timestop(handle)
@@ -631,9 +635,6 @@ CONTAINS
       REAL(dp)                                           :: R_iatom(3), ra(3)
       REAL(dp), DIMENSION(:, :), POINTER                 :: r_nics
       REAL(dp), DIMENSION(:, :, :), POINTER              :: chemical_shift, chemical_shift_nics
-
-!
-!
 
       CALL timeset(routineN, handle)
       !

--- a/src/qs_linres_nmr_shift.F
+++ b/src/qs_linres_nmr_shift.F
@@ -162,6 +162,7 @@ CONTAINS
       ALLOCATE (shift_pw_gspace(3, nspins))
       DO ispin = 1, nspins
          DO idir = 1, 3
+            ALLOCATE (shift_pw_gspace(idir, ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL pw_zero(shift_pw_gspace(idir, ispin)%pw)
@@ -171,6 +172,7 @@ CONTAINS
       !
       CALL set_vecp(iB, iiB, iiiB)
       !
+      ALLOCATE (pw_gspace_work%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_zero(pw_gspace_work%pw)
@@ -184,7 +186,7 @@ CONTAINS
             DO idir2 = 1, 3
                IF (idir /= idir2) THEN
                   ! in reciprocal space multiply (G_idir2(i)/G(i)^2)J_(idir)(G(i))
-                  CALL mult_G_ov_G2_grid(cell, auxbas_pw_pool, jrho_gspace, &
+                  CALL mult_G_ov_G2_grid(auxbas_pw_pool, jrho_gspace, &
                                          pw_gspace_work, idir2, 0.0_dp)
                   !
                   ! scale and add to the correct component of the shift column
@@ -201,6 +203,7 @@ CONTAINS
       !
       ! compute shildings
       IF (interpolate_shift) THEN
+         ALLOCATE (shift_pw_rspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          DO ispin = 1, nspins
@@ -532,8 +535,6 @@ CONTAINS
       TYPE(pw_spline_precond_type), POINTER              :: precond
       TYPE(section_vals_type), POINTER                   :: interp_section
 
-!
-
       CALL timeset(routineN, handle)
       !
       NULLIFY (interp_section)
@@ -553,6 +554,7 @@ CONTAINS
 
       ! calculate spline coefficients
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+      ALLOCATE (shiftspl%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, shiftspl%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 

--- a/src/qs_linres_nmr_shift.F
+++ b/src/qs_linres_nmr_shift.F
@@ -535,13 +535,12 @@ CONTAINS
       REAL(dp), DIMENSION(:, :, :), POINTER              :: chemical_shift, chemical_shift_nics
       TYPE(pw_p_type)                                    :: shiftspl
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_spline_precond_type), POINTER              :: precond
+      TYPE(pw_spline_precond_type)                       :: precond
       TYPE(section_vals_type), POINTER                   :: interp_section
 
       CALL timeset(routineN, handle)
       !
-      NULLIFY (interp_section)
-      NULLIFY (auxbas_pw_pool, precond)
+      NULLIFY (interp_section, auxbas_pw_pool)
       NULLIFY (cs_atom_list, chemical_shift, chemical_shift_nics, r_nics)
 
       CPASSERT(ASSOCIATED(shift_pw_rspace%pw))

--- a/src/qs_loc_methods.F
+++ b/src/qs_loc_methods.F
@@ -1105,6 +1105,7 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
+      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)

--- a/src/qs_loc_methods.F
+++ b/src/qs_loc_methods.F
@@ -1175,6 +1175,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+      DEALLOCATE (wf_r%pw, wf_g%pw)
       CALL timestop(handle)
    END SUBROUTINE qs_print_cubes
 

--- a/src/qs_loc_methods.F
+++ b/src/qs_loc_methods.F
@@ -1137,7 +1137,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, cell=cell, &
                          dft_control=dft_control, particle_set=particle_set, pw_env=pw_env)
 
-         CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env)
 
          ! Formatting the middle part of the name

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -174,6 +174,7 @@ CONTAINS
       END DO
       CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_g%pw)
+      DEALLOCATE (edens_r%pw, edens_g%pw)
 
       ! Hartree energy density correction = -0.5 * V_H(r) * [rho(r) - rho_core(r)]
       ALLOCATE (rho_tot_gspace, rho_tot_rspace)
@@ -204,6 +205,7 @@ CONTAINS
       CALL pw_multiply(hartree_density%pw, v_hartree_rspace%pw, rho_tot_rspace, alpha=ovol)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace)
+      DEALLOCATE (rho_tot_gspace, rho_tot_rspace)
 
       IF (dft_control%do_admm) THEN
          CALL cp_warn(__LOCATION__, "ADMM not supported for local energy calculation")
@@ -249,6 +251,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, band_density%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, hartree_density%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, xc_density%pw)
+      DEALLOCATE (band_density%pw, hartree_density%pw, xc_density%pw)
 
       CALL timestop(handle)
 
@@ -375,8 +378,10 @@ CONTAINS
       CALL pw_derive(efield(2)%pw, (/0, 1, 0/))
       CALL pw_derive(efield(3)%pw, (/0, 0, 1/))
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+      DEALLOCATE (v_hartree_gspace%pw)
       DO i = 1, 3
          CALL pw_pool_give_back_pw(auxbas_pw_pool, efield(i)%pw)
+         DEALLOCATE (efield(i)%pw)
       END DO
 
       pv_loc = 0.0_dp

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -45,7 +45,8 @@ MODULE qs_local_properties
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_core_energies,                ONLY: calculate_ptrace
    USE qs_energy_matrix_w,              ONLY: qs_energies_compute_w
@@ -98,12 +99,12 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type)                                    :: band_density, edens_g, edens_r, &
-                                                            hartree_density, rho_tot_gspace, &
-                                                            rho_tot_rspace, v_hartree_rspace, &
+                                                            hartree_density, v_hartree_rspace, &
                                                             xc_density
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rho_tot_gspace, rho_tot_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_struct
@@ -164,8 +165,8 @@ CONTAINS
       DO ispin = 1, nspins
          rho_ao => matrix_w(ispin, :)
          CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                 rho=edens_r, &
-                                 rho_gspace=edens_g, &
+                                 rho=edens_r%pw, &
+                                 rho_gspace=edens_g%pw, &
                                  ks_env=ks_env, soft_valid=(gapw .OR. gapw_xc))
          CALL pw_axpy(edens_r%pw, band_density%pw)
       END DO
@@ -174,11 +175,11 @@ CONTAINS
 
       ! Hartree energy density correction = -0.5 * V_H(r) * [rho(r) - rho_core(r)]
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_tot_gspace%pw, &
+                             rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_tot_rspace%pw, &
+                             rho_tot_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
       NULLIFY (rho_core)
@@ -188,18 +189,18 @@ CONTAINS
       CALL qs_rho_get(rho, rho_r=rho_r)
       IF (ASSOCIATED(rho_core)) THEN
          CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
-         CALL pw_transfer(rho_core%pw, rho_tot_rspace%pw)
+         CALL pw_transfer(rho_core%pw, rho_tot_rspace)
       ELSE
-         CALL pw_zero(rho_tot_rspace%pw)
+         CALL pw_zero(rho_tot_rspace)
       END IF
       DO ispin = 1, nspins
-         CALL pw_axpy(rho_r(ispin)%pw, rho_tot_rspace%pw, alpha=-1.0_dp)
+         CALL pw_axpy(rho_r(ispin)%pw, rho_tot_rspace, alpha=-1.0_dp)
       END DO
       CALL pw_zero(hartree_density%pw)
       ovol = 0.5_dp/hartree_density%pw%pw_grid%dvol
-      CALL pw_multiply(hartree_density%pw, v_hartree_rspace%pw, rho_tot_rspace%pw, alpha=ovol)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace%pw)
+      CALL pw_multiply(hartree_density%pw, v_hartree_rspace%pw, rho_tot_rspace, alpha=ovol)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace)
 
       IF (dft_control%do_admm) THEN
          CALL cp_warn(__LOCATION__, "ADMM not supported for local energy calculation")

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -129,6 +129,7 @@ CONTAINS
       ! get working arrays
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+      ALLOCATE (band_density%pw, hartree_density%pw, xc_density%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, band_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, hartree_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, xc_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
@@ -153,6 +154,7 @@ CONTAINS
       ! band structure energy density
       CALL qs_energies_compute_w(qs_env, .TRUE.)
       CALL get_qs_env(qs_env, ks_env=ks_env, matrix_w_kp=matrix_w)
+      ALLOCATE (edens_r%pw, edens_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              edens_r%pw, &
                              use_data=REALDATA3D, &
@@ -174,6 +176,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_g%pw)
 
       ! Hartree energy density correction = -0.5 * V_H(r) * [rho(r) - rho_core(r)]
+      ALLOCATE (rho_tot_gspace, rho_tot_rspace)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, &
@@ -332,6 +335,7 @@ CONTAINS
       ! get working arrays
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+      ALLOCATE (xc_density%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, xc_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! init local stress tensor
@@ -357,11 +361,12 @@ CONTAINS
 
       ! Electrical field terms
       CALL get_qs_env(qs_env, v_hartree_rspace=v_hartree_rspace%pw)
+      ALLOCATE (v_hartree_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_transfer(v_hartree_rspace%pw, v_hartree_gspace%pw)
       DO i = 1, 3
-         NULLIFY (efield(i)%pw)
+         ALLOCATE (efield(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, efield(i)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_copy(v_hartree_gspace%pw, efield(i)%pw)

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -102,9 +102,8 @@ CONTAINS
                                                             hartree_density, v_hartree_rspace, &
                                                             xc_density
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
-      TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_gspace, rho_tot_rspace
+      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace, rho_tot_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_struct
@@ -193,7 +192,7 @@ CONTAINS
       CALL qs_rho_get(rho, rho_r=rho_r)
       IF (ASSOCIATED(rho_core)) THEN
          CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
-         CALL pw_transfer(rho_core%pw, rho_tot_rspace)
+         CALL pw_transfer(rho_core, rho_tot_rspace)
       ELSE
          CALL pw_zero(rho_tot_rspace)
       END IF

--- a/src/qs_p_env_methods.F
+++ b/src/qs_p_env_methods.F
@@ -444,8 +444,8 @@ CONTAINS
                CALL dbcsr_copy(rho1_ao(ispin)%matrix, p_env%p1_admm(ispin)%matrix)
                CALL calculate_rho_elec(ks_env=ks_env, &
                                        matrix_p=rho1_ao(ispin)%matrix, &
-                                       rho=rho_r_aux(ispin), &
-                                       rho_gspace=rho_g_aux(ispin), &
+                                       rho=rho_r_aux(ispin)%pw, &
+                                       rho_gspace=rho_g_aux(ispin)%pw, &
                                        soft_valid=.FALSE., &
                                        basis_type=basis_type, &
                                        task_list_external=task_list)

--- a/src/qs_pdos.F
+++ b/src/qs_pdos.F
@@ -649,11 +649,11 @@ CONTAINS
 
                IF (imo > nmo) THEN
                   CALL calculate_wavefunction(mo_virt, imo - nmo, &
-                                              wf_r, wf_g, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
+                                              wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                               pw_env)
                ELSE
                   CALL calculate_wavefunction(mo_coeff, imo, &
-                                              wf_r, wf_g, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
+                                              wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                               pw_env)
                END IF
                r_ldos_p(ildos)%ldos%pdos_array(imo) = 0.0_dp

--- a/src/qs_pdos.F
+++ b/src/qs_pdos.F
@@ -904,6 +904,7 @@ CONTAINS
          DEALLOCATE (r_ldos_index)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+         DEALLOCATE (wf_r%pw, wf_g%pw)
       END IF
       IF (do_virt) THEN
          DEALLOCATE (evals_virt)

--- a/src/qs_pdos.F
+++ b/src/qs_pdos.F
@@ -362,6 +362,7 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
 
+         ALLOCATE (wf_r%pw, wf_g%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -972,7 +972,7 @@ CONTAINS
       DO i = 1, natom
          !collocate gaussian for each atom
          CALL pw_zero(rho_ga%pw)
-         CALL calculate_rho_resp_single(rho_ga, qs_env, resp_env%eta, i)
+         CALL calculate_rho_resp_single(rho_ga%pw, qs_env, resp_env%eta, i)
          !calculate potential va and store the part needed for fitting in vpot
          CALL pw_zero(va_gspace%pw)
          CALL pw_poisson_solve(poisson_env, rho_ga%pw, vhartree=va_gspace%pw)
@@ -1739,7 +1739,7 @@ CONTAINS
                              in_space=REALSPACE)
 
       CALL pw_zero(rho_resp%pw)
-      CALL calculate_rho_resp_all(rho_resp, resp_env%rhs, natom, &
+      CALL calculate_rho_resp_all(rho_resp%pw, resp_env%rhs, natom, &
                                   resp_env%eta, qs_env)
       CALL pw_zero(v_resp_gspace%pw)
       CALL pw_poisson_solve(poisson_env, rho_resp%pw, &

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -990,6 +990,7 @@ CONTAINS
       CALL pw_release(va_gspace%pw)
       CALL pw_release(va_rspace%pw)
       CALL pw_release(rho_ga%pw)
+      DEALLOCATE (va_gspace%pw, va_rspace%pw, rho_ga%pw)
 
       DO i = 1, natom
          DO j = 1, natom
@@ -1756,6 +1757,7 @@ CONTAINS
       END IF
       CALL pw_release(v_resp_gspace%pw)
       CALL pw_release(rho_resp%pw)
+      DEALLOCATE (v_resp_gspace%pw, rho_resp%pw)
 
       !***now print the v_resp_rspace%pw to a cube file if requested
       IF (BTEST(cp_print_key_should_output(logger%iter_info, resp_section, &
@@ -1811,6 +1813,7 @@ CONTAINS
       END IF
 
       CALL pw_release(v_resp_rspace%pw)
+      DEALLOCATE (v_resp_rspace%pw)
 
       CALL timestop(handle)
 

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -950,6 +950,7 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
+      ALLOCATE (rho_ga%pw, va_gspace%pw, va_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              rho_ga%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -1726,6 +1727,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
+      ALLOCATE (rho_resp%pw, v_resp_gspace%pw, v_resp_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
                              rho_resp%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -1762,6 +1764,7 @@ CONTAINS
       !***now print the v_resp_rspace%pw to a cube file if requested
       IF (BTEST(cp_print_key_should_output(logger%iter_info, resp_section, &
                                            "PRINT%V_RESP_CUBE"), cp_p_file)) THEN
+         ALLOCATE (aux_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -1789,6 +1789,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, resp_section, &
                                            "PRINT%V_RESP_CUBE", mpi_io=mpi_io)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
+         DEALLOCATE (aux_r%pw)
       END IF
 
       !*** RMS and RRMS

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -298,6 +298,7 @@ CONTAINS
       ! rho0 density in real space
       IF (ASSOCIATED(rho_rs)) THEN
          CALL pw_release(rho_rs%pw)
+         DEALLOCATE (rho_rs%pw)
          DEALLOCATE (rho_rs)
       END IF
       ALLOCATE (rho_rs)
@@ -308,6 +309,7 @@ CONTAINS
       ! rho0 density in reciprocal space
       IF (ASSOCIATED(rho_gs)) THEN
          CALL pw_release(rho_gs%pw)
+         DEALLOCATE (rho_gs%pw)
          DEALLOCATE (rho_gs)
       END IF
       ALLOCATE (rho_gs)

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -158,6 +158,7 @@ CONTAINS
          ALLOCATE (coeff_rspace)
          ALLOCATE (coeff_gspace)
 
+         ALLOCATE (coeff_rspace%pw, coeff_gspace%pw)
          CALL pw_pool_create_pw(pw_pool, coeff_rspace%pw, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          CALL pw_pool_create_pw(pw_pool, coeff_gspace%pw, &
@@ -247,6 +248,7 @@ CONTAINS
 
       ELSE
 
+         ALLOCATE (rho0_r_tmp%pw)
          CALL pw_pool_create_pw(pw_pool, rho0_r_tmp%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -302,6 +304,7 @@ CONTAINS
          DEALLOCATE (rho_rs)
       END IF
       ALLOCATE (rho_rs)
+      ALLOCATE (rho_rs%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_rs%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       rho0_mpole%rho0_s_rs => rho_rs
@@ -313,6 +316,7 @@ CONTAINS
          DEALLOCATE (rho_gs)
       END IF
       ALLOCATE (rho_gs)
+      ALLOCATE (rho_gs%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_gs%pw, &
                              use_data=COMPLEXDATA1D)
       rho_gs%pw%in_space = RECIPROCALSPACE
@@ -441,6 +445,7 @@ CONTAINS
 
       ALLOCATE (coeff_gspace)
       ALLOCATE (coeff_rspace)
+      ALLOCATE (coeff_gspace%pw, coeff_rspace%pw)
       CALL pw_pool_create_pw(pw_pool, coeff_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -451,6 +456,7 @@ CONTAINS
       IF (igrid /= auxbas_grid) THEN
          pw_aux => pw_pools(auxbas_grid)%pool
          ALLOCATE (coeff_gaux)
+         ALLOCATE (coeff_gaux%pw)
          CALL pw_pool_create_pw(pw_aux, coeff_gaux%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
@@ -460,6 +466,7 @@ CONTAINS
          CALL pw_pool_give_back_pw(pw_aux, coeff_gaux%pw)
          DEALLOCATE (coeff_gaux)
          ALLOCATE (coeff_raux)
+         ALLOCATE (coeff_raux%pw)
          CALL pw_pool_create_pw(pw_aux, coeff_raux%pw, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          scale = coeff_rspace%pw%pw_grid%dvol/coeff_raux%pw%pw_grid%dvol

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -243,6 +243,7 @@ CONTAINS
 
          CALL pw_pool_give_back_pw(pw_pool, coeff_rspace%pw)
          CALL pw_pool_give_back_pw(pw_pool, coeff_gspace%pw)
+         DEALLOCATE (coeff_rspace%pw, coeff_gspace%pw)
 
          DEALLOCATE (coeff_rspace, coeff_gspace)
 
@@ -259,6 +260,7 @@ CONTAINS
 
          CALL pw_transfer(rho0_r_tmp%pw, rho0_s_rs%pw)
          CALL pw_pool_give_back_pw(pw_pool, rho0_r_tmp%pw)
+         DEALLOCATE (rho0_r_tmp%pw)
 
          CALL pw_zero(rho0_s_gs%pw)
          CALL pw_transfer(rho0_s_rs%pw, rho0_s_gs%pw)
@@ -464,6 +466,7 @@ CONTAINS
          CALL pw_copy(coeff_gaux%pw, coeff_gspace%pw)
          CALL pw_transfer(coeff_gspace%pw, coeff_rspace%pw)
          CALL pw_pool_give_back_pw(pw_aux, coeff_gaux%pw)
+         DEALLOCATE (coeff_gaux%pw)
          DEALLOCATE (coeff_gaux)
          ALLOCATE (coeff_raux)
          ALLOCATE (coeff_raux%pw)
@@ -472,6 +475,7 @@ CONTAINS
          scale = coeff_rspace%pw%pw_grid%dvol/coeff_raux%pw%pw_grid%dvol
          coeff_rspace%pw%cr3d = scale*coeff_rspace%pw%cr3d
          CALL pw_pool_give_back_pw(pw_aux, coeff_raux%pw)
+         DEALLOCATE (coeff_raux%pw)
          DEALLOCATE (coeff_raux)
       ELSE
 
@@ -483,6 +487,7 @@ CONTAINS
          END IF
       END IF
       CALL pw_pool_give_back_pw(pw_pool, coeff_gspace%pw)
+      DEALLOCATE (coeff_gspace%pw)
       DEALLOCATE (coeff_gspace)
 
       ! Setup the rs grid at level igrid
@@ -491,6 +496,7 @@ CONTAINS
       CALL rs_pw_transfer(rs_v, coeff_rspace%pw, pw2rs)
 
       CALL pw_pool_give_back_pw(pw_pool, coeff_rspace%pw)
+      DEALLOCATE (coeff_rspace%pw)
       DEALLOCATE (coeff_rspace)
 
       ! Now the potential is on the right grid => integration

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -43,7 +43,8 @@ MODULE qs_rho0_ggrid
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_force_types,                  ONLY: qs_force_type
@@ -342,7 +343,7 @@ CONTAINS
    SUBROUTINE integrate_vhg0_rspace(qs_env, v_rspace, para_env, calculate_forces, local_rho_set)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type)                                    :: v_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_rspace
       TYPE(cp_para_env_type), POINTER                    :: para_env
       LOGICAL, INTENT(IN)                                :: calculate_forces
       TYPE(local_rho_type), OPTIONAL, POINTER            :: local_rho_set
@@ -462,7 +463,7 @@ CONTAINS
          CALL pw_pool_create_pw(pw_aux, coeff_gaux%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
-         CALL pw_transfer(v_rspace%pw, coeff_gaux%pw)
+         CALL pw_transfer(v_rspace, coeff_gaux%pw)
          CALL pw_copy(coeff_gaux%pw, coeff_gspace%pw)
          CALL pw_transfer(coeff_gspace%pw, coeff_rspace%pw)
          CALL pw_pool_give_back_pw(pw_aux, coeff_gaux%pw)
@@ -480,10 +481,10 @@ CONTAINS
       ELSE
 
          IF (coeff_gspace%pw%pw_grid%spherical) THEN
-            CALL pw_transfer(v_rspace%pw, coeff_gspace%pw)
+            CALL pw_transfer(v_rspace, coeff_gspace%pw)
             CALL pw_transfer(coeff_gspace%pw, coeff_rspace%pw)
          ELSE
-            CALL pw_copy(v_rspace%pw, coeff_rspace%pw)
+            CALL pw_copy(v_rspace, coeff_rspace%pw)
          END IF
       END IF
       CALL pw_pool_give_back_pw(pw_pool, coeff_gspace%pw)

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -111,11 +111,11 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho0_r_tmp
-      TYPE(pw_p_type), POINTER                           :: coeff_gspace, coeff_rspace, rho0_s_gs, &
-                                                            rho0_s_rs
+      TYPE(pw_p_type), POINTER                           :: coeff_gspace, coeff_rspace
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: pw_pool
+      TYPE(pw_type)                                      :: rho0_r_tmp
+      TYPE(pw_type), POINTER                             :: rho0_s_gs, rho0_s_rs
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_desc_p_type), DIMENSION(:), &
          POINTER                                         :: descs
@@ -236,9 +236,9 @@ CONTAINS
       IF (igrid /= auxbas_grid) THEN
          CALL rs_pw_transfer(rs_grid, coeff_rspace%pw, rs2pw)
          CALL rs_grid_release(rs_grid)
-         CALL pw_zero(rho0_s_gs%pw)
+         CALL pw_zero(rho0_s_gs)
          CALL pw_transfer(coeff_rspace%pw, coeff_gspace%pw)
-         CALL pw_axpy(coeff_gspace%pw, rho0_s_gs%pw)
+         CALL pw_axpy(coeff_gspace%pw, rho0_s_gs)
 
          tot_rs_int = pw_integrate_function(coeff_rspace%pw, isign=-1)
 
@@ -250,21 +250,19 @@ CONTAINS
 
       ELSE
 
-         ALLOCATE (rho0_r_tmp%pw)
-         CALL pw_pool_create_pw(pw_pool, rho0_r_tmp%pw, &
+         CALL pw_pool_create_pw(pw_pool, rho0_r_tmp, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
 
-         CALL rs_pw_transfer(rs_grid, rho0_r_tmp%pw, rs2pw)
+         CALL rs_pw_transfer(rs_grid, rho0_r_tmp, rs2pw)
          CALL rs_grid_release(rs_grid)
 
-         tot_rs_int = pw_integrate_function(rho0_r_tmp%pw, isign=-1)
+         tot_rs_int = pw_integrate_function(rho0_r_tmp, isign=-1)
 
-         CALL pw_transfer(rho0_r_tmp%pw, rho0_s_rs%pw)
-         CALL pw_pool_give_back_pw(pw_pool, rho0_r_tmp%pw)
-         DEALLOCATE (rho0_r_tmp%pw)
+         CALL pw_transfer(rho0_r_tmp, rho0_s_rs)
+         CALL pw_pool_give_back_pw(pw_pool, rho0_r_tmp)
 
-         CALL pw_zero(rho0_s_gs%pw)
-         CALL pw_transfer(rho0_s_rs%pw, rho0_s_gs%pw)
+         CALL pw_zero(rho0_s_gs)
+         CALL pw_transfer(rho0_s_rs, rho0_s_gs)
       END IF
       CALL timestop(handle)
 
@@ -283,7 +281,6 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'rho0_s_grid_create'
 
       INTEGER                                            :: handle
-      TYPE(pw_p_type), POINTER                           :: rho_gs, rho_rs
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
 
       CALL timeset(routineN, handle)
@@ -295,35 +292,26 @@ CONTAINS
       CPASSERT(ASSOCIATED(auxbas_pw_pool))
 
       ! reallocate rho0 on the global grid in real and reciprocal space
-      NULLIFY (rho_rs, rho_gs)
       CPASSERT(ASSOCIATED(rho0_mpole))
-      rho_rs => rho0_mpole%rho0_s_rs
-      rho_gs => rho0_mpole%rho0_s_gs
 
       ! rho0 density in real space
-      IF (ASSOCIATED(rho_rs)) THEN
-         CALL pw_release(rho_rs%pw)
-         DEALLOCATE (rho_rs%pw)
-         DEALLOCATE (rho_rs)
+      IF (ASSOCIATED(rho0_mpole%rho0_s_rs)) THEN
+         CALL pw_release(rho0_mpole%rho0_s_rs)
+      ELSE
+         ALLOCATE (rho0_mpole%rho0_s_rs)
       END IF
-      ALLOCATE (rho_rs)
-      ALLOCATE (rho_rs%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_rs%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho0_mpole%rho0_s_rs, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      rho0_mpole%rho0_s_rs => rho_rs
 
       ! rho0 density in reciprocal space
-      IF (ASSOCIATED(rho_gs)) THEN
-         CALL pw_release(rho_gs%pw)
-         DEALLOCATE (rho_gs%pw)
-         DEALLOCATE (rho_gs)
+      IF (ASSOCIATED(rho0_mpole%rho0_s_gs)) THEN
+         CALL pw_release(rho0_mpole%rho0_s_gs)
+      ELSE
+         ALLOCATE (rho0_mpole%rho0_s_gs)
       END IF
-      ALLOCATE (rho_gs)
-      ALLOCATE (rho_gs%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_gs%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho0_mpole%rho0_s_gs, &
                              use_data=COMPLEXDATA1D)
-      rho_gs%pw%in_space = RECIPROCALSPACE
-      rho0_mpole%rho0_s_gs => rho_gs
+      rho0_mpole%rho0_s_gs%in_space = RECIPROCALSPACE
 
       ! Find the grid level suitable for rho0_soft
       rho0_mpole%igrid_zet0_s = gaussian_gridlevel(pw_env%gridlevel_info, 2.0_dp*rho0_mpole%zet0_h)

--- a/src/qs_rho0_types.F
+++ b/src/qs_rho0_types.F
@@ -13,8 +13,8 @@ MODULE qs_rho0_types
                                               pi,&
                                               rootpi
    USE memory_utilities,                ONLY: reallocate
-   USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release
+   USE pw_types,                        ONLY: pw_release,&
+                                              pw_type
    USE qs_grid_atom,                    ONLY: grid_atom_type
    USE qs_rho_atom_types,               ONLY: rho_atom_coeff
    USE whittaker,                       ONLY: whittaker_c0a,&
@@ -59,8 +59,8 @@ MODULE qs_rho0_types
       REAL(dp), DIMENSION(:), POINTER             :: norm_g0l_h
       INTEGER, DIMENSION(:), POINTER             :: lmax0_kind
       INTEGER                                     :: lmax_0, igrid_zet0_s
-      TYPE(pw_p_type), POINTER                    :: rho0_s_rs, &
-                                                     rho0_s_gs
+      TYPE(pw_type), POINTER                    :: rho0_s_rs, &
+                                                   rho0_s_gs
    END TYPE rho0_mpole_type
 
 ! **************************************************************************************************
@@ -376,14 +376,12 @@ CONTAINS
          END IF
 
          IF (ASSOCIATED(rho0%rho0_s_rs)) THEN
-            CALL pw_release(rho0%rho0_s_rs%pw)
-            DEALLOCATE (rho0%rho0_s_rs%pw)
+            CALL pw_release(rho0%rho0_s_rs)
             DEALLOCATE (rho0%rho0_s_rs)
          END IF
 
          IF (ASSOCIATED(rho0%rho0_s_gs)) THEN
-            CALL pw_release(rho0%rho0_s_gs%pw)
-            DEALLOCATE (rho0%rho0_s_gs%pw)
+            CALL pw_release(rho0%rho0_s_gs)
             DEALLOCATE (rho0%rho0_s_gs)
 
          END IF
@@ -438,7 +436,7 @@ CONTAINS
       REAL(dp), INTENT(OUT), OPTIONAL                    :: zet0_h
       INTEGER, INTENT(OUT), OPTIONAL                     :: igrid_zet0_s
       REAL(dp), INTENT(OUT), OPTIONAL                    :: rpgf0_h, rpgf0_s, max_rpgf0_s
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho0_s_rs, rho0_s_gs
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho0_s_rs, rho0_s_gs
 
       IF (ASSOCIATED(rho0_mpole)) THEN
 

--- a/src/qs_rho0_types.F
+++ b/src/qs_rho0_types.F
@@ -377,11 +377,13 @@ CONTAINS
 
          IF (ASSOCIATED(rho0%rho0_s_rs)) THEN
             CALL pw_release(rho0%rho0_s_rs%pw)
+            DEALLOCATE (rho0%rho0_s_rs%pw)
             DEALLOCATE (rho0%rho0_s_rs)
          END IF
 
          IF (ASSOCIATED(rho0%rho0_s_gs)) THEN
             CALL pw_release(rho0%rho0_s_gs%pw)
+            DEALLOCATE (rho0%rho0_s_gs%pw)
             DEALLOCATE (rho0%rho0_s_gs)
 
          END IF

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -46,7 +46,8 @@ MODULE qs_rho_methods
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_drho_elec,&
                                               calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -121,9 +122,9 @@ CONTAINS
          POINTER                                         :: sab_orb
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, tau_g, tau_r
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g, drho_r
-      TYPE(pw_p_type), POINTER                           :: rho_r_sccs
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), DIMENSION(:, :), POINTER            :: drho_g, drho_r
+      TYPE(pw_type), POINTER                             :: rho_r_sccs
 
       CALL timeset(routineN, handle)
 
@@ -246,17 +247,15 @@ CONTAINS
       IF (dft_control%do_sccs) THEN
          IF (my_rebuild_grids .OR. (.NOT. ASSOCIATED(rho_r_sccs))) THEN
             IF (ASSOCIATED(rho_r_sccs)) THEN
-               CALL pw_release(rho_r_sccs%pw)
-               DEALLOCATE (rho_r_sccs%pw)
+               CALL pw_release(rho_r_sccs)
                DEALLOCATE (rho_r_sccs)
             END IF
             ALLOCATE (rho_r_sccs)
             CALL qs_rho_set(rho, rho_r_sccs=rho_r_sccs)
-            ALLOCATE (rho_r_sccs%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
-            CALL pw_zero(rho_r_sccs%pw)
+            CALL pw_zero(rho_r_sccs)
          END IF
       END IF
 
@@ -267,8 +266,7 @@ CONTAINS
             IF (ASSOCIATED(drho_r)) THEN
                DO j = 1, SIZE(drho_r, 2)
                   DO i = 1, SIZE(drho_r, 1)
-                     CALL pw_release(drho_r(i, j)%pw)
-                     DEALLOCATE (drho_r(i, j)%pw)
+                     CALL pw_release(drho_r(i, j))
                   END DO
                END DO
                DEALLOCATE (drho_r)
@@ -277,8 +275,7 @@ CONTAINS
             CALL qs_rho_set(rho, drho_r=drho_r)
             DO j = 1, nspins
                DO i = 1, 3
-                  ALLOCATE (drho_r(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(i, j), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                END DO
             END DO
@@ -288,8 +285,7 @@ CONTAINS
             IF (ASSOCIATED(drho_g)) THEN
                DO j = 1, SIZE(drho_g, 2)
                   DO i = 1, SIZE(drho_r, 1)
-                     CALL pw_release(drho_g(i, j)%pw)
-                     DEALLOCATE (drho_g(i, j)%pw)
+                     CALL pw_release(drho_g(i, j))
                   END DO
                END DO
                DEALLOCATE (drho_g)
@@ -298,8 +294,7 @@ CONTAINS
             CALL qs_rho_set(rho, drho_g=drho_g)
             DO j = 1, nspins
                DO i = 1, 3
-                  ALLOCATE (drho_g(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(i, j), &
                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                END DO
             END DO
@@ -489,7 +484,7 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rho_xc_g, rho_xc_r, tau_g, &
                                                             tau_r, tau_xc_g, tau_xc_r
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g, drho_r, drho_xc_g, drho_xc_r
+      TYPE(pw_type), DIMENSION(:, :), POINTER            :: drho_g, drho_r, drho_xc_g, drho_xc_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_xc
@@ -787,9 +782,9 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_in, rho_g_out, rho_r_in, &
                                                             rho_r_out, tau_g_in, tau_g_out, &
                                                             tau_r_in, tau_r_out
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g_in, drho_g_out, drho_r_in, &
+      TYPE(pw_type), DIMENSION(:, :), POINTER            :: drho_g_in, drho_g_out, drho_r_in, &
                                                             drho_r_out
-      TYPE(pw_p_type), POINTER                           :: rho_r_sccs_in, rho_r_sccs_out
+      TYPE(pw_type), POINTER                             :: rho_r_sccs_in, rho_r_sccs_out
 
       CALL timeset(routineN, handle)
 
@@ -910,11 +905,10 @@ CONTAINS
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_in)) THEN
          CALL qs_rho_set(rho_output, rho_r_sccs=rho_r_sccs_out)
-         ALLOCATE (rho_r_sccs_out%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out, &
                                 in_space=REALSPACE, &
                                 use_data=REALDATA3D)
-         rho_r_sccs_out%pw%cr3d(:, :, :) = rho_r_sccs_in%pw%cr3d(:, :, :)
+         rho_r_sccs_out%cr3d(:, :, :) = rho_r_sccs_in%cr3d(:, :, :)
       END IF
 
       ! drho_r
@@ -926,19 +920,17 @@ CONTAINS
          IF (mspin > nspins) THEN
             DO j = 1, mspin
                DO i = 1, 3
-                  ALLOCATE (drho_r_out(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  drho_r_out(i, j)%pw%cr3d(:, :, :) = drho_r_in(i, 1)%pw%cr3d(:, :, :)*ospin
+                  drho_r_out(i, j)%cr3d(:, :, :) = drho_r_in(i, 1)%cr3d(:, :, :)*ospin
                END DO
             END DO
          ELSE
             DO j = 1, nspins
                DO i = 1, 3
-                  ALLOCATE (drho_r_out(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  drho_r_out(i, j)%pw%cr3d(:, :, :) = drho_r_in(i, j)%pw%cr3d(:, :, :)
+                  drho_r_out(i, j)%cr3d(:, :, :) = drho_r_in(i, j)%cr3d(:, :, :)
                END DO
             END DO
          END IF
@@ -953,21 +945,19 @@ CONTAINS
          IF (mspin > nspins) THEN
             DO j = 1, mspin
                DO i = 1, 3
-                  ALLOCATE (drho_g_out(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
                                          use_data=COMPLEXDATA1D, &
                                          in_space=RECIPROCALSPACE)
-                  drho_g_out(i, j)%pw%cc(:) = drho_g_in(i, 1)%pw%cc(:)*ospin
+                  drho_g_out(i, j)%cc(:) = drho_g_in(i, 1)%cc(:)*ospin
                END DO
             END DO
          ELSE
             DO j = 1, nspins
                DO i = 1, 3
-                  ALLOCATE (drho_g_out(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
                                          use_data=COMPLEXDATA1D, &
                                          in_space=RECIPROCALSPACE)
-                  drho_g_out(i, j)%pw%cc(:) = drho_g_in(i, j)%pw%cc(:)
+                  drho_g_out(i, j)%cc(:) = drho_g_in(i, j)%cc(:)
                END DO
             END DO
          END IF
@@ -1091,8 +1081,8 @@ CONTAINS
                                                             rho_ao_im_b
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_a, rho_g_b, rho_r_a, rho_r_b, &
                                                             tau_g_a, tau_g_b, tau_r_a, tau_r_b
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g_a, drho_g_b, drho_r_a, drho_r_b
-      TYPE(pw_p_type), POINTER                           :: rho_r_sccs_a, rho_r_sccs_b
+      TYPE(pw_type), DIMENSION(:, :), POINTER            :: drho_g_a, drho_g_b, drho_r_a, drho_r_b
+      TYPE(pw_type), POINTER                             :: rho_r_sccs_a, rho_r_sccs_b
 
       CALL timeset(routineN, handle)
 
@@ -1167,7 +1157,7 @@ CONTAINS
 
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_a) .AND. ASSOCIATED(rho_r_sccs_b)) THEN
-         rho_r_sccs_a%pw%cr3d(:, :, :) = alpha*rho_r_sccs_a%pw%cr3d(:, :, :) + beta*rho_r_sccs_b%pw%cr3d(:, :, :)
+         rho_r_sccs_a%cr3d(:, :, :) = alpha*rho_r_sccs_a%cr3d(:, :, :) + beta*rho_r_sccs_b%cr3d(:, :, :)
       END IF
 
       ! drho_r
@@ -1175,7 +1165,7 @@ CONTAINS
          CPASSERT(ALL(SHAPE(drho_r_a) == SHAPE(drho_r_b))) ! not implemented
          DO j = 1, SIZE(drho_r_a, 2)
             DO i = 1, SIZE(drho_r_a, 1)
-               drho_r_a(i, j)%pw%cr3d(:, :, :) = alpha*drho_r_a(i, j)%pw%cr3d(:, :, :) + beta*drho_r_b(i, j)%pw%cr3d(:, :, :)
+               drho_r_a(i, j)%cr3d(:, :, :) = alpha*drho_r_a(i, j)%cr3d(:, :, :) + beta*drho_r_b(i, j)%cr3d(:, :, :)
             END DO
          END DO
       END IF
@@ -1185,7 +1175,7 @@ CONTAINS
          CPASSERT(ALL(SHAPE(drho_g_a) == SHAPE(drho_g_b))) ! not implemented
          DO j = 1, SIZE(drho_g_a, 2)
             DO i = 1, SIZE(drho_g_a, 1)
-               drho_g_a(i, j)%pw%cc(:) = alpha*drho_g_a(i, j)%pw%cc(:) + beta*drho_g_b(i, j)%pw%cc(:)
+               drho_g_a(i, j)%cc(:) = alpha*drho_g_a(i, j)%cc(:) + beta*drho_g_b(i, j)%cc(:)
             END DO
          END DO
       END IF
@@ -1264,10 +1254,10 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_in, rho_g_out, rho_r_in, &
                                                             rho_r_out, tau_g_in, tau_g_out, &
                                                             tau_r_in, tau_r_out
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g_in, drho_g_out, drho_r_in, &
-                                                            drho_r_out
-      TYPE(pw_p_type), POINTER                           :: rho_r_sccs_in, rho_r_sccs_out
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), DIMENSION(:, :), POINTER            :: drho_g_in, drho_g_out, drho_r_in, &
+                                                            drho_r_out
+      TYPE(pw_type), POINTER                             :: rho_r_sccs_in, rho_r_sccs_out
 
       CALL timeset(routineN, handle)
 
@@ -1349,11 +1339,10 @@ CONTAINS
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_in)) THEN
          CALL qs_rho_set(rho_output, rho_r_sccs=rho_r_sccs_out)
-         ALLOCATE (rho_r_sccs_out%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out, &
                                 in_space=REALSPACE, &
                                 use_data=REALDATA3D)
-         rho_r_sccs_out%pw%cr3d(:, :, :) = rho_r_sccs_in%pw%cr3d(:, :, :)
+         rho_r_sccs_out%cr3d(:, :, :) = rho_r_sccs_in%cr3d(:, :, :)
       END IF
 
       ! drho_r and drho_g are only needed if calculated by collocation
@@ -1364,10 +1353,9 @@ CONTAINS
             CALL qs_rho_set(rho_output, drho_r=drho_r_out)
             DO j = 1, nspins
                DO i = 1, 3
-                  ALLOCATE (drho_r_out(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  drho_r_out(i, j)%pw%cr3d(:, :, :) = drho_r_in(i, j)%pw%cr3d(:, :, :)
+                  drho_r_out(i, j)%cr3d(:, :, :) = drho_r_in(i, j)%cr3d(:, :, :)
                END DO
             END DO
          END IF
@@ -1378,11 +1366,10 @@ CONTAINS
             CALL qs_rho_set(rho_output, drho_g=drho_g_out)
             DO j = 1, nspins
                DO i = 1, 3
-                  ALLOCATE (drho_g_out(i, j)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j)%pw, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
                                          use_data=COMPLEXDATA1D, &
                                          in_space=RECIPROCALSPACE)
-                  drho_g_out(i, j)%pw%cc(:) = drho_g_in(i, j)%pw%cc(:)
+                  drho_g_out(i, j)%cc(:) = drho_g_in(i, j)%cc(:)
                END DO
             END DO
          END IF

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -511,8 +511,8 @@ CONTAINS
       DO ispin = 1, nspins
          rho_ao => rho_ao_kp(ispin, :)
          CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                 rho=rho_r(ispin), &
-                                 rho_gspace=rho_g(ispin), &
+                                 rho=rho_r(ispin)%pw, &
+                                 rho_gspace=rho_g(ispin)%pw, &
                                  total_rho=tot_rho_r(ispin), &
                                  ks_env=ks_env, soft_valid=gapw, &
                                  task_list_external=task_list_external, &
@@ -540,8 +540,8 @@ CONTAINS
          DO ispin = 1, nspins
             rho_ao => rho_xc_ao(ispin, :)
             CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                    rho=rho_xc_r(ispin), &
-                                    rho_gspace=rho_xc_g(ispin), &
+                                    rho=rho_xc_r(ispin)%pw, &
+                                    rho_gspace=rho_xc_g(ispin)%pw, &
                                     total_rho=tot_rho_r_xc(ispin), &
                                     ks_env=ks_env, soft_valid=gapw_xc, &
                                     task_list_external=task_list_external_soft, &
@@ -582,8 +582,8 @@ CONTAINS
             DO ispin = 1, nspins
                rho_ao => rho_ao_kp(ispin, :)
                CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                       rho=tau_r(ispin), &
-                                       rho_gspace=tau_g(ispin), &
+                                       rho=tau_r(ispin)%pw, &
+                                       rho_gspace=tau_g(ispin)%pw, &
                                        total_rho=dum, & ! presumably not meaningful
                                        ks_env=ks_env, soft_valid=gapw, &
                                        compute_tau=.TRUE., &
@@ -614,8 +614,8 @@ CONTAINS
             DO ispin = 1, nspins
                rho_ao => rho_xc_ao(ispin, :)
                CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                       rho=tau_xc_r(ispin), &
-                                       rho_gspace=tau_xc_g(ispin), &
+                                       rho=tau_xc_r(ispin)%pw, &
+                                       rho_gspace=tau_xc_g(ispin)%pw, &
                                        total_rho=dum, & ! presumably not meaningful
                                        ks_env=ks_env, soft_valid=gapw_xc, &
                                        compute_tau=.TRUE., &
@@ -721,8 +721,8 @@ CONTAINS
          DO ispin = 1, nspins
             rho_ao => rho_ao_kp(ispin, :)
             CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                    rho=rho_r(ispin), &
-                                    rho_gspace=rho_g(ispin), &
+                                    rho=rho_r(ispin)%pw, &
+                                    rho_gspace=rho_g(ispin)%pw, &
                                     total_rho=tot_rho_r(ispin), &
                                     ks_env=ks_env, &
                                     task_list_external=task_list_external, &

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -218,6 +218,7 @@ CONTAINS
          ALLOCATE (rho_r(nspins))
          CALL qs_rho_set(rho, rho_r=rho_r)
          DO i = 1, nspins
+            ALLOCATE (rho_r(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(i)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
          END DO
@@ -235,6 +236,7 @@ CONTAINS
          ALLOCATE (rho_g(nspins))
          CALL qs_rho_set(rho, rho_g=rho_g)
          DO i = 1, nspins
+            ALLOCATE (rho_g(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(i)%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
@@ -250,6 +252,7 @@ CONTAINS
             END IF
             ALLOCATE (rho_r_sccs)
             CALL qs_rho_set(rho, rho_r_sccs=rho_r_sccs)
+            ALLOCATE (rho_r_sccs%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -271,6 +274,7 @@ CONTAINS
             ALLOCATE (drho_r(3*nspins))
             CALL qs_rho_set(rho, drho_r=drho_r)
             DO i = 1, 3*nspins
+               ALLOCATE (drho_r(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
             END DO
@@ -287,6 +291,7 @@ CONTAINS
             ALLOCATE (drho_g(3*nspins))
             CALL qs_rho_set(rho, drho_g=drho_g)
             DO i = 1, 3*nspins
+               ALLOCATE (drho_g(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(i)%pw, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END DO
@@ -307,6 +312,7 @@ CONTAINS
             ALLOCATE (tau_r(nspins))
             CALL qs_rho_set(rho, tau_r=tau_r)
             DO i = 1, nspins
+               ALLOCATE (tau_r(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_r(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
             END DO
@@ -324,6 +330,7 @@ CONTAINS
             ALLOCATE (tau_g(nspins))
             CALL qs_rho_set(rho, tau_g=tau_g)
             DO i = 1, nspins
+               ALLOCATE (tau_g(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_g(i)%pw, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END DO
@@ -848,12 +855,14 @@ CONTAINS
          CALL qs_rho_set(rho_output, rho_r=rho_r_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
+               ALLOCATE (rho_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                rho_r_out(i)%pw%cr3d(:, :, :) = rho_r_in(1)%pw%cr3d(:, :, :)*ospin
             END DO
          ELSE
             DO i = 1, nspins
+               ALLOCATE (rho_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                rho_r_out(i)%pw%cr3d(:, :, :) = rho_r_in(i)%pw%cr3d(:, :, :)
@@ -869,6 +878,7 @@ CONTAINS
          CALL qs_rho_set(rho_output, rho_g=rho_g_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
+               ALLOCATE (rho_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -876,6 +886,7 @@ CONTAINS
             END DO
          ELSE
             DO i = 1, nspins
+               ALLOCATE (rho_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -887,6 +898,7 @@ CONTAINS
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_in)) THEN
          CALL qs_rho_set(rho_output, rho_r_sccs=rho_r_sccs_out)
+         ALLOCATE (rho_r_sccs_out%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out%pw, &
                                 in_space=REALSPACE, &
                                 use_data=REALDATA3D)
@@ -902,12 +914,14 @@ CONTAINS
          IF (mspin > nspins) THEN
             DO i = 1, 3*mspin
                ii = (i + 1)/2
+               ALLOCATE (drho_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                drho_r_out(i)%pw%cr3d(:, :, :) = drho_r_in(ii)%pw%cr3d(:, :, :)*ospin
             END DO
          ELSE
             DO i = 1, 3*nspins
+               ALLOCATE (drho_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                drho_r_out(i)%pw%cr3d(:, :, :) = drho_r_in(i)%pw%cr3d(:, :, :)
@@ -924,6 +938,7 @@ CONTAINS
          IF (mspin > nspins) THEN
             DO i = 1, 3*mspin
                ii = (i + 1)/2
+               ALLOCATE (drho_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -931,6 +946,7 @@ CONTAINS
             END DO
          ELSE
             DO i = 1, 3*nspins
+               ALLOCATE (drho_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -947,12 +963,14 @@ CONTAINS
          CALL qs_rho_set(rho_output, tau_r=tau_r_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
+               ALLOCATE (tau_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                tau_r_out(i)%pw%cr3d(:, :, :) = tau_r_in(1)%pw%cr3d(:, :, :)*ospin
             END DO
          ELSE
             DO i = 1, nspins
+               ALLOCATE (tau_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                tau_r_out(i)%pw%cr3d(:, :, :) = tau_r_in(i)%pw%cr3d(:, :, :)
@@ -968,6 +986,7 @@ CONTAINS
          CALL qs_rho_set(rho_output, tau_g=tau_g_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
+               ALLOCATE (tau_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -975,6 +994,7 @@ CONTAINS
             END DO
          ELSE
             DO i = 1, nspins
+               ALLOCATE (tau_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -1283,6 +1303,7 @@ CONTAINS
          ALLOCATE (rho_r_out(nspins))
          CALL qs_rho_set(rho_output, rho_r=rho_r_out)
          DO i = 1, nspins
+            ALLOCATE (rho_r_out(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             rho_r_out(i)%pw%cr3d(:, :, :) = rho_r_in(i)%pw%cr3d(:, :, :)
@@ -1294,6 +1315,7 @@ CONTAINS
          ALLOCATE (rho_g_out(nspins))
          CALL qs_rho_set(rho_output, rho_g=rho_g_out)
          DO i = 1, nspins
+            ALLOCATE (rho_g_out(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i)%pw, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
@@ -1304,6 +1326,7 @@ CONTAINS
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_in)) THEN
          CALL qs_rho_set(rho_output, rho_r_sccs=rho_r_sccs_out)
+         ALLOCATE (rho_r_sccs_out%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out%pw, &
                                 in_space=REALSPACE, &
                                 use_data=REALDATA3D)
@@ -1317,6 +1340,7 @@ CONTAINS
             ALLOCATE (drho_r_out(3*nspins))
             CALL qs_rho_set(rho_output, drho_r=drho_r_out)
             DO i = 1, 3*nspins
+               ALLOCATE (drho_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                drho_r_out(i)%pw%cr3d(:, :, :) = drho_r_in(i)%pw%cr3d(:, :, :)
@@ -1328,6 +1352,7 @@ CONTAINS
             ALLOCATE (drho_g_out(3*nspins))
             CALL qs_rho_set(rho_output, drho_g=drho_g_out)
             DO i = 1, 3*nspins
+               ALLOCATE (drho_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -1345,6 +1370,7 @@ CONTAINS
             ALLOCATE (tau_r_out(nspins))
             CALL qs_rho_set(rho_output, tau_r=tau_r_out)
             DO i = 1, nspins
+               ALLOCATE (tau_r_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                tau_r_out(i)%pw%cr3d(:, :, :) = tau_r_in(i)%pw%cr3d(:, :, :)
@@ -1356,6 +1382,7 @@ CONTAINS
             ALLOCATE (tau_g_out(nspins))
             CALL qs_rho_set(rho_output, tau_g=tau_g_out)
             DO i = 1, nspins
+               ALLOCATE (tau_g_out(i)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -211,6 +211,7 @@ CONTAINS
          IF (ASSOCIATED(rho_r)) THEN
             DO i = 1, SIZE(rho_r)
                CALL pw_release(rho_r(i)%pw)
+               DEALLOCATE (rho_r(i)%pw)
             END DO
             DEALLOCATE (rho_r)
          END IF
@@ -227,6 +228,7 @@ CONTAINS
          IF (ASSOCIATED(rho_g)) THEN
             DO i = 1, SIZE(rho_g)
                CALL pw_release(rho_g(i)%pw)
+               DEALLOCATE (rho_g(i)%pw)
             END DO
             DEALLOCATE (rho_g)
          END IF
@@ -243,6 +245,7 @@ CONTAINS
          IF (my_rebuild_grids .OR. (.NOT. ASSOCIATED(rho_r_sccs))) THEN
             IF (ASSOCIATED(rho_r_sccs)) THEN
                CALL pw_release(rho_r_sccs%pw)
+               DEALLOCATE (rho_r_sccs%pw)
                DEALLOCATE (rho_r_sccs)
             END IF
             ALLOCATE (rho_r_sccs)
@@ -261,6 +264,7 @@ CONTAINS
             IF (ASSOCIATED(drho_r)) THEN
                DO i = 1, SIZE(drho_r)
                   CALL pw_release(drho_r(i)%pw)
+                  DEALLOCATE (drho_r(i)%pw)
                END DO
                DEALLOCATE (drho_r)
             END IF
@@ -276,6 +280,7 @@ CONTAINS
             IF (ASSOCIATED(drho_g)) THEN
                DO i = 1, SIZE(drho_g)
                   CALL pw_release(drho_g(i)%pw)
+                  DEALLOCATE (drho_g(i)%pw)
                END DO
                DEALLOCATE (drho_g)
             END IF
@@ -295,6 +300,7 @@ CONTAINS
             IF (ASSOCIATED(tau_r)) THEN
                DO i = 1, SIZE(tau_r)
                   CALL pw_release(tau_r(i)%pw)
+                  DEALLOCATE (tau_r(i)%pw)
                END DO
                DEALLOCATE (tau_r)
             END IF
@@ -311,6 +317,7 @@ CONTAINS
             IF (ASSOCIATED(tau_g)) THEN
                DO i = 1, SIZE(tau_g)
                   CALL pw_release(tau_g(i)%pw)
+                  DEALLOCATE (tau_g(i)%pw)
                END DO
                DEALLOCATE (tau_g)
             END IF

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -108,7 +108,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_rho_rebuild'
 
       CHARACTER(LEN=default_string_length)               :: headline
-      INTEGER                                            :: handle, i, ic, nimg, nspins
+      INTEGER                                            :: handle, i, ic, j, nimg, nspins
       LOGICAL                                            :: do_kpoints, my_admm, my_rebuild_ao, &
                                                             my_rebuild_grids
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_r
@@ -120,8 +120,8 @@ CONTAINS
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: drho_g, drho_r, rho_g, rho_r, tau_g, &
-                                                            tau_r
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, tau_g, tau_r
+      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g, drho_r
       TYPE(pw_p_type), POINTER                           :: rho_r_sccs
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
 
@@ -265,35 +265,43 @@ CONTAINS
          ! drho_r
          IF (my_rebuild_grids .OR. .NOT. ASSOCIATED(drho_r)) THEN
             IF (ASSOCIATED(drho_r)) THEN
-               DO i = 1, SIZE(drho_r)
-                  CALL pw_release(drho_r(i)%pw)
-                  DEALLOCATE (drho_r(i)%pw)
+               DO j = 1, SIZE(drho_r, 2)
+                  DO i = 1, SIZE(drho_r, 1)
+                     CALL pw_release(drho_r(i, j)%pw)
+                     DEALLOCATE (drho_r(i, j)%pw)
+                  END DO
                END DO
                DEALLOCATE (drho_r)
             END IF
-            ALLOCATE (drho_r(3*nspins))
+            ALLOCATE (drho_r(3, nspins))
             CALL qs_rho_set(rho, drho_r=drho_r)
-            DO i = 1, 3*nspins
-               ALLOCATE (drho_r(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(i)%pw, &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+            DO j = 1, nspins
+               DO i = 1, 3
+                  ALLOCATE (drho_r(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(i, j)%pw, &
+                                         use_data=REALDATA3D, in_space=REALSPACE)
+               END DO
             END DO
          END IF
          ! drho_g
          IF (my_rebuild_grids .OR. .NOT. ASSOCIATED(drho_g)) THEN
             IF (ASSOCIATED(drho_g)) THEN
-               DO i = 1, SIZE(drho_g)
-                  CALL pw_release(drho_g(i)%pw)
-                  DEALLOCATE (drho_g(i)%pw)
+               DO j = 1, SIZE(drho_g, 2)
+                  DO i = 1, SIZE(drho_r, 1)
+                     CALL pw_release(drho_g(i, j)%pw)
+                     DEALLOCATE (drho_g(i, j)%pw)
+                  END DO
                END DO
                DEALLOCATE (drho_g)
             END IF
-            ALLOCATE (drho_g(3*nspins))
+            ALLOCATE (drho_g(3, nspins))
             CALL qs_rho_set(rho, drho_g=drho_g)
-            DO i = 1, 3*nspins
-               ALLOCATE (drho_g(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(i)%pw, &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            DO j = 1, nspins
+               DO i = 1, 3
+                  ALLOCATE (drho_g(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(i, j)%pw, &
+                                         use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               END DO
             END DO
          END IF
       END IF
@@ -479,9 +487,9 @@ CONTAINS
          POINTER                                         :: sab
       TYPE(oce_matrix_type), POINTER                     :: oce
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: drho_g, drho_r, drho_xc_g, rho_g, rho_r, &
-                                                            rho_xc_g, rho_xc_r, tau_g, tau_r, &
-                                                            tau_xc_g, tau_xc_r
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rho_xc_g, rho_xc_r, tau_g, &
+                                                            tau_r, tau_xc_g, tau_xc_r
+      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g, drho_r, drho_xc_g, drho_xc_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_xc
@@ -584,8 +592,8 @@ CONTAINS
             DO ispin = 1, nspins
                rho_ao => rho_ao_kp(ispin, :)
                CALL calculate_drho_elec(matrix_p_kp=rho_ao, &
-                                        drho=drho_r(3*(ispin - 1) + 1:3*ispin), &
-                                        drho_gspace=drho_g(3*(ispin - 1) + 1:3*ispin), &
+                                        drho=drho_r(:, ispin), &
+                                        drho_gspace=drho_g(:, ispin), &
                                         qs_env=qs_env, soft_valid=gapw)
             END DO
             CALL qs_rho_set(rho_struct, drho_r_valid=.TRUE., drho_g_valid=.TRUE.)
@@ -608,6 +616,7 @@ CONTAINS
          END IF
       ELSE
          CALL qs_rho_get(rho_xc, &
+                         drho_r=drho_xc_r, &
                          drho_g=drho_xc_g, &
                          tau_r=tau_xc_r, &
                          tau_g=tau_xc_g)
@@ -617,8 +626,8 @@ CONTAINS
             DO ispin = 1, nspins
                rho_ao => rho_xc_ao(ispin, :)
                CALL calculate_drho_elec(matrix_p_kp=rho_ao, &
-                                        drho=rho_xc_r(3*(ispin - 1) + 1:3*ispin), &
-                                        drho_gspace=drho_xc_g(3*(ispin - 1) + 1:3*ispin), &
+                                        drho=drho_xc_r(:, ispin), &
+                                        drho_gspace=drho_xc_g(:, ispin), &
                                         qs_env=qs_env, soft_valid=gapw_xc)
             END DO
             CALL qs_rho_set(rho_xc, drho_r_valid=.TRUE., drho_g_valid=.TRUE.)
@@ -767,7 +776,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qs_rho_copy', routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i, ii, nspins, rebuild_each_in
+      INTEGER                                            :: handle, i, j, nspins, rebuild_each_in
       LOGICAL :: drho_g_valid_in, drho_r_valid_in, rho_g_valid_in, rho_r_valid_in, soft_valid_in, &
          tau_g_valid_in, tau_r_valid_in
       REAL(KIND=dp)                                      :: ospin
@@ -775,8 +784,11 @@ CONTAINS
                                                             tot_rho_r_in, tot_rho_r_out
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao_im_in, rho_ao_in, rho_ao_out
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao_kp_in
-      TYPE(pw_p_type), DIMENSION(:), POINTER :: drho_g_in, drho_g_out, drho_r_in, drho_r_out, &
-         rho_g_in, rho_g_out, rho_r_in, rho_r_out, tau_g_in, tau_g_out, tau_r_in, tau_r_out
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_in, rho_g_out, rho_r_in, &
+                                                            rho_r_out, tau_g_in, tau_g_out, &
+                                                            tau_r_in, tau_r_out
+      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g_in, drho_g_out, drho_r_in, &
+                                                            drho_r_out
       TYPE(pw_p_type), POINTER                           :: rho_r_sccs_in, rho_r_sccs_out
 
       CALL timeset(routineN, handle)
@@ -909,22 +921,25 @@ CONTAINS
       IF (ASSOCIATED(drho_r_in)) THEN
          nspins = SIZE(drho_r_in)
          CPASSERT(mspin >= nspins)
-         ALLOCATE (drho_r_out(3*mspin))
+         ALLOCATE (drho_r_out(3, mspin))
          CALL qs_rho_set(rho_output, drho_r=drho_r_out)
          IF (mspin > nspins) THEN
-            DO i = 1, 3*mspin
-               ii = (i + 1)/2
-               ALLOCATE (drho_r_out(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i)%pw, &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
-               drho_r_out(i)%pw%cr3d(:, :, :) = drho_r_in(ii)%pw%cr3d(:, :, :)*ospin
+            DO j = 1, mspin
+               DO i = 1, 3
+                  ALLOCATE (drho_r_out(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j)%pw, &
+                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  drho_r_out(i, j)%pw%cr3d(:, :, :) = drho_r_in(i, 1)%pw%cr3d(:, :, :)*ospin
+               END DO
             END DO
          ELSE
-            DO i = 1, 3*nspins
-               ALLOCATE (drho_r_out(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i)%pw, &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
-               drho_r_out(i)%pw%cr3d(:, :, :) = drho_r_in(i)%pw%cr3d(:, :, :)
+            DO j = 1, nspins
+               DO i = 1, 3
+                  ALLOCATE (drho_r_out(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j)%pw, &
+                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  drho_r_out(i, j)%pw%cr3d(:, :, :) = drho_r_in(i, j)%pw%cr3d(:, :, :)
+               END DO
             END DO
          END IF
       END IF
@@ -933,24 +948,27 @@ CONTAINS
       IF (ASSOCIATED(drho_g_in)) THEN
          nspins = SIZE(drho_g_in)
          CPASSERT(mspin >= nspins)
-         ALLOCATE (drho_g_out(3*mspin))
+         ALLOCATE (drho_g_out(3, mspin))
          CALL qs_rho_set(rho_output, drho_g=drho_g_out)
          IF (mspin > nspins) THEN
-            DO i = 1, 3*mspin
-               ii = (i + 1)/2
-               ALLOCATE (drho_g_out(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i)%pw, &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
-               drho_g_out(i)%pw%cc(:) = drho_g_in(ii)%pw%cc(:)*ospin
+            DO j = 1, mspin
+               DO i = 1, 3
+                  ALLOCATE (drho_g_out(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j)%pw, &
+                                         use_data=COMPLEXDATA1D, &
+                                         in_space=RECIPROCALSPACE)
+                  drho_g_out(i, j)%pw%cc(:) = drho_g_in(i, 1)%pw%cc(:)*ospin
+               END DO
             END DO
          ELSE
-            DO i = 1, 3*nspins
-               ALLOCATE (drho_g_out(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i)%pw, &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
-               drho_g_out(i)%pw%cc(:) = drho_g_in(i)%pw%cc(:)
+            DO j = 1, nspins
+               DO i = 1, 3
+                  ALLOCATE (drho_g_out(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j)%pw, &
+                                         use_data=COMPLEXDATA1D, &
+                                         in_space=RECIPROCALSPACE)
+                  drho_g_out(i, j)%pw%cc(:) = drho_g_in(i, j)%pw%cc(:)
+               END DO
             END DO
          END IF
       END IF
@@ -1066,14 +1084,14 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'qs_rho_scale_and_add', &
          routineP = moduleN//':'//routineN
 
-      INTEGER                                            :: handle, i, ndims, nspina, nspinb, nspins
+      INTEGER                                            :: handle, i, j, nspina, nspinb, nspins
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_g_a, tot_rho_g_b, tot_rho_r_a, &
                                                             tot_rho_r_b
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao_a, rho_ao_b, rho_ao_im_a, &
                                                             rho_ao_im_b
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: drho_g_a, drho_g_b, drho_r_a, drho_r_b, &
-                                                            rho_g_a, rho_g_b, rho_r_a, rho_r_b, &
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_a, rho_g_b, rho_r_a, rho_r_b, &
                                                             tau_g_a, tau_g_b, tau_r_a, tau_r_b
+      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g_a, drho_g_b, drho_r_a, drho_r_b
       TYPE(pw_p_type), POINTER                           :: rho_r_sccs_a, rho_r_sccs_b
 
       CALL timeset(routineN, handle)
@@ -1154,19 +1172,21 @@ CONTAINS
 
       ! drho_r
       IF (ASSOCIATED(drho_r_a) .AND. ASSOCIATED(drho_r_b)) THEN
-         ndims = SIZE(drho_r_a)
-         CPASSERT(ndims == SIZE(drho_r_b)) ! not implemented
-         DO i = 1, ndims
-            drho_r_a(i)%pw%cr3d(:, :, :) = alpha*drho_r_a(i)%pw%cr3d(:, :, :) + beta*drho_r_b(i)%pw%cr3d(:, :, :)
+         CPASSERT(ALL(SHAPE(drho_r_a) == SHAPE(drho_r_b))) ! not implemented
+         DO j = 1, SIZE(drho_r_a, 2)
+            DO i = 1, SIZE(drho_r_a, 1)
+               drho_r_a(i, j)%pw%cr3d(:, :, :) = alpha*drho_r_a(i, j)%pw%cr3d(:, :, :) + beta*drho_r_b(i, j)%pw%cr3d(:, :, :)
+            END DO
          END DO
       END IF
 
       ! drho_g
       IF (ASSOCIATED(drho_g_a) .AND. ASSOCIATED(drho_g_b)) THEN
-         ndims = SIZE(drho_g_a)
-         CPASSERT(ndims == SIZE(drho_r_b)) ! not implemented
-         DO i = 1, ndims
-            drho_g_a(i)%pw%cc(:) = alpha*drho_g_a(i)%pw%cc(:) + beta*drho_g_b(i)%pw%cc(:)
+         CPASSERT(ALL(SHAPE(drho_g_a) == SHAPE(drho_g_b))) ! not implemented
+         DO j = 1, SIZE(drho_g_a, 2)
+            DO i = 1, SIZE(drho_g_a, 1)
+               drho_g_a(i, j)%pw%cc(:) = alpha*drho_g_a(i, j)%pw%cc(:) + beta*drho_g_b(i, j)%pw%cc(:)
+            END DO
          END DO
       END IF
 
@@ -1233,7 +1253,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'duplicate_rho_type'
 
-      INTEGER                                            :: handle, i, nspins, rebuild_each_in
+      INTEGER                                            :: handle, i, j, nspins, rebuild_each_in
       LOGICAL :: drho_g_valid_in, drho_r_valid_in, rho_g_valid_in, rho_r_valid_in, soft_valid_in, &
          tau_g_valid_in, tau_r_valid_in
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_g_in, tot_rho_g_out, &
@@ -1241,8 +1261,11 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao_in, rho_ao_out
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER :: drho_g_in, drho_g_out, drho_r_in, drho_r_out, &
-         rho_g_in, rho_g_out, rho_r_in, rho_r_out, tau_g_in, tau_g_out, tau_r_in, tau_r_out
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g_in, rho_g_out, rho_r_in, &
+                                                            rho_r_out, tau_g_in, tau_g_out, &
+                                                            tau_r_in, tau_r_out
+      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: drho_g_in, drho_g_out, drho_r_in, &
+                                                            drho_r_out
       TYPE(pw_p_type), POINTER                           :: rho_r_sccs_in, rho_r_sccs_out
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
 
@@ -1337,26 +1360,30 @@ CONTAINS
       IF (dft_control%drho_by_collocation) THEN
          ! drho_r
          IF (ASSOCIATED(drho_r_in)) THEN
-            ALLOCATE (drho_r_out(3*nspins))
+            ALLOCATE (drho_r_out(3, nspins))
             CALL qs_rho_set(rho_output, drho_r=drho_r_out)
-            DO i = 1, 3*nspins
-               ALLOCATE (drho_r_out(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i)%pw, &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
-               drho_r_out(i)%pw%cr3d(:, :, :) = drho_r_in(i)%pw%cr3d(:, :, :)
+            DO j = 1, nspins
+               DO i = 1, 3
+                  ALLOCATE (drho_r_out(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j)%pw, &
+                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  drho_r_out(i, j)%pw%cr3d(:, :, :) = drho_r_in(i, j)%pw%cr3d(:, :, :)
+               END DO
             END DO
          END IF
 
          ! drho_g
          IF (ASSOCIATED(drho_g_in)) THEN
-            ALLOCATE (drho_g_out(3*nspins))
+            ALLOCATE (drho_g_out(3, nspins))
             CALL qs_rho_set(rho_output, drho_g=drho_g_out)
-            DO i = 1, 3*nspins
-               ALLOCATE (drho_g_out(i)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i)%pw, &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
-               drho_g_out(i)%pw%cc(:) = drho_g_in(i)%pw%cc(:)
+            DO j = 1, nspins
+               DO i = 1, 3
+                  ALLOCATE (drho_g_out(i, j)%pw)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j)%pw, &
+                                         use_data=COMPLEXDATA1D, &
+                                         in_space=RECIPROCALSPACE)
+                  drho_g_out(i, j)%pw%cc(:) = drho_g_in(i, j)%pw%cc(:)
+               END DO
             END DO
          END IF
       END IF

--- a/src/qs_rho_types.F
+++ b/src/qs_rho_types.F
@@ -26,7 +26,8 @@ MODULE qs_rho_types
                                               set_1d_pointer,&
                                               set_2d_pointer
    USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -73,9 +74,9 @@ MODULE qs_rho_types
                                                         rho_r => Null(), &
                                                         tau_g => Null(), &
                                                         tau_r => Null()
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER :: drho_r => NULL(), drho_g => NULL()
+      TYPE(pw_type), DIMENSION(:, :), POINTER :: drho_r => NULL(), drho_g => NULL()
       ! Final rho_iter of last SCCS cycle (r-space)
-      TYPE(pw_p_type), POINTER                       :: rho_r_sccs => Null()
+      TYPE(pw_type), POINTER                       :: rho_r_sccs => Null()
       LOGICAL                                        :: rho_g_valid = .FALSE., &
                                                         rho_r_valid = .FALSE., &
                                                         drho_r_valid = .FALSE., &
@@ -177,8 +178,7 @@ CONTAINS
       IF (ASSOCIATED(rho_struct%drho_r)) THEN
          DO j = 1, SIZE(rho_struct%drho_r, 2)
             DO i = 1, SIZE(rho_struct%drho_r, 1)
-               CALL pw_release(rho_struct%drho_r(i, j)%pw)
-               DEALLOCATE (rho_struct%drho_r(i, j)%pw)
+               CALL pw_release(rho_struct%drho_r(i, j))
             END DO
          END DO
          DEALLOCATE (rho_struct%drho_r)
@@ -186,8 +186,7 @@ CONTAINS
       IF (ASSOCIATED(rho_struct%drho_g)) THEN
          DO i = 1, SIZE(rho_struct%drho_g, 2)
             DO j = 1, SIZE(rho_struct%drho_g, 1)
-               CALL pw_release(rho_struct%drho_g(i, j)%pw)
-               DEALLOCATE (rho_struct%drho_g(i, j)%pw)
+               CALL pw_release(rho_struct%drho_g(i, j))
             END DO
          END DO
          DEALLOCATE (rho_struct%drho_g)
@@ -214,8 +213,7 @@ CONTAINS
          DEALLOCATE (rho_struct%tau_g)
       END IF
       IF (ASSOCIATED(rho_struct%rho_r_sccs)) THEN
-         CALL pw_release(rho_struct%rho_r_sccs%pw)
-         DEALLOCATE (rho_struct%rho_r_sccs%pw)
+         CALL pw_release(rho_struct%rho_r_sccs)
          DEALLOCATE (rho_struct%rho_r_sccs)
       END IF
 
@@ -268,17 +266,15 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: rho_ao_kp
       TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_r
-      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: drho_r
+      TYPE(pw_type), DIMENSION(:, :), OPTIONAL, POINTER  :: drho_r
       TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_g
-      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: drho_g
+      TYPE(pw_type), DIMENSION(:, :), OPTIONAL, POINTER  :: drho_g
       TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: tau_r, tau_g
       LOGICAL, INTENT(out), OPTIONAL                     :: rho_r_valid, drho_r_valid, rho_g_valid, &
                                                             drho_g_valid, tau_r_valid, tau_g_valid
       INTEGER, INTENT(out), OPTIONAL                     :: rebuild_each
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: tot_rho_r, tot_rho_g
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_r_sccs
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_r_sccs
       LOGICAL, INTENT(out), OPTIONAL                     :: soft_valid
 
       CPASSERT(ASSOCIATED(rho_struct))
@@ -343,17 +339,15 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: rho_ao_kp
       TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_r
-      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: drho_r
+      TYPE(pw_type), DIMENSION(:, :), OPTIONAL, POINTER  :: drho_r
       TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_g
-      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: drho_g
+      TYPE(pw_type), DIMENSION(:, :), OPTIONAL, POINTER  :: drho_g
       TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: tau_r, tau_g
       LOGICAL, INTENT(in), OPTIONAL                      :: rho_r_valid, drho_r_valid, rho_g_valid, &
                                                             drho_g_valid, tau_r_valid, tau_g_valid
       INTEGER, INTENT(in), OPTIONAL                      :: rebuild_each
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: tot_rho_r, tot_rho_g
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_r_sccs
+      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_r_sccs
       LOGICAL, INTENT(in), OPTIONAL                      :: soft_valid
 
       CPASSERT(ASSOCIATED(rho_struct))

--- a/src/qs_rho_types.F
+++ b/src/qs_rho_types.F
@@ -171,41 +171,48 @@ CONTAINS
       IF (ASSOCIATED(rho_struct%rho_r)) THEN
          DO i = 1, SIZE(rho_struct%rho_r)
             CALL pw_release(rho_struct%rho_r(i)%pw)
+            DEALLOCATE (rho_struct%rho_r(i)%pw)
          END DO
          DEALLOCATE (rho_struct%rho_r)
       END IF
       IF (ASSOCIATED(rho_struct%drho_r)) THEN
          DO i = 1, SIZE(rho_struct%drho_r)
             CALL pw_release(rho_struct%drho_r(i)%pw)
+            DEALLOCATE (rho_struct%drho_r(i)%pw)
          END DO
          DEALLOCATE (rho_struct%drho_r)
       END IF
       IF (ASSOCIATED(rho_struct%drho_g)) THEN
          DO i = 1, SIZE(rho_struct%drho_g)
             CALL pw_release(rho_struct%drho_g(i)%pw)
+            DEALLOCATE (rho_struct%drho_g(i)%pw)
          END DO
          DEALLOCATE (rho_struct%drho_g)
       END IF
       IF (ASSOCIATED(rho_struct%tau_r)) THEN
          DO i = 1, SIZE(rho_struct%tau_r)
             CALL pw_release(rho_struct%tau_r(i)%pw)
+            DEALLOCATE (rho_struct%tau_r(i)%pw)
          END DO
          DEALLOCATE (rho_struct%tau_r)
       END IF
       IF (ASSOCIATED(rho_struct%rho_g)) THEN
          DO i = 1, SIZE(rho_struct%rho_g)
             CALL pw_release(rho_struct%rho_g(i)%pw)
+            DEALLOCATE (rho_struct%rho_g(i)%pw)
          END DO
          DEALLOCATE (rho_struct%rho_g)
       END IF
       IF (ASSOCIATED(rho_struct%tau_g)) THEN
          DO i = 1, SIZE(rho_struct%tau_g)
             CALL pw_release(rho_struct%tau_g(i)%pw)
+            DEALLOCATE (rho_struct%tau_g(i)%pw)
          END DO
          DEALLOCATE (rho_struct%tau_g)
       END IF
       IF (ASSOCIATED(rho_struct%rho_r_sccs)) THEN
          CALL pw_release(rho_struct%rho_r_sccs%pw)
+         DEALLOCATE (rho_struct%rho_r_sccs%pw)
          DEALLOCATE (rho_struct%rho_r_sccs)
       END IF
 

--- a/src/qs_rho_types.F
+++ b/src/qs_rho_types.F
@@ -71,10 +71,9 @@ MODULE qs_rho_types
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER      :: rho_ao_im => Null()
       TYPE(pw_p_type), DIMENSION(:), POINTER         :: rho_g => Null(), &
                                                         rho_r => Null(), &
-                                                        drho_g => Null(), &
-                                                        drho_r => Null(), &
                                                         tau_g => Null(), &
                                                         tau_r => Null()
+      TYPE(pw_p_type), DIMENSION(:, :), POINTER :: drho_r => NULL(), drho_g => NULL()
       ! Final rho_iter of last SCCS cycle (r-space)
       TYPE(pw_p_type), POINTER                       :: rho_r_sccs => Null()
       LOGICAL                                        :: rho_g_valid = .FALSE., &
@@ -166,7 +165,7 @@ CONTAINS
    SUBROUTINE qs_rho_clear(rho_struct)
       TYPE(qs_rho_type), POINTER                         :: rho_struct
 
-      INTEGER                                            :: i
+      INTEGER                                            :: i, j
 
       IF (ASSOCIATED(rho_struct%rho_r)) THEN
          DO i = 1, SIZE(rho_struct%rho_r)
@@ -176,16 +175,20 @@ CONTAINS
          DEALLOCATE (rho_struct%rho_r)
       END IF
       IF (ASSOCIATED(rho_struct%drho_r)) THEN
-         DO i = 1, SIZE(rho_struct%drho_r)
-            CALL pw_release(rho_struct%drho_r(i)%pw)
-            DEALLOCATE (rho_struct%drho_r(i)%pw)
+         DO j = 1, SIZE(rho_struct%drho_r, 2)
+            DO i = 1, SIZE(rho_struct%drho_r, 1)
+               CALL pw_release(rho_struct%drho_r(i, j)%pw)
+               DEALLOCATE (rho_struct%drho_r(i, j)%pw)
+            END DO
          END DO
          DEALLOCATE (rho_struct%drho_r)
       END IF
       IF (ASSOCIATED(rho_struct%drho_g)) THEN
-         DO i = 1, SIZE(rho_struct%drho_g)
-            CALL pw_release(rho_struct%drho_g(i)%pw)
-            DEALLOCATE (rho_struct%drho_g(i)%pw)
+         DO i = 1, SIZE(rho_struct%drho_g, 2)
+            DO j = 1, SIZE(rho_struct%drho_g, 1)
+               CALL pw_release(rho_struct%drho_g(i, j)%pw)
+               DEALLOCATE (rho_struct%drho_g(i, j)%pw)
+            END DO
          END DO
          DEALLOCATE (rho_struct%drho_g)
       END IF
@@ -264,8 +267,13 @@ CONTAINS
          POINTER                                         :: rho_ao, rho_ao_im
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: rho_ao_kp
-      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_r, drho_r, rho_g, drho_g, tau_r, &
-                                                            tau_g
+      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_r
+      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: drho_r
+      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_g
+      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: drho_g
+      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: tau_r, tau_g
       LOGICAL, INTENT(out), OPTIONAL                     :: rho_r_valid, drho_r_valid, rho_g_valid, &
                                                             drho_g_valid, tau_r_valid, tau_g_valid
       INTEGER, INTENT(out), OPTIONAL                     :: rebuild_each
@@ -334,8 +342,13 @@ CONTAINS
          POINTER                                         :: rho_ao, rho_ao_im
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: rho_ao_kp
-      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_r, drho_r, rho_g, drho_g, tau_r, &
-                                                            tau_g
+      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_r
+      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: drho_r
+      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rho_g
+      TYPE(pw_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: drho_g
+      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: tau_r, tau_g
       LOGICAL, INTENT(in), OPTIONAL                      :: rho_r_valid, drho_r_valid, rho_g_valid, &
                                                             drho_g_valid, tau_r_valid, tau_g_valid
       INTEGER, INTENT(in), OPTIONAL                      :: rebuild_each

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -284,7 +284,7 @@ CONTAINS
 
       ! Get work storage for the 3d grids in r-space
       DO i = 1, SIZE(work_r3d)
-         NULLIFY (work_r3d(i)%pw)
+         ALLOCATE (work_r3d(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
                                 work_r3d(i)%pw, &
                                 use_data=REALDATA3D, &
@@ -393,7 +393,7 @@ CONTAINS
          ! Calculate the derivative of the electronic density in r-space
          ! TODO: Could be retrieved from the QS environment
          DO i = 1, 3
-            NULLIFY (drho_elec(i)%pw)
+            ALLOCATE (drho_elec(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
                                    drho_elec(i)%pw, &
                                    use_data=REALDATA3D, &
@@ -475,7 +475,7 @@ CONTAINS
             ! Calculate the second derivatives of the electronic density in r-space
             DO di = 1, 3
                DO dj = 1, 3
-                  NULLIFY (d2rho_elec(dj, di)%pw)
+                  ALLOCATE (d2rho_elec(dj, di)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, &
                                          d2rho_elec(dj, di)%pw, &
                                          use_data=REALDATA3D, &
@@ -562,7 +562,7 @@ CONTAINS
 
       ! Build the derivative of ln_eps_elec
       DO i = 1, 3
-         NULLIFY (dln_eps_elec(i)%pw)
+         ALLOCATE (dln_eps_elec(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
                                 dln_eps_elec(i)%pw, &
                                 use_data=REALDATA3D, &
@@ -598,7 +598,7 @@ CONTAINS
 
       ! Get storage for the derivative of the total potential (field) in r-space
       DO i = 1, 3
-         NULLIFY (dphi_tot(i)%pw)
+         ALLOCATE (dphi_tot(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
                                 dphi_tot(i)%pw, &
                                 use_data=REALDATA3D, &
@@ -1128,7 +1128,7 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ! Get work storage for the 1d grids in g-space (derivative calculation)
          DO i = 1, SIZE(work_g1d)
-            NULLIFY (work_g1d(i)%pw)
+            ALLOCATE (work_g1d(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
                                    work_g1d(i)%pw, &
                                    use_data=COMPLEXDATA1D, &

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -155,14 +155,15 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(3)                      :: dln_eps_elec, dphi_tot, drho_elec
-      TYPE(pw_p_type), DIMENSION(3, 3)                   :: d2rho_elec
+      TYPE(pw_p_type), DIMENSION(3)                      :: dphi_tot
       TYPE(pw_p_type), DIMENSION(5)                      :: work_r3d
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_pw_r
       TYPE(pw_p_type), POINTER                           :: rho_pw_r_sccs
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), DIMENSION(3)                        :: dln_eps_elec, drho_elec
+      TYPE(pw_type), DIMENSION(3, 3)                     :: d2rho_elec
       TYPE(pw_type), POINTER :: deps_elec, eps_elec, ln_eps_elec, norm_drho_elec, phi_pol, &
          phi_solute, phi_tot, rho_elec, rho_iter_old, rho_pol, rho_solute, rho_tot, rho_tot_zero, &
          theta
@@ -393,13 +394,12 @@ CONTAINS
          ! Calculate the derivative of the electronic density in r-space
          ! TODO: Could be retrieved from the QS environment
          DO i = 1, 3
-            ALLOCATE (drho_elec(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   drho_elec(i)%pw, &
+                                   drho_elec(i), &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
          END DO
-         CALL derive(rho_elec, drho_elec, sccs_derivative_fft, pw_env, input, para_env)
+         CALL derive(rho_elec, drho_elec, sccs_derivative_fft, pw_env, input)
 
          ! Calculate the norm of the gradient of the electronic density in r-space
          norm_drho_elec => work_r3d(5)%pw
@@ -409,12 +409,12 @@ CONTAINS
          DO k = lb(3), ub(3)
             DO j = lb(2), ub(2)
                DO i = lb(1), ub(1)
-                  norm_drho_elec%cr3d(i, j, k) = SQRT(drho_elec(1)%pw%cr3d(i, j, k)* &
-                                                      drho_elec(1)%pw%cr3d(i, j, k) + &
-                                                      drho_elec(2)%pw%cr3d(i, j, k)* &
-                                                      drho_elec(2)%pw%cr3d(i, j, k) + &
-                                                      drho_elec(3)%pw%cr3d(i, j, k)* &
-                                                      drho_elec(3)%pw%cr3d(i, j, k))
+                  norm_drho_elec%cr3d(i, j, k) = SQRT(drho_elec(1)%cr3d(i, j, k)* &
+                                                      drho_elec(1)%cr3d(i, j, k) + &
+                                                      drho_elec(2)%cr3d(i, j, k)* &
+                                                      drho_elec(2)%cr3d(i, j, k) + &
+                                                      drho_elec(3)%cr3d(i, j, k)* &
+                                                      drho_elec(3)%cr3d(i, j, k))
                END DO
             END DO
          END DO
@@ -475,14 +475,13 @@ CONTAINS
             ! Calculate the second derivatives of the electronic density in r-space
             DO di = 1, 3
                DO dj = 1, 3
-                  ALLOCATE (d2rho_elec(dj, di)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                         d2rho_elec(dj, di)%pw, &
+                                         d2rho_elec(dj, di), &
                                          use_data=REALDATA3D, &
                                          in_space=REALSPACE)
                END DO
-               CALL derive(drho_elec(di)%pw, d2rho_elec(:, di), sccs_derivative_fft, pw_env, &
-                           input, para_env)
+               CALL derive(drho_elec(di), d2rho_elec(:, di), sccs_derivative_fft, pw_env, &
+                           input)
             END DO
 
             ! Calculate the contribution of the cavitation energy to the Kohn-Sham potential
@@ -497,10 +496,10 @@ CONTAINS
                      DO di = 1, 3
                         DO dj = 1, 3
                            v_sccs%cr3d(i, j, k) = sccs_control%gamma_solvent*theta%cr3d(i, j, k)* &
-                                                  (drho_elec(di)%pw%cr3d(i, j, k)* &
-                                                   drho_elec(dj)%pw%cr3d(i, j, k)* &
-                                                   d2rho_elec(di, dj)%pw%cr3d(i, j, k)/norm_drho2 - &
-                                                   d2rho_elec(di, di)%pw%cr3d(i, j, k))/norm_drho2
+                                                  (drho_elec(di)%cr3d(i, j, k)* &
+                                                   drho_elec(dj)%cr3d(i, j, k)* &
+                                                   d2rho_elec(di, dj)%cr3d(i, j, k)/norm_drho2 - &
+                                                   d2rho_elec(di, di)%cr3d(i, j, k))/norm_drho2
                         END DO
                      END DO
                   END DO
@@ -510,8 +509,7 @@ CONTAINS
             CALL pw_scale(v_sccs, dvol)
             DO di = 1, 3
                DO dj = 1, 3
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, d2rho_elec(dj, di)%pw)
-                  DEALLOCATE (d2rho_elec(dj, di)%pw)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, d2rho_elec(dj, di))
                END DO
             END DO
          END IF
@@ -519,8 +517,7 @@ CONTAINS
          ! Release storage
          NULLIFY (theta)
          DO i = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_elec(i)%pw)
-            DEALLOCATE (drho_elec(i)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_elec(i))
          END DO
 
       END IF
@@ -564,14 +561,13 @@ CONTAINS
 
       ! Build the derivative of ln_eps_elec
       DO i = 1, 3
-         ALLOCATE (dln_eps_elec(i)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                dln_eps_elec(i)%pw, &
+                                dln_eps_elec(i), &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(dln_eps_elec(i)%pw)
+         CALL pw_zero(dln_eps_elec(i))
       END DO
-      CALL derive(ln_eps_elec, dln_eps_elec, sccs_control%derivative_method, pw_env, input, para_env)
+      CALL derive(ln_eps_elec, dln_eps_elec, sccs_control%derivative_method, pw_env, input)
 
       ! Print header for the SCCS cycle
       IF (should_output .AND. (output_unit > 0)) THEN
@@ -658,9 +654,9 @@ CONTAINS
          DO k = lb(3), ub(3)
             DO j = lb(2), ub(2)
                DO i = lb(1), ub(1)
-                  rho_iter_new = (dln_eps_elec(1)%pw%cr3d(i, j, k)*dphi_tot(1)%pw%cr3d(i, j, k) + &
-                                  dln_eps_elec(2)%pw%cr3d(i, j, k)*dphi_tot(2)%pw%cr3d(i, j, k) + &
-                                  dln_eps_elec(3)%pw%cr3d(i, j, k)*dphi_tot(3)%pw%cr3d(i, j, k))*f
+                  rho_iter_new = (dln_eps_elec(1)%cr3d(i, j, k)*dphi_tot(1)%pw%cr3d(i, j, k) + &
+                                  dln_eps_elec(2)%cr3d(i, j, k)*dphi_tot(2)%pw%cr3d(i, j, k) + &
+                                  dln_eps_elec(3)%cr3d(i, j, k)*dphi_tot(3)%pw%cr3d(i, j, k))*f
                   rho_iter_new = rho_iter_old%cr3d(i, j, k) + &
                                  sccs_control%mixing*(rho_iter_new - rho_iter_old%cr3d(i, j, k))
                   rho_delta = ABS(rho_iter_new - rho_iter_old%cr3d(i, j, k))
@@ -703,8 +699,7 @@ CONTAINS
 
       ! Release work storage which is no longer needed
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dln_eps_elec(i)%pw)
-         DEALLOCATE (dln_eps_elec(i)%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, dln_eps_elec(i))
       END DO
 
       ! Optional output of the total charge density in cube file format
@@ -1073,20 +1068,18 @@ CONTAINS
 !> \param method ...
 !> \param pw_env ...
 !> \param input ...
-!> \param para_env ...
 !> \par History:
 !>      - Creation (15.11.2013,MK)
 !> \author     Matthias Krack (MK)
 !> \version    1.0
 ! **************************************************************************************************
-   SUBROUTINE derive(f, df, method, pw_env, input, para_env)
+   SUBROUTINE derive(f, df, method, pw_env, input)
 
-      TYPE(pw_type), POINTER                             :: f
-      TYPE(pw_p_type), DIMENSION(3), INTENT(INOUT)       :: df
+      TYPE(pw_type), INTENT(IN)                          :: f
+      TYPE(pw_type), DIMENSION(3), INTENT(INOUT)         :: df
       INTEGER, INTENT(IN)                                :: method
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(section_vals_type), POINTER                   :: input
-      TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'derive'
 
@@ -1101,10 +1094,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CPASSERT(ASSOCIATED(f))
       CPASSERT(ASSOCIATED(pw_env))
-      CPASSERT(ASSOCIATED(para_env))
-      MARK_USED(para_env)
 
       ! Perform method specific setup
       SELECT CASE (method)
@@ -1157,7 +1147,7 @@ CONTAINS
             n(i) = 1
             CALL pw_copy(work_g1d(1)%pw, work_g1d(2)%pw)
             CALL pw_derive(work_g1d(2)%pw, n(:))
-            CALL pw_transfer(work_g1d(2)%pw, df(i)%pw)
+            CALL pw_transfer(work_g1d(2)%pw, df(i))
          END DO
       CASE DEFAULT
          CPABORT("Invalid derivative method for SCCS specified")

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -158,15 +158,14 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(3)                      :: dphi_tot
       TYPE(pw_p_type), DIMENSION(5)                      :: work_r3d
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_pw_r
-      TYPE(pw_p_type), POINTER                           :: rho_pw_r_sccs
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_type), DIMENSION(3)                        :: dln_eps_elec, drho_elec
       TYPE(pw_type), DIMENSION(3, 3)                     :: d2rho_elec
       TYPE(pw_type), POINTER :: deps_elec, eps_elec, ln_eps_elec, norm_drho_elec, phi_pol, &
-         phi_solute, phi_tot, rho_elec, rho_iter_old, rho_pol, rho_solute, rho_tot, rho_tot_zero, &
-         theta
+         phi_solute, phi_tot, rho_elec, rho_iter_old, rho_pol, rho_pw_r_sccs, rho_solute, rho_tot, &
+         rho_tot_zero, theta
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
@@ -310,7 +309,7 @@ CONTAINS
 
       ! Retrieve the last rho_iter from the previous SCCS cycle if available
       CPASSERT(ASSOCIATED(rho_pw_r_sccs))
-      rho_iter_old => rho_pw_r_sccs%pw
+      rho_iter_old => rho_pw_r_sccs
 
       ! Retrieve the total electronic density in r-space
       CALL pw_copy(rho_pw_r(1)%pw, rho_elec)

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -511,6 +511,7 @@ CONTAINS
             DO di = 1, 3
                DO dj = 1, 3
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, d2rho_elec(dj, di)%pw)
+                  DEALLOCATE (d2rho_elec(dj, di)%pw)
                END DO
             END DO
          END IF
@@ -519,6 +520,7 @@ CONTAINS
          NULLIFY (theta)
          DO i = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_elec(i)%pw)
+            DEALLOCATE (drho_elec(i)%pw)
          END DO
 
       END IF
@@ -702,6 +704,7 @@ CONTAINS
       ! Release work storage which is no longer needed
       DO i = 1, 3
          CALL pw_pool_give_back_pw(auxbas_pw_pool, dln_eps_elec(i)%pw)
+         DEALLOCATE (dln_eps_elec(i)%pw)
       END DO
 
       ! Optional output of the total charge density in cube file format
@@ -908,10 +911,12 @@ CONTAINS
       NULLIFY (phi_pol)
       DO i = 1, SIZE(work_r3d)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, work_r3d(i)%pw)
+         DEALLOCATE (work_r3d(i)%pw)
       END DO
       NULLIFY (rho_iter_old)
       DO i = 1, 3
          CALL pw_pool_give_back_pw(auxbas_pw_pool, dphi_tot(i)%pw)
+         DEALLOCATE (dphi_tot(i)%pw)
       END DO
 
       ! Release the SCCS printout environment
@@ -1166,6 +1171,7 @@ CONTAINS
       CASE (sccs_derivative_fft)
          DO i = 1, SIZE(work_g1d)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g1d(i)%pw)
+            DEALLOCATE (work_g1d(i)%pw)
          END DO
       END SELECT
 

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -1099,7 +1099,7 @@ CONTAINS
             CALL dbcsr_copy(cdft_control%wmat(ivar)%matrix, matrix_s(1)%matrix, &
                             name="ET_RESTRAINT_MATRIX")
             CALL dbcsr_set(cdft_control%wmat(ivar)%matrix, 0.0_dp)
-            CALL integrate_v_rspace(cdft_control%group(ivar)%weight, &
+            CALL integrate_v_rspace(cdft_control%group(ivar)%weight%pw, &
                                     hmat=cdft_control%wmat(ivar), qs_env=qs_env, &
                                     calculate_forces=.FALSE., &
                                     gapw=dft_control%qs_control%gapw)

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -1157,10 +1157,12 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          DO iatom = 1, SIZE(cdft_control%group)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight%pw)
+            DEALLOCATE (cdft_control%group(iatom)%weight%pw)
          END DO
          IF (cdft_control%atomic_charges) THEN
             DO iatom = 1, cdft_control%natoms
                CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%charge(iatom)%pw)
+               DEALLOCATE (cdft_control%charge(iatom)%pw)
             END DO
             DEALLOCATE (cdft_control%charge)
          END IF
@@ -1168,12 +1170,15 @@ CONTAINS
              cdft_control%becke_control%cavity_confine) THEN
             IF (.NOT. ASSOCIATED(cdft_control%becke_control%cavity_mat)) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%becke_control%cavity%pw)
+               DEALLOCATE (cdft_control%becke_control%cavity%pw)
             ELSE
                DEALLOCATE (cdft_control%becke_control%cavity_mat)
             END IF
          ELSE IF (cdft_control%type == outer_scf_hirshfeld_constraint) THEN
-            IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) &
+            IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
+               DEALLOCATE (cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
+            END IF
          END IF
          IF (ASSOCIATED(cdft_control%charges_fragment)) DEALLOCATE (cdft_control%charges_fragment)
          cdft_control%need_pot = .TRUE.

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -2149,7 +2149,7 @@ CONTAINS
             q_max = SQRT(SUM((pi/dr(:))**2))
             CALL calculate_rhotot_elec_gspace(qs_env=qs_env, &
                                               auxbas_pw_pool=auxbas_pw_pool, &
-                                              rhotot_elec_gspace=rho_elec_gspace, &
+                                              rhotot_elec_gspace=rho_elec_gspace%pw, &
                                               q_max=q_max, &
                                               rho_hard=rho_hard, &
                                               rho_soft=rho_soft)
@@ -2191,7 +2191,7 @@ CONTAINS
                CALL pw_zero(rho_elec_rspace%pw)
                CALL calculate_rhotot_elec_gspace(qs_env=qs_env, &
                                                  auxbas_pw_pool=auxbas_pw_pool, &
-                                                 rhotot_elec_gspace=rho_elec_gspace, &
+                                                 rhotot_elec_gspace=rho_elec_gspace%pw, &
                                                  q_max=q_max, &
                                                  rho_hard=rho_hard, &
                                                  rho_soft=rho_soft, &

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -3338,11 +3338,11 @@ CONTAINS
 
       LOGICAL                                            :: use_virial
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace
+      TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace
       TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rho_tot_gspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(virial_type), POINTER                         :: virial
 
@@ -3362,19 +3362,19 @@ CONTAINS
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                rho_tot_gspace%pw, &
+                                rho_tot_gspace, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
 
          CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
-         CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, energy%hartree, &
+         CALL pw_poisson_solve(poisson_env, rho_tot_gspace, energy%hartree, &
                                v_hartree_gspace%pw, rho_core=rho_core)
 
          CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
          CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
       END IF
 
    END SUBROUTINE update_hartree_with_mp2

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1074,7 +1074,7 @@ CONTAINS
                             cell=cell, &
                             particle_set=particle_set, &
                             pw_env=pw_env)
-            CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
+            CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
                                         cell, dft_control, particle_set, pw_env)
             WRITE (filename, '(a4,I5.5,a1,I1.1)') "WFN_", ivector, "_", ispin
             mpi_io = .TRUE.
@@ -1152,7 +1152,7 @@ CONTAINS
                             cell=cell, &
                             particle_set=particle_set, &
                             pw_env=pw_env)
-            CALL calculate_wavefunction(unoccupied_orbs, ivector, wf_r, wf_g, atomic_kind_set, &
+            CALL calculate_wavefunction(unoccupied_orbs, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env)
 
             IF (ifirst == 1) THEN

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -726,6 +726,7 @@ CONTAINS
       IF (((do_mo_cubes .OR. do_wannier_cubes) .AND. (nlumo /= 0 .OR. nhomo /= 0)) .OR. p_loc) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+         DEALLOCATE (wf_r%pw, wf_g%pw)
       END IF
 
       ! Destroy the localization environment
@@ -1518,6 +1519,7 @@ CONTAINS
                CALL cp_print_key_finished_output(unit_nr, logger, input, "DFT%PRINT%ELF_CUBE", mpi_io=mpi_io)
 
                CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin)%pw)
+               DEALLOCATE (elf_r(ispin)%pw)
             END DO
 
             ! deallocate
@@ -1829,6 +1831,7 @@ CONTAINS
          IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='(/,(T3,A,T61,F20.10))') &
             "Integrated absolute spin density  : ", total_abs_spin_dens
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
+         DEALLOCATE (wf_r%pw)
          !
          ! XXX Fix Me XXX
          ! should be extended to the case where added MOs are present
@@ -1988,6 +1991,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%TOT_DENSITY_CUBE", mpi_io=mpi_io)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
+         DEALLOCATE (wf_r%pw)
       END IF
 
       ! Write cube file with electron density
@@ -2225,6 +2229,7 @@ CONTAINS
             END IF
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_gspace%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
+            DEALLOCATE (rho_elec_gspace%pw, rho_elec_rspace%pw)
          ELSE
             IF (dft_control%nspins > 1) THEN
                CALL get_qs_env(qs_env=qs_env, &
@@ -2284,6 +2289,7 @@ CONTAINS
                CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                                  "DFT%PRINT%E_DENSITY_CUBE", mpi_io=mpi_io)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
+               DEALLOCATE (rho_elec_rspace%pw)
             ELSE
                filename = "ELECTRON_DENSITY"
                mpi_io = .TRUE.
@@ -2350,6 +2356,7 @@ CONTAINS
                                            "DFT%PRINT%V_HARTREE_CUBE", mpi_io=mpi_io)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
+         DEALLOCATE (aux_r%pw)
       END IF
 
       ! Print the external potential
@@ -2382,6 +2389,7 @@ CONTAINS
                                               "DFT%PRINT%EXTERNAL_POTENTIAL_CUBE", mpi_io=mpi_io)
 
             CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
+            DEALLOCATE (aux_r%pw)
          END IF
       END IF
 
@@ -2431,6 +2439,7 @@ CONTAINS
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_g%pw)
+         DEALLOCATE (aux_r%pw, aux_g%pw)
       END IF
 
       ! Write cube files from the local energy
@@ -2631,6 +2640,7 @@ CONTAINS
 
             IF (dft_control%nspins > 1) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
+               DEALLOCATE (rho_elec_rspace%pw)
             END IF
 
             IF (unit_nr_voro > 0) THEN
@@ -2929,6 +2939,7 @@ CONTAINS
                                            "DFT%PRINT%LOCAL_ENERGY_CUBE", mpi_io=mpi_io)
          !
          CALL pw_pool_give_back_pw(auxbas_pw_pool, eden%pw)
+         DEALLOCATE (eden%pw)
       END IF
       CALL timestop(handle)
 
@@ -3009,6 +3020,7 @@ CONTAINS
                                            "DFT%PRINT%LOCAL_STRESS_CUBE", mpi_io=mpi_io)
          !
          CALL pw_pool_give_back_pw(auxbas_pw_pool, stress%pw)
+         DEALLOCATE (stress%pw)
       END IF
 
       CALL timestop(handle)
@@ -3094,6 +3106,8 @@ CONTAINS
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE", mpi_io=mpi_io)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
+         DEALLOCATE (aux_r%pw)
+         NULLIFY (aux_r%pw)
       END IF
 
       ! Write Dirichlet constraint charges into a cube file
@@ -3143,6 +3157,8 @@ CONTAINS
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE", mpi_io=mpi_io)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
+         DEALLOCATE (aux_r%pw)
+         NULLIFY (aux_r%pw)
       END IF
 
       ! Write Dirichlet type constranits into cube files
@@ -3217,9 +3233,11 @@ CONTAINS
             CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                               "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE", mpi_io=mpi_io)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dirichlet_tile)
+            DEALLOCATE (dirichlet_tile)
          END IF
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
+         DEALLOCATE (aux_r%pw)
       END IF
 
       CALL timestop(handle)
@@ -3393,6 +3411,7 @@ CONTAINS
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+         DEALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
       END IF
 
    END SUBROUTINE update_hartree_with_mp2

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1913,10 +1913,10 @@ CONTAINS
       TYPE(pw_p_type)                                    :: aux_g, aux_r, rho_elec_gspace, &
                                                             rho_elec_rspace, wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
-      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core, vee
+      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: mb_rho, v_hartree_rspace
+      TYPE(pw_type), POINTER                             :: mb_rho, v_hartree_rspace, vee
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_kind_type), POINTER                        :: qs_kind
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -2380,7 +2380,7 @@ CONTAINS
             unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%EXTERNAL_POTENTIAL_CUBE", &
                                            extension=".cube", middle_name="ext_pot", file_position=my_pos_cube, mpi_io=mpi_io)
 
-            CALL pw_copy(vee%pw, aux_r%pw)
+            CALL pw_copy(vee, aux_r%pw)
 
             CALL cp_pw_to_cube(aux_r%pw, unit_nr, "EXTERNAL POTENTIAL", particles=particles, &
                                stride=section_get_ivals(dft_section, &

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -450,6 +450,7 @@ CONTAINS
       IF (((do_mo_cubes .OR. do_wannier_cubes) .AND. (nlumo /= 0 .OR. nhomo /= 0)) .OR. p_loc) THEN
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
+         ALLOCATE (wf_r%pw, wf_g%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -1473,6 +1474,7 @@ CONTAINS
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                             pw_pools=pw_pools)
             DO ispin = 1, dft_control%nspins
+               ALLOCATE (elf_r(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin)%pw, &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
@@ -1817,6 +1819,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
+         ALLOCATE (wf_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -1959,6 +1962,7 @@ CONTAINS
                          rho0_s_gs=rho0_s_gs)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
+         ALLOCATE (wf_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -2123,11 +2127,13 @@ CONTAINS
             CALL pw_env_get(pw_env=pw_env, &
                             auxbas_pw_pool=auxbas_pw_pool, &
                             pw_pools=pw_pools)
+            ALLOCATE (rho_elec_rspace%pw)
             CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                    pw=rho_elec_rspace%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
             CALL pw_zero(rho_elec_rspace%pw)
+            ALLOCATE (rho_elec_gspace%pw)
             CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                    pw=rho_elec_gspace%pw, &
                                    use_data=COMPLEXDATA1D, &
@@ -2226,6 +2232,7 @@ CONTAINS
                CALL pw_env_get(pw_env=pw_env, &
                                auxbas_pw_pool=auxbas_pw_pool, &
                                pw_pools=pw_pools)
+               ALLOCATE (rho_elec_rspace%pw)
                CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                       pw=rho_elec_rspace%pw, &
                                       use_data=REALDATA3D, &
@@ -2316,6 +2323,7 @@ CONTAINS
                          pw_env=pw_env, &
                          v_hartree_rspace=v_hartree_rspace)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (aux_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -2350,6 +2358,7 @@ CONTAINS
          IF (dft_control%apply_external_potential) THEN
             CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, vee=vee)
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+            ALLOCATE (aux_r%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -2382,6 +2391,7 @@ CONTAINS
 
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (aux_r%pw, aux_g%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -2585,6 +2595,7 @@ CONTAINS
                CALL pw_env_get(pw_env=pw_env, &
                                auxbas_pw_pool=auxbas_pw_pool, &
                                pw_pools=pw_pools)
+               ALLOCATE (rho_elec_rspace%pw)
                CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                       pw=rho_elec_rspace%pw, &
                                       use_data=REALDATA3D, &
@@ -2885,6 +2896,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, subsys=subsys)
          CALL qs_subsys_get(subsys, particles=particles)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (eden%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, eden%pw, use_data=REALDATA3D, in_space=REALSPACE)
          !
          CALL qs_local_energy(qs_env, eden)
@@ -2961,6 +2973,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, subsys=subsys)
          CALL qs_subsys_get(subsys, particles=particles)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (stress%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, stress%pw, use_data=REALDATA3D, in_space=REALSPACE)
          !
          ! use beta=0: kinetic energy density in symmetric form
@@ -3059,6 +3072,7 @@ CONTAINS
                                         extension=".cube", middle_name="DIELECTRIC_CONSTANT", file_position=my_pos_cube, &
                                         mpi_io=mpi_io)
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (aux_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
 
          boundary_condition = pw_env%poisson_env%parameters%ps_implicit_params%boundary_condition
@@ -3107,6 +3121,7 @@ CONTAINS
                                         extension=".cube", middle_name="dirichlet_cstr_charge", file_position=my_pos_cube, &
                                         mpi_io=mpi_io)
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (aux_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
 
          boundary_condition = pw_env%poisson_env%parameters%ps_implicit_params%boundary_condition
@@ -3150,6 +3165,7 @@ CONTAINS
          tile_cubes = section_get_lval(input, "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%TILE_CUBES")
 
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
+         ALLOCATE (aux_r%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(aux_r%pw)
 
@@ -3178,6 +3194,7 @@ CONTAINS
          ELSE
             ! a single cube file
             NULLIFY (dirichlet_tile)
+            ALLOCATE (dirichlet_tile)
             CALL pw_pool_create_pw(auxbas_pw_pool, dirichlet_tile, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_tile)
             mpi_io = .TRUE.
@@ -3357,6 +3374,7 @@ CONTAINS
 
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          poisson_env=poisson_env)
+         ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
                                 v_hartree_gspace%pw, &
                                 use_data=COMPLEXDATA1D, &

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1913,10 +1913,10 @@ CONTAINS
       TYPE(pw_p_type)                                    :: aux_g, aux_r, rho_elec_gspace, &
                                                             rho_elec_rspace, wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
-      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: mb_rho, v_hartree_rspace, vee
+      TYPE(pw_type), POINTER                             :: mb_rho, rho0_s_gs, rho_core, &
+                                                            v_hartree_rspace, vee
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_kind_type), POINTER                        :: qs_kind
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -1970,12 +1970,12 @@ CONTAINS
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          IF (dft_control%qs_control%gapw) THEN
-            CALL pw_transfer(rho0_s_gs%pw, wf_r%pw)
+            CALL pw_transfer(rho0_s_gs, wf_r%pw)
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
-               CALL pw_axpy(rho_core%pw, wf_r%pw)
+               CALL pw_axpy(rho_core, wf_r%pw)
             END IF
          ELSE
-            CALL pw_transfer(rho_core%pw, wf_r%pw)
+            CALL pw_transfer(rho_core, wf_r%pw)
          END IF
          DO ispin = 1, dft_control%nspins
             CALL pw_axpy(rho_r(ispin)%pw, wf_r%pw)
@@ -3374,10 +3374,9 @@ CONTAINS
       LOGICAL                                            :: use_virial
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace
-      TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_gspace
+      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(virial_type), POINTER                         :: virial
 

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -1106,6 +1106,7 @@ CONTAINS
                             stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
+         DEALLOCATE (rho_elec_rspace%pw)
       ELSE
          IF (iounit > 0) THEN
             WRITE (UNIT=iounit, FMT="(/,T2,A,T66,F15.6)") &
@@ -1297,6 +1298,8 @@ CONTAINS
                                stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree%pw)
+            DEALLOCATE (vhartree%pw)
+            NULLIFY (vhartree%pw)
          END IF
          IF (my_efield) THEN
             ALLOCATE (vhartree%pw)
@@ -1331,12 +1334,15 @@ CONTAINS
                CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
             END DO
             CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree%pw)
+            DEALLOCATE (vhartree%pw)
          END IF
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+         DEALLOCATE (rho_tot_gspace%pw)
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_core%pw)
+      DEALLOCATE (rho_tot_rspace%pw, rho_core%pw)
 
    END SUBROUTINE print_density_cubes
 
@@ -1434,6 +1440,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, elf_section, '', mpi_io=mpi_io)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin)%pw)
+         DEALLOCATE (elf_r(ispin)%pw)
       END DO
 
       DEALLOCATE (elf_r)
@@ -1597,6 +1604,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
+      DEALLOCATE (wf_g%pw, wf_r%pw)
       IF (ASSOCIATED(list_index)) DEALLOCATE (list_index)
 
    END SUBROUTINE print_mo_cubes

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -1041,8 +1041,8 @@ CONTAINS
       DO ispin = 1, dft_control%nspins
          rho_ao => rho_ao_kp(ispin, :)
          CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                 rho=rho_r(ispin), &
-                                 rho_gspace=rho_g(ispin), &
+                                 rho=rho_r(ispin)%pw, &
+                                 rho_gspace=rho_g(ispin)%pw, &
                                  total_rho=tot_rho_r(ispin), &
                                  ks_env=ks_env)
       END DO
@@ -1206,8 +1206,8 @@ CONTAINS
       DO ispin = 1, dft_control%nspins
          rho_ao => rho_ao_kp(ispin, :)
          CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                 rho=rho_r(ispin), &
-                                 rho_gspace=rho_g(ispin), &
+                                 rho=rho_r(ispin)%pw, &
+                                 rho_gspace=rho_g(ispin)%pw, &
                                  total_rho=tot_rho_r(ispin), &
                                  ks_env=ks_env)
       END DO
@@ -1374,8 +1374,8 @@ CONTAINS
       DO ispin = 1, dft_control%nspins
          rho_ao => rho_ao_kp(ispin, :)
          CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                 rho=rho_r(ispin), &
-                                 rho_gspace=rho_g(ispin), &
+                                 rho=rho_r(ispin)%pw, &
+                                 rho_gspace=rho_g(ispin)%pw, &
                                  total_rho=tot_rho_r(ispin), &
                                  ks_env=ks_env)
       END DO

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -1222,7 +1222,7 @@ CONTAINS
                              pw=rho_core%pw, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL calculate_rho_core(rho_core, total_rho_core_rspace, qs_env)
+      CALL calculate_rho_core(rho_core%pw, total_rho_core_rspace, qs_env)
 
       IF (iounit > 0) THEN
          WRITE (UNIT=iounit, FMT="(/,T2,A,T66,F15.6)") &
@@ -1541,7 +1541,7 @@ CONTAINS
                DO i = 1, nlist
                   ivector = list_index(i)
                   IF (ivector > homo) CYCLE
-                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
+                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
                                               cell, dft_control, particle_set, pw_env)
                   WRITE (filename, '(a4,I5.5,a1,I1.1)') "WFN_", ivector, "_", ispin
                   mpi_io = .TRUE.
@@ -1571,7 +1571,7 @@ CONTAINS
                   ilast = MIN(nmo, ilast)
                END IF
                DO ivector = ifirst, ilast
-                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, &
+                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, &
                                               qs_kind_set, cell, dft_control, particle_set, pw_env)
                   WRITE (filename, '(a4,I5.5,a1,I1.1)') "WFN_", ivector, "_", ispin
                   mpi_io = .TRUE.

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -1058,6 +1058,7 @@ CONTAINS
          END IF
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
+         ALLOCATE (rho_elec_rspace%pw)
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                 pw=rho_elec_rspace%pw, &
                                 use_data=REALDATA3D, &
@@ -1218,6 +1219,7 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
+      ALLOCATE (rho_core%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                              pw=rho_core%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -1231,6 +1233,7 @@ CONTAINS
             "Integrated core density:", total_rho_core_rspace
       END IF
 
+      ALLOCATE (rho_tot_rspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_transfer(rho_core%pw, rho_tot_rspace%pw)
@@ -1259,6 +1262,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
       END IF
       IF (my_v_hartree .OR. my_efield) THEN
+         ALLOCATE (rho_tot_gspace%pw)
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_gspace%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_transfer(rho_tot_rspace%pw, rho_tot_gspace%pw)
@@ -1270,6 +1274,7 @@ CONTAINS
          rho_tot_gspace%pw%cc(:) = rho_tot_gspace%pw%cc(:)*green_fft%influence_fn%cc(:)
          CALL pw_green_release(green_fft, auxbas_pw_pool)
          IF (my_v_hartree) THEN
+            ALLOCATE (vhartree%pw)
             CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(rho_tot_gspace%pw, vhartree%pw)
@@ -1294,6 +1299,7 @@ CONTAINS
             CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree%pw)
          END IF
          IF (my_efield) THEN
+            ALLOCATE (vhartree%pw)
             CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             udvol = 1.0_dp/rho_tot_rspace%pw%pw_grid%dvol
@@ -1388,6 +1394,7 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
       DO ispin = 1, dft_control%nspins
+         ALLOCATE (elf_r(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -1510,6 +1517,7 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
+      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)

--- a/src/qs_tddfpt2_densities.F
+++ b/src/qs_tddfpt2_densities.F
@@ -205,7 +205,7 @@ CONTAINS
          CALL copy_fm_to_dbcsr(wfm_rho_aux_fit, rho_ao_aux_fit(ispin)%matrix, keep_sparsity=.TRUE.)
 
          CALL calculate_rho_elec(matrix_p=rho_ao_aux_fit(ispin)%matrix, &
-                                 rho=rho_aux_fit_r(ispin), rho_gspace=rho_aux_fit_g(ispin), &
+                                 rho=rho_aux_fit_r(ispin)%pw, rho_gspace=rho_aux_fit_g(ispin)%pw, &
                                  total_rho=tot_rho_aux_fit_r(ispin), ks_env=ks_env, &
                                  soft_valid=.FALSE., basis_type=basis_type, &
                                  pw_env_external=sub_env%pw_env, task_list_external=task_list)

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -357,6 +357,7 @@ CONTAINS
                   DEALLOCATE (dbwork)
                   DO ispin = 1, nspins
                      CALL pw_pool_give_back_pw(auxbas_pw_pool, V_rspace_sub(ispin)%pw)
+                     DEALLOCATE (V_rspace_sub(ispin)%pw)
                   END DO
                   DEALLOCATE (V_rspace_sub)
                   CALL cp_fm_release(work_aux_orb)

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -294,7 +294,7 @@ CONTAINS
                   CALL pw_env_get(sub_env%pw_env, auxbas_pw_pool=auxbas_pw_pool)
                   ALLOCATE (V_rspace_sub(nspins))
                   DO ispin = 1, nspins
-                     NULLIFY (V_rspace_sub(ispin)%pw)
+                     ALLOCATE (V_rspace_sub(ispin)%pw)
                      CALL pw_pool_create_pw(auxbas_pw_pool, V_rspace_sub(ispin)%pw, &
                                             use_data=REALDATA3D, in_space=REALSPACE)
                      CALL pw_zero(V_rspace_sub(ispin)%pw)

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -247,7 +247,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL pw_scale(work_matrices%A_ia_rspace_sub(ispin)%pw, &
                              work_matrices%A_ia_rspace_sub(ispin)%pw%pw_grid%dvol)
-               CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
+               CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
                                        hmat=work_matrices%A_ia_munu_sub(ispin), &
                                        qs_env=qs_env, calculate_forces=.FALSE., gapw=gapw_xc, &
                                        pw_env_external=sub_env%pw_env, &
@@ -316,7 +316,7 @@ CONTAINS
                                        work_v_xc_tau=work_matrices%wpw_tau_rspace_sub)
                   DO ispin = 1, nspins
                      CALL pw_scale(V_rspace_sub(ispin)%pw, V_rspace_sub(ispin)%pw%pw_grid%dvol)
-                     CALL integrate_v_rspace(v_rspace=V_rspace_sub(ispin), &
+                     CALL integrate_v_rspace(v_rspace=V_rspace_sub(ispin)%pw, &
                                              hmat=A_xc_munu_sub(ispin), &
                                              qs_env=qs_env, calculate_forces=.FALSE., &
                                              pw_env_external=sub_env%pw_env, &
@@ -405,7 +405,7 @@ CONTAINS
                              work_matrices%A_ia_rspace_sub(ispin)%pw%pw_grid%dvol)
 
                IF (gapw) THEN
-                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
+                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
                                           hmat=work_matrices%A_ia_munu_sub(ispin), &
                                           qs_env=qs_env, calculate_forces=.FALSE., gapw=gapw, &
                                           pw_env_external=sub_env%pw_env, &
@@ -415,7 +415,7 @@ CONTAINS
                                       rho_atom_external=work_matrices%local_rho_set%rho_atom_set)
                ELSEIF (gapw_xc) THEN
                   IF (.NOT. is_rks_triplets) THEN
-                     CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
+                     CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
                                              hmat=work_matrices%A_ia_munu_sub(ispin), &
                                              qs_env=qs_env, calculate_forces=.FALSE., gapw=.FALSE., &
                                              pw_env_external=sub_env%pw_env, task_list_external=sub_env%task_list_orb)
@@ -424,7 +424,7 @@ CONTAINS
                   CALL update_ks_atom(qs_env, work_matrices%A_ia_munu_sub, rho_ia_ao, forces=.FALSE., tddft=.TRUE., &
                                       rho_atom_external=work_matrices%local_rho_set%rho_atom_set)
                ELSE
-                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
+                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
                                           hmat=work_matrices%A_ia_munu_sub(ispin), &
                                           qs_env=qs_env, calculate_forces=.FALSE., gapw=.FALSE., &
                                           pw_env_external=sub_env%pw_env, task_list_external=sub_env%task_list_orb)
@@ -437,21 +437,11 @@ CONTAINS
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(work_matrices%A_ia_rspace_sub(ispin), &
+               CALL integrate_v_rspace_one_center(work_matrices%A_ia_rspace_sub(ispin)%pw, &
                                                   qs_env, lri_v_int, .FALSE., "P_LRI_AUX")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)
                END DO
-               !          IF (lri_env%exact_1c_terms) THEN
-               !             rho_ao => my_rho(ispin, :)
-               !             ksmat => ks_matrix(ispin, :)
-               !             CALL integrate_v_rspace_diagonal(v_rspace, ksmat(1)%matrix, &
-               !                                              rho_ao(1)%matrix, qs_env, &
-               !                                              calculate_forces, "ORB")
-               !          END IF
-               !          IF (lri_env%ppl_ri) THEN
-               !             CALL v_int_ppl_update(qs_env, lri_v_int, calculate_forces)
-               !          END IF
             END IF ! for full kernel using lri
          END DO
 

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -286,7 +286,7 @@ CONTAINS
       DO ispin = 1, nspins
          IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 2.0_dp)
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_px1(ispin)%matrix, &
-                                 rho=rhox_r(ispin), rho_gspace=rhox_g(ispin))
+                                 rho=rhox_r(ispin)%pw, rho_gspace=rhox_g(ispin)%pw)
          CALL pw_axpy(rhox_g(ispin)%pw, rhox_tot_gspace%pw)
          IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 0.5_dp)
       END DO
@@ -451,7 +451,7 @@ CONTAINS
                END DO
                DO ispin = 1, nspins
                   CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_px1_admm(ispin)%matrix, &
-                                          rho=rhox_r_aux(ispin), rho_gspace=rhox_g_aux(ispin), &
+                                          rho=rhox_r_aux(ispin)%pw, rho_gspace=rhox_g_aux(ispin)%pw, &
                                           basis_type="AUX_FIT", &
                                           task_list_external=task_list_aux_fit)
                END DO

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -273,12 +273,13 @@ CONTAINS
 
       ALLOCATE (rhox_r(nspins), rhox_g(nspins))
       DO ispin = 1, nspins
-         NULLIFY (rhox_r(ispin)%pw, rhox_g(ispin)%pw)
+         ALLOCATE (rhox_r(ispin)%pw, rhox_g(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhox_r(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhox_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
+      ALLOCATE (rhox_tot_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhox_tot_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -294,6 +295,7 @@ CONTAINS
       CALL get_qs_env(qs_env, matrix_s=matrix_s, force=force, para_env=para_env)
 
       IF (.NOT. is_rks_triplets) THEN
+         ALLOCATE (xv_hartree_rspace%pw, xv_hartree_gspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_rspace%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_gspace%pw, &
@@ -443,7 +445,7 @@ CONTAINS
                ! rhox_aux
                ALLOCATE (rhox_r_aux(nspins), rhox_g_aux(nspins))
                DO ispin = 1, nspins
-                  NULLIFY (rhox_r_aux(ispin)%pw, rhox_g_aux(ispin)%pw)
+                  ALLOCATE (rhox_r_aux(ispin)%pw, rhox_g_aux(ispin)%pw)
                   CALL pw_pool_create_pw(auxbas_pw_pool, rhox_r_aux(ispin)%pw, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_pool_create_pw(auxbas_pw_pool, rhox_g_aux(ispin)%pw, &

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -314,7 +314,7 @@ CONTAINS
             CALL dbcsr_create(matrix_hx(ispin)%matrix, template=matrix_s(1)%matrix)
             CALL dbcsr_copy(matrix_hx(ispin)%matrix, matrix_s(1)%matrix)
             CALL dbcsr_set(matrix_hx(ispin)%matrix, 0.0_dp)
-            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=xv_hartree_rspace, &
+            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=xv_hartree_rspace%pw, &
                                     pmat=matrix_px1(ispin), &
                                     hmat=matrix_hx(ispin), calculate_forces=.TRUE.)
          END DO
@@ -381,7 +381,7 @@ CONTAINS
             CALL dbcsr_copy(matrix_fx(ispin)%matrix, matrix_s(1)%matrix)
             CALL dbcsr_set(matrix_fx(ispin)%matrix, 0.0_dp)
             CALL pw_scale(fxc_rho(ispin)%pw, fxc_rho(ispin)%pw%pw_grid%dvol)
-            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=fxc_rho(ispin), &
+            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=fxc_rho(ispin)%pw, &
                                     pmat=matrix_px1(ispin), &
                                     hmat=matrix_fx(ispin), calculate_forces=.TRUE.)
          END DO
@@ -401,7 +401,7 @@ CONTAINS
             CALL dbcsr_set(matrix_gx(ispin)%matrix, 0.0_dp)
             CALL pw_scale(gxc_rho(ispin)%pw, gxc_rho(ispin)%pw%pw_grid%dvol)
             CALL pw_scale(gxc_rho(ispin)%pw, 0.5_dp)
-            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=gxc_rho(ispin), &
+            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=gxc_rho(ispin)%pw, &
                                     pmat=matrix_p(ispin), &
                                     hmat=matrix_gx(ispin), calculate_forces=.TRUE.)
             CALL dbcsr_scale(matrix_gx(ispin)%matrix, 2.0_dp)
@@ -492,7 +492,7 @@ CONTAINS
                IF (debug_forces) fodeb(1:3) = force(1)%rho_elec(1:3, 1)
                DO ispin = 1, nspins
                   CALL pw_scale(fxc_rho(ispin)%pw, fxc_rho(ispin)%pw%pw_grid%dvol)
-                  CALL integrate_v_rspace(qs_env=qs_env, v_rspace=fxc_rho(ispin), &
+                  CALL integrate_v_rspace(qs_env=qs_env, v_rspace=fxc_rho(ispin)%pw, &
                                           hmat=mfx(ispin), &
                                           pmat=matrix_px1_admm(ispin), &
                                           basis_type="AUX_FIT", &
@@ -509,7 +509,7 @@ CONTAINS
                DO ispin = 1, nspins
                   CALL pw_scale(gxc_rho(ispin)%pw, gxc_rho(ispin)%pw%pw_grid%dvol)
                   CALL pw_scale(gxc_rho(ispin)%pw, 0.5_dp)
-                  CALL integrate_v_rspace(qs_env=qs_env, v_rspace=gxc_rho(ispin), &
+                  CALL integrate_v_rspace(qs_env=qs_env, v_rspace=gxc_rho(ispin)%pw, &
                                           hmat=mgx(ispin), &
                                           pmat=matrix_p_admm(ispin), &
                                           basis_type="AUX_FIT", &

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -479,6 +479,7 @@ CONTAINS
                DO ispin = 1, nspins
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_r_aux(ispin)%pw)
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_g_aux(ispin)%pw)
+                  DEALLOCATE (rhox_r_aux(ispin)%pw, rhox_g_aux(ispin)%pw)
                END DO
                DEALLOCATE (rhox_r_aux, rhox_g_aux)
                IF (nspins == 2) THEN
@@ -578,14 +579,17 @@ CONTAINS
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_tot_gspace%pw)
+      DEALLOCATE (rhox_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_g(ispin)%pw)
+         DEALLOCATE (rhox_r(ispin)%pw, rhox_g(ispin)%pw)
       END DO
       DEALLOCATE (rhox_r, rhox_g)
       IF (.NOT. is_rks_triplets) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_rspace%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_gspace%pw)
+         DEALLOCATE (xv_hartree_rspace%pw, xv_hartree_gspace%pw)
       END IF
 
       ! HFX

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -71,7 +71,8 @@ MODULE qs_tddfpt2_forces
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_density_matrices,             ONLY: calculate_wx_matrix,&
                                               calculate_xwx_matrix
@@ -157,7 +158,7 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vadmm_rspace, vtau_rspace, vxc_rspace
-      TYPE(pw_p_type), POINTER                           :: vh_rspace
+      TYPE(pw_type), POINTER                             :: vh_rspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: ks_force, td_force
 
       CALL timeset(routineN, handle)
@@ -178,13 +179,17 @@ CONTAINS
          CALL tddfpt_force_direct(qs_env, ex_env, gs_mos, kernel_env, sub_env, &
                                   work_matrices, debug_forces)
       ELSE
-         vh_rspace => ex_env%vh_rspace
+         IF (ASSOCIATED(ex_env%vh_rspace)) THEN
+            vh_rspace => ex_env%vh_rspace%pw
+         ELSE
+            ALLOCATE (ex_env%vh_rspace)
+            NULLIFY (vh_rspace)
+         END IF
          vxc_rspace => ex_env%vxc_rspace
          vtau_rspace => ex_env%vtau_rspace
          vadmm_rspace => ex_env%vadmm_rspace
          IF (ASSOCIATED(vh_rspace)) THEN
-            CALL pw_release(vh_rspace%pw)
-            DEALLOCATE (vh_rspace%pw)
+            CALL pw_release(vh_rspace)
             DEALLOCATE (vh_rspace)
          END IF
          IF (ASSOCIATED(vxc_rspace)) THEN
@@ -210,8 +215,9 @@ CONTAINS
          END IF
          !
          NULLIFY (vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace)
+         ALLOCATE (vh_rspace)
          CALL ks_ref_potential(qs_env, vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace, ehartree, exc)
-         ex_env%vh_rspace => vh_rspace
+         ex_env%vh_rspace%pw => vh_rspace
          ex_env%vxc_rspace => vxc_rspace
          ex_env%vtau_rspace => vtau_rspace
          ex_env%vadmm_rspace => vadmm_rspace

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -641,7 +641,7 @@ CONTAINS
          CALL dbcsr_set(matrix_hz(ispin)%matrix, 0.0_dp)
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
          CALL pw_axpy(v_hartree_rspace%pw, v_xc(ispin)%pw)
-         CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin), &
+         CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin)%pw, &
                                  hmat=matrix_hz(ispin), &
                                  calculate_forces=.FALSE.)
       END DO
@@ -720,7 +720,7 @@ CONTAINS
             !
             DO ispin = 1, nspins
                CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
-               CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin), &
+               CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin)%pw, &
                                        hmat=mhz(ispin, 1), basis_type="AUX_FIT", &
                                        calculate_forces=.FALSE., &
                                        task_list_external=task_list_aux_fit)

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -569,7 +569,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      NULLIFY (v_hartree_gspace%pw, rho_tot_gspace%pw, v_hartree_rspace%pw)
+      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
@@ -579,7 +579,7 @@ CONTAINS
 
       ALLOCATE (trho_r(nspins), trho_g(nspins))
       DO ispin = 1, nspins
-         NULLIFY (trho_r(ispin)%pw, trho_g(ispin)%pw)
+         ALLOCATE (trho_r(ispin)%pw, trho_g(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, trho_r(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, trho_g(ispin)%pw, &
@@ -689,7 +689,7 @@ CONTAINS
             ! rhoz_aux
             ALLOCATE (rhoz_r_aux(nspins), rhoz_g_aux(nspins))
             DO ispin = 1, nspins
-               NULLIFY (rhoz_r_aux(ispin)%pw, rhoz_g_aux(ispin)%pw)
+               ALLOCATE (rhoz_r_aux(ispin)%pw, rhoz_g_aux(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r_aux(ispin)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g_aux(ispin)%pw, &

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -184,23 +184,27 @@ CONTAINS
          vadmm_rspace => ex_env%vadmm_rspace
          IF (ASSOCIATED(vh_rspace)) THEN
             CALL pw_release(vh_rspace%pw)
+            DEALLOCATE (vh_rspace%pw)
             DEALLOCATE (vh_rspace)
          END IF
          IF (ASSOCIATED(vxc_rspace)) THEN
             DO iab = 1, SIZE(vxc_rspace)
                CALL pw_release(vxc_rspace(iab)%pw)
+               DEALLOCATE (vxc_rspace(iab)%pw)
             END DO
             DEALLOCATE (vxc_rspace)
          END IF
          IF (ASSOCIATED(vtau_rspace)) THEN
             DO iab = 1, SIZE(vtau_rspace)
                CALL pw_release(vtau_rspace(iab)%pw)
+               DEALLOCATE (vtau_rspace(iab)%pw)
             END DO
             DEALLOCATE (vtau_rspace)
          END IF
          IF (ASSOCIATED(vadmm_rspace)) THEN
             DO iab = 1, SIZE(vadmm_rspace)
                CALL pw_release(vadmm_rspace(iab)%pw)
+               DEALLOCATE (vadmm_rspace(iab)%pw)
             END DO
             DEALLOCATE (vadmm_rspace)
          END IF

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -584,8 +584,8 @@ CONTAINS
       CALL pw_zero(rho_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_pe(ispin)%matrix, &
-                                 rho=trho_r(ispin), &
-                                 rho_gspace=trho_g(ispin), &
+                                 rho=trho_r(ispin)%pw, &
+                                 rho_gspace=trho_g(ispin)%pw, &
                                  total_rho=total_rho)
          CALL pw_axpy(trho_g(ispin)%pw, rho_tot_gspace%pw)
          IF (ABS(total_rho) > 1.e-08_dp) THEN
@@ -693,7 +693,7 @@ CONTAINS
             END DO
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpe(ispin, 1)%matrix, &
-                                       rho=rhoz_r_aux(ispin), rho_gspace=rhoz_g_aux(ispin), &
+                                       rho=rhoz_r_aux(ispin)%pw, rho_gspace=rhoz_g_aux(ispin)%pw, &
                                        basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)
             END DO

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -649,15 +649,18 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, rho_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_g(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+         DEALLOCATE (trho_r(ispin)%pw, trho_g(ispin)%pw, v_xc(ispin)%pw)
       END DO
       DEALLOCATE (trho_r, trho_g, v_xc)
       IF (ASSOCIATED(v_xc_tau)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+            DEALLOCATE (v_xc_tau(ispin)%pw)
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
@@ -726,6 +729,7 @@ CONTAINS
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r_aux(ispin)%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g_aux(ispin)%pw)
+               DEALLOCATE (v_xc(ispin)%pw, rhoz_r_aux(ispin)%pw, rhoz_g_aux(ispin)%pw)
             END DO
             DEALLOCATE (v_xc, rhoz_r_aux, rhoz_g_aux)
             !

--- a/src/qs_tddfpt2_operators.F
+++ b/src/qs_tddfpt2_operators.F
@@ -209,7 +209,7 @@ CONTAINS
                                  local_rho_set, &
                                  sub_env%para_env, tddft=.TRUE.)
          CALL pw_scale(work_v_rspace%pw, work_v_rspace%pw%pw_grid%dvol)
-         CALL integrate_vhg0_rspace(qs_env, work_v_rspace, sub_env%para_env, &
+         CALL integrate_vhg0_rspace(qs_env, work_v_rspace%pw, sub_env%para_env, &
                                     calculate_forces=.FALSE., &
                                     local_rho_set=local_rho_set)
       END IF

--- a/src/qs_tddfpt2_operators.F
+++ b/src/qs_tddfpt2_operators.F
@@ -190,7 +190,7 @@ CONTAINS
 
       IF (gapw) THEN
          CPASSERT(ASSOCIATED(local_rho_set))
-         CALL pw_axpy(local_rho_set%rho0_mpole%rho0_s_gs%pw, rho_ia_g)
+         CALL pw_axpy(local_rho_set%rho0_mpole%rho0_s_gs, rho_ia_g)
       END IF
 
       CALL pw_poisson_solve(poisson_env, rho_ia_g, pair_energy, work_v_gspace%pw)

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -1362,6 +1362,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
+      DEALLOCATE (wf_g%pw, wf_r%pw)
 
    END SUBROUTINE print_nto_cubes
 

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -1337,7 +1337,7 @@ CONTAINS
       DO iset = 1, 2
          CALL get_mo_set(mo_set=mos(iset)%mo_set, mo_coeff=mo_coeff, nmo=nmo)
          DO i = 1, nmo
-            CALL calculate_wavefunction(mo_coeff, i, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
+            CALL calculate_wavefunction(mo_coeff, i, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
                                         cell, dft_control, particle_set, pw_env)
             IF (iset == 1) THEN
                WRITE (filename, '(a4,I3.3,I2.2,a11)') "NTO_STATE", istate, i, "_Hole_State"

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -1313,6 +1313,7 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
+      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -715,6 +715,8 @@ CONTAINS
             CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_tau_rspace_sub(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_gspace_sub(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin)%pw)
+            DEALLOCATE (work_matrices%wpw_rspace_sub(ispin)%pw, work_matrices%wpw_tau_rspace_sub(ispin)%pw, &
+                        work_matrices%wpw_gspace_sub(ispin)%pw, work_matrices%A_ia_rspace_sub(ispin)%pw)
          END DO
          DEALLOCATE (work_matrices%A_ia_rspace_sub, work_matrices%wpw_gspace_sub, &
                      work_matrices%wpw_rspace_sub, work_matrices%wpw_tau_rspace_sub)

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -419,12 +419,12 @@ CONTAINS
       ALLOCATE (work_matrices%wpw_gspace_sub(nspins), work_matrices%wpw_rspace_sub(nspins), &
                 work_matrices%wpw_tau_rspace_sub(nspins))
       DO ispin = 1, nspins
-         NULLIFY (work_matrices%A_ia_rspace_sub(ispin)%pw)
+         ALLOCATE (work_matrices%A_ia_rspace_sub(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
 
-         NULLIFY (work_matrices%wpw_gspace_sub(ispin)%pw, work_matrices%wpw_rspace_sub(ispin)%pw, &
-                  work_matrices%wpw_tau_rspace_sub(ispin)%pw)
+         ALLOCATE (work_matrices%wpw_gspace_sub(ispin)%pw, work_matrices%wpw_rspace_sub(ispin)%pw, &
+                   work_matrices%wpw_tau_rspace_sub(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%wpw_gspace_sub(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%wpw_rspace_sub(ispin)%pw, &

--- a/src/qs_update_s_mstruct.F
+++ b/src/qs_update_s_mstruct.F
@@ -22,7 +22,8 @@ MODULE qs_update_s_mstruct
                                               kg_tnadd_embed_ri
    USE pw_methods,                      ONLY: pw_transfer
    USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_ppl_grid,&
                                               calculate_rho_core,&
                                               calculate_rho_nlcc
@@ -69,7 +70,8 @@ CONTAINS
       INTEGER                                            :: handle
       LOGICAL                                            :: do_ppl
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(pw_p_type), POINTER                           :: rho_core, rho_nlcc, rho_nlcc_g, vppl
+      TYPE(pw_p_type), POINTER                           :: rho_nlcc, rho_nlcc_g, vppl
+      TYPE(pw_type), POINTER                             :: rho_core
 
       CALL timeset(routineN, handle)
 
@@ -86,12 +88,11 @@ CONTAINS
          qs_env%qs_charges%total_rho_core_rspace = qs_env%local_rho_set%rhoz_tot
          IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
             CPASSERT(ASSOCIATED(rho_core))
-            CALL calculate_rho_core(rho_core%pw, &
+            CALL calculate_rho_core(rho_core, &
                                     qs_env%qs_charges%total_rho_core_rspace, qs_env, only_nopaw=.TRUE.)
          ELSE
             IF (ASSOCIATED(rho_core)) THEN
-               CALL pw_release(rho_core%pw)
-               DEALLOCATE (rho_core%pw)
+               CALL pw_release(rho_core)
                DEALLOCATE (rho_core)
             END IF
          END IF
@@ -105,7 +106,7 @@ CONTAINS
          !??
       ELSE
          CPASSERT(ASSOCIATED(rho_core))
-         CALL calculate_rho_core(rho_core%pw, &
+         CALL calculate_rho_core(rho_core, &
                                  qs_env%qs_charges%total_rho_core_rspace, qs_env)
       END IF
 

--- a/src/qs_update_s_mstruct.F
+++ b/src/qs_update_s_mstruct.F
@@ -86,7 +86,7 @@ CONTAINS
          qs_env%qs_charges%total_rho_core_rspace = qs_env%local_rho_set%rhoz_tot
          IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
             CPASSERT(ASSOCIATED(rho_core))
-            CALL calculate_rho_core(rho_core, &
+            CALL calculate_rho_core(rho_core%pw, &
                                     qs_env%qs_charges%total_rho_core_rspace, qs_env, only_nopaw=.TRUE.)
          ELSE
             IF (ASSOCIATED(rho_core)) THEN
@@ -104,7 +104,7 @@ CONTAINS
          !??
       ELSE
          CPASSERT(ASSOCIATED(rho_core))
-         CALL calculate_rho_core(rho_core, &
+         CALL calculate_rho_core(rho_core%pw, &
                                  qs_env%qs_charges%total_rho_core_rspace, qs_env)
       END IF
 
@@ -114,14 +114,14 @@ CONTAINS
          NULLIFY (vppl)
          CALL get_qs_env(qs_env, vppl=vppl)
          CPASSERT(ASSOCIATED(vppl))
-         CALL calculate_ppl_grid(vppl, qs_env)
+         CALL calculate_ppl_grid(vppl%pw, qs_env)
       END IF
 
       ! compute the rho_nlcc
       NULLIFY (rho_nlcc, rho_nlcc_g)
       CALL get_qs_env(qs_env, rho_nlcc=rho_nlcc, rho_nlcc_g=rho_nlcc_g)
       IF (ASSOCIATED(rho_nlcc)) THEN
-         CALL calculate_rho_nlcc(rho_nlcc, qs_env)
+         CALL calculate_rho_nlcc(rho_nlcc%pw, qs_env)
          CALL pw_transfer(rho_nlcc%pw, rho_nlcc_g%pw)
       END IF
 

--- a/src/qs_update_s_mstruct.F
+++ b/src/qs_update_s_mstruct.F
@@ -91,6 +91,7 @@ CONTAINS
          ELSE
             IF (ASSOCIATED(rho_core)) THEN
                CALL pw_release(rho_core%pw)
+               DEALLOCATE (rho_core%pw)
                DEALLOCATE (rho_core)
             END IF
          END IF

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -438,6 +438,7 @@ CONTAINS
                                     my_vxc_rho(1)%pw%cr3d ! 1=m
                CALL pw_release(my_vxc_rho(1)%pw)
                CALL pw_release(my_vxc_rho(2)%pw)
+               DEALLOCATE (my_vxc_rho(1)%pw, my_vxc_rho(2)%pw)
                DEALLOCATE (my_vxc_rho)
             END IF
 
@@ -508,6 +509,7 @@ CONTAINS
                                            my_vxc_rho(1)%pw%cr3d
                   CALL pw_release(my_vxc_rho(1)%pw)
                   CALL pw_release(my_vxc_rho(2)%pw)
+                  DEALLOCATE (my_vxc_rho(1)%pw, my_vxc_rho(2)%pw)
                   DEALLOCATE (my_vxc_rho)
                END IF
             END DO
@@ -554,6 +556,7 @@ CONTAINS
                                     2.0_dp*dft_control%sic_scaling_b*my_vxc_rho(1)%pw%cr3d
                CALL pw_release(my_vxc_rho(1)%pw)
                CALL pw_release(my_vxc_rho(2)%pw)
+               DEALLOCATE (my_vxc_rho(1)%pw, my_vxc_rho(2)%pw)
                DEALLOCATE (my_vxc_rho)
             END IF
 
@@ -732,9 +735,11 @@ CONTAINS
          ! remove arrays
          DO ispin = 1, nspins
             CALL pw_release(vxc_rho(ispin)%pw)
+            DEALLOCATE (vxc_rho(ispin)%pw)
          END DO
          DEALLOCATE (vxc_rho)
          CALL pw_release(exc_r%pw)
+         DEALLOCATE (exc_r%pw)
          !
       END IF
 

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -434,6 +434,7 @@ CONTAINS
             DO ispin = 1, 2
                CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_rspace(ispin)%pw)
                CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_gspace(ispin)%pw)
+               DEALLOCATE (rho_m_rspace(ispin)%pw, rho_m_gspace(ispin)%pw)
             END DO
             DEALLOCATE (rho_m_rspace)
             DEALLOCATE (rho_m_gspace)
@@ -507,6 +508,7 @@ CONTAINS
             DO ispin = 1, 2
                CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_rspace(ispin)%pw)
                CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_gspace(ispin)%pw)
+               DEALLOCATE (rho_m_rspace(ispin)%pw, rho_m_gspace(ispin)%pw)
             END DO
             DEALLOCATE (rho_m_rspace)
             DEALLOCATE (rho_m_gspace)
@@ -558,6 +560,7 @@ CONTAINS
          IF (uf_grid) THEN
             DO ispin = 1, SIZE(rho_r)
                CALL pw_pool_give_back_pw(xc_pw_pool, rho_r(ispin)%pw)
+               DEALLOCATE (rho_r(ispin)%pw)
             END DO
             IF (ASSOCIATED(vxc_rho)) THEN
                DO ispin = 1, SIZE(vxc_rho)
@@ -575,6 +578,8 @@ CONTAINS
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g2)
                   CALL pw_pool_give_back_pw(xc_pw_pool, tmp_g)
                   CALL pw_pool_give_back_pw(xc_pw_pool, vxc_rho(ispin)%pw)
+                  DEALLOCATE (tmp_g2, tmp_g, vxc_rho(ispin)%pw)
+                  NULLIFY (tmp_g2, tmp_g, vxc_rho(ispin)%pw)
                   vxc_rho(ispin)%pw => tmp_pw
                   NULLIFY (tmp_pw)
                END DO
@@ -595,6 +600,8 @@ CONTAINS
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g2)
                   CALL pw_pool_give_back_pw(xc_pw_pool, tmp_g)
                   CALL pw_pool_give_back_pw(xc_pw_pool, vxc_tau(ispin)%pw)
+                  DEALLOCATE (tmp_g2, tmp_g, vxc_tau(ispin)%pw)
+                  NULLIFY (tmp_g2, tmp_g, vxc_tau(ispin)%pw)
                   vxc_tau(ispin)%pw => tmp_pw
                   NULLIFY (tmp_pw)
                END DO
@@ -606,6 +613,7 @@ CONTAINS
             IF (uf_grid) THEN
                DO ispin = 1, SIZE(rho_g)
                   CALL pw_pool_give_back_pw(xc_pw_pool, rho_g(ispin)%pw)
+                  DEALLOCATE (rho_g(ispin)%pw)
                END DO
             END IF
             DEALLOCATE (rho_g)
@@ -614,6 +622,7 @@ CONTAINS
             IF (uf_grid) THEN
                DO ispin = 1, SIZE(tau)
                   CALL pw_pool_give_back_pw(xc_pw_pool, tau(ispin)%pw)
+                  DEALLOCATE (tau(ispin)%pw)
                END DO
             END IF
             DEALLOCATE (tau)

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -658,10 +658,10 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: exc_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, tau_r, vxc_rho, vxc_tau
       TYPE(pw_p_type), POINTER                           :: rho_nlcc, rho_nlcc_g
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool, xc_pw_pool
+      TYPE(pw_type)                                      :: exc_r
 
       CALL timeset(routineN, handle)
 
@@ -712,7 +712,7 @@ CONTAINS
                CALL pw_axpy(rho_nlcc_g%pw, rho_g(ispin)%pw, factor)
             END DO
          END IF
-         NULLIFY (vxc_rho, vxc_tau, exc_r%pw)
+         NULLIFY (vxc_rho, vxc_tau)
          CALL xc_vxc_pw_create1(vxc_rho=vxc_rho, vxc_tau=vxc_tau, rho_r=rho_r, &
                                 rho_g=rho_g, tau=tau_r, exc=exc, &
                                 xc_section=xc_section, &
@@ -730,7 +730,7 @@ CONTAINS
          END IF
          !
          ovol = 1.0_dp/xc_den%pw%pw_grid%dvol
-         CALL pw_copy(exc_r%pw, xc_den%pw)
+         CALL pw_copy(exc_r, xc_den%pw)
          DO ispin = 1, nspins
 !deb        CALL pw_multiply(xc_den%pw, vxc_rho(ispin)%pw, rho_r(ispin)%pw, alpha=-ovol)
             CALL pw_multiply(xc_den%pw, vxc_rho(ispin)%pw, rho_r(ispin)%pw, alpha=-1.0_dp)
@@ -741,8 +741,7 @@ CONTAINS
             DEALLOCATE (vxc_rho(ispin)%pw)
          END DO
          DEALLOCATE (vxc_rho)
-         CALL pw_release(exc_r%pw)
-         DEALLOCATE (exc_r%pw)
+         CALL pw_release(exc_r)
          !
       END IF
 

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -258,11 +258,13 @@ CONTAINS
             CPASSERT(rho_g_valid)
             ALLOCATE (rho_g(mspin))
             DO ispin = 1, mspin
+               ALLOCATE (rho_g(ispin)%pw)
                CALL pw_pool_create_pw(xc_pw_pool, rho_g(ispin)%pw, &
                                       in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
                CALL pw_transfer(rho_struct_g(ispin)%pw, rho_g(ispin)%pw)
             END DO
             DO ispin = 1, mspin
+               ALLOCATE (rho_r(ispin)%pw)
                CALL pw_pool_create_pw(xc_pw_pool, rho_r(ispin)%pw, &
                                       in_space=REALSPACE, use_data=REALDATA3D)
                CALL pw_transfer(rho_g(ispin)%pw, rho_r(ispin)%pw)
@@ -270,21 +272,6 @@ CONTAINS
             IF (tau_r_valid) THEN
                ! tau with finer grids is not implemented (at least not correctly), which this asserts
                CPABORT("tau with finer grids")
-!                ALLOCATE(tau(dft_control%nspins),stat=stat)
-!                CPPostcondition(stat==0,cp_failure_level,routineP,failure)
-!                DO ispin=1,mspin
-!                   CALL pw_pool_create_pw(xc_pw_pool,tau(ispin)%pw,&
-!                        in_space=REALSPACE, use_data=REALDATA3D)
-!                   CALL pw_pool_create_pw(xc_pw_pool,tmp_g,&
-!                        in_space=RECIPROCALSPACE,use_data=COMPLEXDATA1D)
-!                   CALL pw_pool_create_pw(auxbas_pw_pool,tmp_g2,&
-!                        in_space=RECIPROCALSPACE,use_data=COMPLEXDATA1D)
-!                   CALL pw_transfer(tau(ispin)%pw,tmp_g)
-!                   CALL pw_transfer(tmp_g,tmp_g2)
-!                   CALL pw_transfer(tmp_g2,tmp_pw)
-!                   CALL pw_pool_give_back_pw(auxbas_pw_pool,tmp_g2)
-!                   CALL pw_pool_give_back_pw(xc_pw_pool,tmp_g)
-!                END DO
             END IF
          END IF
 
@@ -388,6 +375,7 @@ CONTAINS
          ! compute again the xc but now for Exc(m,o) and the opposite sign
          IF (dft_control%sic_method_id .EQ. sic_mauri_spz .AND. .NOT. sic_scaling_b_zero) THEN
             ALLOCATE (rho_m_rspace(2), rho_m_gspace(2))
+            ALLOCATE (rho_m_gspace(1)%pw, rho_m_rspace(1)%pw)
             CALL pw_pool_create_pw(xc_pw_pool, rho_m_gspace(1)%pw, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
@@ -399,6 +387,7 @@ CONTAINS
             CALL pw_copy(rho_struct_g(1)%pw, rho_m_gspace(1)%pw)
             CALL pw_axpy(rho_struct_g(2)%pw, rho_m_gspace(1)%pw, alpha=-1._dp)
             ! bit sad, these will be just zero...
+            ALLOCATE (rho_m_gspace(2)%pw, rho_m_rspace(2)%pw)
             CALL pw_pool_create_pw(xc_pw_pool, rho_m_gspace(2)%pw, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
@@ -459,6 +448,7 @@ CONTAINS
 
             ALLOCATE (rho_m_rspace(2), rho_m_gspace(2))
             DO ispin = 1, 2
+               ALLOCATE (rho_m_gspace(ispin)%pw, rho_m_rspace(ispin)%pw)
                CALL pw_pool_create_pw(xc_pw_pool, rho_m_gspace(ispin)%pw, &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
@@ -571,6 +561,8 @@ CONTAINS
             END DO
             IF (ASSOCIATED(vxc_rho)) THEN
                DO ispin = 1, SIZE(vxc_rho)
+                  NULLIFY (tmp_pw, tmp_g, tmp_g2)
+                  ALLOCATE (tmp_pw, tmp_g, tmp_g2)
                   CALL pw_pool_create_pw(auxbas_pw_pool, tmp_pw, &
                                          in_space=REALSPACE, use_data=REALDATA3D)
                   CALL pw_pool_create_pw(xc_pw_pool, tmp_g, &
@@ -589,6 +581,8 @@ CONTAINS
             END IF
             IF (ASSOCIATED(vxc_tau)) THEN
                DO ispin = 1, SIZE(vxc_tau)
+                  NULLIFY (tmp_pw, tmp_g, tmp_g2)
+                  ALLOCATE (tmp_pw, tmp_g, tmp_g2)
                   CALL pw_pool_create_pw(auxbas_pw_pool, tmp_pw, &
                                          in_space=REALSPACE, use_data=REALDATA3D)
                   CALL pw_pool_create_pw(xc_pw_pool, tmp_g, &

--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -213,6 +213,7 @@ CONTAINS
       ELSE IF (ASSOCIATED(snapshot%rho_r)) THEN
          DO ispin = 1, SIZE(snapshot%rho_r)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, snapshot%rho_r(ispin)%pw)
+            DEALLOCATE (snapshot%rho_r(ispin)%pw)
          END DO
          DEALLOCATE (snapshot%rho_r)
       END IF
@@ -234,6 +235,7 @@ CONTAINS
       ELSE IF (ASSOCIATED(snapshot%rho_g)) THEN
          DO ispin = 1, SIZE(snapshot%rho_g)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, snapshot%rho_g(ispin)%pw)
+            DEALLOCATE (snapshot%rho_g(ispin)%pw)
          END DO
          DEALLOCATE (snapshot%rho_g)
       END IF

--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -202,7 +202,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(snapshot%rho_r)) THEN
             ALLOCATE (snapshot%rho_r(nspins))
             DO ispin = 1, nspins
-               NULLIFY (snapshot%rho_r(ispin)%pw)
+               ALLOCATE (snapshot%rho_r(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, snapshot%rho_r(ispin)%pw, &
                                       in_space=REALSPACE, use_data=REALDATA3D)
             END DO
@@ -223,7 +223,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(snapshot%rho_g)) THEN
             ALLOCATE (snapshot%rho_g(nspins))
             DO ispin = 1, nspins
-               NULLIFY (snapshot%rho_g(ispin)%pw)
+               ALLOCATE (snapshot%rho_g(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, snapshot%rho_g(ispin)%pw, &
                                       in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
             END DO

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -1106,7 +1106,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
          CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-         CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
+         CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
                                  hmat=scrm(ispin), pmat=mpa(ispin), &
                                  qs_env=qs_env, calculate_forces=.TRUE.)
       END DO
@@ -1129,7 +1129,7 @@ CONTAINS
          IF (debug_forces) fodeb(1:3) = force(1)%rho_elec(1:3, 1)
          IF (debug_stress .AND. use_virial) stdeb = virial%pv_virial
          DO ispin = 1, nspins
-            CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin), &
+            CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin)%pw, &
                                     hmat=scrm(ispin), pmat=mpa(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.TRUE.)
          END DO
@@ -1344,7 +1344,7 @@ CONTAINS
       CALL pw_transfer(zv_hartree_gspace%pw, zv_hartree_rspace%pw)
       CALL pw_scale(zv_hartree_rspace%pw, zv_hartree_rspace%pw%pw_grid%dvol)
       ! Getting nuclear force contribution from the core charge density
-      CALL integrate_v_core_rspace(zv_hartree_rspace, qs_env)
+      CALL integrate_v_core_rspace(zv_hartree_rspace%pw, qs_env)
       IF (debug_forces) THEN
          fodeb(1:3) = force(1)%rho_core(1:3, 1) - fodeb(1:3)
          CALL mp_sum(fodeb, para_env%group)
@@ -1408,7 +1408,7 @@ CONTAINS
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
          CALL pw_axpy(zv_hartree_rspace%pw, v_xc(ispin)%pw)
          CALL integrate_v_rspace(qs_env=qs_env, &
-                                 v_rspace=v_xc(ispin), &
+                                 v_rspace=v_xc(ispin)%pw, &
                                  hmat=matrix_hz(ispin), &
                                  pmat=matrix_p(ispin, 1), &
                                  calculate_forces=.TRUE.)
@@ -1432,7 +1432,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
             CALL integrate_v_rspace(qs_env=qs_env, &
-                                    v_rspace=v_xc_tau(ispin), &
+                                    v_rspace=v_xc_tau(ispin)%pw, &
                                     hmat=matrix_hz(ispin), &
                                     pmat=matrix_p(ispin, 1), &
                                     compute_tau=.TRUE., &
@@ -1578,7 +1578,7 @@ CONTAINS
             xc_section => admm_env%xc_section_aux
             IF (debug_forces) fodeb(1:3) = force(1)%rho_elec(1:3, 1)
             DO ispin = 1, nspins
-               CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin), &
+               CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin)%pw, &
                                        hmat=mhx(ispin, 1), pmat=mpz(ispin, 1), &
                                        qs_env=qs_env, calculate_forces=.TRUE., &
                                        basis_type="AUX_FIT", task_list_external=task_list_aux_fit)
@@ -1626,7 +1626,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL dbcsr_set(mhy(ispin, 1)%matrix, 0.0_dp)
                CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
-               CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin), &
+               CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin)%pw, &
                                        hmat=mhy(ispin, 1), pmat=matrix_p(ispin, 1), &
                                        calculate_forces=.TRUE., basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -97,7 +97,8 @@ MODULE response_solver
                                               RECIPROCALSPACE,&
                                               pw_create,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_2nd_kernel_ao,                ONLY: build_dm_response
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_core_energies,                ONLY: calculate_ecore_overlap,&
@@ -842,8 +843,7 @@ CONTAINS
          POINTER                                         :: sab_orb, sac_ppl, sap_ppnl
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_tot_gspace, rhoz_tot_gspace, &
-                                                            vhxc_rspace, work_g, &
+      TYPE(pw_p_type)                                    :: rhoz_tot_gspace, vhxc_rspace, work_g, &
                                                             zv_hartree_gspace, zv_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_g_aux, rho_r, rho_r_aux, &
                                                             rhoz_g, rhoz_g_aux, rhoz_r, &
@@ -851,6 +851,7 @@ CONTAINS
                                                             v_xc, v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rho_tot_gspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
@@ -1221,7 +1222,7 @@ CONTAINS
       CALL pw_zero(rhoz_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
-                                 rho=rhoz_r(ispin), rho_gspace=rhoz_g(ispin))
+                                 rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw)
          CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace%pw)
       END DO
 
@@ -1235,7 +1236,7 @@ CONTAINS
             CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
-                                    rho=tauz_r(ispin), rho_gspace=work_g, &
+                                    rho=tauz_r(ispin)%pw, rho_gspace=work_g%pw, &
                                     compute_tau=.TRUE.)
          END DO
          CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g%pw)
@@ -1253,9 +1254,9 @@ CONTAINS
       ! Volume : int epsilon_xc*n_z
       IF (use_virial) THEN
 
-         NULLIFY (rho_tot_gspace%pw)
+         NULLIFY (rho_tot_gspace)
          CALL get_qs_env(qs_env, rho=rho)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
          ! Get the total input density in g-space [ions + electrons]
@@ -1273,9 +1274,9 @@ CONTAINS
                                ehartree=ehartree, &
                                vhartree=zv_hartree_gspace%pw, &  ! v_H[n_z]
                                h_stress=h_stress, &
-                               aux_density=rho_tot_gspace%pw)  ! n_in
+                               aux_density=rho_tot_gspace)  ! n_in
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
 
          ! Stress tensor Green function contribution
          virial%pv_ehartree = virial%pv_ehartree + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
@@ -1593,7 +1594,7 @@ CONTAINS
             END DO
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpz(ispin, 1)%matrix, &
-                                       rho=rhoz_r_aux(ispin), rho_gspace=rhoz_g_aux(ispin), &
+                                       rho=rhoz_r_aux(ispin)%pw, rho_gspace=rhoz_g_aux(ispin)%pw, &
                                        basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)
             END DO
@@ -2141,13 +2142,13 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_p_type)                                    :: rho_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace
+      TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_admm_rspace, v_admm_tau_rspace, &
                                                             v_rspace, v_tau_rspace
       TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rho_tot_gspace
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: xc_section
@@ -2172,24 +2173,24 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      NULLIFY (v_hartree_gspace%pw, rho_tot_gspace%pw, v_hartree_rspace%pw)
+      NULLIFY (v_hartree_gspace%pw, rho_tot_gspace, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! Get the total density in g-space [ions + electrons]
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
-      CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, ehartree, &
+      CALL pw_poisson_solve(poisson_env, rho_tot_gspace, ehartree, &
                             v_hartree_gspace%pw, h_stress=h_stress, rho_core=rho_core)
       CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
       CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
       !
       CALL calculate_ecore_self(qs_env, E_self_core=eself)
       CALL calculate_ecore_overlap(qs_env, para_env, PRESENT(h_stress), E_overlap_core=eovrl)

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -1091,6 +1091,7 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
+      ALLOCATE (vhxc_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -1206,12 +1207,13 @@ CONTAINS
       !
       ALLOCATE (rhoz_r(nspins), rhoz_g(nspins))
       DO ispin = 1, nspins
-         NULLIFY (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
+         ALLOCATE (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
+      ALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace%pw, &
@@ -1227,12 +1229,12 @@ CONTAINS
       END DO
 
       IF (ASSOCIATED(vtau_rspace)) THEN
-         NULLIFY (work_g%pw)
          ALLOCATE (tauz_r(nspins))
+         ALLOCATE (work_g%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, work_g%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          DO ispin = 1, nspins
-            NULLIFY (tauz_r(ispin)%pw)
+            ALLOCATE (tauz_r(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
@@ -1256,6 +1258,7 @@ CONTAINS
 
          NULLIFY (rho_tot_gspace)
          CALL get_qs_env(qs_env, rho=rho)
+         ALLOCATE (rho_tot_gspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1586,7 +1589,7 @@ CONTAINS
             NULLIFY (rhoz_g_aux, rhoz_r_aux)
             ALLOCATE (rhoz_r_aux(nspins), rhoz_g_aux(nspins))
             DO ispin = 1, nspins
-               NULLIFY (rhoz_r_aux(ispin)%pw, rhoz_g_aux(ispin)%pw)
+               ALLOCATE (rhoz_r_aux(ispin)%pw, rhoz_g_aux(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r_aux(ispin)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g_aux(ispin)%pw, &
@@ -2173,7 +2176,8 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      NULLIFY (v_hartree_gspace%pw, rho_tot_gspace, v_hartree_rspace%pw)
+      NULLIFY (rho_tot_gspace)
+      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -2155,10 +2155,9 @@ CONTAINS
       TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_admm_rspace, v_admm_tau_rspace, &
                                                             v_rspace, v_tau_rspace
-      TYPE(pw_p_type), POINTER                           :: rho_core
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_gspace
+      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: xc_section

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -802,12 +802,13 @@ CONTAINS
                              matrix_hz, matrix_pz, matrix_pz_admm, matrix_wz, &
                              zehartree, zexc, rhopz_r, p_env, ex_env)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type)                                    :: vh_rspace
+      TYPE(pw_type), INTENT(IN)                          :: vh_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rspace, vtau_rspace, vadmm_rspace
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_hz, matrix_pz, matrix_pz_admm, &
                                                             matrix_wz
       REAL(KIND=dp), OPTIONAL                            :: zehartree, zexc
-      TYPE(pw_p_type), DIMENSION(:), OPTIONAL, POINTER   :: rhopz_r
+      TYPE(pw_p_type), DIMENSION(:), INTENT(IN), &
+         OPTIONAL                                        :: rhopz_r
       TYPE(qs_p_env_type), OPTIONAL                      :: p_env
       TYPE(excited_energy_type), OPTIONAL, POINTER       :: ex_env
 
@@ -843,15 +844,15 @@ CONTAINS
          POINTER                                         :: sab_orb, sac_ppl, sap_ppnl
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoz_tot_gspace, vhxc_rspace, work_g, &
-                                                            zv_hartree_gspace, zv_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_g_aux, rho_r, rho_r_aux, &
                                                             rhoz_g, rhoz_g_aux, rhoz_r, &
                                                             rhoz_r_aux, tau_r, tau_r_aux, tauz_r, &
                                                             v_xc, v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_gspace
+      TYPE(pw_type)                                      :: rho_tot_gspace, rhoz_tot_gspace, &
+                                                            vhxc_rspace, work_g, &
+                                                            zv_hartree_gspace, zv_hartree_rspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
@@ -1091,8 +1092,7 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      ALLOCATE (vhxc_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       ! Stress-tensor: integration contribution direct term
@@ -1104,9 +1104,9 @@ CONTAINS
       IF (debug_forces) fodeb(1:3) = force(1)%rho_elec(1:3, 1)
       IF (debug_stress .AND. use_virial) stdeb = virial%pv_virial
       DO ispin = 1, nspins
-         CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
-         CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-         CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
+         CALL pw_transfer(vh_rspace, vhxc_rspace)
+         CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace)
+         CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
                                  hmat=scrm(ispin), pmat=mpa(ispin), &
                                  qs_env=qs_env, calculate_forces=.TRUE.)
       END DO
@@ -1145,8 +1145,7 @@ CONTAINS
                'STRESS| INT Pz*dVxc_tau   ', one_third_sum_diag(stdeb), det_3x3(stdeb)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace%pw)
-      DEALLOCATE (vhxc_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace)
 
       ! Stress-tensor Pz*v_Hxc[Pin]
       IF (use_virial) THEN
@@ -1214,36 +1213,33 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      ALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
-      CALL pw_zero(rhoz_tot_gspace%pw)
+      CALL pw_zero(rhoz_tot_gspace)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
                                  rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw)
-         CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace%pw)
+         CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace)
       END DO
 
       IF (ASSOCIATED(vtau_rspace)) THEN
          ALLOCATE (tauz_r(nspins))
-         ALLOCATE (work_g%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, work_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, work_g, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          DO ispin = 1, nspins
             ALLOCATE (tauz_r(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
-                                    rho=tauz_r(ispin)%pw, rho_gspace=work_g%pw, &
+                                    rho=tauz_r(ispin)%pw, rho_gspace=work_g, &
                                     compute_tau=.TRUE.)
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g%pw)
-         DEALLOCATE (work_g%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g)
       END IF
 
       ! Save response density on real space grid for properties
@@ -1258,9 +1254,7 @@ CONTAINS
       ! Volume : int epsilon_xc*n_z
       IF (use_virial) THEN
 
-         NULLIFY (rho_tot_gspace)
          CALL get_qs_env(qs_env, rho=rho)
-         ALLOCATE (rho_tot_gspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
@@ -1275,14 +1269,13 @@ CONTAINS
          ! and count the Volume and Green function contribution
          ! which is stored in h_stress twice
          CALL pw_poisson_solve(poisson_env, &
-                               density=rhoz_tot_gspace%pw, &     ! n_z
+                               density=rhoz_tot_gspace, &     ! n_z
                                ehartree=ehartree, &
-                               vhartree=zv_hartree_gspace%pw, &  ! v_H[n_z]
+                               vhartree=zv_hartree_gspace, &  ! v_H[n_z]
                                h_stress=h_stress, &
                                aux_density=rho_tot_gspace)  ! n_in
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-         DEALLOCATE (rho_tot_gspace)
 
          ! Stress tensor Green function contribution
          virial%pv_ehartree = virial%pv_ehartree + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
@@ -1335,16 +1328,16 @@ CONTAINS
 
       ELSE
          ! calculate associated hartree potential
-         CALL pw_poisson_solve(poisson_env, rhoz_tot_gspace%pw, ehartree, &
-                               zv_hartree_gspace%pw)
+         CALL pw_poisson_solve(poisson_env, rhoz_tot_gspace, ehartree, &
+                               zv_hartree_gspace)
       END IF
 
       IF (debug_forces) fodeb(1:3) = force(1)%rho_core(1:3, 1)
       IF (debug_stress .AND. use_virial) stdeb = virial%pv_ehartree
-      CALL pw_transfer(zv_hartree_gspace%pw, zv_hartree_rspace%pw)
-      CALL pw_scale(zv_hartree_rspace%pw, zv_hartree_rspace%pw%pw_grid%dvol)
+      CALL pw_transfer(zv_hartree_gspace, zv_hartree_rspace)
+      CALL pw_scale(zv_hartree_rspace, zv_hartree_rspace%pw_grid%dvol)
       ! Getting nuclear force contribution from the core charge density
-      CALL integrate_v_core_rspace(zv_hartree_rspace%pw, qs_env)
+      CALL integrate_v_core_rspace(zv_hartree_rspace, qs_env)
       IF (debug_forces) THEN
          fodeb(1:3) = force(1)%rho_core(1:3, 1) - fodeb(1:3)
          CALL mp_sum(fodeb, para_env%group)
@@ -1406,7 +1399,7 @@ CONTAINS
       IF (debug_stress .AND. use_virial) stdeb = virial%pv_virial
       DO ispin = 1, nspins
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
-         CALL pw_axpy(zv_hartree_rspace%pw, v_xc(ispin)%pw)
+         CALL pw_axpy(zv_hartree_rspace, v_xc(ispin)%pw)
          CALL integrate_v_rspace(qs_env=qs_env, &
                                  v_rspace=v_xc(ispin)%pw, &
                                  hmat=matrix_hz(ispin), &
@@ -1504,10 +1497,9 @@ CONTAINS
             END IF
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace%pw)
-      DEALLOCATE (rhoz_tot_gspace%pw, zv_hartree_gspace%pw, zv_hartree_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g(ispin)%pw)
@@ -2136,7 +2128,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE ks_ref_potential(qs_env, vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace, ehartree, exc, h_stress)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), POINTER                           :: vh_rspace
+      TYPE(pw_type), INTENT(INOUT)                       :: vh_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rspace, vtau_rspace, vadmm_rspace
       REAL(KIND=dp), INTENT(OUT)                         :: ehartree, exc
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT), &
@@ -2152,12 +2144,13 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_admm_rspace, v_admm_tau_rspace, &
                                                             v_rspace, v_tau_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace
+      TYPE(pw_type)                                      :: rho_tot_gspace, v_hartree_gspace, &
+                                                            v_hartree_rspace
+      TYPE(pw_type), POINTER                             :: rho_core
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: xc_section
@@ -2182,11 +2175,9 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      NULLIFY (rho_tot_gspace)
-      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace, v_hartree_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
@@ -2195,13 +2186,12 @@ CONTAINS
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
       CALL pw_poisson_solve(poisson_env, rho_tot_gspace, ehartree, &
-                            v_hartree_gspace%pw, h_stress=h_stress, rho_core=rho_core)
-      CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+                            v_hartree_gspace, h_stress=h_stress, rho_core=rho_core)
+      CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
+      CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-      DEALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
       !
       CALL calculate_ecore_self(qs_env, E_self_core=eself)
       CALL calculate_ecore_overlap(qs_env, para_env, PRESENT(h_stress), E_overlap_core=eovrl)
@@ -2235,34 +2225,28 @@ CONTAINS
       END IF
 
       ! allocate potentials
-      IF (ASSOCIATED(vh_rspace)) THEN
-         CALL pw_release(vh_rspace%pw)
-         DEALLOCATE (vh_rspace%pw)
-      ELSE
-         ALLOCATE (vh_rspace)
-         NULLIFY (vh_rspace%pw)
+      IF (ASSOCIATED(vh_rspace%pw_grid)) THEN
+         CALL pw_release(vh_rspace)
       END IF
       IF (ASSOCIATED(vxc_rspace)) THEN
          DO iab = 1, SIZE(vxc_rspace)
             CALL pw_release(vxc_rspace(iab)%pw)
-            DEALLOCATE (vxc_rspace(iab)%pw)
          END DO
       ELSE
          ALLOCATE (vxc_rspace(nspins))
          DO iab = 1, nspins
-            NULLIFY (vxc_rspace(iab)%pw)
+            ALLOCATE (vxc_rspace(iab)%pw)
          END DO
       END IF
       IF (ASSOCIATED(v_tau_rspace)) THEN
          IF (ASSOCIATED(vtau_rspace)) THEN
             DO iab = 1, SIZE(vtau_rspace)
                CALL pw_release(vtau_rspace(iab)%pw)
-               DEALLOCATE (vtau_rspace(iab)%pw)
             END DO
          ELSE
             ALLOCATE (vtau_rspace(nspins))
             DO iab = 1, nspins
-               NULLIFY (vtau_rspace(iab)%pw)
+               ALLOCATE (vtau_rspace(iab)%pw)
             END DO
          END IF
       ELSE
@@ -2272,38 +2256,33 @@ CONTAINS
          IF (ASSOCIATED(vadmm_rspace)) THEN
             DO iab = 1, SIZE(vadmm_rspace)
                CALL pw_release(vadmm_rspace(iab)%pw)
-               DEALLOCATE (vadmm_rspace(iab)%pw)
             END DO
          ELSE
             ALLOCATE (vadmm_rspace(nspins))
             DO iab = 1, nspins
-               NULLIFY (vadmm_rspace(iab)%pw)
+               ALLOCATE (vadmm_rspace(iab)%pw)
             END DO
          END IF
       ELSE
          NULLIFY (vadmm_rspace)
       END IF
 
-      pw_grid => v_hartree_rspace%pw%pw_grid
-      ALLOCATE (vh_rspace%pw)
-      CALL pw_create(vh_rspace%pw, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
+      pw_grid => v_hartree_rspace%pw_grid
+      CALL pw_create(vh_rspace, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
       DO ispin = 1, nspins
-         ALLOCATE (vxc_rspace(ispin)%pw)
          CALL pw_create(vxc_rspace(ispin)%pw, pw_grid, &
                         use_data=REALDATA3D, in_space=REALSPACE)
          IF (ASSOCIATED(vtau_rspace)) THEN
-            ALLOCATE (vtau_rspace(ispin)%pw)
             CALL pw_create(vtau_rspace(ispin)%pw, pw_grid, &
                            use_data=REALDATA3D, in_space=REALSPACE)
          END IF
          IF (ASSOCIATED(vadmm_rspace)) THEN
-            ALLOCATE (vadmm_rspace(ispin)%pw)
             CALL pw_create(vadmm_rspace(ispin)%pw, pw_grid, &
                            use_data=REALDATA3D, in_space=REALSPACE)
          END IF
       END DO
       !
-      CALL pw_transfer(v_hartree_rspace%pw, vh_rspace%pw)
+      CALL pw_transfer(v_hartree_rspace, vh_rspace)
       IF (ASSOCIATED(v_rspace)) THEN
          DO ispin = 1, nspins
             CALL pw_transfer(v_rspace(ispin)%pw, vxc_rspace(ispin)%pw)
@@ -2326,8 +2305,7 @@ CONTAINS
       END IF
 
       ! return pw grids
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      DEALLOCATE (v_hartree_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
       IF (ASSOCIATED(v_rspace)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin)%pw)

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -1146,6 +1146,7 @@ CONTAINS
          END IF
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace%pw)
+      DEALLOCATE (vhxc_rspace%pw)
 
       ! Stress-tensor Pz*v_Hxc[Pin]
       IF (use_virial) THEN
@@ -1242,6 +1243,7 @@ CONTAINS
                                     compute_tau=.TRUE.)
          END DO
          CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g%pw)
+         DEALLOCATE (work_g%pw)
       END IF
 
       ! Save response density on real space grid for properties
@@ -1280,6 +1282,7 @@ CONTAINS
                                aux_density=rho_tot_gspace)  ! n_in
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+         DEALLOCATE (rho_tot_gspace)
 
          ! Stress tensor Green function contribution
          virial%pv_ehartree = virial%pv_ehartree + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
@@ -1504,16 +1507,19 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace%pw)
+      DEALLOCATE (rhoz_tot_gspace%pw, zv_hartree_gspace%pw, zv_hartree_rspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+         DEALLOCATE (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw, v_xc(ispin)%pw)
       END DO
       DEALLOCATE (rhoz_r, rhoz_g, v_xc)
       IF (ASSOCIATED(v_xc_tau)) THEN
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+         DEALLOCATE (tauz_r(ispin)%pw, v_xc_tau(ispin)%pw)
       END DO
       DEALLOCATE (tauz_r, v_xc_tau)
       END IF
@@ -1634,6 +1640,7 @@ CONTAINS
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r_aux(ispin)%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g_aux(ispin)%pw)
+               DEALLOCATE (v_xc(ispin)%pw, rhoz_r_aux(ispin)%pw, rhoz_g_aux(ispin)%pw)
             END DO
             DEALLOCATE (v_xc, rhoz_r_aux, rhoz_g_aux)
             !
@@ -2195,6 +2202,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      DEALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
       !
       CALL calculate_ecore_self(qs_env, E_self_core=eself)
       CALL calculate_ecore_overlap(qs_env, para_env, PRESENT(h_stress), E_overlap_core=eovrl)
@@ -2320,11 +2328,14 @@ CONTAINS
 
       ! return pw grids
       CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
+      DEALLOCATE (v_hartree_rspace%pw)
       IF (ASSOCIATED(v_rspace)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin)%pw)
+            DEALLOCATE (v_rspace(ispin)%pw)
             IF (ASSOCIATED(v_tau_rspace)) THEN
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
+               DEALLOCATE (v_tau_rspace(ispin)%pw)
             END IF
          END DO
          DEALLOCATE (v_rspace)
@@ -2333,6 +2344,7 @@ CONTAINS
       IF (ASSOCIATED(v_admm_rspace)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_admm_rspace(ispin)%pw)
+            DEALLOCATE (v_admm_rspace(ispin)%pw)
          END DO
          DEALLOCATE (v_admm_rspace)
       END IF

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -2226,6 +2226,7 @@ CONTAINS
       ! allocate potentials
       IF (ASSOCIATED(vh_rspace)) THEN
          CALL pw_release(vh_rspace%pw)
+         DEALLOCATE (vh_rspace%pw)
       ELSE
          ALLOCATE (vh_rspace)
          NULLIFY (vh_rspace%pw)
@@ -2233,6 +2234,7 @@ CONTAINS
       IF (ASSOCIATED(vxc_rspace)) THEN
          DO iab = 1, SIZE(vxc_rspace)
             CALL pw_release(vxc_rspace(iab)%pw)
+            DEALLOCATE (vxc_rspace(iab)%pw)
          END DO
       ELSE
          ALLOCATE (vxc_rspace(nspins))
@@ -2244,6 +2246,7 @@ CONTAINS
          IF (ASSOCIATED(vtau_rspace)) THEN
             DO iab = 1, SIZE(vtau_rspace)
                CALL pw_release(vtau_rspace(iab)%pw)
+               DEALLOCATE (vtau_rspace(iab)%pw)
             END DO
          ELSE
             ALLOCATE (vtau_rspace(nspins))
@@ -2258,6 +2261,7 @@ CONTAINS
          IF (ASSOCIATED(vadmm_rspace)) THEN
             DO iab = 1, SIZE(vadmm_rspace)
                CALL pw_release(vadmm_rspace(iab)%pw)
+               DEALLOCATE (vadmm_rspace(iab)%pw)
             END DO
          ELSE
             ALLOCATE (vadmm_rspace(nspins))

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -2274,18 +2274,19 @@ CONTAINS
       END IF
 
       pw_grid => v_hartree_rspace%pw%pw_grid
+      ALLOCATE (vh_rspace%pw)
       CALL pw_create(vh_rspace%pw, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
       DO ispin = 1, nspins
-         NULLIFY (vxc_rspace(ispin)%pw)
+         ALLOCATE (vxc_rspace(ispin)%pw)
          CALL pw_create(vxc_rspace(ispin)%pw, pw_grid, &
                         use_data=REALDATA3D, in_space=REALSPACE)
          IF (ASSOCIATED(vtau_rspace)) THEN
-            NULLIFY (vtau_rspace(ispin)%pw)
+            ALLOCATE (vtau_rspace(ispin)%pw)
             CALL pw_create(vtau_rspace(ispin)%pw, pw_grid, &
                            use_data=REALDATA3D, in_space=REALSPACE)
          END IF
          IF (ASSOCIATED(vadmm_rspace)) THEN
-            NULLIFY (vadmm_rspace(ispin)%pw)
+            ALLOCATE (vadmm_rspace(ispin)%pw)
             CALL pw_create(vadmm_rspace(ispin)%pw, pw_grid, &
                            use_data=REALDATA3D, in_space=REALSPACE)
          END IF

--- a/src/ri_environment_methods.F
+++ b/src/ri_environment_methods.F
@@ -409,7 +409,7 @@ CONTAINS
       CALL qs_rho_get(lri_rho_struct, rho_r=rho_r, rho_g=rho_g, tot_rho_r=tot_rho_r)
       DO ispin = 1, nspin
          lri_coef => lri_density%lri_coefs(ispin)%lri_kinds
-         CALL calculate_lri_rho_elec(rho_g(ispin), rho_r(ispin), qs_env, &
+         CALL calculate_lri_rho_elec(rho_g(ispin)%pw, rho_r(ispin)%pw, qs_env, &
                                      lri_coef, tot_rho_r(ispin), "RI_HXC", .FALSE.)
       END DO
 

--- a/src/rpa_hfx.F
+++ b/src/rpa_hfx.F
@@ -55,7 +55,8 @@ MODULE rpa_hfx
    USE pw_methods,                      ONLY: pw_scale
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_p_type,&
+                                              pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -310,14 +311,14 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vadmm_rspace, vtau_rspace, vxc_rspace
-      TYPE(pw_p_type), POINTER                           :: vh_rspace
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: vh_rspace
       TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit
       TYPE(section_vals_type), POINTER                   :: hfx_section
       TYPE(task_list_type), POINTER                      :: task_list_aux_fit
 
       NULLIFY (dbcsr_work, matrix_ks, rho, hfx_section, pw_env, vadmm_rspace, vtau_rspace, vxc_rspace, &
-               vh_rspace, auxbas_pw_pool, dft_control, rho_ao, rho_aux_fit, rho_ao_aux, work_admm, &
+               auxbas_pw_pool, dft_control, rho_ao, rho_aux_fit, rho_ao_aux, work_admm, &
                matrix_s_aux, admm_env, task_list_aux_fit)
 
       CALL timeset(routineN, handle)
@@ -403,9 +404,7 @@ CONTAINS
       END IF !do_hfx
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace%pw)
-      DEALLOCATE (vh_rspace%pw)
-      DEALLOCATE (vh_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin)%pw)
          DEALLOCATE (vxc_rspace(ispin)%pw)

--- a/src/rpa_hfx.F
+++ b/src/rpa_hfx.F
@@ -358,17 +358,17 @@ CONTAINS
       CALL ks_ref_potential(qs_env, vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace, dummy_real1, dummy_real2)
       DO ispin = 1, nspins
          CALL pw_scale(vxc_rspace(ispin)%pw, -1.0_dp)
-         CALL integrate_v_rspace(v_rspace=vxc_rspace(ispin), hmat=dbcsr_work(ispin), qs_env=qs_env, &
+         CALL integrate_v_rspace(v_rspace=vxc_rspace(ispin)%pw, hmat=dbcsr_work(ispin), qs_env=qs_env, &
                                  calculate_forces=.FALSE.)
          IF (ASSOCIATED(vtau_rspace)) THEN
             CALL pw_scale(vtau_rspace(ispin)%pw, -1.0_dp)
-            CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin), hmat=dbcsr_work(ispin), qs_env=qs_env, &
+            CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin)%pw, hmat=dbcsr_work(ispin), qs_env=qs_env, &
                                     calculate_forces=.FALSE., compute_tau=.TRUE.)
          END IF
          IF (dft_control%do_admm) THEN
             !note: factor -1.0 taken care of later, after HFX ADMM contribution is taken
             IF (.NOT. qs_env%admm_env%aux_exch_func == do_admm_aux_exch_func_none) THEN
-               CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin), hmat=work_admm(ispin), &
+               CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin)%pw, hmat=work_admm(ispin), &
                                        qs_env=qs_env, calculate_forces=.FALSE., basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)
             END IF
@@ -579,7 +579,7 @@ CONTAINS
          IF (use_virial) pv_loc = virial%pv_virial
          DO ispin = 1, nspins
             CALL pw_scale(v_rspace_aux_fit(ispin)%pw, v_rspace_aux_fit(ispin)%pw%pw_grid%dvol)
-            CALL integrate_v_rspace(v_rspace=v_rspace_aux_fit(ispin), hmat=matrix_aux(ispin), &
+            CALL integrate_v_rspace(v_rspace=v_rspace_aux_fit(ispin)%pw, hmat=matrix_aux(ispin), &
                                     pmat=rho_ao_aux_fit(ispin), qs_env=qs_env, &
                                     basis_type="AUX_FIT", calculate_forces=calc_forces, &
                                     task_list_external=qs_env%admm_env%task_list_aux_fit)
@@ -614,7 +614,7 @@ CONTAINS
          IF (use_virial) pv_loc = virial%pv_virial
          DO ispin = 1, nspins
             CALL pw_scale(v_rspace(ispin)%pw, v_rspace(ispin)%pw%pw_grid%dvol)
-            CALL integrate_v_rspace(v_rspace=v_rspace(ispin), hmat=matrix_prim(ispin), &
+            CALL integrate_v_rspace(v_rspace=v_rspace(ispin)%pw, hmat=matrix_prim(ispin), &
                                     pmat=rho_ao(ispin), qs_env=qs_env, &
                                     calculate_forces=calc_forces)
          END DO

--- a/src/rpa_hfx.F
+++ b/src/rpa_hfx.F
@@ -404,11 +404,19 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace%pw)
+      DEALLOCATE (vh_rspace%pw)
       DEALLOCATE (vh_rspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin)%pw)
-         IF (ASSOCIATED(vtau_rspace)) CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin)%pw)
-         IF (ASSOCIATED(vadmm_rspace)) CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin)%pw)
+         DEALLOCATE (vxc_rspace(ispin)%pw)
+         IF (ASSOCIATED(vtau_rspace)) THEN
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin)%pw)
+            DEALLOCATE (vtau_rspace(ispin)%pw)
+         END IF
+         IF (ASSOCIATED(vadmm_rspace)) THEN
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin)%pw)
+            DEALLOCATE (vadmm_rspace(ispin)%pw)
+         END IF
       END DO
       DEALLOCATE (vxc_rspace)
       IF (ASSOCIATED(vtau_rspace)) DEALLOCATE (vtau_rspace)
@@ -582,12 +590,14 @@ CONTAINS
       IF (ASSOCIATED(v_rspace_aux_fit)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_aux_fit(ispin)%pw)
+            DEALLOCATE (v_rspace_aux_fit(ispin)%pw)
          END DO
          DEALLOCATE (v_rspace_aux_fit)
       END IF
       IF (ASSOCIATED(v_dummy)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_dummy(ispin)%pw)
+            DEALLOCATE (v_dummy(ispin)%pw)
          END DO
          DEALLOCATE (v_dummy)
       END IF
@@ -614,12 +624,14 @@ CONTAINS
       IF (ASSOCIATED(v_rspace)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin)%pw)
+            DEALLOCATE (v_rspace(ispin)%pw)
          END DO
          DEALLOCATE (v_rspace)
       END IF
       IF (ASSOCIATED(v_dummy)) THEN
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_dummy(ispin)%pw)
+            DEALLOCATE (v_dummy(ispin)%pw)
          END DO
          DEALLOCATE (v_dummy)
       END IF

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2699,7 +2699,7 @@ CONTAINS
             wf_vector = 0.0_dp
             wf_vector(j_RI) = 1.0_dp
 
-            CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
+            CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env_ext, &
                                         basis_type="RI_AUX", external_vector=wf_vector)
 
@@ -2721,7 +2721,7 @@ CONTAINS
                END DO
 
                CALL pw_copy(rho_g%pw, rho_g_copy%pw)
-               CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
+               CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
                                            qs_kind_set, cell, dft_control, particle_set, pw_env_ext, &
                                            basis_type="RI_AUX", external_vector=wf_vector)
 

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2370,10 +2370,12 @@ CONTAINS
                                  calculate_forces=.FALSE.)
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+         DEALLOCATE (v_xc(ispin)%pw)
       END DO
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace%pw)
+      DEALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
       DEALLOCATE (v_xc)
 
       IF (do_tau) THEN
@@ -2385,6 +2387,7 @@ CONTAINS
                                     compute_tau=.TRUE., &
                                     calculate_forces=.FALSE.)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+            DEALLOCATE (v_xc_tau(ispin)%pw)
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
@@ -2456,6 +2459,7 @@ CONTAINS
                                        basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+               DEALLOCATE (v_xc(ispin)%pw)
             END DO
             DEALLOCATE (v_xc)
 
@@ -2470,6 +2474,7 @@ CONTAINS
                                           task_list_external=task_list_aux_fit, &
                                           compute_tau=.TRUE.)
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+                  DEALLOCATE (v_xc_tau(ispin)%pw)
                END DO
                DEALLOCATE (v_xc_tau)
             END IF
@@ -2479,6 +2484,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g(ispin)%pw)
+         DEALLOCATE (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
       END DO
       DEALLOCATE (rhoz_r, rhoz_g)
 
@@ -2486,6 +2492,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_r(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_g(ispin)%pw)
+            DEALLOCATE (tauz_r(ispin)%pw, tauz_g(ispin)%pw)
          END DO
          DEALLOCATE (tauz_r, tauz_g)
       END IF
@@ -2835,8 +2842,10 @@ CONTAINS
 
       IF (use_virial) THEN
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy%pw)
+         DEALLOCATE (rho_g_copy%pw)
          DO i_xyz = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(i_xyz)%pw)
+            DEALLOCATE (dvg(i_xyz)%pw)
          END DO
       END IF
 
@@ -3189,6 +3198,7 @@ CONTAINS
          END DO
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace%pw)
+      DEALLOCATE (vhxc_rspace%pw)
 
       IF (use_virial) virial%pv_ehartree = virial%pv_ehartree + (virial%pv_virial - pv_loc)
 
@@ -3387,6 +3397,7 @@ CONTAINS
                                   aux_density=rho_tot_gspace%pw)
 
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
+            DEALLOCATE (rho_tot_gspace%pw)
 
             !Green contribution
             virial%pv_ehartree = virial%pv_ehartree + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
@@ -3475,10 +3486,12 @@ CONTAINS
                                     pmat=dbcsr_work_p(ispin, 1), &
                                     calculate_forces=.TRUE.)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+            DEALLOCATE (v_xc(ispin)%pw)
          END DO
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace%pw)
+         DEALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
          DEALLOCATE (v_xc)
 
          IF (do_tau) THEN
@@ -3491,6 +3504,7 @@ CONTAINS
                                        compute_tau=.TRUE., &
                                        calculate_forces=.TRUE.)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+               DEALLOCATE (v_xc_tau(ispin)%pw)
             END DO
             DEALLOCATE (v_xc_tau)
          END IF
@@ -3562,6 +3576,7 @@ CONTAINS
                                              basis_type="AUX_FIT", &
                                              task_list_external=task_list_aux_fit)
                      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
+                     DEALLOCATE (v_xc(ispin)%pw)
                   END DO
                   DEALLOCATE (v_xc)
 
@@ -3577,6 +3592,7 @@ CONTAINS
                                                 task_list_external=task_list_aux_fit, &
                                                 compute_tau=.TRUE.)
                         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin)%pw)
+                        DEALLOCATE (v_xc_tau(ispin)%pw)
                      END DO
                      DEALLOCATE (v_xc_tau)
                   END IF
@@ -3621,6 +3637,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g(ispin)%pw)
+            DEALLOCATE (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
          END DO
          DEALLOCATE (rhoz_r, rhoz_g)
 
@@ -3628,6 +3645,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_r(ispin)%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_g(ispin)%pw)
+               DEALLOCATE (tauz_r(ispin)%pw, tauz_g(ispin)%pw)
             END DO
             DEALLOCATE (tauz_r, tauz_g)
          END IF
@@ -3677,12 +3695,20 @@ CONTAINS
 
       !clean-up
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace%pw)
+      DEALLOCATE (vh_rspace%pw)
       DEALLOCATE (vh_rspace)
 
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin)%pw)
-         IF (ASSOCIATED(vtau_rspace)) CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin)%pw)
-         IF (ASSOCIATED(vadmm_rspace)) CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin)%pw)
+         DEALLOCATE (vxc_rspace(ispin)%pw)
+         IF (ASSOCIATED(vtau_rspace)) THEN
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin)%pw)
+            DEALLOCATE (vtau_rspace(ispin)%pw)
+         END IF
+         IF (ASSOCIATED(vadmm_rspace)) THEN
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin)%pw)
+            DEALLOCATE (vadmm_rspace(ispin)%pw)
+         END IF
       END DO
       DEALLOCATE (vxc_rspace)
       IF (ASSOCIATED(vtau_rspace)) DEALLOCATE (vtau_rspace)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -117,7 +117,8 @@ MODULE rpa_im_time_force_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec,&
                                               calculate_wavefunction
    USE qs_density_matrices,             ONLY: calculate_whz_matrix
@@ -2278,12 +2279,12 @@ CONTAINS
       TYPE(dbcsr_type)                                   :: dbcsr_work
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhoz_tot_gspace, zv_hartree_gspace, &
-                                                            zv_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rhoz_g, rhoz_r, tauz_g, tauz_r, v_xc, &
                                                             v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rhoz_tot_gspace, zv_hartree_gspace, &
+                                                            zv_hartree_rspace
       TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit
       TYPE(section_vals_type), POINTER                   :: hfx_section, xc_section
       TYPE(task_list_type), POINTER                      :: task_list_aux_fit
@@ -2315,26 +2316,25 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      ALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
-      CALL pw_zero(rhoz_tot_gspace%pw)
+      CALL pw_zero(rhoz_tot_gspace)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=force_data%sum_ker_tau(ispin)%matrix, &
                                  rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw)
-         CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace%pw)
+         CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace)
       END DO
 
-      CALL pw_poisson_solve(poisson_env, rhoz_tot_gspace%pw, ehartree, &
-                            zv_hartree_gspace%pw)
+      CALL pw_poisson_solve(poisson_env, rhoz_tot_gspace, ehartree, &
+                            zv_hartree_gspace)
 
-      CALL pw_transfer(zv_hartree_gspace%pw, zv_hartree_rspace%pw)
-      CALL pw_scale(zv_hartree_rspace%pw, zv_hartree_rspace%pw%pw_grid%dvol)
+      CALL pw_transfer(zv_hartree_gspace, zv_hartree_rspace)
+      CALL pw_scale(zv_hartree_rspace, zv_hartree_rspace%pw_grid%dvol)
 
       CALL qs_rho_get(rho, tau_r_valid=do_tau)
       IF (do_tau) THEN
@@ -2363,7 +2363,7 @@ CONTAINS
 
       DO ispin = 1, nspins
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
-         CALL pw_axpy(zv_hartree_rspace%pw, v_xc(ispin)%pw)
+         CALL pw_axpy(zv_hartree_rspace, v_xc(ispin)%pw)
          CALL integrate_v_rspace(qs_env=qs_env, &
                                  v_rspace=v_xc(ispin)%pw, &
                                  hmat=dbcsr_p_work(ispin), &
@@ -2372,10 +2372,9 @@ CONTAINS
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
          DEALLOCATE (v_xc(ispin)%pw)
       END DO
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace%pw)
-      DEALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace)
       DEALLOCATE (v_xc)
 
       IF (do_tau) THEN
@@ -3038,15 +3037,14 @@ CONTAINS
          POINTER                                         :: sab_orb, sac_ppl, sap_ppnl
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_tot_gspace, rhoz_tot_gspace, &
-                                                            vhxc_rspace, zv_hartree_gspace, &
-                                                            zv_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rhoz_g, rhoz_r, tauz_g, tauz_r, v_xc, &
                                                             v_xc_tau, vadmm_rspace, vtau_rspace, &
                                                             vxc_rspace
-      TYPE(pw_p_type), POINTER                           :: vh_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_tot_gspace, rhoz_tot_gspace, &
+                                                            vh_rspace, vhxc_rspace, &
+                                                            zv_hartree_gspace, zv_hartree_rspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit
@@ -3058,9 +3056,8 @@ CONTAINS
                cell_to_index, dbcsr_work_p, dbcsr_work_h, sac_ppl, sap_ppnl, force, virial, &
                qs_kind_set, atomic_kind_set, particle_set, pw_env, poisson_env, auxbas_pw_pool, &
                task_list_aux_fit, matrix_s_aux_fit, scrm_admm, rho_aux_fit, rho_ao_aux, x_data, &
-               hfx_section, xc_section, para_env, vhxc_rspace%pw, rhoz_tot_gspace%pw, tauz_g, &
-               zv_hartree_gspace%pw, zv_hartree_rspace%pw, rhoz_g, rhoz_r, tauz_r, v_xc, v_xc_tau, &
-               vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace, rho_ao, matrix_w)
+               hfx_section, xc_section, para_env, tauz_g, rhoz_g, rhoz_r, tauz_r, v_xc, v_xc_tau, &
+               vxc_rspace, vtau_rspace, vadmm_rspace, rho_ao, matrix_w)
 
       CALL timeset(routineN, handle)
 
@@ -3146,7 +3143,7 @@ CONTAINS
       do_tau = ASSOCIATED(vtau_rspace)
 
       !Core forces from the SCF
-      CALL integrate_v_core_rspace(vh_rspace%pw, qs_env)
+      CALL integrate_v_core_rspace(vh_rspace, qs_env)
 
       !The Hartree-xc potential term, P*dVHxc (mp2 + SCF density x deriv of the SCF potential)
       !Get the total density
@@ -3158,8 +3155,7 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      ALLOCATE (vhxc_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       IF (use_virial) pv_loc = virial%pv_virial
@@ -3168,13 +3164,13 @@ CONTAINS
          !Only want response XC contribution, but SCF+response Hartree contribution
          DO ispin = 1, nspins
             !Hartree
-            CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
+            CALL pw_transfer(vh_rspace, vhxc_rspace)
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
                                     hmat=scrm(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             !XC
-            CALL pw_transfer(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
+            CALL pw_transfer(vxc_rspace(ispin)%pw, vhxc_rspace)
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
                                     hmat=scrm(ispin), pmat=matrix_p_mp2(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (do_tau) THEN
@@ -3185,9 +3181,9 @@ CONTAINS
          END DO
       ELSE
          DO ispin = 1, nspins
-            CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
-            CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
+            CALL pw_transfer(vh_rspace, vhxc_rspace)
+            CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace)
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
                                     hmat=scrm(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (do_tau) THEN
@@ -3197,8 +3193,7 @@ CONTAINS
             END IF
          END DO
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace%pw)
-      DEALLOCATE (vhxc_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace)
 
       IF (use_virial) virial%pv_ehartree = virial%pv_ehartree + (virial%pv_virial - pv_loc)
 
@@ -3364,53 +3359,50 @@ CONTAINS
             CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin)%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
-         ALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
-         CALL pw_zero(rhoz_tot_gspace%pw)
+         CALL pw_zero(rhoz_tot_gspace)
          DO ispin = 1, nspins
             CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=current_density(ispin)%matrix, &
                                     rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw)
-            CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace%pw)
+            CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace)
          END DO
 
          IF (use_virial) THEN
 
-            ALLOCATE (rho_tot_gspace%pw)
             CALL get_qs_env(qs_env, rho=rho)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
-            CALL calc_rho_tot_gspace(rho_tot_gspace%pw, qs_env, rho)
+            CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
             h_stress(:, :) = 0.0_dp
             CALL pw_poisson_solve(poisson_env, &
-                                  density=rhoz_tot_gspace%pw, &
+                                  density=rhoz_tot_gspace, &
                                   ehartree=ehartree, &
-                                  vhartree=zv_hartree_gspace%pw, &
+                                  vhartree=zv_hartree_gspace, &
                                   h_stress=h_stress, &
-                                  aux_density=rho_tot_gspace%pw)
+                                  aux_density=rho_tot_gspace)
 
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
-            DEALLOCATE (rho_tot_gspace%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
 
             !Green contribution
             virial%pv_ehartree = virial%pv_ehartree + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
             virial%pv_virial = virial%pv_virial + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
 
          ELSE
-            CALL pw_poisson_solve(poisson_env, rhoz_tot_gspace%pw, ehartree, &
-                                  zv_hartree_gspace%pw)
+            CALL pw_poisson_solve(poisson_env, rhoz_tot_gspace, ehartree, &
+                                  zv_hartree_gspace)
          END IF
 
-         CALL pw_transfer(zv_hartree_gspace%pw, zv_hartree_rspace%pw)
-         CALL pw_scale(zv_hartree_rspace%pw, zv_hartree_rspace%pw%pw_grid%dvol)
-         CALL integrate_v_core_rspace(zv_hartree_rspace%pw, qs_env)
+         CALL pw_transfer(zv_hartree_gspace, zv_hartree_rspace)
+         CALL pw_scale(zv_hartree_rspace, zv_hartree_rspace%pw_grid%dvol)
+         CALL integrate_v_core_rspace(zv_hartree_rspace, qs_env)
 
          IF (do_tau) THEN
             ALLOCATE (tauz_r(nspins), tauz_g(nspins))
@@ -3479,7 +3471,7 @@ CONTAINS
          CALL qs_rho_get(rho, rho_ao_kp=dbcsr_work_p)
          DO ispin = 1, nspins
             CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
-            CALL pw_axpy(zv_hartree_rspace%pw, v_xc(ispin)%pw)
+            CALL pw_axpy(zv_hartree_rspace, v_xc(ispin)%pw)
             CALL integrate_v_rspace(qs_env=qs_env, &
                                     v_rspace=v_xc(ispin)%pw, &
                                     hmat=current_mat_h(ispin), &
@@ -3488,10 +3480,9 @@ CONTAINS
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
             DEALLOCATE (v_xc(ispin)%pw)
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace%pw)
-         DEALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace)
          DEALLOCATE (v_xc)
 
          IF (do_tau) THEN
@@ -3694,9 +3685,7 @@ CONTAINS
       IF (use_virial) virial%pv_calculate = .FALSE.
 
       !clean-up
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace%pw)
-      DEALLOCATE (vh_rspace%pw)
-      DEALLOCATE (vh_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace)
 
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin)%pw)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2325,7 +2325,7 @@ CONTAINS
       CALL pw_zero(rhoz_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=force_data%sum_ker_tau(ispin)%matrix, &
-                                 rho=rhoz_r(ispin), rho_gspace=rhoz_g(ispin))
+                                 rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw)
          CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace%pw)
       END DO
 
@@ -2346,7 +2346,7 @@ CONTAINS
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
             CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=force_data%sum_ker_tau(ispin)%matrix, &
-                                    rho=tauz_r(ispin), rho_gspace=tauz_g(ispin), compute_tau=.TRUE.)
+                                    rho=tauz_r(ispin)%pw, rho_gspace=tauz_g(ispin)%pw, compute_tau=.TRUE.)
          END DO
       END IF
 
@@ -2428,7 +2428,7 @@ CONTAINS
                CALL pw_zero(rhoz_r(ispin)%pw)
                CALL pw_zero(rhoz_g(ispin)%pw)
                CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=ker_tau_admm(ispin)%matrix, &
-                                       rho=rhoz_r(ispin), rho_gspace=rhoz_g(ispin), &
+                                       rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw, &
                                        basis_type="AUX_FIT", task_list_external=task_list_aux_fit)
             END DO
 
@@ -2437,7 +2437,7 @@ CONTAINS
                   CALL pw_zero(tauz_r(ispin)%pw)
                   CALL pw_zero(tauz_g(ispin)%pw)
                   CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=ker_tau_admm(ispin)%matrix, &
-                                          rho=tauz_r(ispin), rho_gspace=tauz_g(ispin), &
+                                          rho=tauz_r(ispin)%pw, rho_gspace=tauz_g(ispin)%pw, &
                                           basis_type="AUX_FIT", task_list_external=task_list_aux_fit, &
                                           compute_tau=.TRUE.)
                END DO
@@ -2738,7 +2738,7 @@ CONTAINS
             DO i = 1, SIZE(rs_v)
                CALL rs_grid_retain(rs_v(i)%rs_grid)
             END DO
-            CALL potential_pw2rs(rs_v, rho_r, pw_env_ext)
+            CALL potential_pw2rs(rs_v, rho_r%pw, pw_env_ext)
 
             DO iatom = 1, natom
 
@@ -3363,7 +3363,7 @@ CONTAINS
          CALL pw_zero(rhoz_tot_gspace%pw)
          DO ispin = 1, nspins
             CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=current_density(ispin)%matrix, &
-                                    rho=rhoz_r(ispin), rho_gspace=rhoz_g(ispin))
+                                    rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw)
             CALL pw_axpy(rhoz_g(ispin)%pw, rhoz_tot_gspace%pw)
          END DO
 
@@ -3374,7 +3374,7 @@ CONTAINS
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
-            CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
+            CALL calc_rho_tot_gspace(rho_tot_gspace%pw, qs_env, rho)
 
             h_stress(:, :) = 0.0_dp
             CALL pw_poisson_solve(poisson_env, &
@@ -3409,7 +3409,7 @@ CONTAINS
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
                CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=current_density(ispin)%matrix, &
-                                       rho=tauz_r(ispin), rho_gspace=tauz_g(ispin), compute_tau=.TRUE.)
+                                       rho=tauz_r(ispin)%pw, rho_gspace=tauz_g(ispin)%pw, compute_tau=.TRUE.)
             END DO
          END IF
 
@@ -3508,7 +3508,7 @@ CONTAINS
                      CALL pw_zero(rhoz_r(ispin)%pw)
                      CALL pw_zero(rhoz_g(ispin)%pw)
                      CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=current_density_admm(ispin)%matrix, &
-                                             rho=rhoz_r(ispin), rho_gspace=rhoz_g(ispin), &
+                                             rho=rhoz_r(ispin)%pw, rho_gspace=rhoz_g(ispin)%pw, &
                                              basis_type="AUX_FIT", task_list_external=task_list_aux_fit)
                   END DO
 
@@ -3517,7 +3517,7 @@ CONTAINS
                         CALL pw_zero(tauz_r(ispin)%pw)
                         CALL pw_zero(tauz_g(ispin)%pw)
                         CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=current_density(ispin)%matrix, &
-                                                rho=tauz_r(ispin), rho_gspace=tauz_g(ispin), &
+                                                rho=tauz_r(ispin)%pw, rho_gspace=tauz_g(ispin)%pw, &
                                                 basis_type="AUX_FIT", task_list_external=task_list_aux_fit, &
                                                 compute_tau=.TRUE.)
                      END DO

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2309,12 +2309,13 @@ CONTAINS
       !Apply the kernel on the density saved in force_data%sum_ker_tau
       ALLOCATE (rhoz_r(nspins), rhoz_g(nspins))
       DO ispin = 1, nspins
-         NULLIFY (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
+         ALLOCATE (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
+      ALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace%pw, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace%pw, &
@@ -2339,7 +2340,7 @@ CONTAINS
       IF (do_tau) THEN
          ALLOCATE (tauz_r(nspins), tauz_g(nspins))
          DO ispin = 1, nspins
-            NULLIFY (tauz_r(ispin)%pw, tauz_g(ispin)%pw)
+            ALLOCATE (tauz_r(ispin)%pw, tauz_g(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(auxbas_pw_pool, tauz_g(ispin)%pw, &
@@ -2659,12 +2660,12 @@ CONTAINS
                        auxbas_pw_pool, poisson_env, task_list_ext, rho_r, rho_g, pot_g, psi_L, sab_orb)
 
       IF (use_virial) THEN
-         NULLIFY (rho_g_copy%pw)
+         ALLOCATE (rho_g_copy%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
          DO i_xyz = 1, 3
-            NULLIFY (dvg(i_xyz)%pw)
+            ALLOCATE (dvg(i_xyz)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, dvg(i_xyz)%pw, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
@@ -3148,7 +3149,7 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      NULLIFY (vhxc_rspace%pw)
+      ALLOCATE (vhxc_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -3347,12 +3348,13 @@ CONTAINS
          !The core-denstiy derivative
          ALLOCATE (rhoz_r(nspins), rhoz_g(nspins))
          DO ispin = 1, nspins
-            NULLIFY (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
+            ALLOCATE (rhoz_r(ispin)%pw, rhoz_g(ispin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r(ispin)%pw, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin)%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
+         ALLOCATE (rhoz_tot_gspace%pw, zv_hartree_rspace%pw, zv_hartree_gspace%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace%pw, &
@@ -3369,7 +3371,7 @@ CONTAINS
 
          IF (use_virial) THEN
 
-            NULLIFY (rho_tot_gspace%pw)
+            ALLOCATE (rho_tot_gspace%pw)
             CALL get_qs_env(qs_env, rho=rho)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
@@ -3402,7 +3404,7 @@ CONTAINS
          IF (do_tau) THEN
             ALLOCATE (tauz_r(nspins), tauz_g(nspins))
             DO ispin = 1, nspins
-               NULLIFY (tauz_r(ispin)%pw, tauz_g(ispin)%pw)
+               ALLOCATE (tauz_r(ispin)%pw, tauz_g(ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_pool_create_pw(auxbas_pw_pool, tauz_g(ispin)%pw, &

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2365,7 +2365,7 @@ CONTAINS
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
          CALL pw_axpy(zv_hartree_rspace%pw, v_xc(ispin)%pw)
          CALL integrate_v_rspace(qs_env=qs_env, &
-                                 v_rspace=v_xc(ispin), &
+                                 v_rspace=v_xc(ispin)%pw, &
                                  hmat=dbcsr_p_work(ispin), &
                                  calculate_forces=.FALSE.)
 
@@ -2382,7 +2382,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
             CALL integrate_v_rspace(qs_env=qs_env, &
-                                    v_rspace=v_xc_tau(ispin), &
+                                    v_rspace=v_xc_tau(ispin)%pw, &
                                     hmat=dbcsr_p_work(ispin), &
                                     compute_tau=.TRUE., &
                                     calculate_forces=.FALSE.)
@@ -2453,7 +2453,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
                CALL integrate_v_rspace(qs_env=qs_env, &
-                                       v_rspace=v_xc(ispin), &
+                                       v_rspace=v_xc(ispin)%pw, &
                                        hmat=work_admm(ispin), &
                                        calculate_forces=.FALSE., &
                                        basis_type="AUX_FIT", &
@@ -2467,7 +2467,7 @@ CONTAINS
                DO ispin = 1, nspins
                   CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
                   CALL integrate_v_rspace(qs_env=qs_env, &
-                                          v_rspace=v_xc_tau(ispin), &
+                                          v_rspace=v_xc_tau(ispin)%pw, &
                                           hmat=work_admm(ispin), &
                                           calculate_forces=.FALSE., &
                                           basis_type="AUX_FIT", &
@@ -3146,7 +3146,7 @@ CONTAINS
       do_tau = ASSOCIATED(vtau_rspace)
 
       !Core forces from the SCF
-      CALL integrate_v_core_rspace(vh_rspace, qs_env)
+      CALL integrate_v_core_rspace(vh_rspace%pw, qs_env)
 
       !The Hartree-xc potential term, P*dVHxc (mp2 + SCF density x deriv of the SCF potential)
       !Get the total density
@@ -3169,16 +3169,16 @@ CONTAINS
          DO ispin = 1, nspins
             !Hartree
             CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
                                     hmat=scrm(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             !XC
             CALL pw_transfer(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
                                     hmat=scrm(ispin), pmat=matrix_p_mp2(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (do_tau) THEN
-               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin), &
+               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin)%pw, &
                                        hmat=scrm(ispin), pmat=matrix_p_mp2(ispin), &
                                        qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.TRUE.)
             END IF
@@ -3187,11 +3187,11 @@ CONTAINS
          DO ispin = 1, nspins
             CALL pw_transfer(vh_rspace%pw, vhxc_rspace%pw)
             CALL pw_axpy(vxc_rspace(ispin)%pw, vhxc_rspace%pw)
-            CALL integrate_v_rspace(v_rspace=vhxc_rspace, &
+            CALL integrate_v_rspace(v_rspace=vhxc_rspace%pw, &
                                     hmat=scrm(ispin), pmat=rho_ao(ispin), &
                                     qs_env=qs_env, calculate_forces=.TRUE.)
             IF (do_tau) THEN
-               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin), &
+               CALL integrate_v_rspace(v_rspace=vtau_rspace(ispin)%pw, &
                                        hmat=scrm(ispin), pmat=rho_ao(ispin), &
                                        qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.TRUE.)
             END IF
@@ -3219,13 +3219,13 @@ CONTAINS
          IF (.NOT. qs_env%admm_env%aux_exch_func == do_admm_aux_exch_func_none) THEN
             DO ispin = 1, nspins
                IF (do_exx) THEN
-                  CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin), &
+                  CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin)%pw, &
                                           hmat=scrm_admm(ispin), pmat=matrix_p_mp2_admm(ispin), &
                                           qs_env=qs_env, calculate_forces=.TRUE., &
                                           basis_type="AUX_FIT", task_list_external=task_list_aux_fit)
                ELSE
                   CALL dbcsr_add(rho_ao_aux(ispin)%matrix, matrix_p_mp2_admm(ispin)%matrix, 1.0_dp, 1.0_dp)
-                  CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin), &
+                  CALL integrate_v_rspace(v_rspace=vadmm_rspace(ispin)%pw, &
                                           hmat=scrm_admm(ispin), pmat=rho_ao_aux(ispin), &
                                           qs_env=qs_env, calculate_forces=.TRUE., &
                                           basis_type="AUX_FIT", task_list_external=task_list_aux_fit)
@@ -3410,7 +3410,7 @@ CONTAINS
 
          CALL pw_transfer(zv_hartree_gspace%pw, zv_hartree_rspace%pw)
          CALL pw_scale(zv_hartree_rspace%pw, zv_hartree_rspace%pw%pw_grid%dvol)
-         CALL integrate_v_core_rspace(zv_hartree_rspace, qs_env)
+         CALL integrate_v_core_rspace(zv_hartree_rspace%pw, qs_env)
 
          IF (do_tau) THEN
             ALLOCATE (tauz_r(nspins), tauz_g(nspins))
@@ -3481,7 +3481,7 @@ CONTAINS
             CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
             CALL pw_axpy(zv_hartree_rspace%pw, v_xc(ispin)%pw)
             CALL integrate_v_rspace(qs_env=qs_env, &
-                                    v_rspace=v_xc(ispin), &
+                                    v_rspace=v_xc(ispin)%pw, &
                                     hmat=current_mat_h(ispin), &
                                     pmat=dbcsr_work_p(ispin, 1), &
                                     calculate_forces=.TRUE.)
@@ -3498,7 +3498,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
                CALL integrate_v_rspace(qs_env=qs_env, &
-                                       v_rspace=v_xc_tau(ispin), &
+                                       v_rspace=v_xc_tau(ispin)%pw, &
                                        hmat=current_mat_h(ispin), &
                                        pmat=dbcsr_work_p(ispin, 1), &
                                        compute_tau=.TRUE., &
@@ -3569,7 +3569,7 @@ CONTAINS
                   DO ispin = 1, nspins
                      CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
                      CALL integrate_v_rspace(qs_env=qs_env, &
-                                             v_rspace=v_xc(ispin), &
+                                             v_rspace=v_xc(ispin)%pw, &
                                              hmat=scrm_admm(ispin), &
                                              pmat=dbcsr_work_p(ispin, 1), &
                                              calculate_forces=.TRUE., &
@@ -3584,7 +3584,7 @@ CONTAINS
                      DO ispin = 1, nspins
                         CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
                         CALL integrate_v_rspace(qs_env=qs_env, &
-                                                v_rspace=v_xc_tau(ispin), &
+                                                v_rspace=v_xc_tau(ispin)%pw, &
                                                 hmat=scrm_admm(ispin), &
                                                 pmat=dbcsr_work_p(ispin, 1), &
                                                 calculate_forces=.TRUE., &

--- a/src/rpa_rse.F
+++ b/src/rpa_rse.F
@@ -448,6 +448,7 @@ CONTAINS
 
       DO i = 1, SIZE(v_rspace)
          CALL pw_release(v_rspace(i)%pw)
+         DEALLOCATE (v_rspace(i)%pw)
       END DO
       DEALLOCATE (v_rspace)
 

--- a/src/rtp_admm_methods.F
+++ b/src/rtp_admm_methods.F
@@ -143,8 +143,8 @@ CONTAINS
                                     ispin)
 
          CALL calculate_rho_elec(matrix_p=matrix_p_aux(ispin)%matrix, &
-                                 rho=rho_r_aux(ispin), &
-                                 rho_gspace=rho_g_aux(ispin), &
+                                 rho=rho_r_aux(ispin)%pw, &
+                                 rho_gspace=rho_g_aux(ispin)%pw, &
                                  total_rho=tot_rho_r_aux(ispin), &
                                  ks_env=ks_env, soft_valid=.FALSE., &
                                  basis_type="AUX_FIT", &

--- a/src/spme.F
+++ b/src/spme.F
@@ -213,10 +213,14 @@ CONTAINS
       END IF
       !----------- END OF DENSITY CALCULATION -------------
 
+      NULLIFY (rhob_r)
+      ALLOCATE (rhob_r)
       CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL rs_pw_transfer(rden, rhob_r, rs2pw)
       ! transform density to G space and add charge function
+      NULLIFY (rhob_g)
+      ALLOCATE (rhob_g)
       CALL pw_pool_create_pw(pw_pool, rhob_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -227,11 +231,13 @@ CONTAINS
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
       DO i = 1, 3
-         NULLIFY (dphi_g(i)%pw)
+         ALLOCATE (dphi_g(i)%pw)
          CALL pw_pool_create_pw(pw_pool, dphi_g(i)%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
+      NULLIFY (phi_g)
+      ALLOCATE (phi_g)
       CALL pw_pool_create_pw(pw_pool, phi_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -530,10 +536,14 @@ CONTAINS
       DEALLOCATE (center, delta)
       !----------- END OF DENSITY CALCULATION -------------
 
+      NULLIFY (rhob_r)
+      ALLOCATE (rhob_r)
       CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL rs_pw_transfer(rden, rhob_r, rs2pw)
       ! transform density to G space and add charge function
+      NULLIFY (rhob_g)
+      ALLOCATE (rhob_g)
       CALL pw_pool_create_pw(pw_pool, rhob_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -543,6 +553,8 @@ CONTAINS
 
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
+      NULLIFY (phi_g)
+      ALLOCATE (phi_g)
       CALL pw_pool_create_pw(pw_pool, phi_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -669,10 +681,14 @@ CONTAINS
       DEALLOCATE (center, delta)
       !----------- END OF DENSITY CALCULATION -------------
 
+      NULLIFY (rhob_r)
+      ALLOCATE (rhob_r)
       CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL rs_pw_transfer(rden, rhob_r, rs2pw)
       ! transform density to G space and add charge function
+      NULLIFY (rhob_g)
+      ALLOCATE (rhob_g)
       CALL pw_pool_create_pw(pw_pool, rhob_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
@@ -683,11 +699,13 @@ CONTAINS
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
       DO i = 1, 3
-         NULLIFY (dphi_g(i)%pw)
+         ALLOCATE (dphi_g(i)%pw)
          CALL pw_pool_create_pw(pw_pool, dphi_g(i)%pw, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
+      NULLIFY (phi_g)
+      ALLOCATE (phi_g)
       CALL pw_pool_create_pw(pw_pool, phi_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)

--- a/src/spme.F
+++ b/src/spme.F
@@ -338,6 +338,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(pw_pool, phi_g)
       CALL pw_pool_give_back_pw(pw_pool, rhob_g)
+      DEALLOCATE (phi_g, rhob_g)
 
       !------------- STRESS TENSOR CALCULATION ------------
       IF (use_virial) THEN
@@ -361,10 +362,12 @@ CONTAINS
          dphi_g(i)%pw%cc = dphi_g(i)%pw%cc*green%p3m_charge%cr
          CALL pw_transfer(dphi_g(i)%pw, rhob_r)
          CALL pw_pool_give_back_pw(pw_pool, dphi_g(i)%pw)
+         DEALLOCATE (dphi_g(i)%pw)
          CALL rs_pw_transfer(drpot(i)%rs_grid, rhob_r, pw2rs)
       END DO
 
       CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      DEALLOCATE (rhob_r)
       !----------------- FORCE CALCULATION ----------------
       ! initialize the forces
       fg_coulomb = 0.0_dp
@@ -584,6 +587,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, phi_g)
       CALL pw_pool_give_back_pw(pw_pool, rhob_g)
       CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      DEALLOCATE (phi_g, rhob_g, rhob_r)
       CALL rs_grid_release(rden)
 
       DEALLOCATE (rhos)
@@ -721,6 +725,7 @@ CONTAINS
          dphi_g(i)%pw%cc = dphi_g(i)%pw%cc*green%p3m_charge%cr
          CALL pw_transfer(dphi_g(i)%pw, rhob_r)
          CALL pw_pool_give_back_pw(pw_pool, dphi_g(i)%pw)
+         DEALLOCATE (dphi_g(i)%pw)
          CALL rs_pw_transfer(drpot(i)%rs_grid, rhob_r, pw2rs)
       END DO
       !----------------- FORCE CALCULATION ----------------
@@ -749,6 +754,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, phi_g)
       CALL pw_pool_give_back_pw(pw_pool, rhob_g)
       CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      DEALLOCATE (phi_g, rhob_g, rhob_r)
       CALL rs_grid_release(rden)
 
       DEALLOCATE (rhos)

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -159,6 +159,7 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
+      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -372,7 +372,7 @@ CONTAINS
          DO i = 1, SIZE(stm_th_torb)
             iorb = stm_th_torb(i)
             CALL calculate_rho_elec(matrix_p=stm_density_ao, &
-                                    rho=wf_r, rho_gspace=wf_g, &
+                                    rho=wf_r%pw, rho_gspace=wf_g%pw, &
                                     ks_env=ks_env, der_type=iorb)
 
             oname = torb_string(iorb)

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -226,6 +226,7 @@ CONTAINS
       CALL dbcsr_deallocate_matrix(stm_density_ao)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
+      DEALLOCATE (wf_r%pw, wf_g%pw)
 
       DEALLOCATE (stm_th_torb)
       DEALLOCATE (nadd_unocc)

--- a/src/surface_dipole.F
+++ b/src/surface_dipole.F
@@ -77,17 +77,16 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: vdip_r, wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
-      TYPE(pw_p_type), POINTER                           :: rho0_s_gs, rho_core
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: v_hartree_rspace
+      TYPE(pw_type)                                      :: vdip_r, wf_r
+      TYPE(pw_type), POINTER                             :: rho0_s_gs, rho_core, v_hartree_rspace
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
       CALL timeset(routineN, handle)
-      NULLIFY (cell, dft_control, rho, pw_env, rho_core, rho0_s_gs, auxbas_pw_pool, &
+      NULLIFY (cell, dft_control, rho, pw_env, auxbas_pw_pool, &
                pw_pools, subsys, v_hartree_rspace, rho_r)
 
       CALL get_qs_env(qs_env, &
@@ -102,35 +101,34 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
-      ALLOCATE (wf_r%pw, vdip_r%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vdip_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, vdip_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       IF (dft_control%qs_control%gapw) THEN
-         CALL pw_transfer(rho0_s_gs%pw, wf_r%pw)
+         CALL pw_transfer(rho0_s_gs, wf_r)
          IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
-            CALL pw_axpy(rho_core%pw, wf_r%pw)
+            CALL pw_axpy(rho_core, wf_r)
          END IF
       ELSE
-         CALL pw_transfer(rho_core%pw, wf_r%pw)
+         CALL pw_transfer(rho_core, wf_r)
       END IF
       CALL qs_rho_get(rho, rho_r=rho_r)
       DO ispin = 1, dft_control%nspins
-         CALL pw_axpy(rho_r(ispin)%pw, wf_r%pw)
+         CALL pw_axpy(rho_r(ispin)%pw, wf_r)
       END DO
 
-      ngrid(1:3) = wf_r%pw%pw_grid%npts(1:3)
+      ngrid(1:3) = wf_r%pw_grid%npts(1:3)
       idir_surfdip = dft_control%dir_surf_dip
 
       width = 4
 
       DO i = 1, 3
          IF (i /= idir_surfdip) THEN
-            IF (ABS(wf_r%pw%pw_grid%dh(idir_surfdip, i)) > 1.E-7_dp) THEN
+            IF (ABS(wf_r%pw_grid%dh(idir_surfdip, i)) > 1.E-7_dp) THEN
                ! stop surface dipole defined only for slab perpendigular to one of the Cartesian axis
                CALL cp_abort(__LOCATION__, &
                              " Dipole correction only for surface perpendicular to "// &
@@ -142,22 +140,22 @@ CONTAINS
          END IF
       END DO
 
-      ilow = wf_r%pw%pw_grid%bounds(1, idir_surfdip)
-      iup = wf_r%pw%pw_grid%bounds(2, idir_surfdip)
+      ilow = wf_r%pw_grid%bounds(1, idir_surfdip)
+      iup = wf_r%pw_grid%bounds(2, idir_surfdip)
 
       ALLOCATE (rhoavsurf(ilow:iup))
       rhoavsurf = 0.0_dp
 
-      bo => wf_r%pw%pw_grid%bounds_local
-      dh = wf_r%pw%pw_grid%dh
+      bo => wf_r%pw_grid%bounds_local
+      dh = wf_r%pw_grid%dh
 
-      wf_r%pw%cr3d = wf_r%pw%cr3d*wf_r%pw%pw_grid%vol
+      wf_r%cr3d = wf_r%cr3d*wf_r%pw_grid%vol
       IF (idir_surfdip == 3) THEN
          isurf = 1
          jsurf = 2
 
          DO i = bo(1, 3), bo(2, 3)
-            rhoavsurf(i) = accurate_sum(wf_r%pw%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), i))
+            rhoavsurf(i) = accurate_sum(wf_r%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), i))
          END DO
 
       ELSEIF (idir_surfdip == 2) THEN
@@ -165,25 +163,25 @@ CONTAINS
          jsurf = 1
 
          DO i = bo(1, 2), bo(2, 2)
-            rhoavsurf(i) = accurate_sum(wf_r%pw%cr3d(bo(1, 1):bo(2, 1), i, bo(1, 3):bo(2, 3)))
+            rhoavsurf(i) = accurate_sum(wf_r%cr3d(bo(1, 1):bo(2, 1), i, bo(1, 3):bo(2, 3)))
          END DO
       ELSE
          isurf = 2
          jsurf = 3
 
          DO i = bo(1, 1), bo(2, 1)
-            rhoavsurf(i) = accurate_sum(wf_r%pw%cr3d(i, bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)))
+            rhoavsurf(i) = accurate_sum(wf_r%cr3d(i, bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)))
          END DO
       END IF
-      wf_r%pw%cr3d = wf_r%pw%cr3d/wf_r%pw%pw_grid%vol
-      rhoavsurf = rhoavsurf/wf_r%pw%pw_grid%vol
+      wf_r%cr3d = wf_r%cr3d/wf_r%pw_grid%vol
+      rhoavsurf = rhoavsurf/wf_r%pw_grid%vol
 
       surfarea = cell%hmat(isurf, isurf)*cell%hmat(jsurf, jsurf) - &
                  cell%hmat(isurf, jsurf)*cell%hmat(jsurf, isurf)
       dsurf = surfarea/REAL(ngrid(isurf)*ngrid(jsurf), dp)
 
-      IF (wf_r%pw%pw_grid%para%mode /= PW_MODE_LOCAL) THEN
-         CALL mp_sum(rhoavsurf, wf_r%pw%pw_grid%para%group)
+      IF (wf_r%pw_grid%para%mode /= PW_MODE_LOCAL) THEN
+         CALL mp_sum(rhoavsurf, wf_r%pw_grid%para%group)
       END IF
       rhoavsurf(ilow:iup) = dsurf*rhoavsurf(ilow:iup)
 
@@ -206,7 +204,7 @@ CONTAINS
 !   surface dipole form average rhoavsurf
 !   \sum_i NjdjNkdkdi rhoav_i (i-imin)di
       dip_hh = 0.0_dp
-      dip_fac = wf_r%pw%pw_grid%vol*dh(idir_surfdip, idir_surfdip)/REAL(ngrid(idir_surfdip), dp)
+      dip_fac = wf_r%pw_grid%vol*dh(idir_surfdip, idir_surfdip)/REAL(ngrid(idir_surfdip), dp)
 
       DO i = ilayer_min + 1, ilayer_min + ngrid(idir_surfdip)
          hh = REAL((i - ilayer_min), dp)
@@ -229,7 +227,7 @@ CONTAINS
       qs_env%surface_dipole_moment = dip_hh/bohr
 
 !    Calculation of the dipole potential as a function of the perpendicular coordinate
-      CALL pw_zero(vdip_r%pw)
+      CALL pw_zero(vdip_r)
       vdip_fac = dip_hh*4.0_dp*pi
 
       DO i = ilayer_min + 1, ilayer_min + ngrid(idir_surfdip)
@@ -250,34 +248,33 @@ CONTAINS
          vdip = vdip*cutoff
 
          IF (idir_surfdip == 3) THEN
-            vdip_r%pw%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), irho) = &
-               vdip_r%pw%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), irho) + vdip
+            vdip_r%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), irho) = &
+               vdip_r%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), irho) + vdip
          ELSEIF (idir_surfdip == 2) THEN
             IF (irho >= bo(1, 2) .AND. irho <= bo(2, 2)) THEN
-               vdip_r%pw%cr3d(bo(1, 1):bo(2, 1), irho, bo(1, 3):bo(2, 3)) = &
-                  vdip_r%pw%cr3d(bo(1, 1):bo(2, 1), irho, bo(1, 3):bo(2, 3)) + vdip
+               vdip_r%cr3d(bo(1, 1):bo(2, 1), irho, bo(1, 3):bo(2, 3)) = &
+                  vdip_r%cr3d(bo(1, 1):bo(2, 1), irho, bo(1, 3):bo(2, 3)) + vdip
             END IF
          ELSE
             IF (irho >= bo(1, 1) .AND. irho <= bo(2, 1)) THEN
-               vdip_r%pw%cr3d(irho, bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)) = &
-                  vdip_r%pw%cr3d(irho, bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)) + vdip
+               vdip_r%cr3d(irho, bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)) = &
+                  vdip_r%cr3d(irho, bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)) + vdip
             END IF
          END IF
 
       END DO
 
 !    Dipole correction contribution to the energy
-      energy%surf_dipole = 0.5_dp*accurate_dot_product(vdip_r%pw%cr3d, wf_r%pw%cr3d)
-      IF (wf_r%pw%pw_grid%para%mode /= PW_MODE_LOCAL) THEN
-         CALL mp_sum(energy%surf_dipole, wf_r%pw%pw_grid%para%group)
+      energy%surf_dipole = 0.5_dp*accurate_dot_product(vdip_r%cr3d, wf_r%cr3d)
+      IF (wf_r%pw_grid%para%mode /= PW_MODE_LOCAL) THEN
+         CALL mp_sum(energy%surf_dipole, wf_r%pw_grid%para%group)
       END IF
 
 !    Add the dipole potential to the hartree potential on the realspace grid
-      v_hartree_rspace%cr3d = v_hartree_rspace%cr3d + vdip_r%pw%cr3d
+      v_hartree_rspace%cr3d = v_hartree_rspace%cr3d + vdip_r%cr3d
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vdip_r%pw)
-      DEALLOCATE (wf_r%pw, vdip_r%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, vdip_r)
 
       CALL timestop(handle)
 

--- a/src/surface_dipole.F
+++ b/src/surface_dipole.F
@@ -102,6 +102,7 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
+      ALLOCATE (wf_r%pw, vdip_r%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)

--- a/src/surface_dipole.F
+++ b/src/surface_dipole.F
@@ -277,6 +277,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vdip_r%pw)
+      DEALLOCATE (wf_r%pw, vdip_r%pw)
 
       CALL timestop(handle)
 

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -298,6 +298,7 @@ CONTAINS
       CALL mp_bcast(dcell, para_env%source, para_env%group)
 
       NULLIFY (pw, pw_grid)
+      ALLOCATE (pw)
       CALL pw_grid_create(pw_grid, para_env%group)
       CALL pw_grid_setup(dcell, pw_grid, npts=npts)
       CALL pw_create(pw, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
@@ -307,6 +308,7 @@ CONTAINS
       CALL cp_cube_to_pw(pw, scan_env%tip_cube_file, scaling, silent=.TRUE.)
       scan_env%tip_pw_r => pw
       NULLIFY (pw)
+      ALLOCATE (pw)
       CALL pw_create(pw, pw_grid, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_transfer(scan_env%tip_pw_r, pw)
       scan_env%tip_pw_g => pw

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -129,11 +129,13 @@ CONTAINS
          ! scratch memory for tip potentials and structure factor
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ALLOCATE (vtip)
+         ALLOCATE (vtip%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, vtip%pw, use_data=REALDATA3D)
          vtip%pw%in_space = REALSPACE
          CALL pw_zero(vtip%pw)
          NULLIFY (sf, vref)
          ALLOCATE (sf, vref)
+         ALLOCATE (vref%pw, sf%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, vref%pw, use_data=COMPLEXDATA1D)
          vref%pw%in_space = RECIPROCALSPACE
          CALL pw_zero(vref%pw)

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -206,6 +206,7 @@ CONTAINS
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vtip%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vref%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, sf%pw)
+         DEALLOCATE (vtip%pw, vref%pw, sf%pw)
          DEALLOCATE (vtip, sf, vref)
 
          logger%iter_info%print_level = plevel

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -38,7 +38,6 @@ MODULE tip_scan_methods
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_create,&
-                                              pw_p_type,&
                                               pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -89,8 +88,9 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos, mos_ref
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: sf, vee, vref, vtip
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: sf, vref
+      TYPE(pw_type), POINTER                             :: vee, vtip
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(scanning_type)                                :: scan_env
 
@@ -120,7 +120,6 @@ CONTAINS
                          dft_control=dft_control)
          expot = dft_control%apply_external_potential
          dft_control%apply_external_potential = .TRUE.
-         NULLIFY (vee, vtip)
          IF (expot) THEN
             ! save external potential
             CALL get_qs_env(qs_env, vee=vee)
@@ -128,22 +127,19 @@ CONTAINS
 
          ! scratch memory for tip potentials and structure factor
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
+         NULLIFY (vtip)
          ALLOCATE (vtip)
-         ALLOCATE (vtip%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vtip%pw, use_data=REALDATA3D)
-         vtip%pw%in_space = REALSPACE
-         CALL pw_zero(vtip%pw)
-         NULLIFY (sf, vref)
-         ALLOCATE (sf, vref)
-         ALLOCATE (vref%pw, sf%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vref%pw, use_data=COMPLEXDATA1D)
-         vref%pw%in_space = RECIPROCALSPACE
-         CALL pw_zero(vref%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, sf%pw, use_data=COMPLEXDATA1D)
-         sf%pw%in_space = RECIPROCALSPACE
+         CALL pw_pool_create_pw(auxbas_pw_pool, vtip, use_data=REALDATA3D)
+         vtip%in_space = REALSPACE
+         CALL pw_zero(vtip)
+         CALL pw_pool_create_pw(auxbas_pw_pool, vref, use_data=COMPLEXDATA1D)
+         vref%in_space = RECIPROCALSPACE
+         CALL pw_zero(vref)
+         CALL pw_pool_create_pw(auxbas_pw_pool, sf, use_data=COMPLEXDATA1D)
+         sf%in_space = RECIPROCALSPACE
 
          ! get the reference tip potential and store it in reciprocal space (vref)
-         CALL pw_transfer(scan_env%tip_pw_g, vref%pw)
+         CALL pw_transfer(scan_env%tip_pw_g, vref)
 
          ! store reference MOs
          CALL get_qs_env(qs_env, mos=mos)
@@ -169,7 +165,7 @@ CONTAINS
             CALL shift_tip_potential(vref, sf, vtip, rpos)
             ! set the external potential
             IF (ASSOCIATED(vee)) THEN
-               CALL pw_axpy(vee%pw, vtip%pw, alpha=1.0_dp)
+               CALL pw_axpy(vee, vtip, alpha=1.0_dp)
             END IF
             CALL set_ks_env(ks_env, vee=vtip)
 
@@ -203,11 +199,10 @@ CONTAINS
             NULLIFY (vee)
             CALL set_ks_env(ks_env, vee=vee)
          END IF
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vtip%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vref%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, sf%pw)
-         DEALLOCATE (vtip%pw, vref%pw, sf%pw)
-         DEALLOCATE (vtip, sf, vref)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, vtip)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, vref)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, sf)
+         DEALLOCATE (vtip)
 
          logger%iter_info%print_level = plevel
          logger%iter_info%project_name = cname
@@ -236,7 +231,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE shift_tip_potential(vref, sf, vtip, rpos)
 
-      TYPE(pw_p_type), POINTER                           :: vref, sf, vtip
+      TYPE(pw_type), INTENT(IN)                          :: vref, sf
+      TYPE(pw_type), INTENT(INOUT)                       :: vtip
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: rpos
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'shift_tip_potential'
@@ -245,9 +241,9 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL pw_structure_factor(sf%pw, rpos)
-      sf%pw%cc = vref%pw%cc*sf%pw%cc
-      CALL pw_transfer(sf%pw, vtip%pw)
+      CALL pw_structure_factor(sf, rpos)
+      sf%cc = vref%cc*sf%cc
+      CALL pw_transfer(sf, vtip)
 
       CALL timestop(handle)
 

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -269,7 +269,6 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3)                     :: dcell
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_type), POINTER                             :: pw
 
       CALL timeset(routineN, handle)
 
@@ -296,21 +295,16 @@ CONTAINS
       CALL mp_bcast(npts, para_env%source, para_env%group)
       CALL mp_bcast(dcell, para_env%source, para_env%group)
 
-      NULLIFY (pw, pw_grid)
-      ALLOCATE (pw)
+      NULLIFY (pw_grid)
       CALL pw_grid_create(pw_grid, para_env%group)
       CALL pw_grid_setup(dcell, pw_grid, npts=npts)
-      CALL pw_create(pw, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_create(scan_env%tip_pw_r, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
 !deb
       scaling = 0.1_dp
 !deb
-      CALL cp_cube_to_pw(pw, scan_env%tip_cube_file, scaling, silent=.TRUE.)
-      scan_env%tip_pw_r => pw
-      NULLIFY (pw)
-      ALLOCATE (pw)
-      CALL pw_create(pw, pw_grid, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_transfer(scan_env%tip_pw_r, pw)
-      scan_env%tip_pw_g => pw
+      CALL cp_cube_to_pw(scan_env%tip_pw_r, scan_env%tip_cube_file, scaling, silent=.TRUE.)
+      CALL pw_create(scan_env%tip_pw_g, pw_grid, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_transfer(scan_env%tip_pw_r, scan_env%tip_pw_g)
       CALL pw_grid_release(pw_grid)
 
       CALL timestop(handle)

--- a/src/tip_scan_types.F
+++ b/src/tip_scan_types.F
@@ -158,9 +158,11 @@ CONTAINS
       END IF
       IF (ASSOCIATED(scan_info%tip_pw_r)) THEN
          CALL pw_release(scan_info%tip_pw_r)
+         DEALLOCATE (scan_info%tip_pw_r)
       END IF
       IF (ASSOCIATED(scan_info%tip_pw_g)) THEN
          CALL pw_release(scan_info%tip_pw_g)
+         DEALLOCATE (scan_info%tip_pw_g)
       END IF
 
    END SUBROUTINE release_scanning_type

--- a/src/transport.F
+++ b/src/transport.F
@@ -742,6 +742,7 @@ CONTAINS
                CALL dbcsr_deallocate_matrix(zero)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rs%pw)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, gs%pw)
+               DEALLOCATE (rs%pw, gs%pw)
                DEALLOCATE (rs, gs)
             END IF
          END IF

--- a/src/transport.F
+++ b/src/transport.F
@@ -70,7 +70,8 @@ MODULE transport
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
@@ -663,8 +664,8 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
-      TYPE(pw_p_type), POINTER                           :: gs, rs
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: gs, rs
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: dft_section
@@ -701,11 +702,8 @@ CONTAINS
                current_env%gauge = -1
                current_env%gauge_init = .FALSE.
 
-               NULLIFY (rs, gs)
-               ALLOCATE (rs, gs)
-               ALLOCATE (rs%pw, gs%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, rs%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, gs%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL pw_pool_create_pw(auxbas_pw_pool, rs, use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_create_pw(auxbas_pw_pool, gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
                NULLIFY (zero)
                ALLOCATE (zero)
@@ -714,8 +712,8 @@ CONTAINS
                CALL dbcsr_set(zero, 0.0_dp)
 
                DO dir = 1, 3
-                  CALL pw_zero(rs%pw)
-                  CALL pw_zero(gs%pw)
+                  CALL pw_zero(rs)
+                  CALL pw_zero(gs)
                   CALL calculate_jrho_resp(zero, transport_env%dm_imag, &
                                            zero, zero, dir, dir, rs, gs, qs_env, current_env, &
                                            retain_rsgrid=.TRUE.)
@@ -732,7 +730,7 @@ CONTAINS
                   unit_nr = cp_print_key_unit_nr(logger, dft_section, "TRANSPORT%PRINT%CURRENT", &
                                                  extension=ext, file_status="REPLACE", file_action="WRITE", &
                                                  log_filename=.FALSE., mpi_io=mpi_io)
-                  CALL cp_pw_to_cube(rs%pw, unit_nr, "Transport current", particles=particles, &
+                  CALL cp_pw_to_cube(rs, unit_nr, "Transport current", particles=particles, &
                                      stride=section_get_ivals(dft_section, "TRANSPORT%PRINT%CURRENT%STRIDE"), &
                                      mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(unit_nr, logger, dft_section, "TRANSPORT%PRINT%CURRENT", &
@@ -740,10 +738,8 @@ CONTAINS
                END DO
 
                CALL dbcsr_deallocate_matrix(zero)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rs%pw)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, gs%pw)
-               DEALLOCATE (rs%pw, gs%pw)
-               DEALLOCATE (rs, gs)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, rs)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, gs)
             END IF
          END IF
 

--- a/src/transport.F
+++ b/src/transport.F
@@ -703,7 +703,7 @@ CONTAINS
 
                NULLIFY (rs, gs)
                ALLOCATE (rs, gs)
-               NULLIFY (rs%pw, gs%pw)
+               ALLOCATE (rs%pw, gs%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, rs%pw, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_pool_create_pw(auxbas_pw_pool, gs%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 

--- a/src/voronoi_interface.F
+++ b/src/voronoi_interface.F
@@ -21,7 +21,7 @@ MODULE voronoi_interface
                            Brehm2021, cite_reference
    USE kinds, ONLY: dp, default_path_length
    USE cell_types, ONLY: cell_type, pbc
-   USE pw_types, ONLY: pw_p_type, pw_type
+   USE pw_types, ONLY: pw_type
    USE physcon, ONLY: bohr, debye
    USE mathconstants, ONLY: fourpi
    USE orbital_pointers, ONLY: indco

--- a/src/voronoi_interface.F
+++ b/src/voronoi_interface.F
@@ -320,7 +320,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: input_voro, input_bqb
       INTEGER, INTENT(IN)                                :: unit_voro
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_type), POINTER                             :: rspace_pw
+      TYPE(pw_type)                             :: rspace_pw
 
 #if defined(__LIBVORI)
 

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -244,7 +244,7 @@ CONTAINS
 
       ALLOCATE (rho2_r(2))
       DO ispin = 1, 2
-         NULLIFY (rho2_r(ispin)%pw)
+         ALLOCATE (rho2_r(ispin)%pw)
          CALL pw_pool_create_pw(pw_pool, rho2_r(ispin)%pw, in_space=REALSPACE, &
                                 use_data=REALDATA3D)
       END DO
@@ -261,7 +261,7 @@ CONTAINS
       IF (ASSOCIATED(tau)) THEN
          ALLOCATE (tau2(2))
          DO ispin = 1, 2
-            NULLIFY (tau2(ispin)%pw)
+            ALLOCATE (tau2(ispin)%pw)
             CALL pw_pool_create_pw(pw_pool, tau2(ispin)%pw, in_space=REALSPACE, &
                                    use_data=REALDATA3D)
          END DO
@@ -1205,6 +1205,8 @@ CONTAINS
 
          CPASSERT(ASSOCIATED(deriv_data))
          IF (use_virial) THEN
+            NULLIFY (virial_pw)
+            ALLOCATE (virial_pw)
             CALL pw_pool_create_pw(pw_pool, virial_pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -1235,10 +1237,16 @@ CONTAINS
       END IF
 
       IF ((has_gradient .AND. xc_requires_tmp_g(xc_deriv_method_id)) .OR. pw_grid%spherical) THEN
+         NULLIFY (vxc_g)
+         ALLOCATE (vxc_g)
          CALL pw_pool_create_pw(pw_pool, vxc_g, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         IF (.NOT. pw_grid%spherical) CALL pw_pool_create_pw(pw_pool, tmp_g, &
-                                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         IF (.NOT. pw_grid%spherical) THEN
+            NULLIFY (tmp_g)
+            ALLOCATE (tmp_g)
+            CALL pw_pool_create_pw(pw_pool, tmp_g, &
+                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         END IF
       END IF
 
       DO ispin = 1, nspins
@@ -1262,6 +1270,8 @@ CONTAINS
                CALL xc_derivative_get(deriv_att, deriv_data=deriv_data)
 
                IF (use_virial) THEN
+                  NULLIFY (virial_pw)
+                  ALLOCATE (virial_pw)
                   CALL pw_pool_create_pw(pw_pool, virial_pw, &
                                          use_data=REALDATA3D, &
                                          in_space=REALSPACE)
@@ -1362,7 +1372,7 @@ CONTAINS
                             rho_smooth_cutoff_range=density_smooth_cut_range)
 
          v_drho_r => vxc_rho(ispin)%pw
-         NULLIFY (vxc_rho(ispin)%pw)
+         ALLOCATE (vxc_rho(ispin)%pw)
          CALL pw_pool_create_pw(pw_pool, vxc_rho(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL xc_pw_smooth(v_drho_r, vxc_rho(ispin)%pw, xc_rho_smooth_id)
@@ -1570,7 +1580,7 @@ CONTAINS
       NULLIFY (v_xc, v_xc_tau)
       ALLOCATE (v_xc(nspins))
       DO ispin = 1, nspins
-         NULLIFY (v_xc(ispin)%pw)
+         ALLOCATE (v_xc(ispin)%pw)
          CALL pw_pool_create_pw(pw_pool, v_xc(ispin)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -1585,7 +1595,7 @@ CONTAINS
             CPABORT("Tau-dependent functionals requires allocated kinetic energy density grid")
          ALLOCATE (v_xc_tau(nspins))
          DO ispin = 1, nspins
-            NULLIFY (v_xc_tau(ispin)%pw)
+            ALLOCATE (v_xc_tau(ispin)%pw)
             CALL pw_pool_create_pw(pw_pool, v_xc_tau(ispin)%pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -1714,13 +1724,13 @@ CONTAINS
          NULLIFY (vxc_rho, rho_g, vxc_tau)
          ALLOCATE (rho_r(2))
          DO ispin = 1, nspins
-            NULLIFY (rho_r(ispin)%pw)
+            ALLOCATE (rho_r(ispin)%pw)
             CALL pw_pool_create_pw(pw_pool, rho_r(ispin)%pw, in_space=REALSPACE, use_data=REALDATA3D)
          END DO
          IF (ASSOCIATED(tau1_r) .AND. ASSOCIATED(v_tau)) THEN
             ALLOCATE (tau_r(2))
             DO ispin = 1, nspins
-               NULLIFY (tau_r(ispin)%pw)
+               ALLOCATE (tau_r(ispin)%pw)
                CALL pw_pool_create_pw(pw_pool, tau_r(ispin)%pw, in_space=REALSPACE, use_data=REALDATA3D)
             END DO
          END IF
@@ -1754,13 +1764,13 @@ CONTAINS
          NULLIFY (vxc_rho, vxc_tau, rho_g)
          ALLOCATE (rho_r(2))
          DO ispin = 1, 2
-            NULLIFY (rho_r(ispin)%pw)
+            ALLOCATE (rho_r(ispin)%pw)
             CALL pw_pool_create_pw(pw_pool, rho_r(ispin)%pw, in_space=REALSPACE, use_data=REALDATA3D)
          END DO
          IF (ASSOCIATED(tau1_r) .AND. ASSOCIATED(v_tau)) THEN
             ALLOCATE (tau_r(2))
             DO ispin = 1, nspins
-               NULLIFY (tau_r(ispin)%pw)
+               ALLOCATE (tau_r(ispin)%pw)
                CALL pw_pool_create_pw(pw_pool, tau_r(ispin)%pw, in_space=REALSPACE, use_data=REALDATA3D)
             END DO
          END IF
@@ -1843,11 +1853,11 @@ CONTAINS
       ELSE
          NULLIFY (vxc_rho, rho_r, rho_g, vxc_tau, tau_r, tau)
          ALLOCATE (rho_r(1))
-         NULLIFY (rho_r(1)%pw)
+         ALLOCATE (rho_r(1)%pw)
          CALL pw_pool_create_pw(pw_pool, rho_r(1)%pw, in_space=REALSPACE, use_data=REALDATA3D)
          IF (ASSOCIATED(tau1_r) .AND. ASSOCIATED(v_tau)) THEN
             ALLOCATE (tau_r(1))
-            NULLIFY (tau_r(1)%pw)
+            ALLOCATE (tau_r(1)%pw)
             CALL pw_pool_create_pw(pw_pool, tau_r(1)%pw, in_space=REALSPACE, use_data=REALDATA3D)
          END IF
          CALL xc_rho_set_get(rho_set, can_return_null=.TRUE., rho=rho, tau=tau)
@@ -2729,6 +2739,8 @@ CONTAINS
 
          IF (xc_requires_tmp_g(xc_deriv_method_id) .AND. .NOT. my_gapw) THEN
             IF (ASSOCIATED(pw_pool)) THEN
+               NULLIFY (tmp_g, vxc_g)
+               ALLOCATE (tmp_g, vxc_g)
                CALL pw_pool_create_pw(pw_pool, tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                CALL pw_pool_create_pw(pw_pool, vxc_g, &
@@ -3076,6 +3088,8 @@ CONTAINS
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bo
 
       IF (ASSOCIATED(pw_pool)) THEN
+         NULLIFY (pw)
+         ALLOCATE (pw)
          CALL pw_pool_create_pw(pw_pool, pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -3192,7 +3206,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (virial_pw, tmp_g, rho_g)
-
+      ALLOCATE (virial_pw, tmp_g, rho_g)
       CALL pw_pool_create_pw(pw_pool, virial_pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -520,8 +520,10 @@ CONTAINS
       DO ispin = 1, 2
          CALL pw_pool_give_back_pw(pw_pool, rho2_r(ispin)%pw)
          CALL pw_pool_give_back_pw(pw_pool, vxc_rho2(ispin)%pw)
+         DEALLOCATE (rho2_r(ispin)%pw, vxc_rho2(ispin)%pw)
          IF (ASSOCIATED(vxc_tau2)) THEN
             CALL pw_pool_give_back_pw(pw_pool, vxc_tau2(ispin)%pw)
+            DEALLOCATE (vxc_tau2(ispin)%pw)
          END IF
       END DO
       DEALLOCATE (vxc_rho2, rho2_r, rho2_g)
@@ -1223,6 +1225,8 @@ CONTAINS
                END DO
             END DO
             CALL pw_pool_give_back_pw(pw_pool, virial_pw)
+            DEALLOCATE (virial_pw)
+            NULLIFY (virial_pw)
          END IF ! use_virial
          DO idir = 1, 3
             CPASSERT(ASSOCIATED(pw_to_deriv_rho(idir)%pw%cr3d))
@@ -1288,6 +1292,8 @@ CONTAINS
                      END DO
                   END DO
                   CALL pw_pool_give_back_pw(pw_pool, virial_pw)
+                  DEALLOCATE (virial_pw)
+                  NULLIFY (virial_pw)
                END IF ! use_virial
 
                DO idir = 1, 3
@@ -1318,7 +1324,10 @@ CONTAINS
                DO idir = 1, 3
                   CALL pw_axpy(pw_to_deriv_rho(idir)%pw, pw_to_deriv(idir)%pw)
                   IF (ispin == 2) THEN
-                     IF (dealloc_pw_to_deriv_rho) CALL pw_pool_give_back_pw(pw_pool, pw_to_deriv_rho(idir)%pw)
+                     IF (dealloc_pw_to_deriv_rho) THEN
+                        CALL pw_pool_give_back_pw(pw_pool, pw_to_deriv_rho(idir)%pw)
+                        DEALLOCATE (pw_to_deriv_rho(idir)%pw)
+                     END IF
                      NULLIFY (pw_to_deriv_rho(idir)%pw)
                   END IF
                END DO
@@ -1335,6 +1344,7 @@ CONTAINS
             IF (dealloc_pw_to_deriv) THEN
             DO idir = 1, 3
                CALL pw_pool_give_back_pw(pw_pool, pw_to_deriv(idir)%pw)
+               DEALLOCATE (pw_to_deriv(idir)%pw)
             END DO
             END IF
          END IF
@@ -1360,6 +1370,7 @@ CONTAINS
             CALL pw_axpy(pw_to_deriv(1)%pw, vxc_rho(ispin)%pw)
 
             CALL pw_pool_give_back_pw(pw_pool, pw_to_deriv(1)%pw)
+            DEALLOCATE (pw_to_deriv(1)%pw)
          END IF
 
          IF (pw_grid%spherical) THEN
@@ -1377,10 +1388,19 @@ CONTAINS
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL xc_pw_smooth(v_drho_r, vxc_rho(ispin)%pw, xc_rho_smooth_id)
          CALL pw_pool_give_back_pw(pw_pool, v_drho_r)
+         DEALLOCATE (v_drho_r)
       END DO
 
-      IF (ASSOCIATED(vxc_g)) CALL pw_pool_give_back_pw(pw_pool, vxc_g)
-      IF (ASSOCIATED(tmp_g)) CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+      IF (ASSOCIATED(vxc_g)) THEN
+         CALL pw_pool_give_back_pw(pw_pool, vxc_g)
+         DEALLOCATE (vxc_g)
+         NULLIFY (vxc_g)
+      END IF
+      IF (ASSOCIATED(tmp_g)) THEN
+         CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+         DEALLOCATE (tmp_g)
+         NULLIFY (tmp_g)
+      END IF
 
       DO idir = 1, 3
          CPASSERT(.NOT. ASSOCIATED(pw_to_deriv(idir)%pw))
@@ -2278,12 +2298,14 @@ CONTAINS
 
       DO ispin = 1, SIZE(rho_r)
          CALL pw_pool_give_back_pw(pw_pool, rho_r(ispin)%pw)
+         DEALLOCATE (rho_r(ispin)%pw)
       END DO
       DEALLOCATE (rho_r)
 
       IF (ASSOCIATED(tau_r)) THEN
       DO ispin = 1, SIZE(tau_r)
          CALL pw_pool_give_back_pw(pw_pool, tau_r(ispin)%pw)
+         DEALLOCATE (tau_r(ispin)%pw)
       END DO
       DEALLOCATE (tau_r)
       END IF
@@ -3063,10 +3085,12 @@ CONTAINS
 
       IF (ASSOCIATED(tmp_g) .AND. ASSOCIATED(pw_pool)) THEN
          CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+         DEALLOCATE (tmp_g)
       END IF
 
       IF (ASSOCIATED(vxc_g) .AND. ASSOCIATED(pw_pool)) THEN
          CALL pw_pool_give_back_pw(pw_pool, vxc_g)
+         DEALLOCATE (vxc_g)
       END IF
 
       IF (my_compute_virial .AND. (gradient_f .OR. laplace_f)) THEN
@@ -3116,8 +3140,9 @@ CONTAINS
          CALL pw_pool_give_back_pw(pw_pool, pw)
       ELSE
          DEALLOCATE (pw%cr3d)
-         DEALLOCATE (pw)
       END IF
+      DEALLOCATE (pw)
+      NULLIFY (pw)
 
    END SUBROUTINE deallocate_pw
 
@@ -3235,6 +3260,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(pw_pool, virial_pw)
       CALL pw_pool_give_back_pw(pw_pool, tmp_g)
       CALL pw_pool_give_back_pw(pw_pool, rho_g)
+      DEALLOCATE (virial_pw, tmp_g, rho_g)
 
       CALL timestop(handle)
 

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -161,7 +161,7 @@ CONTAINS
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       LOGICAL, INTENT(IN)                                :: compute_virial
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: virial_xc
-      TYPE(pw_p_type), INTENT(INOUT), OPTIONAL           :: exc_r
+      TYPE(pw_type), INTENT(INOUT), OPTIONAL           :: exc_r
 
       INTEGER                                            :: f_routine
 
@@ -1104,7 +1104,7 @@ CONTAINS
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       LOGICAL                                            :: compute_virial
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: virial_xc
-      TYPE(pw_p_type), INTENT(INOUT), OPTIONAL           :: exc_r
+      TYPE(pw_type), INTENT(INOUT), OPTIONAL           :: exc_r
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xc_vxc_pw_create'
       INTEGER, DIMENSION(2), PARAMETER :: norm_drho_spin_name = [deriv_norm_drhoa, deriv_norm_drhob]
@@ -1393,8 +1393,7 @@ CONTAINS
          ! return the xc functional value at the grid points
          !
          IF (PRESENT(exc_r)) THEN
-            ALLOCATE (exc_r%pw)
-            exc_r%pw = v_drho_r
+            exc_r = v_drho_r
          ELSE
             CALL pw_release(v_drho_r)
          END IF

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -50,7 +50,6 @@ MODULE xc
                        REALDATA3D, &
                        REALSPACE, &
                        RECIPROCALSPACE, &
-                       pw_create, &
                        pw_p_type, &
                        pw_release, &
                        pw_type

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -1396,6 +1396,7 @@ CONTAINS
             NULLIFY (v_drho_r)
          ELSE
             CALL pw_release(v_drho_r)
+            DEALLOCATE (v_drho_r)
          END IF
       ELSE
          exc = 0.0_dp
@@ -1739,11 +1740,13 @@ CONTAINS
             END DO
             DO ispin = 1, nspins
                CALL pw_release(vxc_rho(ispin)%pw)
+               DEALLOCATE (vxc_rho(ispin)%pw)
             END DO
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
                DO ispin = 1, nspins
                   CALL pw_release(vxc_tau(ispin)%pw)
+                  DEALLOCATE (vxc_tau(ispin)%pw)
                END DO
                DEALLOCATE (vxc_tau)
             END IF
@@ -1792,11 +1795,13 @@ CONTAINS
             END IF
             DO ispin = 1, 2
                CALL pw_release(vxc_rho(ispin)%pw)
+               DEALLOCATE (vxc_rho(ispin)%pw)
             END DO
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
             DO ispin = 1, 2
                CALL pw_release(vxc_tau(ispin)%pw)
+               DEALLOCATE (vxc_tau(ispin)%pw)
             END DO
             DEALLOCATE (vxc_tau)
             END IF
@@ -1825,11 +1830,13 @@ CONTAINS
             END IF
             DO ispin = 1, 2
                CALL pw_release(vxc_rho(ispin)%pw)
+               DEALLOCATE (vxc_rho(ispin)%pw)
             END DO
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
             DO ispin = 1, 2
                CALL pw_release(vxc_tau(ispin)%pw)
+               DEALLOCATE (vxc_tau(ispin)%pw)
             END DO
             DEALLOCATE (vxc_tau)
             END IF
@@ -1866,9 +1873,11 @@ CONTAINS
                CALL pw_axpy(vxc_tau(1)%pw, v_tau(1)%pw, weight)
             END IF
             CALL pw_release(vxc_rho(1)%pw)
+            DEALLOCATE (vxc_rho(1)%pw)
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
                CALL pw_release(vxc_tau(1)%pw)
+               DEALLOCATE (vxc_tau(1)%pw)
                DEALLOCATE (vxc_tau)
             END IF
          END DO

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -1109,7 +1109,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xc_vxc_pw_create'
       INTEGER, DIMENSION(2), PARAMETER :: norm_drho_spin_name = [deriv_norm_drhoa, deriv_norm_drhob]
 
-      INTEGER                                            :: handle, i, idir, ispin, jdir, &
+      INTEGER                                            :: handle, idir, ispin, jdir, &
                                                             npoints, nspins, &
                                                             xc_deriv_method_id, xc_rho_smooth_id, deriv_id
       INTEGER, DIMENSION(2, 3)                           :: bo
@@ -1122,21 +1122,14 @@ CONTAINS
                                                             rho, rhoa, rhob
       TYPE(cp_sll_xc_deriv_type), POINTER                :: pos
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_p_type), DIMENSION(2)                      :: vxc_to_deriv
       TYPE(pw_p_type), DIMENSION(3)                      :: pw_to_deriv, pw_to_deriv_rho
-      TYPE(pw_type), POINTER                             :: tmp_g, v_drho_r, virial_pw, vxc_g
+      TYPE(pw_type)                             :: tmp_g, v_drho_r, virial_pw, vxc_g
       TYPE(xc_derivative_set_type)                       :: deriv_set
       TYPE(xc_derivative_type), POINTER                  :: deriv_att
       TYPE(xc_rho_set_type)                              :: rho_set
 
       CALL timeset(routineN, handle)
-      NULLIFY (tmp_g, v_drho_r, vxc_g, norm_drho_spin, norm_drho, pos, virial_pw)
-      DO idir = 1, 3
-         NULLIFY (pw_to_deriv(idir)%pw, pw_to_deriv_rho(idir)%pw)
-      END DO
-      DO i = 1, 2
-         NULLIFY (vxc_to_deriv(i)%pw)
-      END DO
+      NULLIFY (norm_drho_spin, norm_drho, pos)
 
       pw_grid => rho_r(1)%pw%pw_grid
 
@@ -1180,7 +1173,7 @@ CONTAINS
 
       ALLOCATE (vxc_rho(nspins))
       DO ispin = 1, nspins
-         NULLIFY (vxc_rho(ispin)%pw)
+         ALLOCATE (vxc_rho(ispin)%pw)
       END DO
 
       CALL xc_rho_set_get(rho_set, rho=rho, rhoa=rhoa, rhob=rhob, &
@@ -1207,8 +1200,6 @@ CONTAINS
 
          CPASSERT(ASSOCIATED(deriv_data))
          IF (use_virial) THEN
-            NULLIFY (virial_pw)
-            ALLOCATE (virial_pw)
             CALL pw_pool_create_pw(pw_pool, virial_pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
@@ -1225,8 +1216,6 @@ CONTAINS
                END DO
             END DO
             CALL pw_pool_give_back_pw(pw_pool, virial_pw)
-            DEALLOCATE (virial_pw)
-            NULLIFY (virial_pw)
          END IF ! use_virial
          DO idir = 1, 3
             CPASSERT(ASSOCIATED(pw_to_deriv_rho(idir)%pw%cr3d))
@@ -1241,13 +1230,9 @@ CONTAINS
       END IF
 
       IF ((has_gradient .AND. xc_requires_tmp_g(xc_deriv_method_id)) .OR. pw_grid%spherical) THEN
-         NULLIFY (vxc_g)
-         ALLOCATE (vxc_g)
          CALL pw_pool_create_pw(pw_pool, vxc_g, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          IF (.NOT. pw_grid%spherical) THEN
-            NULLIFY (tmp_g)
-            ALLOCATE (tmp_g)
             CALL pw_pool_create_pw(pw_pool, tmp_g, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END IF
@@ -1274,8 +1259,6 @@ CONTAINS
                CALL xc_derivative_get(deriv_att, deriv_data=deriv_data)
 
                IF (use_virial) THEN
-                  NULLIFY (virial_pw)
-                  ALLOCATE (virial_pw)
                   CALL pw_pool_create_pw(pw_pool, virial_pw, &
                                          use_data=REALDATA3D, &
                                          in_space=REALSPACE)
@@ -1292,8 +1275,6 @@ CONTAINS
                      END DO
                   END DO
                   CALL pw_pool_give_back_pw(pw_pool, virial_pw)
-                  DEALLOCATE (virial_pw)
-                  NULLIFY (virial_pw)
                END IF ! use_virial
 
                DO idir = 1, 3
@@ -1361,6 +1342,7 @@ CONTAINS
                deriv_id = deriv_laplace_rho
             END IF
 
+            ALLOCATE (pw_to_deriv(1)%pw)
             CALL xc_dset_recover_pw(deriv_set, [deriv_id], pw_to_deriv(1)%pw, pw_grid)
 
             IF (use_virial) CALL virial_laplace(rho_r(ispin)%pw, pw_pool, virial_xc, pw_to_deriv(1)%pw%cr3d)
@@ -1382,25 +1364,15 @@ CONTAINS
                             rho_cutoff=rho_cutoff*density_smooth_cut_range, &
                             rho_smooth_cutoff_range=density_smooth_cut_range)
 
-         v_drho_r => vxc_rho(ispin)%pw
-         ALLOCATE (vxc_rho(ispin)%pw)
+         v_drho_r = vxc_rho(ispin)%pw
          CALL pw_pool_create_pw(pw_pool, vxc_rho(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL xc_pw_smooth(v_drho_r, vxc_rho(ispin)%pw, xc_rho_smooth_id)
          CALL pw_pool_give_back_pw(pw_pool, v_drho_r)
-         DEALLOCATE (v_drho_r)
       END DO
 
-      IF (ASSOCIATED(vxc_g)) THEN
-         CALL pw_pool_give_back_pw(pw_pool, vxc_g)
-         DEALLOCATE (vxc_g)
-         NULLIFY (vxc_g)
-      END IF
-      IF (ASSOCIATED(tmp_g)) THEN
-         CALL pw_pool_give_back_pw(pw_pool, tmp_g)
-         DEALLOCATE (tmp_g)
-         NULLIFY (tmp_g)
-      END IF
+      CALL pw_pool_give_back_pw(pw_pool, vxc_g)
+      CALL pw_pool_give_back_pw(pw_pool, tmp_g)
 
       DO idir = 1, 3
          CPASSERT(.NOT. ASSOCIATED(pw_to_deriv(idir)%pw))
@@ -1421,11 +1393,10 @@ CONTAINS
          ! return the xc functional value at the grid points
          !
          IF (PRESENT(exc_r)) THEN
-            exc_r%pw => v_drho_r
-            NULLIFY (v_drho_r)
+            ALLOCATE (exc_r%pw)
+            exc_r%pw = v_drho_r
          ELSE
             CALL pw_release(v_drho_r)
-            DEALLOCATE (v_drho_r)
          END IF
       ELSE
          exc = 0.0_dp
@@ -1437,7 +1408,7 @@ CONTAINS
       IF (has_tau) THEN
          ALLOCATE (vxc_tau(nspins))
          DO ispin = 1, nspins
-            NULLIFY (vxc_tau(ispin)%pw)
+            ALLOCATE (vxc_tau(ispin)%pw)
          END DO
          IF (lsd) THEN
             CALL xc_dset_recover_pw(deriv_set, [deriv_tau_a], vxc_tau(1)%pw, pw_grid)
@@ -1716,10 +1687,10 @@ CONTAINS
                                                             laplacea, laplaceb, laplace1a, laplace1b, &
                                                             laplace2, laplace2a, laplace2b, deriv_data
       TYPE(cp_3d_r_p_type), DIMENSION(3)                 :: drho, drho1, drho1a, drho1b, drhoa, drhob
-      TYPE(pw_p_type)                                    :: v_drho, v_drhoa, v_drhob
+      TYPE(pw_type)                                    :: v_drho, v_drhoa, v_drhob
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, vxc_rho, &
                                                             tau_r, vxc_tau
-      TYPE(pw_type), POINTER                             :: virial_pw, v_laplace, v_laplacea, v_laplaceb
+      TYPE(pw_type)                            :: virial_pw, v_laplace, v_laplacea, v_laplaceb
       TYPE(section_vals_type), POINTER                   :: xc_fun_section
       TYPE(xc_derivative_set_type)                       :: deriv_set1
       TYPE(xc_rho_cflags_type)                           :: needs
@@ -1967,16 +1938,16 @@ CONTAINS
                CALL prepare_dr1dr(dra1dra, drhoa, drho1a)
                CALL prepare_dr1dr(drb1drb, drhob, drho1b)
 
-               CALL allocate_pw(v_drho%pw, pw_pool, bo)
-               CALL allocate_pw(v_drhoa%pw, pw_pool, bo)
-               CALL allocate_pw(v_drhob%pw, pw_pool, bo)
+               CALL allocate_pw(v_drho, pw_pool, bo)
+               CALL allocate_pw(v_drhoa, pw_pool, bo)
+               CALL allocate_pw(v_drhob, pw_pool, bo)
 
                IF (ASSOCIATED(norm_drhoa)) CALL apply_drho(deriv_set, [deriv_norm_drhoa], virial_pw, drhoa, drho1a, virial_xc, &
-                                                           norm_drhoa, gradient_cut, dra1dra, v_drhoa%pw%cr3d)
+                                                           norm_drhoa, gradient_cut, dra1dra, v_drhoa%cr3d)
                IF (ASSOCIATED(norm_drhob)) CALL apply_drho(deriv_set, [deriv_norm_drhob], virial_pw, drhob, drho1b, virial_xc, &
-                                                           norm_drhob, gradient_cut, drb1drb, v_drhob%pw%cr3d)
+                                                           norm_drhob, gradient_cut, drb1drb, v_drhob%cr3d)
                IF (ASSOCIATED(norm_drho)) CALL apply_drho(deriv_set, [deriv_norm_drho], virial_pw, drho, drho1, virial_xc, &
-                                                          norm_drho, gradient_cut, dr1dr, v_drho%pw%cr3d)
+                                                          norm_drho, gradient_cut, dr1dr, v_drho%cr3d)
                IF (laplace_f) THEN
                   CALL xc_derivative_get(xc_dset_get_derivative(deriv_set, [deriv_laplace_rhoa]), deriv_data=deriv_data)
                   CPASSERT(ASSOCIATED(deriv_data))
@@ -1996,10 +1967,10 @@ CONTAINS
             ELSE
 
                ! Create the work grid for the potential of the gradient part
-               CALL allocate_pw(v_drho%pw, pw_pool, bo)
+               CALL allocate_pw(v_drho, pw_pool, bo)
 
                CALL apply_drho(deriv_set, [deriv_norm_drho], virial_pw, drho, drho1, virial_xc, &
-                               norm_drho, gradient_cut, dr1dr, v_drho%pw%cr3d)
+                               norm_drho, gradient_cut, dr1dr, v_drho%cr3d)
                IF (laplace_f) THEN
                   CALL xc_derivative_get(xc_dset_get_derivative(deriv_set, [deriv_laplace_rho]), deriv_data=deriv_data)
                   CPASSERT(ASSOCIATED(deriv_data))
@@ -2056,78 +2027,78 @@ CONTAINS
                   IF (ASSOCIATED(norm_drhoa)) THEN
                      CALL get_derivs_rho(norm_drho2a, norm_drhoa, step, xc_fun_section, lsd, rho2_set, deriv_set1)
                      CALL update_deriv_rho(deriv_set1, [deriv_rhoa], bo, &
-                                           norm_drhoa, gradient_cut, weight, rho1a, v_drhoa%pw%cr3d)
+                                           norm_drhoa, gradient_cut, weight, rho1a, v_drhoa%cr3d)
                      CALL update_deriv_rho(deriv_set1, [deriv_rhob], bo, &
-                                           norm_drhoa, gradient_cut, weight, rho1b, v_drhoa%pw%cr3d)
+                                           norm_drhoa, gradient_cut, weight, rho1b, v_drhoa%cr3d)
                      CALL update_deriv_rho(deriv_set1, [deriv_norm_drhoa], bo, &
-                                           norm_drhoa, gradient_cut, weight, dra1dra, v_drhoa%pw%cr3d)
+                                           norm_drhoa, gradient_cut, weight, dra1dra, v_drhoa%cr3d)
                      CALL update_deriv_drho_ab(deriv_set1, [deriv_norm_drhob], bo, &
-                                               norm_drhoa, gradient_cut, weight, dra1dra, drb1drb, v_drhoa%pw%cr3d, v_drhob%pw%cr3d)
+                                               norm_drhoa, gradient_cut, weight, dra1dra, drb1drb, v_drhoa%cr3d, v_drhob%cr3d)
                      CALL update_deriv_drho_ab(deriv_set1, [deriv_norm_drho], bo, &
-                                               norm_drhoa, gradient_cut, weight, dra1dra, dr1dr, v_drhoa%pw%cr3d, v_drho%pw%cr3d)
+                                               norm_drhoa, gradient_cut, weight, dra1dra, dr1dr, v_drhoa%cr3d, v_drho%cr3d)
                      IF (tau_f) THEN
                         CALL update_deriv_rho(deriv_set1, [deriv_tau_a], bo, &
-                                              norm_drhoa, gradient_cut, weight, tau1a, v_drhoa%pw%cr3d)
+                                              norm_drhoa, gradient_cut, weight, tau1a, v_drhoa%cr3d)
                         CALL update_deriv_rho(deriv_set1, [deriv_tau_b], bo, &
-                                              norm_drhoa, gradient_cut, weight, tau1b, v_drhoa%pw%cr3d)
+                                              norm_drhoa, gradient_cut, weight, tau1b, v_drhoa%cr3d)
                      END IF
                      IF (laplace_f) THEN
                         CALL update_deriv_rho(deriv_set1, [deriv_laplace_rhoa], bo, &
-                                              norm_drhoa, gradient_cut, weight, laplace1a, v_drhoa%pw%cr3d)
+                                              norm_drhoa, gradient_cut, weight, laplace1a, v_drhoa%cr3d)
                         CALL update_deriv_rho(deriv_set1, [deriv_laplace_rhob], bo, &
-                                              norm_drhoa, gradient_cut, weight, laplace1b, v_drhoa%pw%cr3d)
+                                              norm_drhoa, gradient_cut, weight, laplace1b, v_drhoa%cr3d)
                      END IF
                   END IF
 
                   IF (ASSOCIATED(norm_drhob)) THEN
                      CALL get_derivs_rho(norm_drho2b, norm_drhob, step, xc_fun_section, lsd, rho2_set, deriv_set1)
                      CALL update_deriv_rho(deriv_set1, [deriv_rhoa], bo, &
-                                           norm_drhob, gradient_cut, weight, rho1a, v_drhob%pw%cr3d)
+                                           norm_drhob, gradient_cut, weight, rho1a, v_drhob%cr3d)
                      CALL update_deriv_rho(deriv_set1, [deriv_rhob], bo, &
-                                           norm_drhob, gradient_cut, weight, rho1b, v_drhob%pw%cr3d)
+                                           norm_drhob, gradient_cut, weight, rho1b, v_drhob%cr3d)
                      CALL update_deriv_rho(deriv_set1, [deriv_norm_drhob], bo, &
-                                           norm_drhob, gradient_cut, weight, drb1drb, v_drhob%pw%cr3d)
+                                           norm_drhob, gradient_cut, weight, drb1drb, v_drhob%cr3d)
                      CALL update_deriv_drho_ab(deriv_set1, [deriv_norm_drhoa], bo, &
-                                               norm_drhob, gradient_cut, weight, drb1drb, dra1dra, v_drhob%pw%cr3d, v_drhoa%pw%cr3d)
+                                               norm_drhob, gradient_cut, weight, drb1drb, dra1dra, v_drhob%cr3d, v_drhoa%cr3d)
                      CALL update_deriv_drho_ab(deriv_set1, [deriv_norm_drho], bo, &
-                                               norm_drhob, gradient_cut, weight, drb1drb, dr1dr, v_drhob%pw%cr3d, v_drho%pw%cr3d)
+                                               norm_drhob, gradient_cut, weight, drb1drb, dr1dr, v_drhob%cr3d, v_drho%cr3d)
                      IF (tau_f) THEN
                         CALL update_deriv_rho(deriv_set1, [deriv_tau_a], bo, &
-                                              norm_drhob, gradient_cut, weight, tau1a, v_drhob%pw%cr3d)
+                                              norm_drhob, gradient_cut, weight, tau1a, v_drhob%cr3d)
                         CALL update_deriv_rho(deriv_set1, [deriv_tau_b], bo, &
-                                              norm_drhob, gradient_cut, weight, tau1b, v_drhob%pw%cr3d)
+                                              norm_drhob, gradient_cut, weight, tau1b, v_drhob%cr3d)
                      END IF
                      IF (laplace_f) THEN
                         CALL update_deriv_rho(deriv_set1, [deriv_laplace_rhoa], bo, &
-                                              norm_drhob, gradient_cut, weight, laplace1a, v_drhob%pw%cr3d)
+                                              norm_drhob, gradient_cut, weight, laplace1a, v_drhob%cr3d)
                         CALL update_deriv_rho(deriv_set1, [deriv_laplace_rhob], bo, &
-                                              norm_drhob, gradient_cut, weight, laplace1b, v_drhob%pw%cr3d)
+                                              norm_drhob, gradient_cut, weight, laplace1b, v_drhob%cr3d)
                      END IF
                   END IF
 
                   IF (ASSOCIATED(norm_drho)) THEN
                      CALL get_derivs_rho(norm_drho2, norm_drho, step, xc_fun_section, lsd, rho2_set, deriv_set1)
                      CALL update_deriv_rho(deriv_set1, [deriv_rhoa], bo, &
-                                           norm_drho, gradient_cut, weight, rho1a, v_drho%pw%cr3d)
+                                           norm_drho, gradient_cut, weight, rho1a, v_drho%cr3d)
                      CALL update_deriv_rho(deriv_set1, [deriv_rhob], bo, &
-                                           norm_drho, gradient_cut, weight, rho1b, v_drho%pw%cr3d)
+                                           norm_drho, gradient_cut, weight, rho1b, v_drho%cr3d)
                      CALL update_deriv_rho(deriv_set1, [deriv_norm_drho], bo, &
-                                           norm_drho, gradient_cut, weight, dr1dr, v_drho%pw%cr3d)
+                                           norm_drho, gradient_cut, weight, dr1dr, v_drho%cr3d)
                      CALL update_deriv_drho_ab(deriv_set1, [deriv_norm_drhoa], bo, &
-                                               norm_drho, gradient_cut, weight, dr1dr, dra1dra, v_drho%pw%cr3d, v_drhoa%pw%cr3d)
+                                               norm_drho, gradient_cut, weight, dr1dr, dra1dra, v_drho%cr3d, v_drhoa%cr3d)
                      CALL update_deriv_drho_ab(deriv_set1, [deriv_norm_drhob], bo, &
-                                               norm_drho, gradient_cut, weight, dr1dr, drb1drb, v_drho%pw%cr3d, v_drhob%pw%cr3d)
+                                               norm_drho, gradient_cut, weight, dr1dr, drb1drb, v_drho%cr3d, v_drhob%cr3d)
                      IF (tau_f) THEN
                         CALL update_deriv_rho(deriv_set1, [deriv_tau_a], bo, &
-                                              norm_drho, gradient_cut, weight, tau1a, v_drho%pw%cr3d)
+                                              norm_drho, gradient_cut, weight, tau1a, v_drho%cr3d)
                         CALL update_deriv_rho(deriv_set1, [deriv_tau_b], bo, &
-                                              norm_drho, gradient_cut, weight, tau1b, v_drho%pw%cr3d)
+                                              norm_drho, gradient_cut, weight, tau1b, v_drho%cr3d)
                      END IF
                      IF (laplace_f) THEN
                         CALL update_deriv_rho(deriv_set1, [deriv_laplace_rhoa], bo, &
-                                              norm_drho, gradient_cut, weight, laplace1a, v_drho%pw%cr3d)
+                                              norm_drho, gradient_cut, weight, laplace1a, v_drho%cr3d)
                         CALL update_deriv_rho(deriv_set1, [deriv_laplace_rhob], bo, &
-                                              norm_drho, gradient_cut, weight, laplace1b, v_drho%pw%cr3d)
+                                              norm_drho, gradient_cut, weight, laplace1b, v_drho%cr3d)
                      END IF
                   END IF
 
@@ -2208,9 +2179,9 @@ CONTAINS
                CALL virial_drho_drho(virial_pw, drhob, v_drhob, virial_xc)
                CALL virial_drho_drho(virial_pw, drho, v_drho, virial_xc)
 
-               CALL deallocate_pw(v_drho%pw, pw_pool)
-               CALL deallocate_pw(v_drhoa%pw, pw_pool)
-               CALL deallocate_pw(v_drhob%pw, pw_pool)
+               CALL deallocate_pw(v_drho, pw_pool)
+               CALL deallocate_pw(v_drhoa, pw_pool)
+               CALL deallocate_pw(v_drhob, pw_pool)
 
                IF (laplace_f) THEN
                   virial_pw%cr3d(:, :, :) = -rhoa(:, :, :)
@@ -2242,17 +2213,17 @@ CONTAINS
 
                   ! Obtain the numerical 2nd derivatives w.r.t. to drho and collect the potential
                   CALL update_deriv_rho(deriv_set1, [deriv_rho], bo, &
-                                        norm_drho, gradient_cut, weight, rho1, v_drho%pw%cr3d)
+                                        norm_drho, gradient_cut, weight, rho1, v_drho%cr3d)
                   CALL update_deriv_rho(deriv_set1, [deriv_norm_drho], bo, &
-                                        norm_drho, gradient_cut, weight, dr1dr, v_drho%pw%cr3d)
+                                        norm_drho, gradient_cut, weight, dr1dr, v_drho%cr3d)
 
                   IF (tau_f) THEN
                      CALL update_deriv_rho(deriv_set1, [deriv_tau], bo, &
-                                           norm_drho, gradient_cut, weight, tau1, v_drho%pw%cr3d)
+                                           norm_drho, gradient_cut, weight, tau1, v_drho%cr3d)
                   END IF
                   IF (laplace_f) THEN
                      CALL update_deriv_rho(deriv_set1, [deriv_laplace_rho], bo, &
-                                           norm_drho, gradient_cut, weight, laplace1, v_drho%pw%cr3d)
+                                           norm_drho, gradient_cut, weight, laplace1, v_drho%cr3d)
 
                      CALL get_derivs_rho(laplace2, laplace, step, xc_fun_section, lsd, rho2_set, deriv_set1)
 
@@ -2275,7 +2246,7 @@ CONTAINS
                ! Calculate the virial contribution from the potential
                CALL virial_drho_drho(virial_pw, drho, v_drho, virial_xc)
 
-               CALL deallocate_pw(v_drho%pw, pw_pool)
+               CALL deallocate_pw(v_drho, pw_pool)
 
                IF (laplace_f) THEN
                   virial_pw%cr3d(:, :, :) = -rho(:, :, :)
@@ -2710,12 +2681,12 @@ CONTAINS
       TYPE(cp_3d_r_p_type), DIMENSION(3)                 :: drho, drho1, drho1a, drho1b, drhoa, drhob
       TYPE(pw_p_type), DIMENSION(:), ALLOCATABLE         :: v_drhoa, v_drhob, v_drho, v_laplace
       TYPE(pw_p_type), DIMENSION(:, :), ALLOCATABLE      :: v_drho_r
-      TYPE(pw_type), POINTER                             :: tmp_g, virial_pw, vxc_g
+      TYPE(pw_type)                             :: tmp_g, virial_pw, vxc_g
       TYPE(xc_derivative_type), POINTER                  :: deriv_att
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (e_drhoa, e_drhob, e_drho, tmp_g, vxc_g)
+      NULLIFY (e_drhoa, e_drhob, e_drho)
 
       my_gapw = .FALSE.
       IF (PRESENT(gapw)) my_gapw = gapw
@@ -2752,17 +2723,15 @@ CONTAINS
          ALLOCATE (v_drho_r(3, nspins), v_drho(nspins))
          DO ispin = 1, nspins
             DO idir = 1, 3
-               NULLIFY (v_drho_r(idir, ispin)%pw)
+               ALLOCATE (v_drho_r(idir, ispin)%pw)
                CALL allocate_pw(v_drho_r(idir, ispin)%pw, pw_pool, bo)
             END DO
-            NULLIFY (v_drho(ispin)%pw)
+            ALLOCATE (v_drho(ispin)%pw)
             CALL allocate_pw(v_drho(ispin)%pw, pw_pool, bo)
          END DO
 
          IF (xc_requires_tmp_g(xc_deriv_method_id) .AND. .NOT. my_gapw) THEN
             IF (ASSOCIATED(pw_pool)) THEN
-               NULLIFY (tmp_g, vxc_g)
-               ALLOCATE (tmp_g, vxc_g)
                CALL pw_pool_create_pw(pw_pool, tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                CALL pw_pool_create_pw(pw_pool, vxc_g, &
@@ -2815,7 +2784,7 @@ CONTAINS
 
             ALLOCATE (v_drhoa(nspins), v_drhob(nspins))
             DO ispin = 1, nspins
-               NULLIFY (v_drhoa(ispin)%pw, v_drhob(ispin)%pw)
+               ALLOCATE (v_drhoa(ispin)%pw, v_drhob(ispin)%pw)
             END DO
             DO ispin = 1, nspins
                CALL allocate_pw(v_drhoa(ispin)%pw, pw_pool, bo)
@@ -2829,7 +2798,7 @@ CONTAINS
 
             ALLOCATE (v_laplace(nspins))
             DO ispin = 1, nspins
-               NULLIFY (v_laplace(ispin)%pw)
+               ALLOCATE (v_laplace(ispin)%pw)
                CALL allocate_pw(v_laplace(ispin)%pw, pw_pool, bo)
             END DO
 
@@ -2853,8 +2822,8 @@ CONTAINS
          IF (gradient_f) THEN
 
             IF (my_compute_virial) THEN
-               CALL virial_drho_drho(virial_pw, drhoa, v_drhoa(1), virial_xc)
-               CALL virial_drho_drho(virial_pw, drhob, v_drhob(2), virial_xc)
+               CALL virial_drho_drho(virial_pw, drhoa, v_drhoa(1)%pw, virial_xc)
+               CALL virial_drho_drho(virial_pw, drhob, v_drhob(2)%pw, virial_xc)
                DO idir = 1, 3
 !$OMP          PARALLEL WORKSHARE DEFAULT(NONE) SHARED(drho,idir,v_drho,virial_pw)
                   virial_pw%cr3d(:, :, :) = drho(idir)%array(:, :, :)*(v_drho(1)%pw%cr3d(:, :, :) + v_drho(2)%pw%cr3d(:, :, :))
@@ -2969,6 +2938,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL deallocate_pw(v_drhoa(ispin)%pw, pw_pool)
                CALL deallocate_pw(v_drhob(ispin)%pw, pw_pool)
+               DEALLOCATE (v_drhoa(ispin)%pw, v_drhob(ispin)%pw)
             END DO
 
             DEALLOCATE (v_drhoa, v_drhob)
@@ -3001,7 +2971,7 @@ CONTAINS
 
             ALLOCATE (v_laplace(nspins))
             DO ispin = 1, nspins
-               NULLIFY (v_laplace(ispin)%pw)
+               ALLOCATE (v_laplace(ispin)%pw)
                CALL allocate_pw(v_laplace(ispin)%pw, pw_pool, bo)
             END DO
 
@@ -3017,7 +2987,7 @@ CONTAINS
          IF (gradient_f) THEN
 
             IF (my_compute_virial) THEN
-               CALL virial_drho_drho(virial_pw, drho, v_drho(1), virial_xc)
+               CALL virial_drho_drho(virial_pw, drho, v_drho(1)%pw, virial_xc)
             END IF ! my_compute_virial
 
             IF (my_gapw) THEN
@@ -3068,8 +3038,10 @@ CONTAINS
 
          DO ispin = 1, nspins
             CALL deallocate_pw(v_drho(ispin)%pw, pw_pool)
+            DEALLOCATE (v_drho(ispin)%pw)
             DO idir = 1, 3
                CALL deallocate_pw(v_drho_r(idir, ispin)%pw, pw_pool)
+               DEALLOCATE (v_drho_r(idir, ispin)%pw)
             END DO
          END DO
          DEALLOCATE (v_drho, v_drho_r)
@@ -3079,18 +3051,17 @@ CONTAINS
       IF (laplace_f) THEN
       DO ispin = 1, nspins
          CALL deallocate_pw(v_laplace(ispin)%pw, pw_pool)
+         DEALLOCATE (v_laplace(ispin)%pw)
       END DO
       DEALLOCATE (v_laplace)
       END IF
 
-      IF (ASSOCIATED(tmp_g) .AND. ASSOCIATED(pw_pool)) THEN
+      IF (ASSOCIATED(tmp_g%pw_grid) .AND. ASSOCIATED(pw_pool)) THEN
          CALL pw_pool_give_back_pw(pw_pool, tmp_g)
-         DEALLOCATE (tmp_g)
       END IF
 
-      IF (ASSOCIATED(vxc_g) .AND. ASSOCIATED(pw_pool)) THEN
+      IF (ASSOCIATED(vxc_g%pw_grid) .AND. ASSOCIATED(pw_pool)) THEN
          CALL pw_pool_give_back_pw(pw_pool, vxc_g)
-         DEALLOCATE (vxc_g)
       END IF
 
       IF (my_compute_virial .AND. (gradient_f .OR. laplace_f)) THEN
@@ -3107,20 +3078,16 @@ CONTAINS
 !> \param bo ...
 ! **************************************************************************************************
    SUBROUTINE allocate_pw(pw, pw_pool, bo)
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw
+      TYPE(pw_type), INTENT(OUT)                         :: pw
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bo
 
       IF (ASSOCIATED(pw_pool)) THEN
-         NULLIFY (pw)
-         ALLOCATE (pw)
          CALL pw_pool_create_pw(pw_pool, pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          CALL pw_zero(pw)
       ELSE
-         NULLIFY (pw)
-         ALLOCATE (pw)
          ALLOCATE (pw%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)))
          pw%cr3d = 0.0_dp
       END IF
@@ -3133,7 +3100,7 @@ CONTAINS
 !> \param pw_pool ...
 ! **************************************************************************************************
    SUBROUTINE deallocate_pw(pw, pw_pool)
-      TYPE(pw_type), INTENT(INOUT), POINTER              :: pw
+      TYPE(pw_type), INTENT(INOUT)                       :: pw
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
 
       IF (ASSOCIATED(pw_pool)) THEN
@@ -3141,8 +3108,6 @@ CONTAINS
       ELSE
          DEALLOCATE (pw%cr3d)
       END IF
-      DEALLOCATE (pw)
-      NULLIFY (pw)
 
    END SUBROUTINE deallocate_pw
 
@@ -3188,7 +3153,7 @@ CONTAINS
    SUBROUTINE virial_drho_drho(virial_pw, drho, v_drho, virial_xc)
       TYPE(pw_type), INTENT(IN)                          :: virial_pw
       TYPE(cp_3d_r_p_type), DIMENSION(3), INTENT(IN)     :: drho
-      TYPE(pw_p_type), INTENT(IN)                        :: v_drho
+      TYPE(pw_type), INTENT(IN)                        :: v_drho
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT)      :: virial_xc
 
       INTEGER                                            :: idir, jdir
@@ -3197,7 +3162,7 @@ CONTAINS
       DO idir = 1, 3
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE)&
 !$OMP SHARED(drho,idir,v_drho,virial_pw)
-         virial_pw%cr3d(:, :, :) = drho(idir)%array(:, :, :)*v_drho%pw%cr3d(:, :, :)
+         virial_pw%cr3d(:, :, :) = drho(idir)%array(:, :, :)*v_drho%cr3d(:, :, :)
 !$OMP END PARALLEL WORKSHARE
          DO jdir = 1, idir
             tmp = -virial_pw%pw_grid%dvol*accurate_dot_product(virial_pw%cr3d(:, :, :), &

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -200,7 +200,7 @@ CONTAINS
    SUBROUTINE xc_dset_recover_pw(deriv_set, description, pw, pw_grid, pw_pool)
       TYPE(xc_derivative_set_type), INTENT(IN)           :: deriv_set
       INTEGER, DIMENSION(:), INTENT(IN)                  :: description
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(OUT)                         :: pw
       TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
       TYPE(pw_pool_type), INTENT(IN), OPTIONAL, POINTER  :: pw_pool
 
@@ -208,17 +208,12 @@ CONTAINS
 
       deriv_att => xc_dset_get_derivative(deriv_set, description)
       IF (ASSOCIATED(deriv_att)) THEN
-         ALLOCATE (pw)
          CALL pw_create(pw, pw_grid=pw_grid, cr3d_ptr=deriv_att%deriv_data, &
                         use_data=REALDATA3D, in_space=REALSPACE)
          NULLIFY (deriv_att%deriv_data)
       ELSE IF (PRESENT(pw_pool)) THEN
-         NULLIFY (pw)
-         ALLOCATE (pw)
          CALL pw_pool_create_pw(pw_pool, pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(pw)
-      ELSE
-         NULLIFY (pw)
       END IF
 
    END SUBROUTINE xc_dset_recover_pw

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -208,6 +208,7 @@ CONTAINS
 
       deriv_att => xc_dset_get_derivative(deriv_set, description)
       IF (ASSOCIATED(deriv_att)) THEN
+         ALLOCATE (pw)
          CALL pw_create(pw, pw_grid=pw_grid, cr3d_ptr=deriv_att%deriv_data, &
                         use_data=REALDATA3D, in_space=REALSPACE)
          NULLIFY (deriv_att%deriv_data)

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -213,6 +213,8 @@ CONTAINS
                         use_data=REALDATA3D, in_space=REALSPACE)
          NULLIFY (deriv_att%deriv_data)
       ELSE IF (PRESENT(pw_pool)) THEN
+         NULLIFY (pw)
+         ALLOCATE (pw)
          CALL pw_pool_create_pw(pw_pool, pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(pw)
       ELSE

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -629,15 +629,7 @@ CONTAINS
             REAL(kind=dp)                                      :: rho_cutoff
             TYPE(pw_p_type), DIMENSION(2)                      :: laplace_rho_r, my_rho_r
             TYPE(pw_p_type), DIMENSION(3, 2)                   :: drho_r
-            TYPE(pw_type), POINTER                             :: my_rho_g, tmp_g
-
-            DO ispin = 1, 2
-               NULLIFY (my_rho_r(ispin)%pw)
-               DO idir = 1, 3
-                  NULLIFY (drho_r(idir, ispin)%pw)
-               END DO
-            END DO
-            NULLIFY (tmp_g, my_rho_g)
+            TYPE(pw_type)                             :: my_rho_g, tmp_g
 
             IF (ANY(rho_set%local_bounds /= pw_pool%pw_grid%bounds_local)) &
                CPABORT("pw_pool cr3d have different size than expected")
@@ -690,8 +682,6 @@ CONTAINS
             END IF
 
             IF (needs_rho_g) THEN
-               NULLIFY (tmp_g)
-               ALLOCATE (tmp_g)
                CALL pw_pool_create_pw(pw_pool, tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END IF
@@ -704,7 +694,7 @@ CONTAINS
                   IF (needs_rho_g) THEN
                      IF (ASSOCIATED(rho_g)) THEN
                         my_rho_g_local = .FALSE.
-                        my_rho_g => rho_g(ispin)%pw
+                        my_rho_g = rho_g(ispin)%pw
                      END IF
                   END IF
 
@@ -723,18 +713,14 @@ CONTAINS
                                             use_data=REALDATA3D, in_space=REALSPACE)
                   END DO
                   IF (needs_rho_g) THEN
-                     IF (.NOT. ASSOCIATED(my_rho_g)) THEN
+                     IF (.NOT. ASSOCIATED(my_rho_g%pw_grid)) THEN
                         my_rho_g_local = .TRUE.
-                        NULLIFY (my_rho_g)
-                        ALLOCATE (my_rho_g)
                         CALL pw_pool_create_pw(pw_pool, my_rho_g, &
                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                         CALL pw_transfer(my_rho_r(ispin)%pw, my_rho_g)
                      END IF
                      IF (.NOT. my_rho_g_local .AND. (xc_deriv_method_id == xc_deriv_spline2 .OR. &
                                                      xc_deriv_method_id == xc_deriv_spline3)) THEN
-                        NULLIFY (my_rho_g)
-                        ALLOCATE (my_rho_g)
                         CALL pw_pool_create_pw(pw_pool, my_rho_g, &
                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                         my_rho_g_local = .TRUE.
@@ -753,8 +739,6 @@ CONTAINS
                      IF (my_rho_g_local) THEN
                         my_rho_g_local = .FALSE.
                         CALL pw_pool_give_back_pw(pw_pool, my_rho_g)
-                        DEALLOCATE (my_rho_g)
-                        NULLIFY (my_rho_g)
                      END IF
                   END IF
 
@@ -766,10 +750,8 @@ CONTAINS
 
             END DO
 
-            IF (ASSOCIATED(tmp_g)) THEN
+            IF (ASSOCIATED(tmp_g%pw_grid)) THEN
                CALL pw_pool_give_back_pw(pw_pool, tmp_g)
-               DEALLOCATE (tmp_g)
-               NULLIFY (tmp_g)
             END IF
 
             SELECT CASE (nspins)

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -466,6 +466,7 @@ CONTAINS
             REAL(KIND=dp), DIMENSION(:, :, :), POINTER, OPTIONAL :: rhoa, rhob
 
             IF (ASSOCIATED(rho)) THEN
+               ALLOCATE (rho_pw)
                CALL pw_create(rho_pw, pw_grid=pw_grid, &
                               cr3d_ptr=rho, &
                               use_data=REALDATA3D, in_space=REALSPACE)

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -753,6 +753,8 @@ CONTAINS
                      IF (my_rho_g_local) THEN
                         my_rho_g_local = .FALSE.
                         CALL pw_pool_give_back_pw(pw_pool, my_rho_g)
+                        DEALLOCATE (my_rho_g)
+                        NULLIFY (my_rho_g)
                      END IF
                   END IF
 
@@ -764,7 +766,11 @@ CONTAINS
 
             END DO
 
-            IF (ASSOCIATED(tmp_g)) CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+            IF (ASSOCIATED(tmp_g)) THEN
+               CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+               DEALLOCATE (tmp_g)
+               NULLIFY (tmp_g)
+            END IF
 
             SELECT CASE (nspins)
             CASE (1)
@@ -930,15 +936,20 @@ CONTAINS
                IF (needs%laplace_rho .OR. needs%laplace_rho_spin) THEN
                   CALL pw_pool_give_back_pw(pw_pool, laplace_rho_r(ispin)%pw, &
                                             accept_non_compatible=.TRUE.)
+                  DEALLOCATE (laplace_rho_r(ispin)%pw)
                END IF
                DO idir = 1, 3
-                  CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin)%pw, &
-                                            accept_non_compatible=.TRUE.)
+                  IF (ASSOCIATED(drho_r(idir, ispin)%pw)) THEN
+                     CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin)%pw, &
+                                               accept_non_compatible=.TRUE.)
+                     DEALLOCATE (drho_r(idir, ispin)%pw)
+                  END IF
                END DO
             END DO
             DO ispin = 1, nspins
                CALL pw_pool_give_back_pw(pw_pool, my_rho_r(ispin)%pw, &
                                          accept_non_compatible=.TRUE.)
+               DEALLOCATE (my_rho_r(ispin)%pw)
             END DO
 
             ! tau part

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -472,6 +472,8 @@ CONTAINS
                               use_data=REALDATA3D, in_space=REALSPACE)
                NULLIFY (rho)
             ELSE IF (PRESENT(rhoa) .AND. PRESENT(rhob)) THEN
+               NULLIFY (rho_pw)
+               ALLOCATE (rho_pw)
                CALL pw_pool_create_pw(pw_pool, rho_pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(rho_pw,rhoa,rhob)
@@ -688,10 +690,13 @@ CONTAINS
             END IF
 
             IF (needs_rho_g) THEN
+               NULLIFY (tmp_g)
+               ALLOCATE (tmp_g)
                CALL pw_pool_create_pw(pw_pool, tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END IF
             DO ispin = 1, nspins
+               ALLOCATE (my_rho_r(ispin)%pw)
                CALL pw_pool_create_pw(pw_pool, my_rho_r(ispin)%pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                ! introduce a smoothing kernel on the density
@@ -713,19 +718,23 @@ CONTAINS
                   ! (for the partial integration)
                   ! deriv rho
                   DO idir = 1, 3
-                     NULLIFY (drho_r(idir, ispin)%pw)
+                     ALLOCATE (drho_r(idir, ispin)%pw)
                      CALL pw_pool_create_pw(pw_pool, drho_r(idir, ispin)%pw, &
                                             use_data=REALDATA3D, in_space=REALSPACE)
                   END DO
                   IF (needs_rho_g) THEN
                      IF (.NOT. ASSOCIATED(my_rho_g)) THEN
                         my_rho_g_local = .TRUE.
+                        NULLIFY (my_rho_g)
+                        ALLOCATE (my_rho_g)
                         CALL pw_pool_create_pw(pw_pool, my_rho_g, &
                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                         CALL pw_transfer(my_rho_r(ispin)%pw, my_rho_g)
                      END IF
                      IF (.NOT. my_rho_g_local .AND. (xc_deriv_method_id == xc_deriv_spline2 .OR. &
                                                      xc_deriv_method_id == xc_deriv_spline3)) THEN
+                        NULLIFY (my_rho_g)
+                        ALLOCATE (my_rho_g)
                         CALL pw_pool_create_pw(pw_pool, my_rho_g, &
                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                         my_rho_g_local = .TRUE.
@@ -733,7 +742,7 @@ CONTAINS
                      END IF
                   END IF
                   IF (needs%laplace_rho .OR. needs%laplace_rho_spin) THEN
-                     NULLIFY (laplace_rho_r(ispin)%pw)
+                     ALLOCATE (laplace_rho_r(ispin)%pw)
                      CALL pw_pool_create_pw(pw_pool, laplace_rho_r(ispin)%pw, &
                                             use_data=REALDATA3D, in_space=REALSPACE)
                      CALL xc_pw_laplace(my_rho_g, pw_pool, xc_deriv_method_id, laplace_rho_r(ispin)%pw, tmp_g=tmp_g)

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -934,21 +934,18 @@ CONTAINS
             ! post cleanup
             DO ispin = 1, nspins
                IF (needs%laplace_rho .OR. needs%laplace_rho_spin) THEN
-                  CALL pw_pool_give_back_pw(pw_pool, laplace_rho_r(ispin)%pw, &
-                                            accept_non_compatible=.TRUE.)
+                  CALL pw_pool_give_back_pw(pw_pool, laplace_rho_r(ispin)%pw)
                   DEALLOCATE (laplace_rho_r(ispin)%pw)
                END IF
                DO idir = 1, 3
                   IF (ASSOCIATED(drho_r(idir, ispin)%pw)) THEN
-                     CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin)%pw, &
-                                               accept_non_compatible=.TRUE.)
+                     CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin)%pw)
                      DEALLOCATE (drho_r(idir, ispin)%pw)
                   END IF
                END DO
             END DO
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(pw_pool, my_rho_r(ispin)%pw, &
-                                         accept_non_compatible=.TRUE.)
+               CALL pw_pool_give_back_pw(pw_pool, my_rho_r(ispin)%pw)
                DEALLOCATE (my_rho_r(ispin)%pw)
             END DO
 

--- a/src/xc/xc_util.F
+++ b/src/xc/xc_util.F
@@ -66,7 +66,8 @@ CONTAINS
 !> \param xc_smooth_id ...
 ! **************************************************************************************************
    SUBROUTINE xc_pw_smooth(pw_in, pw_out, xc_smooth_id)
-      TYPE(pw_type), POINTER                             :: pw_in, pw_out
+      TYPE(pw_type), INTENT(IN)                          :: pw_in
+      TYPE(pw_type), INTENT(INOUT)                       :: pw_out
       INTEGER, INTENT(IN)                                :: xc_smooth_id
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xc_pw_smooth'
@@ -115,7 +116,8 @@ CONTAINS
 !> \param xc_deriv_method_id ...
 ! **************************************************************************************************
    SUBROUTINE xc_pw_gradient(pw_r, pw_g, tmp_g, gradient, xc_deriv_method_id)
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw_r, pw_g, tmp_g
+      TYPE(pw_type), INTENT(IN)                          :: pw_r
+      TYPE(pw_type), INTENT(INOUT)                       :: pw_g, tmp_g
       TYPE(pw_p_type), DIMENSION(3), INTENT(IN)          :: gradient
       INTEGER, INTENT(IN)                                :: xc_deriv_method_id
 
@@ -137,28 +139,27 @@ CONTAINS
 !> \param tmp_g scratch grid in reciprocal space, used instead of the internal grid if given explicitly to save memory
 ! **************************************************************************************************
    SUBROUTINE xc_pw_laplace(pw, pw_pool, deriv_method_id, pw_out, tmp_g)
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw
+      TYPE(pw_type), INTENT(INOUT)                       :: pw
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
       INTEGER, INTENT(IN)                                :: deriv_method_id
-      TYPE(pw_type), INTENT(IN), OPTIONAL, POINTER       :: pw_out, tmp_g
+      TYPE(pw_type), INTENT(INOUT), OPTIONAL             :: pw_out
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: tmp_g
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xc_pw_laplace'
 
       INTEGER                                            :: handle
       LOGICAL                                            :: owns_tmp_g
-      TYPE(pw_type), POINTER                             :: my_tmp_g
+      TYPE(pw_type)                                      :: my_tmp_g
 
       CALL timeset(routineN, handle)
 
       SELECT CASE (deriv_method_id)
       CASE (xc_deriv_pw)
 
-         NULLIFY (my_tmp_g)
-         IF (PRESENT(tmp_g)) my_tmp_g => tmp_g
+         IF (PRESENT(tmp_g)) my_tmp_g = tmp_g
 
          owns_tmp_g = .FALSE.
-         IF (.NOT. ASSOCIATED(my_tmp_g)) THEN
-            ALLOCATE (my_tmp_g)
+         IF (.NOT. ASSOCIATED(my_tmp_g%pw_grid)) THEN
             CALL pw_pool_create_pw(pw_pool, my_tmp_g, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             owns_tmp_g = .TRUE.
@@ -175,7 +176,6 @@ CONTAINS
          END IF
          IF (owns_tmp_g) THEN
             CALL pw_pool_give_back_pw(pw_pool, my_tmp_g)
-            DEALLOCATE (my_tmp_g)
          END IF
       CASE default
          CPABORT("Unsupported derivative method")
@@ -196,7 +196,9 @@ CONTAINS
    SUBROUTINE xc_pw_divergence(xc_deriv_method_id, pw_to_deriv, tmp_g, vxc_g, vxc_r)
       INTEGER, INTENT(IN)                                :: xc_deriv_method_id
       TYPE(pw_p_type), DIMENSION(3)                      :: pw_to_deriv
-      TYPE(pw_type), POINTER                             :: tmp_g, vxc_g, vxc_r
+      TYPE(pw_type), INTENT(INOUT)                       :: tmp_g
+      TYPE(pw_type), INTENT(IN)                          :: vxc_g
+      TYPE(pw_type), INTENT(INOUT)                       :: vxc_r
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xc_pw_divergence'
 
@@ -210,14 +212,14 @@ CONTAINS
                                     transpose=.TRUE.)
       END IF
 
-      IF (ASSOCIATED(vxc_g)) CALL pw_zero(vxc_g)
+      IF (ASSOCIATED(vxc_g%pw_grid)) CALL pw_zero(vxc_g)
 
       DO idir = 1, 3
          CALL xc_pw_derive(pw_to_deriv(idir)%pw, tmp_g, vxc_r, idir, xc_deriv_method_id, copy_to_vxcr=.FALSE.)
-         IF (ASSOCIATED(tmp_g) .AND. ASSOCIATED(vxc_g)) CALL pw_axpy(tmp_g, vxc_g)
+         IF (ASSOCIATED(tmp_g%pw_grid) .AND. ASSOCIATED(vxc_g%pw_grid)) CALL pw_axpy(tmp_g, vxc_g)
       END DO
 
-      IF (ASSOCIATED(vxc_g)) THEN
+      IF (ASSOCIATED(vxc_g%pw_grid)) THEN
          CALL pw_transfer(vxc_g, pw_to_deriv(1)%pw)
          CALL pw_axpy(pw_to_deriv(1)%pw, vxc_r)
       END IF
@@ -237,11 +239,11 @@ CONTAINS
 !> \param pw_g ...
 ! **************************************************************************************************
    SUBROUTINE xc_pw_derive(pw, tmp_g, vxc_r, idir, xc_deriv_method_id, copy_to_vxcr, pw_g)
-      TYPE(pw_type), INTENT(IN), POINTER                 :: pw
-      TYPE(pw_type), POINTER                             :: tmp_g, vxc_r
+      TYPE(pw_type), INTENT(IN)                          :: pw
+      TYPE(pw_type), INTENT(INOUT)                       :: tmp_g, vxc_r
       INTEGER, INTENT(IN)                                :: idir, xc_deriv_method_id
       LOGICAL, INTENT(IN), OPTIONAL                      :: copy_to_vxcr
-      TYPE(pw_type), INTENT(IN), OPTIONAL, POINTER       :: pw_g
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: pw_g
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xc_pw_derive'
       INTEGER, DIMENSION(3, 3), PARAMETER :: nd = RESHAPE((/1, 0, 0, 0, 1, 0, 0, 0, 1/), (/3, 3/))
@@ -257,7 +259,7 @@ CONTAINS
       IF (xc_requires_tmp_g(xc_deriv_method_id)) THEN
 
          IF (PRESENT(pw_g)) THEN
-            IF (ASSOCIATED(pw_g)) THEN
+            IF (ASSOCIATED(pw_g%pw_grid)) THEN
                CALL pw_copy(pw_g, tmp_g)
             ELSE
                CALL pw_transfer(pw, tmp_g)

--- a/src/xc/xc_util.F
+++ b/src/xc/xc_util.F
@@ -173,7 +173,10 @@ CONTAINS
          ELSE
             CALL pw_transfer(my_tmp_g, pw)
          END IF
-         IF (owns_tmp_g) CALL pw_pool_give_back_pw(pw_pool, my_tmp_g)
+         IF (owns_tmp_g) THEN
+            CALL pw_pool_give_back_pw(pw_pool, my_tmp_g)
+            DEALLOCATE (my_tmp_g)
+         END IF
       CASE default
          CPABORT("Unsupported derivative method")
       END SELECT

--- a/src/xc/xc_util.F
+++ b/src/xc/xc_util.F
@@ -158,6 +158,7 @@ CONTAINS
 
          owns_tmp_g = .FALSE.
          IF (.NOT. ASSOCIATED(my_tmp_g)) THEN
+            ALLOCATE (my_tmp_g)
             CALL pw_pool_create_pw(pw_pool, my_tmp_g, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             owns_tmp_g = .TRUE.

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -294,6 +294,7 @@ CONTAINS
 
       ALLOCATE (vxc_GLLB(nspins))
       DO ispin = 1, nspins
+         ALLOCATE (vxc_GLLB(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, vxc_GLLB(ispin)%pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
@@ -307,6 +308,7 @@ CONTAINS
 
       CALL xc_dset_release(deriv_set)
 
+      ALLOCATE (orbital%pw, orbital_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, orbital%pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -386,6 +388,7 @@ CONTAINS
                          mo_coeff=mo_coeff, &
                          eigenvalues=mo_eigenvalues, &
                          homo=homo)
+         ALLOCATE (vxc_SAOP(ispin)%pw)
          CALL pw_pool_create_pw(auxbas_pw_pool, vxc_SAOP(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(vxc_SAOP(ispin)%pw)

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -459,6 +459,7 @@ CONTAINS
       CALL xc_rho_set_release(rho_set, auxbas_pw_pool)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital%pw)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital_g%pw)
+      DEALLOCATE (orbital%pw, orbital_g%pw)
 
       !--------------------!
       ! Do the integration !
@@ -482,6 +483,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_SAOP(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_GLLB(ispin)%pw)
+         DEALLOCATE (vxc_SAOP(ispin)%pw, vxc_GLLB(ispin)%pw)
          CALL pw_release(vxc_LB(ispin)%pw)
          CALL pw_release(vxc_tmp(ispin)%pw)
          DEALLOCATE (vxc_LB(ispin)%pw, vxc_tmp(ispin)%pw)

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -349,7 +349,7 @@ CONTAINS
             CALL pw_zero(orbital%pw)
             CALL pw_zero(orbital_g%pw)
             CALL calculate_rho_elec(matrix_p=orbital_density_matrix(ispin)%matrix, &
-                                    rho=orbital, rho_gspace=orbital_g, &
+                                    rho=orbital%pw, rho_gspace=orbital_g%pw, &
                                     ks_env=ks_env)
 
             vxc_tmp(ispin)%pw%cr3d = vxc_tmp(ispin)%pw%cr3d + &
@@ -418,7 +418,7 @@ CONTAINS
             CALL pw_zero(orbital%pw)
             CALL pw_zero(orbital_g%pw)
             CALL calculate_rho_elec(matrix_p=orbital_density_matrix(ispin)%matrix, &
-                                    rho=orbital, rho_gspace=orbital_g, &
+                                    rho=orbital%pw, rho_gspace=orbital_g%pw, &
                                     ks_env=ks_env)
 
 !TC          CALL calculate_wavefunction(mo_coeff,orb,orbital2,orbital2_g,qs_env)

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -481,6 +481,7 @@ CONTAINS
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_GLLB(ispin)%pw)
          CALL pw_release(vxc_LB(ispin)%pw)
          CALL pw_release(vxc_tmp(ispin)%pw)
+         DEALLOCATE (vxc_LB(ispin)%pw, vxc_tmp(ispin)%pw)
       END DO
       DEALLOCATE (vxc_GLLB, vxc_LB, vxc_tmp, orbital_density_matrix)
 

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -51,7 +51,8 @@ MODULE xc_pot_saop
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -147,11 +148,11 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: orbital_density_matrix, rho_struct_ao
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: molecular_orbitals
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: orbital, orbital_g
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rho_struct_r, tau, &
                                                             vxc_GLLB, vxc_LB, vxc_SAOP, vxc_tau, &
                                                             vxc_tmp
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: orbital, orbital_g
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
       TYPE(section_vals_type), POINTER                   :: input, xc_fun_section_orig, &
@@ -308,11 +309,10 @@ CONTAINS
 
       CALL xc_dset_release(deriv_set)
 
-      ALLOCATE (orbital%pw, orbital_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, orbital%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, orbital, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, orbital_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, orbital_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
@@ -348,14 +348,14 @@ CONTAINS
                                        matrix_g=single_mo_coeff(ispin), &
                                        ncol=ncol(ispin), &
                                        alpha=1.0_dp)
-            CALL pw_zero(orbital%pw)
-            CALL pw_zero(orbital_g%pw)
+            CALL pw_zero(orbital)
+            CALL pw_zero(orbital_g)
             CALL calculate_rho_elec(matrix_p=orbital_density_matrix(ispin)%matrix, &
-                                    rho=orbital%pw, rho_gspace=orbital_g%pw, &
+                                    rho=orbital, rho_gspace=orbital_g, &
                                     ks_env=ks_env)
 
             vxc_tmp(ispin)%pw%cr3d = vxc_tmp(ispin)%pw%cr3d + &
-                                     efac*orbital%pw%cr3d
+                                     efac*orbital%cr3d
 
          END DO
          DEALLOCATE (coeff_col)
@@ -418,17 +418,14 @@ CONTAINS
                                        matrix_g=single_mo_coeff(ispin), &
                                        ncol=ncol(ispin), &
                                        alpha=1.0_dp)
-            CALL pw_zero(orbital%pw)
-            CALL pw_zero(orbital_g%pw)
+            CALL pw_zero(orbital)
+            CALL pw_zero(orbital_g)
             CALL calculate_rho_elec(matrix_p=orbital_density_matrix(ispin)%matrix, &
-                                    rho=orbital%pw, rho_gspace=orbital_g%pw, &
+                                    rho=orbital, rho_gspace=orbital_g, &
                                     ks_env=ks_env)
 
-!TC          CALL calculate_wavefunction(mo_coeff,orb,orbital2,orbital2_g,qs_env)
-!TC          write (*,*) orb, maxval(abs(orbital2%pw%cr3d-orbital%pw%cr3d))
-
             vxc_SAOP(ispin)%pw%cr3d = vxc_SAOP(ispin)%pw%cr3d + &
-                                      orbital%pw%cr3d*vxc_tmp(ispin)%pw%cr3d
+                                      orbital%cr3d*vxc_tmp(ispin)%pw%cr3d
 
          END DO
 
@@ -457,9 +454,8 @@ CONTAINS
       DEALLOCATE (single_mo_coeff)
 
       CALL xc_rho_set_release(rho_set, auxbas_pw_pool)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital_g%pw)
-      DEALLOCATE (orbital%pw, orbital_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital_g)
 
       !--------------------!
       ! Do the integration !
@@ -473,7 +469,7 @@ CONTAINS
          END IF
          vxc_SAOP(ispin)%pw%cr3d = vxc_SAOP(ispin)%pw%cr3d*vxc_SAOP(ispin)%pw%pw_grid%dvol
 
-         CALL integrate_v_rspace(v_rspace=vxc_SAOP(ispin), pmat=rho_struct_ao(ispin), &
+         CALL integrate_v_rspace(v_rspace=vxc_SAOP(ispin)%pw, pmat=rho_struct_ao(ispin), &
                                  hmat=ks_matrix(ispin), qs_env=qs_env, &
                                  calculate_forces=.FALSE., &
                                  gapw=gapw)

--- a/src/xray_diffraction.F
+++ b/src/xray_diffraction.F
@@ -477,6 +477,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, &
                                 rhotot_elec_gspace%pw)
+      DEALLOCATE (rhotot_elec_gspace%pw)
 
       CALL timestop(handle)
 
@@ -598,6 +599,7 @@ CONTAINS
 
       CALL pw_pool_give_back_pw(pool=auxbas_pw_pool, &
                                 pw=rho_elec_gspace%pw)
+      DEALLOCATE (rho_elec_gspace%pw)
 
       rho_soft = pw_integrate_function(rhotot_elec_gspace%pw, isign=-1)
 

--- a/src/xray_diffraction.F
+++ b/src/xray_diffraction.F
@@ -114,8 +114,8 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhotot_elec_gspace
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rhotot_elec_gspace
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set
 
@@ -170,14 +170,13 @@ CONTAINS
 
       ! Plane waves grid to assemble the total electronic density
 
-      ALLOCATE (rhotot_elec_gspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rhotot_elec_gspace%pw, &
+                             pw=rhotot_elec_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_zero(rhotot_elec_gspace%pw)
+      CALL pw_zero(rhotot_elec_gspace)
 
-      CALL get_pw_grid_info(pw_grid=rhotot_elec_gspace%pw%pw_grid, &
+      CALL get_pw_grid_info(pw_grid=rhotot_elec_gspace%pw_grid, &
                             dr=dr, &
                             npts=npts, &
                             cutoff=cutoff, &
@@ -251,7 +250,7 @@ CONTAINS
          f2sum(ishell) = 0.0_dp
          f4sum(ishell) = 0.0_dp
          DO ig_shell = 1, ng_shell(ishell)
-            f = ABS(rhotot_elec_gspace%pw%cc(ig + ig_shell))
+            f = ABS(rhotot_elec_gspace%cc(ig + ig_shell))
             fmin(ishell) = MIN(fmin(ishell), f)
             fmax(ishell) = MAX(fmax(ishell), f)
             fsum(ishell) = fsum(ishell) + f
@@ -476,8 +475,7 @@ CONTAINS
       END IF
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, &
-                                rhotot_elec_gspace%pw)
-      DEALLOCATE (rhotot_elec_gspace%pw)
+                                rhotot_elec_gspace)
 
       CALL timestop(handle)
 
@@ -503,7 +501,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rhotot_elec_gspace
+      TYPE(pw_type), INTENT(IN)                          :: rhotot_elec_gspace
       REAL(KIND=dp), INTENT(IN)                          :: q_max
       REAL(KIND=dp), INTENT(OUT)                         :: rho_hard, rho_soft
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: fsign
@@ -526,8 +524,8 @@ CONTAINS
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(paw_proj_set_type), POINTER                   :: paw_proj
-      TYPE(pw_p_type)                                    :: rho_elec_gspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
+      TYPE(pw_type)                                      :: rho_elec_gspace
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(rho_atom_coeff), DIMENSION(:), POINTER        :: cpc_h, cpc_s
@@ -575,35 +573,33 @@ CONTAINS
 
       ! Load the soft contribution of the electronic density
 
-      ALLOCATE (rho_elec_gspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rho_elec_gspace%pw, &
+                             pw=rho_elec_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      CALL pw_zero(rhotot_elec_gspace%pw)
+      CALL pw_zero(rhotot_elec_gspace)
 
       DO ispin = 1, nspin
-         CALL pw_zero(rho_elec_gspace%pw)
-         CALL pw_transfer(rho_r(ispin)%pw, rho_elec_gspace%pw, debug=.FALSE.)
+         CALL pw_zero(rho_elec_gspace)
+         CALL pw_transfer(rho_r(ispin)%pw, rho_elec_gspace, debug=.FALSE.)
          IF (PRESENT(fsign) .AND. (ispin == 2)) THEN
             alpha = fsign
          ELSE
             alpha = 1.0_dp
          END IF
-         CALL pw_axpy(rho_elec_gspace%pw, rhotot_elec_gspace%pw, alpha=alpha)
+         CALL pw_axpy(rho_elec_gspace, rhotot_elec_gspace, alpha=alpha)
       END DO
 
       ! Release the auxiliary PW grid for the calculation of the soft
       ! contribution
 
       CALL pw_pool_give_back_pw(pool=auxbas_pw_pool, &
-                                pw=rho_elec_gspace%pw)
-      DEALLOCATE (rho_elec_gspace%pw)
+                                pw=rho_elec_gspace)
 
-      rho_soft = pw_integrate_function(rhotot_elec_gspace%pw, isign=-1)
+      rho_soft = pw_integrate_function(rhotot_elec_gspace, isign=-1)
 
-      CALL get_pw_grid_info(pw_grid=rhotot_elec_gspace%pw%pw_grid, &
+      CALL get_pw_grid_info(pw_grid=rhotot_elec_gspace%pw_grid, &
                             vol=volume, &
                             orthorhombic=orthorhombic)
       IF (.NOT. orthorhombic) THEN
@@ -611,7 +607,7 @@ CONTAINS
                        "The calculation of XRD spectra for non-orthorhombic cells is not implemented")
       END IF
 
-      CALL pw_scale(rhotot_elec_gspace%pw, volume)
+      CALL pw_scale(rhotot_elec_gspace, volume)
 
       ! Add the hard contribution of the electronic density
 
@@ -734,7 +730,7 @@ CONTAINS
                            nb=nb, &
                            eps_rho_gspace=eps_rho_gspace, &
                            gsq_max=q_max*q_max, &
-                           pw=rhotot_elec_gspace%pw)
+                           pw=rhotot_elec_gspace)
 
                      END DO ! next primitive Gaussian function "jpgf"
                   END DO ! next primitive Gaussian function "ipgf"
@@ -743,7 +739,7 @@ CONTAINS
          END DO ! next atom "iatom" of atomic kind "ikind"
       END DO ! next atomic kind "ikind"
 
-      rho_total = pw_integrate_function(rhotot_elec_gspace%pw, isign=-1)/volume
+      rho_total = pw_integrate_function(rhotot_elec_gspace, isign=-1)/volume
 
       rho_hard = rho_total - rho_soft
 
@@ -801,7 +797,7 @@ CONTAINS
       REAL(dp), DIMENSION(:, :), POINTER                 :: pab
       INTEGER, INTENT(IN)                                :: na, nb
       REAL(dp), INTENT(IN)                               :: eps_rho_gspace, gsq_max
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'collocate_pgf_product_gspace'
 

--- a/src/xray_diffraction.F
+++ b/src/xray_diffraction.F
@@ -170,6 +170,7 @@ CONTAINS
 
       ! Plane waves grid to assemble the total electronic density
 
+      ALLOCATE (rhotot_elec_gspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                              pw=rhotot_elec_gspace%pw, &
                              use_data=COMPLEXDATA1D, &
@@ -573,6 +574,7 @@ CONTAINS
 
       ! Load the soft contribution of the electronic density
 
+      ALLOCATE (rho_elec_gspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                              pw=rho_elec_gspace%pw, &
                              use_data=COMPLEXDATA1D, &


### PR DESCRIPTION
This PR removes the reference counting of some of the types introduced in the PW package such that work grids need not have the POINTER attribute anymore. Further care is necessary to remove the thereby introduced (DE-)ALLOCATE statements or to transform pw_p_type to pw_type.