### PR TITLE
Continue refactoring of pw_type

### DIFF
--- a/src/cp_ddapc.F
+++ b/src/cp_ddapc.F
@@ -48,7 +48,6 @@ MODULE cp_ddapc
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -87,8 +86,8 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_p_type)                                    :: rho_tot_gspace, v_hartree_gspace, &
-                                                            v_spin_ddapc_rest_r
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_gspace, v_hartree_gspace
+      TYPE(pw_type), POINTER                             :: v_spin_ddapc_rest_r
       TYPE(qs_energy_type), POINTER                      :: energy
       LOGICAL, INTENT(in)                                :: calculate_forces
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: ks_matrix
@@ -102,7 +101,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(ddapc_restraint_type), POINTER                :: ddapc_restraint_control
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(pw_p_type)                                    :: v_spin_ddapc_rest_g
+      TYPE(pw_type)                                      :: v_spin_ddapc_rest_g
       TYPE(pw_type), POINTER                             :: v_hartree_rspace
 
       NULLIFY (v_hartree_rspace, dft_control)
@@ -140,11 +139,12 @@ CONTAINS
       dft_control%qs_control%ddapc_explicit_potential = explicit_potential
       dft_control%qs_control%ddapc_restraint_is_spin = ddapc_restraint_is_spin
       IF (explicit_potential) THEN
-         ALLOCATE (v_spin_ddapc_rest_g%pw, v_spin_ddapc_rest_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_spin_ddapc_rest_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, v_spin_ddapc_rest_g, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_zero(v_spin_ddapc_rest_g%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_spin_ddapc_rest_r%pw, &
+         CALL pw_zero(v_spin_ddapc_rest_g)
+         NULLIFY (v_spin_ddapc_rest_r)
+         ALLOCATE (v_spin_ddapc_rest_r)
+         CALL pw_pool_create_pw(auxbas_pw_pool, v_spin_ddapc_rest_r, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
       END IF
 
@@ -168,11 +168,11 @@ CONTAINS
 
       ! CJM Copying the real-space Hartree potential to KS_ENV
       IF ((.NOT. just_energy) .OR. et_coupling_calc) THEN
-         CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace)
+         CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
          CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
          IF (explicit_potential) THEN
-            CALL pw_transfer(v_spin_ddapc_rest_g%pw, v_spin_ddapc_rest_r%pw)
-            CALL pw_scale(v_spin_ddapc_rest_r%pw, v_spin_ddapc_rest_r%pw%pw_grid%dvol)
+            CALL pw_transfer(v_spin_ddapc_rest_g, v_spin_ddapc_rest_r)
+            CALL pw_scale(v_spin_ddapc_rest_r, v_spin_ddapc_rest_r%pw_grid%dvol)
             IF (et_coupling_calc) THEN
                IF (qs_env%et_coupling%keep_matrix) THEN
                   IF (qs_env%et_coupling%first_run) THEN
@@ -181,7 +181,7 @@ CONTAINS
                      CALL dbcsr_copy(qs_env%et_coupling%rest_mat(1)%matrix, ks_matrix(1, 1)%matrix, &
                                      name="ET_RESTRAINT_MATRIX_B")
                      CALL dbcsr_set(qs_env%et_coupling%rest_mat(1)%matrix, 0.0_dp)
-                     CALL integrate_v_rspace(v_spin_ddapc_rest_r%pw, &
+                     CALL integrate_v_rspace(v_spin_ddapc_rest_r, &
                                              hmat=qs_env%et_coupling%rest_mat(1), &
                                              qs_env=qs_env, calculate_forces=.FALSE.)
                      qs_env%et_coupling%order_p = &
@@ -194,7 +194,7 @@ CONTAINS
                      CALL dbcsr_copy(qs_env%et_coupling%rest_mat(2)%matrix, ks_matrix(1, 1)%matrix, &
                                      name="ET_RESTRAINT_MATRIX_B")
                      CALL dbcsr_set(qs_env%et_coupling%rest_mat(2)%matrix, 0.0_dp)
-                     CALL integrate_v_rspace(v_spin_ddapc_rest_r%pw, &
+                     CALL integrate_v_rspace(v_spin_ddapc_rest_r, &
                                              hmat=qs_env%et_coupling%rest_mat(2), &
                                              qs_env=qs_env, calculate_forces=.FALSE.)
                   END IF
@@ -204,8 +204,7 @@ CONTAINS
       END IF
 
       IF (explicit_potential) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_g%pw)
-         DEALLOCATE (v_spin_ddapc_rest_g%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_g)
       END IF
       CALL timestop(handle)
 
@@ -232,9 +231,9 @@ CONTAINS
    SUBROUTINE cp_ddapc_apply_CD(qs_env, rho_tot_gspace, energy, v_hartree_gspace, &
                                 calculate_forces, Itype_of_density)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type)                                    :: rho_tot_gspace
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_gspace
       REAL(KIND=dp), INTENT(INOUT)                       :: energy
-      TYPE(pw_p_type)                                    :: v_hartree_gspace
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_gspace
       LOGICAL, INTENT(IN), OPTIONAL                      :: calculate_forces
       CHARACTER(LEN=*)                                   :: Itype_of_density
 
@@ -299,7 +298,7 @@ CONTAINS
                            qout1=charges, &
                            out_radii=radii, &
                            dq_out=dq, &
-                           ext_rho_tot_g=rho_tot_gspace%pw, &
+                           ext_rho_tot_g=rho_tot_gspace, &
                            Itype_of_density=Itype_of_density)
          ELSE
             CALL get_ddapc(qs_env, &
@@ -307,7 +306,7 @@ CONTAINS
                            density_fit_section, &
                            qout1=charges, &
                            out_radii=radii, &
-                           ext_rho_tot_g=rho_tot_gspace%pw, &
+                           ext_rho_tot_g=rho_tot_gspace, &
                            Itype_of_density=Itype_of_density)
          END IF
          ! Evaluate the Ewald contribution to the decoupling/coupling E2 and E3
@@ -327,7 +326,7 @@ CONTAINS
                                  radii, &
                                  charges)
          ! Modify the Hartree potential due to the decoupling/recoupling
-         energy = 0.5_dp*pw_integral_ab(rho_tot_gspace%pw, v_hartree_gspace%pw)
+         energy = 0.5_dp*pw_integral_ab(rho_tot_gspace, v_hartree_gspace)
          IF (need_f) THEN
             CALL ewald_ddapc_force(qs_env, qs_env%cp_ddapc_ewald%coeff_qm, &
                                    .FALSE., 1.0_dp, multipole_section, cell, particle_set, &
@@ -367,7 +366,7 @@ CONTAINS
                                 v_spin_ddapc_rest_g, ddapc_restraint_control, calculate_forces)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: energy_res
-      TYPE(pw_p_type)                                    :: v_hartree_gspace, v_spin_ddapc_rest_g
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_gspace, v_spin_ddapc_rest_g
       TYPE(ddapc_restraint_type), POINTER                :: ddapc_restraint_control
       LOGICAL, INTENT(IN), OPTIONAL                      :: calculate_forces
 
@@ -470,9 +469,9 @@ CONTAINS
    SUBROUTINE cp_ddapc_apply_RF(qs_env, rho_tot_gspace, energy, &
                                 v_hartree_gspace, calculate_forces, Itype_of_density)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type)                                    :: rho_tot_gspace
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_gspace
       REAL(KIND=dp), INTENT(INOUT)                       :: energy
-      TYPE(pw_p_type)                                    :: v_hartree_gspace
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_gspace
       LOGICAL, INTENT(IN), OPTIONAL                      :: calculate_forces
       CHARACTER(LEN=*)                                   :: Itype_of_density
 
@@ -518,7 +517,7 @@ CONTAINS
                            qout1=charges, &
                            out_radii=radii, &
                            dq_out=dq, &
-                           ext_rho_tot_g=rho_tot_gspace%pw, &
+                           ext_rho_tot_g=rho_tot_gspace, &
                            Itype_of_density=Itype_of_density)
          ELSE
             CALL get_ddapc(qs_env, &
@@ -526,7 +525,7 @@ CONTAINS
                            density_fit_section, &
                            qout1=charges, &
                            out_radii=radii, &
-                           ext_rho_tot_g=rho_tot_gspace%pw, &
+                           ext_rho_tot_g=rho_tot_gspace, &
                            Itype_of_density=Itype_of_density)
          END IF
          ! Evaluate the Ewald contribution to the decoupling/coupling E2 and E3
@@ -542,7 +541,7 @@ CONTAINS
                                  radii, &
                                  charges)
          ! Modify the Hartree potential due to the reaction field
-         energy = 0.5_dp*pw_integral_ab(rho_tot_gspace%pw, v_hartree_gspace%pw)
+         energy = 0.5_dp*pw_integral_ab(rho_tot_gspace, v_hartree_gspace)
          IF (need_f) THEN
             CALL solvation_ddapc_force(qs_env, solvation_section, particle_set, &
                                        radii, dq, charges)

--- a/src/cp_ddapc_forces.F
+++ b/src/cp_ddapc_forces.F
@@ -75,7 +75,7 @@ CONTAINS
    RECURSIVE SUBROUTINE ewald_ddapc_force(qs_env, coeff, apply_qmmm_periodic, &
                                           factor, multipole_section, cell, particle_set, radii, dq, charges)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_type), POINTER                             :: coeff
+      TYPE(pw_type), INTENT(IN), POINTER                 :: coeff
       LOGICAL, INTENT(IN)                                :: apply_qmmm_periodic
       REAL(KIND=dp), INTENT(IN)                          :: factor
       TYPE(section_vals_type), POINTER                   :: multipole_section

--- a/src/cp_ddapc_methods.F
+++ b/src/cp_ddapc_methods.F
@@ -63,7 +63,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: gfunc
       REAL(kind=dp), DIMENSION(:), POINTER               :: w
       REAL(KIND=dp), INTENT(IN)                          :: gcut
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(kind=dp), DIMENSION(:), POINTER               :: radii
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'ddapc_eval_gfunc'
@@ -116,7 +116,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: w
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:), POINTER               :: radii
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), INTENT(IN)                          :: gcut
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'build_b_vector'
@@ -194,7 +194,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: w
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:), POINTER               :: radii
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), INTENT(IN)                          :: gcut
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: g_dot_rvec_sin, g_dot_rvec_cos
 
@@ -280,7 +280,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: w
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: radii
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), INTENT(IN)                          :: gcut
       INTEGER, INTENT(IN)                                :: iparticle0
 
@@ -372,7 +372,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: w
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:), POINTER               :: radii
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), INTENT(IN)                          :: gcut
       INTEGER, INTENT(IN)                                :: iparticle0, nparticles
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: g_dot_rvec_sin, g_dot_rvec_cos
@@ -490,7 +490,7 @@ CONTAINS
 !> \param g_dot_rvec_cos ...
 ! **************************************************************************************************
    SUBROUTINE prep_g_dot_rvec_sin_cos(rho_tot_g, particle_set, gcut, g_dot_rvec_sin, g_dot_rvec_cos)
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), INTENT(IN)                          :: gcut
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: g_dot_rvec_sin, g_dot_rvec_cos
@@ -548,7 +548,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: w
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), INTENT(IN)                          :: gcut
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), DIMENSION(:), POINTER               :: radii
       INTEGER, INTENT(IN)                                :: iw
       REAL(KIND=dp), INTENT(IN)                          :: Vol
@@ -626,7 +626,7 @@ CONTAINS
    RECURSIVE SUBROUTINE ewald_ddapc_pot(cp_para_env, coeff, factor, cell, multipole_section, &
                                         particle_set, M, radii)
       TYPE(cp_para_env_type), POINTER                    :: cp_para_env
-      TYPE(pw_type), POINTER                             :: coeff
+      TYPE(pw_type), INTENT(IN), POINTER                 :: coeff
       REAL(KIND=dp), INTENT(IN)                          :: factor
       TYPE(cell_type), POINTER                           :: cell
       TYPE(section_vals_type), POINTER                   :: multipole_section

--- a/src/cp_ddapc_types.F
+++ b/src/cp_ddapc_types.F
@@ -104,7 +104,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(kind=dp), DIMENSION(:), POINTER               :: radii
       TYPE(cell_type), POINTER                           :: cell, super_cell
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), INTENT(IN)                          :: gcut
       INTEGER, INTENT(IN)                                :: iw2
       REAL(KIND=dp), INTENT(IN)                          :: Vol

--- a/src/cp_ddapc_util.F
+++ b/src/cp_ddapc_util.F
@@ -97,14 +97,14 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pool
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type)                                      :: rho_tot_g
       TYPE(qs_charges_type), POINTER                     :: qs_charges
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: density_fit_section
 
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
-      NULLIFY (dft_control, rho, rho_tot_g, pw_env, &
+      NULLIFY (dft_control, rho, pw_env, &
                radii, inp_radii, particle_set, qs_charges, para_env)
 
       CALL get_qs_env(qs_env, dft_control=dft_control)
@@ -138,8 +138,6 @@ CONTAINS
             WRITE (iw, '(/,A)') " Initializing the DDAPC Environment"
          END IF
          CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pool)
-         NULLIFY (rho_tot_g)
-         ALLOCATE (rho_tot_g)
          CALL pw_pool_create_pw(auxbas_pool, rho_tot_g, in_space=RECIPROCALSPACE, &
                                 use_data=COMPLEXDATA1D)
          Vol = rho_tot_g%pw_grid%vol
@@ -183,7 +181,6 @@ CONTAINS
                                            "PROGRAM_RUN_INFO/CONDITION_NUMBER")
          DEALLOCATE (radii)
          CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
-         DEALLOCATE (rho_tot_g)
       END IF
       CALL timestop(handle)
    END SUBROUTINE cp_ddapc_init
@@ -215,7 +212,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: qout1, qout2, out_radii
       REAL(KIND=dp), DIMENSION(:, :, :), OPTIONAL, &
          POINTER                                         :: dq_out
-      TYPE(pw_type), OPTIONAL, POINTER                   :: ext_rho_tot_g
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: ext_rho_tot_g
       CHARACTER(LEN=*), OPTIONAL                         :: Itype_of_density
       INTEGER, INTENT(IN), OPTIONAL                      :: iwc
 
@@ -241,7 +238,8 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pool
-      TYPE(pw_type), POINTER                             :: rho0_s_gs, rho_core, rho_tot_g
+      TYPE(pw_type)                                      :: rho_tot_g
+      TYPE(pw_type), POINTER                             :: rho0_s_gs, rho_core
       TYPE(qs_charges_type), POINTER                     :: qs_charges
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -256,7 +254,7 @@ CONTAINS
       need_f = .FALSE.
       IF (PRESENT(calc_force)) need_f = calc_force
       logger => cp_get_default_logger()
-      NULLIFY (dft_control, rho, rho_tot_g, rho_core, rho0_s_gs, pw_env, rho_g, rho_r, &
+      NULLIFY (dft_control, rho, rho_core, rho0_s_gs, pw_env, rho_g, rho_r, &
                radii, inp_radii, particle_set, qs_kind_set, qs_charges, cp_ddapc_env)
       CALL get_qs_env(qs_env=qs_env, &
                       dft_control=dft_control, &
@@ -280,8 +278,6 @@ CONTAINS
       END IF
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pool)
-      NULLIFY (rho_tot_g)
-      ALLOCATE (rho_tot_g)
       CALL pw_pool_create_pw(auxbas_pool, rho_tot_g, in_space=RECIPROCALSPACE, &
                              use_data=COMPLEXDATA1D)
       IF (PRESENT(ext_rho_tot_g)) THEN
@@ -522,7 +518,6 @@ CONTAINS
                                            "PROGRAM_RUN_INFO")
       END IF
       CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
-      DEALLOCATE (rho_tot_g)
       CALL timestop(handle)
    END SUBROUTINE get_ddapc
 
@@ -542,7 +537,7 @@ CONTAINS
    SUBROUTINE restraint_functional_potential(v_hartree_gspace, &
                                              density_fit_section, particle_set, AmI, radii, charges, &
                                              ddapc_restraint_control, energy_res)
-      TYPE(pw_p_type)                                    :: v_hartree_gspace
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_gspace
       TYPE(section_vals_type), POINTER                   :: density_fit_section
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: AmI
@@ -558,10 +553,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: arg, fac, fac2, g2, gcut, gcut2, gfunc, &
                                                             gvec(3), rc, rc2, rvec(3), sfac, Vol, w
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: cv, uv
-      TYPE(pw_type), POINTER                             :: g_hartree
 
       CALL timeset(routineN, handle)
-      NULLIFY (g_hartree)
       n_gauss = SIZE(radii)
       ALLOCATE (cv(n_gauss*SIZE(particle_set)))
       ALLOCATE (uv(n_gauss*SIZE(particle_set)))
@@ -571,37 +564,38 @@ CONTAINS
       !
       CALL section_vals_val_get(density_fit_section, "GCUT", r_val=gcut)
       gcut2 = gcut*gcut
-      g_hartree => v_hartree_gspace%pw
-      Vol = g_hartree%pw_grid%vol
-      cv = 1.0_dp/Vol
-      sfac = -1.0_dp/Vol
-      fac = DOT_PRODUCT(cv, MATMUL(AmI, cv))
-      fac2 = DOT_PRODUCT(cv, MATMUL(AmI, uv))
-      cv(:) = uv - cv*fac2/fac
-      cv(:) = MATMUL(AmI, cv)
-      IF (g_hartree%pw_grid%have_g0) g_hartree%cc(1) = g_hartree%cc(1) + sfac*fac2/fac
-      DO ig = g_hartree%pw_grid%first_gne0, g_hartree%pw_grid%ngpts_cut_local
-         g2 = g_hartree%pw_grid%gsq(ig)
-         w = 4.0_dp*pi*(g2 - gcut2)**2.0_dp/(g2*gcut2)
-         IF (g2 > gcut2) EXIT
-         gvec = g_hartree%pw_grid%g(:, ig)
-         g_corr = 0.0_dp
-         idim = 0
-         DO iparticle = 1, SIZE(particle_set)
-            DO igauss = 1, SIZE(radii)
-               idim = idim + 1
-               rc = radii(igauss)
-               rc2 = rc*rc
-               rvec = particle_set(iparticle)%r
-               arg = DOT_PRODUCT(gvec, rvec)
-               phase = CMPLX(COS(arg), -SIN(arg), KIND=dp)
-               gfunc = EXP(-g2*rc2/4.0_dp)
-               g_corr = g_corr + gfunc*cv(idim)*phase
+      ASSOCIATE (pw_grid => v_hartree_gspace%pw_grid)
+         Vol = pw_grid%vol
+         cv = 1.0_dp/Vol
+         sfac = -1.0_dp/Vol
+         fac = DOT_PRODUCT(cv, MATMUL(AmI, cv))
+         fac2 = DOT_PRODUCT(cv, MATMUL(AmI, uv))
+         cv(:) = uv - cv*fac2/fac
+         cv(:) = MATMUL(AmI, cv)
+         IF (pw_grid%have_g0) v_hartree_gspace%cc(1) = v_hartree_gspace%cc(1) + sfac*fac2/fac
+         DO ig = pw_grid%first_gne0, pw_grid%ngpts_cut_local
+            g2 = pw_grid%gsq(ig)
+            w = 4.0_dp*pi*(g2 - gcut2)**2.0_dp/(g2*gcut2)
+            IF (g2 > gcut2) EXIT
+            gvec = pw_grid%g(:, ig)
+            g_corr = 0.0_dp
+            idim = 0
+            DO iparticle = 1, SIZE(particle_set)
+               DO igauss = 1, SIZE(radii)
+                  idim = idim + 1
+                  rc = radii(igauss)
+                  rc2 = rc*rc
+                  rvec = particle_set(iparticle)%r
+                  arg = DOT_PRODUCT(gvec, rvec)
+                  phase = CMPLX(COS(arg), -SIN(arg), KIND=dp)
+                  gfunc = EXP(-g2*rc2/4.0_dp)
+                  g_corr = g_corr + gfunc*cv(idim)*phase
+               END DO
             END DO
+            g_corr = g_corr*w
+            v_hartree_gspace%cc(ig) = v_hartree_gspace%cc(ig) + sfac*g_corr/Vol
          END DO
-         g_corr = g_corr*w
-         g_hartree%cc(ig) = g_hartree%cc(ig) + sfac*g_corr/Vol
-      END DO
+      END ASSOCIATE
       CALL timestop(handle)
    END SUBROUTINE restraint_functional_potential
 
@@ -620,7 +614,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE modify_hartree_pot(v_hartree_gspace, density_fit_section, &
                                  particle_set, M, AmI, radii, charges)
-      TYPE(pw_p_type)                                    :: v_hartree_gspace
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_gspace
       TYPE(section_vals_type), POINTER                   :: density_fit_section
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: M, AmI
@@ -633,46 +627,45 @@ CONTAINS
       REAL(kind=dp)                                      :: arg, fac, fac2, g2, gcut, gcut2, gfunc, &
                                                             gvec(3), rc, rc2, rvec(3), sfac, Vol, w
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: cv, uv
-      TYPE(pw_type), POINTER                             :: g_hartree
 
       CALL timeset(routineN, handle)
-      NULLIFY (g_hartree)
       CALL section_vals_val_get(density_fit_section, "GCUT", r_val=gcut)
       gcut2 = gcut*gcut
-      g_hartree => v_hartree_gspace%pw
-      Vol = g_hartree%pw_grid%vol
-      ALLOCATE (cv(SIZE(M, 1)))
-      ALLOCATE (uv(SIZE(M, 1)))
-      cv = 1.0_dp/Vol
-      uv(:) = MATMUL(M, charges)
-      sfac = -1.0_dp/Vol
-      fac = DOT_PRODUCT(cv, MATMUL(AmI, cv))
-      fac2 = DOT_PRODUCT(cv, MATMUL(AmI, uv))
-      cv(:) = uv - cv*fac2/fac
-      cv(:) = MATMUL(AmI, cv)
-      IF (g_hartree%pw_grid%have_g0) g_hartree%cc(1) = g_hartree%cc(1) + sfac*fac2/fac
-      DO ig = g_hartree%pw_grid%first_gne0, g_hartree%pw_grid%ngpts_cut_local
-         g2 = g_hartree%pw_grid%gsq(ig)
-         w = 4.0_dp*pi*(g2 - gcut2)**2.0_dp/(g2*gcut2)
-         IF (g2 > gcut2) EXIT
-         gvec = g_hartree%pw_grid%g(:, ig)
-         g_corr = 0.0_dp
-         idim = 0
-         DO iparticle = 1, SIZE(particle_set)
-            DO igauss = 1, SIZE(radii)
-               idim = idim + 1
-               rc = radii(igauss)
-               rc2 = rc*rc
-               rvec = particle_set(iparticle)%r
-               arg = DOT_PRODUCT(gvec, rvec)
-               phase = CMPLX(COS(arg), -SIN(arg), KIND=dp)
-               gfunc = EXP(-g2*rc2/4.0_dp)
-               g_corr = g_corr + gfunc*cv(idim)*phase
+      ASSOCIATE (pw_grid => v_hartree_gspace%pw_grid)
+         Vol = pw_grid%vol
+         ALLOCATE (cv(SIZE(M, 1)))
+         ALLOCATE (uv(SIZE(M, 1)))
+         cv = 1.0_dp/Vol
+         uv(:) = MATMUL(M, charges)
+         sfac = -1.0_dp/Vol
+         fac = DOT_PRODUCT(cv, MATMUL(AmI, cv))
+         fac2 = DOT_PRODUCT(cv, MATMUL(AmI, uv))
+         cv(:) = uv - cv*fac2/fac
+         cv(:) = MATMUL(AmI, cv)
+         IF (pw_grid%have_g0) v_hartree_gspace%cc(1) = v_hartree_gspace%cc(1) + sfac*fac2/fac
+         DO ig = pw_grid%first_gne0, pw_grid%ngpts_cut_local
+            g2 = pw_grid%gsq(ig)
+            w = 4.0_dp*pi*(g2 - gcut2)**2.0_dp/(g2*gcut2)
+            IF (g2 > gcut2) EXIT
+            gvec = pw_grid%g(:, ig)
+            g_corr = 0.0_dp
+            idim = 0
+            DO iparticle = 1, SIZE(particle_set)
+               DO igauss = 1, SIZE(radii)
+                  idim = idim + 1
+                  rc = radii(igauss)
+                  rc2 = rc*rc
+                  rvec = particle_set(iparticle)%r
+                  arg = DOT_PRODUCT(gvec, rvec)
+                  phase = CMPLX(COS(arg), -SIN(arg), KIND=dp)
+                  gfunc = EXP(-g2*rc2/4.0_dp)
+                  g_corr = g_corr + gfunc*cv(idim)*phase
+               END DO
             END DO
+            g_corr = g_corr*w
+            v_hartree_gspace%cc(ig) = v_hartree_gspace%cc(ig) + sfac*g_corr/Vol
          END DO
-         g_corr = g_corr*w
-         g_hartree%cc(ig) = g_hartree%cc(ig) + sfac*g_corr/Vol
-      END DO
+      END ASSOCIATE
       CALL timestop(handle)
    END SUBROUTINE modify_hartree_pot
 
@@ -696,7 +689,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: dbv
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:), POINTER               :: radii
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), INTENT(IN)                          :: gcut
       INTEGER, INTENT(in)                                :: iparticle
       REAL(KIND=dp), INTENT(IN)                          :: Vol
@@ -769,7 +762,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: dAm
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:), POINTER               :: radii
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       REAL(KIND=dp), INTENT(IN)                          :: gcut
       INTEGER, INTENT(in)                                :: iparticle
       REAL(KIND=dp), INTENT(IN)                          :: Vol
@@ -851,7 +844,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: density_fit_section
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       REAL(KIND=dp), DIMENSION(:), POINTER               :: radii
-      TYPE(pw_type), POINTER                             :: rho_tot_g
+      TYPE(pw_type), INTENT(IN)                          :: rho_tot_g
       CHARACTER(LEN=*)                                   :: type_of_density
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'debug_charge'

--- a/src/cp_realspace_grid_cube.F
+++ b/src/cp_realspace_grid_cube.F
@@ -90,7 +90,7 @@ CONTAINS
       TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: unit_nr
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: stride
-      TYPE(pw_type), OPTIONAL, POINTER                   :: pw2
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: pw2
 
       IF (.NOT. PRESENT(pw2)) THEN
          CALL pw_to_simple_volumetric(pw, unit_nr, stride)

--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -49,7 +49,7 @@ MODULE dm_ls_scf_qs
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_atomic_block,                 ONLY: calculate_atomic_block_dm
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_density_mixing_types,         ONLY: direct_mixing_nr,&
@@ -655,12 +655,12 @@ CONTAINS
 
       INTEGER                                            :: handle
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks
-      TYPE(dbcsr_type), POINTER                          :: matrix_p_qs
+      TYPE(dbcsr_type), TARGET                           :: matrix_p_qs
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
@@ -677,7 +677,6 @@ CONTAINS
       CALL qs_subsys_get(subsys, particles=particles)
 
       ! convert the density matrix (ls style) to QS style
-      ALLOCATE (matrix_p_qs)
       CALL dbcsr_copy(matrix_p_qs, matrix_ks(1)%matrix)
       CALL dbcsr_set(matrix_p_qs, 0.0_dp) !zero matrix creation
       CALL matrix_ls_to_qs(matrix_p_qs, matrix_p_ls, ls_scf_env%ls_mstruct, covariant=.FALSE.)
@@ -686,32 +685,29 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
-      ALLOCATE (wf_r%pw, wf_g%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=wf_r%pw, &
+                             pw=wf_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_zero(wf_r%pw)
+      CALL pw_zero(wf_r)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=wf_g%pw, &
+                             pw=wf_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_zero(wf_g%pw)
+      CALL pw_zero(wf_g)
       CALL calculate_rho_elec(matrix_p=matrix_p_qs, &
-                              rho=wf_r%pw, &
-                              rho_gspace=wf_g%pw, &
+                              rho=wf_r, &
+                              rho_gspace=wf_g, &
                               ks_env=ks_env)
 
       ! write this to a cube
-      CALL cp_pw_to_cube(wf_r%pw, unit_nr=unit_nr, title=title, &
+      CALL cp_pw_to_cube(wf_r, unit_nr=unit_nr, title=title, &
                          particles=particles, stride=stride)
 
       !free memory
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      DEALLOCATE (wf_r%pw, wf_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
       CALL dbcsr_release(matrix_p_qs)
-      DEALLOCATE (matrix_p_qs)
 
       CALL timestop(handle)
 

--- a/src/ec_env_types.F
+++ b/src/ec_env_types.F
@@ -21,7 +21,8 @@ MODULE ec_env_types
    USE input_section_types,             ONLY: section_vals_type
    USE kinds,                           ONLY: dp
    USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_dispersion_types,             ONLY: qs_dispersion_release,&
                                               qs_dispersion_type
    USE qs_force_types,                  ONLY: deallocate_qs_force,&
@@ -100,7 +101,7 @@ MODULE ec_env_types
       ! Harris (rhoout), and response density (rhoz) on grid
       TYPE(pw_p_type), DIMENSION(:), POINTER           :: rhoout_r, rhoz_r
       ! potentials from input density
-      TYPE(pw_p_type), POINTER                         :: vh_rspace
+      TYPE(pw_type), POINTER                         :: vh_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER           :: vxc_rspace, vtau_rspace, vadmm_rspace
       ! efield
       TYPE(efield_berry_type), POINTER                 :: efield => NULL()
@@ -169,8 +170,7 @@ CONTAINS
          END IF
          ! potential
          IF (ASSOCIATED(ec_env%vh_rspace)) THEN
-            CALL pw_release(ec_env%vh_rspace%pw)
-            DEALLOCATE (ec_env%vh_rspace%pw)
+            CALL pw_release(ec_env%vh_rspace)
             DEALLOCATE (ec_env%vh_rspace)
          END IF
          IF (ASSOCIATED(ec_env%vxc_rspace)) THEN

--- a/src/ec_orth_solver.F
+++ b/src/ec_orth_solver.F
@@ -58,7 +58,8 @@ MODULE ec_orth_solver
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type, pw_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_integrate_potential,          ONLY: integrate_v_rspace
@@ -1138,13 +1139,13 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_G, matrix_s, rho1_ao, rho_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: rho_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho1_g, rho1_r, rho_r, tau1_r, v_xc, &
                                                             v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_tot_gspace, v_hartree_gspace, &
+                                                            v_hartree_rspace
       TYPE(qs_kpp1_env_type), POINTER                    :: kpp1_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_aux
       TYPE(section_vals_type), POINTER                   :: input, xc_section, xc_section_aux

--- a/src/ec_orth_solver.F
+++ b/src/ec_orth_solver.F
@@ -58,7 +58,7 @@ MODULE ec_orth_solver
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type, pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_integrate_potential,          ONLY: integrate_v_rspace
@@ -1138,7 +1138,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_G, matrix_s, rho1_ao, rho_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_tot_gspace, v_hartree_gspace, &
+      TYPE(pw_type)                                    :: rho_tot_gspace, v_hartree_gspace, &
                                                             v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho1_g, rho1_r, rho_r, tau1_r, v_xc, &
                                                             v_xc_tau
@@ -1183,17 +1183,16 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the NSC Hartree potential
-      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=v_hartree_gspace%pw, &
+                             pw=v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rho_tot_gspace%pw, &
+                             pw=rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=v_hartree_rspace%pw, &
+                             pw=v_hartree_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -1239,20 +1238,20 @@ CONTAINS
       END IF
 
       ! take trial density to build G^{H}[B]
-      CALL pw_zero(rho_tot_gspace%pw)
+      CALL pw_zero(rho_tot_gspace)
       DO ispin = 1, nspins
-         CALL pw_axpy(rho1_g(ispin)%pw, rho_tot_gspace%pw)
+         CALL pw_axpy(rho1_g(ispin)%pw, rho_tot_gspace)
       END DO
 
       ! get Hartree potential from rho_tot_gspace
-      CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, &
-                            vhartree=v_hartree_gspace%pw)
-      CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+      CALL pw_poisson_solve(poisson_env, rho_tot_gspace, &
+                            vhartree=v_hartree_gspace)
+      CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
+      CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
 
       ! Add v_xc + v_H
       DO ispin = 1, nspins
-         CALL pw_axpy(v_hartree_rspace%pw, v_xc(ispin)%pw)
+         CALL pw_axpy(v_hartree_rspace, v_xc(ispin)%pw)
       END DO
       IF (nspins == 1) THEN
          CALL pw_scale(v_xc(1)%pw, 2.0_dp)
@@ -1324,10 +1323,9 @@ CONTAINS
       CALL commutator(matrix_G, matrix_p, matrix_Ax, eps_filter, .FALSE., 1.0_dp, 1.0_dp)
 
       ! release pw grids
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
-      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, rho_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin)%pw)
          DEALLOCATE (v_xc(ispin)%pw)

--- a/src/efield_utils.F
+++ b/src/efield_utils.F
@@ -26,7 +26,8 @@ MODULE efield_utils
    USE mathconstants,                   ONLY: pi
    USE message_passing,                 ONLY: mp_sum
    USE particle_types,                  ONLY: particle_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_p_type,&
+                                              pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -60,7 +61,7 @@ CONTAINS
    SUBROUTINE efield_potential(qs_env, v_efield_rspace)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type)                                    :: v_efield_rspace
+      TYPE(pw_type)                                      :: v_efield_rspace
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'efield_potential'
 
@@ -85,13 +86,13 @@ CONTAINS
 
       CALL qs_rho_get(rho, rho_r=rho_r)
 
-      v_efield_rspace%pw%cr3d = 0.0_dp
+      v_efield_rspace%cr3d = 0.0_dp
 
-      bo_local = v_efield_rspace%pw%pw_grid%bounds_local
-      bo_global = v_efield_rspace%pw%pw_grid%bounds
+      bo_local = v_efield_rspace%pw_grid%bounds_local
+      bo_global = v_efield_rspace%pw_grid%bounds
 
-      dvol = v_efield_rspace%pw%pw_grid%dvol
-      dr = v_efield_rspace%pw%pw_grid%dr
+      dvol = v_efield_rspace%pw_grid%dvol
+      dr = v_efield_rspace%pw_grid%dr
 
       CALL make_field(dft_control, field, qs_env%sim_step, qs_env%sim_time)
 
@@ -101,13 +102,13 @@ CONTAINS
                grid_p(1) = (i - bo_global(1, 1))*dr(1)
                grid_p(2) = (j - bo_global(1, 2))*dr(2)
                grid_p(3) = (k - bo_global(1, 3))*dr(3)
-               v_efield_rspace%pw%cr3d(i, j, k) = v_efield_rspace%pw%cr3d(i, j, k) + DOT_PRODUCT(field(:), grid_p(:))
+               v_efield_rspace%cr3d(i, j, k) = v_efield_rspace%cr3d(i, j, k) + DOT_PRODUCT(field(:), grid_p(:))
             END DO
          END DO
       END DO
       efield_ener = 0.0_dp
       DO i = 1, dft_control%nspins
-         efield_ener = efield_ener + accurate_dot_product(v_efield_rspace%pw%cr3d, rho_r(i)%pw%cr3d)*dvol
+         efield_ener = efield_ener + accurate_dot_product(v_efield_rspace%cr3d, rho_r(i)%pw%cr3d)*dvol
       END DO
       CALL mp_sum(efield_ener, para_env%group)
       energy%efield = efield_ener

--- a/src/embed_types.F
+++ b/src/embed_types.F
@@ -70,17 +70,19 @@ MODULE embed_types
 ! **************************************************************************************************
 
    TYPE opt_embed_pot_type
-      TYPE(cp_fm_type), POINTER                 :: embed_pot_coef, embed_pot_grad, &
-                                                   prev_step, step, embed_pot_hess, &
-                                                   prev_embed_pot_coef, prev_embed_pot_grad, &
-                                                   prev_embed_pot_hess, kinetic_mat
+      TYPE(cp_fm_type), POINTER                 :: embed_pot_coef => NULL(), embed_pot_grad => NULL(), &
+                                                   prev_step => NULL(), step => NULL(), embed_pot_hess => NULL(), &
+                                                   prev_embed_pot_coef => NULL(), prev_embed_pot_grad => NULL(), &
+                                                   prev_embed_pot_hess => NULL(), kinetic_mat => NULL()
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)  :: w_func, max_diff, int_diff, int_diff_square, &
                                                    max_grid_step, max_subsys_dens_diff
       INTEGER                                   :: n_iter, i_iter, dimen_aux, last_accepted, dimen_var_aux
       REAL(KIND=dp)                             :: lambda, allowed_decrease, max_trad, min_trad, &
                                                    grad_norm, vw_cutoff, vw_smooth_cutoff_range, eta
-      TYPE(pw_type), POINTER                  :: const_pot, prev_embed_pot, prev_spin_embed_pot, pot_diff
-      TYPE(pw_p_type), DIMENSION(:), POINTER    :: prev_grid_grad, prev_grid_pot, prev_subsys_dens, v_w
+      TYPE(pw_type), POINTER                  :: const_pot => NULL(), prev_embed_pot => NULL(), &
+                                                 prev_spin_embed_pot => NULL(), pot_diff => NULL()
+      TYPE(pw_p_type), DIMENSION(:), POINTER    :: prev_grid_grad => NULL(), prev_grid_pot => NULL(), &
+                                                   prev_subsys_dens => NULL(), v_w => NULL()
       REAL(KIND=dp)                             :: reg_term, trust_rad, conv_max, conv_int, &
                                                    conv_max_spin, conv_int_spin, step_len
       LOGICAL                                   :: accept_step, newton_step, level_shift, steep_desc, &
@@ -89,7 +91,7 @@ MODULE embed_types
                                                    grid_opt, leeuwen, fab, coulomb_guess, fermi_amaldi, &
                                                    diff_guess
       INTEGER, ALLOCATABLE, DIMENSION(:)        :: all_nspins
-      TYPE(lri_kind_type), DIMENSION(:), POINTER :: lri ! Needed to store integrals
+      TYPE(lri_kind_type), DIMENSION(:), POINTER :: lri => NULL() ! Needed to store integrals
 
    END TYPE opt_embed_pot_type
 

--- a/src/embed_types.F
+++ b/src/embed_types.F
@@ -44,7 +44,8 @@ MODULE embed_types
                                               particle_list_release,&
                                               particle_list_type
    USE particle_types,                  ONLY: particle_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_p_type,&
+                                              pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -78,7 +79,7 @@ MODULE embed_types
       INTEGER                                   :: n_iter, i_iter, dimen_aux, last_accepted, dimen_var_aux
       REAL(KIND=dp)                             :: lambda, allowed_decrease, max_trad, min_trad, &
                                                    grad_norm, vw_cutoff, vw_smooth_cutoff_range, eta
-      TYPE(pw_p_type), POINTER                  :: const_pot, prev_embed_pot, prev_spin_embed_pot, pot_diff
+      TYPE(pw_type), POINTER                  :: const_pot, prev_embed_pot, prev_spin_embed_pot, pot_diff
       TYPE(pw_p_type), DIMENSION(:), POINTER    :: prev_grid_grad, prev_grid_pot, prev_subsys_dens, v_w
       REAL(KIND=dp)                             :: reg_term, trust_rad, conv_max, conv_int, &
                                                    conv_max_spin, conv_int_spin, step_len

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -333,9 +333,8 @@ CONTAINS
       IF (ec_env%should_update) THEN
          CALL ec_build_neighborlist(qs_env, ec_env)
          IF (.NOT. ASSOCIATED(ec_env%vh_rspace)) ALLOCATE (ec_env%vh_rspace)
-         IF (.NOT. ASSOCIATED(ec_env%vh_rspace%pw)) ALLOCATE (ec_env%vh_rspace%pw)
          CALL ks_ref_potential(qs_env, &
-                               ec_env%vh_rspace%pw, &
+                               ec_env%vh_rspace, &
                                ec_env%vxc_rspace, &
                                ec_env%vtau_rspace, &
                                ec_env%vadmm_rspace, &
@@ -427,7 +426,7 @@ CONTAINS
          END DO
 
          CALL response_force(qs_env, &
-                             vh_rspace=ec_env%vh_rspace%pw, &
+                             vh_rspace=ec_env%vh_rspace, &
                              vxc_rspace=ec_env%vxc_rspace, &
                              vtau_rspace=ec_env%vtau_rspace, &
                              vadmm_rspace=ec_env%vadmm_rspace, &
@@ -782,7 +781,7 @@ CONTAINS
          ! v_xc[n_in]_GS
          CALL pw_transfer(ec_env%vxc_rspace(ispin)%pw, v_rspace_in(ispin)%pw)
          ! add v_H[n_in]
-         CALL pw_axpy(ec_env%vh_rspace%pw, v_rspace_in(ispin)%pw)
+         CALL pw_axpy(ec_env%vh_rspace, v_rspace_in(ispin)%pw)
       END DO
 
       ! initialize src matrix
@@ -1317,7 +1316,7 @@ CONTAINS
       DO ispin = 1, nspins
          ! Add v_hartree + v_xc = v_rspace
          CALL pw_scale(v_rspace(ispin)%pw, v_rspace(ispin)%pw%pw_grid%dvol)
-         CALL pw_axpy(ec_env%vh_rspace%pw, v_rspace(ispin)%pw)
+         CALL pw_axpy(ec_env%vh_rspace, v_rspace(ispin)%pw)
          ! integrate over potential <a|V|b>
          CALL integrate_v_rspace(v_rspace=v_rspace(ispin)%pw, &
                                  hmat=ec_env%matrix_ks(ispin, 1), &
@@ -1683,7 +1682,7 @@ CONTAINS
       CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
-      CALL pw_transfer(ec_env%vh_rspace%pw, v_hartree_rspace)
+      CALL pw_transfer(ec_env%vh_rspace, v_hartree_rspace)
 
       ! calculate output density on grid
       ! rho_in(R):   CALL qs_rho_get(rho, rho_r=rho_r)

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -73,7 +73,7 @@ MODULE et_coupling_proj
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type, pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -1592,7 +1592,7 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
+      TYPE(pw_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -1629,26 +1629,25 @@ CONTAINS
       ! Grids for wavefunction
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! Calculate the grid values
       CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
                       cell=cell, dft_control=dft_control, particle_set=particle_set)
-      CALL calculate_wavefunction(mo%mo_coeff, im, wf_r%pw, wf_g%pw, atomic_kind_set, &
+      CALL calculate_wavefunction(mo%mo_coeff, im, wf_r, wf_g, atomic_kind_set, &
                                   qs_kind_set, cell, dft_control, particle_set, pw_env)
-      CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
+      CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, &
                          stride=section_get_ivals(input, 'MO_CUBES%STRIDE'))
 
       ! Close file
       CALL cp_print_key_finished_output(unit_nr, logger, input, 'MO_CUBES')
 
       ! Clean memory
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      DEALLOCATE (wf_r%pw, wf_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
 
    END SUBROUTINE save_mo_cube
 

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -73,7 +73,7 @@ MODULE et_coupling_proj
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type, pw_type
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -1592,9 +1592,9 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_subsys_type), POINTER                      :: subsys
 

--- a/src/ewalds.F
+++ b/src/ewalds.F
@@ -126,7 +126,7 @@ CONTAINS
       CALL ewald_env_get(ewald_env, alpha=alpha, group=group)
       CALL ewald_pw_get(ewald_pw, pw_big_pool=pw_pool, dg=dg)
       CALL dg_get(dg, dg_rho0=dg_rho0)
-      rho0 => dg_rho0%density%pw%cr3d
+      rho0 => dg_rho0%density%cr3d
       pw_grid => pw_pool%pw_grid
       bds => pw_grid%bounds
 

--- a/src/ewalds_multipole.F
+++ b/src/ewalds_multipole.F
@@ -689,7 +689,7 @@ CONTAINS
       CALL ewald_env_get(ewald_env, alpha=alpha, group=group)
       CALL ewald_pw_get(ewald_pw, pw_big_pool=pw_pool, dg=dg)
       CALL dg_get(dg, dg_rho0=dg_rho0)
-      rho0 => dg_rho0%density%pw%cr3d
+      rho0 => dg_rho0%density%cr3d
       pw_grid => pw_pool%pw_grid
       bds => pw_grid%bounds
 

--- a/src/excited_states.F
+++ b/src/excited_states.F
@@ -118,7 +118,7 @@ CONTAINS
                CALL response_force_xtb(qs_env, p_env, ex_env%matrix_hz, ex_env)
             ELSE
                ! KS-DFT
-               CALL response_force(qs_env=qs_env, vh_rspace=ex_env%vh_rspace%pw, &
+               CALL response_force(qs_env=qs_env, vh_rspace=ex_env%vh_rspace, &
                                    vxc_rspace=ex_env%vxc_rspace, vtau_rspace=ex_env%vtau_rspace, &
                                    vadmm_rspace=ex_env%vadmm_rspace, matrix_hz=ex_env%matrix_hz, &
                                    matrix_pz=ex_env%matrix_px1, matrix_pz_admm=p_env%p1_admm, &

--- a/src/exstates_types.F
+++ b/src/exstates_types.F
@@ -20,7 +20,8 @@ MODULE exstates_types
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
    USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -51,7 +52,7 @@ MODULE exstates_types
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_px1_asymm => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_px1_admm_asymm => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_wx1 => NULL()
-      TYPE(pw_p_type), POINTER                           :: vh_rspace => NULL()
+      TYPE(pw_type), POINTER                           :: vh_rspace => NULL()
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vxc_rspace => NULL()
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vtau_rspace => NULL()
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: vadmm_rspace => NULL()
@@ -106,8 +107,7 @@ CONTAINS
          NULLIFY (ex_env%matrix_wx1)
          !
          IF (ASSOCIATED(ex_env%vh_rspace)) THEN
-            CALL pw_release(ex_env%vh_rspace%pw)
-            DEALLOCATE (ex_env%vh_rspace%pw)
+            CALL pw_release(ex_env%vh_rspace)
             DEALLOCATE (ex_env%vh_rspace)
          END IF
          IF (ASSOCIATED(ex_env%vxc_rspace)) THEN

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -1801,11 +1801,11 @@ CONTAINS
                ! only in spin_embed_subsys
                CALL make_subsys_embed_pot(force_env%sub_force_env(i_force_eval)%force_env%qs_env, &
                                           embed_pot, embed_pot_subsys, spin_embed_pot, spin_embed_pot_subsys, &
-                                          .TRUE.)
+                                          opt_embed%open_shell_embed, .TRUE.)
             ELSE ! Regular case
                CALL make_subsys_embed_pot(force_env%sub_force_env(i_force_eval)%force_env%qs_env, &
                                           embed_pot, embed_pot_subsys, spin_embed_pot, spin_embed_pot_subsys, &
-                                          .FALSE.)
+                                          opt_embed%open_shell_embed, .FALSE.)
             END IF
 
             ! Subtract Coulomb potential difference if needed
@@ -1878,9 +1878,9 @@ CONTAINS
          ! Print embedding potential for restart
          CALL print_embed_restart(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
                                   opt_embed%dimen_aux, opt_embed%embed_pot_coef, embed_pot, i_iter, &
-                                  spin_embed_pot, opt_embed%grid_opt, .FALSE.)
+                                  spin_embed_pot, opt_embed%open_shell_embed, opt_embed%grid_opt, .FALSE.)
          CALL print_pot_simple_grid(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
-                                    embed_pot, spin_embed_pot, i_iter, .FALSE., &
+                                    embed_pot, spin_embed_pot, i_iter, opt_embed%open_shell_embed, .FALSE., &
                                     force_env%sub_force_env(cluster_subsys_num)%force_env%qs_env)
 
          ! Integrate the potential over density differences and add to w functional; also add regularization contribution
@@ -1927,9 +1927,9 @@ CONTAINS
       ! Print final embedding potential for restart
       CALL print_embed_restart(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
                                opt_embed%dimen_aux, opt_embed%embed_pot_coef, embed_pot, i_iter, &
-                               spin_embed_pot, opt_embed%grid_opt, .TRUE.)
+                               spin_embed_pot, opt_embed%open_shell_embed, opt_embed%grid_opt, .TRUE.)
       CALL print_pot_simple_grid(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
-                                 embed_pot, spin_embed_pot, i_iter, .TRUE., &
+                                 embed_pot, spin_embed_pot, i_iter, opt_embed%open_shell_embed, .TRUE., &
                                  force_env%sub_force_env(cluster_subsys_num)%force_env%qs_env)
 
       ! Print final density difference
@@ -1956,7 +1956,7 @@ CONTAINS
          ! The embedded subsystem corresponds to subsystem #2, where spin change is possible
          CALL make_subsys_embed_pot(force_env%sub_force_env(ref_subsys_number + 1)%force_env%qs_env, &
                                     embed_pot, embed_pot_subsys, spin_embed_pot, spin_embed_pot_subsys, &
-                                    opt_embed%change_spin)
+                                    opt_embed%open_shell_embed, opt_embed%change_spin)
 
          IF (opt_embed%Coulomb_guess) THEN
             embed_pot_subsys%cr3d(:, :, :) = embed_pot_subsys%cr3d(:, :, :) - opt_embed%pot_diff%cr3d(:, :, :)

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -143,7 +143,8 @@ MODULE force_env_methods
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE pwdft_environment,               ONLY: pwdft_calc_energy_force
    USE pwdft_environment_types,         ONLY: pwdft_env_retain,&
                                               pwdft_environment_type
@@ -1414,8 +1415,8 @@ CONTAINS
       TYPE(particle_list_p_type), DIMENSION(:), POINTER  :: particles
       TYPE(particle_list_type), POINTER                  :: particles_embed
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: embed_pot, spin_embed_pot
       TYPE(section_vals_type), POINTER                   :: embed_section, force_env_section, &
                                                             mapping_section, root_section
 
@@ -1509,25 +1510,15 @@ CONTAINS
                CALL get_qs_env(qs_env=force_env%sub_force_env(iforce_eval)%force_env%qs_env, &
                                embed_pot=embed_pot, spin_embed_pot=spin_embed_pot, pw_env=pw_env)
                CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, embed_pot%pw)
-               DEALLOCATE (embed_pot%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, embed_pot)
                IF (ASSOCIATED(embed_pot)) THEN
-               IF (ASSOCIATED(embed_pot%pw)) THEN
-                  CALL pw_release(embed_pot%pw)
-                  DEALLOCATE (embed_pot%pw)
-               END IF
-               DEALLOCATE (embed_pot)
+                  CALL pw_release(embed_pot)
+                  DEALLOCATE (embed_pot)
                END IF
                IF (ASSOCIATED(spin_embed_pot)) THEN
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, spin_embed_pot%pw)
-                  DEALLOCATE (spin_embed_pot%pw)
-                  IF (ASSOCIATED(spin_embed_pot)) THEN
-                  IF (ASSOCIATED(spin_embed_pot%pw)) THEN
-                     CALL pw_release(spin_embed_pot%pw)
-                     DEALLOCATE (spin_embed_pot%pw)
-                  END IF
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, spin_embed_pot)
+                  CALL pw_release(spin_embed_pot)
                   DEALLOCATE (spin_embed_pot)
-                  END IF
                END IF
             END IF
          END IF
@@ -1636,10 +1627,10 @@ CONTAINS
       TYPE(opt_embed_pot_type)                           :: opt_embed
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r_ref, rho_r_subsys
-      TYPE(pw_p_type), POINTER                           :: diff_rho_r, diff_rho_spin, embed_pot, &
-                                                            embed_pot_subsys, spin_embed_pot, &
-                                                            spin_embed_pot_subsys
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: diff_rho_r, diff_rho_spin
+      TYPE(pw_type), POINTER                             :: embed_pot, embed_pot_subsys, &
+                                                            spin_embed_pot, spin_embed_pot_subsys
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_rho_type), POINTER                         :: rho, subsys_rho
       TYPE(section_vals_type), POINTER                   :: dft_section, embed_section, &
@@ -1694,31 +1685,25 @@ CONTAINS
 
       ! Prepare the pw object to store density differences
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      NULLIFY (diff_rho_r)
-      ALLOCATE (diff_rho_r)
-      ALLOCATE (diff_rho_r%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_zero(diff_rho_r%pw)
+      CALL pw_zero(diff_rho_r)
       IF (opt_embed%open_shell_embed) THEN
-         NULLIFY (diff_rho_spin)
-         ALLOCATE (diff_rho_spin)
-         ALLOCATE (diff_rho_spin%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_spin%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_spin, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(diff_rho_spin%pw)
+         CALL pw_zero(diff_rho_spin)
       END IF
 
       ! Check the preliminary density differences
       DO i_spin = 1, nspins
-         diff_rho_r%pw%cr3d(:, :, :) = diff_rho_r%pw%cr3d(:, :, :) - rho_r_ref(i_spin)%pw%cr3d(:, :, :)
+         diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) - rho_r_ref(i_spin)%pw%cr3d(:, :, :)
       END DO
       IF (opt_embed%open_shell_embed) THEN ! Spin part
          IF (nspins .EQ. 2) THEN ! Reference systems has an open shell, else the reference diff_rho_spin is zero
-            diff_rho_spin%pw%cr3d(:, :, :) = diff_rho_spin%pw%cr3d(:, :, :) - rho_r_ref(1)%pw%cr3d(:, :, :) &
-                                             + rho_r_ref(2)%pw%cr3d(:, :, :)
+            diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - rho_r_ref(1)%pw%cr3d(:, :, :) &
+                                          + rho_r_ref(2)%pw%cr3d(:, :, :)
          END IF
       END IF
 
@@ -1730,18 +1715,18 @@ CONTAINS
          ! Add subsystem densities
          CALL qs_rho_get(rho_struct=subsys_rho, rho_r=rho_r_subsys)
          DO i_spin = 1, nspins_subsys
-            diff_rho_r%pw%cr3d(:, :, :) = diff_rho_r%pw%cr3d(:, :, :) + rho_r_subsys(i_spin)%pw%cr3d(:, :, :)
+            diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) + rho_r_subsys(i_spin)%pw%cr3d(:, :, :)
          END DO
          IF (opt_embed%open_shell_embed) THEN ! Spin part
             IF (nspins_subsys .EQ. 2) THEN ! The subsystem makes contribution if it is spin-polarized
                ! We may need to change spin ONLY FOR THE SECOND SUBSYSTEM: that's the internal convention
                IF ((i_force_eval .EQ. 2) .AND. (opt_embed%change_spin)) THEN
-                  diff_rho_spin%pw%cr3d(:, :, :) = diff_rho_spin%pw%cr3d(:, :, :) - &
-                                                   rho_r_subsys(1)%pw%cr3d(:, :, :) + rho_r_subsys(2)%pw%cr3d(:, :, :)
+                  diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - &
+                                                rho_r_subsys(1)%pw%cr3d(:, :, :) + rho_r_subsys(2)%pw%cr3d(:, :, :)
                ELSE
                   ! First subsystem (always) and second subsystem (without spin change)
-                  diff_rho_spin%pw%cr3d(:, :, :) = diff_rho_spin%pw%cr3d(:, :, :) + &
-                                                   rho_r_subsys(1)%pw%cr3d(:, :, :) - rho_r_subsys(2)%pw%cr3d(:, :, :)
+                  diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) + &
+                                                rho_r_subsys(1)%pw%cr3d(:, :, :) - rho_r_subsys(2)%pw%cr3d(:, :, :)
                END IF
             END IF
          END IF
@@ -1774,17 +1759,17 @@ CONTAINS
                                   force_env%sub_force_env(i_force_eval)%force_env%qs_env, nforce_eval, i_force_eval, opt_embed%eta)
             END IF
          END DO
-         embed_pot%pw%cr3d(:, :, :) = embed_pot%pw%cr3d(:, :, :) + opt_embed%pot_diff%pw%cr3d(:, :, :)
-         IF (.NOT. opt_embed%grid_opt) CALL pw_copy(embed_pot%pw, opt_embed%const_pot%pw)
+         embed_pot%cr3d(:, :, :) = embed_pot%cr3d(:, :, :) + opt_embed%pot_diff%cr3d(:, :, :)
+         IF (.NOT. opt_embed%grid_opt) CALL pw_copy(embed_pot, opt_embed%const_pot)
 
       END IF
 
       ! Difference guess
       IF (opt_embed%diff_guess) THEN
-         embed_pot%pw%cr3d(:, :, :) = diff_rho_r%pw%cr3d(:, :, :)
-         IF (.NOT. opt_embed%grid_opt) CALL pw_copy(embed_pot%pw, opt_embed%const_pot%pw)
+         embed_pot%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :)
+         IF (.NOT. opt_embed%grid_opt) CALL pw_copy(embed_pot, opt_embed%const_pot)
          ! Open shell
-         IF (opt_embed%open_shell_embed) spin_embed_pot%pw%cr3d(:, :, :) = diff_rho_spin%pw%cr3d(:, :, :)
+         IF (opt_embed%open_shell_embed) spin_embed_pot%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :)
       END IF
 
       ! Calculate subsystems with trial embedding potential
@@ -1792,17 +1777,17 @@ CONTAINS
          opt_embed%i_iter = i_iter
 
          ! Set the density difference as the negative reference one
-         CALL pw_zero(diff_rho_r%pw)
+         CALL pw_zero(diff_rho_r)
          CALL get_qs_env(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, dft_control=dft_control)
          nspins = dft_control%nspins
          DO i_spin = 1, nspins
-            diff_rho_r%pw%cr3d(:, :, :) = diff_rho_r%pw%cr3d(:, :, :) - rho_r_ref(i_spin)%pw%cr3d(:, :, :)
+            diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) - rho_r_ref(i_spin)%pw%cr3d(:, :, :)
          END DO
          IF (opt_embed%open_shell_embed) THEN ! Spin part
-            CALL pw_zero(diff_rho_spin%pw)
+            CALL pw_zero(diff_rho_spin)
             IF (nspins .EQ. 2) THEN ! Reference systems has an open shell, else the reference diff_rho_spin is zero
-               diff_rho_spin%pw%cr3d(:, :, :) = diff_rho_spin%pw%cr3d(:, :, :) - rho_r_ref(1)%pw%cr3d(:, :, :) &
-                                                + rho_r_ref(2)%pw%cr3d(:, :, :)
+               diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - rho_r_ref(1)%pw%cr3d(:, :, :) &
+                                             + rho_r_ref(2)%pw%cr3d(:, :, :)
             END IF
          END IF
 
@@ -1816,16 +1801,16 @@ CONTAINS
                ! only in spin_embed_subsys
                CALL make_subsys_embed_pot(force_env%sub_force_env(i_force_eval)%force_env%qs_env, &
                                           embed_pot, embed_pot_subsys, spin_embed_pot, spin_embed_pot_subsys, &
-                                          opt_embed%open_shell_embed, .TRUE.)
+                                          .TRUE.)
             ELSE ! Regular case
                CALL make_subsys_embed_pot(force_env%sub_force_env(i_force_eval)%force_env%qs_env, &
                                           embed_pot, embed_pot_subsys, spin_embed_pot, spin_embed_pot_subsys, &
-                                          opt_embed%open_shell_embed, .FALSE.)
+                                          .FALSE.)
             END IF
 
             ! Subtract Coulomb potential difference if needed
             !  IF ((i_force_eval .EQ. 2) .AND. (opt_embed%Coulomb_guess)) THEN
-            !     embed_pot_subsys%pw%cr3d(:, :, :) = embed_pot_subsys%pw%cr3d(:, :, :)-opt_embed%pot_diff%pw%cr3d(:, :, :)
+            !     embed_pot_subsys%cr3d(:, :, :) = embed_pot_subsys%cr3d(:, :, :)-opt_embed%pot_diff%cr3d(:, :, :)
             !  ENDIF
 
             ! Switch on external potential in the subsystems
@@ -1864,29 +1849,27 @@ CONTAINS
             ! Add subsystem densities
             CALL qs_rho_get(rho_struct=subsys_rho, rho_r=rho_r_subsys)
             DO i_spin = 1, nspins_subsys
-               diff_rho_r%pw%cr3d(:, :, :) = diff_rho_r%pw%cr3d(:, :, :) + rho_r_subsys(i_spin)%pw%cr3d(:, :, :)
+               diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) + rho_r_subsys(i_spin)%pw%cr3d(:, :, :)
             END DO
             IF (opt_embed%open_shell_embed) THEN ! Spin part
                IF (nspins_subsys .EQ. 2) THEN ! The subsystem makes contribution if it is spin-polarized
                   ! We may need to change spin ONLY FOR THE SECOND SUBSYSTEM: that's the internal convention
                   IF ((i_force_eval .EQ. 2) .AND. (opt_embed%change_spin)) THEN
-                     diff_rho_spin%pw%cr3d(:, :, :) = diff_rho_spin%pw%cr3d(:, :, :) - &
-                                                      rho_r_subsys(1)%pw%cr3d(:, :, :) + rho_r_subsys(2)%pw%cr3d(:, :, :)
+                     diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - &
+                                                   rho_r_subsys(1)%pw%cr3d(:, :, :) + rho_r_subsys(2)%pw%cr3d(:, :, :)
                   ELSE
                      ! First subsystem (always) and second subsystem (without spin change)
-                     diff_rho_spin%pw%cr3d(:, :, :) = diff_rho_spin%pw%cr3d(:, :, :) + &
-                                                      rho_r_subsys(1)%pw%cr3d(:, :, :) - rho_r_subsys(2)%pw%cr3d(:, :, :)
+                     diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) + &
+                                                   rho_r_subsys(1)%pw%cr3d(:, :, :) - rho_r_subsys(2)%pw%cr3d(:, :, :)
                   END IF
                END IF
             END IF
 
             ! Release embedding potential for subsystem
-            CALL pw_release(embed_pot_subsys%pw)
-            DEALLOCATE (embed_pot_subsys%pw)
+            CALL pw_release(embed_pot_subsys)
             DEALLOCATE (embed_pot_subsys)
             IF (opt_embed%open_shell_embed) THEN
-               CALL pw_release(spin_embed_pot_subsys%pw)
-               DEALLOCATE (spin_embed_pot_subsys%pw)
+               CALL pw_release(spin_embed_pot_subsys)
                DEALLOCATE (spin_embed_pot_subsys)
             END IF
 
@@ -1895,22 +1878,22 @@ CONTAINS
          ! Print embedding potential for restart
          CALL print_embed_restart(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
                                   opt_embed%dimen_aux, opt_embed%embed_pot_coef, embed_pot, i_iter, &
-                                  spin_embed_pot, opt_embed%open_shell_embed, opt_embed%grid_opt, .FALSE.)
+                                  spin_embed_pot, opt_embed%grid_opt, .FALSE.)
          CALL print_pot_simple_grid(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
-                                    embed_pot, spin_embed_pot, i_iter, opt_embed%open_shell_embed, .FALSE., &
+                                    embed_pot, spin_embed_pot, i_iter, .FALSE., &
                                     force_env%sub_force_env(cluster_subsys_num)%force_env%qs_env)
 
          ! Integrate the potential over density differences and add to w functional; also add regularization contribution
          DO i_spin = 1, nspins ! Sum over nspins for the reference system, not subsystem!
-            opt_embed%w_func(i_iter) = opt_embed%w_func(i_iter) - pw_integral_ab(embed_pot%pw, rho_r_ref(i_spin)%pw)
+            opt_embed%w_func(i_iter) = opt_embed%w_func(i_iter) - pw_integral_ab(embed_pot, rho_r_ref(i_spin)%pw)
          END DO
          ! Spin part
          IF (opt_embed%open_shell_embed) THEN
             ! If reference system is not spin-polarized then it does not make a contribution to W functional
             IF (nspins .EQ. 2) THEN
                opt_embed%w_func(i_iter) = opt_embed%w_func(i_iter) &
-                                          - pw_integral_ab(spin_embed_pot%pw, rho_r_ref(1)%pw) &
-                                          + pw_integral_ab(spin_embed_pot%pw, rho_r_ref(2)%pw)
+                                          - pw_integral_ab(spin_embed_pot, rho_r_ref(1)%pw) &
+                                          + pw_integral_ab(spin_embed_pot, rho_r_ref(2)%pw)
             END IF
          END IF
          ! Finally, add the regularization term
@@ -1944,9 +1927,9 @@ CONTAINS
       ! Print final embedding potential for restart
       CALL print_embed_restart(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
                                opt_embed%dimen_aux, opt_embed%embed_pot_coef, embed_pot, i_iter, &
-                               spin_embed_pot, opt_embed%open_shell_embed, opt_embed%grid_opt, .TRUE.)
+                               spin_embed_pot, opt_embed%grid_opt, .TRUE.)
       CALL print_pot_simple_grid(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, &
-                                 embed_pot, spin_embed_pot, i_iter, opt_embed%open_shell_embed, .TRUE., &
+                                 embed_pot, spin_embed_pot, i_iter, .TRUE., &
                                  force_env%sub_force_env(cluster_subsys_num)%force_env%qs_env)
 
       ! Print final density difference
@@ -1956,13 +1939,9 @@ CONTAINS
       END IF
 
       ! Give away plane waves pools
-      CALL pw_release(diff_rho_r%pw)
-      DEALLOCATE (diff_rho_r%pw)
-      DEALLOCATE (diff_rho_r)
+      CALL pw_release(diff_rho_r)
       IF (opt_embed%open_shell_embed) THEN
-         CALL pw_release(diff_rho_spin%pw)
-         DEALLOCATE (diff_rho_spin%pw)
-         DEALLOCATE (diff_rho_spin)
+         CALL pw_release(diff_rho_spin)
       END IF
 
       CALL cp_print_key_finished_output(output_unit, logger, force_env%force_env_section, &
@@ -1977,10 +1956,10 @@ CONTAINS
          ! The embedded subsystem corresponds to subsystem #2, where spin change is possible
          CALL make_subsys_embed_pot(force_env%sub_force_env(ref_subsys_number + 1)%force_env%qs_env, &
                                     embed_pot, embed_pot_subsys, spin_embed_pot, spin_embed_pot_subsys, &
-                                    opt_embed%open_shell_embed, opt_embed%change_spin)
+                                    opt_embed%change_spin)
 
          IF (opt_embed%Coulomb_guess) THEN
-            embed_pot_subsys%pw%cr3d(:, :, :) = embed_pot_subsys%pw%cr3d(:, :, :) - opt_embed%pot_diff%pw%cr3d(:, :, :)
+            embed_pot_subsys%cr3d(:, :, :) = embed_pot_subsys%cr3d(:, :, :) - opt_embed%pot_diff%cr3d(:, :, :)
          END IF
 
          CALL set_qs_env(force_env%sub_force_env(ref_subsys_number + 1)%force_env%qs_env, embed_pot=embed_pot_subsys)
@@ -2000,12 +1979,10 @@ CONTAINS
       CALL release_opt_embed(opt_embed)
 
       ! Deallocate embedding potential
-      CALL pw_release(embed_pot%pw)
-      DEALLOCATE (embed_pot%pw)
+      CALL pw_release(embed_pot)
       DEALLOCATE (embed_pot)
       IF (opt_embed%open_shell_embed) THEN
-         CALL pw_release(spin_embed_pot%pw)
-         DEALLOCATE (spin_embed_pot%pw)
+         CALL pw_release(spin_embed_pot)
          DEALLOCATE (spin_embed_pot)
       END IF
 

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -51,7 +51,6 @@ MODULE hfx_pw_methods
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_create,&
-                                              pw_p_type,&
                                               pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
@@ -112,9 +111,8 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_grid_type), POINTER                        :: grid
-      TYPE(pw_p_type)                                    :: pot_g, rho_g, rho_r
-      TYPE(pw_p_type), ALLOCATABLE, DIMENSION(:)         :: rho_i, rho_j
-      TYPE(pw_type), POINTER                             :: greenfn
+      TYPE(pw_type)                                      :: greenfn, pot_g, rho_g, rho_r
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: rho_i, rho_j
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(section_vals_type), POINTER                   :: ip_section
 
@@ -136,22 +134,19 @@ CONTAINS
          CALL cp_fm_get_info(mo_coeff, ncol_global=norb)
          blocksize = MAX(1, MIN(blocksize, norb))
 
-         ALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, pot_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
 
          ALLOCATE (rho_i(blocksize))
          ALLOCATE (rho_j(blocksize))
 
-         NULLIFY (greenfn)
-         ALLOCATE (greenfn)
          CALL pw_pool_create_pw(auxbas_pw_pool, greenfn, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
@@ -190,12 +185,10 @@ CONTAINS
          END IF
 
          DO iorb_block = 1, blocksize
-            ALLOCATE (rho_i(iorb_block)%pw)
-            CALL pw_create(rho_i(iorb_block)%pw, rho_r%pw%pw_grid, &
+            CALL pw_create(rho_i(iorb_block), rho_r%pw_grid, &
                            use_data=REALDATA3D, &
                            in_space=REALSPACE)
-            ALLOCATE (rho_j(iorb_block)%pw)
-            CALL pw_create(rho_j(iorb_block)%pw, rho_r%pw%pw_grid, &
+            CALL pw_create(rho_j(iorb_block), rho_r%pw_grid, &
                            use_data=REALDATA3D, &
                            in_space=REALSPACE)
          END DO
@@ -216,7 +209,7 @@ CONTAINS
                DO iorb = iorb_block, MIN(iorb_block + blocksize - 1, norb)
 
                   iloc = iorb - iorb_block + 1
-                  CALL calculate_wavefunction(mo_coeff, iorb, rho_i(iloc)%pw, rho_g%pw, &
+                  CALL calculate_wavefunction(mo_coeff, iorb, rho_i(iloc), rho_g, &
                                               atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                               pw_env)
 
@@ -227,7 +220,7 @@ CONTAINS
                   DO jorb = jorb_block, MIN(jorb_block + blocksize - 1, norb)
 
                      jloc = jorb - jorb_block + 1
-                     CALL calculate_wavefunction(mo_coeff, jorb, rho_j(jloc)%pw, rho_g%pw, &
+                     CALL calculate_wavefunction(mo_coeff, jorb, rho_j(jloc), rho_g, &
                                                  atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                                  pw_env)
 
@@ -240,11 +233,11 @@ CONTAINS
                         IF (jorb < iorb) CYCLE
 
                         ! compute the pair density
-                        rho_r%pw%cr3d = rho_i(iloc)%pw%cr3d*rho_j(jloc)%pw%cr3d
+                        rho_r%cr3d = rho_i(iloc)%cr3d*rho_j(jloc)%cr3d
 
                         ! go the g-space and compute hartree energy
-                        CALL pw_transfer(rho_r%pw, rho_g%pw)
-                        CALL pw_poisson_solve(poisson_env, rho_g%pw, pair_energy, pot_g%pw, &
+                        CALL pw_transfer(rho_r, rho_g)
+                        CALL pw_poisson_solve(poisson_env, rho_g, pair_energy, pot_g, &
                                               greenfn=greenfn)
 
                         ! sum up to the full energy
@@ -262,16 +255,14 @@ CONTAINS
          END DO
 
          DO iorb_block = 1, blocksize
-            CALL pw_release(rho_i(iorb_block)%pw)
-            CALL pw_release(rho_j(iorb_block)%pw)
-            DEALLOCATE (rho_i(iorb_block)%pw, rho_j(iorb_block)%pw)
+            CALL pw_release(rho_i(iorb_block))
+            CALL pw_release(rho_j(iorb_block))
          END DO
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, greenfn)
-         DEALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw, greenfn)
 
          iw = cp_print_key_unit_nr(logger, hfx_section, "HF_INFO", &
                                    extension=".scfLog")

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -286,8 +286,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: tnfun
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
-      TYPE(pw_p_type), POINTER                           :: rhonorm
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rhonorm
       TYPE(qs_rho_type), POINTER                         :: rho
 
       NULLIFY (rho_r)
@@ -297,17 +297,14 @@ CONTAINS
       tnfun = pw_integrate_function(hirshfeld_env%fnorm)
       tnfun = ABS(tnfun - SUM(hirshfeld_env%charges))
       !
-      ALLOCATE (rhonorm)
-      !
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      ALLOCATE (rhonorm%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm%pw, use_data=REALDATA3D)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D)
       ! loop over spins
       DO is = 1, SIZE(rho_r)
          IF (rho_r_valid) THEN
-            CALL hfun_scale(rhonorm%pw%cr3d, rho_r(is)%pw%cr3d, &
+            CALL hfun_scale(rhonorm%cr3d, rho_r(is)%pw%cr3d, &
                             hirshfeld_env%fnorm%cr3d)
          ELSE
             CPABORT("We need rho in real space")
@@ -315,10 +312,7 @@ CONTAINS
          CALL hirshfeld_integration(qs_env, hirshfeld_env, rhonorm, charges(:, is))
          charges(:, is) = charges(:, is)*hirshfeld_env%charges(:)
       END DO
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm%pw)
-      DEALLOCATE (rhonorm%pw)
-      !
-      DEALLOCATE (rhonorm)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm)
 
    END SUBROUTINE comp_hirshfeld_charges
 ! **************************************************************************************************
@@ -381,8 +375,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: res, tnfun
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
-      TYPE(pw_p_type), POINTER                           :: rhonorm
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rhonorm
       TYPE(qs_rho_type), POINTER                         :: rho
 
       NULLIFY (rho_r)
@@ -391,13 +385,10 @@ CONTAINS
 
       IF (ounit > 0) WRITE (ounit, "(/,T2,A)") "Hirshfeld charge iterations: Residuals ..."
       !
-      ALLOCATE (rhonorm)
-      !
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      ALLOCATE (rhonorm%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm%pw, use_data=REALDATA3D)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D)
       !
       DO iloop = 1, maxloop
 
@@ -409,7 +400,7 @@ CONTAINS
          ! loop over spins
          DO is = 1, SIZE(rho_r)
             IF (rho_r_valid) THEN
-               CALL hfun_scale(rhonorm%pw%cr3d, rho_r(is)%pw%cr3d, &
+               CALL hfun_scale(rhonorm%cr3d, rho_r(is)%pw%cr3d, &
                                hirshfeld_env%fnorm%cr3d)
             ELSE
                CPABORT("We need rho in real space")
@@ -436,10 +427,7 @@ CONTAINS
 
       END DO
       !
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm%pw)
-      DEALLOCATE (rhonorm%pw)
-      !
-      DEALLOCATE (rhonorm)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm)
 
    END SUBROUTINE comp_hirshfeld_i_charges
 
@@ -565,7 +553,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(hirshfeld_type), POINTER                      :: hirshfeld_env
-      TYPE(pw_p_type), POINTER                           :: rfun
+      TYPE(pw_type)                                      :: rfun
       REAL(KIND=dp), DIMENSION(:), INTENT(inout)         :: fval
       REAL(KIND=dp), DIMENSION(:, :), INTENT(inout), &
          OPTIONAL                                        :: fderiv
@@ -594,14 +582,14 @@ CONTAINS
 
       do_force = PRESENT(fderiv)
       fval = 0.0_dp
-      dvol = rfun%pw%pw_grid%dvol
+      dvol = rfun%pw_grid%dvol
 
       NULLIFY (pw_env, auxbas_rs_desc)
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env=pw_env, auxbas_rs_desc=auxbas_rs_desc, &
                       auxbas_rs_grid=rs_v)
       CALL rs_grid_retain(rs_v)
-      CALL rs_pw_transfer(rs_v, rfun%pw, pw2rs)
+      CALL rs_pw_transfer(rs_v, rfun, pw2rs)
 
       CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, cell=cell, &
                       dft_control=dft_control, particle_set=particle_set)

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -52,7 +52,8 @@ MODULE hirshfeld_methods
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_kind_types,                   ONLY: get_qs_kind,&
@@ -293,7 +294,7 @@ CONTAINS
       ! normalization function on grid
       CALL calculate_hirshfeld_normalization(qs_env, hirshfeld_env)
       ! check normalization
-      tnfun = pw_integrate_function(hirshfeld_env%fnorm%pw)
+      tnfun = pw_integrate_function(hirshfeld_env%fnorm)
       tnfun = ABS(tnfun - SUM(hirshfeld_env%charges))
       !
       ALLOCATE (rhonorm)
@@ -307,7 +308,7 @@ CONTAINS
       DO is = 1, SIZE(rho_r)
          IF (rho_r_valid) THEN
             CALL hfun_scale(rhonorm%pw%cr3d, rho_r(is)%pw%cr3d, &
-                            hirshfeld_env%fnorm%pw%cr3d)
+                            hirshfeld_env%fnorm%cr3d)
          ELSE
             CPABORT("We need rho in real space")
          END IF
@@ -403,13 +404,13 @@ CONTAINS
          ! normalization function on grid
          CALL calculate_hirshfeld_normalization(qs_env, hirshfeld_env)
          ! check normalization
-         tnfun = pw_integrate_function(hirshfeld_env%fnorm%pw)
+         tnfun = pw_integrate_function(hirshfeld_env%fnorm)
          tnfun = ABS(tnfun - SUM(hirshfeld_env%charges))
          ! loop over spins
          DO is = 1, SIZE(rho_r)
             IF (rho_r_valid) THEN
                CALL hfun_scale(rhonorm%pw%cr3d, rho_r(is)%pw%cr3d, &
-                               hirshfeld_env%fnorm%pw%cr3d)
+                               hirshfeld_env%fnorm%cr3d)
             ELSE
                CPABORT("We need rho in real space")
             END IF
@@ -466,8 +467,8 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: fnorm
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: fnorm
       TYPE(realspace_grid_desc_type), POINTER            :: auxbas_rs_desc
       TYPE(realspace_grid_type), POINTER                 :: rs_rho
 
@@ -537,17 +538,15 @@ CONTAINS
       NULLIFY (fnorm)
       CALL get_hirshfeld_info(hirshfeld_env, fnorm=fnorm)
       IF (ASSOCIATED(fnorm)) THEN
-         CALL pw_release(fnorm%pw)
-         DEALLOCATE (fnorm%pw)
+         CALL pw_release(fnorm)
          DEALLOCATE (fnorm)
       END IF
       ALLOCATE (fnorm)
-      ALLOCATE (fnorm%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, fnorm%pw, use_data=REALDATA3D)
-      fnorm%pw%in_space = REALSPACE
+      CALL pw_pool_create_pw(auxbas_pw_pool, fnorm, use_data=REALDATA3D)
+      fnorm%in_space = REALSPACE
       CALL set_hirshfeld_info(hirshfeld_env, fnorm=fnorm)
 
-      CALL rs_pw_transfer(rs_rho, fnorm%pw, rs2pw)
+      CALL rs_pw_transfer(rs_rho, fnorm, rs2pw)
       CALL rs_grid_release(rs_rho)
 
       CALL timestop(handle)

--- a/src/hirshfeld_types.F
+++ b/src/hirshfeld_types.F
@@ -17,8 +17,8 @@ MODULE hirshfeld_types
    USE input_constants,                 ONLY: radius_default,&
                                               shape_function_gaussian
    USE kinds,                           ONLY: dp
-   USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release
+   USE pw_types,                        ONLY: pw_release,&
+                                              pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -44,7 +44,7 @@ MODULE hirshfeld_types
          POINTER                    :: kind_shape_fn
       REAL(KIND=dp), DIMENSION(:), &
          POINTER                    :: charges
-      TYPE(pw_p_type), POINTER      :: fnorm
+      TYPE(pw_type), POINTER      :: fnorm
    END TYPE hirshfeld_type
 
    TYPE shape_fn
@@ -112,8 +112,7 @@ CONTAINS
          END IF
 
          IF (ASSOCIATED(hirshfeld_env%fnorm)) THEN
-            CALL pw_release(hirshfeld_env%fnorm%pw)
-            DEALLOCATE (hirshfeld_env%fnorm%pw)
+            CALL pw_release(hirshfeld_env%fnorm)
             DEALLOCATE (hirshfeld_env%fnorm)
          END IF
 
@@ -140,7 +139,7 @@ CONTAINS
       INTEGER, INTENT(OUT), OPTIONAL                     :: shape_function_type
       LOGICAL, INTENT(OUT), OPTIONAL                     :: iterative
       INTEGER, INTENT(OUT), OPTIONAL                     :: ref_charge
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: fnorm
+      TYPE(pw_type), OPTIONAL, POINTER                   :: fnorm
       INTEGER, INTENT(OUT), OPTIONAL                     :: radius_type
       LOGICAL, INTENT(OUT), OPTIONAL                     :: use_bohr
 
@@ -184,7 +183,7 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: shape_function_type
       LOGICAL, INTENT(IN), OPTIONAL                      :: iterative
       INTEGER, INTENT(IN), OPTIONAL                      :: ref_charge
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: fnorm
+      TYPE(pw_type), OPTIONAL, POINTER                   :: fnorm
       INTEGER, INTENT(IN), OPTIONAL                      :: radius_type
       LOGICAL, INTENT(IN), OPTIONAL                      :: use_bohr
 

--- a/src/localization_tb.F
+++ b/src/localization_tb.F
@@ -39,7 +39,7 @@ MODULE localization_tb
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type, pw_type
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
@@ -100,9 +100,9 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_loc_env_new_type), POINTER                 :: qs_loc_env_homo
       TYPE(qs_subsys_type), POINTER                      :: subsys

--- a/src/localization_tb.F
+++ b/src/localization_tb.F
@@ -39,7 +39,7 @@ MODULE localization_tb
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type, pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
@@ -100,7 +100,7 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
+      TYPE(pw_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -182,11 +182,10 @@ CONTAINS
 
             CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-            ALLOCATE (wf_r%pw, wf_g%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
 
@@ -214,9 +213,8 @@ CONTAINS
             IF (qs_loc_env_homo%do_localize) THEN
                CALL loc_dipole(qs_env%input, dft_control, qs_loc_env_homo, logger, qs_env)
             END IF
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-            DEALLOCATE (wf_g%pw, wf_r%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
             CALL qs_loc_env_destroy(qs_loc_env_homo)
             IF (ASSOCIATED(marked_states)) THEN
                DEALLOCATE (marked_states)

--- a/src/minbas_wfn_analysis.F
+++ b/src/minbas_wfn_analysis.F
@@ -72,7 +72,7 @@ MODULE minbas_wfn_analysis
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -501,8 +501,8 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: minbas_section
@@ -527,9 +527,8 @@ CONTAINS
       END DO
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      ALLOCATE (wf_r%pw, wf_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! loop over list of atoms
       CALL section_vals_val_get(minbas_section, "ATOM_LIST", n_rep_val=n_rep)
@@ -542,9 +541,9 @@ CONTAINS
                iw = cp_print_key_unit_nr(logger, print_section, "MINBAS_CUBE", extension=".cube", &
                                          middle_name=TRIM(filename), file_position="REWIND", log_filename=.FALSE., &
                                          mpi_io=mpi_io)
-               CALL calculate_wavefunction(minbas_coeff, ivec, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
+               CALL calculate_wavefunction(minbas_coeff, ivec, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
                                            cell, dft_control, particle_set, pw_env)
-               CALL cp_pw_to_cube(wf_r%pw, iw, title, particles=particles, stride=stride, mpi_io=mpi_io)
+               CALL cp_pw_to_cube(wf_r, iw, title, particles=particles, stride=stride, mpi_io=mpi_io)
                CALL cp_print_key_finished_output(iw, logger, print_section, "MINBAS_CUBE", mpi_io=mpi_io)
             END DO
          END DO
@@ -560,18 +559,17 @@ CONTAINS
                   iw = cp_print_key_unit_nr(logger, print_section, "MINBAS_CUBE", extension=".cube", &
                                             middle_name=TRIM(filename), file_position="REWIND", log_filename=.FALSE., &
                                             mpi_io=mpi_io)
-                  CALL calculate_wavefunction(minbas_coeff, ivec, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
+                  CALL calculate_wavefunction(minbas_coeff, ivec, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
                                               cell, dft_control, particle_set, pw_env)
-                  CALL cp_pw_to_cube(wf_r%pw, iw, title, particles=particles, stride=stride, mpi_io=mpi_io)
+                  CALL cp_pw_to_cube(wf_r, iw, title, particles=particles, stride=stride, mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(iw, logger, print_section, "MINBAS_CUBE", mpi_io=mpi_io)
                END DO
             END DO
          END DO
       END IF
       DEALLOCATE (blk_sizes, first_bas)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      DEALLOCATE (wf_r%pw, wf_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
 
    END SUBROUTINE post_minbas_cubes
 

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -661,15 +661,15 @@ CONTAINS
       END IF
       ! In principle, we could reduce the memory footprint of becke_pot by only transferring the nonzero portion
       ! of the potential, but this would require a custom integrate_v_rspace
-      ALLOCATE (cdft_control_target%group(1)%weight%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control_target%group(1)%weight%pw, &
+      ALLOCATE (cdft_control_target%group(1)%weight)
+      CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control_target%group(1)%weight, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      cdft_control_target%group(1)%weight%pw%cr3d = 0.0_dp
+      cdft_control_target%group(1)%weight%cr3d = 0.0_dp
       ! Assemble the recved slices
       DO j = 1, SIZE(mixed_cdft%source_list)
-         cdft_control_target%group(1)%weight%pw%cr3d(recvbuffer(j)%imap(1):recvbuffer(j)%imap(2), &
-                                                     recvbuffer(j)%imap(3):recvbuffer(j)%imap(4), &
-                                                     recvbuffer(j)%imap(5):recvbuffer(j)%imap(6)) = recvbuffer(j)%r3
+         cdft_control_target%group(1)%weight%cr3d(recvbuffer(j)%imap(1):recvbuffer(j)%imap(2), &
+                                                  recvbuffer(j)%imap(3):recvbuffer(j)%imap(4), &
+                                                  recvbuffer(j)%imap(5):recvbuffer(j)%imap(6)) = recvbuffer(j)%r3
       END DO
       ! Do the same for slices sent during dlb
       IF (mixed_cdft%dlb) THEN
@@ -683,9 +683,9 @@ CONTAINS
                                UBOUND(mixed_cdft%dlb_control%recvbuff(j)%buffs(i)%weight, 2), &
                                LBOUND(mixed_cdft%dlb_control%recvbuff(j)%buffs(i)%weight, 3), &
                                UBOUND(mixed_cdft%dlb_control%recvbuff(j)%buffs(i)%weight, 3)/)
-                     cdft_control_target%group(1)%weight%pw%cr3d(INDEX(1):INDEX(2), &
-                                                                 INDEX(3):INDEX(4), &
-                                                                 INDEX(5):INDEX(6)) = &
+                     cdft_control_target%group(1)%weight%cr3d(INDEX(1):INDEX(2), &
+                                                              INDEX(3):INDEX(4), &
+                                                              INDEX(5):INDEX(6)) = &
                         mixed_cdft%dlb_control%recvbuff(j)%buffs(i)%weight
                      DEALLOCATE (mixed_cdft%dlb_control%recvbuff(j)%buffs(i)%weight)
                   END DO
@@ -849,8 +849,8 @@ CONTAINS
          cdft_control_target%becke_control%confine_bounds(2) = ub_max
          cdft_control_target%becke_control%confine_bounds(1) = lb_min
       END IF
-      CALL pw_scale(cdft_control_target%group(1)%weight%pw, &
-                    cdft_control_target%group(1)%weight%pw%pw_grid%dvol)
+      CALL pw_scale(cdft_control_target%group(1)%weight, &
+                    cdft_control_target%group(1)%weight%pw_grid%dvol)
       ! Set flags for ET coupling calculation
       IF (mixed_env%do_mixed_et) THEN
          IF (MODULO(mixed_cdft%sim_step, mixed_env%et_freq) == 0) THEN
@@ -957,14 +957,14 @@ CONTAINS
          IF (mixed_cdft%identical_constraints) THEN
             ! Weight function
             DO igroup = 1, SIZE(cdft_control_target%group)
-               ALLOCATE (cdft_control_target%group(igroup)%weight%pw)
+               ALLOCATE (cdft_control_target%group(igroup)%weight)
                CALL pw_pool_create_pw(auxbas_pw_pool_target, &
-                                      cdft_control_target%group(igroup)%weight%pw, &
+                                      cdft_control_target%group(igroup)%weight, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                ! We have ensured that the grids are consistent => no danger in using explicit copy
-               cdft_control_target%group(igroup)%weight%pw%cr3d = cdft_control_source%group(igroup)%weight%pw%cr3d
-               CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%group(igroup)%weight%pw)
-               DEALLOCATE (cdft_control_source%group(igroup)%weight%pw)
+               cdft_control_target%group(igroup)%weight%cr3d = cdft_control_source%group(igroup)%weight%cr3d
+               CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%group(igroup)%weight)
+               DEALLOCATE (cdft_control_source%group(igroup)%weight)
             END DO
             ! Cavity
             IF (cdft_control_source%type == outer_scf_becke_constraint) THEN

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -573,7 +573,7 @@ CONTAINS
          ALLOCATE (cdft_control%group(1))
          ALLOCATE (cdft_control%group(1)%atoms(settings%ncdft))
          ALLOCATE (cdft_control%group(1)%coeff(settings%ncdft))
-         NULLIFY (cdft_control%group(1)%weight%pw)
+         NULLIFY (cdft_control%group(1)%weight)
          NULLIFY (cdft_control%group(1)%gradients)
          NULLIFY (cdft_control%group(1)%integrated)
          cdft_control%group(1)%atoms = cdft_control%atoms

--- a/src/molecular_states.F
+++ b/src/molecular_states.F
@@ -49,7 +49,7 @@ MODULE molecular_states
    USE particle_list_types,             ONLY: particle_list_type
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_type
-   USE pw_types,                        ONLY: pw_p_type, pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -98,8 +98,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(dbcsr_type), POINTER                          :: Hks, matrix_S
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_type), INTENT(INOUT)                     :: wf_r
-      TYPE(pw_type), INTENT(IN)                     :: wf_g
+      TYPE(pw_type), INTENT(INOUT)                       :: wf_r
+      TYPE(pw_type), INTENT(IN)                          :: wf_g
       TYPE(section_vals_type), POINTER                   :: loc_print_section
       TYPE(particle_list_type), POINTER                  :: particles
       CHARACTER(LEN=*), INTENT(IN)                       :: tag

--- a/src/molecular_states.F
+++ b/src/molecular_states.F
@@ -49,7 +49,7 @@ MODULE molecular_states
    USE particle_list_types,             ONLY: particle_list_type
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_p_type, pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -98,7 +98,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(dbcsr_type), POINTER                          :: Hks, matrix_S
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), INTENT(INOUT)                     :: wf_r, wf_g
+      TYPE(pw_type), INTENT(INOUT)                     :: wf_r
+      TYPE(pw_type), INTENT(IN)                     :: wf_g
       TYPE(section_vals_type), POINTER                   :: loc_print_section
       TYPE(particle_list_type), POINTER                  :: particles
       CHARACTER(LEN=*), INTENT(IN)                       :: tag
@@ -322,8 +323,8 @@ CONTAINS
             DO i = 1, ns
                IF (evals(i) < eval_range(1) .OR. evals(i) > eval_range(2)) CYCLE
 
-               CALL calculate_wavefunction(rot_e_vectors, i, wf_r%pw, &
-                                           wf_g%pw, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
+               CALL calculate_wavefunction(rot_e_vectors, i, wf_r, &
+                                           wf_g, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                            pw_env)
 
                WRITE (filename, '(a9,I4.4,a1,I5.5,a4)') "MOLECULE_", imol, "_", i, tag
@@ -333,7 +334,7 @@ CONTAINS
                unit_nr = cp_print_key_unit_nr(logger, loc_print_section, "MOLECULAR_STATES%CUBES", &
                                               extension=".cube", middle_name=TRIM(filename), log_filename=.FALSE., &
                                               mpi_io=mpi_io)
-               CALL cp_pw_to_cube(wf_r%pw, unit_nr, particles=particles, title=title, &
+               CALL cp_pw_to_cube(wf_r, unit_nr, particles=particles, title=title, &
                                   stride=section_get_ivals(loc_print_section, &
                                                            "MOLECULAR_STATES%CUBES%STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, loc_print_section, &

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -117,7 +117,7 @@ CONTAINS
                                        potential_parameter, mat_munu, qs_env, task_list_sub)
 
       TYPE(cp_fm_type), INTENT(IN), POINTER              :: mo_coeff
-      TYPE(pw_p_type), INTENT(INOUT)                     :: psi_L, rho_g
+      TYPE(pw_type), INTENT(INOUT)                       :: psi_L, rho_g
       TYPE(atomic_kind_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: atomic_kind_set
       TYPE(qs_kind_type), DIMENSION(:), INTENT(IN), &
@@ -129,7 +129,7 @@ CONTAINS
       TYPE(pw_env_type), INTENT(IN), POINTER             :: pw_env_sub
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: external_vector
       TYPE(pw_poisson_type), INTENT(IN), POINTER         :: poisson_env
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_r, pot_g
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_r, pot_g
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_munu
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
@@ -142,7 +142,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       ! pseudo psi_L
-      CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+      CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
                                   qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
                                   basis_type="RI_AUX", &
                                   external_vector=external_vector)
@@ -151,7 +151,7 @@ CONTAINS
 
       ! and finally (K|mu nu)
       CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-      CALL integrate_v_rspace(rho_r%pw, hmat=mat_munu, qs_env=qs_env, &
+      CALL integrate_v_rspace(rho_r, hmat=mat_munu, qs_env=qs_env, &
                               calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE., &
                               pw_env_external=pw_env_sub, task_list_external=task_list_sub)
 
@@ -203,9 +203,9 @@ CONTAINS
       TYPE(gto_basis_set_type), POINTER                  :: basis_set_a
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
-      TYPE(pw_p_type)                                    :: pot_g, psi_L, rho_g, rho_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_g, psi_L, rho_g, rho_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_desc_p_type), DIMENSION(:), &
          POINTER                                         :: rs_descs
@@ -226,7 +226,7 @@ CONTAINS
          i_counter = i_counter + 1
 
          ! pseudo psi_L
-         CALL collocate_single_gaussian(psi_L%pw, rho_g%pw, atomic_kind_set, &
+         CALL collocate_single_gaussian(psi_L, rho_g, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
                                         required_function=LLL, basis_type="RI_AUX")
 
@@ -240,7 +240,7 @@ CONTAINS
          DO i = 1, SIZE(rs_v)
             CALL rs_grid_retain(rs_v(i)%rs_grid)
          END DO
-         CALL potential_pw2rs(rs_v, rho_r%pw, pw_env_sub)
+         CALL potential_pw2rs(rs_v, rho_r, pw_env_sub)
 
          CALL timestop(handle2)
 
@@ -393,10 +393,10 @@ CONTAINS
                                             kind_of, atom_of_kind, G_PQ_local, force, h_stress, para_env_sub, &
                                             dft_control, psi_L, factor)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_r
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_r
       INTEGER, INTENT(IN)                                :: LLL
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_g
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_g
       TYPE(atomic_kind_type), DIMENSION(:), INTENT(IN), &
          POINTER                                         :: atomic_kind_set
       TYPE(qs_kind_type), DIMENSION(:), INTENT(IN), &
@@ -406,10 +406,11 @@ CONTAINS
       TYPE(cell_type), INTENT(IN), POINTER               :: cell
       TYPE(pw_env_type), INTENT(IN), POINTER             :: pw_env_sub
       TYPE(pw_poisson_type), INTENT(IN), POINTER         :: poisson_env
-      TYPE(pw_p_type), INTENT(INOUT)                     :: pot_g
+      TYPE(pw_type), INTENT(INOUT)                       :: pot_g
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       LOGICAL, INTENT(IN)                                :: use_virial
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_g_copy, dvg(3)
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_g_copy
+      TYPE(pw_p_type), INTENT(IN)                        :: dvg(3)
       INTEGER, DIMENSION(:), INTENT(IN)                  :: kind_of, atom_of_kind
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: G_PQ_local
       TYPE(qs_force_type), DIMENSION(:), INTENT(IN), &
@@ -417,7 +418,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT)      :: h_stress
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
       TYPE(dft_control_type), INTENT(IN), POINTER        :: dft_control
-      TYPE(pw_p_type), INTENT(INOUT)                     :: psi_L
+      TYPE(pw_type), INTENT(INOUT)                       :: psi_L
       REAL(KIND=dp), INTENT(IN)                          :: factor
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'integrate_potential_forces_2c'
@@ -429,9 +430,9 @@ CONTAINS
       ! calculate potential associated to the single aux function
       CALL timeset(routineN//"_wf_pot", handle2)
       ! pseudo psi_L
-      CALL pw_zero(rho_r%pw)
-      CALL pw_zero(rho_g%pw)
-      CALL collocate_single_gaussian(rho_r%pw, rho_g%pw, atomic_kind_set, &
+      CALL pw_zero(rho_r)
+      CALL pw_zero(rho_g)
+      CALL collocate_single_gaussian(rho_r, rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, &
                                      pw_env_sub, required_function=LLL, basis_type='RI_AUX')
       IF (use_virial) THEN
@@ -443,15 +444,15 @@ CONTAINS
 
       IF (use_virial) THEN
          ! make a copy of the density in G space
-         CALL pw_copy(rho_g%pw, rho_g_copy%pw)
+         CALL pw_copy(rho_g, rho_g_copy)
 
          ! add the volume contribution to the virial due to
          ! the (P|Q) integrals, first we put the full gamme_PQ
          ! pseudo wave-function into grid in order to calculate the
          ! hartree potential derivatives
-         CALL pw_zero(psi_L%pw)
-         CALL pw_zero(rho_g%pw)
-         CALL calculate_wavefunction(matrix, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+         CALL pw_zero(psi_L)
+         CALL pw_zero(rho_g)
+         CALL calculate_wavefunction(matrix, 1, psi_L, rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env_sub, &
                                      basis_type="RI_AUX", &
                                      external_vector=0.5_dp*factor*G_PQ_local)
@@ -483,7 +484,7 @@ CONTAINS
                                                task_list_sub)
 
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_munu
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_r
+      TYPE(pw_type), INTENT(IN)                          :: rho_r
       TYPE(dbcsr_p_type), INTENT(IN)                     :: matrix_P_munu
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(pw_env_type), INTENT(IN), POINTER             :: pw_env_sub
@@ -498,7 +499,7 @@ CONTAINS
       ! integrate the potential of the single gaussian and update
       ! 3-center forces
       CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-      CALL integrate_v_rspace(rho_r%pw, hmat=mat_munu, pmat=matrix_P_munu, &
+      CALL integrate_v_rspace(rho_r, hmat=mat_munu, pmat=matrix_P_munu, &
                               qs_env=qs_env, calculate_forces=.TRUE., compute_tau=.FALSE., gapw=.FALSE., &
                               pw_env_external=pw_env_sub, &
                               task_list_external=task_list_sub)
@@ -538,15 +539,16 @@ CONTAINS
                                                qs_kind_set, particle_set, cell, LLL, force, dft_control)
 
       TYPE(dbcsr_p_type), INTENT(IN)                     :: matrix_P_munu
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_r, rho_g
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_r, rho_g
       TYPE(task_list_type), INTENT(IN), POINTER          :: task_list_sub
       TYPE(pw_env_type), INTENT(IN), POINTER             :: pw_env_sub
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       TYPE(qs_ks_env_type), INTENT(IN), POINTER          :: ks_env
       TYPE(pw_poisson_type), INTENT(IN), POINTER         :: poisson_env
-      TYPE(pw_p_type), INTENT(INOUT)                     :: pot_g
+      TYPE(pw_type), INTENT(INOUT)                       :: pot_g
       LOGICAL, INTENT(IN)                                :: use_virial
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_g_copy, dvg(3)
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_g_copy
+      TYPE(pw_p_type), INTENT(IN)                        :: dvg(3)
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT)      :: h_stress
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
       INTEGER, DIMENSION(:), INTENT(IN)                  :: kind_of, atom_of_kind
@@ -583,11 +585,11 @@ CONTAINS
 
       ! put the gamma density on grid
       CALL timeset(routineN//"_Gpot", handle2)
-      CALL pw_zero(rho_r%pw)
-      CALL pw_zero(rho_g%pw)
+      CALL pw_zero(rho_r)
+      CALL pw_zero(rho_g)
       CALL calculate_rho_elec(matrix_p=matrix_P_munu%matrix, &
-                              rho=rho_r%pw, &
-                              rho_gspace=rho_g%pw, &
+                              rho=rho_r, &
+                              rho_gspace=rho_g, &
                               task_list_external=task_list_sub, &
                               pw_env_external=pw_env_sub, &
                               ks_env=ks_env)
@@ -605,7 +607,7 @@ CONTAINS
       DO i = 1, SIZE(rs_v)
          CALL rs_grid_retain(rs_v(i)%rs_grid)
       END DO
-      CALL potential_pw2rs(rs_v, rho_r%pw, pw_env_sub)
+      CALL potential_pw2rs(rs_v, rho_r, pw_env_sub)
 
       offset = 0
       DO iatom = 1, SIZE(kind_of)
@@ -736,7 +738,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE virial_gpw_potential(rho_g_copy, pot_g, rho_g, dvg, h_stress, potential_parameter, para_env_sub)
 
-      TYPE(pw_p_type)                                    :: rho_g_copy, pot_g, rho_g, dvg(3)
+      TYPE(pw_type), INTENT(IN)                          :: rho_g_copy, pot_g
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_g
+      TYPE(pw_p_type), INTENT(IN)                        :: dvg(3)
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(INOUT)      :: h_stress
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
@@ -750,18 +754,18 @@ CONTAINS
       ! add the volume contribution
       CALL timeset(routineN, handle)
       e_hartree = 0.0_dp
-      e_hartree = pw_integral_ab(rho_g_copy%pw, pot_g%pw)
+      e_hartree = pw_integral_ab(rho_g_copy, pot_g)
 
       DO alpha = 1, 3
          comp = 0
          comp(alpha) = 1
-         CALL pw_copy(pot_g%pw, rho_g%pw)
-         CALL pw_derive(rho_g%pw, comp)
-         CALL factor_virial_gpw(rho_g%pw, potential_parameter)
+         CALL pw_copy(pot_g, rho_g)
+         CALL pw_derive(rho_g, comp)
+         CALL factor_virial_gpw(rho_g, potential_parameter)
          h_stress(alpha, alpha) = h_stress(alpha, alpha) - e_hartree/REAL(para_env_sub%num_pe, dp)
          DO beta = alpha, 3
             h_stress(alpha, beta) = h_stress(alpha, beta) &
-                                    - 2.0_dp*pw_integral_ab(rho_g%pw, dvg(beta)%pw)/fourpi/REAL(para_env_sub%num_pe, dp)
+                                    - 2.0_dp*pw_integral_ab(rho_g, dvg(beta)%pw)/fourpi/REAL(para_env_sub%num_pe, dp)
             h_stress(beta, alpha) = h_stress(alpha, beta)
          END DO
       END DO
@@ -776,7 +780,7 @@ CONTAINS
 !> \param potential_parameter parameters of potential V(g)
 ! **************************************************************************************************
    SUBROUTINE factor_virial_gpw(pw, potential_parameter)
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
 
       INTEGER                                            :: i
@@ -860,7 +864,7 @@ CONTAINS
                                   G_PQ_local, cell, force, use_virial, h_stress, para_env_sub, dft_control)
 
       TYPE(pw_env_type), INTENT(IN), POINTER             :: pw_env_sub
-      TYPE(pw_p_type), INTENT(IN)                        :: pot_r
+      TYPE(pw_type), INTENT(IN)                          :: pot_r
       INTEGER, DIMENSION(:), INTENT(IN)                  :: kind_of, atom_of_kind
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -899,7 +903,7 @@ CONTAINS
       DO i = 1, SIZE(rs_v)
          CALL rs_grid_retain(rs_v(i)%rs_grid)
       END DO
-      CALL potential_pw2rs(rs_v, pot_r%pw, pw_env_sub)
+      CALL potential_pw2rs(rs_v, pot_r, pw_env_sub)
 
       offset = 0
       DO iatom = 1, SIZE(kind_of)
@@ -1036,7 +1040,7 @@ CONTAINS
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: auxbas_pw_pool
       TYPE(pw_poisson_type), INTENT(IN), POINTER         :: poisson_env
       TYPE(task_list_type), POINTER                      :: task_list_sub
-      TYPE(pw_p_type), INTENT(OUT)                       :: rho_r, rho_g, pot_g, psi_L
+      TYPE(pw_type), INTENT(OUT)                         :: rho_r, rho_g, pot_g, psi_L
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          INTENT(IN), POINTER                             :: sab_orb_sub
 
@@ -1087,23 +1091,22 @@ CONTAINS
                                  pw_env_external=pw_env_sub, sab_orb_external=sab_orb_sub)
 
       ! get some of the grids ready
-      ALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw, psi_L%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, psi_L%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, psi_L, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       ! run the FFT once, to set up buffers and to take into account the memory
-      rho_r%pw%cr3d = 0.0D0
-      CALL pw_transfer(rho_r%pw, rho_g%pw)
+      rho_r%cr3d = 0.0D0
+      CALL pw_transfer(rho_r, rho_g)
 
       CALL timestop(handle)
 
@@ -1134,7 +1137,7 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
       TYPE(task_list_type), POINTER                      :: task_list_sub
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: auxbas_pw_pool
-      TYPE(pw_p_type), INTENT(INOUT)                     :: rho_r, rho_g, pot_g, psi_L
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_r, rho_g, pot_g, psi_L
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cleanup_gpw'
 
@@ -1144,11 +1147,10 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       ! and now free the whole lot
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L%pw)
-      DEALLOCATE (rho_r%pw, rho_g%pw, pot_g%pw, psi_L%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L)
 
       CALL deallocate_task_list(task_list_sub)
       CALL pw_env_release(pw_env_sub, para_env=para_env_sub)
@@ -1175,9 +1177,10 @@ CONTAINS
 !> \param no_transfer whether NOT to transform potential from g-space to r-space (default: do it)
 ! **************************************************************************************************
    SUBROUTINE calc_potential_gpw(pot_r, rho_g, poisson_env, pot_g, potential_parameter, dvg, no_transfer)
-      TYPE(pw_p_type), INTENT(IN)                        :: pot_r, rho_g
+      TYPE(pw_type), INTENT(INOUT)                       :: pot_r
+      TYPE(pw_type), INTENT(IN)                          :: rho_g
       TYPE(pw_poisson_type), INTENT(IN), POINTER         :: poisson_env
-      TYPE(pw_p_type), INTENT(IN)                        :: pot_g
+      TYPE(pw_type), INTENT(INOUT)                       :: pot_g
       TYPE(libint_potential_type), INTENT(IN), OPTIONAL  :: potential_parameter
       TYPE(pw_p_type), DIMENSION(3), INTENT(IN), &
          OPTIONAL                                        :: dvg
@@ -1201,29 +1204,29 @@ CONTAINS
       ! in case we do Coulomb metric for RI, we need the Coulomb operator, but for RI with the
       ! overlap metric, we do not need the Coulomb operator
       IF (my_potential_type /= do_potential_id) THEN
-         CALL pw_poisson_solve(poisson_env, rho_g%pw, vhartree=pot_g%pw, dvhartree=dvg)
-         IF (my_potential_type == do_potential_long) CALL pw_gauss_damp(pot_g%pw, potential_parameter%omega)
-         IF (my_potential_type == do_potential_short) CALL pw_compl_gauss_damp(pot_g%pw, potential_parameter%omega)
-         IF (my_potential_type == do_potential_truncated) CALL pw_truncated(pot_g%pw, potential_parameter%cutoff_radius)
-         IF (my_potential_type == do_potential_mix_cl) CALL pw_gauss_damp_mix(pot_g%pw, potential_parameter%omega, &
+         CALL pw_poisson_solve(poisson_env, rho_g, vhartree=pot_g, dvhartree=dvg)
+         IF (my_potential_type == do_potential_long) CALL pw_gauss_damp(pot_g, potential_parameter%omega)
+         IF (my_potential_type == do_potential_short) CALL pw_compl_gauss_damp(pot_g, potential_parameter%omega)
+         IF (my_potential_type == do_potential_truncated) CALL pw_truncated(pot_g, potential_parameter%cutoff_radius)
+         IF (my_potential_type == do_potential_mix_cl) CALL pw_gauss_damp_mix(pot_g, potential_parameter%omega, &
                                                                               potential_parameter%scale_coulomb, &
                                                                               potential_parameter%scale_longrange)
-         IF (my_transfer) CALL pw_transfer(pot_g%pw, pot_r%pw)
+         IF (my_transfer) CALL pw_transfer(pot_g, pot_r)
       ELSE
          ! If we use an overlap metric, make sure to use the correct potential=density on output
-         CALL pw_copy(rho_g%pw, pot_g%pw)
+         CALL pw_copy(rho_g, pot_g)
          IF (PRESENT(dvg)) THEN
          DO idir = 1, 3
-            CALL pw_copy(pot_g%pw, dvg(idir)%pw)
+            CALL pw_copy(pot_g, dvg(idir)%pw)
             comp = 0
             comp(idir) = 1
             CALL pw_derive(dvg(idir)%pw, comp)
          END DO
          END IF
-         IF (my_transfer) CALL pw_transfer(rho_g%pw, pot_r%pw)
+         IF (my_transfer) CALL pw_transfer(rho_g, pot_r)
       END IF
 
-      IF (my_transfer) CALL pw_scale(pot_r%pw, pot_r%pw%pw_grid%dvol)
+      IF (my_transfer) CALL pw_scale(pot_r, pot_r%pw_grid%dvol)
       CALL timestop(handle)
 
    END SUBROUTINE calc_potential_gpw

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -53,8 +53,8 @@ MODULE mp2_gpw_method
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: qs_environment_type
    USE qs_integrate_potential,          ONLY: integrate_v_rspace
@@ -170,10 +170,10 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(group_dist_d1_type)                           :: gd_exchange
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
-      TYPE(pw_p_type)                                    :: pot_g, psi_a, rho_g, rho_r
-      TYPE(pw_p_type), ALLOCATABLE, DIMENSION(:)         :: psi_i
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_g, psi_a, rho_g, rho_r
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: psi_i
       TYPE(task_list_type), POINTER                      :: task_list_sub
 
       CALL timeset(routineN, handle)
@@ -247,7 +247,7 @@ CONTAINS
 
       virtual = nmo - homo
 
-      wfn_size = REAL(SIZE(rho_r%pw%cr3d), KIND=dp)
+      wfn_size = REAL(SIZE(rho_r%cr3d), KIND=dp)
       CALL mp_max(wfn_size, para_env%group)
 
       ngroup = para_env%num_pe/para_env_sub%num_pe
@@ -394,11 +394,10 @@ CONTAINS
 
       ALLOCATE (psi_i(my_I_occupied_start:my_I_occupied_end))
       DO i = my_I_occupied_start, my_I_occupied_end
-         ALLOCATE (psi_i(i)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, psi_i(i)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, psi_i(i), &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL calculate_wavefunction(mo_coeff, i, psi_i(i)%pw, rho_g%pw, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, i, psi_i(i), rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, &
                                      pw_env_sub, external_vector=my_Cocc(:, i - my_I_occupied_start + 1))
       END DO
@@ -417,7 +416,7 @@ CONTAINS
          IF (calc_ex) BIb_C = 0.0_dp
 
          ! psi_a
-         CALL calculate_wavefunction(mo_coeff, a, psi_a%pw, rho_g%pw, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, a, psi_a, rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, &
                                      pw_env_sub, external_vector=my_Cvirt(:, a - (homo + my_A_virtual_start) + 1))
          i_counter = 0
@@ -425,14 +424,14 @@ CONTAINS
             i_counter = i_counter + 1
 
             ! potential
-            rho_r%pw%cr3d = psi_i(i)%pw%cr3d*psi_a%pw%cr3d
-            CALL pw_transfer(rho_r%pw, rho_g%pw)
+            rho_r%cr3d = psi_i(i)%cr3d*psi_a%cr3d
+            CALL pw_transfer(rho_r, rho_g)
             CALL calc_potential_gpw(rho_r, rho_g, poisson_env, pot_g, qs_env%mp2_env%potential_parameter)
 
             ! and finally (ia|munu)
             CALL timeset(routineN//"_int", handle3)
             CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-            CALL integrate_v_rspace(rho_r%pw, hmat=mat_munu, qs_env=qs_env, &
+            CALL integrate_v_rspace(rho_r, hmat=mat_munu, qs_env=qs_env, &
                                     calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE., &
                                     pw_env_external=pw_env_sub, task_list_external=task_list_sub)
             CALL timestop(handle3)
@@ -582,8 +581,7 @@ CONTAINS
       END IF
 
       DO i = my_I_occupied_start, my_I_occupied_end
-         CALL pw_release(psi_i(i)%pw)
-         DEALLOCATE (psi_i(i)%pw)
+         CALL pw_release(psi_i(i))
       END DO
       DEALLOCATE (psi_i)
 

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -80,7 +80,7 @@ MODULE mp2_integrals
    USE pw_env_types,                    ONLY: pw_env_type
    USE pw_poisson_types,                ONLY: pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
@@ -277,9 +277,9 @@ CONTAINS
          DIMENSION(:)                                    :: intermed_mat, intermed_mat_gw
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
-      TYPE(pw_p_type)                                    :: pot_g, psi_L, rho_g, rho_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_g, psi_L, rho_g, rho_r
       TYPE(task_list_type), POINTER                      :: task_list_sub
 
       CALL timeset(routineN, handle)

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -63,7 +63,8 @@ MODULE mp2_ri_grad
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_force_types,                  ONLY: allocate_qs_force,&
@@ -162,10 +163,10 @@ CONTAINS
       TYPE(mp2_eri_force), ALLOCATABLE, DIMENSION(:)     :: force_2c, force_2c_RI, force_3c_aux, &
                                                             force_3c_orb_mu, force_3c_orb_nu
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
-      TYPE(pw_p_type)                                    :: dvg(3), pot_g, psi_L, rho_g, rho_g_copy, &
-                                                            rho_r
+      TYPE(pw_p_type)                                    :: dvg(3)
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_g, psi_L, rho_g, rho_g_copy, rho_r
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force, mp2_force
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(task_list_type), POINTER                      :: task_list_sub
@@ -350,8 +351,7 @@ CONTAINS
          ! for calculate the MP2-volume contribution to the virial
          ! (hartree potential derivatives)
          IF (use_virial) THEN
-            ALLOCATE (rho_g_copy%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
             DO i = 1, 3
@@ -416,8 +416,7 @@ CONTAINS
          DEALLOCATE (atom_of_kind)
 
          IF (use_virial) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy%pw)
-            DEALLOCATE (rho_g_copy%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy)
             DO i = 1, 3
                CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(i)%pw)
                DEALLOCATE (dvg(i)%pw)

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -858,7 +858,7 @@ CONTAINS
 !> \author Sergey Chulkov
 ! **************************************************************************************************
    SUBROUTINE negf_env_init_v_hartree(v_hartree, contact_env, contact_control)
-      TYPE(pw_type), INTENT(OUT)                         :: v_hartree
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree
       TYPE(negf_env_contact_type), DIMENSION(:), &
          INTENT(in)                                      :: contact_env
       TYPE(negf_control_contact_type), DIMENSION(:), &

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -60,7 +60,6 @@ MODULE negf_env_types
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_p_type,&
                                               pw_type
    USE qs_density_mixing_types,         ONLY: mixing_storage_create,&
                                               mixing_storage_release,&
@@ -728,8 +727,8 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_kp, matrix_s_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_hartree
       TYPE(pw_pool_type), POINTER                        :: pw_pool
+      TYPE(pw_type)                                      :: v_hartree
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
       CALL timeset(routineN, handle)
@@ -811,15 +810,13 @@ CONTAINS
          CALL dbcsr_copy(matrix_b=hmat%matrix, matrix_a=matrix_s_kp(1, 1)%matrix)
          CALL dbcsr_set(hmat%matrix, 0.0_dp)
 
-         ALLOCATE (v_hartree%pw)
-         CALL pw_pool_create_pw(pw_pool, v_hartree%pw, use_data=REALDATA3D, in_space=REALSPACE)
-         CALL negf_env_init_v_hartree(v_hartree%pw, negf_env%contacts, negf_control%contacts)
+         CALL pw_pool_create_pw(pw_pool, v_hartree, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL negf_env_init_v_hartree(v_hartree, negf_env%contacts, negf_control%contacts)
 
-         CALL integrate_v_rspace(v_rspace=v_hartree%pw, hmat=hmat, qs_env=qs_env, &
+         CALL integrate_v_rspace(v_rspace=v_hartree, hmat=hmat, qs_env=qs_env, &
                                  calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE.)
 
-         CALL pw_pool_give_back_pw(pw_pool, v_hartree%pw)
-         DEALLOCATE (v_hartree%pw)
+         CALL pw_pool_give_back_pw(pw_pool, v_hartree)
 
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=hmat%matrix, &
                                                fm=negf_env%v_hartree_s, &
@@ -861,7 +858,7 @@ CONTAINS
 !> \author Sergey Chulkov
 ! **************************************************************************************************
    SUBROUTINE negf_env_init_v_hartree(v_hartree, contact_env, contact_control)
-      TYPE(pw_type), POINTER                             :: v_hartree
+      TYPE(pw_type), INTENT(OUT)                         :: v_hartree
       TYPE(negf_env_contact_type), DIMENSION(:), &
          INTENT(in)                                      :: contact_env
       TYPE(negf_control_contact_type), DIMENSION(:), &

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -913,35 +913,43 @@ CONTAINS
          DEALLOCATE (opt_embed%lri)
       END IF
 
-      DO i_dens = 1, SIZE(opt_embed%prev_subsys_dens)
-         CALL pw_release(opt_embed%prev_subsys_dens(i_dens)%pw)
-         DEALLOCATE (opt_embed%prev_subsys_dens(i_dens)%pw)
-      END DO
-      DEALLOCATE (opt_embed%prev_subsys_dens)
+      IF (ASSOCIATED(opt_embed%prev_subsys_dens)) THEN
+         DO i_dens = 1, SIZE(opt_embed%prev_subsys_dens)
+            IF (ASSOCIATED(opt_embed%prev_subsys_dens(i_dens)%pw)) THEN
+               CALL pw_release(opt_embed%prev_subsys_dens(i_dens)%pw)
+               DEALLOCATE (opt_embed%prev_subsys_dens(i_dens)%pw)
+            END IF
+         END DO
+         DEALLOCATE (opt_embed%prev_subsys_dens)
+      END IF
       DEALLOCATE (opt_embed%max_subsys_dens_diff)
 
       DEALLOCATE (opt_embed%all_nspins)
 
-      IF (opt_embed%add_const_pot .AND. (.NOT. opt_embed%grid_opt)) THEN
+      IF (ASSOCIATED(opt_embed%const_pot)) THEN
          CALL pw_release(opt_embed%const_pot)
          DEALLOCATE (opt_embed%const_pot)
       END IF
 
-      IF (opt_embed%Coulomb_guess) THEN
+      IF (ASSOCIATED(opt_embed%pot_diff)) THEN
          CALL pw_release(opt_embed%pot_diff)
          DEALLOCATE (opt_embed%pot_diff)
       END IF
 
-      IF (opt_embed%fab) THEN
+      IF (ASSOCIATED(opt_embed%prev_embed_pot)) THEN
          CALL pw_release(opt_embed%prev_embed_pot)
          DEALLOCATE (opt_embed%prev_embed_pot)
-         IF (ASSOCIATED(opt_embed%prev_spin_embed_pot)) THEN
-            CALL pw_release(opt_embed%prev_spin_embed_pot)
-            DEALLOCATE (opt_embed%prev_spin_embed_pot)
-         END IF
+      END IF
+      IF (ASSOCIATED(opt_embed%prev_spin_embed_pot)) THEN
+         CALL pw_release(opt_embed%prev_spin_embed_pot)
+         DEALLOCATE (opt_embed%prev_spin_embed_pot)
+      END IF
+      IF (ASSOCIATED(opt_embed%v_w)) THEN
          DO i_spin = 1, SIZE(opt_embed%v_w)
-            CALL pw_release(opt_embed%v_w(i_spin)%pw)
-            DEALLOCATE (opt_embed%v_w(i_spin)%pw)
+            IF (ASSOCIATED(opt_embed%v_w(i_spin)%pw)) THEN
+               CALL pw_release(opt_embed%v_w(i_spin)%pw)
+               DEALLOCATE (opt_embed%v_w(i_spin)%pw)
+            END IF
          END DO
          DEALLOCATE (opt_embed%v_w)
       END IF

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -1069,8 +1069,9 @@ CONTAINS
                                     change_spin_sign)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_type), INTENT(IN)                          :: embed_pot
-      TYPE(pw_type), POINTER                             :: embed_pot_subsys, spin_embed_pot, &
-                                                            spin_embed_pot_subsys
+      TYPE(pw_type), POINTER                             :: embed_pot_subsys
+      TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
+      TYPE(pw_type), POINTER                             :: spin_embed_pot_subsys
       LOGICAL                                            :: change_spin_sign
 
       TYPE(pw_env_type), POINTER                         :: pw_env

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -2724,9 +2724,10 @@ CONTAINS
 
       INTEGER                                            :: handle, i_spin, nspins
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: curr_rho, new_embed_pot, temp_embed_pot, &
-                                                            v_w
+      TYPE(pw_p_type), ALLOCATABLE, DIMENSION(:)         :: v_w
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: curr_rho
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: new_embed_pot, temp_embed_pot
 
       CALL timeset(routineN, handle)
 
@@ -2764,18 +2765,15 @@ CONTAINS
          ! redefine nspins
          nspins = 1
          IF (open_shell_embed) nspins = 2
-         NULLIFY (new_embed_pot)
          ALLOCATE (new_embed_pot(nspins))
-         NULLIFY (v_w)
          ALLOCATE (v_w(nspins))
          NULLIFY (curr_rho)
          ALLOCATE (curr_rho(nspins))
          DO i_spin = 1, nspins
-            ALLOCATE (new_embed_pot(i_spin)%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, new_embed_pot(i_spin)%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, new_embed_pot(i_spin), &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
-            CALL pw_zero(new_embed_pot(i_spin)%pw)
+            CALL pw_zero(new_embed_pot(i_spin))
 
             ALLOCATE (v_w(i_spin)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, v_w(i_spin)%pw, &
@@ -2799,13 +2797,13 @@ CONTAINS
             ! Compute von Weizsaecker potential
             CALL Von_Weizsacker(curr_rho, v_w, qs_env, vw_cutoff, vw_smooth_cutoff_range)
             ! Compute new embedding potential
-            CALL pw_copy(prev_embed_pot, new_embed_pot(1)%pw)
-            CALL pw_axpy(v_w(1)%pw, new_embed_pot(1)%pw, step_len)
-            CALL pw_axpy(v_w_ref(1)%pw, new_embed_pot(1)%pw, -step_len)
+            CALL pw_copy(prev_embed_pot, new_embed_pot(1))
+            CALL pw_axpy(v_w(1)%pw, new_embed_pot(1), step_len)
+            CALL pw_axpy(v_w_ref(1)%pw, new_embed_pot(1), -step_len)
             ! Copy the potentials
 
             CALL pw_copy(embed_pot, prev_embed_pot)
-            CALL pw_copy(new_embed_pot(1)%pw, embed_pot)
+            CALL pw_copy(new_embed_pot(1), embed_pot)
 
          ELSE
             ! Reconstruct current density
@@ -2828,36 +2826,34 @@ CONTAINS
             CALL Von_Weizsacker(curr_rho, v_w, qs_env, vw_cutoff, vw_smooth_cutoff_range)
 
             ! Reconstruct corrent spin components of the potential
-            NULLIFY (temp_embed_pot)
             ALLOCATE (temp_embed_pot(nspins))
             DO i_spin = 1, nspins
-               ALLOCATE (temp_embed_pot(i_spin)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, temp_embed_pot(i_spin)%pw, &
+               CALL pw_pool_create_pw(auxbas_pw_pool, temp_embed_pot(i_spin), &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
-               CALL pw_zero(temp_embed_pot(i_spin)%pw)
+               CALL pw_zero(temp_embed_pot(i_spin))
             END DO
-            CALL pw_copy(embed_pot, temp_embed_pot(1)%pw)
-            CALL pw_copy(embed_pot, temp_embed_pot(2)%pw)
-            CALL pw_axpy(spin_embed_pot, temp_embed_pot(1)%pw, 1.0_dp)
-            CALL pw_axpy(spin_embed_pot, temp_embed_pot(2)%pw, -1.0_dp)
+            CALL pw_copy(embed_pot, temp_embed_pot(1))
+            CALL pw_copy(embed_pot, temp_embed_pot(2))
+            CALL pw_axpy(spin_embed_pot, temp_embed_pot(1), 1.0_dp)
+            CALL pw_axpy(spin_embed_pot, temp_embed_pot(2), -1.0_dp)
 
             ! Compute new embedding potential
             IF (SIZE(v_w_ref) .EQ. 1) THEN ! Reference system is closed-shell
-               CALL pw_copy(temp_embed_pot(1)%pw, new_embed_pot(1)%pw)
-               CALL pw_axpy(v_w(1)%pw, new_embed_pot(1)%pw, 0.5_dp*step_len)
-               CALL pw_axpy(v_w_ref(1)%pw, new_embed_pot(1)%pw, -0.5_dp*step_len)
+               CALL pw_copy(temp_embed_pot(1), new_embed_pot(1))
+               CALL pw_axpy(v_w(1)%pw, new_embed_pot(1), 0.5_dp*step_len)
+               CALL pw_axpy(v_w_ref(1)%pw, new_embed_pot(1), -0.5_dp*step_len)
 
-               CALL pw_copy(temp_embed_pot(2)%pw, new_embed_pot(2)%pw)
-               CALL pw_axpy(v_w(2)%pw, new_embed_pot(2)%pw, 0.5_dp)
-               CALL pw_axpy(v_w_ref(1)%pw, new_embed_pot(2)%pw, -0.5_dp)
+               CALL pw_copy(temp_embed_pot(2), new_embed_pot(2))
+               CALL pw_axpy(v_w(2)%pw, new_embed_pot(2), 0.5_dp)
+               CALL pw_axpy(v_w_ref(1)%pw, new_embed_pot(2), -0.5_dp)
 
             ELSE ! Reference system is open-shell
 
                DO i_spin = 1, nspins
-                  CALL pw_copy(temp_embed_pot(i_spin)%pw, new_embed_pot(i_spin)%pw)
-                  CALL pw_axpy(v_w(1)%pw, new_embed_pot(i_spin)%pw, step_len)
-                  CALL pw_axpy(v_w_ref(i_spin)%pw, new_embed_pot(i_spin)%pw, -step_len)
+                  CALL pw_copy(temp_embed_pot(i_spin), new_embed_pot(i_spin))
+                  CALL pw_axpy(v_w(1)%pw, new_embed_pot(i_spin), step_len)
+                  CALL pw_axpy(v_w_ref(i_spin)%pw, new_embed_pot(i_spin), -step_len)
                END DO
             END IF
 
@@ -2865,16 +2861,15 @@ CONTAINS
             CALL pw_copy(embed_pot, prev_embed_pot)
             CALL pw_copy(spin_embed_pot, prev_spin_embed_pot)
 
-            CALL pw_copy(new_embed_pot(1)%pw, embed_pot)
-            CALL pw_axpy(new_embed_pot(2)%pw, embed_pot, 1.0_dp)
+            CALL pw_copy(new_embed_pot(1), embed_pot)
+            CALL pw_axpy(new_embed_pot(2), embed_pot, 1.0_dp)
             CALL pw_scale(embed_pot, a=0.5_dp)
-            CALL pw_copy(new_embed_pot(1)%pw, spin_embed_pot)
-            CALL pw_axpy(new_embed_pot(2)%pw, spin_embed_pot, -1.0_dp)
+            CALL pw_copy(new_embed_pot(1), spin_embed_pot)
+            CALL pw_axpy(new_embed_pot(2), spin_embed_pot, -1.0_dp)
             CALL pw_scale(spin_embed_pot, a=0.5_dp)
 
             DO i_spin = 1, nspins
-               CALL pw_release(temp_embed_pot(i_spin)%pw)
-               DEALLOCATE (temp_embed_pot(i_spin)%pw)
+               CALL pw_release(temp_embed_pot(i_spin))
             END DO
             DEALLOCATE (temp_embed_pot)
 
@@ -2882,9 +2877,9 @@ CONTAINS
 
          DO i_spin = 1, nspins
             CALL pw_release(curr_rho(i_spin)%pw)
-            CALL pw_release(new_embed_pot(i_spin)%pw)
+            CALL pw_release(new_embed_pot(i_spin))
             CALL pw_release(v_w(i_spin)%pw)
-            DEALLOCATE (curr_rho(i_spin)%pw, new_embed_pot(i_spin)%pw, v_w(i_spin)%pw)
+            DEALLOCATE (curr_rho(i_spin)%pw, v_w(i_spin)%pw)
          END DO
 
          DEALLOCATE (new_embed_pot)
@@ -2906,7 +2901,8 @@ CONTAINS
 !> \param vw_smooth_cutoff_range ...
 ! **************************************************************************************************
    SUBROUTINE Von_Weizsacker(rho_r, v_w, qs_env, vw_cutoff, vw_smooth_cutoff_range)
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, v_w
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
+      TYPE(pw_p_type), DIMENSION(:), INTENT(IN)          :: v_w
       TYPE(qs_environment_type), POINTER                 :: qs_env
       REAL(KIND=dp)                                      :: vw_cutoff, vw_smooth_cutoff_range
 

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -702,7 +702,7 @@ CONTAINS
       ! Read the potential as a vector in the auxiliary basis
       IF (opt_embed%read_embed_pot) &
          CALL read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, &
-opt_embed%embed_pot_coef, opt_embed%open_shell_embed)
+                                    opt_embed%embed_pot_coef, opt_embed%open_shell_embed)
       ! Read the potential as a cube (two cubes for open shell)
       IF (opt_embed%read_embed_pot_cube) &
          CALL read_embed_pot_cube(embed_pot, spin_embed_pot, section, opt_embed%open_shell_embed)
@@ -755,6 +755,7 @@ opt_embed%embed_pot_coef, opt_embed%open_shell_embed)
 !> \param spin_embed_pot ...
 !> \param section ...
 !> \param embed_pot_coef ...
+!> \param open_shell_embed ...
 ! **************************************************************************************************
    SUBROUTINE read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, embed_pot_coef, open_shell_embed)
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -762,7 +763,7 @@ opt_embed%embed_pot_coef, opt_embed%open_shell_embed)
       TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(cp_fm_type), INTENT(IN)                       :: embed_pot_coef
-LOGICAL, INTENT(IN) :: open_shell_embed
+      LOGICAL, INTENT(IN)                                :: open_shell_embed
 
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: dimen_aux, dimen_restart_basis, &
@@ -1757,6 +1758,7 @@ LOGICAL, INTENT(IN) :: open_shell_embed
 !> \param spin_embed_pot ...
 !> \param qs_env ...
 !> \param add_const_pot ...
+!> \param open_shell_embed ...
 !> \param const_pot ...
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
@@ -2526,6 +2528,7 @@ LOGICAL, INTENT(IN) :: open_shell_embed
 !> \param diff_rho_r ...
 !> \param diff_rho_spin ...
 !> \param rho_r_ref ...
+!> \param open_shell_embed ...
 !> \param step_len ...
 ! **************************************************************************************************
    SUBROUTINE Leeuwen_Baerends_potential_update(pw_env, embed_pot, spin_embed_pot, diff_rho_r, diff_rho_spin, &
@@ -2535,8 +2538,8 @@ LOGICAL, INTENT(IN) :: open_shell_embed
       TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r_ref
-LOGICAL, INTENT(IN) :: open_shell_embed
-      REAL(KIND=dp)                    , INTENT(IN)                  :: step_len
+      LOGICAL, INTENT(IN)                                :: open_shell_embed
+      REAL(KIND=dp), INTENT(IN)                          :: step_len
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'Leeuwen_Baerends_potential_update'
 
@@ -2917,7 +2920,7 @@ LOGICAL, INTENT(IN) :: open_shell_embed
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_p_type), DIMENSION(:), INTENT(IN)          :: v_w
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(KIND=dp)  , INTENT(IN)                                    :: vw_cutoff, vw_smooth_cutoff_range
+      REAL(KIND=dp), INTENT(IN)                          :: vw_cutoff, vw_smooth_cutoff_range
 
       REAL(KIND=dp), PARAMETER                           :: one_4 = 0.25_dp, one_8 = 0.125_dp
 

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -701,7 +701,8 @@ CONTAINS
 
       ! Read the potential as a vector in the auxiliary basis
       IF (opt_embed%read_embed_pot) &
-         CALL read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, opt_embed%embed_pot_coef)
+         CALL read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, &
+opt_embed%embed_pot_coef, opt_embed%open_shell_embed)
       ! Read the potential as a cube (two cubes for open shell)
       IF (opt_embed%read_embed_pot_cube) &
          CALL read_embed_pot_cube(embed_pot, spin_embed_pot, section, opt_embed%open_shell_embed)
@@ -755,12 +756,13 @@ CONTAINS
 !> \param section ...
 !> \param embed_pot_coef ...
 ! **************************************************************************************************
-   SUBROUTINE read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, embed_pot_coef)
+   SUBROUTINE read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, embed_pot_coef, open_shell_embed)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
       TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(cp_fm_type), INTENT(IN)                       :: embed_pot_coef
+LOGICAL, INTENT(IN) :: open_shell_embed
 
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: dimen_aux, dimen_restart_basis, &
@@ -775,7 +777,7 @@ CONTAINS
 
       ! Get the vector dimension
       CALL find_aux_dimen(qs_env, dimen_aux)
-      IF (ASSOCIATED(spin_embed_pot)) THEN
+      IF (open_shell_embed) THEN
          dimen_var_aux = dimen_aux*2
       ELSE
          dimen_var_aux = dimen_aux
@@ -850,7 +852,7 @@ CONTAINS
 
       ! Build the embedding potential on the grid
       CALL update_embed_pot(embed_pot_coef, dimen_aux, embed_pot, spin_embed_pot, &
-                            qs_env, .FALSE.)
+                            qs_env, .FALSE., open_shell_embed)
 
       ! Release my_embed_pot_coef
       CALL cp_fm_release(my_embed_pot_coef)
@@ -1061,18 +1063,19 @@ CONTAINS
 !> \param embed_pot_subsys ...
 !> \param spin_embed_pot ...
 !> \param spin_embed_pot_subsys ...
+!> \param open_shell_embed ...
 !> \param change_spin_sign ...
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
    SUBROUTINE make_subsys_embed_pot(qs_env, embed_pot, embed_pot_subsys, &
-                                    spin_embed_pot, spin_embed_pot_subsys, &
+                                    spin_embed_pot, spin_embed_pot_subsys, open_shell_embed, &
                                     change_spin_sign)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_type), INTENT(IN)                          :: embed_pot
       TYPE(pw_type), POINTER                             :: embed_pot_subsys
       TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(pw_type), POINTER                             :: spin_embed_pot_subsys
-      LOGICAL                                            :: change_spin_sign
+      LOGICAL                                            :: open_shell_embed, change_spin_sign
 
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool_subsys
@@ -1093,7 +1096,7 @@ CONTAINS
       ! Hard copy the grid
       embed_pot_subsys%cr3d(:, :, :) = embed_pot%cr3d(:, :, :)
 
-      IF (ASSOCIATED(spin_embed_pot)) THEN
+      IF (open_shell_embed) THEN
          NULLIFY (spin_embed_pot_subsys)
          ALLOCATE (spin_embed_pot_subsys)
          CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot_subsys, &
@@ -1551,7 +1554,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          IF (opt_embed%leeuwen) THEN
             CALL Leeuwen_Baerends_potential_update(pw_env, embed_pot, spin_embed_pot, diff_rho_r, diff_rho_spin, &
-                                                   rho_r_ref, opt_embed%trust_rad)
+                                                   rho_r_ref, opt_embed%open_shell_embed, opt_embed%trust_rad)
          ELSE
             IF (opt_embed%fab) THEN
                CALL FAB_update(qs_env, rho_r_ref, opt_embed%prev_embed_pot, opt_embed%prev_spin_embed_pot, &
@@ -1699,7 +1702,7 @@ CONTAINS
          ! Update the embedding potential
          CALL update_embed_pot(opt_embed%embed_pot_coef, opt_embed%dimen_aux, embed_pot, &
                                spin_embed_pot, qs_env, opt_embed%add_const_pot, &
-                               opt_embed%const_pot)
+                               opt_embed%open_shell_embed, opt_embed%const_pot)
       END IF ! Grid-based optimization
 
       CALL timestop(handle)
@@ -1736,7 +1739,7 @@ CONTAINS
       CALL grid_regularize(embed_pot, pw_env, opt_embed%lambda, my_reg_term)
       opt_embed%reg_term = opt_embed%reg_term + my_reg_term
 
-      IF (ASSOCIATED(spin_embed_pot)) THEN
+      IF (opt_embed%open_shell_embed) THEN
          CALL pw_axpy(diff_rho_spin, spin_embed_pot, opt_embed%step_len)
          CALL grid_regularize(spin_embed_pot, pw_env, opt_embed%lambda, my_reg_term)
          opt_embed%reg_term = opt_embed%reg_term + my_reg_term
@@ -1759,13 +1762,13 @@ CONTAINS
 ! **************************************************************************************************
 
    SUBROUTINE update_embed_pot(embed_pot_coef, dimen_aux, embed_pot, spin_embed_pot, &
-                               qs_env, add_const_pot, const_pot)
+                               qs_env, add_const_pot, open_shell_embed, const_pot)
       TYPE(cp_fm_type), INTENT(IN)                       :: embed_pot_coef
       INTEGER                                            :: dimen_aux
       TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
       TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL                                            :: add_const_pot
+      LOGICAL                                            :: add_const_pot, open_shell_embed
       TYPE(pw_type), INTENT(IN), OPTIONAL                :: const_pot
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'update_embed_pot'
@@ -1817,7 +1820,7 @@ CONTAINS
       wf_vector = 0.0_dp
 
       ! Create auxiliary full matrices for open-shell case
-      IF (ASSOCIATED(spin_embed_pot)) THEN
+      IF (open_shell_embed) THEN
          NULLIFY (blacs_env)
          CALL cp_fm_get_info(matrix=embed_pot_coef, context=blacs_env)
          CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
@@ -1925,7 +1928,7 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
 
-      IF (ASSOCIATED(spin_embed_pot)) THEN
+      IF (open_shell_embed) THEN
          CALL cp_fm_release(embed_pot_coef_spin)
          CALL cp_fm_release(embed_pot_coef_spinless)
       END IF
@@ -2526,13 +2529,14 @@ CONTAINS
 !> \param step_len ...
 ! **************************************************************************************************
    SUBROUTINE Leeuwen_Baerends_potential_update(pw_env, embed_pot, spin_embed_pot, diff_rho_r, diff_rho_spin, &
-                                                rho_r_ref, step_len)
+                                                rho_r_ref, open_shell_embed, step_len)
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
       TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r_ref
-      REAL(KIND=dp)                                      :: step_len
+LOGICAL, INTENT(IN) :: open_shell_embed
+      REAL(KIND=dp)                    , INTENT(IN)                  :: step_len
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'Leeuwen_Baerends_potential_update'
 
@@ -2551,7 +2555,7 @@ CONTAINS
       NULLIFY (new_embed_pot)
 
       nspins = 1
-      IF (ASSOCIATED(spin_embed_pot)) nspins = 2
+      IF (open_shell_embed) nspins = 2
       NULLIFY (new_embed_pot)
       ALLOCATE (new_embed_pot(nspins))
       DO i_spin = 1, nspins
@@ -2565,7 +2569,7 @@ CONTAINS
       lb(1:3) = embed_pot%pw_grid%bounds_local(1, 1:3)
       ub(1:3) = embed_pot%pw_grid%bounds_local(2, 1:3)
 
-      IF (.NOT. ASSOCIATED(spin_embed_pot)) THEN
+      IF (.NOT. open_shell_embed) THEN
 !$OMP    PARALLEL DO DEFAULT(NONE) &
 !$OMP                PRIVATE(i,j,k, my_rho) &
 !$OMP                SHARED(new_embed_pot, embed_pot, diff_rho_r, rho_r_ref, lb, ub, rho_cutoff, step_len)
@@ -2763,7 +2767,7 @@ CONTAINS
          ! For the first step previous are set to current
          CALL pw_copy(embed_pot, prev_embed_pot)
          CALL pw_axpy(diff_rho_r, embed_pot, 0.5_dp)
-         IF (ASSOCIATED(spin_embed_pot) .AND. ASSOCIATED(prev_spin_embed_pot)) THEN
+         IF (open_shell_embed) THEN
             CALL pw_copy(spin_embed_pot, prev_spin_embed_pot)
             CALL pw_axpy(diff_rho_r, embed_pot, 0.5_dp)
          END IF
@@ -2799,7 +2803,7 @@ CONTAINS
 
          ! Now, deal with the current density
 
-         IF (.NOT. ASSOCIATED(spin_embed_pot)) THEN
+         IF (.NOT. open_shell_embed) THEN
             ! Reconstruct current density
             CALL pw_copy(diff_rho_r, curr_rho(1)%pw)
             CALL pw_axpy(rho_r_ref(1)%pw, curr_rho(1)%pw, 1.0_dp)
@@ -2913,7 +2917,7 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_p_type), DIMENSION(:), INTENT(IN)          :: v_w
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(KIND=dp)                                      :: vw_cutoff, vw_smooth_cutoff_range
+      REAL(KIND=dp)  , INTENT(IN)                                    :: vw_cutoff, vw_smooth_cutoff_range
 
       REAL(KIND=dp), PARAMETER                           :: one_4 = 0.25_dp, one_8 = 0.125_dp
 
@@ -3199,18 +3203,19 @@ CONTAINS
 !> \param embed_pot ...
 !> \param i_iter ...
 !> \param embed_pot_spin ...
+!> \param open_shell_embed ...
 !> \param grid_opt ...
 !> \param final_one ...
 ! **************************************************************************************************
    SUBROUTINE print_embed_restart(qs_env, dimen_aux, embed_pot_coef, embed_pot, i_iter, &
-                                  embed_pot_spin, grid_opt, final_one)
+                                  embed_pot_spin, open_shell_embed, grid_opt, final_one)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER                                            :: dimen_aux
       TYPE(cp_fm_type), INTENT(IN), POINTER              :: embed_pot_coef
       TYPE(pw_type), INTENT(IN)                          :: embed_pot
       INTEGER                                            :: i_iter
       TYPE(pw_type), INTENT(IN), POINTER                 :: embed_pot_spin
-      LOGICAL                                            :: grid_opt, final_one
+      LOGICAL                                            :: open_shell_embed, grid_opt, final_one
 
       CHARACTER(LEN=default_path_length)                 :: filename, my_pos_cube, title
       INTEGER                                            :: unit_nr
@@ -3268,7 +3273,7 @@ CONTAINS
 !                            stride=section_get_ivals(dft_section, "QS%OPT_EMBED%EMBED_POT_CUBE%STRIDE"))
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%QS%OPT_EMBED%EMBED_POT_CUBE")
-         IF (ASSOCIATED(embed_pot_spin)) THEN ! Print spin part of the embedding potential
+         IF (open_shell_embed) THEN ! Print spin part of the embedding potential
             my_pos_cube = "REWIND"
             IF (.NOT. final_one) THEN
                WRITE (filename, '(a15,I3.3)') "spin_embed_pot_", i_iter
@@ -3296,21 +3301,22 @@ CONTAINS
 !> \param embed_pot ...
 !> \param embed_pot_spin ...
 !> \param i_iter ...
+!> \param open_shell_embed ...
 !> \param final_one ...
 !> \param qs_env_cluster ...
 ! **************************************************************************************************
-   SUBROUTINE print_pot_simple_grid(qs_env, embed_pot, embed_pot_spin, i_iter, &
+   SUBROUTINE print_pot_simple_grid(qs_env, embed_pot, embed_pot_spin, i_iter, open_shell_embed, &
                                     final_one, qs_env_cluster)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_type), INTENT(IN)                          :: embed_pot
       TYPE(pw_type), INTENT(IN), POINTER                 :: embed_pot_spin
       INTEGER                                            :: i_iter
-      LOGICAL                                            :: final_one
+      LOGICAL                                            :: open_shell_embed, final_one
       TYPE(qs_environment_type), POINTER                 :: qs_env_cluster
 
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: my_units, unit_nr
-      LOGICAL                                            :: angstrom, bohr, open_shell_embed
+      LOGICAL                                            :: angstrom, bohr
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
@@ -3319,8 +3325,6 @@ CONTAINS
 
       NULLIFY (input)
       CALL get_qs_env(qs_env=qs_env, input=input, pw_env=pw_env)
-
-      open_shell_embed = ASSOCIATED(embed_pot_spin)
 
       ! Second, cube files
       dft_section => section_vals_get_subs_vals(input, "DFT")

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -214,24 +214,24 @@ CONTAINS
    SUBROUTINE init_embed_pot(qs_env, embed_pot, add_const_pot, Fermi_Amaldi, const_pot, open_shell_embed, &
                              spin_embed_pot, pot_diff, Coulomb_guess, grid_opt)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot
+      TYPE(pw_type), POINTER                             :: embed_pot
       LOGICAL                                            :: add_const_pot, Fermi_Amaldi
-      TYPE(pw_p_type), POINTER                           :: const_pot
+      TYPE(pw_type), POINTER                             :: const_pot
       LOGICAL                                            :: open_shell_embed
-      TYPE(pw_p_type), POINTER                           :: spin_embed_pot, pot_diff
+      TYPE(pw_type), POINTER                             :: spin_embed_pot, pot_diff
       LOGICAL                                            :: Coulomb_guess, grid_opt
 
       INTEGER                                            :: nelectrons
       INTEGER, DIMENSION(2)                              :: nelectron_spin
       REAL(KIND=dp)                                      :: factor
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_hartree_r_space
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: v_hartree_r_space
 
       ! Extract  plane waves environment
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, &
                       nelectron_spin=nelectron_spin, &
-                      v_hartree_rspace=v_hartree_r_space%pw)
+                      v_hartree_rspace=v_hartree_r_space)
 
       ! Prepare plane-waves pool
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
@@ -239,32 +239,29 @@ CONTAINS
       ! Create embedding potential and set to zero
       NULLIFY (embed_pot)
       ALLOCATE (embed_pot)
-      ALLOCATE (embed_pot%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_zero(embed_pot%pw)
+      CALL pw_zero(embed_pot)
 
       ! Spin embedding potential if asked
       IF (open_shell_embed) THEN
          NULLIFY (spin_embed_pot)
          ALLOCATE (spin_embed_pot)
-         ALLOCATE (spin_embed_pot%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(spin_embed_pot%pw)
+         CALL pw_zero(spin_embed_pot)
       END IF
 
       ! Coulomb guess/constant potential
       IF (Coulomb_guess) THEN
          NULLIFY (pot_diff)
          ALLOCATE (pot_diff)
-         ALLOCATE (pot_diff%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, pot_diff%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, pot_diff, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(pot_diff%pw)
+         CALL pw_zero(pot_diff)
       END IF
 
       ! Initialize constant part of the embedding potential
@@ -272,31 +269,30 @@ CONTAINS
          ! Now the constant potential is the Coulomb one
          NULLIFY (const_pot)
          ALLOCATE (const_pot)
-         ALLOCATE (const_pot%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, const_pot%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, const_pot, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(const_pot%pw)
+         CALL pw_zero(const_pot)
       END IF
 
       ! Add Fermi-Amaldi potential if requested
       IF (Fermi_Amaldi) THEN
 
          ! Extract  Hartree potential
-         NULLIFY (v_hartree_r_space%pw)
+         NULLIFY (v_hartree_r_space)
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, &
-                         v_hartree_rspace=v_hartree_r_space%pw)
-         CALL pw_copy(v_hartree_r_space%pw, embed_pot%pw)
+                         v_hartree_rspace=v_hartree_r_space)
+         CALL pw_copy(v_hartree_r_space, embed_pot)
 
          ! Calculate the number of electrons
          nelectrons = nelectron_spin(1) + nelectron_spin(2)
          factor = (REAL(nelectrons, dp) - 1.0_dp)/(REAL(nelectrons, dp))
 
          ! Scale the Hartree potential to get Fermi-Amaldi
-         CALL pw_scale(embed_pot%pw, a=factor)
+         CALL pw_scale(embed_pot, a=factor)
 
          ! Copy Fermi-Amaldi to embedding potential for basis-based optimization
-         IF (.NOT. grid_opt) CALL pw_copy(embed_pot%pw, embed_pot%pw)
+         IF (.NOT. grid_opt) CALL pw_copy(embed_pot, embed_pot)
 
       END IF
 
@@ -431,19 +427,17 @@ CONTAINS
       IF (opt_embed%fab) THEN
          NULLIFY (opt_embed%prev_embed_pot)
          ALLOCATE (opt_embed%prev_embed_pot)
-         ALLOCATE (opt_embed%prev_embed_pot%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_embed_pot%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_embed_pot, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(opt_embed%prev_embed_pot%pw)
+         CALL pw_zero(opt_embed%prev_embed_pot)
          IF (opt_embed%open_shell_embed) THEN
             NULLIFY (opt_embed%prev_spin_embed_pot)
             ALLOCATE (opt_embed%prev_spin_embed_pot)
-            ALLOCATE (opt_embed%prev_spin_embed_pot%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_spin_embed_pot%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_spin_embed_pot, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
-            CALL pw_zero(opt_embed%prev_spin_embed_pot%pw)
+            CALL pw_zero(opt_embed%prev_spin_embed_pot)
          END IF
       END IF
 
@@ -648,8 +642,8 @@ CONTAINS
       LOGICAL                                            :: open_shell_embed
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool_subsys
+      TYPE(pw_type), POINTER                             :: embed_pot, spin_embed_pot
       TYPE(section_vals_type), POINTER                   :: input, qs_section
 
       qs_env%given_embed_pot = .TRUE.
@@ -670,15 +664,13 @@ CONTAINS
       !CALL get_qs_env(qs_env=qs_env, &
       !                embed_pot=embed_pot)
       ALLOCATE (embed_pot)
-      ALLOCATE (embed_pot%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
       IF (open_shell_embed) THEN
          ! Create spin embedding potential
          ALLOCATE (spin_embed_pot)
-         ALLOCATE (spin_embed_pot%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
       END IF
@@ -703,14 +695,13 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE read_embed_pot(qs_env, embed_pot, spin_embed_pot, section, opt_embed)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
+      TYPE(pw_type), POINTER                             :: embed_pot, spin_embed_pot
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(opt_embed_pot_type)                           :: opt_embed
 
       ! Read the potential as a vector in the auxiliary basis
       IF (opt_embed%read_embed_pot) &
-         CALL read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, opt_embed%embed_pot_coef, &
-                                    opt_embed%open_shell_embed)
+         CALL read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, opt_embed%embed_pot_coef)
       ! Read the potential as a cube (two cubes for open shell)
       IF (opt_embed%read_embed_pot_cube) &
          CALL read_embed_pot_cube(embed_pot, spin_embed_pot, section, opt_embed%open_shell_embed)
@@ -725,7 +716,7 @@ CONTAINS
 !> \param open_shell_embed ...
 ! **************************************************************************************************
    SUBROUTINE read_embed_pot_cube(embed_pot, spin_embed_pot, section, open_shell_embed)
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
+      TYPE(pw_type), INTENT(IN)                          :: embed_pot, spin_embed_pot
       TYPE(section_vals_type), POINTER                   :: section
       LOGICAL                                            :: open_shell_embed
 
@@ -740,7 +731,7 @@ CONTAINS
          CPABORT("Embedding cube file not found. ")
 
       scaling_factor = 1.0_dp
-      CALL cp_cube_to_pw(embed_pot%pw, filename, scaling_factor)
+      CALL cp_cube_to_pw(embed_pot, filename, scaling_factor)
 
       ! Spin-dependent part of the potential
       IF (open_shell_embed) THEN
@@ -751,7 +742,7 @@ CONTAINS
             CPABORT("Embedding spin cube file not found. ")
 
          scaling_factor = 1.0_dp
-         CALL cp_cube_to_pw(spin_embed_pot%pw, filename, scaling_factor)
+         CALL cp_cube_to_pw(spin_embed_pot, filename, scaling_factor)
       END IF
 
    END SUBROUTINE read_embed_pot_cube
@@ -763,15 +754,13 @@ CONTAINS
 !> \param spin_embed_pot ...
 !> \param section ...
 !> \param embed_pot_coef ...
-!> \param open_shell_embed ...
 ! **************************************************************************************************
-   SUBROUTINE read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, embed_pot_coef, &
-                                    open_shell_embed)
+   SUBROUTINE read_embed_pot_vector(qs_env, embed_pot, spin_embed_pot, section, embed_pot_coef)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
+      TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(cp_fm_type), INTENT(IN)                       :: embed_pot_coef
-      LOGICAL                                            :: open_shell_embed
 
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: dimen_aux, dimen_restart_basis, &
@@ -786,7 +775,7 @@ CONTAINS
 
       ! Get the vector dimension
       CALL find_aux_dimen(qs_env, dimen_aux)
-      IF (open_shell_embed) THEN
+      IF (ASSOCIATED(spin_embed_pot)) THEN
          dimen_var_aux = dimen_aux*2
       ELSE
          dimen_var_aux = dimen_aux
@@ -861,7 +850,7 @@ CONTAINS
 
       ! Build the embedding potential on the grid
       CALL update_embed_pot(embed_pot_coef, dimen_aux, embed_pot, spin_embed_pot, &
-                            qs_env, .FALSE., open_shell_embed)
+                            qs_env, .FALSE.)
 
       ! Release my_embed_pot_coef
       CALL cp_fm_release(my_embed_pot_coef)
@@ -934,24 +923,20 @@ CONTAINS
       DEALLOCATE (opt_embed%all_nspins)
 
       IF (opt_embed%add_const_pot .AND. (.NOT. opt_embed%grid_opt)) THEN
-         CALL pw_release(opt_embed%const_pot%pw)
-         DEALLOCATE (opt_embed%const_pot%pw)
+         CALL pw_release(opt_embed%const_pot)
          DEALLOCATE (opt_embed%const_pot)
       END IF
 
       IF (opt_embed%Coulomb_guess) THEN
-         CALL pw_release(opt_embed%pot_diff%pw)
-         DEALLOCATE (opt_embed%pot_diff%pw)
+         CALL pw_release(opt_embed%pot_diff)
          DEALLOCATE (opt_embed%pot_diff)
       END IF
 
       IF (opt_embed%fab) THEN
-         CALL pw_release(opt_embed%prev_embed_pot%pw)
-         DEALLOCATE (opt_embed%prev_embed_pot%pw)
+         CALL pw_release(opt_embed%prev_embed_pot)
          DEALLOCATE (opt_embed%prev_embed_pot)
-         IF (opt_embed%open_shell_embed) THEN
-            CALL pw_release(opt_embed%prev_spin_embed_pot%pw)
-            DEALLOCATE (opt_embed%prev_spin_embed_pot%pw)
+         IF (ASSOCIATED(opt_embed%prev_spin_embed_pot)) THEN
+            CALL pw_release(opt_embed%prev_spin_embed_pot)
             DEALLOCATE (opt_embed%prev_spin_embed_pot)
          END IF
          DO i_spin = 1, SIZE(opt_embed%v_w)
@@ -974,7 +959,7 @@ CONTAINS
 !> \param eta ...
 ! **************************************************************************************************
    SUBROUTINE Coulomb_guess(v_rspace, rhs, mapping_section, qs_env, nforce_eval, iforce_eval, eta)
-      TYPE(pw_p_type)                                    :: v_rspace
+      TYPE(pw_type)                                      :: v_rspace
       REAL(KIND=dp), DIMENSION(:), POINTER               :: rhs
       TYPE(section_vals_type), POINTER                   :: mapping_section
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -987,9 +972,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: rhs_subsys
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_resp, v_resp_gspace, v_resp_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_resp, v_resp_gspace, v_resp_rspace
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
       ! Get available particles
@@ -1016,45 +1001,43 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      ALLOCATE (v_resp_gspace%pw, v_resp_rspace%pw, rho_resp%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_gspace%pw, &
+                             v_resp_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_rspace%pw, &
+                             v_resp_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_resp%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_resp, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       ! Calculate charge density
-      CALL pw_zero(rho_resp%pw)
-      CALL calculate_rho_resp_all(rho_resp%pw, rhs_subsys, natom, eta, qs_env)
+      CALL pw_zero(rho_resp)
+      CALL calculate_rho_resp_all(rho_resp, rhs_subsys, natom, eta, qs_env)
 
       ! Calculate potential
-      CALL pw_zero(v_resp_gspace%pw)
-      CALL pw_poisson_solve(poisson_env, rho_resp%pw, &
-                            vhartree=v_resp_gspace%pw)
-      CALL pw_zero(v_resp_rspace%pw)
-      CALL pw_transfer(v_resp_gspace%pw, v_resp_rspace%pw)
-      dvol = v_resp_rspace%pw%pw_grid%dvol
-      CALL pw_scale(v_resp_rspace%pw, dvol)
+      CALL pw_zero(v_resp_gspace)
+      CALL pw_poisson_solve(poisson_env, rho_resp, &
+                            vhartree=v_resp_gspace)
+      CALL pw_zero(v_resp_rspace)
+      CALL pw_transfer(v_resp_gspace, v_resp_rspace)
+      dvol = v_resp_rspace%pw_grid%dvol
+      CALL pw_scale(v_resp_rspace, dvol)
       normalize_factor = SQRT((eta/pi)**3)
       !normalize_factor = -2.0_dp
-      CALL pw_scale(v_resp_rspace%pw, normalize_factor)
+      CALL pw_scale(v_resp_rspace, normalize_factor)
 
       ! Hard copy potential
-      v_rspace%pw%cr3d(:, :, :) = v_resp_rspace%pw%cr3d(:, :, :)
+      v_rspace%cr3d(:, :, :) = v_resp_rspace%cr3d(:, :, :)
 
       ! Release plane waves
-      CALL pw_release(v_resp_gspace%pw)
-      CALL pw_release(v_resp_rspace%pw)
-      CALL pw_release(rho_resp%pw)
-      DEALLOCATE (v_resp_gspace%pw, v_resp_rspace%pw, rho_resp%pw)
+      CALL pw_release(v_resp_gspace)
+      CALL pw_release(v_resp_rspace)
+      CALL pw_release(rho_resp)
 
       ! Deallocate map_index array
       DEALLOCATE (map_index)
@@ -1070,17 +1053,17 @@ CONTAINS
 !> \param embed_pot_subsys ...
 !> \param spin_embed_pot ...
 !> \param spin_embed_pot_subsys ...
-!> \param open_shell_embed ...
 !> \param change_spin_sign ...
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
    SUBROUTINE make_subsys_embed_pot(qs_env, embed_pot, embed_pot_subsys, &
-                                    spin_embed_pot, spin_embed_pot_subsys, open_shell_embed, &
+                                    spin_embed_pot, spin_embed_pot_subsys, &
                                     change_spin_sign)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, embed_pot_subsys, &
-                                                            spin_embed_pot, spin_embed_pot_subsys
-      LOGICAL                                            :: open_shell_embed, change_spin_sign
+      TYPE(pw_type), INTENT(IN)                          :: embed_pot
+      TYPE(pw_type), POINTER                             :: embed_pot_subsys, spin_embed_pot, &
+                                                            spin_embed_pot_subsys
+      LOGICAL                                            :: change_spin_sign
 
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool_subsys
@@ -1094,26 +1077,24 @@ CONTAINS
       ! Create embedding potential and set to zero
       NULLIFY (embed_pot_subsys)
       ALLOCATE (embed_pot_subsys)
-      ALLOCATE (embed_pot_subsys%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot_subsys%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot_subsys, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       ! Hard copy the grid
-      embed_pot_subsys%pw%cr3d(:, :, :) = embed_pot%pw%cr3d(:, :, :)
+      embed_pot_subsys%cr3d(:, :, :) = embed_pot%cr3d(:, :, :)
 
-      IF (open_shell_embed) THEN
+      IF (ASSOCIATED(spin_embed_pot)) THEN
          NULLIFY (spin_embed_pot_subsys)
          ALLOCATE (spin_embed_pot_subsys)
-         ALLOCATE (spin_embed_pot_subsys%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot_subsys%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot_subsys, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          ! Hard copy the grid
          IF (change_spin_sign) THEN
-            spin_embed_pot_subsys%pw%cr3d(:, :, :) = -spin_embed_pot%pw%cr3d(:, :, :)
+            spin_embed_pot_subsys%cr3d(:, :, :) = -spin_embed_pot%cr3d(:, :, :)
          ELSE
-            spin_embed_pot_subsys%pw%cr3d(:, :, :) = spin_embed_pot%pw%cr3d(:, :, :)
+            spin_embed_pot_subsys%cr3d(:, :, :) = spin_embed_pot%cr3d(:, :, :)
          END IF
       END IF
 
@@ -1130,7 +1111,7 @@ CONTAINS
 
    SUBROUTINE calculate_embed_pot_grad(qs_env, diff_rho_r, diff_rho_spin, opt_embed)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), POINTER                           :: diff_rho_r, diff_rho_spin
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       TYPE(opt_embed_pot_type)                           :: opt_embed
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_embed_pot_grad'
@@ -1268,7 +1249,7 @@ CONTAINS
                                              open_shell_embed, lri)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER                                            :: dimen_aux
-      TYPE(pw_p_type), POINTER                           :: rho_r, rho_spin
+      TYPE(pw_type), INTENT(IN)                          :: rho_r, rho_spin
       TYPE(cp_fm_type), INTENT(IN)                       :: embed_pot_grad
       LOGICAL                                            :: open_shell_embed
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri
@@ -1310,7 +1291,7 @@ CONTAINS
          lri(ikind)%v_int = 0.0_dp
       END DO
 
-      CALL integrate_v_rspace_one_center(rho_r%pw, qs_env, lri, &
+      CALL integrate_v_rspace_one_center(rho_r, qs_env, lri, &
                                          .FALSE., "RI_AUX")
       DO ikind = 1, SIZE(lri)
          CALL mp_sum(lri(ikind)%v_int, para_env%group)
@@ -1332,7 +1313,7 @@ CONTAINS
             lri(ikind)%v_int = 0.0_dp
          END DO
 
-         CALL integrate_v_rspace_one_center(rho_spin%pw, qs_env, lri, &
+         CALL integrate_v_rspace_one_center(rho_spin, qs_env, lri, &
                                             .FALSE., "RI_AUX")
          DO ikind = 1, SIZE(lri)
             CALL mp_sum(lri(ikind)%v_int, para_env%group)
@@ -1349,7 +1330,7 @@ CONTAINS
       END IF
 
       ! Scale by the cell volume
-      pot_grad = pot_grad*rho_r%pw%pw_grid%dvol
+      pot_grad = pot_grad*rho_r%pw_grid%dvol
 
       ! Information about full matrix gradient
       CALL cp_fm_get_info(matrix=embed_pot_grad, &
@@ -1417,16 +1398,16 @@ CONTAINS
 !> \param reg_term ...
 ! **************************************************************************************************
    SUBROUTINE grid_regularize(potential, pw_env, lambda, reg_term)
-      TYPE(pw_p_type), POINTER                           :: potential
+      TYPE(pw_type), INTENT(IN)                          :: potential
       TYPE(pw_env_type), POINTER                         :: pw_env
       REAL(KIND=dp)                                      :: lambda, reg_term
 
       INTEGER                                            :: i, j, k
       INTEGER, DIMENSION(3)                              :: lb, n, ub
-      TYPE(pw_p_type), DIMENSION(3)                      :: dpot, dpot_g
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: dr2_pot, grid_reg, grid_reg_g, &
+      TYPE(pw_type)                                      :: dr2_pot, grid_reg, grid_reg_g, &
                                                             potential_g, square_norm_dpot
+      TYPE(pw_type), DIMENSION(3)                        :: dpot, dpot_g
 
       !
       ! First, the contribution to the gradient
@@ -1435,33 +1416,25 @@ CONTAINS
       ! Get some of the grids ready
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
-      NULLIFY (potential_g)
-      ALLOCATE (potential_g)
       CALL pw_pool_create_pw(auxbas_pw_pool, potential_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      NULLIFY (dr2_pot)
-      ALLOCATE (dr2_pot)
       CALL pw_pool_create_pw(auxbas_pw_pool, dr2_pot, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      NULLIFY (grid_reg)
-      ALLOCATE (grid_reg)
       CALL pw_pool_create_pw(auxbas_pw_pool, grid_reg, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
-      NULLIFY (grid_reg_g)
-      ALLOCATE (grid_reg_g)
       CALL pw_pool_create_pw(auxbas_pw_pool, grid_reg_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_zero(grid_reg_g)
 
       ! Transfer potential to the reciprocal space
-      CALL pw_transfer(potential%pw, potential_g)
+      CALL pw_transfer(potential, potential_g)
 
       ! Calculate second derivatives: dx^2, dy^2, dz^2
       DO i = 1, 3
@@ -1472,24 +1445,20 @@ CONTAINS
       CALL pw_transfer(grid_reg_g, grid_reg)
 
       ! Update the potential with a regularization term
-      CALL pw_axpy(grid_reg, potential%pw, -4.0_dp*lambda)
+      CALL pw_axpy(grid_reg, potential, -4.0_dp*lambda)
 
       !
       ! Second, the contribution to the functional
       !
       DO i = 1, 3
-         ALLOCATE (dpot(i)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, dpot(i)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, dpot(i), &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         ALLOCATE (dpot_g(i)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, dpot_g(i)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, dpot_g(i), &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
 
-      NULLIFY (square_norm_dpot)
-      ALLOCATE (square_norm_dpot)
       CALL pw_pool_create_pw(auxbas_pw_pool, square_norm_dpot, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -1497,9 +1466,9 @@ CONTAINS
       DO i = 1, 3
          n(:) = 0
          n(i) = 1
-         CALL pw_copy(potential_g, dpot_g(i)%pw)
-         CALL pw_derive(dpot_g(i)%pw, n(:))
-         CALL pw_transfer(dpot_g(i)%pw, dpot(i)%pw)
+         CALL pw_copy(potential_g, dpot_g(i))
+         CALL pw_derive(dpot_g(i), n(:))
+         CALL pw_transfer(dpot_g(i), dpot(i))
       END DO
 
       lb(1:3) = square_norm_dpot%pw_grid%bounds_local(1, 1:3)
@@ -1510,12 +1479,12 @@ CONTAINS
       DO k = lb(3), ub(3)
          DO j = lb(2), ub(2)
             DO i = lb(1), ub(1)
-               square_norm_dpot%cr3d(i, j, k) = (dpot(1)%pw%cr3d(i, j, k)* &
-                                                 dpot(1)%pw%cr3d(i, j, k) + &
-                                                 dpot(2)%pw%cr3d(i, j, k)* &
-                                                 dpot(2)%pw%cr3d(i, j, k) + &
-                                                 dpot(3)%pw%cr3d(i, j, k)* &
-                                                 dpot(3)%pw%cr3d(i, j, k))
+               square_norm_dpot%cr3d(i, j, k) = (dpot(1)%cr3d(i, j, k)* &
+                                                 dpot(1)%cr3d(i, j, k) + &
+                                                 dpot(2)%cr3d(i, j, k)* &
+                                                 dpot(2)%cr3d(i, j, k) + &
+                                                 dpot(3)%cr3d(i, j, k)* &
+                                                 dpot(3)%cr3d(i, j, k))
             END DO
          END DO
       END DO
@@ -1529,11 +1498,9 @@ CONTAINS
       CALL pw_pool_give_back_pw(auxbas_pw_pool, grid_reg)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, grid_reg_g)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, square_norm_dpot)
-      DEALLOCATE (potential_g, dr2_pot, grid_reg, grid_reg_g, square_norm_dpot)
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot(i)%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot_g(i)%pw)
-         DEALLOCATE (dpot(i)%pw, dpot_g(i)%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot(i))
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot_g(i))
       END DO
 
    END SUBROUTINE grid_regularize
@@ -1550,9 +1517,10 @@ CONTAINS
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
    SUBROUTINE opt_embed_step(diff_rho_r, diff_rho_spin, opt_embed, embed_pot, spin_embed_pot, rho_r_ref, qs_env)
-      TYPE(pw_p_type), POINTER                           :: diff_rho_r, diff_rho_spin
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       TYPE(opt_embed_pot_type)                           :: opt_embed
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
+      TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r_ref
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
@@ -1574,7 +1542,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          IF (opt_embed%leeuwen) THEN
             CALL Leeuwen_Baerends_potential_update(pw_env, embed_pot, spin_embed_pot, diff_rho_r, diff_rho_spin, &
-                                                   rho_r_ref, opt_embed%open_shell_embed, opt_embed%trust_rad)
+                                                   rho_r_ref, opt_embed%trust_rad)
          ELSE
             IF (opt_embed%fab) THEN
                CALL FAB_update(qs_env, rho_r_ref, opt_embed%prev_embed_pot, opt_embed%prev_spin_embed_pot, &
@@ -1722,7 +1690,7 @@ CONTAINS
          ! Update the embedding potential
          CALL update_embed_pot(opt_embed%embed_pot_coef, opt_embed%dimen_aux, embed_pot, &
                                spin_embed_pot, qs_env, opt_embed%add_const_pot, &
-                               opt_embed%open_shell_embed, opt_embed%const_pot)
+                               opt_embed%const_pot)
       END IF ! Grid-based optimization
 
       CALL timestop(handle)
@@ -1740,10 +1708,11 @@ CONTAINS
 !> \param spin_embed_pot ...
 ! **************************************************************************************************
    SUBROUTINE grid_based_step(diff_rho_r, diff_rho_spin, pw_env, opt_embed, embed_pot, spin_embed_pot)
-      TYPE(pw_p_type), POINTER                           :: diff_rho_r, diff_rho_spin
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(opt_embed_pot_type)                           :: opt_embed
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
+      TYPE(pw_type), INTENT(IN)                          :: embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'grid_based_step'
 
@@ -1753,13 +1722,13 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       ! Take the step for spin-free part
-      CALL pw_axpy(diff_rho_r%pw, embed_pot%pw, opt_embed%step_len)
+      CALL pw_axpy(diff_rho_r, embed_pot, opt_embed%step_len)
       ! Regularize
       CALL grid_regularize(embed_pot, pw_env, opt_embed%lambda, my_reg_term)
       opt_embed%reg_term = opt_embed%reg_term + my_reg_term
 
-      IF (opt_embed%open_shell_embed) THEN
-         CALL pw_axpy(diff_rho_spin%pw, spin_embed_pot%pw, opt_embed%step_len)
+      IF (ASSOCIATED(spin_embed_pot)) THEN
+         CALL pw_axpy(diff_rho_spin, spin_embed_pot, opt_embed%step_len)
          CALL grid_regularize(spin_embed_pot, pw_env, opt_embed%lambda, my_reg_term)
          opt_embed%reg_term = opt_embed%reg_term + my_reg_term
       END IF
@@ -1776,19 +1745,19 @@ CONTAINS
 !> \param spin_embed_pot ...
 !> \param qs_env ...
 !> \param add_const_pot ...
-!> \param open_shell_embed ...
 !> \param const_pot ...
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
 
    SUBROUTINE update_embed_pot(embed_pot_coef, dimen_aux, embed_pot, spin_embed_pot, &
-                               qs_env, add_const_pot, open_shell_embed, const_pot)
+                               qs_env, add_const_pot, const_pot)
       TYPE(cp_fm_type), INTENT(IN)                       :: embed_pot_coef
       INTEGER                                            :: dimen_aux
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot
+      TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL                                            :: add_const_pot, open_shell_embed
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: const_pot
+      LOGICAL                                            :: add_const_pot
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: const_pot
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'update_embed_pot'
 
@@ -1807,8 +1776,8 @@ CONTAINS
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: psi_L, rho_g
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: psi_L, rho_g
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
       CALL timeset(routineN, handle)
@@ -1826,13 +1795,11 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
       ! get some of the grids ready
-      ALLOCATE (rho_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      ALLOCATE (psi_L%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, psi_L%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, psi_L, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -1841,7 +1808,7 @@ CONTAINS
       wf_vector = 0.0_dp
 
       ! Create auxiliary full matrices for open-shell case
-      IF (open_shell_embed) THEN
+      IF (ASSOCIATED(spin_embed_pot)) THEN
          NULLIFY (blacs_env)
          CALL cp_fm_get_info(matrix=embed_pot_coef, context=blacs_env)
          CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
@@ -1877,18 +1844,18 @@ CONTAINS
          CALL mp_sum(wf_vector, para_env%group)
 
          ! Calculate the variable part of the embedding potential
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env, &
                                      basis_type="RI_AUX", &
                                      external_vector=wf_vector)
          ! Update the full embedding potential
          IF (add_const_pot) THEN
-            CALL pw_copy(const_pot%pw, embed_pot%pw)
+            CALL pw_copy(const_pot, embed_pot)
          ELSE
-            CALL pw_zero(embed_pot%pw)
+            CALL pw_zero(embed_pot)
          END IF
 
-         CALL pw_axpy(psi_L%pw, embed_pot%pw)
+         CALL pw_axpy(psi_L, embed_pot)
 
          ! Spin-dependent potential
          wf_vector = 0.0_dp
@@ -1904,13 +1871,13 @@ CONTAINS
          CALL mp_sum(wf_vector, para_env%group)
 
          ! Calculate the variable part of the embedding potential
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env, &
                                      basis_type="RI_AUX", &
                                      external_vector=wf_vector)
          ! No constant potential for spin-dependent potential
-         CALL pw_zero(spin_embed_pot%pw)
-         CALL pw_axpy(psi_L%pw, spin_embed_pot%pw)
+         CALL pw_zero(spin_embed_pot)
+         CALL pw_axpy(psi_L, spin_embed_pot)
 
       ELSE ! Closed shell
 
@@ -1926,31 +1893,30 @@ CONTAINS
          CALL mp_sum(wf_vector, para_env%group)
 
          ! Calculate the variable part of the embedding potential
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env)
 
-         CALL calculate_wavefunction(mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env, &
                                      basis_type="RI_AUX", &
                                      external_vector=wf_vector)
 
          ! Update the full embedding potential
          IF (add_const_pot) THEN
-            CALL pw_copy(const_pot%pw, embed_pot%pw)
+            CALL pw_copy(const_pot, embed_pot)
          ELSE
-            CALL pw_zero(embed_pot%pw)
+            CALL pw_zero(embed_pot)
          END IF
 
-         CALL pw_axpy(psi_L%pw, embed_pot%pw)
+         CALL pw_axpy(psi_L, embed_pot)
       END IF ! Open/closed shell
 
       ! Deallocate memory and release objects
       DEALLOCATE (wf_vector)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
-      DEALLOCATE (psi_L%pw, rho_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
 
-      IF (open_shell_embed) THEN
+      IF (ASSOCIATED(spin_embed_pot)) THEN
          CALL cp_fm_release(embed_pot_coef_spin)
          CALL cp_fm_release(embed_pot_coef_spinless)
       END IF
@@ -2548,16 +2514,15 @@ CONTAINS
 !> \param diff_rho_r ...
 !> \param diff_rho_spin ...
 !> \param rho_r_ref ...
-!> \param open_shell_embed ...
 !> \param step_len ...
 ! **************************************************************************************************
    SUBROUTINE Leeuwen_Baerends_potential_update(pw_env, embed_pot, spin_embed_pot, diff_rho_r, diff_rho_spin, &
-                                                rho_r_ref, open_shell_embed, step_len)
+                                                rho_r_ref, step_len)
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, spin_embed_pot, diff_rho_r, &
-                                                            diff_rho_spin
+      TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r_ref
-      LOGICAL                                            :: open_shell_embed
       REAL(KIND=dp)                                      :: step_len
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'Leeuwen_Baerends_potential_update'
@@ -2577,7 +2542,7 @@ CONTAINS
       NULLIFY (new_embed_pot)
 
       nspins = 1
-      IF (open_shell_embed) nspins = 2
+      IF (ASSOCIATED(spin_embed_pot)) nspins = 2
       NULLIFY (new_embed_pot)
       ALLOCATE (new_embed_pot(nspins))
       DO i_spin = 1, nspins
@@ -2588,10 +2553,10 @@ CONTAINS
          CALL pw_zero(new_embed_pot(i_spin)%pw)
       END DO
 
-      lb(1:3) = embed_pot%pw%pw_grid%bounds_local(1, 1:3)
-      ub(1:3) = embed_pot%pw%pw_grid%bounds_local(2, 1:3)
+      lb(1:3) = embed_pot%pw_grid%bounds_local(1, 1:3)
+      ub(1:3) = embed_pot%pw_grid%bounds_local(2, 1:3)
 
-      IF (.NOT. open_shell_embed) THEN
+      IF (.NOT. ASSOCIATED(spin_embed_pot)) THEN
 !$OMP    PARALLEL DO DEFAULT(NONE) &
 !$OMP                PRIVATE(i,j,k, my_rho) &
 !$OMP                SHARED(new_embed_pot, embed_pot, diff_rho_r, rho_r_ref, lb, ub, rho_cutoff, step_len)
@@ -2603,13 +2568,13 @@ CONTAINS
                   ELSE
                      my_rho = rho_cutoff
                   END IF
-                  new_embed_pot(1)%pw%cr3d(i, j, k) = step_len*embed_pot%pw%cr3d(i, j, k)* &
-                                                      (diff_rho_r%pw%cr3d(i, j, k) + rho_r_ref(1)%pw%cr3d(i, j, k))/my_rho
+                  new_embed_pot(1)%pw%cr3d(i, j, k) = step_len*embed_pot%cr3d(i, j, k)* &
+                                                      (diff_rho_r%cr3d(i, j, k) + rho_r_ref(1)%pw%cr3d(i, j, k))/my_rho
                END DO
             END DO
          END DO
 !$OMP    END PARALLEL DO
-         CALL pw_copy(new_embed_pot(1)%pw, embed_pot%pw)
+         CALL pw_copy(new_embed_pot(1)%pw, embed_pot)
 
       ELSE
          ! One has to work with spin components rather than with total and spin density
@@ -2629,17 +2594,17 @@ CONTAINS
                                    in_space=REALSPACE)
             CALL pw_zero(temp_embed_pot(i_spin)%pw)
          END DO
-         CALL pw_copy(diff_rho_r%pw, rho_n_1(1)%pw)
-         CALL pw_copy(diff_rho_r%pw, rho_n_1(2)%pw)
-         CALL pw_axpy(diff_rho_spin%pw, rho_n_1(1)%pw, 1.0_dp)
-         CALL pw_axpy(diff_rho_spin%pw, rho_n_1(2)%pw, -1.0_dp)
+         CALL pw_copy(diff_rho_r, rho_n_1(1)%pw)
+         CALL pw_copy(diff_rho_r, rho_n_1(2)%pw)
+         CALL pw_axpy(diff_rho_spin, rho_n_1(1)%pw, 1.0_dp)
+         CALL pw_axpy(diff_rho_spin, rho_n_1(2)%pw, -1.0_dp)
          CALL pw_scale(rho_n_1(1)%pw, a=0.5_dp)
          CALL pw_scale(rho_n_1(2)%pw, a=0.5_dp)
 
-         CALL pw_copy(embed_pot%pw, temp_embed_pot(1)%pw)
-         CALL pw_copy(embed_pot%pw, temp_embed_pot(2)%pw)
-         CALL pw_axpy(spin_embed_pot%pw, temp_embed_pot(1)%pw, 1.0_dp)
-         CALL pw_axpy(spin_embed_pot%pw, temp_embed_pot(2)%pw, -1.0_dp)
+         CALL pw_copy(embed_pot, temp_embed_pot(1)%pw)
+         CALL pw_copy(embed_pot, temp_embed_pot(2)%pw)
+         CALL pw_axpy(spin_embed_pot, temp_embed_pot(1)%pw, 1.0_dp)
+         CALL pw_axpy(spin_embed_pot, temp_embed_pot(2)%pw, -1.0_dp)
 
          IF (SIZE(rho_r_ref) .EQ. 2) THEN
             CALL pw_axpy(rho_r_ref(1)%pw, rho_n_1(1)%pw, 1.0_dp)
@@ -2695,12 +2660,12 @@ CONTAINS
 !$OMP    END PARALLEL DO
          END IF
 
-         CALL pw_copy(new_embed_pot(1)%pw, embed_pot%pw)
-         CALL pw_axpy(new_embed_pot(2)%pw, embed_pot%pw, 1.0_dp)
-         CALL pw_scale(embed_pot%pw, a=0.5_dp)
-         CALL pw_copy(new_embed_pot(1)%pw, spin_embed_pot%pw)
-         CALL pw_axpy(new_embed_pot(2)%pw, spin_embed_pot%pw, -1.0_dp)
-         CALL pw_scale(spin_embed_pot%pw, a=0.5_dp)
+         CALL pw_copy(new_embed_pot(1)%pw, embed_pot)
+         CALL pw_axpy(new_embed_pot(2)%pw, embed_pot, 1.0_dp)
+         CALL pw_scale(embed_pot, a=0.5_dp)
+         CALL pw_copy(new_embed_pot(1)%pw, spin_embed_pot)
+         CALL pw_axpy(new_embed_pot(2)%pw, spin_embed_pot, -1.0_dp)
+         CALL pw_scale(spin_embed_pot, a=0.5_dp)
 
          DO i_spin = 1, nspins
             CALL pw_release(rho_n_1(i_spin)%pw)
@@ -2744,9 +2709,11 @@ CONTAINS
                          vw_cutoff, vw_smooth_cutoff_range)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r_ref
-      TYPE(pw_p_type), POINTER                           :: prev_embed_pot, prev_spin_embed_pot, &
-                                                            embed_pot, spin_embed_pot, diff_rho_r, &
-                                                            diff_rho_spin
+      TYPE(pw_type), INTENT(INOUT)                       :: prev_embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: prev_spin_embed_pot
+      TYPE(pw_type), INTENT(INOUT)                       :: embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: spin_embed_pot
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_w_ref
       INTEGER, INTENT(IN)                                :: i_iter
       REAL(KIND=dp)                                      :: step_len
@@ -2784,11 +2751,11 @@ CONTAINS
          END DO
          CALL Von_Weizsacker(rho_r_ref, v_w_ref, qs_env, vw_cutoff, vw_smooth_cutoff_range)
          ! For the first step previous are set to current
-         CALL pw_copy(embed_pot%pw, prev_embed_pot%pw)
-         CALL pw_axpy(diff_rho_r%pw, embed_pot%pw, 0.5_dp)
-         IF (open_shell_embed) THEN
-            CALL pw_copy(spin_embed_pot%pw, prev_spin_embed_pot%pw)
-            CALL pw_axpy(diff_rho_r%pw, embed_pot%pw, 0.5_dp)
+         CALL pw_copy(embed_pot, prev_embed_pot)
+         CALL pw_axpy(diff_rho_r, embed_pot, 0.5_dp)
+         IF (ASSOCIATED(spin_embed_pot) .AND. ASSOCIATED(prev_spin_embed_pot)) THEN
+            CALL pw_copy(spin_embed_pot, prev_spin_embed_pot)
+            CALL pw_axpy(diff_rho_r, embed_pot, 0.5_dp)
          END IF
 
       ELSE
@@ -2825,27 +2792,27 @@ CONTAINS
 
          ! Now, deal with the current density
 
-         IF (.NOT. open_shell_embed) THEN
+         IF (.NOT. ASSOCIATED(spin_embed_pot)) THEN
             ! Reconstruct current density
-            CALL pw_copy(diff_rho_r%pw, curr_rho(1)%pw)
+            CALL pw_copy(diff_rho_r, curr_rho(1)%pw)
             CALL pw_axpy(rho_r_ref(1)%pw, curr_rho(1)%pw, 1.0_dp)
             ! Compute von Weizsaecker potential
             CALL Von_Weizsacker(curr_rho, v_w, qs_env, vw_cutoff, vw_smooth_cutoff_range)
             ! Compute new embedding potential
-            CALL pw_copy(prev_embed_pot%pw, new_embed_pot(1)%pw)
+            CALL pw_copy(prev_embed_pot, new_embed_pot(1)%pw)
             CALL pw_axpy(v_w(1)%pw, new_embed_pot(1)%pw, step_len)
             CALL pw_axpy(v_w_ref(1)%pw, new_embed_pot(1)%pw, -step_len)
             ! Copy the potentials
 
-            CALL pw_copy(embed_pot%pw, prev_embed_pot%pw)
-            CALL pw_copy(new_embed_pot(1)%pw, embed_pot%pw)
+            CALL pw_copy(embed_pot, prev_embed_pot)
+            CALL pw_copy(new_embed_pot(1)%pw, embed_pot)
 
          ELSE
             ! Reconstruct current density
-            CALL pw_copy(diff_rho_r%pw, curr_rho(1)%pw)
-            CALL pw_copy(diff_rho_r%pw, curr_rho(2)%pw)
-            CALL pw_axpy(diff_rho_spin%pw, curr_rho(1)%pw, 1.0_dp)
-            CALL pw_axpy(diff_rho_spin%pw, curr_rho(2)%pw, -1.0_dp)
+            CALL pw_copy(diff_rho_r, curr_rho(1)%pw)
+            CALL pw_copy(diff_rho_r, curr_rho(2)%pw)
+            CALL pw_axpy(diff_rho_spin, curr_rho(1)%pw, 1.0_dp)
+            CALL pw_axpy(diff_rho_spin, curr_rho(2)%pw, -1.0_dp)
             CALL pw_scale(curr_rho(1)%pw, a=0.5_dp)
             CALL pw_scale(curr_rho(2)%pw, a=0.5_dp)
 
@@ -2870,10 +2837,10 @@ CONTAINS
                                       in_space=REALSPACE)
                CALL pw_zero(temp_embed_pot(i_spin)%pw)
             END DO
-            CALL pw_copy(embed_pot%pw, temp_embed_pot(1)%pw)
-            CALL pw_copy(embed_pot%pw, temp_embed_pot(2)%pw)
-            CALL pw_axpy(spin_embed_pot%pw, temp_embed_pot(1)%pw, 1.0_dp)
-            CALL pw_axpy(spin_embed_pot%pw, temp_embed_pot(2)%pw, -1.0_dp)
+            CALL pw_copy(embed_pot, temp_embed_pot(1)%pw)
+            CALL pw_copy(embed_pot, temp_embed_pot(2)%pw)
+            CALL pw_axpy(spin_embed_pot, temp_embed_pot(1)%pw, 1.0_dp)
+            CALL pw_axpy(spin_embed_pot, temp_embed_pot(2)%pw, -1.0_dp)
 
             ! Compute new embedding potential
             IF (SIZE(v_w_ref) .EQ. 1) THEN ! Reference system is closed-shell
@@ -2895,15 +2862,15 @@ CONTAINS
             END IF
 
             ! Update embedding potentials
-            CALL pw_copy(embed_pot%pw, prev_embed_pot%pw)
-            CALL pw_copy(spin_embed_pot%pw, prev_spin_embed_pot%pw)
+            CALL pw_copy(embed_pot, prev_embed_pot)
+            CALL pw_copy(spin_embed_pot, prev_spin_embed_pot)
 
-            CALL pw_copy(new_embed_pot(1)%pw, embed_pot%pw)
-            CALL pw_axpy(new_embed_pot(2)%pw, embed_pot%pw, 1.0_dp)
-            CALL pw_scale(embed_pot%pw, a=0.5_dp)
-            CALL pw_copy(new_embed_pot(1)%pw, spin_embed_pot%pw)
-            CALL pw_axpy(new_embed_pot(2)%pw, spin_embed_pot%pw, -1.0_dp)
-            CALL pw_scale(spin_embed_pot%pw, a=0.5_dp)
+            CALL pw_copy(new_embed_pot(1)%pw, embed_pot)
+            CALL pw_axpy(new_embed_pot(2)%pw, embed_pot, 1.0_dp)
+            CALL pw_scale(embed_pot, a=0.5_dp)
+            CALL pw_copy(new_embed_pot(1)%pw, spin_embed_pot)
+            CALL pw_axpy(new_embed_pot(2)%pw, spin_embed_pot, -1.0_dp)
+            CALL pw_scale(spin_embed_pot, a=0.5_dp)
 
             DO i_spin = 1, nspins
                CALL pw_release(temp_embed_pot(i_spin)%pw)
@@ -3088,7 +3055,7 @@ CONTAINS
 !> \return ...
 ! **************************************************************************************************
    FUNCTION max_dens_diff(diff_rho_r) RESULT(total_max_diff)
-      TYPE(pw_p_type)                                    :: diff_rho_r
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r
       REAL(KIND=dp)                                      :: total_max_diff
 
       INTEGER                                            :: size_x, size_y, size_z
@@ -3098,20 +3065,20 @@ CONTAINS
       !, i_x, i_y, i_z
 
       ! Get the sizes
-      size_x = SIZE(diff_rho_r%pw%cr3d, 1)
-      size_y = SIZE(diff_rho_r%pw%cr3d, 2)
-      size_z = SIZE(diff_rho_r%pw%cr3d, 3)
+      size_x = SIZE(diff_rho_r%cr3d, 1)
+      size_y = SIZE(diff_rho_r%cr3d, 2)
+      size_z = SIZE(diff_rho_r%cr3d, 3)
 
       ! Allocate the density
       ALLOCATE (grid_3d(size_x, size_y, size_z))
 
       ! Copy density
-      grid_3d(:, :, :) = diff_rho_r%pw%cr3d(:, :, :)
+      grid_3d(:, :, :) = diff_rho_r%cr3d(:, :, :)
 
       ! Find the maximum absolute value
       max_diff = MAXVAL(ABS(grid_3d))
       total_max_diff = max_diff
-      CALL mp_max(total_max_diff, diff_rho_r%pw%pw_grid%para%group)
+      CALL mp_max(total_max_diff, diff_rho_r%pw_grid%para%group)
 
       ! Deallocate the density
       DEALLOCATE (grid_3d)
@@ -3127,10 +3094,10 @@ CONTAINS
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
    SUBROUTINE print_rho_diff(diff_rho_r, i_iter, qs_env, final_one)
-      TYPE(pw_p_type), POINTER                           :: diff_rho_r
-      INTEGER                                            :: i_iter
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL                                            :: final_one
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r
+      INTEGER, INTENT(IN)                                :: i_iter
+      TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
+      LOGICAL, INTENT(IN)                                :: final_one
 
       CHARACTER(LEN=default_path_length)                 :: filename, my_pos_cube, title
       INTEGER                                            :: unit_nr
@@ -3161,7 +3128,7 @@ CONTAINS
                                         log_filename=.FALSE.)
 
          WRITE (title, *) "EMBEDDING DENSITY DIFFERENCE ", " optimization step ", i_iter
-         CALL cp_pw_to_cube(diff_rho_r%pw, unit_nr, title, particles=particles, &
+         CALL cp_pw_to_cube(diff_rho_r, unit_nr, title, particles=particles, &
                             stride=section_get_ivals(dft_section, "QS%OPT_EMBED%EMBED_DENS_DIFF%STRIDE"))
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%QS%OPT_EMBED%EMBED_DENS_DIFF")
@@ -3178,10 +3145,10 @@ CONTAINS
 !> \author Vladimir Rybkin
 ! **************************************************************************************************
    SUBROUTINE print_rho_spin_diff(spin_diff_rho_r, i_iter, qs_env, final_one)
-      TYPE(pw_p_type), POINTER                           :: spin_diff_rho_r
-      INTEGER                                            :: i_iter
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL                                            :: final_one
+      TYPE(pw_type), INTENT(IN)                          :: spin_diff_rho_r
+      INTEGER, INTENT(IN)                                :: i_iter
+      TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
+      LOGICAL, INTENT(IN)                                :: final_one
 
       CHARACTER(LEN=default_path_length)                 :: filename, my_pos_cube, title
       INTEGER                                            :: unit_nr
@@ -3212,7 +3179,7 @@ CONTAINS
                                         log_filename=.FALSE.)
 
          WRITE (title, *) "EMBEDDING SPIN DENSITY DIFFERENCE ", " optimization step ", i_iter
-         CALL cp_pw_to_cube(spin_diff_rho_r%pw, unit_nr, title, particles=particles, &
+         CALL cp_pw_to_cube(spin_diff_rho_r, unit_nr, title, particles=particles, &
                             stride=section_get_ivals(dft_section, "QS%OPT_EMBED%EMBED_DENS_DIFF%STRIDE"))
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%QS%OPT_EMBED%EMBED_DENS_DIFF")
@@ -3227,19 +3194,18 @@ CONTAINS
 !> \param embed_pot ...
 !> \param i_iter ...
 !> \param embed_pot_spin ...
-!> \param open_shell_embed ...
 !> \param grid_opt ...
 !> \param final_one ...
 ! **************************************************************************************************
    SUBROUTINE print_embed_restart(qs_env, dimen_aux, embed_pot_coef, embed_pot, i_iter, &
-                                  embed_pot_spin, open_shell_embed, grid_opt, final_one)
+                                  embed_pot_spin, grid_opt, final_one)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER                                            :: dimen_aux
       TYPE(cp_fm_type), INTENT(IN), POINTER              :: embed_pot_coef
-      TYPE(pw_p_type), POINTER                           :: embed_pot
+      TYPE(pw_type), INTENT(IN)                          :: embed_pot
       INTEGER                                            :: i_iter
-      TYPE(pw_p_type), POINTER                           :: embed_pot_spin
-      LOGICAL                                            :: open_shell_embed, grid_opt, final_one
+      TYPE(pw_type), INTENT(IN), POINTER                 :: embed_pot_spin
+      LOGICAL                                            :: grid_opt, final_one
 
       CHARACTER(LEN=default_path_length)                 :: filename, my_pos_cube, title
       INTEGER                                            :: unit_nr
@@ -3292,12 +3258,12 @@ CONTAINS
                                         log_filename=.FALSE.)
 
          WRITE (title, *) "EMBEDDING POTENTIAL at optimization step ", i_iter
-         CALL cp_pw_to_cube(embed_pot%pw, unit_nr, title, particles=particles)
+         CALL cp_pw_to_cube(embed_pot, unit_nr, title, particles=particles)
 !, &
 !                            stride=section_get_ivals(dft_section, "QS%OPT_EMBED%EMBED_POT_CUBE%STRIDE"))
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%QS%OPT_EMBED%EMBED_POT_CUBE")
-         IF (open_shell_embed) THEN ! Print spin part of the embedding potential
+         IF (ASSOCIATED(embed_pot_spin)) THEN ! Print spin part of the embedding potential
             my_pos_cube = "REWIND"
             IF (.NOT. final_one) THEN
                WRITE (filename, '(a15,I3.3)') "spin_embed_pot_", i_iter
@@ -3309,7 +3275,7 @@ CONTAINS
                                            log_filename=.FALSE.)
 
             WRITE (title, *) "SPIN EMBEDDING POTENTIAL at optimization step ", i_iter
-            CALL cp_pw_to_cube(embed_pot_spin%pw, unit_nr, title, particles=particles)
+            CALL cp_pw_to_cube(embed_pot_spin, unit_nr, title, particles=particles)
 !,  &
 !                               stride=section_get_ivals(dft_section, "QS%OPT_EMBED%EMBED_POT_CUBE%STRIDE"))
             CALL cp_print_key_finished_output(unit_nr, logger, input, &
@@ -3325,29 +3291,31 @@ CONTAINS
 !> \param embed_pot ...
 !> \param embed_pot_spin ...
 !> \param i_iter ...
-!> \param open_shell_embed ...
 !> \param final_one ...
 !> \param qs_env_cluster ...
 ! **************************************************************************************************
-   SUBROUTINE print_pot_simple_grid(qs_env, embed_pot, embed_pot_spin, i_iter, open_shell_embed, &
+   SUBROUTINE print_pot_simple_grid(qs_env, embed_pot, embed_pot_spin, i_iter, &
                                     final_one, qs_env_cluster)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, embed_pot_spin
+      TYPE(pw_type), INTENT(IN)                          :: embed_pot
+      TYPE(pw_type), INTENT(IN), POINTER                 :: embed_pot_spin
       INTEGER                                            :: i_iter
-      LOGICAL                                            :: open_shell_embed, final_one
+      LOGICAL                                            :: final_one
       TYPE(qs_environment_type), POINTER                 :: qs_env_cluster
 
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: my_units, unit_nr
-      LOGICAL                                            :: angstrom, bohr
+      LOGICAL                                            :: angstrom, bohr, open_shell_embed
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: pot_alpha, pot_beta
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_alpha, pot_beta
       TYPE(section_vals_type), POINTER                   :: dft_section, input
 
       NULLIFY (input)
       CALL get_qs_env(qs_env=qs_env, input=input, pw_env=pw_env)
+
+      open_shell_embed = ASSOCIATED(embed_pot_spin)
 
       ! Second, cube files
       dft_section => section_vals_get_subs_vals(input, "DFT")
@@ -3378,27 +3346,21 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
          ! Create embedding potential and set to zero
-         NULLIFY (pot_alpha)
-         ALLOCATE (pot_alpha)
-         ALLOCATE (pot_alpha%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, pot_alpha%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, pot_alpha, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(pot_alpha%pw)
+         CALL pw_zero(pot_alpha)
 
-         CALL pw_copy(embed_pot%pw, pot_alpha%pw)
+         CALL pw_copy(embed_pot, pot_alpha)
 
          IF (open_shell_embed) THEN
-            NULLIFY (pot_beta)
-            ALLOCATE (pot_beta)
-            ALLOCATE (pot_beta%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, pot_beta%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, pot_beta, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
-            CALL pw_copy(embed_pot%pw, pot_beta%pw)
+            CALL pw_copy(embed_pot, pot_beta)
             ! Add spin potential to the alpha, and subtract from the beta part
-            CALL pw_axpy(embed_pot_spin%pw, pot_alpha%pw, 1.0_dp)
-            CALL pw_axpy(embed_pot_spin%pw, pot_beta%pw, -1.0_dp)
+            CALL pw_axpy(embed_pot_spin, pot_alpha, 1.0_dp)
+            CALL pw_axpy(embed_pot_spin, pot_beta, -1.0_dp)
          END IF
 
          IF (.NOT. final_one) THEN
@@ -3410,24 +3372,20 @@ CONTAINS
                                         middle_name=TRIM(filename), file_form="FORMATTED", file_position="REWIND")
 
          IF (open_shell_embed) THEN ! Print spin part of the embedding potential
-            CALL cp_pw_to_simple_volumetric(pw=pot_alpha%pw, unit_nr=unit_nr, &
+            CALL cp_pw_to_simple_volumetric(pw=pot_alpha, unit_nr=unit_nr, &
                                             stride=section_get_ivals(dft_section, "QS%OPT_EMBED%WRITE_SIMPLE_GRID%STRIDE"), &
-                                            pw2=pot_beta%pw)
+                                            pw2=pot_beta)
          ELSE
-            CALL cp_pw_to_simple_volumetric(pot_alpha%pw, unit_nr, &
+            CALL cp_pw_to_simple_volumetric(pot_alpha, unit_nr, &
                                             stride=section_get_ivals(dft_section, "QS%OPT_EMBED%WRITE_SIMPLE_GRID%STRIDE"))
          END IF
 
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%QS%OPT_EMBED%WRITE_SIMPLE_GRID")
          ! Release structures
-         CALL pw_release(pot_alpha%pw)
-         DEALLOCATE (pot_alpha%pw)
-         DEALLOCATE (pot_alpha)
+         CALL pw_release(pot_alpha)
          IF (open_shell_embed) THEN
-            CALL pw_release(pot_beta%pw)
-            DEALLOCATE (pot_beta%pw)
-            DEALLOCATE (pot_beta)
+            CALL pw_release(pot_beta)
          END IF
 
       END IF
@@ -3593,7 +3551,7 @@ CONTAINS
          opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1)%pw%cr3d(:, :, :) = &
             rho_r(i_spin)%pw%cr3d(:, :, :) - opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1)%pw%cr3d(:, :, :)
          opt_embed%max_subsys_dens_diff(i_dens_start + i_spin - 1) = &
-            max_dens_diff(opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1))
+            max_dens_diff(opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1)%pw)
       END DO
 
    END SUBROUTINE get_max_subsys_diff
@@ -3607,7 +3565,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE conv_check_embed(opt_embed, diff_rho_r, diff_rho_spin, output_unit)
       TYPE(opt_embed_pot_type)                           :: opt_embed
-      TYPE(pw_p_type), POINTER                           :: diff_rho_r, diff_rho_spin
+      TYPE(pw_type), INTENT(IN)                          :: diff_rho_r, diff_rho_spin
       INTEGER                                            :: output_unit
 
       INTEGER                                            :: i_dens, i_dens_start, i_spin
@@ -3618,12 +3576,12 @@ CONTAINS
 
       ! Calculate the convergence target values
       opt_embed%max_diff(1) = max_dens_diff(diff_rho_r)
-      opt_embed%int_diff(1) = pw_integrate_function(fun=diff_rho_r%pw, oprt='ABS')
-      opt_embed%int_diff_square(1) = pw_integral_ab(diff_rho_r%pw, diff_rho_r%pw)
+      opt_embed%int_diff(1) = pw_integrate_function(fun=diff_rho_r, oprt='ABS')
+      opt_embed%int_diff_square(1) = pw_integral_ab(diff_rho_r, diff_rho_r)
       IF (opt_embed%open_shell_embed) THEN
          opt_embed%max_diff(2) = max_dens_diff(diff_rho_spin)
-         opt_embed%int_diff(2) = pw_integrate_function(fun=diff_rho_spin%pw, oprt='ABS')
-         opt_embed%int_diff_square(2) = pw_integral_ab(diff_rho_spin%pw, diff_rho_spin%pw)
+         opt_embed%int_diff(2) = pw_integrate_function(fun=diff_rho_spin, oprt='ABS')
+         opt_embed%int_diff_square(2) = pw_integral_ab(diff_rho_spin, diff_rho_spin)
       END IF
 
       ! Find out the convergence

--- a/src/pme.F
+++ b/src/pme.F
@@ -121,11 +121,11 @@ CONTAINS
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
       TYPE(dg_type), POINTER                             :: dg
       TYPE(pw_grid_type), POINTER                        :: grid_b, grid_s
-      TYPE(pw_p_type)                                    :: rhos1, rhos2
       TYPE(pw_p_type), DIMENSION(3)                      :: dphi_g
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: pw_big_pool, pw_small_pool
-      TYPE(pw_type), POINTER                             :: phi_g, phi_r, rhob_g, rhob_r
+      TYPE(pw_type)                                      :: phi_g, phi_r, rhob_g, rhob_r, rhos1, &
+                                                            rhos2
       TYPE(realspace_grid_desc_type), POINTER            :: rs_desc
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: drpot
       TYPE(realspace_grid_type), POINTER                 :: rden, rpot
@@ -161,10 +161,9 @@ CONTAINS
                                         allocate_centre=.TRUE.)
       END IF
 
-      ALLOCATE (rhos1%pw, rhos2%pw)
-      CALL pw_pool_create_pw(pw_small_pool, rhos1%pw, &
+      CALL pw_pool_create_pw(pw_small_pool, rhos1, &
                              use_data=REALDATA3D)
-      CALL pw_pool_create_pw(pw_small_pool, rhos2%pw, &
+      CALL pw_pool_create_pw(pw_small_pool, rhos2, &
                              use_data=REALDATA3D)
 
       CALL rs_grid_create(rden, rs_desc)
@@ -203,21 +202,21 @@ CONTAINS
 
             ! add boxes to real space grid (big box)
             IF (is1_core) THEN
-               CALL dg_sum_patch(rden, rhos1%pw, exp_igr%core_centre(:, particle_set(p1)%shell_index))
+               CALL dg_sum_patch(rden, rhos1, exp_igr%core_centre(:, particle_set(p1)%shell_index))
             ELSE
-               CALL dg_sum_patch(rden, rhos1%pw, exp_igr%centre(:, p1))
+               CALL dg_sum_patch(rden, rhos1, exp_igr%centre(:, p1))
             END IF
             IF (p2 /= 0 .AND. is2_core) THEN
-               CALL dg_sum_patch(rden, rhos2%pw, exp_igr%core_centre(:, particle_set(p2)%shell_index))
+               CALL dg_sum_patch(rden, rhos2, exp_igr%core_centre(:, particle_set(p2)%shell_index))
             ELSE IF (p2 /= 0) THEN
-               CALL dg_sum_patch(rden, rhos2%pw, exp_igr%centre(:, p2))
+               CALL dg_sum_patch(rden, rhos2, exp_igr%centre(:, p2))
             END IF
          ELSE
             CALL get_patch(dg, particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                            rhos1, rhos2, charges=charges)
             ! add boxes to real space grid (big box)
-            CALL dg_sum_patch(rden, rhos1%pw, exp_igr%centre(:, p1))
-            IF (p2 /= 0) CALL dg_sum_patch(rden, rhos2%pw, exp_igr%centre(:, p2))
+            CALL dg_sum_patch(rden, rhos1, exp_igr%centre(:, p1))
+            IF (p2 /= 0) CALL dg_sum_patch(rden, rhos2, exp_igr%centre(:, p2))
          END IF
 
       END DO
@@ -231,12 +230,11 @@ CONTAINS
             CALL get_patch(dg, shell_particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                            rhos1, rhos2, is1_shell=.TRUE., is2_shell=.TRUE., charges=charges)
             ! add boxes to real space grid (big box)
-            CALL dg_sum_patch(rpot, rhos1%pw, exp_igr%shell_centre(:, p1))
-            IF (p2 /= 0) CALL dg_sum_patch(rpot, rhos2%pw, exp_igr%shell_centre(:, p2))
+            CALL dg_sum_patch(rpot, rhos1, exp_igr%shell_centre(:, p1))
+            IF (p2 /= 0) CALL dg_sum_patch(rpot, rhos2, exp_igr%shell_centre(:, p2))
          END DO
       END IF
 
-      ALLOCATE (rhob_r)
       CALL pw_pool_create_pw(pw_big_pool, rhob_r, use_data=REALDATA3D, in_space=REALSPACE)
       CALL rs_pw_transfer(rden, rhob_r, rs2pw)
 
@@ -249,8 +247,6 @@ CONTAINS
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
-      NULLIFY (phi_r)
-      ALLOCATE (phi_r)
       CALL pw_pool_create_pw(pw_big_pool, phi_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
@@ -259,7 +255,7 @@ CONTAINS
 
       ! atomic energies
       IF (atprop%energy .OR. atprop%stress) THEN
-         dvols = rhos1%pw%pw_grid%dvol
+         dvols = rhos1%pw_grid%dvol
          CALL rs_grid_create(rpot, rs_desc)
          CALL rs_pw_transfer(rpot, phi_r, pw2rs)
          ipart = 0
@@ -271,7 +267,7 @@ CONTAINS
             CALL get_patch(dg, particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                            rhos1, rhos2, charges=charges)
             ! add boxes to real space grid (big box)
-            CALL dg_sum_patch_force_1d(rpot, rhos1%pw, exp_igr%centre(:, p1), fat1)
+            CALL dg_sum_patch_force_1d(rpot, rhos1, exp_igr%centre(:, p1), fat1)
             IF (atprop%energy) THEN
                atprop%atener(p1) = atprop%atener(p1) + 0.5_dp*fat1*dvols
             END IF
@@ -281,7 +277,7 @@ CONTAINS
                atprop%atstress(3, 3, p1) = atprop%atstress(3, 3, p1) + 0.5_dp*fat1*dvols
             END IF
             IF (p2 /= 0) THEN
-               CALL dg_sum_patch_force_1d(rpot, rhos2%pw, exp_igr%centre(:, p2), fat1)
+               CALL dg_sum_patch_force_1d(rpot, rhos2, exp_igr%centre(:, p2), fat1)
                IF (atprop%energy) THEN
                   atprop%atener(p2) = atprop%atener(p2) + 0.5_dp*fat1*dvols
                END IF
@@ -293,8 +289,6 @@ CONTAINS
             END IF
          END DO
          IF (atprop%stress) THEN
-            NULLIFY (phi_g, rhob_g)
-            ALLOCATE (phi_g, rhob_g)
             CALL pw_pool_create_pw(pw_big_pool, phi_g, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
@@ -326,11 +320,11 @@ CONTAINS
                      CALL get_patch(dg, particle_set, exp_igr, box, p1, p2, grid_b, grid_s, &
                                     rhos1, rhos2, charges=charges)
                      ! add boxes to real space grid (big box)
-                     CALL dg_sum_patch_force_1d(rpot, rhos1%pw, exp_igr%centre(:, p1), fat1)
+                     CALL dg_sum_patch_force_1d(rpot, rhos1, exp_igr%centre(:, p1), fat1)
                      atprop%atstress(i, j, p1) = atprop%atstress(i, j, p1) + fat1*dvols
                      IF (i /= j) atprop%atstress(j, i, p1) = atprop%atstress(j, i, p1) + fat1*dvols
                      IF (p2 /= 0) THEN
-                        CALL dg_sum_patch_force_1d(rpot, rhos2%pw, exp_igr%centre(:, p2), fat1)
+                        CALL dg_sum_patch_force_1d(rpot, rhos2, exp_igr%centre(:, p2), fat1)
                         atprop%atstress(i, j, p2) = atprop%atstress(i, j, p2) + fat1*dvols
                         IF (i /= j) atprop%atstress(j, i, p2) = atprop%atstress(j, i, p2) + fat1*dvols
                      END IF
@@ -339,13 +333,11 @@ CONTAINS
             END DO
             CALL pw_pool_give_back_pw(pw_big_pool, phi_g)
             CALL pw_pool_give_back_pw(pw_big_pool, rhob_g)
-            DEALLOCATE (phi_g, rhob_g)
          END IF
          CALL rs_grid_release(rpot)
       END IF
 
       CALL pw_pool_give_back_pw(pw_big_pool, phi_r)
-      DEALLOCATE (phi_r)
 
       !---------- END OF ELECTROSTATIC CALCULATION --------
 
@@ -376,14 +368,13 @@ CONTAINS
       END DO
 
       CALL pw_pool_give_back_pw(pw_big_pool, rhob_r)
-      DEALLOCATE (rhob_r)
 
       !----------------- FORCE CALCULATION ----------------
 
       ! initialize the forces
       IF (PRESENT(fg_coulomb)) THEN
          fg_coulomb = 0.0_dp
-         dvols = rhos1%pw%pw_grid%dvol
+         dvols = rhos1%pw_grid%dvol
 
          ipart = 0
          DO
@@ -406,7 +397,7 @@ CONTAINS
 
             ! sum boxes on real space grids (big box)
             IF (is1_core) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos1%pw, &
+               CALL dg_sum_patch_force_3d(drpot, rhos1, &
                                           exp_igr%core_centre(:, particle_set(p1)%shell_index), fat)
                fgcore_coulomb(1, particle_set(p1)%shell_index) = &
                   fgcore_coulomb(1, particle_set(p1)%shell_index) - fat(1)*dvols
@@ -415,13 +406,13 @@ CONTAINS
                fgcore_coulomb(3, particle_set(p1)%shell_index) = &
                   fgcore_coulomb(3, particle_set(p1)%shell_index) - fat(3)*dvols
             ELSE
-               CALL dg_sum_patch_force_3d(drpot, rhos1%pw, exp_igr%centre(:, p1), fat)
+               CALL dg_sum_patch_force_3d(drpot, rhos1, exp_igr%centre(:, p1), fat)
                fg_coulomb(1, p1) = fg_coulomb(1, p1) - fat(1)*dvols
                fg_coulomb(2, p1) = fg_coulomb(2, p1) - fat(2)*dvols
                fg_coulomb(3, p1) = fg_coulomb(3, p1) - fat(3)*dvols
             END IF
             IF (p2 /= 0 .AND. is2_core) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos1%pw, &
+               CALL dg_sum_patch_force_3d(drpot, rhos1, &
                                           exp_igr%core_centre(:, particle_set(p2)%shell_index), fat)
                fgcore_coulomb(1, particle_set(p2)%shell_index) = &
                   fgcore_coulomb(1, particle_set(p2)%shell_index) - fat(1)*dvols
@@ -430,7 +421,7 @@ CONTAINS
                fgcore_coulomb(3, particle_set(p2)%shell_index) = &
                   fgcore_coulomb(3, particle_set(p2)%shell_index) - fat(3)*dvols
             ELSEIF (p2 /= 0) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos2%pw, exp_igr%centre(:, p2), fat)
+               CALL dg_sum_patch_force_3d(drpot, rhos2, exp_igr%centre(:, p2), fat)
                fg_coulomb(1, p2) = fg_coulomb(1, p2) - fat(1)*dvols
                fg_coulomb(2, p2) = fg_coulomb(2, p2) - fat(2)*dvols
                fg_coulomb(3, p2) = fg_coulomb(3, p2) - fat(3)*dvols
@@ -440,7 +431,7 @@ CONTAINS
       END IF
       IF (PRESENT(fgshell_coulomb)) THEN
          fgshell_coulomb = 0.0_dp
-         dvols = rhos1%pw%pw_grid%dvol
+         dvols = rhos1%pw_grid%dvol
 
          ipart = 0
          DO
@@ -453,12 +444,12 @@ CONTAINS
                                  is1_shell=.TRUE., is2_shell=.TRUE., charges=charges)
 
             ! sum boxes on real space grids (big box)
-            CALL dg_sum_patch_force_3d(drpot, rhos1%pw, exp_igr%shell_centre(:, p1), fat)
+            CALL dg_sum_patch_force_3d(drpot, rhos1, exp_igr%shell_centre(:, p1), fat)
             fgshell_coulomb(1, p1) = fgshell_coulomb(1, p1) - fat(1)*dvols
             fgshell_coulomb(2, p1) = fgshell_coulomb(2, p1) - fat(2)*dvols
             fgshell_coulomb(3, p1) = fgshell_coulomb(3, p1) - fat(3)*dvols
             IF (p2 /= 0) THEN
-               CALL dg_sum_patch_force_3d(drpot, rhos2%pw, exp_igr%shell_centre(:, p2), fat)
+               CALL dg_sum_patch_force_3d(drpot, rhos2, exp_igr%shell_centre(:, p2), fat)
                fgshell_coulomb(1, p2) = fgshell_coulomb(1, p2) - fat(1)*dvols
                fgshell_coulomb(2, p2) = fgshell_coulomb(2, p2) - fat(2)*dvols
                fgshell_coulomb(3, p2) = fgshell_coulomb(3, p2) - fat(3)*dvols
@@ -478,9 +469,8 @@ CONTAINS
          DEALLOCATE (drpot)
       END IF
 
-      CALL pw_pool_give_back_pw(pw_small_pool, rhos1%pw)
-      CALL pw_pool_give_back_pw(pw_small_pool, rhos2%pw)
-      DEALLOCATE (rhos1%pw, rhos2%pw)
+      CALL pw_pool_give_back_pw(pw_small_pool, rhos1)
+      CALL pw_pool_give_back_pw(pw_small_pool, rhos2)
       CALL structure_factor_deallocate(exp_igr)
 
       CALL timestop(handle)
@@ -519,7 +509,7 @@ CONTAINS
       TYPE(cell_type), INTENT(IN)                        :: box
       INTEGER, INTENT(IN)                                :: p1, p2
       TYPE(pw_grid_type), INTENT(IN)                     :: grid_b, grid_s
-      TYPE(pw_p_type)                                    :: rhos1, rhos2
+      TYPE(pw_type), INTENT(INOUT)                       :: rhos1, rhos2
       LOGICAL, OPTIONAL                                  :: is1_core, is2_core, is1_shell, is2_shell
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: core_particle_set
@@ -633,9 +623,9 @@ CONTAINS
       END IF
 
       IF (p2 == 0) THEN
-         CALL dg_get_patch(rho0%pw, rhos1%pw, q1, ex1, ey1, ez1)
+         CALL dg_get_patch(rho0%pw, rhos1, q1, ex1, ey1, ez1)
       ELSE
-         CALL dg_get_patch(rho0%pw, rhos1%pw, rhos2%pw, q1, q2, ex1, ey1, ez1, ex2, ey2, ez2)
+         CALL dg_get_patch(rho0%pw, rhos1, rhos2, q1, q2, ex1, ey1, ez1, ex2, ey2, ez2)
       END IF
 
    END SUBROUTINE get_patch
@@ -662,7 +652,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(structure_factor_type)                        :: exp_igr
       INTEGER, INTENT(IN)                                :: p1, p2
-      TYPE(pw_p_type)                                    :: rhos1, rhos2
+      TYPE(pw_type), INTENT(INOUT)                       :: rhos1, rhos2
       LOGICAL, OPTIONAL                                  :: is1_core, is2_core, is1_shell, is2_shell
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: charges
 
@@ -743,9 +733,9 @@ CONTAINS
       END IF
 
       IF (p2 == 0) THEN
-         CALL dg_get_patch(rho0%pw, rhos1%pw, q1, ex1, ey1, ez1)
+         CALL dg_get_patch(rho0%pw, rhos1, q1, ex1, ey1, ez1)
       ELSE
-         CALL dg_get_patch(rho0%pw, rhos1%pw, rhos2%pw, q1, q2, &
+         CALL dg_get_patch(rho0%pw, rhos1, rhos2, q1, q2, &
                            ex1, ey1, ez1, ex2, ey2, ez2)
       END IF
 

--- a/src/pme.F
+++ b/src/pme.F
@@ -523,7 +523,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: r1, r2
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
-      TYPE(pw_p_type), POINTER                           :: rho0
+      TYPE(pw_type), POINTER                             :: rho0
       TYPE(shell_kind_type), POINTER                     :: shell
 
       NULLIFY (shell)
@@ -623,9 +623,9 @@ CONTAINS
       END IF
 
       IF (p2 == 0) THEN
-         CALL dg_get_patch(rho0%pw, rhos1, q1, ex1, ey1, ez1)
+         CALL dg_get_patch(rho0, rhos1, q1, ex1, ey1, ez1)
       ELSE
-         CALL dg_get_patch(rho0%pw, rhos1, rhos2, q1, q2, ex1, ey1, ez1, ex2, ey2, ez2)
+         CALL dg_get_patch(rho0, rhos1, rhos2, q1, q2, ex1, ey1, ez1, ex2, ey2, ez2)
       END IF
 
    END SUBROUTINE get_patch
@@ -662,7 +662,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: q1, q2
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
-      TYPE(pw_p_type), POINTER                           :: rho0
+      TYPE(pw_type), POINTER                             :: rho0
       TYPE(shell_kind_type), POINTER                     :: shell
 
       NULLIFY (shell)
@@ -733,9 +733,9 @@ CONTAINS
       END IF
 
       IF (p2 == 0) THEN
-         CALL dg_get_patch(rho0%pw, rhos1, q1, ex1, ey1, ez1)
+         CALL dg_get_patch(rho0, rhos1, q1, ex1, ey1, ez1)
       ELSE
-         CALL dg_get_patch(rho0%pw, rhos1, rhos2, q1, q2, &
+         CALL dg_get_patch(rho0, rhos1, rhos2, q1, q2, &
                            ex1, ey1, ez1, ex2, ey2, ez2)
       END IF
 

--- a/src/pw/dg_rho0_types.F
+++ b/src/pw/dg_rho0_types.F
@@ -20,7 +20,6 @@ MODULE dg_rho0_types
                                               do_ewald_spme
    USE pw_types,                        ONLY: REALDATA3D,&
                                               pw_create,&
-                                              pw_p_type,&
                                               pw_release,&
                                               pw_type
 #include "../base/base_uses.f90"
@@ -49,7 +48,7 @@ MODULE dg_rho0_types
       REAL(KIND=dp) :: cutoff_radius
       REAL(KIND=dp), DIMENSION(:), POINTER :: gcc
       REAL(KIND=dp), DIMENSION(:), POINTER :: zet
-      TYPE(pw_p_type) :: density
+      TYPE(pw_type), POINTER :: density
    END TYPE dg_rho0_type
 
 CONTAINS
@@ -73,11 +72,11 @@ CONTAINS
       INTEGER, OPTIONAL                                  :: grid, kind
       REAL(KIND=dp), OPTIONAL                            :: cutoff_radius
       REAL(KIND=dp), OPTIONAL, POINTER                   :: gcc(:), zet(:)
-      TYPE(pw_p_type), OPTIONAL                          :: density
+      TYPE(pw_type), OPTIONAL, POINTER                   :: density
 
       IF (PRESENT(grid)) dg_rho0%grid = grid
       IF (PRESENT(kind)) dg_rho0%kind = kind
-      IF (PRESENT(density)) dg_rho0%density = density
+      IF (PRESENT(density)) dg_rho0%density => density
       IF (PRESENT(gcc)) dg_rho0%gcc => gcc
       IF (PRESENT(zet)) dg_rho0%zet => zet
       IF (PRESENT(TYPE)) dg_rho0%type = TYPE
@@ -103,11 +102,11 @@ CONTAINS
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
       INTEGER, OPTIONAL                                  :: grid, kind
       REAL(KIND=dp), OPTIONAL, POINTER                   :: gcc(:), zet(:)
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: density
+      TYPE(pw_type), OPTIONAL, POINTER                   :: density
 
       IF (PRESENT(grid)) grid = dg_rho0%grid
       IF (PRESENT(kind)) kind = dg_rho0%kind
-      IF (PRESENT(density)) density = dg_rho0%density
+      IF (PRESENT(density)) density => dg_rho0%density
       IF (PRESENT(gcc)) gcc => dg_rho0%gcc
       IF (PRESENT(zet)) zet => dg_rho0%zet
       IF (PRESENT(TYPE)) TYPE = dg_rho0%type
@@ -133,7 +132,7 @@ CONTAINS
       last_dg_rho0_id_nr = last_dg_rho0_id_nr + 1
       dg_rho0%id_nr = last_dg_rho0_id_nr
       dg_rho0%ref_count = 1
-      NULLIFY (dg_rho0%density%pw)
+      NULLIFY (dg_rho0%density)
 
    END SUBROUTINE dg_rho0_create
 
@@ -176,9 +175,9 @@ CONTAINS
             IF (ASSOCIATED(dg_rho0%zet)) THEN
                DEALLOCATE (dg_rho0%zet)
             END IF
-            IF (ASSOCIATED(dg_rho0%density%pw)) THEN
-               CALL pw_release(dg_rho0%density%pw)
-               DEALLOCATE (dg_rho0%density%pw)
+            IF (ASSOCIATED(dg_rho0%density)) THEN
+               CALL pw_release(dg_rho0%density)
+               DEALLOCATE (dg_rho0%density)
             END IF
             NULLIFY (dg_rho0%gcc)
             NULLIFY (dg_rho0%zet)
@@ -197,19 +196,18 @@ CONTAINS
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
-      IF (ASSOCIATED(dg_rho0%density%pw)) THEN
-         CALL pw_release(dg_rho0%density%pw)
-         DEALLOCATE (dg_rho0%density%pw)
+      IF (ASSOCIATED(dg_rho0%density)) THEN
+         CALL pw_release(dg_rho0%density)
+      ELSE
+         ALLOCATE (dg_rho0%density)
       END IF
       SELECT CASE (dg_rho0%type)
       CASE (do_ewald_ewald)
-         ALLOCATE (dg_rho0%density%pw)
-         CALL pw_create(dg_rho0%density%pw, pw_grid, REALDATA3D)
-         CALL dg_rho0_pme_gauss(dg_rho0%density%pw, dg_rho0%zet(1))
+         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D)
+         CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_pme)
-         ALLOCATE (dg_rho0%density%pw)
-         CALL pw_create(dg_rho0%density%pw, pw_grid, REALDATA3D)
-         CALL dg_rho0_pme_gauss(dg_rho0%density%pw, dg_rho0%zet(1))
+         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D)
+         CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_spme)
          CPABORT('SPME type not implemented')
       END SELECT

--- a/src/qmmm_gpw_energy.F
+++ b/src/qmmm_gpw_energy.F
@@ -136,7 +136,7 @@ CONTAINS
       !
       ! Initializing vectors:
       !        Zeroing v_qmmm_rspace
-      CALL pw_zero(ks_qmmm_env_loc%v_qmmm_rspace%pw)
+      CALL pw_zero(ks_qmmm_env_loc%v_qmmm_rspace)
       IF (dft_control%qs_control%semi_empirical) THEN
          ! SEMIEMPIRICAL
          SELECT CASE (qmmm_env%qmmm_coupl_type)
@@ -185,7 +185,7 @@ CONTAINS
             interp_section => section_vals_get_subs_vals(input_section, &
                                                          "QMMM%INTERPOLATOR")
             CALL qmmm_elec_with_gaussian(qmmm_env=qmmm_env, &
-                                         v_qmmm=ks_qmmm_env_loc%v_qmmm_rspace%pw, &
+                                         v_qmmm=ks_qmmm_env_loc%v_qmmm_rspace, &
                                          mm_particles=mm_particles, &
                                          aug_pools=qmmm_env%aug_pools, &
                                          para_env=para_env, &
@@ -209,7 +209,7 @@ CONTAINS
             mpi_io = .TRUE.
             iw2 = cp_print_key_unit_nr(logger, print_section, "POTENTIAL", &
                                        extension=".qmmmLog", mpi_io=mpi_io)
-            CALL cp_pw_to_cube(ks_qmmm_env_loc%v_qmmm_rspace%pw, iw2, &
+            CALL cp_pw_to_cube(ks_qmmm_env_loc%v_qmmm_rspace, iw2, &
                                particles=particles, &
                                stride=section_get_ivals(print_section, "POTENTIAL%STRIDE"), &
                                title="QM/MM: MM ELECTROSTATIC POTENTIAL ", &

--- a/src/qmmm_gpw_energy.F
+++ b/src/qmmm_gpw_energy.F
@@ -185,7 +185,7 @@ CONTAINS
             interp_section => section_vals_get_subs_vals(input_section, &
                                                          "QMMM%INTERPOLATOR")
             CALL qmmm_elec_with_gaussian(qmmm_env=qmmm_env, &
-                                         v_qmmm=ks_qmmm_env_loc%v_qmmm_rspace, &
+                                         v_qmmm=ks_qmmm_env_loc%v_qmmm_rspace%pw, &
                                          mm_particles=mm_particles, &
                                          aug_pools=qmmm_env%aug_pools, &
                                          para_env=para_env, &
@@ -246,7 +246,7 @@ CONTAINS
                                       aug_pools, cube_info, para_env, eps_mm_rspace, pw_pools, &
                                       auxbas_grid, coarser_grid, interp_section, mm_cell)
       TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
-      TYPE(pw_p_type), INTENT(INOUT)                     :: v_qmmm
+      TYPE(pw_type), INTENT(IN)                          :: v_qmmm
       TYPE(particle_type), DIMENSION(:), POINTER         :: mm_particles
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: aug_pools
       TYPE(cube_info_type), DIMENSION(:), POINTER        :: cube_info
@@ -332,12 +332,12 @@ CONTAINS
       CASE DEFAULT
          CPABORT("")
       END SELECT
-      lb = v_qmmm%pw%pw_grid%bounds_local(1, :)
-      ub = v_qmmm%pw%pw_grid%bounds_local(2, :)
+      lb = v_qmmm%pw_grid%bounds_local(1, :)
+      ub = v_qmmm%pw_grid%bounds_local(2, :)
 
-      v_qmmm%pw%cr3d = grids(auxbas_grid)%pw%cr3d(lb(1):ub(1), &
-                                                  lb(2):ub(2), &
-                                                  lb(3):ub(3))
+      v_qmmm%cr3d = grids(auxbas_grid)%pw%cr3d(lb(1):ub(1), &
+                                               lb(2):ub(2), &
+                                               lb(3):ub(3))
 
       CALL pw_pools_give_back_pws(aug_pools, grids)
 

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -1352,8 +1352,8 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_qmmm_rspace
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
+      TYPE(pw_type)                                      :: v_qmmm_rspace
       TYPE(qs_ks_qmmm_env_type), POINTER                 :: ks_qmmm_env_loc
       TYPE(section_vals_type), POINTER                   :: input_section, print_section
 
@@ -1368,8 +1368,7 @@ CONTAINS
       logger => cp_get_default_logger()
       iw = cp_print_key_unit_nr(logger, print_section, "PROGRAM_RUN_INFO", extension=".qmmmLog")
       CALL pw_env_get(pw_env=pw_env, pw_pools=pw_pools)
-      ALLOCATE (v_qmmm_rspace%pw)
-      CALL pw_pool_create_pw(pw_pools(1)%pool, v_qmmm_rspace%pw, &
+      CALL pw_pool_create_pw(pw_pools(1)%pool, v_qmmm_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       ALLOCATE (Num_Forces(3, num_mm_atoms))
       ks_qmmm_env_loc => qs_env%ks_qmmm_env
@@ -1381,7 +1380,7 @@ CONTAINS
             energy = 0.0_dp
             Diff: DO K = 1, 2
                mm_particles(IndMM)%r(J) = Coord_save + (-1)**K*Dx
-               CALL pw_zero(v_qmmm_rspace%pw)
+               CALL pw_zero(v_qmmm_rspace)
                SELECT CASE (qmmm_env%qmmm_coupl_type)
                CASE (do_qmmm_coulomb)
                   CPABORT("Coulomb QM/MM electrostatic coupling not implemented for GPW/GAPW.")
@@ -1406,7 +1405,7 @@ CONTAINS
                   IF (iw > 0) WRITE (iw, '(T3,A)') "Unknown Coupling..."
                   CPABORT("")
                END SELECT
-               energy(K) = pw_integral_ab(rho, v_qmmm_rspace%pw)
+               energy(K) = pw_integral_ab(rho, v_qmmm_rspace)
             END DO Diff
             IF (iw > 0) THEN
                WRITE (iw, '(A,I6,A,I3,A,2F15.9)') &
@@ -1448,8 +1447,7 @@ CONTAINS
       END SELECT
       CALL cp_print_key_finished_output(iw, logger, print_section, "PROGRAM_RUN_INFO")
 
-      CALL pw_pool_give_back_pw(pw_pools(1)%pool, v_qmmm_rspace%pw)
-      DEALLOCATE (v_qmmm_rspace%pw)
+      CALL pw_pool_give_back_pw(pw_pools(1)%pool, v_qmmm_rspace)
       DEALLOCATE (Num_Forces)
       CALL timestop(handle)
 100   FORMAT(I5, 2F15.9, " ( ", F7.2, " ) ", 2F15.9, " ( ", F7.2, " ) ", 2F15.9, " ( ", F7.2, " ) ")

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -218,7 +218,7 @@ CONTAINS
          IF (gapw) THEN
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
                CALL pw_transfer(rho_core, rho_tot_r)
-               energy%qmmm_nu = pw_integral_ab(rho_tot_r, ks_qmmm_env_loc%v_qmmm_rspace%pw)
+               energy%qmmm_nu = pw_integral_ab(rho_tot_r, ks_qmmm_env_loc%v_qmmm_rspace)
                NULLIFY (rho_tot_r2)
                ALLOCATE (rho_tot_r2)
                CALL pw_pool_create_pw(auxbas_pool, rho_tot_r2, &
@@ -240,7 +240,7 @@ CONTAINS
             !
             ! Computes the QM/MM Nuclear Electrostatic Potential
             !
-            energy%qmmm_nu = pw_integral_ab(rho_tot_r, ks_qmmm_env_loc%v_qmmm_rspace%pw)
+            energy%qmmm_nu = pw_integral_ab(rho_tot_r, ks_qmmm_env_loc%v_qmmm_rspace)
          END IF
          IF (need_f) THEN
             !

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -57,7 +57,6 @@ MODULE qmmm_image_charge
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_release,&
                                               pw_type
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type
@@ -104,7 +103,7 @@ CONTAINS
    SUBROUTINE calculate_image_pot(v_hartree_rspace, rho_hartree_gspace, energy, &
                                   qmmm_env, qs_env)
 
-      TYPE(pw_p_type), INTENT(IN)                        :: v_hartree_rspace, rho_hartree_gspace
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_rspace, rho_hartree_gspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -137,8 +136,9 @@ CONTAINS
       END IF
 
       ! calculate the image/metal potential with the optimized coefficients
+      ALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace%pw)
       CALL calculate_potential_metal(v_metal_rspace= &
-                                     qs_env%ks_qmmm_env%v_metal_rspace, coeff=qs_env%image_coeff, &
+                                     qs_env%ks_qmmm_env%v_metal_rspace%pw, coeff=qs_env%image_coeff, &
                                      rho_hartree_gspace=rho_hartree_gspace, &
                                      energy=energy, qs_env=qs_env)
 
@@ -158,7 +158,7 @@ CONTAINS
    SUBROUTINE calc_image_coeff_gaussalgorithm(v_hartree_rspace, coeff, qmmm_env, &
                                               qs_env)
 
-      TYPE(pw_p_type), INTENT(IN)                        :: v_hartree_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_rspace
       REAL(KIND=dp), DIMENSION(:), POINTER               :: coeff
       TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -214,7 +214,7 @@ CONTAINS
    SUBROUTINE calc_image_coeff_iterative(v_hartree_rspace, coeff, qmmm_env, &
                                          qs_env)
 
-      TYPE(pw_p_type), INTENT(IN)                        :: v_hartree_rspace
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree_rspace
       REAL(KIND=dp), DIMENSION(:), POINTER               :: coeff
       TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -225,7 +225,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: alpha, eta, rsnew, rsold, V0
       REAL(KIND=dp), DIMENSION(:), POINTER               :: Ad, d, pot_const, r, vmetal_const, z
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(pw_p_type)                                    :: auxpot_Ad_rspace, v_metal_rspace_guess
+      TYPE(pw_type)                                      :: auxpot_Ad_rspace, v_metal_rspace_guess
       TYPE(section_vals_type), POINTER                   :: input
 
       CALL timeset(routineN, handle)
@@ -293,14 +293,12 @@ CONTAINS
          iter_steps = iter_steps + 1
          ! SQRT(rsnew) < 1.0E-08
          IF (rsnew < 1.0E-16) THEN
-            CALL pw_release(auxpot_Ad_rspace%pw)
-            DEALLOCATE (auxpot_Ad_rspace%pw)
+            CALL pw_release(auxpot_Ad_rspace)
             EXIT
          END IF
          d = z + rsnew/rsold*d
          rsold = rsnew
-         CALL pw_release(auxpot_Ad_rspace%pw)
-         DEALLOCATE (auxpot_Ad_rspace%pw)
+         CALL pw_release(auxpot_Ad_rspace)
       END DO
 
       ! print iteration info
@@ -320,8 +318,7 @@ CONTAINS
          qs_env%calc_image_preconditioner = .TRUE.
       END IF
 
-      CALL pw_release(v_metal_rspace_guess%pw)
-      DEALLOCATE (v_metal_rspace_guess%pw)
+      CALL pw_release(v_metal_rspace_guess)
       DEALLOCATE (pot_const)
       DEALLOCATE (vmetal_const)
       DEALLOCATE (r)
@@ -345,7 +342,7 @@ CONTAINS
    SUBROUTINE integrate_potential_ga_rspace(potential, qmmm_env, qs_env, int_res, &
                                             atom_num, atom_num_ref)
 
-      TYPE(pw_p_type), INTENT(IN)                        :: potential
+      TYPE(pw_type), INTENT(IN)                          :: potential
       TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       REAL(KIND=dp), DIMENSION(:), POINTER               :: int_res
@@ -376,7 +373,7 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, auxbas_rs_desc=auxbas_rs_desc, &
                       auxbas_rs_grid=rs_v)
       CALL rs_grid_retain(rs_v)
-      CALL rs_pw_transfer(rs_v, potential%pw, pw2rs)
+      CALL rs_pw_transfer(rs_v, potential, pw2rs)
 
       CALL get_qs_env(qs_env=qs_env, &
                       cell=cell, &
@@ -720,9 +717,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: int_res
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_gb, vb_gspace, vb_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_gb, vb_gspace, vb_rspace
 
       CALL timeset(routineN, handle)
       NULLIFY (pw_env, auxbas_pw_pool, poisson_env, para_env, int_res)
@@ -736,31 +733,30 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      ALLOCATE (rho_gb%pw, vb_gspace%pw, vb_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_gb%pw, &
+                             rho_gb, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             vb_gspace%pw, &
+                             vb_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             vb_rspace%pw, &
+                             vb_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       ! calculate vb only once for one reference atom
       iatom_ref = 1 !
       !collocate gaussian of reference MM atom on grid
-      CALL pw_zero(rho_gb%pw)
-      CALL calculate_rho_single_gaussian(rho_gb%pw, qs_env, iatom_ref)
+      CALL pw_zero(rho_gb)
+      CALL calculate_rho_single_gaussian(rho_gb, qs_env, iatom_ref)
       !calculate potential vb like hartree potential
-      CALL pw_zero(vb_gspace%pw)
-      CALL pw_poisson_solve(poisson_env, rho_gb%pw, vhartree=vb_gspace%pw)
-      CALL pw_zero(vb_rspace%pw)
-      CALL pw_transfer(vb_gspace%pw, vb_rspace%pw)
-      CALL pw_scale(vb_rspace%pw, vb_rspace%pw%pw_grid%dvol)
+      CALL pw_zero(vb_gspace)
+      CALL pw_poisson_solve(poisson_env, rho_gb, vhartree=vb_gspace)
+      CALL pw_zero(vb_rspace)
+      CALL pw_transfer(vb_gspace, vb_rspace)
+      CALL pw_scale(vb_rspace, vb_rspace%pw_grid%dvol)
 
       DO iatom = 1, natom
          !calculate integral vb_rspace*ga
@@ -772,10 +768,9 @@ CONTAINS
          image_matrix(iatom + 1:natom, iatom) = int_res(iatom + 1:natom)
       END DO
 
-      CALL pw_release(vb_gspace%pw)
-      CALL pw_release(vb_rspace%pw)
-      CALL pw_release(rho_gb%pw)
-      DEALLOCATE (vb_gspace%pw, vb_rspace%pw, rho_gb%pw)
+      CALL pw_release(vb_gspace)
+      CALL pw_release(vb_rspace)
+      CALL pw_release(rho_gb)
 
       DEALLOCATE (int_res)
 
@@ -884,9 +879,9 @@ CONTAINS
    SUBROUTINE calculate_potential_metal(v_metal_rspace, coeff, rho_hartree_gspace, energy, &
                                         qs_env)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: v_metal_rspace
+      TYPE(pw_type), INTENT(OUT)                         :: v_metal_rspace
       REAL(KIND=dp), DIMENSION(:), POINTER               :: coeff
-      TYPE(pw_p_type), INTENT(IN), OPTIONAL              :: rho_hartree_gspace
+      TYPE(pw_type), INTENT(IN), OPTIONAL                :: rho_hartree_gspace
       TYPE(qs_energy_type), OPTIONAL, POINTER            :: energy
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
@@ -896,9 +891,9 @@ CONTAINS
       REAL(KIND=dp)                                      :: en_external, en_vmetal_rhohartree, &
                                                             total_rho_metal
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_metal, v_metal_gspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_metal, v_metal_gspace
 
       CALL timeset(routineN, handle)
 
@@ -910,45 +905,43 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      ALLOCATE (rho_metal%pw, v_metal_gspace%pw, v_metal_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_metal%pw, &
+                             rho_metal, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_metal_gspace%pw, &
+                             v_metal_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_metal_rspace%pw, &
+                             v_metal_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
-      CALL pw_zero(rho_metal%pw)
-      CALL calculate_rho_metal(rho_metal%pw, coeff, total_rho_metal=total_rho_metal, &
+      CALL pw_zero(rho_metal)
+      CALL calculate_rho_metal(rho_metal, coeff, total_rho_metal=total_rho_metal, &
                                qs_env=qs_env)
 
-      CALL pw_zero(v_metal_gspace%pw)
-      CALL pw_poisson_solve(poisson_env, rho_metal%pw, &
-                            vhartree=v_metal_gspace%pw)
+      CALL pw_zero(v_metal_gspace)
+      CALL pw_poisson_solve(poisson_env, rho_metal, &
+                            vhartree=v_metal_gspace)
 
       IF (PRESENT(rho_hartree_gspace)) THEN
-         en_vmetal_rhohartree = 0.5_dp*pw_integral_ab(v_metal_gspace%pw, &
-                                                      rho_hartree_gspace%pw)
+         en_vmetal_rhohartree = 0.5_dp*pw_integral_ab(v_metal_gspace, &
+                                                      rho_hartree_gspace)
          en_external = qs_env%qmmm_env_qm%image_charge_pot%V0*total_rho_metal
          energy%image_charge = en_vmetal_rhohartree - 0.5_dp*en_external
          CALL print_image_energy_terms(en_vmetal_rhohartree, en_external, &
                                        total_rho_metal, qs_env)
       END IF
 
-      CALL pw_zero(v_metal_rspace%pw)
-      CALL pw_transfer(v_metal_gspace%pw, v_metal_rspace%pw)
-      CALL pw_scale(v_metal_rspace%pw, v_metal_rspace%pw%pw_grid%dvol)
-      CALL pw_release(v_metal_gspace%pw)
-      CALL pw_release(rho_metal%pw)
-      DEALLOCATE (v_metal_gspace%pw, rho_metal%pw)
+      CALL pw_zero(v_metal_rspace)
+      CALL pw_transfer(v_metal_gspace, v_metal_rspace)
+      CALL pw_scale(v_metal_rspace, v_metal_rspace%pw_grid%dvol)
+      CALL pw_release(v_metal_gspace)
+      CALL pw_release(rho_metal)
 
       CALL timestop(handle)
 
@@ -962,8 +955,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE add_image_pot_to_hartree_pot(v_hartree, v_metal, qs_env)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: v_hartree
-      TYPE(pw_p_type), INTENT(IN)                        :: v_metal
+      TYPE(pw_type), INTENT(IN)                          :: v_hartree, v_metal
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'add_image_pot_to_hartree_pot'
@@ -978,7 +970,7 @@ CONTAINS
       logger => cp_get_default_logger()
 
       !add image charge potential
-      v_hartree%pw%cr3d = v_hartree%pw%cr3d + v_metal%pw%cr3d
+      v_hartree%cr3d = v_hartree%cr3d + v_metal%cr3d
 
       ! print info
       CALL get_qs_env(qs_env=qs_env, &

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -136,9 +136,9 @@ CONTAINS
       END IF
 
       ! calculate the image/metal potential with the optimized coefficients
-      ALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace%pw)
+      ALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace)
       CALL calculate_potential_metal(v_metal_rspace= &
-                                     qs_env%ks_qmmm_env%v_metal_rspace%pw, coeff=qs_env%image_coeff, &
+                                     qs_env%ks_qmmm_env%v_metal_rspace, coeff=qs_env%image_coeff, &
                                      rho_hartree_gspace=rho_hartree_gspace, &
                                      energy=energy, qs_env=qs_env)
 

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -88,8 +88,8 @@ MODULE qs_active_space_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_active_space_types,           ONLY: active_space_type,&
                                               create_active_space_type,&
                                               csr_idx_from_combined,&
@@ -950,7 +950,7 @@ CONTAINS
    SUBROUTINE calculate_eri_gpw(mos, eri_env, qs_env, iw)
 
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
-      TYPE(eri_type)                                     :: eri_env
+      TYPE(eri_type), INTENT(IN)                         :: eri_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: iw
 
@@ -973,11 +973,10 @@ CONTAINS
          POINTER                                         :: sab_orb_sub
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
-      TYPE(pw_p_type)                                    :: pot_g, rho_g, rho_r, wfn_r
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: wfn_a
-      TYPE(pw_p_type), POINTER                           :: wfn1, wfn2, wfn3, wfn4
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_g, rho_g, rho_r, wfn_r
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:, :)        :: wfn_a
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(task_list_type), POINTER                      :: task_list_sub
@@ -1064,9 +1063,8 @@ CONTAINS
                                     pw_env_external=pw_env_sub, sab_orb_external=sab_orb_sub)
       END IF
 
-      ALLOCATE (wfn_r%pw, rho_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wfn_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, wfn_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL get_qs_env(qs_env, qs_kind_set=qs_kind_set, cell=cell, &
                       particle_set=particle_set, atomic_kind_set=atomic_kind_set)
 
@@ -1078,7 +1076,7 @@ CONTAINS
          DO ispin = 1, nspins
             CALL get_mo_set(mo_set=mos(ispin)%mo_set, nmo=nx)
             nmo = MAX(nmo, nx)
-            rsize = REAL(SIZE(wfn_r%pw%cr3d), KIND=dp)*nx
+            rsize = REAL(SIZE(wfn_r%cr3d), KIND=dp)*nx
          END DO
          IF (print1 .AND. iw > 0) THEN
             rsize = rsize*8._dp/1000000._dp
@@ -1088,11 +1086,10 @@ CONTAINS
          DO ispin = 1, nspins
             CALL get_mo_set(mo_set=mos(ispin)%mo_set, mo_coeff=mo_coeff, nmo=nmo)
             DO iwfn = 1, nmo
-               ALLOCATE (wfn_a(iwfn, ispin)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, wfn_a(iwfn, ispin)%pw, &
+               CALL pw_pool_create_pw(auxbas_pw_pool, wfn_a(iwfn, ispin), &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
-               CALL calculate_wavefunction(mo_coeff, iwfn, wfn_a(iwfn, ispin)%pw, rho_g%pw, atomic_kind_set, &
+               CALL calculate_wavefunction(mo_coeff, iwfn, wfn_a(iwfn, ispin), rho_g, atomic_kind_set, &
                                            qs_kind_set, cell, dft_control, particle_set, pw_env_sub)
                IF (print2 .AND. iw > 0) THEN
                   WRITE (iw, "(T4,'ERI_GPW|',' Orbital stored ',I4,'  Spin ',i1)") iwfn, ispin
@@ -1102,14 +1099,13 @@ CONTAINS
       END IF
 
       ! get some of the grids ready
-      ALLOCATE (rho_r%pw, pot_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! run the FFT once, to set up buffers and to take into account the memory
-      rho_r%pw%cr3d = 0.0D0
-      CALL pw_transfer(rho_r%pw, rho_g%pw)
-      dvol = rho_r%pw%pw_grid%dvol
+      rho_r%cr3d = 0.0D0
+      CALL pw_transfer(rho_r, rho_g)
+      dvol = rho_r%pw_grid%dvol
 
       ! calculate the integrals
       intcount = 0
@@ -1118,11 +1114,7 @@ CONTAINS
          nmm = (nmo1*(nmo1 + 1))/2
          irange = get_irange_csr(nmm, eri_env%eri(1)%csr_mat%mp_group)
          DO iwa1 = 1, nmo1
-            IF (eri_env%eri_gpw%store_wfn) THEN
-               wfn1 => wfn_a(iwa1, isp1)
-            ELSE
-               CPABORT("")
-            END IF
+            CPASSERT(eri_env%eri_gpw%store_wfn)
             DO iwa2 = iwa1, nmo1
                iwa12 = csr_idx_to_combined(iwa1, iwa2, nmo1)
                IF (iwa12 >= irange(1) .AND. iwa12 <= irange(2)) THEN
@@ -1130,23 +1122,18 @@ CONTAINS
                ELSE
                   iwa12 = 0
                END IF
-               IF (eri_env%eri_gpw%store_wfn) THEN
-                  wfn2 => wfn_a(iwa2, isp1)
-               ELSE
-                  CPABORT("")
-               END IF
                ! calculate charge distribution and potential
-               rho_r%pw%cr3d = wfn1%pw%cr3d*wfn2%pw%cr3d
+               rho_r%cr3d = wfn_a(iwa1, isp1)%cr3d*wfn_a(iwa2, isp1)%cr3d
                IF (print2 .AND. iw > 0) THEN
-                  erint = pw_integrate_function(rho_r%pw)/dvol
+                  erint = pw_integrate_function(rho_r)/dvol
                   WRITE (iw, "(T4,'ERI_GPW| Integral rho_ab ',T32,2I4,' [',I1,']',T58,G20.14)") &
                      iwa1, iwa2, isp1, erint
                END IF
-               CALL pw_transfer(rho_r%pw, rho_g%pw)
-               CALL pw_poisson_solve(poisson_env, rho_g%pw, pair_int, pot_g%pw)
+               CALL pw_transfer(rho_r, rho_g)
+               CALL pw_poisson_solve(poisson_env, rho_g, pair_int, pot_g)
                ! screening using pair_int
                IF (pair_int < eri_env%eps_integral) CYCLE
-               CALL pw_transfer(pot_g%pw, rho_r%pw)
+               CALL pw_transfer(pot_g, rho_r)
                !
                IF (eri_env%method == eri_method_gpw_ht) THEN
                   CPABORT("Not available")
@@ -1160,21 +1147,11 @@ CONTAINS
                      IF (isp1 == isp2) iwbs = iwa1
                      isp = (isp1 - 1)*isp2 - ((isp1 - 1)*(isp1 - 2))/2 + (isp2 - isp1 + 1)
                      DO iwb1 = iwbs, nmo2
-                        IF (eri_env%eri_gpw%store_wfn) THEN
-                           wfn3 => wfn_a(iwb1, isp2)
-                        ELSE
-                           CPABORT("")
-                        END IF
                         iwbt = iwb1
                         IF (isp1 == isp2 .AND. iwa1 == iwb1) iwbt = iwa2
                         DO iwb2 = iwbt, nmo2
-                           IF (eri_env%eri_gpw%store_wfn) THEN
-                              wfn4 => wfn_a(iwb2, isp2)
-                           ELSE
-                              CPABORT("")
-                           END IF
-                           wfn_r%pw%cr3d = rho_r%pw%cr3d*wfn3%pw%cr3d*wfn4%pw%cr3d
-                           erint = pw_integrate_function(wfn_r%pw)
+                           wfn_r%cr3d = rho_r%cr3d*wfn_a(iwb1, isp2)%cr3d*wfn_a(iwb2, isp2)%cr3d
+                           erint = pw_integrate_function(wfn_r)
                            IF (ABS(erint) > eri_env%eps_integral) THEN
                               intcount = intcount + 1
                               IF (print2 .AND. iw > 0) THEN
@@ -1207,17 +1184,15 @@ CONTAINS
          DO ispin = 1, nspins
             CALL get_mo_set(mo_set=mos(ispin)%mo_set, nmo=nmo)
             DO iwfn = 1, nmo
-               CALL pw_release(wfn_a(iwfn, ispin)%pw)
-               DEALLOCATE (wfn_a(iwfn, ispin)%pw)
+               CALL pw_release(wfn_a(iwfn, ispin))
             END DO
          END DO
          DEALLOCATE (wfn_a)
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wfn_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g%pw)
-      DEALLOCATE (wfn_r%pw, rho_g%pw, rho_r%pw, pot_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wfn_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
 
       IF (eri_env%method == eri_method_gpw_ht) THEN
          CALL deallocate_task_list(task_list_sub)
@@ -1418,8 +1393,8 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
@@ -1447,9 +1422,8 @@ CONTAINS
       CALL qs_subsys_get(subsys, particles=particles)
       !
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      ALLOCATE (wf_r%pw, wf_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       !
       DO isp = 1, SIZE(mos)
          CALL get_mo_set(mo_set=mos(isp)%mo_set, mo_coeff=mo_coeff, nmo=nmo)
@@ -1476,7 +1450,7 @@ CONTAINS
                do_mo = .TRUE.
             END IF
             IF (.NOT. do_mo) CYCLE
-            CALL calculate_wavefunction(mo_coeff, imo, wf_r%pw, wf_g%pw, atomic_kind_set, &
+            CALL calculate_wavefunction(mo_coeff, imo, wf_r, wf_g, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env)
             IF (para_env%ionode) THEN
                WRITE (filename, '(A,A1,I4.4,A1,I1.1,A)') TRIM(filebody), "_", imo, "_", isp, ".cube"
@@ -1485,16 +1459,15 @@ CONTAINS
             ELSE
                unit_nr = -1
             END IF
-            CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, stride=istride)
+            CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, stride=istride)
             IF (para_env%ionode) THEN
                CALL close_file(unit_nr)
             END IF
          END DO
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      DEALLOCATE (wf_r%pw, wf_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
 
    END SUBROUTINE print_orbital_cubes
 

--- a/src/qs_cdft_methods.F
+++ b/src/qs_cdft_methods.F
@@ -246,10 +246,10 @@ CONTAINS
              becke_control%should_skip) &
             is_constraint(catom(i)) = .TRUE.
       END DO
-      bo = group(1)%weight%pw%pw_grid%bounds_local
-      dvol = group(1)%weight%pw%pw_grid%dvol
-      dr = group(1)%weight%pw%pw_grid%dr
-      np = group(1)%weight%pw%pw_grid%npts
+      bo = group(1)%weight%pw_grid%bounds_local
+      dvol = group(1)%weight%pw_grid%dvol
+      dr = group(1)%weight%pw_grid%dr
+      np = group(1)%weight%pw_grid%npts
       shift = -REAL(MODULO(np, 2), dp)*dr/2.0_dp
       DO i = 1, 3
          cell_v(i) = cell%hmat(i, i)
@@ -535,7 +535,7 @@ CONTAINS
                ! Weight function(s) at (k,j,i)
                IF (.NOT. my_just_gradients .AND. ABS(sum_cell_f_all) .GT. 0.000001) THEN
                   DO igroup = 1, SIZE(group)
-                     group(igroup)%weight%pw%cr3d(k, j, i) = sum_cell_f_group(igroup)/sum_cell_f_all
+                     group(igroup)%weight%cr3d(k, j, i) = sum_cell_f_group(igroup)/sum_cell_f_all
                   END DO
                   IF (cdft_control%atomic_charges) THEN
                      DO iatom = 1, cdft_control%natoms
@@ -727,7 +727,7 @@ CONTAINS
          ub_rs(1) = UBOUND(rs_rho_all%r(:, :, :), 1)
          ub_rs(2) = UBOUND(rs_rho_all%r(:, :, :), 2)
          ub_rs(3) = UBOUND(rs_rho_all%r(:, :, :), 3)
-         bo = cdft_control%group(igroup)%weight%pw%pw_grid%bounds_local
+         bo = cdft_control%group(igroup)%weight%pw_grid%bounds_local
 
          ! Coefficients
          coefficients(:) = 0.0_dp
@@ -753,18 +753,16 @@ CONTAINS
          END IF
 
          ! Setup pw
-         cdft_control%group(igroup)%weight%pw%cr3d = 0.0_dp
+         cdft_control%group(igroup)%weight%cr3d = 0.0_dp
 
-         ALLOCATE (cdft_control%group(igroup)%hw_rho_total_constraint%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
-         cdft_control%group(igroup)%hw_rho_total_constraint%pw%cr3d = 1.0_dp
+         cdft_control%group(igroup)%hw_rho_total_constraint%cr3d = 1.0_dp
 
          IF (igroup == 1) THEN
-            ALLOCATE (cdft_control%group(igroup)%hw_rho_total%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
-            cdft_control%group(igroup)%hw_rho_total%pw%cr3d = 1.0_dp
+            cdft_control%group(igroup)%hw_rho_total%cr3d = 1.0_dp
 
             IF (hirshfeld_control%print_density) THEN
                DO iatom = 1, cdft_control%natoms
@@ -892,17 +890,17 @@ CONTAINS
          DEALLOCATE (pab)
 
          IF (igroup == 1) THEN
-            CALL rs_pw_transfer(rs_rho_all, cdft_control%group(igroup)%hw_rho_total%pw, rs2pw)
+            CALL rs_pw_transfer(rs_rho_all, cdft_control%group(igroup)%hw_rho_total, rs2pw)
             IF (.NOT. cdft_control%in_memory) CALL rs_grid_release(rs_rho_all)
          END IF
 
-         CALL rs_pw_transfer(rs_rho_constr, cdft_control%group(igroup)%hw_rho_total_constraint%pw, rs2pw)
+         CALL rs_pw_transfer(rs_rho_constr, cdft_control%group(igroup)%hw_rho_total_constraint, rs2pw)
          CALL rs_grid_release(rs_rho_constr)
 
          ! Calculate weight function
-         CALL hfun_scale(cdft_control%group(igroup)%weight%pw%cr3d, &
-                         cdft_control%group(igroup)%hw_rho_total_constraint%pw%cr3d, &
-                         cdft_control%group(1)%hw_rho_total%pw%cr3d, divide=.TRUE., &
+         CALL hfun_scale(cdft_control%group(igroup)%weight%cr3d, &
+                         cdft_control%group(igroup)%hw_rho_total_constraint%cr3d, &
+                         cdft_control%group(1)%hw_rho_total%cr3d, divide=.TRUE., &
                          small=hirshfeld_control%eps_cutoff)
 
          ! Calculate charges
@@ -911,7 +909,7 @@ CONTAINS
                CALL rs_pw_transfer(rs_single_charge(i)%rs_grid, cdft_control%group(igroup)%hw_rho_atomic_charge(i)%pw, rs2pw)
                CALL hfun_scale(cdft_control%charge(i)%pw%cr3d, &
                                cdft_control%group(igroup)%hw_rho_atomic_charge(i)%pw%cr3d, &
-                               cdft_control%group(igroup)%hw_rho_total%pw%cr3d, divide=.TRUE., &
+                               cdft_control%group(igroup)%hw_rho_total%cr3d, divide=.TRUE., &
                                small=hirshfeld_control%eps_cutoff)
             END DO
          END IF
@@ -928,12 +926,10 @@ CONTAINS
 
       DO igroup = 1, SIZE(cdft_control%group)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint%pw)
-         DEALLOCATE (cdft_control%group(igroup)%hw_rho_total_constraint%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint)
 
          IF (.NOT. cdft_control%in_memory .AND. igroup == 1) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total%pw)
-            DEALLOCATE (cdft_control%group(1)%hw_rho_total%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total)
          END IF
 
          IF (hirshfeld_control%print_density .AND. igroup == 1) THEN
@@ -1106,11 +1102,11 @@ CONTAINS
 
                      ra(:) = particle_set(iatom)%r
 
-                     IF (cdft_control%group(igroup)%hw_rho_total%pw%cr3d(i, j, k) > hirshfeld_control%eps_cutoff) THEN
+                     IF (cdft_control%group(igroup)%hw_rho_total%cr3d(i, j, k) > hirshfeld_control%eps_cutoff) THEN
 
                         exp_eval = (coefficients(iatom) - &
-                                    cdft_control%group(igroup)%weight%pw%cr3d(i, j, k))/ &
-                                   cdft_control%group(igroup)%hw_rho_total%pw%cr3d(i, j, k)
+                                    cdft_control%group(igroup)%weight%cr3d(i, j, k))/ &
+                                   cdft_control%group(igroup)%hw_rho_total%cr3d(i, j, k)
 
                         r2 = (/i*dr_pw(1), j*dr_pw(2), k*dr_pw(3)/) + origin
                         r_pbc = pbc(ra, r2, cell)
@@ -1137,8 +1133,7 @@ CONTAINS
             END DO
 
             IF (igroup == 1) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total%pw)
-               DEALLOCATE (cdft_control%group(1)%hw_rho_total%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total)
             END IF
             CALL rs_grid_release(rs_rho_all)
          END DO
@@ -1216,7 +1211,7 @@ CONTAINS
       target_val(:) = cdft_control%target(:)
       sign = 1.0_dp
       dE = 0.0_dp
-      dvol = group(1)%weight%pw%pw_grid%dvol
+      dvol = group(1)%weight%pw_grid%dvol
       IF (cdft_control%atomic_charges) THEN
          charge => cdft_control%charge
          ALLOCATE (electronic_charge(cdft_control%natoms, dft_control%nspins))
@@ -1249,10 +1244,10 @@ CONTAINS
                IF (igroup /= 1) &
                   CALL cp_abort(__LOCATION__, &
                                 "Multiple constraints not yet supported by parallel mixed calculations.")
-               dE(igroup) = dE(igroup) + sign*accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_r(i)%pw%cr3d, &
+               dE(igroup) = dE(igroup) + sign*accurate_dot_product(group(igroup)%weight%cr3d, rho_r(i)%pw%cr3d, &
                                                                    becke_control%cavity_mat, eps_cavity)*dvol
             ELSE
-               dE(igroup) = dE(igroup) + sign*accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_r(i)%pw%cr3d)*dvol
+               dE(igroup) = dE(igroup) + sign*accurate_dot_product(group(igroup)%weight%cr3d, rho_r(i)%pw%cr3d)*dvol
             END IF
          END DO
          IF (cdft_control%atomic_charges) THEN
@@ -1413,8 +1408,8 @@ CONTAINS
 
       lb(1:3) = rho_r(1)%pw%pw_grid%bounds_local(1, 1:3)
       ub(1:3) = rho_r(1)%pw%pw_grid%bounds_local(2, 1:3)
-      bo = cdft_control%group(1)%weight%pw%pw_grid%bounds_local
-      dvol = cdft_control%group(1)%weight%pw%pw_grid%dvol
+      bo = cdft_control%group(1)%weight%pw_grid%bounds_local
+      dvol = cdft_control%group(1)%weight%pw_grid%dvol
       sign = 1.0_dp
 
       IF (cdft_control%type == outer_scf_becke_constraint) THEN
@@ -1654,7 +1649,7 @@ CONTAINS
       IF (is_becke .AND. .NOT. ASSOCIATED(becke_control)) &
          CPABORT("Becke control has not been allocated.")
       group => cdft_control%group
-      dvol = group(1)%weight%pw%pw_grid%dvol
+      dvol = group(1)%weight%pw_grid%dvol
       ! Fragment densities are meaningful only for some calculation types
       IF (.NOT. qs_env%single_point_run) &
          CALL cp_abort(__LOCATION__, &
@@ -1744,11 +1739,11 @@ CONTAINS
          END IF
          IF (is_becke .AND. (cdft_control%external_control .AND. becke_control%cavity_confine)) THEN
             cdft_control%target(igroup) = cdft_control%target(igroup) + &
-                                          accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_frag(i)%cr3d, &
+                                          accurate_dot_product(group(igroup)%weight%cr3d, rho_frag(i)%cr3d, &
                                                                becke_control%cavity_mat, becke_control%eps_cavity)*dvol
          ELSE
             cdft_control%target(igroup) = cdft_control%target(igroup) + &
-                                          accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_frag(i)%cr3d)*dvol
+                                          accurate_dot_product(group(igroup)%weight%cr3d, rho_frag(i)%cr3d)*dvol
          END IF
       END DO
       CALL mp_sum(cdft_control%target, para_env%group)

--- a/src/qs_cdft_methods.F
+++ b/src/qs_cdft_methods.F
@@ -50,7 +50,8 @@ MODULE qs_cdft_methods
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_cdft_types,                   ONLY: becke_constraint_type,&
                                               cdft_control_type,&
                                               cdft_group_type,&
@@ -649,14 +650,15 @@ CONTAINS
       TYPE(hirshfeld_type), POINTER                      :: hirshfeld_env
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: pw_single_dr, rho_r
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: pw_single_dr
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(realspace_grid_desc_type), POINTER            :: auxbas_rs_desc
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: rs_single, rs_single_charge, rs_single_dr
       TYPE(realspace_grid_type), POINTER                 :: rs_rho_all, rs_rho_constr
 
-      NULLIFY (atom_list, atomic_kind_set, dft_control, pw_single_dr, &
+      NULLIFY (atom_list, atomic_kind_set, dft_control, &
                hirshfeld_env, particle_set, pw_env, auxbas_pw_pool, para_env, &
                auxbas_rs_desc, cdft_control, pab, rs_rho_all, &
                hirshfeld_control, cell, rho_r, rho, rs_single, rs_single_dr, &
@@ -982,10 +984,9 @@ CONTAINS
                ALLOCATE (rs_single_dr(num_species))
 
                DO i = 1, num_species
-                  ALLOCATE (pw_single_dr(i)%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, pw_single_dr(i)%pw, use_data=REALDATA3D, &
+                  CALL pw_pool_create_pw(auxbas_pw_pool, pw_single_dr(i), use_data=REALDATA3D, &
                                          in_space=REALSPACE)
-                  pw_single_dr(i)%pw%cr3d(:, :, :) = 0.0_dp
+                  pw_single_dr(i)%cr3d(:, :, :) = 0.0_dp
                END DO
 
                atoms_memory_num = SIZE((/(j, j=1, num_species, atoms_memory)/))
@@ -1062,7 +1063,7 @@ CONTAINS
                   END DO
 
                   DO iatom = num_species_small(k), num_species_small(k + 1)
-                     CALL rs_pw_transfer(rs_single_dr(iatom)%rs_grid, pw_single_dr(iatom)%pw, rs2pw)
+                     CALL rs_pw_transfer(rs_single_dr(iatom)%rs_grid, pw_single_dr(iatom), rs2pw)
                      CALL rs_grid_release(rs_single_dr(iatom)%rs_grid)
                   END DO
 
@@ -1071,9 +1072,8 @@ CONTAINS
 
                DO iatom = 1, num_species
                   atom_a = atom_list(iatom)
-                  cdft_control%group(igroup)%gradients_x(atom_a, :, :, :) = pw_single_dr(iatom)%pw%cr3d(:, :, :)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_single_dr(iatom)%pw)
-                  DEALLOCATE (pw_single_dr(iatom)%pw)
+                  cdft_control%group(igroup)%gradients_x(atom_a, :, :, :) = pw_single_dr(iatom)%cr3d(:, :, :)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_single_dr(iatom))
                END DO
 
                DEALLOCATE (rs_single_dr)
@@ -1636,11 +1636,11 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_frag
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: rho_frag
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
-      NULLIFY (para_env, dft_control, logger, subsys, pw_env, auxbas_pw_pool, group, rho_frag)
+      NULLIFY (para_env, dft_control, logger, subsys, pw_env, auxbas_pw_pool, group)
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
       CALL get_qs_env(qs_env, &
@@ -1717,11 +1717,10 @@ CONTAINS
       END IF
       ! Sum up fragments
       DO i = 1, nfrag_spins
-         ALLOCATE (rho_frag(i)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_frag(i)%pw, use_data=REALDATA3D, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_frag(i), use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_copy(cdft_control%fragments(i, 1)%pw, rho_frag(i)%pw)
-         CALL pw_axpy(cdft_control%fragments(i, 2)%pw, rho_frag(i)%pw, 1.0_dp)
+         CALL pw_copy(cdft_control%fragments(i, 1)%pw, rho_frag(i))
+         CALL pw_axpy(cdft_control%fragments(i, 2)%pw, rho_frag(i), 1.0_dp)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%fragments(i, 1)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%fragments(i, 2)%pw)
          DEALLOCATE (cdft_control%fragments(i, 1)%pw, cdft_control%fragments(i, 2)%pw)
@@ -1730,7 +1729,7 @@ CONTAINS
       ! Check that the number of electrons is consistent
       CALL get_qs_env(qs_env, subsys=subsys)
       CALL qs_subsys_get(subsys, nelectron_total=nelectron_total)
-      nelectron_frag = pw_integrate_function(rho_frag(1)%pw)
+      nelectron_frag = pw_integrate_function(rho_frag(1))
       IF (NINT(nelectron_frag) /= nelectron_total) &
          CALL cp_abort(__LOCATION__, &
                        "The number of electrons in the reference and interacting "// &
@@ -1745,11 +1744,11 @@ CONTAINS
          END IF
          IF (is_becke .AND. (cdft_control%external_control .AND. becke_control%cavity_confine)) THEN
             cdft_control%target(igroup) = cdft_control%target(igroup) + &
-                                          accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_frag(i)%pw%cr3d, &
+                                          accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_frag(i)%cr3d, &
                                                                becke_control%cavity_mat, becke_control%eps_cavity)*dvol
          ELSE
             cdft_control%target(igroup) = cdft_control%target(igroup) + &
-                                          accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_frag(i)%pw%cr3d)*dvol
+                                          accurate_dot_product(group(igroup)%weight%pw%cr3d, rho_frag(i)%cr3d)*dvol
          END IF
       END DO
       CALL mp_sum(cdft_control%target, para_env%group)
@@ -1759,14 +1758,13 @@ CONTAINS
          DO i = 1, nfrag_spins
             DO iatom = 1, cdft_control%natoms
                cdft_control%charges_fragment(iatom, i) = &
-                  accurate_dot_product(cdft_control%charge(iatom)%pw%cr3d, rho_frag(i)%pw%cr3d)*dvol
+                  accurate_dot_product(cdft_control%charge(iatom)%pw%cr3d, rho_frag(i)%cr3d)*dvol
             END DO
          END DO
          CALL mp_sum(cdft_control%charges_fragment, para_env%group)
       END IF
       DO i = 1, nfrag_spins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_frag(i)%pw)
-         DEALLOCATE (rho_frag(i)%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_frag(i))
       END DO
       DEALLOCATE (rho_frag)
       cdft_control%fragments_integrated = .TRUE.

--- a/src/qs_cdft_types.F
+++ b/src/qs_cdft_types.F
@@ -27,7 +27,8 @@ MODULE qs_cdft_types
                                               dp
    USE outer_scf_control_types,         ONLY: outer_scf_control_type,&
                                               qs_outer_scf_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_p_type,&
+                                              pw_type
    USE qs_cdft_opt_types,               ONLY: cdft_opt_type_release
 #include "./base/base_uses.f90"
 
@@ -209,12 +210,12 @@ MODULE qs_cdft_types
       REAL(KIND=dp), POINTER, &
          DIMENSION(:, :, :, :)             :: gradients_z
       ! The weight function of this constraint group
-      TYPE(pw_p_type)                      :: weight
+      TYPE(pw_type), POINTER                      :: weight
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: hw_rho_atomic
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: hw_rho_atomic_dr
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: hw_rho_atomic_charge
-      TYPE(pw_p_type)             :: hw_rho_total_constraint
-      TYPE(pw_p_type)          :: hw_rho_total
+      TYPE(pw_type)             :: hw_rho_total_constraint
+      TYPE(pw_type)          :: hw_rho_total
    END TYPE cdft_group_type
 
    TYPE cdft_control_type

--- a/src/qs_cdft_utils.F
+++ b/src/qs_cdft_utils.F
@@ -201,7 +201,7 @@ CONTAINS
       END IF
       ! Zero weight functions
       DO igroup = 1, SIZE(group)
-         group(igroup)%weight%pw%cr3d = 0.0_dp
+         group(igroup)%weight%cr3d = 0.0_dp
       END DO
       IF (cdft_control%atomic_charges) THEN
          DO iatom = 1, cdft_control%natoms
@@ -408,7 +408,7 @@ CONTAINS
          IF (in_memory .OR. cdft_control%save_pot) THEN
             CALL hfun_zero(becke_control%cavity%pw%cr3d, eps_cavity, just_bounds=.TRUE., bounds=bounds)
             ! Save bounds (first nonzero grid point indices)
-            bo = group(1)%weight%pw%pw_grid%bounds_local
+            bo = group(1)%weight%pw_grid%bounds_local
             IF (bounds(2) .LT. bo(2, 3)) THEN
                bounds(2) = bounds(2) - 1
             ELSE
@@ -566,7 +566,7 @@ CONTAINS
          END DO
          ALLOCATE (cdft_control%group(k)%atoms(natoms))
          ALLOCATE (cdft_control%group(k)%coeff(natoms))
-         NULLIFY (cdft_control%group(k)%weight%pw)
+         NULLIFY (cdft_control%group(k)%weight)
          NULLIFY (cdft_control%group(k)%integrated)
          tot_natoms = tot_natoms + natoms
          ! Now parse
@@ -1306,7 +1306,7 @@ CONTAINS
             CALL cp_abort(__LOCATION__, &
                           "Please turn on PROGRAM_RUN_INFO to print CDFT weight function.")
 
-         CALL cp_pw_to_cube(cdft_control%group(igroup)%weight%pw, &
+         CALL cp_pw_to_cube(cdft_control%group(igroup)%weight, &
                             unit_nr, &
                             "CDFT Weight Function", &
                             particles=particles, &
@@ -1356,7 +1356,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, cdft_constraint_section, "PROGRAM_RUN_INFO", mpi_io=mpi_io, &
                                         file_position="REWIND", middle_name=middle_name, extension=".cube")
 
-         CALL cp_pw_to_cube(cdft_control%group(igroup)%hw_rho_total%pw, unit_nr, "CDFT Weight Function", mpi_io=mpi_io, &
+         CALL cp_pw_to_cube(cdft_control%group(igroup)%hw_rho_total, unit_nr, "CDFT Weight Function", mpi_io=mpi_io, &
                   particles=particles, stride=section_get_ivals(cdft_constraint_section, "PROGRAM_RUN_INFO%WEIGHT_FUNCTION%STRIDE"))
 
          CALL cp_print_key_finished_output(unit_nr, logger, cdft_constraint_section, "PROGRAM_RUN_INFO", mpi_io=mpi_io)
@@ -1369,7 +1369,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, cdft_constraint_section, "PROGRAM_RUN_INFO", mpi_io=mpi_io, &
                                         file_position="REWIND", middle_name=middle_name, extension=".cube")
 
-         CALL cp_pw_to_cube(cdft_control%group(igroup)%hw_rho_total_constraint%pw, unit_nr, &
+         CALL cp_pw_to_cube(cdft_control%group(igroup)%hw_rho_total_constraint, unit_nr, &
                             "CDFT Weight Function", mpi_io=mpi_io, particles=particles, &
                             stride=section_get_ivals(cdft_constraint_section, "PROGRAM_RUN_INFO%WEIGHT_FUNCTION%STRIDE"))
 

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -1480,7 +1480,7 @@ CONTAINS
                                  ks_env, soft_valid, compute_tau, compute_grad, &
                                  basis_type, der_type, idir, task_list_external, pw_env_external)
 
-      TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_p
+      TYPE(dbcsr_type), OPTIONAL, TARGET                 :: matrix_p
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
       TYPE(pw_type), INTENT(INOUT)                       :: rho, rho_gspace
@@ -1647,7 +1647,7 @@ CONTAINS
    SUBROUTINE calculate_drho_elec(matrix_p, matrix_p_kp, drho, drho_gspace, qs_env, &
                                   soft_valid, basis_type)
 
-      TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_p
+      TYPE(dbcsr_type), OPTIONAL, TARGET                 :: matrix_p
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
       TYPE(pw_type), DIMENSION(3), INTENT(INOUT)         :: drho, drho_gspace
@@ -2030,7 +2030,7 @@ CONTAINS
    SUBROUTINE calculate_drho_elec_dR(matrix_p, matrix_p_kp, drho, drho_gspace, qs_env, &
                                      soft_valid, basis_type, beta, lambda)
 
-      TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_p
+      TYPE(dbcsr_type), OPTIONAL, TARGET                 :: matrix_p
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_p_kp
       TYPE(pw_type), INTENT(INOUT)                       :: drho, drho_gspace

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -264,6 +264,7 @@ CONTAINS
                              rho1_r, rho1_g_pw, tau1_r, auxbas_pw_pool, xc_section, gapw=.FALSE.)
 
       v_rspace_new = v_xc(1)%pw
+      DEALLOCATE (v_xc(1)%pw)
       DEALLOCATE (v_xc)
 
       ! Done calculating the potentials

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -132,12 +132,12 @@ CONTAINS
                                                             s1_ao
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho1_ao, rho_ao
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho1_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho1_g, rho1_g_pw, rho1_r, rho_r, &
-                                                            tau1_r, v_rspace_new, v_xc, v_xc_tau
+                                                            tau1_r, v_xc, v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho1_tot_gspace, v_hartree_gspace, &
+                                                            v_hartree_rspace, v_rspace_new
       TYPE(qs_rho_type), POINTER                         :: perturbed_density, rho
       TYPE(section_vals_type), POINTER                   :: input, xc_section
       TYPE(xc_derivative_set_type)                       :: deriv_set
@@ -163,7 +163,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (auxbas_pw_pool, pw_env, v_rspace_new, rho1_r, rho1_g_pw, &
+      NULLIFY (auxbas_pw_pool, pw_env, rho1_r, rho1_g_pw, &
                v_xc, poisson_env, input, rho, rho1_g, v_xc_tau)
 
       CALL dbcsr_set(dcdr_env%perturbed_dm_correction, 0._dp)
@@ -237,37 +237,33 @@ CONTAINS
 
       ! Done with deriv_set and rho_set
 
-      ALLOCATE (v_rspace_new(1))
-      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       ! Calculate the Hartree potential on the total density
-      ALLOCATE (rho1_tot_gspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       CALL qs_rho_get(perturbed_density, rho_g=rho1_g, rho_r=rho1_r, tau_r=tau1_r)
-      CALL pw_copy(rho1_g(1)%pw, rho1_tot_gspace%pw)
+      CALL pw_copy(rho1_g(1)%pw, rho1_tot_gspace)
 
-      CALL pw_poisson_solve(poisson_env, rho1_tot_gspace%pw, &
+      CALL pw_poisson_solve(poisson_env, rho1_tot_gspace, &
                             energy_hartree, &
-                            v_hartree_gspace%pw)
-      CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
+                            v_hartree_gspace)
+      CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace%pw)
-      DEALLOCATE (rho1_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace)
 
       ! Calculate the second derivative of the exchange-correlation potential
       CALL xc_calc_2nd_deriv(v_xc, v_xc_tau, deriv_set, rho_set, &
                              rho1_r, rho1_g_pw, tau1_r, auxbas_pw_pool, xc_section, gapw=.FALSE.)
 
-      v_rspace_new(1)%pw => v_xc(1)%pw
+      v_rspace_new = v_xc(1)%pw
       DEALLOCATE (v_xc)
 
       ! Done calculating the potentials
@@ -275,23 +271,21 @@ CONTAINS
       !-------------------------------!
       ! Add both hartree and xc terms !
       !-------------------------------!
-      CALL pw_scale(v_rspace_new(1)%pw, 2._dp*v_rspace_new(1)%pw%pw_grid%dvol)
-      CALL pw_scale(v_hartree_rspace%pw, 2._dp*v_hartree_rspace%pw%pw_grid%dvol)
+      CALL pw_scale(v_rspace_new, 2._dp*v_rspace_new%pw_grid%dvol)
+      CALL pw_scale(v_hartree_rspace, 2._dp*v_hartree_rspace%pw_grid%dvol)
 
       ! pw2 = 1.*pw1 + pw2
-      CALL pw_axpy(v_hartree_rspace%pw, v_rspace_new(1)%pw, 1._dp)
+      CALL pw_axpy(v_hartree_rspace, v_rspace_new, 1._dp)
 
       CALL dbcsr_set(dcdr_env%matrix_apply_op_constant(1)%matrix, 0.0_dp)
-      CALL integrate_v_rspace(v_rspace=v_rspace_new(1)%pw, &
+      CALL integrate_v_rspace(v_rspace=v_rspace_new, &
                               hmat=dcdr_env%matrix_apply_op_constant(1), &
                               qs_env=qs_env, &
                               calculate_forces=.FALSE.)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(1)%pw)
-      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, v_rspace_new(1)%pw)
-      DEALLOCATE (v_rspace_new)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new)
 
       IF (ASSOCIATED(v_xc_tau)) THEN
          CALL pw_scale(v_xc_tau(1)%pw, 2._dp*v_xc_tau(1)%pw%pw_grid%dvol)
@@ -334,11 +328,11 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: drho_g, v_hartree_gspace, &
-                                                            v_hartree_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: drho_g, v_hartree_gspace, &
+                                                            v_hartree_rspace
       TYPE(qs_rho_type), POINTER                         :: rho
 
       CALL timeset(routineN, handle)
@@ -346,7 +340,7 @@ CONTAINS
       logger => cp_get_default_logger()
 
       NULLIFY (pw_env, auxbas_pw_pool, pw_pools, poisson_env, dft_control, &
-               v_hartree_gspace%pw, v_hartree_rspace%pw, rho)
+               rho)
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho, &
                       dft_control=dft_control)
@@ -355,44 +349,41 @@ CONTAINS
                       pw_pools=pw_pools)
 
       ! Create the Hartree potential grids in real and reciprocal space.
-      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_hartree_gspace%pw, &
+                             v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_hartree_rspace%pw, &
+                             v_hartree_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
       ! Create the grid for the derivative of the core potential
-      ALLOCATE (drho_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, drho_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, drho_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       DO beta = 1, 3
-         CALL pw_zero(v_hartree_gspace%pw)
-         CALL pw_zero(v_hartree_rspace%pw)
-         CALL pw_zero(drho_g%pw)
+         CALL pw_zero(v_hartree_gspace)
+         CALL pw_zero(v_hartree_rspace)
+         CALL pw_zero(drho_g)
 
          ! Calculate the Hartree potential on the perturbed density and Poisson solve it
-         CALL calculate_drho_core(drho_core=drho_g%pw, qs_env=qs_env, &
+         CALL calculate_drho_core(drho_core=drho_g, qs_env=qs_env, &
                                   beta=beta, lambda=dcdr_env%lambda)
-         CALL pw_poisson_solve(poisson_env, drho_g%pw, &
-                               vhartree=v_hartree_gspace%pw)
-         CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
-         CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+         CALL pw_poisson_solve(poisson_env, drho_g, &
+                               vhartree=v_hartree_gspace)
+         CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
+         CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
 
          ! Calculate the integrals
-         CALL integrate_v_rspace(v_rspace=v_hartree_rspace%pw, &
+         CALL integrate_v_rspace(v_rspace=v_hartree_rspace, &
                                  hmat=dcdr_env%matrix_core_charge_1(beta), &
                                  qs_env=qs_env, &
                                  calculate_forces=.FALSE.)
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      DEALLOCATE (drho_g%pw, v_hartree_rspace%pw, v_hartree_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
 
       CALL timestop(handle)
    END SUBROUTINE d_core_charge_density_dR

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -189,9 +189,9 @@ CONTAINS
                                                             q0, rho
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: drho, thetas
       TYPE(pw_grid_type), POINTER                        :: grid
-      TYPE(pw_p_type), ALLOCATABLE, DIMENSION(:)         :: thetas_g
-      TYPE(pw_p_type), ALLOCATABLE, DIMENSION(:, :)      :: drho_r
-      TYPE(pw_type), POINTER                             :: tmp_g, tmp_r, vxc_g, vxc_r
+      TYPE(pw_type)                                      :: tmp_g, tmp_r, vxc_g, vxc_r
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: thetas_g
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:, :)        :: drho_r
 
       CALL timeset(routineN, handle)
 
@@ -220,8 +220,6 @@ CONTAINS
       const = 1.0_dp/(3.0_dp*SQRT(pi)*b_value**1.5_dp)/(pi**0.75_dp)
 
       ! temporary arrays for FFT
-      NULLIFY (tmp_g, tmp_r)
-      ALLOCATE (tmp_g, tmp_r)
       CALL pw_pool_create_pw(pw_pool, tmp_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(pw_pool, tmp_r, use_data=REALDATA3D, in_space=REALSPACE)
 
@@ -229,12 +227,11 @@ CONTAINS
       ALLOCATE (drho_r(3, nspin))
       DO ispin = 1, nspin
          DO idir = 1, 3
-            ALLOCATE (drho_r(idir, ispin)%pw)
-            CALL pw_pool_create_pw(pw_pool, drho_r(idir, ispin)%pw, &
+            CALL pw_pool_create_pw(pw_pool, drho_r(idir, ispin), &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(rho_g(ispin)%pw, tmp_g)
             CALL pw_derive(tmp_g, nd(:, idir))
-            CALL pw_transfer(tmp_g, drho_r(idir, ispin)%pw)
+            CALL pw_transfer(tmp_g, drho_r(idir, ispin))
          END DO
       END DO
 
@@ -295,7 +292,7 @@ CONTAINS
                DO q = 0, n(2) - 1
                   DO p = 0, n(1) - 1
                      s = r*n(2)*n(1) + q*n(1) + p + 1
-                     drho(s, i) = drho(s, i) + drho_r(i, ispin)%pw%cr3d(p + lo(1), q + lo(2), r + lo(3))
+                     drho(s, i) = drho(s, i) + drho_r(i, ispin)%cr3d(p + lo(1), q + lo(2), r + lo(3))
                   END DO
                END DO
             END DO
@@ -400,11 +397,10 @@ CONTAINS
             END DO
          END DO
 !$OMP END PARALLEL DO
-         ALLOCATE (thetas_g(i)%pw)
-         CALL pw_pool_create_pw(pw_pool, thetas_g(i)%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_transfer(tmp_r, thetas_g(i)%pw)
+         CALL pw_pool_create_pw(pw_pool, thetas_g(i), use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL pw_transfer(tmp_r, thetas_g(i))
       END DO
-      grid => thetas_g(1)%pw%pw_grid
+      grid => thetas_g(1)%pw_grid
       !! ---------------------------------------------------------------------------------------------
       !! Carry out the integration in equation 8 of SOLER.  This also turns the thetas array into the
       !! precursor to the u_i(k) array which is inverse fourier transformed to get the u_i(r) functions
@@ -447,7 +443,7 @@ CONTAINS
             n(i) = hi(i) - lo(i) + 1
          END DO
          DO i = 1, dispersion_env%nqs
-            CALL pw_transfer(thetas_g(i)%pw, tmp_r)
+            CALL pw_transfer(thetas_g(i), tmp_r)
 !$OMP PARALLEL DO DEFAULT(NONE)                        &
 !$OMP             SHARED(i,n,lo,thetas,tmp_r)          &
 !$OMP             COLLAPSE(3)
@@ -482,8 +478,6 @@ CONTAINS
             potential(:) = (0.5_dp*potential(:) + beta)*dispersion_env%scale_rvv10
             hpot(:) = 0.5_dp*dispersion_env%scale_rvv10*hpot(:)
          END SELECT
-         NULLIFY (vxc_r)
-         ALLOCATE (vxc_r)
          CALL pw_pool_create_pw(pw_pool, vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
          DO i = 1, 3
             lo(i) = LBOUND(vxc_r%cr3d, i)
@@ -527,7 +521,7 @@ CONTAINS
                      DO p = 0, n(1) - 1
                         tmp_r%cr3d(p + lo(1), q + lo(2), r + lo(3)) = tmp_r%cr3d(p + lo(1), q + lo(2), r + lo(3)) &
                                                                       + hpot(r*n(2)*n(1) + q*n(1) + p + 1) &
-                                                                      *drho_r(idir, ispin)%pw%cr3d(p + lo(1), q + lo(2), r + lo(3))
+                                                                      *drho_r(idir, ispin)%cr3d(p + lo(1), q + lo(2), r + lo(3))
                      END DO
                   END DO
                END DO
@@ -540,9 +534,6 @@ CONTAINS
          END DO
          CALL pw_transfer(vxc_r, tmp_g)
          CALL pw_pool_give_back_pw(pw_pool, vxc_r)
-         DEALLOCATE (vxc_r)
-         NULLIFY (vxc_r)
-         ALLOCATE (vxc_r, vxc_g)
          CALL pw_pool_create_pw(xc_pw_pool, vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_pool_create_pw(xc_pw_pool, vxc_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_transfer(tmp_g, vxc_g)
@@ -552,25 +543,21 @@ CONTAINS
          END DO
          CALL pw_pool_give_back_pw(xc_pw_pool, vxc_r)
          CALL pw_pool_give_back_pw(xc_pw_pool, vxc_g)
-         DEALLOCATE (vxc_r, vxc_g)
          DEALLOCATE (q0, dq0_drho, dq0_dgradrho)
       END IF
 
       DEALLOCATE (thetas)
 
       DO i = 1, dispersion_env%nqs
-         CALL pw_pool_give_back_pw(pw_pool, thetas_g(i)%pw)
-         DEALLOCATE (thetas_g(i)%pw)
+         CALL pw_pool_give_back_pw(pw_pool, thetas_g(i))
       END DO
       DO ispin = 1, nspin
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin)%pw)
-            DEALLOCATE (drho_r(idir, ispin)%pw)
+            CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin))
          END DO
       END DO
       CALL pw_pool_give_back_pw(pw_pool, tmp_r)
       CALL pw_pool_give_back_pw(pw_pool, tmp_g)
-      DEALLOCATE (tmp_r, tmp_g)
 
       DEALLOCATE (rho, drho, drho_r, thetas_g)
 
@@ -592,7 +579,7 @@ CONTAINS
 !>    OpenMP added: Aug 2016  MTucker
 ! **************************************************************************************************
    SUBROUTINE vdW_energy(thetas_g, dispersion_env, vdW_xc_energy, energy_only, virial)
-      TYPE(pw_p_type), ALLOCATABLE, DIMENSION(:)         :: thetas_g
+      TYPE(pw_type), DIMENSION(:), INTENT(IN)            :: thetas_g
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
       REAL(KIND=dp), INTENT(OUT)                         :: vdW_xc_energy
       LOGICAL, INTENT(IN)                                :: energy_only
@@ -618,7 +605,7 @@ CONTAINS
       virial_thread(:, :) = 0.0_dp ! always initialize to avoid floating point exceptions in OMP REDUCTION
 
       vdW_xc_energy = 0._dp
-      grid => thetas_g(1)%pw%pw_grid
+      grid => thetas_g(1)%pw_grid
 
       IF (grid%grid_span == HALFSPACE) THEN
          g_multiplier = 2._dp
@@ -660,7 +647,7 @@ CONTAINS
             IF (use_virial) CALL interpolate_dkernel_dk(g, dkernel_of_dk, dispersion_env)
          END IF
          DO iq = 1, nqs
-            theta(iq) = thetas_g(iq)%pw%cc(ig)
+            theta(iq) = thetas_g(iq)%cc(ig)
          END DO
          DO q2_i = 1, nqs
             uu = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
@@ -699,7 +686,7 @@ CONTAINS
 !$OMP DO
          DO ig = 1, grid%ngpts_cut_local
             DO iq = 1, nqs
-               thetas_g(iq)%pw%cc(ig) = u_vdW(ig, iq)
+               thetas_g(iq)%cc(ig) = u_vdW(ig, iq)
             END DO
          END DO
 !$OMP END DO
@@ -906,7 +893,7 @@ CONTAINS
 !> \par History
 !>     Created:  MTucker, Aug 2016
 ! **************************************************************************************************
-   SUBROUTINE calculate_exponent(hi, alpha, exponent)
+   ELEMENTAL SUBROUTINE calculate_exponent(hi, alpha, exponent)
       INTEGER, INTENT(in)                                :: hi
       REAL(dp), INTENT(in)                               :: alpha
       REAL(dp), INTENT(out)                              :: exponent
@@ -933,7 +920,7 @@ CONTAINS
 !> \par History
 !>     Created:  MTucker, Aug 2016
 ! **************************************************************************************************
-   SUBROUTINE calculate_exponent_derivative(hi, alpha, exponent, derivative)
+   ELEMENTAL SUBROUTINE calculate_exponent_derivative(hi, alpha, exponent, derivative)
       INTEGER, INTENT(in)                                :: hi
       REAL(dp), INTENT(in)                               :: alpha
       REAL(dp), INTENT(out)                              :: exponent, derivative
@@ -1074,7 +1061,7 @@ CONTAINS
 !> \param dq0_dgradrho ...
 !> \param dispersion_env ...
 ! **************************************************************************************************
-   SUBROUTINE get_q0_on_grid_rvv10(total_rho, gradient_rho, q0, dq0_drho, dq0_dgradrho, dispersion_env)
+   PURE SUBROUTINE get_q0_on_grid_rvv10(total_rho, gradient_rho, q0, dq0_drho, dq0_dgradrho, dispersion_env)
       !!
       !! more specifically it calculates the following
       !!
@@ -1232,7 +1219,7 @@ CONTAINS
 !> \param q0 ...
 !> \param dispersion_env ...
 ! **************************************************************************************************
-   SUBROUTINE get_q0_on_grid_eo_rvv10(total_rho, gradient_rho, q0, dispersion_env)
+   PURE SUBROUTINE get_q0_on_grid_eo_rvv10(total_rho, gradient_rho, q0, dispersion_env)
 
       REAL(dp), INTENT(IN)                               :: total_rho(:), gradient_rho(:, :)
       REAL(dp), INTENT(OUT)                              :: q0(:)

--- a/src/qs_electric_field_gradient.F
+++ b/src/qs_electric_field_gradient.F
@@ -59,7 +59,6 @@ MODULE qs_electric_field_gradient
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -114,13 +113,12 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: dvr2rs, structure_factor, &
-                                                            v_hartree_gspace
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: dvr2, dvspl
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_spline_precond_type)                       :: precond
-      TYPE(pw_type), POINTER                             :: rho_tot_gspace
+      TYPE(pw_type)                                      :: dvr2rs, rho_tot_gspace, &
+                                                            structure_factor, v_hartree_gspace
+      TYPE(pw_type), DIMENSION(6)                        :: dvr2, dvspl
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set
@@ -163,13 +161,11 @@ CONTAINS
       ELSEIF (ecut == -1._dp .AND. sigma == -1._dp) THEN
          smoothing = .TRUE.
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (dvr2rs%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
-         ecut = 2._dp*dvr2rs%pw%pw_grid%cutoff*0.875_dp
-         sigma = 2._dp*dvr2rs%pw%pw_grid%cutoff*0.125_dp
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs%pw)
-         DEALLOCATE (dvr2rs%pw)
+         ecut = 2._dp*dvr2rs%pw_grid%cutoff*0.875_dp
+         sigma = 2._dp*dvr2rs%pw_grid%cutoff*0.125_dp
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs)
       ELSE
          smoothing = .TRUE.
       END IF
@@ -213,44 +209,36 @@ CONTAINS
       ALLOCATE (vh0(1:natom, -2:2))
       vh0 = 0._dp
 
-      ALLOCATE (dvr2(6))
-      ALLOCATE (dvspl(6))
-
       !prepare calculation
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
       IF (gapw) CALL prepare_gapw_den(qs_env, do_rho0=.TRUE.)
 
       !calculate electrostatic potential
-      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
       CALL pw_poisson_solve(poisson_env, rho_tot_gspace, ehartree, &
-                            v_hartree_gspace%pw)
+                            v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
 
       ! smoothing of potential
-      IF (smoothing) CALL pw_smoothing(v_hartree_gspace%pw, ecut, sigma)
-
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-      DEALLOCATE (rho_tot_gspace)
+      IF (smoothing) CALL pw_smoothing(v_hartree_gspace, ecut, sigma)
 
       DO i = 1, 3
          DO j = 1, i
             ij = (i*(i - 1))/2 + j
-            ALLOCATE (dvr2(ij)%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, dvr2(ij)%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, dvr2(ij), &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-            CALL pw_dr2(v_hartree_gspace%pw, dvr2(ij)%pw, i, j)
+            CALL pw_dr2(v_hartree_gspace, dvr2(ij), i, j)
          END DO
       END DO
 
       IF (.NOT. efg_interpolation) THEN
-         ALLOCATE (structure_factor%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, structure_factor%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, structure_factor, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       ELSE
 
@@ -263,29 +251,25 @@ CONTAINS
          CALL section_vals_val_get(interp_section, "eps_r", r_val=eps_r)
          CALL section_vals_val_get(interp_section, "eps_x", r_val=eps_x)
 
-         ALLOCATE (dvr2rs%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          DO i = 1, 6
-            ALLOCATE (dvspl(i)%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, dvspl(i)%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, dvspl(i), &
                                    use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_transfer(dvr2(i)%pw, dvr2rs%pw)
+            CALL pw_transfer(dvr2(i), dvr2rs)
             ! calculate spline coefficients
             CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                           pool=auxbas_pw_pool, pbc=.TRUE., transpose=.FALSE.)
-            CALL pw_spline_do_precond(precond, dvr2rs%pw, dvspl(i)%pw)
+            CALL pw_spline_do_precond(precond, dvr2rs, dvspl(i))
             CALL pw_spline_precond_set_kind(precond, precond_kind)
-            success = find_coeffs(values=dvr2rs%pw, coeffs=dvspl(i)%pw, &
+            success = find_coeffs(values=dvr2rs, coeffs=dvspl(i), &
                                   linOp=spl3_pbc, preconditioner=precond, pool=auxbas_pw_pool, &
                                   eps_r=eps_r, eps_x=eps_x, max_iter=max_iter)
             CPASSERT(success)
             CALL pw_spline_precond_release(precond)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i)%pw)
-            DEALLOCATE (dvr2(i)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i))
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs%pw)
-         DEALLOCATE (dvr2rs%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs)
       END IF
 
       nkind = SIZE(qs_kind_set)
@@ -301,25 +285,25 @@ CONTAINS
                DO i = 1, 3
                   DO j = 1, i
                      ij = (i*(i - 1))/2 + j
-                     efg_val = Eval_Interp_Spl3_pbc(ra, dvspl(ij)%pw)
+                     efg_val = Eval_Interp_Spl3_pbc(ra, dvspl(ij))
                      efg_tensor(i, j, iatom) = -efg_val
                      efg_tensor(j, i, iatom) = efg_tensor(i, j, iatom)
                      IF (efg_debug) THEN
                         chk_spl = chk_spl + efg_val + &
-                                  SUM(Eval_d_Interp_Spl3_pbc(ra, dvspl(ij)%pw))
+                                  SUM(Eval_d_Interp_Spl3_pbc(ra, dvspl(ij)))
                      END IF
                   END DO
                END DO
             ELSE
-               CALL pw_structure_factor(structure_factor%pw, ra)
+               CALL pw_structure_factor(structure_factor, ra)
                DO i = 1, 3
                   DO j = 1, i
                      ij = (i*(i - 1))/2 + j
-                     efg_tensor(i, j, iatom) = -pw_integral_ab(dvr2(ij)%pw, structure_factor%pw)
+                     efg_tensor(i, j, iatom) = -pw_integral_ab(dvr2(ij), structure_factor)
                      efg_tensor(j, i, iatom) = efg_tensor(i, j, iatom)
                   END DO
                END DO
-               efg_tensor(:, :, iatom) = efg_tensor(:, :, iatom)/structure_factor%pw%pw_grid%vol
+               efg_tensor(:, :, iatom) = efg_tensor(:, :, iatom)/structure_factor%pw_grid%vol
             END IF
             IF (efg_debug) THEN
                efg_pw(:, :, iatom) = efg_tensor(:, :, iatom)
@@ -394,19 +378,15 @@ CONTAINS
          END IF
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      DEALLOCATE (v_hartree_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
       IF (.NOT. efg_interpolation) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, structure_factor%pw)
-         DEALLOCATE (structure_factor%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, structure_factor)
          DO i = 1, 6
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i)%pw)
-            DEALLOCATE (dvr2(i)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i))
          END DO
       ELSE
          DO i = 1, 6
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvspl(i)%pw)
-            DEALLOCATE (dvspl(i)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvspl(i))
          END DO
       END IF
 
@@ -416,9 +396,6 @@ CONTAINS
       END IF
 
       DEALLOCATE (vh0)
-
-      DEALLOCATE (dvr2)
-      DEALLOCATE (dvspl)
 
       CALL timestop(handle)
 

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -58,7 +58,7 @@ CONTAINS
    SUBROUTINE qs_elf_calc(qs_env, elf_r, rho_cutoff)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: elf_r
+      TYPE(pw_type), DIMENSION(:), INTENT(IN)            :: elf_r
       REAL(kind=dp), INTENT(IN)                          :: rho_cutoff
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'qs_elf_calc'
@@ -178,8 +178,8 @@ CONTAINS
                   rho_53 = cfermi*MAX(rho_r(ispin)%pw%cr3d(i, j, k), rho_cutoff)**f53
                   elf_kernel = (tau_r(ispin)%pw%cr3d(i, j, k) - f18*norm_drho) + 2.87E-5_dp
                   elf_kernel = (elf_kernel/rho_53)**2
-                  elf_r(ispin)%pw%cr3d(i, j, k) = 1.0_dp/(1.0_dp + elf_kernel)
-                  IF (elf_r(ispin)%pw%cr3d(i, j, k) < ELFCUT) elf_r(ispin)%pw%cr3d(i, j, k) = 0.0_dp
+                  elf_r(ispin)%cr3d(i, j, k) = 1.0_dp/(1.0_dp + elf_kernel)
+                  IF (elf_r(ispin)%cr3d(i, j, k) < ELFCUT) elf_r(ispin)%cr3d(i, j, k) = 0.0_dp
                END DO
             END DO
          END DO

--- a/src/qs_energy_init.F
+++ b/src/qs_energy_init.F
@@ -281,7 +281,7 @@ CONTAINS
             dft_control%qs_control%cdft_control%need_pot = .TRUE.
          IF (ASSOCIATED(dft_control%qs_control%cdft_control%group)) THEN
             ! In case CDFT weight function was built beforehand (in mixed force_eval)
-            IF (ASSOCIATED(dft_control%qs_control%cdft_control%group(1)%weight%pw)) &
+            IF (ASSOCIATED(dft_control%qs_control%cdft_control%group(1)%weight)) &
                dft_control%qs_control%cdft_control%need_pot = .FALSE.
          END IF
       END IF

--- a/src/qs_energy_utils.F
+++ b/src/qs_energy_utils.F
@@ -39,7 +39,7 @@ MODULE qs_energy_utils
    USE kpoint_types,                    ONLY: kpoint_type
    USE mp2,                             ONLY: mp2_main
    USE pw_env_types,                    ONLY: pw_env_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_density_matrices,             ONLY: calculate_w_matrix,&
                                               calculate_w_matrix_ot
    USE qs_energy_types,                 ONLY: qs_energy_type
@@ -217,7 +217,7 @@ CONTAINS
       TYPE(atprop_type), POINTER                         :: atprop
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_hartree_rspace
+      TYPE(pw_type), POINTER                             :: v_hartree_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(section_vals_type), POINTER                   :: input, proj_section, rest_b_section, &
                                                             tip_scan_section
@@ -225,15 +225,13 @@ CONTAINS
       NULLIFY (atprop, energy, pw_env)
       CALL timeset(routineN, handle)
 
-      NULLIFY (v_hartree_rspace%pw)
-
       ! atomic energies using Mulliken partition
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
                       input=input, &
                       atprop=atprop, &
                       energy=energy, &
-                      v_hartree_rspace=v_hartree_rspace%pw, &
+                      v_hartree_rspace=v_hartree_rspace, &
                       pw_env=pw_env)
       IF (atprop%energy) THEN
          CALL qs_energies_mulliken(qs_env)
@@ -241,7 +239,7 @@ CONTAINS
              .NOT. dft_control%qs_control%xtb .AND. &
              .NOT. dft_control%qs_control%dftb) THEN
             ! Nuclear charge correction
-            CALL integrate_v_core_rspace(v_hartree_rspace%pw, qs_env)
+            CALL integrate_v_core_rspace(v_hartree_rspace, qs_env)
             ! Kohn-Sham Functional corrections
          END IF
          CALL atprop_array_add(atprop%atener, atprop%ateb)

--- a/src/qs_energy_window.F
+++ b/src/qs_energy_window.F
@@ -54,7 +54,7 @@ MODULE qs_energy_window
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -110,8 +110,8 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: rho_ao_ortho, window
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: rho_g, rho_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_g, rho_r
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_subsys_type), POINTER                      :: subsys
@@ -160,11 +160,8 @@ CONTAINS
       CALL cp_fm_create(S_minus_half_fm, ao_ao_fmstruct)
       CALL cp_fm_create(eigenvectors, ao_ao_fmstruct)
       CALL cp_fm_create(eigenvectors_nonorth, ao_ao_fmstruct)
-      NULLIFY (rho_r, rho_g)
-      ALLOCATE (rho_r, rho_g)
-      ALLOCATE (rho_r%pw, rho_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g%pw, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       !calculate S_minus_half
       CALL matrix_sqrt_Newton_Schulz(S_half, S_minus_half, matrix_s(1)%matrix, filter_eps, &
@@ -212,10 +209,10 @@ CONTAINS
          CALL dbcsr_copy(window, matrix_ks(1)%matrix)
          CALL dbcsr_copy_into_existing(window, tmp)
          CALL calculate_rho_elec(matrix_p=window, &
-                                 rho=rho_r%pw, &
-                                 rho_gspace=rho_g%pw, &
+                                 rho=rho_r, &
+                                 rho_gspace=rho_g, &
                                  ks_env=ks_env)
-         density_total = pw_integrate_function(rho_r%pw)
+         density_total = pw_integrate_function(rho_r)
          IF (unit_nr > 0) WRITE (unit_nr, *) " Ground-state density: ", density_total
          frob_norm = dbcsr_frobenius_norm(window)
          IF (unit_nr > 0) WRITE (unit_nr, *) " Frob norm of calculated ground-state density matrix: ", frob_norm
@@ -279,8 +276,8 @@ CONTAINS
             CALL dbcsr_copy(window, matrix_ks(1)%matrix)
             CALL dbcsr_copy_into_existing(window, tmp)
             CALL calculate_rho_elec(matrix_p=window, &
-                                    rho=rho_r%pw, &
-                                    rho_gspace=rho_g%pw, &
+                                    rho=rho_r, &
+                                    rho_gspace=rho_g, &
                                     ks_env=ks_env)
             WRITE (ext, "(A14,I5.5,A)") "-ENERGY-WINDOW", i, TRIM(cp_iter_string(logger%iter_info))//".cube"
             mpi_io = .TRUE.
@@ -288,10 +285,10 @@ CONTAINS
                                               extension=ext, file_status="REPLACE", file_action="WRITE", &
                                               log_filename=.FALSE., mpi_io=mpi_io)
             WRITE (title, "(A14,I5)") "ENERGY WINDOW ", i
-            CALL cp_pw_to_cube(rho_r%pw, print_unit, title, particles=particles, stride=stride, mpi_io=mpi_io)
+            CALL cp_pw_to_cube(rho_r, print_unit, title, particles=particles, stride=stride, mpi_io=mpi_io)
             CALL cp_print_key_finished_output(print_unit, logger, dft_section, &
                                               "PRINT%ENERGY_WINDOWS", mpi_io=mpi_io)
-            density_ewindow_total = pw_integrate_function(rho_r%pw)
+            density_ewindow_total = pw_integrate_function(rho_r)
             IF (unit_nr > 0) WRITE (unit_nr, "(A,F16.10,A,I5,A,F20.14,A,F20.14)") " Energy Level: ", &
                lower_bound + (i - 0.5_dp)*bin_width, " Number of states: ", next - last, " Occupation: ", &
                occupation, " Grid Density ", density_ewindow_total
@@ -320,10 +317,8 @@ CONTAINS
       CALL cp_fm_release(P_window_fm)
       CALL cp_fm_release(eigenvectors_nonorth)
       CALL cp_fm_release(S_minus_half_fm)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g%pw)
-      DEALLOCATE (rho_r%pw, rho_g%pw)
-      DEALLOCATE (rho_r, rho_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
       DEALLOCATE (eigenvalues)
       DEALLOCATE (STRIDE)
 

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -42,7 +42,6 @@ MODULE qs_environment_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_release,&
                                               pw_type
    USE qs_charges_types,                ONLY: qs_charges_create,&
@@ -208,10 +207,10 @@ CONTAINS
       TYPE(ewald_environment_type), POINTER              :: ewald_env
       TYPE(ewald_pw_type), POINTER                       :: ewald_pw
       TYPE(pw_env_type), POINTER                         :: new_pw_env
-      TYPE(pw_p_type), POINTER                           :: rho_nlcc, rho_nlcc_g, vppl
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_type), POINTER                             :: embed_pot, external_vxc, rho_core, &
-                                                            spin_embed_pot, v_hartree_rspace, vee
+                                                            rho_nlcc, rho_nlcc_g, spin_embed_pot, &
+                                                            v_hartree_rspace, vee, vppl
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(rho0_mpole_type), POINTER                     :: rho0_mpole
@@ -293,15 +292,13 @@ CONTAINS
             NULLIFY (vppl)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, vppl=vppl)
             IF (ASSOCIATED(vppl)) THEN
-               CALL pw_release(vppl%pw)
-               DEALLOCATE (vppl%pw)
-               DEALLOCATE (vppl)
+               CALL pw_release(vppl)
+            ELSE
+               ALLOCATE (vppl)
             END IF
-            ALLOCATE (vppl)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (vppl%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, vppl%pw, use_data=REALDATA3D)
-            vppl%pw%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, vppl, use_data=REALDATA3D)
+            vppl%in_space = REALSPACE
             CALL set_ks_env(ks_env, vppl=vppl)
          END IF
 
@@ -313,29 +310,25 @@ CONTAINS
             NULLIFY (rho_nlcc)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, rho_nlcc=rho_nlcc)
             IF (ASSOCIATED(rho_nlcc)) THEN
-               CALL pw_release(rho_nlcc%pw)
-               DEALLOCATE (rho_nlcc%pw)
-               DEALLOCATE (rho_nlcc)
+               CALL pw_release(rho_nlcc)
+            ELSE
+               ALLOCATE (rho_nlcc)
             END IF
-            ALLOCATE (rho_nlcc)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (rho_nlcc%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc%pw, use_data=REALDATA3D)
-            rho_nlcc%pw%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc, use_data=REALDATA3D)
+            rho_nlcc%in_space = REALSPACE
             CALL set_ks_env(ks_env, rho_nlcc=rho_nlcc)
             ! the g-space version
             NULLIFY (rho_nlcc_g)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, rho_nlcc_g=rho_nlcc_g)
             IF (ASSOCIATED(rho_nlcc_g)) THEN
-               CALL pw_release(rho_nlcc_g%pw)
-               DEALLOCATE (rho_nlcc_g%pw)
-               DEALLOCATE (rho_nlcc_g)
+               CALL pw_release(rho_nlcc_g)
+            ELSE
+               ALLOCATE (rho_nlcc_g)
             END IF
-            ALLOCATE (rho_nlcc_g)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (rho_nlcc_g%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc_g%pw, use_data=COMPLEXDATA1D)
-            rho_nlcc_g%pw%in_space = RECIPROCALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc_g, use_data=COMPLEXDATA1D)
+            rho_nlcc_g%in_space = RECIPROCALSPACE
             CALL set_ks_env(ks_env, rho_nlcc_g=rho_nlcc_g)
          END IF
 

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -208,10 +208,10 @@ CONTAINS
       TYPE(ewald_environment_type), POINTER              :: ewald_env
       TYPE(ewald_pw_type), POINTER                       :: ewald_pw
       TYPE(pw_env_type), POINTER                         :: new_pw_env
-      TYPE(pw_p_type), POINTER                           :: embed_pot, external_vxc, rho_nlcc, &
-                                                            rho_nlcc_g, spin_embed_pot, vppl
+      TYPE(pw_p_type), POINTER                           :: external_vxc, rho_nlcc, rho_nlcc_g, vppl
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_core, v_hartree_rspace, vee
+      TYPE(pw_type), POINTER                             :: embed_pot, rho_core, spin_embed_pot, &
+                                                            v_hartree_rspace, vee
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(rho0_mpole_type), POINTER                     :: rho0_mpole
@@ -378,29 +378,26 @@ CONTAINS
             NULLIFY (embed_pot)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, embed_pot=embed_pot)
             IF (ASSOCIATED(embed_pot)) THEN
-               CALL pw_release(embed_pot%pw)
-               DEALLOCATE (embed_pot%pw)
-               DEALLOCATE (embed_pot)
+               CALL pw_release(embed_pot)
+            ELSE
+               ALLOCATE (embed_pot)
             END IF
-            ALLOCATE (embed_pot)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (embed_pot%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot%pw, use_data=REALDATA3D)
-            embed_pot%pw%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot, use_data=REALDATA3D)
+            embed_pot%in_space = REALSPACE
             CALL set_qs_env(qs_env, embed_pot=embed_pot)
 
             NULLIFY (spin_embed_pot)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, spin_embed_pot=spin_embed_pot)
             IF (ASSOCIATED(spin_embed_pot)) THEN
-               CALL pw_release(spin_embed_pot%pw)
-               DEALLOCATE (spin_embed_pot%pw)
+               CALL pw_release(spin_embed_pot)
                DEALLOCATE (spin_embed_pot)
+            ELSE
+               ALLOCATE (spin_embed_pot)
             END IF
-            ALLOCATE (spin_embed_pot)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (spin_embed_pot%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot%pw, use_data=REALDATA3D)
-            spin_embed_pot%pw%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot, use_data=REALDATA3D)
+            spin_embed_pot%in_space = REALSPACE
             CALL set_qs_env(qs_env, spin_embed_pot=spin_embed_pot)
          END IF
 

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -208,10 +208,10 @@ CONTAINS
       TYPE(ewald_environment_type), POINTER              :: ewald_env
       TYPE(ewald_pw_type), POINTER                       :: ewald_pw
       TYPE(pw_env_type), POINTER                         :: new_pw_env
-      TYPE(pw_p_type), POINTER                           :: external_vxc, rho_nlcc, rho_nlcc_g, vppl
+      TYPE(pw_p_type), POINTER                           :: rho_nlcc, rho_nlcc_g, vppl
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: embed_pot, rho_core, spin_embed_pot, &
-                                                            v_hartree_rspace, vee
+      TYPE(pw_type), POINTER                             :: embed_pot, external_vxc, rho_core, &
+                                                            spin_embed_pot, v_hartree_rspace, vee
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(rho0_mpole_type), POINTER                     :: rho0_mpole
@@ -360,15 +360,13 @@ CONTAINS
             NULLIFY (external_vxc)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, external_vxc=external_vxc)
             IF (ASSOCIATED(external_vxc)) THEN
-               CALL pw_release(external_vxc%pw)
-               DEALLOCATE (external_vxc%pw)
-               DEALLOCATE (external_vxc)
+               CALL pw_release(external_vxc)
+            ELSE
+               ALLOCATE (external_vxc)
             END IF
-            ALLOCATE (external_vxc)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (external_vxc%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, external_vxc%pw, use_data=REALDATA3D)
-            external_vxc%pw%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, external_vxc, use_data=REALDATA3D)
+            external_vxc%in_space = REALSPACE
             CALL set_qs_env(qs_env, external_vxc=external_vxc)
             dft_control%read_external_vxc = .TRUE.
          END IF

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -312,8 +312,8 @@ MODULE qs_environment_types
       ! Subsystem densities
       TYPE(qs_rho_p_type), DIMENSION(:), POINTER            :: subsys_dens
       ! Embedding potential
-      TYPE(pw_p_type), POINTER                              :: embed_pot
-      TYPE(pw_p_type), POINTER                              :: spin_embed_pot
+      TYPE(pw_type), POINTER                              :: embed_pot
+      TYPE(pw_type), POINTER                              :: spin_embed_pot
       ! Polarizability tensor
       TYPE(polar_env_type), POINTER                         :: polar_env
       ! Resp charges
@@ -649,7 +649,7 @@ CONTAINS
          POINTER                                         :: mscfg_env
       TYPE(almo_scf_env_type), OPTIONAL, POINTER         :: almo_scf_env
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: gradient_history, variable_history
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: embed_pot, spin_embed_pot
+      TYPE(pw_type), OPTIONAL, POINTER                   :: embed_pot, spin_embed_pot
       TYPE(polar_env_type), OPTIONAL, POINTER            :: polar_env
       TYPE(mo_set_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: mos_last_converged
@@ -1124,7 +1124,7 @@ CONTAINS
          OPTIONAL, POINTER                               :: WannierCentres
       TYPE(almo_scf_env_type), OPTIONAL, POINTER         :: almo_scf_env
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: gradient_history, variable_history
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: embed_pot, spin_embed_pot
+      TYPE(pw_type), OPTIONAL, POINTER                   :: embed_pot, spin_embed_pot
       TYPE(polar_env_type), OPTIONAL, POINTER            :: polar_env
       TYPE(mo_set_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: mos_last_converged
@@ -1458,12 +1458,10 @@ CONTAINS
             END IF
             ! Embedding potentials if provided as input
             IF (qs_env%given_embed_pot) THEN
-               CALL pw_release(qs_env%embed_pot%pw)
-               DEALLOCATE (qs_env%embed_pot%pw)
+               CALL pw_release(qs_env%embed_pot)
                DEALLOCATE (qs_env%embed_pot)
                IF (ASSOCIATED(qs_env%spin_embed_pot)) THEN
-                  CALL pw_release(qs_env%spin_embed_pot%pw)
-                  DEALLOCATE (qs_env%spin_embed_pot%pw)
+                  CALL pw_release(qs_env%spin_embed_pot)
                   DEALLOCATE (qs_env%spin_embed_pot)
                END IF
             END IF
@@ -1658,12 +1656,10 @@ CONTAINS
             END IF
             ! Embedding potentials if provided as input
             IF (qs_env%given_embed_pot) THEN
-               CALL pw_release(qs_env%embed_pot%pw)
-               DEALLOCATE (qs_env%embed_pot%pw)
+               CALL pw_release(qs_env%embed_pot)
                DEALLOCATE (qs_env%embed_pot)
                IF (ASSOCIATED(qs_env%spin_embed_pot)) THEN
-                  CALL pw_release(qs_env%spin_embed_pot%pw)
-                  DEALLOCATE (qs_env%spin_embed_pot%pw)
+                  CALL pw_release(qs_env%spin_embed_pot)
                   DEALLOCATE (qs_env%spin_embed_pot)
                END IF
             END IF

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -84,8 +84,7 @@ MODULE qs_environment_types
                                               molecular_scf_guess_env_type
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_type
-   USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release,&
+   USE pw_types,                        ONLY: pw_release,&
                                               pw_type
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type
    USE qs_active_space_types,           ONLY: active_space_type,&
@@ -569,9 +568,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: kinetic
       TYPE(qs_charges_type), OPTIONAL, POINTER           :: qs_charges
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl
-      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_nlcc, rho_nlcc_g
+      TYPE(pw_type), OPTIONAL, POINTER                   :: vppl, rho_core, rho_nlcc, rho_nlcc_g
       TYPE(qs_ks_env_type), OPTIONAL, POINTER            :: ks_env
       TYPE(qs_ks_qmmm_env_type), OPTIONAL, POINTER       :: ks_qmmm_env
       TYPE(qs_wf_history_type), OPTIONAL, POINTER        :: wf_history

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -255,8 +255,8 @@ MODULE qs_environment_types
       TYPE(rel_control_type), POINTER                       :: rel_control
       ! ZMP adding variables
       TYPE(qs_rho_type), POINTER                            :: rho_external
-      TYPE(pw_p_type), POINTER                              :: external_vxc
-      TYPE(pw_p_type), POINTER                              :: mask
+      TYPE(pw_type), POINTER                              :: external_vxc
+      TYPE(pw_type), POINTER                              :: mask
       TYPE(qs_charges_type), POINTER                        :: qs_charges
       TYPE(qs_ks_env_type), POINTER                         :: ks_env
       TYPE(qs_ks_qmmm_env_type), POINTER                    :: ks_qmmm_env
@@ -633,7 +633,7 @@ CONTAINS
       TYPE(qs_gcp_type), OPTIONAL, POINTER               :: gcp_env
       TYPE(pw_type), OPTIONAL, POINTER                   :: vee
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_external
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: external_vxc, mask
+      TYPE(pw_type), OPTIONAL, POINTER                   :: external_vxc, mask
       TYPE(mp2_type), OPTIONAL, POINTER                  :: mp2_env
       TYPE(kg_environment_type), OPTIONAL, POINTER       :: kg_env
       TYPE(wannier_centres_type), DIMENSION(:), &
@@ -1063,7 +1063,7 @@ CONTAINS
       TYPE(ewald_pw_type), OPTIONAL, POINTER             :: ewald_pw
       TYPE(qs_matrix_pools_type), OPTIONAL, POINTER      :: mpools
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_external
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: external_vxc, mask
+      TYPE(pw_type), OPTIONAL, POINTER                   :: external_vxc, mask
       TYPE(scf_control_type), OPTIONAL, POINTER          :: scf_control
       TYPE(rel_control_type), OPTIONAL, POINTER          :: rel_control
       TYPE(qs_charges_type), OPTIONAL, POINTER           :: qs_charges
@@ -1444,13 +1444,11 @@ CONTAINS
                CALL qs_rho_release(qs_env%rho_external)
             END IF
             IF (ASSOCIATED(qs_env%external_vxc)) THEN
-               CALL pw_release(qs_env%external_vxc%pw)
-               DEALLOCATE (qs_env%external_vxc%pw)
+               CALL pw_release(qs_env%external_vxc)
                DEALLOCATE (qs_env%external_vxc)
             END IF
             IF (ASSOCIATED(qs_env%mask)) THEN
-               CALL pw_release(qs_env%mask%pw)
-               DEALLOCATE (qs_env%mask%pw)
+               CALL pw_release(qs_env%mask)
                DEALLOCATE (qs_env%mask)
             END IF
             IF (ASSOCIATED(qs_env%active_space)) THEN
@@ -1642,13 +1640,11 @@ CONTAINS
                CALL qs_rho_release(qs_env%rho_external)
             END IF
             IF (ASSOCIATED(qs_env%external_vxc)) THEN
-               CALL pw_release(qs_env%external_vxc%pw)
-               DEALLOCATE (qs_env%external_vxc%pw)
+               CALL pw_release(qs_env%external_vxc)
                DEALLOCATE (qs_env%external_vxc)
             END IF
             IF (ASSOCIATED(qs_env%mask)) THEN
-               CALL pw_release(qs_env%mask%pw)
-               DEALLOCATE (qs_env%mask%pw)
+               CALL pw_release(qs_env%mask)
                DEALLOCATE (qs_env%mask)
             END IF
             IF (ASSOCIATED(qs_env%active_space)) THEN

--- a/src/qs_epr_hyp.F
+++ b/src/qs_epr_hyp.F
@@ -49,7 +49,8 @@ MODULE qs_epr_hyp
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_grid_atom,                    ONLY: grid_atom_type
@@ -104,8 +105,8 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g
-      TYPE(pw_p_type), POINTER                           :: hypaniso_gspace, rhototspin_elec_gspace
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: hypaniso_gspace, rhototspin_elec_gspace
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(rho_atom_coeff), DIMENSION(:), POINTER        :: rho_rad_h, rho_rad_s
@@ -115,7 +116,7 @@ CONTAINS
 
       NULLIFY (pw_env, cell, atomic_kind_set, qs_kind_set, auxbas_pw_pool, dft_control, &
                logger, dft_section, para_env, particle_set, rho, rho_atom, &
-               rho_atom_set, rhototspin_elec_gspace, hypaniso_gspace, rho_g)
+               rho_atom_set, rho_g)
 
       logger => cp_get_default_logger()
       dft_section => section_vals_get_subs_vals(qs_env%input, "DFT")
@@ -287,41 +288,37 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pw_pool)
 
-      ALLOCATE (rhototspin_elec_gspace)
-      ALLOCATE (rhototspin_elec_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rhototspin_elec_gspace%pw, &
+                             rhototspin_elec_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_zero(rhototspin_elec_gspace%pw)
+      CALL pw_zero(rhototspin_elec_gspace)
 
-      pw_grid => rhototspin_elec_gspace%pw%pw_grid
+      pw_grid => rhototspin_elec_gspace%pw_grid
 
       ! Load the contribution of the soft electronic density
       CALL qs_rho_get(rho, rho_g=rho_g)
       CPASSERT(SIZE(rho_g) > 1)
-      CALL pw_axpy(rho_g(1)%pw, rhototspin_elec_gspace%pw)
-      CALL pw_axpy(rho_g(2)%pw, rhototspin_elec_gspace%pw, alpha=-1._dp)
+      CALL pw_axpy(rho_g(1)%pw, rhototspin_elec_gspace)
+      CALL pw_axpy(rho_g(2)%pw, rhototspin_elec_gspace, alpha=-1._dp)
       ! grid to assemble anisotropic hyperfine terms
-      ALLOCATE (hypaniso_gspace)
-      ALLOCATE (hypaniso_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             hypaniso_gspace%pw, &
+                             hypaniso_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       DO idir1 = 1, 3
          DO idir2 = idir1, 3 ! tensor symmetry
-            CALL pw_zero(hypaniso_gspace%pw)
-            CALL pw_dr2_gg(rhototspin_elec_gspace%pw, hypaniso_gspace%pw, &
+            CALL pw_zero(hypaniso_gspace)
+            CALL pw_dr2_gg(rhototspin_elec_gspace, hypaniso_gspace, &
                            idir1, idir2)
             DO iatom = 1, natom
                esum = 0.0_dp
                ra(:) = pbc(particle_set(iatom)%r, cell)
-               DO ig = 1, SIZE(hypaniso_gspace%pw%cc)
+               DO ig = 1, SIZE(hypaniso_gspace%cc)
                   arg = DOT_PRODUCT(pw_grid%g(:, ig), ra)
-                  esum = esum + COS(arg)*REAL(hypaniso_gspace%pw%cc(ig), dp) &
-                         - SIN(arg)*AIMAG(hypaniso_gspace%pw%cc(ig))
+                  esum = esum + COS(arg)*REAL(hypaniso_gspace%cc(ig), dp) &
+                         - SIN(arg)*AIMAG(hypaniso_gspace%cc(ig))
                END DO
                ! Actually, we need -1.0 * fourpi * hypaniso_gspace
                esum = esum*fourpi*(-1.0_dp)
@@ -330,13 +327,8 @@ CONTAINS
          END DO ! idir2
       END DO ! idir1
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhototspin_elec_gspace%pw)
-      DEALLOCATE (rhototspin_elec_gspace%pw)
-      DEALLOCATE (rhototspin_elec_gspace)
-
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, hypaniso_gspace%pw)
-      DEALLOCATE (hypaniso_gspace%pw)
-      DEALLOCATE (hypaniso_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhototspin_elec_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, hypaniso_gspace)
 
       ! Multiply hyperfine matrices with constant*gyromagnetic ratio's
       ! to have it in units of Mhz.

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -86,7 +86,7 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_tmp
+      TYPE(pw_type)                                      :: rho_tmp
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
 
       CALL timeset(routineN, handle)
@@ -109,7 +109,6 @@ CONTAINS
 
          IF (nspin == 2) THEN
             CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (rho_tmp)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
                                    rho_tmp, &
                                    use_data=COMPLEXDATA1D, &
@@ -148,7 +147,6 @@ CONTAINS
                CALL pw_axpy(rho_g(1)%pw, rho_g(2)%pw, -1.0_dp)
                CALL pw_scale(rho_g(2)%pw, -1.0_dp)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp)
-               DEALLOCATE (rho_tmp)
             END IF
             CALL timestop(handle)
             RETURN
@@ -182,7 +180,6 @@ CONTAINS
             CALL pw_axpy(rho_g(1)%pw, rho_g(2)%pw, -1.0_dp)
             CALL pw_scale(rho_g(2)%pw, -1.0_dp)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp)
-            DEALLOCATE (rho_tmp)
          END IF
 
          DO ispin = 1, nspin

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -26,7 +26,8 @@ MODULE qs_gspace_mixing
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_density_mixing_types,         ONLY: broyden_mixing_new_nr,&
                                               broyden_mixing_nr,&
                                               cp_1d_z_p_type,&
@@ -83,9 +84,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_r
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_tmp
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: rho_tmp
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
 
       CALL timeset(routineN, handle)
@@ -108,15 +109,15 @@ CONTAINS
 
          IF (nspin == 2) THEN
             CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (rho_tmp%pw)
+            ALLOCATE (rho_tmp)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   rho_tmp%pw, &
+                                   rho_tmp, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
-            CALL pw_zero(rho_tmp%pw)
-            CALL pw_copy(rho_g(1)%pw, rho_tmp%pw)
+            CALL pw_zero(rho_tmp)
+            CALL pw_copy(rho_g(1)%pw, rho_tmp)
             CALL pw_axpy(rho_g(2)%pw, rho_g(1)%pw, 1.0_dp)
-            CALL pw_axpy(rho_tmp%pw, rho_g(2)%pw, -1.0_dp)
+            CALL pw_axpy(rho_tmp, rho_g(2)%pw, -1.0_dp)
             CALL pw_scale(rho_g(2)%pw, -1.0_dp)
          END IF
 
@@ -146,8 +147,8 @@ CONTAINS
                CALL pw_scale(rho_g(1)%pw, 0.5_dp)
                CALL pw_axpy(rho_g(1)%pw, rho_g(2)%pw, -1.0_dp)
                CALL pw_scale(rho_g(2)%pw, -1.0_dp)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp%pw)
-               DEALLOCATE (rho_tmp%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp)
+               DEALLOCATE (rho_tmp)
             END IF
             CALL timestop(handle)
             RETURN
@@ -180,8 +181,8 @@ CONTAINS
             CALL pw_scale(rho_g(1)%pw, 0.5_dp)
             CALL pw_axpy(rho_g(1)%pw, rho_g(2)%pw, -1.0_dp)
             CALL pw_scale(rho_g(2)%pw, -1.0_dp)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp%pw)
-            DEALLOCATE (rho_tmp%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp)
+            DEALLOCATE (rho_tmp)
          END IF
 
          DO ispin = 1, nspin

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -67,7 +67,8 @@ MODULE qs_kpp1_env_methods
                                               RECIPROCALSPACE,&
                                               pw_create,&
                                               pw_p_type,&
-                                              pw_release
+                                              pw_release,&
+                                              pw_type
    USE qs_energy_types,                 ONLY: allocate_qs_energy,&
                                               deallocate_qs_energy,&
                                               qs_energy_type
@@ -224,13 +225,12 @@ CONTAINS
       TYPE(lri_environment_type), POINTER                :: lri_env
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri_v_int
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho1_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho1_g, rho1_g_pw, rho1_r, rho1_r_pw, &
                                                             tau1_r, tau1_r_pw, v_rspace_new, v_xc, &
                                                             v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho1_tot_gspace, v_hartree_rspace
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho1_atom_set, rho_atom_set
       TYPE(section_vals_type), POINTER                   :: input, scf_section
@@ -281,8 +281,7 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
       ALLOCATE (v_rspace_new(nspins))
-      ALLOCATE (v_hartree_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -290,17 +289,16 @@ CONTAINS
          CALL prepare_gapw_den(qs_env, p_env%local_rho_set, do_rho0=(.NOT. gapw_xc))
 
       ! *** calculate the hartree potential on the total density ***
-      ALLOCATE (rho1_tot_gspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      CALL pw_copy(rho1_g(1)%pw, rho1_tot_gspace%pw)
+      CALL pw_copy(rho1_g(1)%pw, rho1_tot_gspace)
       DO ispin = 2, nspins
-         CALL pw_axpy(rho1_g(ispin)%pw, rho1_tot_gspace%pw)
+         CALL pw_axpy(rho1_g(ispin)%pw, rho1_tot_gspace)
       END DO
       IF (gapw) &
-         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs, rho1_tot_gspace%pw)
+         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs, rho1_tot_gspace)
 
       scf_section => section_vals_get_subs_vals(input, "DFT%SCF")
       IF (cp_print_key_should_output(logger%iter_info, scf_section, "PRINT%TOTAL_DENSITIES") &
@@ -313,21 +311,21 @@ CONTAINS
       END IF
 
       IF (.NOT. (nspins == 1 .AND. do_excitations .AND. do_triplet)) THEN
-         ALLOCATE (v_hartree_gspace%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
-         CALL pw_poisson_solve(poisson_env, rho1_tot_gspace%pw, &
-                               energy_hartree, &
-                               v_hartree_gspace%pw)
-         CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-         DEALLOCATE (v_hartree_gspace%pw)
-         CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+         BLOCK
+            TYPE(pw_type) :: v_hartree_gspace
+            CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
+                                   use_data=COMPLEXDATA1D, &
+                                   in_space=RECIPROCALSPACE)
+            CALL pw_poisson_solve(poisson_env, rho1_tot_gspace, &
+                                  energy_hartree, &
+                                  v_hartree_gspace)
+            CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+         END BLOCK
+         CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace%pw)
-      DEALLOCATE (rho1_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace)
 
       ! *** calculate the xc potential ***
       IF (gapw_xc) THEN
@@ -455,7 +453,7 @@ CONTAINS
 
                ! add hartree only for SINGLETS
                IF (.NOT. do_triplet) THEN
-                  v_rspace_new(1)%pw%cr3d = v_hartree_rspace%pw%cr3d
+                  v_rspace_new(1)%pw%cr3d = v_hartree_rspace%cr3d
 
                   CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
@@ -479,7 +477,7 @@ CONTAINS
                                           calculate_forces=my_calc_forces, gapw=gapw_xc)
                END IF
 
-               v_rspace_new(ispin)%pw%cr3d = v_hartree_rspace%pw%cr3d
+               v_rspace_new(ispin)%pw%cr3d = v_hartree_rspace%cr3d
                CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=p_env%kpp1_env%v_ao(ispin), &
@@ -494,11 +492,11 @@ CONTAINS
                ! add hartree only for SINGLETS
                IF (.NOT. do_triplet) THEN
                   v_rspace_new(1)%pw%cr3d = v_rspace_new(1)%pw%cr3d + &
-                                            v_hartree_rspace%pw%cr3d
+                                            v_hartree_rspace%cr3d
                END IF
             ELSE
                v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d + &
-                                             v_hartree_rspace%pw%cr3d
+                                             v_hartree_rspace%cr3d
             END IF
 
             IF (lrigpw) THEN
@@ -549,7 +547,7 @@ CONTAINS
                                     p_env%hartree_local%ecoul_1c, &
                                     p_env%local_rho_set, &
                                     para_env, tddft=.TRUE.)
-            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace%pw, para_env, &
+            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace, para_env, &
                                        calculate_forces=my_calc_forces, &
                                        local_rho_set=p_env%local_rho_set)
          END IF
@@ -570,8 +568,7 @@ CONTAINS
                              rho_atom_external=p_env%local_rho_set%rho_atom_set)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      DEALLOCATE (v_hartree_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
       DO ispin = 1, SIZE(v_rspace_new)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin)%pw)
          DEALLOCATE (v_rspace_new(ispin)%pw)
@@ -845,7 +842,7 @@ CONTAINS
    SUBROUTINE print_densities(rho1, rho1_tot_gspace, out_unit)
 
       TYPE(qs_rho_type), POINTER                         :: rho1
-      TYPE(pw_p_type), INTENT(IN)                        :: rho1_tot_gspace
+      TYPE(pw_type), INTENT(IN)                          :: rho1_tot_gspace
       INTEGER                                            :: out_unit
 
       REAL(KIND=dp)                                      :: total_rho_gspace
@@ -853,7 +850,7 @@ CONTAINS
 
       NULLIFY (tot_rho1_r)
 
-      total_rho_gspace = pw_integrate_function(rho1_tot_gspace%pw, isign=-1)
+      total_rho_gspace = pw_integrate_function(rho1_tot_gspace, isign=-1)
       IF (out_unit > 0) THEN
          CALL qs_rho_get(rho1, tot_rho_r=tot_rho1_r)
          WRITE (UNIT=out_unit, FMT="(T3,A,T60,F20.10)") &

--- a/src/qs_ks_apply_restraints.F
+++ b/src/qs_ks_apply_restraints.F
@@ -83,8 +83,8 @@ CONTAINS
             IF (cdft_control%need_pot) THEN
                ! First SCF iteraration => allocate storage
                DO igroup = 1, SIZE(cdft_control%group)
-                  ALLOCATE (cdft_control%group(igroup)%weight%pw)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%weight%pw, &
+                  ALLOCATE (cdft_control%group(igroup)%weight)
+                  CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%weight, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
                   ! Sanity check
                   IF (cdft_control%group(igroup)%constraint_type /= cdft_charge_constraint &
@@ -108,8 +108,8 @@ CONTAINS
                                 "The number of constraint atoms exceeds the total number of atoms.")
             ELSE
                DO igroup = 1, SIZE(cdft_control%group)
-                  inv_vol = 1.0_dp/cdft_control%group(igroup)%weight%pw%pw_grid%dvol
-                  CALL pw_scale(cdft_control%group(igroup)%weight%pw, inv_vol)
+                  inv_vol = 1.0_dp/cdft_control%group(igroup)%weight%pw_grid%dvol
+                  CALL pw_scale(cdft_control%group(igroup)%weight, inv_vol)
                END DO
             END IF
             ! Build/Integrate CDFT constraints with selected population analysis method
@@ -119,7 +119,7 @@ CONTAINS
                CALL hirshfeld_constraint(qs_env, calc_pot=cdft_control%need_pot, calculate_forces=calculate_forces)
             END IF
             DO igroup = 1, SIZE(cdft_control%group)
-               CALL pw_scale(cdft_control%group(igroup)%weight%pw, cdft_control%group(igroup)%weight%pw%pw_grid%dvol)
+               CALL pw_scale(cdft_control%group(igroup)%weight, cdft_control%group(igroup)%weight%pw_grid%dvol)
             END DO
             IF (cdft_control%need_pot) cdft_control%need_pot = .FALSE.
          CASE DEFAULT

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -731,8 +731,8 @@ CONTAINS
       IF (calculate_forces .AND. dft_control%qs_control%cdft) THEN
          IF (.NOT. cdft_control%transfer_pot) THEN
             DO iatom = 1, SIZE(cdft_control%group)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight%pw)
-               DEALLOCATE (cdft_control%group(iatom)%weight%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight)
+               DEALLOCATE (cdft_control%group(iatom)%weight)
             END DO
             IF (cdft_control%atomic_charges) THEN
                DO iatom = 1, cdft_control%natoms

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -209,10 +209,10 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, v_rspace_embed, v_rspace_new, &
                                                             v_rspace_new_aux_fit, v_tau_rspace, &
                                                             v_tau_rspace_aux_fit
-      TYPE(pw_p_type), POINTER                           :: rho_nlcc, vppl_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho0_s_rs, rho_core, vee
+      TYPE(pw_type), POINTER                             :: rho0_s_rs, rho_core, rho_nlcc, vee, &
+                                                            vppl_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_struct, rho_xc
@@ -859,7 +859,7 @@ CONTAINS
          ecore_ppl = 0._dp
          DO ispin = 1, nspins
             ecore_ppl = ecore_ppl + &
-                        SUM(vppl_rspace%pw%cr3d*rho_r(ispin)%pw%cr3d)*vppl_rspace%pw%pw_grid%dvol
+                        SUM(vppl_rspace%cr3d*rho_r(ispin)%pw%cr3d)*vppl_rspace%pw_grid%dvol
          END DO
          CALL mp_sum(ecore_ppl, para_env%group)
          energy%core = energy%core + ecore_ppl

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -476,7 +476,7 @@ CONTAINS
       IF (qs_env%qmmm) THEN
          CALL qmmm_calculate_energy(qs_env=qs_env, &
                                     rho=rho_r, &
-                                    v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace, &
+                                    v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace%pw, &
                                     qmmm_energy=energy%qmmm_el)
          IF (qs_env%qmmm_env_qm%image_charge) THEN
             CALL calculate_image_pot(v_hartree_rspace=v_hartree_rspace, &

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -480,14 +480,14 @@ CONTAINS
                                     v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace, &
                                     qmmm_energy=energy%qmmm_el)
          IF (qs_env%qmmm_env_qm%image_charge) THEN
-            CALL calculate_image_pot(v_hartree_rspace=v_hartree_rspace, &
-                                     rho_hartree_gspace=rho_tot_gspace, &
+            CALL calculate_image_pot(v_hartree_rspace=v_hartree_rspace%pw, &
+                                     rho_hartree_gspace=rho_tot_gspace%pw, &
                                      energy=energy, &
                                      qmmm_env=qs_env%qmmm_env_qm, &
                                      qs_env=qs_env)
             IF (.NOT. just_energy) THEN
-               CALL add_image_pot_to_hartree_pot(v_hartree=v_hartree_rspace, &
-                                                 v_metal=qs_env%ks_qmmm_env%v_metal_rspace, &
+               CALL add_image_pot_to_hartree_pot(v_hartree=v_hartree_rspace%pw, &
+                                                 v_metal=qs_env%ks_qmmm_env%v_metal_rspace%pw, &
                                                  qs_env=qs_env)
                IF (calculate_forces) THEN
                   CALL integrate_potential_devga_rspace( &

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -750,8 +750,7 @@ CONTAINS
                END IF
             ELSE IF (cdft_control%type == outer_scf_hirshfeld_constraint) THEN
                IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) THEN
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
-                  DEALLOCATE (cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm)
                END IF
             END IF
             IF (ASSOCIATED(cdft_control%charges_fragment)) DEALLOCATE (cdft_control%charges_fragment)

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -204,15 +204,14 @@ CONTAINS
       TYPE(lri_environment_type), POINTER                :: lri_env
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri_v_int
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type) :: rho_tot_gspace, v_efield_rspace, v_hartree_gspace, v_hartree_rspace, &
-         v_minus_veps, v_sccs_rspace, v_sic_rspace, v_spin_ddapc_rest_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r, v_rspace_embed, v_rspace_new, &
                                                             v_rspace_new_aux_fit, v_tau_rspace, &
                                                             v_tau_rspace_aux_fit
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho0_s_rs, rho_core, rho_nlcc, vee, &
-                                                            vppl_rspace
+      TYPE(pw_type)                                      :: rho_tot_gspace, v_hartree_gspace
+      TYPE(pw_type), POINTER :: rho0_s_rs, rho_core, rho_nlcc, v_efield_rspace, v_hartree_rspace, &
+         v_sccs_rspace, v_sic_rspace, v_spin_ddapc_rest_r, vee, vppl_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_struct, rho_xc
@@ -224,7 +223,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       NULLIFY (admm_env, cell, dft_control, logger, mo_derivs, my_rho, &
                rho_struct, para_env, pw_env, virial, vppl_rspace, &
-               v_hartree_rspace%pw, adiabatic_rescaling_section, hfx_sections, &
+               adiabatic_rescaling_section, hfx_sections, &
                input, scf_section, xc_section, matrix_h, matrix_s, &
                auxbas_pw_pool, poisson_env, v_rspace_new, v_rspace_new_aux_fit, &
                v_tau_rspace, v_tau_rspace_aux_fit, matrix_vxc, vee, rho_nlcc, &
@@ -248,7 +247,7 @@ CONTAINS
                       para_env=para_env, &
                       input=input, &
                       virial=virial, &
-                      v_hartree_rspace=v_hartree_rspace%pw, &
+                      v_hartree_rspace=v_hartree_rspace, &
                       vee=vee, &
                       rho_nlcc=rho_nlcc, &
                       rho=rho, &
@@ -342,13 +341,12 @@ CONTAINS
       END IF
 
       ! Calculate the Hartree potential
-      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_hartree_gspace%pw, &
+                             v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_tot_gspace%pw, &
+                             rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
@@ -358,16 +356,16 @@ CONTAINS
                 cp_p_file) .AND. &
           (.NOT. gapw) .AND. (.NOT. gapw_xc) .AND. &
           (.NOT. (poisson_env%parameters%solver .EQ. pw_poisson_implicit))) THEN
-         CALL pw_zero(rho_tot_gspace%pw)
-         CALL calc_rho_tot_gspace(rho_tot_gspace%pw, qs_env, rho, skip_nuclear_density=.TRUE.)
-         CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, energy%e_hartree, &
-                               v_hartree_gspace%pw)
-         CALL pw_zero(rho_tot_gspace%pw)
-         CALL pw_zero(v_hartree_gspace%pw)
+         CALL pw_zero(rho_tot_gspace)
+         CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho, skip_nuclear_density=.TRUE.)
+         CALL pw_poisson_solve(poisson_env, rho_tot_gspace, energy%e_hartree, &
+                               v_hartree_gspace)
+         CALL pw_zero(rho_tot_gspace)
+         CALL pw_zero(v_hartree_gspace)
       END IF
 
       ! Get the total density in g-space [ions + electrons]
-      CALL calc_rho_tot_gspace(rho_tot_gspace%pw, qs_env, rho)
+      CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
       IF (my_print) THEN
          CALL print_densities(qs_env, rho)
@@ -375,9 +373,10 @@ CONTAINS
 
       IF (dft_control%do_sccs) THEN
          ! Self-consistent continuum solvation (SCCS) model
-         ALLOCATE (v_sccs_rspace%pw)
+         NULLIFY (v_sccs_rspace)
+         ALLOCATE (v_sccs_rspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                v_sccs_rspace%pw, &
+                                v_sccs_rspace, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
 
@@ -386,26 +385,26 @@ CONTAINS
          END IF
 
          IF (use_virial .AND. calculate_forces) THEN
-            CALL sccs(qs_env, rho_tot_gspace%pw, v_hartree_gspace%pw, v_sccs_rspace%pw, &
+            CALL sccs(qs_env, rho_tot_gspace, v_hartree_gspace, v_sccs_rspace, &
                       h_stress=h_stress)
             virial%pv_ehartree = virial%pv_ehartree + h_stress/REAL(para_env%num_pe, dp)
             virial%pv_virial = virial%pv_virial + h_stress/REAL(para_env%num_pe, dp)
          ELSE
-            CALL sccs(qs_env, rho_tot_gspace%pw, v_hartree_gspace%pw, v_sccs_rspace%pw)
+            CALL sccs(qs_env, rho_tot_gspace, v_hartree_gspace, v_sccs_rspace)
          END IF
       ELSE
          ! Getting the Hartree energy and Hartree potential.  Also getting the stress tensor
          ! from the Hartree term if needed.  No nuclear force information here
          IF (use_virial .AND. calculate_forces) THEN
             h_stress(:, :) = 0.0_dp
-            CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, energy%hartree, &
-                                  v_hartree_gspace%pw, h_stress=h_stress, &
+            CALL pw_poisson_solve(poisson_env, rho_tot_gspace, energy%hartree, &
+                                  v_hartree_gspace, h_stress=h_stress, &
                                   rho_core=rho_core)
             virial%pv_ehartree = virial%pv_ehartree + h_stress/REAL(para_env%num_pe, dp)
             virial%pv_virial = virial%pv_virial + h_stress/REAL(para_env%num_pe, dp)
          ELSE
-            CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, energy%hartree, &
-                                  v_hartree_gspace%pw, rho_core=rho_core)
+            CALL pw_poisson_solve(poisson_env, rho_tot_gspace, energy%hartree, &
+                                  v_hartree_gspace, rho_core=rho_core)
          END IF
       END IF
 
@@ -418,21 +417,21 @@ CONTAINS
          dft_control%qs_control%ddapc_explicit_potential = .FALSE.
          dft_control%qs_control%ddapc_restraint_is_spin = .FALSE.
          IF (.NOT. just_energy) THEN
-            CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
-            CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+            CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
+            CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      DEALLOCATE (v_hartree_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
 
       IF (dft_control%apply_efield_field) THEN
-         ALLOCATE (v_efield_rspace%pw)
+         NULLIFY (v_efield_rspace)
+         ALLOCATE (v_efield_rspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                v_efield_rspace%pw, &
+                                v_efield_rspace, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          CALL efield_potential(qs_env, v_efield_rspace)
-         CALL pw_scale(v_efield_rspace%pw, v_efield_rspace%pw%pw_grid%dvol)
+         CALL pw_scale(v_efield_rspace, v_efield_rspace%pw_grid%dvol)
       END IF
 
       IF (dft_control%correct_surf_dip) THEN
@@ -480,18 +479,18 @@ CONTAINS
                                     v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace, &
                                     qmmm_energy=energy%qmmm_el)
          IF (qs_env%qmmm_env_qm%image_charge) THEN
-            CALL calculate_image_pot(v_hartree_rspace=v_hartree_rspace%pw, &
-                                     rho_hartree_gspace=rho_tot_gspace%pw, &
+            CALL calculate_image_pot(v_hartree_rspace=v_hartree_rspace, &
+                                     rho_hartree_gspace=rho_tot_gspace, &
                                      energy=energy, &
                                      qmmm_env=qs_env%qmmm_env_qm, &
                                      qs_env=qs_env)
             IF (.NOT. just_energy) THEN
-               CALL add_image_pot_to_hartree_pot(v_hartree=v_hartree_rspace%pw, &
+               CALL add_image_pot_to_hartree_pot(v_hartree=v_hartree_rspace, &
                                                  v_metal=qs_env%ks_qmmm_env%v_metal_rspace%pw, &
                                                  qs_env=qs_env)
                IF (calculate_forces) THEN
                   CALL integrate_potential_devga_rspace( &
-                     potential=v_hartree_rspace%pw, coeff=qs_env%image_coeff, &
+                     potential=v_hartree_rspace, coeff=qs_env%image_coeff, &
                      forces=qs_env%qmmm_env_qm%image_charge_pot%image_forcesMM, &
                      qmmm_env=qs_env%qmmm_env_qm, qs_env=qs_env)
                END IF
@@ -500,12 +499,11 @@ CONTAINS
             DEALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace%pw)
          END IF
          IF (.NOT. just_energy) THEN
-            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace%pw, &
+            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace, &
                                          v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace%pw, scale=1.0_dp)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
-      DEALLOCATE (rho_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
 
       ! calculate the density matrix for the fitted mo_coeffs
       IF (dft_control%do_admm) THEN
@@ -646,15 +644,16 @@ CONTAINS
             ! Getting nuclear force contribution from the core charge density
             IF ((poisson_env%parameters%solver .EQ. pw_poisson_implicit) .AND. &
                 (poisson_env%parameters%dielectric_params%dielec_core_correction)) THEN
-               ALLOCATE (v_minus_veps%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_minus_veps%pw, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_copy(v_hartree_rspace%pw, v_minus_veps%pw)
-               CALL pw_axpy(poisson_env%implicit_env%v_eps, v_minus_veps%pw, -v_hartree_rspace%pw%pw_grid%dvol)
-               CALL integrate_v_core_rspace(v_minus_veps%pw, qs_env)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_minus_veps%pw)
-               DEALLOCATE (v_minus_veps%pw)
+               BLOCK
+                  TYPE(pw_type) :: v_minus_veps
+                  CALL pw_pool_create_pw(auxbas_pw_pool, v_minus_veps, use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL pw_copy(v_hartree_rspace, v_minus_veps)
+                  CALL pw_axpy(poisson_env%implicit_env%v_eps, v_minus_veps, -v_hartree_rspace%pw_grid%dvol)
+                  CALL integrate_v_core_rspace(v_minus_veps, qs_env)
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, v_minus_veps)
+               END BLOCK
             ELSE
-               CALL integrate_v_core_rspace(v_hartree_rspace%pw, qs_env)
+               CALL integrate_v_core_rspace(v_hartree_rspace, qs_env)
             END IF
          END IF
 
@@ -719,13 +718,13 @@ CONTAINS
       END IF ! .NOT. just energy
 
       IF (dft_control%qs_control%ddapc_explicit_potential) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_r%pw)
-         DEALLOCATE (v_spin_ddapc_rest_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_r)
+         DEALLOCATE (v_spin_ddapc_rest_r)
       END IF
 
       IF (dft_control%apply_efield_field) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_efield_rspace%pw)
-         DEALLOCATE (v_efield_rspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_efield_rspace)
+         DEALLOCATE (v_efield_rspace)
       END IF
 
       IF (calculate_forces .AND. dft_control%qs_control%cdft) THEN
@@ -763,17 +762,17 @@ CONTAINS
       END IF
 
       IF (dft_control%do_sccs) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sccs_rspace%pw)
-         DEALLOCATE (v_sccs_rspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sccs_rspace)
+         DEALLOCATE (v_sccs_rspace)
       END IF
 
       IF (gapw) THEN
          IF (dft_control%apply_external_potential) THEN
             ! Integrals of the Hartree potential with g0_soft
-            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace%pw, &
+            CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace, &
                                          v_qmmm=vee, scale=-1.0_dp)
          END IF
-         CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace%pw, para_env, calculate_forces)
+         CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace, para_env, calculate_forces)
       END IF
 
       IF (gapw .OR. gapw_xc) THEN

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -476,7 +476,7 @@ CONTAINS
       IF (qs_env%qmmm) THEN
          CALL qmmm_calculate_energy(qs_env=qs_env, &
                                     rho=rho_r, &
-                                    v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace%pw, &
+                                    v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace, &
                                     qmmm_energy=energy%qmmm_el)
          IF (qs_env%qmmm_env_qm%image_charge) THEN
             CALL calculate_image_pot(v_hartree_rspace=v_hartree_rspace, &
@@ -486,7 +486,7 @@ CONTAINS
                                      qs_env=qs_env)
             IF (.NOT. just_energy) THEN
                CALL add_image_pot_to_hartree_pot(v_hartree=v_hartree_rspace, &
-                                                 v_metal=qs_env%ks_qmmm_env%v_metal_rspace%pw, &
+                                                 v_metal=qs_env%ks_qmmm_env%v_metal_rspace, &
                                                  qs_env=qs_env)
                IF (calculate_forces) THEN
                   CALL integrate_potential_devga_rspace( &
@@ -495,12 +495,12 @@ CONTAINS
                      qmmm_env=qs_env%qmmm_env_qm, qs_env=qs_env)
                END IF
             END IF
-            CALL pw_release(qs_env%ks_qmmm_env%v_metal_rspace%pw)
-            DEALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace%pw)
+            CALL pw_release(qs_env%ks_qmmm_env%v_metal_rspace)
+            DEALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace)
          END IF
          IF (.NOT. just_energy) THEN
             CALL qmmm_modify_hartree_pot(v_hartree=v_hartree_rspace, &
-                                         v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace%pw, scale=1.0_dp)
+                                         v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace, scale=1.0_dp)
          END IF
       END IF
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -157,7 +157,7 @@ CONTAINS
    SUBROUTINE qmmm_calculate_energy(qs_env, rho, v_qmmm, qmmm_energy)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho
-      TYPE(pw_p_type), INTENT(IN)                        :: v_qmmm
+      TYPE(pw_type), INTENT(IN)                          :: v_qmmm
       REAL(KIND=dp), INTENT(INOUT)                       :: qmmm_energy
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qmmm_calculate_energy'
@@ -184,13 +184,13 @@ CONTAINS
 
       qmmm_energy = 0.0_dp
       DO ispin = 1, dft_control%nspins
-         qmmm_energy = qmmm_energy + pw_integral_ab(rho(ispin)%pw, v_qmmm%pw)
+         qmmm_energy = qmmm_energy + pw_integral_ab(rho(ispin)%pw, v_qmmm)
       END DO
       IF (dft_control%qs_control%gapw) THEN
          CALL get_qs_env(qs_env=qs_env, &
                          rho0_s_rs=rho0_s_rs)
          CPASSERT(ASSOCIATED(rho0_s_rs))
-         qmmm_energy = qmmm_energy + pw_integral_ab(rho0_s_rs, v_qmmm%pw)
+         qmmm_energy = qmmm_energy + pw_integral_ab(rho0_s_rs, v_qmmm)
       END IF
 
       CALL cp_print_key_finished_output(output_unit, logger, input, &

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -118,8 +118,7 @@ CONTAINS
       last_ks_qmmm_nr = last_ks_qmmm_nr + 1
       ks_qmmm_env%id_nr = last_ks_qmmm_nr
 
-      ALLOCATE (ks_qmmm_env%v_qmmm_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, ks_qmmm_env%v_qmmm_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, ks_qmmm_env%v_qmmm_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       IF ((qmmm_env%qmmm_coupl_type == do_qmmm_gauss) .OR. (qmmm_env%qmmm_coupl_type == do_qmmm_swave)) THEN

--- a/src/qs_ks_qmmm_types.F
+++ b/src/qs_ks_qmmm_types.F
@@ -21,7 +21,7 @@ MODULE qs_ks_qmmm_types
                                               pw_env_type
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -50,8 +50,8 @@ MODULE qs_ks_qmmm_types
                  id_nr, ref_count
       REAL(KIND=dp)                               :: pc_ener
       TYPE(pw_env_type), POINTER                  :: pw_env
-      TYPE(pw_p_type)                             :: v_qmmm_rspace
-      TYPE(pw_p_type)                             :: v_metal_rspace
+      TYPE(pw_type)                             :: v_qmmm_rspace
+      TYPE(pw_type), POINTER                             :: v_metal_rspace
       TYPE(cube_info_type), DIMENSION(:), POINTER  :: cube_info
       TYPE(dbcsr_p_type), DIMENSION(:), &
          POINTER                                :: matrix_h
@@ -88,8 +88,7 @@ CONTAINS
 
          IF (ks_qmmm_env%ref_count < 1) THEN
             CALL pw_env_get(ks_qmmm_env%pw_env, auxbas_pw_pool=pool)
-            CALL pw_pool_give_back_pw(pool, ks_qmmm_env%v_qmmm_rspace%pw)
-            DEALLOCATE (ks_qmmm_env%v_qmmm_rspace%pw)
+            CALL pw_pool_give_back_pw(pool, ks_qmmm_env%v_qmmm_rspace)
             CALL pw_env_release(ks_qmmm_env%pw_env)
             IF (ASSOCIATED(ks_qmmm_env%cube_info)) THEN
                DO i = 1, SIZE(ks_qmmm_env%cube_info)

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -49,8 +49,7 @@ MODULE qs_ks_types
    USE pw_env_types,                    ONLY: pw_env_release,&
                                               pw_env_retain,&
                                               pw_env_type
-   USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release,&
+   USE pw_types,                        ONLY: pw_release,&
                                               pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_force_types,                  ONLY: qs_force_type
@@ -166,9 +165,9 @@ MODULE qs_ks_types
                                                                rho_buffer => Null(), &
                                                                rho_xc => Null()
 
-      TYPE(pw_p_type), POINTER                              :: vppl => Null(), &
-                                                               rho_nlcc => Null(), &
-                                                               rho_nlcc_g => Null()
+      TYPE(pw_type), POINTER                              :: vppl => Null(), &
+                                                             rho_nlcc => Null(), &
+                                                             rho_nlcc_g => Null()
 
       TYPE(pw_type), POINTER :: rho_core => NULL(), &
                                 vee => NULL()
@@ -352,10 +351,7 @@ CONTAINS
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho, rho_buffer, rho_xc
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl
-      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_nlcc, rho_nlcc_g
-      TYPE(pw_type), OPTIONAL, POINTER                   :: vee
+      TYPE(pw_type), OPTIONAL, POINTER                   :: vppl, rho_core, rho_nlcc, rho_nlcc_g, vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
          sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, sab_se, sab_xtbe, sab_tbe, sab_core, &
@@ -578,10 +574,7 @@ CONTAINS
                                                             matrix_vxc_kp, kinetic_kp, &
                                                             matrix_s_kp, matrix_w_kp, &
                                                             matrix_s_RI_aux_kp
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: vppl
-      TYPE(pw_type), OPTIONAL, POINTER                   :: rho_core
-      TYPE(pw_p_type), OPTIONAL, POINTER                 :: rho_nlcc, rho_nlcc_g
-      TYPE(pw_type), OPTIONAL, POINTER                   :: vee
+      TYPE(pw_type), OPTIONAL, POINTER                   :: vppl, rho_core, rho_nlcc, rho_nlcc_g, vee
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
@@ -747,13 +740,11 @@ CONTAINS
                CALL deallocate_task_list(ks_env%task_list_soft)
 
             IF (ASSOCIATED(ks_env%rho_nlcc_g)) THEN
-               CALL pw_release(ks_env%rho_nlcc_g%pw)
-               DEALLOCATE (ks_env%rho_nlcc_g%pw)
+               CALL pw_release(ks_env%rho_nlcc_g)
                DEALLOCATE (ks_env%rho_nlcc_g)
             END IF
             IF (ASSOCIATED(ks_env%rho_nlcc)) THEN
-               CALL pw_release(ks_env%rho_nlcc%pw)
-               DEALLOCATE (ks_env%rho_nlcc%pw)
+               CALL pw_release(ks_env%rho_nlcc)
                DEALLOCATE (ks_env%rho_nlcc)
             END IF
             IF (ASSOCIATED(ks_env%rho_core)) THEN
@@ -761,8 +752,7 @@ CONTAINS
                DEALLOCATE (ks_env%rho_core)
             END IF
             IF (ASSOCIATED(ks_env%vppl)) THEN
-               CALL pw_release(ks_env%vppl%pw)
-               DEALLOCATE (ks_env%vppl%pw)
+               CALL pw_release(ks_env%vppl)
                DEALLOCATE (ks_env%vppl)
             END IF
             IF (ASSOCIATED(ks_env%vee)) THEN
@@ -847,13 +837,11 @@ CONTAINS
                CALL deallocate_task_list(ks_env%task_list_soft)
 
             IF (ASSOCIATED(ks_env%rho_nlcc_g)) THEN
-               CALL pw_release(ks_env%rho_nlcc_g%pw)
-               DEALLOCATE (ks_env%rho_nlcc_g%pw)
+               CALL pw_release(ks_env%rho_nlcc_g)
                DEALLOCATE (ks_env%rho_nlcc_g)
             END IF
             IF (ASSOCIATED(ks_env%rho_nlcc)) THEN
-               CALL pw_release(ks_env%rho_nlcc%pw)
-               DEALLOCATE (ks_env%rho_nlcc%pw)
+               CALL pw_release(ks_env%rho_nlcc)
                DEALLOCATE (ks_env%rho_nlcc)
             END IF
             IF (ASSOCIATED(ks_env%rho_core)) THEN
@@ -861,8 +849,7 @@ CONTAINS
                DEALLOCATE (ks_env%rho_core)
             END IF
             IF (ASSOCIATED(ks_env%vppl)) THEN
-               CALL pw_release(ks_env%vppl%pw)
-               DEALLOCATE (ks_env%vppl%pw)
+               CALL pw_release(ks_env%vppl)
                DEALLOCATE (ks_env%vppl)
             END IF
             IF (ASSOCIATED(ks_env%vee)) THEN

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -712,7 +712,7 @@ CONTAINS
                                 qs_env, dft_control, rho, poisson_env, just_energy, &
                                 calculate_forces, auxbas_pw_pool)
 
-      TYPE(pw_p_type), INTENT(INOUT)                     :: v_sic_rspace
+      TYPE(pw_type), POINTER                             :: v_sic_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -725,8 +725,8 @@ CONTAINS
       REAL(kind=dp)                                      :: ener, full_scaling, scaling
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: store_forces
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mo_array
-      TYPE(pw_p_type)                                    :: work_rho, work_v
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g
+      TYPE(pw_type)                                      :: work_rho, work_v
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
 
       NULLIFY (mo_array, rho_g)
@@ -740,11 +740,10 @@ CONTAINS
       ! OK, right now we like two spins to do sic, could be relaxed for AD
       CPASSERT(dft_control%nspins == 2)
 
-      ALLOCATE (work_rho%pw, work_v%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_rho%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, work_rho, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, work_v, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
@@ -753,20 +752,20 @@ CONTAINS
       ! Hartree sic corrections
       SELECT CASE (dft_control%sic_method_id)
       CASE (sic_mauri_us, sic_mauri_spz)
-         CALL pw_copy(rho_g(1)%pw, work_rho%pw)
-         CALL pw_axpy(rho_g(2)%pw, work_rho%pw, alpha=-1._dp)
-         CALL pw_poisson_solve(poisson_env, work_rho%pw, ener, work_v%pw)
+         CALL pw_copy(rho_g(1)%pw, work_rho)
+         CALL pw_axpy(rho_g(2)%pw, work_rho, alpha=-1._dp)
+         CALL pw_poisson_solve(poisson_env, work_rho, ener, work_v)
       CASE (sic_ad)
          ! find out how many elecs we have
          CALL get_qs_env(qs_env, mos=mo_array)
          CALL get_mo_set(mo_set=mo_array(1)%mo_set, nelectron=nelec_a)
          CALL get_mo_set(mo_set=mo_array(2)%mo_set, nelectron=nelec_b)
          nelec = nelec_a + nelec_b
-         CALL pw_copy(rho_g(1)%pw, work_rho%pw)
-         CALL pw_axpy(rho_g(2)%pw, work_rho%pw)
+         CALL pw_copy(rho_g(1)%pw, work_rho)
+         CALL pw_axpy(rho_g(2)%pw, work_rho)
          scaling = 1.0_dp/REAL(nelec, KIND=dp)
-         CALL pw_scale(work_rho%pw, scaling)
-         CALL pw_poisson_solve(poisson_env, work_rho%pw, ener, work_v%pw)
+         CALL pw_scale(work_rho, scaling)
+         CALL pw_poisson_solve(poisson_env, work_rho, ener, work_v)
       CASE DEFAULT
          CPABORT("Unknown sic method id")
       END SELECT
@@ -816,18 +815,17 @@ CONTAINS
       END IF
 
       IF (.NOT. just_energy) THEN
-         ALLOCATE (v_sic_rspace%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_sic_rspace%pw, &
+         ALLOCATE (v_sic_rspace)
+         CALL pw_pool_create_pw(auxbas_pw_pool, v_sic_rspace, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_transfer(work_v%pw, v_sic_rspace%pw)
+         CALL pw_transfer(work_v, v_sic_rspace)
          ! also take into account the scaling (in addition to the volume element)
-         CALL pw_scale(v_sic_rspace%pw, &
-                       dft_control%sic_scaling_a*v_sic_rspace%pw%pw_grid%dvol)
+         CALL pw_scale(v_sic_rspace, &
+                       dft_control%sic_scaling_a*v_sic_rspace%pw_grid%dvol)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_rho%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v%pw)
-      DEALLOCATE (work_rho%pw, work_v%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_rho)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v)
 
    END SUBROUTINE calc_v_sic_rspace
 
@@ -1214,7 +1212,7 @@ CONTAINS
       TYPE(pw_type), POINTER                             :: vppl_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_rspace_new, v_rspace_new_aux_fit, &
                                                             v_tau_rspace, v_tau_rspace_aux_fit
-      TYPE(pw_p_type)                                    :: v_efield_rspace, v_sic_rspace, &
+      TYPE(pw_type), POINTER                             :: v_efield_rspace, v_sic_rspace, &
                                                             v_spin_ddapc_rest_r, v_sccs_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_rspace_embed
       TYPE(cdft_control_type), POINTER                   :: cdft_control
@@ -1310,14 +1308,14 @@ CONTAINS
                IF (dft_control%qs_control%ddapc_restraint_is_spin) THEN
                   IF (ispin == 1) THEN
                      v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d &
-                                                   + v_spin_ddapc_rest_r%pw%cr3d
+                                                   + v_spin_ddapc_rest_r%cr3d
                   ELSE
                      v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d &
-                                                   - v_spin_ddapc_rest_r%pw%cr3d
+                                                   - v_spin_ddapc_rest_r%cr3d
                   END IF
                ELSE
                   v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d &
-                                                + v_spin_ddapc_rest_r%pw%cr3d
+                                                + v_spin_ddapc_rest_r%cr3d
                END IF
             END IF
             ! CDFT constraint contribution
@@ -1349,7 +1347,7 @@ CONTAINS
             ! The efield contribution
             IF (dft_control%apply_efield_field) THEN
                v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d + &
-                                             v_efield_rspace%pw%cr3d
+                                             v_efield_rspace%cr3d
             END IF
             ! functional derivative of the Hartree energy wrt the density in the presence of dielectric
             ! (vhartree + v_eps); v_eps is nonzero only if the dielectric constant is defind as a function
@@ -1362,7 +1360,7 @@ CONTAINS
             ! Add SCCS contribution
             IF (dft_control%do_sccs) THEN
                v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d + &
-                                             v_sccs_rspace%pw%cr3d
+                                             v_sccs_rspace%cr3d
             END IF
             ! External electrostatic potential
             IF (dft_control%apply_external_potential) THEN
@@ -1381,13 +1379,13 @@ CONTAINS
             CASE (sic_mauri_us, sic_mauri_spz)
                IF (ispin == 1) THEN
                   v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d - &
-                                                v_sic_rspace%pw%cr3d
+                                                v_sic_rspace%cr3d
                ELSE
                   v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d + &
-                                                v_sic_rspace%pw%cr3d
+                                                v_sic_rspace%cr3d
                END IF
             CASE (sic_ad)
-               v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d - v_sic_rspace%pw%cr3d
+               v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d - v_sic_rspace%cr3d
             CASE (sic_eo)
                ! NOTHING TO BE DONE
             END SELECT
@@ -1447,8 +1445,8 @@ CONTAINS
          SELECT CASE (dft_control%sic_method_id)
          CASE (sic_none)
          CASE (sic_mauri_us, sic_mauri_spz, sic_ad)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sic_rspace%pw)
-            DEALLOCATE (v_sic_rspace%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sic_rspace)
+            DEALLOCATE (v_sic_rspace)
          END SELECT
          DEALLOCATE (v_rspace_new)
 
@@ -1459,7 +1457,7 @@ CONTAINS
          DO ispin = 1, nspins
             ! the efield contribution
             IF (dft_control%apply_efield_field) THEN
-               v_rspace%cr3d = v_rspace%cr3d + v_efield_rspace%pw%cr3d
+               v_rspace%cr3d = v_rspace%cr3d + v_efield_rspace%cr3d
             END IF
             ! extra contribution attributed to the dependency of the dielectric constant to the charge density
             IF (poisson_env%parameters%solver .EQ. pw_poisson_implicit) THEN
@@ -1468,7 +1466,7 @@ CONTAINS
             END IF
             ! Add SCCS contribution
             IF (dft_control%do_sccs) THEN
-               v_rspace%cr3d = v_rspace%cr3d + v_sccs_rspace%pw%cr3d
+               v_rspace%cr3d = v_rspace%cr3d + v_sccs_rspace%cr3d
             END IF
             ! DFT embedding
             IF (dft_control%apply_embed_pot) THEN

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -1814,21 +1814,21 @@ CONTAINS
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_rspace_embed(ispin)%pw, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(v_rspace_embed(ispin)%pw)
-         ns1 = SIZE(qs_env%embed_pot%pw%cr3d)
+         ns1 = SIZE(qs_env%embed_pot%cr3d)
          ns2 = SIZE(v_rspace_embed(ispin)%pw%cr3d)
          IF (ns1 .NE. ns2) CPABORT("Subsystem grids must be identical")
 
-         v_rspace_embed(ispin)%pw%cr3d(:, :, :) = qs_env%embed_pot%pw%cr3d
+         v_rspace_embed(ispin)%pw%cr3d(:, :, :) = qs_env%embed_pot%cr3d
          embed_corr_local = 0.0_dp
 
          ! Spin embedding potential in open-shell case
          IF (dft_control%nspins .EQ. 2) THEN
-            ns1 = SIZE(qs_env%spin_embed_pot%pw%cr3d)
+            ns1 = SIZE(qs_env%spin_embed_pot%cr3d)
             IF (ns1 .NE. ns2) CPABORT("Subsystem grids must be identical")
             IF (ispin .EQ. 1) v_rspace_embed(ispin)%pw%cr3d(:, :, :) = &
-               v_rspace_embed(ispin)%pw%cr3d(:, :, :) + qs_env%spin_embed_pot%pw%cr3d
+               v_rspace_embed(ispin)%pw%cr3d(:, :, :) + qs_env%spin_embed_pot%cr3d
             IF (ispin .EQ. 2) v_rspace_embed(ispin)%pw%cr3d(:, :, :) = &
-               v_rspace_embed(ispin)%pw%cr3d(:, :, :) - qs_env%spin_embed_pot%pw%cr3d
+               v_rspace_embed(ispin)%pw%cr3d(:, :, :) - qs_env%spin_embed_pot%cr3d
          END IF
          ! Integrate the density*potential
          embed_corr_local = accurate_dot_product(v_rspace_embed(ispin)%pw%cr3d, rho_r(ispin)%pw%cr3d)* &

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -1703,7 +1703,7 @@ CONTAINS
       CALL pw_zero(v_rspace_new(1)%pw)
       do_zmp_read = dft_control%apply_external_vxc
       IF (do_zmp_read) THEN
-         CALL pw_copy(qs_env%external_vxc%pw, v_rspace_new(1)%pw)
+         CALL pw_copy(qs_env%external_vxc, v_rspace_new(1)%pw)
          exc = 0.0_dp
          exc = accurate_dot_product(v_rspace_new(1)%pw%cr3d, rho_r(1)%pw%cr3d)* &
                v_rspace_new(1)%pw%pw_grid%dvol

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -426,7 +426,7 @@ CONTAINS
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, tau, vxc, vxc_tau
       TYPE(pw_pool_type), POINTER                        :: xc_pw_pool
       TYPE(pw_type)                                      :: work_v_gspace, work_v_rspace
-      TYPE(pw_type), TARGET                             :: orb_rho_g, orb_rho_r, tmp_g, tmp_r
+      TYPE(pw_type), TARGET                              :: orb_rho_g, orb_rho_r, tmp_g, tmp_r
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: input, xc_section

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -1342,7 +1342,7 @@ CONTAINS
                      CPABORT("Unknown constraint type.")
                   END SELECT
                   v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d &
-                                                + sign*cdft_control%group(igroup)%weight%pw%cr3d* &
+                                                + sign*cdft_control%group(igroup)%weight%cr3d* &
                                                 cdft_control%strength(igroup)
                END DO
             END IF

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -174,9 +174,9 @@ CONTAINS
                                                             mo_coeff
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mo_array
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: work_v_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, tau, vxc, vxc_tau
       TYPE(pw_pool_type), POINTER                        :: xc_pw_pool
+      TYPE(pw_type)                                      :: work_v_rspace
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: input, low_spin_roks_section, xc_section
@@ -285,8 +285,7 @@ CONTAINS
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
-      ALLOCATE (work_v_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -337,11 +336,11 @@ CONTAINS
             ! get the potential in matrix form
             DO ispin = 1, Nspin
                ! use a work_v_rspace
-               work_v_rspace%pw%cr3d = (energy_scaling(iterm)*vxc(ispin)%pw%pw_grid%dvol)* &
-                                       vxc(ispin)%pw%cr3d
+               work_v_rspace%cr3d = (energy_scaling(iterm)*vxc(ispin)%pw%pw_grid%dvol)* &
+                                    vxc(ispin)%pw%cr3d
                ! zero first ?!
                CALL dbcsr_set(matrix_h(ispin)%matrix, 0.0_dp)
-               CALL integrate_v_rspace(v_rspace=work_v_rspace%pw, pmat=matrix_p(ispin), hmat=matrix_h(ispin), &
+               CALL integrate_v_rspace(v_rspace=work_v_rspace, pmat=matrix_p(ispin), hmat=matrix_h(ispin), &
                                        qs_env=qs_env, calculate_forces=calculate_forces)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc(ispin)%pw)
                DEALLOCATE (vxc(ispin)%pw)
@@ -373,8 +372,7 @@ CONTAINS
       CALL dbcsr_deallocate_matrix_set(matrix_p)
       CALL dbcsr_deallocate_matrix_set(matrix_h)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace%pw)
-      DEALLOCATE (work_v_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace)
 
       CALL dbcsr_release_p(fm_deriv)
       CALL dbcsr_release_p(fm_scaled)
@@ -425,10 +423,10 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: orb_density_matrix, orb_h
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mo_array
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: orb_rho_g, orb_rho_r, tmp_g, tmp_r, &
-                                                            work_v_gspace, work_v_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, tau, vxc, vxc_tau
       TYPE(pw_pool_type), POINTER                        :: xc_pw_pool
+      TYPE(pw_type)                                      :: work_v_gspace, work_v_rspace
+      TYPE(pw_type), TARGET                             :: orb_rho_g, orb_rho_r, tmp_g, tmp_r
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: input, xc_section
@@ -546,23 +544,22 @@ CONTAINS
       END SELECT
 
       ! data needed for each of the orbs
-      ALLOCATE (orb_rho_r%pw, tmp_r%pw, orb_rho_g%pw, tmp_g%pw, work_v_gspace%pw, work_v_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, orb_rho_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, orb_rho_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, tmp_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, tmp_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, orb_rho_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, orb_rho_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, tmp_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, tmp_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -594,14 +591,14 @@ CONTAINS
       END DO
 
       ALLOCATE (rho_r(2))
-      rho_r(1)%pw => orb_rho_r%pw
-      rho_r(2)%pw => tmp_r%pw
-      CALL pw_zero(tmp_r%pw)
+      rho_r(1)%pw => orb_rho_r
+      rho_r(2)%pw => tmp_r
+      CALL pw_zero(tmp_r)
 
       ALLOCATE (rho_g(2))
-      rho_g(1)%pw => orb_rho_g%pw
-      rho_g(2)%pw => tmp_g%pw
-      CALL pw_zero(tmp_g%pw)
+      rho_g(1)%pw => orb_rho_g
+      rho_g(2)%pw => tmp_g
+      CALL pw_zero(tmp_g)
 
       NULLIFY (vxc)
       ! now apply to SIC correction to each selected orbital
@@ -616,18 +613,18 @@ CONTAINS
                                     alpha=1.0_dp)
 
          CALL calculate_rho_elec(matrix_p=orb_density_matrix, &
-                                 rho=orb_rho_r%pw, rho_gspace=orb_rho_g%pw, &
+                                 rho=orb_rho_r, rho_gspace=orb_rho_g, &
                                  ks_env=ks_env)
 
          ! compute the energy functional for this orbital and its derivative
 
-         CALL pw_poisson_solve(poisson_env, orb_rho_g%pw, ener, work_v_gspace%pw)
+         CALL pw_poisson_solve(poisson_env, orb_rho_g, ener, work_v_gspace)
          ! no PBC correction is done here, see "calc_v_sic_rspace" for SIC methods
          ! with PBC aware corrections
          energy%hartree = energy%hartree - dft_control%sic_scaling_a*ener
          IF (.NOT. just_energy) THEN
-            CALL pw_transfer(work_v_gspace%pw, work_v_rspace%pw)
-            CALL pw_scale(work_v_rspace%pw, -dft_control%sic_scaling_a*work_v_rspace%pw%pw_grid%dvol)
+            CALL pw_transfer(work_v_gspace, work_v_rspace)
+            CALL pw_scale(work_v_rspace, -dft_control%sic_scaling_a*work_v_rspace%pw_grid%dvol)
             CALL dbcsr_set(orb_h, 0.0_dp)
          END IF
 
@@ -640,14 +637,14 @@ CONTAINS
                                    rho_g=rho_g, tau=tau, vxc_tau=vxc_tau, exc=exc, xc_section=xc_section, &
                                    pw_pool=xc_pw_pool, compute_virial=compute_virial, virial_xc=virial_xc_tmp)
             ! add to the existing work_v_rspace
-            work_v_rspace%pw%cr3d = work_v_rspace%pw%cr3d - &
-                                    dft_control%sic_scaling_b*vxc(1)%pw%pw_grid%dvol*vxc(1)%pw%cr3d
+            work_v_rspace%cr3d = work_v_rspace%cr3d - &
+                                 dft_control%sic_scaling_b*vxc(1)%pw%pw_grid%dvol*vxc(1)%pw%cr3d
          END IF
          energy%exc = energy%exc - dft_control%sic_scaling_b*exc
 
          IF (.NOT. just_energy) THEN
             ! note, orb_h (which is being pointed to with orb_h_p) is zeroed above
-            CALL integrate_v_rspace(v_rspace=work_v_rspace%pw, pmat=orb_density_matrix_p, hmat=orb_h_p, &
+            CALL integrate_v_rspace(v_rspace=work_v_rspace, pmat=orb_density_matrix_p, hmat=orb_h_p, &
                                     qs_env=qs_env, calculate_forces=calculate_forces)
 
             ! add this to the mo_derivs
@@ -670,13 +667,12 @@ CONTAINS
 
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orb_rho_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orb_rho_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace%pw)
-      DEALLOCATE (orb_rho_r%pw, tmp_r%pw, orb_rho_g%pw, tmp_g%pw, work_v_gspace%pw, work_v_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, orb_rho_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, orb_rho_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace)
 
       CALL dbcsr_deallocate_matrix(orb_density_matrix)
       CALL dbcsr_deallocate_matrix(orb_h)
@@ -1663,10 +1659,10 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_ext_r
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_eff_gspace, v_xc_gspace, v_xc_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_ext_g, rho_g, rho_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: v_xc_rspace
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(section_vals_type), POINTER                   :: ext_den_section, input
 
@@ -1692,10 +1688,10 @@ CONTAINS
       CALL qs_rho_get(rho, rho_r=rho_r, rho_g=rho_g)
       nspins = 1
       ALLOCATE (v_rspace_new(nspins))
-      ALLOCATE (v_rspace_new(1)%pw, v_xc_rspace%pw)
+      ALLOCATE (v_rspace_new(1)%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_rspace_new(1)%pw, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_xc_rspace%pw, &
+      CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_xc_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL pw_zero(v_rspace_new(1)%pw)
@@ -1706,61 +1702,61 @@ CONTAINS
          exc = accurate_dot_product(v_rspace_new(1)%pw%cr3d, rho_r(1)%pw%cr3d)* &
                v_rspace_new(1)%pw%pw_grid%dvol
       ELSE
-         ALLOCATE (rho_eff_gspace%pw, v_xc_gspace%pw)
-         CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                pw=rho_eff_gspace%pw, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                pw=v_xc_gspace%pw, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
-         CALL pw_zero(rho_eff_gspace%pw)
-         CALL pw_zero(v_xc_gspace%pw)
-         CALL pw_zero(v_xc_rspace%pw)
-         factor = pw_integrate_function(rho_g(1)%pw)
-         CALL qs_rho_get(qs_env%rho_external, &
-                         rho_g=rho_ext_g, &
-                         tot_rho_r=tot_rho_ext_r)
-         factor = tot_rho_ext_r(1)/factor
+         BLOCK
+            TYPE(pw_type) :: rho_eff_gspace, v_xc_gspace
+            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
+                                   pw=rho_eff_gspace, &
+                                   use_data=COMPLEXDATA1D, &
+                                   in_space=RECIPROCALSPACE)
+            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
+                                   pw=v_xc_gspace, &
+                                   use_data=COMPLEXDATA1D, &
+                                   in_space=RECIPROCALSPACE)
+            CALL pw_zero(rho_eff_gspace)
+            CALL pw_zero(v_xc_gspace)
+            CALL pw_zero(v_xc_rspace)
+            factor = pw_integrate_function(rho_g(1)%pw)
+            CALL qs_rho_get(qs_env%rho_external, &
+                            rho_g=rho_ext_g, &
+                            tot_rho_r=tot_rho_ext_r)
+            factor = tot_rho_ext_r(1)/factor
 
-         CALL pw_axpy(rho_g(1)%pw, rho_eff_gspace%pw, alpha=factor)
-         CALL pw_axpy(rho_ext_g(1)%pw, rho_eff_gspace%pw, alpha=-1.0_dp)
-         ext_den_section => section_vals_get_subs_vals(input, "DFT%EXTERNAL_DENSITY")
-         CALL section_vals_val_get(ext_den_section, "LAMBDA", r_val=lambda)
-         CALL section_vals_val_get(ext_den_section, "ZMP_CONSTRAINT", i_val=my_val)
-         CALL section_vals_val_get(ext_den_section, "FERMI_AMALDI", l_val=fermi_amaldi)
+            CALL pw_axpy(rho_g(1)%pw, rho_eff_gspace, alpha=factor)
+            CALL pw_axpy(rho_ext_g(1)%pw, rho_eff_gspace, alpha=-1.0_dp)
+            ext_den_section => section_vals_get_subs_vals(input, "DFT%EXTERNAL_DENSITY")
+            CALL section_vals_val_get(ext_den_section, "LAMBDA", r_val=lambda)
+            CALL section_vals_val_get(ext_den_section, "ZMP_CONSTRAINT", i_val=my_val)
+            CALL section_vals_val_get(ext_den_section, "FERMI_AMALDI", l_val=fermi_amaldi)
 
-         CALL pw_scale(rho_eff_gspace%pw, a=lambda)
-         nelectron = nelectron_spin(1)
-         factor = -1.0_dp/nelectron
-         CALL pw_axpy(rho_g(1)%pw, rho_eff_gspace%pw, alpha=factor)
+            CALL pw_scale(rho_eff_gspace, a=lambda)
+            nelectron = nelectron_spin(1)
+            factor = -1.0_dp/nelectron
+            CALL pw_axpy(rho_g(1)%pw, rho_eff_gspace, alpha=factor)
 
-         CALL pw_poisson_solve(poisson_env, rho_eff_gspace%pw, vhartree=v_xc_gspace%pw)
-         CALL pw_transfer(v_xc_gspace%pw, v_rspace_new(1)%pw)
-         CALL pw_copy(v_rspace_new(1)%pw, v_xc_rspace%pw)
+            CALL pw_poisson_solve(poisson_env, rho_eff_gspace, vhartree=v_xc_gspace)
+            CALL pw_transfer(v_xc_gspace, v_rspace_new(1)%pw)
+            CALL pw_copy(v_rspace_new(1)%pw, v_xc_rspace)
 
-         exc = 0.0_dp
-         exc = accurate_sum(v_rspace_new(1)%pw%cr3d*rho_r(1)%pw%cr3d)* &
-               v_rspace_new(1)%pw%pw_grid%dvol
-         IF (v_rspace_new(1)%pw%pw_grid%para%mode == PW_MODE_DISTRIBUTED) THEN
-            CALL mp_sum(exc, v_rspace_new(1)%pw%pw_grid%para%group)
-         END IF
+            exc = 0.0_dp
+            exc = accurate_sum(v_rspace_new(1)%pw%cr3d*rho_r(1)%pw%cr3d)* &
+                  v_rspace_new(1)%pw%pw_grid%dvol
+            IF (v_rspace_new(1)%pw%pw_grid%para%mode == PW_MODE_DISTRIBUTED) THEN
+               CALL mp_sum(exc, v_rspace_new(1)%pw%pw_grid%para%group)
+            END IF
 
 !     IF (v_rspace_new(1)%pw%pw_grid%para%my_pos==0) &
 !           WRITE(*,FMT="(T3,A,T61,F20.10)") "ZMP| Integral of (electron density)*(v_xc):    " , exc
 !Note that this is not the xc energy but \int(\rho*v_xc)
 !Vxc---> v_rspace_new
 !Exc---> energy%exc
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, &
-                                   rho_eff_gspace%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, &
-                                   v_xc_gspace%pw)
-         DEALLOCATE (rho_eff_gspace%pw, v_xc_gspace%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, &
+                                      rho_eff_gspace)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, &
+                                      v_xc_gspace)
+         END BLOCK
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rspace%pw)
-      DEALLOCATE (v_xc_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rspace)
 
       CALL timestop(handle)
 

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -1211,7 +1211,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: ks_matrix
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: my_rho
-      TYPE(pw_p_type), POINTER                           :: vppl_rspace
+      TYPE(pw_type), POINTER                             :: vppl_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: v_rspace_new, v_rspace_new_aux_fit, &
                                                             v_tau_rspace, v_tau_rspace_aux_fit
       TYPE(pw_p_type)                                    :: v_efield_rspace, v_sic_rspace, &
@@ -1372,7 +1372,7 @@ CONTAINS
             IF (do_ppl) THEN
                CPASSERT(.NOT. gapw)
                v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d + &
-                                             vppl_rspace%pw%cr3d*vppl_rspace%pw%pw_grid%dvol
+                                             vppl_rspace%cr3d*vppl_rspace%pw_grid%dvol
             END IF
             ! the electrostatic sic contribution
             SELECT CASE (dft_control%sic_method_id)

--- a/src/qs_linres_epr_nablavks.F
+++ b/src/qs_linres_epr_nablavks.F
@@ -147,11 +147,11 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho1_r, rho2_r, rho_r, v_rspace_new, &
                                                             v_tau_rspace
-      TYPE(pw_p_type), POINTER :: v_coulomb_gspace, v_coulomb_gtemp, v_coulomb_rtemp, &
-         v_hartree_gspace, v_hartree_gtemp, v_hartree_rtemp, v_xc_gtemp, v_xc_rtemp, wf_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: pwx, pwy, pwz, rho_tot_gspace
+      TYPE(pw_type) :: rho_tot_gspace, v_coulomb_gspace, v_coulomb_gtemp, v_coulomb_rtemp, &
+         v_hartree_gspace, v_hartree_gtemp, v_hartree_rtemp, v_xc_gtemp, v_xc_rtemp, wf_r
+      TYPE(pw_type), POINTER                             :: pwx, pwy, pwz
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_p_type), DIMENSION(:, :), POINTER      :: nablavks_set
@@ -283,16 +283,11 @@ CONTAINS
 !   Add Hartree potential
 !   -------------------------------------
 
-      ALLOCATE (v_hartree_gspace)
-      ALLOCATE (v_hartree_gtemp)
-      ALLOCATE (v_hartree_rtemp)
-
-      ALLOCATE (v_hartree_gspace%pw, v_hartree_gtemp%pw, v_hartree_rtemp%pw, rho_tot_gspace)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gtemp%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gtemp, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rtemp%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rtemp, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
@@ -311,7 +306,7 @@ CONTAINS
                                skip_nuclear_density=.NOT. gapw)
 
       CALL pw_poisson_solve(poisson_env, rho_tot_gspace, ehartree, &
-                            v_hartree_gspace%pw)
+                            v_hartree_gspace)
 
       !   -------------------------------------
       !   Atomic grids part
@@ -446,30 +441,25 @@ CONTAINS
 
       END IF ! gapw
 
-      CALL pw_copy(v_hartree_gspace%pw, v_hartree_gtemp%pw)
-      CALL pw_derive(v_hartree_gtemp%pw, (/1, 0, 0/))
-      CALL pw_transfer(v_hartree_gtemp%pw, v_hartree_rtemp%pw)
-      CALL pw_copy(v_hartree_rtemp%pw, pwx)
+      CALL pw_copy(v_hartree_gspace, v_hartree_gtemp)
+      CALL pw_derive(v_hartree_gtemp, (/1, 0, 0/))
+      CALL pw_transfer(v_hartree_gtemp, v_hartree_rtemp)
+      CALL pw_copy(v_hartree_rtemp, pwx)
 
-      CALL pw_copy(v_hartree_gspace%pw, v_hartree_gtemp%pw)
-      CALL pw_derive(v_hartree_gtemp%pw, (/0, 1, 0/))
-      CALL pw_transfer(v_hartree_gtemp%pw, v_hartree_rtemp%pw)
-      CALL pw_copy(v_hartree_rtemp%pw, pwy)
+      CALL pw_copy(v_hartree_gspace, v_hartree_gtemp)
+      CALL pw_derive(v_hartree_gtemp, (/0, 1, 0/))
+      CALL pw_transfer(v_hartree_gtemp, v_hartree_rtemp)
+      CALL pw_copy(v_hartree_rtemp, pwy)
 
-      CALL pw_copy(v_hartree_gspace%pw, v_hartree_gtemp%pw)
-      CALL pw_derive(v_hartree_gtemp%pw, (/0, 0, 1/))
-      CALL pw_transfer(v_hartree_gtemp%pw, v_hartree_rtemp%pw)
-      CALL pw_copy(v_hartree_rtemp%pw, pwz)
+      CALL pw_copy(v_hartree_gspace, v_hartree_gtemp)
+      CALL pw_derive(v_hartree_gtemp, (/0, 0, 1/))
+      CALL pw_transfer(v_hartree_gtemp, v_hartree_rtemp)
+      CALL pw_copy(v_hartree_rtemp, pwz)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gtemp%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rtemp%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gtemp)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rtemp)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-      DEALLOCATE (v_hartree_gspace%pw, v_hartree_gtemp%pw, v_hartree_rtemp%pw, rho_tot_gspace)
-
-      DEALLOCATE (v_hartree_gspace)
-      DEALLOCATE (v_hartree_gtemp)
-      DEALLOCATE (v_hartree_rtemp)
 
 !   -------------------------------------
 !   Add Coulomb potential
@@ -515,26 +505,21 @@ CONTAINS
 
             IF (gth_gspace) THEN
 
-               ALLOCATE (v_coulomb_gspace)
-               ALLOCATE (v_coulomb_gtemp)
-               ALLOCATE (v_coulomb_rtemp)
-
-               ALLOCATE (v_coulomb_gspace%pw, v_coulomb_gtemp%pw, v_coulomb_rtemp%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gspace%pw, &
+               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gspace, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gtemp%pw, &
+               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gtemp, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_rtemp%pw, &
+               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_rtemp, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
 
-               CALL pw_zero(v_coulomb_gspace%pw)
+               CALL pw_zero(v_coulomb_gspace)
 
                DO iat = 1, natom ! natom = # atoms for ikind
 
                   iatom = atom_list(iat)
                   ratom = particle_set(iatom)%r
 
-                  DO ig = v_coulomb_gspace%pw%pw_grid%first_gne0, v_coulomb_gspace%pw%pw_grid%ngpts_cut_local
+                  DO ig = v_coulomb_gspace%pw_grid%first_gne0, v_coulomb_gspace%pw_grid%ngpts_cut_local
                      gtemp = 0.0_dp
                      ! gtemp = - fourpi * charge / cell%deth * &
                      !         EXP ( - v_coulomb_gspace%pw%pw_grid%gsq(ig) / (4.0_dp * alpha) ) &
@@ -546,89 +531,84 @@ CONTAINS
                         CASE (1)
                            gtemp = gtemp + &
                                    (twopi)**(1.5_dp)/(cell%deth*(2.0_dp*alpha)**(1.5_dp))* &
-                                   EXP(-v_coulomb_gspace%pw%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
+                                   EXP(-v_coulomb_gspace%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
                                    ! C1
                                    +cexp_ppl(1) &
                                    )
                         CASE (2)
                            gtemp = gtemp + &
                                    (twopi)**(1.5_dp)/(cell%deth*(2.0_dp*alpha)**(1.5_dp))* &
-                                   EXP(-v_coulomb_gspace%pw%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
+                                   EXP(-v_coulomb_gspace%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
                                    ! C1
                                    +cexp_ppl(1) &
                                    ! C2
                                    + cexp_ppl(2)/(2.0_dp*alpha)* &
-                                   (3.0_dp - v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha)) &
+                                   (3.0_dp - v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha)) &
                                    )
                         CASE (3)
                            gtemp = gtemp + &
                                    (twopi)**(1.5_dp)/(cell%deth*(2.0_dp*alpha)**(1.5_dp))* &
-                                   EXP(-v_coulomb_gspace%pw%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
+                                   EXP(-v_coulomb_gspace%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
                                    ! C1
                                    +cexp_ppl(1) &
                                    ! C2
                                    + cexp_ppl(2)/(2.0_dp*alpha)* &
-                                   (3.0_dp - v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha)) &
+                                   (3.0_dp - v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha)) &
                                    ! C3
                                    + cexp_ppl(3)/(2.0_dp*alpha)**2* &
-                                   (15.0_dp - 10.0_dp*v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha) &
-                                    + (v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha))**2) &
+                                   (15.0_dp - 10.0_dp*v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha) &
+                                    + (v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha))**2) &
                                    )
                         CASE (4)
                            gtemp = gtemp + &
                                    (twopi)**(1.5_dp)/(cell%deth*(2.0_dp*alpha)**(1.5_dp))* &
-                                   EXP(-v_coulomb_gspace%pw%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
+                                   EXP(-v_coulomb_gspace%pw_grid%gsq(ig)/(4.0_dp*alpha))*( &
                                    ! C1
                                    +cexp_ppl(1) &
                                    ! C2
                                    + cexp_ppl(2)/(2.0_dp*alpha)* &
-                                   (3.0_dp - v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha)) &
+                                   (3.0_dp - v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha)) &
                                    ! C3
                                    + cexp_ppl(3)/(2.0_dp*alpha)**2* &
-                                   (15.0_dp - 10.0_dp*v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha) &
-                                    + (v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha))**2) &
+                                   (15.0_dp - 10.0_dp*v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha) &
+                                    + (v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha))**2) &
                                    ! C4
                                    + cexp_ppl(4)/(2.0_dp*alpha)**3* &
-                                   (105.0_dp - 105.0_dp*v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha) &
-                                    + 21.0_dp*(v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha))**2 &
-                                    - (v_coulomb_gspace%pw%pw_grid%gsq(ig)/(2.0_dp*alpha))**3) &
+                                   (105.0_dp - 105.0_dp*v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha) &
+                                    + 21.0_dp*(v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha))**2 &
+                                    - (v_coulomb_gspace%pw_grid%gsq(ig)/(2.0_dp*alpha))**3) &
                                    )
                         END SELECT
 
                      END IF
 
-                     arg = DOT_PRODUCT(v_coulomb_gspace%pw%pw_grid%g(:, ig), ratom)
+                     arg = DOT_PRODUCT(v_coulomb_gspace%pw_grid%g(:, ig), ratom)
 
                      gtemp = gtemp*CMPLX(COS(arg), -SIN(arg), KIND=dp)
-                     v_coulomb_gspace%pw%cc(ig) = v_coulomb_gspace%pw%cc(ig) + gtemp
+                     v_coulomb_gspace%cc(ig) = v_coulomb_gspace%cc(ig) + gtemp
                   END DO
-                  IF (v_coulomb_gspace%pw%pw_grid%have_g0) v_coulomb_gspace%pw%cc(1) = 0.0_dp
+                  IF (v_coulomb_gspace%pw_grid%have_g0) v_coulomb_gspace%cc(1) = 0.0_dp
 
                END DO
 
-               CALL pw_copy(v_coulomb_gspace%pw, v_coulomb_gtemp%pw)
-               CALL pw_derive(v_coulomb_gtemp%pw, (/1, 0, 0/))
-               CALL pw_transfer(v_coulomb_gtemp%pw, v_coulomb_rtemp%pw)
-               CALL pw_axpy(v_coulomb_rtemp%pw, pwx)
+               CALL pw_copy(v_coulomb_gspace, v_coulomb_gtemp)
+               CALL pw_derive(v_coulomb_gtemp, (/1, 0, 0/))
+               CALL pw_transfer(v_coulomb_gtemp, v_coulomb_rtemp)
+               CALL pw_axpy(v_coulomb_rtemp, pwx)
 
-               CALL pw_copy(v_coulomb_gspace%pw, v_coulomb_gtemp%pw)
-               CALL pw_derive(v_coulomb_gtemp%pw, (/0, 1, 0/))
-               CALL pw_transfer(v_coulomb_gtemp%pw, v_coulomb_rtemp%pw)
-               CALL pw_axpy(v_coulomb_rtemp%pw, pwy)
+               CALL pw_copy(v_coulomb_gspace, v_coulomb_gtemp)
+               CALL pw_derive(v_coulomb_gtemp, (/0, 1, 0/))
+               CALL pw_transfer(v_coulomb_gtemp, v_coulomb_rtemp)
+               CALL pw_axpy(v_coulomb_rtemp, pwy)
 
-               CALL pw_copy(v_coulomb_gspace%pw, v_coulomb_gtemp%pw)
-               CALL pw_derive(v_coulomb_gtemp%pw, (/0, 0, 1/))
-               CALL pw_transfer(v_coulomb_gtemp%pw, v_coulomb_rtemp%pw)
-               CALL pw_axpy(v_coulomb_rtemp%pw, pwz)
+               CALL pw_copy(v_coulomb_gspace, v_coulomb_gtemp)
+               CALL pw_derive(v_coulomb_gtemp, (/0, 0, 1/))
+               CALL pw_transfer(v_coulomb_gtemp, v_coulomb_rtemp)
+               CALL pw_axpy(v_coulomb_rtemp, pwz)
 
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gspace%pw)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gtemp%pw)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_rtemp%pw)
-               DEALLOCATE (v_coulomb_gspace%pw, v_coulomb_gtemp%pw, v_coulomb_rtemp%pw)
-
-               DEALLOCATE (v_coulomb_gspace)
-               DEALLOCATE (v_coulomb_gtemp)
-               DEALLOCATE (v_coulomb_rtemp)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gspace)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gtemp)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_rtemp)
             ELSE
 
                ! Attic of the atomic parallellisation
@@ -871,13 +851,9 @@ CONTAINS
 !   Add V_xc potential
 !   -------------------------------------
 
-      ALLOCATE (v_xc_gtemp)
-      ALLOCATE (v_xc_rtemp)
-
-      ALLOCATE (v_xc_gtemp%pw, v_xc_rtemp%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_gtemp%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_gtemp, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_rtemp%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_rtemp, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       xc_section => section_vals_get_subs_vals(input, "PROPERTIES%LINRES%EPR%PRINT%G_TENSOR%XC")
@@ -895,23 +871,23 @@ CONTAINS
 
          DO ispin = 1, nspins
 
-            CALL pw_transfer(v_rspace_new(ispin)%pw, v_xc_gtemp%pw)
-            CALL pw_derive(v_xc_gtemp%pw, (/1, 0, 0/))
-            CALL pw_transfer(v_xc_gtemp%pw, v_xc_rtemp%pw)
+            CALL pw_transfer(v_rspace_new(ispin)%pw, v_xc_gtemp)
+            CALL pw_derive(v_xc_gtemp, (/1, 0, 0/))
+            CALL pw_transfer(v_xc_gtemp, v_xc_rtemp)
             CALL qs_rho_get(nablavks_set(1, ispin)%rho, rho_r=rho_r)
-            CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
+            CALL pw_axpy(v_xc_rtemp, rho_r(1)%pw)
 
-            CALL pw_transfer(v_rspace_new(ispin)%pw, v_xc_gtemp%pw)
-            CALL pw_derive(v_xc_gtemp%pw, (/0, 1, 0/))
-            CALL pw_transfer(v_xc_gtemp%pw, v_xc_rtemp%pw)
+            CALL pw_transfer(v_rspace_new(ispin)%pw, v_xc_gtemp)
+            CALL pw_derive(v_xc_gtemp, (/0, 1, 0/))
+            CALL pw_transfer(v_xc_gtemp, v_xc_rtemp)
             CALL qs_rho_get(nablavks_set(2, ispin)%rho, rho_r=rho_r)
-            CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
+            CALL pw_axpy(v_xc_rtemp, rho_r(1)%pw)
 
-            CALL pw_transfer(v_rspace_new(ispin)%pw, v_xc_gtemp%pw)
-            CALL pw_derive(v_xc_gtemp%pw, (/0, 0, 1/))
-            CALL pw_transfer(v_xc_gtemp%pw, v_xc_rtemp%pw)
+            CALL pw_transfer(v_rspace_new(ispin)%pw, v_xc_gtemp)
+            CALL pw_derive(v_xc_gtemp, (/0, 0, 1/))
+            CALL pw_transfer(v_xc_gtemp, v_xc_rtemp)
             CALL qs_rho_get(nablavks_set(3, ispin)%rho, rho_r=rho_r)
-            CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
+            CALL pw_axpy(v_xc_rtemp, rho_r(1)%pw)
 
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin)%pw)
             DEALLOCATE (v_rspace_new(ispin)%pw)
@@ -925,23 +901,23 @@ CONTAINS
 
          DO ispin = 1, nspins
 
-            CALL pw_transfer(v_tau_rspace(ispin)%pw, v_xc_gtemp%pw)
-            CALL pw_derive(v_xc_gtemp%pw, (/1, 0, 0/))
-            CALL pw_transfer(v_xc_gtemp%pw, v_xc_rtemp%pw)
+            CALL pw_transfer(v_tau_rspace(ispin)%pw, v_xc_gtemp)
+            CALL pw_derive(v_xc_gtemp, (/1, 0, 0/))
+            CALL pw_transfer(v_xc_gtemp, v_xc_rtemp)
             CALL qs_rho_get(nablavks_set(1, ispin)%rho, rho_r=rho_r)
-            CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
+            CALL pw_axpy(v_xc_rtemp, rho_r(1)%pw)
 
-            CALL pw_transfer(v_tau_rspace(ispin)%pw, v_xc_gtemp%pw)
-            CALL pw_derive(v_xc_gtemp%pw, (/0, 1, 0/))
-            CALL pw_transfer(v_xc_gtemp%pw, v_xc_rtemp%pw)
+            CALL pw_transfer(v_tau_rspace(ispin)%pw, v_xc_gtemp)
+            CALL pw_derive(v_xc_gtemp, (/0, 1, 0/))
+            CALL pw_transfer(v_xc_gtemp, v_xc_rtemp)
             CALL qs_rho_get(nablavks_set(2, ispin)%rho, rho_r=rho_r)
-            CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
+            CALL pw_axpy(v_xc_rtemp, rho_r(1)%pw)
 
-            CALL pw_transfer(v_tau_rspace(ispin)%pw, v_xc_gtemp%pw)
-            CALL pw_derive(v_xc_gtemp%pw, (/0, 0, 1/))
-            CALL pw_transfer(v_xc_gtemp%pw, v_xc_rtemp%pw)
+            CALL pw_transfer(v_tau_rspace(ispin)%pw, v_xc_gtemp)
+            CALL pw_derive(v_xc_gtemp, (/0, 0, 1/))
+            CALL pw_transfer(v_xc_gtemp, v_xc_rtemp)
             CALL qs_rho_get(nablavks_set(3, ispin)%rho, rho_r=rho_r)
-            CALL pw_axpy(v_xc_rtemp%pw, rho_r(1)%pw)
+            CALL pw_axpy(v_xc_rtemp, rho_r(1)%pw)
 
             CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin)%pw)
             DEALLOCATE (v_tau_rspace(ispin)%pw)
@@ -951,12 +927,8 @@ CONTAINS
          DEALLOCATE (v_tau_rspace)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_gtemp%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rtemp%pw)
-      DEALLOCATE (v_xc_gtemp%pw, v_xc_rtemp%pw)
-
-      DEALLOCATE (v_xc_gtemp)
-      DEALLOCATE (v_xc_rtemp)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_gtemp)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rtemp)
 
       IF (gapw .OR. gapw_xc) THEN
          CALL calculate_vxc_atom(qs_env=qs_env, energy_only=.FALSE., exc1=exc1, &
@@ -969,15 +941,13 @@ CONTAINS
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, lr_section, &
                                            "EPR%PRINT%NABLAVKS_CUBES"), cp_p_file)) THEN
-         ALLOCATE (wf_r)
-         ALLOCATE (wf_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          DO idir = 1, 3
-            CALL pw_zero(wf_r%pw)
+            CALL pw_zero(wf_r)
             CALL qs_rho_get(nablavks_set(idir, 1)%rho, rho_r=rho_r)
-            CALL pw_copy(rho_r(1)%pw, wf_r%pw) ! RA
+            CALL pw_copy(rho_r(1)%pw, wf_r) ! RA
             filename = "nablavks"
             mpi_io = .TRUE.
             WRITE (ext, '(a2,I1,a5)') "_d", idir, ".cube"
@@ -985,7 +955,7 @@ CONTAINS
                                            extension=TRIM(ext), middle_name=TRIM(filename), &
                                            log_filename=.FALSE., file_position="REWIND", &
                                            mpi_io=mpi_io)
-            CALL cp_pw_to_cube(wf_r%pw, unit_nr, "NABLA V_KS ", &
+            CALL cp_pw_to_cube(wf_r, unit_nr, "NABLA V_KS ", &
                                particles=particles, &
                                stride=section_get_ivals(lr_section, &
                                                         "EPR%PRINT%NABLAVKS_CUBES%STRIDE"), &
@@ -993,9 +963,7 @@ CONTAINS
             CALL cp_print_key_finished_output(unit_nr, logger, lr_section, &
                                               "EPR%PRINT%NABLAVKS_CUBES", mpi_io=mpi_io)
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-         DEALLOCATE (wf_r%pw)
-         DEALLOCATE (wf_r)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
       END IF
 
       CALL cp_print_key_finished_output(output_unit, logger, lr_section, &

--- a/src/qs_linres_epr_ownutils.F
+++ b/src/qs_linres_epr_ownutils.F
@@ -54,7 +54,8 @@ MODULE qs_linres_epr_ownutils
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_core_energies,                ONLY: calculate_ptrace
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -311,9 +312,9 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: jrho2_r, jrho3_r, nrho1_r, nrho2_r, &
                                                             nrho3_r
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: vks_pw_spline
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_spline_precond_type)                       :: precond
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:, :)        :: vks_pw_spline
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_p_type), DIMENSION(:), POINTER         :: jrho1_set
       TYPE(qs_rho_p_type), DIMENSION(:, :), POINTER      :: nablavks_set
@@ -385,19 +386,18 @@ CONTAINS
 
          DO ispin = 1, nspins
             DO idir1 = 1, 3
-               ALLOCATE (vks_pw_spline(idir1, ispin)%pw)
                CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                      vks_pw_spline(idir1, ispin)%pw, &
+                                      vks_pw_spline(idir1, ispin), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                ! calculate spline coefficients
                CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                              pool=auxbas_pw_pool, pbc=.TRUE., transpose=.FALSE.)
                CALL qs_rho_get(nablavks_set(idir1, ispin)%rho, rho_r=nrho1_r)
                CALL pw_spline_do_precond(precond, nrho1_r(1)%pw, &
-                                         vks_pw_spline(idir1, ispin)%pw)
+                                         vks_pw_spline(idir1, ispin))
                CALL pw_spline_precond_set_kind(precond, precond_kind)
                success = find_coeffs(values=nrho1_r(1)%pw, &
-                                     coeffs=vks_pw_spline(idir1, ispin)%pw, linOp=spl3_pbc, &
+                                     coeffs=vks_pw_spline(idir1, ispin), linOp=spl3_pbc, &
                                      preconditioner=precond, pool=auxbas_pw_pool, &
                                      eps_r=eps_r, eps_x=eps_x, max_iter=max_iter)
                CPASSERT(success)
@@ -440,9 +440,9 @@ CONTAINS
                            ra = particle_set(iatom)%r
                            ra(:) = ra(:) + grid_atom%rad(ir)*harmonics%a(:, ia)
                            vks_ra_idir2 = Eval_Interp_Spl3_pbc(ra, &
-                                                               vks_pw_spline(idir2, ispin)%pw)
+                                                               vks_pw_spline(idir2, ispin))
                            vks_ra_idir3 = Eval_Interp_Spl3_pbc(ra, &
-                                                               vks_pw_spline(idir3, ispin)%pw)
+                                                               vks_pw_spline(idir3, ispin))
 
                            IF (iat .LT. bo(1) .OR. iat .GT. bo(2)) CYCLE !quick and dirty:
                            !                                    !here take care of the partition
@@ -521,11 +521,9 @@ CONTAINS
 
          DO ispin = 1, nspins
             DO idir1 = 1, 3
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vks_pw_spline(idir1, ispin)%pw)
-               DEALLOCATE (vks_pw_spline(idir1, ispin)%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, vks_pw_spline(idir1, ispin))
             END DO
          END DO
-
          DEALLOCATE (vks_pw_spline)
 
       END IF ! gapw
@@ -576,9 +574,9 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: brho1_r, rho_r
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: bind_pw_spline
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_spline_precond_type)                       :: precond
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:, :)        :: bind_pw_spline
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_p_type), DIMENSION(:, :), POINTER      :: bind_set
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -658,19 +656,18 @@ CONTAINS
          CALL section_vals_val_get(interp_section, "eps_x", r_val=eps_x)
 
          DO idir1 = 1, 3
-            ALLOCATE (bind_pw_spline(idir1, iB)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   bind_pw_spline(idir1, iB)%pw, &
+                                   bind_pw_spline(idir1, iB), &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             ! calculate spline coefficients
             CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                           pool=auxbas_pw_pool, pbc=.TRUE., transpose=.FALSE.)
             CALL qs_rho_get(bind_set(idir1, iB)%rho, rho_r=brho1_r)
             CALL pw_spline_do_precond(precond, brho1_r(1)%pw, &
-                                      bind_pw_spline(idir1, iB)%pw)
+                                      bind_pw_spline(idir1, iB))
             CALL pw_spline_precond_set_kind(precond, precond_kind)
             success = find_coeffs(values=brho1_r(1)%pw, &
-                                  coeffs=bind_pw_spline(idir1, iB)%pw, linOp=spl3_pbc, &
+                                  coeffs=bind_pw_spline(idir1, iB), linOp=spl3_pbc, &
                                   preconditioner=precond, pool=auxbas_pw_pool, &
                                   eps_r=eps_r, eps_x=eps_x, max_iter=max_iter)
             CPASSERT(success)
@@ -712,7 +709,7 @@ CONTAINS
                            ra = particle_set(iatom)%r
                            ra(:) = ra(:) + grid_atom%rad(ir)*harmonics%a(:, ia)
                            bind_ra_idir1 = Eval_Interp_Spl3_pbc(ra, &
-                                                                bind_pw_spline(idir1, iB)%pw)
+                                                                bind_pw_spline(idir1, iB))
 
                            IF (iat .LT. bo(1) .OR. iat .GT. bo(2)) CYCLE !quick and dirty:
                            !                                    !here take care of the partition
@@ -751,10 +748,8 @@ CONTAINS
          g_soo(iB, :) = g_soo(iB, :) + temp_soo_gapw(iB, :)
 
          DO idir1 = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, bind_pw_spline(idir1, iB)%pw)
-            DEALLOCATE (bind_pw_spline(idir1, iB)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, bind_pw_spline(idir1, iB))
          END DO
-
          DEALLOCATE (bind_pw_spline)
 
       END IF ! gapw
@@ -790,18 +785,17 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: pw_gspace_work, shift_pw_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: epr_rho_r, jrho1_g
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: shift_pw_gspace
-      TYPE(pw_p_type), POINTER                           :: rho_gspace
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pw_gspace_work, shift_pw_rspace
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:, :)        :: shift_pw_gspace
       TYPE(realspace_grid_desc_type), POINTER            :: auxbas_rs_desc
 
       CALL timeset(routineN, handle)
 
       NULLIFY (cell, dft_control, pw_env, auxbas_rs_desc, auxbas_pw_pool, &
-               rho_gspace, pw_pools, particle_set, jrho1_g, epr_rho_r)
+               pw_pools, particle_set, jrho1_g, epr_rho_r)
 
       CALL get_qs_env(qs_env=qs_env, cell=cell, dft_control=dft_control, &
                       particle_set=particle_set)
@@ -823,22 +817,19 @@ CONTAINS
       ALLOCATE (shift_pw_gspace(3, nspins))
       DO ispin = 1, nspins
          DO idir = 1, 3
-            ALLOCATE (shift_pw_gspace(idir, ispin)%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin), &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
-            CALL pw_zero(shift_pw_gspace(idir, ispin)%pw)
+            CALL pw_zero(shift_pw_gspace(idir, ispin))
          END DO
       END DO
-      ALLOCATE (shift_pw_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_zero(shift_pw_rspace%pw)
-      ALLOCATE (pw_gspace_work%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work%pw, &
+      CALL pw_zero(shift_pw_rspace)
+      CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_zero(pw_gspace_work%pw)
+      CALL pw_zero(pw_gspace_work)
       !
       CALL set_vecp(iB, iiB, iiiB)
       !
@@ -846,24 +837,23 @@ CONTAINS
          !
          DO idir3 = 1, 3
             ! set to zero for the calculation of the shift
-            CALL pw_zero(shift_pw_gspace(idir3, ispin)%pw)
+            CALL pw_zero(shift_pw_gspace(idir3, ispin))
          END DO
          DO idir = 1, 3
             CALL qs_rho_get(current_env%jrho1_set(idir)%rho, rho_g=jrho1_g)
-            rho_gspace => jrho1_g(ispin)
             ! Field gradient
             ! loop over the Gvec  components: x,y,z
             DO idir2 = 1, 3
                IF (idir /= idir2) THEN
                   ! in reciprocal space multiply (G_idir2(i)/G(i)^2)J_(idir)(G(i))
-                  CALL mult_G_ov_G2_grid(auxbas_pw_pool, rho_gspace, &
+                  CALL mult_G_ov_G2_grid(auxbas_pw_pool, jrho1_g(ispin)%pw, &
                                          pw_gspace_work, idir2, 0.0_dp)
                   !
                   ! scale and add to the correct component of the shift column
                   CALL set_vecp_rev(idir, idir2, idir3)
                   scale_fac = fac_vecp(idir3, idir2, idir)
-                  CALL pw_scale(pw_gspace_work%pw, scale_fac)
-                  CALL pw_axpy(pw_gspace_work%pw, shift_pw_gspace(idir3, ispin)%pw)
+                  CALL pw_scale(pw_gspace_work, scale_fac)
+                  CALL pw_axpy(pw_gspace_work, shift_pw_gspace(idir3, ispin))
                END IF
             END DO
             !
@@ -874,22 +864,19 @@ CONTAINS
       IF (dft_control%nspins == 2) THEN
          DO idir = 1, 3
             CALL qs_rho_get(epr_env%bind_set(idir, iB)%rho, rho_r=epr_rho_r)
-            CALL pw_transfer(shift_pw_gspace(idir, 2)%pw, epr_rho_r(1)%pw)
+            CALL pw_transfer(shift_pw_gspace(idir, 2), epr_rho_r(1)%pw)
          END DO
       END IF
       !
       ! Dellocate grids for the calculation of jrho and the shift
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work%pw)
-      DEALLOCATE (pw_gspace_work%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work)
       DO ispin = 1, dft_control%nspins
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw)
-            DEALLOCATE (shift_pw_gspace(idir, ispin)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin))
          END DO
       END DO
       DEALLOCATE (shift_pw_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace%pw)
-      DEALLOCATE (shift_pw_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace)
       !
       ! Finalize
       CALL timestop(handle)

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -74,7 +74,8 @@ MODULE qs_linres_kernel
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_fxc,                          ONLY: qs_fxc_analytic,&
@@ -197,12 +198,12 @@ CONTAINS
       TYPE(lri_environment_type), POINTER                :: lri_env
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri_v_int
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho1_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho1_g, rho1_r, rho_r, tau1_r, &
                                                             v_rspace_new, v_xc, v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho1_tot_gspace, v_hartree_gspace, &
+                                                            v_hartree_rspace
       TYPE(qs_kpp1_env_type), POINTER                    :: kpp1_env
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho1, rho1_xc, rho1a, rho_aux
@@ -277,11 +278,10 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
       ALLOCATE (v_rspace_new(nspins))
-      ALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -289,28 +289,26 @@ CONTAINS
          CALL prepare_gapw_den(qs_env, p_env%local_rho_set, do_rho0=(.NOT. gapw_xc))
 
       ! *** calculate the hartree potential on the total density ***
-      ALLOCATE (rho1_tot_gspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
       CALL qs_rho_get(rho1, rho_g=rho1_g)
-      CALL pw_copy(rho1_g(1)%pw, rho1_tot_gspace%pw)
+      CALL pw_copy(rho1_g(1)%pw, rho1_tot_gspace)
       DO ispin = 2, nspins
-         CALL pw_axpy(rho1_g(ispin)%pw, rho1_tot_gspace%pw)
+         CALL pw_axpy(rho1_g(ispin)%pw, rho1_tot_gspace)
       END DO
       IF (gapw) &
-         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs, rho1_tot_gspace%pw)
+         CALL pw_axpy(p_env%local_rho_set%rho0_mpole%rho0_s_gs, rho1_tot_gspace)
 
       IF (.NOT. (nspins == 1 .AND. lr_triplet)) THEN
-         CALL pw_poisson_solve(poisson_env, rho1_tot_gspace%pw, &
+         CALL pw_poisson_solve(poisson_env, rho1_tot_gspace, &
                                energy_hartree, &
-                               v_hartree_gspace%pw)
-         CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
+                               v_hartree_gspace)
+         CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace%pw)
-      DEALLOCATE (rho1_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace)
 
       ! *** calculate the xc potential ***
       NULLIFY (rho1a)
@@ -341,7 +339,7 @@ CONTAINS
       END DO
       DEALLOCATE (v_xc)
 
-      CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+      CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
       DO ispin = 1, nspins
          CALL pw_scale(v_rspace_new(ispin)%pw, v_rspace_new(ispin)%pw%pw_grid%dvol)
          IF (ASSOCIATED(v_xc_tau)) CALL pw_scale(v_xc_tau(ispin)%pw, v_xc_tau(ispin)%pw%pw_grid%dvol)
@@ -398,7 +396,7 @@ CONTAINS
 
                ! add hartree only for SINGLETS
                IF (.NOT. lr_triplet) THEN
-                  v_rspace_new(1)%pw%cr3d = 2.0_dp*v_hartree_rspace%pw%cr3d
+                  v_rspace_new(1)%pw%cr3d = 2.0_dp*v_hartree_rspace%cr3d
 
                   CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                           pmat=rho_ao(ispin), &
@@ -423,7 +421,7 @@ CONTAINS
                                           calculate_forces=.FALSE., gapw=gapw_xc)
                END IF
 
-               v_rspace_new(ispin)%pw%cr3d = v_hartree_rspace%pw%cr3d
+               v_rspace_new(ispin)%pw%cr3d = v_hartree_rspace%cr3d
                CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin)%pw, &
                                        pmat=rho_ao(ispin), &
                                        hmat=kpp1_env%v_ao(ispin), &
@@ -442,11 +440,11 @@ CONTAINS
                !IF (res_etype == tddfpt_singlet) THEN
                IF (.NOT. lr_triplet) THEN
                   v_rspace_new(1)%pw%cr3d = v_rspace_new(1)%pw%cr3d + &
-                                            2.0_dp*v_hartree_rspace%pw%cr3d
+                                            2.0_dp*v_hartree_rspace%cr3d
                END IF
             ELSE
                v_rspace_new(ispin)%pw%cr3d = v_rspace_new(ispin)%pw%cr3d + &
-                                             v_hartree_rspace%pw%cr3d
+                                             v_hartree_rspace%cr3d
             END IF
 
             IF (lrigpw) THEN
@@ -500,7 +498,7 @@ CONTAINS
                                     p_env%local_rho_set, &
                                     para_env, tddft=.TRUE.)
 
-            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace%pw, para_env, &
+            CALL integrate_vhg0_rspace(qs_env, v_hartree_rspace, para_env, &
                                        calculate_forces=.FALSE., &
                                        local_rho_set=p_env%local_rho_set)
          END IF
@@ -540,9 +538,8 @@ CONTAINS
          END IF
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin)%pw)
          DEALLOCATE (v_rspace_new(ispin)%pw)

--- a/src/qs_linres_nmr_epr_common_utils.F
+++ b/src/qs_linres_nmr_epr_common_utils.F
@@ -24,7 +24,6 @@ MODULE qs_linres_nmr_epr_common_utils
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_type
 #include "./base/base_uses.f90"
 
@@ -61,8 +60,8 @@ CONTAINS
    SUBROUTINE mult_G_ov_G2_grid(pw_pool, rho_gspace, funcG_times_rho, idir, my_chi)
 
       TYPE(pw_pool_type), POINTER                        :: pw_pool
-      TYPE(pw_p_type), POINTER                           :: rho_gspace
-      TYPE(pw_p_type)                                    :: funcG_times_rho
+      TYPE(pw_type), INTENT(IN)                          :: rho_gspace
+      TYPE(pw_type), INTENT(INOUT)                       :: funcG_times_rho
       INTEGER, INTENT(IN)                                :: idir
       REAL(dp), INTENT(IN)                               :: my_chi
 
@@ -85,11 +84,11 @@ CONTAINS
       END DO ! ig
       IF (grid%have_g0) influence_fn%cc(1) = 0.0_dp
 
-      CALL pw_transfer(rho_gspace%pw, funcG_times_rho%pw)
+      CALL pw_transfer(rho_gspace, funcG_times_rho)
 
       ng = SIZE(grid%gsq)
-      funcG_times_rho%pw%cc(1:ng) = funcG_times_rho%pw%cc(1:ng)*influence_fn%cc(1:ng)
-      IF (grid%have_g0) funcG_times_rho%pw%cc(1) = my_chi
+      funcG_times_rho%cc(1:ng) = funcG_times_rho%cc(1:ng)*influence_fn%cc(1:ng)
+      IF (grid%have_g0) funcG_times_rho%cc(1) = my_chi
 
       CALL pw_pool_give_back_pw(pw_pool, influence_fn)
 

--- a/src/qs_linres_nmr_shift.F
+++ b/src/qs_linres_nmr_shift.F
@@ -121,20 +121,19 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: pw_gspace_work, shift_pw_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: jrho1_g
-      TYPE(pw_p_type), DIMENSION(:, :), POINTER          :: shift_pw_gspace
-      TYPE(pw_p_type), POINTER                           :: jrho_gspace
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pw_gspace_work, shift_pw_rspace
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:, :)        :: shift_pw_gspace
       TYPE(realspace_grid_desc_type), POINTER            :: auxbas_rs_desc
       TYPE(section_vals_type), POINTER                   :: nmr_section
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (chemical_shift, chemical_shift_loc, chemical_shift_nics, chemical_shift_nics_loc, &
-               cell, dft_control, pw_env, auxbas_rs_desc, auxbas_pw_pool, jrho_gspace, &
-               pw_pools, particle_set, jrho1_g)
+      NULLIFY (chemical_shift, chemical_shift_loc, chemical_shift_nics, &
+               chemical_shift_nics_loc, cell, dft_control, pw_env, &
+               auxbas_rs_desc, auxbas_pw_pool, pw_pools, particle_set, jrho1_g)
 
       CALL get_qs_env(qs_env=qs_env, cell=cell, dft_control=dft_control, &
                       particle_set=particle_set)
@@ -162,63 +161,57 @@ CONTAINS
       ALLOCATE (shift_pw_gspace(3, nspins))
       DO ispin = 1, nspins
          DO idir = 1, 3
-            ALLOCATE (shift_pw_gspace(idir, ispin)%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin), &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-            CALL pw_zero(shift_pw_gspace(idir, ispin)%pw)
+            CALL pw_zero(shift_pw_gspace(idir, ispin))
          END DO
       END DO
       !
       !
       CALL set_vecp(iB, iiB, iiiB)
       !
-      ALLOCATE (pw_gspace_work%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_zero(pw_gspace_work%pw)
+      CALL pw_zero(pw_gspace_work)
       DO ispin = 1, nspins
          !
          DO idir = 1, 3
             CALL qs_rho_get(current_env%jrho1_set(idir)%rho, rho_g=jrho1_g)
-            jrho_gspace => jrho1_g(ispin)
             ! Field gradient
             ! loop over the Gvec  components: x,y,z
             DO idir2 = 1, 3
                IF (idir /= idir2) THEN
                   ! in reciprocal space multiply (G_idir2(i)/G(i)^2)J_(idir)(G(i))
-                  CALL mult_G_ov_G2_grid(auxbas_pw_pool, jrho_gspace, &
+                  CALL mult_G_ov_G2_grid(auxbas_pw_pool, jrho1_g(ispin)%pw, &
                                          pw_gspace_work, idir2, 0.0_dp)
                   !
                   ! scale and add to the correct component of the shift column
                   CALL set_vecp_rev(idir, idir2, idir3)
                   scale_fac = fac_vecp(idir3, idir2, idir)
-                  CALL pw_axpy(pw_gspace_work%pw, shift_pw_gspace(idir3, ispin)%pw, scale_fac)
+                  CALL pw_axpy(pw_gspace_work, shift_pw_gspace(idir3, ispin), scale_fac)
                END IF
             END DO
             !
          END DO ! idir
       END DO ! ispin
       !
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work%pw)
-      DEALLOCATE (pw_gspace_work%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work)
       !
       ! compute shildings
       IF (interpolate_shift) THEN
-         ALLOCATE (shift_pw_rspace%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          DO ispin = 1, nspins
             DO idir = 1, 3
                ! Here first G->R and then interpolation to get the shifts.
                ! The interpolation doesnt work in parallel yet.
                ! The choice between both methods should be left to the user.
-               CALL pw_transfer(shift_pw_gspace(idir, ispin)%pw, shift_pw_rspace%pw)
+               CALL pw_transfer(shift_pw_gspace(idir, ispin), shift_pw_rspace)
                CALL interpolate_shift_pwgrid(nmr_env, pw_env, particle_set, cell, shift_pw_rspace, &
                                              iB, idir, nmr_section)
             END DO
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace%pw)
-         DEALLOCATE (shift_pw_rspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace)
       ELSE
          DO ispin = 1, nspins
             DO idir = 1, 3
@@ -241,8 +234,7 @@ CONTAINS
       ! Dellocate grids for the calculation of jrho and the shift
       DO ispin = 1, nspins
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin)%pw)
-            DEALLOCATE (shift_pw_gspace(idir, ispin)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin))
          END DO
       END DO
       DEALLOCATE (shift_pw_gspace)
@@ -519,7 +511,7 @@ CONTAINS
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(pw_p_type)                                    :: shift_pw_rspace
+      TYPE(pw_type), INTENT(IN)                          :: shift_pw_rspace
       INTEGER, INTENT(IN)                                :: i_B, idir
       TYPE(section_vals_type), POINTER                   :: nmr_section
 
@@ -533,17 +525,15 @@ CONTAINS
                                                             shift_val
       REAL(dp), DIMENSION(:, :), POINTER                 :: r_nics
       REAL(dp), DIMENSION(:, :, :), POINTER              :: chemical_shift, chemical_shift_nics
-      TYPE(pw_p_type)                                    :: shiftspl
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_spline_precond_type)                       :: precond
+      TYPE(pw_type)                                      :: shiftspl
       TYPE(section_vals_type), POINTER                   :: interp_section
 
       CALL timeset(routineN, handle)
       !
       NULLIFY (interp_section, auxbas_pw_pool)
       NULLIFY (cs_atom_list, chemical_shift, chemical_shift_nics, r_nics)
-
-      CPASSERT(ASSOCIATED(shift_pw_rspace%pw))
 
       interp_section => section_vals_get_subs_vals(nmr_section, &
                                                    "INTERPOLATOR")
@@ -556,15 +546,14 @@ CONTAINS
 
       ! calculate spline coefficients
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      ALLOCATE (shiftspl%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, shiftspl%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, shiftspl, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                     pool=auxbas_pw_pool, pbc=.TRUE., transpose=.FALSE.)
-      CALL pw_spline_do_precond(precond, shift_pw_rspace%pw, shiftspl%pw)
+      CALL pw_spline_do_precond(precond, shift_pw_rspace, shiftspl)
       CALL pw_spline_precond_set_kind(precond, precond_kind)
-      success = find_coeffs(values=shift_pw_rspace%pw, coeffs=shiftspl%pw, &
+      success = find_coeffs(values=shift_pw_rspace, coeffs=shiftspl, &
                             linOp=spl3_pbc, preconditioner=precond, pool=auxbas_pw_pool, &
                             eps_r=eps_r, eps_x=eps_x, max_iter=max_iter)
       CPASSERT(success)
@@ -585,7 +574,7 @@ CONTAINS
       DO iat = 1, natom
          iatom = cs_atom_list(iat)
          R_iatom = pbc(particle_set(iatom)%r, cell)
-         shift_val = Eval_Interp_Spl3_pbc(R_iatom, shiftspl%pw)
+         shift_val = Eval_Interp_Spl3_pbc(R_iatom, shiftspl)
          chemical_shift(idir, i_B, iatom) = chemical_shift(idir, i_B, iatom) + &
                                             nmr_env%shift_factor*twopi**2*shift_val
       END DO
@@ -594,14 +583,13 @@ CONTAINS
          DO iatom = 1, n_nics
             ra(:) = r_nics(:, iatom)
             R_iatom = pbc(ra, cell)
-            shift_val = Eval_Interp_Spl3_pbc(R_iatom, shiftspl%pw)
+            shift_val = Eval_Interp_Spl3_pbc(R_iatom, shiftspl)
             chemical_shift_nics(idir, i_B, iatom) = chemical_shift_nics(idir, i_B, iatom) + &
                                                     nmr_env%shift_factor*twopi**2*shift_val
          END DO
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, shiftspl%pw)
-      DEALLOCATE (shiftspl%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, shiftspl)
 
       !
       CALL timestop(handle)
@@ -622,7 +610,7 @@ CONTAINS
       TYPE(nmr_env_type)                                 :: nmr_env
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(pw_p_type)                                    :: shift_pw_gspace
+      TYPE(pw_type), INTENT(IN)                          :: shift_pw_gspace
       INTEGER, INTENT(IN)                                :: i_B, idir
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'gsum_shift_pwgrid'
@@ -638,7 +626,6 @@ CONTAINS
       CALL timeset(routineN, handle)
       !
       NULLIFY (cs_atom_list, chemical_shift, chemical_shift_nics, r_nics)
-      CPASSERT(ASSOCIATED(shift_pw_gspace%pw))
       !
       CALL get_nmr_env(nmr_env=nmr_env, cs_atom_list=cs_atom_list, &
                        chemical_shift=chemical_shift, &
@@ -655,7 +642,7 @@ CONTAINS
       DO iat = 1, natom
          iatom = cs_atom_list(iat)
          R_iatom = pbc(particle_set(iatom)%r, cell)
-         CALL gsumr(R_iatom, shift_pw_gspace%pw, cplx)
+         CALL gsumr(R_iatom, shift_pw_gspace, cplx)
          chemical_shift(idir, i_B, iatom) = chemical_shift(idir, i_B, iatom) + &
                                             nmr_env%shift_factor*twopi**2*REAL(cplx, dp)
       END DO
@@ -664,7 +651,7 @@ CONTAINS
       IF (do_nics) THEN
          DO iat = 1, n_nics
             ra = pbc(r_nics(:, iat), cell)
-            CALL gsumr(ra, shift_pw_gspace%pw, cplx)
+            CALL gsumr(ra, shift_pw_gspace, cplx)
             chemical_shift_nics(idir, i_B, iat) = chemical_shift_nics(idir, i_B, iat) + &
                                                   nmr_env%shift_factor*twopi**2*REAL(cplx, dp)
          END DO
@@ -682,7 +669,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE gsumr(r, pw, cplx)
       REAL(dp), INTENT(IN)                               :: r(3)
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type), INTENT(IN)                          :: pw
       COMPLEX(dp)                                        :: cplx
 
       COMPLEX(dp)                                        :: rg

--- a/src/qs_loc_methods.F
+++ b/src/qs_loc_methods.F
@@ -95,7 +95,7 @@ MODULE qs_loc_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_atomic_block,                 ONLY: calculate_atomic_block_dm
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -1091,8 +1091,8 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
@@ -1105,11 +1105,10 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
-      ALLOCATE (wf_r%pw, wf_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
@@ -1138,7 +1137,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, cell=cell, &
                          dft_control=dft_control, particle_set=particle_set, pw_env=pw_env)
 
-         CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, &
+         CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, pw_env)
 
          ! Formatting the middle part of the name
@@ -1167,15 +1166,14 @@ CONTAINS
             WRITE (title, '(A7,I5.5,A2,I1.1,A1,3F10.4)') "WFN ", ivector, "_s", my_ispin, " ", &
                centers(1:3, istate)*angstrom
          END IF
-         CALL cp_pw_to_cube(wf_r%pw, unit_out_c, title, &
+         CALL cp_pw_to_cube(wf_r, unit_out_c, title, &
                             particles=particles, &
                             stride=section_get_ivals(print_key, "STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_out_c, logger, print_key, "", mpi_io=mpi_io)
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      DEALLOCATE (wf_r%pw, wf_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
       CALL timestop(handle)
    END SUBROUTINE qs_print_cubes
 

--- a/src/qs_loc_states.F
+++ b/src/qs_loc_states.F
@@ -27,7 +27,7 @@ MODULE qs_loc_states
    USE molecular_states,                ONLY: construct_molecular_states
    USE molecule_types,                  ONLY: molecule_type
    USE particle_list_types,             ONLY: particle_list_type
-   USE pw_types,                        ONLY: pw_p_type
+   USE pw_types,                        ONLY: pw_p_type, pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
@@ -72,7 +72,8 @@ CONTAINS
       TYPE(qs_loc_env_new_type), POINTER                 :: qs_loc_env
       TYPE(section_vals_type), POINTER                   :: loc_section
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_local
-      TYPE(pw_p_type)                                    :: wf_r, wf_g
+      TYPE(pw_type), INTENT(INOUT)                     :: wf_r
+      TYPE(pw_type), INTENT(IN)                                    :: wf_g
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: coeff
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: evals

--- a/src/qs_loc_states.F
+++ b/src/qs_loc_states.F
@@ -27,7 +27,7 @@ MODULE qs_loc_states
    USE molecular_states,                ONLY: construct_molecular_states
    USE molecule_types,                  ONLY: molecule_type
    USE particle_list_types,             ONLY: particle_list_type
-   USE pw_types,                        ONLY: pw_p_type, pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
                                               set_qs_env
@@ -72,8 +72,8 @@ CONTAINS
       TYPE(qs_loc_env_new_type), POINTER                 :: qs_loc_env
       TYPE(section_vals_type), POINTER                   :: loc_section
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_local
-      TYPE(pw_type), INTENT(INOUT)                     :: wf_r
-      TYPE(pw_type), INTENT(IN)                                    :: wf_g
+      TYPE(pw_type), INTENT(INOUT)                       :: wf_r
+      TYPE(pw_type), INTENT(IN)                          :: wf_g
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: coeff
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: evals

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -84,7 +84,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE qs_local_energy(qs_env, energy_density)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_p_type), INTENT(INOUT)                     :: energy_density
+      TYPE(pw_type), INTENT(INOUT)                     :: energy_density
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_local_energy'
 
@@ -98,9 +98,10 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: matrix
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: band_density, edens_g, edens_r, &
-                                                            hartree_density, v_hartree_rspace, &
+      TYPE(pw_type)                                    :: band_density, edens_g, edens_r, &
+                                                            hartree_density, &
                                                             xc_density
+TYPE(pw_type), POINTER :: v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace, rho_tot_rspace
@@ -128,10 +129,9 @@ CONTAINS
       ! get working arrays
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      ALLOCATE (band_density%pw, hartree_density%pw, xc_density%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, band_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, hartree_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, xc_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, band_density, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, hartree_density, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, xc_density, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! w matrix
       CALL get_qs_env(qs_env, matrix_w_kp=matrix_w)
@@ -153,27 +153,25 @@ CONTAINS
       ! band structure energy density
       CALL qs_energies_compute_w(qs_env, .TRUE.)
       CALL get_qs_env(qs_env, ks_env=ks_env, matrix_w_kp=matrix_w)
-      ALLOCATE (edens_r%pw, edens_g%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             edens_r%pw, &
+                             edens_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             edens_g%pw, &
+                             edens_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL pw_zero(band_density%pw)
+      CALL pw_zero(band_density)
       DO ispin = 1, nspins
          rho_ao => matrix_w(ispin, :)
          CALL calculate_rho_elec(matrix_p_kp=rho_ao, &
-                                 rho=edens_r%pw, &
-                                 rho_gspace=edens_g%pw, &
+                                 rho=edens_r, &
+                                 rho_gspace=edens_g, &
                                  ks_env=ks_env, soft_valid=(gapw .OR. gapw_xc))
-         CALL pw_axpy(edens_r%pw, band_density%pw)
+         CALL pw_axpy(edens_r, band_density)
       END DO
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_g%pw)
-      DEALLOCATE (edens_r%pw, edens_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_g)
 
       ! Hartree energy density correction = -0.5 * V_H(r) * [rho(r) - rho_core(r)]
       ALLOCATE (rho_tot_gspace, rho_tot_rspace)
@@ -187,7 +185,7 @@ CONTAINS
                              in_space=REALSPACE)
       NULLIFY (rho_core)
       CALL get_qs_env(qs_env, &
-                      v_hartree_rspace=v_hartree_rspace%pw, &
+                      v_hartree_rspace=v_hartree_rspace, &
                       rho_core=rho_core, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r)
       IF (ASSOCIATED(rho_core)) THEN
@@ -199,9 +197,9 @@ CONTAINS
       DO ispin = 1, nspins
          CALL pw_axpy(rho_r(ispin)%pw, rho_tot_rspace, alpha=-1.0_dp)
       END DO
-      CALL pw_zero(hartree_density%pw)
-      ovol = 0.5_dp/hartree_density%pw%pw_grid%dvol
-      CALL pw_multiply(hartree_density%pw, v_hartree_rspace%pw, rho_tot_rspace, alpha=ovol)
+      CALL pw_zero(hartree_density)
+      ovol = 0.5_dp/hartree_density%pw_grid%dvol
+      CALL pw_multiply(hartree_density, v_hartree_rspace, rho_tot_rspace, alpha=ovol)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace)
       DEALLOCATE (rho_tot_gspace, rho_tot_rspace)
@@ -221,9 +219,9 @@ CONTAINS
       !
       ! energies
       CALL get_qs_env(qs_env=qs_env, energy=energy)
-      eban = pw_integrate_function(band_density%pw)
-      eh = pw_integrate_function(hartree_density%pw)
-      exc = pw_integrate_function(xc_density%pw)
+      eban = pw_integrate_function(band_density)
+      eh = pw_integrate_function(hartree_density)
+      exc = pw_integrate_function(xc_density)
 
       ! band energy
       CALL get_qs_env(qs_env, matrix_ks_kp=matrix_ks)
@@ -231,9 +229,9 @@ CONTAINS
       CALL calculate_ptrace(matrix_ks, rho_ao_kp, eband, nspins)
 
       ! get full density
-      CALL pw_copy(band_density%pw, energy_density%pw)
-      CALL pw_axpy(hartree_density%pw, energy_density%pw)
-      CALL pw_axpy(xc_density%pw, energy_density%pw)
+      CALL pw_copy(band_density, energy_density)
+      CALL pw_axpy(hartree_density, energy_density)
+      CALL pw_axpy(xc_density, energy_density)
 
       IF (iounit > 0) THEN
          WRITE (UNIT=iounit, FMT="(/,T3,A)") REPEAT("=", 78)
@@ -247,10 +245,9 @@ CONTAINS
       END IF
 
       ! return temp arrays
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, band_density%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, hartree_density%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, xc_density%pw)
-      DEALLOCATE (band_density%pw, hartree_density%pw, xc_density%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, band_density)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, hartree_density)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, xc_density)
 
       CALL timestop(handle)
 
@@ -260,33 +257,32 @@ CONTAINS
 !> \brief Routine to calculate the local stress
 !> \param qs_env the qs_env to update
 !> \param stress_tensor ...
-!> \param pressure ...
 !> \param beta ...
 !> \par History
 !>      07.2019 created
 !> \author JGH
 ! **************************************************************************************************
-   SUBROUTINE qs_local_stress(qs_env, stress_tensor, pressure, beta)
+   SUBROUTINE qs_local_stress(qs_env, stress_tensor, beta)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(pw_p_type), DIMENSION(:, :), INTENT(INOUT), &
          OPTIONAL                                        :: stress_tensor
-      TYPE(pw_p_type), INTENT(INOUT), OPTIONAL           :: pressure
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: beta
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_local_stress'
 
       INTEGER                                            :: handle, i, iounit, j, nimages, nkind, &
                                                             nspins
-      LOGICAL                                            :: do_pressure, do_stress, gapw, gapw_xc, &
+      LOGICAL                                            :: do_stress, gapw, gapw_xc, &
                                                             use_virial
       REAL(KIND=dp)                                      :: my_beta
       REAL(KIND=dp), DIMENSION(3, 3)                     :: pv_loc
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace, &
+      TYPE(pw_type)                                    :: v_hartree_gspace, &
                                                             xc_density
-      TYPE(pw_p_type), DIMENSION(3)                      :: efield
+TYPE(pw_type), POINTER :: v_hartree_rspace
+      TYPE(pw_type), DIMENSION(3)                      :: efield
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
@@ -307,11 +303,6 @@ CONTAINS
          do_stress = .TRUE.
       ELSE
          do_stress = .FALSE.
-      END IF
-      IF (PRESENT(pressure)) THEN
-         do_pressure = .TRUE.
-      ELSE
-         do_pressure = .FALSE.
       END IF
       IF (PRESENT(beta)) THEN
          my_beta = beta
@@ -337,8 +328,7 @@ CONTAINS
       ! get working arrays
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      ALLOCATE (xc_density%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, xc_density%pw, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_create_pw(auxbas_pw_pool, xc_density, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! init local stress tensor
       IF (do_stress) THEN
@@ -362,25 +352,21 @@ CONTAINS
       CALL qs_xc_density(ks_env, rho_struct, xc_section, xc_density)
 
       ! Electrical field terms
-      CALL get_qs_env(qs_env, v_hartree_rspace=v_hartree_rspace%pw)
-      ALLOCATE (v_hartree_gspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL get_qs_env(qs_env, v_hartree_rspace=v_hartree_rspace)
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_transfer(v_hartree_rspace%pw, v_hartree_gspace%pw)
+      CALL pw_transfer(v_hartree_rspace, v_hartree_gspace)
       DO i = 1, 3
-         ALLOCATE (efield(i)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, efield(i)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, efield(i), &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_copy(v_hartree_gspace%pw, efield(i)%pw)
+         CALL pw_copy(v_hartree_gspace, efield(i))
       END DO
-      CALL pw_derive(efield(1)%pw, (/1, 0, 0/))
-      CALL pw_derive(efield(2)%pw, (/0, 1, 0/))
-      CALL pw_derive(efield(3)%pw, (/0, 0, 1/))
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      DEALLOCATE (v_hartree_gspace%pw)
+      CALL pw_derive(efield(1), (/1, 0, 0/))
+      CALL pw_derive(efield(2), (/0, 1, 0/))
+      CALL pw_derive(efield(3), (/0, 0, 1/))
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, efield(i)%pw)
-         DEALLOCATE (efield(i)%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, efield(i))
       END DO
 
       pv_loc = 0.0_dp

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -84,7 +84,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE qs_local_energy(qs_env, energy_density)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_type), INTENT(INOUT)                     :: energy_density
+      TYPE(pw_type), INTENT(INOUT)                       :: energy_density
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_local_energy'
 
@@ -98,13 +98,12 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: matrix
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: band_density, edens_g, edens_r, &
-                                                            hartree_density, &
-                                                            xc_density
-TYPE(pw_type), POINTER :: v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace, rho_tot_rspace
+      TYPE(pw_type)                                      :: band_density, edens_g, edens_r, &
+                                                            hartree_density, xc_density
+      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace, &
+                                                            rho_tot_rspace, v_hartree_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_struct
@@ -272,18 +271,16 @@ TYPE(pw_type), POINTER :: v_hartree_rspace
 
       INTEGER                                            :: handle, i, iounit, j, nimages, nkind, &
                                                             nspins
-      LOGICAL                                            :: do_stress, gapw, gapw_xc, &
-                                                            use_virial
+      LOGICAL                                            :: do_stress, gapw, gapw_xc, use_virial
       REAL(KIND=dp)                                      :: my_beta
       REAL(KIND=dp), DIMENSION(3, 3)                     :: pv_loc
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: v_hartree_gspace, &
-                                                            xc_density
-TYPE(pw_type), POINTER :: v_hartree_rspace
-      TYPE(pw_type), DIMENSION(3)                      :: efield
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: v_hartree_gspace, xc_density
+      TYPE(pw_type), DIMENSION(3)                        :: efield
+      TYPE(pw_type), POINTER                             :: v_hartree_rspace
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
       TYPE(section_vals_type), POINTER                   :: input, xc_section

--- a/src/qs_mixing_utils.F
+++ b/src/qs_mixing_utils.F
@@ -691,18 +691,10 @@ CONTAINS
 !>      02.2019 created [JGH]
 !> \author JGH
 ! **************************************************************************************************
-   SUBROUTINE charge_mixing_init(mixing_store)
-      TYPE(mixing_storage_type), POINTER                 :: mixing_store
-
-      CHARACTER(len=*), PARAMETER :: routineN = 'charge_mixing_init'
-
-      INTEGER                                            :: handle
-
-      CALL timeset(routineN, handle)
+   ELEMENTAL SUBROUTINE charge_mixing_init(mixing_store)
+      TYPE(mixing_storage_type), INTENT(INOUT)           :: mixing_store
 
       mixing_store%acharge = 0.0_dp
-
-      CALL timestop(handle)
 
    END SUBROUTINE charge_mixing_init
 

--- a/src/qs_pdos.F
+++ b/src/qs_pdos.F
@@ -68,7 +68,7 @@ MODULE qs_pdos
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -192,9 +192,9 @@ CONTAINS
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
       TYPE(ldos_p_type), DIMENSION(:), POINTER           :: ldos_p
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(r_ldos_p_type), DIMENSION(:), POINTER         :: r_ldos_p
       TYPE(section_vals_type), POINTER                   :: ldos_section
 
@@ -362,11 +362,10 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
 
-         ALLOCATE (wf_r%pw, wf_g%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
          ALLOCATE (read_r(4, n_r_ldos))
@@ -433,10 +432,10 @@ CONTAINS
                r_ldos_p(ildos)%ldos%eval_range(2) = +HUGE(0.0_dp)
             END IF
 
-            bo => wf_r%pw%pw_grid%bounds_local
-            dh = wf_r%pw%pw_grid%dh
-            dvol = wf_r%pw%pw_grid%dvol
-            np_tot = wf_r%pw%pw_grid%npts(1)*wf_r%pw%pw_grid%npts(2)*wf_r%pw%pw_grid%npts(3)
+            bo => wf_r%pw_grid%bounds_local
+            dh = wf_r%pw_grid%dh
+            dvol = wf_r%pw_grid%dvol
+            np_tot = wf_r%pw_grid%npts(1)*wf_r%pw_grid%npts(2)*wf_r%pw_grid%npts(3)
             ALLOCATE (r_ldos_p(ildos)%ldos%index_grid_local(3, np_tot))
 
             r_ldos_p(ildos)%ldos%npoints = 0
@@ -444,9 +443,9 @@ CONTAINS
             DO jy = bo(1, 2), bo(2, 2)
             DO jx = bo(1, 1), bo(2, 1)
                !compute the position of the grid point
-               i = jx - wf_r%pw%pw_grid%bounds(1, 1)
-               j = jy - wf_r%pw%pw_grid%bounds(1, 2)
-               k = jz - wf_r%pw%pw_grid%bounds(1, 3)
+               i = jx - wf_r%pw_grid%bounds(1, 1)
+               j = jy - wf_r%pw_grid%bounds(1, 2)
+               k = jz - wf_r%pw_grid%bounds(1, 3)
                r(3) = k*dh(3, 3) + j*dh(3, 2) + i*dh(3, 1)
                r(2) = k*dh(2, 3) + j*dh(2, 2) + i*dh(2, 1)
                r(1) = k*dh(1, 3) + j*dh(1, 2) + i*dh(1, 1)
@@ -650,11 +649,11 @@ CONTAINS
 
                IF (imo > nmo) THEN
                   CALL calculate_wavefunction(mo_virt, imo - nmo, &
-                                              wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
+                                              wf_r, wf_g, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                               pw_env)
                ELSE
                   CALL calculate_wavefunction(mo_coeff, imo, &
-                                              wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
+                                              wf_r, wf_g, atomic_kind_set, qs_kind_set, cell, dft_control, particle_set, &
                                               pw_env)
                END IF
                r_ldos_p(ildos)%ldos%pdos_array(imo) = 0.0_dp
@@ -664,7 +663,7 @@ CONTAINS
                   jy = r_ldos_p(ildos)%ldos%index_grid_local(2, il)
                   jz = r_ldos_p(ildos)%ldos%index_grid_local(3, il)
                   r_ldos_p(ildos)%ldos%pdos_array(imo) = r_ldos_p(ildos)%ldos%pdos_array(imo) + &
-                                                         wf_r%pw%cr3d(jx, jy, jz)*wf_r%pw%cr3d(jx, jy, jz)
+                                                         wf_r%cr3d(jx, jy, jz)*wf_r%cr3d(jx, jy, jz)
                END DO
                r_ldos_p(ildos)%ldos%pdos_array(imo) = r_ldos_p(ildos)%ldos%pdos_array(imo)*dvol
             END IF
@@ -902,9 +901,8 @@ CONTAINS
          DEALLOCATE (read_r)
          DEALLOCATE (r_ldos_p)
          DEALLOCATE (r_ldos_index)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-         DEALLOCATE (wf_r%pw, wf_g%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
       END IF
       IF (do_virt) THEN
          DEALLOCATE (evals_virt)

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -871,7 +871,7 @@ CONTAINS
          ! correct for the fact that v_hartree is scaled by dvol, and has the opposite sign
          IF (qs_env%qmmm) THEN
             ! If it's a QM/MM run let's remove the contribution of the MM potential out of the Hartree pot
-            vj = -v_hartree_pw%cr3d(jx, jy, jz)/dvol + qs_env%ks_qmmm_env%v_qmmm_rspace%pw%cr3d(jx, jy, jz)
+            vj = -v_hartree_pw%cr3d(jx, jy, jz)/dvol + qs_env%ks_qmmm_env%v_qmmm_rspace%cr3d(jx, jy, jz)
          ELSE
             vj = -v_hartree_pw%cr3d(jx, jy, jz)/dvol
          END IF
@@ -1208,7 +1208,7 @@ CONTAINS
          vhartree(ip) = -v_hartree_pw%cr3d(jx, jy, jz)/dvol
          IF (qs_env%qmmm) THEN
             !taking into account that v_qmmm has also opposite sign
-            vhartree(ip) = vhartree(ip) + qs_env%ks_qmmm_env%v_qmmm_rspace%pw%cr3d(jx, jy, jz)
+            vhartree(ip) = vhartree(ip) + qs_env%ks_qmmm_env%v_qmmm_rspace%cr3d(jx, jy, jz)
          END IF
          rhs = rhs + 2.0_dp*vhartree(ip)*vpot(ip)
       END DO

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -81,7 +81,6 @@ MODULE qs_resp
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_resp_all,&
@@ -930,9 +929,9 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vpot
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_ga, va_gspace, va_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_ga, va_gspace, va_rspace
 
       CALL timeset(routineN, handle)
 
@@ -950,17 +949,16 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      ALLOCATE (rho_ga%pw, va_gspace%pw, va_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_ga%pw, &
+                             rho_ga, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             va_gspace%pw, &
+                             va_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             va_rspace%pw, &
+                             va_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
@@ -972,26 +970,25 @@ CONTAINS
 
       DO i = 1, natom
          !collocate gaussian for each atom
-         CALL pw_zero(rho_ga%pw)
-         CALL calculate_rho_resp_single(rho_ga%pw, qs_env, resp_env%eta, i)
+         CALL pw_zero(rho_ga)
+         CALL calculate_rho_resp_single(rho_ga, qs_env, resp_env%eta, i)
          !calculate potential va and store the part needed for fitting in vpot
-         CALL pw_zero(va_gspace%pw)
-         CALL pw_poisson_solve(poisson_env, rho_ga%pw, vhartree=va_gspace%pw)
-         CALL pw_zero(va_rspace%pw)
-         CALL pw_transfer(va_gspace%pw, va_rspace%pw)
-         CALL pw_scale(va_rspace%pw, normalize_factor)
+         CALL pw_zero(va_gspace)
+         CALL pw_poisson_solve(poisson_env, rho_ga, vhartree=va_gspace)
+         CALL pw_zero(va_rspace)
+         CALL pw_transfer(va_gspace, va_rspace)
+         CALL pw_scale(va_rspace, normalize_factor)
          DO ip = 1, resp_env%npoints_proc
             jx = resp_env%fitpoints(1, ip)
             jy = resp_env%fitpoints(2, ip)
             jz = resp_env%fitpoints(3, ip)
-            vpot(ip, i) = va_rspace%pw%cr3d(jx, jy, jz)
+            vpot(ip, i) = va_rspace%cr3d(jx, jy, jz)
          END DO
       END DO
 
-      CALL pw_release(va_gspace%pw)
-      CALL pw_release(va_rspace%pw)
-      CALL pw_release(rho_ga%pw)
-      DEALLOCATE (va_gspace%pw, va_rspace%pw, rho_ga%pw)
+      CALL pw_release(va_gspace)
+      CALL pw_release(va_rspace)
+      CALL pw_release(rho_ga)
 
       DO i = 1, natom
          DO j = 1, natom
@@ -1701,10 +1698,10 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: aux_r, rho_resp, v_resp_gspace, &
-                                                            v_resp_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: aux_r, rho_resp, v_resp_gspace, &
+                                                            v_resp_rspace
       TYPE(pw_type), POINTER                             :: v_hartree_rspace
       TYPE(section_vals_type), POINTER                   :: input, print_key, resp_section
 
@@ -1727,45 +1724,42 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      ALLOCATE (rho_resp%pw, v_resp_gspace%pw, v_resp_rspace%pw)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_resp%pw, &
+                             rho_resp, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_gspace%pw, &
+                             v_resp_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_rspace%pw, &
+                             v_resp_rspace, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
-      CALL pw_zero(rho_resp%pw)
-      CALL calculate_rho_resp_all(rho_resp%pw, resp_env%rhs, natom, &
+      CALL pw_zero(rho_resp)
+      CALL calculate_rho_resp_all(rho_resp, resp_env%rhs, natom, &
                                   resp_env%eta, qs_env)
-      CALL pw_zero(v_resp_gspace%pw)
-      CALL pw_poisson_solve(poisson_env, rho_resp%pw, &
-                            vhartree=v_resp_gspace%pw)
-      CALL pw_zero(v_resp_rspace%pw)
-      CALL pw_transfer(v_resp_gspace%pw, v_resp_rspace%pw)
-      dvol = v_resp_rspace%pw%pw_grid%dvol
-      CALL pw_scale(v_resp_rspace%pw, dvol)
-      CALL pw_scale(v_resp_rspace%pw, -normalize_factor)
+      CALL pw_zero(v_resp_gspace)
+      CALL pw_poisson_solve(poisson_env, rho_resp, &
+                            vhartree=v_resp_gspace)
+      CALL pw_zero(v_resp_rspace)
+      CALL pw_transfer(v_resp_gspace, v_resp_rspace)
+      dvol = v_resp_rspace%pw_grid%dvol
+      CALL pw_scale(v_resp_rspace, dvol)
+      CALL pw_scale(v_resp_rspace, -normalize_factor)
       ! REPEAT: correct for offset, take into account that potentials have reverse sign
       ! and are scaled by dvol
       IF (resp_env%use_repeat_method) THEN
-         v_resp_rspace%pw%cr3d(:, :, :) = v_resp_rspace%pw%cr3d(:, :, :) - resp_env%offset*dvol
+         v_resp_rspace%cr3d(:, :, :) = v_resp_rspace%cr3d(:, :, :) - resp_env%offset*dvol
       END IF
-      CALL pw_release(v_resp_gspace%pw)
-      CALL pw_release(rho_resp%pw)
-      DEALLOCATE (v_resp_gspace%pw, rho_resp%pw)
+      CALL pw_release(v_resp_gspace)
+      CALL pw_release(rho_resp)
 
       !***now print the v_resp_rspace%pw to a cube file if requested
       IF (BTEST(cp_print_key_should_output(logger%iter_info, resp_section, &
                                            "PRINT%V_RESP_CUBE"), cp_p_file)) THEN
-         ALLOCATE (aux_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          append_cube = section_get_lval(resp_section, "PRINT%V_RESP_CUBE%APPEND")
@@ -1780,16 +1774,15 @@ CONTAINS
                                         file_position=my_pos_cube, &
                                         mpi_io=mpi_io)
          udvol = 1.0_dp/dvol
-         CALL pw_copy(v_resp_rspace%pw, aux_r%pw)
-         CALL pw_scale(aux_r%pw, udvol)
-         CALL cp_pw_to_cube(aux_r%pw, unit_nr, "RESP POTENTIAL", particles=particles, &
+         CALL pw_copy(v_resp_rspace, aux_r)
+         CALL pw_scale(aux_r, udvol)
+         CALL cp_pw_to_cube(aux_r, unit_nr, "RESP POTENTIAL", particles=particles, &
                             stride=section_get_ivals(resp_section, &
                                                      "PRINT%V_RESP_CUBE%STRIDE"), &
                             mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, resp_section, &
                                            "PRINT%V_RESP_CUBE", mpi_io=mpi_io)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-         DEALLOCATE (aux_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
       END IF
 
       !*** RMS and RRMS
@@ -1802,7 +1795,7 @@ CONTAINS
          jy = resp_env%fitpoints(2, ip)
          jz = resp_env%fitpoints(3, ip)
          sum_diff = sum_diff + (v_hartree_rspace%cr3d(jx, jy, jz) - &
-                                v_resp_rspace%pw%cr3d(jx, jy, jz))**2
+                                v_resp_rspace%cr3d(jx, jy, jz))**2
          sum_hartree = sum_hartree + v_hartree_rspace%cr3d(jx, jy, jz)**2
       END DO
       CALL mp_sum(sum_diff, para_env%group)
@@ -1816,8 +1809,7 @@ CONTAINS
             "(RRMS) error of RESP fit:", rrms
       END IF
 
-      CALL pw_release(v_resp_rspace%pw)
-      DEALLOCATE (v_resp_rspace%pw)
+      CALL pw_release(v_resp_rspace)
 
       CALL timestop(handle)
 

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -42,7 +42,6 @@ MODULE qs_rho0_ggrid
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type,&
                                               pw_release,&
                                               pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -111,10 +110,9 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: coeff_gspace, coeff_rspace
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: pw_pool
-      TYPE(pw_type)                                      :: rho0_r_tmp
+      TYPE(pw_type)                                      :: coeff_gspace, coeff_rspace, rho0_r_tmp
       TYPE(pw_type), POINTER                             :: rho0_s_gs, rho0_s_rs
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_desc_p_type), DIMENSION(:), &
@@ -147,7 +145,7 @@ CONTAINS
                           rho0_s_rs=rho0_s_rs)
 
       ! *** set up the rs grid at level igrid
-      NULLIFY (rs_grid, desc, pw_pool, coeff_rspace, coeff_gspace)
+      NULLIFY (rs_grid, desc, pw_pool)
       desc => descs(igrid)%rs_desc
       rs_grid => grids(igrid)%rs_grid
       pw_pool => pw_pools(igrid)%pool
@@ -156,13 +154,9 @@ CONTAINS
       CPASSERT(ASSOCIATED(pw_pool))
 
       IF (igrid /= auxbas_grid) THEN
-         ALLOCATE (coeff_rspace)
-         ALLOCATE (coeff_gspace)
-
-         ALLOCATE (coeff_rspace%pw, coeff_gspace%pw)
-         CALL pw_pool_create_pw(pw_pool, coeff_rspace%pw, use_data=REALDATA3D, &
+         CALL pw_pool_create_pw(pw_pool, coeff_rspace, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_pool_create_pw(pw_pool, coeff_gspace%pw, &
+         CALL pw_pool_create_pw(pw_pool, coeff_gspace, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END IF
@@ -234,20 +228,16 @@ CONTAINS
       DEALLOCATE (pab)
 
       IF (igrid /= auxbas_grid) THEN
-         CALL rs_pw_transfer(rs_grid, coeff_rspace%pw, rs2pw)
+         CALL rs_pw_transfer(rs_grid, coeff_rspace, rs2pw)
          CALL rs_grid_release(rs_grid)
          CALL pw_zero(rho0_s_gs)
-         CALL pw_transfer(coeff_rspace%pw, coeff_gspace%pw)
-         CALL pw_axpy(coeff_gspace%pw, rho0_s_gs)
+         CALL pw_transfer(coeff_rspace, coeff_gspace)
+         CALL pw_axpy(coeff_gspace, rho0_s_gs)
 
-         tot_rs_int = pw_integrate_function(coeff_rspace%pw, isign=-1)
+         tot_rs_int = pw_integrate_function(coeff_rspace, isign=-1)
 
-         CALL pw_pool_give_back_pw(pw_pool, coeff_rspace%pw)
-         CALL pw_pool_give_back_pw(pw_pool, coeff_gspace%pw)
-         DEALLOCATE (coeff_rspace%pw, coeff_gspace%pw)
-
-         DEALLOCATE (coeff_rspace, coeff_gspace)
-
+         CALL pw_pool_give_back_pw(pw_pool, coeff_rspace)
+         CALL pw_pool_give_back_pw(pw_pool, coeff_gspace)
       ELSE
 
          CALL pw_pool_create_pw(pw_pool, rho0_r_tmp, &
@@ -360,10 +350,10 @@ CONTAINS
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), POINTER                           :: coeff_gaux, coeff_gspace, coeff_raux, &
-                                                            coeff_rspace
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: pw_aux, pw_pool
+      TYPE(pw_type)                                      :: coeff_gaux, coeff_gspace, coeff_raux, &
+                                                            coeff_rspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_desc_p_type), DIMENSION(:), &
@@ -430,63 +420,48 @@ CONTAINS
       auxbas_grid = pw_env%auxbas_grid
 
       ! Get the potential on the right grid
-      NULLIFY (rs_v, rs_desc, pw_pool, pw_aux, coeff_rspace, coeff_gspace)
+      NULLIFY (rs_v, rs_desc, pw_pool, pw_aux)
       rs_desc => rs_descs(igrid)%rs_desc
       pw_pool => pw_pools(igrid)%pool
 
-      ALLOCATE (coeff_gspace)
-      ALLOCATE (coeff_rspace)
-      ALLOCATE (coeff_gspace%pw, coeff_rspace%pw)
-      CALL pw_pool_create_pw(pw_pool, coeff_gspace%pw, &
+      CALL pw_pool_create_pw(pw_pool, coeff_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(pw_pool, coeff_rspace%pw, use_data=REALDATA3D, &
+      CALL pw_pool_create_pw(pw_pool, coeff_rspace, use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       IF (igrid /= auxbas_grid) THEN
          pw_aux => pw_pools(auxbas_grid)%pool
-         ALLOCATE (coeff_gaux)
-         ALLOCATE (coeff_gaux%pw)
-         CALL pw_pool_create_pw(pw_aux, coeff_gaux%pw, &
+         CALL pw_pool_create_pw(pw_aux, coeff_gaux, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
-         CALL pw_transfer(v_rspace, coeff_gaux%pw)
-         CALL pw_copy(coeff_gaux%pw, coeff_gspace%pw)
-         CALL pw_transfer(coeff_gspace%pw, coeff_rspace%pw)
-         CALL pw_pool_give_back_pw(pw_aux, coeff_gaux%pw)
-         DEALLOCATE (coeff_gaux%pw)
-         DEALLOCATE (coeff_gaux)
-         ALLOCATE (coeff_raux)
-         ALLOCATE (coeff_raux%pw)
-         CALL pw_pool_create_pw(pw_aux, coeff_raux%pw, use_data=REALDATA3D, &
+         CALL pw_transfer(v_rspace, coeff_gaux)
+         CALL pw_copy(coeff_gaux, coeff_gspace)
+         CALL pw_transfer(coeff_gspace, coeff_rspace)
+         CALL pw_pool_give_back_pw(pw_aux, coeff_gaux)
+         CALL pw_pool_create_pw(pw_aux, coeff_raux, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         scale = coeff_rspace%pw%pw_grid%dvol/coeff_raux%pw%pw_grid%dvol
-         coeff_rspace%pw%cr3d = scale*coeff_rspace%pw%cr3d
-         CALL pw_pool_give_back_pw(pw_aux, coeff_raux%pw)
-         DEALLOCATE (coeff_raux%pw)
-         DEALLOCATE (coeff_raux)
+         scale = coeff_rspace%pw_grid%dvol/coeff_raux%pw_grid%dvol
+         coeff_rspace%cr3d = scale*coeff_rspace%cr3d
+         CALL pw_pool_give_back_pw(pw_aux, coeff_raux)
       ELSE
 
-         IF (coeff_gspace%pw%pw_grid%spherical) THEN
-            CALL pw_transfer(v_rspace, coeff_gspace%pw)
-            CALL pw_transfer(coeff_gspace%pw, coeff_rspace%pw)
+         IF (coeff_gspace%pw_grid%spherical) THEN
+            CALL pw_transfer(v_rspace, coeff_gspace)
+            CALL pw_transfer(coeff_gspace, coeff_rspace)
          ELSE
-            CALL pw_copy(v_rspace, coeff_rspace%pw)
+            CALL pw_copy(v_rspace, coeff_rspace)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(pw_pool, coeff_gspace%pw)
-      DEALLOCATE (coeff_gspace%pw)
-      DEALLOCATE (coeff_gspace)
+      CALL pw_pool_give_back_pw(pw_pool, coeff_gspace)
 
       ! Setup the rs grid at level igrid
       CALL rs_grid_create(rs_v, rs_desc)
       CALL rs_grid_zero(rs_v)
-      CALL rs_pw_transfer(rs_v, coeff_rspace%pw, pw2rs)
+      CALL rs_pw_transfer(rs_v, coeff_rspace, pw2rs)
 
-      CALL pw_pool_give_back_pw(pw_pool, coeff_rspace%pw)
-      DEALLOCATE (coeff_rspace%pw)
-      DEALLOCATE (coeff_rspace)
+      CALL pw_pool_give_back_pw(pw_pool, coeff_rspace)
 
       ! Now the potential is on the right grid => integration
 

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -127,7 +127,7 @@ CONTAINS
    SUBROUTINE sccs(qs_env, rho_tot_gspace, v_hartree_gspace, v_sccs, h_stress)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(pw_type), POINTER                             :: rho_tot_gspace, v_hartree_gspace, v_sccs
+      TYPE(pw_type), INTENT(INOUT)                       :: rho_tot_gspace, v_hartree_gspace, v_sccs
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
          OPTIONAL                                        :: h_stress
 
@@ -218,9 +218,6 @@ CONTAINS
       sccs_control => dft_control%sccs_control
 
       CPASSERT(ASSOCIATED(qs_env))
-      CPASSERT(ASSOCIATED(rho_tot_gspace))
-      CPASSERT(ASSOCIATED(v_hartree_gspace))
-      CPASSERT(ASSOCIATED(v_sccs))
 
       IF (PRESENT(h_stress)) THEN
          calculate_stress_tensor = .TRUE.

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -156,16 +156,13 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(3)                      :: dphi_tot
-      TYPE(pw_p_type), DIMENSION(5)                      :: work_r3d
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_pw_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), DIMENSION(3)                        :: dln_eps_elec, drho_elec
-      TYPE(pw_type), DIMENSION(3, 3)                     :: d2rho_elec
-      TYPE(pw_type), POINTER :: deps_elec, eps_elec, ln_eps_elec, norm_drho_elec, phi_pol, &
-         phi_solute, phi_tot, rho_elec, rho_iter_old, rho_pol, rho_pw_r_sccs, rho_solute, rho_tot, &
-         rho_tot_zero, theta
+      TYPE(pw_type)                                      :: deps_elec, eps_elec
+      TYPE(pw_type), DIMENSION(3)                        :: dln_eps_elec
+      TYPE(pw_type), POINTER                             :: rho_pw_r_sccs
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
@@ -176,32 +173,18 @@ CONTAINS
 
       NULLIFY (auxbas_pw_pool)
       NULLIFY (cp_subsys)
-      NULLIFY (deps_elec)
       NULLIFY (dft_control)
       NULLIFY (energy)
-      NULLIFY (eps_elec)
       NULLIFY (input)
-      NULLIFY (ln_eps_elec)
       NULLIFY (logger)
-      NULLIFY (norm_drho_elec)
       NULLIFY (para_env)
       NULLIFY (particles)
-      NULLIFY (phi_pol)
-      NULLIFY (phi_solute)
-      NULLIFY (phi_tot)
       NULLIFY (poisson_env)
       NULLIFY (pw_env)
       NULLIFY (pw_pools)
       NULLIFY (rho)
-      NULLIFY (rho_elec)
-      NULLIFY (rho_iter_old)
-      NULLIFY (rho_pol)
-      NULLIFY (rho_solute)
-      NULLIFY (rho_tot)
-      NULLIFY (rho_tot_zero)
       NULLIFY (sccs_control)
       NULLIFY (scf_env)
-      NULLIFY (theta)
 
       ! Load data from Quickstep environment
       CALL get_qs_env(qs_env=qs_env, &
@@ -279,26 +262,6 @@ CONTAINS
                                          ignore_should_output=should_output, &
                                          log_filename=.FALSE.)
 
-      ! Get work storage for the 3d grids in r-space
-      DO i = 1, SIZE(work_r3d)
-         ALLOCATE (work_r3d(i)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                work_r3d(i)%pw, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-      END DO
-
-      ! Assign total electronic density in r-space
-      rho_elec => work_r3d(1)%pw
-
-      ! Retrieve grid parameters
-      ngpts = rho_elec%pw_grid%ngpts
-      dvol = rho_elec%pw_grid%dvol
-      cell_volume = rho_elec%pw_grid%vol
-      abc(1:3) = REAL(rho_elec%pw_grid%npts(1:3), KIND=dp)*rho_elec%pw_grid%dr(1:3)
-      lb(1:3) = rho_elec%pw_grid%bounds_local(1, 1:3)
-      ub(1:3) = rho_elec%pw_grid%bounds_local(2, 1:3)
-
       ! Get rho
       CALL qs_rho_get(rho_struct=rho, &
                       rho_r=rho_pw_r, &
@@ -306,118 +269,54 @@ CONTAINS
 
       ! Retrieve the last rho_iter from the previous SCCS cycle if available
       CPASSERT(ASSOCIATED(rho_pw_r_sccs))
-      rho_iter_old => rho_pw_r_sccs
 
       ! Retrieve the total electronic density in r-space
-      CALL pw_copy(rho_pw_r(1)%pw, rho_elec)
-      DO ispin = 2, nspin
-         CALL pw_axpy(rho_pw_r(ispin)%pw, rho_elec)
-      END DO
-      tot_rho_elec = accurate_sum(rho_elec%cr3d)*dvol
-      CALL mp_sum(tot_rho_elec, para_env%group)
+      BLOCK
+         TYPE(pw_type) :: rho_elec
+         CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                rho_elec, &
+                                use_data=REALDATA3D, &
+                                in_space=REALSPACE)
 
-      ! Calculate the dielectric (smoothed) function of rho_elec in r-space
-      eps_elec => work_r3d(2)%pw
-      deps_elec => work_r3d(3)%pw
-      ! Relative permittivity or dielectric constant of the solvent (medium)
-      epsilon_solvent = sccs_control%epsilon_solvent
-      SELECT CASE (sccs_control%method_id)
-      CASE (sccs_andreussi)
-         CALL andreussi(rho_elec, eps_elec, deps_elec, epsilon_solvent, sccs_control%rho_max, &
-                        sccs_control%rho_min)
-      CASE (sccs_fattebert_gygi)
-         CALL fattebert_gygi(rho_elec, eps_elec, deps_elec, epsilon_solvent, sccs_control%beta, &
-                             sccs_control%rho_zero)
-      CASE DEFAULT
-         CPABORT("Invalid method specified for SCCS model")
-      END SELECT
+         ! Retrieve grid parameters
+         ngpts = rho_elec%pw_grid%ngpts
+         dvol = rho_elec%pw_grid%dvol
+         cell_volume = rho_elec%pw_grid%vol
+         abc(1:3) = REAL(rho_elec%pw_grid%npts(1:3), KIND=dp)*rho_elec%pw_grid%dr(1:3)
+         lb(1:3) = rho_elec%pw_grid%bounds_local(1, 1:3)
+         ub(1:3) = rho_elec%pw_grid%bounds_local(2, 1:3)
 
-      ! Optional output of the dielectric function in cube file format
-      filename = "DIELECTRIC_FUNCTION"
-      cube_path = TRIM(print_path)//"%"//TRIM(filename)
-      IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), &
-                cp_p_file)) THEN
-         append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
-         my_pos_cube = "REWIND"
-         IF (append_cube) my_pos_cube = "APPEND"
-         mpi_io = .TRUE.
-         cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
-                                          extension=".cube", middle_name=TRIM(filename), &
-                                          file_position=my_pos_cube, log_filename=.FALSE., &
-                                          mpi_io=mpi_io, fout=mpi_filename)
-         IF (output_unit > 0) THEN
-            IF (.NOT. mpi_io) THEN
-               INQUIRE (UNIT=cube_unit, NAME=filename)
-            ELSE
-               filename = mpi_filename
-            END IF
-            WRITE (UNIT=output_unit, FMT="(T3,A)") &
-               "SCCS| The dielectric function is written in cube file format to the file:", &
-               "SCCS| "//TRIM(filename)
-         END IF
-         CALL cp_pw_to_cube(eps_elec, cube_unit, TRIM(filename), particles=particles, &
-                            stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), &
-                            mpi_io=mpi_io)
-         CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
-      END IF
-
-      ! Calculate the (quantum) volume and surface of the solute cavity
-      cavity_surface = 0.0_dp
-      cavity_volume = 0.0_dp
-
-      IF (should_output .AND. (ABS(epsilon_solvent - 1.0_dp) > epstol)) THEN
-
-         ! Initialise the switching function theta
-         theta => work_r3d(4)%pw
-         CALL pw_zero(theta)
-
-         ! Calculate the (quantum) volume of the solute cavity
-         f = 1.0_dp/(epsilon_solvent - 1.0_dp)
-!$OMP    PARALLEL DO DEFAULT(NONE) &
-!$OMP                PRIVATE(i,j,k) &
-!$OMP                SHARED(epsilon_solvent,eps_elec,f,lb,theta,ub)
-         DO k = lb(3), ub(3)
-            DO j = lb(2), ub(2)
-               DO i = lb(1), ub(1)
-                  theta%cr3d(i, j, k) = f*(epsilon_solvent - eps_elec%cr3d(i, j, k))
-               END DO
-            END DO
+         CALL pw_copy(rho_pw_r(1)%pw, rho_elec)
+         DO ispin = 2, nspin
+            CALL pw_axpy(rho_pw_r(ispin)%pw, rho_elec)
          END DO
-!$OMP    END PARALLEL DO
-         cavity_volume = accurate_sum(theta%cr3d)*dvol
-         CALL mp_sum(cavity_volume, para_env%group)
+         tot_rho_elec = accurate_sum(rho_elec%cr3d)*dvol
+         CALL mp_sum(tot_rho_elec, para_env%group)
 
-         ! Calculate the derivative of the electronic density in r-space
-         ! TODO: Could be retrieved from the QS environment
-         DO i = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   drho_elec(i), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
-         END DO
-         CALL derive(rho_elec, drho_elec, sccs_derivative_fft, pw_env, input)
+         ! Calculate the dielectric (smoothed) function of rho_elec in r-space
+         CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                eps_elec, &
+                                use_data=REALDATA3D, &
+                                in_space=REALSPACE)
+         CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                deps_elec, &
+                                use_data=REALDATA3D, &
+                                in_space=REALSPACE)
+         ! Relative permittivity or dielectric constant of the solvent (medium)
+         epsilon_solvent = sccs_control%epsilon_solvent
+         SELECT CASE (sccs_control%method_id)
+         CASE (sccs_andreussi)
+            CALL andreussi(rho_elec, eps_elec, deps_elec, epsilon_solvent, sccs_control%rho_max, &
+                           sccs_control%rho_min)
+         CASE (sccs_fattebert_gygi)
+            CALL fattebert_gygi(rho_elec, eps_elec, deps_elec, epsilon_solvent, sccs_control%beta, &
+                                sccs_control%rho_zero)
+         CASE DEFAULT
+            CPABORT("Invalid method specified for SCCS model")
+         END SELECT
 
-         ! Calculate the norm of the gradient of the electronic density in r-space
-         norm_drho_elec => work_r3d(5)%pw
-!$OMP    PARALLEL DO DEFAULT(NONE) &
-!$OMP                PRIVATE(i,j,k) &
-!$OMP                SHARED(drho_elec,lb,norm_drho_elec,ub)
-         DO k = lb(3), ub(3)
-            DO j = lb(2), ub(2)
-               DO i = lb(1), ub(1)
-                  norm_drho_elec%cr3d(i, j, k) = SQRT(drho_elec(1)%cr3d(i, j, k)* &
-                                                      drho_elec(1)%cr3d(i, j, k) + &
-                                                      drho_elec(2)%cr3d(i, j, k)* &
-                                                      drho_elec(2)%cr3d(i, j, k) + &
-                                                      drho_elec(3)%cr3d(i, j, k)* &
-                                                      drho_elec(3)%cr3d(i, j, k))
-               END DO
-            END DO
-         END DO
-!$OMP    END PARALLEL DO
-
-         ! Optional output of the norm of the density gradient in cube file format
-         filename = "DENSITY_GRADIENT"
+         ! Optional output of the dielectric function in cube file format
+         filename = "DIELECTRIC_FUNCTION"
          cube_path = TRIM(print_path)//"%"//TRIM(filename)
          IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), &
                    cp_p_file)) THEN
@@ -436,397 +335,508 @@ CONTAINS
                   filename = mpi_filename
                END IF
                WRITE (UNIT=output_unit, FMT="(T3,A)") &
-                  "SCCS| The norm of the density gradient is written in cube file format to the file:", &
+                  "SCCS| The dielectric function is written in cube file format to the file:", &
                   "SCCS| "//TRIM(filename)
             END IF
-            CALL cp_pw_to_cube(norm_drho_elec, cube_unit, TRIM(filename), particles=particles, &
+            CALL cp_pw_to_cube(eps_elec, cube_unit, TRIM(filename), particles=particles, &
                                stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), &
                                mpi_io=mpi_io)
             CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
          END IF
 
-         ! Calculate the (quantum) surface of the solute cavity
-         SELECT CASE (sccs_control%method_id)
-         CASE (sccs_andreussi)
-            CALL surface_andreussi(rho_elec, norm_drho_elec, theta, epsilon_solvent, &
-                                   sccs_control%rho_max, sccs_control%rho_min, &
-                                   sccs_control%delta_rho)
-         CASE (sccs_fattebert_gygi)
-            CALL surface_fattebert_gygi(rho_elec, norm_drho_elec, theta, epsilon_solvent, &
-                                        sccs_control%beta, sccs_control%rho_zero, &
-                                        sccs_control%delta_rho)
-         CASE DEFAULT
-            CPABORT("Invalid method specified for SCCS model")
-         END SELECT
-         cavity_surface = accurate_sum(theta%cr3d)*dvol
-         CALL mp_sum(cavity_surface, para_env%group)
+         ! Calculate the (quantum) volume and surface of the solute cavity
+         cavity_surface = 0.0_dp
+         cavity_volume = 0.0_dp
 
-         IF (sccs_control%gamma_solvent > 0.0_dp) THEN
+         IF (should_output .AND. (ABS(epsilon_solvent - 1.0_dp) > epstol)) THEN
 
-            CALL cp_warn(__LOCATION__, &
-                         "Experimental feature requested: The contribution from the "// &
-                         "cavitation energy is added as an extra potential term to the "// &
-                         "Kohn-Sham potential")
+            BLOCK
+               TYPE(pw_type) :: theta, norm_drho_elec
+               TYPE(pw_type), DIMENSION(3)                        :: drho_elec
+               TYPE(pw_type), DIMENSION(3, 3)                     :: d2rho_elec
+               CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                      theta, &
+                                      use_data=REALDATA3D, &
+                                      in_space=REALSPACE)
+               CALL pw_zero(theta)
 
-            ! Calculate the second derivatives of the electronic density in r-space
-            DO di = 1, 3
-               DO dj = 1, 3
+               ! Calculate the (quantum) volume of the solute cavity
+               f = 1.0_dp/(epsilon_solvent - 1.0_dp)
+!$OMP    PARALLEL DO DEFAULT(NONE) &
+!$OMP                PRIVATE(i,j,k) &
+!$OMP                SHARED(epsilon_solvent,eps_elec,f,lb,theta,ub)
+               DO k = lb(3), ub(3)
+                  DO j = lb(2), ub(2)
+                     DO i = lb(1), ub(1)
+                        theta%cr3d(i, j, k) = f*(epsilon_solvent - eps_elec%cr3d(i, j, k))
+                     END DO
+                  END DO
+               END DO
+!$OMP    END PARALLEL DO
+               cavity_volume = accurate_sum(theta%cr3d)*dvol
+               CALL mp_sum(cavity_volume, para_env%group)
+
+               ! Calculate the derivative of the electronic density in r-space
+               ! TODO: Could be retrieved from the QS environment
+               DO i = 1, 3
                   CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                         d2rho_elec(dj, di), &
+                                         drho_elec(i), &
                                          use_data=REALDATA3D, &
                                          in_space=REALSPACE)
                END DO
-               CALL derive(drho_elec(di), d2rho_elec(:, di), sccs_derivative_fft, pw_env, &
-                           input)
-            END DO
+               CALL derive(rho_elec, drho_elec, sccs_derivative_fft, pw_env, input)
 
-            ! Calculate the contribution of the cavitation energy to the Kohn-Sham potential
+               CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                      norm_drho_elec, &
+                                      use_data=REALDATA3D, &
+                                      in_space=REALSPACE)
+
+               ! Calculate the norm of the gradient of the electronic density in r-space
+!$OMP    PARALLEL DO DEFAULT(NONE) &
+!$OMP                PRIVATE(i,j,k) &
+!$OMP                SHARED(drho_elec,lb,norm_drho_elec,ub)
+               DO k = lb(3), ub(3)
+                  DO j = lb(2), ub(2)
+                     DO i = lb(1), ub(1)
+                        norm_drho_elec%cr3d(i, j, k) = SQRT(drho_elec(1)%cr3d(i, j, k)* &
+                                                            drho_elec(1)%cr3d(i, j, k) + &
+                                                            drho_elec(2)%cr3d(i, j, k)* &
+                                                            drho_elec(2)%cr3d(i, j, k) + &
+                                                            drho_elec(3)%cr3d(i, j, k)* &
+                                                            drho_elec(3)%cr3d(i, j, k))
+                     END DO
+                  END DO
+               END DO
+!$OMP    END PARALLEL DO
+
+               ! Optional output of the norm of the density gradient in cube file format
+               filename = "DENSITY_GRADIENT"
+               cube_path = TRIM(print_path)//"%"//TRIM(filename)
+               IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), &
+                         cp_p_file)) THEN
+                  append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
+                  my_pos_cube = "REWIND"
+                  IF (append_cube) my_pos_cube = "APPEND"
+                  mpi_io = .TRUE.
+                  cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
+                                                   extension=".cube", middle_name=TRIM(filename), &
+                                                   file_position=my_pos_cube, log_filename=.FALSE., &
+                                                   mpi_io=mpi_io, fout=mpi_filename)
+                  IF (output_unit > 0) THEN
+                     IF (.NOT. mpi_io) THEN
+                        INQUIRE (UNIT=cube_unit, NAME=filename)
+                     ELSE
+                        filename = mpi_filename
+                     END IF
+                     WRITE (UNIT=output_unit, FMT="(T3,A)") &
+                        "SCCS| The norm of the density gradient is written in cube file format to the file:", &
+                        "SCCS| "//TRIM(filename)
+                  END IF
+                  CALL cp_pw_to_cube(norm_drho_elec, cube_unit, TRIM(filename), particles=particles, &
+                                     stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), &
+                                     mpi_io=mpi_io)
+                  CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
+               END IF
+
+               ! Calculate the (quantum) surface of the solute cavity
+               SELECT CASE (sccs_control%method_id)
+               CASE (sccs_andreussi)
+                  CALL surface_andreussi(rho_elec, norm_drho_elec, theta, epsilon_solvent, &
+                                         sccs_control%rho_max, sccs_control%rho_min, &
+                                         sccs_control%delta_rho)
+               CASE (sccs_fattebert_gygi)
+                  CALL surface_fattebert_gygi(rho_elec, norm_drho_elec, theta, epsilon_solvent, &
+                                              sccs_control%beta, sccs_control%rho_zero, &
+                                              sccs_control%delta_rho)
+               CASE DEFAULT
+                  CPABORT("Invalid method specified for SCCS model")
+               END SELECT
+               cavity_surface = accurate_sum(theta%cr3d)*dvol
+               CALL mp_sum(cavity_surface, para_env%group)
+
+               IF (sccs_control%gamma_solvent > 0.0_dp) THEN
+
+                  CALL cp_warn(__LOCATION__, &
+                               "Experimental feature requested: The contribution from the "// &
+                               "cavitation energy is added as an extra potential term to the "// &
+                               "Kohn-Sham potential")
+
+                  ! Calculate the second derivatives of the electronic density in r-space
+                  DO di = 1, 3
+                     DO dj = 1, 3
+                        CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                               d2rho_elec(dj, di), &
+                                               use_data=REALDATA3D, &
+                                               in_space=REALSPACE)
+                     END DO
+                     CALL derive(drho_elec(di), d2rho_elec(:, di), sccs_derivative_fft, pw_env, &
+                                 input)
+                  END DO
+
+                  ! Calculate the contribution of the cavitation energy to the Kohn-Sham potential
 !$OMP       PARALLEL DO DEFAULT(NONE) &
 !$OMP                   PRIVATE(di,dj,i,j,k,norm_drho2) &
 !$OMP                   SHARED(d2rho_elec,drho_elec,lb,norm_drho_elec,sccs_control) &
 !$OMP                   SHARED(theta,ub,v_sccs)
-            DO k = lb(3), ub(3)
-               DO j = lb(2), ub(2)
-                  DO i = lb(1), ub(1)
-                     norm_drho2 = norm_drho_elec%cr3d(i, j, k)*norm_drho_elec%cr3d(i, j, k)
-                     DO di = 1, 3
-                        DO dj = 1, 3
-                           v_sccs%cr3d(i, j, k) = sccs_control%gamma_solvent*theta%cr3d(i, j, k)* &
-                                                  (drho_elec(di)%cr3d(i, j, k)* &
-                                                   drho_elec(dj)%cr3d(i, j, k)* &
-                                                   d2rho_elec(di, dj)%cr3d(i, j, k)/norm_drho2 - &
-                                                   d2rho_elec(di, di)%cr3d(i, j, k))/norm_drho2
+                  DO k = lb(3), ub(3)
+                     DO j = lb(2), ub(2)
+                        DO i = lb(1), ub(1)
+                           norm_drho2 = norm_drho_elec%cr3d(i, j, k)*norm_drho_elec%cr3d(i, j, k)
+                           DO di = 1, 3
+                              DO dj = 1, 3
+                                 v_sccs%cr3d(i, j, k) = sccs_control%gamma_solvent*theta%cr3d(i, j, k)* &
+                                                        (drho_elec(di)%cr3d(i, j, k)* &
+                                                         drho_elec(dj)%cr3d(i, j, k)* &
+                                                         d2rho_elec(di, dj)%cr3d(i, j, k)/norm_drho2 - &
+                                                         d2rho_elec(di, di)%cr3d(i, j, k))/norm_drho2
+                              END DO
+                           END DO
                         END DO
                      END DO
                   END DO
-               END DO
-            END DO
 !$OMP       END PARALLEL DO
-            CALL pw_scale(v_sccs, dvol)
-            DO di = 1, 3
-               DO dj = 1, 3
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, d2rho_elec(dj, di))
+                  CALL pw_scale(v_sccs, dvol)
+                  DO di = 1, 3
+                     DO dj = 1, 3
+                        CALL pw_pool_give_back_pw(auxbas_pw_pool, d2rho_elec(dj, di))
+                     END DO
+                  END DO
+               END IF
+
+               ! Release storage
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, theta)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, norm_drho_elec)
+               DO i = 1, 3
+                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_elec(i))
                END DO
-            END DO
+            END BLOCK
+
          END IF
 
-         ! Release storage
-         NULLIFY (theta)
-         DO i = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_elec(i))
-         END DO
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec)
+      END BLOCK
 
-      END IF
+      BLOCK
+         TYPE(pw_type) :: rho_tot, phi_tot, rho_solute, rho_tot_zero
+         ! Retrieve the total charge density (core + elec) of the solute in r-space
+         CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                rho_solute, &
+                                use_data=REALDATA3D, &
+                                in_space=REALSPACE)
+         CALL pw_zero(rho_solute)
+         CALL pw_transfer(rho_tot_gspace, rho_solute)
+         tot_rho_solute = accurate_sum(rho_solute%cr3d)*dvol
+         CALL mp_sum(tot_rho_solute, para_env%group)
 
-      ! Retrieve the total charge density (core + elec) of the solute in r-space
-      rho_solute => work_r3d(4)%pw
-      CALL pw_zero(rho_solute)
-      CALL pw_transfer(rho_tot_gspace, rho_solute)
-      tot_rho_solute = accurate_sum(rho_solute%cr3d)*dvol
-      CALL mp_sum(tot_rho_solute, para_env%group)
+         ! Reassign work storage to rho_tot_zero, because rho_elec is no longer needed
+         CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                rho_tot_zero, &
+                                use_data=REALDATA3D, &
+                                in_space=REALSPACE)
 
-      ! Reassign work storage to rho_tot_zero, because rho_elec is no longer needed
-      rho_tot_zero => rho_elec
-      NULLIFY (rho_elec)
-
-      ! Build the initial (rho_iter = 0) total charge density (solute plus polarisation) in r-space
-      ! eps_elec <- ln(eps_elec)
+         ! Build the initial (rho_iter = 0) total charge density (solute plus polarisation) in r-space
+         ! eps_elec <- ln(eps_elec)
 !$OMP PARALLEL DO DEFAULT(NONE) &
 !$OMP             PRIVATE(i,j,k) &
 !$OMP             SHARED(eps_elec,lb,message,output_unit,para_env,ub) &
 !$OMP             SHARED(rho_solute,rho_tot_zero)
-      DO k = lb(3), ub(3)
-         DO j = lb(2), ub(2)
-            DO i = lb(1), ub(1)
-               IF (eps_elec%cr3d(i, j, k) < 1.0_dp) THEN
-                  WRITE (UNIT=message, FMT="(A,ES12.3,A,3(I0,A))") &
-                     "SCCS| Invalid dielectric function value ", eps_elec%cr3d(i, j, k), &
-                     " encountered at grid point (", i, ",", j, ",", k, ")"
-                  CPABORT(message)
-               END IF
-               rho_tot_zero%cr3d(i, j, k) = rho_solute%cr3d(i, j, k)/eps_elec%cr3d(i, j, k)
-               eps_elec%cr3d(i, j, k) = LOG(eps_elec%cr3d(i, j, k))
-            END DO
-         END DO
-      END DO
-!$OMP END PARALLEL DO
-
-      ! Reassign pointers due to new content
-      ln_eps_elec => eps_elec
-      NULLIFY (eps_elec)
-
-      ! Build the derivative of ln_eps_elec
-      DO i = 1, 3
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                dln_eps_elec(i), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_zero(dln_eps_elec(i))
-      END DO
-      CALL derive(ln_eps_elec, dln_eps_elec, sccs_control%derivative_method, pw_env, input)
-
-      ! Print header for the SCCS cycle
-      IF (should_output .AND. (output_unit > 0)) THEN
-         IF (print_level > low_print_level) THEN
-            WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.12)") &
-               "SCCS| Total electronic charge density ", -tot_rho_elec, &
-               "SCCS| Total charge density (solute)   ", -tot_rho_solute
-            WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.3)") &
-               "SCCS| Volume of the cell           [bohr^3]", cell_volume, &
-               "SCCS|                              [angstrom^3]", &
-               cp_unit_from_cp2k(cell_volume, "angstrom^3")
-            IF (ABS(epsilon_solvent - 1.0_dp) > epstol) THEN
-               WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.3)") &
-                  "SCCS| Volume of the solute cavity  [bohr^3]", cavity_volume, &
-                  "SCCS|                              [angstrom^3]", &
-                  cp_unit_from_cp2k(cavity_volume, "angstrom^3"), &
-                  "SCCS| Surface of the solute cavity [bohr^2]", cavity_surface, &
-                  "SCCS|                              [angstrom^2]", &
-                  cp_unit_from_cp2k(cavity_surface, "angstrom^2")
-            END IF
-            WRITE (UNIT=output_unit, FMT="(T3,A)") &
-               "SCCS|", &
-               "SCCS|   Step    Average residual    Maximum residual         E(Hartree) [a.u.]"
-         END IF
-      END IF
-
-      ! Get storage for the derivative of the total potential (field) in r-space
-      DO i = 1, 3
-         ALLOCATE (dphi_tot(i)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                dphi_tot(i)%pw, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-      END DO
-
-      ! Reassign work storage to rho_tot, because ln_eps_elec is no longer needed
-      rho_tot => ln_eps_elec
-      NULLIFY (ln_eps_elec)
-
-      ! Initialise the total charge density in r-space rho_tot with rho_tot_zero + rho_iter_zero
-      CALL pw_copy(rho_tot_zero, rho_tot)
-      CALL pw_axpy(rho_iter_old, rho_tot)
-
-      phi_tot => work_r3d(5)%pw
-      CALL pw_zero(phi_tot)
-      NULLIFY (norm_drho_elec)
-
-      ! Main SCCS iteration loop
-      iter = 0
-
-      iter_loop: DO
-
-         ! Increment iteration counter
-         iter = iter + 1
-
-         ! Check if the requested maximum number of SCCS iterations is reached
-         IF (iter > sccs_control%max_iter) THEN
-            IF (output_unit > 0) THEN
-               WRITE (UNIT=output_unit, FMT="(T3,A,/,T3,A,I0,A)") &
-                  "SCCS| Maximum number of SCCS iterations reached", &
-                  "SCCS| Iteration cycle did not converge in ", sccs_control%max_iter, " steps"
-            END IF
-            EXIT iter_loop
-         END IF
-
-         ! Calculate derivative of the current total potential in r-space
-         CALL pw_poisson_solve(poisson_env=poisson_env, &
-                               density=rho_tot, &
-                               vhartree=phi_tot, &
-                               dvhartree=dphi_tot)
-         energy%sccs_hartree = 0.5_dp*pw_integral_ab(rho_solute, phi_tot)
-
-         ! Update total charge density (solute plus polarisation) in r-space
-         ! based on the iterated polarisation charge density
-         f = 1.0_dp/fourpi
-         rho_delta_avg = 0.0_dp
-         rho_delta_max = 0.0_dp
-!$OMP    PARALLEL DO DEFAULT(NONE) &
-!$OMP                PRIVATE(i,j,k,rho_delta,rho_iter_new) &
-!$OMP                SHARED(dln_eps_elec,dphi_tot,f,lb,rho_iter_old,ub) &
-!$OMP                SHARED(rho_tot,rho_tot_zero,sccs_control) &
-!$OMP                REDUCTION(+:rho_delta_avg) &
-!$OMP                REDUCTION(MAX:rho_delta_max)
          DO k = lb(3), ub(3)
             DO j = lb(2), ub(2)
                DO i = lb(1), ub(1)
-                  rho_iter_new = (dln_eps_elec(1)%cr3d(i, j, k)*dphi_tot(1)%pw%cr3d(i, j, k) + &
-                                  dln_eps_elec(2)%cr3d(i, j, k)*dphi_tot(2)%pw%cr3d(i, j, k) + &
-                                  dln_eps_elec(3)%cr3d(i, j, k)*dphi_tot(3)%pw%cr3d(i, j, k))*f
-                  rho_iter_new = rho_iter_old%cr3d(i, j, k) + &
-                                 sccs_control%mixing*(rho_iter_new - rho_iter_old%cr3d(i, j, k))
-                  rho_delta = ABS(rho_iter_new - rho_iter_old%cr3d(i, j, k))
-                  rho_delta_max = MAX(rho_delta, rho_delta_max)
-                  rho_delta_avg = rho_delta_avg + rho_delta
-                  rho_tot%cr3d(i, j, k) = rho_tot_zero%cr3d(i, j, k) + rho_iter_new
-                  rho_iter_old%cr3d(i, j, k) = rho_iter_new
+                  IF (eps_elec%cr3d(i, j, k) < 1.0_dp) THEN
+                     WRITE (UNIT=message, FMT="(A,ES12.3,A,3(I0,A))") &
+                        "SCCS| Invalid dielectric function value ", eps_elec%cr3d(i, j, k), &
+                        " encountered at grid point (", i, ",", j, ",", k, ")"
+                     CPABORT(message)
+                  END IF
+                  rho_tot_zero%cr3d(i, j, k) = rho_solute%cr3d(i, j, k)/eps_elec%cr3d(i, j, k)
+                  eps_elec%cr3d(i, j, k) = LOG(eps_elec%cr3d(i, j, k))
                END DO
             END DO
          END DO
-!$OMP    END PARALLEL DO
+!$OMP END PARALLEL DO
 
-         CALL mp_sum(rho_delta_avg, para_env%group)
-         rho_delta_avg = rho_delta_avg/REAL(ngpts, KIND=dp)
-         CALL mp_max(rho_delta_max, para_env%group)
+         ! Build the derivative of LOG(eps_elec)
+         DO i = 1, 3
+            CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                   dln_eps_elec(i), &
+                                   use_data=REALDATA3D, &
+                                   in_space=REALSPACE)
+            CALL pw_zero(dln_eps_elec(i))
+         END DO
+         CALL derive(eps_elec, dln_eps_elec, sccs_control%derivative_method, pw_env, input)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, eps_elec)
 
+         ! Print header for the SCCS cycle
          IF (should_output .AND. (output_unit > 0)) THEN
             IF (print_level > low_print_level) THEN
-               IF ((ABS(rho_delta_avg) < 1.0E-8_dp) .OR. &
-                   (ABS(rho_delta_avg) >= 1.0E5_dp)) THEN
-                  WRITE (UNIT=output_unit, FMT="(T3,A,I6,4X,ES16.4,4X,ES16.4,1X,F25.12)") &
-                     "SCCS| ", iter, rho_delta_avg, rho_delta_max, energy%sccs_hartree
-               ELSE
-                  WRITE (UNIT=output_unit, FMT="(T3,A,I6,4X,F16.8,4X,F16.8,1X,F25.12)") &
-                     "SCCS| ", iter, rho_delta_avg, rho_delta_max, energy%sccs_hartree
+               WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.12)") &
+                  "SCCS| Total electronic charge density ", -tot_rho_elec, &
+                  "SCCS| Total charge density (solute)   ", -tot_rho_solute
+               WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.3)") &
+                  "SCCS| Volume of the cell           [bohr^3]", cell_volume, &
+                  "SCCS|                              [angstrom^3]", &
+                  cp_unit_from_cp2k(cell_volume, "angstrom^3")
+               IF (ABS(epsilon_solvent - 1.0_dp) > epstol) THEN
+                  WRITE (UNIT=output_unit, FMT="(T3,A,T56,F25.3)") &
+                     "SCCS| Volume of the solute cavity  [bohr^3]", cavity_volume, &
+                     "SCCS|                              [angstrom^3]", &
+                     cp_unit_from_cp2k(cavity_volume, "angstrom^3"), &
+                     "SCCS| Surface of the solute cavity [bohr^2]", cavity_surface, &
+                     "SCCS|                              [angstrom^2]", &
+                     cp_unit_from_cp2k(cavity_surface, "angstrom^2")
+               END IF
+               WRITE (UNIT=output_unit, FMT="(T3,A)") &
+                  "SCCS|", &
+                  "SCCS|   Step    Average residual    Maximum residual         E(Hartree) [a.u.]"
+            END IF
+         END IF
+
+         ! Get storage for the derivative of the total potential (field) in r-space
+         DO i = 1, 3
+            ALLOCATE (dphi_tot(i)%pw)
+            CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                   dphi_tot(i)%pw, &
+                                   use_data=REALDATA3D, &
+                                   in_space=REALSPACE)
+         END DO
+
+         ! Initialise the total charge density in r-space rho_tot with rho_tot_zero + rho_iter_zero
+         CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                rho_tot, &
+                                use_data=REALDATA3D, &
+                                in_space=REALSPACE)
+         CALL pw_copy(rho_tot_zero, rho_tot)
+         CALL pw_axpy(rho_pw_r_sccs, rho_tot)
+
+         CALL pw_pool_create_pw(auxbas_pw_pool, &
+                                phi_tot, &
+                                use_data=REALDATA3D, &
+                                in_space=REALSPACE)
+         CALL pw_zero(phi_tot)
+
+         ! Main SCCS iteration loop
+         iter = 0
+
+         iter_loop: DO
+
+            ! Increment iteration counter
+            iter = iter + 1
+
+            ! Check if the requested maximum number of SCCS iterations is reached
+            IF (iter > sccs_control%max_iter) THEN
+               IF (output_unit > 0) THEN
+                  WRITE (UNIT=output_unit, FMT="(T3,A,/,T3,A,I0,A)") &
+                     "SCCS| Maximum number of SCCS iterations reached", &
+                     "SCCS| Iteration cycle did not converge in ", sccs_control%max_iter, " steps"
+               END IF
+               EXIT iter_loop
+            END IF
+
+            ! Calculate derivative of the current total potential in r-space
+            CALL pw_poisson_solve(poisson_env=poisson_env, &
+                                  density=rho_tot, &
+                                  vhartree=phi_tot, &
+                                  dvhartree=dphi_tot)
+            energy%sccs_hartree = 0.5_dp*pw_integral_ab(rho_solute, phi_tot)
+
+            ! Update total charge density (solute plus polarisation) in r-space
+            ! based on the iterated polarisation charge density
+            f = 1.0_dp/fourpi
+            rho_delta_avg = 0.0_dp
+            rho_delta_max = 0.0_dp
+!$OMP    PARALLEL DO DEFAULT(NONE) &
+!$OMP                PRIVATE(i,j,k,rho_delta,rho_iter_new) &
+!$OMP                SHARED(dln_eps_elec,dphi_tot,f,lb,rho_pw_r_sccs,ub) &
+!$OMP                SHARED(rho_tot,rho_tot_zero,sccs_control) &
+!$OMP                REDUCTION(+:rho_delta_avg) &
+!$OMP                REDUCTION(MAX:rho_delta_max)
+            DO k = lb(3), ub(3)
+               DO j = lb(2), ub(2)
+                  DO i = lb(1), ub(1)
+                     rho_iter_new = (dln_eps_elec(1)%cr3d(i, j, k)*dphi_tot(1)%pw%cr3d(i, j, k) + &
+                                     dln_eps_elec(2)%cr3d(i, j, k)*dphi_tot(2)%pw%cr3d(i, j, k) + &
+                                     dln_eps_elec(3)%cr3d(i, j, k)*dphi_tot(3)%pw%cr3d(i, j, k))*f
+                     rho_iter_new = rho_pw_r_sccs%cr3d(i, j, k) + &
+                                    sccs_control%mixing*(rho_iter_new - rho_pw_r_sccs%cr3d(i, j, k))
+                     rho_delta = ABS(rho_iter_new - rho_pw_r_sccs%cr3d(i, j, k))
+                     rho_delta_max = MAX(rho_delta, rho_delta_max)
+                     rho_delta_avg = rho_delta_avg + rho_delta
+                     rho_tot%cr3d(i, j, k) = rho_tot_zero%cr3d(i, j, k) + rho_iter_new
+                     rho_pw_r_sccs%cr3d(i, j, k) = rho_iter_new
+                  END DO
+               END DO
+            END DO
+!$OMP    END PARALLEL DO
+
+            CALL mp_sum(rho_delta_avg, para_env%group)
+            rho_delta_avg = rho_delta_avg/REAL(ngpts, KIND=dp)
+            CALL mp_max(rho_delta_max, para_env%group)
+
+            IF (should_output .AND. (output_unit > 0)) THEN
+               IF (print_level > low_print_level) THEN
+                  IF ((ABS(rho_delta_avg) < 1.0E-8_dp) .OR. &
+                      (ABS(rho_delta_avg) >= 1.0E5_dp)) THEN
+                     WRITE (UNIT=output_unit, FMT="(T3,A,I6,4X,ES16.4,4X,ES16.4,1X,F25.12)") &
+                        "SCCS| ", iter, rho_delta_avg, rho_delta_max, energy%sccs_hartree
+                  ELSE
+                     WRITE (UNIT=output_unit, FMT="(T3,A,I6,4X,F16.8,4X,F16.8,1X,F25.12)") &
+                        "SCCS| ", iter, rho_delta_avg, rho_delta_max, energy%sccs_hartree
+                  END IF
                END IF
             END IF
-         END IF
 
-         ! Check if the SCCS iteration cycle is converged to the requested tolerance
-         IF (rho_delta_max <= sccs_control%eps_sccs) THEN
-            IF (should_output .AND. (output_unit > 0)) THEN
-               WRITE (UNIT=output_unit, FMT="(T3,A,I0,A)") &
-                  "SCCS| Iteration cycle converged in ", iter, " steps"
+            ! Check if the SCCS iteration cycle is converged to the requested tolerance
+            IF (rho_delta_max <= sccs_control%eps_sccs) THEN
+               IF (should_output .AND. (output_unit > 0)) THEN
+                  WRITE (UNIT=output_unit, FMT="(T3,A,I0,A)") &
+                     "SCCS| Iteration cycle converged in ", iter, " steps"
+               END IF
+               EXIT iter_loop
             END IF
-            EXIT iter_loop
-         END IF
 
-      END DO iter_loop
+         END DO iter_loop
 
-      ! Release work storage which is no longer needed
-      DO i = 1, 3
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dln_eps_elec(i))
-      END DO
+         ! Release work storage which is no longer needed
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_zero)
+         DO i = 1, 3
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, dln_eps_elec(i))
+         END DO
 
-      ! Optional output of the total charge density in cube file format
-      filename = "TOTAL_CHARGE_DENSITY"
-      cube_path = TRIM(print_path)//"%"//TRIM(filename)
-      IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), cp_p_file)) THEN
-         append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
-         my_pos_cube = "REWIND"
-         IF (append_cube) my_pos_cube = "APPEND"
-         mpi_io = .TRUE.
-         cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
-                                          extension=".cube", middle_name=TRIM(filename), &
-                                          file_position=my_pos_cube, log_filename=.FALSE., &
-                                          mpi_io=mpi_io, fout=mpi_filename)
-         IF (output_unit > 0) THEN
-            IF (.NOT. mpi_io) THEN
-               INQUIRE (UNIT=cube_unit, NAME=filename)
-            ELSE
-               filename = mpi_filename
+         ! Optional output of the total charge density in cube file format
+         filename = "TOTAL_CHARGE_DENSITY"
+         cube_path = TRIM(print_path)//"%"//TRIM(filename)
+         IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), cp_p_file)) THEN
+            append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
+            my_pos_cube = "REWIND"
+            IF (append_cube) my_pos_cube = "APPEND"
+            mpi_io = .TRUE.
+            cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
+                                             extension=".cube", middle_name=TRIM(filename), &
+                                             file_position=my_pos_cube, log_filename=.FALSE., &
+                                             mpi_io=mpi_io, fout=mpi_filename)
+            IF (output_unit > 0) THEN
+               IF (.NOT. mpi_io) THEN
+                  INQUIRE (UNIT=cube_unit, NAME=filename)
+               ELSE
+                  filename = mpi_filename
+               END IF
+               WRITE (UNIT=output_unit, FMT="(T3,A)") &
+                  "SCCS| The total SCCS charge density is written in cube file format to the file:", &
+                  "SCCS| "//TRIM(filename)
             END IF
-            WRITE (UNIT=output_unit, FMT="(T3,A)") &
-               "SCCS| The total SCCS charge density is written in cube file format to the file:", &
-               "SCCS| "//TRIM(filename)
+            CALL cp_pw_to_cube(rho_tot, cube_unit, TRIM(filename), particles=particles, &
+                               stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), mpi_io=mpi_io)
+            CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
          END IF
-         CALL cp_pw_to_cube(rho_tot, cube_unit, TRIM(filename), particles=particles, &
-                            stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), mpi_io=mpi_io)
-         CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
-      END IF
 
-      ! Calculate the total SCCS Hartree energy, potential, and its
-      ! derivatives of the solute and the implicit solvent
-      CALL pw_transfer(rho_tot, rho_tot_gspace)
-      IF (calculate_stress_tensor) THEN
-         ! Request also the calculation of the stress tensor contribution
-         CALL pw_poisson_solve(poisson_env=poisson_env, &
-                               density=rho_tot_gspace, &
-                               ehartree=e_tot, &
-                               vhartree=v_hartree_gspace, &
-                               dvhartree=dphi_tot, &
-                               h_stress=h_stress)
-      ELSE
-         CALL pw_poisson_solve(poisson_env=poisson_env, &
-                               density=rho_tot_gspace, &
-                               ehartree=e_tot, &
-                               vhartree=v_hartree_gspace, &
-                               dvhartree=dphi_tot)
-      END IF
-      CALL pw_transfer(v_hartree_gspace, phi_tot)
-      energy%sccs_hartree = 0.5_dp*pw_integral_ab(rho_solute, phi_tot)
+         ! Calculate the total SCCS Hartree energy, potential, and its
+         ! derivatives of the solute and the implicit solvent
+         CALL pw_transfer(rho_tot, rho_tot_gspace)
+         IF (calculate_stress_tensor) THEN
+            ! Request also the calculation of the stress tensor contribution
+            CALL pw_poisson_solve(poisson_env=poisson_env, &
+                                  density=rho_tot_gspace, &
+                                  ehartree=e_tot, &
+                                  vhartree=v_hartree_gspace, &
+                                  dvhartree=dphi_tot, &
+                                  h_stress=h_stress)
+         ELSE
+            CALL pw_poisson_solve(poisson_env=poisson_env, &
+                                  density=rho_tot_gspace, &
+                                  ehartree=e_tot, &
+                                  vhartree=v_hartree_gspace, &
+                                  dvhartree=dphi_tot)
+         END IF
+         CALL pw_transfer(v_hartree_gspace, phi_tot)
+         energy%sccs_hartree = 0.5_dp*pw_integral_ab(rho_solute, phi_tot)
 
-      ! Calculate the Hartree energy and potential of the solute only
-      phi_solute => rho_tot_zero
-      CALL pw_zero(phi_solute)
-      NULLIFY (rho_tot_zero)
-      CALL pw_poisson_solve(poisson_env=poisson_env, &
-                            density=rho_solute, &
-                            ehartree=energy%hartree, &
-                            vhartree=phi_solute)
+         ! Calculate the Hartree energy and potential of the solute only
+         BLOCK
+            TYPE(pw_type) :: phi_solute
+            CALL pw_pool_create_pw(auxbas_pw_pool, phi_solute, &
+                                   use_data=REALDATA3D, &
+                                   in_space=REALSPACE)
+            CALL pw_zero(phi_solute)
+            CALL pw_poisson_solve(poisson_env=poisson_env, &
+                                  density=rho_solute, &
+                                  ehartree=energy%hartree, &
+                                  vhartree=phi_solute)
 
-      ! Calculate the polarisation potential
-      ! phi_pol = phi_tot - phi_solute
-      CALL pw_axpy(phi_solute, phi_tot, alpha=-1.0_dp)
-      phi_pol => phi_tot
-      NULLIFY (phi_tot)
+            ! Calculate the polarisation potential (store it in phi_tot)
+            ! phi_pol = phi_tot - phi_solute
+            CALL pw_axpy(phi_solute, phi_tot, alpha=-1.0_dp)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, phi_solute)
+         END BLOCK
 
-      ! Optional output of the SCCS polarisation potential in cube file format
-      filename = "POLARISATION_POTENTIAL"
-      cube_path = TRIM(print_path)//"%"//TRIM(filename)
-      IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), &
-                cp_p_file)) THEN
-         append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
-         my_pos_cube = "REWIND"
-         IF (append_cube) my_pos_cube = "APPEND"
-         mpi_io = .TRUE.
-         cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
-                                          extension=".cube", middle_name=TRIM(filename), &
-                                          file_position=my_pos_cube, log_filename=.FALSE., &
-                                          mpi_io=mpi_io, fout=mpi_filename)
-         IF (output_unit > 0) THEN
-            IF (.NOT. mpi_io) THEN
-               INQUIRE (UNIT=cube_unit, NAME=filename)
-            ELSE
-               filename = mpi_filename
+         ! Optional output of the SCCS polarisation potential in cube file format
+         filename = "POLARISATION_POTENTIAL"
+         cube_path = TRIM(print_path)//"%"//TRIM(filename)
+         IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), &
+                   cp_p_file)) THEN
+            append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
+            my_pos_cube = "REWIND"
+            IF (append_cube) my_pos_cube = "APPEND"
+            mpi_io = .TRUE.
+            cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
+                                             extension=".cube", middle_name=TRIM(filename), &
+                                             file_position=my_pos_cube, log_filename=.FALSE., &
+                                             mpi_io=mpi_io, fout=mpi_filename)
+            IF (output_unit > 0) THEN
+               IF (.NOT. mpi_io) THEN
+                  INQUIRE (UNIT=cube_unit, NAME=filename)
+               ELSE
+                  filename = mpi_filename
+               END IF
+               WRITE (UNIT=output_unit, FMT="(T3,A)") &
+                  "SCCS| The SCCS polarisation potential is written in cube file format to the file:", &
+                  "SCCS| "//TRIM(filename)
             END IF
-            WRITE (UNIT=output_unit, FMT="(T3,A)") &
-               "SCCS| The SCCS polarisation potential is written in cube file format to the file:", &
-               "SCCS| "//TRIM(filename)
+            CALL cp_pw_to_cube(phi_tot, cube_unit, TRIM(filename), particles=particles, &
+                               stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), mpi_io=mpi_io)
+            CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
          END IF
-         CALL cp_pw_to_cube(phi_pol, cube_unit, TRIM(filename), particles=particles, &
-                            stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), mpi_io=mpi_io)
-         CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
-      END IF
 
-      ! Calculate the polarisation charge
-      ! rho_pol = rho_tot - rho_solute
-      CALL pw_axpy(rho_solute, rho_tot, alpha=-1.0_dp)
-      rho_pol => rho_tot
-      NULLIFY (rho_tot)
-      polarisation_charge = accurate_sum(rho_pol%cr3d)*dvol
-      CALL mp_sum(polarisation_charge, para_env%group)
+         ! Calculate the polarisation charge (store it in rho_tot)
+         ! rho_pol = rho_tot - rho_solute
+         CALL pw_axpy(rho_solute, rho_tot, alpha=-1.0_dp)
+         polarisation_charge = accurate_sum(rho_tot%cr3d)*dvol
+         CALL mp_sum(polarisation_charge, para_env%group)
 
-      ! Optional output of the SCCS polarisation charge in cube file format
-      filename = "POLARISATION_CHARGE_DENSITY"
-      cube_path = TRIM(print_path)//"%"//TRIM(filename)
-      IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), &
-                cp_p_file)) THEN
-         append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
-         my_pos_cube = "REWIND"
-         IF (append_cube) my_pos_cube = "APPEND"
-         mpi_io = .TRUE.
-         cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
-                                          extension=".cube", middle_name=TRIM(filename), &
-                                          file_position=my_pos_cube, log_filename=.FALSE., &
-                                          mpi_io=mpi_io, fout=mpi_filename)
-         IF (output_unit > 0) THEN
-            IF (.NOT. mpi_io) THEN
-               INQUIRE (UNIT=cube_unit, NAME=filename)
-            ELSE
-               filename = mpi_filename
+         ! Optional output of the SCCS polarisation charge in cube file format
+         filename = "POLARISATION_CHARGE_DENSITY"
+         cube_path = TRIM(print_path)//"%"//TRIM(filename)
+         IF (BTEST(cp_print_key_should_output(logger%iter_info, input, TRIM(cube_path)), &
+                   cp_p_file)) THEN
+            append_cube = section_get_lval(input, TRIM(cube_path)//"%APPEND")
+            my_pos_cube = "REWIND"
+            IF (append_cube) my_pos_cube = "APPEND"
+            mpi_io = .TRUE.
+            cube_unit = cp_print_key_unit_nr(logger, input, TRIM(cube_path), &
+                                             extension=".cube", middle_name=TRIM(filename), &
+                                             file_position=my_pos_cube, log_filename=.FALSE., &
+                                             mpi_io=mpi_io, fout=mpi_filename)
+            IF (output_unit > 0) THEN
+               IF (.NOT. mpi_io) THEN
+                  INQUIRE (UNIT=cube_unit, NAME=filename)
+               ELSE
+                  filename = mpi_filename
+               END IF
+               WRITE (UNIT=output_unit, FMT="(T3,A)") &
+                  "SCCS| The SCCS polarisation charge density is written in cube file format to the file:", &
+                  "SCCS| "//TRIM(filename)
             END IF
-            WRITE (UNIT=output_unit, FMT="(T3,A)") &
-               "SCCS| The SCCS polarisation charge density is written in cube file format to the file:", &
-               "SCCS| "//TRIM(filename)
+            CALL cp_pw_to_cube(rho_tot, cube_unit, TRIM(filename), particles=particles, &
+                               stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), mpi_io=mpi_io)
+            CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
          END IF
-         CALL cp_pw_to_cube(rho_pol, cube_unit, TRIM(filename), particles=particles, &
-                            stride=section_get_ivals(input, TRIM(cube_path)//"%STRIDE"), mpi_io=mpi_io)
-         CALL cp_print_key_finished_output(cube_unit, logger, input, TRIM(cube_path), mpi_io=mpi_io)
-      END IF
 
-      ! Calculate SCCS polarisation energy
-      energy%sccs_pol = 0.5_dp*pw_integral_ab(rho_solute, phi_pol)
+         ! Calculate SCCS polarisation energy
+         energy%sccs_pol = 0.5_dp*pw_integral_ab(rho_solute, phi_tot)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_solute)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, phi_tot)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot)
+      END BLOCK
 
       ! Calculate the Makov-Payne energy correction for charged systems with PBC
       ! Madelung energy of a simple cubic lattice of point charges immersed in neutralising jellium
@@ -894,17 +904,7 @@ CONTAINS
       END DO
 !$OMP END PARALLEL DO
 
-      ! Release work storage
-      NULLIFY (phi_solute)
-      NULLIFY (rho_pol)
-      NULLIFY (deps_elec)
-      NULLIFY (rho_solute)
-      NULLIFY (phi_pol)
-      DO i = 1, SIZE(work_r3d)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, work_r3d(i)%pw)
-         DEALLOCATE (work_r3d(i)%pw)
-      END DO
-      NULLIFY (rho_iter_old)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, deps_elec)
       DO i = 1, 3
          CALL pw_pool_give_back_pw(auxbas_pw_pool, dphi_tot(i)%pw)
          DEALLOCATE (dphi_tot(i)%pw)
@@ -935,7 +935,7 @@ CONTAINS
    SUBROUTINE andreussi(rho_elec, eps_elec, deps_elec, epsilon_solvent, rho_max, &
                         rho_min)
 
-      TYPE(pw_type), POINTER                             :: rho_elec, eps_elec, deps_elec
+      TYPE(pw_type), INTENT(IN)                          :: rho_elec, eps_elec, deps_elec
       REAL(KIND=dp), INTENT(IN)                          :: epsilon_solvent, rho_max, rho_min
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'andreussi'
@@ -1009,7 +1009,7 @@ CONTAINS
    SUBROUTINE fattebert_gygi(rho_elec, eps_elec, deps_elec, epsilon_solvent, beta, &
                              rho_zero)
 
-      TYPE(pw_type), POINTER                             :: rho_elec, eps_elec, deps_elec
+      TYPE(pw_type), INTENT(IN)                          :: rho_elec, eps_elec, deps_elec
       REAL(KIND=dp), INTENT(IN)                          :: epsilon_solvent, beta, rho_zero
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'fattebert_gygi'
@@ -1081,8 +1081,8 @@ CONTAINS
 
       INTEGER                                            :: border_points, handle, i
       INTEGER, DIMENSION(3)                              :: lb, n, ub
-      TYPE(pw_p_type), DIMENSION(2)                      :: work_g1d
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), DIMENSION(2)                        :: work_g1d
       TYPE(realspace_grid_desc_type), POINTER            :: rs_desc
       TYPE(realspace_grid_input_type)                    :: input_settings
       TYPE(realspace_grid_type), POINTER                 :: rs_grid
@@ -1119,9 +1119,8 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ! Get work storage for the 1d grids in g-space (derivative calculation)
          DO i = 1, SIZE(work_g1d)
-            ALLOCATE (work_g1d(i)%pw)
             CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   work_g1d(i)%pw, &
+                                   work_g1d(i), &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
          END DO
@@ -1137,13 +1136,13 @@ CONTAINS
          CALL derive_fdm_cd7(f, df, rs_grid)
       CASE (sccs_derivative_fft)
          ! FFT
-         CALL pw_transfer(f, work_g1d(1)%pw)
+         CALL pw_transfer(f, work_g1d(1))
          DO i = 1, 3
             n(:) = 0
             n(i) = 1
-            CALL pw_copy(work_g1d(1)%pw, work_g1d(2)%pw)
-            CALL pw_derive(work_g1d(2)%pw, n(:))
-            CALL pw_transfer(work_g1d(2)%pw, df(i))
+            CALL pw_copy(work_g1d(1), work_g1d(2))
+            CALL pw_derive(work_g1d(2), n(:))
+            CALL pw_transfer(work_g1d(2), df(i))
          END DO
       CASE DEFAULT
          CPABORT("Invalid derivative method for SCCS specified")
@@ -1156,8 +1155,7 @@ CONTAINS
          CALL rs_grid_release_descriptor(rs_desc)
       CASE (sccs_derivative_fft)
          DO i = 1, SIZE(work_g1d)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g1d(i)%pw)
-            DEALLOCATE (work_g1d(i)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g1d(i))
          END DO
       END SELECT
 
@@ -1185,7 +1183,7 @@ CONTAINS
    SUBROUTINE surface_andreussi(rho_elec, norm_drho_elec, dtheta, &
                                 epsilon_solvent, rho_max, rho_min, delta_rho)
 
-      TYPE(pw_type), POINTER                             :: rho_elec, norm_drho_elec, dtheta
+      TYPE(pw_type), INTENT(IN)                          :: rho_elec, norm_drho_elec, dtheta
       REAL(KIND=dp), INTENT(IN)                          :: epsilon_solvent, rho_max, rho_min, &
                                                             delta_rho
 
@@ -1265,7 +1263,7 @@ CONTAINS
    SUBROUTINE surface_fattebert_gygi(rho_elec, norm_drho_elec, dtheta, &
                                      epsilon_solvent, beta, rho_zero, delta_rho)
 
-      TYPE(pw_type), POINTER                             :: rho_elec, norm_drho_elec, dtheta
+      TYPE(pw_type), INTENT(IN)                          :: rho_elec, norm_drho_elec, dtheta
       REAL(KIND=dp), INTENT(IN)                          :: epsilon_solvent, beta, rho_zero, &
                                                             delta_rho
 

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -1176,8 +1176,7 @@ CONTAINS
             END IF
          ELSE IF (cdft_control%type == outer_scf_hirshfeld_constraint) THEN
             IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
-               DEALLOCATE (cdft_control%hirshfeld_control%hirshfeld_env%fnorm%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm)
             END IF
          END IF
          IF (ASSOCIATED(cdft_control%charges_fragment)) DEALLOCATE (cdft_control%charges_fragment)

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -1099,7 +1099,7 @@ CONTAINS
             CALL dbcsr_copy(cdft_control%wmat(ivar)%matrix, matrix_s(1)%matrix, &
                             name="ET_RESTRAINT_MATRIX")
             CALL dbcsr_set(cdft_control%wmat(ivar)%matrix, 0.0_dp)
-            CALL integrate_v_rspace(cdft_control%group(ivar)%weight%pw, &
+            CALL integrate_v_rspace(cdft_control%group(ivar)%weight, &
                                     hmat=cdft_control%wmat(ivar), qs_env=qs_env, &
                                     calculate_forces=.FALSE., &
                                     gapw=dft_control%qs_control%gapw)
@@ -1156,8 +1156,8 @@ CONTAINS
          CALL get_qs_env(qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          DO iatom = 1, SIZE(cdft_control%group)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight%pw)
-            DEALLOCATE (cdft_control%group(iatom)%weight%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight)
+            DEALLOCATE (cdft_control%group(iatom)%weight)
          END DO
          IF (cdft_control%atomic_charges) THEN
             DO iatom = 1, cdft_control%natoms

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -272,7 +272,7 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
+      TYPE(pw_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -450,11 +450,10 @@ CONTAINS
       IF (((do_mo_cubes .OR. do_wannier_cubes) .AND. (nlumo /= 0 .OR. nhomo /= 0)) .OR. p_loc) THEN
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         ALLOCATE (wf_r%pw, wf_g%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END IF
@@ -724,9 +723,8 @@ CONTAINS
 
       ! Deallocate grids needed to compute wavefunctions
       IF (((do_mo_cubes .OR. do_wannier_cubes) .AND. (nlumo /= 0 .OR. nhomo /= 0)) .OR. p_loc) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-         DEALLOCATE (wf_r%pw, wf_g%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
       END IF
 
       ! Destroy the localization environment
@@ -1015,7 +1013,8 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
+      TYPE(pw_type), INTENT(IN)                                    :: wf_g
+      TYPE(pw_type), INTENT(INOUT)                                    :: wf_r
       TYPE(particle_list_type), POINTER                  :: particles
       INTEGER, INTENT(IN)                                :: homo, ispin
 
@@ -1076,7 +1075,7 @@ CONTAINS
                             cell=cell, &
                             particle_set=particle_set, &
                             pw_env=pw_env)
-            CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
+            CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
                                         cell, dft_control, particle_set, pw_env)
             WRITE (filename, '(a4,I5.5,a1,I1.1)') "WFN_", ivector, "_", ispin
             mpi_io = .TRUE.
@@ -1084,7 +1083,7 @@ CONTAINS
                                            middle_name=TRIM(filename), file_position=my_pos_cube, log_filename=.FALSE., &
                                            mpi_io=mpi_io)
             WRITE (title, *) "WAVEFUNCTION ", ivector, " spin ", ispin, " i.e. HOMO - ", ivector - homo
-            CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
+            CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, &
                                stride=section_get_ivals(dft_section, "PRINT%MO_CUBES%STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, "DFT%PRINT%MO_CUBES", mpi_io=mpi_io)
          END DO
@@ -1118,7 +1117,8 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_type), INTENT(IN)                       :: unoccupied_orbs
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
+      TYPE(pw_type), INTENT(IN)                                    :: wf_g
+      TYPE(pw_type), INTENT(INOUT)                                    :: wf_r
       TYPE(particle_list_type), POINTER                  :: particles
       INTEGER, INTENT(IN)                                :: nlumos, homo, ispin
       INTEGER, INTENT(IN), OPTIONAL                      :: lumo
@@ -1154,7 +1154,7 @@ CONTAINS
                             cell=cell, &
                             particle_set=particle_set, &
                             pw_env=pw_env)
-            CALL calculate_wavefunction(unoccupied_orbs, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, &
+            CALL calculate_wavefunction(unoccupied_orbs, ivector, wf_r, wf_g, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env)
 
             IF (ifirst == 1) THEN
@@ -1169,7 +1169,7 @@ CONTAINS
                                            middle_name=TRIM(filename), file_position=my_pos_cube, log_filename=.FALSE., &
                                            mpi_io=mpi_io)
             WRITE (title, *) "WAVEFUNCTION ", index_mo, " spin ", ispin, " i.e. LUMO + ", ifirst + ivector - 2
-            CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
+            CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, &
                                stride=section_get_ivals(dft_section, "PRINT%MO_CUBES%STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, "DFT%PRINT%MO_CUBES", mpi_io=mpi_io)
          END DO
@@ -1701,7 +1701,7 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_r
+      TYPE(pw_type)                                    :: wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
@@ -1821,17 +1821,15 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         ALLOCATE (wf_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_copy(rho_r(1)%pw, wf_r%pw)
-         CALL pw_axpy(rho_r(2)%pw, wf_r%pw, alpha=-1._dp)
-         total_abs_spin_dens = pw_integrate_function(wf_r%pw, oprt="ABS")
+         CALL pw_copy(rho_r(1)%pw, wf_r)
+         CALL pw_axpy(rho_r(2)%pw, wf_r, alpha=-1._dp)
+         total_abs_spin_dens = pw_integrate_function(wf_r, oprt="ABS")
          IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='(/,(T3,A,T61,F20.10))') &
             "Integrated absolute spin density  : ", total_abs_spin_dens
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-         DEALLOCATE (wf_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
          !
          ! XXX Fix Me XXX
          ! should be extended to the case where added MOs are present
@@ -1910,7 +1908,7 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: aux_g, aux_r, rho_elec_gspace, &
+      TYPE(pw_type)                                    :: aux_g, aux_r, rho_elec_gspace, &
                                                             rho_elec_rspace, wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
@@ -1965,33 +1963,31 @@ CONTAINS
                          rho0_s_gs=rho0_s_gs)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         ALLOCATE (wf_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          IF (dft_control%qs_control%gapw) THEN
-            CALL pw_transfer(rho0_s_gs, wf_r%pw)
+            CALL pw_transfer(rho0_s_gs, wf_r)
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
-               CALL pw_axpy(rho_core, wf_r%pw)
+               CALL pw_axpy(rho_core, wf_r)
             END IF
          ELSE
-            CALL pw_transfer(rho_core, wf_r%pw)
+            CALL pw_transfer(rho_core, wf_r)
          END IF
          DO ispin = 1, dft_control%nspins
-            CALL pw_axpy(rho_r(ispin)%pw, wf_r%pw)
+            CALL pw_axpy(rho_r(ispin)%pw, wf_r)
          END DO
          filename = "TOTAL_DENSITY"
          mpi_io = .TRUE.
          unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%TOT_DENSITY_CUBE", &
                                         extension=".cube", middle_name=TRIM(filename), file_position=my_pos_cube, &
                                         log_filename=.FALSE., mpi_io=mpi_io)
-         CALL cp_pw_to_cube(wf_r%pw, unit_nr, "TOTAL DENSITY", &
+         CALL cp_pw_to_cube(wf_r, unit_nr, "TOTAL DENSITY", &
                             particles=particles, &
                             stride=section_get_ivals(dft_section, "PRINT%TOT_DENSITY_CUBE%STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%TOT_DENSITY_CUBE", mpi_io=mpi_io)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-         DEALLOCATE (wf_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
       END IF
 
       ! Write cube file with electron density
@@ -2131,33 +2127,31 @@ CONTAINS
             CALL pw_env_get(pw_env=pw_env, &
                             auxbas_pw_pool=auxbas_pw_pool, &
                             pw_pools=pw_pools)
-            ALLOCATE (rho_elec_rspace%pw)
             CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                   pw=rho_elec_rspace%pw, &
+                                   pw=rho_elec_rspace, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
-            CALL pw_zero(rho_elec_rspace%pw)
-            ALLOCATE (rho_elec_gspace%pw)
+            CALL pw_zero(rho_elec_rspace)
             CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                   pw=rho_elec_gspace%pw, &
+                                   pw=rho_elec_gspace, &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
-            CALL pw_zero(rho_elec_gspace%pw)
-            CALL get_pw_grid_info(pw_grid=rho_elec_gspace%pw%pw_grid, &
+            CALL pw_zero(rho_elec_gspace)
+            CALL get_pw_grid_info(pw_grid=rho_elec_gspace%pw_grid, &
                                   dr=dr, &
                                   vol=volume)
             q_max = SQRT(SUM((pi/dr(:))**2))
             CALL calculate_rhotot_elec_gspace(qs_env=qs_env, &
                                               auxbas_pw_pool=auxbas_pw_pool, &
-                                              rhotot_elec_gspace=rho_elec_gspace%pw, &
+                                              rhotot_elec_gspace=rho_elec_gspace, &
                                               q_max=q_max, &
                                               rho_hard=rho_hard, &
                                               rho_soft=rho_soft)
             rho_total = rho_hard + rho_soft
-            CALL get_pw_grid_info(pw_grid=rho_elec_gspace%pw%pw_grid, &
+            CALL get_pw_grid_info(pw_grid=rho_elec_gspace%pw_grid, &
                                   vol=volume)
-            CALL pw_transfer(rho_elec_gspace%pw, rho_elec_rspace%pw, debug=.FALSE.)
-            rho_total_rspace = pw_integrate_function(rho_elec_rspace%pw, isign=-1)/volume
+            CALL pw_transfer(rho_elec_gspace, rho_elec_rspace, debug=.FALSE.)
+            rho_total_rspace = pw_integrate_function(rho_elec_rspace, isign=-1)/volume
             filename = "TOTAL_ELECTRON_DENSITY"
             mpi_io = .TRUE.
             unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%E_DENSITY_CUBE", &
@@ -2180,25 +2174,25 @@ CONTAINS
                   "Total electronic charge (G-space):", rho_total, &
                   "Total electronic charge (R-space):", rho_total_rspace
             END IF
-            CALL cp_pw_to_cube(rho_elec_rspace%pw, unit_nr, "TOTAL ELECTRON DENSITY", &
+            CALL cp_pw_to_cube(rho_elec_rspace, unit_nr, "TOTAL ELECTRON DENSITY", &
                                particles=particles, &
                                stride=section_get_ivals(dft_section, "PRINT%E_DENSITY_CUBE%STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                               "DFT%PRINT%E_DENSITY_CUBE", mpi_io=mpi_io)
             ! Print total spin density for spin-polarized systems
             IF (dft_control%nspins > 1) THEN
-               CALL pw_zero(rho_elec_gspace%pw)
-               CALL pw_zero(rho_elec_rspace%pw)
+               CALL pw_zero(rho_elec_gspace)
+               CALL pw_zero(rho_elec_rspace)
                CALL calculate_rhotot_elec_gspace(qs_env=qs_env, &
                                                  auxbas_pw_pool=auxbas_pw_pool, &
-                                                 rhotot_elec_gspace=rho_elec_gspace%pw, &
+                                                 rhotot_elec_gspace=rho_elec_gspace, &
                                                  q_max=q_max, &
                                                  rho_hard=rho_hard, &
                                                  rho_soft=rho_soft, &
                                                  fsign=-1.0_dp)
                rho_total = rho_hard + rho_soft
-               CALL pw_transfer(rho_elec_gspace%pw, rho_elec_rspace%pw, debug=.FALSE.)
-               rho_total_rspace = pw_integrate_function(rho_elec_rspace%pw, isign=-1)/volume
+               CALL pw_transfer(rho_elec_gspace, rho_elec_rspace, debug=.FALSE.)
+               rho_total_rspace = pw_integrate_function(rho_elec_rspace, isign=-1)/volume
                filename = "TOTAL_SPIN_DENSITY"
                mpi_io = .TRUE.
                unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%E_DENSITY_CUBE", &
@@ -2221,15 +2215,14 @@ CONTAINS
                      "Total spin density (G-space)           :", rho_total, &
                      "Total spin density (R-space)           :", rho_total_rspace
                END IF
-               CALL cp_pw_to_cube(rho_elec_rspace%pw, unit_nr, "TOTAL SPIN DENSITY", &
+               CALL cp_pw_to_cube(rho_elec_rspace, unit_nr, "TOTAL SPIN DENSITY", &
                                   particles=particles, &
                                   stride=section_get_ivals(dft_section, "PRINT%E_DENSITY_CUBE%STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                                  "DFT%PRINT%E_DENSITY_CUBE", mpi_io=mpi_io)
             END IF
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_gspace%pw)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
-            DEALLOCATE (rho_elec_gspace%pw, rho_elec_rspace%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_gspace)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
          ELSE
             IF (dft_control%nspins > 1) THEN
                CALL get_qs_env(qs_env=qs_env, &
@@ -2237,13 +2230,12 @@ CONTAINS
                CALL pw_env_get(pw_env=pw_env, &
                                auxbas_pw_pool=auxbas_pw_pool, &
                                pw_pools=pw_pools)
-               ALLOCATE (rho_elec_rspace%pw)
                CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                      pw=rho_elec_rspace%pw, &
+                                      pw=rho_elec_rspace, &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
-               CALL pw_copy(rho_r(1)%pw, rho_elec_rspace%pw)
-               CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace%pw)
+               CALL pw_copy(rho_r(1)%pw, rho_elec_rspace)
+               CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace)
                filename = "ELECTRON_DENSITY"
                mpi_io = .TRUE.
                unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%E_DENSITY_CUBE", &
@@ -2260,13 +2252,13 @@ CONTAINS
                      "The sum of alpha and beta density is written in cube file format to the file:", &
                      TRIM(filename)
                END IF
-               CALL cp_pw_to_cube(rho_elec_rspace%pw, unit_nr, "SUM OF ALPHA AND BETA DENSITY", &
+               CALL cp_pw_to_cube(rho_elec_rspace, unit_nr, "SUM OF ALPHA AND BETA DENSITY", &
                                   particles=particles, stride=section_get_ivals(dft_section, "PRINT%E_DENSITY_CUBE%STRIDE"), &
                                   mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                                  "DFT%PRINT%E_DENSITY_CUBE", mpi_io=mpi_io)
-               CALL pw_copy(rho_r(1)%pw, rho_elec_rspace%pw)
-               CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace%pw, alpha=-1.0_dp)
+               CALL pw_copy(rho_r(1)%pw, rho_elec_rspace)
+               CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace, alpha=-1.0_dp)
                filename = "SPIN_DENSITY"
                mpi_io = .TRUE.
                unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%E_DENSITY_CUBE", &
@@ -2283,13 +2275,12 @@ CONTAINS
                      "The spin density is written in cube file format to the file:", &
                      TRIM(filename)
                END IF
-               CALL cp_pw_to_cube(rho_elec_rspace%pw, unit_nr, "SPIN DENSITY", &
+               CALL cp_pw_to_cube(rho_elec_rspace, unit_nr, "SPIN DENSITY", &
                                   particles=particles, &
                                   stride=section_get_ivals(dft_section, "PRINT%E_DENSITY_CUBE%STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                                  "DFT%PRINT%E_DENSITY_CUBE", mpi_io=mpi_io)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
-               DEALLOCATE (rho_elec_rspace%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
             ELSE
                filename = "ELECTRON_DENSITY"
                mpi_io = .TRUE.
@@ -2329,8 +2320,7 @@ CONTAINS
                          pw_env=pw_env, &
                          v_hartree_rspace=v_hartree_rspace)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (aux_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
 
@@ -2346,17 +2336,16 @@ CONTAINS
                                         extension=".cube", middle_name="v_hartree", file_position=my_pos_cube, mpi_io=mpi_io)
          udvol = 1.0_dp/v_hartree_rspace%pw_grid%dvol
 
-         CALL pw_copy(v_hartree_rspace, aux_r%pw)
-         CALL pw_scale(aux_r%pw, udvol)
+         CALL pw_copy(v_hartree_rspace, aux_r)
+         CALL pw_scale(aux_r, udvol)
 
-         CALL cp_pw_to_cube(aux_r%pw, unit_nr, "HARTREE POTENTIAL", particles=particles, &
+         CALL cp_pw_to_cube(aux_r, unit_nr, "HARTREE POTENTIAL", particles=particles, &
                             stride=section_get_ivals(dft_section, &
                                                      "PRINT%V_HARTREE_CUBE%STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%V_HARTREE_CUBE", mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-         DEALLOCATE (aux_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
       END IF
 
       ! Print the external potential
@@ -2365,8 +2354,7 @@ CONTAINS
          IF (dft_control%apply_external_potential) THEN
             CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, vee=vee)
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            ALLOCATE (aux_r%pw)
-            CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
+            CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
 
@@ -2380,16 +2368,15 @@ CONTAINS
             unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%EXTERNAL_POTENTIAL_CUBE", &
                                            extension=".cube", middle_name="ext_pot", file_position=my_pos_cube, mpi_io=mpi_io)
 
-            CALL pw_copy(vee, aux_r%pw)
+            CALL pw_copy(vee, aux_r)
 
-            CALL cp_pw_to_cube(aux_r%pw, unit_nr, "EXTERNAL POTENTIAL", particles=particles, &
+            CALL cp_pw_to_cube(aux_r, unit_nr, "EXTERNAL POTENTIAL", particles=particles, &
                                stride=section_get_ivals(dft_section, &
                                                         "PRINT%EXTERNAL_POTENTIAL_CUBE%STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                               "DFT%PRINT%EXTERNAL_POTENTIAL_CUBE", mpi_io=mpi_io)
 
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-            DEALLOCATE (aux_r%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
          END IF
       END IF
 
@@ -2399,11 +2386,10 @@ CONTAINS
 
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (aux_r%pw, aux_g%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_g%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, aux_g, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
 
@@ -2422,14 +2408,14 @@ CONTAINS
                                            extension=".cube", middle_name="efield_"//cdir(id), file_position=my_pos_cube, &
                                            mpi_io=mpi_io)
 
-            CALL pw_transfer(v_hartree_rspace, aux_g%pw)
+            CALL pw_transfer(v_hartree_rspace, aux_g)
             nd = 0
             nd(id) = 1
-            CALL pw_derive(aux_g%pw, nd)
-            CALL pw_transfer(aux_g%pw, aux_r%pw)
-            CALL pw_scale(aux_r%pw, udvol)
+            CALL pw_derive(aux_g, nd)
+            CALL pw_transfer(aux_g, aux_r)
+            CALL pw_scale(aux_r, udvol)
 
-            CALL cp_pw_to_cube(aux_r%pw, &
+            CALL cp_pw_to_cube(aux_r, &
                                unit_nr, "ELECTRIC FIELD", particles=particles, &
                                stride=section_get_ivals(dft_section, &
                                                         "PRINT%EFIELD_CUBE%STRIDE"), mpi_io=mpi_io)
@@ -2437,9 +2423,8 @@ CONTAINS
                                               "DFT%PRINT%EFIELD_CUBE", mpi_io=mpi_io)
          END DO
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_g%pw)
-         DEALLOCATE (aux_r%pw, aux_g%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_g)
       END IF
 
       ! Write cube files from the local energy
@@ -2604,14 +2589,14 @@ CONTAINS
                CALL pw_env_get(pw_env=pw_env, &
                                auxbas_pw_pool=auxbas_pw_pool, &
                                pw_pools=pw_pools)
-               ALLOCATE (rho_elec_rspace%pw)
+NULLIFY(mb_rho)
+ALLOCATE(mb_rho)
                CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                      pw=rho_elec_rspace%pw, &
+                                      pw=mb_rho, &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
-               CALL pw_copy(rho_r(1)%pw, rho_elec_rspace%pw)
-               CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace%pw)
-               mb_rho => rho_elec_rspace%pw
+               CALL pw_copy(rho_r(1)%pw, mb_rho)
+               CALL pw_axpy(rho_r(2)%pw, mb_rho)
                !CALL voronoi_analysis( qs_env, rho_elec_rspace%pw, print_key, unit_nr )
             ELSE
                mb_rho => rho_r(1)%pw
@@ -2639,8 +2624,8 @@ CONTAINS
                                       unit_nr_voro, qs_env, mb_rho)
 
             IF (dft_control%nspins > 1) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
-               DEALLOCATE (rho_elec_rspace%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, mb_rho)
+               DEALLOCATE (mb_rho)
             END IF
 
             IF (unit_nr_voro > 0) THEN
@@ -2890,7 +2875,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: eden
+      TYPE(pw_type)                                    :: eden
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: dft_section
@@ -2906,8 +2891,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, subsys=subsys)
          CALL qs_subsys_get(subsys, particles=particles)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (eden%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, eden%pw, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool_create_pw(auxbas_pw_pool, eden, use_data=REALDATA3D, in_space=REALSPACE)
          !
          CALL qs_local_energy(qs_env, eden)
          !
@@ -2921,7 +2905,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%LOCAL_ENERGY_CUBE", &
                                         extension=".cube", middle_name="local_energy", &
                                         file_position=my_pos_cube, mpi_io=mpi_io)
-         CALL cp_pw_to_cube(eden%pw, &
+         CALL cp_pw_to_cube(eden, &
                             unit_nr, "LOCAL ENERGY", particles=particles, &
                             stride=section_get_ivals(dft_section, &
                                                      "PRINT%LOCAL_ENERGY_CUBE%STRIDE"), mpi_io=mpi_io)
@@ -2938,8 +2922,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%LOCAL_ENERGY_CUBE", mpi_io=mpi_io)
          !
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, eden%pw)
-         DEALLOCATE (eden%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, eden)
       END IF
       CALL timestop(handle)
 
@@ -2968,7 +2951,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: stress
+      TYPE(pw_type)                                    :: stress
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: dft_section
@@ -2984,12 +2967,11 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, subsys=subsys)
          CALL qs_subsys_get(subsys, particles=particles)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (stress%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, stress%pw, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool_create_pw(auxbas_pw_pool, stress, use_data=REALDATA3D, in_space=REALSPACE)
          !
          ! use beta=0: kinetic energy density in symmetric form
          beta = 0.0_dp
-         CALL qs_local_stress(qs_env, pressure=stress, beta=beta)
+         CALL qs_local_stress(qs_env, beta=beta)
          !
          append_cube = section_get_lval(input, "DFT%PRINT%LOCAL_STRESS_CUBE%APPEND")
          IF (append_cube) THEN
@@ -3001,7 +2983,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%LOCAL_STRESS_CUBE", &
                                         extension=".cube", middle_name="local_stress", &
                                         file_position=my_pos_cube, mpi_io=mpi_io)
-         CALL cp_pw_to_cube(stress%pw, &
+         CALL cp_pw_to_cube(stress, &
                             unit_nr, "LOCAL STRESS", particles=particles, &
                             stride=section_get_ivals(dft_section, &
                                                      "PRINT%LOCAL_STRESS_CUBE%STRIDE"), mpi_io=mpi_io)
@@ -3019,8 +3001,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%LOCAL_STRESS_CUBE", mpi_io=mpi_io)
          !
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, stress%pw)
-         DEALLOCATE (stress%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, stress)
       END IF
 
       CALL timestop(handle)
@@ -3050,7 +3031,7 @@ CONTAINS
          has_dirichlet_bc, has_implicit_ps, mpi_io, tile_cubes
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: aux_r
+      TYPE(pw_type)                                    :: aux_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_type), POINTER                             :: dirichlet_tile
@@ -3084,30 +3065,27 @@ CONTAINS
                                         extension=".cube", middle_name="DIELECTRIC_CONSTANT", file_position=my_pos_cube, &
                                         mpi_io=mpi_io)
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (aux_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, use_data=REALDATA3D, in_space=REALSPACE)
 
          boundary_condition = pw_env%poisson_env%parameters%ps_implicit_params%boundary_condition
          SELECT CASE (boundary_condition)
          CASE (PERIODIC_BC, MIXED_PERIODIC_BC)
-            CALL pw_copy(poisson_env%implicit_env%dielectric%eps, aux_r%pw)
+            CALL pw_copy(poisson_env%implicit_env%dielectric%eps, aux_r)
          CASE (MIXED_BC, NEUMANN_BC)
             CALL pw_shrink(pw_env%poisson_env%parameters%ps_implicit_params%neumann_directions, &
                            pw_env%poisson_env%implicit_env%dct_env%dests_shrink, &
                            pw_env%poisson_env%implicit_env%dct_env%srcs_shrink, &
                            pw_env%poisson_env%implicit_env%dct_env%bounds_local_shftd, &
-                           poisson_env%implicit_env%dielectric%eps, aux_r%pw)
+                           poisson_env%implicit_env%dielectric%eps, aux_r)
          END SELECT
 
-         CALL cp_pw_to_cube(aux_r%pw, unit_nr, "DIELECTRIC CONSTANT", particles=particles, &
+         CALL cp_pw_to_cube(aux_r, unit_nr, "DIELECTRIC CONSTANT", particles=particles, &
                             stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE%STRIDE"), &
                             mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE", mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-         DEALLOCATE (aux_r%pw)
-         NULLIFY (aux_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
       END IF
 
       ! Write Dirichlet constraint charges into a cube file
@@ -3135,30 +3113,27 @@ CONTAINS
                                         extension=".cube", middle_name="dirichlet_cstr_charge", file_position=my_pos_cube, &
                                         mpi_io=mpi_io)
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (aux_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, use_data=REALDATA3D, in_space=REALSPACE)
 
          boundary_condition = pw_env%poisson_env%parameters%ps_implicit_params%boundary_condition
          SELECT CASE (boundary_condition)
          CASE (MIXED_PERIODIC_BC)
-            CALL pw_copy(poisson_env%implicit_env%cstr_charge, aux_r%pw)
+            CALL pw_copy(poisson_env%implicit_env%cstr_charge, aux_r)
          CASE (MIXED_BC)
             CALL pw_shrink(pw_env%poisson_env%parameters%ps_implicit_params%neumann_directions, &
                            pw_env%poisson_env%implicit_env%dct_env%dests_shrink, &
                            pw_env%poisson_env%implicit_env%dct_env%srcs_shrink, &
                            pw_env%poisson_env%implicit_env%dct_env%bounds_local_shftd, &
-                           poisson_env%implicit_env%cstr_charge, aux_r%pw)
+                           poisson_env%implicit_env%cstr_charge, aux_r)
          END SELECT
 
-         CALL cp_pw_to_cube(aux_r%pw, unit_nr, "DIRICHLET CONSTRAINT CHARGE", particles=particles, &
+         CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET CONSTRAINT CHARGE", particles=particles, &
                             stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE%STRIDE"), &
                             mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE", mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-         DEALLOCATE (aux_r%pw)
-         NULLIFY (aux_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
       END IF
 
       ! Write Dirichlet type constranits into cube files
@@ -3181,9 +3156,8 @@ CONTAINS
          tile_cubes = section_get_lval(input, "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%TILE_CUBES")
 
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
-         ALLOCATE (aux_r%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r%pw, use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_zero(aux_r%pw)
+         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_zero(aux_r)
 
          IF (tile_cubes) THEN
             ! one cube file per tile
@@ -3198,9 +3172,9 @@ CONTAINS
                                                  extension=".cube", middle_name=filename, file_position=my_pos_cube, &
                                                  mpi_io=mpi_io)
 
-                  CALL pw_copy(poisson_env%implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, aux_r%pw)
+                  CALL pw_copy(poisson_env%implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, aux_r)
 
-                  CALL cp_pw_to_cube(aux_r%pw, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
+                  CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
                                      stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%STRIDE"), &
                                      mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(unit_nr, logger, input, &
@@ -3223,11 +3197,11 @@ CONTAINS
                n_tiles = poisson_env%implicit_env%contacts(j)%dirichlet_bc%n_tiles
                DO i = 1, n_tiles
                   CALL pw_copy(poisson_env%implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, dirichlet_tile)
-                  CALL pw_axpy(dirichlet_tile, aux_r%pw)
+                  CALL pw_axpy(dirichlet_tile, aux_r)
                END DO
             END DO
 
-            CALL cp_pw_to_cube(aux_r%pw, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
+            CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
                                stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%STRIDE"), &
                                mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, &
@@ -3236,8 +3210,7 @@ CONTAINS
             DEALLOCATE (dirichlet_tile)
          END IF
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r%pw)
-         DEALLOCATE (aux_r%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
       END IF
 
       CALL timestop(handle)
@@ -3373,17 +3346,18 @@ CONTAINS
 
       LOGICAL                                            :: use_virial
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: v_hartree_gspace, v_hartree_rspace
+      TYPE(pw_type)                                    :: v_hartree_gspace, rho_tot_gspace
+TYPE(pw_type), POINTER :: v_hartree_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_core, rho_tot_gspace
+      TYPE(pw_type), POINTER                             :: rho_core
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(virial_type), POINTER                         :: virial
 
-      NULLIFY (auxbas_pw_pool, pw_env, poisson_env, energy, rho_core, v_hartree_rspace%pw, virial)
+      NULLIFY (auxbas_pw_pool, pw_env, poisson_env, energy, rho_core, v_hartree_rspace, virial)
       CALL get_qs_env(qs_env, pw_env=pw_env, energy=energy, &
                       rho_core=rho_core, virial=virial, &
-                      v_hartree_rspace=v_hartree_rspace%pw)
+                      v_hartree_rspace=v_hartree_rspace)
 
       use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
 
@@ -3391,9 +3365,8 @@ CONTAINS
 
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          poisson_env=poisson_env)
-         ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                v_hartree_gspace%pw, &
+                                v_hartree_gspace, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
          CALL pw_pool_create_pw(auxbas_pw_pool, &
@@ -3403,14 +3376,13 @@ CONTAINS
 
          CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
          CALL pw_poisson_solve(poisson_env, rho_tot_gspace, energy%hartree, &
-                               v_hartree_gspace%pw, rho_core=rho_core)
+                               v_hartree_gspace, rho_core=rho_core)
 
-         CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
-         CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+         CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
+         CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-         DEALLOCATE (v_hartree_gspace%pw, rho_tot_gspace)
       END IF
 
    END SUBROUTINE update_hartree_with_mp2

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1451,9 +1451,9 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: elf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: elf_r
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: elf_section
 
@@ -1464,7 +1464,7 @@ CONTAINS
       IF (BTEST(cp_print_key_should_output(logger%iter_info, input, &
                                            "DFT%PRINT%ELF_CUBE"), cp_p_file)) THEN
 
-         NULLIFY (dft_control, pw_env, auxbas_pw_pool, pw_pools, particles, subsys, elf_r)
+         NULLIFY (dft_control, pw_env, auxbas_pw_pool, pw_pools, particles, subsys)
          CALL get_qs_env(qs_env, dft_control=dft_control, pw_env=pw_env, subsys=subsys)
          CALL qs_subsys_get(subsys, particles=particles)
 
@@ -1475,11 +1475,10 @@ CONTAINS
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                             pw_pools=pw_pools)
             DO ispin = 1, dft_control%nspins
-               ALLOCATE (elf_r(ispin)%pw)
-               CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin)%pw, &
+               CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin), &
                                       use_data=REALDATA3D, &
                                       in_space=REALSPACE)
-               CALL pw_zero(elf_r(ispin)%pw)
+               CALL pw_zero(elf_r(ispin))
             END DO
 
             IF (output_unit > 0) THEN
@@ -1514,12 +1513,11 @@ CONTAINS
                      TRIM(filename)
                END IF
 
-               CALL cp_pw_to_cube(elf_r(ispin)%pw, unit_nr, title, particles=particles, &
+               CALL cp_pw_to_cube(elf_r(ispin), unit_nr, title, particles=particles, &
                                   stride=section_get_ivals(elf_section, "STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, input, "DFT%PRINT%ELF_CUBE", mpi_io=mpi_io)
 
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin)%pw)
-               DEALLOCATE (elf_r(ispin)%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin))
             END DO
 
             ! deallocate

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -272,9 +272,9 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_loc_env_new_type), POINTER                 :: qs_loc_env_homo, qs_loc_env_lumo, &
                                                             qs_loc_env_mixed
@@ -1013,8 +1013,8 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
-      TYPE(pw_type), INTENT(IN)                                    :: wf_g
-      TYPE(pw_type), INTENT(INOUT)                                    :: wf_r
+      TYPE(pw_type), INTENT(IN)                          :: wf_g
+      TYPE(pw_type), INTENT(INOUT)                       :: wf_r
       TYPE(particle_list_type), POINTER                  :: particles
       INTEGER, INTENT(IN)                                :: homo, ispin
 
@@ -1117,8 +1117,8 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_type), INTENT(IN)                       :: unoccupied_orbs
-      TYPE(pw_type), INTENT(IN)                                    :: wf_g
-      TYPE(pw_type), INTENT(INOUT)                                    :: wf_r
+      TYPE(pw_type), INTENT(IN)                          :: wf_g
+      TYPE(pw_type), INTENT(INOUT)                       :: wf_r
       TYPE(particle_list_type), POINTER                  :: particles
       INTEGER, INTENT(IN)                                :: nlumos, homo, ispin
       INTEGER, INTENT(IN), OPTIONAL                      :: lumo
@@ -1701,10 +1701,10 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_r
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
@@ -1908,11 +1908,11 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: aux_g, aux_r, rho_elec_gspace, &
-                                                            rho_elec_rspace, wf_r
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: aux_g, aux_r, rho_elec_gspace, &
+                                                            rho_elec_rspace, wf_r
       TYPE(pw_type), POINTER                             :: mb_rho, rho0_s_gs, rho_core, &
                                                             v_hartree_rspace, vee
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -2589,8 +2589,8 @@ CONTAINS
                CALL pw_env_get(pw_env=pw_env, &
                                auxbas_pw_pool=auxbas_pw_pool, &
                                pw_pools=pw_pools)
-NULLIFY(mb_rho)
-ALLOCATE(mb_rho)
+               NULLIFY (mb_rho)
+               ALLOCATE (mb_rho)
                CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
                                       pw=mb_rho, &
                                       use_data=REALDATA3D, &
@@ -2875,8 +2875,8 @@ ALLOCATE(mb_rho)
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: eden
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: eden
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: dft_section
 
@@ -2951,8 +2951,8 @@ ALLOCATE(mb_rho)
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: stress
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: stress
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: dft_section
 
@@ -3031,9 +3031,9 @@ ALLOCATE(mb_rho)
          has_dirichlet_bc, has_implicit_ps, mpi_io, tile_cubes
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: aux_r
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: aux_r
       TYPE(pw_type), POINTER                             :: dirichlet_tile
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(section_vals_type), POINTER                   :: dft_section
@@ -3346,11 +3346,10 @@ ALLOCATE(mb_rho)
 
       LOGICAL                                            :: use_virial
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_type)                                    :: v_hartree_gspace, rho_tot_gspace
-TYPE(pw_type), POINTER :: v_hartree_rspace
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
-      TYPE(pw_type), POINTER                             :: rho_core
+      TYPE(pw_type)                                      :: rho_tot_gspace, v_hartree_gspace
+      TYPE(pw_type), POINTER                             :: rho_core, v_hartree_rspace
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(virial_type), POINTER                         :: virial
 

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -1361,9 +1361,10 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: elf_r, rho_g, rho_r
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: elf_r
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_subsys_type), POINTER                      :: subsys
@@ -1393,11 +1394,10 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
       DO ispin = 1, dft_control%nspins
-         ALLOCATE (elf_r(ispin)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin), &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_zero(elf_r(ispin)%pw)
+         CALL pw_zero(elf_r(ispin))
       END DO
 
       IF (iounit > 0) THEN
@@ -1428,12 +1428,11 @@ CONTAINS
                "ELF is written in cube file format to the file:", ADJUSTR(TRIM(filename))
          END IF
 
-         CALL cp_pw_to_cube(elf_r(ispin)%pw, unit_nr, title, particles=particles, &
+         CALL cp_pw_to_cube(elf_r(ispin), unit_nr, title, particles=particles, &
                             stride=section_get_ivals(elf_section, "STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, elf_section, '', mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin)%pw)
-         DEALLOCATE (elf_r(ispin)%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin))
       END DO
 
       DEALLOCATE (elf_r)

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -99,7 +99,8 @@ MODULE qs_scf_post_tb
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_core,&
                                               calculate_rho_elec,&
                                               calculate_wavefunction
@@ -1016,7 +1017,6 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_elec_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
@@ -1058,55 +1058,56 @@ CONTAINS
          END IF
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-         ALLOCATE (rho_elec_rspace%pw)
-         CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                pw=rho_elec_rspace%pw, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_copy(rho_r(1)%pw, rho_elec_rspace%pw)
-         CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace%pw)
-         filename = "ELECTRON_DENSITY"
-         mpi_io = .TRUE.
-         unit_nr = cp_print_key_unit_nr(logger, cube_section, '', &
-                                        extension=".cube", middle_name=TRIM(filename), &
-                                        file_position=my_pos_cube, log_filename=.FALSE., mpi_io=mpi_io, &
-                                        fout=mpi_filename)
-         IF (iounit > 0) THEN
-            IF (.NOT. mpi_io) THEN
-               INQUIRE (UNIT=unit_nr, NAME=filename)
-            ELSE
-               filename = mpi_filename
+         BLOCK
+            TYPE(pw_type) :: rho_elec_rspace
+            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
+                                   pw=rho_elec_rspace, &
+                                   use_data=REALDATA3D, &
+                                   in_space=REALSPACE)
+            CALL pw_copy(rho_r(1)%pw, rho_elec_rspace)
+            CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace)
+            filename = "ELECTRON_DENSITY"
+            mpi_io = .TRUE.
+            unit_nr = cp_print_key_unit_nr(logger, cube_section, '', &
+                                           extension=".cube", middle_name=TRIM(filename), &
+                                           file_position=my_pos_cube, log_filename=.FALSE., mpi_io=mpi_io, &
+                                           fout=mpi_filename)
+            IF (iounit > 0) THEN
+               IF (.NOT. mpi_io) THEN
+                  INQUIRE (UNIT=unit_nr, NAME=filename)
+               ELSE
+                  filename = mpi_filename
+               END IF
+               WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
+                  "The sum of alpha and beta density is written in cube file format to the file:", ADJUSTR(TRIM(filename))
             END IF
-            WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
-               "The sum of alpha and beta density is written in cube file format to the file:", ADJUSTR(TRIM(filename))
-         END IF
-         CALL cp_pw_to_cube(rho_elec_rspace%pw, unit_nr, "SUM OF ALPHA AND BETA DENSITY", &
-                            particles=particles, stride=section_get_ivals(cube_section, "STRIDE"), &
-                            mpi_io=mpi_io)
-         CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-         CALL pw_copy(rho_r(1)%pw, rho_elec_rspace%pw)
-         CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace%pw, alpha=-1.0_dp)
-         filename = "SPIN_DENSITY"
-         mpi_io = .TRUE.
-         unit_nr = cp_print_key_unit_nr(logger, cube_section, '', &
-                                        extension=".cube", middle_name=TRIM(filename), &
-                                        file_position=my_pos_cube, log_filename=.FALSE., mpi_io=mpi_io, &
-                                        fout=mpi_filename)
-         IF (iounit > 0) THEN
-            IF (.NOT. mpi_io) THEN
-               INQUIRE (UNIT=unit_nr, NAME=filename)
-            ELSE
-               filename = mpi_filename
+            CALL cp_pw_to_cube(rho_elec_rspace, unit_nr, "SUM OF ALPHA AND BETA DENSITY", &
+                               particles=particles, stride=section_get_ivals(cube_section, "STRIDE"), &
+                               mpi_io=mpi_io)
+            CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
+            CALL pw_copy(rho_r(1)%pw, rho_elec_rspace)
+            CALL pw_axpy(rho_r(2)%pw, rho_elec_rspace, alpha=-1.0_dp)
+            filename = "SPIN_DENSITY"
+            mpi_io = .TRUE.
+            unit_nr = cp_print_key_unit_nr(logger, cube_section, '', &
+                                           extension=".cube", middle_name=TRIM(filename), &
+                                           file_position=my_pos_cube, log_filename=.FALSE., mpi_io=mpi_io, &
+                                           fout=mpi_filename)
+            IF (iounit > 0) THEN
+               IF (.NOT. mpi_io) THEN
+                  INQUIRE (UNIT=unit_nr, NAME=filename)
+               ELSE
+                  filename = mpi_filename
+               END IF
+               WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
+                  "The spin density is written in cube file format to the file:", ADJUSTR(TRIM(filename))
             END IF
-            WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
-               "The spin density is written in cube file format to the file:", ADJUSTR(TRIM(filename))
-         END IF
-         CALL cp_pw_to_cube(rho_elec_rspace%pw, unit_nr, "SPIN DENSITY", &
-                            particles=particles, &
-                            stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
-         CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace%pw)
-         DEALLOCATE (rho_elec_rspace%pw)
+            CALL cp_pw_to_cube(rho_elec_rspace, unit_nr, "SPIN DENSITY", &
+                               particles=particles, &
+                               stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
+            CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
+         END BLOCK
       ELSE
          IF (iounit > 0) THEN
             WRITE (UNIT=iounit, FMT="(/,T2,A,T66,F15.6)") &
@@ -1165,12 +1166,11 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_grid_type), POINTER                        :: pwdummy
-      TYPE(pw_p_type)                                    :: rho_core, rho_tot_gspace, &
-                                                            rho_tot_rspace, vhartree
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r
       TYPE(pw_poisson_parameter_type)                    :: poisson_params
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_core, rho_tot_rspace, vhartree
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_subsys_type), POINTER                      :: subsys
@@ -1220,12 +1220,11 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      ALLOCATE (rho_core%pw)
       CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rho_core%pw, &
+                             pw=rho_core, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
-      CALL calculate_rho_core(rho_core%pw, total_rho_core_rspace, qs_env)
+      CALL calculate_rho_core(rho_core, total_rho_core_rspace, qs_env)
 
       IF (iounit > 0) THEN
          WRITE (UNIT=iounit, FMT="(/,T2,A,T66,F15.6)") &
@@ -1234,12 +1233,11 @@ CONTAINS
             "Integrated core density:", total_rho_core_rspace
       END IF
 
-      ALLOCATE (rho_tot_rspace%pw)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_rspace%pw, &
+      CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_transfer(rho_core%pw, rho_tot_rspace%pw)
+      CALL pw_transfer(rho_core, rho_tot_rspace)
       DO ispin = 1, dft_control%nspins
-         CALL pw_axpy(rho_r(ispin)%pw, rho_tot_rspace%pw)
+         CALL pw_axpy(rho_r(ispin)%pw, rho_tot_rspace)
       END DO
 
       IF (my_total_density) THEN
@@ -1257,64 +1255,29 @@ CONTAINS
             WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
                "The total density is written in cube file format to the file:", ADJUSTR(TRIM(filename))
          END IF
-         CALL cp_pw_to_cube(rho_tot_rspace%pw, unit_nr, "TOTAL DENSITY", &
+         CALL cp_pw_to_cube(rho_tot_rspace, unit_nr, "TOTAL DENSITY", &
                             particles=particles, &
                             stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
       END IF
       IF (my_v_hartree .OR. my_efield) THEN
-         ALLOCATE (rho_tot_gspace%pw)
-         CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_gspace%pw, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_transfer(rho_tot_rspace%pw, rho_tot_gspace%pw)
-         poisson_params%solver = pw_poisson_analytic
-         poisson_params%periodic = cell%perd
-         poisson_params%ewald_type = do_ewald_none
-         NULLIFY (green_fft, pwdummy)
-         CALL pw_green_create(green_fft, poisson_params, cell%hmat, auxbas_pw_pool, pwdummy, pwdummy)
-         rho_tot_gspace%pw%cc(:) = rho_tot_gspace%pw%cc(:)*green_fft%influence_fn%cc(:)
-         CALL pw_green_release(green_fft, auxbas_pw_pool)
-         IF (my_v_hartree) THEN
-            ALLOCATE (vhartree%pw)
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree%pw, &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_transfer(rho_tot_gspace%pw, vhartree%pw)
-            filename = "V_HARTREE"
-            mpi_io = .TRUE.
-            unit_nr = cp_print_key_unit_nr(logger, cube_section, '', &
-                                           extension=".cube", middle_name=TRIM(filename), file_position=my_pos_cube, &
-                                           log_filename=.FALSE., mpi_io=mpi_io, fout=mpi_filename)
-            IF (iounit > 0) THEN
-               IF (.NOT. mpi_io) THEN
-                  INQUIRE (UNIT=unit_nr, NAME=filename)
-               ELSE
-                  filename = mpi_filename
-               END IF
-               WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
-                  "The Hartree potential is written in cube file format to the file:", ADJUSTR(TRIM(filename))
-            END IF
-            CALL cp_pw_to_cube(vhartree%pw, unit_nr, "Hartree Potential", &
-                               particles=particles, &
-                               stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
-            CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree%pw)
-            DEALLOCATE (vhartree%pw)
-            NULLIFY (vhartree%pw)
-         END IF
-         IF (my_efield) THEN
-            ALLOCATE (vhartree%pw)
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree%pw, &
+         BLOCK
+            TYPE(pw_type) :: rho_tot_gspace
+            CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_gspace, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-            udvol = 1.0_dp/rho_tot_rspace%pw%pw_grid%dvol
-            DO id = 1, 3
-               CALL pw_transfer(rho_tot_gspace%pw, vhartree%pw)
-               nd = 0
-               nd(id) = 1
-               CALL pw_derive(vhartree%pw, nd)
-               CALL pw_transfer(vhartree%pw, rho_tot_rspace%pw)
-               CALL pw_scale(rho_tot_rspace%pw, udvol)
-
-               filename = "EFIELD_"//cdir(id)
+            CALL pw_transfer(rho_tot_rspace, rho_tot_gspace)
+            poisson_params%solver = pw_poisson_analytic
+            poisson_params%periodic = cell%perd
+            poisson_params%ewald_type = do_ewald_none
+            NULLIFY (green_fft, pwdummy)
+            CALL pw_green_create(green_fft, poisson_params, cell%hmat, auxbas_pw_pool, pwdummy, pwdummy)
+            rho_tot_gspace%cc(:) = rho_tot_gspace%cc(:)*green_fft%influence_fn%cc(:)
+            CALL pw_green_release(green_fft, auxbas_pw_pool)
+            IF (my_v_hartree) THEN
+               CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree, &
+                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_transfer(rho_tot_gspace, vhartree)
+               filename = "V_HARTREE"
                mpi_io = .TRUE.
                unit_nr = cp_print_key_unit_nr(logger, cube_section, '', &
                                               extension=".cube", middle_name=TRIM(filename), file_position=my_pos_cube, &
@@ -1326,23 +1289,53 @@ CONTAINS
                      filename = mpi_filename
                   END IF
                   WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
-                     "The Efield is written in cube file format to the file:", ADJUSTR(TRIM(filename))
+                     "The Hartree potential is written in cube file format to the file:", ADJUSTR(TRIM(filename))
                END IF
-               CALL cp_pw_to_cube(rho_tot_rspace%pw, unit_nr, "EFIELD "//cdir(id), &
+               CALL cp_pw_to_cube(vhartree, unit_nr, "Hartree Potential", &
                                   particles=particles, &
                                   stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-            END DO
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree%pw)
-            DEALLOCATE (vhartree%pw)
-         END IF
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
-         DEALLOCATE (rho_tot_gspace%pw)
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree)
+            END IF
+            IF (my_efield) THEN
+               CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree, &
+                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               udvol = 1.0_dp/rho_tot_rspace%pw_grid%dvol
+               DO id = 1, 3
+                  CALL pw_transfer(rho_tot_gspace, vhartree)
+                  nd = 0
+                  nd(id) = 1
+                  CALL pw_derive(vhartree, nd)
+                  CALL pw_transfer(vhartree, rho_tot_rspace)
+                  CALL pw_scale(rho_tot_rspace, udvol)
+
+                  filename = "EFIELD_"//cdir(id)
+                  mpi_io = .TRUE.
+                  unit_nr = cp_print_key_unit_nr(logger, cube_section, '', &
+                                                 extension=".cube", middle_name=TRIM(filename), file_position=my_pos_cube, &
+                                                 log_filename=.FALSE., mpi_io=mpi_io, fout=mpi_filename)
+                  IF (iounit > 0) THEN
+                     IF (.NOT. mpi_io) THEN
+                        INQUIRE (UNIT=unit_nr, NAME=filename)
+                     ELSE
+                        filename = mpi_filename
+                     END IF
+                     WRITE (UNIT=iounit, FMT="(T2,A,/,T2,A79)") &
+                        "The Efield is written in cube file format to the file:", ADJUSTR(TRIM(filename))
+                  END IF
+                  CALL cp_pw_to_cube(rho_tot_rspace, unit_nr, "EFIELD "//cdir(id), &
+                                     particles=particles, &
+                                     stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
+                  CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
+               END DO
+               CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree)
+            END IF
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+         END BLOCK
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_core%pw)
-      DEALLOCATE (rho_tot_rspace%pw, rho_core%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_core)
 
    END SUBROUTINE print_density_cubes
 
@@ -1474,9 +1467,9 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(scf_control_type), POINTER                    :: scf_control
@@ -1524,11 +1517,10 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      ALLOCATE (wf_r%pw, wf_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
@@ -1556,7 +1548,7 @@ CONTAINS
                DO i = 1, nlist
                   ivector = list_index(i)
                   IF (ivector > homo) CYCLE
-                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
+                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
                                               cell, dft_control, particle_set, pw_env)
                   WRITE (filename, '(a4,I5.5,a1,I1.1)') "WFN_", ivector, "_", ispin
                   mpi_io = .TRUE.
@@ -1564,7 +1556,7 @@ CONTAINS
                                                  middle_name=TRIM(filename), file_position=my_pos_cube, &
                                                  log_filename=.FALSE., mpi_io=mpi_io)
                   WRITE (title, *) "WAVEFUNCTION ", ivector, " spin ", ispin, " i.e. HOMO - ", ivector - homo
-                  CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
+                  CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, &
                                      stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
                END DO
@@ -1586,7 +1578,7 @@ CONTAINS
                   ilast = MIN(nmo, ilast)
                END IF
                DO ivector = ifirst, ilast
-                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r%pw, wf_g%pw, atomic_kind_set, &
+                  CALL calculate_wavefunction(mo_coeff, ivector, wf_r, wf_g, atomic_kind_set, &
                                               qs_kind_set, cell, dft_control, particle_set, pw_env)
                   WRITE (filename, '(a4,I5.5,a1,I1.1)') "WFN_", ivector, "_", ispin
                   mpi_io = .TRUE.
@@ -1594,7 +1586,7 @@ CONTAINS
                                                  middle_name=TRIM(filename), file_position=my_pos_cube, &
                                                  log_filename=.FALSE., mpi_io=mpi_io)
                   WRITE (title, *) "WAVEFUNCTION ", ivector, " spin ", ispin, " i.e. LUMO + ", ivector - ifirst
-                  CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
+                  CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, &
                                      stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
                END DO
@@ -1602,9 +1594,8 @@ CONTAINS
          END DO
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      DEALLOCATE (wf_g%pw, wf_r%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
       IF (ASSOCIATED(list_index)) DEALLOCATE (list_index)
 
    END SUBROUTINE print_mo_cubes

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -37,7 +37,8 @@ MODULE qs_tddfpt2_fhxc
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_gapw_densities,               ONLY: prepare_gapw_den
@@ -125,8 +126,9 @@ CONTAINS
       TYPE(lri_kind_type), DIMENSION(:), POINTER         :: lri_v_int
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_ia_g, rho_ia_g_aux_fit, rho_ia_r, &
                                                             rho_ia_r_aux_fit, tau_ia_r, &
-                                                            tau_ia_r_aux_fit, V_rspace_sub
+                                                            tau_ia_r_aux_fit
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: V_rspace_sub
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho1_atom_set, rho_atom_set
       TYPE(task_list_type), POINTER                      :: task_list
 
@@ -233,7 +235,7 @@ CONTAINS
 
          ! electron-hole exchange-correlation interaction
          DO ispin = 1, nspins
-            CALL pw_zero(work_matrices%A_ia_rspace_sub(ispin)%pw)
+            CALL pw_zero(work_matrices%A_ia_rspace_sub(ispin))
          END DO
 
          ! C_x d^{2}E_{x}^{DFT}[\rho] / d\rho^2
@@ -245,14 +247,14 @@ CONTAINS
                                  work_v_xc=work_matrices%wpw_rspace_sub, &
                                  work_v_xc_tau=work_matrices%wpw_tau_rspace_sub)
             DO ispin = 1, nspins
-               CALL pw_scale(work_matrices%A_ia_rspace_sub(ispin)%pw, &
-                             work_matrices%A_ia_rspace_sub(ispin)%pw%pw_grid%dvol)
-               CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
+               CALL pw_scale(work_matrices%A_ia_rspace_sub(ispin), &
+                             work_matrices%A_ia_rspace_sub(ispin)%pw_grid%dvol)
+               CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
                                        hmat=work_matrices%A_ia_munu_sub(ispin), &
                                        qs_env=qs_env, calculate_forces=.FALSE., gapw=gapw_xc, &
                                        pw_env_external=sub_env%pw_env, &
                                        task_list_external=sub_env%task_list_orb_soft)
-               CALL pw_zero(work_matrices%A_ia_rspace_sub(ispin)%pw)
+               CALL pw_zero(work_matrices%A_ia_rspace_sub(ispin))
             END DO
          ELSE
             CALL tddfpt_apply_xc(A_ia_rspace=work_matrices%A_ia_rspace_sub, kernel_env=kernel_env, &
@@ -294,10 +296,9 @@ CONTAINS
                   CALL pw_env_get(sub_env%pw_env, auxbas_pw_pool=auxbas_pw_pool)
                   ALLOCATE (V_rspace_sub(nspins))
                   DO ispin = 1, nspins
-                     ALLOCATE (V_rspace_sub(ispin)%pw)
-                     CALL pw_pool_create_pw(auxbas_pw_pool, V_rspace_sub(ispin)%pw, &
+                     CALL pw_pool_create_pw(auxbas_pw_pool, V_rspace_sub(ispin), &
                                             use_data=REALDATA3D, in_space=REALSPACE)
-                     CALL pw_zero(V_rspace_sub(ispin)%pw)
+                     CALL pw_zero(V_rspace_sub(ispin))
                   END DO
 
                   IF (admm_env%do_gapw) THEN
@@ -315,8 +316,8 @@ CONTAINS
                                        work_v_xc=work_matrices%wpw_rspace_sub, &
                                        work_v_xc_tau=work_matrices%wpw_tau_rspace_sub)
                   DO ispin = 1, nspins
-                     CALL pw_scale(V_rspace_sub(ispin)%pw, V_rspace_sub(ispin)%pw%pw_grid%dvol)
-                     CALL integrate_v_rspace(v_rspace=V_rspace_sub(ispin)%pw, &
+                     CALL pw_scale(V_rspace_sub(ispin), V_rspace_sub(ispin)%pw_grid%dvol)
+                     CALL integrate_v_rspace(v_rspace=V_rspace_sub(ispin), &
                                              hmat=A_xc_munu_sub(ispin), &
                                              qs_env=qs_env, calculate_forces=.FALSE., &
                                              pw_env_external=sub_env%pw_env, &
@@ -356,8 +357,7 @@ CONTAINS
                   CALL dbcsr_release(dbwork)
                   DEALLOCATE (dbwork)
                   DO ispin = 1, nspins
-                     CALL pw_pool_give_back_pw(auxbas_pw_pool, V_rspace_sub(ispin)%pw)
-                     DEALLOCATE (V_rspace_sub(ispin)%pw)
+                     CALL pw_pool_give_back_pw(auxbas_pw_pool, V_rspace_sub(ispin))
                   END DO
                   DEALLOCATE (V_rspace_sub)
                   CALL cp_fm_release(work_aux_orb)
@@ -394,18 +394,18 @@ CONTAINS
                                       local_rho_set=work_matrices%local_rho_set, &
                                       hartree_local=work_matrices%hartree_local, &
                                       qs_env=qs_env, sub_env=sub_env, gapw=gapw, &
-                                      work_v_gspace=work_matrices%wpw_gspace_sub(1), &
-                                      work_v_rspace=work_matrices%wpw_rspace_sub(1))
+                                      work_v_gspace=work_matrices%wpw_gspace_sub(1)%pw, &
+                                      work_v_rspace=work_matrices%wpw_rspace_sub(1)%pw)
          END IF
 
          ! convert from the plane-wave representation into the Gaussian basis set representation
          DO ispin = 1, nspins
             IF (.NOT. do_lrigpw) THEN
-               CALL pw_scale(work_matrices%A_ia_rspace_sub(ispin)%pw, &
-                             work_matrices%A_ia_rspace_sub(ispin)%pw%pw_grid%dvol)
+               CALL pw_scale(work_matrices%A_ia_rspace_sub(ispin), &
+                             work_matrices%A_ia_rspace_sub(ispin)%pw_grid%dvol)
 
                IF (gapw) THEN
-                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
+                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
                                           hmat=work_matrices%A_ia_munu_sub(ispin), &
                                           qs_env=qs_env, calculate_forces=.FALSE., gapw=gapw, &
                                           pw_env_external=sub_env%pw_env, &
@@ -415,7 +415,7 @@ CONTAINS
                                       rho_atom_external=work_matrices%local_rho_set%rho_atom_set)
                ELSEIF (gapw_xc) THEN
                   IF (.NOT. is_rks_triplets) THEN
-                     CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
+                     CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
                                              hmat=work_matrices%A_ia_munu_sub(ispin), &
                                              qs_env=qs_env, calculate_forces=.FALSE., gapw=.FALSE., &
                                              pw_env_external=sub_env%pw_env, task_list_external=sub_env%task_list_orb)
@@ -424,20 +424,20 @@ CONTAINS
                   CALL update_ks_atom(qs_env, work_matrices%A_ia_munu_sub, rho_ia_ao, forces=.FALSE., tddft=.TRUE., &
                                       rho_atom_external=work_matrices%local_rho_set%rho_atom_set)
                ELSE
-                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin)%pw, &
+                  CALL integrate_v_rspace(v_rspace=work_matrices%A_ia_rspace_sub(ispin), &
                                           hmat=work_matrices%A_ia_munu_sub(ispin), &
                                           qs_env=qs_env, calculate_forces=.FALSE., gapw=.FALSE., &
                                           pw_env_external=sub_env%pw_env, task_list_external=sub_env%task_list_orb)
                END IF
             ELSE ! for full kernel using lri
-               CALL pw_scale(work_matrices%A_ia_rspace_sub(ispin)%pw, &
-                             work_matrices%A_ia_rspace_sub(ispin)%pw%pw_grid%dvol)
+               CALL pw_scale(work_matrices%A_ia_rspace_sub(ispin), &
+                             work_matrices%A_ia_rspace_sub(ispin)%pw_grid%dvol)
                lri_v_int => kernel_env%lri_density%lri_coefs(ispin)%lri_kinds
                CALL get_qs_env(qs_env, nkind=nkind, para_env=para_env)
                DO ikind = 1, nkind
                   lri_v_int(ikind)%v_int = 0.0_dp
                END DO
-               CALL integrate_v_rspace_one_center(work_matrices%A_ia_rspace_sub(ispin)%pw, &
+               CALL integrate_v_rspace_one_center(work_matrices%A_ia_rspace_sub(ispin), &
                                                   qs_env, lri_v_int, .FALSE., "P_LRI_AUX")
                DO ikind = 1, nkind
                   CALL mp_sum(lri_v_int(ikind)%v_int, para_env%group)

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -90,7 +90,8 @@ MODULE qs_tddfpt2_fhxc_forces
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -175,14 +176,13 @@ CONTAINS
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rhox_tot_gspace, xv_hartree_gspace, &
-                                                            xv_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: fxc_rho, fxc_tau, gxc_rho, gxc_tau, &
                                                             rho_g_aux, rho_r_aux, rhox_g, &
                                                             rhox_g_aux, rhox_r, rhox_r_aux, &
                                                             tau_r_aux
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type), POINTER                             :: xv_hartree_gspace, xv_hartree_rspace
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit, rhox, rhox_aux
@@ -279,51 +279,56 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, rhox_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      ALLOCATE (rhox_tot_gspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhox_tot_gspace%pw, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
-      CALL pw_zero(rhox_tot_gspace%pw)
-      DO ispin = 1, nspins
-         IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 2.0_dp)
-         CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_px1(ispin)%matrix, &
-                                 rho=rhox_r(ispin)%pw, rho_gspace=rhox_g(ispin)%pw)
-         CALL pw_axpy(rhox_g(ispin)%pw, rhox_tot_gspace%pw)
-         IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 0.5_dp)
-      END DO
-
-      CALL get_qs_env(qs_env, matrix_s=matrix_s, force=force, para_env=para_env)
-
-      IF (.NOT. is_rks_triplets) THEN
-         ALLOCATE (xv_hartree_rspace%pw, xv_hartree_gspace%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_rspace%pw, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_gspace%pw, &
+      BLOCK
+         TYPE(pw_type) :: rhox_tot_gspace
+         CALL pw_pool_create_pw(auxbas_pw_pool, rhox_tot_gspace, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         ! calculate associated hartree potential
-         CALL pw_poisson_solve(poisson_env, rhox_tot_gspace%pw, xehartree, &
-                               xv_hartree_gspace%pw)
-         CALL pw_transfer(xv_hartree_gspace%pw, xv_hartree_rspace%pw)
-         CALL pw_scale(xv_hartree_rspace%pw, xv_hartree_rspace%pw%pw_grid%dvol)
-         !
-         IF (debug_forces) fodeb(1:3) = force(1)%rho_elec(1:3, 1)
-         NULLIFY (matrix_hx)
-         CALL dbcsr_allocate_matrix_set(matrix_hx, nspins)
+         CALL pw_zero(rhox_tot_gspace)
          DO ispin = 1, nspins
-            ALLOCATE (matrix_hx(ispin)%matrix)
-            CALL dbcsr_create(matrix_hx(ispin)%matrix, template=matrix_s(1)%matrix)
-            CALL dbcsr_copy(matrix_hx(ispin)%matrix, matrix_s(1)%matrix)
-            CALL dbcsr_set(matrix_hx(ispin)%matrix, 0.0_dp)
-            CALL integrate_v_rspace(qs_env=qs_env, v_rspace=xv_hartree_rspace%pw, &
-                                    pmat=matrix_px1(ispin), &
-                                    hmat=matrix_hx(ispin), calculate_forces=.TRUE.)
+            IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 2.0_dp)
+            CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_px1(ispin)%matrix, &
+                                    rho=rhox_r(ispin)%pw, rho_gspace=rhox_g(ispin)%pw)
+            CALL pw_axpy(rhox_g(ispin)%pw, rhox_tot_gspace)
+            IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 0.5_dp)
          END DO
-         IF (debug_forces) THEN
-            fodeb(1:3) = force(1)%rho_elec(1:3, 1) - fodeb(1:3)
-            CALL mp_sum(fodeb, para_env%group)
-            IF (iounit > 0) WRITE (iounit, "(T3,A,T33,3F16.8)") "DEBUG:: Px*dKh[X]   ", fodeb
+
+         CALL get_qs_env(qs_env, matrix_s=matrix_s, force=force, para_env=para_env)
+
+         IF (.NOT. is_rks_triplets) THEN
+            NULLIFY (xv_hartree_rspace, xv_hartree_gspace)
+            ALLOCATE (xv_hartree_rspace, xv_hartree_gspace)
+            CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_rspace, &
+                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_gspace, &
+                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            ! calculate associated hartree potential
+            CALL pw_poisson_solve(poisson_env, rhox_tot_gspace, xehartree, &
+                                  xv_hartree_gspace)
+            CALL pw_transfer(xv_hartree_gspace, xv_hartree_rspace)
+            CALL pw_scale(xv_hartree_rspace, xv_hartree_rspace%pw_grid%dvol)
+            !
+            IF (debug_forces) fodeb(1:3) = force(1)%rho_elec(1:3, 1)
+            NULLIFY (matrix_hx)
+            CALL dbcsr_allocate_matrix_set(matrix_hx, nspins)
+            DO ispin = 1, nspins
+               ALLOCATE (matrix_hx(ispin)%matrix)
+               CALL dbcsr_create(matrix_hx(ispin)%matrix, template=matrix_s(1)%matrix)
+               CALL dbcsr_copy(matrix_hx(ispin)%matrix, matrix_s(1)%matrix)
+               CALL dbcsr_set(matrix_hx(ispin)%matrix, 0.0_dp)
+               CALL integrate_v_rspace(qs_env=qs_env, v_rspace=xv_hartree_rspace, &
+                                       pmat=matrix_px1(ispin), &
+                                       hmat=matrix_hx(ispin), calculate_forces=.TRUE.)
+            END DO
+            IF (debug_forces) THEN
+               fodeb(1:3) = force(1)%rho_elec(1:3, 1) - fodeb(1:3)
+               CALL mp_sum(fodeb, para_env%group)
+               IF (iounit > 0) WRITE (iounit, "(T3,A,T33,3F16.8)") "DEBUG:: Px*dKh[X]   ", fodeb
+            END IF
          END IF
-      END IF
+
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_tot_gspace)
+      END BLOCK
 
       ! XC
       NULLIFY (fxc_rho, fxc_tau, gxc_rho, gxc_tau)
@@ -578,8 +583,6 @@ CONTAINS
 
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_tot_gspace%pw)
-      DEALLOCATE (rhox_tot_gspace%pw)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_g(ispin)%pw)
@@ -587,9 +590,9 @@ CONTAINS
       END DO
       DEALLOCATE (rhox_r, rhox_g)
       IF (.NOT. is_rks_triplets) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_rspace%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_gspace%pw)
-         DEALLOCATE (xv_hartree_rspace%pw, xv_hartree_gspace%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_rspace)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_gspace)
+         DEALLOCATE (xv_hartree_rspace, xv_hartree_gspace)
       END IF
 
       ! HFX

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -180,7 +180,7 @@ CONTAINS
                                   work_matrices, debug_forces)
       ELSE
          IF (ASSOCIATED(ex_env%vh_rspace)) THEN
-            vh_rspace => ex_env%vh_rspace%pw
+            vh_rspace => ex_env%vh_rspace
          ELSE
             ALLOCATE (ex_env%vh_rspace)
             NULLIFY (vh_rspace)
@@ -217,7 +217,7 @@ CONTAINS
          NULLIFY (vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace)
          ALLOCATE (vh_rspace)
          CALL ks_ref_potential(qs_env, vh_rspace, vxc_rspace, vtau_rspace, vadmm_rspace, ehartree, exc)
-         ex_env%vh_rspace%pw => vh_rspace
+         ex_env%vh_rspace => vh_rspace
          ex_env%vxc_rspace => vxc_rspace
          ex_env%vtau_rspace => vtau_rspace
          ex_env%vadmm_rspace => vadmm_rspace

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -550,14 +550,14 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(hfx_type), DIMENSION(:, :), POINTER           :: x_data
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: rho_tot_gspace, v_hartree_gspace, &
-                                                            v_hartree_rspace
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_g_aux, rho_r, rho_r_aux, &
                                                             rhoz_g_aux, rhoz_r_aux, tau_r, &
                                                             tau_r_aux, trho_g, trho_r, v_xc, &
                                                             v_xc_tau
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: rho_tot_gspace, v_hartree_gspace, &
+                                                            v_hartree_rspace
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_aux_fit, rhoz_aux, trho
       TYPE(section_vals_type), POINTER                   :: hfx_section, input, xc_section
@@ -575,12 +575,11 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      ALLOCATE (v_hartree_gspace%pw, rho_tot_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       ALLOCATE (trho_r(nspins), trho_g(nspins))
@@ -591,13 +590,13 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, trho_g(ispin)%pw, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_zero(rho_tot_gspace%pw)
+      CALL pw_zero(rho_tot_gspace)
       DO ispin = 1, nspins
          CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_pe(ispin)%matrix, &
                                  rho=trho_r(ispin)%pw, &
                                  rho_gspace=trho_g(ispin)%pw, &
                                  total_rho=total_rho)
-         CALL pw_axpy(trho_g(ispin)%pw, rho_tot_gspace%pw)
+         CALL pw_axpy(trho_g(ispin)%pw, rho_tot_gspace)
          IF (ABS(total_rho) > 1.e-08_dp) THEN
             logger => cp_get_default_logger()
             IF (logger%para_env%ionode) THEN
@@ -613,10 +612,10 @@ CONTAINS
          END IF
       END DO
       ! calculate associated hartree potential
-      CALL pw_poisson_solve(poisson_env, rho_tot_gspace%pw, thartree, &
-                            v_hartree_gspace%pw)
-      CALL pw_transfer(v_hartree_gspace%pw, v_hartree_rspace%pw)
-      CALL pw_scale(v_hartree_rspace%pw, v_hartree_rspace%pw%pw_grid%dvol)
+      CALL pw_poisson_solve(poisson_env, rho_tot_gspace, thartree, &
+                            v_hartree_gspace)
+      CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
+      CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
 
       ! Fxc*drho term
       CALL get_qs_env(qs_env, rho=rho)
@@ -647,16 +646,15 @@ CONTAINS
       DO ispin = 1, nspins
          CALL dbcsr_set(matrix_hz(ispin)%matrix, 0.0_dp)
          CALL pw_scale(v_xc(ispin)%pw, v_xc(ispin)%pw%pw_grid%dvol)
-         CALL pw_axpy(v_hartree_rspace%pw, v_xc(ispin)%pw)
+         CALL pw_axpy(v_hartree_rspace, v_xc(ispin)%pw)
          CALL integrate_v_rspace(qs_env=qs_env, v_rspace=v_xc(ispin)%pw, &
                                  hmat=matrix_hz(ispin), &
                                  calculate_forces=.FALSE.)
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace%pw)
-      DEALLOCATE (v_hartree_gspace%pw, v_hartree_rspace%pw, rho_tot_gspace%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_r(ispin)%pw)
          CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_g(ispin)%pw)

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -182,7 +182,6 @@ CONTAINS
          IF (ASSOCIATED(ex_env%vh_rspace)) THEN
             vh_rspace => ex_env%vh_rspace
          ELSE
-            ALLOCATE (ex_env%vh_rspace)
             NULLIFY (vh_rspace)
          END IF
          vxc_rspace => ex_env%vxc_rspace

--- a/src/qs_tddfpt2_operators.F
+++ b/src/qs_tddfpt2_operators.F
@@ -158,14 +158,14 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_apply_coulomb(A_ia_rspace, rho_ia_g, local_rho_set, hartree_local, &
                                    qs_env, sub_env, gapw, work_v_gspace, work_v_rspace)
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: A_ia_rspace
+      TYPE(pw_type), DIMENSION(:), INTENT(IN)            :: A_ia_rspace
       TYPE(pw_type), POINTER                             :: rho_ia_g
       TYPE(local_rho_type), POINTER                      :: local_rho_set
       TYPE(hartree_local_type), POINTER                  :: hartree_local
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(tddfpt_subgroup_env_type), INTENT(in)         :: sub_env
       LOGICAL, INTENT(IN)                                :: gapw
-      TYPE(pw_p_type), INTENT(inout)                     :: work_v_gspace, work_v_rspace
+      TYPE(pw_type), INTENT(inout)                       :: work_v_gspace, work_v_rspace
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_apply_coulomb'
 
@@ -193,14 +193,14 @@ CONTAINS
          CALL pw_axpy(local_rho_set%rho0_mpole%rho0_s_gs, rho_ia_g)
       END IF
 
-      CALL pw_poisson_solve(poisson_env, rho_ia_g, pair_energy, work_v_gspace%pw)
-      CALL pw_transfer(work_v_gspace%pw, work_v_rspace%pw)
+      CALL pw_poisson_solve(poisson_env, rho_ia_g, pair_energy, work_v_gspace)
+      CALL pw_transfer(work_v_gspace, work_v_rspace)
 
       ! (i a || j b) = ( i_alpha a_alpha + i_beta a_beta || j_alpha b_alpha + j_beta b_beta) =
       !                tr (Cj_alpha^T * [J_i{alpha}a{alpha}_munu + J_i{beta}a{beta}_munu] * Cb_alpha) +
       !                tr (Cj_beta^T * [J_i{alpha}a{alpha}_munu + J_i{beta}a{beta}_munu] * Cb_beta)
       DO ispin = 1, nspins
-         CALL pw_axpy(work_v_rspace%pw, A_ia_rspace(ispin)%pw, alpha)
+         CALL pw_axpy(work_v_rspace, A_ia_rspace(ispin), alpha)
       END DO
 
       IF (gapw) THEN
@@ -208,8 +208,8 @@ CONTAINS
                                  hartree_local%ecoul_1c, &
                                  local_rho_set, &
                                  sub_env%para_env, tddft=.TRUE.)
-         CALL pw_scale(work_v_rspace%pw, work_v_rspace%pw%pw_grid%dvol)
-         CALL integrate_vhg0_rspace(qs_env, work_v_rspace%pw, sub_env%para_env, &
+         CALL pw_scale(work_v_rspace, work_v_rspace%pw_grid%dvol)
+         CALL integrate_vhg0_rspace(qs_env, work_v_rspace, sub_env%para_env, &
                                     calculate_forces=.FALSE., &
                                     local_rho_set=local_rho_set)
       END IF
@@ -232,7 +232,7 @@ CONTAINS
 !> \param work_v_xc_tau ...
 ! **************************************************************************************************
    SUBROUTINE tddfpt_apply_xc(A_ia_rspace, kernel_env, rho_ia_struct, is_rks_triplets, pw_env, work_v_xc, work_v_xc_tau)
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: A_ia_rspace
+      TYPE(pw_type), DIMENSION(:), INTENT(IN)            :: A_ia_rspace
       TYPE(full_kernel_env_type), INTENT(in)             :: kernel_env
       TYPE(qs_rho_type), POINTER                         :: rho_ia_struct
       LOGICAL, INTENT(in)                                :: is_rks_triplets
@@ -251,7 +251,7 @@ CONTAINS
 
       DO ispin = 1, SIZE(work_v_xc)
          ! pw2 = pw2 + alpha * pw1
-         CALL pw_axpy(work_v_xc(ispin)%pw, A_ia_rspace(ispin)%pw, kernel_env%alpha)
+         CALL pw_axpy(work_v_xc(ispin)%pw, A_ia_rspace(ispin), kernel_env%alpha)
       END DO
 
    END SUBROUTINE tddfpt_apply_xc
@@ -278,7 +278,7 @@ CONTAINS
 !>       Mohamed Fawzi on 10.2002.
 ! **************************************************************************************************
    SUBROUTINE tddfpt_apply_xc_analytic(A_ia_rspace, kernel_env, rho_ia_struct, is_rks_triplets, pw_env, work_v_xc, work_v_xc_tau)
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: A_ia_rspace
+      TYPE(pw_type), DIMENSION(:), INTENT(IN)            :: A_ia_rspace
       TYPE(full_kernel_env_type), INTENT(in)             :: kernel_env
       TYPE(qs_rho_type), POINTER                         :: rho_ia_struct
       LOGICAL, INTENT(in)                                :: is_rks_triplets
@@ -372,7 +372,7 @@ CONTAINS
 !> \param work_v_xc_tau ...
 ! **************************************************************************************************
    SUBROUTINE tddfpt_apply_xc_fd(A_ia_rspace, kernel_env, rho_ia_struct, is_rks_triplets, pw_env, work_v_xc, work_v_xc_tau)
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: A_ia_rspace
+      TYPE(pw_type), DIMENSION(:), INTENT(IN)            :: A_ia_rspace
       TYPE(full_kernel_env_type), INTENT(in)             :: kernel_env
       TYPE(qs_rho_type), POINTER                         :: rho_ia_struct
       LOGICAL, INTENT(in)                                :: is_rks_triplets

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -93,7 +93,7 @@ MODULE qs_tddfpt2_properties
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -1303,9 +1303,9 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_subsys_type), POINTER                      :: subsys
 
@@ -1313,11 +1313,10 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      ALLOCATE (wf_r%pw, wf_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
@@ -1338,7 +1337,7 @@ CONTAINS
       DO iset = 1, 2
          CALL get_mo_set(mo_set=mos(iset)%mo_set, mo_coeff=mo_coeff, nmo=nmo)
          DO i = 1, nmo
-            CALL calculate_wavefunction(mo_coeff, i, wf_r%pw, wf_g%pw, atomic_kind_set, qs_kind_set, &
+            CALL calculate_wavefunction(mo_coeff, i, wf_r, wf_g, atomic_kind_set, qs_kind_set, &
                                         cell, dft_control, particle_set, pw_env)
             IF (iset == 1) THEN
                WRITE (filename, '(a4,I3.3,I2.2,a11)') "NTO_STATE", istate, i, "_Hole_State"
@@ -1354,15 +1353,14 @@ CONTAINS
             ELSEIF (iset == 2) THEN
                WRITE (title, *) "Natural Transition Orbital Particle State", i
             END IF
-            CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, stride=stride, mpi_io=mpi_io)
+            CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, stride=stride, mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, print_section, '', &
                                               ignore_should_output=.TRUE., mpi_io=mpi_io)
          END DO
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      DEALLOCATE (wf_g%pw, wf_r%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
 
    END SUBROUTINE print_nto_cubes
 

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -51,7 +51,8 @@ MODULE qs_tddfpt2_types
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_p_type,&
+                                              pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_kind_types,                   ONLY: qs_kind_type
@@ -161,7 +162,7 @@ MODULE qs_tddfpt2_types
       !> electron density in terms of auxiliary basis set
       TYPE(qs_rho_type), POINTER                         :: rho_aux_fit_struct_sub
       !> group-specific copy of a Coulomb/xc-potential on a real-space grid
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: A_ia_rspace_sub
+      TYPE(pw_type), DIMENSION(:), POINTER             :: A_ia_rspace_sub
       !> group-specific copy of a reciprocal-space grid
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: wpw_gspace_sub
       !> group-specific copy of a real-space grid
@@ -419,8 +420,7 @@ CONTAINS
       ALLOCATE (work_matrices%wpw_gspace_sub(nspins), work_matrices%wpw_rspace_sub(nspins), &
                 work_matrices%wpw_tau_rspace_sub(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (work_matrices%A_ia_rspace_sub(ispin)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
 
          ALLOCATE (work_matrices%wpw_gspace_sub(ispin)%pw, work_matrices%wpw_rspace_sub(ispin)%pw, &
@@ -714,9 +714,9 @@ CONTAINS
             CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_rspace_sub(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_tau_rspace_sub(ispin)%pw)
             CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_gspace_sub(ispin)%pw)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin)%pw)
+            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin))
             DEALLOCATE (work_matrices%wpw_rspace_sub(ispin)%pw, work_matrices%wpw_tau_rspace_sub(ispin)%pw, &
-                        work_matrices%wpw_gspace_sub(ispin)%pw, work_matrices%A_ia_rspace_sub(ispin)%pw)
+                        work_matrices%wpw_gspace_sub(ispin)%pw)
          END DO
          DEALLOCATE (work_matrices%A_ia_rspace_sub, work_matrices%wpw_gspace_sub, &
                      work_matrices%wpw_rspace_sub, work_matrices%wpw_tau_rspace_sub)

--- a/src/qs_update_s_mstruct.F
+++ b/src/qs_update_s_mstruct.F
@@ -21,8 +21,7 @@ MODULE qs_update_s_mstruct
                                               kg_tnadd_embed,&
                                               kg_tnadd_embed_ri
    USE pw_methods,                      ONLY: pw_transfer
-   USE pw_types,                        ONLY: pw_p_type,&
-                                              pw_release,&
+   USE pw_types,                        ONLY: pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_ppl_grid,&
                                               calculate_rho_core,&
@@ -70,8 +69,7 @@ CONTAINS
       INTEGER                                            :: handle
       LOGICAL                                            :: do_ppl
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(pw_p_type), POINTER                           :: rho_nlcc, rho_nlcc_g, vppl
-      TYPE(pw_type), POINTER                             :: rho_core
+      TYPE(pw_type), POINTER                             :: rho_core, rho_nlcc, rho_nlcc_g, vppl
 
       CALL timeset(routineN, handle)
 
@@ -116,15 +114,15 @@ CONTAINS
          NULLIFY (vppl)
          CALL get_qs_env(qs_env, vppl=vppl)
          CPASSERT(ASSOCIATED(vppl))
-         CALL calculate_ppl_grid(vppl%pw, qs_env)
+         CALL calculate_ppl_grid(vppl, qs_env)
       END IF
 
       ! compute the rho_nlcc
       NULLIFY (rho_nlcc, rho_nlcc_g)
       CALL get_qs_env(qs_env, rho_nlcc=rho_nlcc, rho_nlcc_g=rho_nlcc_g)
       IF (ASSOCIATED(rho_nlcc)) THEN
-         CALL calculate_rho_nlcc(rho_nlcc%pw, qs_env)
-         CALL pw_transfer(rho_nlcc%pw, rho_nlcc_g%pw)
+         CALL calculate_rho_nlcc(rho_nlcc, qs_env)
+         CALL pw_transfer(rho_nlcc, rho_nlcc_g)
       END IF
 
       ! allocates and creates the task_list

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -647,7 +647,7 @@ CONTAINS
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
       TYPE(section_vals_type), POINTER                   :: xc_section
-      TYPE(pw_type), INTENT(INOUT)                     :: xc_den
+      TYPE(pw_type), INTENT(INOUT)                       :: xc_den
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'qs_xc_density'
 

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -647,7 +647,7 @@ CONTAINS
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
       TYPE(section_vals_type), POINTER                   :: xc_section
-      TYPE(pw_p_type), INTENT(INOUT)                     :: xc_den
+      TYPE(pw_type), INTENT(INOUT)                     :: xc_den
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'qs_xc_density'
 
@@ -665,7 +665,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL pw_zero(xc_den%pw)
+      CALL pw_zero(xc_den)
 
       CALL get_ks_env(ks_env, &
                       dft_control=dft_control, &
@@ -729,11 +729,11 @@ CONTAINS
             END DO
          END IF
          !
-         ovol = 1.0_dp/xc_den%pw%pw_grid%dvol
-         CALL pw_copy(exc_r, xc_den%pw)
+         ovol = 1.0_dp/xc_den%pw_grid%dvol
+         CALL pw_copy(exc_r, xc_den)
          DO ispin = 1, nspins
-!deb        CALL pw_multiply(xc_den%pw, vxc_rho(ispin)%pw, rho_r(ispin)%pw, alpha=-ovol)
-            CALL pw_multiply(xc_den%pw, vxc_rho(ispin)%pw, rho_r(ispin)%pw, alpha=-1.0_dp)
+!deb        CALL pw_multiply(xc_den, vxc_rho(ispin)%pw, rho_r(ispin)%pw, alpha=-ovol)
+            CALL pw_multiply(xc_den, vxc_rho(ispin)%pw, rho_r(ispin)%pw, alpha=-1.0_dp)
          END DO
          ! remove arrays
          DO ispin = 1, nspins

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -131,9 +131,9 @@ CONTAINS
                                                             rho_m_gspace, rho_m_rspace, rho_r, &
                                                             rho_struct_g, rho_struct_r, tau, &
                                                             tau_struct_r
-      TYPE(pw_p_type), POINTER                           :: rho_nlcc, rho_nlcc_g
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool, vdw_pw_pool, xc_pw_pool
-      TYPE(pw_type), POINTER                             :: tmp_g, tmp_g2, tmp_pw
+      TYPE(pw_type), POINTER                             :: rho_nlcc, rho_nlcc_g, tmp_g, tmp_g2, &
+                                                            tmp_pw
       TYPE(virial_type), POINTER                         :: virial
 
       CALL timeset(routineN, handle)
@@ -279,8 +279,8 @@ CONTAINS
          IF (ASSOCIATED(rho_nlcc)) THEN
             factor = 1.0_dp
             DO ispin = 1, mspin
-               CALL pw_axpy(rho_nlcc%pw, rho_r(ispin)%pw, factor)
-               CALL pw_axpy(rho_nlcc_g%pw, rho_g(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc, rho_r(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc_g, rho_g(ispin)%pw, factor)
             END DO
          END IF
 
@@ -306,8 +306,8 @@ CONTAINS
          IF (ASSOCIATED(rho_nlcc)) THEN
             factor = -1.0_dp
             DO ispin = 1, mspin
-               CALL pw_axpy(rho_nlcc%pw, rho_r(ispin)%pw, factor)
-               CALL pw_axpy(rho_nlcc_g%pw, rho_g(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc, rho_r(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc_g, rho_g(ispin)%pw, factor)
             END DO
          END IF
 
@@ -659,9 +659,9 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, tau_r, vxc_rho, vxc_tau
-      TYPE(pw_p_type), POINTER                           :: rho_nlcc, rho_nlcc_g
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool, xc_pw_pool
       TYPE(pw_type)                                      :: exc_r
+      TYPE(pw_type), POINTER                             :: rho_nlcc, rho_nlcc_g
 
       CALL timeset(routineN, handle)
 
@@ -708,8 +708,8 @@ CONTAINS
          IF (ASSOCIATED(rho_nlcc)) THEN
             factor = 1.0_dp
             DO ispin = 1, nspins
-               CALL pw_axpy(rho_nlcc%pw, rho_r(ispin)%pw, factor)
-               CALL pw_axpy(rho_nlcc_g%pw, rho_g(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc, rho_r(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc_g, rho_g(ispin)%pw, factor)
             END DO
          END IF
          NULLIFY (vxc_rho, vxc_tau)
@@ -724,8 +724,8 @@ CONTAINS
          IF (ASSOCIATED(rho_nlcc)) THEN
             factor = -1.0_dp
             DO ispin = 1, dft_control%nspins
-               CALL pw_axpy(rho_nlcc%pw, rho_r(ispin)%pw, factor)
-               CALL pw_axpy(rho_nlcc_g%pw, rho_g(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc, rho_r(ispin)%pw, factor)
+               CALL pw_axpy(rho_nlcc_g, rho_g(ispin)%pw, factor)
             END DO
          END IF
          !

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2582,10 +2582,10 @@ CONTAINS
          POINTER                                         :: sab_orb
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env_ext
-      TYPE(pw_p_type)                                    :: dvg(3), pot_g, psi_L, rho_g, rho_g_copy, &
-                                                            rho_r
+      TYPE(pw_p_type)                                    :: dvg(3)
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: pot_g, psi_L, rho_g, rho_g_copy, rho_r
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(realspace_grid_p_type), DIMENSION(:), POINTER :: rs_v
       TYPE(task_list_type), POINTER                      :: task_list_ext
@@ -2666,8 +2666,7 @@ CONTAINS
                        auxbas_pw_pool, poisson_env, task_list_ext, rho_r, rho_g, pot_g, psi_L, sab_orb)
 
       IF (use_virial) THEN
-         ALLOCATE (rho_g_copy%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
          DO i_xyz = 1, 3
@@ -2706,7 +2705,7 @@ CONTAINS
             wf_vector = 0.0_dp
             wf_vector(j_RI) = 1.0_dp
 
-            CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+            CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
                                         qs_kind_set, cell, dft_control, particle_set, pw_env_ext, &
                                         basis_type="RI_AUX", external_vector=wf_vector)
 
@@ -2727,8 +2726,8 @@ CONTAINS
                   wf_vector(i_RI + 1:i_RI + sizes_RI(iatom)) = pblock(:, j_RI - lb_RI)
                END DO
 
-               CALL pw_copy(rho_g%pw, rho_g_copy%pw)
-               CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L%pw, rho_g%pw, atomic_kind_set, &
+               CALL pw_copy(rho_g, rho_g_copy)
+               CALL calculate_wavefunction(mos(1)%mo_set%mo_coeff, 1, psi_L, rho_g, atomic_kind_set, &
                                            qs_kind_set, cell, dft_control, particle_set, pw_env_ext, &
                                            basis_type="RI_AUX", external_vector=wf_vector)
 
@@ -2745,7 +2744,7 @@ CONTAINS
             DO i = 1, SIZE(rs_v)
                CALL rs_grid_retain(rs_v(i)%rs_grid)
             END DO
-            CALL potential_pw2rs(rs_v, rho_r%pw, pw_env_ext)
+            CALL potential_pw2rs(rs_v, rho_r, pw_env_ext)
 
             DO iatom = 1, natom
 
@@ -2840,8 +2839,7 @@ CONTAINS
       END DO !jatom
 
       IF (use_virial) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy%pw)
-         DEALLOCATE (rho_g_copy%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy)
          DO i_xyz = 1, 3
             CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(i_xyz)%pw)
             DEALLOCATE (dvg(i_xyz)%pw)

--- a/src/semi_empirical_int_gks.F
+++ b/src/semi_empirical_int_gks.F
@@ -580,7 +580,7 @@ CONTAINS
       pw_pool => se_int_control%ewald_gks%pw_pool
       dg => se_int_control%ewald_gks%dg
       CALL dg_get(dg, dg_rho0=dg_rho0)
-      rho0 => dg_rho0%density%pw%cr3d
+      rho0 => dg_rho0%density%cr3d
       pw_grid => pw_pool%pw_grid
       bds => pw_grid%bounds
 
@@ -797,7 +797,7 @@ CONTAINS
       pw_pool => se_int_control%ewald_gks%pw_pool
       dg => se_int_control%ewald_gks%dg
       CALL dg_get(dg, dg_rho0=dg_rho0)
-      rho0 => dg_rho0%density%pw%cr3d
+      rho0 => dg_rho0%density%cr3d
       pw_grid => pw_pool%pw_grid
       bds => pw_grid%bounds
 
@@ -1165,7 +1165,7 @@ CONTAINS
       pw_pool => se_int_control%ewald_gks%pw_pool
       dg => se_int_control%ewald_gks%dg
       CALL dg_get(dg, dg_rho0=dg_rho0)
-      rho0 => dg_rho0%density%pw%cr3d
+      rho0 => dg_rho0%density%cr3d
       pw_grid => pw_pool%pw_grid
       bds => pw_grid%bounds
 

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -52,7 +52,7 @@ MODULE stm_images
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_p_type
+                                              pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -117,9 +117,9 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: stm_density_ao
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: mos
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type)                                    :: wf_g, wf_r
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(pw_type)                                      :: wf_g, wf_r
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
 
@@ -159,11 +159,10 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
-      ALLOCATE (wf_r%pw, wf_g%pw)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g%pw, &
+      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
@@ -224,9 +223,8 @@ CONTAINS
       DEALLOCATE (occupation)
 
       CALL dbcsr_deallocate_matrix(stm_density_ao)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r%pw)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g%pw)
-      DEALLOCATE (wf_r%pw, wf_g%pw)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
 
       DEALLOCATE (stm_th_torb)
       DEALLOCATE (nadd_unocc)
@@ -266,7 +264,7 @@ CONTAINS
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(section_vals_type), POINTER                   :: stm_section
       TYPE(dbcsr_type), POINTER                          :: stm_density_ao
-      TYPE(pw_p_type)                                    :: wf_r, wf_g
+      TYPE(pw_type), INTENT(INOUT)                       :: wf_r, wf_g
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: mo_arrays
       TYPE(cp_1d_r_p_type), DIMENSION(:), INTENT(IN)     :: evals, occupation
       REAL(KIND=dp)                                      :: efermi
@@ -374,7 +372,7 @@ CONTAINS
          DO i = 1, SIZE(stm_th_torb)
             iorb = stm_th_torb(i)
             CALL calculate_rho_elec(matrix_p=stm_density_ao, &
-                                    rho=wf_r%pw, rho_gspace=wf_g%pw, &
+                                    rho=wf_r, rho_gspace=wf_g, &
                                     ks_env=ks_env, der_type=iorb)
 
             oname = torb_string(iorb)
@@ -390,7 +388,7 @@ CONTAINS
                                            middle_name=TRIM(filename), file_position=my_pos, file_action="WRITE", &
                                            log_filename=.FALSE., mpi_io=mpi_io)
             WRITE (title, '(A,I0,A,I0,A,F16.8)') "STM cube ", ibias, " wfn deriv. ", iorb, " at bias ", stm_biases(ibias)
-            CALL cp_pw_to_cube(wf_r%pw, unit_nr, title, particles=particles, &
+            CALL cp_pw_to_cube(wf_r, unit_nr, title, particles=particles, &
                                stride=section_get_ivals(stm_section, "STRIDE"), zero_tails=.TRUE., &
                                mpi_io=mpi_io)
 

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -148,11 +148,11 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: orbital_density_matrix, rho_struct_ao
       TYPE(mo_set_p_type), DIMENSION(:), POINTER         :: molecular_orbitals
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rho_struct_r, tau, &
-                                                            vxc_GLLB, vxc_LB, vxc_SAOP, vxc_tau, &
-                                                            vxc_tmp
+      TYPE(pw_p_type), DIMENSION(:), POINTER             :: rho_g, rho_r, rho_struct_r, tau, vxc_LB, &
+                                                            vxc_tau, vxc_tmp
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
       TYPE(pw_type)                                      :: orbital, orbital_g
+      TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: vxc_GLLB, vxc_SAOP
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho_struct
       TYPE(section_vals_type), POINTER                   :: input, xc_fun_section_orig, &
@@ -166,7 +166,7 @@ CONTAINS
 
       NULLIFY (ks_env, pw_env, auxbas_pw_pool, input)
       NULLIFY (rho_g, rho_r, tau, rho_struct, e_uniform)
-      NULLIFY (vxc_GLLB, vxc_LB, vxc_tmp, vxc_SAOP, vxc_tau)
+      NULLIFY (vxc_LB, vxc_tmp, vxc_tau)
       NULLIFY (mo_eigenvalues, deriv, rho_struct_r, rho_struct_ao)
       NULLIFY (orbital_density_matrix, dummy, xc_section_tmp, xc_fun_section_tmp)
 
@@ -295,14 +295,13 @@ CONTAINS
 
       ALLOCATE (vxc_GLLB(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (vxc_GLLB(ispin)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vxc_GLLB(ispin)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, vxc_GLLB(ispin), &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
       END DO
 
       DO ispin = 1, nspins
-         dummy => vxc_GLLB(ispin)%pw%cr3d
+         dummy => vxc_GLLB(ispin)%cr3d
          CALL calc_2excpbe(dummy, rho_set, e_uniform, lsd)
       END DO
       NULLIFY (dummy)
@@ -373,7 +372,7 @@ CONTAINS
             END DO
          END DO
 
-         vxc_GLLB(ispin)%pw%cr3d = vxc_GLLB(ispin)%pw%cr3d + vxc_tmp(ispin)%pw%cr3d
+         vxc_GLLB(ispin)%cr3d = vxc_GLLB(ispin)%cr3d + vxc_tmp(ispin)%pw%cr3d
 
       END DO
 
@@ -388,10 +387,9 @@ CONTAINS
                          mo_coeff=mo_coeff, &
                          eigenvalues=mo_eigenvalues, &
                          homo=homo)
-         ALLOCATE (vxc_SAOP(ispin)%pw)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vxc_SAOP(ispin)%pw, &
+         CALL pw_pool_create_pw(auxbas_pw_pool, vxc_SAOP(ispin), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_zero(vxc_SAOP(ispin)%pw)
+         CALL pw_zero(vxc_SAOP(ispin))
 
          ALLOCATE (coeff_col(nrow(ispin), 1))
 
@@ -405,7 +403,7 @@ CONTAINS
             END IF
 
             vxc_tmp(ispin)%pw%cr3d = we_LB*vxc_LB(ispin)%pw%cr3d + &
-                                     we_GLLB*vxc_GLLB(ispin)%pw%cr3d
+                                     we_GLLB*vxc_GLLB(ispin)%cr3d
 
             CALL cp_fm_set_all(single_mo_coeff(ispin), 0.0_dp)
             CALL cp_fm_get_submatrix(mo_coeff, coeff_col, &
@@ -424,8 +422,8 @@ CONTAINS
                                     rho=orbital, rho_gspace=orbital_g, &
                                     ks_env=ks_env)
 
-            vxc_SAOP(ispin)%pw%cr3d = vxc_SAOP(ispin)%pw%cr3d + &
-                                      orbital%cr3d*vxc_tmp(ispin)%pw%cr3d
+            vxc_SAOP(ispin)%cr3d = vxc_SAOP(ispin)%cr3d + &
+                                   orbital%cr3d*vxc_tmp(ispin)%pw%cr3d
 
          END DO
 
@@ -437,10 +435,10 @@ CONTAINS
             DO j = bo(1, 2), bo(2, 2)
                DO i = bo(1, 1), bo(2, 1)
                   IF (rho_r(ispin)%pw%cr3d(i, j, k) > density_cut) THEN
-                     vxc_SAOP(ispin)%pw%cr3d(i, j, k) = vxc_SAOP(ispin)%pw%cr3d(i, j, k)/ &
-                                                        rho_r(ispin)%pw%cr3d(i, j, k)
+                     vxc_SAOP(ispin)%cr3d(i, j, k) = vxc_SAOP(ispin)%cr3d(i, j, k)/ &
+                                                     rho_r(ispin)%pw%cr3d(i, j, k)
                   ELSE
-                     vxc_SAOP(ispin)%pw%cr3d(i, j, k) = 0.0_dp
+                     vxc_SAOP(ispin)%cr3d(i, j, k) = 0.0_dp
                   END IF
                END DO
             END DO
@@ -463,13 +461,13 @@ CONTAINS
       DO ispin = 1, nspins
 
          IF (oe_corr == oe_lb) THEN
-            vxc_SAOP(ispin)%pw%cr3d = vxc_LB(ispin)%pw%cr3d
+            vxc_SAOP(ispin)%cr3d = vxc_LB(ispin)%pw%cr3d
          ELSE IF (oe_corr == oe_gllb) THEN
-            vxc_SAOP(ispin)%pw%cr3d = vxc_GLLB(ispin)%pw%cr3d
+            vxc_SAOP(ispin)%cr3d = vxc_GLLB(ispin)%cr3d
          END IF
-         vxc_SAOP(ispin)%pw%cr3d = vxc_SAOP(ispin)%pw%cr3d*vxc_SAOP(ispin)%pw%pw_grid%dvol
+         vxc_SAOP(ispin)%cr3d = vxc_SAOP(ispin)%cr3d*vxc_SAOP(ispin)%pw_grid%dvol
 
-         CALL integrate_v_rspace(v_rspace=vxc_SAOP(ispin)%pw, pmat=rho_struct_ao(ispin), &
+         CALL integrate_v_rspace(v_rspace=vxc_SAOP(ispin), pmat=rho_struct_ao(ispin), &
                                  hmat=ks_matrix(ispin), qs_env=qs_env, &
                                  calculate_forces=.FALSE., &
                                  gapw=gapw)
@@ -477,9 +475,8 @@ CONTAINS
       END DO
 
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_SAOP(ispin)%pw)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_GLLB(ispin)%pw)
-         DEALLOCATE (vxc_SAOP(ispin)%pw, vxc_GLLB(ispin)%pw)
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_SAOP(ispin))
+         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_GLLB(ispin))
          CALL pw_release(vxc_LB(ispin)%pw)
          CALL pw_release(vxc_tmp(ispin)%pw)
          DEALLOCATE (vxc_LB(ispin)%pw, vxc_tmp(ispin)%pw)


### PR DESCRIPTION
This PR
- removes POINTER attributes from many pw_type
- converts (POINTER of) pw_p_type to (POINTER of) pw_type
- partially converts arrays of pw_p_type to arrays of pw_type (currently, we miss densities, XC potentials and derivatives of the Hartree potential)
- makes sporadic use of the BLOCK construct to restrict the scope of variables (should reduce the requirements on the stack)