### PR TITLE
Docker: Upgrade HIP tests to Ubuntu 22.04

### DIFF
--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.build_hip_rocm_Mi100 ../../
 #
 
-FROM rocm/dev-ubuntu-20.04:4.5.2-complete
+FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
 # Install some Ubuntu packages.
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.build_hip_rocm_Mi50 ../../
 #
 
-FROM rocm/dev-ubuntu-20.04:4.5.2-complete
+FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
 # Install some Ubuntu packages.
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \

--- a/tools/docker/Dockerfile.test_hip_cuda_A100
+++ b/tools/docker/Dockerfile.test_hip_cuda_A100
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.test_hip_cuda_A100 ../../
 #
 
-FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 # Setup CUDA environment.
 ENV CUDA_PATH /usr/local/cuda

--- a/tools/docker/Dockerfile.test_hip_cuda_P100
+++ b/tools/docker/Dockerfile.test_hip_cuda_P100
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.test_hip_cuda_P100 ../../
 #
 
-FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 # Setup CUDA environment.
 ENV CUDA_PATH /usr/local/cuda

--- a/tools/docker/Dockerfile.test_hip_cuda_V100
+++ b/tools/docker/Dockerfile.test_hip_cuda_V100
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.test_hip_cuda_V100 ../../
 #
 
-FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 # Setup CUDA environment.
 ENV CUDA_PATH /usr/local/cuda

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi100
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.test_hip_rocm_Mi100 ../../
 #
 
-FROM rocm/dev-ubuntu-20.04:4.5.2-complete
+FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
 # Install some Ubuntu packages.
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi50
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.test_hip_rocm_Mi50 ../../
 #
 
-FROM rocm/dev-ubuntu-20.04:4.5.2-complete
+FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
 # Install some Ubuntu packages.
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -559,7 +559,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 # ======================================================================================
 def toolchain_hip_cuda(gpu_ver: str) -> str:
     return rf"""
-FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 # Setup CUDA environment.
 ENV CUDA_PATH /usr/local/cuda
@@ -662,7 +662,7 @@ RUN hipconfig
 # ======================================================================================
 def toolchain_hip_rocm(gpu_ver: str) -> str:
     return rf"""
-FROM rocm/dev-ubuntu-20.04:4.5.2-complete
+FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
 # Install some Ubuntu packages.
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \


### PR DESCRIPTION
This is a followup to #2388. It started building ScaLAPACK with `-fallow-argument-mismatch`, which is not supported by the GCC 9.4 that ships with Ubuntu 20.04.