### PR TITLE
Fix and improve RPA and SOS-MP2 gradients

### DIFF
--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -1329,6 +1329,8 @@ CONTAINS
       DEALLOCATE (mepos_2_grid)
       DEALLOCATE (sizes)
 
+      WRITE (*, *) "P ", mp2_env%ri_grad%P_mo(kspin)%matrix%local_data
+
       ! deallocate the local P_ab
       DEALLOCATE (mp2_env%ri_grad%P_ab(kspin)%array)
       CALL timestop(handle2)

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -1329,8 +1329,6 @@ CONTAINS
       DEALLOCATE (mepos_2_grid)
       DEALLOCATE (sizes)
 
-      WRITE (*, *) "P ", mp2_env%ri_grad%P_mo(kspin)%matrix%local_data
-
       ! deallocate the local P_ab
       DEALLOCATE (mp2_env%ri_grad%P_ab(kspin)%array)
       CALL timestop(handle2)

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -548,6 +548,13 @@ CONTAINS
             CALL mp_sendrecv(sos_mp2_work%index2send(pcol_send)%array, blacs2mpi(my_prow, pcol_send), &
                              sos_mp2_work%index2recv(pcol_recv)%array, blacs2mpi(my_prow, pcol_recv), &
                              para_env%group, tag)
+
+            ! Convert to global coordinates to local coordinates as we always work with them
+            DO counter = 1, data2send(pcol_send)
+               sos_mp2_work%index2send(pcol_send)%array(counter) = &
+                  cp_fm_indxg2l(sos_mp2_work%index2send(pcol_send)%array(counter), &
+                                ncol_block, 0, first_p_pos_col, num_pe_col)
+            END DO
          END DO
 
          CALL cp_para_env_release(para_env_exchange)
@@ -675,6 +682,13 @@ CONTAINS
             CALL mp_sendrecv(sos_mp2_work%index2send(pcol_send)%array, blacs2mpi(my_prow, pcol_send), &
                              sos_mp2_work%index2recv(pcol_recv)%array, blacs2mpi(my_prow, pcol_recv), &
                              para_env%group, tag)
+
+            ! Convert to global coordinates to local coordinates as we always work with them
+            DO counter = 1, data2send(pcol_send)
+               sos_mp2_work%index2send(pcol_send)%array(counter) = &
+                  cp_fm_indxg2l(sos_mp2_work%index2send(pcol_send)%array(counter), &
+                                ncol_block, 0, first_p_pos_col, num_pe_col)
+            END DO
          END DO
 
          CALL cp_para_env_release(para_env_exchange)
@@ -1273,8 +1287,7 @@ CONTAINS
             IF (ALLOCATED(index2send(pcol_send)%array)) send_size = SIZE(index2send(pcol_send)%array)
 
             DO counter = 1, send_size
-               col_local = cp_fm_indxg2l(index2send(pcol_send)%array(counter), ncol_block, 0, first_p_pos_col, num_pe_col)
-               buffer_send(:, counter) = fm_work_iaP%local_data(:, col_local)
+               buffer_send(:, counter) = fm_work_iaP%local_data(:, index2send(pcol_send)%array(counter))
             END DO
 
             recv_size = 0

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -409,7 +409,8 @@ CONTAINS
 ! Trivial cases: diagonal elements
       num_pairs = 0
       DO my_i = 1, num_orbitals
-      DO my_j = my_i + 1, num_orbitals
+      DO my_j = 1, num_orbitals
+         IF (my_i == my_j) CYCLE
          IF (ABS(Eigenval(my_i) - Eigenval(my_j)) < eps_degen) num_pairs = num_pairs + 1
       END DO
       END DO
@@ -418,12 +419,13 @@ CONTAINS
 ! Print the required pairs
       pair_counter = 1
       DO my_i = 1, num_orbitals
-      DO my_j = my_i + 1, num_orbitals
-      IF (ABS(Eigenval(my_i) - Eigenval(my_j)) < eps_degen) THEN
-         pair_list(1, pair_counter) = my_i
-         pair_list(2, pair_counter) = my_j
-         pair_counter = pair_counter + 1
-      END IF
+      DO my_j = 1, num_orbitals
+         IF (my_i == my_j) CYCLE
+         IF (ABS(Eigenval(my_i) - Eigenval(my_j)) < eps_degen) THEN
+            pair_list(1, pair_counter) = my_i
+            pair_list(2, pair_counter) = my_j
+            pair_counter = pair_counter + 1
+         END IF
       END DO
       END DO
 
@@ -1933,9 +1935,12 @@ CONTAINS
             my_j = sos_mp2_work_occ(ispin)%pair_list(2, ij_counter)
 
             mp2_env%ri_grad%P_ij(ispin)%array(my_i, my_j) = my_scale*sos_mp2_work_occ(ispin)%P(homo(ispin) + ij_counter)
-            mp2_env%ri_grad%P_ij(ispin)%array(my_j, my_i) = my_scale*sos_mp2_work_occ(ispin)%P(homo(ispin) + ij_counter)
          END DO
          DEALLOCATE (sos_mp2_work_occ(ispin)%P, sos_mp2_work_occ(ispin)%pair_list)
+
+         ! Symmetrize P_ij
+         mp2_env%ri_grad%P_ij(ispin)%array(:, :) = 0.5_dp*(mp2_env%ri_grad%P_ij(ispin)%array + &
+                                                           TRANSPOSE(mp2_env%ri_grad%P_ij(ispin)%array))
 
          ! The first index of P_ab has to be distributed within the subgroups, so sum it up first and add the required elements later
          CALL mp_sum(sos_mp2_work_virt(ispin)%P, para_env%group)
@@ -1954,11 +1959,51 @@ CONTAINS
 
             IF (my_a >= itmp(1) .AND. my_a <= itmp(2)) mp2_env%ri_grad%P_ab(ispin)%array(my_a - itmp(1) + 1, my_b) = &
                my_scale*sos_mp2_work_virt(ispin)%P(virtual(ispin) + ab_counter)
-            IF (my_b >= itmp(1) .AND. my_b <= itmp(2)) mp2_env%ri_grad%P_ab(ispin)%array(my_b - itmp(1) + 1, my_a) = &
-               my_scale*sos_mp2_work_virt(ispin)%P(virtual(ispin) + ab_counter)
          END DO
 
          DEALLOCATE (sos_mp2_work_virt(ispin)%P, sos_mp2_work_virt(ispin)%pair_list)
+
+         ! Symmetrize P_ab
+         IF (para_env_sub%num_pe > 1) THEN
+            BLOCK
+               INTEGER :: my_B_start, my_B_end, my_B_size, send_a_start, send_a_end, send_a_size, &
+                          recv_a_start, recv_a_end, recv_a_size, proc_shift, proc_send, proc_recv
+               REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE :: buffer_send, buffer_recv
+               TYPE(group_dist_d1_type)                           :: gd_virtual_sub
+               CALL create_group_dist(gd_virtual_sub, para_env_sub%num_pe, virtual(ispin))
+
+               mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_start:my_B_end) = &
+                  0.5_dp*(mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_start:my_B_end) &
+                          + TRANSPOSE(mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_start:my_B_end)))
+
+               ALLOCATE (buffer_send(my_B_size, maxsize(gd_virtual_sub)))
+               ALLOCATE (buffer_recv(my_B_size, maxsize(gd_virtual_sub)))
+
+               DO proc_shift = 1, para_env_sub%num_pe - 1
+
+                  proc_send = MODULO(para_env_sub%mepos + proc_shift, para_env_sub%num_pe)
+                  proc_recv = MODULO(para_env_sub%mepos - proc_shift, para_env_sub%num_pe)
+
+                  CALL get_group_dist(gd_virtual_sub, proc_send, send_a_start, send_a_end, send_a_size)
+                  CALL get_group_dist(gd_virtual_sub, proc_recv, recv_a_start, recv_a_end, recv_a_size)
+
+                  buffer_send(:, :send_a_size) = mp2_env%ri_grad%P_ab(ispin)%array(:, send_a_start:send_a_end)
+                  CALL mp_sendrecv(buffer_send(:, :send_a_size), proc_send, &
+                                   buffer_recv(:, :recv_a_size), proc_recv, para_env_sub%group)
+
+                  mp2_env%ri_grad%P_ab(ispin)%array(:, recv_a_start:recv_a_end) = &
+                     0.5_dp*(mp2_env%ri_grad%P_ab(ispin)%array(:, recv_a_start:recv_a_end) + buffer_send)
+
+               END DO
+
+               DEALLOCATE (buffer_send, buffer_recv)
+
+               CALL release_group_dist(gd_virtual_sub)
+            END BLOCK
+         ELSE
+            mp2_env%ri_grad%P_ab(ispin)%array(:, :) = 0.5_dp*(mp2_env%ri_grad%P_ab(ispin)%array + &
+                                                              TRANSPOSE(mp2_env%ri_grad%P_ab(ispin)%array))
+         END IF
 
       END DO
       DEALLOCATE (sos_mp2_work_occ, sos_mp2_work_virt)
@@ -2022,6 +2067,8 @@ CONTAINS
          mp2_env%ri_grad%P_ij(ispin)%array(my_i_start:my_i_end, :) = my_scale*rpa_work%P_ij(ispin)%array
          DEALLOCATE (rpa_work%P_ij(ispin)%array)
          CALL mp_sum(mp2_env%ri_grad%P_ij(ispin)%array, para_env%group)
+
+         ! Symmetrize P_ij
          mp2_env%ri_grad%P_ij(ispin)%array(:, :) = 0.5_dp*(mp2_env%ri_grad%P_ij(ispin)%array + &
                                                            TRANSPOSE(mp2_env%ri_grad%P_ij(ispin)%array))
 

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -1274,7 +1274,8 @@ CONTAINS
             IF (ALLOCATED(index2send(pcol_send)%array)) send_size = SIZE(index2send(pcol_send)%array)
 
             DO counter = 1, send_size
-               buffer_send(:, counter) = fm_work_iaP%local_data(:, index2send(pcol_send)%array(counter))
+               col_local = cp_fm_indxg2l(index2send(pcol_send)%array(counter), ncol_block, 0, first_p_pos_col, num_pe_col)
+               buffer_send(:, counter) = fm_work_iaP%local_data(:, col_local)
             END DO
 
             recv_size = 0

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -38,6 +38,7 @@ MODULE rpa_grad
                                               group_dist_proc,&
                                               maxsize,&
                                               release_group_dist
+USE kahan_sum, ONLY: accurate_dot_product
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE libint_2c_3c,                    ONLY: compare_potential_types
@@ -1206,7 +1207,7 @@ CONTAINS
          recv_size, send_size, size_recv_buffer, size_send_buffer, tag
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, ncol_locals
       INTEGER, DIMENSION(:, :), POINTER                  :: blacs2mpi
-      REAL(KIND=dp)                                      :: ddot, trace
+      REAL(KIND=dp)                                      :: trace
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: buffer_recv, buffer_send
       TYPE(cp_blacs_env_type), POINTER                   :: context
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1241,7 +1242,7 @@ CONTAINS
 
             my_col_local = cp_fm_indxg2l((my_i - 1)*virtual + avirt, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-            trace = ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, fm_work_iaP%local_data(:, col_local), 1)
+            trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
 
             P_ij(ij_counter) = P_ij(ij_counter) &
                                - trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
@@ -1334,7 +1335,7 @@ CONTAINS
 
                      my_col_local = cp_fm_indxg2l((my_i - 1)*virtual + avirt, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-                     trace = trace + ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, buffer_recv(:, col_local), 1)
+                     trace = trace + accurate_dot_product(fm_mat_S%local_data(:, my_col_local), buffer_recv(:, col_local))
                   END DO
 
                   P_ij(ij_counter) = P_ij(ij_counter) &
@@ -1384,7 +1385,7 @@ CONTAINS
          proc_shift, recv_size, send_size, size_recv_buffer, size_send_buffer, tag
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, ncol_locals
       INTEGER, DIMENSION(:, :), POINTER                  :: blacs2mpi
-      REAL(KIND=dp)                                      :: ddot, trace
+      REAL(KIND=dp)                                      :: trace
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: buffer_recv, buffer_send
       TYPE(cp_blacs_env_type), POINTER                   :: context
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1418,7 +1419,7 @@ CONTAINS
             IF (pcol /= my_pcol) CYCLE
             my_col_local = cp_fm_indxg2l((iocc - 1)*virtual + my_a, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-            trace = ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, fm_work_iaP%local_data(:, col_local), 1)
+            trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
 
             P_ab(ab_counter) = P_ab(ab_counter) &
                                - trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
@@ -1511,7 +1512,7 @@ CONTAINS
 
                      my_col_local = cp_fm_indxg2l((iocc - 1)*virtual + my_a, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-                     trace = trace + ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, buffer_recv(:, col_local), 1)
+                     trace = trace + accurate_dot_product(fm_mat_S%local_data(:, my_col_local), buffer_recv(:, col_local))
                   END DO
 
                   P_ab(ab_counter) = P_ab(ab_counter) &

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -38,7 +38,6 @@ MODULE rpa_grad
                                               group_dist_proc,&
                                               maxsize,&
                                               release_group_dist
-   USE kahan_sum,                       ONLY: accurate_dot_product
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE libint_2c_3c,                    ONLY: compare_potential_types
@@ -1206,7 +1205,7 @@ CONTAINS
          recv_size, send_size, size_recv_buffer, size_send_buffer, tag
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, ncol_locals
       INTEGER, DIMENSION(:, :), POINTER                  :: blacs2mpi
-      REAL(KIND=dp)                                      :: trace
+      REAL(KIND=dp)                                      :: ddot, trace
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: buffer_recv, buffer_send
       TYPE(cp_blacs_env_type), POINTER                   :: context
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1241,7 +1240,7 @@ CONTAINS
 
             my_col_local = cp_fm_indxg2l((my_i - 1)*virtual + avirt, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-            trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
+            trace = ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, fm_work_iaP%local_data(:, col_local), 1)
 
             P_ij(ij_counter) = P_ij(ij_counter) &
                                - trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
@@ -1310,7 +1309,7 @@ CONTAINS
 
                      my_col_local = cp_fm_indxg2l((my_i - 1)*virtual + avirt, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-                     trace = trace + accurate_dot_product(fm_mat_S%local_data(:, my_col_local), buffer_recv(:, col_local))
+                     trace = trace + ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, buffer_recv(:, col_local), 1)
                   END DO
 
                   P_ij(ij_counter) = P_ij(ij_counter) &
@@ -1360,7 +1359,7 @@ CONTAINS
          proc_shift, recv_size, send_size, size_recv_buffer, size_send_buffer, tag
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, ncol_locals
       INTEGER, DIMENSION(:, :), POINTER                  :: blacs2mpi
-      REAL(KIND=dp)                                      :: trace
+      REAL(KIND=dp)                                      :: ddot, trace
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: buffer_recv, buffer_send
       TYPE(cp_blacs_env_type), POINTER                   :: context
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1394,7 +1393,7 @@ CONTAINS
             IF (pcol /= my_pcol) CYCLE
             my_col_local = cp_fm_indxg2l((iocc - 1)*virtual + my_a, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-            trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
+            trace = ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, fm_work_iaP%local_data(:, col_local), 1)
 
             P_ab(ab_counter) = P_ab(ab_counter) &
                                + trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
@@ -1462,7 +1461,7 @@ CONTAINS
 
                      my_col_local = cp_fm_indxg2l((iocc - 1)*virtual + my_a, ncol_block, 0, first_p_pos_col, num_pe_col)
 
-                     trace = trace + accurate_dot_product(fm_mat_S%local_data(:, my_col_local), buffer_recv(:, col_local))
+                     trace = trace + ddot(nrow_local, fm_mat_S%local_data(:, my_col_local), 1, buffer_recv(:, col_local), 1)
                   END DO
 
                   P_ab(ab_counter) = P_ab(ab_counter) &

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -1654,8 +1654,6 @@ CONTAINS
          CALL rpa_grad_work_finalize(rpa_grad%rpa_work, mp2_env, homo, &
                                      virtual, para_env, para_env_sub)
       END IF
-      !IF (para_env%mepos == 0) WRITE (*, *) "P_ij", mp2_env%ri_grad%P_ij(1)%array
-      !IF (para_env%mepos == 0) WRITE (*, *) "P_ab1", mp2_env%ri_grad%P_ab(1)%array
 
       CALL get_qs_env(qs_env, blacs_env=blacs_env)
 
@@ -1885,8 +1883,6 @@ CONTAINS
             my_j = sos_mp2_work_occ(ispin)%pair_list(2, ij_counter)
 
             mp2_env%ri_grad%P_ij(ispin)%array(my_i, my_j) = my_scale*sos_mp2_work_occ(ispin)%P(homo(ispin) + ij_counter)
-            IF (para_env%mepos == 0) WRITE (*, *) "P_ij", my_i, my_j, &
-               sos_mp2_work_occ(ispin)%P(homo(ispin) + ij_counter)
          END DO
          DEALLOCATE (sos_mp2_work_occ(ispin)%P, sos_mp2_work_occ(ispin)%pair_list)
 
@@ -1911,8 +1907,6 @@ CONTAINS
 
             IF (my_a >= itmp(1) .AND. my_a <= itmp(2)) mp2_env%ri_grad%P_ab(ispin)%array(my_a - itmp(1) + 1, my_b) = &
                my_scale*sos_mp2_work_virt(ispin)%P(virtual(ispin) + ab_counter)
-            IF (para_env%mepos == 0) WRITE (*, *) "P_ab ", my_a, my_b, &
-               sos_mp2_work_virt(ispin)%P(virtual(ispin) + ab_counter)
          END DO
 
          DEALLOCATE (sos_mp2_work_virt(ispin)%P, sos_mp2_work_virt(ispin)%pair_list)

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -38,7 +38,7 @@ MODULE rpa_grad
                                               group_dist_proc,&
                                               maxsize,&
                                               release_group_dist
-USE kahan_sum, ONLY: accurate_dot_product
+   USE kahan_sum,                       ONLY: accurate_dot_product
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE libint_2c_3c,                    ONLY: compare_potential_types
@@ -1238,7 +1238,7 @@ CONTAINS
 
             IF (iocc /= my_j) CYCLE
             pcol = cp_fm_indxg2p((my_i - 1)*virtual + avirt, ncol_block, 0, first_p_pos_col, num_pe_col)
-            IF (pcol /= pcol_send) CYCLE
+            IF (pcol /= my_pcol) CYCLE
 
             my_col_local = cp_fm_indxg2l((my_i - 1)*virtual + avirt, ncol_block, 0, first_p_pos_col, num_pe_col)
 

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -484,7 +484,6 @@ CONTAINS
 
          DO proc_shift = 0, num_pe_col - 1
             pcol_send = MODULO(my_pcol + proc_shift, num_pe_col)
-            pcol_recv = MODULO(my_pcol - proc_shift, num_pe_col)
 
             counter = 0
             DO col_local = 1, ncol_local
@@ -1245,7 +1244,7 @@ CONTAINS
             trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
 
             P_ij(ij_counter) = P_ij(ij_counter) &
-                               - trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
+                               - 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
 
             EXIT
 
@@ -1276,32 +1275,9 @@ CONTAINS
             send_size = 0
             IF (ALLOCATED(index2send(pcol_send)%array)) send_size = SIZE(index2send(pcol_send)%array)
 
-            IF (send_size > 0) THEN
-               counter = 0
-               DO col_local = 1, ncol_local
-                  col_global = col_indices(col_local)
-
-                  iocc = MAX(1, col_global - 1)/virtual + 1
-                  avirt = col_global - (iocc - 1)*virtual
-
-                  DO ij_counter = 1, num_ij_pairs
-
-                     my_i = pair_list(1, ij_counter)
-                     my_j = pair_list(2, ij_counter)
-
-                     IF (iocc /= my_j) CYCLE
-                     pcol = cp_fm_indxg2p((my_i - 1)*virtual + avirt, ncol_block, 0, first_p_pos_col, num_pe_col)
-                     IF (pcol /= pcol_send) CYCLE
-
-                     counter = counter + 1
-
-                     buffer_send(:, counter) = fm_work_iaP%local_data(:, col_local)
-
-                     EXIT
-
-                  END DO
-               END DO
-            END IF
+            DO counter = 1, send_size
+               buffer_send(:, counter) = fm_work_iaP%local_data(:, index2send(pcol_send)%array(counter))
+            END DO
 
             recv_size = 0
             IF (ALLOCATED(index2recv(pcol_recv)%array)) recv_size = SIZE(index2recv(pcol_recv)%array)
@@ -1339,7 +1315,7 @@ CONTAINS
                   END DO
 
                   P_ij(ij_counter) = P_ij(ij_counter) &
-                                     - trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
+                                     - 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
                END DO
             ELSE IF (send_size > 0) THEN
                CALL timeset(routineN//"_send", handle2)
@@ -1422,7 +1398,7 @@ CONTAINS
             trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
 
             P_ab(ab_counter) = P_ab(ab_counter) &
-                               - trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
+                               + 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
 
             EXIT
 
@@ -1453,32 +1429,9 @@ CONTAINS
             send_size = 0
             IF (ALLOCATED(index2send(pcol_send)%array)) send_size = SIZE(index2send(pcol_send)%array)
 
-            IF (send_size > 0) THEN
-               counter = 0
-               DO col_local = 1, ncol_local
-                  col_global = col_indices(col_local)
-
-                  iocc = MAX(1, col_global - 1)/virtual + 1
-                  avirt = col_global - (iocc - 1)*virtual
-
-                  DO ab_counter = 1, num_ab_pairs
-
-                     my_a = pair_list(1, ab_counter)
-                     my_b = pair_list(2, ab_counter)
-
-                     IF (avirt /= my_b) CYCLE
-                     pcol = cp_fm_indxg2p((iocc - 1)*virtual + my_a, ncol_block, 0, first_p_pos_col, num_pe_col)
-                     IF (pcol /= pcol_send) CYCLE
-
-                     counter = counter + 1
-
-                     buffer_send(:, counter) = fm_work_iaP%local_data(:, col_local)
-
-                     EXIT
-
-                  END DO
-               END DO
-            END IF
+            DO counter = 1, send_size
+               buffer_send(:, counter) = fm_work_iaP%local_data(:, index2send(pcol_send)%array(counter))
+            END DO
 
             recv_size = 0
             IF (ALLOCATED(index2recv(pcol_recv)%array)) recv_size = SIZE(index2recv(pcol_recv)%array)
@@ -1516,7 +1469,7 @@ CONTAINS
                   END DO
 
                   P_ab(ab_counter) = P_ab(ab_counter) &
-                                     - trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
+                                     + 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
 
                END DO
             ELSE IF (send_size > 0) THEN
@@ -1608,11 +1561,9 @@ CONTAINS
 
             send_size = 0
             IF (ALLOCATED(index2send(proc_send)%array)) send_size = SIZE(index2send(proc_send)%array)
-            IF (send_size > 0) THEN
-               DO col_local = 1, send_size
-                  buffer_send(:, col_local) = fm_mat_S%local_data(:, index2send(proc_send)%array(col_local))
-               END DO
-            END IF
+            DO col_local = 1, send_size
+               buffer_send(:, col_local) = fm_mat_S%local_data(:, index2send(proc_send)%array(col_local))
+            END DO
 
             recv_size = 0
             IF (ALLOCATED(index2recv(proc_recv)%array)) recv_size = SIZE(index2recv(proc_recv)%array, 2)
@@ -1707,6 +1658,8 @@ CONTAINS
          CALL rpa_grad_work_finalize(rpa_grad%rpa_work, mp2_env, homo, &
                                      virtual, para_env, para_env_sub)
       END IF
+      !IF (para_env%mepos == 0) WRITE (*, *) "P_ij", mp2_env%ri_grad%P_ij(1)%array
+      !IF (para_env%mepos == 0) WRITE (*, *) "P_ab1", mp2_env%ri_grad%P_ab(1)%array
 
       CALL get_qs_env(qs_env, blacs_env=blacs_env)
 
@@ -1936,6 +1889,8 @@ CONTAINS
             my_j = sos_mp2_work_occ(ispin)%pair_list(2, ij_counter)
 
             mp2_env%ri_grad%P_ij(ispin)%array(my_i, my_j) = my_scale*sos_mp2_work_occ(ispin)%P(homo(ispin) + ij_counter)
+            IF (para_env%mepos == 0) WRITE (*, *) "P_ij", my_i, my_j, &
+               sos_mp2_work_occ(ispin)%P(homo(ispin) + ij_counter)
          END DO
          DEALLOCATE (sos_mp2_work_occ(ispin)%P, sos_mp2_work_occ(ispin)%pair_list)
 
@@ -1960,6 +1915,8 @@ CONTAINS
 
             IF (my_a >= itmp(1) .AND. my_a <= itmp(2)) mp2_env%ri_grad%P_ab(ispin)%array(my_a - itmp(1) + 1, my_b) = &
                my_scale*sos_mp2_work_virt(ispin)%P(virtual(ispin) + ab_counter)
+            IF (para_env%mepos == 0) WRITE (*, *) "P_ab ", my_a, my_b, &
+               sos_mp2_work_virt(ispin)%P(virtual(ispin) + ab_counter)
          END DO
 
          DEALLOCATE (sos_mp2_work_virt(ispin)%P, sos_mp2_work_virt(ispin)%pair_list)

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -1244,9 +1244,7 @@ CONTAINS
             trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
 
             P_ij(ij_counter) = P_ij(ij_counter) &
-                               - 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
-
-            EXIT
+                               - trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
 
          END DO
       END DO
@@ -1315,7 +1313,7 @@ CONTAINS
                   END DO
 
                   P_ij(ij_counter) = P_ij(ij_counter) &
-                                     - 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
+                                     - trace*sinh_over_x(0.5_dp*(Eigenval(my_i) - Eigenval(my_j))*omega)*omega*weight
                END DO
             ELSE IF (send_size > 0) THEN
                CALL timeset(routineN//"_send", handle2)
@@ -1398,9 +1396,7 @@ CONTAINS
             trace = accurate_dot_product(fm_mat_S%local_data(:, my_col_local), fm_work_iaP%local_data(:, col_local))
 
             P_ab(ab_counter) = P_ab(ab_counter) &
-                               + 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
-
-            EXIT
+                               + trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
 
          END DO
       END DO
@@ -1469,7 +1465,7 @@ CONTAINS
                   END DO
 
                   P_ab(ab_counter) = P_ab(ab_counter) &
-                                     + 2.0_dp*trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
+                                     + trace*sinh_over_x(0.5_dp*(Eigenval(my_a) - Eigenval(my_b))*omega)*omega*weight
 
                END DO
             ELSE IF (send_size > 0) THEN

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -1913,6 +1913,10 @@ CONTAINS
             IF (ALLOCATED(sos_mp2_work_virt(ispin)%index2recv(pcol)%array)) &
                DEALLOCATE (sos_mp2_work_virt(ispin)%index2recv(pcol)%array)
          END DO
+         DEALLOCATE (sos_mp2_work_occ(ispin)%index2send, &
+                     sos_mp2_work_occ(ispin)%index2recv, &
+                     sos_mp2_work_virt(ispin)%index2send, &
+                     sos_mp2_work_virt(ispin)%index2recv)
       END DO
 
       ! Sum P_ij and P_ab and redistribute them
@@ -1986,8 +1990,8 @@ CONTAINS
 
       INTEGER :: handle, ispin, itmp(2), my_a_end, my_a_size, my_a_start, my_B_end, my_B_size, &
          my_B_start, my_i_end, my_i_size, my_i_start, nspins, proc, proc_recv, proc_send, &
-         proc_shift, recv_a_end, recv_a_start, recv_end, recv_start, send_a_end, send_a_start, &
-         send_end, send_start, size_recv_buffer, size_send_buffer
+         proc_shift, recv_a_end, recv_a_size, recv_a_start, recv_end, recv_start, send_a_end, &
+         send_a_size, send_a_start, send_end, send_start, size_recv_buffer, size_send_buffer
       REAL(KIND=dp)                                      :: my_scale
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: buffer_recv, buffer_send
       TYPE(cp_para_env_type), POINTER                    :: para_env_exchange
@@ -2018,6 +2022,8 @@ CONTAINS
          mp2_env%ri_grad%P_ij(ispin)%array(my_i_start:my_i_end, :) = my_scale*rpa_work%P_ij(ispin)%array
          DEALLOCATE (rpa_work%P_ij(ispin)%array)
          CALL mp_sum(mp2_env%ri_grad%P_ij(ispin)%array, para_env%group)
+         mp2_env%ri_grad%P_ij(ispin)%array(:, :) = 0.5_dp*(mp2_env%ri_grad%P_ij(ispin)%array + &
+                                                           TRANSPOSE(mp2_env%ri_grad%P_ij(ispin)%array))
 
          itmp = get_limit(virtual(ispin), para_env_sub%num_pe, para_env_sub%mepos)
          my_B_start = itmp(1)
@@ -2043,8 +2049,7 @@ CONTAINS
          recv_end = MIN(my_B_size, my_a_end - my_B_start + 1)
 
          mp2_env%ri_grad%P_ab(ispin)%array(recv_start:recv_end, :) = &
-            mp2_env%ri_grad%P_ab(ispin)%array(recv_start:recv_end, :) &
-            + my_scale*rpa_work%P_ab(ispin)%array(send_start:send_end, :)
+            my_scale*rpa_work%P_ab(ispin)%array(send_start:send_end, :)
 
          IF (para_env_sub%num_pe > 1) THEN
             size_send_buffer = 0
@@ -2090,7 +2095,8 @@ CONTAINS
                                 buffer_recv(1:MAX(recv_end - recv_start + 1, 0), :), proc_recv, para_env_sub%group)
 
                mp2_env%ri_grad%P_ab(ispin)%array(recv_start:recv_end, :) = &
-            mp2_env%ri_grad%P_ab(ispin)%array(recv_start:recv_end, :) + my_scale*buffer_recv(1:MAX(recv_end - recv_start + 1, 0), :)
+                  mp2_env%ri_grad%P_ab(ispin)%array(recv_start:recv_end, :) + &
+                  my_scale*buffer_recv(1:MAX(recv_end - recv_start + 1, 0), :)
 
             END DO
 
@@ -2099,12 +2105,46 @@ CONTAINS
          END IF
          DEALLOCATE (rpa_work%P_ab(ispin)%array)
 
-         CALL release_group_dist(gd_virtual_sub)
          CALL release_group_dist(gd_a_sub)
 
          CALL cp_para_env_split(para_env_exchange, para_env, para_env_sub%mepos)
          CALL mp_sum(mp2_env%ri_grad%P_ab(ispin)%array, para_env_exchange%group)
          CALL cp_para_env_release(para_env_exchange)
+
+         ! Symmetrize P_ab
+         IF (para_env_sub%num_pe > 1) THEN
+
+            mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_start:my_B_end) = &
+               0.5_dp*(mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_start:my_B_end) &
+                       + TRANSPOSE(mp2_env%ri_grad%P_ab(ispin)%array(:, my_B_start:my_B_end)))
+
+            ALLOCATE (buffer_send(my_B_size, maxsize(gd_virtual_sub)))
+            ALLOCATE (buffer_recv(my_B_size, maxsize(gd_virtual_sub)))
+
+            DO proc_shift = 1, para_env_sub%num_pe - 1
+
+               proc_send = MODULO(para_env_sub%mepos + proc_shift, para_env_sub%num_pe)
+               proc_recv = MODULO(para_env_sub%mepos - proc_shift, para_env_sub%num_pe)
+
+               CALL get_group_dist(gd_virtual_sub, proc_send, send_a_start, send_a_end, send_a_size)
+               CALL get_group_dist(gd_virtual_sub, proc_recv, recv_a_start, recv_a_end, recv_a_size)
+
+               buffer_send(:, :send_a_size) = mp2_env%ri_grad%P_ab(ispin)%array(:, send_a_start:send_a_end)
+               CALL mp_sendrecv(buffer_send(:, :send_a_size), proc_send, &
+                                buffer_recv(:, :recv_a_size), proc_recv, para_env_sub%group)
+
+               mp2_env%ri_grad%P_ab(ispin)%array(:, recv_a_start:recv_a_end) = &
+                  0.5_dp*(mp2_env%ri_grad%P_ab(ispin)%array(:, recv_a_start:recv_a_end) + buffer_send)
+
+            END DO
+
+            DEALLOCATE (buffer_send, buffer_recv)
+         ELSE
+            mp2_env%ri_grad%P_ab(ispin)%array(:, :) = 0.5_dp*(mp2_env%ri_grad%P_ab(ispin)%array + &
+                                                              TRANSPOSE(mp2_env%ri_grad%P_ab(ispin)%array))
+         END IF
+
+         CALL release_group_dist(gd_virtual_sub)
 
       END DO
       DEALLOCATE (rpa_work%gd_homo, rpa_work%gd_virtual, rpa_work%P_ij, rpa_work%P_ab)

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -540,8 +540,12 @@ CONTAINS
 
       CALL timestop(handle2)
 
-      NULLIFY (para_env_RPA)
-      CALL cp_para_env_split(para_env_RPA, para_env, color_rpa_group)
+      IF (num_integ_group > 1) THEN
+         NULLIFY (para_env_RPA)
+         CALL cp_para_env_split(para_env_RPA, para_env, color_rpa_group)
+      ELSE
+         para_env_RPA => para_env
+      END IF
 
       ! now create the matrices needed for the calculation, Q, S and G
       ! Q and G will have omega dependence
@@ -632,7 +636,7 @@ CONTAINS
 
       CALL release_group_dist(gd_array)
 
-      CALL cp_para_env_release(para_env_RPA)
+      IF (num_integ_group > 1) CALL cp_para_env_release(para_env_RPA)
 
       IF (.NOT. do_im_time) THEN
          DO ispin = 1, SIZE(fm_mat_Q_gemm)

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -76,7 +76,8 @@ MODULE rpa_main
                                               three_dim_real_array,&
                                               two_dim_int_array,&
                                               two_dim_real_array
-   USE qs_environment_types,            ONLY: qs_environment_type
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
    USE rpa_axk,                         ONLY: compute_axk_ener
    USE rpa_grad,                        ONLY: rpa_grad_copy_Q,&
                                               rpa_grad_create,&
@@ -570,7 +571,7 @@ CONTAINS
                             my_group_L_size, my_group_L_start, my_group_L_end, &
                             para_env_RPA, fm_mat_S, nrow_block_mat, ncol_block_mat, &
                             dimen_ia_for_block_size=dimen_ia(1), &
-                            do_im_time=do_im_time, fm_mat_Q_gemm=fm_mat_Q_gemm, fm_mat_Q=fm_mat_Q)
+                            do_im_time=do_im_time, fm_mat_Q_gemm=fm_mat_Q_gemm, fm_mat_Q=fm_mat_Q, qs_env=qs_env)
 
       DEALLOCATE (BIb_C_2D, my_ia_end, my_ia_size, my_ia_start)
 
@@ -806,6 +807,7 @@ CONTAINS
 !> \param do_im_time ...
 !> \param fm_mat_Q_gemm ...
 !> \param fm_mat_Q ...
+!> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE create_integ_mat(BIb_C_2D, para_env, para_env_sub, color_sub, ngroup, integ_group_size, &
                                dimen_RI, dimen_ia, color_rpa_group, &
@@ -814,7 +816,7 @@ CONTAINS
                                my_group_L_size, my_group_L_start, my_group_L_end, &
                                para_env_RPA, fm_mat_S, nrow_block_mat, ncol_block_mat, &
                                blacs_env_ext, blacs_env_ext_S, dimen_ia_for_block_size, &
-                               do_im_time, fm_mat_Q_gemm, fm_mat_Q)
+                               do_im_time, fm_mat_Q_gemm, fm_mat_Q, qs_env)
 
       TYPE(two_dim_real_array), DIMENSION(:), &
          INTENT(INOUT)                                   :: BIb_C_2D
@@ -834,6 +836,8 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: dimen_ia_for_block_size
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_im_time
       TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL         :: fm_mat_Q_gemm, fm_mat_Q
+      TYPE(qs_environment_type), INTENT(IN), OPTIONAL, &
+         POINTER                                         :: qs_env
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'create_integ_mat'
 
@@ -977,6 +981,8 @@ CONTAINS
          NULLIFY (blacs_env_Q)
          IF (my_blacs_ext) THEN
             blacs_env_Q => blacs_env_ext
+         ELSE IF (para_env_RPA%num_pe == para_env%num_pe .AND. PRESENT(qs_env)) THEN
+            CALL get_qs_env(qs_env, blacs_env=blacs_env_Q)
          ELSE
             CALL cp_blacs_env_create(blacs_env=blacs_env_Q, para_env=para_env_RPA)
          END IF
@@ -990,11 +996,11 @@ CONTAINS
 
          CALL cp_fm_struct_release(fm_struct)
 
-         IF (.NOT. my_blacs_ext) CALL cp_blacs_env_release(blacs_env_Q)
+         IF (.NOT. (my_blacs_ext .OR. (para_env_RPA%num_pe == para_env%num_pe .AND. PRESENT(qs_env)))) &
+            CALL cp_blacs_env_release(blacs_env_Q)
       END IF
 
       ! release blacs_env
-      IF (.NOT. my_blacs_ext) CALL cp_blacs_env_release(blacs_env_Q)
       IF (.NOT. my_blacs_S_ext) CALL cp_blacs_env_release(blacs_env)
 
       CALL timestop(handle)

--- a/tests/QS/regtest-sos-mp2-grad/RI_laplace_MP2_H2O_degen.inp
+++ b/tests/QS/regtest-sos-mp2-grad/RI_laplace_MP2_H2O_degen.inp
@@ -48,7 +48,7 @@
         &CANONICAL_GRADIENTS
           # This increases the computational costs significantly as the default suffices
           # We use it just to test the code path with degenerate orbital pairs
-          EPS_CANONICAL 0.1
+          EPS_CANONICAL 1.0
         &END
         &RI_SOS_MP2
           QUADRATURE_POINTS  4


### PR DESCRIPTION
- There was some bug with the SOS-MP2 gradients in case that nearly degenerate occupied orbital pairs are present. Adjust the regtest
- Improve the numerical accuracy by symmetrizing the diagonal blocks of the density matrix
- Use the already available contexts and communicators in case of all quadrature points being calculated from all processes to save memory