### PR TITLE
Fix ScalaPACK toolchain

### DIFF
--- a/tools/toolchain/scripts/stage4/install_scalapack.sh
+++ b/tools/toolchain/scripts/stage4/install_scalapack.sh
@@ -45,7 +45,11 @@ case "$with_scalapack" in
       mkdir -p "scalapack-${scalapack_ver}/build"
       pushd "scalapack-${scalapack_ver}/build" > /dev/null
 
-      FFLAGS="-fallow-argument-mismatch" cmake -DCMAKE_FIND_ROOT_PATH="$ROOTDIR" \
+      flags=""
+      if ("${FC}" --version | grep -q 'GNU'); then
+        flags=$(allowed_gfortran_flags "-fallow-argument-mismatch")
+      fi
+      FFLAGS=$flags cmake -DCMAKE_FIND_ROOT_PATH="$ROOTDIR" \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DBUILD_SHARED_LIBS=NO \


### PR DESCRIPTION
Fixing the issue occuring when intalling ScalaPACK with the toolchain, when system GCC has version <10.