### PR TITLE
Limit the number of parallel communication channels

### DIFF
--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -475,6 +475,17 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
+         name="MAX_PARALLEL_COMM", &
+         description="Sets the maximum number of parallel communication steps of the non-blocking communication scheme. "// &
+         "The number of channels is determined from the available memory. If set to a value smaller than one, "// &
+         "CP2K will use all memory for communication. A value of one enforces the blocking communication scheme "// &
+         "increasing the communication costs.", &
+         default_i_val=2)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
    END SUBROUTINE create_canonical_gradients
 
 ! **************************************************************************************************

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -375,6 +375,7 @@ CONTAINS
       CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%EPS_CANONICAL", r_val=mp2_env%ri_grad%eps_canonical)
       CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%USE_OLD_GRADIENT_CODE", l_val=mp2_env%ri_grad%use_old_grad)
       CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%DOT_PRODUCT_BLKSIZE", i_val=mp2_env%ri_grad%dot_blksize)
+      CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%MAX_PARALLEL_COMM", i_val=mp2_env%ri_grad%max_parallel_comm)
       cphf_section => section_vals_get_subs_vals(mp2_section, "CANONICAL_GRADIENTS%CPHF")
       IF (ASSOCIATED(cphf_section)) THEN
          CALL section_vals_val_get(cphf_section, "MAX_ITER", i_val=mp2_env%ri_grad%cphf_max_num_iter)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -236,6 +236,7 @@ MODULE mp2_types
       LOGICAL                  :: free_hfx_buffer
       LOGICAL                  :: use_old_grad
       INTEGER :: dot_blksize
+      INTEGER :: max_parallel_comm
    END TYPE
 
    TYPE mp2_type

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -1067,6 +1067,8 @@ CONTAINS
       mem_per_block = REAL(number_of_elements_per_blk, KIND=dp)*8.0_dp
       number_of_parallel_channels = MAX(1, MIN(MAXVAL(grid) - 1, FLOOR(mem_real/mem_per_block)))
       CALL mp_min(number_of_parallel_channels, para_env%group)
+      IF (mp2_env%ri_grad%max_parallel_comm > 0) &
+         number_of_parallel_channels = MIN(number_of_parallel_channels, mp2_env%ri_grad%max_parallel_comm)
 
       IF (unit_nr > 0) THEN
          WRITE (unit_nr, '(T3,A,T75,I6)') 'GRAD_INFO| Number of parallel communication channels:', number_of_parallel_channels


### PR DESCRIPTION
to reduce the memory footprint

The used estimate does not consider overhead from MPI which may lead to an out-of-memory event.