### PR TITLE
Torch: Use CUDA backend when available

### DIFF
--- a/src/nequip_unittest.F
+++ b/src/nequip_unittest.F
@@ -14,9 +14,9 @@ PROGRAM nequip_unittest
                                               sp
    USE mathlib,                         ONLY: inv_3x3
    USE torch_api,                       ONLY: &
-        torch_dict_create, torch_dict_get, torch_dict_insert, torch_dict_release, torch_dict_type, &
-        torch_model_eval, torch_model_load, torch_model_read_metadata, torch_model_release, &
-        torch_model_type
+        torch_cuda_is_available, torch_dict_create, torch_dict_get, torch_dict_insert, &
+        torch_dict_release, torch_dict_type, torch_model_eval, torch_model_load, &
+        torch_model_read_metadata, torch_model_release, torch_model_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -153,6 +153,8 @@ PROGRAM nequip_unittest
    atom_types(:64) = 0 ! Hydrogen
    atom_types(65:) = 1 ! Oxygen
 
+   WRITE (*, *) "CUDA is available: ", torch_cuda_is_available()
+
    filename = discover_file('NequIP/water.pth')
    WRITE (*, *) "Loading NequIP model from: "//TRIM(filename)
    CALL torch_model_load(model, filename)
@@ -182,7 +184,7 @@ PROGRAM nequip_unittest
    CALL torch_dict_get(outputs, "atomic_energy", atomic_energy)
    CALL torch_dict_get(outputs, "forces", forces)
    WRITE (*, *) "Total Energy: ", total_energy(1, 1)
-   CPASSERT(ABS(-14985.61621_dp - REAL(total_energy(1, 1), kind=dp)) < 1e-3_dp)
+   CPASSERT(ABS(-14985.615_dp - REAL(total_energy(1, 1), kind=dp)) < 2e-3_dp)
 
    CALL torch_dict_release(inputs)
    CALL torch_dict_release(outputs)

--- a/src/torch_api.F
+++ b/src/torch_api.F
@@ -6,6 +6,7 @@
 !--------------------------------------------------------------------------------------------------!
 MODULE torch_api
    USE ISO_C_BINDING, ONLY: C_ASSOCIATED, &
+                            C_BOOL, &
                             C_CHAR, &
                             C_FLOAT, &
                             C_F_POINTER, &
@@ -52,6 +53,7 @@ MODULE torch_api
    PUBLIC :: torch_dict_insert, torch_dict_get
    PUBLIC :: torch_model_type, torch_model_load, torch_model_eval, torch_model_release
    PUBLIC :: torch_model_read_metadata
+   PUBLIC :: torch_cuda_is_available
 
 CONTAINS
 
@@ -342,5 +344,27 @@ CONTAINS
       MARK_USED(res)
 #endif
    END FUNCTION torch_model_read_metadata
+
+! **************************************************************************************************
+!> \brief Returns true iff the Torch CUDA backend is available.
+!> \author Ole Schuett
+! **************************************************************************************************
+   FUNCTION torch_cuda_is_available() RESULT(res)
+      LOGICAL                                            :: res
+
+#if defined(__LIBTORCH)
+      INTERFACE
+         FUNCTION torch_c_cuda_is_available() BIND(C, name="torch_c_cuda_is_available")
+            IMPORT :: C_BOOL
+            LOGICAL(C_BOOL)                           :: torch_c_cuda_is_available
+         END FUNCTION torch_c_cuda_is_available
+      END INTERFACE
+
+      res = torch_c_cuda_is_available()
+#else
+      CPABORT("CP2K was compiled without Torch library.")
+      MARK_USED(res)
+#endif
+   END FUNCTION torch_cuda_is_available
 
 END MODULE torch_api

--- a/src/torch_c_api.cpp
+++ b/src/torch_c_api.cpp
@@ -7,10 +7,19 @@
 
 #if defined(__LIBTORCH)
 
+#include <torch/csrc/api/include/torch/cuda.h>
 #include <torch/script.h>
 
 typedef c10::Dict<std::string, torch::Tensor> torch_c_dict_t;
 typedef torch::jit::Module torch_c_model_t;
+
+/*******************************************************************************
+ * \brief Internal helper for selecting the CUDA device when available.
+ * \author Ole Schuett
+ ******************************************************************************/
+static torch::Device get_device() {
+  return (torch::cuda::is_available()) ? torch::kCUDA : torch::kCPU;
+}
 
 /*******************************************************************************
  * \brief Internal helper for retrieving arrays from Torch dictionary.
@@ -21,7 +30,7 @@ static void torch_c_dict_get(const torch_c_dict_t *dict, const char *key,
                              const int ndims, int64_t sizes[], T **dest) {
 
   assert(dict->contains(key));
-  const torch::Tensor tensor = dict->at(key);
+  const torch::Tensor tensor = dict->at(key).cpu();
 
   assert(tensor.ndimension() == ndims);
   int64_t size_flat = 1;
@@ -53,7 +62,7 @@ void torch_c_dict_insert_float(torch_c_dict_t *dict, const char *key,
   const auto options = torch::TensorOptions().dtype(torch::kFloat32);
   const auto sizes_ref = c10::IntArrayRef(sizes, ndims);
   const torch::Tensor tensor = torch::from_blob(source, sizes_ref, options);
-  dict->insert(key, tensor);
+  dict->insert(key, tensor.to(get_device()));
 }
 
 /*******************************************************************************
@@ -67,7 +76,7 @@ void torch_c_dict_insert_int64(torch_c_dict_t *dict, const char *key,
   const auto options = torch::TensorOptions().dtype(torch::kInt64);
   const auto sizes_ref = c10::IntArrayRef(sizes, ndims);
   const torch::Tensor tensor = torch::from_blob(source, sizes_ref, options);
-  dict->insert(key, tensor);
+  dict->insert(key, tensor.to(get_device()));
 }
 
 /*******************************************************************************
@@ -113,8 +122,9 @@ void torch_c_dict_release(torch_c_dict_t *dict) { delete (dict); }
  * \author Ole Schuett
  ******************************************************************************/
 void torch_c_model_load(torch_c_model_t **model_out, const char *filename) {
+
   torch::jit::Module *model = new torch::jit::Module();
-  *model = torch::jit::load(filename);
+  *model = torch::jit::load(filename, get_device());
   model->eval();
 
   assert(*model_out == NULL);
@@ -159,6 +169,12 @@ void torch_c_model_read_metadata(const char *filename, const char *key,
   *content = (char *)malloc(content_str.length() + 1); // +1 for null terminator
   strcpy(*content, content_str.c_str());
 }
+
+/*******************************************************************************
+ * \brief Returns true iff the Torch CUDA backend is available.
+ * \author Ole Schuett
+ ******************************************************************************/
+bool torch_c_cuda_is_available() { return torch::cuda::is_available(); }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The [Torch archive](https://pytorch.org/get-started/locally/) for CUDA is 10x larger than the CPU-only version - namely 1.8GB! I'm therefore not adding Torch-CUDA to the toolchain - at least for now.

I did test this PR using the following linker line:
```LIBS += -lc10 -lc10_cuda -ltorch_cpu -ltorch_cuda -ltorch -lstdc++```