### PR TITLE
Docker: Disable CUDA JIT cache for HIP tests

### DIFF
--- a/tests/QS/regtest-gw-cubic/TEST_FILES
+++ b/tests/QS/regtest-gw-cubic/TEST_FILES
@@ -2,7 +2,7 @@ scGW0_H2O_PBE_default_values.inp                      78      1e-05             
 evGW_H2O_PBE_default_values.inp                       78      1e-05                         17.474
 G0W0_H2O_PBE_GAPW.inp                                 78      1e-05                         16.699
 G0W0_H2O_PBE0.inp                                     78      1e-05                         16.717
-G0W0_H2O_PBE0_30_pts.inp                              78      1e-05                         15.607
+G0W0_H2O_PBE0_30_pts.inp                              78      7e-05                         15.607
 scGW0_and_evGW_H2O_PBE0_trunc_minimax.inp             11      1e-08            -17.108489005370274
 scGW0_H2O_PBE0_trunc_minimax_RI_HFX.inp               11      1e-08            -13.191093644224157
 G0W0_H2O_PBE_periodic.inp                             78      1e-05                         16.475

--- a/tools/docker/Dockerfile.test_hip_cuda_A100
+++ b/tools/docker/Dockerfile.test_hip_cuda_A100
@@ -13,6 +13,10 @@ ENV ROCM_VER 4.5.2
 ENV HIP_DIR /opt/HIP-rocm-4.5.2
 ENV HIPAMD_DIR /opt/hipamd-rocm-4.5.2
 
+# Disable JIT cache as there seems to be an issue with file locking on overlayfs.
+# See also https://github.com/cp2k/cp2k/pull/2337
+ENV CUDA_CACHE_DISABLE 1
+
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get update -qq && apt-get install -qq --no-install-recommends \
     ca-certificates \

--- a/tools/docker/Dockerfile.test_hip_cuda_P100
+++ b/tools/docker/Dockerfile.test_hip_cuda_P100
@@ -13,6 +13,10 @@ ENV ROCM_VER 4.5.2
 ENV HIP_DIR /opt/HIP-rocm-4.5.2
 ENV HIPAMD_DIR /opt/hipamd-rocm-4.5.2
 
+# Disable JIT cache as there seems to be an issue with file locking on overlayfs.
+# See also https://github.com/cp2k/cp2k/pull/2337
+ENV CUDA_CACHE_DISABLE 1
+
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get update -qq && apt-get install -qq --no-install-recommends \
     ca-certificates \

--- a/tools/docker/Dockerfile.test_hip_cuda_V100
+++ b/tools/docker/Dockerfile.test_hip_cuda_V100
@@ -13,6 +13,10 @@ ENV ROCM_VER 4.5.2
 ENV HIP_DIR /opt/HIP-rocm-4.5.2
 ENV HIPAMD_DIR /opt/hipamd-rocm-4.5.2
 
+# Disable JIT cache as there seems to be an issue with file locking on overlayfs.
+# See also https://github.com/cp2k/cp2k/pull/2337
+ENV CUDA_CACHE_DISABLE 1
+
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get update -qq && apt-get install -qq --no-install-recommends \
     ca-certificates \

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -569,6 +569,10 @@ ENV ROCM_VER 4.5.2
 ENV HIP_DIR /opt/HIP-rocm-4.5.2
 ENV HIPAMD_DIR /opt/hipamd-rocm-4.5.2
 
+# Disable JIT cache as there seems to be an issue with file locking on overlayfs.
+# See also https://github.com/cp2k/cp2k/pull/2337
+ENV CUDA_CACHE_DISABLE 1
+
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get update -qq && apt-get install -qq --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
This is a followup to #2410, applying the workaround discussed in #2337.