### PR TITLE
WFC: Add the option to set gap and range externally for RPA/SOS-MP2

### DIFF
--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -92,6 +92,31 @@ CONTAINS
 
       CALL keyword_create( &
          keyword, __LOCATION__, &
+         name="E_GAP", &
+         description="Gap energy for integration grids in Hartree. Defaults to -1.0 (automatic determination). "// &
+         "Recommended to set if several RPA or SOS-MP2 gradient calculations are requested or to be restarted. "// &
+         "In this way, differences of integration grids across different runs are removed as CP2K "// &
+         "does not include derivatives thereof.", &
+         usage="E_GAP  0.5", &
+         default_r_val=-1.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
+         name="E_RANGE", &
+         description="Energy range (ratio of largest and smallest) energy difference "// &
+         "of unoccupied and occupied orbitals for integration grids. Defaults to 0.0 (automatic determination). "// &
+         "Recommended to set if several RPA or SOS-MP2 gradient calculations are requested or to be restarted. "// &
+         "In this way, differences of integration grids across different runs are removed as CP2K "// &
+         "does not include derivatives thereof.", &
+         usage="E_RANGE  10.0", &
+         default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
          name="SCALE_S", &
          description="Scaling factor of the singlet energy component (opposite spin, OS) of the "// &
          "MP2, RI-MP2 and SOS-MP2 correlation energy. ", &

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -111,7 +111,7 @@ CONTAINS
          "In this way, differences of integration grids across different runs are removed as CP2K "// &
          "does not include derivatives thereof.", &
          usage="E_RANGE  10.0", &
-         default_r_val=0.0_dp)
+         default_r_val=-1.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/mp2_grids.F
+++ b/src/mp2_grids.F
@@ -18,6 +18,8 @@ MODULE mp2_grids
    USE cp_para_env,                     ONLY: cp_para_env_release,&
                                               cp_para_env_split
    USE cp_para_types,                   ONLY: cp_para_env_type
+   USE input_section_types,             ONLY: section_vals_type,&
+                                              section_vals_val_set
    USE kinds,                           ONLY: dp
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_env_type,&
@@ -57,6 +59,8 @@ CONTAINS
 !> \param do_im_time ...
 !> \param do_ri_sos_laplace_mp2 ...
 !> \param do_print ...
+!> \param e_gap ...
+!> \param e_range ...
 !> \param tau_tj ...
 !> \param tau_wj ...
 !> \param qs_env ...
@@ -70,7 +74,7 @@ CONTAINS
 !> \param weights_sin_tf_t_to_w ...
 ! **************************************************************************************************
    SUBROUTINE get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_integ_points, &
-                               do_im_time, do_ri_sos_laplace_mp2, do_print, tau_tj, tau_wj, qs_env, do_gw_im_time, &
+                               do_im_time, do_ri_sos_laplace_mp2, do_print, e_gap, e_range, tau_tj, tau_wj, qs_env, do_gw_im_time, &
                                do_kpoints_cubic_RPA, e_fermi, tj, wj, weights_cos_tf_t_to_w, &
                                weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)
 
@@ -81,6 +85,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: num_integ_points
       LOGICAL, INTENT(IN)                                :: do_im_time, do_ri_sos_laplace_mp2, &
                                                             do_print
+      REAL(KIND=dp), INTENT(IN)                          :: e_gap, e_range
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(OUT)                                     :: tau_tj, tau_wj
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -98,9 +103,10 @@ CONTAINS
 
       INTEGER                                            :: handle, ierr, ispin, jquad, nspins
       LOGICAL                                            :: my_do_kpoints, my_open_shell
-      REAL(KIND=dp)                                      :: E_Range, Emax, Emin, max_error_min, &
+      REAL(KIND=dp)                                      :: Emax, Emin, max_error_min, my_E_Range, &
                                                             scaling
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: x_tw
+      TYPE(section_vals_type), POINTER                   :: input
 
       CALL timeset(routineN, handle)
 
@@ -116,20 +122,31 @@ CONTAINS
 
       IF (my_do_kpoints) THEN
          CALL gap_and_max_eig_diff_kpoints(qs_env, para_env, Emin, Emax, e_fermi)
-         E_Range = Emax/Emin
+         my_E_Range = Emax/Emin
       ELSE
-         Emin = HUGE(dp)
-         Emax = 0.0_dp
-         DO ispin = 1, nspins
-            IF (homo(ispin) > 0) THEN
-               Emin = MIN(Emin, Eigenval(homo(ispin) + 1, 1, ispin) - Eigenval(homo(ispin), 1, ispin))
-               Emax = MAX(Emax, MAXVAL(Eigenval(:, :, ispin)) - MINVAL(Eigenval(:, :, ispin)))
-            END IF
-         END DO
-         E_Range = Emax/Emin
+         IF (E_range <= 1.0_dp .OR. E_gap <= 0.0_dp) THEN
+            Emin = HUGE(dp)
+            Emax = 0.0_dp
+            DO ispin = 1, nspins
+               IF (homo(ispin) > 0) THEN
+                  Emin = MIN(Emin, Eigenval(homo(ispin) + 1, 1, ispin) - Eigenval(homo(ispin), 1, ispin))
+                  Emax = MAX(Emax, MAXVAL(Eigenval(:, :, ispin)) - MINVAL(Eigenval(:, :, ispin)))
+               END IF
+            END DO
+            my_E_Range = Emax/Emin
+            qs_env%mp2_env%e_range = my_e_range
+            qs_env%mp2_env%e_gap = Emin
+
+            CALL get_qs_env(qs_env, input=input)
+            CALL section_vals_val_set(input, "DFT%XC%WF_CORRELATION%E_RANGE", r_val=my_e_range)
+            CALL section_vals_val_set(input, "DFT%XC%WF_CORRELATION%E_GAP", r_val=emin)
+         ELSE
+            my_E_range = E_range
+            Emin = E_gap
+         END IF
       END IF
 
-      IF (num_integ_points > 20 .AND. E_Range < 100.0_dp) THEN
+      IF (num_integ_points > 20 .AND. my_E_Range < 100.0_dp) THEN
          IF (unit_nr > 0) &
             CALL cp_warn(__LOCATION__, &
                          "You requested a large minimax grid (> 20 points) for a small minimax range R (R < 100). "// &
@@ -143,9 +160,9 @@ CONTAINS
          x_tw = 0.0_dp
          ierr = 0
          IF (num_integ_points .LE. 20) THEN
-            CALL get_rpa_minimax_coeff(num_integ_points, E_Range, x_tw, ierr)
+            CALL get_rpa_minimax_coeff(num_integ_points, my_E_Range, x_tw, ierr)
          ELSE
-            CALL get_rpa_minimax_coeff_larger_grid(num_integ_points, E_Range, x_tw)
+            CALL get_rpa_minimax_coeff_larger_grid(num_integ_points, my_E_Range, x_tw)
          END IF
 
          ALLOCATE (tj(num_integ_points))
@@ -165,7 +182,7 @@ CONTAINS
             WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
                "MINIMAX_INFO| Number of integration points:", num_integ_points
             WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.4)") &
-               "MINIMAX_INFO| Range for the minimax approximation:", E_Range
+               "MINIMAX_INFO| Range for the minimax approximation:", my_E_Range
             WRITE (UNIT=unit_nr, FMT="(T3,A,T54,A,T72,A)") "MINIMAX_INFO| Minimax parameters:", "Weights", "Abscissas"
             DO jquad = 1, num_integ_points
                WRITE (UNIT=unit_nr, FMT="(T41,F20.10,F20.10)") wj(jquad), tj(jquad)
@@ -190,9 +207,9 @@ CONTAINS
          x_tw = 0.0_dp
 
          IF (num_integ_points .LE. 20) THEN
-            CALL get_exp_minimax_coeff(num_integ_points, E_Range, x_tw)
+            CALL get_exp_minimax_coeff(num_integ_points, my_E_Range, x_tw)
          ELSE
-            CALL get_exp_minimax_coeff_gw(num_integ_points, E_Range, x_tw)
+            CALL get_exp_minimax_coeff_gw(num_integ_points, my_E_Range, x_tw)
          END IF
 
          ! For RPA we include already a factor of two (see later steps)
@@ -214,7 +231,7 @@ CONTAINS
 
          IF (unit_nr > 0 .AND. do_print) THEN
             WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.4)") &
-               "MINIMAX_INFO| Range for the minimax approximation:", E_Range
+               "MINIMAX_INFO| Range for the minimax approximation:", my_E_Range
             ! For testing the gap
             WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.4)") &
                "MINIMAX_INFO| Gap:", Emin
@@ -329,7 +346,6 @@ CONTAINS
       IF (my_do_gw .AND. ext_scaling > 0.0_dp) THEN
          a_scaling = ext_scaling
       ELSE
-         a_scaling = 1.0_dp
          CALL calc_scaling_factor(a_scaling, para_env, para_env_RPA, homo, virtual, Eigenval, &
                                   num_integ_points, num_integ_group, color_rpa_group, &
                                   tj, wj, fm_mat_S)
@@ -361,7 +377,7 @@ CONTAINS
    SUBROUTINE calc_scaling_factor(a_scaling_ext, para_env, para_env_RPA, homo, virtual, Eigenval, &
                                   num_integ_points, num_integ_group, color_rpa_group, &
                                   tj_ext, wj_ext, fm_mat_S)
-      REAL(KIND=dp), INTENT(INOUT)                       :: a_scaling_ext
+      REAL(KIND=dp), INTENT(OUT)                         :: a_scaling_ext
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_RPA
       INTEGER, DIMENSION(:), INTENT(IN)                  :: homo, virtual
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: Eigenval

--- a/src/mp2_grids.F
+++ b/src/mp2_grids.F
@@ -59,8 +59,6 @@ CONTAINS
 !> \param do_im_time ...
 !> \param do_ri_sos_laplace_mp2 ...
 !> \param do_print ...
-!> \param e_gap ...
-!> \param e_range ...
 !> \param tau_tj ...
 !> \param tau_wj ...
 !> \param qs_env ...
@@ -74,7 +72,7 @@ CONTAINS
 !> \param weights_sin_tf_t_to_w ...
 ! **************************************************************************************************
    SUBROUTINE get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_integ_points, &
-                               do_im_time, do_ri_sos_laplace_mp2, do_print, e_gap, e_range, tau_tj, tau_wj, qs_env, do_gw_im_time, &
+                               do_im_time, do_ri_sos_laplace_mp2, do_print, tau_tj, tau_wj, qs_env, do_gw_im_time, &
                                do_kpoints_cubic_RPA, e_fermi, tj, wj, weights_cos_tf_t_to_w, &
                                weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)
 
@@ -85,7 +83,6 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: num_integ_points
       LOGICAL, INTENT(IN)                                :: do_im_time, do_ri_sos_laplace_mp2, &
                                                             do_print
-      REAL(KIND=dp), INTENT(IN)                          :: e_gap, e_range
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(OUT)                                     :: tau_tj, tau_wj
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -124,7 +121,7 @@ CONTAINS
          CALL gap_and_max_eig_diff_kpoints(qs_env, para_env, Emin, Emax, e_fermi)
          my_E_Range = Emax/Emin
       ELSE
-         IF (E_range <= 1.0_dp .OR. E_gap <= 0.0_dp) THEN
+         IF (qs_env%mp2_env%E_range <= 1.0_dp .OR. qs_env%mp2_env%E_gap <= 0.0_dp) THEN
             Emin = HUGE(dp)
             Emax = 0.0_dp
             DO ispin = 1, nspins
@@ -141,8 +138,8 @@ CONTAINS
             CALL section_vals_val_set(input, "DFT%XC%WF_CORRELATION%E_RANGE", r_val=my_e_range)
             CALL section_vals_val_set(input, "DFT%XC%WF_CORRELATION%E_GAP", r_val=emin)
          ELSE
-            my_E_range = E_range
-            Emin = E_gap
+            my_E_range = qs_env%mp2_env%E_range
+            Emin = qs_env%mp2_env%E_gap
             Emax = Emin*my_E_range
          END IF
       END IF

--- a/src/mp2_grids.F
+++ b/src/mp2_grids.F
@@ -143,6 +143,7 @@ CONTAINS
          ELSE
             my_E_range = E_range
             Emin = E_gap
+            Emax = Emin*my_E_range
          END IF
       END IF
 
@@ -181,6 +182,8 @@ CONTAINS
          IF (unit_nr > 0 .AND. do_print) THEN
             WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
                "MINIMAX_INFO| Number of integration points:", num_integ_points
+            WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.4)") &
+               "MINIMAX_INFO| Gap for the minimax approximation:", Emin
             WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.4)") &
                "MINIMAX_INFO| Range for the minimax approximation:", my_E_Range
             WRITE (UNIT=unit_nr, FMT="(T3,A,T54,A,T72,A)") "MINIMAX_INFO| Minimax parameters:", "Weights", "Abscissas"

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -85,6 +85,8 @@ CONTAINS
       CALL section_vals_val_get(mp2_section, "SCALE_S", r_val=mp2_env%scale_S)
       CALL section_vals_val_get(mp2_section, "SCALE_T", r_val=mp2_env%scale_T)
       CALL section_vals_val_get(mp2_section, "GROUP_SIZE", i_val=mp2_env%mp2_num_proc)
+      CALL section_vals_val_get(mp2_section, "E_GAP", r_val=mp2_env%e_gap)
+      CALL section_vals_val_get(mp2_section, "E_RANGE", r_val=mp2_env%e_range)
 
       CALL section_vals_val_get(mp2_section, "MP2%_SECTION_PARAMETERS_", l_val=do_mp2)
       CALL section_vals_val_get(mp2_section, "MP2%BIG_SEND", l_val=mp2_env%direct_canonical%big_send)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -268,6 +268,7 @@ MODULE mp2_types
       REAL(KIND=dp) :: eps_range
       TYPE(libint_potential_type) :: ri_metric
       TYPE(C_ptr)                 :: local_gemm_ctx
+      REAL(dp) :: e_gap, e_range
    END TYPE
 
    TYPE integ_mat_buffer_type

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -3813,8 +3813,8 @@ CONTAINS
    SUBROUTINE keep_initial_quad(tj, wj, tau_tj, tau_wj, weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, &
                                 do_laplace, do_im_time, num_integ_points, unit_nr, qs_env)
 
-      REAL(dp), DIMENSION(:), INTENT(INOUT)              :: tj, wj, tau_tj, tau_wj
-      REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: weights_cos_tf_t_to_w, &
+      REAL(dp), DIMENSION(:), ALLOCATABLE, INTENT(INOUT)              :: tj, wj, tau_tj, tau_wj
+      REAL(dp), DIMENSION(:, :), ALLOCATABLE, INTENT(INOUT)           :: weights_cos_tf_t_to_w, &
                                                             weights_cos_tf_w_to_t
       LOGICAL, INTENT(IN)                                :: do_laplace, do_im_time
       INTEGER, INTENT(IN)                                :: num_integ_points, unit_nr
@@ -3823,7 +3823,7 @@ CONTAINS
       INTEGER                                            :: jquad
 
       IF (do_laplace .OR. do_im_time) THEN
-         IF (.NOT. ASSOCIATED(qs_env%mp2_env%ri_rpa_im_time%tau_tj) .AND. do_laplace) THEN
+         IF (.NOT. ASSOCIATED(qs_env%mp2_env%ri_rpa_im_time%tau_tj)) THEN
             ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%tau_tj(0:num_integ_points))
             ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%tau_wj(num_integ_points))
             qs_env%mp2_env%ri_rpa_im_time%tau_tj(:) = tau_tj(:)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -3861,7 +3861,7 @@ CONTAINS
             WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &
                "MINIMAX_INFO| Number of integration points:", num_integ_points
             WRITE (UNIT=unit_nr, FMT="(T3,A,T54,A,T72,A)") &
-               "MINIMAX_INFO| Minimax params (freq gird, scaled):", "Weights", "Abscissas"
+               "MINIMAX_INFO| Minimax params (freq grid, scaled):", "Weights", "Abscissas"
             DO jquad = 1, num_integ_points
                WRITE (UNIT=unit_nr, FMT="(T41,F20.10,F20.10)") wj(jquad), tj(jquad)
             END DO

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -3805,31 +3805,34 @@ CONTAINS
 !> \param weights_cos_tf_t_to_w ...
 !> \param weights_cos_tf_w_to_t ...
 !> \param do_laplace ...
+!> \param do_im_time ...
 !> \param num_integ_points ...
 !> \param unit_nr ...
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE keep_initial_quad(tj, wj, tau_tj, tau_wj, weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, &
-                                do_laplace, num_integ_points, unit_nr, qs_env)
+                                do_laplace, do_im_time, num_integ_points, unit_nr, qs_env)
 
       REAL(dp), DIMENSION(:), INTENT(INOUT)              :: tj, wj, tau_tj, tau_wj
       REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: weights_cos_tf_t_to_w, &
                                                             weights_cos_tf_w_to_t
-      LOGICAL, INTENT(IN)                                :: do_laplace
+      LOGICAL, INTENT(IN)                                :: do_laplace, do_im_time
       INTEGER, INTENT(IN)                                :: num_integ_points, unit_nr
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       INTEGER                                            :: jquad
 
-      IF (.NOT. ASSOCIATED(qs_env%mp2_env%ri_rpa_im_time%tau_tj)) THEN
-         ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%tau_tj(0:num_integ_points))
-         ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%tau_wj(num_integ_points))
-         qs_env%mp2_env%ri_rpa_im_time%tau_tj(:) = tau_tj(:)
-         qs_env%mp2_env%ri_rpa_im_time%tau_wj(:) = tau_wj(:)
-      ELSE
-         !If weights already stored, we overwrite the new ones
-         tau_tj(:) = qs_env%mp2_env%ri_rpa_im_time%tau_tj(:)
-         tau_wj(:) = qs_env%mp2_env%ri_rpa_im_time%tau_wj(:)
+      IF (do_laplace .OR. do_im_time) THEN
+         IF (.NOT. ASSOCIATED(qs_env%mp2_env%ri_rpa_im_time%tau_tj) .AND. do_laplace) THEN
+            ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%tau_tj(0:num_integ_points))
+            ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%tau_wj(num_integ_points))
+            qs_env%mp2_env%ri_rpa_im_time%tau_tj(:) = tau_tj(:)
+            qs_env%mp2_env%ri_rpa_im_time%tau_wj(:) = tau_wj(:)
+         ELSE
+            !If weights already stored, we overwrite the new ones
+            tau_tj(:) = qs_env%mp2_env%ri_rpa_im_time%tau_tj(:)
+            tau_wj(:) = qs_env%mp2_env%ri_rpa_im_time%tau_wj(:)
+         END IF
       END IF
       IF (.NOT. do_laplace) THEN
          IF (.NOT. ASSOCIATED(qs_env%mp2_env%ri_rpa_im_time%tj)) THEN
@@ -3837,15 +3840,19 @@ CONTAINS
             ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%wj(num_integ_points))
             qs_env%mp2_env%ri_rpa_im_time%tj(:) = tj(:)
             qs_env%mp2_env%ri_rpa_im_time%wj(:) = wj(:)
-            ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_t_to_w(num_integ_points, num_integ_points))
-            ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_w_to_t(num_integ_points, num_integ_points))
-            qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_t_to_w(:, :) = weights_cos_tf_t_to_w(:, :)
-            qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_w_to_t(:, :) = weights_cos_tf_w_to_t(:, :)
+            IF (do_im_time) THEN
+               ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_t_to_w(num_integ_points, num_integ_points))
+               ALLOCATE (qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_w_to_t(num_integ_points, num_integ_points))
+               qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_t_to_w(:, :) = weights_cos_tf_t_to_w(:, :)
+               qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_w_to_t(:, :) = weights_cos_tf_w_to_t(:, :)
+            END IF
          ELSE
             tj(:) = qs_env%mp2_env%ri_rpa_im_time%tj(:)
             wj(:) = qs_env%mp2_env%ri_rpa_im_time%wj(:)
-            weights_cos_tf_t_to_w(:, :) = qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_t_to_w(:, :)
-            weights_cos_tf_w_to_t(:, :) = qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_w_to_t(:, :)
+            IF (do_im_time) THEN
+               weights_cos_tf_t_to_w(:, :) = qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_t_to_w(:, :)
+               weights_cos_tf_w_to_t(:, :) = qs_env%mp2_env%ri_rpa_im_time%weights_cos_tf_w_to_t(:, :)
+            END IF
          END IF
       END IF
       IF (unit_nr > 0) THEN

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -3813,8 +3813,9 @@ CONTAINS
    SUBROUTINE keep_initial_quad(tj, wj, tau_tj, tau_wj, weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, &
                                 do_laplace, do_im_time, num_integ_points, unit_nr, qs_env)
 
-      REAL(dp), DIMENSION(:), ALLOCATABLE, INTENT(INOUT)              :: tj, wj, tau_tj, tau_wj
-      REAL(dp), DIMENSION(:, :), ALLOCATABLE, INTENT(INOUT)           :: weights_cos_tf_t_to_w, &
+      REAL(dp), ALLOCATABLE, DIMENSION(:), INTENT(INOUT) :: tj, wj, tau_tj, tau_wj
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: weights_cos_tf_t_to_w, &
                                                             weights_cos_tf_w_to_t
       LOGICAL, INTENT(IN)                                :: do_laplace, do_im_time
       INTEGER, INTENT(IN)                                :: num_integ_points, unit_nr

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -1283,9 +1283,9 @@ CONTAINS
                                weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)
 
          !For sos_laplace_mp2 and low-scaling RPA, potentially need to store/retrieve the initial weights
-         IF (do_im_time .AND. qs_env%mp2_env%ri_rpa_im_time%keep_quad) THEN
+         IF (qs_env%mp2_env%ri_rpa_im_time%keep_quad) THEN
             CALL keep_initial_quad(tj, wj, tau_tj, tau_wj, weights_cos_tf_t_to_w, &
-                                   weights_cos_tf_w_to_t, do_ri_sos_laplace_mp2, &
+                                   weights_cos_tf_w_to_t, do_ri_sos_laplace_mp2, do_im_time, &
                                    num_integ_points, unit_nr, qs_env)
          END IF
       ELSE

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -289,15 +289,18 @@ CONTAINS
          input_num_integ_groups = mp2_env%ri_laplace%num_integ_groups
 
          ! check the range for the minimax approximation
-         Emin = HUGE(dp)
-         Emax = 0.0_dp
-         DO ispin = 1, nspins
-            IF (homo(ispin) > 0) THEN
-               Emin = MIN(Emin, 2.0_dp*(Eigenval(homo(ispin) + 1, ispin) - Eigenval(homo(ispin), ispin)))
-               Emax = MAX(Emax, 2.0_dp*(MAXVAL(Eigenval(:, ispin)) - MINVAL(Eigenval(:, ispin))))
-            END IF
-         END DO
-         E_Range = Emax/Emin
+         E_Range = mp2_env%e_range
+         IF (E_range <= 1.0_dp) THEN
+            Emin = HUGE(dp)
+            Emax = 0.0_dp
+            DO ispin = 1, nspins
+               IF (homo(ispin) > 0) THEN
+                  Emin = MIN(Emin, 2.0_dp*(Eigenval(homo(ispin) + 1, ispin) - Eigenval(homo(ispin), ispin)))
+                  Emax = MAX(Emax, 2.0_dp*(MAXVAL(Eigenval(:, ispin)) - MINVAL(Eigenval(:, ispin))))
+               END IF
+            END DO
+            E_Range = Emax/Emin
+         END IF
          IF (E_Range < 2.0_dp) E_Range = 2.0_dp
          ierr = 0
          CALL check_exp_minimax_range(num_integ_points, E_Range, ierr)
@@ -1274,7 +1277,8 @@ CONTAINS
       IF (do_minimax_quad .OR. do_ri_sos_laplace_mp2) THEN
          do_print = .NOT. do_ic_model .AND. (.NOT. qs_env%mp2_env%ri_rpa_im_time%keep_quad)
          CALL get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_integ_points, do_im_time, &
-                               do_ri_sos_laplace_mp2, do_print, tau_tj, tau_wj, qs_env, do_gw_im_time, &
+                               do_ri_sos_laplace_mp2, do_print, mp2_env%e_gap, mp2_env%e_range, &
+                               tau_tj, tau_wj, qs_env, do_gw_im_time, &
                                do_kpoints_cubic_RPA, e_fermi(1), tj, wj, &
                                weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)
 
@@ -1285,6 +1289,7 @@ CONTAINS
                                    num_integ_points, unit_nr, qs_env)
          END IF
       ELSE
+         IF (calc_forces) CPABORT("Forces with Clenshaw-Curtis grid not implemented.")
          CALL get_clenshaw_grid(para_env, para_env_RPA, unit_nr, homo, virtual, Eigenval, num_integ_points, &
                                 num_integ_group, color_rpa_group, fm_mat_S, my_do_gw, &
                                 ext_scaling, a_scaling, tj, wj)

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -290,7 +290,7 @@ CONTAINS
 
          ! check the range for the minimax approximation
          E_Range = mp2_env%e_range
-         IF (E_range <= 1.0_dp) THEN
+         IF (mp2_env%e_range <= 1.0_dp .OR. mp2_env%e_gap <= 0.0_dp) THEN
             Emin = HUGE(dp)
             Emax = 0.0_dp
             DO ispin = 1, nspins
@@ -1277,7 +1277,7 @@ CONTAINS
       IF (do_minimax_quad .OR. do_ri_sos_laplace_mp2) THEN
          do_print = .NOT. do_ic_model .AND. (.NOT. qs_env%mp2_env%ri_rpa_im_time%keep_quad)
          CALL get_minimax_grid(para_env, unit_nr, homo, Eigenval, num_integ_points, do_im_time, &
-                               do_ri_sos_laplace_mp2, do_print, mp2_env%e_gap, mp2_env%e_range, &
+                               do_ri_sos_laplace_mp2, do_print, &
                                tau_tj, tau_wj, qs_env, do_gw_im_time, &
                                do_kpoints_cubic_RPA, e_fermi(1), tj, wj, &
                                weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, weights_sin_tf_t_to_w)

--- a/tests/QS/regtest-ri-rpa-grad/TEST_FILES
+++ b/tests/QS/regtest-ri-rpa-grad/TEST_FILES
@@ -1,5 +1,5 @@
-RI_RPA_grad_MP2_H2O.inp                                11     5e-08            -16.994626142112192
-RI_RPA_grad_MP2_CH3.inp                                11     7e-08             -7.515645339785070
-RI_RPA_grad_MP2_H2O_HF_PBE.inp                         11     6e-08            -17.057888508919117
-RI_RPA_grad_MP2_H2O_HF_PBE_ADMM.inp                    11     1e-07            -17.066276945129722
+RI_RPA_grad_MP2_H2O.inp                                11     5e-08            -16.994621951831640
+RI_RPA_grad_MP2_CH3.inp                                11     7e-08             -7.515607384605213
+RI_RPA_grad_MP2_H2O_HF_PBE.inp                         11     6e-08            -17.057843090414949
+RI_RPA_grad_MP2_H2O_HF_PBE_ADMM.inp                    11     1e-07            -17.066232490836303
 #EOF


### PR DESCRIPTION
These quantities will be written to the restart input file, too, in order to ensure compatible runs of geometry optimizations or MDs.

Misc: Fixes subsequent calculations of RPA/SOS-MP2 with gradients: In case of quartically scaling RPA/SOS-MP2, the integration grids were recalculated although they were supposed to be fixed within a run. The errors should be rather small if the number of integration points is large enough (6-8). Single runs were not affected.