### PR TITLE
Drop Support for MPI 2.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -119,9 +119,9 @@ there are several freely available alternatives:
   - Recently a [ScaLAPACK installer](http://www.netlib.org/scalapack/scalapack_installer.tgz)
     has been added that simplifies the installation.
 
-CP2K assumes that the MPI library implements MPI version 3. If you have an older
-version of MPI (e.g., MPI 2.0) available you must define `-D__MPI_VERSION=2` in
-the arch file.
+CP2K assumes that the MPI library implements MPI version 3. Older
+version of MPI (e.g., MPI 2.0) are not supported and the flag `-D__MPI_VERSION` in
+the arch file will be ignored.
 
 ### 2f. FFTW (optional, improved performance of FFTs)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,7 +120,7 @@ there are several freely available alternatives:
     has been added that simplifies the installation.
 
 CP2K assumes that the MPI library implements MPI version 3. Older
-version of MPI (e.g., MPI 2.0) are not supported and the flag `-D__MPI_VERSION` in
+versions of MPI (e.g., MPI 2.0) are not supported and the old flag `-D__MPI_VERSION` in
 the arch file will be ignored.
 
 ### 2f. FFTW (optional, improved performance of FFTs)

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -115,11 +115,7 @@ CONTAINS
 #endif
 #if defined(__parallel)
       flags = TRIM(flags)//" parallel"
-#if !defined(__MPI_VERSION) || (__MPI_VERSION > 2)
       flags = TRIM(flags)//" mpi3"
-#else
-      flags = TRIM(flags)//" mpi2"
-#endif
 #endif
 #if defined(__SCALAPACK)
       flags = TRIM(flags)//" scalapack"

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -30,10 +30,6 @@ MODULE message_passing
 
 #include "../base/base_uses.f90"
 
-#if defined(__parallel) && !defined(__MPI_VERSION)
-#define __MPI_VERSION 3
-#endif
-
 #if defined(__parallel)
    USE mpi
 ! subroutines: unfortunately, mpi implementations do not provide interfaces for all subroutines (problems with types and ranks explosion),
@@ -81,11 +77,7 @@ MODULE message_passing
    ! Set max allocatable memory by MPI to 2 GiByte
    INTEGER(KIND=MPI_ADDRESS_KIND), PARAMETER, PRIVATE :: mp_max_memory_size = HUGE(INT(1, KIND=int_4))
 
-#if __MPI_VERSION > 2
    INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = MPI_MAX_LIBRARY_VERSION_STRING
-#else
-   INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = 1
-#endif
 
    INTEGER, PARAMETER, PUBLIC :: file_offset = MPI_OFFSET_KIND
    INTEGER, PARAMETER, PUBLIC :: address_kind = MPI_ADDRESS_KIND
@@ -757,11 +749,7 @@ CONTAINS
 !$       END IF
 !$OMP END MASTER
 !$    END IF
-#if __MPI_VERSION > 2
       CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
-#else
-      CALL mpi_errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
       mp_comm = MPI_COMM_WORLD
       debug_comm_count = 1
@@ -1150,15 +1138,9 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_ibarrier(group, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibarrier @ mp_isync")
       CALL add_perf(perf_id=26, count=1)
-#else
-      MARK_USED(group)
-      MARK_USED(request)
-      CPABORT("mp_isum requires MPI-3 standard")
-#endif
 #else
       MARK_USED(group)
       request = mp_request_null
@@ -2125,7 +2107,6 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
       CALL mpi_comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, comm, ierr)
@@ -2134,9 +2115,6 @@ CONTAINS
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
       CALL mpi_comm_free(comm, ierr)
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
-#else
-      CPABORT("mp_get_node_global_rank requires MPI-3 standard")
-#endif
 #else
       node_rank = 0
 #endif
@@ -3039,19 +3017,12 @@ CONTAINS
       ierr = 0
       msglen = SIZE(msg)
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       IF (msglen .GT. 0) THEN
          CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       ELSE
          request = mp_request_null
       END IF
-#else
-      MARK_USED(msg)
-      MARK_USED(gid)
-      MARK_USED(request)
-      CPABORT("mp_isum requires MPI-3 standard")
-#endif
 #else
       MARK_USED(msg)
       MARK_USED(gid)
@@ -3080,14 +3051,8 @@ CONTAINS
       version = ''
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_get_library_version(version, resultlen, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_get_library_version @ "//routineN)
-#else
-      MARK_USED(version)
-      MARK_USED(resultlen)
-      CPABORT("mp_get_library_version requires MPI-3 standard")
-#endif
 #else
       MARK_USED(version)
       resultlen = 0
@@ -4112,13 +4077,8 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_win_flush_all(win, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_flush_all @ "//routineN)
-#else
-      MARK_USED(win)
-      CPABORT("mp_win_flush_all requires MPI-3 standard")
-#endif
 #else
       MARK_USED(win)
 #endif
@@ -4141,12 +4101,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-#if __MPI_VERSION > 2
       CALL mpi_win_lock_all(MPI_MODE_NOCHECK, win, ierr)
-#else
-      MARK_USED(win)
-      CPABORT("mp_win_lock_all requires MPI-3 standard")
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_lock_all @ "//routineN)
 
       CALL add_perf(perf_id=19, count=1)
@@ -4172,12 +4127,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-#if __MPI_VERSION > 2
       CALL mpi_win_unlock_all(win, ierr)
-#else
-      MARK_USED(win)
-      CPABORT("mp_win_unlock_all requires MPI-3 standard")
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_unlock_all @ "//routineN)
 
       CALL add_perf(perf_id=19, count=1)

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -2563,6 +2563,7 @@
 !> \param ierr ...
 !> \author Alfio Lazzaro
 ! **************************************************************************************************
+#if defined(__parallel)
    SUBROUTINE mp_iallgatherv_${nametype1}$v_internal(msgout, scount, msgin, rsize, rcount, rdispl, gid, request, ierr)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
@@ -2574,6 +2575,7 @@
                            rdispl, ${mpi_type1}$, gid, request, ierr)
 
    END SUBROUTINE mp_iallgatherv_${nametype1}$v_internal
+#endif
 
 ! **************************************************************************************************
 !> \brief Sums a vector and partitions the result among processes
@@ -3490,12 +3492,14 @@
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_rget_${nametype1}$v'
 
       INTEGER                                  :: ierr, handle
+#if defined(__parallel)
       INTEGER                                  :: len, &
                                                   handle_origin_datatype, &
                                                   handle_target_datatype, &
                                                   origin_len, target_len
       LOGICAL                                  :: do_local_copy
       INTEGER(kind=mpi_address_kind)           :: disp_aint
+#endif
 
       ierr = 0
       CALL mp_timeset(routineN, handle)

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -954,17 +954,9 @@
 
       msglen = 1
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
       CALL add_perf(perf_id=22, count=1, msg_size=msglen*${bytes1}$)
-#else
-      MARK_USED(msg)
-      MARK_USED(source)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_ibcast requires MPI-3 standard")
-#endif
 #else
       MARK_USED(msg)
       MARK_USED(source)
@@ -1025,16 +1017,9 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
       CALL add_perf(perf_id=22, count=1, msg_size=msglen*${bytes1}$)
-#else
-      MARK_USED(source)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_ibcast requires MPI-3 standard")
-#endif
 #else
       MARK_USED(source)
       MARK_USED(gid)
@@ -1189,7 +1174,6 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       msglen = SIZE(msg)
       IF (msglen > 0) THEN
          CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, request, ierr)
@@ -1198,13 +1182,6 @@
          request = mp_request_null
       END IF
       CALL add_perf(perf_id=23, count=1, msg_size=msglen*${bytes1}$)
-#else
-      MARK_USED(msg)
-      MARK_USED(msglen)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_isum requires MPI-3 standard")
-#endif
 #else
       MARK_USED(msg)
       MARK_USED(gid)
@@ -1661,19 +1638,10 @@
 
       msglen = 1
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
                         msglen, ${mpi_type1}$, root, gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
-#else
-      MARK_USED(msg_scatter)
-      MARK_USED(msg)
-      MARK_USED(root)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iscatter requires MPI-3 standard")
-#endif
 #else
       MARK_USED(root)
       MARK_USED(gid)
@@ -1706,19 +1674,10 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
                         msglen, ${mpi_type1}$, root, gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
-#else
-      MARK_USED(msg_scatter)
-      MARK_USED(msg)
-      MARK_USED(root)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iscatter requires MPI-3 standard")
-#endif
 #else
       MARK_USED(root)
       MARK_USED(gid)
@@ -1751,22 +1710,10 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_iscatterv(msg_scatter, sendcounts, displs, ${mpi_type1}$, msg, &
                          recvcount, ${mpi_type1}$, root, gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatterv @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
-#else
-      MARK_USED(msg_scatter)
-      MARK_USED(sendcounts)
-      MARK_USED(displs)
-      MARK_USED(msg)
-      MARK_USED(recvcount)
-      MARK_USED(root)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iscatterv requires MPI-3 standard")
-#endif
 #else
       MARK_USED(sendcounts)
       MARK_USED(displs)
@@ -1970,7 +1917,6 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       CALL mpi_igatherv(sendbuf, sendcount, ${mpi_type1}$, &
                         recvbuf, recvcounts, displs, ${mpi_type1}$, &
                         root, comm, request, ierr)
@@ -1978,17 +1924,6 @@
       CALL add_perf(perf_id=24, &
                     count=1, &
                     msg_size=sendcount*${bytes1}$)
-#else
-      MARK_USED(sendbuf)
-      MARK_USED(sendcount)
-      MARK_USED(recvbuf)
-      MARK_USED(recvcounts)
-      MARK_USED(displs)
-      MARK_USED(root)
-      MARK_USED(comm)
-      request = mp_request_null
-      CPABORT("mp_igatherv requires MPI-3 standard")
-#endif
 #else
       MARK_USED(sendcount)
       MARK_USED(recvcounts)
@@ -2110,16 +2045,10 @@
 #if defined(__parallel)
       scount = 1
       rcount = 1
-#if __MPI_VERSION > 2
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
                           gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
-#else
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
       MARK_USED(gid)
       msgin = msgout
@@ -2307,22 +2236,12 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       scount = SIZE(msgout(:))
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
                           gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-      MARK_USED(msgout)
-      MARK_USED(msgin)
-      MARK_USED(rcount)
-      MARK_USED(scount)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
       MARK_USED(gid)
       msgin = msgout
@@ -2357,22 +2276,12 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       scount = SIZE(msgout(:))
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
                           gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-      MARK_USED(msgout)
-      MARK_USED(msgin)
-      MARK_USED(rcount)
-      MARK_USED(scount)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
       MARK_USED(gid)
       msgin(:, 1, 1) = msgout(:)
@@ -2407,22 +2316,12 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       scount = SIZE(msgout(:, :))
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
                           gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-      MARK_USED(msgout)
-      MARK_USED(msgin)
-      MARK_USED(rcount)
-      MARK_USED(scount)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
       MARK_USED(gid)
       msgin(:, :) = msgout(:, :)
@@ -2457,22 +2356,12 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       scount = SIZE(msgout(:, :))
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
                           gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
-#else
-      MARK_USED(msgout)
-      MARK_USED(msgin)
-      MARK_USED(rcount)
-      MARK_USED(scount)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iallgather requires MPI-3 standard")
-#endif
 #else
       MARK_USED(gid)
       msgin(:, :, 1, 1) = msgout(:, :)
@@ -2507,21 +2396,11 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       scount = SIZE(msgout(:, :, :))
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
                           gid, request, ierr)
-#else
-      MARK_USED(msgout)
-      MARK_USED(msgin)
-      MARK_USED(rcount)
-      MARK_USED(scount)
-      MARK_USED(gid)
-      request = mp_request_null
-      CPABORT("mp_iallgather requires MPI-3 standard")
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2613,18 +2492,9 @@
 #if defined(__parallel)
       scount = SIZE(msgout)
       rsize = SIZE(rcount)
-#if __MPI_VERSION > 2
       CALL mp_iallgatherv_${nametype1}$v_internal(msgout, scount, msgin, rsize, rcount, &
                                                   rdispl, gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgatherv @ "//routineN)
-#else
-      MARK_USED(rcount)
-      MARK_USED(rdispl)
-      MARK_USED(gid)
-      MARK_USED(msgin)
-      request = mp_request_null
-      CPABORT("mp_iallgatherv requires MPI-3 standard")
-#endif
 #else
       MARK_USED(rcount)
       MARK_USED(rdispl)
@@ -2671,18 +2541,9 @@
 #if defined(__parallel)
       scount = SIZE(msgout)
       rsize = SIZE(rcount)
-#if __MPI_VERSION > 2
       CALL mp_iallgatherv_${nametype1}$v_internal(msgout, scount, msgin, rsize, rcount, &
                                                   rdispl, gid, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgatherv @ "//routineN)
-#else
-      MARK_USED(rcount)
-      MARK_USED(rdispl)
-      MARK_USED(gid)
-      MARK_USED(msgin)
-      request = mp_request_null
-      CPABORT("mp_iallgatherv requires MPI-3 standard")
-#endif
 #else
       MARK_USED(rcount)
       MARK_USED(rdispl)
@@ -2702,7 +2563,6 @@
 !> \param ierr ...
 !> \author Alfio Lazzaro
 ! **************************************************************************************************
-#if defined(__parallel) && (__MPI_VERSION > 2)
    SUBROUTINE mp_iallgatherv_${nametype1}$v_internal(msgout, scount, msgin, rsize, rcount, rdispl, gid, request, ierr)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
@@ -2714,7 +2574,6 @@
                            rdispl, ${mpi_type1}$, gid, request, ierr)
 
    END SUBROUTINE mp_iallgatherv_${nametype1}$v_internal
-#endif
 
 ! **************************************************************************************************
 !> \brief Sums a vector and partitions the result among processes
@@ -3631,20 +3490,17 @@
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_rget_${nametype1}$v'
 
       INTEGER                                  :: ierr, handle
-#if defined(__parallel) && (__MPI_VERSION > 2)
       INTEGER                                  :: len, &
                                                   handle_origin_datatype, &
                                                   handle_target_datatype, &
                                                   origin_len, target_len
       LOGICAL                                  :: do_local_copy
       INTEGER(kind=mpi_address_kind)           :: disp_aint
-#endif
 
       ierr = 0
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-#if __MPI_VERSION > 2
       len = SIZE(base)
       disp_aint = 0
       IF (PRESENT(disp)) THEN
@@ -3681,18 +3537,6 @@
          request = mp_request_null
          ierr = 0
       END IF
-#else
-      MARK_USED(source)
-      MARK_USED(win)
-      MARK_USED(disp)
-      MARK_USED(myproc)
-      MARK_USED(origin_datatype)
-      MARK_USED(target_datatype)
-      MARK_USED(win_data)
-
-      request = mp_request_null
-      CPABORT("mp_rget requires MPI-3 standard")
-#endif
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_rget @ "//routineN)
 
       CALL add_perf(perf_id=25, count=1, msg_size=SIZE(base)*${bytes1}$)

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -121,6 +121,7 @@ message_passing.fypp: Rank mismatch between actual argument at (1) and actual ar
 message_passing.fypp: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-3)
 message_passing.fypp: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-4)
 message_passing.fypp: Type mismatch between actual argument at (1) and actual argument at (2) (COMPLEX(8)/COMPLEX(4)).
+message_passing.F: Flag '__MPI_VERSION' not mentioned in cp2k_flags()
 mltfftsg_tools.F: Found WRITE statement with hardcoded unit in "ctrig"
 mode_selective.F: Found READ with unchecked STAT in "bfgs_guess"
 nequip_unittest.F: Found WRITE statement with hardcoded unit in "nequip_unittest"

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -61,9 +61,11 @@ case "${with_openmpi}" in
       else
         EXTRA_CONFIGURE_FLAGS=""
       fi
+      # We still require MPI-1.0-compatability for PTSCOTCH
       ./configure CFLAGS="${CFLAGS}" \
         --prefix=${pkg_install_dir} \
         --libdir="${pkg_install_dir}/lib" \
+        --enable-mpi1-compatibility \
         ${EXTRA_CONFIGURE_FLAGS} \
         > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
       make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -64,7 +64,6 @@ case "${with_openmpi}" in
       ./configure CFLAGS="${CFLAGS}" \
         --prefix=${pkg_install_dir} \
         --libdir="${pkg_install_dir}/lib" \
-        --enable-mpi1-compatibility \
         ${EXTRA_CONFIGURE_FLAGS} \
         > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
       make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log


### PR DESCRIPTION
The MPI-3.0-specification was published 10 years (!) ago. Thus, we may safely assume that all MPI implementations in use support the MPI-3.0-standard. (MPI-4.1 was released last year. Hints to "older" implementations of MPI in CP2K are ca. 7 years old.)

As a follow-up, we may switch from the Fortran 90 bindings to the Fortran 2008 bindings.
One should apply these changes to DBCSR, too.
PT-Scotch and PEXSI could be updated to a later version to drop the mp1-compatability-flag and stick completely to the MPI-3.0-standard.