### PR TITLE
Adapt linker syntax for MacOS

### DIFF
--- a/arch/Darwin-arm64.psmp
+++ b/arch/Darwin-arm64.psmp
@@ -1,0 +1,306 @@
+#!/bin/bash
+#
+# CP2K Darwin arch file for a parallel arm64 binary
+#
+# Tested with: GNU 12.2.0, MPICH 3.4.3,
+#              ScaLAPACK 2.1.0, OpenBLAS 0.3.21, FFTW 3.3.10, LIBINT 2.6.0,
+#              LIBXC 6.0.0, SPGLIB 1.16.2,
+#              LIBVORI 220621, GSL 2.7, COSMA 2.6.2, SIRIUS 7.3.2
+# on an Apple M1 (macOS Ventura 13.0.1)
+#
+# Usage: Source this arch file and then run make as instructed.
+#
+# Author: Matthias Krack (16.11.2022)
+#
+# \
+   if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
+      echo "ERROR: Script ${0##*/} must be sourced"; \
+      echo "Usage: source ${0##*/}"; \
+      exit 1; \
+   fi; \
+   this_file=${BASH_SOURCE##*/}; \
+   cd tools/toolchain; \
+   [[ -z "${mpi_implementation}" ]] && mpi_implementation="mpich"; \
+   [[ -z "${target_cpu}" ]] && target_cpu="native"; \
+   if $(command -v brew >/dev/null 2>&1); then \
+      brew install cmake; \
+      brew install coreutils; \
+      brew install gcc; \
+      brew install pkg-config; \
+   else \
+      echo "ERROR: Homebrew installation not found"; \
+      cd ../..; \
+      return 1; \
+   fi; \
+   ./install_cp2k_toolchain.sh --install-all --no-arch-files --target-cpu=${target_cpu} --with-cmake=system --with-gcc=system --with-${mpi_implementation} --with-elpa=no --with-libxsmm=no --with-pexsi=no --with-plumed=no --with-quip=no; \
+   source ./install/setup; \
+   cd ../..; \
+   echo; \
+   echo "Check the output above for error messages and consistency!"; \
+   echo "If everything is OK, you can build a CP2K production binary with"; \
+   echo "   make -j ARCH=${this_file%.*} VERSION=${this_file##*.}"; \
+   echo "Alternatively, you can add further checks, e.g. for regression testing, with"; \
+   echo "   make -j ARCH=${this_file%.*} VERSION=${this_file##*.} DO_CHECKS=yes"; \
+   return
+
+# Set options
+DO_CHECKS      := no
+SHARED         := no
+TARGET_CPU     := native
+USE_COSMA      := 2.6.2
+USE_FFTW       := 3.3.10
+USE_LIBINT     := 2.6.0
+USE_LIBVORI    := 220621
+USE_LIBXC      := 6.0.0
+USE_OPENBLAS   := 0.3.21
+#USE_PLUMED     := 2.8.0
+USE_SCALAPACK  := 2.1.0
+USE_SIRIUS     := 7.3.2
+USE_SPGLIB     := 1.16.2
+
+LMAX           := 5
+MAX_CONTR      := 4
+
+CC             := mpicc
+FC             := mpif90
+LD             := mpif90
+AR             := ar -r -s
+
+CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)
+
+DFLAGS         := -D__parallel
+DFLAGS         += -D__SCALAPACK
+DFLAGS         += -D__HAS_IEEE_EXCEPTIONS
+DFLAGS         += -D__MPI_VERSION=3
+DFLAGS         += -D__MAX_CONTR=$(strip $(MAX_CONTR))
+DFLAGS         += -D__NO_STATM_ACCESS
+
+INSTALL_PATH   := $(PWD)/tools/toolchain/install
+
+ifeq ($(SHARED), yes)
+   LD_SHARED      := $(FC) -shared
+   CFLAGS         += -fPIC
+   LDFLAGS        := -Wl,--enable-new-dtags
+   CP2K_LIB       := $(PWD)/lib/$(ARCH)/$(ONEVERSION)
+   LDFLAGS        += -Wl,-rpath,$(CP2K_LIB)
+   LDFLAGS        += -Wl,-rpath,$(CP2K_LIB)/exts/dbcsr
+endif
+
+# Settings for regression testing
+ifeq ($(DO_CHECKS), yes)
+   DFLAGS         += -D__CHECK_DIAG
+#  CFLAGS_DEBUG   := -fsanitize=address
+#  CFLAGS_DEBUG   := -fsanitize=leak
+   FCFLAGS_DEBUG  := -fcheck=bounds,do,recursion,pointer
+   FCFLAGS_DEBUG  += -fcheck=all,no-array-temps
+   FCFLAGS_DEBUG  += -ffpe-trap=invalid,overflow,zero
+   FCFLAGS_DEBUG  += -fimplicit-none
+   FCFLAGS_DEBUG  += -finit-derived
+   FCFLAGS_DEBUG  += -finit-real=snan
+   FCFLAGS_DEBUG  += -finit-integer=-42
+   FCFLAGS_DEBUG  += -finline-matmul-limit=0
+   WFLAGS         := -Werror=aliasing
+   WFLAGS         += -Werror=ampersand
+   WFLAGS         += -Werror=c-binding-type
+   WFLAGS         += -Werror=conversion
+   WFLAGS         += -Werror=intrinsic-shadow
+   WFLAGS         += -Werror=intrinsics-std
+   WFLAGS         += -Werror=line-truncation
+   WFLAGS         += -Wrealloc-lhs
+   WFLAGS         += -Werror=tabs
+   WFLAGS         += -Werror=target-lifetime
+   WFLAGS         += -Werror=underflow
+   WFLAGS         += -Werror=unused-but-set-variable
+   WFLAGS         += -Werror=unused-dummy-argument
+   WFLAGS         += -Werror=unused-variable
+endif
+
+ifneq ($(USE_PLUMED),)
+   USE_GSL        := 2.7
+   USE_PLUMED     := $(strip $(USE_PLUMED))
+   PLUMED_LIB     := $(INSTALL_PATH)/plumed-$(USE_PLUMED)/lib
+   DFLAGS         += -D__PLUMED2
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(PLUMED_LIB) -L$(PLUMED_LIB) -lplumed -lplumedKernel
+   else
+      LIBS           += $(PLUMED_LIB)/libplumed.a
+   endif
+endif
+
+ifneq ($(USE_LIBVORI),)
+   USE_LIBVORI    := $(strip $(USE_LIBVORI))
+   LIBVORI_LIB    := $(INSTALL_PATH)/libvori-$(USE_LIBVORI)/lib
+   DFLAGS         += -D__LIBVORI
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(LIBVORI_LIB) -L$(LIBVORI_LIB) -lvori
+   else
+      LIBS           += $(LIBVORI_LIB)/libvori.a
+   endif
+endif
+
+ifneq ($(USE_LIBXC),)
+   USE_LIBXC      := $(strip $(USE_LIBXC))
+   LIBXC_INC      := $(INSTALL_PATH)/libxc-$(USE_LIBXC)/include
+   LIBXC_LIB      := $(INSTALL_PATH)/libxc-$(USE_LIBXC)/lib
+   CFLAGS         += -I$(LIBXC_INC)
+   DFLAGS         += -D__LIBXC
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(LIBXC_LIB) -L$(LIBXC_LIB) -lxcf03 -lxc
+   else
+      LIBS           += $(LIBXC_LIB)/libxcf03.a
+      LIBS           += $(LIBXC_LIB)/libxc.a
+   endif
+endif
+
+ifneq ($(USE_LIBINT),)
+   USE_LIBINT     := $(strip $(USE_LIBINT))
+   LMAX           := $(strip $(LMAX))
+   LIBINT_INC     := $(INSTALL_PATH)/libint-v$(USE_LIBINT)-cp2k-lmax-$(LMAX)/include
+   LIBINT_LIB     := $(INSTALL_PATH)/libint-v$(USE_LIBINT)-cp2k-lmax-$(LMAX)/lib
+   CFLAGS         += -I$(LIBINT_INC)
+   DFLAGS         += -D__LIBINT
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(LIBINT_LIB) -L$(LIBINT_LIB) -lint2
+   else
+      LIBS           += $(LIBINT_LIB)/libint2.a
+      LIBS           += $(LIBINT_LIB)/libint2.a
+   endif
+endif
+
+ifneq ($(USE_SPGLIB),)
+   USE_SPGLIB     := $(strip $(USE_SPGLIB))
+   SPGLIB_INC     := $(INSTALL_PATH)/spglib-$(USE_SPGLIB)/include
+   SPGLIB_LIB     := $(INSTALL_PATH)/spglib-$(USE_SPGLIB)/lib
+   CFLAGS         += -I$(SPGLIB_INC)
+   DFLAGS         += -D__SPGLIB
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(SPGLIB_LIB) -L$(SPGLIB_LIB) -lsymspg
+   else
+      LIBS           += $(SPGLIB_LIB)/libsymspg.a
+   endif
+endif
+
+ifneq ($(USE_SIRIUS),)
+   USE_GSL        := 2.7
+   HDF5_VER       := 1.12.0
+   LIBVDWXC_VER   := 0.4.0
+   SPFFT_VER      := 1.0.6
+   SPLA_VER       := 1.5.4
+   USE_SIRIUS     := $(strip $(USE_SIRIUS))
+   HDF5_VER       := $(strip $(HDF5_VER))
+   HDF5_LIB       := $(INSTALL_PATH)/hdf5-$(HDF5_VER)/lib
+   LIBVDWXC_VER   := $(strip $(LIBVDWXC_VER))
+   LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
+   LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
+   SPFFT_VER      := $(strip $(SPFFT_VER))
+   SPFFT_INC      := $(INSTALL_PATH)/SpFFT-$(SPFFT_VER)/include
+   SPFFT_LIB      := $(INSTALL_PATH)/SpFFT-$(SPFFT_VER)/lib
+   SPLA_VER       := $(strip $(SPLA_VER))
+   SPLA_INC       := $(INSTALL_PATH)/SpLA-$(SPLA_VER)/include/spla
+   SPLA_LIB       := $(INSTALL_PATH)/SpLA-$(SPLA_VER)/lib
+   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
+   CFLAGS         += -I$(LIBVDWXC_INC)
+   CFLAGS         += -I$(SPFFT_INC)
+   CFLAGS         += -I$(SPLA_INC)
+   CFLAGS         += -I$(SIRIUS_INC)
+   DFLAGS         += -D__HDF5
+   DFLAGS         += -D__LIBVDWXC
+   DFLAGS         += -D__SPFFT
+   DFLAGS         += -D__SPLA
+   DFLAGS         += -D__SIRIUS
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
+      LIBS           += -Wl,-rpath,$(SPLA_LIB) -L$(SPLA_LIB) -lspla
+      LIBS           += -Wl,-rpath,$(SPFFT_LIB) -L$(SPFFT_LIB) -lspfft
+      LIBS           += -Wl,-rpath,$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
+      LIBS           += -Wl,-rpath,$(HDF5_LIB) -L$(HDF5_LIB) -lhdf5
+   else
+      LIBS           += $(SIRIUS_LIB)/libsirius.a
+      LIBS           += $(SPLA_LIB)/libspla.a
+      LIBS           += $(SPFFT_LIB)/libspfft.a
+      LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
+      LIBS           += $(HDF5_LIB)/libhdf5.a
+   endif
+endif
+
+ifneq ($(USE_COSMA),)
+   USE_COSMA      := $(strip $(USE_COSMA))
+   COSMA_INC      := $(INSTALL_PATH)/COSMA-$(USE_COSMA)/include
+   COSMA_LIB      := $(INSTALL_PATH)/COSMA-$(USE_COSMA)/lib
+   CFLAGS         += -I$(COSMA_INC)
+   DFLAGS         += -D__COSMA
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(COSMA_LIB) -L$(COSMA_LIB) -lcosma_prefixed_pxgemm -lcosma -lcosta_prefixed_scalapack -lcosta
+   else
+      LIBS           += $(COSMA_LIB)/libcosma_prefixed_pxgemm.a
+      LIBS           += $(COSMA_LIB)/libcosma.a
+      LIBS           += $(COSMA_LIB)/libcosta_prefixed_scalapack.a
+      LIBS           += $(COSMA_LIB)/libcosta.a
+   endif
+endif
+
+ifneq ($(USE_FFTW),)
+   USE_FFTW       := $(strip $(USE_FFTW))
+   FFTW_INC       := $(INSTALL_PATH)/fftw-$(USE_FFTW)/include
+   FFTW_LIB       := $(INSTALL_PATH)/fftw-$(USE_FFTW)/lib
+   CFLAGS         += -I$(FFTW_INC)
+   DFLAGS         += -D__FFTW3
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(FFTW_LIB) -L$(FFTW_LIB) -lfftw3_mpi -lfftw3_omp -lfftw3
+   else
+      LIBS           += $(FFTW_LIB)/libfftw3_mpi.a
+      LIBS           += $(FFTW_LIB)/libfftw3_omp.a
+      LIBS           += $(FFTW_LIB)/libfftw3.a
+   endif
+endif
+
+ifneq ($(USE_SCALAPACK),)
+   SCALAPACK_LIB  := $(INSTALL_PATH)/scalapack-$(USE_SCALAPACK)/lib
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(SCALAPACK_LIB) -L$(SCALAPACK_LIB) -lscalapack
+   else
+      LIBS           += $(SCALAPACK_LIB)/libscalapack.a
+   endif
+endif
+
+ifneq ($(USE_OPENBLAS),)
+   USE_OPENBLAS   := $(strip $(USE_OPENBLAS))
+   OPENBLAS_INC   := $(INSTALL_PATH)/openblas-$(USE_OPENBLAS)/include
+   OPENBLAS_LIB   := $(INSTALL_PATH)/openblas-$(USE_OPENBLAS)/lib
+   CFLAGS         += -I$(OPENBLAS_INC)
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(OPENBLAS_LIB) -L$(OPENBLAS_LIB) -lopenblas
+   else
+      LIBS           += $(OPENBLAS_LIB)/libopenblas.a
+   endif
+endif
+
+ifneq ($(USE_GSL),)
+   USE_GSL        := $(strip $(USE_GSL))
+   GSL_INC        := $(INSTALL_PATH)/gsl-$(USE_GSL)/include
+   GSL_LIB        := $(INSTALL_PATH)/gsl-$(USE_GSL)/lib
+   CFLAGS         += -I$(GSL_INC)
+   DFLAGS         += -D__GSL
+   ifeq ($(SHARED), yes)
+      LIBS           += -Wl,-rpath,$(GSL_LIB) -L$(GSL_LIB) -lgsl
+   else
+      LIBS           += $(GSL_LIB)/libgsl.a
+   endif
+endif
+
+CFLAGS         += $(DFLAGS) $(CFLAGS_DEBUG)
+
+FCFLAGS        := $(CFLAGS) $(FCFLAGS_DEBUG) $(WFLAGS)
+FCFLAGS        += -fallow-argument-mismatch
+FCFLAGS        += -fbacktrace
+FCFLAGS        += -ffree-form
+FCFLAGS        += -ffree-line-length-none
+FCFLAGS        += -fno-omit-frame-pointer
+FCFLAGS        += -std=f2008
+
+LDFLAGS        += $(FCFLAGS)
+
+LIBS           += -lz -ldl -lstdc++
+
+# End

--- a/arch/Darwin-arm64.ssmp
+++ b/arch/Darwin-arm64.ssmp
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# CP2K Darwin arch file for a serial aarch64 (arm64) binary
+# CP2K Darwin arch file for a serial arm64 binary
 #
 # Tested with: GNU 12.2.0, FFTW 3.3.10, LIBINT 2.6.0, LIBVORI 220621,
 #              LIBXC 6.0.0, OpenBLAS 0.3.21, SPGLIB 1.16.2
-#          on: Apple M1 (macOS Ventura 13.0.1)
+# on an Apple M1 (macOS Ventura 13.0.1)
 #
 # Usage: Source this arch file and then run make as instructed.
 #
@@ -18,23 +18,26 @@
    fi; \
    this_file=${BASH_SOURCE##*/}; \
    cd tools/toolchain; \
+   [[ -z "${target_cpu}" ]] && target_cpu="native"; \
    if $(command -v brew >/dev/null 2>&1); then \
       brew install cmake; \
+      brew install coreutils; \
       brew install gcc; \
+      brew install pkg-config; \
    else \
       echo "ERROR: Homebrew installation not found"; \
       cd ../..; \
       return 1; \
    fi; \
-   ./install_cp2k_toolchain.sh -j8 --mpi-mode=no --no-arch-files --with-cmake=system --with-gcc=system --with-libxsmm=no; \
+   ./install_cp2k_toolchain.sh --mpi-mode=no --no-arch-files --target-cpu=${target_cpu} --with-cmake=system --with-gcc=system --with-libxsmm=no; \
    source ./install/setup; \
    cd ../..; \
    echo; \
    echo "Check the output above for error messages and consistency!"; \
    echo "If everything is OK, you can build a CP2K production binary with"; \
-   echo "   make -j8 ARCH=${this_file%.*} VERSION=${this_file##*.}"; \
+   echo "   make -j ARCH=${this_file%.*} VERSION=${this_file##*.}"; \
    echo "Alternatively, you can add further checks, e.g. for regression testing, with"; \
-   echo "   make -j8 ARCH=${this_file%.*} VERSION=${this_file##*.} DO_CHECKS=yes"; \
+   echo "   make -j ARCH=${this_file%.*} VERSION=${this_file##*.} DO_CHECKS=yes"; \
    return
 
 # Set options

--- a/tools/toolchain/scripts/stage0/install_gcc.sh
+++ b/tools/toolchain/scripts/stage0/install_gcc.sh
@@ -112,7 +112,7 @@ case "${with_gcc}" in
     F90="${FC}"
     F77="${FC}"
     GCC_CFLAGS="-I'${pkg_install_dir}/include'"
-    GCC_LDFLAGS="-L'${pkg_install_dir}/lib64' -L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib64' -Wl,-rpath='${pkg_install_dir}/lib64'"
+    GCC_LDFLAGS="-L'${pkg_install_dir}/lib64' -L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib64' -Wl,-rpath,'${pkg_install_dir}/lib64'"
     ;;
   __SYSTEM__)
     echo "==================== Finding GCC from system paths ===================="
@@ -140,7 +140,7 @@ case "${with_gcc}" in
     F90="${FC}"
     F77="${FC}"
     GCC_CFLAGS="-I'${pkg_install_dir}/include'"
-    GCC_LDFLAGS="-L'${pkg_install_dir}/lib64' -L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib64' -Wl,-rpath='${pkg_install_dir}/lib64'"
+    GCC_LDFLAGS="-L'${pkg_install_dir}/lib64' -L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib64' -Wl,-rpath,'${pkg_install_dir}/lib64'"
     ;;
 esac
 if [ "${ENABLE_TSAN}" = "__TRUE__" ]; then

--- a/tools/toolchain/scripts/stage0/install_intel.sh
+++ b/tools/toolchain/scripts/stage0/install_intel.sh
@@ -49,7 +49,7 @@ case "${with_intel}" in
     F90="${FC}"
     F77="${FC}"
     INTEL_CFLAGS="-I'${pkg_install_dir}/include'"
-    INTEL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    INTEL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "${with_intel}" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -70,7 +70,7 @@ case "${with_intelmpi}" in
     MPIF77="${MPIFC}"
     # include path is already handled by compiler wrapper scripts (can cause wrong mpi.mod with GNU Fortran)
     #INTELMPI_CFLAGS="-I'${pkg_install_dir}/include'"
-    INTELMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    INTELMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "${with_intelmpi}" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -75,7 +75,7 @@ case "${with_mpich}" in
     MPIF90="${MPIFC}"
     MPIF77="${MPIFC}"
     MPICH_CFLAGS="-I'${pkg_install_dir}/include'"
-    MPICH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    MPICH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding MPICH from system paths ===================="
@@ -111,7 +111,7 @@ case "${with_mpich}" in
     MPIF90="${MPIFC}"
     MPIF77="${MPIFC}"
     MPICH_CFLAGS="-I'${pkg_install_dir}/include'"
-    MPICH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    MPICH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "${with_mpich}" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -80,7 +80,7 @@ case "${with_openmpi}" in
     MPIF90="${MPIFC}"
     MPIF77="${MPIFC}"
     OPENMPI_CFLAGS="-I'${pkg_install_dir}/include'"
-    OPENMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    OPENMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding OpenMPI from system paths ===================="
@@ -111,7 +111,7 @@ case "${with_openmpi}" in
     MPIF90="${MPIFC}"
     MPIF77="${MPIFC}"
     OPENMPI_CFLAGS="-I'${pkg_install_dir}/include'"
-    OPENMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    OPENMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "${with_openmpi}" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage2/install_acml.sh
+++ b/tools/toolchain/scripts/stage2/install_acml.sh
@@ -39,7 +39,7 @@ case "$with_acml" in
     pkg_install_dir="$with_acml"
     check_dir "${pkg_install_dir}/lib"
     ACML_CFLAGS="-I'${pkg_install_dir}/include'"
-    ACML_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    ACML_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_acml" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage2/install_mkl.sh
+++ b/tools/toolchain/scripts/stage2/install_mkl.sh
@@ -95,7 +95,7 @@ if [ "${with_mkl}" != "__DONTUSE__" ]; then
   esac
 
   # set the correct lib flags from MLK link adviser
-  MKL_LIBS="-L${mkl_lib_dir} -Wl,-rpath=${mkl_lib_dir} ${mkl_scalapack_lib}"
+  MKL_LIBS="-L${mkl_lib_dir} -Wl,-rpath,${mkl_lib_dir} ${mkl_scalapack_lib}"
   MKL_LIBS+=" -Wl,--start-group -lmkl_gf_lp64 -lmkl_sequential -lmkl_core"
   MKL_LIBS+=" ${mkl_blacs_lib} -Wl,--end-group -lpthread -lm -ldl"
   # setup_mkl disables using separate FFTW library (see below)

--- a/tools/toolchain/scripts/stage2/install_openblas.sh
+++ b/tools/toolchain/scripts/stage2/install_openblas.sh
@@ -104,7 +104,7 @@ case "${with_openblas}" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage2/$(basename ${SCRIPT_NAME})"
     fi
     OPENBLAS_CFLAGS="-I'${pkg_install_dir}/include'"
-    OPENBLAS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    OPENBLAS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     OPENBLAS_ROOT="${pkg_install_dir}"
     OPENBLAS_LIBS="-lopenblas"
     ;;
@@ -127,7 +127,7 @@ case "${with_openblas}" in
     check_dir "${pkg_install_dir}/include"
     check_dir "${pkg_install_dir}/lib"
     OPENBLAS_CFLAGS="-I'${pkg_install_dir}/include'"
-    OPENBLAS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    OPENBLAS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     OPENBLAS_LIBS="-lopenblas"
     # detect separate omp builds
     (__libdir="${pkg_install_dir}/lib" LIB_PATHS="__libdir" check_lib -lopenblas_openmp 2> /dev/null) &&

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -62,7 +62,7 @@ case "$with_fftw" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
     fi
     FFTW_CFLAGS="-I'${pkg_install_dir}/include'"
-    FFTW_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    FFTW_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding FFTW from system paths ===================="
@@ -81,7 +81,7 @@ case "$with_fftw" in
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
     FFTW_CFLAGS="-I'${pkg_install_dir}/include'"
-    FFTW_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    FFTW_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_fftw" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -48,7 +48,7 @@ case "$with_libxc" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
     fi
     LIBXC_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    LIBXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding LIBXC from system paths ===================="
@@ -65,7 +65,7 @@ case "$with_libxc" in
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
     LIBXC_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    LIBXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_libxc" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -126,11 +126,11 @@ case "$with_cosma" in
 
     # Check if COSMA is compiled with 64bits and set up COSMA_LIBDIR accordingly.
     COSMA_LIBDIR="${pkg_install_dir}/lib"
-    COSMA_LDFLAGS="-L'${COSMA_LIBDIR}' -Wl,-rpath='${COSMA_LIBDIR}'"
+    COSMA_LDFLAGS="-L'${COSMA_LIBDIR}' -Wl,-rpath,'${COSMA_LIBDIR}'"
     COSMA_CUDA_LIBDIR="${pkg_install_dir}-cuda/lib"
-    COSMA_CUDA_LDFLAGS="-L'${COSMA_CUDA_LIBDIR}' -Wl,-rpath='${COSMA_CUDA_LIBDIR}'"
+    COSMA_CUDA_LDFLAGS="-L'${COSMA_CUDA_LIBDIR}' -Wl,-rpath,'${COSMA_CUDA_LIBDIR}'"
     COSMA_HIP_LIBDIR="${pkg_install_dir}-cuda/lib"
-    COSMA_HIP_LDFLAGS="-L'${COSMA_HIP_LIBDIR}' -Wl,-rpath='${COSMA_HIP_LIBDIR}'"
+    COSMA_HIP_LDFLAGS="-L'${COSMA_HIP_LIBDIR}' -Wl,-rpath,'${COSMA_HIP_LIBDIR}'"
     ;;
   __SYSTEM__)
     echo "==================== Finding COSMA from system paths ===================="
@@ -152,7 +152,7 @@ case "$with_cosma" in
     check_dir "$pkg_install_dir/include"
 
     COSMA_CFLAGS="-I'${pkg_install_dir}/include'"
-    COSMA_LDFLAGS="-L'${COSMA_LIBDIR}' -Wl,-rpath='${COSMA_LIBDIR}'"
+    COSMA_LDFLAGS="-L'${COSMA_LIBDIR}' -Wl,-rpath,'${COSMA_LIBDIR}'"
     ;;
 esac
 if [ "$with_cosma" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -73,7 +73,7 @@ EOF
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})"
     fi
     LIBXSMM_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBXSMM_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    LIBXSMM_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding Libxsmm from system paths ===================="
@@ -91,7 +91,7 @@ EOF
     check_dir "${pkg_install_dir}/include"
     check_dir "${pkg_install_dir}/lib"
     LIBXSMM_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBXSMM_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    LIBXSMM_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_libxsmm" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage4/install_scalapack.sh
+++ b/tools/toolchain/scripts/stage4/install_scalapack.sh
@@ -66,7 +66,7 @@ case "$with_scalapack" in
       popd > /dev/null
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})"
     fi
-    SCALAPACK_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SCALAPACK_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding ScaLAPACK from system paths ===================="
@@ -79,7 +79,7 @@ case "$with_scalapack" in
     echo "==================== Linking ScaLAPACK to user paths ===================="
     pkg_install_dir="$with_scalapack"
     check_dir "${pkg_install_dir}/lib"
-    SCALAPACK_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SCALAPACK_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_scalapack" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -139,7 +139,7 @@ case "$with_elpa" in
     fi
     [ "$enable_openmp" != "yes" ] && elpa_dir_openmp=""
     ELPA_CFLAGS="-I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}/modules' -I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}/elpa'"
-    ELPA_LDFLAGS="-L'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib' -Wl,-rpath='${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib'"
+    ELPA_LDFLAGS="-L'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib' -Wl,-rpath,'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding ELPA from system paths ===================="
@@ -173,7 +173,7 @@ case "$with_elpa" in
       echo "Cannot find elpa_openmp-* from path $user_include_path"
       exit 1
     fi
-    ELPA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    ELPA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_elpa" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage5/install_pexsi.sh
+++ b/tools/toolchain/scripts/stage5/install_pexsi.sh
@@ -92,7 +92,7 @@ case "$with_pexsi" in
     fi
     PEXSI_CFLAGS="-I'${pkg_install_dir}/include'"
 
-    PEXSI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    PEXSI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding Pexsi_DIST from system paths ===================="

--- a/tools/toolchain/scripts/stage5/install_ptscotch.sh
+++ b/tools/toolchain/scripts/stage5/install_ptscotch.sh
@@ -60,7 +60,7 @@ case "${with_ptscotch}" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage5/$(basename ${SCRIPT_NAME})"
     fi
     SCOTCH_CFLAGS="-I'${pkg_install_dir}/include'"
-    SCOTCH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SCOTCH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding PT-Scotch from system paths ===================="
@@ -82,7 +82,7 @@ case "${with_ptscotch}" in
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
     SCOTCH_CFLAGS="-I'${pkg_install_dir}/include'"
-    SCOTCH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SCOTCH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_ptscotch" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage5/install_superlu.sh
+++ b/tools/toolchain/scripts/stage5/install_superlu.sh
@@ -57,7 +57,7 @@ case "$with_superlu" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage5/$(basename ${SCRIPT_NAME})"
     fi
     SUPERLU_CFLAGS="-I'${pkg_install_dir}/include'"
-    SUPERLU_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SUPERLU_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding SuperLU_DIST from system paths ===================="
@@ -73,7 +73,7 @@ case "$with_superlu" in
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
     SUPERLU_CFLAGS="-I'${pkg_install_dir}/include'"
-    SUPERLU_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SUPERLU_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_superlu" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage6/install_gsl.sh
+++ b/tools/toolchain/scripts/stage6/install_gsl.sh
@@ -48,7 +48,7 @@ case "$with_gsl" in
     fi
 
     GSL_CFLAGS="-I'${pkg_install_dir}/include'"
-    GSL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    GSL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding gsl from system paths ===================="
@@ -65,7 +65,7 @@ case "$with_gsl" in
     check_dir "$pkg_install_dir/lib"
     check_dir "$pkg_install_dir/include"
     GSL_CFLAGS="-I'${pkg_install_dir}/include'"
-    GSL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    GSL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_gsl" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage6/install_plumed.sh
+++ b/tools/toolchain/scripts/stage6/install_plumed.sh
@@ -65,7 +65,7 @@ case "$with_plumed" in
       make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage6/$(basename ${SCRIPT_NAME})"
     fi
-    PLUMED_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    PLUMED_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding PLUMED from system paths ===================="
@@ -78,7 +78,7 @@ case "$with_plumed" in
     echo "==================== Linking PLUMED to user paths ===================="
     pkg_install_dir="$with_plumed"
     check_dir "${pkg_install_dir}/lib"
-    PLUMED_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    PLUMED_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 

--- a/tools/toolchain/scripts/stage6/install_quip.sh
+++ b/tools/toolchain/scripts/stage6/install_quip.sh
@@ -135,7 +135,7 @@ case "${with_quip}" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage6/$(basename ${SCRIPT_NAME})"
     fi
     QUIP_CFLAGS="-I'${pkg_install_dir}/include'"
-    QUIP_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    QUIP_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding Quip_DIST from system paths ===================="
@@ -156,7 +156,7 @@ case "${with_quip}" in
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
     QUIP_CFLAGS="-I'${pkg_install_dir}/include'"
-    QUIP_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    QUIP_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "${with_quip}" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage7/install_hdf5.sh
+++ b/tools/toolchain/scripts/stage7/install_hdf5.sh
@@ -49,7 +49,7 @@ case "$with_hdf5" in
     fi
 
     HDF5_CFLAGS="-I${pkg_install_dir}/include"
-    HDF5_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    HDF5_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding hdf5 from system paths ===================="

--- a/tools/toolchain/scripts/stage7/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/stage7/install_libvdwxc.sh
@@ -73,7 +73,7 @@ case "$with_libvdwxc" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
     fi
     LIBVDWXC_CFLAGS="-I${pkg_install_dir}/include"
-    LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding libvdwxc from system paths ===================="
@@ -90,7 +90,7 @@ case "$with_libvdwxc" in
     check_dir "$pkg_install_dir/lib"
     check_dir "$pkg_install_dir/include"
     LIBVDWXC_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_libvdwxc" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage7/install_libvori.sh
+++ b/tools/toolchain/scripts/stage7/install_libvori.sh
@@ -55,7 +55,7 @@ case "${with_libvori:=__INSTALL__}" in
 
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename "${SCRIPT_NAME}")"
     fi
-    LIBVORI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    LIBVORI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding libvori from system paths ===================="
@@ -73,7 +73,7 @@ case "${with_libvori:=__INSTALL__}" in
     [ -d "${pkg_install_dir}/lib64" ] && LIBVORI_LIBDIR="${pkg_install_dir}/lib64"
 
     check_dir "${LIBVORI_LIBDIR}"
-    LIBVORI_LDFLAGS="-L'${LIBVORI_LIBDIR}' -Wl,-rpath='${LIBVORI_LIBDIR}'"
+    LIBVORI_LDFLAGS="-L'${LIBVORI_LIBDIR}' -Wl,-rpath,'${LIBVORI_LIBDIR}'"
     ;;
 esac
 

--- a/tools/toolchain/scripts/stage7/install_spglib.sh
+++ b/tools/toolchain/scripts/stage7/install_spglib.sh
@@ -54,7 +54,7 @@ case "$with_spglib" in
     fi
 
     SPGLIB_CFLAGS="-I${pkg_install_dir}/include"
-    SPGLIB_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SPGLIB_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     if [ -d "${pkg_install_dir}/lib64" ]; then
       ln -sf lib64 ${pkg_install_dir}/lib
       cd ${pkg_install_dir}
@@ -74,7 +74,7 @@ case "$with_spglib" in
     check_dir "$pkg_install_dir/lib"
     check_dir "$pkg_install_dir/include"
     SPGLIB_CFLAGS="-I'${pkg_install_dir}/include'"
-    SPGLIB_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+    SPGLIB_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_spglib" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -183,11 +183,11 @@ case "$with_sirius" in
         install -d ${pkg_install_dir}/include/cuda
         install -m 644 src/*.a ${pkg_install_dir}/lib/cuda >> install.log 2>&1
         install -m 644 src/mod_files/*.mod ${pkg_install_dir}/include/cuda >> install.log 2>&1
-        SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath='${pkg_install_dir}/lib/cuda'"
+        SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
         cd ..
       fi
       SIRIUS_CFLAGS="-I'${pkg_install_dir}/include/cuda'"
-      SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+      SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
     ;;
@@ -243,8 +243,8 @@ case "$with_sirius" in
 esac
 if [ "$with_sirius" != "__DONTUSE__" ]; then
   SIRIUS_LIBS="-lsirius IF_CUDA(-lcusolver|)"
-  SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath='${pkg_install_dir}/lib/cuda'"
-  SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
+  SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
+  SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
   SIRIUS_CFLAGS="-I'${pkg_install_dir}/include'"
   if [ "$with_sirius" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_sirius"
@@ -261,8 +261,8 @@ EOF
   cat << EOF >> "${BUILDDIR}/setup_sirius"
 export SIRIUS_CFLAGS="IF_CUDA(-I${pkg_install_dir}/include/cuda|-I${pkg_install_dir}/include)"
 export SIRIUS_FFLAGS="IF_CUDA(-I${pkg_install_dir}/include/cuda|-I${pkg_install_dir}/include)"
-export SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
-export SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath='${pkg_install_dir}/lib/cuda'"
+export SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
+export SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
 export SIRIUS_LIBS="${SIRIUS_LIBS}"
 export CP_DFLAGS="\${CP_DFLAGS} IF_MPI("-D__SIRIUS"|)"
 export CP_CFLAGS="\${CP_CFLAGS} IF_MPI("\${SIRIUS_CFLAGS}"|)"

--- a/tools/toolchain/scripts/stage8/install_spfft.sh
+++ b/tools/toolchain/scripts/stage8/install_spfft.sh
@@ -141,8 +141,8 @@ case "${with_spfft}" in
     fi
     SPFFT_ROOT="${pkg_install_dir}"
     SPFFT_CFLAGS="-I'${pkg_install_dir}/include'"
-    SPFFT_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
-    SPFFT_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath='${pkg_install_dir}/lib/cuda'"
+    SPFFT_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
+    SPFFT_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
     ;;
   __SYSTEM__)
     echo "==================== Finding spfft from system paths ===================="
@@ -164,7 +164,7 @@ case "${with_spfft}" in
     check_dir "${SPFFT_LIBDIR}"
     check_dir "${pkg_install_dir}/include"
     SPFFT_CFLAGS="-I'${pkg_install_dir}/include'"
-    SPFFT_LDFLAGS="-L'${SPFFT_LIBDIR}' -Wl,-rpath='${SPFFT_LIBDIR}'"
+    SPFFT_LDFLAGS="-L'${SPFFT_LIBDIR}' -Wl,-rpath,'${SPFFT_LIBDIR}'"
     ;;
 esac
 if [ "$with_spfft" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -139,9 +139,9 @@ case "${with_spla}" in
     fi
     SPLA_ROOT="${pkg_install_dir}"
     SPLA_CFLAGS="-I'${pkg_install_dir}/include/spla'"
-    SPLA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
-    SPLA_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath='${pkg_install_dir}/lib/cuda'"
-    SPLA_HIP_LDFLAGS="-L'${pkg_install_dir}/lib/hip' -Wl,-rpath='${pkg_install_dir}/lib/hip'"
+    SPLA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
+    SPLA_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
+    SPLA_HIP_LDFLAGS="-L'${pkg_install_dir}/lib/hip' -Wl,-rpath,'${pkg_install_dir}/lib/hip'"
     ;;
   __SYSTEM__)
     echo "==================== Finding spla from system paths ===================="
@@ -163,7 +163,7 @@ case "${with_spla}" in
     check_dir "${SPLA_LIBDIR}"
     check_dir "${pkg_install_dir}/include/spla"
     SPLA_CFLAGS="-I'${pkg_install_dir}/include/spla'"
-    SPLA_LDFLAGS="-L'${SPLA_LIBDIR}' -Wl,-rpath='${SPLA_LIBDIR}'"
+    SPLA_LDFLAGS="-L'${SPLA_LIBDIR}' -Wl,-rpath,'${SPLA_LIBDIR}'"
     ;;
 esac
 if [ "$with_spla" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/tool_kit.sh
+++ b/tools/toolchain/scripts/tool_kit.sh
@@ -144,6 +144,8 @@ get_nprocs() {
     echo ${NPROCS_OVERWRITE} | sed 's/^0*//'
   elif $(command -v nproc > /dev/null 2>&1); then
     echo $(nproc --all)
+  elif $(command -v sysctl > /dev/null 2>&1); then
+    echo $(sysctl -n hw.ncpu)
   else
     echo 1
   fi
@@ -298,7 +300,7 @@ add_lib_from_paths() {
     fi
     echo "Found lib directory $__found_target"
     eval __ldflags=\$"${__ldflags_name}"
-    __ldflags="${__ldflags} -L'${__found_target}' -Wl,-rpath='${__found_target}'"
+    __ldflags="${__ldflags} -L'${__found_target}' -Wl,-rpath,'${__found_target}'"
     # remove possible duplicates
     __ldflags="$(unique $__ldflags)"
     # must escape all quotes again before the last eval, as


### PR DESCRIPTION
Linux accepts as linker syntax both `-rpath=` and `-rpath,`, but MacOS (clang) works only with `-rpath,`.