### PR TITLE
Fix enum vs int mix-up in offload_fft.h

### DIFF
--- a/src/offload/offload_fft.h
+++ b/src/offload/offload_fft.h
@@ -228,13 +228,13 @@ static inline void offload_fftDestroy(offload_fftHandle plan) {
  ******************************************************************************/
 static inline void offload_fftExecZ2Z(offload_fftHandle plan,
                                       const double *idata, double *odata,
-                                      offload_fftType type) {
+                                      int direction) {
 #if defined(__OFFLOAD_CUDA)
   OFFLOAD_FFT_CHECK(cufftExecZ2Z(plan, (cufftDoubleComplex *)idata,
-                                 (cufftDoubleComplex *)odata, type));
+                                 (cufftDoubleComplex *)odata, direction));
 #elif defined(__OFFLOAD_HIP)
   OFFLOAD_FFT_CHECK(hipfftExecZ2Z(plan, (hipfftDoubleComplex *)idata,
-                                  (hipfftDoubleComplex *)odata, type));
+                                  (hipfftDoubleComplex *)odata, direction));
 #endif
 }
 

--- a/src/pw/gpu/pw_gpu_internal.c
+++ b/src/pw/gpu/pw_gpu_internal.c
@@ -147,9 +147,9 @@ static void add_plan_to_cache(const int key[4], offload_fftHandle *plan) {
  *          Input/output are DEVICE pointers (data_in, date_out).
  * \author  Andreas Gloess, Ole Schuett
  ******************************************************************************/
-static void fft_1d(const offload_fftType fft_type, const int n, const int m,
+static void fft_1d(const int direction, const int n, const int m,
                    const double *data_in, double *data_out) {
-  const int key[4] = {1, fft_type, n, m}; // first key entry is dimensions
+  const int key[4] = {1, direction, n, m}; // first key entry is dimensions
   offload_fftHandle *plan = lookup_plan_from_cache(key);
 
   if (plan == NULL) {
@@ -158,7 +158,7 @@ static void fft_1d(const offload_fftType fft_type, const int n, const int m,
     int onembed[1] = {0}; // Is ignored, but is not allowed to be NULL.
     int batch = m;
     int istride, idist, ostride, odist;
-    if ((int)fft_type == (int)OFFLOAD_FFT_FORWARD) {
+    if (direction == OFFLOAD_FFT_FORWARD) {
       istride = m;
       idist = 1;
       ostride = 1;
@@ -176,7 +176,7 @@ static void fft_1d(const offload_fftType fft_type, const int n, const int m,
     add_plan_to_cache(key, plan);
   }
 
-  offload_fftExecZ2Z(*plan, data_in, data_out, fft_type);
+  offload_fftExecZ2Z(*plan, data_in, data_out, direction);
 }
 
 /*******************************************************************************
@@ -184,7 +184,7 @@ static void fft_1d(const offload_fftType fft_type, const int n, const int m,
  *          Input/output is a DEVICE pointer (data).
  * \author  Andreas Gloess, Ole Schuett
  ******************************************************************************/
-static void fft_3d(const offload_fftType fft_type, const int nx, const int ny,
+static void fft_3d(const int direction, const int nx, const int ny,
                    const int nz, double *data) {
   const int key[4] = {3, nx, ny, nz}; // first key entry is dimensions
   offload_fftHandle *plan = lookup_plan_from_cache(key);
@@ -196,7 +196,7 @@ static void fft_3d(const offload_fftType fft_type, const int nx, const int ny,
     add_plan_to_cache(key, plan);
   }
 
-  offload_fftExecZ2Z(*plan, data, data, fft_type);
+  offload_fftExecZ2Z(*plan, data, data, direction);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
The enum vs int mix-up was reported in the [forum](https://groups.google.com/g/cp2k/c/W5_w5d37y9E/m/NQOVnCMaCAAJ?utm_medium=email&utm_source=footer).
With [GCC 13](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105131) we will eventually be able to detect this type of issue ourselves.