### PR TITLE
Remove null pointers if they are passed as optional arguments

### DIFF
--- a/src/qs_initial_guess.F
+++ b/src/qs_initial_guess.F
@@ -585,7 +585,6 @@ CONTAINS
                              cholesky_method=scf_env%cholesky_method, &
                              do_level_shift=.FALSE., &
                              level_shift=0.0_dp, &
-                             matrix_u_fm=null(), &
                              use_jacobi=.FALSE.)
          END IF
 

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -152,7 +152,7 @@ CONTAINS
       INTEGER                                            :: ispin, nspin
       LOGICAL                                            :: do_level_shift, use_jacobi
       REAL(KIND=dp)                                      :: diis_error, eps_diis
-      TYPE(cp_fm_type), POINTER                          :: matrix_u_fm, ortho
+      TYPE(cp_fm_type), POINTER                          :: ortho
       TYPE(dbcsr_type), POINTER                          :: ortho_dbcsr
 
       nspin = SIZE(matrix_ks)
@@ -223,38 +223,38 @@ CONTAINS
          END DO
 
       ELSE IF (scf_env%cholesky_method > cholesky_off) THEN
+         IF (scf_env%cholesky_method == cholesky_inverse) THEN
+            ortho => scf_env%ortho_m1
+         ELSE
+            ortho => scf_env%ortho
+         END IF
+
          DO ispin = 1, nspin
-            IF (scf_env%cholesky_method == cholesky_inverse) THEN
-               ortho => scf_env%ortho_m1
-            ELSE
-               ortho => scf_env%ortho
-            END IF
-
             IF (do_level_shift) THEN
-               matrix_u_fm => scf_env%ortho
+               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+                                mo_set=mos(ispin)%mo_set, &
+                                ortho=ortho, &
+                                work=scf_env%scf_work2, &
+                                cholesky_method=scf_env%cholesky_method, &
+                                do_level_shift=do_level_shift, &
+                                level_shift=scf_control%level_shift, &
+                                matrix_u_fm=scf_env%ortho, &
+                                use_jacobi=use_jacobi)
             ELSE
-               NULLIFY (matrix_u_fm)
+               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+                                mo_set=mos(ispin)%mo_set, &
+                                ortho=ortho, &
+                                work=scf_env%scf_work2, &
+                                cholesky_method=scf_env%cholesky_method, &
+                                do_level_shift=do_level_shift, &
+                                level_shift=scf_control%level_shift, &
+                                use_jacobi=use_jacobi)
             END IF
-
-            CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
-                             mo_set=mos(ispin)%mo_set, &
-                             ortho=ortho, &
-                             work=scf_env%scf_work2, &
-                             cholesky_method=scf_env%cholesky_method, &
-                             do_level_shift=do_level_shift, &
-                             level_shift=scf_control%level_shift, &
-                             matrix_u_fm=matrix_u_fm, &
-                             use_jacobi=use_jacobi)
          END DO
       ELSE
          ortho => scf_env%ortho
 
          IF (do_level_shift) THEN
-            matrix_u_fm => scf_env%ortho_m1
-         ELSE
-            NULLIFY (matrix_u_fm)
-         END IF
-
          DO ispin = 1, nspin
             CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
                                   mo_set=mos(ispin)%mo_set, &
@@ -262,10 +262,22 @@ CONTAINS
                                   work=scf_env%scf_work2, &
                                   do_level_shift=do_level_shift, &
                                   level_shift=scf_control%level_shift, &
-                                  matrix_u_fm=matrix_u_fm, &
+                                  matrix_u_fm=scf_env%ortho_m1, &
                                   use_jacobi=use_jacobi, &
                                   jacobi_threshold=scf_control%diagonalization%jacobi_threshold)
          END DO
+         ELSE
+         DO ispin = 1, nspin
+            CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+                                  mo_set=mos(ispin)%mo_set, &
+                                  ortho=ortho, &
+                                  work=scf_env%scf_work2, &
+                                  do_level_shift=do_level_shift, &
+                                  level_shift=scf_control%level_shift, &
+                                  use_jacobi=use_jacobi, &
+                                  jacobi_threshold=scf_control%diagonalization%jacobi_threshold)
+         END DO
+         END IF
       END IF
 
    END SUBROUTINE general_eigenproblem

--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -357,7 +357,7 @@ CONTAINS
             cholesky_method_inout = cholesky_method
             CALL eigensolver(matrix_ks_fm=matrix_ks_fm, mo_set=mos_extended, ortho=ortho_fm, &
                              work=work_fm, cholesky_method=cholesky_method_inout, &
-                             do_level_shift=.FALSE., level_shift=0.0_dp, matrix_u_fm=null(), use_jacobi=.FALSE.)
+                             do_level_shift=.FALSE., level_shift=0.0_dp, use_jacobi=.FALSE.)
          END IF
 
          ! -- clean up needless matrices


### PR DESCRIPTION
Passing NULL() as an optional argument is standard conform to indicate an absent actual argument but does not work with some compilers under special circumstances. My last PR #2294 has triggered them (not on Dashboard) in the context of the eigensolvers. This PR removes the null pointers such that the optional arguments are omitted makes the calls to the eigensolver routines more explicit.

@juerghutter Does this PR fix your issue?