### PR TITLE
Refactor MPI handles

### DIFF
--- a/src/almo_scf.F
+++ b/src/almo_scf.F
@@ -81,7 +81,8 @@ MODULE almo_scf
    USE kinds,                           ONLY: default_path_length,&
                                               dp
    USE mathlib,                         ONLY: binomial
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE molecule_types,                  ONLY: get_molecule_set_info,&
                                               molecule_type
    USE mscfg_types,                     ONLY: get_matrix_from_submatrices,&
@@ -1923,10 +1924,8 @@ CONTAINS
       TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: matrix
 
-      INTEGER                                            :: iblock_col, iblock_col_size, iblock_row, &
-                                                            iblock_row_size, icol, irow, ispin, &
-                                                            Ncols, Nrows, nspins, para_group, &
-                                                            unit_nr
+      INTEGER :: iblock_col, iblock_col_size, iblock_row, iblock_row_size, icol, irow, ispin, &
+         Ncols, Nrows, nspins, para_group_handle, unit_nr
       LOGICAL                                            :: element_by_element
       REAL(KIND=dp)                                      :: energy, eps_local, eps_start, &
                                                             max_element, spin_factor
@@ -1935,6 +1934,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: matrix_p_tmp, matrix_t_tmp
+      TYPE(mp_comm_type)                                 :: para_group
 
       ! define the output_unit
       logger => cp_get_default_logger()
@@ -2032,9 +2032,10 @@ CONTAINS
             CALL dbcsr_finalize(matrix_t_tmp(ispin))
             CALL dbcsr_filter(matrix_t_tmp(ispin), eps_local)
 
-            CALL dbcsr_get_info(matrix_t_tmp(ispin), group=para_group, &
+            CALL dbcsr_get_info(matrix_t_tmp(ispin), group=para_group_handle, &
                                 nfullrows_total=Nrows, &
                                 nfullcols_total=Ncols)
+            CALL para_group%set_handle(para_group_handle)
             CALL mp_sum(retained(ispin), para_group)
 
             !devide by the total no. elements

--- a/src/almo_scf_methods.F
+++ b/src/almo_scf_methods.F
@@ -55,6 +55,7 @@ MODULE almo_scf_methods
                                               matrix_sqrt_Newton_Schulz
    USE kinds,                           ONLY: dp
    USE mathlib,                         ONLY: binomial
+   USE message_passing,                 ONLY: mp_comm_type
    USE util,                            ONLY: sort
 #include "./base/base_uses.f90"
 
@@ -3237,11 +3238,13 @@ CONTAINS
       TYPE(dbcsr_type)                                   :: copy1
       TYPE(domain_submatrix_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: subm_nn, subm_no
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
       ndomains = dbcsr_nblkcols_total(dpattern)
       CALL dbcsr_get_info(dpattern, group=GroupID)
+      CALL group%set_handle(groupid)
 
       ALLOCATE (subm_no(ndomains), subm_nn(ndomains))
       CALL init_submatrices(subm_no)
@@ -3249,11 +3252,11 @@ CONTAINS
 
       !CALL dbcsr_print(matrix_nn)
       !CALL construct_submatrices(matrix_nn,subm_nn,dpattern,map,select_row_col)
-      !CALL print_submatrices(subm_nn,GroupID)
+      !CALL print_submatrices(subm_nn,Group)
 
       !CALL dbcsr_print(matrix_no)
       CALL construct_submatrices(matrix_no, subm_no, dpattern, map, node_of_domain, select_row)
-      CALL print_submatrices(subm_no, GroupID)
+      CALL print_submatrices(subm_no, group)
 
       CALL dbcsr_create(copy1, template=matrix_no)
       CALL dbcsr_copy(copy1, matrix_no)

--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -93,7 +93,8 @@ MODULE almo_scf_optimizer
    USE kinds,                           ONLY: dp
    USE machine,                         ONLY: m_flush,&
                                               m_walltime
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE particle_methods,                ONLY: get_particle_set
    USE particle_types,                  ONLY: particle_type
    USE qs_energy_types,                 ONLY: qs_energy_type
@@ -880,7 +881,7 @@ CONTAINS
       CHARACTER(LEN=20)                                  :: iter_type
       INTEGER :: cg_iteration, dim_op, fixed_line_search_niter, handle, idim0, ielem, ispin, &
          iteration, line_search_iteration, max_iter, my_special_case, ndomains, nmo, nspins, &
-         outer_iteration, outer_max_iter, para_group, prec_type, reim, unit_nr
+         outer_iteration, outer_max_iter, para_group_handle, prec_type, reim, unit_nr
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: nocc
       LOGICAL :: blissful_neglect, converged, just_started, line_search, normalize_orbitals, &
          optimize_theta, outer_prepare_to_exit, penalty_occ_local, penalty_occ_vol, &
@@ -902,6 +903,7 @@ CONTAINS
          STsiginv_0, tempNOcc, tempNOcc_1, tempOccOcc
       TYPE(domain_submatrix_type), ALLOCATABLE, &
          DIMENSION(:, :)                                 :: bad_modes_projector_down, domain_r_down
+      TYPE(mp_comm_type)                                 :: para_group
 
       CALL timeset(routineN, handle)
 
@@ -1315,7 +1317,8 @@ CONTAINS
                   ALLOCATE (z2(nmo))
                   ALLOCATE (reim_diag(nmo))
 
-                  CALL dbcsr_get_info(tempOccOcc(ispin), group=para_group)
+                  CALL dbcsr_get_info(tempOccOcc(ispin), group=para_group_handle)
+                  CALL para_group%set_handle(para_group_handle)
 
                   DO idim0 = 1, SIZE(op_sm_set_qs, 2) ! this loop is over miller ind
 
@@ -2020,7 +2023,7 @@ CONTAINS
       CHARACTER(LEN=30)                                  :: iter_type, print_string
       INTEGER :: cg_iteration, dim_op, handle, iatom, idim0, isgf, ispin, iteration, &
          line_search_iteration, linear_search_type, max_iter, natom, ncol, nspins, &
-         outer_iteration, outer_max_iter, para_group, prec_type, reim, unit_nr
+         outer_iteration, outer_max_iter, para_group_handle, prec_type, reim, unit_nr
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf, nocc, nsgf
       LOGICAL                                            :: converged, d_bfgs, just_started, l_bfgs, &
                                                             line_search, outer_prepare_to_exit, &
@@ -2043,6 +2046,7 @@ CONTAINS
          tempOccOcc2, tempOccOcc3
       TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:, :, :)  :: m_B0
       TYPE(lbfgs_history_type)                           :: nlmo_lbfgs_history
+      TYPE(mp_comm_type)                                 :: para_group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
@@ -2413,7 +2417,8 @@ CONTAINS
 
             DO ispin = 1, nspins
 
-               CALL dbcsr_get_info(m_sig_sqrti_ii(ispin), group=para_group)
+               CALL dbcsr_get_info(m_sig_sqrti_ii(ispin), group=para_group_handle)
+               CALL para_group%set_handle(para_group_handle)
 
                ! compute diagonal (a^t.sigma0.a)^(-1/2)
                CALL dbcsr_multiply("N", "N", 1.0_dp, &
@@ -6474,10 +6479,12 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'compute_obj_nlmos'
 
-      INTEGER                                            :: handle, idim0, ielem, para_group, reim
+      INTEGER                                            :: handle, idim0, ielem, para_group_handle, &
+                                                            reim
       REAL(KIND=dp)                                      :: det1, fval
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: reim_diag, z2
       TYPE(dbcsr_type)                                   :: tempNOcc1, tempOccOcc1, tempOccOcc2
+      TYPE(mp_comm_type)                                 :: para_group
 
       CALL timeset(routineN, handle)
 
@@ -6496,7 +6503,8 @@ CONTAINS
       ALLOCATE (z2(nocc))
       ALLOCATE (reim_diag(nocc))
 
-      CALL dbcsr_get_info(tempOccOcc2, group=para_group)
+      CALL dbcsr_get_info(tempOccOcc2, group=para_group_handle)
+      CALL para_group%set_handle(para_group_handle)
 
       DO idim0 = 1, SIZE(m_B0, 2) ! this loop is over miller ind
 

--- a/src/almo_scf_qs.F
+++ b/src/almo_scf_qs.F
@@ -50,7 +50,8 @@ MODULE almo_scf_qs
                                               do_bondparm_covalent,&
                                               do_bondparm_vdw
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_allgather
+   USE message_passing,                 ONLY: mp_allgather,&
+                                              mp_comm_type
    USE molecule_types,                  ONLY: get_molecule_set_info,&
                                               molecule_type
    USE particle_types,                  ONLY: particle_type
@@ -871,6 +872,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dbcsr_type)                                   :: matrix_s_sym
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: nl_iterator, nl_iterator2
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
@@ -944,6 +946,7 @@ CONTAINS
 
       CALL dbcsr_get_info(almo_scf_env%quench_t(ispin), distribution=dist)
       CALL dbcsr_distribution_get(dist, numnodes=nNodes, group=GroupID, mynode=mynode)
+      CALL group%set_handle(groupid)
 
       ! create global atom neighbor list from the local lists
       ! first, calculate number of local pairs
@@ -977,7 +980,7 @@ CONTAINS
 
       ! third, communicate local length to the other nodes
       ALLOCATE (list_length_cpu(nNodes), list_offset_cpu(nNodes))
-      CALL mp_allgather(2*local_list_length, list_length_cpu, GroupID)
+      CALL mp_allgather(2*local_list_length, list_length_cpu, group)
 
       ! fourth, create a global list
       list_offset_cpu(1) = 0
@@ -990,7 +993,7 @@ CONTAINS
       ! fifth, communicate all list data
       ALLOCATE (global_list(global_list_length))
       CALL mp_allgather(local_list, global_list, &
-                        list_length_cpu, list_offset_cpu, GroupID)
+                        list_length_cpu, list_offset_cpu, group)
       DEALLOCATE (list_length_cpu, list_offset_cpu)
       DEALLOCATE (local_list)
 
@@ -1393,7 +1396,7 @@ CONTAINS
 
       ! first, communicate map sizes on the other nodes
       ALLOCATE (domain_entries_cpu(nNodes), offset_for_cpu(nNodes))
-      CALL mp_allgather(2*domain_map_local_entries, domain_entries_cpu, GroupID)
+      CALL mp_allgather(2*domain_map_local_entries, domain_entries_cpu, group)
 
       ! second, create
       offset_for_cpu(1) = 0
@@ -1411,7 +1414,7 @@ CONTAINS
          domain_map_local(2*ientry) = almo_scf_env%domain_map(ispin)%pairs(ientry, 2)
       END DO
       CALL mp_allgather(domain_map_local, domain_map_global, &
-                        domain_entries_cpu, offset_for_cpu, GroupID)
+                        domain_entries_cpu, offset_for_cpu, group)
       DEALLOCATE (domain_entries_cpu, offset_for_cpu)
       DEALLOCATE (domain_map_local)
 

--- a/src/arnoldi/arnoldi_api.F
+++ b/src/arnoldi/arnoldi_api.F
@@ -41,7 +41,8 @@ MODULE arnoldi_api
                                               create_replicated_row_vec_from_matrix,&
                                               dbcsr_matrix_colvec_multiply
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -309,7 +310,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'arnoldi_conjugate_gradient'
 
-      INTEGER                                            :: handle, i, j, mpgrp, nb, nloc, no
+      INTEGER                                            :: handle, i, j, nb, nloc, no
       INTEGER, DIMENSION(:), POINTER                     :: rb_offset, rb_size
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xvec
       TYPE(arnoldi_control_type), POINTER                :: control
@@ -368,8 +369,7 @@ CONTAINS
       END DO
       CALL dbcsr_iterator_stop(dbcsr_iter)
       control => get_control(my_arnoldi)
-      mpgrp = control%mp_group
-      CALL mp_sum(vec_x, mpgrp)
+      CALL mp_sum(vec_x, control%mp_group)
       ! Deallocated the work vectors
       CALL dbcsr_release(x)
       CALL dbcsr_release(vectors%input_vec)
@@ -395,11 +395,12 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:)                   :: arnoldi_matrices
       TYPE(m_x_v_vectors_type)                           :: vectors
 
-      INTEGER                                            :: iter, mpgrp, pcgrp
+      INTEGER                                            :: iter
       REAL(KIND=dp)                                      :: alpha, beta, pap, rsnew, rsold
       TYPE(arnoldi_control_type), POINTER                :: control
       TYPE(dbcsr_type)                                   :: apvec, pvec, rvec, zvec
       TYPE(dbcsr_type), POINTER                          :: amat, pmat, xvec
+      TYPE(mp_comm_type)                                 :: mpgrp, pcgrp
 
       control => get_control(arnoldi_data)
       control%converged = .FALSE.
@@ -507,7 +508,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION vec_dot_vec(avec, bvec, mpgrp) RESULT(adotb)
       TYPE(dbcsr_type)                                   :: avec, bvec
-      INTEGER, INTENT(IN)                                :: mpgrp
+      TYPE(mp_comm_type), INTENT(IN)                     :: mpgrp
       REAL(KIND=dp)                                      :: adotb
 
       INTEGER                                            :: i, j

--- a/src/arnoldi/arnoldi_data_methods.F
+++ b/src/arnoldi/arnoldi_data_methods.F
@@ -107,6 +107,7 @@ CONTAINS
       INTEGER                                            :: selection_crit, nval_request, nrestarts
       LOGICAL                                            :: generalized_ev, iram
 
+      INTEGER :: prow_handle, pcol_handle, group_handle
       LOGICAL                                            :: subgroups_defined
       TYPE(arnoldi_control_type), POINTER                :: control
       TYPE(dbcsr_distribution_type)                      :: distri
@@ -116,11 +117,15 @@ CONTAINS
       CALL dbcsr_get_info(matrix=matrix(1)%matrix, distribution=distri)
       CALL dbcsr_mp_grid_setup(distri)
       CALL dbcsr_distribution_get(distri, &
-                                  group=control%mp_group, &
+                                  group=group_handle, &
                                   mynode=control%myproc, &
                                   subgroups_defined=subgroups_defined, &
-                                  prow_group=control%prow_group, &
-                                  pcol_group=control%pcol_group)
+                                  prow_group=prow_handle, &
+                                  pcol_group=pcol_handle)
+
+      CALL control%mp_group%set_handle(group_handle)
+      CALL control%prow_group%set_handle(prow_handle)
+      CALL control%pcol_group%set_handle(pcol_handle)
 
       IF (.NOT. subgroups_defined) &
          CPABORT("arnoldi only with subgroups")

--- a/src/arnoldi/arnoldi_methods.F
+++ b/src/arnoldi/arnoldi_methods.F
@@ -29,7 +29,7 @@ MODULE arnoldi_methods
    USE kinds, ONLY: real_4, &
                     real_8
    USE message_passing, ONLY: mp_bcast, &
-                              mp_sum
+                              mp_sum, mp_comm_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -355,7 +355,7 @@ CONTAINS
          TYPE(arnoldi_data_type)                 :: arnoldi_data
 
          INTEGER                                  :: i, iseed(4), row_size, col_size, &
-                                                     nrow_local, ncol_local, pcol_group, &
+                                                     nrow_local, ncol_local, &
                                                      row, col
          REAL(${type_prec}$)                        :: rnorm
          TYPE(dbcsr_iterator_type)                     :: iter
@@ -366,6 +366,7 @@ CONTAINS
          LOGICAL                                  :: local_comp
          TYPE(arnoldi_data_${nametype1}$_type), POINTER            :: ar_data
          TYPE(arnoldi_control_type), POINTER           :: control
+         TYPE(mp_comm_type)                       :: pcol_group
 
          control => get_control(arnoldi_data)
          pcol_group = control%pcol_group
@@ -663,7 +664,8 @@ CONTAINS
                                                    j, local_history, reorth_mat, local_comp, pcol_group)
          ${type_nametype1}$, DIMENSION(:)      :: h_vec, s_vec, f_vec, w_vec
          ${type_nametype1}$, DIMENSION(:, :)    :: local_history, reorth_mat
-         INTEGER                                          :: nrow_local, j, pcol_group
+         INTEGER                                          :: nrow_local, j
+         TYPE(mp_comm_type), INTENT(IN)                   :: pcol_group
          LOGICAL                                          :: local_comp
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'Gram_Schmidt_ortho_${nametype1}$'
@@ -701,7 +703,8 @@ CONTAINS
                                            local_history, reorth_mat, local_comp, pcol_group)
          ${type_nametype1}$, DIMENSION(:)      :: h_vec, s_vec, f_vec
          ${type_nametype1}$, DIMENSION(:, :)    :: local_history, reorth_mat
-         INTEGER                                          :: nrow_local, j, pcol_group
+         INTEGER                                          :: nrow_local, j
+         TYPE(mp_comm_type), INTENT(IN)           :: pcol_group
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'DGKS_ortho_${nametype1}$'
          LOGICAL                                          :: local_comp
@@ -732,7 +735,7 @@ CONTAINS
          ${type_nametype1}$, DIMENSION(:)           :: vec
          REAL(${type_prec}$)                        :: rnorm
          ${type_nametype1}$                         :: norm
-         INTEGER                                  :: pcol_group
+         TYPE(mp_comm_type), INTENT(IN)             :: pcol_group
 
          ! the norm is computed along the processor column
          norm = DOT_PRODUCT(vec, vec)
@@ -758,7 +761,7 @@ CONTAINS
          TYPE(arnoldi_data_type)                 :: arnoldi_data
 
          INTEGER                                  :: iseed(4), row_size, col_size, &
-                                                     nrow_local, ncol_local, pcol_group, &
+                                                     nrow_local, ncol_local, &
                                                      row, col
          REAL(${type_prec}$)                        :: rnorm
          TYPE(dbcsr_iterator_type)                     :: iter
@@ -769,6 +772,7 @@ CONTAINS
          LOGICAL                                  :: local_comp
          TYPE(arnoldi_data_${nametype1}$_type), POINTER            :: ar_data
          TYPE(arnoldi_control_type), POINTER           :: control
+         TYPE(mp_comm_type)                         :: pcol_group
 
          control => get_control(arnoldi_data)
          pcol_group = control%pcol_group
@@ -847,12 +851,13 @@ CONTAINS
          TYPE(m_x_v_vectors_type)                :: vectors
          TYPE(arnoldi_data_type)                 :: arnoldi_data
 
-         INTEGER                                  :: j, ncol_local, nrow_local, pcol_group
+         INTEGER                                  :: j, ncol_local, nrow_local
          TYPE(arnoldi_control_type), POINTER           :: control
          TYPE(arnoldi_data_${nametype1}$_type), POINTER            :: ar_data
          ${type_nametype1}$                         :: norm
          ${type_nametype1}$, ALLOCATABLE, DIMENSION(:)      :: h_vec, s_vec, v_vec, w_vec
          ${type_nametype1}$, ALLOCATABLE, DIMENSION(:, :)    :: Zmat, CZmat, BZmat
+         TYPE(mp_comm_type)                           :: pcol_group
 
          ar_data => get_data_${nametype1}$ (arnoldi_data)
          control => get_control(arnoldi_data)

--- a/src/arnoldi/arnoldi_types.F
+++ b/src/arnoldi/arnoldi_types.F
@@ -16,6 +16,7 @@ MODULE arnoldi_types
    USE dbcsr_api,                       ONLY: dbcsr_type
    USE kinds,                           ONLY: real_4,&
                                               real_8
+   USE message_passing,                 ONLY: mp_comm_type
 
    IMPLICIT NONE
 
@@ -24,7 +25,8 @@ MODULE arnoldi_types
 ! Give him everything we have and create some easy to use routines to post process externally
    TYPE arnoldi_control_type
       LOGICAL                                 :: local_comp, converged
-      INTEGER                                 :: myproc, mp_group, pcol_group, prow_group
+      INTEGER                                 :: myproc
+      TYPE(mp_comm_type)                      :: mp_group, pcol_group, prow_group
       INTEGER                                 :: max_iter ! Maximum number of iterations
       INTEGER                                 :: current_step ! In case subspace converged early contains last iteration
       INTEGER                                 :: nval_req

--- a/src/bse.F
+++ b/src/bse.F
@@ -25,6 +25,7 @@ MODULE bse
                                               group_dist_d1_type
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_alltoall,&
+                                              mp_request_type,&
                                               mp_sum
    USE mp2_types,                       ONLY: integ_mat_buffer_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
@@ -491,10 +492,10 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: entry_counter, mepos_from_RI_index, &
                                                             num_entries_rec, num_entries_send
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      INTEGER, DIMENSION(:, :), POINTER                  :: req_array
       REAL(KIND=dp)                                      :: matrix_el
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_send
+      TYPE(mp_request_type), DIMENSION(:, :), POINTER    :: req_array
 
       CALL timeset(routineN, handle)
 

--- a/src/common/cp_log_handling.F
+++ b/src/common/cp_log_handling.F
@@ -621,7 +621,7 @@ CONTAINS
                CALL m_hostnm(host_name)
                PRINT *, " *** Error trying to WRITE to the local logger ***"
                PRINT *, " *** MPI_id           = ", lggr%para_env%mepos
-               PRINT *, " *** MPI_Communicator = ", lggr%para_env%group
+               PRINT *, " *** MPI_Communicator = ", lggr%para_env%group%get_handle()
                PRINT *, " *** PID              = ", pid
                PRINT *, " *** Hostname         = "//TRIM(host_name)
                CALL print_stack(default_output_unit)
@@ -640,7 +640,7 @@ CONTAINS
                            unit_number=lggr%default_local_unit_nr)
             WRITE (UNIT=lggr%default_local_unit_nr, FMT='(/,T2,A,I0,A,I0,A)', IOSTAT=iostat) &
                '*** Local logger file of MPI task ', lggr%para_env%mepos, &
-               ' in communicator ', lggr%para_env%group, ' ***'
+               ' in communicator ', lggr%para_env%group%get_handle(), ' ***'
             IF (iostat == 0) THEN
                CALL m_getpid(pid)
                CALL m_hostnm(host_name)
@@ -654,7 +654,7 @@ CONTAINS
                CALL m_hostnm(host_name)
                PRINT *, " *** Error trying to WRITE to the local logger ***"
                PRINT *, " *** MPI_id           = ", lggr%para_env%mepos
-               PRINT *, " *** MPI_Communicator = ", lggr%para_env%group
+               PRINT *, " *** MPI_Communicator = ", lggr%para_env%group%get_handle()
                PRINT *, " *** PID              = ", pid
                PRINT *, " *** Hostname         = "//TRIM(host_name)
                CALL print_stack(default_output_unit)

--- a/src/common/cp_para_env.F
+++ b/src/common/cp_para_env.F
@@ -17,6 +17,7 @@ MODULE cp_para_env
                                               cp_para_env_type
    USE message_passing,                 ONLY: mp_comm_free,&
                                               mp_comm_split_direct,&
+                                              mp_comm_type,&
                                               mp_environ
 #include "../base/base_uses.f90"
 
@@ -46,7 +47,7 @@ CONTAINS
    SUBROUTINE cp_para_env_create(para_env, group, source, mepos, num_pe, &
                                  owns_group)
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(in)                                :: group
+      TYPE(mp_comm_type), INTENT(in)                     :: group
       INTEGER, INTENT(in), OPTIONAL                      :: source, mepos, num_pe
       LOGICAL, INTENT(in), OPTIONAL                      :: owns_group
 
@@ -59,7 +60,7 @@ CONTAINS
       IF (PRESENT(source)) para_env%source = source
       IF (PRESENT(owns_group)) para_env%owns_group = owns_group
       IF (.NOT. (PRESENT(mepos) .AND. PRESENT(num_pe))) THEN
-         CALL mp_environ(taskid=para_env%mepos, numtask=para_env%num_pe, groupid=group)
+         CALL mp_environ(taskid=para_env%mepos, numtask=para_env%num_pe, group=group)
       ELSE
          para_env%mepos = mepos
          para_env%num_pe = num_pe
@@ -94,7 +95,7 @@ CONTAINS
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_template
       INTEGER, INTENT(IN)                                :: color
 
-      INTEGER                                            :: comm
+      TYPE(mp_comm_type)                                 :: comm
 
       CPASSERT(para_env_template%ref_count > 0)
       CALL mp_comm_split_direct(para_env_template%group, comm, color)
@@ -141,7 +142,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_cart_create(cart, group, ndims, owns_group)
       TYPE(cp_para_cart_type), POINTER                   :: cart
-      INTEGER, INTENT(in)                                :: group, ndims
+      TYPE(mp_comm_type), INTENT(in)                     :: group
+      INTEGER, INTENT(in)                                :: ndims
       LOGICAL, INTENT(in), OPTIONAL                      :: owns_group
 
       CPASSERT(.NOT. ASSOCIATED(cart))
@@ -173,7 +175,7 @@ CONTAINS
       CPASSERT(cart%ref_count > 0)
       CALL mp_environ(cart%group, cart%ndims, cart%num_pe, task_coor=cart%mepos, &
                       periods=cart%periodic)
-      CALL mp_environ(numtask=cart%ntask, taskid=cart%rank, groupid=cart%group)
+      CALL mp_environ(numtask=cart%ntask, taskid=cart%rank, group=cart%group)
    END SUBROUTINE cp_cart_update
 
 ! **************************************************************************************************

--- a/src/common/cp_para_types.F
+++ b/src/common/cp_para_types.F
@@ -14,7 +14,8 @@
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
 MODULE cp_para_types
-   USE message_passing,                 ONLY: mp_comm_type
+   USE message_passing,                 ONLY: mp_comm_null,&
+                                              mp_comm_type
 
    IMPLICIT NONE
    PRIVATE
@@ -43,7 +44,7 @@ MODULE cp_para_types
    TYPE cp_para_env_type
       LOGICAL :: owns_group, ionode
       INTEGER :: mepos, source, num_pe, ref_count
-      TYPE(mp_comm_type) :: group
+      TYPE(mp_comm_type) :: group = mp_comm_null
    END TYPE cp_para_env_type
 
 ! **************************************************************************************************
@@ -79,7 +80,7 @@ MODULE cp_para_types
       INTEGER :: ndims, rank, ntask
       INTEGER, DIMENSION(:), POINTER :: mepos, source, num_pe
       LOGICAL, DIMENSION(:), POINTER :: periodic
-      TYPE(mp_comm_type) :: group
+      TYPE(mp_comm_type) :: group = mp_comm_null
       INTEGER :: ref_count
    END TYPE cp_para_cart_type
 

--- a/src/common/cp_para_types.F
+++ b/src/common/cp_para_types.F
@@ -14,6 +14,7 @@
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
 MODULE cp_para_types
+   USE message_passing,                 ONLY: mp_comm_type
 
    IMPLICIT NONE
    PRIVATE
@@ -42,7 +43,7 @@ MODULE cp_para_types
    TYPE cp_para_env_type
       LOGICAL :: owns_group, ionode
       INTEGER :: mepos, source, num_pe, ref_count
-      INTEGER :: group
+      TYPE(mp_comm_type) :: group
    END TYPE cp_para_env_type
 
 ! **************************************************************************************************
@@ -78,7 +79,8 @@ MODULE cp_para_types
       INTEGER :: ndims, rank, ntask
       INTEGER, DIMENSION(:), POINTER :: mepos, source, num_pe
       LOGICAL, DIMENSION(:), POINTER :: periodic
-      INTEGER :: group, ref_count
+      TYPE(mp_comm_type) :: group
+      INTEGER :: ref_count
    END TYPE cp_para_cart_type
 
 END MODULE cp_para_types

--- a/src/common/parallel_rng_types_unittest.F
+++ b/src/common/parallel_rng_types_unittest.F
@@ -8,7 +8,7 @@
 PROGRAM parallel_rng_types_TEST
    USE message_passing, ONLY: mp_world_finalize, &
                               mp_world_init, &
-                              mp_environ
+                              mp_environ, mp_comm_type
    USE kinds, ONLY: dp
    USE machine, ONLY: m_walltime, &
                       default_output_unit
@@ -22,9 +22,10 @@ PROGRAM parallel_rng_types_TEST
 
    IMPLICIT NONE
 
-   INTEGER                          :: mpi_comm, i, nsamples, nargs, stat, mepos, num_pe
+   INTEGER                          :: i, nsamples, nargs, stat, mepos, num_pe
    LOGICAL                          :: ionode
    REAL(KIND=dp)                    :: t, tend, tmax, tmin, tstart, tsum, tsum2
+   TYPE(mp_comm_type) :: mpi_comm
    TYPE(rng_stream_type)            :: rng_stream
    CHARACTER(len=32)                :: arg
 
@@ -42,7 +43,7 @@ PROGRAM parallel_rng_types_TEST
    END IF
 
    CALL mp_world_init(mpi_comm)
-   CALL mp_environ(numtask=num_pe, taskid=mepos, groupid=mpi_comm)
+   CALL mp_environ(numtask=num_pe, taskid=mepos, group=mpi_comm)
    ionode = mepos == 0
 
    CALL check_rng(default_output_unit, ionode)

--- a/src/common/t_c_g0.F
+++ b/src/common/t_c_g0.F
@@ -56,7 +56,8 @@
 ! **************************************************************************************************
 MODULE t_c_g0
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -1354,7 +1355,8 @@ CONTAINS
 !> \param group ...
 ! **************************************************************************************************
    SUBROUTINE init(Nder, iunit, mepos, group)
-      INTEGER, INTENT(IN)                                :: Nder, iunit, mepos, group
+      INTEGER, INTENT(IN)                                :: Nder, iunit, mepos
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       INTEGER                                            :: I
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: chunk

--- a/src/common/t_sh_p_s_c.F
+++ b/src/common/t_sh_p_s_c.F
@@ -38,7 +38,8 @@
 ! **************************************************************************************************
 MODULE t_sh_p_s_c
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -1109,7 +1110,8 @@ CONTAINS
 !> \param group ...
 ! **************************************************************************************************
    SUBROUTINE INIT(Nder, iunit, mepos, group)
-      INTEGER, INTENT(IN)                                :: Nder, iunit, mepos, group
+      INTEGER, INTENT(IN)                                :: Nder, iunit, mepos
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       INTEGER                                            :: I
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: chunk

--- a/src/constraint.F
+++ b/src/constraint.F
@@ -51,7 +51,8 @@ MODULE constraint
    USE kinds,                           ONLY: default_string_length,&
                                               dp
    USE memory_utilities,                ONLY: reallocate
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE molecule_kind_types,             ONLY: get_molecule_kind,&
                                               get_molecule_kind_set,&
                                               molecule_kind_type
@@ -109,7 +110,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: log_unit, lagrange_mult
       LOGICAL, INTENT(IN)                                :: dump_lm
       TYPE(cell_type), POINTER                           :: cell
-      INTEGER, INTENT(in)                                :: group
+      TYPE(mp_comm_type), INTENT(in)                     :: group
       TYPE(distribution_1d_type), POINTER                :: local_particles
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'shake_control'
@@ -236,7 +237,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: log_unit, lagrange_mult
       LOGICAL, INTENT(IN)                                :: dump_lm
       TYPE(cell_type), POINTER                           :: cell
-      INTEGER, INTENT(in)                                :: group
+      TYPE(mp_comm_type), INTENT(in)                     :: group
       TYPE(distribution_1d_type), POINTER                :: local_particles
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'rattle_control'
@@ -355,7 +356,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(OUT)                         :: roll_tol
       INTEGER, INTENT(INOUT)                             :: iroll
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: vector_r, vector_v
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
          OPTIONAL                                        :: u
       TYPE(cell_type), POINTER                           :: cell
@@ -623,7 +624,7 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(global_constraint_type), POINTER              :: gci
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind_set(:)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       CHARACTER(LEN=1), INTENT(IN)                       :: id_type
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dump_lagrange_mult'

--- a/src/constraint_util.F
+++ b/src/constraint_util.F
@@ -15,7 +15,8 @@ MODULE constraint_util
    USE colvar_methods,                  ONLY: colvar_eval_mol_f
    USE distribution_1d_types,           ONLY: distribution_1d_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE molecule_kind_types,             ONLY: colvar_constraint_type,&
                                               fixd_constraint_type,&
                                               g3x3_constraint_type,&
@@ -202,7 +203,7 @@ CONTAINS
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(virial_type), INTENT(INOUT)                   :: virial
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       INTEGER                                            :: first_atom, i, ikind, imol, ng3x3, &
                                                             ng4x6, nkind, nmol_per_kind
@@ -633,7 +634,7 @@ CONTAINS
 !>      Teodoro Laino [tlaino] 2007
 ! **************************************************************************************************
    SUBROUTINE update_temporary_set(group, pos, vel)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT), &
          OPTIONAL                                        :: pos, vel
 

--- a/src/cp_dbcsr_operations.F
+++ b/src/cp_dbcsr_operations.F
@@ -48,6 +48,7 @@ MODULE cp_dbcsr_operations
    USE distribution_2d_types, ONLY: distribution_2d_get, &
                                     distribution_2d_type
    USE kinds, ONLY: dp, default_string_length
+   USE message_passing, ONLY: mp_comm_type
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
 #include "base/base_uses.f90"
@@ -142,13 +143,14 @@ CONTAINS
 
          CHARACTER(LEN=*), PARAMETER :: routineN = 'copy_${fm}$_to_dbcsr_bc'
 
-         INTEGER :: col, group, handle, ncol_block, ncol_global, nrow_block, nrow_global, row
+         INTEGER :: col, handle, ncol_block, ncol_global, nrow_block, nrow_global, row
          INTEGER, ALLOCATABLE, DIMENSION(:)                  :: first_col, first_row, last_col, last_row
          INTEGER, DIMENSION(:), POINTER                      :: col_blk_size, row_blk_size
          ${type}$ (KIND=dp), DIMENSION(:, :), POINTER        :: fm_block, dbcsr_block
          TYPE(dbcsr_distribution_type)                       :: bc_dist
          TYPE(dbcsr_iterator_type)                           :: iter
          INTEGER, DIMENSION(:, :), POINTER                   :: pgrid
+         TYPE(mp_comm_type) :: group
 
          CALL timeset(routineN, handle)
 
@@ -169,7 +171,7 @@ CONTAINS
          CALL dbcsr_create_dist_block_cyclic(bc_dist, &
                                              nrows=nrow_global, ncolumns=ncol_global, & ! Actual full matrix size
                                              nrow_block=nrow_block, ncol_block=ncol_block, & ! BLACS parameters
-                                             group=group, pgrid=pgrid, &
+                                             group_handle=group%get_handle(), pgrid=pgrid, &
                                              row_blk_sizes=row_blk_size, col_blk_sizes=col_blk_size) ! block-cyclic row/col sizes
 
          ! Create the block-cyclic DBCSR matrix
@@ -211,12 +213,11 @@ CONTAINS
          CHARACTER(LEN=*), PARAMETER :: routineN = 'copy_dbcsr_to_${fm}$'
 
          INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, row_blk_size
-         INTEGER :: handle, ncol_block, nfullcols_total, &
+         INTEGER :: handle, ncol_block, nfullcols_total, group_handle, &
                     nfullrows_total, nrow_block
          TYPE(dbcsr_type)                                   :: bc_mat, matrix_nosym
          TYPE(dbcsr_distribution_type)                      :: dist, bc_dist
          CHARACTER(len=default_string_length)               :: name
-         INTEGER                                            :: group
          INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
 
          CALL timeset(routineN, handle)
@@ -237,11 +238,11 @@ CONTAINS
 
          ! Convert DBCSR to a block-cyclic
          NULLIFY (col_blk_size, row_blk_size)
-         CALL dbcsr_distribution_get(dist, group=group, pgrid=pgrid)
+         CALL dbcsr_distribution_get(dist, group=group_handle, pgrid=pgrid)
          CALL dbcsr_create_dist_block_cyclic(bc_dist, &
                                              nrows=nfullrows_total, ncolumns=nfullcols_total, &
                                              nrow_block=nrow_block, ncol_block=ncol_block, &
-                                             group=group, pgrid=pgrid, &
+                                             group_handle=group_handle, pgrid=pgrid, &
                                              row_blk_sizes=row_blk_size, col_blk_sizes=col_blk_size)
 
          CALL dbcsr_create(bc_mat, "Block-cyclic"//name, bc_dist, &
@@ -436,7 +437,7 @@ CONTAINS
       !col_cluster => col_dist_data(:, 2)
 
       CALL dbcsr_distribution_new(dist, &
-                                  group=para_env%group, pgrid=pgrid, &
+                                  group=para_env%group%get_handle(), pgrid=pgrid, &
                                   row_dist=row_dist, &
                                   col_dist=col_dist)
 
@@ -1220,10 +1221,10 @@ CONTAINS
 !> \param[out] col_blk_sizes  column block sizes
 ! **************************************************************************************************
    SUBROUTINE dbcsr_create_dist_block_cyclic(dist, nrows, ncolumns, &
-                                             nrow_block, ncol_block, group, pgrid, row_blk_sizes, col_blk_sizes)
+                                             nrow_block, ncol_block, group_handle, pgrid, row_blk_sizes, col_blk_sizes)
       TYPE(dbcsr_distribution_type), INTENT(OUT)          :: dist
       INTEGER, INTENT(IN)                                :: nrows, ncolumns, nrow_block, ncol_block
-      INTEGER, INTENT(IN)                                :: group
+      INTEGER, INTENT(IN)                                :: group_handle
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       INTEGER, DIMENSION(:), INTENT(OUT), POINTER        :: row_blk_sizes, col_blk_sizes
 
@@ -1284,7 +1285,7 @@ CONTAINS
       END IF
       !
       CALL dbcsr_distribution_new(dist, &
-                                  group=group, pgrid=pgrid, &
+                                  group=group_handle, pgrid=pgrid, &
                                   row_dist=rd_data, &
                                   col_dist=cd_data, &
                                   reuse_arrays=.TRUE.)

--- a/src/cp_dbcsr_output.F
+++ b/src/cp_dbcsr_output.F
@@ -35,7 +35,8 @@ MODULE cp_dbcsr_output
                                               int_8
    USE machine,                         ONLY: m_flush
    USE mathlib,                         ONLY: symmetrize_matrix
-   USE message_passing,                 ONLY: mp_max,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_max,&
                                               mp_sum,&
                                               mp_sync
    USE orbital_pointers,                ONLY: nso
@@ -88,10 +89,11 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: omit_headers
 
       CHARACTER(LEN=60)                                  :: matrix_name
-      INTEGER                                            :: col1, col2, group, ncol_global, &
-                                                            nrow_global, nsgf, row1, row2
+      INTEGER                                            :: col1, col2, ncol_global, nrow_global, &
+                                                            nsgf, row1, row2
       LOGICAL                                            :: my_omit_headers
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: matrix
+      TYPE(mp_comm_type)                                 :: group
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
       group = para_env%group
@@ -175,10 +177,10 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: omit_headers
 
       CHARACTER(LEN=default_string_length)               :: matrix_name
-      INTEGER                                            :: col1, col2, dim_col, dim_row, group, &
-                                                            row1, row2
+      INTEGER                                            :: col1, col2, dim_col, dim_row, row1, row2
       LOGICAL                                            :: my_omit_headers, print_sym
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: matrix
+      TYPE(mp_comm_type)                                 :: group
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
       group = para_env%group
@@ -353,15 +355,16 @@ CONTAINS
       CHARACTER(LEN=25)                                  :: fmtstr1
       CHARACTER(LEN=35)                                  :: fmtstr2
       CHARACTER(LEN=6), DIMENSION(:), POINTER            :: sgf_symbol
-      INTEGER                                            :: from, group, iatom, icol, ikind, irow, &
-                                                            iset, isgf, ishell, iso, jcol, l, &
-                                                            left, natom, ncol, ndigits, nset, &
-                                                            nsgf, right, to, width
+      INTEGER                                            :: from, iatom, icol, ikind, irow, iset, &
+                                                            isgf, ishell, iso, jcol, l, left, &
+                                                            natom, ncol, ndigits, nset, nsgf, &
+                                                            right, to, width
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
       INTEGER, DIMENSION(:), POINTER                     :: nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: lshell
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
@@ -517,8 +520,9 @@ CONTAINS
 
       CHARACTER(LEN=25)                                  :: fmtstr1
       CHARACTER(LEN=35)                                  :: fmtstr2
-      INTEGER                                            :: from, group, icol, irow, jcol, left, &
-                                                            ncol, ndigits, right, to, width
+      INTEGER                                            :: from, icol, irow, jcol, left, ncol, &
+                                                            ndigits, right, to, width
+      TYPE(mp_comm_type)                                 :: group
 
       group = para_env%group
 
@@ -604,14 +608,14 @@ CONTAINS
 
       CHARACTER                                          :: matrix_type
       CHARACTER(LEN=default_string_length)               :: matrix_name
-      INTEGER                                            :: group, handle, ipe, mype, natom, &
-                                                            nblock_max, nelement_max, npe, nrow, &
-                                                            tmp(2)
+      INTEGER                                            :: handle, ipe, mype, natom, nblock_max, &
+                                                            nelement_max, npe, nrow, tmp(2)
       INTEGER(KIND=int_8)                                :: nblock_sum, nblock_tot, nelement_sum
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: nblock, nelement
       LOGICAL                                            :: ionode
       REAL(KIND=dp)                                      :: occupation
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: group
 
       NULLIFY (logger)
       logger => cp_get_default_logger()

--- a/src/cp_external_control.F
+++ b/src/cp_external_control.F
@@ -24,6 +24,7 @@ MODULE cp_external_control
                                               dp
    USE machine,                         ONLY: m_walltime
    USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type,&
                                               mp_probe
 #include "./base/base_uses.f90"
 
@@ -36,7 +37,7 @@ MODULE cp_external_control
    PUBLIC :: external_control
    PUBLIC :: set_external_comm
 
-   INTEGER, SAVE :: external_comm = -1
+   TYPE(mp_comm_type), SAVE :: external_comm
    INTEGER, SAVE :: external_master_id = -1
    INTEGER, SAVE :: scf_energy_message_tag = -1
    INTEGER, SAVE :: exit_tag = -1
@@ -55,7 +56,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE set_external_comm(comm, in_external_master_id, &
                                 in_scf_energy_message_tag, in_exit_tag)
-      INTEGER, INTENT(IN)                                :: comm, in_external_master_id
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
+      INTEGER, INTENT(IN)                                :: in_external_master_id
       INTEGER, INTENT(IN), OPTIONAL                      :: in_scf_energy_message_tag, in_exit_tag
 
       CPASSERT(in_external_master_id .GE. 0)

--- a/src/cp_subsys_methods.F
+++ b/src/cp_subsys_methods.F
@@ -293,7 +293,7 @@ CONTAINS
 
       CPASSERT(.NOT. ASSOCIATED(small_subsys))
       CPASSERT(ASSOCIATED(big_subsys))
-      IF (big_subsys%para_env%group /= small_para_env%group) &
+      IF (big_subsys%para_env%group%get_handle() /= small_para_env%group%get_handle()) &
          CPABORT("big_subsys%para_env%group==small_para_env%group")
 
       !-----------------------------------------------------------------------------

--- a/src/cp_subsys_methods.F
+++ b/src/cp_subsys_methods.F
@@ -293,7 +293,7 @@ CONTAINS
 
       CPASSERT(.NOT. ASSOCIATED(small_subsys))
       CPASSERT(ASSOCIATED(big_subsys))
-      IF (big_subsys%para_env%group%get_handle() /= small_para_env%group%get_handle()) &
+      IF (big_subsys%para_env%group /= small_para_env%group) &
          CPABORT("big_subsys%para_env%group==small_para_env%group")
 
       !-----------------------------------------------------------------------------

--- a/src/dbcsrx/dbcsr_vector.F
+++ b/src/dbcsrx/dbcsr_vector.F
@@ -44,7 +44,7 @@ MODULE dbcsr_vector
                     real_4, &
                     real_8
    USE message_passing, ONLY: mp_bcast, &
-                              mp_sum
+                              mp_sum, mp_comm_type
 
 #include "../base/base_uses.f90"
 
@@ -591,10 +591,11 @@ CONTAINS
          CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_matrix_vector_mult'
 
          INTEGER                                  :: col, mypcol, &
-                                                     myprow, &
-                                                     ncols, pcol_group, nrows, &
-                                                     prow_group, row, &
+                                                     myprow, prow_handle, pcol_handle, &
+                                                     ncols, nrows, &
+                                                     row, &
                                                      handle, handle1, ithread
+         TYPE(mp_comm_type) :: prow_group, pcol_group
          ${type}$, DIMENSION(:), POINTER          :: data_vec
          ${type}$, DIMENSION(:, :), POINTER       :: data_d, vec_res
          TYPE(dbcsr_distribution_type)            :: dist
@@ -607,7 +608,10 @@ CONTAINS
 
 ! Collect some data about the parallel environment. We will use them later to move the vector around
          CALL dbcsr_get_info(matrix, distribution=dist)
-         CALL dbcsr_distribution_get(dist, prow_group=prow_group, pcol_group=pcol_group, myprow=myprow, mypcol=mypcol)
+         CALL dbcsr_distribution_get(dist, prow_group=prow_handle, pcol_group=pcol_handle, myprow=myprow, mypcol=mypcol)
+
+         CALL prow_group%set_handle(prow_handle)
+         CALL pcol_group%set_handle(pcol_handle)
 
          CALL create_fast_row_vec_access(work_row, fast_vec_row)
          CALL create_fast_col_vec_access(work_col, fast_vec_col)
@@ -702,10 +706,11 @@ CONTAINS
          CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_matrixT_vector_mult'
 
          INTEGER                                  :: col, col_size, mypcol, &
-                                                     myprow, &
-                                                     ncols, pcol_group, nrows, &
-                                                     prow_group, row, row_size, &
+                                                     myprow, pcol_handle, prow_handle, &
+                                                     ncols, nrows, &
+                                                     row, row_size, &
                                                      handle, handle1, ithread
+         TYPE(mp_comm_type) :: pcol_group, prow_group
          ${type}$, DIMENSION(:), POINTER          :: data_vec
          ${type}$, DIMENSION(:, :), POINTER       :: data_d, vec_bl, vec_res
          TYPE(dbcsr_distribution_type)            :: dist
@@ -719,7 +724,10 @@ CONTAINS
 
 ! Collect some data about the parallel environment. We will use them later to move the vector around
          CALL dbcsr_get_info(matrix, distribution=dist)
-         CALL dbcsr_distribution_get(dist, prow_group=prow_group, pcol_group=pcol_group, myprow=myprow, mypcol=mypcol)
+         CALL dbcsr_distribution_get(dist, prow_group=prow_handle, pcol_group=pcol_handle, myprow=myprow, mypcol=mypcol)
+
+         CALL prow_group%set_handle(prow_handle)
+         CALL pcol_group%set_handle(pcol_handle)
 
          CALL create_fast_row_vec_access(work_row, fast_vec_row)
          CALL create_fast_col_vec_access(work_col, fast_vec_col)
@@ -810,8 +818,9 @@ CONTAINS
          CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_col_vec_to_rep_row'
 
          INTEGER                                  :: col, mypcol, myprow, ncols, &
-                                                     nrows, pcol_group, &
-                                                     prow_group, row, handle
+                                                     nrows, pcol_handle, prow_handle, &
+                                                     row, handle
+         TYPE(mp_comm_type) :: pcol_group, prow_group
          INTEGER, DIMENSION(:), POINTER           :: local_cols, row_dist
          ${type}$, DIMENSION(:), POINTER          :: data_vec, data_vec_rep
          ${type}$, DIMENSION(:, :), POINTER       :: vec_row
@@ -823,10 +832,13 @@ CONTAINS
 ! get information about the parallel environment
          CALL dbcsr_get_info(vec_in, distribution=dist_in)
          CALL dbcsr_distribution_get(dist_in, &
-                                     prow_group=prow_group, &
-                                     pcol_group=pcol_group, &
+                                     prow_group=prow_handle, &
+                                     pcol_group=pcol_handle, &
                                      myprow=myprow, &
                                      mypcol=mypcol)
+
+         CALL prow_group%set_handle(prow_handle)
+         CALL pcol_group%set_handle(pcol_handle)
 
 ! Get the vector which tells us which blocks are local to which processor row in the col vec
          CALL dbcsr_get_info(rep_col_vec, distribution=dist_rep_col)
@@ -880,9 +892,10 @@ CONTAINS
          CHARACTER(LEN=*), PARAMETER :: routineN = 'dbcsr_rep_row_to_rep_col_vec'
 
          INTEGER                                  :: col, mypcol, myprow, ncols, &
-                                                     nrows, pcol_group, &
-                                                     prow_group, row, handle
+                                                     nrows, prow_handle, pcol_handle, &
+                                                     row, handle
          INTEGER, DIMENSION(:), POINTER           :: col_dist
+         TYPE(mp_comm_type) :: pcol_group, prow_group
          ${type}$, DIMENSION(:), POINTER          :: data_vec_rep
          ${type}$, DIMENSION(:, :), POINTER       :: vec_col
          TYPE(dbcsr_distribution_type)            :: dist_rep_row, dist_rep_col
@@ -893,10 +906,13 @@ CONTAINS
 ! get information about the parallel environment
          CALL dbcsr_get_info(matrix=rep_col_vec, distribution=dist_rep_col)
          CALL dbcsr_distribution_get(dist_rep_col, &
-                                     prow_group=prow_group, &
-                                     pcol_group=pcol_group, &
+                                     prow_group=prow_handle, &
+                                     pcol_group=pcol_handle, &
                                      myprow=myprow, &
                                      mypcol=mypcol)
+
+         CALL prow_group%set_handle(prow_handle)
+         CALL pcol_group%set_handle(pcol_handle)
 
 ! Get the vector which tells us which blocks are local to which processor col in the row vec
          CALL dbcsr_get_info(matrix=rep_row_vec, distribution=dist_rep_row)
@@ -1046,14 +1062,15 @@ CONTAINS
 
          INTEGER                                  :: col, mypcol, &
                                                      myprow, &
-                                                     pcol_group, nrows, ncols, &
-                                                     prow_group, row, &
+                                                     nrows, ncols, &
+                                                     row, prow_handle, pcol_handle, &
                                                      handle, handle1, ithread, vec_dim
          ${type}$, DIMENSION(:), POINTER          :: data_vec
          ${type}$, DIMENSION(:, :), POINTER       :: data_d, vec_res
          TYPE(dbcsr_distribution_type)            :: dist
          TYPE(dbcsr_iterator_type)                :: iter
          TYPE(dbcsr_type)                         :: result_row, result_col
+         TYPE(mp_comm_type) :: prow_group, pcol_group
 
          TYPE(fast_vec_access_type)               :: fast_vec_row, fast_vec_col, res_fast_vec_row, res_fast_vec_col
          INTEGER                                  :: prow, pcol, rprow, rpcol
@@ -1070,7 +1087,10 @@ CONTAINS
 
 ! Collect some data about the parallel environment. We will use them later to move the vector around
          CALL dbcsr_get_info(matrix=matrix, distribution=dist)
-         CALL dbcsr_distribution_get(dist, prow_group=prow_group, pcol_group=pcol_group, myprow=myprow, mypcol=mypcol)
+         CALL dbcsr_distribution_get(dist, prow_group=prow_handle, pcol_group=pcol_handle, myprow=myprow, mypcol=mypcol)
+
+         CALL prow_group%set_handle(prow_handle)
+         CALL pcol_group%set_handle(pcol_handle)
 
          CALL create_fast_row_vec_access(work_row, fast_vec_row)
          CALL create_fast_col_vec_access(work_col, fast_vec_col)

--- a/src/dbm/dbm_api.F
+++ b/src/dbm/dbm_api.F
@@ -12,7 +12,7 @@ MODULE dbm_api
                     dp, &
                     int_8
    USE message_passing, ONLY: mp_cart_rank, &
-                              mp_environ
+                              mp_environ, mp_comm_type
    USE string_utilities, ONLY: strlcpy_c2f
 
 ! Uncomment the following line to enable validation.
@@ -63,7 +63,6 @@ MODULE dbm_api
    USE dbcsr_work_operations, ONLY: dbcsr_create, &
                                     dbcsr_finalize
    USE dbcsr_data_methods, ONLY: dbcsr_scalar
-
 #endif
 
 #include "../base/base_uses.f90"
@@ -1293,7 +1292,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbm_distribution_new(dist, mp_comm, row_dist_block, col_dist_block)
       TYPE(dbm_distribution_obj), INTENT(OUT)            :: dist
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       INTEGER, CONTIGUOUS, DIMENSION(:), INTENT(IN), &
          POINTER                                         :: row_dist_block, col_dist_block
 
@@ -1312,7 +1311,7 @@ CONTAINS
 
       CPASSERT(.NOT. C_ASSOCIATED(dist%c_ptr))
       CALL dbm_distribution_new_c(dist=dist%c_ptr, &
-                                  fortran_comm=mp_comm, &
+                                  fortran_comm=mp_comm%get_handle(), &
                                   nrows=SIZE(row_dist_block), &
                                   ncols=SIZE(col_dist_block), &
                                   row_dist=row_dist_block, &
@@ -1509,7 +1508,8 @@ CONTAINS
 !> \author Ole Schuett
 ! **************************************************************************************************
    SUBROUTINE dbm_library_print_stats(mpi_comm, output_unit)
-      INTEGER, INTENT(IN)                                :: mpi_comm, output_unit
+      TYPE(mp_comm_type), INTENT(IN)                     :: mpi_comm
+      INTEGER, INTENT(IN)                                :: output_unit
 
       INTERFACE
          SUBROUTINE dbm_library_print_stats_c(mpi_comm, print_func, output_unit) &
@@ -1522,7 +1522,7 @@ CONTAINS
       END INTERFACE
 
       ! Since Fortran units groups can't be used from C, we pass a function pointer instead.
-      CALL dbm_library_print_stats_c(mpi_comm=mpi_comm, &
+      CALL dbm_library_print_stats_c(mpi_comm=mpi_comm%get_handle(), &
                                      print_func=C_FUNLOC(print_func), &
                                      output_unit=output_unit)
 

--- a/src/dbm/dbm_tests.F
+++ b/src/dbm/dbm_tests.F
@@ -17,6 +17,7 @@ MODULE dbm_tests
    USE machine,                         ONLY: m_flush
    USE message_passing,                 ONLY: mp_cart_create,&
                                               mp_comm_free,&
+                                              mp_comm_type,&
                                               mp_dims_create,&
                                               mp_environ,&
                                               mp_max,&
@@ -56,7 +57,8 @@ CONTAINS
                             bs_m, bs_n, bs_k, sparsities, alpha, beta, &
                             n_loops, eps, retain_sparsity, always_checksum)
 
-      INTEGER, INTENT(IN)                                :: mp_group, io_unit
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
+      INTEGER, INTENT(IN)                                :: io_unit
       INTEGER, DIMENSION(:), INTENT(in)                  :: matrix_sizes
       LOGICAL, DIMENSION(2), INTENT(in)                  :: trs
       INTEGER, DIMENSION(:), POINTER                     :: bs_m, bs_n, bs_k
@@ -68,14 +70,14 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'dbm_run_tests'
 
-      INTEGER                                            :: bmax, bmin, cart_group, handle, mynode, &
-                                                            numnodes
+      INTEGER                                            :: bmax, bmin, handle, mynode, numnodes
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_dist_a, col_dist_b, col_dist_c, &
                                                             row_dist_a, row_dist_b, row_dist_c, &
                                                             sizes_k, sizes_m, sizes_n
       INTEGER, DIMENSION(2)                              :: mycoord, npdims
       TYPE(dbm_distribution_obj)                         :: dist_a, dist_b, dist_c
       TYPE(dbm_type), TARGET                             :: matrix_a, matrix_b, matrix_c
+      TYPE(mp_comm_type)                                 :: cart_group
 
       CALL timeset(routineN, handle)
 
@@ -209,7 +211,8 @@ CONTAINS
       LOGICAL, INTENT(in)                                :: retain_sparsity
       INTEGER, INTENT(IN)                                :: n_loops
       REAL(kind=dp), INTENT(in)                          :: eps
-      INTEGER, INTENT(IN)                                :: group, io_unit
+      TYPE(mp_comm_type)                                 :: group
+      INTEGER, INTENT(IN)                                :: io_unit
       LOGICAL, INTENT(in)                                :: always_checksum
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'run_multiply_test'
@@ -272,7 +275,7 @@ CONTAINS
    SUBROUTINE fill_matrix(matrix, sparsity, group)
       TYPE(dbm_type), INTENT(inout)                      :: matrix
       REAL(kind=dp), INTENT(in)                          :: sparsity
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'fill_matrix'
 

--- a/src/dbt/dbt_io.F
+++ b/src/dbt/dbt_io.F
@@ -20,7 +20,7 @@ MODULE dbt_io
       blk_dims_tensor, dbt_get_stored_coordinates, dbt_get_nze, dbt_get_nze_total, &
       dbt_pgrid_type, dbt_nblks_total
    USE kinds, ONLY: default_string_length, int_8, dp
-   USE message_passing, ONLY: mp_environ, mp_sum, mp_max
+   USE message_passing, ONLY: mp_environ, mp_sum, mp_max, mp_comm_type
    USE dbt_block, ONLY: &
       dbt_iterator_type, dbt_iterator_next_block, dbt_iterator_start, &
       dbt_iterator_blocks_left, dbt_iterator_stop, dbt_get_block
@@ -125,7 +125,7 @@ CONTAINS
       INTEGER                        :: nproc, myproc, nblock_max, nelement_max
       INTEGER(KIND=int_8)            :: nblock_sum, nelement_sum, nblock_tot
       INTEGER                        :: nblock, nelement, unit_nr_prv
-      INTEGER                        :: mp_comm
+      TYPE(mp_comm_type)             :: mp_comm
       INTEGER, DIMENSION(2)          :: tmp
       INTEGER, DIMENSION(ndims_tensor(tensor)) :: bdims
       REAL(KIND=dp)              :: occupation

--- a/src/dbt/dbt_methods.F
+++ b/src/dbt/dbt_methods.F
@@ -67,6 +67,7 @@ MODULE dbt_methods
       dbt_split_copyback, dbt_make_compatible_blocks, dbt_crop
    USE dbt_io, ONLY: &
       dbt_write_tensor_info, dbt_write_tensor_dist, prep_output_unit, dbt_write_split_info
+   USE message_passing, ONLY: mp_comm_type
 
 #include "../base/base_uses.f90"
 
@@ -605,8 +606,9 @@ CONTAINS
       TYPE(dbt_type), POINTER                    :: tensor_small, tensor_large
 
       LOGICAL                                        :: assert_stmt, tensors_remapped
-      INTEGER                                        :: max_mm_dim, max_tensor, mp_comm, &
-                                                        unit_nr_prv, ref_tensor, mp_comm_opt, handle
+      INTEGER                                        :: max_mm_dim, max_tensor, &
+                                                        unit_nr_prv, ref_tensor, handle
+      TYPE(mp_comm_type) :: mp_comm, mp_comm_opt
       INTEGER, DIMENSION(SIZE(contract_1))           :: contract_1_mod
       INTEGER, DIMENSION(SIZE(notcontract_1))        :: notcontract_1_mod
       INTEGER, DIMENSION(SIZE(contract_2))           :: contract_2_mod
@@ -1181,7 +1183,8 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL               :: optimize_dist
       INTEGER, INTENT(IN), OPTIONAL               :: unit_nr
       INTEGER                                     :: compat1, compat1_old, compat2, compat2_old, &
-                                                     comm_2d, unit_nr_prv
+                                                     unit_nr_prv
+      TYPE(mp_comm_type) :: comm_2d
       TYPE(array_list)                            :: dist_list
       INTEGER, DIMENSION(:), ALLOCATABLE          :: mp_dims
       TYPE(dbt_distribution_type)             :: dist_in
@@ -1580,7 +1583,7 @@ CONTAINS
       TYPE(dbt_type), INTENT(OUT)        :: tensor_out
       CHARACTER(len=*), INTENT(IN), OPTIONAL :: name
       LOGICAL, INTENT(IN), OPTIONAL          :: nodata, move_data
-      INTEGER, INTENT(IN), OPTIONAL          :: comm_2d
+      TYPE(mp_comm_type), INTENT(IN), OPTIONAL          :: comm_2d
       TYPE(array_list), INTENT(IN), OPTIONAL :: dist1, dist2
       INTEGER, DIMENSION(SIZE(map1_2d)), OPTIONAL :: mp_dims_1
       INTEGER, DIMENSION(SIZE(map2_2d)), OPTIONAL :: mp_dims_2
@@ -1588,7 +1591,8 @@ CONTAINS
       INTEGER, DIMENSION(:), ALLOCATABLE     :: ${varlist("blk_sizes")}$, &
                                                 ${varlist("nd_dist")}$
       TYPE(dbt_distribution_type)        :: dist
-      INTEGER                                :: comm_2d_prv, handle, i
+      TYPE(mp_comm_type) :: comm_2d_prv
+      INTEGER                                :: handle, i
       INTEGER, DIMENSION(ndims_tensor(tensor_in)) :: pdims, myploc
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_remap'
       LOGICAL                               :: nodata_prv
@@ -2129,7 +2133,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbt_change_pgrid_2d(tensor, mp_comm, pdims, nodata, nsplit, dimsplit, pgrid_changed, unit_nr)
       TYPE(dbt_type), INTENT(INOUT)                  :: tensor
-      INTEGER, INTENT(IN)               :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)               :: mp_comm
       INTEGER, DIMENSION(2), INTENT(IN), OPTIONAL :: pdims
       LOGICAL, INTENT(IN), OPTIONAL                      :: nodata
       INTEGER, INTENT(IN), OPTIONAL :: nsplit, dimsplit

--- a/src/dbt/dbt_reshape_ops.F
+++ b/src/dbt/dbt_reshape_ops.F
@@ -32,7 +32,7 @@ MODULE dbt_reshape_ops
                               mp_environ, &
                               mp_irecv, &
                               mp_isend, &
-                              mp_waitall
+                              mp_waitall, mp_comm_type
 
 #include "../base/base_uses.f90"
 
@@ -63,7 +63,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_reshape'
 
-      INTEGER                                            :: iproc, mp_comm, mynode, numnodes, &
+      INTEGER                                            :: iproc, mynode, numnodes, &
                                                             handle, iblk, jblk, offset, ndata, &
                                                             nblks_recv_mythread
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: blks_to_allocate
@@ -76,6 +76,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: nblks_send_total, ndata_send_total, &
                                                             nblks_recv_total, ndata_recv_total, &
                                                             nblks_send_mythread, ndata_send_mythread
+      TYPE(mp_comm_type) :: mp_comm
 
       CALL timeset(routineN, handle)
 
@@ -226,7 +227,7 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
    SUBROUTINE dbt_communicate_buffer(mp_comm, buffer_recv, buffer_send)
-      INTEGER, INTENT(IN)                    :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                    :: mp_comm
       TYPE(block_buffer_type), DIMENSION(0:), INTENT(INOUT) :: buffer_recv, buffer_send
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_communicate_buffer'

--- a/src/dbt/dbt_reshape_ops.F
+++ b/src/dbt/dbt_reshape_ops.F
@@ -32,7 +32,7 @@ MODULE dbt_reshape_ops
                               mp_environ, &
                               mp_irecv, &
                               mp_isend, &
-                              mp_waitall, mp_comm_type
+                              mp_waitall, mp_comm_type, mp_request_type
 
 #include "../base/base_uses.f90"
 
@@ -234,7 +234,7 @@ CONTAINS
 
       INTEGER                                               :: iproc, mynode, numnodes, &
                                                                rec_counter, send_counter, i
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)                 :: req_array
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:, :)                 :: req_array
       INTEGER                                               :: handle
 
       CALL timeset(routineN, handle)

--- a/src/dbt/dbt_test.F
+++ b/src/dbt/dbt_test.F
@@ -41,6 +41,7 @@ MODULE dbt_test
    USE dbt_index, ONLY: &
       combine_tensor_index, get_2d_indices_tensor, dbt_get_mapping_info
    USE dbt_tas_test, ONLY: dbt_tas_checksum
+   USE message_passing, ONLY: mp_comm_type
 
 #include "../base/base_uses.f90"
 
@@ -186,7 +187,7 @@ CONTAINS
       INTEGER, INTENT(IN)                         :: ndims
       INTEGER, INTENT(IN)                         :: unit_nr
       LOGICAL, INTENT(IN)                         :: verbose
-      INTEGER, INTENT(IN)                         :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)              :: mp_comm
       TYPE(dbt_distribution_type)             :: dist1, dist2
       TYPE(dbt_type)                          :: tensor1, tensor2
       INTEGER                                     :: isep, iblk
@@ -373,7 +374,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbt_setup_test_tensor(tensor, mp_comm, enumerate, ${varlist("blk_ind")}$)
       TYPE(dbt_type), INTENT(INOUT)                  :: tensor
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       LOGICAL, INTENT(IN)                                :: enumerate
       INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: ${varlist("blk_ind")}$
       INTEGER                                            :: numnodes, mynode
@@ -593,7 +594,8 @@ CONTAINS
                OPTIONAL                          :: bounds_3
             LOGICAL, INTENT(IN), OPTIONAL        :: log_verbose
             LOGICAL, INTENT(IN), OPTIONAL        :: write_int
-            INTEGER                              :: io_unit, mynode, numnodes, mp_comm
+            INTEGER                              :: io_unit, mynode, numnodes
+            TYPE(mp_comm_type) :: mp_comm
             INTEGER, DIMENSION(:), ALLOCATABLE   :: size_1, size_2, size_3, &
                                                     order_t1, order_t2, order_t3
             INTEGER, DIMENSION(2, ndims_tensor(tensor_1)) :: bounds_t1

--- a/src/dbt/dbt_types.F
+++ b/src/dbt/dbt_types.F
@@ -39,7 +39,7 @@ MODULE dbt_types
       dbt_tas_create_split, dbt_tas_get_split_info, dbt_tas_set_strict_split
    USE kinds, ONLY: default_string_length, int_8, dp
    USE message_passing, ONLY: &
-      mp_cart_create, mp_cart_rank, mp_environ, mp_dims_create, mp_comm_free, mp_comm_dup, mp_sum, mp_max
+      mp_cart_create, mp_cart_rank, mp_environ, mp_dims_create, mp_comm_free, mp_comm_dup, mp_sum, mp_max, mp_comm_type
    USE dbt_tas_global, ONLY: dbt_tas_distribution, dbt_tas_rowcol_data, dbt_tas_default_distvec
    USE dbt_allocate_wrap, ONLY: allocate_any
    USE dbm_api, ONLY: dbm_scale
@@ -97,7 +97,7 @@ MODULE dbt_types
 
    TYPE dbt_pgrid_type
       TYPE(nd_to_2d_mapping)                  :: nd_index_grid
-      INTEGER                                 :: mp_comm_2d
+      TYPE(mp_comm_type)                      :: mp_comm_2d
       TYPE(dbt_tas_split_info), ALLOCATABLE :: tas_split_info
       INTEGER                                 :: nproc
    END TYPE
@@ -499,7 +499,7 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
          SUBROUTINE dbt_pgrid_create_expert(mp_comm, dims, pgrid, map1_2d, map2_2d, tensor_dims, nsplit, dimsplit)
-            INTEGER, INTENT(IN) :: mp_comm
+            TYPE(mp_comm_type), INTENT(IN) :: mp_comm
             INTEGER, DIMENSION(:), INTENT(INOUT) :: dims
             TYPE(dbt_pgrid_type), INTENT(OUT) :: pgrid
             INTEGER, DIMENSION(:), INTENT(IN) :: map1_2d, map2_2d
@@ -558,7 +558,7 @@ CONTAINS
 ! **************************************************************************************************
          FUNCTION dbt_nd_mp_comm(comm_2d, map1_2d, map2_2d, dims_nd, dims1_nd, dims2_nd, pdims_2d, tdims, &
                                  nsplit, dimsplit)
-            INTEGER, INTENT(IN)                               :: comm_2d
+            TYPE(mp_comm_type), INTENT(IN)                               :: comm_2d
             INTEGER, DIMENSION(:), INTENT(IN)                 :: map1_2d, map2_2d
             INTEGER, DIMENSION(SIZE(map1_2d) + SIZE(map2_2d)), &
                INTENT(IN), OPTIONAL                           :: dims_nd
@@ -631,7 +631,7 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
          SUBROUTINE dbt_nd_mp_free(mp_comm)
-            INTEGER, INTENT(INOUT)                               :: mp_comm
+            TYPE(mp_comm_type), INTENT(INOUT)                               :: mp_comm
 
             CALL mp_comm_free(mp_comm)
          END SUBROUTINE dbt_nd_mp_free
@@ -693,7 +693,8 @@ CONTAINS
             INTEGER, DIMENSION(:), INTENT(IN)               :: map2_2d
             INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL     :: ${varlist("nd_dist")}$
             LOGICAL, INTENT(IN), OPTIONAL                   :: own_comm
-            INTEGER                                         :: ndims, comm_2d
+            INTEGER                                         :: ndims
+            TYPE(mp_comm_type) :: comm_2d
             INTEGER, DIMENSION(2)                           :: pdims_2d_check, &
                                                                pdims_2d, task_coor_2d
             INTEGER, DIMENSION(SIZE(map1_2d) + SIZE(map2_2d)) :: dims, nblks_nd, task_coor
@@ -1186,12 +1187,12 @@ CONTAINS
 
             CHARACTER(len=default_string_length)        :: name_in
             INTEGER, DIMENSION(2)                       :: order_in
-            INTEGER                                     :: comm_2d
+            TYPE(mp_comm_type)                                     :: comm_2d
             TYPE(dbcsr_distribution_type)               :: matrix_dist
-            TYPE(dbt_distribution_type)        :: dist
+            TYPE(dbt_distribution_type)                 :: dist
             INTEGER, DIMENSION(:), POINTER              :: row_blk_size, col_blk_size
             INTEGER, DIMENSION(:), POINTER              :: col_dist, row_dist
-            INTEGER                                   :: handle
+            INTEGER                                   :: handle, comm_2d_handle
             CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_create_matrix'
             TYPE(dbt_pgrid_type)                  :: comm_nd
             INTEGER, DIMENSION(2)                     :: pdims_2d
@@ -1212,8 +1213,9 @@ CONTAINS
             END IF
 
             CALL dbcsr_get_info(matrix_in, distribution=matrix_dist)
-            CALL dbcsr_distribution_get(matrix_dist, group=comm_2d, row_dist=row_dist, col_dist=col_dist, &
+            CALL dbcsr_distribution_get(matrix_dist, group=comm_2d_handle, row_dist=row_dist, col_dist=col_dist, &
                                         nprows=pdims_2d(1), npcols=pdims_2d(2))
+            CALL comm_2d%set_handle(comm_2d_handle)
             comm_nd = dbt_nd_mp_comm(comm_2d, [order_in(1)], [order_in(2)], pdims_2d=pdims_2d)
 
             CALL dbt_distribution_new_expert( &
@@ -1353,7 +1355,7 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
          SUBROUTINE dbt_pgrid_create(mp_comm, dims, pgrid, tensor_dims)
-            INTEGER, INTENT(IN) :: mp_comm
+            TYPE(mp_comm_type), INTENT(IN) :: mp_comm
             INTEGER, DIMENSION(:), INTENT(INOUT) :: dims
             TYPE(dbt_pgrid_type), INTENT(OUT) :: pgrid
             INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL :: tensor_dims

--- a/src/dbt/dbt_unittest.F
+++ b/src/dbt/dbt_unittest.F
@@ -25,7 +25,8 @@ PROGRAM dbt_unittest
         dbt_pgrid_destroy, dbt_pgrid_type, dbt_type, ndims_tensor
    USE kinds,                           ONLY: dp
    USE machine,                         ONLY: default_output_unit
-   USE message_passing,                 ONLY: mp_environ,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_environ,&
                                               mp_world_finalize,&
                                               mp_world_init
    USE offload_api,                     ONLY: offload_get_device_count,&
@@ -34,7 +35,8 @@ PROGRAM dbt_unittest
 
    IMPLICIT NONE
 
-   INTEGER                            :: mp_comm, numnodes, mynode, io_unit
+   TYPE(mp_comm_type) :: mp_comm
+   INTEGER                            :: numnodes, mynode, io_unit
    INTEGER                            :: ndims, nblks_alloc, nblks_1, nblks_2, nblks_3, nblks_4, nblks_5, &
                                          nblks_alloc_1, nblks_alloc_2, nblks_alloc_3, nblks_alloc_4, nblks_alloc_5
    INTEGER, DIMENSION(:), ALLOCATABLE :: size_1, size_2, size_3, size_4, size_5, dist1_1, dist1_2, dist1_3, &
@@ -71,7 +73,7 @@ PROGRAM dbt_unittest
    io_unit = -1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   CALL dbcsr_init_lib(mp_comm, io_unit) ! Needed for DBM_VALIDATE_AGAINST_DBCSR.
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit) ! Needed for DBM_VALIDATE_AGAINST_DBCSR.
    CALL dbm_library_init()
 
    CALL dbt_reset_randmat_seed()

--- a/src/dbt/tas/dbt_tas_base.F
+++ b/src/dbt/tas/dbt_tas_base.F
@@ -40,6 +40,7 @@ MODULE dbt_tas_base
                                               dp,&
                                               int_8
    USE message_passing,                 ONLY: mp_cart_rank,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_sum
 #include "../../base/base_uses.f90"
@@ -346,7 +347,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbt_tas_distribution_new(dist, mp_comm, row_dist, col_dist, split_info, nosplit)
       TYPE(dbt_tas_distribution_type), INTENT(OUT)       :: dist
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
 
       CLASS(dbt_tas_distribution), INTENT(IN)        :: row_dist, col_dist
       TYPE(dbt_tas_split_info), INTENT(IN), OPTIONAL :: split_info

--- a/src/dbt/tas/dbt_tas_io.F
+++ b/src/dbt/tas/dbt_tas_io.F
@@ -31,7 +31,8 @@ MODULE dbt_tas_io
    USE kinds,                           ONLY: default_string_length,&
                                               dp,&
                                               int_8
-   USE message_passing,                 ONLY: mp_environ,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_environ,&
                                               mp_max,&
                                               mp_sum
 #include "../../base/base_uses.f90"
@@ -126,8 +127,10 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: full_info
 
       CHARACTER(default_string_length)                   :: name
-      INTEGER :: icol, igroup, iproc, irow, mp_comm, mp_comm_group, nblock, ndbt_p_max, nelement, &
-         nelement_p_max, ngroup, nproc, split_rowcol, unit_nr_prv
+      INTEGER                                            :: icol, igroup, iproc, irow, nblock, &
+                                                            ndbt_p_max, nelement, nelement_p_max, &
+                                                            ngroup, nproc, split_rowcol, &
+                                                            unit_nr_prv
       INTEGER(KIND=int_8)                                :: ndbt_p_sum, ndbt_s, ndbt_s_max, &
                                                             ndbt_tot, nelement_p_sum, nelement_s, &
                                                             nelement_s_max
@@ -136,6 +139,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: coldist, rowdist
       REAL(KIND=dp)                                      :: occupation
       TYPE(dbm_distribution_obj)                         :: dist
+      TYPE(mp_comm_type)                                 :: mp_comm, mp_comm_group
 
       unit_nr_prv = prep_output_unit(unit_nr)
       IF (unit_nr_prv == 0) RETURN
@@ -216,11 +220,11 @@ CONTAINS
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: name
 
       CHARACTER(len=:), ALLOCATABLE                      :: name_prv
-      INTEGER                                            :: groupsize, igroup, mp_comm, &
-                                                            mp_comm_group, mynode, nsplit, &
+      INTEGER                                            :: groupsize, igroup, mynode, nsplit, &
                                                             numnodes, split_rowcol, unit_nr_prv
       INTEGER, DIMENSION(2)                              :: coord, dims, groupcoord, groupdims, &
                                                             pgrid_offset
+      TYPE(mp_comm_type)                                 :: mp_comm, mp_comm_group
 
       unit_nr_prv = prep_output_unit(unit_nr)
       IF (unit_nr_prv == 0) RETURN

--- a/src/dbt/tas/dbt_tas_mm.F
+++ b/src/dbt/tas/dbt_tas_mm.F
@@ -56,6 +56,7 @@ MODULE dbt_tas_mm
                                               int_8
    USE message_passing,                 ONLY: mp_cart_create,&
                                               mp_comm_free,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_max,&
                                               mp_sum,&
@@ -124,10 +125,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'dbt_tas_multiply'
 
-      INTEGER :: batched_repl, comm_tmp, handle, handle2, handle3, handle4, iproc, max_mm_dim, &
-         max_mm_dim_batched, mp_comm, mp_comm_group, mp_comm_mm, mp_comm_opt, nsplit, &
-         nsplit_batched, nsplit_opt, numproc, numproc_sub, split_a, split_b, split_c, split_rc, &
-         unit_nr_prv
+      INTEGER :: batched_repl, handle, handle2, handle3, handle4, iproc, max_mm_dim, &
+         max_mm_dim_batched, nsplit, nsplit_batched, nsplit_opt, numproc, numproc_sub, split_a, &
+         split_b, split_c, split_rc, unit_nr_prv
       INTEGER(KIND=int_8)                                :: nze_a, nze_b, nze_c, nze_c_sum
       INTEGER(KIND=int_8), DIMENSION(2)                  :: dims_a, dims_b, dims_c
       INTEGER(KIND=int_8), DIMENSION(3)                  :: dims
@@ -139,6 +139,8 @@ CONTAINS
       TYPE(dbt_tas_split_info)                           :: info, info_a, info_b, info_c
       TYPE(dbt_tas_type), POINTER                        :: matrix_a_rep, matrix_a_rs, matrix_b_rep, &
                                                             matrix_b_rs, matrix_c_rep, matrix_c_rs
+      TYPE(mp_comm_type)                                 :: comm_tmp, mp_comm, mp_comm_group, &
+                                                            mp_comm_mm, mp_comm_opt
 
       CALL timeset(routineN, handle)
       CALL mp_sync(matrix_a%dist%info%mp_comm)
@@ -831,7 +833,7 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
    SUBROUTINE reshape_mm_small(mp_comm, matrix_in, matrix_out, transposed, nodata, move_data)
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       TYPE(dbt_tas_type), INTENT(INOUT)                  :: matrix_in
       TYPE(dbt_tas_type), INTENT(OUT)                    :: matrix_out
       LOGICAL, INTENT(IN)                                :: transposed
@@ -916,13 +918,13 @@ CONTAINS
       INTEGER, INTENT(INOUT)                             :: split_rc_1, split_rc_2
       LOGICAL, INTENT(IN), OPTIONAL                      :: nodata1, nodata2
       LOGICAL, INTENT(INOUT), OPTIONAL                   :: move_data_1, move_data_2
-      INTEGER, INTENT(OUT), OPTIONAL                     :: comm_new
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: comm_new
       INTEGER, INTENT(IN), OPTIONAL                      :: unit_nr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'reshape_mm_compatible'
 
-      INTEGER                                            :: handle, mp_comm, nsplit_prv, numnodes, &
-                                                            ref, split_rc_ref, unit_nr_prv
+      INTEGER                                            :: handle, nsplit_prv, numnodes, ref, &
+                                                            split_rc_ref, unit_nr_prv
       INTEGER(KIND=int_8)                                :: d1, d2, nze1, nze2
       INTEGER(KIND=int_8), DIMENSION(2)                  :: dims1, dims2, dims_ref
       INTEGER, DIMENSION(2)                              :: pcoord, pdims
@@ -933,6 +935,7 @@ CONTAINS
                                                             row_dist_2
       TYPE(dbt_tas_distribution_type)                    :: dist_1, dist_2
       TYPE(dbt_tas_split_info)                           :: split_info
+      TYPE(mp_comm_type)                                 :: mp_comm
 
       CALL timeset(routineN, handle)
       new1 = .FALSE.; new2 = .FALSE.
@@ -1154,11 +1157,12 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: nodata
 
       CHARACTER(len=default_string_length)               :: name
-      INTEGER                                            :: handle, mp_comm, nsplit_new, nsplit_old, &
+      INTEGER                                            :: handle, nsplit_new, nsplit_old, &
                                                             nsplit_prv, split_rc
       LOGICAL                                            :: nodata_prv
       TYPE(dbt_tas_distribution_type)                    :: dist
       TYPE(dbt_tas_split_info)                           :: split_info
+      TYPE(mp_comm_type)                                 :: mp_comm
 
       CLASS(dbt_tas_distribution), ALLOCATABLE :: rdist, cdist
       CLASS(dbt_tas_rowcol_data), ALLOCATABLE  :: rbsize, cbsize
@@ -1324,10 +1328,11 @@ CONTAINS
 
       TYPE(dbt_tas_distribution_type)          :: dist_new
       TYPE(dbt_tas_split_info)                 :: info_template, info_matrix
-      INTEGER                                    :: mp_comm, dim_split_template, dim_split_matrix, &
+      INTEGER                                    :: dim_split_template, dim_split_matrix, &
                                                     numnodes, handle
       INTEGER, DIMENSION(2)                      :: pcoord, pdims
       LOGICAL                                    :: nodata_prv, transposed
+      TYPE(mp_comm_type) :: mp_comm
       CHARACTER(LEN=*), PARAMETER :: routineN = 'reshape_mm_template'
 
       CALL timeset(routineN, handle)
@@ -1410,12 +1415,13 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_tas_estimate_result_nze'
 
-      INTEGER                                            :: col_size, handle, mp_comm, row_size
+      INTEGER                                            :: col_size, handle, row_size
       INTEGER(int_8)                                     :: col, row
       LOGICAL                                            :: retain_sparsity_prv
       TYPE(dbt_tas_iterator)                             :: iter
       TYPE(dbt_tas_type), POINTER                        :: matrix_a_bnorm, matrix_b_bnorm, &
                                                             matrix_c_bnorm
+      TYPE(mp_comm_type)                                 :: mp_comm
 
       CALL timeset(routineN, handle)
 
@@ -1574,7 +1580,7 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
    SUBROUTINE convert_to_new_pgrid(mp_comm_cart, matrix_in, matrix_out, move_data, nodata, optimize_pgrid)
-      INTEGER, INTENT(IN)                                :: mp_comm_cart
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm_cart
       TYPE(dbm_type), INTENT(INOUT)                      :: matrix_in
       TYPE(dbm_type), INTENT(OUT)                        :: matrix_out
       LOGICAL, INTENT(IN), OPTIONAL                      :: move_data, nodata, optimize_pgrid

--- a/src/dbt/tas/dbt_tas_reshape_ops.F
+++ b/src/dbt/tas/dbt_tas_reshape_ops.F
@@ -48,6 +48,7 @@ MODULE dbt_tas_reshape_ops
                                               mp_environ,&
                                               mp_irecv,&
                                               mp_isend,&
+                                              mp_request_type,&
                                               mp_waitall
 #include "../../base/base_uses.f90"
 
@@ -95,7 +96,6 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
                                                             num_rec, num_send
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: req_array
       INTEGER, DIMENSION(2)                              :: blk_size
       LOGICAL                                            :: move_prv, tr_in
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block
@@ -103,6 +103,8 @@ CONTAINS
       TYPE(dbt_tas_iterator)                             :: iter
       TYPE(dbt_tas_split_info)                           :: info
       TYPE(mp_comm_type)                                 :: mp_comm
+      TYPE(mp_request_type), ALLOCATABLE, &
+         DIMENSION(:, :)                                 :: req_array
 
       CALL timeset(routineN, handle)
 
@@ -292,7 +294,8 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
                                                             num_rec, num_send
-      INTEGER, ALLOCATABLE, DIMENSION(:, :) :: req_array, blks_to_allocate
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:, :) :: req_array
+      INTEGER, ALLOCATABLE, DIMENSION(:, :) :: blks_to_allocate
       INTEGER, DIMENSION(2) :: blk_size
       INTEGER, DIMENSION(2) :: blk_index
       INTEGER(KIND=int_8), DIMENSION(2) :: blk_index_i8
@@ -516,7 +519,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
                                                             num_entries_recv, num_entries_send, &
                                                             num_rec, num_send
-      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: blks_to_allocate, req_array
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: blks_to_allocate
       INTEGER, DIMENSION(2)                              :: blk_index, blk_size
       INTEGER, DIMENSION(:), POINTER                     :: col_block_sizes, row_block_sizes
       LOGICAL                                            :: move_prv
@@ -525,6 +528,8 @@ CONTAINS
       TYPE(dbt_buffer_type), ALLOCATABLE, DIMENSION(:)   :: buffer_recv, buffer_send
       TYPE(dbt_tas_split_info)                           :: info
       TYPE(mp_comm_type)                                 :: mp_comm
+      TYPE(mp_request_type), ALLOCATABLE, &
+         DIMENSION(:, :)                                 :: req_array
 
 !!
 
@@ -838,7 +843,8 @@ CONTAINS
       TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       TYPE(dbt_buffer_type), DIMENSION(0:), &
          INTENT(INOUT)                                   :: buffer_recv, buffer_send
-      INTEGER, DIMENSION(:, :), INTENT(OUT)              :: req_array
+      TYPE(mp_request_type), DIMENSION(:, :), &
+         INTENT(OUT)                                     :: req_array
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_tas_communicate_buffer'
 

--- a/src/dbt/tas/dbt_tas_reshape_ops.F
+++ b/src/dbt/tas/dbt_tas_reshape_ops.F
@@ -44,6 +44,7 @@ MODULE dbt_tas_reshape_ops
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE message_passing,                 ONLY: mp_alltoall,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_irecv,&
                                               mp_isend,&
@@ -85,8 +86,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'dbt_tas_reshape'
 
       INTEGER                                            :: a, b, bcount, handle, handle2, iproc, &
-                                                            mp_comm, mynode, nblk, &
-                                                            nblk_per_thread, ndata, numnodes
+                                                            mynode, nblk, nblk_per_thread, ndata, &
+                                                            numnodes
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :)  :: blks_to_allocate, index_recv
       INTEGER(KIND=int_8), DIMENSION(2)                  :: blk_index
       INTEGER(kind=omp_lock_kind), ALLOCATABLE, &
@@ -101,6 +102,7 @@ CONTAINS
       TYPE(dbt_buffer_type), ALLOCATABLE, DIMENSION(:)   :: buffer_recv, buffer_send
       TYPE(dbt_tas_iterator)                             :: iter
       TYPE(dbt_tas_split_info)                           :: info
+      TYPE(mp_comm_type)                                 :: mp_comm
 
       CALL timeset(routineN, handle)
 
@@ -284,7 +286,7 @@ CONTAINS
       TYPE(dbt_tas_blk_size_repl), TARGET :: repl_blksize
       TYPE(dbt_tas_blk_size_arb), TARGET :: dir_blksize
       TYPE(dbt_tas_distribution_type) :: dist
-      INTEGER :: mp_comm, numnodes, mynode, ngroup
+      INTEGER :: numnodes, mynode, ngroup
       INTEGER(kind=omp_lock_kind), ALLOCATABLE, DIMENSION(:) :: locks
       TYPE(dbt_buffer_type), ALLOCATABLE, DIMENSION(:) :: buffer_recv, buffer_send
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_blocks_recv, num_blocks_send, &
@@ -300,6 +302,7 @@ CONTAINS
       LOGICAL :: nodata_prv, move_prv
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :) :: index_recv
       INTEGER :: ndata
+      TYPE(mp_comm_type) :: mp_comm
 
       REAL(KIND=dp), DIMENSION(:, :), POINTER :: block
 
@@ -504,8 +507,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'dbt_tas_merge'
 
       INTEGER                                            :: a, b, bcount, handle, handle2, iproc, &
-                                                            mp_comm, mynode, nblk, &
-                                                            nblk_per_thread, ndata, numnodes
+                                                            mynode, nblk, nblk_per_thread, ndata, &
+                                                            numnodes
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :)  :: index_recv
       INTEGER(KIND=int_8), DIMENSION(2)                  :: blk_index_i8
       INTEGER(kind=omp_lock_kind), ALLOCATABLE, &
@@ -521,6 +524,7 @@ CONTAINS
       TYPE(dbm_iterator)                                 :: iter
       TYPE(dbt_buffer_type), ALLOCATABLE, DIMENSION(:)   :: buffer_recv, buffer_send
       TYPE(dbt_tas_split_info)                           :: info
+      TYPE(mp_comm_type)                                 :: mp_comm
 
 !!
 
@@ -831,7 +835,7 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
    SUBROUTINE dbt_tas_communicate_buffer(mp_comm, buffer_recv, buffer_send, req_array)
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       TYPE(dbt_buffer_type), DIMENSION(0:), &
          INTENT(INOUT)                                   :: buffer_recv, buffer_send
       INTEGER, DIMENSION(:, :), INTENT(OUT)              :: req_array

--- a/src/dbt/tas/dbt_tas_split.F
+++ b/src/dbt/tas/dbt_tas_split.F
@@ -21,6 +21,7 @@ MODULE dbt_tas_split
                                               mp_comm_dup,&
                                               mp_comm_free,&
                                               mp_comm_split_direct,&
+                                              mp_comm_type,&
                                               mp_dims_create,&
                                               mp_environ
    USE util,                            ONLY: sort
@@ -74,17 +75,20 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbt_tas_create_split_rows_or_cols(split_info, mp_comm, ngroup, igroup, split_rowcol, own_comm)
       TYPE(dbt_tas_split_info), INTENT(OUT)              :: split_info
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       INTEGER, INTENT(INOUT)                             :: ngroup
       INTEGER, INTENT(IN)                                :: igroup, split_rowcol
       LOGICAL, INTENT(IN), OPTIONAL                      :: own_comm
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_tas_create_split_rows_or_cols'
 
-      INTEGER :: handle, igroup_check, iproc, iproc_group, iproc_group_check, mp_comm_group, &
-         numproc, numproc_group, numproc_group_check
+      INTEGER                                            :: handle, igroup_check, iproc, &
+                                                            iproc_group, iproc_group_check, &
+                                                            numproc, numproc_group, &
+                                                            numproc_group_check
       INTEGER, DIMENSION(2)                              :: pcoord, pcoord_group, pdims, pdims_group
       LOGICAL                                            :: own_comm_prv, to_assert
+      TYPE(mp_comm_type)                                 :: mp_comm_group
 
       CALL timeset(routineN, handle)
 
@@ -153,8 +157,9 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
    FUNCTION dbt_tas_mp_comm(mp_comm, split_rowcol, nsplit)
-      INTEGER, INTENT(IN)                                :: mp_comm, split_rowcol, nsplit
-      INTEGER                                            :: dbt_tas_mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
+      INTEGER, INTENT(IN)                                :: split_rowcol, nsplit
+      TYPE(mp_comm_type)                                 :: dbt_tas_mp_comm
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'dbt_tas_mp_comm'
 
@@ -302,9 +307,9 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
    FUNCTION dbt_tas_mp_comm_from_matrix_sizes(mp_comm, nblkrows, nblkcols) RESULT(mp_comm_new)
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       INTEGER(KIND=int_8), INTENT(IN)                    :: nblkrows, nblkcols
-      INTEGER                                            :: mp_comm_new
+      TYPE(mp_comm_type)                                 :: mp_comm_new
 
       INTEGER                                            :: nsplit, split_rowcol
 
@@ -331,7 +336,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbt_tas_create_split(split_info, mp_comm, split_rowcol, nsplit, own_comm, opt_nsplit)
       TYPE(dbt_tas_split_info), INTENT(OUT)              :: split_info
-      INTEGER, INTENT(IN)                                :: mp_comm, split_rowcol, nsplit
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
+      INTEGER, INTENT(IN)                                :: split_rowcol, nsplit
       LOGICAL, INTENT(IN), OPTIONAL                      :: own_comm, opt_nsplit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'dbt_tas_create_split'
@@ -423,8 +429,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE dbt_tas_get_split_info(info, mp_comm, nsplit, igroup, mp_comm_group, split_rowcol, pgrid_offset)
       TYPE(dbt_tas_split_info), INTENT(IN)               :: info
-      INTEGER, INTENT(OUT), OPTIONAL                     :: mp_comm, nsplit, igroup, mp_comm_group, &
-                                                            split_rowcol
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: mp_comm
+      INTEGER, INTENT(OUT), OPTIONAL                     :: nsplit, igroup
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: mp_comm_group
+      INTEGER, INTENT(OUT), OPTIONAL                     :: split_rowcol
       INTEGER, DIMENSION(2), INTENT(OUT), OPTIONAL       :: pgrid_offset
 
       IF (PRESENT(mp_comm)) mp_comm = info%mp_comm

--- a/src/dbt/tas/dbt_tas_test.F
+++ b/src/dbt/tas/dbt_tas_test.F
@@ -32,6 +32,7 @@ MODULE dbt_tas_test
                                               int_8
    USE message_passing,                 ONLY: mp_cart_create,&
                                               mp_comm_free,&
+                                              mp_comm_type,&
                                               mp_environ
 #include "../../base/base_uses.f90"
 
@@ -69,8 +70,8 @@ CONTAINS
    SUBROUTINE dbt_tas_setup_test_matrix(matrix, mp_comm_out, mp_comm, nrows, ncols, rbsizes, &
                                         cbsizes, dist_splitsize, name, sparsity, reuse_comm)
       TYPE(dbt_tas_type), INTENT(OUT)                    :: matrix
-      INTEGER, INTENT(OUT)                               :: mp_comm_out
-      INTEGER, INTENT(IN)                                :: mp_comm
+      TYPE(mp_comm_type), INTENT(OUT)                    :: mp_comm_out
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm
       INTEGER(KIND=int_8), INTENT(IN)                    :: nrows, ncols
       INTEGER, DIMENSION(nrows), INTENT(IN)              :: rbsizes
       INTEGER, DIMENSION(ncols), INTENT(IN)              :: cbsizes
@@ -187,7 +188,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: filter_eps
       INTEGER, INTENT(IN), OPTIONAL                      :: io_unit
 
-      INTEGER                                            :: comm_dbm, handle1, handle2, mp_comm
+      INTEGER                                            :: handle1, handle2
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER :: cd_a, cd_b, cd_c, col_block_sizes_a, &
          col_block_sizes_b, col_block_sizes_c, rd_a, rd_b, rd_c, row_block_sizes_a, &
          row_block_sizes_b, row_block_sizes_c
@@ -195,6 +196,7 @@ CONTAINS
       TYPE(dbm_distribution_obj)                         :: dist_a, dist_b, dist_c
       TYPE(dbm_type)                                     :: dbm_a, dbm_a_mm, dbm_b, dbm_b_mm, dbm_c, &
                                                             dbm_c_mm
+      TYPE(mp_comm_type)                                 :: comm_dbm, mp_comm
 
 !
 ! TODO: Dedup with code in dbt_tas_test_mm.
@@ -325,8 +327,7 @@ CONTAINS
       REAL(KIND=dp), PARAMETER                           :: test_tol = 1.0E-10_dp
 
       CHARACTER(LEN=8)                                   :: status_str
-      INTEGER                                            :: comm_dbm, io_unit, mp_comm, mynode, &
-                                                            numnodes
+      INTEGER                                            :: io_unit, mynode, numnodes
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER :: cd_a, cd_b, cd_c, col_block_sizes_a, &
          col_block_sizes_b, col_block_sizes_c, rd_a, rd_b, rd_c, row_block_sizes_a, &
          row_block_sizes_b, row_block_sizes_c
@@ -336,6 +337,7 @@ CONTAINS
       TYPE(dbm_distribution_obj)                         :: dist_a, dist_b, dist_c
       TYPE(dbm_type)                                     :: dbm_a, dbm_a_mm, dbm_b, dbm_b_mm, dbm_c, &
                                                             dbm_c_mm, dbm_c_mm_check
+      TYPE(mp_comm_type)                                 :: comm_dbm, mp_comm
 
 !
 ! TODO: Dedup with code in dbt_tas_benchmark_mm.

--- a/src/dbt/tas/dbt_tas_types.F
+++ b/src/dbt/tas/dbt_tas_types.F
@@ -18,6 +18,7 @@ MODULE dbt_tas_types
                                               dbt_tas_rowcol_data
    USE kinds,                           ONLY: dp,&
                                               int_8
+   USE message_passing,                 ONLY: mp_comm_type
 #include "../../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -35,14 +36,14 @@ MODULE dbt_tas_types
    ! info on MPI Cartesian grid that is split on MPI subgroups.
    ! info on distribution of matrix rows / columns to different subgroups.
    TYPE dbt_tas_split_info
-      INTEGER :: mp_comm ! global communicator
+      TYPE(mp_comm_type) :: mp_comm ! global communicator
       INTEGER, DIMENSION(2) :: pdims ! dimensions of process grid
       INTEGER :: igroup ! which subgroup do I belong to
       INTEGER :: ngroup ! how many groups in total
       INTEGER :: split_rowcol ! split row or column?
       INTEGER :: pgrid_split_size ! how many process rows/cols in subgroups
       INTEGER :: group_size ! group size (how many cores) of subgroups
-      INTEGER :: mp_comm_group ! sub communicator
+      TYPE(mp_comm_type) :: mp_comm_group ! sub communicator
       INTEGER, ALLOCATABLE :: ngroup_opt ! optimal number of groups (split factor)
       LOGICAL, DIMENSION(2) :: strict_split = [.FALSE., .FALSE.]
       ! if .true., split factor should not be modified (2 parameters for current and general settings)

--- a/src/dbt/tas/dbt_tas_unittest.F
+++ b/src/dbt/tas/dbt_tas_unittest.F
@@ -31,6 +31,7 @@ PROGRAM dbt_tas_unittest
                                               int_8
    USE machine,                         ONLY: default_output_unit
    USE message_passing,                 ONLY: mp_comm_free,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_world_finalize,&
                                               mp_world_init
@@ -46,8 +47,8 @@ PROGRAM dbt_tas_unittest
    INTEGER, DIMENSION(n)          :: bsize_n
    INTEGER, DIMENSION(k)          :: bsize_k
    REAL(KIND=dp), PARAMETER   :: sparsity = 0.1
-   INTEGER                        :: mp_comm, numnodes, mynode, io_unit
-   INTEGER                        :: mp_comm_A, mp_comm_At, mp_comm_B, mp_comm_Bt, mp_comm_C, mp_comm_Ct
+   INTEGER                        :: numnodes, mynode, io_unit
+   TYPE(mp_comm_type)             :: mp_comm, mp_comm_A, mp_comm_At, mp_comm_B, mp_comm_Bt, mp_comm_C, mp_comm_Ct
    REAL(KIND=dp), PARAMETER   :: filter_eps = 1.0E-08
 
    CALL mp_world_init(mp_comm)
@@ -62,7 +63,7 @@ PROGRAM dbt_tas_unittest
    io_unit = -1
    IF (mynode .EQ. 0) io_unit = default_output_unit
 
-   CALL dbcsr_init_lib(mp_comm, io_unit) ! Needed for DBM_VALIDATE_AGAINST_DBCSR.
+   CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit) ! Needed for DBM_VALIDATE_AGAINST_DBCSR.
    CALL dbm_library_init()
 
    CALL dbt_tas_reset_randmat_seed()

--- a/src/distribution_2d_types.F
+++ b/src/distribution_2d_types.F
@@ -437,7 +437,7 @@ CONTAINS
                   CALL cp_blacs_env_write(distribution_2d%blacs_env, unit_nr=unit_nr)
                ELSE
                   WRITE (unit=unit_nr, fmt="('    blacs_env=<blacs_env id=',i6,'>')") &
-                     distribution_2d%blacs_env%group
+                     distribution_2d%blacs_env%group%get_handle()
                END IF
             ELSE
                WRITE (unit=unit_nr, fmt="('    blacs_env=*null*')")

--- a/src/distribution_methods.F
+++ b/src/distribution_methods.F
@@ -55,7 +55,8 @@ MODULE distribution_methods
    USE mathconstants,                   ONLY: pi
    USE mathlib,                         ONLY: gcd,&
                                               lcm
-   USE message_passing,                 ONLY: mp_sum,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum,&
                                               mp_sync
    USE molecule_kind_types,             ONLY: get_molecule_kind,&
                                               get_molecule_kind_set,&
@@ -121,7 +122,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'distribute_molecules_1d'
 
-      INTEGER :: atom_a, bin, group, handle, iatom, imolecule, imolecule_kind, imolecule_local, &
+      INTEGER :: atom_a, bin, handle, iatom, imolecule, imolecule_kind, imolecule_local, &
          imolecule_prev_kind, iparticle_kind, ipe, iw, kind_a, molecule_a, mype, n, natom, nbins, &
          nload, nmolecule, nmolecule_kind, nparticle_kind, npe, nsgf, output_unit
       INTEGER(int_8)                                     :: bin_price
@@ -133,6 +134,7 @@ CONTAINS
       TYPE(cp_heap_type)                                 :: bin_heap_count, bin_heap_fill
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind
+      TYPE(mp_comm_type)                                 :: group
 
 ! integer n_local_molecules
 ! integer, allocatable :: all_local_molecules(:)
@@ -489,10 +491,10 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'distribute_molecules_2d'
 
-      INTEGER :: cluster_price, cost_model, group, handle, iatom, iatom_mol, iatom_one, ikind, &
-         imol, imolecule, imolecule_kind, iparticle_kind, ipcol, iprow, iw, kind_a, mypcol, &
-         myprow, n, natom, natom_mol, nclusters, nmolecule, nmolecule_kind, nparticle_kind, npcol, &
-         nprow, nsgf, output_unit
+      INTEGER :: cluster_price, cost_model, handle, iatom, iatom_mol, iatom_one, ikind, imol, &
+         imolecule, imolecule_kind, iparticle_kind, ipcol, iprow, iw, kind_a, mypcol, myprow, n, &
+         natom, natom_mol, nclusters, nmolecule, nmolecule_kind, nparticle_kind, npcol, nprow, &
+         nsgf, output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cluster_list, cluster_prices, &
                                                             nparticle_local_col, &
                                                             nparticle_local_row, work
@@ -508,6 +510,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind
+      TYPE(mp_comm_type)                                 :: group
       TYPE(section_vals_type), POINTER                   :: distribution_section
 
 !...

--- a/src/domain_submatrix_methods.F
+++ b/src/domain_submatrix_methods.F
@@ -94,7 +94,7 @@ CONTAINS
       subm%nrows = -1
       subm%ncols = -1
       subm%nnodes = -1
-      CALL subm%group%set_handle(mp_comm_null)
+      subm%group = mp_comm_null
 
    END SUBROUTINE init_submatrices_0d
 
@@ -113,7 +113,7 @@ CONTAINS
       subm(:)%nrows = -1
       subm(:)%ncols = -1
       subm(:)%nnodes = -1
-      CALL subm(:)%group%set_handle(mp_comm_null)
+      subm(:)%group = mp_comm_null
 
    END SUBROUTINE init_submatrices_1d
 
@@ -132,7 +132,7 @@ CONTAINS
       subm(:, :)%nrows = -1
       subm(:, :)%ncols = -1
       subm(:, :)%nnodes = -1
-      CALL subm(:, :)%group%set_handle(mp_comm_null)
+      subm(:, :)%group = mp_comm_null
 
    END SUBROUTINE init_submatrices_2d
 
@@ -403,7 +403,7 @@ CONTAINS
       subm%nrows = -1
       subm%ncols = -1
       subm%nnodes = -1
-      CALL subm%group%set_handle(mp_comm_null)
+      subm%group = mp_comm_null
 
       IF (ALLOCATED(subm%dbcsr_row)) THEN
          DEALLOCATE (subm%dbcsr_row)

--- a/src/domain_submatrix_methods.F
+++ b/src/domain_submatrix_methods.F
@@ -29,6 +29,8 @@ MODULE domain_submatrix_methods
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_allgather,&
                                               mp_alltoall,&
+                                              mp_comm_null,&
+                                              mp_comm_type,&
                                               mp_sync
 #include "./base/base_uses.f90"
 
@@ -92,7 +94,7 @@ CONTAINS
       subm%nrows = -1
       subm%ncols = -1
       subm%nnodes = -1
-      subm%groupid = -1
+      CALL subm%group%set_handle(mp_comm_null)
 
    END SUBROUTINE init_submatrices_0d
 
@@ -111,7 +113,7 @@ CONTAINS
       subm(:)%nrows = -1
       subm(:)%ncols = -1
       subm(:)%nnodes = -1
-      subm(:)%groupid = -1
+      CALL subm(:)%group%set_handle(mp_comm_null)
 
    END SUBROUTINE init_submatrices_1d
 
@@ -130,7 +132,7 @@ CONTAINS
       subm(:, :)%nrows = -1
       subm(:, :)%ncols = -1
       subm(:, :)%nnodes = -1
-      subm(:, :)%groupid = -1
+      CALL subm(:, :)%group%set_handle(mp_comm_null)
 
    END SUBROUTINE init_submatrices_2d
 
@@ -158,7 +160,7 @@ CONTAINS
       ndomainsB = SIZE(copy)
       CPASSERT(ndomains .EQ. ndomainsB)
       copy(:)%nnodes = original(:)%nnodes
-      copy(:)%groupid = original(:)%groupid
+      copy(:)%group = original(:)%group
       DO idomain = 1, ndomains
          IF (original(idomain)%domain .GT. 0) THEN
             CALL copy_submatrix(original(idomain), copy(idomain), copy_data)
@@ -189,7 +191,7 @@ CONTAINS
 
       copy%domain = original%domain
       copy%nnodes = original%nnodes
-      copy%groupid = original%groupid
+      copy%group = original%group
 
       IF (original%domain .GT. 0) THEN
 
@@ -401,7 +403,7 @@ CONTAINS
       subm%nrows = -1
       subm%ncols = -1
       subm%nnodes = -1
-      subm%groupid = -1
+      CALL subm%group%set_handle(mp_comm_null)
 
       IF (ALLOCATED(subm%dbcsr_row)) THEN
          DEALLOCATE (subm%dbcsr_row)
@@ -545,7 +547,7 @@ CONTAINS
       CALL DGEMM(transA, transB, M, N, K, alpha, A%mdata, LDA, B%mdata, LDB, beta, C%mdata, LDC)
 
       C%nnodes = A%nnodes
-      C%groupid = A%groupid
+      C%group = A%group
 
       CALL timestop(handle)
 
@@ -749,7 +751,7 @@ CONTAINS
 
       ! communicate local norm to the other nodes
       ALLOCATE (recv_norm(submatrices(1)%nnodes))
-      CALL mp_allgather(send_norm, recv_norm, submatrices(1)%groupid)
+      CALL mp_allgather(send_norm, recv_norm, submatrices(1)%group)
 
       norm = MAXVAL(recv_norm)
 
@@ -812,7 +814,7 @@ CONTAINS
 
       ! communicate local norm to the other nodes
       ALLOCATE (recv_trace(A(1)%nnodes))
-      CALL mp_allgather(send_trace, recv_trace, A(1)%groupID)
+      CALL mp_allgather(send_trace, recv_trace, A(1)%group)
 
       trace = SUM(recv_trace)
 
@@ -864,6 +866,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: recv_data, send_data
       REAL(KIND=dp), DIMENSION(:), POINTER               :: block_p
       TYPE(dbcsr_distribution_type)                      :: pattern_dist
+      TYPE(mp_comm_type)                                 :: group
 
 !INTEGER, PARAMETER                         :: select_row_col = 1
 !INTEGER, PARAMETER                         :: select_row = 2
@@ -878,6 +881,8 @@ CONTAINS
       ndomains = nblkcols_tot ! RZK-warning not true for atomic distributions
       CALL dbcsr_get_info(distr_pattern, distribution=pattern_dist)
       CALL dbcsr_distribution_get(pattern_dist, numnodes=nNodes, group=GroupID, mynode=myNode)
+
+      CALL group%set_handle(groupid)
 
       matrix_type = dbcsr_get_matrix_type(matrix)
 
@@ -966,7 +971,7 @@ CONTAINS
       !CALL dbcsr_iterator_stop(iter)
 
       ! communicate number of blocks and their sizes to the other nodes
-      CALL mp_alltoall(send_descriptor, recv_descriptor, ldesc, GroupID)
+      CALL mp_alltoall(send_descriptor, recv_descriptor, ldesc, group)
 
       ALLOCATE (send_size_cpu(nNodes), send_offset_cpu(nNodes))
       send_offset_cpu(1) = 0
@@ -1130,10 +1135,10 @@ CONTAINS
 
       ! send-receive all blocks
       CALL mp_alltoall(send_data, send_size_cpu, send_offset_cpu, &
-                       recv_data, recv_size_cpu, recv_offset_cpu, GroupID)
+                       recv_data, recv_size_cpu, recv_offset_cpu, group)
       ! send-receive rows and cols of the blocks
       CALL mp_alltoall(send_data2, send_size2_cpu, send_offset2_cpu, &
-                       recv_data2, recv_size2_cpu, recv_offset2_cpu, GroupID)
+                       recv_data2, recv_size2_cpu, recv_offset2_cpu, group)
 
       DEALLOCATE (send_size_cpu, send_offset_cpu)
       DEALLOCATE (send_size2_cpu, send_offset2_cpu)
@@ -1153,7 +1158,7 @@ CONTAINS
       END IF
       CALL release_submatrices(submatrix)
       submatrix(:)%nnodes = nNodes
-      submatrix(:)%groupID = GroupID
+      submatrix(:)%group = Group
       submatrix(:)%nrows = 0
       submatrix(:)%ncols = 0
 
@@ -1355,6 +1360,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_distribution_type)                      :: pattern_dist
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
@@ -1378,6 +1384,8 @@ CONTAINS
 
       CALL dbcsr_get_info(distr_pattern, distribution=pattern_dist)
       CALL dbcsr_distribution_get(pattern_dist, numnodes=nNodes, group=GroupID, mynode=myNode)
+
+      CALL group%set_handle(GroupID)
 
       matrix_type = dbcsr_get_matrix_type(matrix)
       IF (matrix_type .NE. dbcsr_type_no_symmetry) THEN
@@ -1434,7 +1442,7 @@ CONTAINS
       END DO ! loop over domains
 
       ! communicate number of blocks and their sizes to the other nodes
-      CALL mp_alltoall(send_descriptor, recv_descriptor, ldesc, GroupID)
+      CALL mp_alltoall(send_descriptor, recv_descriptor, ldesc, group)
 
       ALLOCATE (send_size_cpu(nNodes), send_offset_cpu(nNodes))
       send_offset_cpu(1) = 0
@@ -1535,10 +1543,10 @@ CONTAINS
 
       ! send-receive all blocks
       CALL mp_alltoall(send_data, send_size_cpu, send_offset_cpu, &
-                       recv_data, recv_size_cpu, recv_offset_cpu, GroupID)
+                       recv_data, recv_size_cpu, recv_offset_cpu, group)
       ! send-receive rows and cols of the blocks
       CALL mp_alltoall(send_data2, send_size2_cpu, send_offset2_cpu, &
-                       recv_data2, recv_size2_cpu, recv_offset2_cpu, GroupID)
+                       recv_data2, recv_size2_cpu, recv_offset2_cpu, group)
 
       DEALLOCATE (send_size_cpu, send_offset_cpu)
       DEALLOCATE (send_size2_cpu, send_offset2_cpu)
@@ -1592,7 +1600,7 @@ CONTAINS
 
       TYPE(domain_submatrix_type), DIMENSION(:), &
          INTENT(IN)                                      :: submatrices
-      INTEGER, INTENT(IN)                                :: mpgroup
+      TYPE(mp_comm_type), INTENT(IN)                     :: mpgroup
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'print_submatrices'
 

--- a/src/domain_submatrix_types.F
+++ b/src/domain_submatrix_types.F
@@ -13,6 +13,7 @@
 ! **************************************************************************************************
 MODULE domain_submatrix_types
    USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_comm_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -40,7 +41,7 @@ MODULE domain_submatrix_types
       INTEGER, DIMENSION(:), ALLOCATABLE            :: size_brow
       INTEGER, DIMENSION(:), ALLOCATABLE            :: size_bcol
       INTEGER                                       :: nnodes
-      INTEGER                                       :: groupid
+      TYPE(mp_comm_type)                            :: group
    END TYPE domain_submatrix_type
 
    TYPE domain_map_type

--- a/src/embed_types.F
+++ b/src/embed_types.F
@@ -31,6 +31,7 @@ MODULE embed_types
                                               section_vals_type
    USE kinds,                           ONLY: dp
    USE lri_environment_types,           ONLY: lri_kind_type
+   USE message_passing,                 ONLY: mp_comm_type
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_create,&
                                               molecule_kind_list_release,&
                                               molecule_kind_list_type
@@ -122,7 +123,8 @@ MODULE embed_types
       TYPE(section_vals_type), POINTER                 :: input
       REAL(KIND=dp), DIMENSION(:), POINTER             :: energies
       ! Parallelization of multiple force_eval
-      INTEGER                                          :: new_group, ngroups
+      TYPE(mp_comm_type) :: new_group
+      INTEGER                                          :: ngroups
       INTEGER, DIMENSION(:), POINTER                   :: group_distribution
       TYPE(cp_para_env_p_type), DIMENSION(:), POINTER  :: sub_para_env
       TYPE(cp_logger_p_type), DIMENSION(:), POINTER    :: sub_logger

--- a/src/emd/rt_propagation_output.F
+++ b/src/emd/rt_propagation_output.F
@@ -51,7 +51,8 @@ MODULE rt_propagation_output
    USE kinds,                           ONLY: default_path_length,&
                                               dp
    USE machine,                         ONLY: m_flush
-   USE message_passing,                 ONLY: mp_max
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_max
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_list_types,             ONLY: particle_list_type
    USE particle_types,                  ONLY: particle_type
@@ -461,13 +462,14 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'rt_convergence_density'
       REAL(KIND=dp), PARAMETER                           :: one = 1.0_dp, zero = 0.0_dp
 
-      INTEGER                                            :: col_atom, group, handle, i, ispin, &
-                                                            row_atom
+      INTEGER                                            :: col_atom, group_handle, handle, i, &
+                                                            ispin, row_atom
       REAL(dp)                                           :: alpha, max_alpha
       REAL(dp), DIMENSION(:), POINTER                    :: block_values
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_new
       TYPE(dbcsr_type), POINTER                          :: tmp
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
@@ -504,7 +506,8 @@ CONTAINS
          END DO
          CALL dbcsr_iterator_stop(iter)
       END DO
-      CALL dbcsr_get_info(delta_P(1)%matrix, group=group)
+      CALL dbcsr_get_info(delta_P(1)%matrix, group=group_handle)
+      CALL group%set_handle(group_handle)
       CALL mp_max(max_alpha, group)
       delta_eps = SQRT(max_alpha)
       CALL dbcsr_deallocate_matrix(tmp)

--- a/src/ewald_environment_types.F
+++ b/src/ewald_environment_types.F
@@ -35,6 +35,7 @@ MODULE ewald_environment_types
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: twopi
+   USE message_passing,                 ONLY: mp_comm_type
    USE pw_grid_info,                    ONLY: pw_grid_n_for_fft
    USE pw_poisson_types,                ONLY: do_ewald_ewald,&
                                               do_ewald_none,&
@@ -123,7 +124,8 @@ CONTAINS
       TYPE(ewald_environment_type), INTENT(IN)           :: ewald_env
       INTEGER, OPTIONAL                                  :: ewald_type
       REAL(KIND=dp), OPTIONAL                            :: alpha, eps_pol, epsilon
-      INTEGER, OPTIONAL                                  :: gmax(3), ns_max, o_spline, group
+      INTEGER, OPTIONAL                                  :: gmax(3), ns_max, o_spline
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: group
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
       TYPE(section_vals_type), OPTIONAL, POINTER         :: poisson_section
       REAL(KIND=dp), OPTIONAL                            :: precs, rcut

--- a/src/ewald_methods_tb.F
+++ b/src/ewald_methods_tb.F
@@ -23,6 +23,7 @@ MODULE ewald_methods_tb
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: fourpi,&
                                               oorootpi
+   USE message_passing,                 ONLY: mp_comm_type
    USE particle_types,                  ONLY: particle_type
    USE pme_tools,                       ONLY: get_center,&
                                               set_list
@@ -97,8 +98,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'tb_spme_evaluate'
 
-      INTEGER                                            :: group, handle, i, ig, ipart, j, n, &
-                                                            npart, o_spline, p1
+      INTEGER                                            :: handle, i, ig, ipart, j, n, npart, &
+                                                            o_spline, p1
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: center
       INTEGER, DIMENSION(3)                              :: nd, npts
       REAL(KIND=dp)                                      :: alpha, dvols, fat(3), ffa, ffb, fint, vgc
@@ -107,6 +108,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3)                     :: f_stress, h_stress
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(greens_fn_type), POINTER                      :: green
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: grid_spme
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: pw_pool
@@ -438,8 +440,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'tb_spme_zforce'
 
-      INTEGER                                            :: group, handle, i, ipart, n, npart, &
-                                                            o_spline, p1
+      INTEGER                                            :: handle, i, ipart, n, npart, o_spline, p1
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: center
       INTEGER, DIMENSION(3)                              :: npts
       REAL(KIND=dp)                                      :: alpha, dvols, fat(3), fint, vgc
@@ -447,6 +448,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: rhos
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(greens_fn_type), POINTER                      :: green
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: grid_spme
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: pw_pool

--- a/src/ewald_pw_types.F
+++ b/src/ewald_pw_types.F
@@ -28,8 +28,7 @@ MODULE ewald_pw_types
                                               section_vals_type
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: pi
-   USE message_passing,                 ONLY: mp_comm_self,&
-                                              mp_comm_type
+   USE message_passing,                 ONLY: mp_comm_self
    USE pw_grid_types,                   ONLY: HALFSPACE,&
                                               pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
@@ -138,7 +137,6 @@ CONTAINS
                                                             norm
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(mp_comm_type)                                 :: comm_self
       TYPE(pw_grid_type), POINTER                        :: pw_big_grid, pw_small_grid
       TYPE(pw_poisson_parameter_type)                    :: poisson_params
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
@@ -165,14 +163,12 @@ CONTAINS
 
       rs_grid_section => section_vals_get_subs_vals(poisson_section, "EWALD%RS_GRID")
 
-      CALL comm_self%set_handle(mp_comm_self)
-
       SELECT CASE (ewald_type)
       CASE (do_ewald_ewald)
          ! set up Classic EWALD sum
          logger => cp_get_default_logger()
          output_unit = cp_print_key_unit_nr(logger, print_section, "", extension=".Log")
-         CALL pw_grid_create(pw_big_grid, comm_self)
+         CALL pw_grid_create(pw_big_grid, mp_comm_self)
 
          IF (ANY(gmax == 2*(gmax/2))) THEN
             CPABORT("gmax has to be odd.")
@@ -194,7 +190,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(ewald_pw%poisson_env)) THEN
             CALL pw_poisson_create(ewald_pw%poisson_env)
          END IF
-         CALL pw_grid_create(pw_small_grid, comm_self)
+         CALL pw_grid_create(pw_small_grid, mp_comm_self)
          CALL pw_grid_create(pw_big_grid, para_env%group)
          IF (ns_max == 2*(ns_max/2)) THEN
             CPABORT("ns_max has to be odd.")

--- a/src/ewald_pw_types.F
+++ b/src/ewald_pw_types.F
@@ -28,7 +28,8 @@ MODULE ewald_pw_types
                                               section_vals_type
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: pi
-   USE message_passing,                 ONLY: mp_comm_self
+   USE message_passing,                 ONLY: mp_comm_self,&
+                                              mp_comm_type
    USE pw_grid_types,                   ONLY: HALFSPACE,&
                                               pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
@@ -137,6 +138,7 @@ CONTAINS
                                                             norm
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_comm_type)                                 :: comm_self
       TYPE(pw_grid_type), POINTER                        :: pw_big_grid, pw_small_grid
       TYPE(pw_poisson_parameter_type)                    :: poisson_params
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
@@ -163,12 +165,14 @@ CONTAINS
 
       rs_grid_section => section_vals_get_subs_vals(poisson_section, "EWALD%RS_GRID")
 
+      CALL comm_self%set_handle(mp_comm_self)
+
       SELECT CASE (ewald_type)
       CASE (do_ewald_ewald)
          ! set up Classic EWALD sum
          logger => cp_get_default_logger()
          output_unit = cp_print_key_unit_nr(logger, print_section, "", extension=".Log")
-         CALL pw_grid_create(pw_big_grid, mp_comm_self)
+         CALL pw_grid_create(pw_big_grid, comm_self)
 
          IF (ANY(gmax == 2*(gmax/2))) THEN
             CPABORT("gmax has to be odd.")
@@ -190,7 +194,7 @@ CONTAINS
          IF (.NOT. ASSOCIATED(ewald_pw%poisson_env)) THEN
             CALL pw_poisson_create(ewald_pw%poisson_env)
          END IF
-         CALL pw_grid_create(pw_small_grid, mp_comm_self)
+         CALL pw_grid_create(pw_small_grid, comm_self)
          CALL pw_grid_create(pw_big_grid, para_env%group)
          IF (ns_max == 2*(ns_max/2)) THEN
             CPABORT("ns_max has to be odd.")

--- a/src/ewalds.F
+++ b/src/ewalds.F
@@ -29,7 +29,8 @@ MODULE ewalds
    USE mathconstants,                   ONLY: fourpi,&
                                               oorootpi,&
                                               pi
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE particle_types,                  ONLY: particle_type
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_poisson_types,                ONLY: do_ewald_none
@@ -94,8 +95,9 @@ CONTAINS
 
       COMPLEX(KIND=dp)                                   :: snode
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: summe
-      INTEGER :: gpt, group, handle, iparticle, iparticle_kind, iparticle_local, lp, mp, nnodes, &
-         node, np, nparticle_kind, nparticle_local
+      INTEGER                                            :: gpt, handle, iparticle, iparticle_kind, &
+                                                            iparticle_local, lp, mp, nnodes, node, &
+                                                            np, nparticle_kind, nparticle_local
       INTEGER, DIMENSION(:, :), POINTER                  :: bds
       LOGICAL                                            :: atenergy, atstress, use_charge_array
       REAL(KIND=dp)                                      :: alpha, denom, e_igdotr, factor, &
@@ -106,6 +108,7 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
       TYPE(dg_type), POINTER                             :: dg
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(structure_factor_type)                        :: exp_igr
@@ -308,12 +311,13 @@ CONTAINS
       REAL(KIND=dp), INTENT(OUT)                         :: e_self, e_neut
       REAL(KIND=dp), DIMENSION(:), POINTER               :: charges
 
-      INTEGER                                            :: ewald_type, group, iparticle_kind, &
+      INTEGER                                            :: ewald_type, iparticle_kind, &
                                                             nparticle_kind, nparticle_local
       LOGICAL                                            :: is_shell
       REAL(KIND=dp)                                      :: alpha, mm_radius, q, q_neutg, q_self, &
                                                             q_sum, qcore, qshell
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
+      TYPE(mp_comm_type)                                 :: group
       TYPE(shell_kind_type), POINTER                     :: shell
 
       CALL ewald_env_get(ewald_env, ewald_type=ewald_type, &

--- a/src/ewalds_multipole.F
+++ b/src/ewalds_multipole.F
@@ -43,7 +43,7 @@ MODULE ewalds_multipole
                             oorootpi, &
                             pi, &
                             sqrthalf
-   USE message_passing, ONLY: mp_sum
+   USE message_passing, ONLY: mp_sum, mp_comm_type
    USE parallel_rng_types, ONLY: UNIFORM, &
                                  rng_stream_type
    USE particle_types, ONLY: particle_type
@@ -149,7 +149,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'ewald_multipole_evaluate'
 
-      INTEGER                                            :: group, handle, i, j, size1, size2
+      INTEGER                                            :: handle, i, j, size1, size2
       LOGICAL                                            :: check_debug, check_efield, check_forces, &
                                                             do_task(3)
       LOGICAL, DIMENSION(3, 3)                           :: my_task
@@ -158,6 +158,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: efield0_lr, efield0_sr
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: efield1_lr, efield1_sr, efield2_lr, &
                                                             efield2_sr
+      TYPE(mp_comm_type) :: group
 
       CALL cite_reference(Aguado2003)
       CALL cite_reference(Laino2008)
@@ -664,7 +665,7 @@ CONTAINS
                                                             fac, summe_tmp
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: summe_ef
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: summe_st
-      INTEGER :: gpt, group, handle, iparticle, iparticle_kind, iparticle_local, lp, mp, nnodes, &
+      INTEGER :: gpt, handle, iparticle, iparticle_kind, iparticle_local, lp, mp, nnodes, &
                  node, np, nparticle_kind, nparticle_local
       INTEGER, DIMENSION(:, :), POINTER                  :: bds
       LOGICAL                                            :: do_efield0, do_efield1, do_efield2
@@ -679,6 +680,7 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(structure_factor_type)                        :: exp_igr
+      TYPE(mp_comm_type) :: group
 
       CALL timeset(routineN, handle)
       do_efield0 = do_efield .AND. ASSOCIATED(efield0)
@@ -1093,7 +1095,7 @@ CONTAINS
       REAL(KIND=dp), PARAMETER                           :: f23 = 2.0_dp/3.0_dp, &
                                                             f415 = 4.0_dp/15.0_dp
 
-      INTEGER                                            :: ewald_type, group, i, iparticle, &
+      INTEGER                                            :: ewald_type, i, iparticle, &
                                                             iparticle_kind, iparticle_local, j, &
                                                             nparticle_local
       LOGICAL                                            :: do_efield0, do_efield1, do_efield2, &
@@ -1102,6 +1104,7 @@ CONTAINS
                                                             dipole_self, fac1, fac2, fac3, fac4, &
                                                             q, q_neutg, q_self, q_sum, qu_qu_self, &
                                                             radius
+      TYPE(mp_comm_type) :: group
 
       CALL ewald_env_get(ewald_env, ewald_type=ewald_type, alpha=alpha, &
                          group=group)

--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -228,7 +228,7 @@ CONTAINS
             ! get the default system wide communicator
             CALL mp_world_init(mpi_comm_default)
          ELSE
-            CALL mpi_comm_default%set_handle(mp_comm_world)
+            mpi_comm_default = mp_comm_world
          END IF
 
          CALL string_table_allocate()

--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -97,8 +97,9 @@ MODULE f77_interface
                                               m_getcwd,&
                                               m_memory
    USE message_passing,                 ONLY: &
-        add_mp_perf_env, get_mp_perf_env, mp_comm_world, mp_environ, mp_max, mp_perf_env_release, &
-        mp_perf_env_retain, mp_perf_env_type, mp_world_finalize, mp_world_init, rm_mp_perf_env
+        add_mp_perf_env, get_mp_perf_env, mp_comm_type, mp_comm_world, mp_environ, mp_max, &
+        mp_perf_env_release, mp_perf_env_retain, mp_perf_env_type, mp_world_finalize, &
+        mp_world_init, rm_mp_perf_env
    USE metadynamics_types,              ONLY: meta_env_type
    USE metadynamics_utils,              ONLY: metadyn_read
    USE mixed_environment_types,         ONLY: mixed_environment_type
@@ -206,9 +207,9 @@ CONTAINS
       LOGICAL, INTENT(in)                                :: init_mpi
       INTEGER, INTENT(out)                               :: ierr
 
-      INTEGER                                            :: mpi_comm_default, numtask, taskid, &
-                                                            unit_nr
+      INTEGER                                            :: numtask, taskid, unit_nr
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: mpi_comm_default
 
       IF (.NOT. module_initialized) THEN
          ! install error handler hooks
@@ -221,13 +222,13 @@ CONTAINS
          CALL init_preconnection_list()
 
          ! get runtime information
-         CALL get_runtime_info
+         CALL get_runtime_info()
 
          IF (init_mpi) THEN
             ! get the default system wide communicator
             CALL mp_world_init(mpi_comm_default)
          ELSE
-            mpi_comm_default = mp_comm_world
+            CALL mpi_comm_default%set_handle(mp_comm_world)
          END IF
 
          CALL string_table_allocate()
@@ -263,7 +264,7 @@ CONTAINS
 
          ! Select active offload device when available.
          IF (offload_get_device_count() > 0) THEN
-            CALL mp_environ(numtask=numtask, taskid=taskid, groupid=mpi_comm_default)
+            CALL mp_environ(numtask=numtask, taskid=taskid, group=mpi_comm_default)
             CALL offload_set_chosen_device(MOD(taskid, offload_get_device_count()))
          END IF
 
@@ -279,7 +280,7 @@ CONTAINS
                                 cp_abort_hook, cp_warn_hook, io_unit=unit_nr)
          END IF
 #else
-         CALL dbcsr_init_lib(default_para_env%group, timeset_hook, timestop_hook, &
+         CALL dbcsr_init_lib(default_para_env%group%get_handle(), timeset_hook, timestop_hook, &
                              cp_abort_hook, cp_warn_hook, io_unit=unit_nr)
 #endif
          CALL pw_gpu_init()
@@ -554,7 +555,8 @@ CONTAINS
       TYPE(section_type), POINTER                        :: input_declaration
       CHARACTER(len=*), INTENT(in)                       :: input_path
       CHARACTER(len=*), INTENT(in), OPTIONAL             :: output_path
-      INTEGER, INTENT(in), OPTIONAL                      :: mpi_comm, output_unit
+      TYPE(mp_comm_type), INTENT(IN), OPTIONAL           :: mpi_comm
+      INTEGER, INTENT(in), OPTIONAL                      :: output_unit
       LOGICAL, INTENT(in), OPTIONAL                      :: owns_out_unit
       TYPE(section_vals_type), OPTIONAL, POINTER         :: input
       INTEGER, INTENT(out), OPTIONAL                     :: ierr
@@ -1435,7 +1437,7 @@ CONTAINS
       TYPE(section_type), POINTER                        :: input_declaration
       CHARACTER(len=*), INTENT(in)                       :: input_file_path, output_file_path
       LOGICAL, INTENT(in), OPTIONAL                      :: echo_input
-      INTEGER, INTENT(in), OPTIONAL                      :: mpi_comm
+      TYPE(mp_comm_type), INTENT(in), OPTIONAL           :: mpi_comm
       CHARACTER(len=default_path_length), &
          DIMENSION(:, :), INTENT(IN)                     :: initial_variables
       INTEGER, INTENT(out)                               :: ierr

--- a/src/fist_nonbond_force.F
+++ b/src/fist_nonbond_force.F
@@ -35,7 +35,8 @@ MODULE fist_nonbond_force
    USE machine,                         ONLY: m_memory
    USE mathconstants,                   ONLY: oorootpi,&
                                               sqrthalf
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE pair_potential_coulomb,          ONLY: potential_coulomb
    USE pair_potential_types,            ONLY: &
         gal21_type, gal_type, nosh_nosh, nosh_sh, pair_potential_pp_type, &
@@ -660,8 +661,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'bonded_correct_gaussian'
 
-      INTEGER :: atom_a, atom_b, group, handle, iatom, iend, igrp, ilist, ipair, istart, kind_a, &
-         kind_b, natoms_per_kind, nkind, npairs, shell_a, shell_b
+      INTEGER :: atom_a, atom_b, handle, iatom, iend, igrp, ilist, ipair, istart, kind_a, kind_b, &
+         natoms_per_kind, nkind, npairs, shell_a, shell_b
       INTEGER, DIMENSION(:, :), POINTER                  :: list
       LOGICAL                                            :: a_is_shell, b_is_shell, do_multipoles, &
                                                             full_nl, shell_adiabatic
@@ -672,6 +673,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: ij_kind_full_fac
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(fist_neighbor_type), POINTER                  :: nonbonded
+      TYPE(mp_comm_type)                                 :: group
       TYPE(neighbor_kind_pairs_type), POINTER            :: neighbor_kind_pair
       TYPE(pair_potential_pp_type), POINTER              :: potparm, potparm14
       TYPE(pair_potential_single_type), POINTER          :: pot

--- a/src/fm/cp_blacs_calls.F
+++ b/src/fm/cp_blacs_calls.F
@@ -18,6 +18,7 @@
 MODULE cp_blacs_calls
 
    USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_comm_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -41,11 +42,14 @@ CONTAINS
 !> \param npcol ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_gridinit(context, order, nprow, npcol)
-      INTEGER, INTENT(INOUT) :: context
+      TYPE(mp_comm_type), INTENT(INOUT) :: context
       CHARACTER(len=1), INTENT(IN):: order
       INTEGER, INTENT(IN)    :: nprow, npcol
 #if defined(__SCALAPACK)
-      CALL blacs_gridinit(context, order, nprow, npcol)
+      INTEGER :: blacs_handle
+      blacs_handle = context%get_handle()
+      CALL blacs_gridinit(blacs_handle, order, nprow, npcol)
+      CALL context%set_handle(blacs_handle)
 #else
       MARK_USED(context)
       MARK_USED(order)
@@ -59,9 +63,9 @@ CONTAINS
 !> \param context ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_gridexit(context)
-      INTEGER, INTENT(IN) :: context
+      TYPE(mp_comm_type), INTENT(IN) :: context
 #if defined(__SCALAPACK)
-      CALL blacs_gridexit(context)
+      CALL blacs_gridexit(context%get_handle())
 #else
       MARK_USED(context)
 #endif
@@ -76,10 +80,10 @@ CONTAINS
 !> \param mypcol ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_gridinfo(context, nprow, npcol, myprow, mypcol)
-      INTEGER, INTENT(IN)  :: context
+      TYPE(mp_comm_type), INTENT(IN)  :: context
       INTEGER, INTENT(OUT) :: nprow, npcol, myprow, mypcol
 #if defined(__SCALAPACK)
-      CALL blacs_gridinfo(context, nprow, npcol, myprow, mypcol)
+      CALL blacs_gridinfo(context%get_handle(), nprow, npcol, myprow, mypcol)
 #else
       MARK_USED(context)
       nprow = 1
@@ -103,7 +107,8 @@ CONTAINS
 !> \param val ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_set(context, what, val)
-      INTEGER, INTENT(IN)  :: context, what, val
+      TYPE(mp_comm_type), INTENT(IN) :: context
+      INTEGER, INTENT(IN)  :: what, val
 #if defined(__SCALAPACK)
       CALL blacs_set(context, what, val)
 #else
@@ -124,12 +129,12 @@ CONTAINS
 !> \param LDA ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_zgebs2d(ICONTXT, SCOPE, TOP, M, N, A, LDA)
-      INTEGER, INTENT(IN)     :: ICONTXT
+      TYPE(mp_comm_type), INTENT(IN)     :: ICONTXT
       CHARACTER(len=1), INTENT(IN) :: SCOPE, TOP
       INTEGER, INTENT(IN)     :: M, N, LDA
       COMPLEX(KIND=dp)            :: A
 #if defined(__SCALAPACK)
-      CALL zgebs2d(ICONTXT, SCOPE, TOP, M, N, A, LDA)
+      CALL zgebs2d(ICONTXT%get_handle(), SCOPE, TOP, M, N, A, LDA)
 #else
       MARK_USED(ICONTXT)
       MARK_USED(SCOPE)
@@ -153,13 +158,13 @@ CONTAINS
 !> \param CSRC ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_zgebr2d(ICONTXT, SCOPE, TOP, M, N, A, LDA, RSRC, CSRC)
-      INTEGER, INTENT(IN)     :: ICONTXT
+      TYPE(mp_comm_type), INTENT(IN)     :: ICONTXT
       CHARACTER(len=1), INTENT(IN) :: SCOPE, TOP
       INTEGER, INTENT(IN)     :: M, N, LDA
       INTEGER, INTENT(IN)     :: RSRC, CSRC
       COMPLEX(KIND=dp)            :: A
 #if defined(__SCALAPACK)
-      CALL zgebr2d(ICONTXT, SCOPE, TOP, M, N, A, LDA, RSRC, CSRC)
+      CALL zgebr2d(ICONTXT%get_handle(), SCOPE, TOP, M, N, A, LDA, RSRC, CSRC)
 #else
       MARK_USED(ICONTXT)
       MARK_USED(SCOPE)
@@ -184,12 +189,12 @@ CONTAINS
 !> \param LDA ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_dgebs2d(ICONTXT, SCOPE, TOP, M, N, A, LDA)
-      INTEGER, INTENT(IN)     :: ICONTXT
+      TYPE(mp_comm_type), INTENT(IN)     :: ICONTXT
       CHARACTER(len=1), INTENT(IN) :: SCOPE, TOP
       INTEGER, INTENT(IN)     :: M, N, LDA
       REAL(KIND=dp)               :: A
 #if defined(__SCALAPACK)
-      CALL dgebs2d(ICONTXT, SCOPE, TOP, M, N, A, LDA)
+      CALL dgebs2d(ICONTXT%get_handle(), SCOPE, TOP, M, N, A, LDA)
 #else
       MARK_USED(ICONTXT)
       MARK_USED(SCOPE)
@@ -213,13 +218,13 @@ CONTAINS
 !> \param CSRC ...
 ! **************************************************************************************************
    SUBROUTINE cp_blacs_dgebr2d(ICONTXT, SCOPE, TOP, M, N, A, LDA, RSRC, CSRC)
-      INTEGER, INTENT(IN)     :: ICONTXT
+      TYPE(mp_comm_type), INTENT(IN)     :: ICONTXT
       CHARACTER(len=1), INTENT(IN) :: SCOPE, TOP
       INTEGER, INTENT(IN)     :: M, N, LDA
       INTEGER, INTENT(IN)     :: RSRC, CSRC
       REAL(KIND=dp)               :: A
 #if defined(__SCALAPACK)
-      CALL dgebr2d(ICONTXT, SCOPE, TOP, M, N, A, LDA, RSRC, CSRC)
+      CALL dgebr2d(ICONTXT%get_handle(), SCOPE, TOP, M, N, A, LDA, RSRC, CSRC)
 #else
       MARK_USED(ICONTXT)
       MARK_USED(SCOPE)

--- a/src/fm/cp_blacs_env.F
+++ b/src/fm/cp_blacs_env.F
@@ -24,7 +24,8 @@ MODULE cp_blacs_env
    USE kinds,                           ONLY: dp
    USE machine,                         ONLY: m_flush
    USE mathlib,                         ONLY: gcd
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -61,7 +62,8 @@ MODULE cp_blacs_env
 ! **************************************************************************************************
    TYPE cp_blacs_env_type
       INTEGER, DIMENSION(2) :: mepos, num_pe
-      INTEGER :: group, my_pid, n_pid, ref_count
+      TYPE(mp_comm_type) :: group
+      INTEGER :: my_pid, n_pid, ref_count
       TYPE(cp_para_env_type), POINTER :: para_env
       INTEGER, DIMENSION(:, :), POINTER :: blacs2mpi
       INTEGER, DIMENSION(:, :), POINTER :: mpi2blacs
@@ -155,7 +157,6 @@ CONTAINS
       CPASSERT(.NOT. ASSOCIATED(blacs_env))
 
       ALLOCATE (blacs_env)
-      blacs_env%group = 0
       blacs_env%ref_count = 1
       blacs_env%mepos(:) = 0
       blacs_env%num_pe(:) = 1
@@ -305,7 +306,7 @@ CONTAINS
 
       IF (ASSOCIATED(blacs_env)) THEN
          WRITE (unit=unit_nr, fmt="('  group=',i10,', ref_count=',i10,',')", &
-                iostat=iostat) blacs_env%group, blacs_env%ref_count
+                iostat=iostat) blacs_env%group%get_handle(), blacs_env%ref_count
          CPASSERT(iostat == 0)
          WRITE (unit=unit_nr, fmt="('  mepos=(',i8,',',i8,'),')", &
                 iostat=iostat) blacs_env%mepos(1), blacs_env%mepos(2)
@@ -323,7 +324,7 @@ CONTAINS
          END IF
          IF (ASSOCIATED(blacs_env%para_env)) THEN
             WRITE (unit=unit_nr, fmt="('  para_env=<cp_para_env id=',i6,'>,')") &
-               blacs_env%para_env%group
+               blacs_env%para_env%group%get_handle()
          ELSE
             WRITE (unit=unit_nr, fmt="('  para_env=*null*')")
          END IF

--- a/src/fm/cp_blacs_env.F
+++ b/src/fm/cp_blacs_env.F
@@ -24,7 +24,8 @@ MODULE cp_blacs_env
    USE kinds,                           ONLY: dp
    USE machine,                         ONLY: m_flush
    USE mathlib,                         ONLY: gcd
-   USE message_passing,                 ONLY: mp_comm_type,&
+   USE message_passing,                 ONLY: mp_comm_null,&
+                                              mp_comm_type,&
                                               mp_sum
 #include "../base/base_uses.f90"
 
@@ -62,7 +63,7 @@ MODULE cp_blacs_env
 ! **************************************************************************************************
    TYPE cp_blacs_env_type
       INTEGER, DIMENSION(2) :: mepos, num_pe
-      TYPE(mp_comm_type) :: group
+      TYPE(mp_comm_type) :: group = mp_comm_null
       INTEGER :: my_pid, n_pid, ref_count
       TYPE(cp_para_env_type), POINTER :: para_env
       INTEGER, DIMENSION(:, :), POINTER :: blacs2mpi

--- a/src/fm/cp_cfm_basic_linalg.F
+++ b/src/fm/cp_cfm_basic_linalg.F
@@ -23,7 +23,8 @@ MODULE cp_cfm_basic_linalg
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: z_one,&
                                               z_zero
-   USE message_passing,                 ONLY: mp_prod,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_prod,&
                                               mp_sum
 #include "../base/base_uses.f90"
 
@@ -194,7 +195,7 @@ CONTAINS
 
       ELSE
          CPASSERT(PRESENT(matrix_b))
-         IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
+         IF (matrix_a%matrix_struct%context%group%get_handle() /= matrix_b%matrix_struct%context%group%get_handle()) &
             CPABORT("matrixes must be in the same blacs context")
 
          IF (cp_fm_struct_equivalent(matrix_a%matrix_struct, &
@@ -301,7 +302,7 @@ CONTAINS
          END IF
 
       ELSE
-         IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
+         IF (matrix_a%matrix_struct%context%group%get_handle() /= matrix_b%matrix_struct%context%group%get_handle()) &
             CPABORT("matrices must be in the same blacs context")
 
          IF (cp_fm_struct_equivalent(matrix_a%matrix_struct, &
@@ -952,9 +953,10 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_cfm_trace'
 
-      INTEGER                                            :: group, handle, mypcol, myprow, &
-                                                            ncol_local, npcol, nprow, nrow_local
+      INTEGER                                            :: handle, mypcol, myprow, ncol_local, &
+                                                            npcol, nprow, nrow_local
       TYPE(cp_blacs_env_type), POINTER                   :: context
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 

--- a/src/fm/cp_cfm_basic_linalg.F
+++ b/src/fm/cp_cfm_basic_linalg.F
@@ -195,7 +195,7 @@ CONTAINS
 
       ELSE
          CPASSERT(PRESENT(matrix_b))
-         IF (matrix_a%matrix_struct%context%group%get_handle() /= matrix_b%matrix_struct%context%group%get_handle()) &
+         IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
             CPABORT("matrixes must be in the same blacs context")
 
          IF (cp_fm_struct_equivalent(matrix_a%matrix_struct, &
@@ -302,7 +302,7 @@ CONTAINS
          END IF
 
       ELSE
-         IF (matrix_a%matrix_struct%context%group%get_handle() /= matrix_b%matrix_struct%context%group%get_handle()) &
+         IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
             CPABORT("matrices must be in the same blacs context")
 
          IF (cp_fm_struct_equivalent(matrix_a%matrix_struct, &

--- a/src/fm/cp_cfm_types.F
+++ b/src/fm/cp_cfm_types.F
@@ -25,7 +25,7 @@ MODULE cp_cfm_types
                                               z_zero
    USE message_passing,                 ONLY: &
         cp2k_is_parallel, mp_allgather, mp_any_source, mp_bcast, mp_comm_type, mp_irecv, mp_isend, &
-        mp_proc_null, mp_request_null, mp_sum, mp_waitall
+        mp_proc_null, mp_request_null, mp_request_type, mp_sum, mp_waitall
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -97,7 +97,7 @@ MODULE cp_cfm_types
       !> displacements into recv_buf
       INTEGER, ALLOCATABLE, DIMENSION(:)          :: recv_disp
       !> MPI requests for non-blocking receive and send operations
-      INTEGER, ALLOCATABLE, DIMENSION(:)          :: recv_request, send_request
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)          :: recv_request, send_request
       !> global column and row indices of locally stored elements of the destination matrix
       INTEGER, DIMENSION(:), POINTER              :: recv_col_indices, recv_row_indices
       !> rank of MPI process with BLACS coordinates (prow, pcol)
@@ -892,11 +892,11 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: dest_blacs2mpi
       INTEGER, DIMENSION(2)                              :: dest_block, dest_block_tmp, dest_num_pe, &
                                                             src_block, src_block_tmp, src_num_pe
-      INTEGER, DIMENSION(6)                              :: recv_req, send_req
       INTEGER, DIMENSION(:), POINTER                     :: recv_col_indices, recv_row_indices, &
                                                             send_col_indices, send_row_indices
       TYPE(cp_fm_struct_type), POINTER                   :: recv_dist, send_dist
       TYPE(mp_comm_type)                                 :: global_comm
+      TYPE(mp_request_type), DIMENSION(6)                :: recv_req, send_req
 
       CALL timeset(routineN, handle)
 

--- a/src/fm/cp_cfm_types.F
+++ b/src/fm/cp_cfm_types.F
@@ -24,8 +24,8 @@ MODULE cp_cfm_types
    USE mathconstants,                   ONLY: z_one,&
                                               z_zero
    USE message_passing,                 ONLY: &
-        cp2k_is_parallel, mp_allgather, mp_any_source, mp_bcast, mp_irecv, mp_isend, mp_proc_null, &
-        mp_request_null, mp_sum, mp_waitall
+        cp2k_is_parallel, mp_allgather, mp_any_source, mp_bcast, mp_comm_type, mp_irecv, mp_isend, &
+        mp_proc_null, mp_request_null, mp_sum, mp_waitall
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -882,8 +882,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_start_copy_general'
 
-      INTEGER :: dest_p_i, dest_q_j, global_comm, global_rank, global_size, handle, i, j, k, &
-         mpi_rank, ncol_block_dest, ncol_block_src, ncol_local_recv, ncol_local_send, ncols, &
+      INTEGER :: dest_p_i, dest_q_j, global_rank, global_size, handle, i, j, k, mpi_rank, &
+         ncol_block_dest, ncol_block_src, ncol_local_recv, ncol_local_send, ncols, &
          nrow_block_dest, nrow_block_src, nrow_local_recv, nrow_local_send, nrows, p, q, &
          recv_rank, recv_size, send_rank, send_size
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: all_ranks, dest2global, dest_p, dest_q, &
@@ -896,6 +896,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: recv_col_indices, recv_row_indices, &
                                                             send_col_indices, send_row_indices
       TYPE(cp_fm_struct_type), POINTER                   :: recv_dist, send_dist
+      TYPE(mp_comm_type)                                 :: global_comm
 
       CALL timeset(routineN, handle)
 

--- a/src/fm/cp_fm_basic_linalg.F
+++ b/src/fm/cp_fm_basic_linalg.F
@@ -137,7 +137,7 @@ CONTAINS
          END IF
       END IF
       IF (my_beta .NE. 0.0_dp) THEN
-         IF (matrix_a%matrix_struct%context%group%get_handle() /= matrix_b%matrix_struct%context%group%get_handle()) &
+         IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
             CPABORT("matrixes must be in the same blacs context")
 
          IF (cp_fm_struct_equivalent(matrix_a%matrix_struct, &

--- a/src/fm/cp_fm_basic_linalg.F
+++ b/src/fm/cp_fm_basic_linalg.F
@@ -28,7 +28,8 @@ MODULE cp_fm_basic_linalg
    USE machine,                         ONLY: m_memory
    USE mathlib,                         ONLY: get_pseudo_inverse_svd,&
                                               invert_matrix
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -136,7 +137,7 @@ CONTAINS
          END IF
       END IF
       IF (my_beta .NE. 0.0_dp) THEN
-         IF (matrix_a%matrix_struct%context%group /= matrix_b%matrix_struct%context%group) &
+         IF (matrix_a%matrix_struct%context%group%get_handle() /= matrix_b%matrix_struct%context%group%get_handle()) &
             CPABORT("matrixes must be in the same blacs context")
 
          IF (cp_fm_struct_equivalent(matrix_a%matrix_struct, &
@@ -550,7 +551,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER  :: a
       REAL(KIND=dp), EXTERNAL                  :: DDOT
 #if defined(__SCALAPACK)
-      INTEGER                                  :: group
+      TYPE(mp_comm_type)                       :: group
 #endif
 
       CALL timeset(routineN, handle)
@@ -696,11 +697,12 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a0b0t0'
 
-      INTEGER                                            :: group, handle, mypcol, myprow, &
-                                                            ncol_local, npcol, nprow, nrow_local
+      INTEGER                                            :: handle, mypcol, myprow, ncol_local, &
+                                                            npcol, nprow, nrow_local
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: a, b
       REAL(KIND=sp), DIMENSION(:, :), POINTER            :: a_sp, b_sp
       TYPE(cp_blacs_env_type), POINTER                   :: context
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
@@ -767,11 +769,12 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b0t1'
 
-      INTEGER                                            :: group, handle, imatrix, n_matrices, &
+      INTEGER                                            :: handle, imatrix, n_matrices, &
                                                             ncols_local, nrows_local
       LOGICAL                                            :: use_sp_a, use_sp_b
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
       REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
@@ -840,11 +843,12 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b1t1'
 
-      INTEGER                                            :: group, handle, imatrix, n_matrices, &
+      INTEGER                                            :: handle, imatrix, n_matrices, &
                                                             ncols_local, nrows_local
       LOGICAL                                            :: use_accurate_sum, use_sp_a, use_sp_b
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
       REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
@@ -908,13 +912,14 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_contracted_trace_a2b2t2'
 
-      INTEGER                                            :: group, handle, ia, ib, iz, na, nb, &
-                                                            ncols_local, nrows_local, nz
+      INTEGER                                            :: handle, ia, ib, iz, na, nb, ncols_local, &
+                                                            nrows_local, nz
       INTEGER(kind=int_8)                                :: ib8, itrace, na8, ntraces
       LOGICAL                                            :: use_accurate_sum, use_sp_a, use_sp_b
       REAL(kind=dp)                                      :: t
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
       REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
@@ -1454,7 +1459,8 @@ CONTAINS
 
 #if defined(__SCALAPACK)
       TYPE(cp_fm_type)                :: u, vt, sigma, inv_sigma_ut
-      INTEGER                                  :: i, info, liwork, lwork, group, exponent_of_minus_one
+      TYPE(mp_comm_type) :: group
+      INTEGER                                  :: i, info, liwork, lwork, exponent_of_minus_one
       INTEGER, DIMENSION(9)                    :: desca
       LOGICAL                                  :: quenched
       REAL(KIND=dp)                            :: alpha, beta

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -48,6 +48,9 @@ MODULE cp_fm_diag
    USE machine, ONLY: default_output_unit, &
                       m_memory
    USE message_passing, ONLY: mp_bcast
+#if defined (__SCALAPACK)
+   USE message_passing, ONLY: mp_comm_type
+#endif
 #if defined (__HAS_IEEE_EXCEPTIONS)
    USE ieee_exceptions, ONLY: ieee_get_halting_mode, &
                               ieee_set_halting_mode, &
@@ -1035,12 +1038,13 @@ CONTAINS
 #if defined(__SCALAPACK)
       TYPE(cp_blacs_env_type), POINTER :: context
 
-      INTEGER :: myprow, mypcol, nprow, npcol, ictxt_loc, block_dim_row, block_dim_col, &
-                 info, ev_row_block_size, iam, source, allgrp, mynumrows, ictxt, mype, npe, &
+      INTEGER :: myprow, mypcol, nprow, npcol, block_dim_row, block_dim_col, &
+                 info, ev_row_block_size, iam, source, mynumrows, mype, npe, &
                  q_loc
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE :: a_loc, ev_loc
       INTEGER, DIMENSION(9)                        :: desca, descz, desc_a_block, &
                                                       desc_ev_loc
+      TYPE(mp_comm_type):: allgrp, ictxt, ictxt_loc
       INTEGER, EXTERNAL :: numroc, indxl2g, indxg2l
 #endif
 
@@ -1081,10 +1085,10 @@ CONTAINS
       CALL cp_blacs_gridinit(ictxt_loc, 'Row-major', NPROW*NPCOL, 1)
 
       CALL descinit(desc_a_block, block_dim_row, block_dim_col, block_dim_row, &
-                    block_dim_col, 0, 0, ictxt_loc, block_dim_row, info)
+                    block_dim_col, 0, 0, ictxt_loc%get_handle(), block_dim_row, info)
 
       CALL pdgemr2d(block_dim_row, block_dim_col, A, 1, start_sec_block, desca, &
-                    A_loc, 1, 1, desc_a_block, ictxt)
+                    A_loc, 1, 1, desc_a_block, ictxt%get_handle())
       ! Only the master (root) process received data yet
       CALL mp_bcast(A_loc, 0, allgrp)
 
@@ -1098,10 +1102,10 @@ CONTAINS
 
       ALLOCATE (EV_loc(mynumrows, N), c_ip(mynumrows))
 
-      CALL descinit(desc_ev_loc, N, N, ev_row_block_size, N, 0, 0, ictxt_loc, &
+      CALL descinit(desc_ev_loc, N, N, ev_row_block_size, N, 0, 0, ictxt_loc%get_handle(), &
                     mynumrows, info)
 
-      CALL pdgemr2d(N, N, EV, 1, 1, descz, EV_loc, 1, 1, desc_ev_loc, ictxt)
+      CALL pdgemr2d(N, N, EV, 1, 1, descz, EV_loc, 1, 1, desc_ev_loc, ictxt%get_handle())
 
       ! Start block diagonalization of matrix
 
@@ -1138,7 +1142,7 @@ CONTAINS
       END DO
 
       ! Copy eigenvectors back to the original distribution
-      CALL pdgemr2d(N, N, EV_loc, 1, 1, desc_ev_loc, EV, 1, 1, descz, ictxt)
+      CALL pdgemr2d(N, N, EV_loc, 1, 1, desc_ev_loc, EV, 1, 1, descz, ictxt%get_handle())
 
       ! Release work storage
       DEALLOCATE (A_loc, EV_loc, c_ip)

--- a/src/fm/cp_fm_diag_utils.F
+++ b/src/fm/cp_fm_diag_utils.F
@@ -34,7 +34,9 @@ MODULE cp_fm_diag_utils
    USE mathlib,                         ONLY: gcd
    USE message_passing,                 ONLY: mp_bcast,&
                                               mp_comm_free,&
+                                              mp_comm_null,&
                                               mp_comm_split,&
+                                              mp_comm_type,&
                                               mp_sync
 #include "../base/base_uses.f90"
 
@@ -63,7 +65,7 @@ MODULE cp_fm_diag_utils
       LOGICAL                                  :: should_print
       LOGICAL                                  :: elpa_force_redistribute
       ! Temporaries
-      INTEGER                                  :: subgroup
+      TYPE(mp_comm_type)                       :: subgroup
       INTEGER, DIMENSION(:), POINTER           :: group_distribution, &
                                                   group_partition
       TYPE(cp_blacs_env_type), POINTER         :: blacs_env_new
@@ -121,7 +123,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_redistribute_work_init()
 
-      work_redistribute%subgroup = -1
+      CALL work_redistribute%subgroup%set_handle(mp_comm_null)
       NULLIFY (work_redistribute%group_distribution)
       NULLIFY (work_redistribute%group_partition)
       NULLIFY (work_redistribute%blacs_env_new)

--- a/src/fm/cp_fm_diag_utils.F
+++ b/src/fm/cp_fm_diag_utils.F
@@ -123,7 +123,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_redistribute_work_init()
 
-      CALL work_redistribute%subgroup%set_handle(mp_comm_null)
+      work_redistribute%subgroup = mp_comm_null
       NULLIFY (work_redistribute%group_distribution)
       NULLIFY (work_redistribute%group_partition)
       NULLIFY (work_redistribute%blacs_env_new)

--- a/src/fm/cp_fm_elpa.F
+++ b/src/fm/cp_fm_elpa.F
@@ -35,7 +35,7 @@ MODULE cp_fm_elpa
                     dp
    USE message_passing, ONLY: mp_comm_free, &
                               mp_comm_split_direct, &
-                              mp_bcast
+                              mp_bcast, mp_comm_type
    USE OMP_LIB, ONLY: omp_get_max_threads
 
 #include "../base/base_uses.f90"
@@ -334,7 +334,8 @@ CONTAINS
 
       CLASS(elpa_t), POINTER                   :: elpa_obj
       CHARACTER(len=default_string_length)     :: kernel_name
-      INTEGER                                  :: group, i, &
+      TYPE(mp_comm_type) :: group
+      INTEGER                                  :: i, &
                                                   mypcol, myprow, n, &
                                                   n_rows, n_cols, &
                                                   nblk, neig, io_unit, &
@@ -489,7 +490,7 @@ CONTAINS
       CALL elpa_obj%set("nblk", nblk, success)
       CPASSERT(success == elpa_ok)
 
-      CALL elpa_obj%set("mpi_comm_parent", group, success)
+      CALL elpa_obj%set("mpi_comm_parent", group%get_handle(), success)
       CPASSERT(success == elpa_ok)
 
       CALL elpa_obj%set("process_row", myprow, success)

--- a/src/fm/cp_fm_struct.F
+++ b/src/fm/cp_fm_struct.F
@@ -370,7 +370,7 @@ CONTAINS
       IF (ASSOCIATED(fmstruct1, fmstruct2)) THEN
          res = .TRUE.
       ELSE
-         res = (fmstruct1%context%group%get_handle() == fmstruct2%context%group%get_handle()) .AND. &
+         res = (fmstruct1%context%group == fmstruct2%context%group) .AND. &
                (fmstruct1%nrow_global == fmstruct2%nrow_global) .AND. &
                (fmstruct1%ncol_global == fmstruct2%ncol_global) .AND. &
                (fmstruct1%local_leading_dimension == &

--- a/src/fm/cp_fm_struct.F
+++ b/src/fm/cp_fm_struct.F
@@ -370,7 +370,7 @@ CONTAINS
       IF (ASSOCIATED(fmstruct1, fmstruct2)) THEN
          res = .TRUE.
       ELSE
-         res = (fmstruct1%context%group == fmstruct2%context%group) .AND. &
+         res = (fmstruct1%context%group%get_handle() == fmstruct2%context%group%get_handle()) .AND. &
                (fmstruct1%nrow_global == fmstruct2%nrow_global) .AND. &
                (fmstruct1%ncol_global == fmstruct2%ncol_global) .AND. &
                (fmstruct1%local_leading_dimension == &

--- a/src/fm/cp_fm_types.F
+++ b/src/fm/cp_fm_types.F
@@ -29,8 +29,8 @@ MODULE cp_fm_types
    USE kinds,                           ONLY: dp,&
                                               sp
    USE message_passing,                 ONLY: &
-        cp2k_is_parallel, mp_allgather, mp_any_source, mp_bcast, mp_irecv, mp_isend, mp_max, &
-        mp_proc_null, mp_recv, mp_request_null, mp_send, mp_sum, mp_waitall
+        cp2k_is_parallel, mp_allgather, mp_any_source, mp_bcast, mp_comm_type, mp_irecv, mp_isend, &
+        mp_max, mp_proc_null, mp_recv, mp_request_null, mp_send, mp_sum, mp_waitall
    USE parallel_rng_types,              ONLY: UNIFORM,&
                                               rng_stream_type
 #include "../base/base_uses.f90"
@@ -1370,8 +1370,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_start_copy_general'
 
-      INTEGER :: dest_p_i, dest_q_j, global_comm, global_rank, global_size, handle, i, j, k, &
-         mpi_rank, ncol_block_dest, ncol_block_src, ncol_local_recv, ncol_local_send, ncols, &
+      INTEGER :: dest_p_i, dest_q_j, global_rank, global_size, handle, i, j, k, mpi_rank, &
+         ncol_block_dest, ncol_block_src, ncol_local_recv, ncol_local_send, ncols, &
          nrow_block_dest, nrow_block_src, nrow_local_recv, nrow_local_send, nrows, p, q, &
          recv_rank, recv_size, send_rank, send_size
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: all_ranks, dest2global, dest_p, dest_q, &
@@ -1386,6 +1386,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: src_blacs2mpi
       REAL(KIND=dp), DIMENSION(:), POINTER               :: recv_buf, send_buf
       TYPE(cp_fm_struct_type), POINTER                   :: recv_dist, send_dist
+      TYPE(mp_comm_type)                                 :: global_comm
 
       CALL timeset(routineN, handle)
 
@@ -1840,8 +1841,8 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)             :: source, destination
       INTEGER, INTENT(IN)                      :: nrows, ncols, &
                                                   s_firstrow, s_firstcol, &
-                                                  d_firstrow, d_firstcol, &
-                                                  global_context
+                                                  d_firstrow, d_firstcol
+      TYPE(mp_comm_type), INTENT(IN) ::                                                  global_context
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_to_fm_submat_general'
 
@@ -1907,7 +1908,7 @@ CONTAINS
                        d_firstrow, &
                        d_firstcol, &
                        descb, &
-                       global_context)
+                       global_context%get_handle())
 #else
          MARK_USED(global_context)
          CPABORT("this subroutine only supports SCALAPACK")
@@ -1990,13 +1991,14 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER          :: para_env
 #if defined(__SCALAPACK)
       INTEGER                                  :: i, i_block, icol_local, &
-                                                  ictxt_loc, in, info, ipcol, &
+                                                  in, info, ipcol, &
                                                   iprow, irow_local, &
                                                   mepos, mypcol, myprow, &
                                                   npcol, nprow, num_pe, rb, tag
       INTEGER, DIMENSION(9)                    :: desc
       REAL(KIND=dp), DIMENSION(:), POINTER     :: vecbuf
       REAL(KIND=dp), DIMENSION(:, :), POINTER  :: newdat
+      TYPE(mp_comm_type) :: ictxt_loc
       INTEGER, EXTERNAL                        :: numroc
 #endif
 
@@ -2022,7 +2024,7 @@ CONTAINS
       ! do the actual scalapack to cols reordering
       CALL pdgemr2d(nrow_global, ncol_global, fm%local_data, 1, 1, &
                     fm%matrix_struct%descriptor, &
-                    newdat, 1, 1, desc, ictxt_loc)
+                    newdat, 1, 1, desc, ictxt_loc%get_handle())
 
       ALLOCATE (vecbuf(nrow_global*max_block))
       vecbuf = HUGE(1.0_dp) ! init for valgrind
@@ -2095,7 +2097,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER          :: para_env
 #if defined(__SCALAPACK)
       INTEGER                                  :: i_block, icol_local, &
-                                                  ictxt_loc, in, info, ipcol, &
+                                                  in, info, ipcol, &
                                                   iprow, irow_local, &
                                                   mepos, mypcol, myprow, &
                                                   npcol, nprow, num_pe, rb, tag, k, &
@@ -2103,6 +2105,7 @@ CONTAINS
       INTEGER, DIMENSION(9)                    :: desc
       REAL(KIND=dp), DIMENSION(:), POINTER     :: vecbuf
       REAL(KIND=dp), DIMENSION(:, :), POINTER  :: newdat
+      TYPE(mp_comm_type) :: ictxt_loc
       INTEGER, EXTERNAL                        :: numroc
 #endif
 
@@ -2140,7 +2143,7 @@ CONTAINS
       ! do the actual scalapack to cols reordering
       CALL pdgemr2d(nrow_global, ncol_global, fm%local_data, 1, 1, &
                     fm%matrix_struct%descriptor, &
-                    newdat, 1, 1, desc, ictxt_loc)
+                    newdat, 1, 1, desc, ictxt_loc%get_handle())
 
       ALLOCATE (vecbuf(nrow_global*max_block))
       vecbuf = HUGE(1.0_dp) ! init for valgrind

--- a/src/fm/cp_fm_types.F
+++ b/src/fm/cp_fm_types.F
@@ -30,7 +30,8 @@ MODULE cp_fm_types
                                               sp
    USE message_passing,                 ONLY: &
         cp2k_is_parallel, mp_allgather, mp_any_source, mp_bcast, mp_comm_type, mp_irecv, mp_isend, &
-        mp_max, mp_proc_null, mp_recv, mp_request_null, mp_send, mp_sum, mp_waitall
+        mp_max, mp_proc_null, mp_recv, mp_request_null, mp_request_type, mp_send, mp_sum, &
+        mp_waitall
    USE parallel_rng_types,              ONLY: UNIFORM,&
                                               rng_stream_type
 #include "../base/base_uses.f90"
@@ -128,7 +129,8 @@ MODULE cp_fm_types
    TYPE copy_info_type
       INTEGER :: send_size
       INTEGER, DIMENSION(2) :: nlocal_recv, nblock_src, src_num_pe ! 1->row  2->col
-      INTEGER, DIMENSION(:), POINTER       :: send_request, recv_request, recv_disp
+      TYPE(mp_request_type), DIMENSION(:), POINTER :: send_request, recv_request
+      INTEGER, DIMENSION(:), POINTER       :: recv_disp
       INTEGER, DIMENSION(:), POINTER       :: recv_col_indices, recv_row_indices
       INTEGER, DIMENSION(:, :), POINTER    :: src_blacs2mpi
       REAL(KIND=dp), DIMENSION(:), POINTER :: recv_buf, send_buf
@@ -1380,13 +1382,15 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: dest_blacs2mpi
       INTEGER, DIMENSION(2)                              :: dest_block, dest_block_tmp, dest_num_pe, &
                                                             src_block, src_block_tmp, src_num_pe
-      INTEGER, DIMENSION(6)                              :: recv_req, send_req
-      INTEGER, DIMENSION(:), POINTER :: recv_col_indices, recv_disp, recv_request, &
-         recv_row_indices, send_col_indices, send_request, send_row_indices
+      INTEGER, DIMENSION(:), POINTER                     :: recv_col_indices, recv_disp, &
+                                                            recv_row_indices, send_col_indices, &
+                                                            send_row_indices
       INTEGER, DIMENSION(:, :), POINTER                  :: src_blacs2mpi
       REAL(KIND=dp), DIMENSION(:), POINTER               :: recv_buf, send_buf
       TYPE(cp_fm_struct_type), POINTER                   :: recv_dist, send_dist
       TYPE(mp_comm_type)                                 :: global_comm
+      TYPE(mp_request_type), DIMENSION(6)                :: recv_req, send_req
+      TYPE(mp_request_type), DIMENSION(:), POINTER       :: recv_request, send_request
 
       CALL timeset(routineN, handle)
 
@@ -1703,10 +1707,10 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: recv_count
       INTEGER, DIMENSION(2)                              :: nblock_src, nlocal_recv, src_num_pe
       INTEGER, DIMENSION(:), POINTER                     :: recv_col_indices, recv_disp, &
-                                                            recv_request, recv_row_indices, &
-                                                            send_request
+                                                            recv_row_indices
       INTEGER, DIMENSION(:, :), POINTER                  :: src_blacs2mpi
       REAL(KIND=dp), DIMENSION(:), POINTER               :: recv_buf, send_buf
+      TYPE(mp_request_type), DIMENSION(:), POINTER       :: recv_request, send_request
 
       CALL timeset(routineN, handle)
 
@@ -1776,9 +1780,9 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_cleanup_copy_general'
 
       INTEGER                                            :: handle
-      INTEGER, DIMENSION(:), POINTER                     :: send_request
       INTEGER, DIMENSION(:, :), POINTER                  :: src_blacs2mpi
       REAL(KIND=dp), DIMENSION(:), POINTER               :: send_buf
+      TYPE(mp_request_type), DIMENSION(:), POINTER       :: send_request
 
       CALL timeset(routineN, handle)
 

--- a/src/grid/grid_api.F
+++ b/src/grid/grid_api.F
@@ -14,7 +14,8 @@ MODULE grid_api
         C_ASSOCIATED, C_BOOL, C_CHAR, C_DOUBLE, C_FUNLOC, C_FUNPTR, C_INT, C_LOC, C_LONG, &
         C_NULL_PTR, C_PTR
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE offload_api,                     ONLY: offload_buffer_type
    USE realspace_grid_types,            ONLY: realspace_grid_type
    USE string_utilities,                ONLY: strlcpy_c2f
@@ -1188,7 +1189,8 @@ CONTAINS
 !> \author Ole Schuett
 ! **************************************************************************************************
    SUBROUTINE grid_library_print_stats(mpi_comm, output_unit)
-      INTEGER, INTENT(IN)                                :: mpi_comm, output_unit
+      TYPE(mp_comm_type)                                 :: mpi_comm
+      INTEGER, INTENT(IN)                                :: output_unit
 
       INTERFACE
          SUBROUTINE grid_library_print_stats_c(mpi_sum_func, mpi_comm, print_func, output_unit) &
@@ -1203,7 +1205,7 @@ CONTAINS
 
       ! Since Fortran units and mpi groups can't be used from C, we pass function pointers instead.
       CALL grid_library_print_stats_c(mpi_sum_func=C_FUNLOC(mpi_sum_func), &
-                                      mpi_comm=mpi_comm, &
+                                      mpi_comm=mpi_comm%get_handle(), &
                                       print_func=C_FUNLOC(print_func), &
                                       output_unit=output_unit)
 
@@ -1219,7 +1221,12 @@ CONTAINS
       INTEGER(KIND=C_LONG), INTENT(INOUT)                :: number
       INTEGER(KIND=C_INT), INTENT(IN), VALUE             :: mpi_comm
 
-      CALL mp_sum(number, mpi_comm)
+      TYPE(mp_comm_type)                                 :: my_mpi_comm
+
+      ! Convert the handle to the default integer kind and convert it to the communicator type
+      CALL my_mpi_comm%set_handle(INT(mpi_comm))
+
+      CALL mp_sum(number, my_mpi_comm)
    END SUBROUTINE mpi_sum_func
 
 ! **************************************************************************************************

--- a/src/hfx_communication.F
+++ b/src/hfx_communication.F
@@ -32,6 +32,7 @@ MODULE hfx_communication
    USE message_passing,                 ONLY: mp_allgather,&
                                               mp_isendrecv,&
                                               mp_max,&
+                                              mp_request_type,&
                                               mp_sync,&
                                               mp_waitall
    USE particle_types,                  ONLY: particle_type
@@ -89,15 +90,14 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: antisymmetric
 
       INTEGER :: blk, block_size, data_from, dest, i, iatom, icpu, ikind, iset, jatom, jkind, &
-         jset, mepos, ncpu, nseta, nsetb, pa, pa1, pb, pb1, req(2), source, source_cpu
+         jset, mepos, ncpu, nseta, nsetb, pa, pa1, pb, pb1, source, source_cpu
       INTEGER, DIMENSION(:), POINTER                     :: nsgfa, nsgfb
       LOGICAL                                            :: found
       REAL(dp)                                           :: symmfac
       REAL(dp), DIMENSION(:), POINTER                    :: recbuffer, sendbuffer, swapbuffer
       REAL(dp), DIMENSION(:, :), POINTER                 :: sparse_block, sparse_block_beta
       TYPE(dbcsr_iterator_type)                          :: iter
-
-!debREAL(dp), DIMENSION(:), POINTER          :: full_density
+      TYPE(mp_request_type), DIMENSION(2)                :: req
 
       full_density = 0.0_dp
       ALLOCATE (sendbuffer(number_of_p_entries))
@@ -213,12 +213,13 @@ CONTAINS
       REAL(dp), INTENT(IN), OPTIONAL                     :: off_diag_fac, diag_fac
 
       INTEGER :: blk, block_size, data_to, dest, dest_cpu, i, iatom, icpu, ikind, iset, jatom, &
-         jkind, jset, mepos, ncpu, nseta, nsetb, pa, pa1, pb, pb1, req(2), source
+         jkind, jset, mepos, ncpu, nseta, nsetb, pa, pa1, pb, pb1, source
       INTEGER, DIMENSION(:), POINTER                     :: nsgfa, nsgfb
       REAL(dp)                                           :: my_fac, myd_fac
       REAL(dp), DIMENSION(:), POINTER                    :: recbuffer, sendbuffer, swapbuffer
       REAL(dp), DIMENSION(:, :), POINTER                 :: sparse_block
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_request_type), DIMENSION(2)                :: req
 
       my_fac = 1.0_dp; myd_fac = 1.0_dp
       IF (PRESENT(off_diag_fac)) my_fac = off_diag_fac

--- a/src/hfx_load_balance_methods.F
+++ b/src/hfx_load_balance_methods.F
@@ -32,7 +32,7 @@ MODULE hfx_load_balance_methods
                               mp_max, &
                               mp_sum, &
                               mp_sync, &
-                              mp_waitall
+                              mp_waitall, mp_request_type
    USE parallel_rng_types, ONLY: UNIFORM, &
                                  rng_stream_type
    USE particle_types, ONLY: particle_type
@@ -165,7 +165,8 @@ CONTAINS
                  jatom_end, jatom_start, katom_block, katom_end, katom_start, latom_block, latom_end, &
                  latom_start, mepos, my_process_id, n_processes, natom, nbins, nblocks, ncpu, &
                  new_iatom_end, new_iatom_start, new_jatom_end, new_jatom_start, non_empty_blocks, &
-                 objective_block_size, objective_nblocks, req(2), source, total_blocks
+                 objective_block_size, objective_nblocks, source, total_blocks
+      TYPE(mp_request_type), DIMENSION(2) :: req
       INTEGER(int_8) :: atom_block, cost_per_bin, cost_per_core, current_cost, &
                         distribution_counter_end, distribution_counter_start, global_quartet_counter, &
                         local_quartet_counter, self_cost_per_block, tmp_block, total_block_self_cost
@@ -1494,7 +1495,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_update_load_balance'
 
       INTEGER :: data_from, dest, end_idx, handle, i, ibin, icpu, iprocess, j, mepos, my_bin_size, &
-                 my_global_start_idx, my_process_id, n_processes, nbins, ncpu, req(2), source, start_idx
+                 my_global_start_idx, my_process_id, n_processes, nbins, ncpu, source, start_idx
+      TYPE(mp_request_type), DIMENSION(2) :: req
       INTEGER(int_8), DIMENSION(:), POINTER              :: local_cost_matrix, recbuffer, &
                                                             sendbuffer, swapbuffer
       INTEGER(int_8), DIMENSION(:), POINTER, SAVE        :: cost_matrix

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -83,6 +83,7 @@ MODULE hfx_ri
                                               int_8
    USE machine,                         ONLY: m_walltime
    USE message_passing,                 ONLY: mp_cart_create,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_sum,&
                                               mp_sync
@@ -452,8 +453,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_ri_pre_scf_calc_tensors'
 
-      INTEGER                                            :: handle, i_mem, ibasis, mp_comm_t3c, &
-                                                            n_mem, natom, nkind
+      INTEGER                                            :: handle, i_mem, ibasis, n_mem, natom, &
+                                                            nkind
       INTEGER, ALLOCATABLE, DIMENSION(:) :: dist_AO_1, dist_AO_2, dist_RI, &
          ends_array_mc_block_int, ends_array_mc_int, sizes_AO, sizes_RI, &
          starts_array_mc_block_int, starts_array_mc_int
@@ -471,6 +472,7 @@ CONTAINS
       TYPE(gto_basis_set_p_type), ALLOCATABLE, &
          DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
+      TYPE(mp_comm_type)                                 :: mp_comm_t3c
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: nl_2c_pot, nl_2c_RI
@@ -1133,9 +1135,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_ri_update_ks_mo'
 
-      INTEGER                                            :: bsize, bsum, comm_2d, handle, handle2, &
-                                                            i_mem, iblock, iproc, ispin, n_mem, &
-                                                            n_mos, nblock, nproc, unit_nr_dbcsr
+      INTEGER                                            :: bsize, bsum, comm_2d_handle, handle, &
+                                                            handle2, i_mem, iblock, iproc, ispin, &
+                                                            n_mem, n_mos, nblock, nproc, &
+                                                            unit_nr_dbcsr
       INTEGER(int_8)                                     :: nblks, nflop
       INTEGER, ALLOCATABLE, DIMENSION(:) :: batch_ranges_1, batch_ranges_2, dist1, dist2, dist3, &
          mem_end, mem_end_block_1, mem_end_block_2, mem_size, mem_start, mem_start_block_1, &
@@ -1151,6 +1154,7 @@ CONTAINS
       TYPE(dbt_type)                                     :: ks_t, ks_t_mat, mo_coeff_t, &
                                                             mo_coeff_t_split
       TYPE(dbt_type), DIMENSION(1, 1)                    :: t_3c_int_mo_1, t_3c_int_mo_2
+      TYPE(mp_comm_type)                                 :: comm_2d
 
       CALL timeset(routineN, handle)
 
@@ -1192,8 +1196,9 @@ CONTAINS
       ALLOCATE (bounds(2, 1))
 
       CALL dbcsr_get_info(ks_matrix(1, 1)%matrix, distribution=ks_dist)
-      CALL dbcsr_distribution_get(ks_dist, group=comm_2d, nprows=pdims_2d(1), npcols=pdims_2d(2))
+      CALL dbcsr_distribution_get(ks_dist, group=comm_2d_handle, nprows=pdims_2d(1), npcols=pdims_2d(2))
 
+      CALL comm_2d%set_handle(comm_2d_handle)
       pgrid_2d = dbt_nd_mp_comm(comm_2d, [1], [2], pdims_2d=pdims_2d)
 
       CALL create_2c_tensor(ks_t, dist1, dist2, pgrid_2d, ri_data%bsizes_AO_fit, ri_data%bsizes_AO_fit, &
@@ -3036,8 +3041,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'precalc_derivatives'
 
-      INTEGER                                            :: handle, i_mem, i_xyz, ibasis, &
-                                                            mp_comm_t3c, n_mem, nkind
+      INTEGER                                            :: handle, i_mem, i_xyz, ibasis, n_mem, &
+                                                            nkind
       INTEGER(int_8)                                     :: nze, nze_tot
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist_AO_1, dist_AO_2, &
                                                             dist_RI, dummy_end, dummy_start, &
@@ -3056,6 +3061,7 @@ CONTAINS
       TYPE(gto_basis_set_p_type), ALLOCATABLE, &
          DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
+      TYPE(mp_comm_type)                                 :: mp_comm_t3c
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: nl_2c
@@ -3764,8 +3770,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_RI_density_coeffs'
 
-      INTEGER                                            :: a, b, handle, i_mem, idx, mp_comm_t3c, &
-                                                            n_dependent, n_mem, n_mem_RI, natom, &
+      INTEGER                                            :: a, b, handle, i_mem, idx, n_dependent, &
+                                                            n_mem, n_mem_RI, natom, &
                                                             nblk_per_thread, nblks, nkind
       INTEGER(int_8)                                     :: nze
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: batch_block_end, batch_block_start, &
@@ -3790,6 +3796,7 @@ CONTAINS
       TYPE(dbt_type), DIMENSION(1, 1)                    :: t_3c_int_batched
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_3d_type)                         :: dist_nl3c
+      TYPE(mp_comm_type)                                 :: mp_comm_t3c
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set

--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -67,6 +67,7 @@ MODULE hfx_types
                                               m_getcwd
    USE mathlib,                         ONLY: erfc_cutoff
    USE message_passing,                 ONLY: mp_cart_create,&
+                                              mp_comm_type,&
                                               mp_environ
    USE orbital_pointers,                ONLY: nco,&
                                               ncoset,&
@@ -1187,7 +1188,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_ri_init'
 
       INTEGER                                            :: handle, i_mem, iproc, j_mem, MO_dim, &
-                                                            mp_comm_3d, natom, nkind, nproc
+                                                            natom, nkind, nproc
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_AO_store, bsizes_RI_store, dist1, &
                                                             dist2, dist3, dist_AO_1, dist_AO_2, &
                                                             dist_RI
@@ -1197,6 +1198,7 @@ CONTAINS
       TYPE(distribution_3d_type)                         :: dist_3d
       TYPE(gto_basis_set_p_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: basis_set_AO, basis_set_RI
+      TYPE(mp_comm_type)                                 :: mp_comm_3d
 
       CALL timeset(routineN, handle)
 

--- a/src/input/cp_output_handling.F
+++ b/src/input/cp_output_handling.F
@@ -53,7 +53,8 @@ MODULE cp_output_handling
    USE message_passing,                 ONLY: mp_file_close,&
                                               mp_file_delete,&
                                               mp_file_get_amode,&
-                                              mp_file_open
+                                              mp_file_open,&
+                                              mp_file_type
    USE string_utilities,                ONLY: compress,&
                                               s2a
 #include "../base/base_uses.f90"
@@ -821,13 +822,14 @@ CONTAINS
       CHARACTER(len=default_string_length)               :: my_file_action, my_file_form, &
                                                             my_file_position, my_file_status, &
                                                             outPath
-      INTEGER                                            :: c_i_level, f_backup_level, i, iounit, &
-                                                            mpi_amode, my_backup_level, my_nbak, &
-                                                            nbak, s_backup_level, unit_nr
+      INTEGER                                            :: c_i_level, f_backup_level, i, mpi_amode, &
+                                                            my_backup_level, my_nbak, nbak, &
+                                                            s_backup_level, unit_nr
       LOGICAL                                            :: do_log, found, my_do_backup, my_local, &
                                                             my_mpi_io, my_on_file, &
                                                             my_should_output, replace
       TYPE(cp_iteration_info_type), POINTER              :: iteration_info
+      TYPE(mp_file_type)                                 :: mp_unit
       TYPE(section_vals_type), POINTER                   :: print_key
 
       my_local = .FALSE.
@@ -968,9 +970,9 @@ CONTAINS
             ELSE
                IF (replace) CALL mp_file_delete(filename)
                CALL mp_file_open(groupid=logger%para_env%group, &
-                                 fh=iounit, filepath=filename, amode_status=mpi_amode)
+                                 fh=mp_unit, filepath=filename, amode_status=mpi_amode)
                IF (PRESENT(fout)) fout = filename
-               res = iounit
+               res = mp_unit%get_handle()
             END IF
             IF (do_log) THEN
                unit_nr = cp_logger_get_unit_nr(logger, local=my_local)
@@ -1020,6 +1022,7 @@ CONTAINS
       CHARACTER(len=default_string_length)               :: outPath
       LOGICAL                                            :: my_local, my_mpi_io, my_on_file, &
                                                             my_should_output
+      TYPE(mp_file_type)                                 :: mp_unit
       TYPE(section_vals_type), POINTER                   :: print_key
 
       my_local = .FALSE.
@@ -1044,7 +1047,8 @@ CONTAINS
             IF (.NOT. my_mpi_io) THEN
                CALL close_file(unit_nr, "KEEP")
             ELSE
-               CALL mp_file_close(unit_nr)
+               CALL mp_unit%set_handle(unit_nr)
+               CALL mp_file_close(mp_unit)
             END IF
             unit_nr = -1
          ELSE

--- a/src/input/cp_parser_types.F
+++ b/src/input/cp_parser_types.F
@@ -40,8 +40,7 @@ MODULE cp_parser_types
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               max_line_length
-   USE message_passing,                 ONLY: mp_comm_self,&
-                                              mp_comm_type
+   USE message_passing,                 ONLY: mp_comm_self
    USE string_utilities,                ONLY: compress
 #include "../base/base_uses.f90"
 
@@ -193,13 +192,9 @@ CONTAINS
          parser%para_env => para_env
          CALL cp_para_env_retain(para_env)
       ELSE
-         BLOCK
-            TYPE(mp_comm_type) :: comm_self
-            NULLIFY (parser%para_env)
-            CALL comm_self%set_handle(mp_comm_self)
-            CALL cp_para_env_create(parser%para_env, group=comm_self, source=0, &
-                                    mepos=0, num_pe=1, owns_group=.FALSE.)
-         END BLOCK
+         NULLIFY (parser%para_env)
+         CALL cp_para_env_create(parser%para_env, group=mp_comm_self, source=0, &
+                                 mepos=0, num_pe=1, owns_group=.FALSE.)
       END IF
 
       !   *** Get the logical output unit number for error messages ***

--- a/src/input/cp_parser_types.F
+++ b/src/input/cp_parser_types.F
@@ -40,7 +40,8 @@ MODULE cp_parser_types
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               max_line_length
-   USE message_passing,                 ONLY: mp_comm_self
+   USE message_passing,                 ONLY: mp_comm_self,&
+                                              mp_comm_type
    USE string_utilities,                ONLY: compress
 #include "../base/base_uses.f90"
 
@@ -192,9 +193,13 @@ CONTAINS
          parser%para_env => para_env
          CALL cp_para_env_retain(para_env)
       ELSE
-         NULLIFY (parser%para_env)
-         CALL cp_para_env_create(parser%para_env, group=mp_comm_self, source=0, &
-                                 mepos=0, num_pe=1, owns_group=.FALSE.)
+         BLOCK
+            TYPE(mp_comm_type) :: comm_self
+            NULLIFY (parser%para_env)
+            CALL comm_self%set_handle(mp_comm_self)
+            CALL cp_para_env_create(parser%para_env, group=comm_self, source=0, &
+                                    mepos=0, num_pe=1, owns_group=.FALSE.)
+         END BLOCK
       END IF
 
       !   *** Get the logical output unit number for error messages ***

--- a/src/ipi_driver.F
+++ b/src/ipi_driver.F
@@ -44,6 +44,7 @@ MODULE ipi_driver
                                               int_4
    USE message_passing,                 ONLY: mp_bcast,&
                                               mp_irecv,&
+                                              mp_request_type,&
                                               mp_send,&
                                               mp_sync,&
                                               mp_testany
@@ -324,8 +325,8 @@ CONTAINS
       CHARACTER(LEN=default_string_length)     :: header
       INTEGER                                  :: drv_port, handle, i_drv_unix, &
                                                   idir, ii, inet, ip, iwait, &
-                                                  nat, output_unit, socket, &
-                                                  wait_req(2)
+                                                  nat, output_unit, socket
+      TYPE(mp_request_type), DIMENSION(2) ::                                            wait_req
       INTEGER(KIND=int_4), POINTER             :: wait_msg(:)
       LOGICAL                                  :: drv_unix, fwait, hasdata, &
                                                   ionode, should_stop

--- a/src/iterate_matrix.F
+++ b/src/iterate_matrix.F
@@ -35,7 +35,7 @@ MODULE iterate_matrix
                       m_walltime
    USE mathconstants, ONLY: ifac
    USE mathlib, ONLY: abnormal_value
-   USE message_passing, ONLY: mp_sum
+   USE message_passing, ONLY: mp_sum, mp_comm_type
    USE submatrix_dissection, ONLY: submatrix_dissection_type
 #include "./base/base_uses.f90"
 
@@ -84,7 +84,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'determinant'
 
-      INTEGER                                            :: group, handle, i, max_iter_lanczos, &
+      INTEGER                                            :: handle, i, max_iter_lanczos, &
                                                             nsize, order_lanczos, sign_iter, &
                                                             unit_nr
       INTEGER(KIND=int_8)                                :: flop1
@@ -117,11 +117,16 @@ CONTAINS
                         matrix_type=dbcsr_type_no_symmetry)
 
       ! compute the product of the diagonal elements
-      CALL dbcsr_get_info(matrix, nfullrows_total=nsize, group=group)
-      ALLOCATE (diagonal(nsize))
-      CALL dbcsr_get_diag(matrix, diagonal)
-      CALL mp_sum(diagonal, group)
-      det = PRODUCT(diagonal)
+      BLOCK
+         TYPE(mp_comm_type) :: group
+         INTEGER :: group_handle
+         CALL dbcsr_get_info(matrix, nfullrows_total=nsize, group=group_handle)
+         CALL group%set_handle(group_handle)
+         ALLOCATE (diagonal(nsize))
+         CALL dbcsr_get_diag(matrix, diagonal)
+         CALL mp_sum(diagonal, group)
+         det = PRODUCT(diagonal)
+      END BLOCK
 
       ! create diagonal SQRTI matrix
       diagonal(:) = 1.0_dp/(SQRT(diagonal(:)))
@@ -1444,7 +1449,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'matrix_sign_submatrix_mu_adjust'
 
-      INTEGER                                            :: group, handle, i, j, myrank, nblkcols, &
+      INTEGER                                            :: group_handle, handle, i, j, myrank, nblkcols, &
                                                             sm_size, unit_nr, sm_firstcol, sm_lastcol
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: my_sms
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: sm, sm_sign, tmp
@@ -1454,6 +1459,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: trace, increment, new_mu, mu_low, mu_high
       TYPE(eigbuf), DIMENSION(:), ALLOCATABLE            :: eigbufs
       LOGICAL                                            :: has_mu_low, has_mu_high
+      TYPE(mp_comm_type) :: group
 
       REAL(KIND=dp), PARAMETER                           :: initial_increment = 0.01_dp
 
@@ -1463,8 +1469,10 @@ CONTAINS
       logger => cp_get_default_logger()
       unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
 
-      CALL dbcsr_get_info(matrix=matrix, nblkcols_total=nblkcols, distribution=dist, group=group)
+      CALL dbcsr_get_info(matrix=matrix, nblkcols_total=nblkcols, distribution=dist, group=group_handle)
       CALL dbcsr_distribution_get(dist=dist, mynode=myrank)
+
+      CALL group%set_handle(group_handle)
 
       CALL dissection%init(matrix)
       CALL dissection%get_sm_ids_for_rank(myrank, my_sms)

--- a/src/kpoint_io.F
+++ b/src/kpoint_io.F
@@ -37,7 +37,8 @@ MODULE kpoint_io
    USE kinds,                           ONLY: default_path_length
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_type
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE orbital_pointers,                ONLY: nso
    USE particle_types,                  ONLY: particle_type
    USE qs_dftb_types,                   ONLY: qs_dftb_atom_type
@@ -309,9 +310,10 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_kpoints_restart'
 
       CHARACTER(LEN=default_path_length)                 :: file_name
-      INTEGER                                            :: group, handle, restart_unit, source
+      INTEGER                                            :: handle, restart_unit, source
       LOGICAL                                            :: exist
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
@@ -376,11 +378,14 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: natom, rst_unit
       LOGICAL, INTENT(OUT)                               :: natom_mismatch
 
-      INTEGER :: group, ic, image, ispin, nao, nao_read, natom_read, ni, nimages, nset_max, &
-         nshell_max, nspin, nspin_read, source, version_read
+      INTEGER                                            :: ic, image, ispin, nao, nao_read, &
+                                                            natom_read, ni, nimages, nset_max, &
+                                                            nshell_max, nspin, nspin_read, source, &
+                                                            version_read
       INTEGER, DIMENSION(3)                              :: cell
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: natom_match
+      TYPE(mp_comm_type)                                 :: group
 
       group = para_env%group
       source = para_env%source

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -63,6 +63,7 @@ MODULE kpoint_methods
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_cart_create,&
                                               mp_cart_sub,&
+                                              mp_comm_type,&
                                               mp_max,&
                                               mp_sum
    USE parallel_gemm_api,               ONLY: parallel_gemm
@@ -272,9 +273,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_env_initialize'
 
-      INTEGER                                            :: comm_cart, comm_inter_kp, comm_kp, &
-                                                            handle, igr, ik, ikk, ngr, niogrp, &
-                                                            nkp, nkp_grp, nkp_loc, npe, unit_nr
+      INTEGER                                            :: handle, igr, ik, ikk, ngr, niogrp, nkp, &
+                                                            nkp_grp, nkp_loc, npe, unit_nr
       INTEGER, DIMENSION(2)                              :: dims, pos
       LOGICAL, DIMENSION(2)                              :: rdim
       TYPE(cp_para_cart_type), POINTER                   :: cart
@@ -282,6 +282,7 @@ CONTAINS
                                                             para_env_inter_kp, para_env_kp
       TYPE(kpoint_env_p_type), DIMENSION(:), POINTER     :: kp_env
       TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(mp_comm_type)                                 :: comm_cart, comm_inter_kp, comm_kp
 
       CALL timeset(routineN, handle)
 

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -74,6 +74,7 @@ MODULE library_tests
    USE machine,                         ONLY: m_flush,&
                                               m_walltime
    USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type,&
                                               mp_max,&
                                               mp_sum,&
                                               mp_sync,&
@@ -1040,7 +1041,7 @@ CONTAINS
       INTEGER                                            :: iw
       TYPE(section_vals_type), POINTER                   :: eigensolver_section
 
-      INTEGER                                            :: diag_method, group, i, i_loop, i_rep, &
+      INTEGER                                            :: diag_method, i, i_loop, i_rep, &
                                                             init_method, j, n, n_loop, n_rep, &
                                                             neig, source, unit_number
       REAL(KIND=dp)                                      :: t1, t2
@@ -1049,6 +1050,7 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct
       TYPE(cp_fm_type)                                   :: eigenvectors, matrix, work
+      TYPE(mp_comm_type)                                 :: group
       TYPE(rng_stream_type), ALLOCATABLE                 :: rng_stream
 
       group = para_env%group
@@ -1466,7 +1468,7 @@ CONTAINS
                                    i_rep_section=i_rep, r_val=filter_eps)
          CALL section_vals_val_get(input_section, "ALWAYS_CHECKSUM", i_rep_section=i_rep, l_val=always_checksum)
 
-         CALL dbcsr_run_tests(para_env%group, iw, nproc, &
+         CALL dbcsr_run_tests(para_env%group%get_handle(), iw, nproc, &
                               (/m, n, k/), &
                               (/transa_p, transb_p/), &
                               bs_m, bs_n, bs_k, &

--- a/src/manybody_quip.F
+++ b/src/manybody_quip.F
@@ -134,7 +134,7 @@ CONTAINS
             calc_args_str=TRIM(quip%calc_args), &
             calc_args_str_len=LEN_TRIM(quip%calc_args), &
             energy=pot_quip, force=force, virial=virial, &
-            output_unit=output_unit, mpi_communicator=para_env%group)
+            output_unit=output_unit, mpi_communicator=para_env%group%get_handle())
       ELSE
          CALL quip_unified_wrapper( &
             N=n_atoms_use, pos=pos, lattice=lattice, symbol=elem_symbol, &

--- a/src/mao_methods.F
+++ b/src/mao_methods.F
@@ -49,7 +49,8 @@ MODULE mao_methods
                                               kpoint_type
    USE lapack,                          ONLY: lapack_ssyev,&
                                               lapack_ssygv
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE particle_types,                  ONLY: particle_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -92,8 +93,8 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: eps1
       INTEGER, INTENT(IN)                                :: iolevel, iw
 
-      INTEGER                                            :: group, i, iatom, info, jatom, lwork, m, &
-                                                            n, nblk
+      INTEGER                                            :: group_handle, i, iatom, info, jatom, &
+                                                            lwork, m, n, nblk
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, mao_blk, row_blk, &
                                                             row_blk_sizes
       LOGICAL                                            :: found
@@ -103,6 +104,7 @@ CONTAINS
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbcsr_iterator_type)                          :: dbcsr_iter
       TYPE(mblocks), ALLOCATABLE, DIMENSION(:)           :: mbl
+      TYPE(mp_comm_type)                                 :: group
 
       CALL dbcsr_get_info(mao_coef, nblkrows_total=nblk)
       ALLOCATE (mbl(nblk))
@@ -141,7 +143,8 @@ CONTAINS
       CALL dbcsr_iterator_stop(dbcsr_iter)
 
       IF (eps1 < 10.0_dp) THEN
-         CALL dbcsr_get_info(mao_coef, row_blk_size=row_blk_sizes, group=group)
+         CALL dbcsr_get_info(mao_coef, row_blk_size=row_blk_sizes, group=group_handle)
+         CALL group%set_handle(group_handle)
          ALLOCATE (row_blk(nblk), mao_blk(nblk))
          mao_blk = 0
          row_blk = row_blk_sizes
@@ -182,7 +185,8 @@ CONTAINS
 
       IF (iolevel > 2) THEN
          CALL dbcsr_get_info(mao_coef, col_blk_size=col_blk_sizes, &
-                             row_blk_size=row_blk_sizes, group=group)
+                             row_blk_size=row_blk_sizes, group=group_handle)
+         CALL group%set_handle(group_handle)
          DO iatom = 1, nblk
             n = row_blk_sizes(iatom)
             m = col_blk_sizes(iatom)
@@ -401,10 +405,11 @@ CONTAINS
       TYPE(dbcsr_type)                                   :: fmat1, fmat2
       REAL(KIND=dp)                                      :: spro
 
-      INTEGER                                            :: group, iatom, jatom, m, n
+      INTEGER                                            :: group_handle, iatom, jatom, m, n
       LOGICAL                                            :: found
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: ablock, bblock
       TYPE(dbcsr_iterator_type)                          :: dbcsr_iter
+      TYPE(mp_comm_type)                                 :: group
 
       spro = 0.0_dp
 
@@ -420,7 +425,8 @@ CONTAINS
       END DO
       CALL dbcsr_iterator_stop(dbcsr_iter)
 
-      CALL dbcsr_get_info(fmat1, group=group)
+      CALL dbcsr_get_info(fmat1, group=group_handle)
+      CALL group%set_handle(group_handle)
       CALL mp_sum(spro, group)
 
    END FUNCTION mao_scalar_product

--- a/src/matrix_exp.F
+++ b/src/matrix_exp.F
@@ -40,6 +40,7 @@ MODULE matrix_exp
                                               z_one,&
                                               z_zero
    USE message_passing,                 ONLY: mp_comm_free,&
+                                              mp_comm_type,&
                                               mp_max,&
                                               mp_reordering,&
                                               mp_sum
@@ -706,10 +707,9 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'arnoldi'
       REAL(KIND=dp), PARAMETER                           :: rone = 1.0_dp, rzero = 0.0_dp
 
-      INTEGER                                            :: col_group, handle, i, icol_local, idim, &
-                                                            info, j, l, mydim, nao, narnoldi, &
-                                                            ncol_local, newdim, nmo, npade, &
-                                                            pade_step
+      INTEGER                                            :: handle, i, icol_local, idim, info, j, l, &
+                                                            mydim, nao, narnoldi, ncol_local, &
+                                                            newdim, nmo, npade, pade_step
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ipivot
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, col_procs
       LOGICAL                                            :: convergence, double_col, double_row
@@ -720,6 +720,7 @@ CONTAINS
       TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: V_mats
       TYPE(cp_fm_struct_type), POINTER                   :: mo_struct, newstruct
       TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_comm_type)                                 :: col_group
 
       CALL timeset(routineN, handle)
       para_env => mos_new(1)%matrix_struct%para_env

--- a/src/metadynamics.F
+++ b/src/metadynamics.F
@@ -169,7 +169,7 @@ CONTAINS
          CPABORT("NO PLUMED IN YOUR LD_LIBRARY_PATH?")
       ELSE
          CALL plumed_gcreate()
-         IF (cp2k_is_parallel) CALL plumed_gcmd_int("setMPIFComm"//CHAR(0), force_env%para_env%group)
+         IF (cp2k_is_parallel) CALL plumed_gcmd_int("setMPIFComm"//CHAR(0), force_env%para_env%group%get_handle())
          CALL plumed_gcmd_int("setRealPrecision"//CHAR(0), 8)
          CALL plumed_gcmd_double("setMDEnergyUnits"//CHAR(0), kjmol) ! Hartree to kjoule/mol
          CALL plumed_gcmd_double("setMDLengthUnits"//CHAR(0), angstrom*0.1_dp) ! Bohr to nm

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -72,14 +72,9 @@ MODULE mixed_cdft_methods
    USE machine,                         ONLY: m_walltime
    USE mathlib,                         ONLY: diamat_all
    USE memory_utilities,                ONLY: reallocate
-   USE message_passing,                 ONLY: mp_bcast,&
-                                              mp_irecv,&
-                                              mp_isend,&
-                                              mp_sum,&
-                                              mp_test,&
-                                              mp_testall,&
-                                              mp_wait,&
-                                              mp_waitall
+   USE message_passing,                 ONLY: &
+        mp_bcast, mp_irecv, mp_isend, mp_request_type, mp_sum, mp_test, mp_testall, mp_wait, &
+        mp_waitall
    USE mixed_cdft_types,                ONLY: mixed_cdft_result_type_set,&
                                               mixed_cdft_settings_type,&
                                               mixed_cdft_type,&
@@ -451,7 +446,7 @@ CONTAINS
       INTEGER :: handle, handle2, i, iforce_eval, ind, INDEX(6), iounit, j, lb_min, &
          my_special_work, natom, nforce_eval, recv_offset, ub_max
       INTEGER, DIMENSION(2, 3)                           :: bo
-      INTEGER, DIMENSION(:), POINTER                     :: lb, req_total, sendbuffer_i, ub
+      INTEGER, DIMENSION(:), POINTER                     :: lb, sendbuffer_i, ub
       REAL(KIND=dp)                                      :: t1, t2
       TYPE(cdft_control_type), POINTER                   :: cdft_control, cdft_control_target
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -460,6 +455,7 @@ CONTAINS
       TYPE(force_env_type), POINTER                      :: force_env_qs
       TYPE(mixed_cdft_type), POINTER                     :: mixed_cdft
       TYPE(mixed_environment_type), POINTER              :: mixed_env
+      TYPE(mp_request_type), DIMENSION(:), POINTER       :: req_total
       TYPE(particle_list_type), POINTER                  :: particles_mix
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool, mixed_auxbas_pw_pool
@@ -2758,10 +2754,9 @@ CONTAINS
 
       INTEGER :: actually_sent, exhausted_work, handle, i, ind, iounit, ispecial, j, max_targets, &
          more_work, my_pos, my_special_work, my_target, no_overloaded, no_underloaded, nsend, &
-         nsend_limit, nsend_max, offset, offset_proc, offset_special, req(4), send_total, tags(2)
+         nsend_limit, nsend_max, offset, offset_proc, offset_special, send_total, tags(2)
       INTEGER, DIMENSION(:), POINTER :: buffsize, cumulative_work, expected_work, load_imbalance, &
-         nrecv, nsend_proc, req_recv, req_total, sendbuffer, should_warn, tmp, work_index, &
-         work_size
+         nrecv, nsend_proc, sendbuffer, should_warn, tmp, work_index, work_size
       INTEGER, DIMENSION(:, :), POINTER                  :: targets, tmp_bo
       LOGICAL                                            :: consistent
       LOGICAL, DIMENSION(:), POINTER                     :: mask_recv, mask_send, touched
@@ -2770,6 +2765,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: cavity
       TYPE(cdft_control_type), POINTER                   :: cdft_control
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_request_type), DIMENSION(4)                :: req
+      TYPE(mp_request_type), DIMENSION(:), POINTER       :: req_recv, req_total
       TYPE(section_vals_type), POINTER                   :: force_env_section, print_section
 
       TYPE buffers
@@ -3537,8 +3534,8 @@ CONTAINS
       INTEGER :: handle, i, iatom, icomm, iforce_eval, index, iounit, ip, ispecial, iwork, j, &
          jatom, jcomm, k, my_special_work, my_work, natom, nbuffs, nforce_eval, np(3), &
          nsent_total, nskipped, nwork, offset, offset_repl
-      INTEGER, DIMENSION(:), POINTER                     :: req_recv, req_total, work, work_dlb
-      INTEGER, DIMENSION(:, :), POINTER                  :: nsent, req_send
+      INTEGER, DIMENSION(:), POINTER                     :: work, work_dlb
+      INTEGER, DIMENSION(:, :), POINTER                  :: nsent
       LOGICAL                                            :: completed_recv, should_communicate
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: skip_me
       LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: completed
@@ -3561,6 +3558,8 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys_mix
       TYPE(force_env_type), POINTER                      :: force_env_qs
+      TYPE(mp_request_type), DIMENSION(:), POINTER       :: req_recv, req_total
+      TYPE(mp_request_type), DIMENSION(:, :), POINTER    :: req_send
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -80,6 +80,7 @@ MODULE mixed_cdft_utils
                                               dp
    USE message_passing,                 ONLY: mp_irecv,&
                                               mp_isend,&
+                                              mp_request_type,&
                                               mp_sum,&
                                               mp_wait,&
                                               mp_waitall
@@ -643,7 +644,7 @@ CONTAINS
       CHARACTER(len=default_path_length)                 :: c_val, input_file_path, output_file_path
       INTEGER                                            :: i, imap, iounit, j, lp, n_force_eval, &
                                                             ncpu, nforce_eval, ntargets, offset, &
-                                                            req(3), unit_nr
+                                                            unit_nr
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: bounds
       INTEGER, DIMENSION(2, 3)                           :: bo, bo_mixed
       INTEGER, DIMENSION(3)                              :: higher_grid_layout
@@ -656,6 +657,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys_mix
       TYPE(global_environment_type), POINTER             :: globenv
+      TYPE(mp_request_type), DIMENSION(3)                :: req
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools

--- a/src/mixed_environment_types.F
+++ b/src/mixed_environment_types.F
@@ -34,6 +34,7 @@ MODULE mixed_environment_types
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE mixed_cdft_types,                ONLY: mixed_cdft_type,&
                                               mixed_cdft_type_release
    USE mixed_energy_types,              ONLY: deallocate_mixed_energy,&
@@ -70,7 +71,8 @@ MODULE mixed_environment_types
       TYPE(section_vals_type), POINTER                 :: input
       REAL(KIND=dp), DIMENSION(:), POINTER             :: energies
       ! Parallelization of multiple force_eval
-      INTEGER                                          :: new_group, ngroups
+      TYPE(mp_comm_type) :: new_group
+      INTEGER                                          :: ngroups
       INTEGER, DIMENSION(:), POINTER                   :: group_distribution
       TYPE(cp_para_env_p_type), DIMENSION(:), POINTER  :: sub_para_env
       TYPE(cp_logger_p_type), DIMENSION(:), POINTER    :: sub_logger

--- a/src/motion/helium_methods.F
+++ b/src/motion/helium_methods.F
@@ -61,7 +61,8 @@ MODULE helium_methods
    USE message_passing,                 ONLY: mp_allgather,&
                                               mp_bcast,&
                                               mp_comm_free,&
-                                              mp_comm_split_direct
+                                              mp_comm_split_direct,&
+                                              mp_comm_type
    USE parallel_rng_types,              ONLY: GAUSSIAN,&
                                               UNIFORM,&
                                               rng_stream_p_type,&
@@ -113,8 +114,8 @@ CONTAINS
 
       CHARACTER(len=default_path_length)                 :: msg_str, potential_file_name
       INTEGER                                            :: color_sub, handle, i, input_unit, isize, &
-                                                            itmp, j, k, mepos, new_comm, nlines, &
-                                                            ntab, num_env, pdx
+                                                            itmp, j, k, mepos, nlines, ntab, &
+                                                            num_env, pdx
       INTEGER, DIMENSION(:), POINTER                     :: env_all
       LOGICAL                                            :: expl_cell, expl_dens, expl_nats, &
                                                             expl_pot, explicit, ltmp
@@ -122,6 +123,7 @@ CONTAINS
                                                             tcheck, x1, x_spline
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: pot_transfer
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: new_comm
       TYPE(section_vals_type), POINTER                   :: helium_section, input_worm
 
       CALL timeset(routineN, handle)

--- a/src/motion/helium_types.F
+++ b/src/motion/helium_types.F
@@ -20,6 +20,7 @@ MODULE helium_types
    USE kinds,                           ONLY: default_string_length,&
                                               dp,&
                                               int_8
+   USE message_passing,                 ONLY: mp_comm_type
    USE parallel_rng_types,              ONLY: rng_stream_type
    USE splines_types,                   ONLY: spline_data_type
 #include "../base/base_uses.f90"
@@ -293,7 +294,7 @@ MODULE helium_types
 ! ***************************************************************************
    TYPE helium_solvent_p_type
       TYPE(helium_solvent_type), POINTER   :: helium
-      INTEGER                              :: comm
+      TYPE(mp_comm_type)                   :: comm
       INTEGER, DIMENSION(:), POINTER       :: env_all
    END TYPE helium_solvent_p_type
 

--- a/src/motion/integrator_utils.F
+++ b/src/motion/integrator_utils.F
@@ -37,7 +37,8 @@ MODULE integrator_utils
    USE kinds,                           ONLY: dp
    USE md_environment_types,            ONLY: get_md_env,&
                                               md_environment_type
-   USE message_passing,                 ONLY: mp_max,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_max,&
                                               mp_sum
    USE molecule_kind_types,             ONLY: local_fixd_constraint_type,&
                                               molecule_kind_type
@@ -528,7 +529,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: gamma1
       TYPE(npt_info_type), INTENT(IN)                    :: npt
       REAL(KIND=dp), INTENT(IN)                          :: dt
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       INTEGER                                            :: first_atom, ikind, imol, imol_local, &
                                                             ipart, last_atom, nmol_local
@@ -608,7 +609,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: gamma1
       TYPE(npt_info_type), INTENT(IN)                    :: npt
       REAL(KIND=dp), INTENT(IN)                          :: dt
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       INTEGER                                            :: first_atom, ikind, imol, imol_local, &
                                                             ipart, last_atom, nmol_local
@@ -804,7 +805,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(OUT)                         :: kin
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT)        :: pv_kin
       TYPE(virial_type), INTENT(INOUT)                   :: virial
-      INTEGER, INTENT(IN)                                :: int_group
+      TYPE(mp_comm_type), INTENT(IN)                     :: int_group
 
       INTEGER                                            :: i, iparticle, iparticle_kind, &
                                                             iparticle_local, j, nparticle_local
@@ -878,7 +879,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(OUT)                         :: kin
       REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: pv_kin
       TYPE(virial_type), INTENT(INOUT)                   :: virial
-      INTEGER, INTENT(IN)                                :: int_group
+      TYPE(mp_comm_type), INTENT(IN)                     :: int_group
 
       INTEGER                                            :: i, iparticle, iparticle_kind, &
                                                             iparticle_local, j, nparticle_local

--- a/src/motion/mc/mc_control.F
+++ b/src/motion/mc/mc_control.F
@@ -42,7 +42,8 @@ MODULE mc_control
                                               mc_molecule_info_type,&
                                               mc_simpar_type,&
                                               set_mc_par
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_type
    USE molecule_kind_types,             ONLY: atom_type,&
                                               get_molecule_kind,&
@@ -181,9 +182,9 @@ CONTAINS
          DIMENSION(:, :), POINTER                        :: atom_names
       CHARACTER(LEN=20)                                  :: ensemble, mc_ensemble
       CHARACTER(LEN=default_path_length)                 :: dat_file, restart_file_name
-      INTEGER                                            :: group, handle, i, ipart, iunit, &
-                                                            nmol_types, nstart, nunits_tot, &
-                                                            print_level, source, unit
+      INTEGER                                            :: handle, i, ipart, iunit, nmol_types, &
+                                                            nstart, nunits_tot, print_level, &
+                                                            source, unit
       INTEGER, DIMENSION(:), POINTER                     :: nchains, nunits
       LOGICAL                                            :: ionode
       REAL(KIND=dp)                                      :: mc_temp, rand, temperature
@@ -193,6 +194,7 @@ CONTAINS
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(mc_input_file_type), POINTER                  :: mc_input_file
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles
 
       CALL timeset(routineN, handle)

--- a/src/motion/mc/mc_coordinates.F
+++ b/src/motion/mc/mc_coordinates.F
@@ -24,7 +24,8 @@ MODULE mc_coordinates
                                               get_mc_par,&
                                               mc_molecule_info_type,&
                                               mc_simpar_type
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE molecule_types,                  ONLY: molecule_type
    USE parallel_rng_types,              ONLY: rng_stream_type
    USE particle_list_types,             ONLY: particle_list_type
@@ -342,7 +343,8 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: old_energy
       LOGICAL, INTENT(IN)                                :: ionode, lremove
       INTEGER, DIMENSION(:), INTENT(IN)                  :: mol_type, nchains
-      INTEGER, INTENT(IN)                                :: source, group
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_comm_type)                                 :: group
       TYPE(rng_stream_type), INTENT(INOUT)               :: rng_stream
       INTEGER, INTENT(IN), OPTIONAL                      :: avbmc_atom
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: rmin, rmax

--- a/src/motion/mc/mc_ensembles.F
+++ b/src/motion/mc/mc_ensembles.F
@@ -74,7 +74,8 @@ MODULE mc_ensembles
                                               mc_moves_p_type,&
                                               mc_simulation_parameters_p_type,&
                                               set_mc_par
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE parallel_rng_types,              ONLY: rng_stream_type
    USE particle_list_types,             ONLY: particle_list_p_type,&
                                               particle_list_type
@@ -135,11 +136,11 @@ CONTAINS
       INTEGER, DIMENSION(1:nboxes)                       :: box_flag, cl, data_unit, diff, istep, &
                                                             move_unit, rm
       INTEGER, DIMENSION(1:3, 1:2)                       :: discrete_array
-      INTEGER :: atom_number, box_number, cell_unit, com_crd, com_ene, com_mol, end_mol, group, &
-         handle, ibox, idum, imol_type, imolecule, imove, iparticle, iprint, itype, iunit, &
-         iuptrans, iupvolume, iw, jbox, jdum, molecule_type, molecule_type_swap, &
-         molecule_type_target, nchain_total, nmol_types, nmoves, nnstep, nstart, nstep, source, &
-         start_atom, start_atom_swap, start_atom_target, start_mol
+      INTEGER :: atom_number, box_number, cell_unit, com_crd, com_ene, com_mol, end_mol, handle, &
+         ibox, idum, imol_type, imolecule, imove, iparticle, iprint, itype, iunit, iuptrans, &
+         iupvolume, iw, jbox, jdum, molecule_type, molecule_type_swap, molecule_type_target, &
+         nchain_total, nmol_types, nmoves, nnstep, nstart, nstep, source, start_atom, &
+         start_atom_swap, start_atom_target, start_mol
       CHARACTER(LEN=default_string_length)               :: unit_str
       CHARACTER(LEN=40), DIMENSION(1:nboxes)             :: cell_file, coords_file, data_file, &
                                                             displacement_file, energy_file, &
@@ -171,6 +172,7 @@ CONTAINS
       TYPE(mc_moves_p_type), DIMENSION(:, :), POINTER    :: move_updates, moves
       TYPE(mc_simulation_parameters_p_type), &
          DIMENSION(:), POINTER                           :: mc_par
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_p_type), DIMENSION(:), POINTER  :: particles_old
       TYPE(particle_list_type), POINTER                  :: particles_bias
       TYPE(section_vals_type), POINTER                   :: root_section
@@ -1178,8 +1180,8 @@ CONTAINS
       TYPE(mc_environment_p_type), DIMENSION(:), POINTER :: mc_env
       TYPE(rng_stream_type), INTENT(INOUT)               :: rng_stream
 
-      INTEGER :: current_division, end_atom, group, ibin, idivision, iparticle, iprint, itemp, &
-         iunit, ivirial, iw, nbins, nchain_total, nintegral_divisions, nmol_types, nvirial, &
+      INTEGER :: current_division, end_atom, ibin, idivision, iparticle, iprint, itemp, iunit, &
+         ivirial, iw, nbins, nchain_total, nintegral_divisions, nmol_types, nvirial, &
          nvirial_temps, source, start_atom
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, nunits, nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
@@ -1196,6 +1198,7 @@ CONTAINS
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
       TYPE(mc_simulation_parameters_p_type), &
          DIMENSION(:), POINTER                           :: mc_par
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_p_type), DIMENSION(:), POINTER  :: particles
 
 ! these are current magic numbers for how we compute the virial...

--- a/src/motion/mc/mc_ge_moves.F
+++ b/src/motion/mc/mc_ge_moves.F
@@ -46,7 +46,8 @@ MODULE mc_ge_moves
         get_mc_molecule_info, get_mc_par, mc_determine_molecule_info, mc_input_file_type, &
         mc_molecule_info_destroy, mc_molecule_info_type, mc_moves_p_type, &
         mc_simulation_parameters_p_type, set_mc_par
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE parallel_rng_types,              ONLY: rng_stream_type
    USE particle_list_types,             ONLY: particle_list_p_type,&
                                               particle_list_type
@@ -123,7 +124,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mc_Quickstep_move'
 
-      INTEGER                                            :: end_mol, group, handle, ibox, iparticle, &
+      INTEGER                                            :: end_mol, handle, ibox, iparticle, &
                                                             iprint, itype, jbox, nmol_types, &
                                                             source, start_mol
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
@@ -134,6 +135,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(1:nboxes)                 :: bias_energy_old, new_energy
       TYPE(cp_subsys_p_type), DIMENSION(:), POINTER      :: subsys_bias
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_p_type), DIMENSION(:), POINTER  :: particles_bias
 
 ! begin the timing of the subroutine
@@ -445,9 +447,9 @@ CONTAINS
          DIMENSION(:, :), POINTER                        :: atom_names
       CHARACTER(LEN=200)                                 :: fft_lib
       CHARACTER(LEN=40), DIMENSION(1:2)                  :: dat_file
-      INTEGER :: end_mol, group, handle, iatom, ibox, idim, iiatom, imolecule, ins_atoms, &
-         insert_box, ipart, itype, jbox, molecule_type, nmol_types, nswapmoves, print_level, &
-         rem_atoms, remove_box, source, start_atom_ins, start_atom_rem, start_mol
+      INTEGER :: end_mol, handle, iatom, ibox, idim, iiatom, imolecule, ins_atoms, insert_box, &
+         ipart, itype, jbox, molecule_type, nmol_types, nswapmoves, print_level, rem_atoms, &
+         remove_box, source, start_atom_ins, start_atom_rem, start_mol
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, mol_type_test, nunits, &
                                                             nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains, nchains_test
@@ -468,6 +470,7 @@ CONTAINS
       TYPE(force_env_p_type), DIMENSION(:), POINTER      :: test_env, test_env_bias
       TYPE(mc_input_file_type), POINTER                  :: mc_bias_file, mc_input_file
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info, mc_molecule_info_test
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_p_type), DIMENSION(:), POINTER  :: particles_old
       TYPE(particle_list_type), POINTER                  :: particles_insert, particles_remove
 
@@ -1143,8 +1146,8 @@ CONTAINS
 
       CHARACTER(LEN=200)                                 :: fft_lib
       CHARACTER(LEN=40), DIMENSION(1:2)                  :: dat_file
-      INTEGER :: cl, end_atom, end_mol, group, handle, iatom, ibox, imolecule, iside, j, jatom, &
-         jbox, max_atoms, molecule_index, molecule_type, print_level, source, start_atom, start_mol
+      INTEGER :: cl, end_atom, end_mol, handle, iatom, ibox, imolecule, iside, j, jatom, jbox, &
+         max_atoms, molecule_index, molecule_type, print_level, source, start_atom, start_mol
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, nunits, nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
       LOGICAL                                            :: ionode
@@ -1162,6 +1165,7 @@ CONTAINS
       TYPE(cp_subsys_p_type), DIMENSION(:), POINTER      :: oldsys
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_p_type), DIMENSION(:), POINTER  :: particles_old
 
 ! begin the timing of the subroutine

--- a/src/motion/mc/mc_moves.F
+++ b/src/motion/mc/mc_moves.F
@@ -46,7 +46,8 @@ MODULE mc_moves
                                               mc_moves_type,&
                                               mc_simpar_type
    USE md_run,                          ONLY: qs_mol_dyn
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_type
    USE molecule_kind_types,             ONLY: bend_type,&
                                               bond_type,&
@@ -152,7 +153,7 @@ CONTAINS
       CHARACTER(default_string_length)                   :: name
       CHARACTER(default_string_length), DIMENSION(:), &
          POINTER                                         :: names
-      INTEGER :: atom_number, end_atom, end_mol, group, handle, imol_type, imolecule, ipart, jbox, &
+      INTEGER :: atom_number, end_atom, end_mol, handle, imol_type, imolecule, ipart, jbox, &
          molecule_number, nunits_mol, source, start_mol
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, nunits
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
@@ -165,6 +166,7 @@ CONTAINS
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
       TYPE(molecule_kind_list_type), POINTER             :: molecule_kinds
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind, molecule_kind_test
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles
 
 ! begin the timing of the subroutine
@@ -444,7 +446,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mc_molecule_translation'
 
-      INTEGER :: atom_number, end_atom, end_mol, group, handle, imolecule, ipart, iparticle, jbox, &
+      INTEGER :: atom_number, end_atom, end_mol, handle, imolecule, ipart, iparticle, jbox, &
          molecule_number, move_direction, nunits_mol, source, start_mol
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, nunits, nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
@@ -456,6 +458,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: r_old
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles
 
 !   *** Local Counters ***
@@ -666,8 +669,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mc_molecule_rotation'
 
-      INTEGER :: atom_number, dir, end_atom, end_mol, group, handle, ii, imolecule, ipart, iunit, &
-         jbox, molecule_number, nunits_mol, source, start_mol
+      INTEGER :: atom_number, dir, end_atom, end_mol, handle, ii, imolecule, ipart, iunit, jbox, &
+         molecule_number, nunits_mol, source, start_mol
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, nunits, nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
       LOGICAL                                            :: ionode, lbias, loverlap, lx, ly
@@ -679,6 +682,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: r_old
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles
 
 ! begin the timing of the subroutine
@@ -972,9 +976,8 @@ CONTAINS
 
       CHARACTER(LEN=200)                                 :: fft_lib
       CHARACTER(LEN=40)                                  :: dat_file
-      INTEGER :: cl, end_atom, end_mol, group, handle, iatom, idim, imolecule, iside, &
-         iside_change, iunit, jbox, nunits_mol, output_unit, print_level, source, start_atom, &
-         start_mol
+      INTEGER :: cl, end_atom, end_mol, handle, iatom, idim, imolecule, iside, iside_change, &
+         iunit, jbox, nunits_mol, output_unit, print_level, source, start_atom, start_mol
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, nunits, nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
       LOGICAL                                            :: ionode, ldiscrete, lincrease, loverlap, &
@@ -990,6 +993,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: oldsys
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles_old
 
 ! begin the timing of the subroutine
@@ -1313,8 +1317,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'change_bond_length'
 
-      INTEGER                                            :: bond_number, group, handle, i, iatom, &
-                                                            ibond, ipart, natom, nbond, source
+      INTEGER                                            :: bond_number, handle, i, iatom, ibond, &
+                                                            ipart, natom, nbond, source
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_a, atom_b, counter
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: connection, connectivity
       INTEGER, DIMENSION(:), POINTER                     :: nunits
@@ -1325,6 +1329,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(1:3)                      :: bond_a, bond_b
       TYPE(bond_type), DIMENSION(:), POINTER             :: bond_list
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
 
 ! begin the timing of the subroutine
 
@@ -1479,9 +1484,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'change_bond_angle'
 
-      INTEGER                                            :: bend_number, group, handle, i, iatom, &
-                                                            ibond, ipart, natom, nbend, nbond, &
-                                                            source
+      INTEGER                                            :: bend_number, handle, i, iatom, ibond, &
+                                                            ipart, natom, nbend, nbond, source
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_a, atom_c, counter
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: connection, connectivity
       INTEGER, DIMENSION(:), POINTER                     :: nunits
@@ -1494,6 +1498,7 @@ CONTAINS
       TYPE(bend_type), DIMENSION(:), POINTER             :: bend_list
       TYPE(bond_type), DIMENSION(:), POINTER             :: bond_list
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
 
 ! begin the timing of the subroutine
 
@@ -1738,9 +1743,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'change_dihedral'
 
-      INTEGER                                            :: group, handle, i, iatom, ibond, ipart, &
-                                                            natom, nbond, ntorsion, source, &
-                                                            torsion_number
+      INTEGER                                            :: handle, i, iatom, ibond, ipart, natom, &
+                                                            nbond, ntorsion, source, torsion_number
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_a, atom_d, counter
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: connection, connectivity
       INTEGER, DIMENSION(:), POINTER                     :: nunits
@@ -1752,6 +1756,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(1:3)                      :: bond_a, temp
       TYPE(bond_type), DIMENSION(:), POINTER             :: bond_list
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(torsion_type), DIMENSION(:), POINTER          :: torsion_list
 
 ! begin the timing of the subroutine
@@ -1958,8 +1963,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mc_avbmc_move'
 
-      INTEGER                                            :: end_mol, group, handle, ipart, jbox, &
-                                                            natom, nswapmoves, source, start_mol
+      INTEGER                                            :: end_mol, handle, ipart, jbox, natom, &
+                                                            nswapmoves, source, start_mol
       INTEGER, DIMENSION(:), POINTER                     :: avbmc_atom, mol_type, nunits, nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
       LOGICAL                                            :: ionode, lbias, ldum, lin, loverlap
@@ -1975,6 +1980,7 @@ CONTAINS
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
       TYPE(molecule_kind_list_type), POINTER             :: molecule_kinds
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles, particles_force
 
       rdum = 1.0_dp
@@ -2354,7 +2360,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mc_hmc_move'
 
-      INTEGER                                            :: group, handle, iatom, source
+      INTEGER                                            :: handle, iatom, source
       INTEGER, DIMENSION(:), POINTER                     :: nunits_tot
       LOGICAL                                            :: ionode
       REAL(KIND=dp)                                      :: BETA, energy_term, exp_max_val, &
@@ -2363,6 +2369,7 @@ CONTAINS
       TYPE(cp_subsys_type), POINTER                      :: oldsys
       TYPE(mc_ekin_type), POINTER                        :: hmc_ekin
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles_old
 
 ! begin the timing of the subroutine
@@ -2489,8 +2496,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mc_cluster_translation'
 
-      INTEGER :: cstart, end_mol, group, handle, imol, ipart, iparticle, iunit, jbox, jpart, &
-         junit, move_direction, nend, nunit, source, start_mol, total_clus, total_clusafmo
+      INTEGER :: cstart, end_mol, handle, imol, ipart, iparticle, iunit, jbox, jpart, junit, &
+         move_direction, nend, nunit, source, start_mol, total_clus, total_clusafmo
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: cluster
       INTEGER, DIMENSION(:), POINTER                     :: mol_type, nunits, nunits_tot
       INTEGER, DIMENSION(:, :), POINTER                  :: nchains
@@ -2501,6 +2508,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: r_old
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(mc_molecule_info_type), POINTER               :: mc_molecule_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles
 
 !   *** Local Counters ***

--- a/src/motion/mc/mc_types.F
+++ b/src/motion/mc/mc_types.F
@@ -44,6 +44,7 @@ MODULE mc_types
                                               default_string_length,&
                                               dp
    USE mathconstants,                   ONLY: pi
+   USE message_passing,                 ONLY: mp_comm_type
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_p_type
    USE molecule_kind_types,             ONLY: atom_type,&
                                               get_molecule_kind,&
@@ -94,7 +95,7 @@ MODULE mc_types
       INTEGER :: diff
       INTEGER :: nstart
       INTEGER :: source
-      INTEGER :: group
+      TYPE(mp_comm_type) :: group
       INTEGER :: iprint
       LOGICAL :: ldiscrete
       LOGICAL :: lbias
@@ -401,7 +402,8 @@ CONTAINS
       TYPE(mc_simpar_type), POINTER                      :: mc_par
       INTEGER, INTENT(OUT), OPTIONAL                     :: nstep, nvirial, iuptrans, iupcltrans, &
                                                             iupvolume, nmoves, nswapmoves, rm, cl, &
-                                                            diff, nstart, source, group
+                                                            diff, nstart, source
+      TYPE(mp_comm_type), INTENT(OUT), OPTIONAL          :: group
       LOGICAL, INTENT(OUT), OPTIONAL                     :: lbias, ionode, lrestart, lstop
       REAL(KIND=dp), INTENT(OUT), OPTIONAL               :: rmvolume, rmcltrans
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: rmbond, rmangle, rmrot, rmtrans
@@ -687,7 +689,9 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: exp_max_val, exp_min_val, min_val, &
                                                             max_val, pmhmc, pmhmc_box
       LOGICAL, INTENT(IN), OPTIONAL                      :: lhmc, ionode
-      INTEGER, INTENT(IN), OPTIONAL                      :: source, group, rand2skip
+      INTEGER, INTENT(IN), OPTIONAL                      :: source
+      TYPE(mp_comm_type), INTENT(IN), OPTIONAL           :: group
+      INTEGER, INTENT(IN), OPTIONAL                      :: rand2skip
 
       INTEGER                                            :: iparm
 

--- a/src/motion/mc/tamc_run.F
+++ b/src/motion/mc/tamc_run.F
@@ -85,6 +85,7 @@ MODULE tamc_run
                                               md_environment_type,&
                                               set_md_env
    USE md_run,                          ONLY: qs_mol_dyn
+   USE message_passing,                 ONLY: mp_comm_type
    USE metadynamics_types,              ONLY: meta_env_type,&
                                               metavar_type,&
                                               set_meta_env
@@ -1131,7 +1132,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mc_hmc_move'
 
-      INTEGER                                            :: group, handle, iatom, j, nAtoms, source
+      INTEGER                                            :: handle, iatom, j, nAtoms, source
       LOGICAL                                            :: ionode, localise
       REAL(KIND=dp)                                      :: BETA, energy_term, exp_max_val, &
                                                             exp_min_val, new_energy, new_epx, &
@@ -1139,6 +1140,7 @@ CONTAINS
       TYPE(cp_subsys_type), POINTER                      :: oldsys
       TYPE(mc_ekin_type), POINTER                        :: hmc_ekin
       TYPE(meta_env_type), POINTER                       :: meta_env_saved
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_list_type), POINTER                  :: particles_set
       TYPE(section_vals_type), POINTER                   :: dft_section, input
 

--- a/src/motion/md_conserved_quantities.F
+++ b/src/motion/md_conserved_quantities.F
@@ -36,7 +36,8 @@ MODULE md_conserved_quantities
    USE md_environment_types,            ONLY: get_md_env,&
                                               md_environment_type,&
                                               set_md_env
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE particle_list_types,             ONLY: particle_list_type
    USE particle_types,                  ONLY: particle_type
    USE physcon,                         ONLY: kelvin
@@ -447,7 +448,7 @@ CONTAINS
       TYPE(md_environment_type), POINTER                 :: md_env
       TYPE(md_ener_type), POINTER                        :: md_ener
       LOGICAL, INTENT(IN)                                :: tkind, tshell
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       INTEGER                                            :: i, iparticle, iparticle_kind, &
                                                             iparticle_local, nparticle_kind, &

--- a/src/motion/pint_methods.F
+++ b/src/motion/pint_methods.F
@@ -85,7 +85,8 @@ MODULE pint_methods
    USE mathconstants,                   ONLY: twopi
    USE mathlib,                         ONLY: gcd
    USE message_passing,                 ONLY: mp_bcast,&
-                                              mp_comm_self
+                                              mp_comm_self,&
+                                              mp_comm_type
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_type
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_list_types,             ONLY: molecule_list_type
@@ -1219,6 +1220,7 @@ CONTAINS
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_list_type), POINTER                  :: molecules
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(mp_comm_type)                                 :: comm_self
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: input_section
@@ -1234,6 +1236,8 @@ CONTAINS
          NULLIFY (atomic_kinds, local_particles, particles)
          NULLIFY (local_molecules, molecules, molecule_kinds, gci)
          NULLIFY (atomic_kind_set, molecule_kind_set, particle_set, molecule_set)
+
+         CALL comm_self%set_handle(mp_comm_self)
 
          CALL f_env_add_defaults(f_env_id=pint_env%replicas%f_env_id, f_env=f_env)
          CALL force_env_get(force_env=f_env%force_env, subsys=subsys)
@@ -1495,7 +1499,7 @@ CONTAINS
                                       pint_env%simpar%info_constraint, &
                                       pint_env%simpar%lagrange_multipliers, &
                                       .FALSE., &
-                                      cell, mp_comm_self, &
+                                      cell, comm_self, &
                                       local_particles)
                   DO i = 1, nparticle
                      DO j = 1, 3
@@ -1530,7 +1534,7 @@ CONTAINS
                                    pint_env%simpar%info_constraint, &
                                    pint_env%simpar%lagrange_multipliers, &
                                    .FALSE., &
-                                   cell, mp_comm_self, &
+                                   cell, comm_self, &
                                    local_particles)
             END IF
             ! Broadcast updated velocities to other nodes
@@ -1949,6 +1953,7 @@ CONTAINS
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_list_type), POINTER                  :: molecules
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(mp_comm_type)                                 :: comm_self
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
@@ -1960,6 +1965,8 @@ CONTAINS
       dti2 = dti/2._dp
       tdti = 2.*dti
       dti22 = dti**2/2._dp
+
+      CALL comm_self%set_handle(mp_comm_self)
 
       ! Get constraint info, if needed
       ! Create a force environment which will be identical to
@@ -2127,7 +2134,7 @@ CONTAINS
                                      pint_env%simpar%info_constraint, &
                                      pint_env%simpar%lagrange_multipliers, &
                                      pint_env%simpar%dump_lm, cell, &
-                                     mp_comm_self, local_particles)
+                                     comm_self, local_particles)
                END IF
                ! Positions and velocities of centroid were constrained by SHAKE
                CALL mp_bcast(pos, &
@@ -2312,7 +2319,7 @@ CONTAINS
                                          pint_env%simpar%info_constraint, &
                                          pint_env%simpar%lagrange_multipliers, &
                                          pint_env%simpar%dump_lm, cell, &
-                                         mp_comm_self, local_particles)
+                                         comm_self, local_particles)
                   END IF
                   ! Velocities of centroid were constrained by RATTLE
                   ! Broadcast updated velocities to other nodes
@@ -2433,7 +2440,7 @@ CONTAINS
                                         pint_env%simpar%info_constraint, &
                                         pint_env%simpar%lagrange_multipliers, &
                                         pint_env%simpar%dump_lm, cell, &
-                                        mp_comm_self, local_particles)
+                                        comm_self, local_particles)
                      DO i = 1, nparticle
                         DO j = 1, 3
                            pint_env%x(ib, j + (i - 1)*3) = pos(j, i)
@@ -2472,7 +2479,7 @@ CONTAINS
                                      pint_env%simpar%info_constraint, &
                                      pint_env%simpar%lagrange_multipliers, &
                                      pint_env%simpar%dump_lm, cell, &
-                                     mp_comm_self, local_particles)
+                                     comm_self, local_particles)
                END IF
                ! Broadcast positions and velocities to all nodes
                CALL mp_bcast(pos, &
@@ -2566,7 +2573,7 @@ CONTAINS
                                          pint_env%simpar%info_constraint, &
                                          pint_env%simpar%lagrange_multipliers, &
                                          pint_env%simpar%dump_lm, cell, &
-                                         mp_comm_self, local_particles)
+                                         comm_self, local_particles)
                      DO i = 1, nparticle
                         DO j = 1, 3
                            pint_env%v(ib, j + (i - 1)*3) = vel(j, i)
@@ -2597,7 +2604,7 @@ CONTAINS
                                       pint_env%simpar%info_constraint, &
                                       pint_env%simpar%lagrange_multipliers, &
                                       pint_env%simpar%dump_lm, cell, &
-                                      mp_comm_self, local_particles)
+                                      comm_self, local_particles)
                END IF
                ! Velocities of centroid were constrained by RATTLE
                ! Broadcast updated velocities to other nodes

--- a/src/motion/pint_methods.F
+++ b/src/motion/pint_methods.F
@@ -85,8 +85,7 @@ MODULE pint_methods
    USE mathconstants,                   ONLY: twopi
    USE mathlib,                         ONLY: gcd
    USE message_passing,                 ONLY: mp_bcast,&
-                                              mp_comm_self,&
-                                              mp_comm_type
+                                              mp_comm_self
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_type
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_list_types,             ONLY: molecule_list_type
@@ -1220,7 +1219,6 @@ CONTAINS
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_list_type), POINTER                  :: molecules
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
-      TYPE(mp_comm_type)                                 :: comm_self
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: input_section
@@ -1236,8 +1234,6 @@ CONTAINS
          NULLIFY (atomic_kinds, local_particles, particles)
          NULLIFY (local_molecules, molecules, molecule_kinds, gci)
          NULLIFY (atomic_kind_set, molecule_kind_set, particle_set, molecule_set)
-
-         CALL comm_self%set_handle(mp_comm_self)
 
          CALL f_env_add_defaults(f_env_id=pint_env%replicas%f_env_id, f_env=f_env)
          CALL force_env_get(force_env=f_env%force_env, subsys=subsys)
@@ -1499,7 +1495,7 @@ CONTAINS
                                       pint_env%simpar%info_constraint, &
                                       pint_env%simpar%lagrange_multipliers, &
                                       .FALSE., &
-                                      cell, comm_self, &
+                                      cell, mp_comm_self, &
                                       local_particles)
                   DO i = 1, nparticle
                      DO j = 1, 3
@@ -1534,7 +1530,7 @@ CONTAINS
                                    pint_env%simpar%info_constraint, &
                                    pint_env%simpar%lagrange_multipliers, &
                                    .FALSE., &
-                                   cell, comm_self, &
+                                   cell, mp_comm_self, &
                                    local_particles)
             END IF
             ! Broadcast updated velocities to other nodes
@@ -1953,7 +1949,6 @@ CONTAINS
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_list_type), POINTER                  :: molecules
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
-      TYPE(mp_comm_type)                                 :: comm_self
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
@@ -1965,8 +1960,6 @@ CONTAINS
       dti2 = dti/2._dp
       tdti = 2.*dti
       dti22 = dti**2/2._dp
-
-      CALL comm_self%set_handle(mp_comm_self)
 
       ! Get constraint info, if needed
       ! Create a force environment which will be identical to
@@ -2134,7 +2127,7 @@ CONTAINS
                                      pint_env%simpar%info_constraint, &
                                      pint_env%simpar%lagrange_multipliers, &
                                      pint_env%simpar%dump_lm, cell, &
-                                     comm_self, local_particles)
+                                     mp_comm_self, local_particles)
                END IF
                ! Positions and velocities of centroid were constrained by SHAKE
                CALL mp_bcast(pos, &
@@ -2319,7 +2312,7 @@ CONTAINS
                                          pint_env%simpar%info_constraint, &
                                          pint_env%simpar%lagrange_multipliers, &
                                          pint_env%simpar%dump_lm, cell, &
-                                         comm_self, local_particles)
+                                         mp_comm_self, local_particles)
                   END IF
                   ! Velocities of centroid were constrained by RATTLE
                   ! Broadcast updated velocities to other nodes
@@ -2440,7 +2433,7 @@ CONTAINS
                                         pint_env%simpar%info_constraint, &
                                         pint_env%simpar%lagrange_multipliers, &
                                         pint_env%simpar%dump_lm, cell, &
-                                        comm_self, local_particles)
+                                        mp_comm_self, local_particles)
                      DO i = 1, nparticle
                         DO j = 1, 3
                            pint_env%x(ib, j + (i - 1)*3) = pos(j, i)
@@ -2479,7 +2472,7 @@ CONTAINS
                                      pint_env%simpar%info_constraint, &
                                      pint_env%simpar%lagrange_multipliers, &
                                      pint_env%simpar%dump_lm, cell, &
-                                     comm_self, local_particles)
+                                     mp_comm_self, local_particles)
                END IF
                ! Broadcast positions and velocities to all nodes
                CALL mp_bcast(pos, &
@@ -2573,7 +2566,7 @@ CONTAINS
                                          pint_env%simpar%info_constraint, &
                                          pint_env%simpar%lagrange_multipliers, &
                                          pint_env%simpar%dump_lm, cell, &
-                                         comm_self, local_particles)
+                                         mp_comm_self, local_particles)
                      DO i = 1, nparticle
                         DO j = 1, 3
                            pint_env%v(ib, j + (i - 1)*3) = vel(j, i)
@@ -2604,7 +2597,7 @@ CONTAINS
                                       pint_env%simpar%info_constraint, &
                                       pint_env%simpar%lagrange_multipliers, &
                                       pint_env%simpar%dump_lm, cell, &
-                                      comm_self, local_particles)
+                                      mp_comm_self, local_particles)
                END IF
                ! Velocities of centroid were constrained by RATTLE
                ! Broadcast updated velocities to other nodes

--- a/src/motion/thermostat/al_system_dynamics.F
+++ b/src/motion/thermostat/al_system_dynamics.F
@@ -18,6 +18,7 @@ MODULE al_system_dynamics
    USE extended_system_types,           ONLY: map_info_type
    USE force_env_types,                 ONLY: force_env_type
    USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_types,                  ONLY: get_molecule,&
                                               molecule_type
@@ -58,7 +59,7 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: vel(:, :)
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'al_particles'

--- a/src/motion/thermostat/csvr_system_dynamics.F
+++ b/src/motion/thermostat/csvr_system_dynamics.F
@@ -17,6 +17,7 @@ MODULE csvr_system_dynamics
    USE extended_system_types,           ONLY: map_info_type,&
                                               npt_info_type
    USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_types,                  ONLY: molecule_type
    USE parallel_rng_types,              ONLY: rng_stream_type
@@ -53,7 +54,7 @@ CONTAINS
       TYPE(csvr_system_type), POINTER                    :: csvr
       TYPE(npt_info_type), DIMENSION(:, :), &
          INTENT(INOUT)                                   :: npt
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'csvr_barostat'
 
@@ -106,7 +107,7 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_molecules
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell_adiabatic
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)
@@ -167,7 +168,7 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: vel(:, :), shell_vel(:, :), &

--- a/src/motion/thermostat/extended_system_dynamics.F
+++ b/src/motion/thermostat/extended_system_dynamics.F
@@ -21,6 +21,7 @@ MODULE extended_system_dynamics
                                               map_info_type,&
                                               npt_info_type
    USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_types,                  ONLY: molecule_type
    USE particle_types,                  ONLY: particle_type
@@ -61,7 +62,7 @@ CONTAINS
       TYPE(lnhc_parameters_type), POINTER                :: nhc
       TYPE(npt_info_type), DIMENSION(:, :), &
          INTENT(INOUT)                                   :: npt
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'lnhc_barostat'
 
@@ -110,7 +111,7 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_molecules
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell_adiabatic
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)
@@ -166,7 +167,7 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: vel(:, :), shell_vel(:, :), &

--- a/src/motion/thermostat/gle_system_dynamics.F
+++ b/src/motion/thermostat/gle_system_dynamics.F
@@ -27,7 +27,8 @@ MODULE gle_system_dynamics
                                               section_vals_type,&
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_types,                  ONLY: global_constraint_type,&
                                               molecule_type
@@ -80,7 +81,7 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_molecules
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell_adiabatic
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)

--- a/src/motion/thermostat/thermostat_methods.F
+++ b/src/motion/thermostat/thermostat_methods.F
@@ -59,6 +59,7 @@ MODULE thermostat_methods
                                               section_vals_val_set
    USE kinds,                           ONLY: default_path_length,&
                                               dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_type
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_list_types,             ONLY: molecule_list_type
@@ -533,7 +534,7 @@ CONTAINS
    SUBROUTINE apply_thermostat_baro(thermostat, npt, group)
       TYPE(thermostat_type), POINTER                     :: thermostat
       TYPE(npt_info_type), DIMENSION(:, :), POINTER      :: npt
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       IF (ASSOCIATED(thermostat)) THEN
          IF (thermostat%type_of_thermostat == do_thermo_nose) THEN
@@ -579,7 +580,7 @@ CONTAINS
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       LOGICAL, INTENT(IN), OPTIONAL                      :: shell_adiabatic
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)
@@ -638,7 +639,7 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       TYPE(particle_type), OPTIONAL, POINTER             :: shell_particle_set(:), &
                                                             core_particle_set(:)
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: vel(:, :), shell_vel(:, :), &

--- a/src/motion/thermostat/thermostat_utils.F
+++ b/src/motion/thermostat/thermostat_utils.F
@@ -41,7 +41,8 @@ MODULE thermostat_utils
    USE kinds,                           ONLY: default_string_length,&
                                               dp
    USE machine,                         ONLY: m_flush
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE molecule_kind_types,             ONLY: get_molecule_kind,&
                                               get_molecule_kind_set,&
                                               molecule_kind_type
@@ -922,7 +923,7 @@ CONTAINS
       TYPE(map_info_type), POINTER                       :: map_info
       TYPE(npt_info_type), DIMENSION(:, :), &
          INTENT(INOUT)                                   :: npt
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       INTEGER                                            :: i, j, ncoef
 
@@ -983,7 +984,7 @@ CONTAINS
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: vel(:, :)
 
       INTEGER                                            :: first_atom, ii, ikind, imol, imol_local, &
@@ -1049,7 +1050,7 @@ CONTAINS
       TYPE(molecule_kind_type), POINTER                  :: molecule_kind_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_molecules
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: vel(:, :)
 
       INTEGER                                            :: first_atom, ii, ikind, imol, imol_local, &
@@ -1218,7 +1219,7 @@ CONTAINS
       TYPE(particle_type), POINTER                       :: particle_set(:)
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)
       TYPE(distribution_1d_type), POINTER                :: local_particles
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       TYPE(particle_type), OPTIONAL, POINTER             :: core_particle_set(:), &
                                                             shell_particle_set(:)
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: core_vel(:, :), shell_vel(:, :)

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -67,6 +67,7 @@ MODULE mp2_integrals
                                               libint_potential_type
    USE machine,                         ONLY: m_flush
    USE message_passing,                 ONLY: mp_cart_create,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_max,&
                                               mp_sendrecv,&
@@ -249,10 +250,10 @@ CONTAINS
 
       INTEGER :: cm, cut_memory, cut_memory_int, eri_method, gw_corr_lev_total, handle, handle2, &
          handle4, i, i_counter, i_mem, ibasis, ispin, itmp(2), j, jcell, kcell, LLL, min_bsize, &
-         mp_comm_t3c_2, my_B_all_end, my_B_all_size, my_B_all_start, my_B_occ_bse_end, &
-         my_B_occ_bse_size, my_B_occ_bse_start, my_B_virt_bse_end, my_B_virt_bse_size, &
-         my_B_virt_bse_start, my_group_L_end, my_group_L_size, my_group_L_start, n_rep, natom, &
-         ngroup, nimg, nkind, nspins, potential_type, ri_metric_type
+         my_B_all_end, my_B_all_size, my_B_all_start, my_B_occ_bse_end, my_B_occ_bse_size, &
+         my_B_occ_bse_start, my_B_virt_bse_end, my_B_virt_bse_size, my_B_virt_bse_start, &
+         my_group_L_end, my_group_L_size, my_group_L_start, n_rep, natom, ngroup, nimg, nkind, &
+         nspins, potential_type, ri_metric_type
       INTEGER(int_8)                                     :: nze
       INTEGER, ALLOCATABLE, DIMENSION(:) :: dist_AO_1, dist_AO_2, dist_RI, &
          ends_array_mc_block_int, ends_array_mc_int, my_B_size, my_B_virtual_end, &
@@ -279,6 +280,7 @@ CONTAINS
       TYPE(intermediate_matrix_type)                     :: intermed_mat_bse_ab, intermed_mat_bse_ij
       TYPE(intermediate_matrix_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: intermed_mat, intermed_mat_gw
+      TYPE(mp_comm_type)                                 :: mp_comm_t3c_2
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
@@ -900,7 +902,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: my_Lrows
       INTEGER, DIMENSION(:), INTENT(IN)                  :: sizes_B, sizes_L
       INTEGER, DIMENSION(2), INTENT(IN)                  :: blk_size
-      INTEGER, INTENT(IN)                                :: ngroup, igroup, mp_comm
+      INTEGER, INTENT(IN)                                :: ngroup, igroup
+      TYPE(mp_comm_type)                                 :: mp_comm
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'contract_B_L'

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -83,6 +83,7 @@ MODULE mp2_ri_2c
                                               mp_alltoall,&
                                               mp_bcast,&
                                               mp_max,&
+                                              mp_request_type,&
                                               mp_sendrecv,&
                                               mp_sum
    USE mp2_eri,                         ONLY: mp2_eri_2c_integrate
@@ -1201,9 +1202,9 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: entry_counter, num_entries_rec, &
                                                             num_entries_send
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      INTEGER, DIMENSION(:, :), POINTER                  :: req_array
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_send
+      TYPE(mp_request_type), DIMENSION(:, :), POINTER    :: req_array
 
       CALL timeset(routineN, handle)
 

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -40,8 +40,8 @@ MODULE mp2_ri_grad
    USE kinds,                           ONLY: dp
    USE libint_2c_3c,                    ONLY: compare_potential_types
    USE message_passing,                 ONLY: &
-        mp_allgather, mp_alltoall, mp_irecv, mp_isend, mp_request_null, mp_sendrecv, mp_sum, &
-        mp_wait, mp_waitall
+        mp_allgather, mp_alltoall, mp_irecv, mp_isend, mp_request_null, mp_request_type, &
+        mp_sendrecv, mp_sum, mp_wait, mp_waitall
    USE mp2_eri,                         ONLY: mp2_eri_2c_integrate,&
                                               mp2_eri_3c_integrate,&
                                               mp2_eri_deallocate_forces,&
@@ -676,8 +676,7 @@ CONTAINS
       INTEGER :: rec_counter, rec_row_size, send_col_size, send_counter, send_pcol, send_prow, &
          send_row_size, size_rec_buffer, size_send_buffer
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii_vet, map_rec_size, map_send_size, &
-                                                            pos_info, pos_info_ex, &
-                                                            proc_2_send_pos, req_send
+                                                            pos_info, pos_info_ex, proc_2_send_pos
       INTEGER, ALLOCATABLE, DIMENSION(:, :) :: grid_2_mepos, mepos_2_grid, my_col_indeces_info_1i, &
          my_col_indeces_info_2a, my_row_indeces_info_1i, my_row_indeces_info_2a, sizes, sizes_1i, &
          sizes_2a
@@ -697,6 +696,7 @@ CONTAINS
          DIMENSION(:)                                    :: buffer_rec, buffer_send
       TYPE(integ_mat_buffer_type_2D), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_cyclic
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: req_send
 
       CALL timeset(routineN, handle)
 

--- a/src/mp2_ri_grad_util.F
+++ b/src/mp2_ri_grad_util.F
@@ -35,13 +35,9 @@ MODULE mp2_ri_grad_util
                                               release_group_dist
    USE kinds,                           ONLY: dp
    USE libint_2c_3c,                    ONLY: compare_potential_types
-   USE message_passing,                 ONLY: mp_allgather,&
-                                              mp_irecv,&
-                                              mp_isend,&
-                                              mp_sendrecv,&
-                                              mp_sum,&
-                                              mp_wait,&
-                                              mp_waitall
+   USE message_passing,                 ONLY: &
+        mp_allgather, mp_irecv, mp_isend, mp_request_null, mp_request_type, mp_sendrecv, mp_sum, &
+        mp_wait, mp_waitall
    USE mp2_types,                       ONLY: integ_mat_buffer_type,&
                                               mp2_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
@@ -522,7 +518,7 @@ CONTAINS
          ref_send_prow, send_counter, send_pcol, send_prow, size_rec_buffer, size_send_buffer
       INTEGER :: start_col_block, start_row_block
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii_vet, index_col_rec, map_rec_size, &
-                                                            map_send_size, req_send
+                                                            map_send_size
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: blocks_ranges_col, blocks_ranges_row, &
                                                             grid_2_mepos, grid_ref_2_send_pos, &
                                                             mepos_2_grid
@@ -532,6 +528,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_send
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: req_send
 
       CALL timeset(routineN, handle)
 
@@ -921,7 +918,7 @@ CONTAINS
          proc_shift, rec_col_size, rec_counter, rec_pcol, rec_prow, rec_row_size, ref_send_pcol, &
          ref_send_prow, send_counter, send_pcol, send_prow, size_rec_buffer, size_send_buffer
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii_vet, index_row_rec, map_rec_size, &
-                                                            map_send_size, req_send
+                                                            map_send_size
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: grid_2_mepos, grid_ref_2_send_pos, &
                                                             mepos_2_grid, sizes
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
@@ -929,6 +926,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_send
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: req_send
 
       CALL timeset(routineN, handle)
 
@@ -1271,8 +1269,7 @@ CONTAINS
          rec_counter, rec_iaia_end, rec_iaia_size, rec_iaia_start, rec_pcol, rec_prow, &
          ref_send_pcol, ref_send_prow, send_counter, send_pcol, send_prow, size_rec_buffer, &
          size_send_buffer
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii_vet, map_rec_size, map_send_size, &
-                                                            req_send
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii_vet, map_rec_size, map_send_size
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: grid_2_mepos, grid_ref_2_send_pos, &
                                                             indeces_map_my, mepos_2_grid
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
@@ -1283,6 +1280,7 @@ CONTAINS
       TYPE(index_map), ALLOCATABLE, DIMENSION(:)         :: indeces_rec
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_send
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: req_send
 
       CALL timeset(routineN, handle)
 
@@ -1509,7 +1507,7 @@ CONTAINS
                buffer_send(send_counter)%msg(iii) = Gamma_2D(iaia - my_ia_start + 1, kkB)
             END IF
          END DO
-         req_send = 0
+         req_send = mp_request_null
          send_counter = 0
          DO proc_shift = 1, para_env_sub%num_pe - 1
             proc_send = MODULO(para_env_sub%mepos + proc_shift, para_env_sub%num_pe)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -38,6 +38,7 @@ MODULE mp2_types
                                               local_gemm_create,&
                                               local_gemm_destroy,&
                                               local_gemm_set_op_threshold_gpu
+   USE message_passing,                 ONLY: mp_request_type
    USE qs_force_types,                  ONLY: qs_force_type
    USE qs_p_env_types,                  ONLY: qs_p_env_type
 #include "./base/base_uses.f90"
@@ -278,13 +279,13 @@ MODULE mp2_types
       INTEGER, DIMENSION(:), ALLOCATABLE  :: sizes
       INTEGER, DIMENSION(:, :), ALLOCATABLE  :: indx
       INTEGER :: proc
-      INTEGER :: msg_req
+      TYPE(mp_request_type) :: msg_req
    END TYPE
 
    TYPE integ_mat_buffer_type_2D
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE  :: msg
       INTEGER :: proc
-      INTEGER :: msg_req
+      TYPE(mp_request_type) :: msg_req
    END TYPE
 
    TYPE pair_list_type_mp2

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -2505,7 +2505,7 @@ CONTAINS
       LOGICAL, DIMENSION(:, :, :)              :: msgin
       INTEGER, INTENT(IN)                      :: dest
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_bm3'
@@ -2526,10 +2526,10 @@ CONTAINS
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)*SIZE(msgin, 3)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1, 1), msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -2539,9 +2539,8 @@ CONTAINS
       MARK_USED(msgin)
       MARK_USED(dest)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_isend_bm3
@@ -2564,7 +2563,7 @@ CONTAINS
       LOGICAL, DIMENSION(:, :, :)              :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_bm3'
@@ -2585,10 +2584,10 @@ CONTAINS
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)*SIZE(msgout, 3)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1, 1), msglen, MPI_LOGICAL, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, MPI_LOGICAL, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -2600,7 +2599,7 @@ CONTAINS
       MARK_USED(comm)
       MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_irecv_bm3

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -191,6 +191,16 @@ MODULE message_passing
 
    PUBLIC :: mp_get_library_version
 
+   PUBLIC :: mp_comm_type
+
+   TYPE mp_comm_type
+      PRIVATE
+      INTEGER :: handle = mp_comm_null
+   CONTAINS
+      PROCEDURE :: set_handle => mp_comm_type_set_handle
+      PROCEDURE :: get_handle => mp_comm_type_get_handle
+   END TYPE
+
    ! assumed to be private
 
 ! Interface declarations for non-data-oriented subroutines.
@@ -706,6 +716,20 @@ MODULE message_passing
 
 CONTAINS
 
+   ELEMENTAL SUBROUTINE mp_comm_type_set_handle(this, handle)
+      CLASS(mp_comm_type), INTENT(INOUT) :: this
+      INTEGER, INTENT(IN) :: handle
+
+      this%handle = handle
+   END SUBROUTINE mp_comm_type_set_handle
+
+   ELEMENTAL FUNCTION mp_comm_type_get_handle(this) RESULT(handle)
+      CLASS(mp_comm_type), INTENT(IN) :: this
+      INTEGER :: handle
+
+      handle = this%handle
+   END FUNCTION mp_comm_type_get_handle
+
 ! **************************************************************************************************
 !> \brief initializes the system default communicator
 !> \param mp_comm [output] : handle of the default communicator
@@ -715,7 +739,7 @@ CONTAINS
 !>      should only be called once
 ! **************************************************************************************************
    SUBROUTINE mp_world_init(mp_comm)
-      INTEGER, INTENT(OUT)                     :: mp_comm
+      TYPE(mp_comm_type), INTENT(OUT)                     :: mp_comm
 #if defined(__parallel)
       INTEGER                                  :: ierr
 !$    INTEGER                                  :: provided_tsl
@@ -751,10 +775,10 @@ CONTAINS
 !$    END IF
       CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
-      mp_comm = MPI_COMM_WORLD
+      mp_comm%handle = MPI_COMM_WORLD
       debug_comm_count = 1
 #else
-      mp_comm = 0
+      mp_comm%handle = 0
 #endif
       CALL add_mp_perf_env()
    END SUBROUTINE mp_world_init
@@ -771,27 +795,28 @@ CONTAINS
 !>      should only be called once, at very beginning of CP2K run
 ! **************************************************************************************************
    SUBROUTINE mp_reordering(mp_comm, mp_new_comm, ranks_order)
-      INTEGER, INTENT(IN)                      :: mp_comm
-      INTEGER, INTENT(out)                     :: mp_new_comm
+      TYPE(mp_comm_type), INTENT(IN)                      :: mp_comm
+      TYPE(mp_comm_type), INTENT(out)                     :: mp_new_comm
       INTEGER, DIMENSION(:)                    :: ranks_order
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_reordering'
 
       INTEGER                                  :: handle, ierr
 #if defined(__parallel)
-      INTEGER                                  :: newcomm, newgroup, oldgroup
+      TYPE(mp_comm_type) :: newcomm
+      INTEGER                                  :: newgroup, oldgroup
 #endif
 
       CALL mp_timeset(routineN, handle)
       ierr = 0
 #if defined(__parallel)
 
-      CALL mpi_comm_group(mp_comm, oldgroup, ierr)
+      CALL mpi_comm_group(mp_comm%handle, oldgroup, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_group @ mp_reordering")
       CALL mpi_group_incl(oldgroup, SIZE(ranks_order), ranks_order, newgroup, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_group_incl @ mp_reordering")
 
-      CALL mpi_comm_create(mp_comm, newgroup, newcomm, ierr)
+      CALL mpi_comm_create(mp_comm%handle, newgroup, newcomm%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_create @ mp_reordering")
 
       CALL mpi_group_free(oldgroup, ierr)
@@ -1101,7 +1126,7 @@ CONTAINS
 !> \param group mpi communicator
 ! **************************************************************************************************
    SUBROUTINE mp_sync(group)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sync'
 
@@ -1111,7 +1136,7 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_barrier(group, ierr)
+      CALL mpi_barrier(group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_barrier @ mp_sync")
       CALL add_perf(perf_id=5, count=1)
 #else
@@ -1127,7 +1152,7 @@ CONTAINS
 !> \param request ...
 ! **************************************************************************************************
    SUBROUTINE mp_isync(group, request)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
       INTEGER, INTENT(OUT)                               :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isync'
@@ -1138,7 +1163,7 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_ibarrier(group, request, ierr)
+      CALL mpi_ibarrier(group%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibarrier @ mp_isync")
       CALL add_perf(perf_id=26, count=1)
 #else
@@ -1158,10 +1183,10 @@ CONTAINS
 !> \note
 !>         ..mp_world_setup is gone, use mp_environ instead (i.e. give a groupid explicitly)
 ! **************************************************************************************************
-   RECURSIVE SUBROUTINE mp_environ_l(numtask, taskid, groupid)
+   SUBROUTINE mp_environ_l(numtask, taskid, group)
 
       INTEGER, INTENT(OUT)                               :: numtask, taskid
-      INTEGER, INTENT(IN)                                :: groupid
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_environ_l'
 
@@ -1173,13 +1198,13 @@ CONTAINS
       numtask = 1
       taskid = 0
 #if defined(__parallel)
-      CALL mpi_comm_rank(groupid, taskid, ierr)
+      CALL mpi_comm_rank(group%handle, taskid, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ mp_environ_l")
 
-      CALL mpi_comm_size(groupid, numtask, ierr)
+      CALL mpi_comm_size(group%handle, numtask, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ mp_environ_l")
 #else
-      MARK_USED(groupid)
+      MARK_USED(group)
 #endif
       CALL mp_timestop(handle)
 
@@ -1190,13 +1215,13 @@ CONTAINS
 !> \param numtask ...
 !> \param dims ...
 !> \param task_coor ...
-!> \param groupid ...
+!> \param group ...
 ! **************************************************************************************************
-   SUBROUTINE mp_environ_c(numtask, dims, task_coor, groupid)
+   SUBROUTINE mp_environ_c(numtask, dims, task_coor, group)
 
       INTEGER, INTENT(OUT)                     :: numtask, dims(2), &
                                                   task_coor(2)
-      INTEGER, INTENT(IN)                      :: groupid
+      TYPE(mp_comm_type), INTENT(IN)                      :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_environ_c'
 
@@ -1211,13 +1236,13 @@ CONTAINS
       task_coor = 0
       dims = 1
 #if defined(__parallel)
-      CALL mpi_comm_size(groupid, numtask, ierr)
+      CALL mpi_comm_size(group%handle, numtask, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ mp_environ_c")
 
-      CALL mpi_cart_get(groupid, 2, dims, periods, task_coor, ierr)
+      CALL mpi_cart_get(group%handle, 2, dims, periods, task_coor, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_get @ mp_environ_c")
 #else
-      MARK_USED(groupid)
+      MARK_USED(group)
 #endif
       CALL mp_timestop(handle)
 
@@ -1233,7 +1258,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_environ_c2(comm, ndims, dims, task_coor, periods)
 
-      INTEGER, INTENT(IN)                                :: comm, ndims
+      TYPE(mp_comm_type), INTENT(IN) :: comm
+      INTEGER, INTENT(IN)                                :: ndims
       INTEGER, INTENT(OUT)                               :: dims(ndims), task_coor(ndims)
       LOGICAL, INTENT(out)                               :: periods(ndims)
 
@@ -1248,7 +1274,7 @@ CONTAINS
       dims = 1
       periods = .FALSE.
 #if defined(__parallel)
-      CALL mpi_cart_get(comm, ndims, dims, periods, task_coor, ierr)
+      CALL mpi_cart_get(comm%handle, ndims, dims, periods, task_coor, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_get @ mp_environ_c")
 #else
       MARK_USED(comm)
@@ -1268,9 +1294,11 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_cart_create(comm_old, ndims, dims, pos, comm_cart)
 
-      INTEGER, INTENT(IN)                      :: comm_old, ndims
+      TYPE(mp_comm_type), INTENT(IN) :: comm_old
+      INTEGER, INTENT(IN)                      :: ndims
       INTEGER, INTENT(INOUT)                   :: dims(:)
-      INTEGER, INTENT(OUT)                     :: pos(:), comm_cart
+      INTEGER, INTENT(OUT)                     :: pos(:)
+      TYPE(mp_comm_type), INTENT(OUT) :: comm_cart
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_cart_create'
 
@@ -1288,7 +1316,7 @@ CONTAINS
       comm_cart = comm_old
 #if defined(__parallel)
 
-      CALL mpi_comm_size(comm_old, nodes, ierr)
+      CALL mpi_comm_size(comm_old%handle, nodes, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ mp_cart_create")
 
       IF (ANY(dims == 0)) CALL mpi_dims_create(nodes, ndims, dims, ierr)
@@ -1299,20 +1327,20 @@ CONTAINS
       ! communicator
       reorder = .FALSE.
       period = .TRUE.
-      CALL mpi_cart_create(comm_old, ndims, dims, period, reorder, comm_cart, &
+      CALL mpi_cart_create(comm_old%handle, ndims, dims, period, reorder, comm_cart%handle, &
                            ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_create @ mp_cart_create")
 
-      IF (comm_cart /= MPI_COMM_NULL) THEN
+      IF (comm_cart%handle /= MPI_COMM_NULL) THEN
          debug_comm_count = debug_comm_count + 1
-         CALL mpi_cart_get(comm_cart, ndims, dims, period, pos, ierr)
+         CALL mpi_cart_get(comm_cart%handle, ndims, dims, period, pos, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_get @ mp_cart_create")
       END IF
       CALL add_perf(perf_id=1, count=1)
 #else
       pos(1:ndims) = 0
       dims = 1
-      comm_cart = 0
+      comm_cart%handle = 0
 #endif
       CALL mp_timestop(handle)
 
@@ -1327,7 +1355,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_cart_coords(comm, rank, coords)
 
-      INTEGER, INTENT(IN)                                :: comm, rank
+      TYPE(mp_comm_type), INTENT(IN) :: comm
+      INTEGER, INTENT(IN)                                :: rank
       INTEGER, DIMENSION(:), INTENT(OUT)                 :: coords
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_cart_coords'
@@ -1339,7 +1368,7 @@ CONTAINS
 
       m = SIZE(coords)
 #if defined(__parallel)
-      CALL mpi_cart_coords(comm, rank, m, coords, ierr)
+      CALL mpi_cart_coords(comm%handle, rank, m, coords, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_coords @ mp_cart_coords")
 #else
       coords = 0
@@ -1359,7 +1388,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_comm_compare(comm1, comm2, res)
 
-      INTEGER, INTENT(IN)                                :: comm1, comm2
+      TYPE(mp_comm_type), INTENT(IN)                                :: comm1, comm2
       INTEGER, INTENT(OUT)                               :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_comm_compare'
@@ -1372,7 +1401,7 @@ CONTAINS
       iout = 0
       res = 0
 #if defined(__parallel)
-      CALL mpi_comm_compare(comm1, comm2, iout, ierr)
+      CALL mpi_comm_compare(comm1%handle, comm2%handle, iout, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_compare @ mp_comm_compare")
       SELECT CASE (iout)
       CASE (MPI_IDENT)
@@ -1403,9 +1432,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_cart_sub(comm, rdim, sub_comm)
 
-      INTEGER, INTENT(IN)                                :: comm
+      TYPE(mp_comm_type), INTENT(IN)                                :: comm
       LOGICAL, DIMENSION(:), INTENT(IN)                  :: rdim
-      INTEGER, INTENT(OUT)                               :: sub_comm
+      TYPE(mp_comm_type), INTENT(OUT)                               :: sub_comm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_cart_sub'
 
@@ -1414,9 +1443,8 @@ CONTAINS
       ierr = 0
       CALL mp_timeset(routineN, handle)
 
-      sub_comm = 0
 #if defined(__parallel)
-      CALL mpi_cart_sub(comm, rdim, sub_comm, ierr)
+      CALL mpi_cart_sub(comm%handle, rdim, sub_comm%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_sub @ mp_cart_sub")
       debug_comm_count = debug_comm_count + 1
 #else
@@ -1434,7 +1462,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_comm_free(comm)
 
-      INTEGER, INTENT(INOUT)                             :: comm
+      TYPE(mp_comm_type), INTENT(INOUT)                             :: comm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_comm_free'
 
@@ -1444,11 +1472,11 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_comm_free(comm, ierr)
+      CALL mpi_comm_free(comm%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_free @ mp_comm_free")
       debug_comm_count = debug_comm_count - 1
 #else
-      MARK_USED(comm)
+      comm%handle = mp_comm_null
 #endif
       CALL mp_timestop(handle)
 
@@ -1462,8 +1490,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_comm_dup(comm1, comm2)
 
-      INTEGER, INTENT(IN)                                :: comm1
-      INTEGER, INTENT(OUT)                               :: comm2
+      TYPE(mp_comm_type), INTENT(IN)                                :: comm1
+      TYPE(mp_comm_type), INTENT(OUT)                               :: comm2
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_comm_dup'
 
@@ -1473,7 +1501,7 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_comm_dup(comm1, comm2, ierr)
+      CALL mpi_comm_dup(comm1%handle, comm2%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_dup @ mp_comm_dup")
       debug_comm_count = debug_comm_count + 1
 #else
@@ -1492,7 +1520,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_rank_compare(comm1, comm2, rank)
 
-      INTEGER, INTENT(IN)                      :: comm1, comm2
+      TYPE(mp_comm_type), INTENT(IN)                      :: comm1, comm2
       INTEGER, DIMENSION(:), INTENT(OUT)       :: rank
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_rank_compare'
@@ -1508,14 +1536,14 @@ CONTAINS
 
       rank = 0
 #if defined(__parallel)
-      CALL mpi_comm_size(comm1, n1, ierr)
+      CALL mpi_comm_size(comm1%handle, n1, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ mp_rank_compare")
-      CALL mpi_comm_size(comm2, n2, ierr)
+      CALL mpi_comm_size(comm2%handle, n2, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ mp_rank_compare")
       n = MAX(n1, n2)
-      CALL mpi_comm_group(comm1, g1, ierr)
+      CALL mpi_comm_group(comm1%handle, g1, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_group @ mp_rank_compare")
-      CALL mpi_comm_group(comm2, g2, ierr)
+      CALL mpi_comm_group(comm2%handle, g2, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_group @ mp_rank_compare")
       ALLOCATE (rin(0:n - 1), STAT=ierr)
       IF (ierr /= 0) &
@@ -1579,7 +1607,7 @@ CONTAINS
 !> \param rank ...
 ! **************************************************************************************************
    SUBROUTINE mp_cart_rank(group, pos, rank)
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
       INTEGER, DIMENSION(:), INTENT(IN)                  :: pos
       INTEGER, INTENT(OUT)                               :: rank
 
@@ -1591,7 +1619,7 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_cart_rank(group, pos, rank, ierr)
+      CALL mpi_cart_rank(group%handle, pos, rank, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_cart_rank @ mp_cart_rank")
 #else
       rank = 0
@@ -1933,8 +1961,8 @@ CONTAINS
 !> \author Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE mp_comm_split_direct(comm, sub_comm, color, key)
-      INTEGER, INTENT(in)                                :: comm
-      INTEGER, INTENT(OUT)                               :: sub_comm
+      TYPE(mp_comm_type), INTENT(in)                                :: comm
+      TYPE(mp_comm_type), INTENT(OUT)                               :: sub_comm
       INTEGER, INTENT(in)                                :: color
       INTEGER, INTENT(in), OPTIONAL                      :: key
 
@@ -1948,7 +1976,7 @@ CONTAINS
       my_key = 0
 #if defined(__parallel)
       IF (PRESENT(key)) my_key = key
-      CALL mpi_comm_split(comm, color, my_key, sub_comm, ierr)
+      CALL mpi_comm_split(comm%handle, color, my_key, sub_comm%handle, ierr)
       debug_comm_count = debug_comm_count + 1
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
       CALL add_perf(perf_id=10, count=1)
@@ -1985,8 +2013,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_comm_split(comm, sub_comm, ngroups, group_distribution, &
                             subgroup_min_size, n_subgroups, group_partition, stride)
-      INTEGER, INTENT(in)                      :: comm
-      INTEGER, INTENT(out)                     :: sub_comm, ngroups
+      TYPE(mp_comm_type), INTENT(in)                      :: comm
+      TYPE(mp_comm_type), INTENT(out) :: sub_comm
+      INTEGER, INTENT(out)                     :: ngroups
       INTEGER, DIMENSION(0:)                    :: group_distribution
       INTEGER, INTENT(in), OPTIONAL            :: subgroup_min_size, n_subgroups
       INTEGER, DIMENSION(0:), OPTIONAL          :: group_partition
@@ -2072,7 +2101,7 @@ CONTAINS
          END IF
       END IF
       color = group_distribution(mepos)
-      CALL mpi_comm_split(comm, color, 0, sub_comm, ierr)
+      CALL mpi_comm_split(comm%handle, color, 0, sub_comm%handle, ierr)
       debug_comm_count = debug_comm_count + 1
       IF (ierr /= mpi_success) CALL mp_stop(ierr, "in "//routineP//" split")
 
@@ -2099,21 +2128,23 @@ CONTAINS
       INTEGER                                            :: node_rank
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_get_node_global_rank'
-      INTEGER                                            :: handle, comm, ierr, rank
+      INTEGER                                            :: handle, ierr, rank
+#if defined(__parallel)
+      TYPE(mp_comm_type) :: comm
+#endif
 
       ierr = 0
       rank = 0
-      comm = 0
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
       CALL mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
-      CALL mpi_comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, comm, ierr)
+      CALL mpi_comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, comm%handle, ierr)
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
-      CALL mpi_comm_rank(comm, node_rank, ierr)
+      CALL mpi_comm_rank(comm%handle, node_rank, ierr)
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
-      CALL mpi_comm_free(comm, ierr)
+      CALL mpi_comm_free(comm%handle, ierr)
       IF (ierr /= mpi_success) CALL mp_stop(ierr, routineN)
 #else
       node_rank = 0
@@ -2135,7 +2166,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_probe(source, comm, tag)
       INTEGER                                  :: source
-      INTEGER, INTENT(IN)                      :: comm
+      TYPE(mp_comm_type), INTENT(IN)           :: comm
       INTEGER, INTENT(OUT)                     :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_probe'
@@ -2153,13 +2184,13 @@ CONTAINS
       ierr = 0
 #if defined(__parallel)
       IF (source .EQ. mp_any_source) THEN
-         CALL mpi_probe(mp_any_source, mp_any_tag, comm, status_single, ierr)
+         CALL mpi_probe(mp_any_source, mp_any_tag, comm%handle, status_single, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_probe @ mp_probe")
          source = status_single(MPI_SOURCE)
          tag = status_single(MPI_TAG)
       ELSE
          flag = .FALSE.
-         CALL mpi_iprobe(source, mp_any_tag, comm, flag, status_single, ierr)
+         CALL mpi_iprobe(source, mp_any_tag, comm%handle, flag, status_single, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iprobe @ mp_probe")
          IF (flag .EQV. .FALSE.) THEN
             source = mp_any_source
@@ -2188,7 +2219,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_b(msg, source, gid)
       LOGICAL                                            :: msg
-      INTEGER                                            :: source, gid
+      INTEGER                                            :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_b'
 
@@ -2199,7 +2231,7 @@ CONTAINS
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, count=1, msg_size=msglen*loglen)
 #else
@@ -2218,7 +2250,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_bv(msg, source, gid)
       LOGICAL                                            :: msg(:)
-      INTEGER                                            :: source, gid
+      INTEGER                                            :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_bv'
 
@@ -2229,7 +2262,7 @@ CONTAINS
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, MPI_LOGICAL, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, count=1, msg_size=msglen*loglen)
 #else
@@ -2255,7 +2288,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_isend_bv(msgin, dest, comm, request, tag)
       LOGICAL, DIMENSION(:)                    :: msgin
-      INTEGER, INTENT(IN)                      :: dest, comm
+      INTEGER, INTENT(IN)                      :: dest
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -2277,10 +2311,10 @@ CONTAINS
       msglen = SIZE(msgin, 1)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -2313,7 +2347,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_irecv_bv(msgout, source, comm, request, tag)
       LOGICAL, DIMENSION(:)                    :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -2335,10 +2370,10 @@ CONTAINS
       msglen = SIZE(msgout, 1)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, MPI_LOGICAL, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, MPI_LOGICAL, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -2371,7 +2406,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_isend_bm3(msgin, dest, comm, request, tag)
       LOGICAL, DIMENSION(:, :, :)              :: msgin
-      INTEGER, INTENT(IN)                      :: dest, comm
+      INTEGER, INTENT(IN)                      :: dest
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -2393,10 +2429,10 @@ CONTAINS
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)*SIZE(msgin, 3)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1, 1), msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -2429,7 +2465,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_irecv_bm3(msgout, source, comm, request, tag)
       LOGICAL, DIMENSION(:, :, :)              :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -2451,10 +2488,10 @@ CONTAINS
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)*SIZE(msgout, 3)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1, 1), msglen, MPI_LOGICAL, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, MPI_LOGICAL, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -2479,7 +2516,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_av(msg, source, gid)
       CHARACTER(LEN=*)                         :: msg
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_av'
 
@@ -2502,12 +2540,12 @@ CONTAINS
       ! at the moment we have a data alignment error when trying to
       ! broadcast characters on the T3E (not always!)
       ! JH 19/3/99 on galileo
-      ! CALL mpi_bcast(msg,msglen,MPI_CHARACTER,source,gid,ierr)
+      ! CALL mpi_bcast(msg,msglen,MPI_CHARACTER,source,gid%handle,ierr)
       ALLOCATE (imsg(1:msglen))
       DO i = 1, msglen
          imsg(i) = ICHAR(msg(i:i))
       END DO
-      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid, ierr)
+      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       msg = ""
       DO i = 1, msglen
@@ -2531,7 +2569,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_am(msg, source, gid)
       CHARACTER(LEN=*)                         :: msg(:)
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_am'
 
@@ -2559,7 +2598,7 @@ CONTAINS
       ! at the moment we have a data alignment error when trying to
       ! broadcast characters on the T3E (not always!)
       ! JH 19/3/99 on galileo
-      ! CALL mpi_bcast(msg,msglen,MPI_CHARACTER,source,gid,ierr)
+      ! CALL mpi_bcast(msg,msglen,MPI_CHARACTER,source,gid%handle,ierr)
       ALLOCATE (imsg(1:msglen))
       k = 0
       DO j = 1, msgsiz
@@ -2568,7 +2607,7 @@ CONTAINS
             imsg(k) = ICHAR(msg(j) (i:i))
          END DO
       END DO
-      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid, ierr)
+      CALL mpi_bcast(imsg, msglen, MPI_INTEGER, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       msg = ""
       k = 0
@@ -2601,7 +2640,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_minloc_dv(msg, gid)
       REAL(kind=real_8), INTENT(INOUT)         :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_minloc_dv'
 
@@ -2622,7 +2661,7 @@ CONTAINS
       ALLOCATE (res(1:msglen), STAT=ierr)
       IF (ierr /= 0) &
          CPABORT("allocate @ "//routineN)
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MINLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MINLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2646,7 +2685,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_minloc_iv(msg, gid)
       INTEGER(KIND=int_4), INTENT(INOUT)       :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_minloc_iv'
 
@@ -2665,7 +2704,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2INTEGER, MPI_MINLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2INTEGER, MPI_MINLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2689,7 +2728,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_minloc_lv(msg, gid)
       INTEGER(KIND=int_8), INTENT(INOUT)       :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_minloc_lv'
 
@@ -2708,7 +2747,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_INTEGER8, MPI_MINLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_INTEGER8, MPI_MINLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2732,7 +2771,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_minloc_rv(msg, gid)
       REAL(kind=real_4), INTENT(INOUT)         :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_minloc_rv'
 
@@ -2751,7 +2790,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2REAL, MPI_MINLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2REAL, MPI_MINLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2775,7 +2814,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_maxloc_dv(msg, gid)
       REAL(kind=real_8), INTENT(INOUT)         :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_maxloc_dv'
 
@@ -2794,7 +2833,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MAXLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2DOUBLE_PRECISION, MPI_MAXLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2818,7 +2857,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_maxloc_iv(msg, gid)
       INTEGER(KIND=int_4), INTENT(INOUT)       :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_maxloc_iv'
 
@@ -2837,7 +2876,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2INTEGER, MPI_MAXLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2INTEGER, MPI_MAXLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2861,7 +2900,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_maxloc_lv(msg, gid)
       INTEGER(KIND=int_8), INTENT(INOUT)       :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_maxloc_lv'
 
@@ -2880,7 +2919,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_INTEGER8, MPI_MAXLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_INTEGER8, MPI_MAXLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2904,7 +2943,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_maxloc_rv(msg, gid)
       REAL(kind=real_4), INTENT(INOUT)         :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN)                      :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_maxloc_rv'
 
@@ -2923,7 +2962,7 @@ CONTAINS
 #if defined(__parallel)
       msglen = SIZE(msg)
       ALLOCATE (res(1:msglen))
-      CALL mpi_allreduce(msg, res, msglen/2, MPI_2REAL, MPI_MAXLOC, gid, ierr)
+      CALL mpi_allreduce(msg, res, msglen/2, MPI_2REAL, MPI_MAXLOC, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       msg = res
       DEALLOCATE (res)
@@ -2945,7 +2984,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_sum_b(msg, gid)
       LOGICAL, INTENT(INOUT)                             :: msg
-      INTEGER, INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                                :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_b'
 
@@ -2955,7 +2994,7 @@ CONTAINS
       ierr = 0
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
 #else
       MARK_USED(msg)
@@ -2974,7 +3013,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_sum_bv(msg, gid)
       LOGICAL, DIMENSION(:), INTENT(INOUT)               :: msg
-      INTEGER, INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                                :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_bv'
 
@@ -2985,7 +3024,7 @@ CONTAINS
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen .GT. 0) THEN
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       END IF
 #else
@@ -3006,7 +3045,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_isum_bv(msg, gid, request)
       LOGICAL, DIMENSION(:), INTENT(INOUT)               :: msg
-      INTEGER, INTENT(IN)                                :: gid
+      TYPE(mp_comm_type), INTENT(IN)                                :: gid
       INTEGER, INTENT(INOUT)                             :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isum_bv'
@@ -3018,7 +3057,7 @@ CONTAINS
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen .GT. 0) THEN
-         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid, request, ierr)
+         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       ELSE
          request = mp_request_null
@@ -3074,7 +3113,7 @@ CONTAINS
 !>      11.2012 created [Hossein Bani-Hashemian]
 ! **************************************************************************************************
    SUBROUTINE mp_file_open(groupid, fh, filepath, amode_status, info)
-      INTEGER, INTENT(IN)                      :: groupid
+      TYPE(mp_comm_type), INTENT(IN)                      :: groupid
       INTEGER, INTENT(OUT)                     :: fh
       CHARACTER(len=*), INTENT(IN)             :: filepath
       INTEGER, INTENT(IN)                      :: amode_status
@@ -3094,7 +3133,7 @@ CONTAINS
 #if defined(__parallel)
       my_info = mpi_info_null
       IF (PRESENT(info)) my_info = info
-      CALL mpi_file_open(groupid, filepath, amode_status, my_info, fh, ierr)
+      CALL mpi_file_open(groupid%handle, filepath, amode_status, my_info, fh, ierr)
       CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_open")
 #else
@@ -3967,7 +4006,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_isend_custom(msgin, dest, comm, request, tag)
       TYPE(mp_type_descriptor_type), INTENT(IN)          :: msgin
-      INTEGER, INTENT(IN)                                :: dest, comm
+      INTEGER, INTENT(IN)                                :: dest
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
@@ -3982,7 +4022,7 @@ CONTAINS
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_isend(MPI_BOTTOM, 1, msgin%type_handle, dest, my_tag, &
-                     comm, request, ierr)
+                     comm%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 #else
       MARK_USED(msgin)
@@ -4006,7 +4046,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_irecv_custom(msgout, source, comm, request, tag)
       TYPE(mp_type_descriptor_type), INTENT(INOUT)       :: msgout
-      INTEGER, INTENT(IN)                                :: source, comm
+      INTEGER, INTENT(IN)                                :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
@@ -4021,7 +4062,7 @@ CONTAINS
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_irecv(MPI_BOTTOM, 1, msgout%type_handle, source, my_tag, &
-                     comm, request, ierr)
+                     comm%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 #else
       MARK_USED(msgout)
@@ -4149,8 +4190,8 @@ CONTAINS
 !>      quickly adapted benchmark code, will only work on an even number of CPUs.
 ! **************************************************************************************************
    SUBROUTINE mpi_perf_test(comm, npow, output_unit)
-
-      INTEGER, INTENT(IN)                      :: comm, npow, output_unit
+      TYPE(mp_comm_type), INTENT(IN) :: comm
+      INTEGER, INTENT(IN)                      :: npow, output_unit
 
 #if defined(__parallel)
 
@@ -4170,8 +4211,8 @@ CONTAINS
       ! set system sizes !
       ngrid = 10**npow
 
-      CALL mpi_comm_rank(comm, taskid, ierror)
-      CALL mpi_comm_size(comm, Nprocs, ierror)
+      CALL mpi_comm_rank(comm%handle, taskid, ierror)
+      CALL mpi_comm_size(comm%handle, Nprocs, ierror)
       ionode = (taskid == 0)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Running with ", nprocs
@@ -4211,7 +4252,7 @@ CONTAINS
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ some in memory tests                   ---------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Testing in memory copies just 1 CPU "
          WRITE (output_unit, *) "  could tell something about the motherboard / cache / compiler "
@@ -4221,21 +4262,21 @@ CONTAINS
          t2 = 0.0E0_dp
          IF (ncount .GT. nbufmax) CPABORT("")
          DO j = 1, 3**(npow - i)
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
             buffer2(1:ncount) = buffer1(1:ncount)
             t2 = t2 + MPI_WTIME() - t1 + threshold
          END DO
-         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, '(I9,A,F12.4,A)') 8*ncount, " Bytes ", (3**(npow - i))*ncount*8.0E-6_dp/t1, " MB/s"
          END IF
       END DO
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ some in memory tests                   ---------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Testing in memory copies all cpus"
          WRITE (output_unit, *) "  is the memory bandwidth affected on an SMP machine ?"
@@ -4245,21 +4286,21 @@ CONTAINS
          t2 = 0.0E0_dp
          IF (ncount .GT. nbufmax) CPABORT("")
          DO j = 1, 3**(npow - i)
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
             buffer2(1:ncount) = buffer1(1:ncount)
             t2 = t2 + MPI_WTIME() - t1 + threshold
          END DO
-         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, '(I9,A,F12.4,A)') 8*ncount, " Bytes ", (3**(npow - i))*ncount*8.0E-6_dp/t1, " MB/s"
          END IF
       END DO
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ first test point to point communication ---------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Testing truly point to point communication (i with j only)"
          WRITE (output_unit, *) "  is there some different connection between i j (e.g. shared memory comm)"
@@ -4269,19 +4310,19 @@ CONTAINS
       IF (ncount .GT. nbufmax) CPABORT("")
       DO itask = 0, nprocs - 1
          DO jtask = itask + 1, nprocs - 1
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
             IF (taskid .EQ. itask) THEN
-               CALL MPI_SEND(buffer1, ncount, MPI_DOUBLE_PRECISION, jtask, itask*jtask, comm, ierror)
+               CALL MPI_SEND(buffer1, ncount, MPI_DOUBLE_PRECISION, jtask, itask*jtask, comm%handle, ierror)
             END IF
             IF (taskid .EQ. jtask) THEN
-               CALL MPI_RECV(buffer1, ncount, MPI_DOUBLE_PRECISION, itask, itask*jtask, comm, MPI_STATUS_IGNORE, ierror)
+               CALL MPI_RECV(buffer1, ncount, MPI_DOUBLE_PRECISION, itask, itask*jtask, comm%handle, MPI_STATUS_IGNORE, ierror)
             END IF
             send_timings(itask, jtask) = MPI_WTIME() - t1 + threshold
          END DO
       END DO
       send_timings2(:, :) = send_timings
-      CALL MPI_REDUCE(send_timings2, send_timings, nprocs**2, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+      CALL MPI_REDUCE(send_timings2, send_timings, nprocs**2, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          DO itask = 0, nprocs - 1
             DO jtask = itask + 1, nprocs - 1
@@ -4289,11 +4330,11 @@ CONTAINS
             END DO
          END DO
       END IF
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ second test point to point communication -------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Testing all nearby point to point communication (0,1)(2,3)..."
          WRITE (output_unit, *) "    these could / should all be on the same shared memory node "
@@ -4303,25 +4344,25 @@ CONTAINS
          t2 = 0.0E0_dp
          IF (ncount .GT. nbufmax) CPABORT("")
          DO j = 1, 3**(npow - i)
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
             IF (MODULO(taskid, 2) == 0) THEN
-               CALL MPI_SEND(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid + 1, 0, comm, ierror)
+               CALL MPI_SEND(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid + 1, 0, comm%handle, ierror)
             ELSE
-               CALL MPI_RECV(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid - 1, 0, comm, MPI_STATUS_IGNORE, ierror)
+               CALL MPI_RECV(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid - 1, 0, comm%handle, MPI_STATUS_IGNORE, ierror)
             END IF
             t2 = t2 + MPI_WTIME() - t1 + threshold
          END DO
-         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, '(I9,A,F12.4,A)') 8*ncount, " Bytes ", (3**(npow - i))*ncount*8.0E-6_dp/t1, " MB/s"
          END IF
       END DO
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ third test point to point communication -------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Testing all far point to point communication (0,nprocs/2),(1,nprocs/2+1),.."
          WRITE (output_unit, *) "    these could all be going over the network, and stress it a lot"
@@ -4331,17 +4372,17 @@ CONTAINS
          t2 = 0.0E0_dp
          IF (ncount .GT. nbufmax) CPABORT("")
          DO j = 1, 3**(npow - i)
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
             ! first half with partner
             IF (taskid .LT. nprocs/2) THEN
-               CALL MPI_SEND(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid + nprocs/2, 0, comm, ierror)
+               CALL MPI_SEND(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid + nprocs/2, 0, comm%handle, ierror)
             ELSE
-               CALL MPI_RECV(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid - nprocs/2, 0, comm, MPI_STATUS_IGNORE, ierror)
+               CALL MPI_RECV(buffer1, ncount, MPI_DOUBLE_PRECISION, taskid - nprocs/2, 0, comm%handle, MPI_STATUS_IGNORE, ierror)
             END IF
             t2 = t2 + MPI_WTIME() - t1 + threshold
          END DO
-         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, '(I9,A,F12.4,A)') 8*ncount, " Bytes ", (3**(npow - i))*ncount*8.0E-6_dp/t1, " MB/s"
          END IF
@@ -4349,7 +4390,7 @@ CONTAINS
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ test root to all broadcast               -------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Testing root to all broadcast "
          WRITE (output_unit, *) "    using trees at least ? "
@@ -4359,12 +4400,12 @@ CONTAINS
          t2 = 0.0E0_dp
          IF (ncount .GT. nbufmax) CPABORT("")
          DO j = 1, 3**(npow - i)
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
-            CALL MPI_BCAST(buffer1, ncount, MPI_DOUBLE_PRECISION, 0, comm, ierror)
+            CALL MPI_BCAST(buffer1, ncount, MPI_DOUBLE_PRECISION, 0, comm%handle, ierror)
             t2 = t2 + MPI_WTIME() - t1 + threshold
          END DO
-         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, '(I9,A,F12.4,A)') 8*ncount, " Bytes ", (3**(npow - i))*ncount*8.0E-6_dp/t1, " MB/s"
          END IF
@@ -4372,19 +4413,19 @@ CONTAINS
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ test mp_sum like behavior                -------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) WRITE (output_unit, *) "Test global summation (mp_sum / mpi_allreduce) "
       DO i = 1, npow
          ncount = 10**i
          t2 = 0.0E0_dp
          IF (ncount .GT. nbufmax) CPABORT("")
          DO j = 1, 3**(npow - i)
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
-            CALL MPI_ALLREDUCE(buffer1, buffer2, ncount, MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
+            CALL MPI_ALLREDUCE(buffer1, buffer2, ncount, MPI_DOUBLE_PRECISION, MPI_SUM, comm%handle, ierr)
             t2 = t2 + MPI_WTIME() - t1 + threshold
          END DO
-         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, '(I9,A,F12.4,A)') 8*ncount, " Bytes ", (3**(npow - i))*ncount*8.0E-6_dp/t1, " MB/s"
          END IF
@@ -4392,7 +4433,7 @@ CONTAINS
       ! -------------------------------------------------------------------------------------------
       ! ------------------------------ test all to all communication            -------------------
       ! -------------------------------------------------------------------------------------------
-      CALL MPI_BARRIER(comm, ierror)
+      CALL MPI_BARRIER(comm%handle, ierror)
       IF (ionode .AND. output_unit > 0) THEN
          WRITE (output_unit, *) "Test all to all communication (mpi_alltoallv)"
          WRITE (output_unit, *) "    mpi/network getting confused ? "
@@ -4408,13 +4449,13 @@ CONTAINS
             rdispl(j) = (j - 1)*(ncount/nprocs)
          END DO
          DO j = 1, 3**(npow - i)
-            CALL MPI_BARRIER(comm, ierror)
+            CALL MPI_BARRIER(comm%handle, ierror)
             t1 = MPI_WTIME()
             CALL mpi_alltoallv(buffer1, scount, sdispl, MPI_DOUBLE_PRECISION, &
-                               buffer2, rcount, rdispl, MPI_DOUBLE_PRECISION, comm, ierr)
+                               buffer2, rcount, rdispl, MPI_DOUBLE_PRECISION, comm%handle, ierr)
             t2 = t2 + MPI_WTIME() - t1 + threshold
          END DO
-         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm, ierror)
+         CALL MPI_REDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, comm%handle, ierror)
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, '(I9,A,F12.4,A)') 8*(ncount/nprocs)*nprocs, " Bytes ", &
                (3**(npow - i))*(ncount/nprocs)*nprocs*8.0E-6_dp/t1, " MB/s"
@@ -4439,9 +4480,9 @@ CONTAINS
             END DO
          END DO
          t1 = MPI_WTIME()
-         CALL MPI_REDUCE_SCATTER(grid, lgrid, rcount, MPI_DOUBLE_PRECISION, MPI_SUM, comm, ierr)
+         CALL MPI_REDUCE_SCATTER(grid, lgrid, rcount, MPI_DOUBLE_PRECISION, MPI_SUM, comm%handle, ierr)
          t2 = MPI_WTIME() - t1 + threshold
-         CALL mpi_allreduce(t2, res, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm, ierr)
+         CALL mpi_allreduce(t2, res, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm%handle, ierr)
          IF (ionode .AND. output_unit > 0) WRITE (output_unit, *) "MPI_REDUCE_SCATTER    ", res
          ! *** simple shift ***
          DO j = 1, Nprocs
@@ -4456,12 +4497,12 @@ CONTAINS
          DO i = 1, Nprocs
             lgrid2(:) = lgrid2 + grid(:, MODULO(taskid - i, Nprocs) + 1)
             IF (i .EQ. nprocs) EXIT
-            CALL MPI_SENDRECV_REPLACE(lgrid2, nloc, MPI_DOUBLE_PRECISION, right, 0, left, 0, comm, MPI_STATUS_IGNORE, ierr)
+            CALL MPI_SENDRECV_REPLACE(lgrid2, nloc, MPI_DOUBLE_PRECISION, right, 0, left, 0, comm%handle, MPI_STATUS_IGNORE, ierr)
          END DO
          t4 = MPI_WTIME() - t3 + threshold
-         CALL mpi_allreduce(t4, res, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm, ierr)
+         CALL mpi_allreduce(t4, res, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm%handle, ierr)
          maxdiff = MAXVAL(ABS(lgrid2 - lgrid))
-         CALL mpi_allreduce(maxdiff, res2, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm, ierr)
+         CALL mpi_allreduce(maxdiff, res2, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm%handle, ierr)
          IF (ionode .AND. output_unit > 0) WRITE (output_unit, *) "MPI_SENDRECV_REPLACE  ", res, res2
          ! *** involved shift ****
          IF (MODULO(nprocs, 2) /= 0) CPABORT("")
@@ -4479,14 +4520,14 @@ CONTAINS
             partner = taskid + 1
             DO i = 1, Nprocs, 2 ! sum the full grid with the partner
                CALL MPI_SENDRECV(grid3(1, i + 1), nloc, MPI_DOUBLE_PRECISION, partner, 17, &
-                                 lgrid3, nloc, MPI_DOUBLE_PRECISION, partner, 19, comm, MPI_STATUS_IGNORE, ierr)
+                                 lgrid3, nloc, MPI_DOUBLE_PRECISION, partner, 19, comm%handle, MPI_STATUS_IGNORE, ierr)
                grid3(:, i) = grid3(:, i) + lgrid3(:)
             END DO
          ELSE
             partner = taskid - 1
             DO i = 1, Nprocs, 2
                CALL MPI_SENDRECV(grid3(1, i), nloc, MPI_DOUBLE_PRECISION, partner, 19, &
-                                 lgrid3, nloc, MPI_DOUBLE_PRECISION, partner, 17, comm, MPI_STATUS_IGNORE, ierr)
+                                 lgrid3, nloc, MPI_DOUBLE_PRECISION, partner, 17, comm%handle, MPI_STATUS_IGNORE, ierr)
                grid3(:, i + 1) = grid3(:, i + 1) + lgrid3(:)
             END DO
          END IF
@@ -4500,13 +4541,13 @@ CONTAINS
          DO i = 1, Nprocs, 2
             lgrid3(:) = lgrid3 + grid3(:, MODULO(taskid - i - 1, Nprocs) + 1)
             IF (i .EQ. nprocs - 1) EXIT
-            CALL MPI_SENDRECV_REPLACE(lgrid3, nloc, MPI_DOUBLE_PRECISION, right, 0, left, 0, comm, MPI_STATUS_IGNORE, ierr)
+            CALL MPI_SENDRECV_REPLACE(lgrid3, nloc, MPI_DOUBLE_PRECISION, right, 0, left, 0, comm%handle, MPI_STATUS_IGNORE, ierr)
          END DO
          t5 = MPI_WTIME() - t3 + threshold
-         CALL mpi_allreduce(t4, res, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm, ierr)
-         CALL mpi_allreduce(t5, res2, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm, ierr)
+         CALL mpi_allreduce(t4, res, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm%handle, ierr)
+         CALL mpi_allreduce(t5, res2, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm%handle, ierr)
          maxdiff = MAXVAL(ABS(lgrid3 - lgrid))
-         CALL mpi_allreduce(maxdiff, res3, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm, ierr)
+         CALL mpi_allreduce(maxdiff, res3, 1, MPI_DOUBLE_PRECISION, MPI_MAX, comm%handle, ierr)
        IF (ionode .AND. output_unit > 0) WRITE (output_unit, *) "INVOLVED SHIFT        ", res + res2, "(", res, ",", res2, ")", res3
       END DO
       DEALLOCATE (rcount)

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -71,7 +71,7 @@ MODULE message_passing
    INTEGER, PARAMETER :: mp_comm_self_handle = MPI_COMM_SELF
    INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
    INTEGER, PARAMETER :: mp_request_null_handle = MPI_REQUEST_NULL
-   INTEGER, PARAMETER, PUBLIC :: mp_win_null = MPI_WIN_NULL
+   INTEGER, PARAMETER :: mp_win_null_handle = MPI_WIN_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = MPI_PROC_NULL
    ! Set max allocatable memory by MPI to 2 GiByte
@@ -95,7 +95,7 @@ MODULE message_passing
    INTEGER, PARAMETER :: mp_comm_self_handle = -11
    INTEGER, PARAMETER :: mp_comm_world_handle = -12
    INTEGER, PARAMETER :: mp_request_null_handle = -4
-   INTEGER, PARAMETER, PUBLIC :: mp_win_null = -5
+   INTEGER, PARAMETER :: mp_win_null_handle = -5
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -7
    INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = 1
@@ -124,6 +124,7 @@ MODULE message_passing
 
    PUBLIC :: mp_comm_type
    PUBLIC :: mp_request_type
+   PUBLIC :: mp_win_type
 
    TYPE mp_comm_type
       PRIVATE
@@ -149,11 +150,24 @@ MODULE message_passing
       GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_request_op_neq
    END TYPE
 
-   ! The actual constants
+   TYPE mp_win_type
+      PRIVATE
+      INTEGER :: handle = mp_win_null_handle
+   CONTAINS
+      PROCEDURE :: set_handle => mp_win_type_set_handle
+      PROCEDURE :: get_handle => mp_win_type_get_handle
+      PROCEDURE, PRIVATE :: mp_win_op_eq
+      PROCEDURE, PRIVATE :: mp_win_op_neq
+      GENERIC, PUBLIC :: OPERATOR(.EQ.) => mp_win_op_eq
+      GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_win_op_neq
+   END TYPE
+
+   ! Create the constants from the corresponding handles
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_world = mp_comm_type(mp_comm_world_handle)
    TYPE(mp_request_type), PARAMETER, PUBLIC :: mp_request_null = mp_request_type(mp_request_null_handle)
+   TYPE(mp_win_type), PARAMETER, PUBLIC :: mp_win_null = mp_win_type(mp_win_null_handle)
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -739,7 +753,7 @@ MODULE message_passing
 CONTAINS
 
    #:mute
-      #:set types = ["comm", "request"]
+      #:set types = ["comm", "request", "win"]
    #:endmute
    #:for type in types
       ELEMENTAL LOGICAL FUNCTION mp_${type}$_op_eq(${type}$1, ${type}$2)
@@ -4146,7 +4160,7 @@ CONTAINS
 !> \param win ...
 ! **************************************************************************************************
    SUBROUTINE mp_win_free(win)
-      INTEGER, INTENT(INOUT)                             :: win
+      TYPE(mp_win_type), INTENT(INOUT)                             :: win
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_win_free'
 
@@ -4157,12 +4171,11 @@ CONTAINS
 
 #if defined(__parallel)
 
-      CALL mpi_win_free(win, ierr)
+      CALL mpi_win_free(win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_free @ "//routineN)
 
       CALL add_perf(perf_id=21, count=1)
 #else
-      MARK_USED(win)
       win = mp_win_null
 #endif
       CALL mp_timestop(handle)
@@ -4173,7 +4186,7 @@ CONTAINS
 !> \param win ...
 ! **************************************************************************************************
    SUBROUTINE mp_win_flush_all(win)
-      INTEGER, INTENT(IN)                                :: win
+      TYPE(mp_win_type), INTENT(IN)                                :: win
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_win_flush_all'
 
@@ -4183,7 +4196,7 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_win_flush_all(win, ierr)
+      CALL mpi_win_flush_all(win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_flush_all @ "//routineN)
 #else
       MARK_USED(win)
@@ -4196,7 +4209,7 @@ CONTAINS
 !> \param win ...
 ! **************************************************************************************************
    SUBROUTINE mp_win_lock_all(win)
-      INTEGER, INTENT(INOUT)                             :: win
+      TYPE(mp_win_type), INTENT(IN)                             :: win
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_win_lock_all'
 
@@ -4207,7 +4220,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-      CALL mpi_win_lock_all(MPI_MODE_NOCHECK, win, ierr)
+      CALL mpi_win_lock_all(MPI_MODE_NOCHECK, win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_lock_all @ "//routineN)
 
       CALL add_perf(perf_id=19, count=1)
@@ -4222,7 +4235,7 @@ CONTAINS
 !> \param win ...
 ! **************************************************************************************************
    SUBROUTINE mp_win_unlock_all(win)
-      INTEGER, INTENT(INOUT)                             :: win
+      TYPE(mp_win_type), INTENT(IN)                             :: win
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_win_unlock_all'
 
@@ -4233,7 +4246,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-      CALL mpi_win_unlock_all(win, ierr)
+      CALL mpi_win_unlock_all(win%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_unlock_all @ "//routineN)
 
       CALL add_perf(perf_id=19, count=1)

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -72,6 +72,7 @@ MODULE message_passing
    INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
    INTEGER, PARAMETER :: mp_request_null_handle = MPI_REQUEST_NULL
    INTEGER, PARAMETER :: mp_win_null_handle = MPI_WIN_NULL
+   INTEGER, PARAMETER :: mp_file_null_handle = MPI_FILE_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = MPI_PROC_NULL
    ! Set max allocatable memory by MPI to 2 GiByte
@@ -96,8 +97,9 @@ MODULE message_passing
    INTEGER, PARAMETER :: mp_comm_world_handle = -12
    INTEGER, PARAMETER :: mp_request_null_handle = -4
    INTEGER, PARAMETER :: mp_win_null_handle = -5
-   INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
-   INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -7
+   INTEGER, PARAMETER :: mp_file_null_handle = -6
+   INTEGER, PARAMETER, PUBLIC :: mp_status_size = -7
+   INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -8
    INTEGER, PARAMETER, PUBLIC :: mp_max_library_version_string = 1
 
    INTEGER, PARAMETER, PUBLIC :: file_offset = int_8
@@ -125,6 +127,7 @@ MODULE message_passing
    PUBLIC :: mp_comm_type
    PUBLIC :: mp_request_type
    PUBLIC :: mp_win_type
+   PUBLIC :: mp_file_type
 
    TYPE mp_comm_type
       PRIVATE
@@ -162,12 +165,25 @@ MODULE message_passing
       GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_win_op_neq
    END TYPE
 
+   TYPE mp_file_type
+      PRIVATE
+      INTEGER :: handle = mp_file_null_handle
+   CONTAINS
+      PROCEDURE :: set_handle => mp_file_type_set_handle
+      PROCEDURE :: get_handle => mp_file_type_get_handle
+      PROCEDURE, PRIVATE :: mp_file_op_eq
+      PROCEDURE, PRIVATE :: mp_file_op_neq
+      GENERIC, PUBLIC :: OPERATOR(.EQ.) => mp_file_op_eq
+      GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_file_op_neq
+   END TYPE
+
    ! Create the constants from the corresponding handles
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_world = mp_comm_type(mp_comm_world_handle)
    TYPE(mp_request_type), PARAMETER, PUBLIC :: mp_request_null = mp_request_type(mp_request_null_handle)
    TYPE(mp_win_type), PARAMETER, PUBLIC :: mp_win_null = mp_win_type(mp_win_null_handle)
+   TYPE(mp_file_type), PARAMETER, PUBLIC :: mp_file_null = mp_file_type(mp_file_null_handle)
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -753,7 +769,7 @@ MODULE message_passing
 CONTAINS
 
    #:mute
-      #:set types = ["comm", "request", "win"]
+      #:set types = ["comm", "request", "win", "file"]
    #:endmute
    #:for type in types
       ELEMENTAL LOGICAL FUNCTION mp_${type}$_op_eq(${type}$1, ${type}$2)
@@ -3195,7 +3211,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_open(groupid, fh, filepath, amode_status, info)
       TYPE(mp_comm_type), INTENT(IN)                      :: groupid
-      INTEGER, INTENT(OUT)                     :: fh
+      TYPE(mp_file_type), INTENT(OUT)                     :: fh
       CHARACTER(len=*), INTENT(IN)             :: filepath
       INTEGER, INTENT(IN)                      :: amode_status
       INTEGER, INTENT(IN), OPTIONAL            :: info
@@ -3205,7 +3221,7 @@ CONTAINS
       INTEGER                                  :: my_info
 #else
       CHARACTER(LEN=10)                        :: fstatus, fposition
-      INTEGER                                  :: amode
+      INTEGER                                  :: amode, handle
       LOGICAL                                  :: exists, is_open
 #endif
 
@@ -3214,8 +3230,8 @@ CONTAINS
 #if defined(__parallel)
       my_info = mpi_info_null
       IF (PRESENT(info)) my_info = info
-      CALL mpi_file_open(groupid%handle, filepath, amode_status, my_info, fh, ierr)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_open(groupid%handle, filepath, amode_status, my_info, fh%handle, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_open")
 #else
       MARK_USED(groupid)
@@ -3235,11 +3251,12 @@ CONTAINS
          fstatus = "OLD"
       END IF
       ! Get a new unit number
-      DO fh = 1, 999
-         INQUIRE (UNIT=fh, EXIST=exists, OPENED=is_open, IOSTAT=istat)
+      DO handle = 1, 999
+         INQUIRE (UNIT=handle, EXIST=exists, OPENED=is_open, IOSTAT=istat)
          IF (exists .AND. (.NOT. is_open) .AND. (istat == 0)) EXIT
       END DO
-      OPEN (UNIT=fh, FILE=filepath, STATUS=fstatus, ACCESS="STREAM", POSITION=fposition)
+      OPEN (UNIT=handle, FILE=filepath, STATUS=fstatus, ACCESS="STREAM", POSITION=fposition)
+      fh%handle = handle
 #endif
    END SUBROUTINE mp_file_open
 
@@ -3286,17 +3303,17 @@ CONTAINS
 !>      11.2012 created [Hossein Bani-Hashemian]
 ! **************************************************************************************************
    SUBROUTINE mp_file_close(fh)
-      INTEGER, INTENT(INOUT)                             :: fh
+      TYPE(mp_file_type), INTENT(INOUT)                             :: fh
 
       INTEGER                                            :: ierr
 
       ierr = 0
 #if defined(__parallel)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL mpi_file_close(fh, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_close(fh%handle, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_close")
 #else
-      CLOSE (fh)
+      CLOSE (fh%handle)
 #endif
    END SUBROUTINE mp_file_close
 
@@ -3311,18 +3328,18 @@ CONTAINS
 !>      12.2012 created [Hossein Bani-Hashemian]
 ! **************************************************************************************************
    SUBROUTINE mp_file_get_size(fh, file_size)
-      INTEGER, INTENT(IN)                                :: fh
+      TYPE(mp_file_type), INTENT(IN)                                :: fh
       INTEGER(kind=file_offset), INTENT(OUT)             :: file_size
 
       INTEGER                                            :: ierr
 
       ierr = 0
 #if defined(__parallel)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL mpi_file_get_size(fh, file_size, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_get_size(fh%handle, file_size, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_get_size")
 #else
-      INQUIRE (UNIT=fh, SIZE=file_size)
+      INQUIRE (UNIT=fh%handle, SIZE=file_size)
 #endif
    END SUBROUTINE mp_file_get_size
 
@@ -3337,18 +3354,18 @@ CONTAINS
 !>      11.2017 created [Nico Holmberg]
 ! **************************************************************************************************
    SUBROUTINE mp_file_get_position(fh, pos)
-      INTEGER, INTENT(IN)                                :: fh
+      TYPE(mp_file_type), INTENT(IN)                                :: fh
       INTEGER(kind=file_offset), INTENT(OUT)             :: pos
 
       INTEGER                                            :: ierr
 
       ierr = 0
 #if defined(__parallel)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL mpi_file_get_position(fh, pos, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL mpi_file_get_position(fh%handle, pos, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ mp_file_get_position")
 #else
-      INQUIRE (UNIT=fh, POS=pos)
+      INQUIRE (UNIT=fh%handle, POS=pos)
 #endif
    END SUBROUTINE mp_file_get_position
 
@@ -3365,7 +3382,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_chv(fh, offset, msg, msglen)
       CHARACTER, INTENT(IN)                      :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3376,12 +3393,12 @@ CONTAINS
 
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
-      CALL MPI_FILE_WRITE_AT(fh, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT(fh%handle, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_chv @ "//routineN)
 #else
       MARK_USED(msglen)
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_chv
 
@@ -3393,7 +3410,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_ch(fh, offset, msg)
       CHARACTER(LEN=*), INTENT(IN)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_write_at_ch'
@@ -3401,11 +3418,11 @@ CONTAINS
 #if defined(__parallel)
       INTEGER                                    :: ierr
 
-      CALL MPI_FILE_WRITE_AT(fh, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT(fh%handle, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_ch @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_ch
 
@@ -3421,7 +3438,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_all_chv(fh, offset, msg, msglen)
       CHARACTER, INTENT(IN)                      :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3432,12 +3449,12 @@ CONTAINS
 
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
-      CALL MPI_FILE_WRITE_AT_ALL(fh, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT_ALL(fh%handle, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_all_chv @ "//routineN)
 #else
       MARK_USED(msglen)
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_all_chv
 
@@ -3449,7 +3466,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_all_ch(fh, offset, msg)
       CHARACTER(LEN=*), INTENT(IN)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_write_at_all_ch'
@@ -3457,11 +3474,11 @@ CONTAINS
 #if defined(__parallel)
       INTEGER                                    :: ierr
 
-      CALL MPI_FILE_WRITE_AT_ALL(fh, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT_ALL(fh%handle, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_all_ch @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_all_ch
 
@@ -3478,7 +3495,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_chv(fh, offset, msg, msglen)
       CHARACTER, INTENT(OUT)                     :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3489,12 +3506,12 @@ CONTAINS
 
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
-      CALL MPI_FILE_READ_AT(fh, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT(fh%handle, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_chv @ "//routineN)
 #else
       MARK_USED(msglen)
-      READ (UNIT=fh, POS=offset + 1) msg
+      READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_read_at_chv
 
@@ -3506,7 +3523,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_ch(fh, offset, msg)
       CHARACTER(LEN=*), INTENT(OUT)              :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_read_at_ch'
@@ -3514,11 +3531,11 @@ CONTAINS
 #if defined(__parallel)
       INTEGER                                    :: ierr
 
-      CALL MPI_FILE_READ_AT(fh, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT(fh%handle, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_ch @ "//routineN)
 #else
-      READ (UNIT=fh, POS=offset + 1) msg
+      READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_read_at_ch
 
@@ -3534,7 +3551,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_all_chv(fh, offset, msg, msglen)
       CHARACTER, INTENT(OUT)                     :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3545,12 +3562,12 @@ CONTAINS
 
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
-      CALL MPI_FILE_READ_AT_ALL(fh, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT_ALL(fh%handle, offset, msg, msg_len, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_all_chv @ "//routineN)
 #else
       MARK_USED(msglen)
-      READ (UNIT=fh, POS=offset + 1) msg
+      READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_read_at_all_chv
 
@@ -3562,7 +3579,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_all_ch(fh, offset, msg)
       CHARACTER(LEN=*), INTENT(OUT)              :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_read_at_all_ch'
@@ -3570,11 +3587,11 @@ CONTAINS
 #if defined(__parallel)
       INTEGER                                    :: ierr
 
-      CALL MPI_FILE_READ_AT_ALL(fh, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT_ALL(fh%handle, offset, msg, LEN(msg), MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_all_ch @ "//routineN)
 #else
-      READ (UNIT=fh, POS=offset + 1) msg
+      READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_read_at_all_ch
 
@@ -3779,7 +3796,7 @@ CONTAINS
 !> \author Nico Holmberg [05.2017]
 ! **************************************************************************************************
    SUBROUTINE mp_file_type_set_view_chv(fh, offset, type_descriptor)
-      INTEGER, INTENT(IN)                      :: fh
+      TYPE(mp_file_type), INTENT(IN)                      :: fh
       INTEGER(kind=file_offset), INTENT(IN)    :: offset
       TYPE(mp_file_descriptor_type)            :: type_descriptor
 
@@ -3791,8 +3808,8 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL MPI_File_set_view(fh, offset, MPI_CHARACTER, &
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL MPI_File_set_view(fh%handle, offset, MPI_CHARACTER, &
                              type_descriptor%type_handle, "native", MPI_INFO_NULL, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ MPI_File_set_view")
 #else
@@ -3818,7 +3835,7 @@ CONTAINS
 !> \author Nico Holmberg [05.2017]
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_all_chv(fh, msglen, ndims, buffer, type_descriptor)
-      INTEGER, INTENT(IN)                       :: fh
+      TYPE(mp_file_type), INTENT(IN)                       :: fh
       INTEGER, INTENT(IN)                       :: msglen
       INTEGER, INTENT(IN)                       :: ndims
       CHARACTER(LEN=msglen), DIMENSION(ndims)   :: buffer
@@ -3835,7 +3852,7 @@ CONTAINS
 
 #if defined(__parallel)
       MARK_USED(type_descriptor)
-      CALL MPI_File_read_all(fh, buffer, ndims*msglen, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_File_read_all(fh%handle, buffer, ndims*msglen, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ MPI_File_read_all")
       CALL add_perf(perf_id=28, count=1, msg_size=ndims*msglen)
 #else
@@ -3849,7 +3866,7 @@ CONTAINS
                        "File view has not been set in mp_file_descriptor_type.")
       ! Use explicit offsets
       DO i = 1, ndims
-         READ (fh, POS=type_descriptor%index_descriptor%chunks(i)) buffer(i)
+         READ (fh%handle, POS=type_descriptor%index_descriptor%chunks(i)) buffer(i)
       END DO
 #endif
 
@@ -3869,7 +3886,7 @@ CONTAINS
 !> \author Nico Holmberg [05.2017]
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_all_chv(fh, msglen, ndims, buffer, type_descriptor)
-      INTEGER, INTENT(IN)                       :: fh
+      TYPE(mp_file_type), INTENT(IN)                       :: fh
       INTEGER, INTENT(IN)                       :: msglen
       INTEGER, INTENT(IN)                       :: ndims
       CHARACTER(LEN=msglen), DIMENSION(ndims)   :: buffer
@@ -3886,8 +3903,8 @@ CONTAINS
 
 #if defined(__parallel)
       MARK_USED(type_descriptor)
-      CALL mpi_file_set_errhandler(fh, MPI_ERRORS_RETURN, ierr)
-      CALL MPI_File_write_all(fh, buffer, ndims*msglen, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
+      CALL mpi_file_set_errhandler(fh%handle, MPI_ERRORS_RETURN, ierr)
+      CALL MPI_File_write_all(fh%handle, buffer, ndims*msglen, MPI_CHARACTER, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) CALL mp_stop(ierr, "mpi_file_set_errhandler @ MPI_File_write_all")
       CALL add_perf(perf_id=28, count=1, msg_size=ndims*msglen)
 #else
@@ -3901,7 +3918,7 @@ CONTAINS
                        "File view has not been set in mp_file_descriptor_type.")
       ! Use explicit offsets
       DO i = 1, ndims
-         WRITE (fh, POS=type_descriptor%index_descriptor%chunks(i)) buffer(i)
+         WRITE (fh%handle, POS=type_descriptor%index_descriptor%chunks(i)) buffer(i)
       END DO
 #endif
 

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -70,7 +70,7 @@ MODULE message_passing
    INTEGER, PARAMETER :: mp_comm_null_handle = MPI_COMM_NULL
    INTEGER, PARAMETER :: mp_comm_self_handle = MPI_COMM_SELF
    INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
-   INTEGER, PARAMETER, PUBLIC :: mp_request_null = MPI_REQUEST_NULL
+   INTEGER, PARAMETER :: mp_request_null_handle = MPI_REQUEST_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = MPI_WIN_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = MPI_PROC_NULL
@@ -94,7 +94,7 @@ MODULE message_passing
    INTEGER, PARAMETER :: mp_comm_null_handle = -3
    INTEGER, PARAMETER :: mp_comm_self_handle = -11
    INTEGER, PARAMETER :: mp_comm_world_handle = -12
-   INTEGER, PARAMETER, PUBLIC :: mp_request_null = -4
+   INTEGER, PARAMETER :: mp_request_null_handle = -4
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = -5
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
    INTEGER, PARAMETER, PUBLIC :: mp_proc_null = -7
@@ -123,6 +123,7 @@ MODULE message_passing
 #endif
 
    PUBLIC :: mp_comm_type
+   PUBLIC :: mp_request_type
 
    TYPE mp_comm_type
       PRIVATE
@@ -130,16 +131,29 @@ MODULE message_passing
    CONTAINS
       PROCEDURE :: set_handle => mp_comm_type_set_handle
       PROCEDURE :: get_handle => mp_comm_type_get_handle
-PROCEDURE, PRIVATE :: mp_comm_op_eq
-PROCEDURE, PRIVATE :: mp_comm_op_neq
-GENERIC, PUBLIC :: operator(.EQ.) => mp_comm_op_eq
-GENERIC, PUBLIC :: operator(.NE.) => mp_comm_op_neq
+      PROCEDURE, PRIVATE :: mp_comm_op_eq
+      PROCEDURE, PRIVATE :: mp_comm_op_neq
+      GENERIC, PUBLIC :: operator(.EQ.) => mp_comm_op_eq
+      GENERIC, PUBLIC :: operator(.NE.) => mp_comm_op_neq
+   END TYPE
+
+   TYPE mp_request_type
+      PRIVATE
+      INTEGER :: handle = mp_request_null_handle
+   CONTAINS
+      PROCEDURE :: set_handle => mp_request_type_set_handle
+      PROCEDURE :: get_handle => mp_request_type_get_handle
+      PROCEDURE, PRIVATE :: mp_request_op_eq
+      PROCEDURE, PRIVATE :: mp_request_op_neq
+      GENERIC, PUBLIC :: OPERATOR(.EQ.) => mp_request_op_eq
+      GENERIC, PUBLIC :: OPERATOR(.NE.) => mp_request_op_neq
    END TYPE
 
    ! The actual constants
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
    TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_world = mp_comm_type(mp_comm_world_handle)
+   TYPE(mp_request_type), PARAMETER, PUBLIC :: mp_request_null = mp_request_type(mp_request_null_handle)
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -724,29 +738,34 @@ GENERIC, PUBLIC :: operator(.NE.) => mp_comm_op_neq
 
 CONTAINS
 
-   ELEMENTAL LOGICAL FUNCTION mp_comm_op_eq(comm1, comm2)
-      CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
-      mp_comm_op_eq = (comm1%handle .EQ. comm2%handle)
-   END FUNCTION mp_comm_op_eq
+   #:mute
+      #:set types = ["comm", "request"]
+   #:endmute
+   #:for type in types
+      ELEMENTAL LOGICAL FUNCTION mp_${type}$_op_eq(${type}$1, ${type}$2)
+         CLASS(mp_${type}$_type), INTENT(IN) :: ${type}$1, ${type}$2
+         mp_${type}$_op_eq = (${type}$1%handle .EQ. ${type}$2%handle)
+      END FUNCTION mp_${type}$_op_eq
 
-   ELEMENTAL LOGICAL FUNCTION mp_comm_op_neq(comm1, comm2)
-      CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
-      mp_comm_op_neq = (comm1%handle .NE. comm2%handle)
-   END FUNCTION mp_comm_op_neq
+      ELEMENTAL LOGICAL FUNCTION mp_${type}$_op_neq(${type}$1, ${type}$2)
+         CLASS(mp_${type}$_type), INTENT(IN) :: ${type}$1, ${type}$2
+         mp_${type}$_op_neq = (${type}$1%handle .NE. ${type}$2%handle)
+      END FUNCTION mp_${type}$_op_neq
 
-   ELEMENTAL SUBROUTINE mp_comm_type_set_handle(this, handle)
-      CLASS(mp_comm_type), INTENT(INOUT) :: this
-      INTEGER, INTENT(IN) :: handle
+      ELEMENTAL SUBROUTINE mp_${type}$_type_set_handle(this, handle)
+         CLASS(mp_${type}$_type), INTENT(INOUT) :: this
+         INTEGER, INTENT(IN) :: handle
 
-      this%handle = handle
-   END SUBROUTINE mp_comm_type_set_handle
+         this%handle = handle
+      END SUBROUTINE mp_${type}$_type_set_handle
 
-   ELEMENTAL FUNCTION mp_comm_type_get_handle(this) RESULT(handle)
-      CLASS(mp_comm_type), INTENT(IN) :: this
-      INTEGER :: handle
+      ELEMENTAL FUNCTION mp_${type}$_type_get_handle(this) RESULT(handle)
+         CLASS(mp_${type}$_type), INTENT(IN) :: this
+         INTEGER :: handle
 
-      handle = this%handle
-   END FUNCTION mp_comm_type_get_handle
+         handle = this%handle
+      END FUNCTION mp_${type}$_type_get_handle
+   #:endfor
 
 ! **************************************************************************************************
 !> \brief initializes the system default communicator
@@ -1169,7 +1188,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE mp_isync(group, request)
       TYPE(mp_comm_type), INTENT(IN)                                :: group
-      INTEGER, INTENT(OUT)                               :: request
+      TYPE(mp_request_type), INTENT(OUT)                               :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isync'
 
@@ -1179,7 +1198,7 @@ CONTAINS
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_ibarrier(group%handle, request, ierr)
+      CALL mpi_ibarrier(group%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibarrier @ mp_isync")
       CALL add_perf(perf_id=26, count=1)
 #else
@@ -1657,7 +1676,7 @@ CONTAINS
 !>      see isendrecv
 ! **************************************************************************************************
    SUBROUTINE mp_wait(request)
-      INTEGER, INTENT(inout)                             :: request
+      TYPE(mp_request_type), INTENT(inout)                             :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_wait'
 
@@ -1668,12 +1687,12 @@ CONTAINS
 
 #if defined(__parallel)
 
-      CALL mpi_wait(request, MPI_STATUS_IGNORE, ierr)
+      CALL mpi_wait(request%handle, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_wait @ mp_wait")
 
       CALL add_perf(perf_id=9, count=1)
 #else
-      MARK_USED(request)
+      request = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_wait
@@ -1688,7 +1707,7 @@ CONTAINS
 !>      see isendrecv
 ! **************************************************************************************************
    SUBROUTINE mp_waitall_1(requests)
-      INTEGER, DIMENSION(:), INTENT(inout)     :: requests
+      TYPE(mp_request_type), DIMENSION(:), INTENT(inout)     :: requests
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_waitall_1'
 
@@ -1709,7 +1728,7 @@ CONTAINS
       DEALLOCATE (status)
       CALL add_perf(perf_id=9, count=1)
 #else
-      MARK_USED(requests)
+      requests = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_waitall_1
@@ -1722,7 +1741,7 @@ CONTAINS
 !> \author joost & fawzi
 ! **************************************************************************************************
    SUBROUTINE mp_waitall_2(requests)
-      INTEGER, DIMENSION(:, :), INTENT(inout)  :: requests
+      TYPE(mp_request_type), DIMENSION(:, :), INTENT(inout)  :: requests
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_waitall_2'
 
@@ -1745,7 +1764,7 @@ CONTAINS
 
       CALL add_perf(perf_id=9, count=1)
 #else
-      MARK_USED(requests)
+      requests = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_waitall_2
@@ -1762,12 +1781,24 @@ CONTAINS
 #if defined(__parallel)
    SUBROUTINE mpi_waitall_internal(count, array_of_requests, array_of_statuses, ierr)
       INTEGER, INTENT(in)                                :: count
-      INTEGER, DIMENSION(count), INTENT(inout)           :: array_of_requests
+      TYPE(mp_request_type), DIMENSION(count), INTENT(inout)           :: array_of_requests
       INTEGER, DIMENSION(MPI_STATUS_SIZE, *), &
          INTENT(out)                                     :: array_of_statuses
       INTEGER, INTENT(out)                               :: ierr
 
-      CALL mpi_waitall(count, array_of_requests, array_of_statuses, ierr)
+      INTEGER :: i
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: request_handles
+
+      ALLOCATE (request_handles(count))
+      DO i = 1, count
+         request_handles(i) = array_of_requests(i)%handle
+      END DO
+
+      CALL mpi_waitall(count, request_handles, array_of_statuses, ierr)
+
+      DO i = 1, count
+         array_of_requests(i)%handle = request_handles(i)
+      END DO
 
    END SUBROUTINE mpi_waitall_internal
 #endif
@@ -1781,14 +1812,15 @@ CONTAINS
 !> \author Iain Bethune (c) The Numerical Algorithms Group (NAG) Ltd, 2008 on behalf of the HECToR project
 ! **************************************************************************************************
    SUBROUTINE mp_waitany(requests, completed)
-      INTEGER, DIMENSION(:), INTENT(inout)     :: requests
+      TYPE(mp_request_type), DIMENSION(:), INTENT(inout)     :: requests
       INTEGER, INTENT(out)                     :: completed
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_waitany'
 
       INTEGER                                  :: handle, ierr
 #if defined(__parallel)
-      INTEGER                                  :: count
+      INTEGER                                  :: count, i
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: request_handles
 #endif
 
       ierr = 0
@@ -1796,13 +1828,21 @@ CONTAINS
 
 #if defined(__parallel)
       count = SIZE(requests)
-
-      CALL mpi_waitany(count, requests, completed, MPI_STATUS_IGNORE, ierr)
+! Convert CP2K's request_handles to the plane handle for the library
+! (Maybe, the compiler optimizes it away)
+      ALLOCATE (request_handles(count))
+      DO i = 1, count
+         request_handles(i) = requests(i)%handle
+      END DO
+      CALL mpi_waitany(count, request_handles, completed, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_waitany @ mp_waitany")
-
+! Convert the plane handles to CP2K handles
+      DO i = 1, count
+         requests(i)%handle = request_handles(i)
+      END DO
       CALL add_perf(perf_id=9, count=1)
 #else
-      MARK_USED(requests)
+      requests = mp_request_null
       completed = 1
 #endif
       CALL mp_timestop(handle)
@@ -1818,7 +1858,7 @@ CONTAINS
 !> \author Alfio Lazzaro
 ! **************************************************************************************************
    FUNCTION mp_testall_tv(requests) RESULT(flag)
-      INTEGER, DIMENSION(:)                 :: requests
+      TYPE(mp_request_type), DIMENSION(:), INTENT(INOUT) :: requests
       LOGICAL                               :: flag
 
       INTEGER                               :: ierr
@@ -1834,7 +1874,7 @@ CONTAINS
 #if defined(__parallel)
       ALLOCATE (flags(SIZE(requests)))
       DO i = 1, SIZE(requests)
-         CALL mpi_test(requests(i), flags(i), MPI_STATUS_IGNORE, ierr)
+         CALL mpi_test(requests(i)%handle, flags(i), MPI_STATUS_IGNORE, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_testall @ mp_testall_tv")
          flag = flag .AND. flags(i)
       END DO
@@ -1853,7 +1893,7 @@ CONTAINS
 !> \author Nico Holmberg
 ! **************************************************************************************************
    SUBROUTINE mp_test_1(request, flag)
-      INTEGER, INTENT(inout)                             :: request
+      TYPE(mp_request_type), INTENT(inout)                             :: request
       LOGICAL, INTENT(out)                               :: flag
 
       INTEGER                                            :: ierr
@@ -1861,7 +1901,7 @@ CONTAINS
       ierr = 0
 
 #if defined(__parallel)
-      CALL mpi_test(request, flag, MPI_STATUS_IGNORE, ierr)
+      CALL mpi_test(request%handle, flag, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_test @ mp_test_1")
 #else
       MARK_USED(request)
@@ -1879,7 +1919,7 @@ CONTAINS
 !> \author Iain Bethune
 ! **************************************************************************************************
    SUBROUTINE mp_testany_1(requests, completed, flag)
-      INTEGER, DIMENSION(:), INTENT(inout)  :: requests
+      TYPE(mp_request_type), DIMENSION(:), INTENT(inout)  :: requests
       INTEGER, INTENT(out), OPTIONAL           :: completed
       LOGICAL, INTENT(out), OPTIONAL           :: flag
 
@@ -1916,7 +1956,7 @@ CONTAINS
 !> \author Iain Bethune
 ! **************************************************************************************************
    SUBROUTINE mp_testany_2(requests, completed, flag)
-      INTEGER, DIMENSION(:, :), INTENT(inout)   :: requests
+      TYPE(mp_request_type), DIMENSION(:, :), INTENT(inout)   :: requests
       INTEGER, INTENT(out), OPTIONAL           :: completed
       LOGICAL, INTENT(out), OPTIONAL           :: flag
 
@@ -1957,13 +1997,25 @@ CONTAINS
 #if defined(__parallel)
    SUBROUTINE mpi_testany_internal(count, array_of_requests, index, flag, status, ierr)
       INTEGER, INTENT(in)                                :: count
-      INTEGER, DIMENSION(count), INTENT(inout)           :: array_of_requests
+      TYPE(mp_request_type), DIMENSION(count), INTENT(inout)           :: array_of_requests
       INTEGER, INTENT(out)                               :: index
       LOGICAL, INTENT(out)                               :: flag
       INTEGER, DIMENSION(MPI_STATUS_SIZE), INTENT(out)   :: status
       INTEGER, INTENT(out)                               :: ierr
 
-      CALL mpi_testany(count, array_of_requests, index, flag, status, ierr)
+      INTEGER :: i
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: request_handles
+
+      ALLOCATE (request_handles(count))
+      DO i = 1, count
+         request_handles(i) = array_of_requests(i)%handle
+      END DO
+
+      CALL mpi_testany(count, request_handles, index, flag, status, ierr)
+
+      DO i = 1, count
+         array_of_requests(i)%handle = request_handles(i)
+      END DO
 
    END SUBROUTINE mpi_testany_internal
 #endif
@@ -2307,7 +2359,7 @@ CONTAINS
       LOGICAL, DIMENSION(:)                    :: msgin
       INTEGER, INTENT(IN)                      :: dest
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_bv'
@@ -2328,10 +2380,10 @@ CONTAINS
       msglen = SIZE(msgin, 1)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, MPI_LOGICAL, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -2341,9 +2393,8 @@ CONTAINS
       MARK_USED(msgin)
       MARK_USED(dest)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_isend_bv
@@ -2366,7 +2417,7 @@ CONTAINS
       LOGICAL, DIMENSION(:)                    :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_bv'
@@ -2387,10 +2438,10 @@ CONTAINS
       msglen = SIZE(msgout, 1)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, MPI_LOGICAL, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, MPI_LOGICAL, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -2400,9 +2451,8 @@ CONTAINS
       MARK_USED(msgout)
       MARK_USED(source)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_irecv_bv
@@ -3063,7 +3113,7 @@ CONTAINS
    SUBROUTINE mp_isum_bv(msg, gid, request)
       LOGICAL, DIMENSION(:), INTENT(INOUT)               :: msg
       TYPE(mp_comm_type), INTENT(IN)                                :: gid
-      INTEGER, INTENT(INOUT)                             :: request
+      TYPE(mp_request_type), INTENT(INOUT)                             :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isum_bv'
 
@@ -3074,7 +3124,7 @@ CONTAINS
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen .GT. 0) THEN
-         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, request, ierr)
+         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, MPI_LOGICAL, MPI_LOR, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       ELSE
          request = mp_request_null
@@ -3082,7 +3132,7 @@ CONTAINS
 #else
       MARK_USED(msg)
       MARK_USED(gid)
-      MARK_USED(request)
+      request = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_isum_bv
@@ -4025,7 +4075,7 @@ CONTAINS
       TYPE(mp_type_descriptor_type), INTENT(IN)          :: msgin
       INTEGER, INTENT(IN)                                :: dest
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                               :: request
+      TYPE(mp_request_type), INTENT(out)                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_custom'
@@ -4039,16 +4089,15 @@ CONTAINS
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_isend(MPI_BOTTOM, 1, msgin%type_handle, dest, my_tag, &
-                     comm%handle, request, ierr)
+                     comm%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 #else
       MARK_USED(msgin)
       MARK_USED(dest)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
    END SUBROUTINE mp_isend_custom
@@ -4065,7 +4114,7 @@ CONTAINS
       TYPE(mp_type_descriptor_type), INTENT(INOUT)       :: msgout
       INTEGER, INTENT(IN)                                :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                               :: request
+      TYPE(mp_request_type), INTENT(out)                               :: request
       INTEGER, INTENT(in), OPTIONAL                      :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_custom'
@@ -4079,16 +4128,15 @@ CONTAINS
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_irecv(MPI_BOTTOM, 1, msgout%type_handle, source, my_tag, &
-                     comm%handle, request, ierr)
+                     comm%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 #else
       MARK_USED(msgout)
       MARK_USED(source)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       CPABORT("mp_irecv called in non parallel case")
 #endif
    END SUBROUTINE mp_irecv_custom

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -67,9 +67,9 @@ MODULE message_passing
    LOGICAL, PARAMETER :: cp2k_is_parallel = .TRUE.
    INTEGER, PARAMETER, PUBLIC :: mp_any_tag = MPI_ANY_TAG
    INTEGER, PARAMETER, PUBLIC :: mp_any_source = MPI_ANY_SOURCE
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_null = MPI_COMM_NULL
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_self = MPI_COMM_SELF
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_world = MPI_COMM_WORLD
+   INTEGER, PARAMETER :: mp_comm_null_handle = MPI_COMM_NULL
+   INTEGER, PARAMETER :: mp_comm_self_handle = MPI_COMM_SELF
+   INTEGER, PARAMETER :: mp_comm_world_handle = MPI_COMM_WORLD
    INTEGER, PARAMETER, PUBLIC :: mp_request_null = MPI_REQUEST_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = MPI_WIN_NULL
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = MPI_STATUS_SIZE
@@ -91,9 +91,9 @@ MODULE message_passing
    LOGICAL, PARAMETER :: cp2k_is_parallel = .FALSE.
    INTEGER, PARAMETER, PUBLIC :: mp_any_tag = -1
    INTEGER, PARAMETER, PUBLIC :: mp_any_source = -2
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_null = -3
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_self = -11
-   INTEGER, PARAMETER, PUBLIC :: mp_comm_world = -12
+   INTEGER, PARAMETER :: mp_comm_null_handle = -3
+   INTEGER, PARAMETER :: mp_comm_self_handle = -11
+   INTEGER, PARAMETER :: mp_comm_world_handle = -12
    INTEGER, PARAMETER, PUBLIC :: mp_request_null = -4
    INTEGER, PARAMETER, PUBLIC :: mp_win_null = -5
    INTEGER, PARAMETER, PUBLIC :: mp_status_size = -6
@@ -108,7 +108,6 @@ MODULE message_passing
    INTEGER, PARAMETER, PUBLIC :: file_amode_rdwr = 8
    INTEGER, PARAMETER, PUBLIC :: file_amode_excl = 64
    INTEGER, PARAMETER, PUBLIC :: file_amode_append = 128
-
 #endif
 
    ! we need to fix this to a given number (crossing fingers)
@@ -122,6 +121,21 @@ MODULE message_passing
    ! internal reference counter used to debug communicator leaks
    INTEGER, PRIVATE, SAVE :: debug_comm_count
 #endif
+
+   PUBLIC :: mp_comm_type
+
+   TYPE mp_comm_type
+      PRIVATE
+      INTEGER :: handle = mp_comm_null_handle
+   CONTAINS
+      PROCEDURE :: set_handle => mp_comm_type_set_handle
+      PROCEDURE :: get_handle => mp_comm_type_get_handle
+   END TYPE
+
+   ! The actual constants
+   TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_null = mp_comm_type(mp_comm_null_handle)
+   TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_self = mp_comm_type(mp_comm_self_handle)
+   TYPE(mp_comm_type), PARAMETER, PUBLIC :: mp_comm_world = mp_comm_type(mp_comm_world_handle)
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize
@@ -190,16 +204,6 @@ MODULE message_passing
    PUBLIC :: mp_file_write_all_chv
 
    PUBLIC :: mp_get_library_version
-
-   PUBLIC :: mp_comm_type
-
-   TYPE mp_comm_type
-      PRIVATE
-      INTEGER :: handle = mp_comm_null
-   CONTAINS
-      PROCEDURE :: set_handle => mp_comm_type_set_handle
-      PROCEDURE :: get_handle => mp_comm_type_get_handle
-   END TYPE
 
    ! assumed to be private
 
@@ -775,11 +779,9 @@ CONTAINS
 !$    END IF
       CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
-      mp_comm%handle = MPI_COMM_WORLD
       debug_comm_count = 1
-#else
-      mp_comm%handle = 0
 #endif
+      mp_comm = mp_comm_world
       CALL add_mp_perf_env()
    END SUBROUTINE mp_world_init
 
@@ -1340,7 +1342,7 @@ CONTAINS
 #else
       pos(1:ndims) = 0
       dims = 1
-      comm_cart%handle = 0
+      comm_cart = mp_comm_self
 #endif
       CALL mp_timestop(handle)
 
@@ -1450,6 +1452,7 @@ CONTAINS
 #else
       MARK_USED(comm)
       MARK_USED(rdim)
+      sub_comm = mp_comm_self
 #endif
       CALL mp_timestop(handle)
 
@@ -1476,7 +1479,7 @@ CONTAINS
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_free @ mp_comm_free")
       debug_comm_count = debug_comm_count - 1
 #else
-      comm%handle = mp_comm_null
+      comm = mp_comm_null
 #endif
       CALL mp_timestop(handle)
 

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -130,6 +130,10 @@ MODULE message_passing
    CONTAINS
       PROCEDURE :: set_handle => mp_comm_type_set_handle
       PROCEDURE :: get_handle => mp_comm_type_get_handle
+PROCEDURE, PRIVATE :: mp_comm_op_eq
+PROCEDURE, PRIVATE :: mp_comm_op_neq
+GENERIC, PUBLIC :: operator(.EQ.) => mp_comm_op_eq
+GENERIC, PUBLIC :: operator(.NE.) => mp_comm_op_neq
    END TYPE
 
    ! The actual constants
@@ -719,6 +723,16 @@ MODULE message_passing
    LOGICAL, PUBLIC, SAVE :: mp_collect_timings = .FALSE.
 
 CONTAINS
+
+   ELEMENTAL LOGICAL FUNCTION mp_comm_op_eq(comm1, comm2)
+      CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
+      mp_comm_op_eq = (comm1%handle .EQ. comm2%handle)
+   END FUNCTION mp_comm_op_eq
+
+   ELEMENTAL LOGICAL FUNCTION mp_comm_op_neq(comm1, comm2)
+      CLASS(mp_comm_type), INTENT(IN) :: comm1, comm2
+      mp_comm_op_neq = (comm1%handle .NE. comm2%handle)
+   END FUNCTION mp_comm_op_neq
 
    ELEMENTAL SUBROUTINE mp_comm_type_set_handle(this, handle)
       CLASS(mp_comm_type), INTENT(INOUT) :: this

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -957,7 +957,7 @@
       ${type1}$                                  :: msg
       INTEGER                                  :: source
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_ibcast_${nametype1}$'
 
@@ -968,7 +968,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
+      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
       CALL add_perf(perf_id=22, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1022,7 +1022,7 @@
       ${type1}$                                  :: msg(:)
       INTEGER                                  :: source
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_ibcast_${nametype1}$v'
 
@@ -1033,7 +1033,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
+      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
       CALL add_perf(perf_id=22, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1179,7 +1179,7 @@
    SUBROUTINE mp_isum_${nametype1}$v(msg, gid, request)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isum_${nametype1}$v'
 
@@ -1194,7 +1194,7 @@
 #if defined(__parallel)
       msglen = SIZE(msg)
       IF (msglen > 0) THEN
-         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, request, ierr)
+         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, request%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallreduce @ "//routineN)
       ELSE
          request = mp_request_null
@@ -1649,7 +1649,7 @@
       ${type1}$, INTENT(INOUT)                   :: msg
       INTEGER, INTENT(IN)                      :: root
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iscatter_${nametype1}$'
 
@@ -1661,7 +1661,7 @@
       msglen = 1
 #if defined(__parallel)
       CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                        msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
+                        msglen, ${mpi_type1}$, root, gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
 #else
@@ -1686,7 +1686,7 @@
       ${type1}$, INTENT(INOUT)                   :: msg(:)
       INTEGER, INTENT(IN)                      :: root
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iscatter_${nametype1}$v2'
 
@@ -1698,7 +1698,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                        msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
+                        msglen, ${mpi_type1}$, root, gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
 #else
@@ -1724,7 +1724,7 @@
       ${type1}$, INTENT(INOUT)                   :: msg(:)
       INTEGER, INTENT(IN)                      :: recvcount, root
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iscatterv_${nametype1}$v'
 
@@ -1735,7 +1735,7 @@
 
 #if defined(__parallel)
       CALL mpi_iscatterv(msg_scatter, sendcounts, displs, ${mpi_type1}$, msg, &
-                         recvcount, ${mpi_type1}$, root, gid%handle, request, ierr)
+                         recvcount, ${mpi_type1}$, root, gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatterv @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
 #else
@@ -1936,7 +1936,7 @@
       INTEGER, DIMENSION(:), INTENT(IN)        :: recvcounts, displs
       INTEGER, INTENT(IN)                      :: sendcount, root
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_igatherv_${nametype1}$v'
 
@@ -1948,7 +1948,7 @@
 #if defined(__parallel)
       CALL mpi_igatherv(sendbuf, sendcount, ${mpi_type1}$, &
                         recvbuf, recvcounts, displs, ${mpi_type1}$, &
-                        root, comm%handle, request, ierr)
+                        root, comm%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gatherv @ "//routineN)
       CALL add_perf(perf_id=24, &
                     count=1, &
@@ -2059,7 +2059,7 @@
       ${type1}$, INTENT(IN)                      :: msgout
       ${type1}$, INTENT(OUT)                     :: msgin(:)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$'
 
@@ -2076,7 +2076,7 @@
       rcount = 1
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid%handle, request, ierr)
+                          gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2252,7 +2252,7 @@
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(OUT)                     :: request
+      TYPE(mp_request_type), INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$11'
 
@@ -2269,7 +2269,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid%handle, request, ierr)
+                          gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2292,7 +2292,7 @@
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(OUT)                     :: request
+      TYPE(mp_request_type), INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$13'
 
@@ -2309,7 +2309,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid%handle, request, ierr)
+                          gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2332,7 +2332,7 @@
       ${type1}$, INTENT(IN)                      :: msgout(:, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(OUT)                     :: request
+      TYPE(mp_request_type), INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$22'
 
@@ -2349,7 +2349,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid%handle, request, ierr)
+                          gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2372,7 +2372,7 @@
       ${type1}$, INTENT(IN)                      :: msgout(:, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :, :)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(OUT)                     :: request
+      TYPE(mp_request_type), INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$24'
 
@@ -2389,7 +2389,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid%handle, request, ierr)
+                          gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2412,7 +2412,7 @@
       ${type1}$, INTENT(IN)                      :: msgout(:, :, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(OUT)                     :: request
+      TYPE(mp_request_type), INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$33'
 
@@ -2429,7 +2429,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid%handle, request, ierr)
+                          gid%handle, request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2508,7 +2508,7 @@
       ${type1}$, INTENT(OUT)                     :: msgin(:)
       INTEGER, INTENT(IN)                      :: rcount(:), rdispl(:)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgatherv_${nametype1}$v'
 
@@ -2558,7 +2558,7 @@
       ${type1}$, INTENT(OUT)                     :: msgin(:)
       INTEGER, INTENT(IN)                      :: rcount(:, :), rdispl(:, :)
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request
+      TYPE(mp_request_type), INTENT(OUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgatherv_${nametype1}$v2'
 
@@ -2602,10 +2602,11 @@
       INTEGER, INTENT(IN)                      :: rsize
       INTEGER, INTENT(IN)                      :: rcount(rsize), rdispl(rsize), scount
       TYPE(mp_comm_type), INTENT(IN) :: gid
-      INTEGER, INTENT(INOUT)                   :: request, ierr
+      TYPE(mp_request_type), INTENT(OUT) :: request
+      INTEGER, INTENT(INOUT)                   :: ierr
 
       CALL MPI_IALLGATHERV(msgout, scount, ${mpi_type1}$, msgin, rcount, &
-                           rdispl, ${mpi_type1}$, gid%handle, request, ierr)
+                           rdispl, ${mpi_type1}$, gid%handle, request%handle, ierr)
 
    END SUBROUTINE mp_iallgatherv_${nametype1}$v_internal
 #endif
@@ -2877,7 +2878,7 @@
       ${type1}$                                  :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: send_request, recv_request
+      TYPE(mp_request_type), INTENT(out)                     :: send_request, recv_request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isendrecv_${nametype1}$'
@@ -2895,11 +2896,11 @@
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_irecv(msgout, 1, ${mpi_type1}$, source, my_tag, &
-                     comm%handle, recv_request, ierr)
+                     comm%handle, recv_request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
       CALL mpi_isend(msgin, 1, ${mpi_type1}$, dest, my_tag, &
-                     comm%handle, send_request, ierr)
+                     comm%handle, send_request%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
       CALL add_perf(perf_id=8, count=1, msg_size=2*${bytes1}$)
@@ -2908,8 +2909,8 @@
       MARK_USED(source)
       MARK_USED(comm)
       MARK_USED(tag)
-      send_request = 0
-      recv_request = 0
+      send_request = mp_request_null
+      recv_request = mp_request_null
       msgout = msgin
 #endif
       CALL mp_timestop(handle)
@@ -2939,7 +2940,7 @@
       ${type1}$, DIMENSION(:)                    :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: send_request, recv_request
+      TYPE(mp_request_type), INTENT(out)                     :: send_request, recv_request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isendrecv_${nametype1}$v'
@@ -2960,20 +2961,20 @@
       msglen = SIZE(msgout, 1)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, recv_request, ierr)
+                        comm%handle, recv_request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, recv_request, ierr)
+                        comm%handle, recv_request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
       msglen = SIZE(msgin, 1)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, send_request, ierr)
+                        comm%handle, send_request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, send_request, ierr)
+                        comm%handle, send_request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -2984,8 +2985,8 @@
       MARK_USED(source)
       MARK_USED(comm)
       MARK_USED(tag)
-      send_request = 0
-      recv_request = 0
+      send_request = mp_request_null
+      recv_request = mp_request_null
       msgout = msgin
 #endif
       CALL mp_timestop(handle)
@@ -3008,7 +3009,7 @@
       ${type1}$, DIMENSION(:)                    :: msgin
       INTEGER, INTENT(IN)                      :: dest
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$v'
@@ -3029,10 +3030,10 @@
       msglen = SIZE(msgin)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3044,7 +3045,7 @@
       MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
       CALL mp_timestop(handle)
@@ -3069,7 +3070,7 @@
       ${type1}$, DIMENSION(:, :)                 :: msgin
       INTEGER, INTENT(IN)                      :: dest
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$m2'
@@ -3090,10 +3091,10 @@
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3105,7 +3106,7 @@
       MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
       CALL mp_timestop(handle)
@@ -3132,7 +3133,7 @@
       ${type1}$, DIMENSION(:, :, :)              :: msgin
       INTEGER, INTENT(IN)                      :: dest
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$m3'
@@ -3153,10 +3154,10 @@
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)*SIZE(msgin, 3)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3168,7 +3169,7 @@
       MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
       CALL mp_timestop(handle)
@@ -3192,7 +3193,7 @@
       ${type1}$, DIMENSION(:, :, :, :)           :: msgin
       INTEGER, INTENT(IN)                      :: dest
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isend_${nametype1}$m4'
@@ -3213,10 +3214,10 @@
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)*SIZE(msgin, 3)*SIZE(msgin, 4)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1, 1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3228,7 +3229,7 @@
       MARK_USED(request)
       MARK_USED(tag)
       ierr = 1
-      request = 0
+      request = mp_request_null
       CALL mp_stop(ierr, "mp_isend called in non parallel case")
 #endif
       CALL mp_timestop(handle)
@@ -3252,7 +3253,7 @@
       ${type1}$, DIMENSION(:)                    :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$v'
@@ -3273,10 +3274,10 @@
       msglen = SIZE(msgout)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -3286,9 +3287,8 @@
       MARK_USED(msgout)
       MARK_USED(source)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_irecv_${nametype1}$v
@@ -3312,7 +3312,7 @@
       ${type1}$, DIMENSION(:, :)                 :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$m2'
@@ -3333,10 +3333,10 @@
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -3345,9 +3345,8 @@
       MARK_USED(msgout)
       MARK_USED(source)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
       CPABORT("mp_irecv called in non parallel case")
 #endif
       CALL mp_timestop(handle)
@@ -3373,7 +3372,7 @@
       ${type1}$, DIMENSION(:, :, :)              :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$m3'
@@ -3394,10 +3393,10 @@
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)*SIZE(msgout, 3)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -3406,9 +3405,8 @@
       MARK_USED(msgout)
       MARK_USED(source)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
       CPABORT("mp_irecv called in non parallel case")
 #endif
       CALL mp_timestop(handle)
@@ -3432,7 +3430,7 @@
       ${type1}$, DIMENSION(:, :, :, :)           :: msgout
       INTEGER, INTENT(IN)                      :: source
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(out)                     :: request
+      TYPE(mp_request_type), INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_irecv_${nametype1}$m4'
@@ -3453,10 +3451,10 @@
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)*SIZE(msgout, 3)*SIZE(msgout, 4)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1, 1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm%handle, request, ierr)
+                        comm%handle, request%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -3465,9 +3463,8 @@
       MARK_USED(msgout)
       MARK_USED(source)
       MARK_USED(comm)
-      MARK_USED(request)
       MARK_USED(tag)
-      request = 0
+      request = mp_request_null
       CPABORT("mp_irecv called in non parallel case")
 #endif
       CALL mp_timestop(handle)
@@ -3534,7 +3531,7 @@
       INTEGER, INTENT(IN)                                 :: source, win
       ${type1}$, DIMENSION(:)                               :: win_data
       INTEGER, INTENT(IN), OPTIONAL                       :: myproc, disp
-      INTEGER, INTENT(OUT)                                :: request
+      TYPE(mp_request_type), INTENT(OUT)                                :: request
       TYPE(mp_type_descriptor_type), INTENT(IN), OPTIONAL :: origin_datatype, target_datatype
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_rget_${nametype1}$v'
@@ -3583,7 +3580,7 @@
             ierr = 0
          ELSE
             CALL mpi_rget(base(1), origin_len, handle_origin_datatype, source, disp_aint, &
-                          target_len, handle_target_datatype, win, request, ierr)
+                          target_len, handle_target_datatype, win, request%handle, ierr)
          END IF
       ELSE
          request = mp_request_null

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -3483,7 +3483,7 @@
    SUBROUTINE mp_win_create_${nametype1}$v(base, comm, win)
       ${type1}$, DIMENSION(:)          :: base
       TYPE(mp_comm_type), INTENT(IN) :: comm
-      INTEGER, INTENT(INOUT)         :: win
+      TYPE(mp_win_type), INTENT(INOUT)         :: win
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_win_create_${nametype1}$v'
 
@@ -3500,9 +3500,9 @@
 
       len = SIZE(base)*${bytes1}$
       IF (len > 0) THEN
-         CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
+         CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win%handle, ierr)
       ELSE
-         CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
+         CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win%handle, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_create @ "//routineN)
 

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -31,7 +31,7 @@
    SUBROUTINE mp_shift_${nametype1}$m(msg, group, displ_in)
 
       ${type1}$, INTENT(INOUT)                   :: msg(:, :)
-      INTEGER, INTENT(IN)                      :: group
+      TYPE(mp_comm_type), INTENT(IN)                      :: group
       INTEGER, INTENT(IN), OPTIONAL            :: displ_in
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_shift_${nametype1}$m'
@@ -47,9 +47,9 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_comm_rank(group, myrank, ierror)
+      CALL mpi_comm_rank(group%handle, myrank, ierror)
       IF (ierror /= 0) CALL mp_stop(ierror, "mpi_comm_rank @ "//routineN)
-      CALL mpi_comm_size(group, nprocs, ierror)
+      CALL mpi_comm_size(group%handle, nprocs, ierror)
       IF (ierror /= 0) CALL mp_stop(ierror, "mpi_comm_size @ "//routineN)
       IF (PRESENT(displ_in)) THEN
          displ = displ_in
@@ -61,7 +61,7 @@
       tag = 17
       msglen = SIZE(msg)
       CALL mpi_sendrecv_replace(msg, msglen, ${mpi_type1}$, right, tag, left, tag, &
-                                group, MPI_STATUS_IGNORE, ierror)
+                                group%handle, MPI_STATUS_IGNORE, ierror)
       IF (ierror /= 0) CALL mp_stop(ierror, "mpi_sendrecv_replace @ "//routineN)
       CALL add_perf(perf_id=7, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -87,7 +87,7 @@
    SUBROUTINE mp_shift_${nametype1}$ (msg, group, displ_in)
 
       ${type1}$, INTENT(INOUT)                   :: msg(:)
-      INTEGER, INTENT(IN)                      :: group
+      TYPE(mp_comm_type), INTENT(IN)                      :: group
       INTEGER, INTENT(IN), OPTIONAL            :: displ_in
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_shift_${nametype1}$'
@@ -103,9 +103,9 @@
       CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-      CALL mpi_comm_rank(group, myrank, ierror)
+      CALL mpi_comm_rank(group%handle, myrank, ierror)
       IF (ierror /= 0) CALL mp_stop(ierror, "mpi_comm_rank @ "//routineN)
-      CALL mpi_comm_size(group, nprocs, ierror)
+      CALL mpi_comm_size(group%handle, nprocs, ierror)
       IF (ierror /= 0) CALL mp_stop(ierror, "mpi_comm_size @ "//routineN)
       IF (PRESENT(displ_in)) THEN
          displ = displ_in
@@ -117,7 +117,7 @@
       tag = 19
       msglen = SIZE(msg)
       CALL mpi_sendrecv_replace(msg, msglen, ${mpi_type1}$, right, tag, left, &
-                                tag, group, MPI_STATUS_IGNORE, ierror)
+                                tag, group%handle, MPI_STATUS_IGNORE, ierror)
       IF (ierror /= 0) CALL mp_stop(ierror, "mpi_sendrecv_replace @ "//routineN)
       CALL add_perf(perf_id=7, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -154,7 +154,7 @@
       INTEGER, DIMENSION(:), INTENT(IN)        :: scount, sdispl
       ${type1}$, DIMENSION(:), INTENT(INOUT)     :: rb
       INTEGER, DIMENSION(:), INTENT(IN)        :: rcount, rdispl
-      INTEGER, INTENT(IN)                      :: group
+      TYPE(mp_comm_type), INTENT(IN)                      :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$11v'
 
@@ -170,7 +170,7 @@
       ierr = 0
 #if defined(__parallel)
       CALL mpi_alltoallv(sb, scount, sdispl, ${mpi_type1}$, &
-                         rb, rcount, rdispl, ${mpi_type1}$, group, ierr)
+                         rb, rcount, rdispl, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoallv @ "//routineN)
       msglen = SUM(scount) + SUM(rcount)
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -208,7 +208,7 @@
       ${type1}$, DIMENSION(:, :), &
          INTENT(INOUT)                          :: rb
       INTEGER, DIMENSION(:), INTENT(IN)        :: rcount, rdispl
-      INTEGER, INTENT(IN)                      :: group
+      TYPE(mp_comm_type), INTENT(IN)                      :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$22v'
 
@@ -222,7 +222,7 @@
 
 #if defined(__parallel)
       CALL mpi_alltoallv(sb, scount, sdispl, ${mpi_type1}$, &
-                         rb, rcount, rdispl, ${mpi_type1}$, group, ierr)
+                         rb, rcount, rdispl, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoallv @ "//routineN)
       msglen = SUM(scount) + SUM(rcount)
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*2*${bytes1}$)
@@ -257,7 +257,8 @@
 
       ${type1}$, DIMENSION(:), INTENT(IN)        :: sb
       ${type1}$, DIMENSION(:), INTENT(OUT)       :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$'
 
@@ -271,9 +272,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*count*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -298,7 +299,8 @@
 
       ${type1}$, DIMENSION(:, :), INTENT(IN)     :: sb
       ${type1}$, DIMENSION(:, :), INTENT(OUT)    :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$22'
 
@@ -312,9 +314,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*SIZE(sb)*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -339,7 +341,8 @@
 
       ${type1}$, DIMENSION(:, :, :), INTENT(IN)  :: sb
       ${type1}$, DIMENSION(:, :, :), INTENT(OUT) :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$33'
 
@@ -353,9 +356,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*count*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -382,7 +385,8 @@
          INTENT(IN)                             :: sb
       ${type1}$, DIMENSION(:, :, :, :), &
          INTENT(OUT)                            :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$44'
 
@@ -396,9 +400,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*count*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -425,7 +429,8 @@
          INTENT(IN)                             :: sb
       ${type1}$, DIMENSION(:, :, :, :, :), &
          INTENT(OUT)                            :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$55'
 
@@ -439,9 +444,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*count*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -469,7 +474,8 @@
          INTENT(IN)                             :: sb
       ${type1}$, &
          DIMENSION(:, :, :, :, :), INTENT(OUT)  :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$45'
 
@@ -483,9 +489,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*count*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -513,7 +519,8 @@
          INTENT(IN)                             :: sb
       ${type1}$, DIMENSION(:, :, :, :), &
          INTENT(OUT)                            :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$34'
 
@@ -527,9 +534,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*count*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -557,7 +564,8 @@
          DIMENSION(:, :, :, :, :), INTENT(IN)   :: sb
       ${type1}$, DIMENSION(:, :, :, :), &
          INTENT(OUT)                            :: rb
-      INTEGER, INTENT(IN)                      :: count, group
+      INTEGER, INTENT(IN)                      :: count
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_alltoall_${nametype1}$54'
 
@@ -571,9 +579,9 @@
 
 #if defined(__parallel)
       CALL mpi_alltoall(sb, count, ${mpi_type1}$, &
-                        rb, count, ${mpi_type1}$, group, ierr)
+                        rb, count, ${mpi_type1}$, group%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_alltoall @ "//routineN)
-      CALL mpi_comm_size(group, np, ierr)
+      CALL mpi_comm_size(group%handle, np, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_size @ "//routineN)
       msglen = 2*count*np
       CALL add_perf(perf_id=6, count=1, msg_size=msglen*${bytes1}$)
@@ -597,7 +605,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_send_${nametype1}$ (msg, dest, tag, gid)
       ${type1}$                                  :: msg
-      INTEGER                                  :: dest, tag, gid
+      INTEGER                                  :: dest, tag
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_send_${nametype1}$'
 
@@ -608,7 +617,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid, ierr)
+      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_send @ "//routineN)
       CALL add_perf(perf_id=13, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -632,7 +641,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_send_${nametype1}$v(msg, dest, tag, gid)
       ${type1}$                                  :: msg(:)
-      INTEGER                                  :: dest, tag, gid
+      INTEGER                                  :: dest, tag
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_send_${nametype1}$v'
 
@@ -643,7 +653,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid, ierr)
+      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_send @ "//routineN)
       CALL add_perf(perf_id=13, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -667,7 +677,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_send_${nametype1}$m2(msg, dest, tag, gid)
       ${type1}$                                  :: msg(:, :)
-      INTEGER                                  :: dest, tag, gid
+      INTEGER                                  :: dest, tag
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_send_${nametype1}$m2'
 
@@ -678,7 +689,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid, ierr)
+      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_send @ "//routineN)
       CALL add_perf(perf_id=13, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -702,7 +713,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_send_${nametype1}$m3(msg, dest, tag, gid)
       ${type1}$                                  :: msg(:, :, :)
-      INTEGER                                  :: dest, tag, gid
+      INTEGER                                  :: dest, tag
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_send_${nametype1}m3'
 
@@ -713,7 +725,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid, ierr)
+      CALL mpi_send(msg, msglen, ${mpi_type1}$, dest, tag, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_send @ "//routineN)
       CALL add_perf(perf_id=13, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -739,7 +751,7 @@
    SUBROUTINE mp_recv_${nametype1}$ (msg, source, tag, gid)
       ${type1}$, INTENT(INOUT)                   :: msg
       INTEGER, INTENT(INOUT)                   :: source, tag
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_recv_${nametype1}$'
 
@@ -754,7 +766,7 @@
       msglen = 1
 #if defined(__parallel)
       ALLOCATE (status(MPI_STATUS_SIZE))
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid, status, ierr)
+      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid%handle, status, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
       CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
       source = status(MPI_SOURCE)
@@ -782,7 +794,7 @@
    SUBROUTINE mp_recv_${nametype1}$v(msg, source, tag, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
       INTEGER, INTENT(INOUT)                   :: source, tag
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_recv_${nametype1}$v'
 
@@ -797,7 +809,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       ALLOCATE (status(MPI_STATUS_SIZE))
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid, status, ierr)
+      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid%handle, status, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
       CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
       source = status(MPI_SOURCE)
@@ -825,7 +837,7 @@
    SUBROUTINE mp_recv_${nametype1}$m2(msg, source, tag, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:, :)
       INTEGER, INTENT(INOUT)                   :: source, tag
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_recv_${nametype1}$m2'
 
@@ -840,7 +852,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       ALLOCATE (status(MPI_STATUS_SIZE))
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid, status, ierr)
+      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid%handle, status, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
       CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
       source = status(MPI_SOURCE)
@@ -868,7 +880,7 @@
    SUBROUTINE mp_recv_${nametype1}$m3(msg, source, tag, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:, :, :)
       INTEGER, INTENT(INOUT)                   :: source, tag
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_recv_${nametype1}$m3'
 
@@ -883,7 +895,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       ALLOCATE (status(MPI_STATUS_SIZE))
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid, status, ierr)
+      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, gid%handle, status, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
       CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
       source = status(MPI_SOURCE)
@@ -910,7 +922,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_${nametype1}$ (msg, source, gid)
       ${type1}$                                  :: msg
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$'
 
@@ -921,7 +934,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -942,7 +955,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_ibcast_${nametype1}$ (msg, source, gid, request)
       ${type1}$                                  :: msg
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_ibcast_${nametype1}$'
@@ -954,7 +968,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
+      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
       CALL add_perf(perf_id=22, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -975,7 +989,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_${nametype1}$v(msg, source, gid)
       ${type1}$                                  :: msg(:)
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$v'
 
@@ -986,7 +1001,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1005,7 +1020,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_ibcast_${nametype1}$v(msg, source, gid, request)
       ${type1}$                                  :: msg(:)
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_ibcast_${nametype1}$v'
@@ -1017,7 +1033,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid, request, ierr)
+      CALL mpi_ibcast(msg, msglen, ${mpi_type1}$, source, gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ibcast @ "//routineN)
       CALL add_perf(perf_id=22, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1037,7 +1053,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_${nametype1}$m(msg, source, gid)
       ${type1}$                                  :: msg(:, :)
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_im'
 
@@ -1048,7 +1065,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1067,7 +1084,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_bcast_${nametype1}$3(msg, source, gid)
       ${type1}$                                  :: msg(:, :, :)
-      INTEGER                                  :: source, gid
+      INTEGER                                  :: source
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$3'
 
@@ -1078,7 +1096,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid, ierr)
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, source, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
       CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1097,7 +1115,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_sum_${nametype1}$ (msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$'
 
@@ -1108,7 +1126,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1126,7 +1144,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_sum_${nametype1}$v(msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$v'
 
@@ -1141,7 +1159,7 @@
 #if defined(__parallel)
       msglen = SIZE(msg)
       IF (msglen > 0) THEN
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       END IF
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
@@ -1160,7 +1178,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_isum_${nametype1}$v(msg, gid, request)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_isum_${nametype1}$v'
@@ -1176,7 +1194,7 @@
 #if defined(__parallel)
       msglen = SIZE(msg)
       IF (msglen > 0) THEN
-         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, request, ierr)
+         CALL mpi_iallreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, request, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallreduce @ "//routineN)
       ELSE
          request = mp_request_null
@@ -1198,7 +1216,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_sum_${nametype1}$m(msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$m'
 
@@ -1219,7 +1237,7 @@
          msglen = SIZE(msg, 1)*(MIN(UBOUND(msg, 2), m1 + step - 1) - m1 + 1)
          msglensum = msglensum + msglen
          IF (msglen > 0) THEN
-            CALL mpi_allreduce(MPI_IN_PLACE, msg(LBOUND(msg, 1), m1), msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+            CALL mpi_allreduce(MPI_IN_PLACE, msg(LBOUND(msg, 1), m1), msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
             IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
          END IF
       END DO
@@ -1239,7 +1257,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_sum_${nametype1}$m3(msg, gid)
       ${type1}$, INTENT(INOUT), CONTIGUOUS     :: msg(:, :, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$m3'
 
@@ -1251,7 +1269,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen > 0) THEN
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       END IF
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
@@ -1269,7 +1287,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_sum_${nametype1}$m4(msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:, :, :, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$m4'
 
@@ -1282,7 +1300,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       IF (msglen > 0) THEN
-         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+         CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       END IF
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
@@ -1304,7 +1322,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_sum_root_${nametype1}$v(msg, root, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_root_${nametype1}$v'
 
@@ -1319,13 +1338,13 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_comm_rank(gid, taskid, ierr)
+      CALL mpi_comm_rank(gid%handle, taskid, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ "//routineN)
       IF (msglen > 0) THEN
          m1 = SIZE(msg, 1)
          ALLOCATE (res(m1))
          CALL mpi_reduce(msg, res, msglen, ${mpi_type1}$, MPI_SUM, &
-                         root, gid, ierr)
+                         root, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_reduce @ "//routineN)
          IF (taskid == root) THEN
             msg = res
@@ -1351,7 +1370,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_sum_root_${nametype1}$m(msg, root, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:, :)
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_root_rm'
 
@@ -1366,13 +1386,13 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_comm_rank(gid, taskid, ierr)
+      CALL mpi_comm_rank(gid%handle, taskid, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ "//routineN)
       IF (msglen > 0) THEN
          m1 = SIZE(msg, 1)
          m2 = SIZE(msg, 2)
          ALLOCATE (res(m1, m2))
-         CALL mpi_reduce(msg, res, msglen, ${mpi_type1}$, MPI_SUM, root, gid, ierr)
+         CALL mpi_reduce(msg, res, msglen, ${mpi_type1}$, MPI_SUM, root, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_reduce @ "//routineN)
          IF (taskid == root) THEN
             msg = res
@@ -1396,7 +1416,7 @@
    SUBROUTINE mp_sum_partial_${nametype1}$m(msg, res, gid)
       ${type1}$, CONTIGUOUS, INTENT(IN)   :: msg(:, :)
       ${type1}$, CONTIGUOUS, INTENT(OUT)  :: res(:, :)
-      INTEGER, INTENT(IN)                 :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_partial_${nametype1}$m'
 
@@ -1410,10 +1430,10 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_comm_rank(gid, taskid, ierr)
+      CALL mpi_comm_rank(gid%handle, taskid, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_rank @ "//routineN)
       IF (msglen > 0) THEN
-         CALL mpi_scan(msg, res, msglen, ${mpi_type1}$, MPI_SUM, gid, ierr)
+         CALL mpi_scan(msg, res, msglen, ${mpi_type1}$, MPI_SUM, gid%handle, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_scan @ "//routineN)
       END IF
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
@@ -1435,7 +1455,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_max_${nametype1}$ (msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_max_${nametype1}$'
 
@@ -1446,7 +1466,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1466,7 +1486,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_max_${nametype1}$v(msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_max_${nametype1}$v'
 
@@ -1477,7 +1497,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MAX, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1496,7 +1516,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_min_${nametype1}$ (msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_min_${nametype1}$'
 
@@ -1507,7 +1527,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1529,7 +1549,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_min_${nametype1}$v(msg, gid)
       ${type1}$, INTENT(INOUT), CONTIGUOUS     :: msg(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_min_${nametype1}$v'
 
@@ -1540,7 +1560,7 @@
 
       msglen = SIZE(msg)
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_MIN, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1559,7 +1579,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_prod_${nametype1}$ (msg, gid)
       ${type1}$, INTENT(INOUT)                   :: msg
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_${nametype1}$'
 
@@ -1570,7 +1590,7 @@
 
       msglen = 1
 #if defined(__parallel)
-      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_PROD, gid, ierr)
+      CALL mpi_allreduce(MPI_IN_PLACE, msg, msglen, ${mpi_type1}$, MPI_PROD, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allreduce @ "//routineN)
       CALL add_perf(perf_id=3, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1592,7 +1612,8 @@
    SUBROUTINE mp_scatter_${nametype1}$v(msg_scatter, msg, root, gid)
       ${type1}$, INTENT(IN)                      :: msg_scatter(:)
       ${type1}$, INTENT(OUT)                     :: msg(:)
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_scatter_${nametype1}$v'
 
@@ -1604,7 +1625,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       CALL mpi_scatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                       msglen, ${mpi_type1}$, root, gid, ierr)
+                       msglen, ${mpi_type1}$, root, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_scatter @ "//routineN)
       CALL add_perf(perf_id=4, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1626,7 +1647,8 @@
    SUBROUTINE mp_iscatter_${nametype1}$ (msg_scatter, msg, root, gid, request)
       ${type1}$, INTENT(IN)                      :: msg_scatter(:)
       ${type1}$, INTENT(INOUT)                   :: msg
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iscatter_${nametype1}$'
@@ -1639,7 +1661,7 @@
       msglen = 1
 #if defined(__parallel)
       CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                        msglen, ${mpi_type1}$, root, gid, request, ierr)
+                        msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
 #else
@@ -1662,7 +1684,8 @@
    SUBROUTINE mp_iscatter_${nametype1}$v2(msg_scatter, msg, root, gid, request)
       ${type1}$, INTENT(IN)                      :: msg_scatter(:, :)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iscatter_${nametype1}$v2'
@@ -1675,7 +1698,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       CALL mpi_iscatter(msg_scatter, msglen, ${mpi_type1}$, msg, &
-                        msglen, ${mpi_type1}$, root, gid, request, ierr)
+                        msglen, ${mpi_type1}$, root, gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatter @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
 #else
@@ -1699,7 +1722,8 @@
       ${type1}$, INTENT(IN)                      :: msg_scatter(:)
       INTEGER, INTENT(IN)                      :: sendcounts(:), displs(:)
       ${type1}$, INTENT(INOUT)                   :: msg(:)
-      INTEGER, INTENT(IN)                      :: recvcount, root, gid
+      INTEGER, INTENT(IN)                      :: recvcount, root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iscatterv_${nametype1}$v'
@@ -1711,7 +1735,7 @@
 
 #if defined(__parallel)
       CALL mpi_iscatterv(msg_scatter, sendcounts, displs, ${mpi_type1}$, msg, &
-                         recvcount, ${mpi_type1}$, root, gid, request, ierr)
+                         recvcount, ${mpi_type1}$, root, gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iscatterv @ "//routineN)
       CALL add_perf(perf_id=24, count=1, msg_size=1*${bytes1}$)
 #else
@@ -1738,7 +1762,8 @@
    SUBROUTINE mp_gather_${nametype1}$ (msg, msg_gather, root, gid)
       ${type1}$, INTENT(IN)                      :: msg
       ${type1}$, INTENT(OUT)                     :: msg_gather(:)
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$'
 
@@ -1750,7 +1775,7 @@
       msglen = 1
 #if defined(__parallel)
       CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
-                      msglen, ${mpi_type1}$, root, gid, ierr)
+                      msglen, ${mpi_type1}$, root, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
       CALL add_perf(perf_id=4, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1776,7 +1801,8 @@
    SUBROUTINE mp_gather_${nametype1}$v(msg, msg_gather, root, gid)
       ${type1}$, INTENT(IN)                      :: msg(:)
       ${type1}$, INTENT(OUT)                     :: msg_gather(:)
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$v'
 
@@ -1788,7 +1814,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
-                      msglen, ${mpi_type1}$, root, gid, ierr)
+                      msglen, ${mpi_type1}$, root, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
       CALL add_perf(perf_id=4, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1814,7 +1840,8 @@
    SUBROUTINE mp_gather_${nametype1}$m(msg, msg_gather, root, gid)
       ${type1}$, INTENT(IN)                      :: msg(:, :)
       ${type1}$, INTENT(OUT)                     :: msg_gather(:, :)
-      INTEGER, INTENT(IN)                      :: root, gid
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$m'
 
@@ -1826,7 +1853,7 @@
       msglen = SIZE(msg)
 #if defined(__parallel)
       CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
-                      msglen, ${mpi_type1}$, root, gid, ierr)
+                      msglen, ${mpi_type1}$, root, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
       CALL add_perf(perf_id=4, count=1, msg_size=msglen*${bytes1}$)
 #else
@@ -1857,7 +1884,8 @@
       ${type1}$, DIMENSION(:), INTENT(IN)        :: sendbuf
       ${type1}$, DIMENSION(:), INTENT(OUT)       :: recvbuf
       INTEGER, DIMENSION(:), INTENT(IN)        :: recvcounts, displs
-      INTEGER, INTENT(IN)                      :: root, comm
+      INTEGER, INTENT(IN)                      :: root
+      TYPE(mp_comm_type), INTENT(IN) :: comm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_gatherv_${nametype1}$v'
 
@@ -1873,7 +1901,7 @@
       sendcount = SIZE(sendbuf)
       CALL mpi_gatherv(sendbuf, sendcount, ${mpi_type1}$, &
                        recvbuf, recvcounts, displs, ${mpi_type1}$, &
-                       root, comm, ierr)
+                       root, comm%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gatherv @ "//routineN)
       CALL add_perf(perf_id=4, &
                     count=1, &
@@ -1906,7 +1934,8 @@
       ${type1}$, DIMENSION(:), INTENT(IN)        :: sendbuf
       ${type1}$, DIMENSION(:), INTENT(OUT)       :: recvbuf
       INTEGER, DIMENSION(:), INTENT(IN)        :: recvcounts, displs
-      INTEGER, INTENT(IN)                      :: sendcount, root, comm
+      INTEGER, INTENT(IN)                      :: sendcount, root
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_igatherv_${nametype1}$v'
@@ -1919,7 +1948,7 @@
 #if defined(__parallel)
       CALL mpi_igatherv(sendbuf, sendcount, ${mpi_type1}$, &
                         recvbuf, recvcounts, displs, ${mpi_type1}$, &
-                        root, comm, request, ierr)
+                        root, comm%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gatherv @ "//routineN)
       CALL add_perf(perf_id=24, &
                     count=1, &
@@ -1949,7 +1978,7 @@
    SUBROUTINE mp_allgather_${nametype1}$ (msgout, msgin, gid)
       ${type1}$, INTENT(IN)                      :: msgout
       ${type1}$, INTENT(OUT)                     :: msgin(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$'
 
@@ -1966,7 +1995,7 @@
       rcount = 1
       CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                          msgin, rcount, ${mpi_type1}$, &
-                         gid, ierr)
+                         gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -1989,7 +2018,7 @@
    SUBROUTINE mp_allgather_${nametype1}$2(msgout, msgin, gid)
       ${type1}$, INTENT(IN)                      :: msgout
       ${type1}$, INTENT(OUT)                     :: msgin(:, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$2'
 
@@ -2006,7 +2035,7 @@
       rcount = 1
       CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                          msgin, rcount, ${mpi_type1}$, &
-                         gid, ierr)
+                         gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2029,7 +2058,7 @@
    SUBROUTINE mp_iallgather_${nametype1}$ (msgout, msgin, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout
       ${type1}$, INTENT(OUT)                     :: msgin(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$'
@@ -2047,7 +2076,7 @@
       rcount = 1
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid, request, ierr)
+                          gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2073,7 +2102,7 @@
    SUBROUTINE mp_allgather_${nametype1}$12(msgout, msgin, gid)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$12'
 
@@ -2090,7 +2119,7 @@
       rcount = scount
       CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                          msgin, rcount, ${mpi_type1}$, &
-                         gid, ierr)
+                         gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2110,7 +2139,7 @@
    SUBROUTINE mp_allgather_${nametype1}$23(msgout, msgin, gid)
       ${type1}$, INTENT(IN)                      :: msgout(:, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$23'
 
@@ -2127,7 +2156,7 @@
       rcount = scount
       CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                          msgin, rcount, ${mpi_type1}$, &
-                         gid, ierr)
+                         gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2147,7 +2176,7 @@
    SUBROUTINE mp_allgather_${nametype1}$34(msgout, msgin, gid)
       ${type1}$, INTENT(IN)                      :: msgout(:, :, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$34'
 
@@ -2164,7 +2193,7 @@
       rcount = scount
       CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                          msgin, rcount, ${mpi_type1}$, &
-                         gid, ierr)
+                         gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2184,7 +2213,7 @@
    SUBROUTINE mp_allgather_${nametype1}$22(msgout, msgin, gid)
       ${type1}$, INTENT(IN)                      :: msgout(:, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgather_${nametype1}$22'
 
@@ -2201,7 +2230,7 @@
       rcount = scount
       CALL MPI_ALLGATHER(msgout, scount, ${mpi_type1}$, &
                          msgin, rcount, ${mpi_type1}$, &
-                         gid, ierr)
+                         gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2222,7 +2251,7 @@
    SUBROUTINE mp_iallgather_${nametype1}$11(msgout, msgin, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$11'
@@ -2240,7 +2269,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid, request, ierr)
+                          gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2262,7 +2291,7 @@
    SUBROUTINE mp_iallgather_${nametype1}$13(msgout, msgin, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$13'
@@ -2280,7 +2309,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid, request, ierr)
+                          gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2302,7 +2331,7 @@
    SUBROUTINE mp_iallgather_${nametype1}$22(msgout, msgin, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout(:, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$22'
@@ -2320,7 +2349,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid, request, ierr)
+                          gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2342,7 +2371,7 @@
    SUBROUTINE mp_iallgather_${nametype1}$24(msgout, msgin, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout(:, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$24'
@@ -2360,7 +2389,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid, request, ierr)
+                          gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2382,7 +2411,7 @@
    SUBROUTINE mp_iallgather_${nametype1}$33(msgout, msgin, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout(:, :, :)
       ${type1}$, INTENT(OUT)                     :: msgin(:, :, :)
-      INTEGER, INTENT(IN)                      :: gid
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(OUT)                     :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgather_${nametype1}$33'
@@ -2400,7 +2429,7 @@
       rcount = scount
       CALL MPI_IALLGATHER(msgout, scount, ${mpi_type1}$, &
                           msgin, rcount, ${mpi_type1}$, &
-                          gid, request, ierr)
+                          gid%handle, request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_iallgather @ "//routineN)
 #else
       MARK_USED(gid)
@@ -2430,7 +2459,8 @@
    SUBROUTINE mp_allgatherv_${nametype1}$v(msgout, msgin, rcount, rdispl, gid)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
-      INTEGER, INTENT(IN)                      :: rcount(:), rdispl(:), gid
+      INTEGER, INTENT(IN)                      :: rcount(:), rdispl(:)
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_allgatherv_${nametype1}$v'
 
@@ -2445,7 +2475,7 @@
 #if defined(__parallel)
       scount = SIZE(msgout)
       CALL MPI_ALLGATHERV(msgout, scount, ${mpi_type1}$, msgin, rcount, &
-                          rdispl, ${mpi_type1}$, gid, ierr)
+                          rdispl, ${mpi_type1}$, gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_allgatherv @ "//routineN)
 #else
       MARK_USED(rcount)
@@ -2476,7 +2506,8 @@
    SUBROUTINE mp_iallgatherv_${nametype1}$v(msgout, msgin, rcount, rdispl, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
-      INTEGER, INTENT(IN)                      :: rcount(:), rdispl(:), gid
+      INTEGER, INTENT(IN)                      :: rcount(:), rdispl(:)
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgatherv_${nametype1}$v'
@@ -2525,7 +2556,8 @@
    SUBROUTINE mp_iallgatherv_${nametype1}$v2(msgout, msgin, rcount, rdispl, gid, request)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
-      INTEGER, INTENT(IN)                      :: rcount(:, :), rdispl(:, :), gid
+      INTEGER, INTENT(IN)                      :: rcount(:, :), rdispl(:, :)
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_iallgatherv_${nametype1}$v2'
@@ -2568,11 +2600,12 @@
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
       INTEGER, INTENT(IN)                      :: rsize
-      INTEGER, INTENT(IN)                      :: rcount(rsize), rdispl(rsize), gid, scount
+      INTEGER, INTENT(IN)                      :: rcount(rsize), rdispl(rsize), scount
+      TYPE(mp_comm_type), INTENT(IN) :: gid
       INTEGER, INTENT(INOUT)                   :: request, ierr
 
       CALL MPI_IALLGATHERV(msgout, scount, ${mpi_type1}$, msgin, rcount, &
-                           rdispl, ${mpi_type1}$, gid, request, ierr)
+                           rdispl, ${mpi_type1}$, gid%handle, request, ierr)
 
    END SUBROUTINE mp_iallgatherv_${nametype1}$v_internal
 #endif
@@ -2588,7 +2621,8 @@
    SUBROUTINE mp_sum_scatter_${nametype1}$v(msgout, msgin, rcount, gid)
       ${type1}$, INTENT(IN)                      :: msgout(:)
       ${type1}$, INTENT(OUT)                     :: msgin(:)
-      INTEGER, INTENT(IN)                      :: rcount(:), gid
+      INTEGER, INTENT(IN)                      :: rcount(:)
+      TYPE(mp_comm_type), INTENT(IN) :: gid
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sum_scatter_${nametype1}$v'
 
@@ -2599,7 +2633,7 @@
 
 #if defined(__parallel)
       CALL MPI_REDUCE_SCATTER(msgout, msgin, rcount, ${mpi_type1}$, MPI_SUM, &
-                              gid, ierr)
+                              gid%handle, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_reduce_scatter @ "//routineN)
 
       CALL add_perf(perf_id=3, count=1, &
@@ -2625,7 +2659,8 @@
       ${type1}$, INTENT(IN)                      :: msgin(:)
       INTEGER, INTENT(IN)                      :: dest
       ${type1}$, INTENT(OUT)                     :: msgout(:)
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(IN), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$v'
@@ -2649,7 +2684,7 @@
          recv_tag = tag
       END IF
       CALL mpi_sendrecv(msgin, msglen_in, ${mpi_type1}$, dest, send_tag, msgout, &
-                        msglen_out, ${mpi_type1}$, source, recv_tag, comm, MPI_STATUS_IGNORE, ierr)
+                        msglen_out, ${mpi_type1}$, source, recv_tag, comm%handle, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_sendrecv @ "//routineN)
       CALL add_perf(perf_id=7, count=1, &
                     msg_size=(msglen_in + msglen_out)*${bytes1}$/2)
@@ -2677,7 +2712,8 @@
       ${type1}$, INTENT(IN)                      :: msgin(:, :)
       INTEGER, INTENT(IN)                      :: dest
       ${type1}$, INTENT(OUT)                     :: msgout(:, :)
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(IN), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$m2'
@@ -2701,7 +2737,7 @@
          recv_tag = tag
       END IF
       CALL mpi_sendrecv(msgin, msglen_in, ${mpi_type1}$, dest, send_tag, msgout, &
-                        msglen_out, ${mpi_type1}$, source, recv_tag, comm, MPI_STATUS_IGNORE, ierr)
+                        msglen_out, ${mpi_type1}$, source, recv_tag, comm%handle, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_sendrecv @ "//routineN)
       CALL add_perf(perf_id=7, count=1, &
                     msg_size=(msglen_in + msglen_out)*${bytes1}$/2)
@@ -2728,7 +2764,8 @@
       ${type1}$, INTENT(IN)                      :: msgin(:, :, :)
       INTEGER, INTENT(IN)                      :: dest
       ${type1}$, INTENT(OUT)                     :: msgout(:, :, :)
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(IN), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$m3'
@@ -2752,7 +2789,7 @@
          recv_tag = tag
       END IF
       CALL mpi_sendrecv(msgin, msglen_in, ${mpi_type1}$, dest, send_tag, msgout, &
-                        msglen_out, ${mpi_type1}$, source, recv_tag, comm, MPI_STATUS_IGNORE, ierr)
+                        msglen_out, ${mpi_type1}$, source, recv_tag, comm%handle, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_sendrecv @ "//routineN)
       CALL add_perf(perf_id=7, count=1, &
                     msg_size=(msglen_in + msglen_out)*${bytes1}$/2)
@@ -2779,7 +2816,8 @@
       ${type1}$, INTENT(IN)                      :: msgin(:, :, :, :)
       INTEGER, INTENT(IN)                      :: dest
       ${type1}$, INTENT(OUT)                     :: msgout(:, :, :, :)
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(IN), OPTIONAL            :: tag
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_sendrecv_${nametype1}$m4'
@@ -2803,7 +2841,7 @@
          recv_tag = tag
       END IF
       CALL mpi_sendrecv(msgin, msglen_in, ${mpi_type1}$, dest, send_tag, msgout, &
-                        msglen_out, ${mpi_type1}$, source, recv_tag, comm, MPI_STATUS_IGNORE, ierr)
+                        msglen_out, ${mpi_type1}$, source, recv_tag, comm%handle, MPI_STATUS_IGNORE, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_sendrecv @ "//routineN)
       CALL add_perf(perf_id=7, count=1, &
                     msg_size=(msglen_in + msglen_out)*${bytes1}$/2)
@@ -2837,7 +2875,8 @@
       ${type1}$                                  :: msgin
       INTEGER, INTENT(IN)                      :: dest
       ${type1}$                                  :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: send_request, recv_request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -2856,11 +2895,11 @@
       IF (PRESENT(tag)) my_tag = tag
 
       CALL mpi_irecv(msgout, 1, ${mpi_type1}$, source, my_tag, &
-                     comm, recv_request, ierr)
+                     comm%handle, recv_request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
       CALL mpi_isend(msgin, 1, ${mpi_type1}$, dest, my_tag, &
-                     comm, send_request, ierr)
+                     comm%handle, send_request, ierr)
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
       CALL add_perf(perf_id=8, count=1, msg_size=2*${bytes1}$)
@@ -2898,7 +2937,8 @@
       ${type1}$, DIMENSION(:)                    :: msgin
       INTEGER, INTENT(IN)                      :: dest
       ${type1}$, DIMENSION(:)                    :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: send_request, recv_request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -2920,20 +2960,20 @@
       msglen = SIZE(msgout, 1)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, recv_request, ierr)
+                        comm%handle, recv_request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, recv_request, ierr)
+                        comm%handle, recv_request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
       msglen = SIZE(msgin, 1)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, send_request, ierr)
+                        comm%handle, send_request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, send_request, ierr)
+                        comm%handle, send_request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -2966,7 +3006,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_isend_${nametype1}$v(msgin, dest, comm, request, tag)
       ${type1}$, DIMENSION(:)                    :: msgin
-      INTEGER, INTENT(IN)                      :: dest, comm
+      INTEGER, INTENT(IN)                      :: dest
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -2988,10 +3029,10 @@
       msglen = SIZE(msgin)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3026,7 +3067,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_isend_${nametype1}$m2(msgin, dest, comm, request, tag)
       ${type1}$, DIMENSION(:, :)                 :: msgin
-      INTEGER, INTENT(IN)                      :: dest, comm
+      INTEGER, INTENT(IN)                      :: dest
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -3048,10 +3090,10 @@
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3088,7 +3130,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_isend_${nametype1}$m3(msgin, dest, comm, request, tag)
       ${type1}$, DIMENSION(:, :, :)              :: msgin
-      INTEGER, INTENT(IN)                      :: dest, comm
+      INTEGER, INTENT(IN)                      :: dest
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -3110,10 +3153,10 @@
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)*SIZE(msgin, 3)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3147,7 +3190,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_isend_${nametype1}$m4(msgin, dest, comm, request, tag)
       ${type1}$, DIMENSION(:, :, :, :)           :: msgin
-      INTEGER, INTENT(IN)                      :: dest, comm
+      INTEGER, INTENT(IN)                      :: dest
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -3169,10 +3213,10 @@
       msglen = SIZE(msgin, 1)*SIZE(msgin, 2)*SIZE(msgin, 3)*SIZE(msgin, 4)
       IF (msglen > 0) THEN
          CALL mpi_isend(msgin(1, 1, 1, 1), msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_isend(foo, msglen, ${mpi_type1}$, dest, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_isend @ "//routineN)
 
@@ -3206,7 +3250,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_irecv_${nametype1}$v(msgout, source, comm, request, tag)
       ${type1}$, DIMENSION(:)                    :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -3228,10 +3273,10 @@
       msglen = SIZE(msgout)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -3265,7 +3310,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_irecv_${nametype1}$m2(msgout, source, comm, request, tag)
       ${type1}$, DIMENSION(:, :)                 :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -3287,10 +3333,10 @@
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_irecv @ "//routineN)
 
@@ -3325,7 +3371,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_irecv_${nametype1}$m3(msgout, source, comm, request, tag)
       ${type1}$, DIMENSION(:, :, :)              :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -3347,10 +3394,10 @@
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)*SIZE(msgout, 3)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -3383,7 +3430,8 @@
 ! **************************************************************************************************
    SUBROUTINE mp_irecv_${nametype1}$m4(msgout, source, comm, request, tag)
       ${type1}$, DIMENSION(:, :, :, :)           :: msgout
-      INTEGER, INTENT(IN)                      :: source, comm
+      INTEGER, INTENT(IN)                      :: source
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(out)                     :: request
       INTEGER, INTENT(in), OPTIONAL            :: tag
 
@@ -3405,10 +3453,10 @@
       msglen = SIZE(msgout, 1)*SIZE(msgout, 2)*SIZE(msgout, 3)*SIZE(msgout, 4)
       IF (msglen > 0) THEN
          CALL mpi_irecv(msgout(1, 1, 1, 1), msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       ELSE
          CALL mpi_irecv(foo, msglen, ${mpi_type1}$, source, my_tag, &
-                        comm, request, ierr)
+                        comm%handle, request, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_ircv @ "//routineN)
 
@@ -3437,7 +3485,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_win_create_${nametype1}$v(base, comm, win)
       ${type1}$, DIMENSION(:)          :: base
-      INTEGER, INTENT(IN)            :: comm
+      TYPE(mp_comm_type), INTENT(IN) :: comm
       INTEGER, INTENT(INOUT)         :: win
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_win_create_${nametype1}$v'
@@ -3455,9 +3503,9 @@
 
       len = SIZE(base)*${bytes1}$
       IF (len > 0) THEN
-         CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm, win, ierr)
+         CALL mpi_win_create(base(1), len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
       ELSE
-         CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm, win, ierr)
+         CALL mpi_win_create(foo, len, ${bytes1}$, MPI_INFO_NULL, comm%handle, win, ierr)
       END IF
       IF (ierr /= 0) CALL mp_stop(ierr, "mpi_win_create @ "//routineN)
 

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -3730,7 +3730,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_${nametype1}$v(fh, offset, msg, msglen)
       ${type1}$, INTENT(IN)                      :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3742,11 +3742,11 @@
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
 #if defined(__parallel)
-      CALL MPI_FILE_WRITE_AT(fh, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT(fh%handle, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_${nametype1}$v @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg(1:msg_len)
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg(1:msg_len)
 #endif
    END SUBROUTINE mp_file_write_at_${nametype1}$v
 
@@ -3758,7 +3758,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_${nametype1}$ (fh, offset, msg)
       ${type1}$, INTENT(IN)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_write_at_${nametype1}$'
@@ -3767,11 +3767,11 @@
 
       ierr = 0
 #if defined(__parallel)
-      CALL MPI_FILE_WRITE_AT(fh, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT(fh%handle, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_${nametype1}$ @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_${nametype1}$
 
@@ -3787,24 +3787,23 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_all_${nametype1}$v(fh, offset, msg, msglen)
       ${type1}$, INTENT(IN)                      :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
-      INTEGER                                    :: msg_len
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_write_at_all_${nametype1}$v'
 
-      INTEGER                                    :: ierr
+      INTEGER                                    :: ierr, msg_len
 
       ierr = 0
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
 #if defined(__parallel)
-      CALL MPI_FILE_WRITE_AT_ALL(fh, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT_ALL(fh%handle, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_all_${nametype1}$v @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg(1:msg_len)
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg(1:msg_len)
 #endif
    END SUBROUTINE mp_file_write_at_all_${nametype1}$v
 
@@ -3816,7 +3815,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_write_at_all_${nametype1}$ (fh, offset, msg)
       ${type1}$, INTENT(IN)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_write_at_all_${nametype1}$'
@@ -3825,11 +3824,11 @@
 
       ierr = 0
 #if defined(__parallel)
-      CALL MPI_FILE_WRITE_AT_ALL(fh, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_WRITE_AT_ALL(fh%handle, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_write_at_all_${nametype1}$ @ "//routineN)
 #else
-      WRITE (UNIT=fh, POS=offset + 1) msg
+      WRITE (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_write_at_all_${nametype1}$
 
@@ -3846,24 +3845,23 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_${nametype1}$v(fh, offset, msg, msglen)
       ${type1}$, INTENT(OUT)                     :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
-      INTEGER                                    :: msg_len
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_read_at_${nametype1}$v'
 
-      INTEGER                                    :: ierr
+      INTEGER                                    :: ierr, msg_len
 
       ierr = 0
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
 #if defined(__parallel)
-      CALL MPI_FILE_READ_AT(fh, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT(fh%handle, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_${nametype1}$v @ "//routineN)
 #else
-      READ (UNIT=fh, POS=offset + 1) msg(1:msg_len)
+      READ (UNIT=fh%handle, POS=offset + 1) msg(1:msg_len)
 #endif
    END SUBROUTINE mp_file_read_at_${nametype1}$v
 
@@ -3875,7 +3873,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_${nametype1}$ (fh, offset, msg)
       ${type1}$, INTENT(OUT)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_read_at_${nametype1}$'
@@ -3884,11 +3882,11 @@
 
       ierr = 0
 #if defined(__parallel)
-      CALL MPI_FILE_READ_AT(fh, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT(fh%handle, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_${nametype1}$ @ "//routineN)
 #else
-      READ (UNIT=fh, POS=offset + 1) msg
+      READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_read_at_${nametype1}$
 
@@ -3904,7 +3902,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_all_${nametype1}$v(fh, offset, msg, msglen)
       ${type1}$, INTENT(OUT)                     :: msg(:)
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER, INTENT(IN), OPTIONAL              :: msglen
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
@@ -3916,11 +3914,11 @@
       msg_len = SIZE(msg)
       IF (PRESENT(msglen)) msg_len = msglen
 #if defined(__parallel)
-      CALL MPI_FILE_READ_AT_ALL(fh, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT_ALL(fh%handle, offset, msg, msg_len, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_all_${nametype1}$v @ "//routineN)
 #else
-      READ (UNIT=fh, POS=offset + 1) msg(1:msg_len)
+      READ (UNIT=fh%handle, POS=offset + 1) msg(1:msg_len)
 #endif
    END SUBROUTINE mp_file_read_at_all_${nametype1}$v
 
@@ -3932,7 +3930,7 @@
 ! **************************************************************************************************
    SUBROUTINE mp_file_read_at_all_${nametype1}$ (fh, offset, msg)
       ${type1}$, INTENT(OUT)               :: msg
-      INTEGER, INTENT(IN)                        :: fh
+      TYPE(mp_file_type), INTENT(IN)                        :: fh
       INTEGER(kind=file_offset), INTENT(IN)      :: offset
 
       CHARACTER(len=*), PARAMETER :: routineN = 'mp_file_read_at_all_${nametype1}$'
@@ -3941,11 +3939,11 @@
 
       ierr = 0
 #if defined(__parallel)
-      CALL MPI_FILE_READ_AT_ALL(fh, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
+      CALL MPI_FILE_READ_AT_ALL(fh%handle, offset, msg, 1, ${mpi_type1}$, MPI_STATUS_IGNORE, ierr)
       IF (ierr .NE. 0) &
          CPABORT("mpi_file_read_at_all_${nametype1}$ @ "//routineN)
 #else
-      READ (UNIT=fh, POS=offset + 1) msg
+      READ (UNIT=fh%handle, POS=offset + 1) msg
 #endif
    END SUBROUTINE mp_file_read_at_all_${nametype1}$
 

--- a/src/negf_matrix_utils.F
+++ b/src/negf_matrix_utils.F
@@ -20,7 +20,8 @@ MODULE negf_matrix_utils
         dbcsr_add, dbcsr_copy, dbcsr_deallocate_matrix, dbcsr_get_block_p, dbcsr_get_info, &
         dbcsr_init_p, dbcsr_p_type, dbcsr_set, dbcsr_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_irecv,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_irecv,&
                                               mp_isend,&
                                               mp_sum,&
                                               mp_wait
@@ -184,7 +185,7 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: fm
       INTEGER, DIMENSION(:), INTENT(in)                  :: atomlist_row, atomlist_col
       TYPE(qs_subsys_type), POINTER                      :: subsys
-      INTEGER, INTENT(in)                                :: mpi_comm_global
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_comm_global
       LOGICAL, INTENT(in)                                :: do_upper_diag, do_lower
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'negf_copy_sym_dbcsr_to_fm_submat'
@@ -301,7 +302,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :), INTENT(in)               :: index_to_cell
       INTEGER, DIMENSION(:), INTENT(in)                  :: atom_list0, atom_list1
       TYPE(qs_subsys_type), POINTER                      :: subsys
-      INTEGER, INTENT(in)                                :: mpi_comm_global
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_comm_global
       INTEGER, DIMENSION(:, :), INTENT(inout)            :: is_same_cell
       TYPE(dbcsr_type), OPTIONAL, POINTER                :: matrix_ref
 

--- a/src/negf_matrix_utils.F
+++ b/src/negf_matrix_utils.F
@@ -23,6 +23,7 @@ MODULE negf_matrix_utils
    USE message_passing,                 ONLY: mp_comm_type,&
                                               mp_irecv,&
                                               mp_isend,&
+                                              mp_request_type,&
                                               mp_sum,&
                                               mp_wait
    USE negf_alloc_types,                ONLY: negf_allocatable_rvector
@@ -505,11 +506,11 @@ CONTAINS
       INTEGER                                            :: handle, i1, i2, iatom_col, iatom_row, &
                                                             icol, iproc, irow, max_atom, &
                                                             mepos_plus1, n1, n2, natoms, offset
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: recv_handlers, recv_nelems, &
-                                                            send_handlers, send_nelems
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: recv_nelems, send_nelems
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: rank_contact, rank_device
       LOGICAL                                            :: found, transp
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: rblock
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_handlers, send_handlers
       TYPE(negf_allocatable_rvector), ALLOCATABLE, &
          DIMENSION(:)                                    :: recv_packed_blocks, send_packed_blocks
 

--- a/src/negf_subgroup_types.F
+++ b/src/negf_subgroup_types.F
@@ -20,7 +20,8 @@ MODULE negf_subgroup_types
                                               cp_para_env_release,&
                                               cp_para_env_retain
    USE cp_para_types,                   ONLY: cp_para_env_type
-   USE message_passing,                 ONLY: mp_comm_split
+   USE message_passing,                 ONLY: mp_comm_split,&
+                                              mp_comm_type
    USE negf_control_types,              ONLY: negf_control_type
 #include "./base/base_uses.f90"
 
@@ -47,9 +48,9 @@ MODULE negf_subgroup_types
       !> Useful to find out the current group index by accessing the 'group_distribution' array.
       INTEGER                                            :: mepos_global
       !> global MPI communicator
-      INTEGER                                            :: mpi_comm_global
+      TYPE(mp_comm_type)                                 :: mpi_comm_global
       !> MPI communicator of the current parallel group
-      INTEGER                                            :: mpi_comm
+      TYPE(mp_comm_type)                                 :: mpi_comm
       !> group_distribution(0:num_pe) : a process with rank 'i' belongs to the parallel group
       !> with index 'group_distribution(i)'
       INTEGER, DIMENSION(:), ALLOCATABLE                 :: group_distribution

--- a/src/optimize_basis.F
+++ b/src/optimize_basis.F
@@ -41,6 +41,7 @@ MODULE optimize_basis
                                               mp_bcast,&
                                               mp_comm_free,&
                                               mp_comm_split,&
+                                              mp_comm_type,&
                                               mp_sum,&
                                               mp_sync
    USE optbas_fenv_manipulation,        ONLY: allocate_mo_sets,&
@@ -129,9 +130,10 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'driver_para_opt_basis'
 
-      INTEGER                                            :: handle, n_groups_created, opt_group
+      INTEGER                                            :: handle, n_groups_created
       INTEGER, DIMENSION(:), POINTER                     :: group_distribution_p
       INTEGER, DIMENSION(0:para_env%num_pe-1), TARGET    :: group_distribution
+      TYPE(mp_comm_type)                                 :: opt_group
 
       CALL timeset(routineN, handle)
       group_distribution_p => group_distribution
@@ -162,7 +164,7 @@ CONTAINS
       TYPE(basis_optimization_type)                      :: opt_bas
       TYPE(section_type), POINTER                        :: input_declaration
       TYPE(cp_para_env_type), POINTER                    :: para_env_top
-      INTEGER                                            :: mpi_comm_opt
+      TYPE(mp_comm_type), INTENT(IN)                     :: mpi_comm_opt
 
       CHARACTER(len=*), PARAMETER :: routineN = 'driver_optimization_para_low'
 
@@ -402,7 +404,7 @@ CONTAINS
       TYPE(section_type), POINTER                        :: input_declaration
       TYPE(cp_fm_type), DIMENSION(:), INTENT(OUT)        :: matrix_S_inv
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER                                            :: mpi_comm_opt
+      TYPE(mp_comm_type)                                 :: mpi_comm_opt
 
       CHARACTER(len=*), PARAMETER :: routineN = 'init_training_force_envs'
 

--- a/src/optimize_input.F
+++ b/src/optimize_input.F
@@ -44,6 +44,7 @@ MODULE optimize_input
                                               mp_comm_free,&
                                               mp_comm_split,&
                                               mp_comm_split_direct,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_sum
    USE parallel_rng_types,              ONLY: UNIFORM,&
@@ -168,9 +169,8 @@ CONTAINS
       CHARACTER(len=default_string_length), &
          ALLOCATABLE, DIMENSION(:, :)                    :: initial_variables
       INTEGER :: color, energies_unit, handle, history_unit, i_atom, i_el, i_frame, i_free_var, &
-         i_var, ierr, mepos_master, mepos_slave, mpi_comm_master, mpi_comm_slave, &
-         mpi_comm_slave_primus, n_atom, n_el, n_frames, n_free_var, n_groups, n_var, new_env_id, &
-         num_pe_master, num_pe_slave, output_unit, restart_unit, state
+         i_var, ierr, mepos_master, mepos_slave, n_atom, n_el, n_frames, n_free_var, n_groups, &
+         n_var, new_env_id, num_pe_master, num_pe_slave, output_unit, restart_unit, state
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: free_var_index
       INTEGER, DIMENSION(:), POINTER                     :: group_distribution
       LOGICAL                                            :: should_stop
@@ -183,6 +183,8 @@ CONTAINS
                                                             force_traj_read, force_var, pos_traj, &
                                                             pos_traj_read
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: mpi_comm_master, mpi_comm_slave, &
+                                                            mpi_comm_slave_primus
       TYPE(opt_state_type)                               :: ostate
       TYPE(section_vals_type), POINTER                   :: oi_section, variable_section
 

--- a/src/pao_param.F
+++ b/src/pao_param.F
@@ -18,7 +18,8 @@ MODULE pao_param
         dbcsr_p_type, dbcsr_release, dbcsr_reserve_diag_blocks, dbcsr_type
    USE dm_ls_scf_types,                 ONLY: ls_mstruct_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_max
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_max
    USE pao_input,                       ONLY: pao_exp_param,&
                                               pao_fock_param,&
                                               pao_gth_param,&
@@ -301,11 +302,13 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_assert_unitary'
 
-      INTEGER                                            :: acol, arow, group, handle, i, iatom, M, N
+      INTEGER                                            :: acol, arow, group_handle, handle, i, &
+                                                            iatom, M, N
       INTEGER, DIMENSION(:), POINTER                     :: blk_sizes_pao, blk_sizes_pri
       REAL(dp)                                           :: delta_max
       REAL(dp), DIMENSION(:, :), POINTER                 :: block_test, tmp1, tmp2
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_comm_type)                                 :: group
 
       IF (pao%check_unitary_tol < 0.0_dp) RETURN ! no checking
 
@@ -339,7 +342,8 @@ CONTAINS
       CALL dbcsr_iterator_stop(iter)
 !$OMP END PARALLEL
 
-      CALL dbcsr_get_info(pao%matrix_U, group=group)
+      CALL dbcsr_get_info(pao%matrix_U, group=group_handle)
+      CALL group%set_handle(group_handle)
       CALL mp_max(delta_max, group)
       IF (pao%iw > 0) WRITE (pao%iw, *) 'PAO| checked unitaryness, max delta:', delta_max
       IF (delta_max > pao%check_unitary_tol) &

--- a/src/pao_param_gth.F
+++ b/src/pao_param_gth.F
@@ -24,7 +24,8 @@ MODULE pao_param_gth
    USE iterate_matrix,                  ONLY: matrix_sqrt_Newton_Schulz
    USE kinds,                           ONLY: dp
    USE machine,                         ONLY: m_flush
-   USE message_passing,                 ONLY: mp_min,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_min,&
                                               mp_sum
    USE orbital_pointers,                ONLY: init_orbital_pointers
    USE pao_param_fock,                  ONLY: pao_calc_U_block_fock
@@ -156,20 +157,22 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_param_gth_preconditioner'
 
-      INTEGER                                            :: acol, arow, group, handle, i, iatom, &
-                                                            ioffset, j, jatom, joffset, m, n, &
-                                                            natoms
+      INTEGER                                            :: acol, arow, group_handle, handle, i, &
+                                                            iatom, ioffset, j, jatom, joffset, m, &
+                                                            n, natoms
       LOGICAL                                            :: arnoldi_converged, converged, found
       REAL(dp)                                           :: eval_max, eval_min
       REAL(dp), DIMENSION(:, :), POINTER                 :: block, block_overlap, block_V_term
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_type)                                   :: matrix_gth_overlap
       TYPE(ls_scf_env_type), POINTER                     :: ls_scf_env
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, ls_scf_env=ls_scf_env)
-      CALL dbcsr_get_info(pao%matrix_V_terms, group=group)
+      CALL dbcsr_get_info(pao%matrix_V_terms, group=group_handle)
+      CALL group%set_handle(group_handle)
       natoms = SIZE(nterms)
 
       CALL dbcsr_create(matrix_gth_overlap, &
@@ -250,8 +253,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pao_calc_U_gth'
 
-      INTEGER                                            :: acol, arow, group, handle, iatom, idx, &
-                                                            iterm, n, natoms
+      INTEGER                                            :: acol, arow, group_handle, handle, iatom, &
+                                                            idx, iterm, n, natoms
       INTEGER, DIMENSION(:), POINTER                     :: nterms
       LOGICAL                                            :: found
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: gaps
@@ -260,10 +263,12 @@ CONTAINS
                                                             block_V, block_V_term, block_X, &
                                                             vec_V_terms
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
-      CALL dbcsr_get_info(pao%matrix_X, row_blk_size=nterms, group=group)
+      CALL dbcsr_get_info(pao%matrix_X, row_blk_size=nterms, group=group_handle)
+      CALL group%set_handle(group_handle)
       natoms = SIZE(nterms)
       ALLOCATE (gaps(natoms))
       gaps(:) = HUGE(dp)

--- a/src/pao_param_linpot.F
+++ b/src/pao_param_linpot.F
@@ -21,7 +21,8 @@ MODULE pao_param_linpot
    USE kinds,                           ONLY: dp
    USE machine,                         ONLY: m_flush
    USE mathlib,                         ONLY: diamat_all
-   USE message_passing,                 ONLY: mp_min,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_min,&
                                               mp_sum,&
                                               mp_sync
    USE pao_input,                       ONLY: pao_fock_param,&
@@ -359,8 +360,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pao_calc_U_linpot'
 
-      INTEGER                                            :: acol, arow, group, handle, iatom, kterm, &
-                                                            n, natoms, nterms
+      INTEGER                                            :: acol, arow, group_handle, handle, iatom, &
+                                                            kterm, n, natoms, nterms
       LOGICAL                                            :: found
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: gaps
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: evals
@@ -371,6 +372,7 @@ CONTAINS
       REAL(dp), DIMENSION(:, :, :), POINTER              :: M_blocks
       REAL(KIND=dp)                                      :: regu_energy
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
@@ -381,7 +383,8 @@ CONTAINS
       evals(:, :) = 0.0_dp
       gaps(:) = HUGE(1.0_dp)
       regu_energy = 0.0_dp
-      CALL dbcsr_get_info(pao%matrix_U, group=group)
+      CALL dbcsr_get_info(pao%matrix_U, group=group_handle)
+      CALL group%set_handle(group_handle)
 
       CALL dbcsr_iterator_start(iter, pao%matrix_X)
       DO WHILE (dbcsr_iterator_blocks_left(iter))

--- a/src/pexsi_interface.F
+++ b/src/pexsi_interface.F
@@ -31,6 +31,7 @@ MODULE pexsi_interface
    USE kinds, ONLY: int_8, &
                     real_8
    USE ISO_C_BINDING, ONLY: C_INTPTR_T
+   USE message_passing, ONLY: mp_comm_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -268,7 +269,8 @@ CONTAINS
 !> \return ...
 ! **************************************************************************************************
    FUNCTION cp_pexsi_plan_initialize(comm, numProcRow, numProcCol, outputFileIndex)
-      INTEGER, INTENT(IN)                      :: comm, numProcRow, numProcCol, &
+      TYPE(mp_comm_type), INTENT(IN) :: comm
+      INTEGER, INTENT(IN)                      :: numProcRow, numProcCol, &
                                                   outputFileIndex
       INTEGER(KIND=C_INTPTR_T)                 :: cp_pexsi_plan_initialize
 
@@ -277,7 +279,7 @@ CONTAINS
       INTEGER                                  :: info, handle
 
       CALL timeset(routineN, handle)
-      cp_pexsi_plan_initialize = f_ppexsi_plan_initialize(comm, numProcRow, &
+      cp_pexsi_plan_initialize = f_ppexsi_plan_initialize(comm%get_handle(), numProcRow, &
                                                           numProcCol, outputFileIndex, info)
       IF (info .NE. 0) &
          CPABORT("Pexsi returned an error. Consider logPEXSI0 for details.")

--- a/src/pexsi_types.F
+++ b/src/pexsi_types.F
@@ -28,7 +28,8 @@ MODULE pexsi_types
                                               dbcsr_scale,&
                                               dbcsr_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_dims_create,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_dims_create,&
                                               mp_environ
    USE pexsi_interface,                 ONLY: cp_pexsi_get_options,&
                                               cp_pexsi_options,&
@@ -94,8 +95,8 @@ MODULE pexsi_types
       TYPE(dbcsr_p_type), DIMENSION(:), &
          POINTER                               :: matrix_w => NULL()
       INTEGER(KIND=C_INTPTR_T)                 :: plan
-      INTEGER                                  :: nspin, num_ranks_per_pole, mp_group
-
+      INTEGER                                  :: nspin, num_ranks_per_pole
+      TYPE(mp_comm_type) :: mp_group
       TYPE(dbcsr_type), DIMENSION(:), &
          POINTER                               :: max_ev_vector
       TYPE(dbcsr_type)                         :: csr_sparsity
@@ -119,7 +120,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE lib_pexsi_init(pexsi_env, mp_group, nspin)
       TYPE(lib_pexsi_env), INTENT(INOUT)                 :: pexsi_env
-      INTEGER, INTENT(IN)                                :: mp_group, nspin
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
+      INTEGER, INTENT(IN)                                :: nspin
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'lib_pexsi_init'
 

--- a/src/pme.F
+++ b/src/pme.F
@@ -32,6 +32,7 @@ MODULE pme
                                               ewald_pw_type
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: fourpi
+   USE message_passing,                 ONLY: mp_comm_type
    USE particle_types,                  ONLY: particle_type
    USE pme_tools,                       ONLY: get_center,&
                                               set_list
@@ -111,14 +112,15 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'pme_evaluate'
 
-      INTEGER                                            :: group, handle, i, ig, ipart, j, nd(3), &
-                                                            npart, nshell, p1, p2
+      INTEGER                                            :: handle, i, ig, ipart, j, nd(3), npart, &
+                                                            nshell, p1, p2
       LOGICAL                                            :: is1_core, is2_core
       REAL(KIND=dp)                                      :: alpha, dvols, fat1, ffa, ffb
       REAL(KIND=dp), DIMENSION(3)                        :: fat
       REAL(KIND=dp), DIMENSION(3, 3)                     :: f_stress, h_stress
       TYPE(dg_rho0_type), POINTER                        :: dg_rho0
       TYPE(dg_type), POINTER                             :: dg
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: grid_b, grid_s
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: pw_big_pool, pw_small_pool

--- a/src/pw/dct.F
+++ b/src/pw/dct.F
@@ -19,6 +19,7 @@ MODULE dct
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_allgather,&
                                               mp_cart_rank,&
+                                              mp_comm_type,&
                                               mp_irecv,&
                                               mp_isend,&
                                               mp_request_null,&
@@ -276,12 +277,13 @@ CONTAINS
 
       INTEGER                                            :: group_size, handle, i, j, k, &
                                                             maxn_sendrecv, rs_dim1, rs_dim2, &
-                                                            rs_group, rs_mpo, tmp_size1, tmp_size2
+                                                            rs_mpo, tmp_size1, tmp_size2
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: src_pos1_onesdd, src_pos2_onesdd, &
                                                             tmp1_arr, tmp2_arr
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: dests_shrink_all, src_pos1, src_pos2, &
                                                             srcs_coord, srcs_expand_all
       INTEGER, DIMENSION(2)                              :: rs_dims, rs_pos
+      TYPE(mp_comm_type)                                 :: rs_group
 
       CALL timeset(routineN, handle)
 
@@ -531,13 +533,14 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'pw_expand'
 
       INTEGER :: group_size, handle, i, ind, lb1, lb1_loc, lb1_new, lb2, lb2_loc, lb2_new, lb3, &
-         lb3_loc, lb3_new, loc, maxn_sendrecv, rs_group, rs_mpo, ub1, ub1_loc, ub1_new, ub2, &
-         ub2_loc, ub2_new, ub3, ub3_loc, ub3_new
+         lb3_loc, lb3_new, loc, maxn_sendrecv, rs_mpo, ub1, ub1_loc, ub1_new, ub2, ub2_loc, &
+         ub2_new, ub3, ub3_loc, ub3_new
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dest_hist, recv_reqs, send_reqs, src_hist
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: pcs_bnds
       INTEGER, DIMENSION(2, 3)                           :: bounds_local_new
       REAL(dp), DIMENSION(:, :, :), POINTER              :: catd, catd_flipdbf, cr3d_xpndd, send_msg
       TYPE(dct_msg_type), DIMENSION(:), POINTER          :: pcs, recv_msgs
+      TYPE(mp_comm_type)                                 :: rs_group
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
       CALL timeset(routineN, handle)
@@ -716,12 +719,13 @@ CONTAINS
 
       COMPLEX(dp), DIMENSION(:, :, :), POINTER           :: cc3d
       INTEGER :: group_size, handle, i, in_space, in_use, lb1_orig, lb1_xpnd, lb2_orig, lb2_xpnd, &
-         lb3_orig, lb3_xpnd, maxn_sendrecv, recv_req, rs_group, rs_mpo, send_lb1, send_lb2, &
-         send_lb3, send_req, send_ub1, send_ub2, send_ub3, ub1_orig, ub1_xpnd, ub2_orig, ub2_xpnd, &
-         ub3_orig, ub3_xpnd
+         lb3_orig, lb3_xpnd, maxn_sendrecv, recv_req, rs_mpo, send_lb1, send_lb2, send_lb3, &
+         send_req, send_ub1, send_ub2, send_ub3, ub1_orig, ub1_xpnd, ub2_orig, ub2_xpnd, ub3_orig, &
+         ub3_xpnd
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: bounds_local_all
       INTEGER, DIMENSION(2, 3)                           :: bounds_local_xpnd
       REAL(dp), DIMENSION(:, :, :), POINTER              :: cr3d, send_crmsg
+      TYPE(mp_comm_type)                                 :: rs_group
       TYPE(pw_grid_type), POINTER                        :: pw_grid_orig
 
       CALL timeset(routineN, handle)
@@ -1064,13 +1068,14 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'expansion_bounds'
 
       INTEGER                                            :: group_size, handle, i, lb1_new, lb2_new, &
-                                                            lb3_new, loc, maxn_sendrecv, rs_group, &
-                                                            rs_mpo, ub1_new, ub2_new, ub3_new
+                                                            lb3_new, loc, maxn_sendrecv, rs_mpo, &
+                                                            ub1_new, ub2_new, ub3_new
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: src_hist
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: bounds_local_all, bounds_local_new_all, &
                                                             pcs_bnds
       INTEGER, DIMENSION(2, 3)                           :: bounds, bounds_local
       INTEGER, DIMENSION(3)                              :: npts_new, shf_yesno, shift
+      TYPE(mp_comm_type)                                 :: rs_group
 
       CALL timeset(routineN, handle)
 

--- a/src/pw/dct.F
+++ b/src/pw/dct.F
@@ -17,14 +17,9 @@ MODULE dct
 
    USE fast,                            ONLY: copy_cr
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_allgather,&
-                                              mp_cart_rank,&
-                                              mp_comm_type,&
-                                              mp_irecv,&
-                                              mp_isend,&
-                                              mp_request_null,&
-                                              mp_wait,&
-                                              mp_waitall
+   USE message_passing,                 ONLY: &
+        mp_allgather, mp_cart_rank, mp_comm_type, mp_irecv, mp_isend, mp_request_null, &
+        mp_request_type, mp_wait, mp_waitall
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
                                               pw_grid_setup
@@ -535,12 +530,13 @@ CONTAINS
       INTEGER :: group_size, handle, i, ind, lb1, lb1_loc, lb1_new, lb2, lb2_loc, lb2_new, lb3, &
          lb3_loc, lb3_new, loc, maxn_sendrecv, rs_mpo, ub1, ub1_loc, ub1_new, ub2, ub2_loc, &
          ub2_new, ub3, ub3_loc, ub3_new
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dest_hist, recv_reqs, send_reqs, src_hist
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dest_hist, src_hist
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: pcs_bnds
       INTEGER, DIMENSION(2, 3)                           :: bounds_local_new
       REAL(dp), DIMENSION(:, :, :), POINTER              :: catd, catd_flipdbf, cr3d_xpndd, send_msg
       TYPE(dct_msg_type), DIMENSION(:), POINTER          :: pcs, recv_msgs
       TYPE(mp_comm_type)                                 :: rs_group
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_reqs, send_reqs
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
       CALL timeset(routineN, handle)
@@ -719,13 +715,13 @@ CONTAINS
 
       COMPLEX(dp), DIMENSION(:, :, :), POINTER           :: cc3d
       INTEGER :: group_size, handle, i, in_space, in_use, lb1_orig, lb1_xpnd, lb2_orig, lb2_xpnd, &
-         lb3_orig, lb3_xpnd, maxn_sendrecv, recv_req, rs_mpo, send_lb1, send_lb2, send_lb3, &
-         send_req, send_ub1, send_ub2, send_ub3, ub1_orig, ub1_xpnd, ub2_orig, ub2_xpnd, ub3_orig, &
-         ub3_xpnd
+         lb3_orig, lb3_xpnd, maxn_sendrecv, rs_mpo, send_lb1, send_lb2, send_lb3, send_ub1, &
+         send_ub2, send_ub3, ub1_orig, ub1_xpnd, ub2_orig, ub2_xpnd, ub3_orig, ub3_xpnd
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: bounds_local_all
       INTEGER, DIMENSION(2, 3)                           :: bounds_local_xpnd
       REAL(dp), DIMENSION(:, :, :), POINTER              :: cr3d, send_crmsg
       TYPE(mp_comm_type)                                 :: rs_group
+      TYPE(mp_request_type)                              :: recv_req, send_req
       TYPE(pw_grid_type), POINTER                        :: pw_grid_orig
 
       CALL timeset(routineN, handle)

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -2753,13 +2753,13 @@ CONTAINS
          DEALLOCATE (fft_scratch%rbuf6)
       END IF
 
-      IF (fft_scratch%cart_sub_comm(1)%get_handle() .NE. mp_comm_null) THEN
+      IF (fft_scratch%cart_sub_comm(1)%get_handle() .NE. mp_comm_null%get_handle()) THEN
          CALL mp_comm_free(fft_scratch%cart_sub_comm(1))
       END IF
-      IF (fft_scratch%cart_sub_comm(2)%get_handle() .NE. mp_comm_null) THEN
+      IF (fft_scratch%cart_sub_comm(2)%get_handle() .NE. mp_comm_null%get_handle()) THEN
          CALL mp_comm_free(fft_scratch%cart_sub_comm(2))
       END IF
-      CALL fft_scratch%cart_sub_comm%set_handle(mp_comm_null)
+      fft_scratch%cart_sub_comm = mp_comm_null
 
       CALL fft_destroy_plan(fft_scratch%fft_plan(1))
       CALL fft_destroy_plan(fft_scratch%fft_plan(2))

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -43,8 +43,8 @@ MODULE fft_tools
                                               sp
    USE message_passing,                 ONLY: &
         mp_alltoall, mp_cart_coords, mp_cart_rank, mp_cart_sub, mp_comm_compare, mp_comm_free, &
-        mp_comm_null, mp_comm_type, mp_environ, mp_irecv, mp_isend, mp_rank_compare, mp_sum, &
-        mp_sync, mp_waitall
+        mp_comm_null, mp_comm_type, mp_environ, mp_irecv, mp_isend, mp_rank_compare, &
+        mp_request_type, mp_sum, mp_sync, mp_waitall
    USE offload_api,                     ONLY: offload_free_pinned_mem,&
                                               offload_malloc_pinned_mem
 
@@ -3330,8 +3330,8 @@ CONTAINS
       TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       COMPLEX(KIND=dp), DIMENSION(:), POINTER            :: msgin, msgout
-      INTEGER                                            :: ip, n, nr, ns, pos, rn, sn
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rreq, sreq
+      INTEGER                                            :: ip, n, nr, ns, pos
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: rreq, sreq
 
       CALL mp_sync(group)
       CALL mp_environ(n, pos, group)
@@ -3342,18 +3342,16 @@ CONTAINS
          IF (rcount(ip) == 0) CYCLE
          IF (ip == pos) CYCLE
          msgout => rq(rdispl(ip) + 1:rdispl(ip) + rcount(ip))
-         CALL mp_irecv(msgout, ip, group, rn)
+         CALL mp_irecv(msgout, ip, group, rreq(nr))
          nr = nr + 1
-         rreq(nr - 1) = rn
       END DO
       ns = 0
       DO ip = 0, n - 1
          IF (scount(ip) == 0) CYCLE
          IF (ip == pos) CYCLE
          msgin => rs(sdispl(ip) + 1:sdispl(ip) + scount(ip))
-         CALL mp_isend(msgin, ip, group, sn)
+         CALL mp_isend(msgin, ip, group, sreq(ns))
          ns = ns + 1
-         sreq(ns - 1) = sn
       END DO
       IF (rcount(pos) /= 0) THEN
          IF (rcount(pos) /= scount(pos)) CPABORT("")

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -2753,10 +2753,10 @@ CONTAINS
          DEALLOCATE (fft_scratch%rbuf6)
       END IF
 
-      IF (fft_scratch%cart_sub_comm(1)%get_handle() .NE. mp_comm_null%get_handle()) THEN
+      IF (fft_scratch%cart_sub_comm(1) /= mp_comm_null) THEN
          CALL mp_comm_free(fft_scratch%cart_sub_comm(1))
       END IF
-      IF (fft_scratch%cart_sub_comm(2)%get_handle() .NE. mp_comm_null%get_handle()) THEN
+      IF (fft_scratch%cart_sub_comm(2) /= mp_comm_null) THEN
          CALL mp_comm_free(fft_scratch%cart_sub_comm(2))
       END IF
       fft_scratch%cart_sub_comm = mp_comm_null
@@ -2921,7 +2921,7 @@ CONTAINS
                CYCLE
             END IF
             IF (PRESENT(fft_sizes)) THEN
-               IF (fft_sizes%gs_group%get_handle() /= fft_scratch_current%fft_scratch%group%get_handle()) THEN
+               IF (fft_sizes%gs_group /= fft_scratch_current%fft_scratch%group) THEN
                   fft_scratch_last => fft_scratch_current
                   fft_scratch_current => fft_scratch_current%fft_scratch_next
                   CYCLE
@@ -3410,8 +3410,8 @@ CONTAINS
       equal = equal .AND. fft_size_1%nmray == fft_size_2%nmray
       equal = equal .AND. fft_size_1%nyzray == fft_size_2%nyzray
 
-      equal = equal .AND. fft_size_1%gs_group%get_handle() == fft_size_2%gs_group%get_handle()
-      equal = equal .AND. fft_size_1%rs_group%get_handle() == fft_size_2%rs_group%get_handle()
+      equal = equal .AND. fft_size_1%gs_group == fft_size_2%gs_group
+      equal = equal .AND. fft_size_1%rs_group == fft_size_2%rs_group
 
       equal = equal .AND. ALL(fft_size_1%g_pos == fft_size_2%g_pos)
       equal = equal .AND. ALL(fft_size_1%r_pos == fft_size_2%r_pos)

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -43,7 +43,8 @@ MODULE fft_tools
                                               sp
    USE message_passing,                 ONLY: &
         mp_alltoall, mp_cart_coords, mp_cart_rank, mp_cart_sub, mp_comm_compare, mp_comm_free, &
-        mp_comm_null, mp_environ, mp_irecv, mp_isend, mp_rank_compare, mp_sum, mp_sync, mp_waitall
+        mp_comm_null, mp_comm_type, mp_environ, mp_irecv, mp_isend, mp_rank_compare, mp_sum, &
+        mp_sync, mp_waitall
    USE offload_api,                     ONLY: offload_free_pinned_mem,&
                                               offload_malloc_pinned_mem
 
@@ -68,7 +69,7 @@ MODULE fft_tools
       INTEGER                              :: lg = 0, mg = 0
       INTEGER                              :: nbx = 0, nbz = 0
       INTEGER                              :: nmray = 0, nyzray = 0
-      INTEGER                              :: gs_group = 0, rs_group = 0
+      TYPE(mp_comm_type)                   :: gs_group, rs_group
       INTEGER, DIMENSION(2)                :: g_pos = 0, r_pos = 0, r_dim = 0
       INTEGER                              :: numtask = 0
    END TYPE fft_scratch_sizes
@@ -77,10 +78,11 @@ MODULE fft_tools
       INTEGER                              :: fft_scratch_id
       INTEGER                              :: tf_type
       LOGICAL                              :: in_use
-      INTEGER                              :: group
+      TYPE(mp_comm_type)                   :: group
       INTEGER, DIMENSION(3)                :: nfft
       ! to be used in cube_transpose_* routines
-      INTEGER, DIMENSION(2)                :: cart_sub_comm = mp_comm_null, dim, pos
+      TYPE(mp_comm_type), DIMENSION(2)     :: cart_sub_comm
+      INTEGER, DIMENSION(2)                :: dim, pos
       ! to be used in fft3d_s
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER &
          :: ziptr, zoptr
@@ -495,7 +497,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: cin
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: gin
-      INTEGER, INTENT(IN)                                :: gs_group, rs_group
+      TYPE(mp_comm_type), INTENT(IN)                     :: gs_group, rs_group
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nyzray
       INTEGER, DIMENSION(:, :, 0:, :), INTENT(IN)        :: bo
@@ -942,7 +944,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: zin
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: gin
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(:, :, 0:, :), INTENT(IN)        :: bo
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
       INTEGER, INTENT(OUT), OPTIONAL                     :: status
@@ -1366,7 +1368,8 @@ CONTAINS
    SUBROUTINE x_to_yz(sb, group, my_pos, p2p, yzp, nray, bo, tb, fft_scratch)
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: sb
-      INTEGER, INTENT(IN)                                :: group, my_pos
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
+      INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
@@ -1475,7 +1478,8 @@ CONTAINS
    SUBROUTINE yz_to_x(tb, group, my_pos, p2p, yzp, nray, bo, sb, fft_scratch)
 
       COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(IN)   :: tb
-      INTEGER, INTENT(IN)                                :: group, my_pos
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
+      INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
@@ -1585,7 +1589,7 @@ CONTAINS
    SUBROUTINE yz_to_xz(sb, group, dims, my_pos, p2p, yzp, nray, bo, tb, fft_scratch)
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: sb
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(2), INTENT(IN)                  :: dims
       INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
@@ -1793,7 +1797,7 @@ CONTAINS
    SUBROUTINE xz_to_yz(sb, group, dims, my_pos, p2p, yzp, nray, bo, tb, fft_scratch)
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: sb
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(2), INTENT(IN)                  :: dims
       INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
@@ -1993,14 +1997,13 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, is, ixy, iz, mip, &
-                                                            mz, np, nx, ny, nz, sub_group
+                                                            mz, np, nx, ny, nz
       INTEGER, DIMENSION(2)                              :: dim, pos
       INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
 
       CALL timeset(routineN, handle)
 
-      sub_group = fft_scratch%cart_sub_comm(2)
       mip = fft_scratch%mip
       dim = fft_scratch%dim
       pos = fft_scratch%pos
@@ -2039,7 +2042,7 @@ CONTAINS
 
       rbuf => fft_scratch%rbuf1
 
-      CALL mp_alltoall(cin, scount, sdispl, rbuf, rcount, rdispl, sub_group)
+      CALL mp_alltoall(cin, scount, sdispl, rbuf, rcount, rdispl, fft_scratch%cart_sub_comm(2))
 
 !$OMP PARALLEL DO DEFAULT(NONE) COLLAPSE(2) &
 !$OMP             PRIVATE(ip,ipl,nz,iz,is,ir) &
@@ -2080,10 +2083,11 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, ixy, iz, mip, mz, &
-                                                            np, nx, ny, nz, sub_group
+                                                            np, nx, ny, nz
       INTEGER, DIMENSION(2)                              :: dim, pos
       INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
+      TYPE(mp_comm_type)                                 :: sub_group
 
       CALL timeset(routineN, handle)
 
@@ -2166,10 +2170,11 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, is, ixz, iy, lb, &
                                                             mip, my, my_id, np, num_threads, nx, &
-                                                            ny, nz, sub_group, ub
+                                                            ny, nz, ub
       INTEGER, DIMENSION(2)                              :: dim, pos
       INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
+      TYPE(mp_comm_type)                                 :: sub_group
 
       CALL timeset(routineN, handle)
 
@@ -2266,10 +2271,11 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, iy, izx, lb, mip, &
                                                             my, my_id, np, num_threads, nx, ny, &
-                                                            nz, sub_group, ub
+                                                            nz, ub
       INTEGER, DIMENSION(2)                              :: dim, pos
       INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
+      TYPE(mp_comm_type)                                 :: sub_group
 
       CALL timeset(routineN, handle)
 
@@ -2354,7 +2360,7 @@ CONTAINS
    SUBROUTINE cube_transpose_5(cin, group, boin, boout, sout, fft_scratch)
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
@@ -2447,7 +2453,7 @@ CONTAINS
    SUBROUTINE cube_transpose_6(cin, group, boin, boout, sout, fft_scratch)
 
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
@@ -2538,7 +2544,6 @@ CONTAINS
       NULLIFY (fft_scratch_first%fft_scratch_next)
       fft_scratch_first%fft_scratch%fft_scratch_id = 0
       fft_scratch_first%fft_scratch%in_use = .TRUE.
-      fft_scratch_first%fft_scratch%group = 0
       NULLIFY (fft_scratch_first%fft_scratch%ziptr)
       NULLIFY (fft_scratch_first%fft_scratch%zoptr)
       NULLIFY (fft_scratch_first%fft_scratch%p1buf)
@@ -2748,13 +2753,13 @@ CONTAINS
          DEALLOCATE (fft_scratch%rbuf6)
       END IF
 
-      IF (fft_scratch%cart_sub_comm(1) .NE. mp_comm_null) THEN
+      IF (fft_scratch%cart_sub_comm(1)%get_handle() .NE. mp_comm_null) THEN
          CALL mp_comm_free(fft_scratch%cart_sub_comm(1))
       END IF
-      IF (fft_scratch%cart_sub_comm(2) .NE. mp_comm_null) THEN
+      IF (fft_scratch%cart_sub_comm(2)%get_handle() .NE. mp_comm_null) THEN
          CALL mp_comm_free(fft_scratch%cart_sub_comm(2))
       END IF
-      fft_scratch%cart_sub_comm = mp_comm_null
+      CALL fft_scratch%cart_sub_comm%set_handle(mp_comm_null)
 
       CALL fft_destroy_plan(fft_scratch%fft_plan(1))
       CALL fft_destroy_plan(fft_scratch%fft_plan(2))
@@ -2916,7 +2921,7 @@ CONTAINS
                CYCLE
             END IF
             IF (PRESENT(fft_sizes)) THEN
-               IF (fft_sizes%gs_group /= fft_scratch_current%fft_scratch%group) THEN
+               IF (fft_sizes%gs_group%get_handle() /= fft_scratch_current%fft_scratch%group%get_handle()) THEN
                   fft_scratch_last => fft_scratch_current
                   fft_scratch_current => fft_scratch_current%fft_scratch_next
                   CYCLE
@@ -2937,7 +2942,6 @@ CONTAINS
             ! Generate a new scratch set
             ALLOCATE (fft_scratch_new)
             ALLOCATE (fft_scratch_new%fft_scratch)
-            fft_scratch_new%fft_scratch%group = 0
             NULLIFY (fft_scratch_new%fft_scratch%ziptr)
             NULLIFY (fft_scratch_new%fft_scratch%zoptr)
             NULLIFY (fft_scratch_new%fft_scratch%p1buf)
@@ -2976,8 +2980,6 @@ CONTAINS
             DO i = 1, 6
                fft_scratch_new%fft_scratch%fft_plan(i)%valid = .FALSE.
             END DO
-
-            fft_scratch_new%fft_scratch%cart_sub_comm = mp_comm_null
 
             IF (tf_type .NE. 400) THEN
                fft_scratch_new%fft_scratch%sizes = fft_sizes
@@ -3325,7 +3327,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: scount, sdispl
       COMPLEX(KIND=dp), DIMENSION(:), POINTER            :: rq
       INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       COMPLEX(KIND=dp), DIMENSION(:), POINTER            :: msgin, msgout
       INTEGER                                            :: ip, n, nr, ns, pos, rn, sn
@@ -3408,8 +3410,8 @@ CONTAINS
       equal = equal .AND. fft_size_1%nmray == fft_size_2%nmray
       equal = equal .AND. fft_size_1%nyzray == fft_size_2%nyzray
 
-      equal = equal .AND. fft_size_1%gs_group == fft_size_2%gs_group
-      equal = equal .AND. fft_size_1%rs_group == fft_size_2%rs_group
+      equal = equal .AND. fft_size_1%gs_group%get_handle() == fft_size_2%gs_group%get_handle()
+      equal = equal .AND. fft_size_1%rs_group%get_handle() == fft_size_2%rs_group%get_handle()
 
       equal = equal .AND. ALL(fft_size_1%g_pos == fft_size_2%g_pos)
       equal = equal .AND. ALL(fft_size_1%r_pos == fft_size_2%r_pos)

--- a/src/pw/ps_wavelet_base.F
+++ b/src/pw/ps_wavelet_base.F
@@ -12,7 +12,8 @@
 MODULE ps_wavelet_base
 
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_alltoall
+   USE message_passing,                 ONLY: mp_alltoall,&
+                                              mp_comm_type
    USE ps_wavelet_fft3d,                ONLY: ctrig,&
                                               ctrig_length,&
                                               fftstp
@@ -55,7 +56,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(md1, md3, md2/nproc), &
          INTENT(inout)                                   :: zf
       REAL(KIND=dp), INTENT(in)                          :: scal, hx, hy, hz
-      INTEGER, INTENT(in)                                :: mpi_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_group
 
       INTEGER, PARAMETER                                 :: ncache_optimal = 8*1024
 
@@ -845,7 +846,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(md1, md3, md2/nproc), &
          INTENT(inout)                                   :: zf
       REAL(KIND=dp), INTENT(in)                          :: scal
-      INTEGER, INTENT(in)                                :: mpi_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_group
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'S_PoissonSolver'
       INTEGER, PARAMETER                                 :: ncache_optimal = 8*1024
@@ -1591,7 +1592,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(md1, md3, md2/nproc), &
          INTENT(inout)                                   :: zf
       REAL(KIND=dp), INTENT(in)                          :: scal
-      INTEGER, INTENT(in)                                :: mpi_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_group
 
       INTEGER, PARAMETER                                 :: ncache_optimal = 8*1024
 

--- a/src/pw/ps_wavelet_kernel.F
+++ b/src/pw/ps_wavelet_kernel.F
@@ -12,7 +12,8 @@
 MODULE ps_wavelet_kernel
 
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_alltoall
+   USE message_passing,                 ONLY: mp_alltoall,&
+                                              mp_comm_type
    USE ps_wavelet_base,                 ONLY: scramble_unpack
    USE ps_wavelet_fft3d,                ONLY: ctrig,&
                                               ctrig_length,&
@@ -83,7 +84,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(in)                          :: hx, hy, hz
       INTEGER, INTENT(in)                                :: itype_scf, iproc, nproc
       REAL(KIND=dp), POINTER                             :: kernel(:)
-      INTEGER, INTENT(in)                                :: mpi_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_group
 
       INTEGER                                            :: m1, m2, m3, md1, md2, md3, n1, n2, n3, &
                                                             nd1, nd2, nd3, nlimd, nlimk
@@ -225,7 +226,7 @@ CONTAINS
       REAL(KIND=dp), &
          DIMENSION(nker1, nker2, nker3/nproc), &
          INTENT(out)                                     :: karray
-      INTEGER, INTENT(in)                                :: mpi_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_group
 
       INTEGER, PARAMETER                                 :: n_points = 2**6, ncache_optimal = 8*1024
 
@@ -843,7 +844,7 @@ CONTAINS
       INTEGER, INTENT(in)                                :: itype_scf, iproc, nproc
       REAL(KIND=dp), DIMENSION(n1k, n2k, n3k/nproc), &
          INTENT(out)                                     :: karray
-      INTEGER, INTENT(in)                                :: mpi_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_group
 
       INTEGER, PARAMETER                                 :: n_gauss = 89, n_points = 2**6
       REAL(KIND=dp), PARAMETER                           :: p0_ref = 1._dp
@@ -1103,7 +1104,7 @@ CONTAINS
          INTENT(in)                                      :: zf
       REAL(KIND=dp), DIMENSION(nk1, nk2, nk3/nproc), &
          INTENT(inout)                                   :: zr
-      INTEGER, INTENT(in)                                :: mpi_group
+      TYPE(mp_comm_type), INTENT(in)                     :: mpi_group
 
       INTEGER, PARAMETER                                 :: ncache_optimal = 8*1024
 

--- a/src/pw/pw_copy_all.F
+++ b/src/pw/pw_copy_all.F
@@ -14,7 +14,8 @@
 ! **************************************************************************************************
 MODULE pw_copy_all
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_shift,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_shift,&
                                               mp_sum
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
@@ -46,11 +47,12 @@ CONTAINS
       TYPE(pw_type), INTENT(INOUT)                       :: pw2
 
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: cc
-      INTEGER                                            :: group, group_size, ig1, ig2, ip, jg2, &
-                                                            me, ng1, ng2, ngm, penow
+      INTEGER                                            :: group_size, ig1, ig2, ip, jg2, me, ng1, &
+                                                            ng2, ngm, penow
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ngr
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: g_hat
       INTEGER, DIMENSION(3)                              :: k1, k2
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: pg1, pg2
 
       IF (pw1%in_use == COMPLEXDATA1D .AND. &

--- a/src/pw/pw_gpu.F
+++ b/src/pw/pw_gpu.F
@@ -34,6 +34,7 @@ MODULE pw_gpu
         release_fft_scratch, x_to_yz, xz_to_yz, yz_to_x, yz_to_xz
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_comm_compare,&
+                                              mp_comm_type,&
                                               mp_environ,&
                                               mp_rank_compare
    USE pw_grid_types,                   ONLY: FULLSPACE
@@ -231,10 +232,9 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: grays, pbuf, qbuf, rbuf, sbuf
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER      :: tbuf
-      INTEGER                                            :: g_pos, gs_group, handle, iout, lg, lmax, &
-                                                            mg, mmax, mx2, mz2, n1, n2, ngpts, &
-                                                            nmax, numtask, numtask_g, numtask_r, &
-                                                            rp, rs_group
+      INTEGER                                            :: g_pos, handle, iout, lg, lmax, mg, mmax, &
+                                                            mx2, mz2, n1, n2, ngpts, nmax, &
+                                                            numtask, numtask_g, numtask_r, rp
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: p2p
       INTEGER, DIMENSION(2)                              :: r_dim, r_pos
       INTEGER, DIMENSION(:), POINTER                     :: n, nloc, nyzray
@@ -242,6 +242,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :, :), POINTER            :: bo
       TYPE(fft_scratch_sizes)                            :: fft_scratch_size
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(mp_comm_type)                                 :: gs_group, rs_group
 
 !nyzray(0:)
 !yzp(:,:,0:)
@@ -411,10 +412,9 @@ CONTAINS
 
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: grays, pbuf, qbuf, rbuf, sbuf
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER      :: tbuf
-      INTEGER                                            :: g_pos, gs_group, handle, iout, lg, lmax, &
-                                                            mg, mmax, mx2, mz2, n1, n2, ngpts, &
-                                                            nmax, numtask, numtask_g, numtask_r, &
-                                                            rp, rs_group
+      INTEGER                                            :: g_pos, handle, iout, lg, lmax, mg, mmax, &
+                                                            mx2, mz2, n1, n2, ngpts, nmax, &
+                                                            numtask, numtask_g, numtask_r, rp
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: p2p
       INTEGER, DIMENSION(2)                              :: r_dim, r_pos
       INTEGER, DIMENSION(:), POINTER                     :: n, nloc, nyzray
@@ -422,6 +422,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :, :), POINTER            :: bo
       TYPE(fft_scratch_sizes)                            :: fft_scratch_size
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(mp_comm_type)                                 :: gs_group, rs_group
 
 !nyzray(0:)
 !yzp(:,:,0:)

--- a/src/pw/pw_grid_types.F
+++ b/src/pw/pw_grid_types.F
@@ -14,6 +14,7 @@ MODULE pw_grid_types
 
    USE kinds,                           ONLY: dp,&
                                               int_8
+   USE message_passing,                 ONLY: mp_comm_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -38,7 +39,7 @@ MODULE pw_grid_types
       INTEGER :: mode ! 0 = local = PW_MODE_LOCAL ; 1 = distributed = PW_MODE_DISTRIBUTED
       LOGICAL :: ray_distribution ! block or pencil distribution
       LOGICAL :: blocked ! block or pencil distribution
-      INTEGER :: group ! MPI group id
+      TYPE(mp_comm_type) :: group ! MPI group
       INTEGER :: my_pos ! Position within group
       INTEGER :: group_size ! # of Processors in group
       LOGICAL :: group_head ! Master process within group
@@ -46,7 +47,7 @@ MODULE pw_grid_types
       INTEGER, DIMENSION(:, :, :), POINTER :: yzp ! g-space rays (xy,k,pe)
       INTEGER, DIMENSION(:, :), POINTER :: yzq ! local inverse pointer of yzp
       INTEGER, DIMENSION(:), POINTER :: nyzray ! number of g-space rays (pe)
-      INTEGER :: rs_group ! real space group (2-dim cart)
+      TYPE(mp_comm_type) :: rs_group ! real space group (2-dim cart)
       INTEGER :: rs_mpo ! real space group position
       INTEGER, DIMENSION(2) :: rs_dims ! real space group dimensions
       INTEGER, DIMENSION(2) :: rs_pos ! real space group positions in grid

--- a/src/pw/pw_grids.F
+++ b/src/pw/pw_grids.F
@@ -46,7 +46,8 @@ MODULE pw_grids
                                               inv_3x3
    USE message_passing,                 ONLY: &
         mp_allgather, mp_cart_coords, mp_cart_create, mp_cart_rank, mp_comm_compare, mp_comm_dup, &
-        mp_comm_free, mp_comm_self, mp_dims_create, mp_environ, mp_max, mp_min, mp_sum
+        mp_comm_free, mp_comm_self, mp_comm_type, mp_dims_create, mp_environ, mp_max, mp_min, &
+        mp_sum
    USE offload_api,                     ONLY: offload_activate_chosen_device,&
                                               offload_free_pinned_mem,&
                                               offload_malloc_pinned_mem
@@ -92,7 +93,7 @@ CONTAINS
    SUBROUTINE pw_grid_create(pw_grid, pe_group, local)
 
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      INTEGER, INTENT(in)                                :: pe_group
+      TYPE(mp_comm_type), INTENT(in)                     :: pe_group
       LOGICAL, INTENT(IN), OPTIONAL                      :: local
 
       LOGICAL                                            :: my_local
@@ -801,6 +802,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: axis_dist_all
       INTEGER, DIMENSION(2, 3)                           :: axis_dist
       LOGICAL                                            :: blocking
+      TYPE(mp_comm_type)                                 :: mp_comm_old
 
 !------------------------------------------------------------------------------
 
@@ -834,7 +836,8 @@ CONTAINS
          CPASSERT(pw_grid%ngpts < HUGE(pw_grid%ngpts_local))
          pw_grid%ngpts_local = INT(pw_grid%ngpts)
          pw_grid%para%rs_dims = 1
-         CALL mp_cart_create(mp_comm_self, 2, &
+         CALL mp_comm_old%set_handle(mp_comm_self)
+         CALL mp_cart_create(mp_comm_old, 2, &
                              pw_grid%para%rs_dims, &
                              pw_grid%para%rs_pos, &
                              pw_grid%para%rs_group)

--- a/src/pw/pw_grids.F
+++ b/src/pw/pw_grids.F
@@ -836,7 +836,7 @@ CONTAINS
          CPASSERT(pw_grid%ngpts < HUGE(pw_grid%ngpts_local))
          pw_grid%ngpts_local = INT(pw_grid%ngpts)
          pw_grid%para%rs_dims = 1
-         CALL mp_comm_old%set_handle(mp_comm_self)
+         mp_comm_old = mp_comm_self
          CALL mp_cart_create(mp_comm_old, 2, &
                              pw_grid%para%rs_dims, &
                              pw_grid%para%rs_pos, &

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -1694,7 +1694,7 @@ CONTAINS
          IF (pw1%pw_grid%dvol /= pw2%pw_grid%dvol) THEN
             CPABORT("PW grids not compatible")
          END IF
-         IF (pw1%pw_grid%para%group%get_handle() /= pw2%pw_grid%para%group%get_handle()) THEN
+         IF (pw1%pw_grid%para%group /= pw2%pw_grid%para%group) THEN
             CPABORT("PW grids have not compatible MPI groups")
          END IF
       END IF

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -1694,7 +1694,7 @@ CONTAINS
          IF (pw1%pw_grid%dvol /= pw2%pw_grid%dvol) THEN
             CPABORT("PW grids not compatible")
          END IF
-         IF (pw1%pw_grid%para%group /= pw2%pw_grid%para%group) THEN
+         IF (pw1%pw_grid%para%group%get_handle() /= pw2%pw_grid%para%group%get_handle()) THEN
             CPABORT("PW grids have not compatible MPI groups")
          END IF
       END IF

--- a/src/pw/realspace_grid_cube.F
+++ b/src/pw/realspace_grid_cube.F
@@ -14,10 +14,11 @@ MODULE realspace_grid_cube
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: &
-        file_amode_rdonly, file_offset, mp_bcast, mp_file_close, mp_file_descriptor_type, &
-        mp_file_get_position, mp_file_open, mp_file_read_all_chv, mp_file_type_free, &
-        mp_file_type_hindexed_make_chv, mp_file_type_set_view_chv, mp_file_write_all_chv, &
-        mp_file_write_at, mp_maxloc, mp_recv, mp_send, mp_sum, mp_sync, mpi_character_size
+        file_amode_rdonly, file_offset, mp_bcast, mp_comm_type, mp_file_close, &
+        mp_file_descriptor_type, mp_file_get_position, mp_file_open, mp_file_read_all_chv, &
+        mp_file_type_free, mp_file_type_hindexed_make_chv, mp_file_type_set_view_chv, &
+        mp_file_write_all_chv, mp_file_write_at, mp_maxloc, mp_recv, mp_send, mp_sum, mp_sync, &
+        mpi_character_size
    USE pw_grid_types,                   ONLY: PW_MODE_LOCAL
    USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
@@ -61,10 +62,11 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_to_cube'
       INTEGER, PARAMETER                                 :: entry_len = 13, num_entries_line = 6
 
-      INTEGER :: checksum, dest, gid, handle, i, I1, I2, I3, iat, ip, L1, L2, L3, msglen, my_rank, &
+      INTEGER :: checksum, dest, handle, i, I1, I2, I3, iat, ip, L1, L2, L3, msglen, my_rank, &
          my_stride(3), np, num_linebreak, num_pe, rank(2), size_of_z, source, tag, U1, U2, U3
       LOGICAL                                            :: be_silent, my_zero_tails, parallel_write
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: buf
+      TYPE(mp_comm_type)                                 :: gid
 
       CALL timeset(routineN, handle)
 
@@ -243,8 +245,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_to_pw'
       INTEGER, PARAMETER                                 :: entry_len = 13, num_entries_line = 6
 
-      INTEGER                                            :: extunit, gid, handle, i, ip, j, k, &
-                                                            master, msglen, my_rank, nat, ndum, &
+      INTEGER                                            :: extunit, handle, i, ip, j, k, master, &
+                                                            msglen, my_rank, nat, ndum, &
                                                             num_linebreak, num_pe, output_unit, &
                                                             size_of_z, tag
       INTEGER, DIMENSION(3)                              :: lbounds, lbounds_local, npoints, &
@@ -252,6 +254,7 @@ CONTAINS
       LOGICAL                                            :: be_silent
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: buffer
       REAL(kind=dp), DIMENSION(3)                        :: dr, rdum
+      TYPE(mp_comm_type)                                 :: gid
 
       output_unit = cp_logger_get_default_io_unit()
 
@@ -388,13 +391,14 @@ CONTAINS
       INTEGER(kind=file_offset), ALLOCATABLE, &
          DIMENSION(:), TARGET                            :: displacements
       INTEGER(kind=file_offset)                          :: BOF
-      INTEGER :: extunit, gid, i, ientry, ip, islice, j, k, master, my_rank, nat, ndum, nslices, &
+      INTEGER :: extunit, i, ientry, ip, islice, j, k, master, my_rank, nat, ndum, nslices, &
          num_pe, offset_global, output_unit, pos, readstat, size_of_z, tag
       CHARACTER(LEN=msglen), ALLOCATABLE, DIMENSION(:)   :: readbuffer
       CHARACTER(LEN=msglen)                              :: tmp
       LOGICAL                                            :: be_silent, should_read(2)
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: buffer
       REAL(kind=dp), DIMENSION(3)                        :: dr, rdum
+      TYPE(mp_comm_type)                                 :: gid
       TYPE(mp_file_descriptor_type)                      :: mp_file_type
 
       output_unit = cp_logger_get_default_io_unit()
@@ -657,11 +661,12 @@ CONTAINS
       INTEGER(kind=file_offset), ALLOCATABLE, &
          DIMENSION(:), TARGET                            :: displacements
       INTEGER(kind=file_offset)                          :: BOF
-      INTEGER                                            :: counter, gid, i, islice, j, k, last_z, &
+      INTEGER                                            :: counter, i, islice, j, k, last_z, &
                                                             my_rank, np, nslices, size_of_z
       CHARACTER(LEN=msglen), ALLOCATABLE, DIMENSION(:)   :: writebuffer
       CHARACTER(LEN=msglen)                              :: tmp
       LOGICAL                                            :: should_write(2)
+      TYPE(mp_comm_type)                                 :: gid
       TYPE(mp_file_descriptor_type)                      :: mp_file_type
 
       !get rs grids and parallel envnment
@@ -834,13 +839,14 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_to_simple_volumetric'
 
-      INTEGER                                            :: checksum, dest, gid, handle, i, I1, I2, &
-                                                            I3, ip, L1, L2, L3, my_rank, &
-                                                            my_stride(3), ngrids, npoints, num_pe, &
-                                                            rank(2), source, tag, U1, U2, U3
+      INTEGER                                            :: checksum, dest, handle, i, I1, I2, I3, &
+                                                            ip, L1, L2, L3, my_rank, my_stride(3), &
+                                                            ngrids, npoints, num_pe, rank(2), &
+                                                            source, tag, U1, U2, U3
       LOGICAL                                            :: DOUBLE
       REAL(KIND=dp)                                      :: x, y, z
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: buf, buf2
+      TYPE(mp_comm_type)                                 :: gid
 
       CALL timeset(routineN, handle)
 

--- a/src/pw/realspace_grid_cube.F
+++ b/src/pw/realspace_grid_cube.F
@@ -16,9 +16,9 @@ MODULE realspace_grid_cube
    USE message_passing,                 ONLY: &
         file_amode_rdonly, file_offset, mp_bcast, mp_comm_type, mp_file_close, &
         mp_file_descriptor_type, mp_file_get_position, mp_file_open, mp_file_read_all_chv, &
-        mp_file_type_free, mp_file_type_hindexed_make_chv, mp_file_type_set_view_chv, &
-        mp_file_write_all_chv, mp_file_write_at, mp_maxloc, mp_recv, mp_send, mp_sum, mp_sync, &
-        mpi_character_size
+        mp_file_type, mp_file_type_free, mp_file_type_hindexed_make_chv, &
+        mp_file_type_set_view_chv, mp_file_write_all_chv, mp_file_write_at, mp_maxloc, mp_recv, &
+        mp_send, mp_sum, mp_sync, mpi_character_size
    USE pw_grid_types,                   ONLY: PW_MODE_LOCAL
    USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
@@ -67,6 +67,7 @@ CONTAINS
       LOGICAL                                            :: be_silent, my_zero_tails, parallel_write
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: buf
       TYPE(mp_comm_type)                                 :: gid
+      TYPE(mp_file_type)                                 :: mp_unit
 
       CALL timeset(routineN, handle)
 
@@ -215,7 +216,8 @@ CONTAINS
          IF (MODULO(size_of_z, num_entries_line) /= 0) &
             num_linebreak = num_linebreak + 1
          msglen = (size_of_z*entry_len + num_linebreak)*mpi_character_size
-         CALL pw_to_cube_parallel(pw, unit_nr, title, particles_r, particles_z, my_stride, my_zero_tails, msglen)
+         CALL mp_unit%set_handle(unit_nr)
+         CALL pw_to_cube_parallel(pw, mp_unit, title, particles_r, particles_z, my_stride, my_zero_tails, msglen)
       END IF
 
       CALL timestop(handle)
@@ -391,7 +393,7 @@ CONTAINS
       INTEGER(kind=file_offset), ALLOCATABLE, &
          DIMENSION(:), TARGET                            :: displacements
       INTEGER(kind=file_offset)                          :: BOF
-      INTEGER :: extunit, i, ientry, ip, islice, j, k, master, my_rank, nat, ndum, nslices, &
+      INTEGER :: extunit_handle, i, ientry, ip, islice, j, k, master, my_rank, nat, ndum, nslices, &
          num_pe, offset_global, output_unit, pos, readstat, size_of_z, tag
       CHARACTER(LEN=msglen), ALLOCATABLE, DIMENSION(:)   :: readbuffer
       CHARACTER(LEN=msglen)                              :: tmp
@@ -399,7 +401,8 @@ CONTAINS
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: buffer
       REAL(kind=dp), DIMENSION(3)                        :: dr, rdum
       TYPE(mp_comm_type)                                 :: gid
-      TYPE(mp_file_descriptor_type)                      :: mp_file_type
+      TYPE(mp_file_descriptor_type)                      :: mp_file_desc
+      TYPE(mp_file_type)                                 :: extunit
 
       output_unit = cp_logger_get_default_io_unit()
 
@@ -440,15 +443,15 @@ CONTAINS
                         file_form="FORMATTED", &
                         file_action="READ", &
                         file_access="STREAM", &
-                        unit_number=extunit)
+                        unit_number=extunit_handle)
 
          !skip header comments
          DO i = 1, 2
-            READ (extunit, *)
+            READ (extunit_handle, *)
          END DO
-         READ (extunit, *) nat, rdum
+         READ (extunit_handle, *) nat, rdum
          DO i = 1, 3
-            READ (extunit, *) ndum, rdum
+            READ (extunit_handle, *) ndum, rdum
             IF ((ndum /= npoints(i) .OR. (ABS(rdum(i) - dr(i)) > 1e-4)) .AND. &
                 output_unit > 0) THEN
                WRITE (output_unit, *) "Restart from density | ERROR! | CUBE FILE NOT COINCIDENT WITH INTERNAL GRID ", i
@@ -458,11 +461,11 @@ CONTAINS
          END DO
          !ignore atomic position data - read from coord or topology instead
          DO i = 1, nat
-            READ (extunit, *)
+            READ (extunit_handle, *)
          END DO
          ! Get byte offset
-         INQUIRE (extunit, POS=offset_global)
-         CALL close_file(unit_number=extunit)
+         INQUIRE (extunit_handle, POS=offset_global)
+         CALL close_file(unit_number=extunit_handle)
       END IF
       ! Sync offset and start parallel read
       CALL mp_bcast(offset_global, grid%pw_grid%para%group_head_id, gid)
@@ -496,14 +499,14 @@ CONTAINS
       ALLOCATE (blocklengths(nslices))
       blocklengths(:) = msglen
       ! Create indexed MPI type using calculated byte offsets as displacements and use it as a file view
-      mp_file_type = mp_file_type_hindexed_make_chv(nslices, blocklengths, displacements)
+      mp_file_desc = mp_file_type_hindexed_make_chv(nslices, blocklengths, displacements)
       BOF = 0
-      CALL mp_file_type_set_view_chv(extunit, BOF, mp_file_type)
+      CALL mp_file_type_set_view_chv(extunit, BOF, mp_file_desc)
       ! Collective read of cube
       ALLOCATE (readbuffer(nslices))
       readbuffer(:) = ''
-      CALL mp_file_read_all_chv(extunit, msglen, nslices, readbuffer, mp_file_type)
-      CALL mp_file_type_free(mp_file_type)
+      CALL mp_file_read_all_chv(extunit, msglen, nslices, readbuffer, mp_file_desc)
+      CALL mp_file_type_free(mp_file_desc)
       CALL mp_file_close(extunit)
       ! Convert cube values string -> real
       i = lbounds_local(1)
@@ -565,15 +568,15 @@ CONTAINS
                            file_status="OLD", &
                            file_form="FORMATTED", &
                            file_action="READ", &
-                           unit_number=extunit)
+                           unit_number=extunit_handle)
 
             !skip header comments
             DO i = 1, 2
-               READ (extunit, *)
+               READ (extunit_handle, *)
             END DO
-            READ (extunit, *) nat, rdum
+            READ (extunit_handle, *) nat, rdum
             DO i = 1, 3
-               READ (extunit, *) ndum, rdum
+               READ (extunit_handle, *) ndum, rdum
                IF ((ndum /= npoints(i) .OR. (ABS(rdum(i) - dr(i)) > 1e-4)) .AND. &
                    output_unit > 0) THEN
                   WRITE (output_unit, *) "Restart from density | ERROR! | CUBE FILE NOT COINCIDENT WITH INTERNAL GRID ", i
@@ -583,7 +586,7 @@ CONTAINS
             END DO
             !ignore atomic position data - read from coord or topology instead
             DO i = 1, nat
-               READ (extunit, *)
+               READ (extunit_handle, *)
             END DO
          END IF
 
@@ -591,7 +594,7 @@ CONTAINS
          DO i = lbounds(1), ubounds(1)
             DO j = lbounds(2), ubounds(2)
                IF (my_rank .EQ. 0) THEN
-                  READ (extunit, *) (buffer(k), k=lbounds(3), ubounds(3))
+                  READ (extunit_handle, *) (buffer(k), k=lbounds(3), ubounds(3))
                   IF (num_pe .GT. 1) THEN
                      DO ip = 1, num_pe - 1
                         CALL mp_send(buffer(lbounds(3):ubounds(3)), ip, tag, gid)
@@ -615,7 +618,7 @@ CONTAINS
             END DO
          END DO
 
-         IF (my_rank == 0) CALL close_file(unit_number=extunit)
+         IF (my_rank == 0) CALL close_file(unit_number=extunit_handle)
 
          CALL mp_sync(gid)
       END IF
@@ -640,7 +643,7 @@ CONTAINS
                                   msglen)
 
       TYPE(pw_type), INTENT(IN)                          :: grid
-      INTEGER, INTENT(IN)                                :: unit_nr
+      TYPE(mp_file_type), INTENT(IN)                     :: unit_nr
       CHARACTER(*), INTENT(IN), OPTIONAL                 :: title
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN), &
          OPTIONAL                                        :: particles_r

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -253,7 +253,7 @@ CONTAINS
          END IF
          desc%parallel = .FALSE.
          desc%distributed = .FALSE.
-         CALL desc%group%set_handle(mp_comm_null)
+         desc%group = mp_comm_null
          desc%group_size = 1
          desc%group_head = .TRUE.
          desc%group_dim = 1

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -27,7 +27,8 @@ MODULE realspace_grid_types
    USE mathlib,                         ONLY: det_3x3
    USE message_passing,                 ONLY: &
         mp_comm_dup, mp_comm_free, mp_comm_null, mp_comm_type, mp_environ, mp_irecv, mp_isend, &
-        mp_isendrecv, mp_max, mp_min, mp_request_null, mp_sum, mp_sync, mp_waitall, mp_waitany
+        mp_isendrecv, mp_max, mp_min, mp_request_null, mp_sendrecv, mp_sum, mp_sync, mp_waitall, &
+        mp_waitany
    USE offload_api,                     ONLY: offload_buffer_type,&
                                               offload_create_buffer,&
                                               offload_free_buffer
@@ -873,9 +874,8 @@ CONTAINS
                END DO
             END DO
             IF (ip .EQ. np) EXIT
-            CALL mp_isendrecv(sendbuf, dest, recvbuf, source, &
-                              group, req(1), req(2), 13)
-            CALL mp_waitall(req)
+            CALL mp_sendrecv(sendbuf, dest, recvbuf, source, &
+                             group, 13)
             swapptr => sendbuf
             sendbuf => recvbuf
             recvbuf => swapptr

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -27,8 +27,8 @@ MODULE realspace_grid_types
    USE mathlib,                         ONLY: det_3x3
    USE message_passing,                 ONLY: &
         mp_comm_dup, mp_comm_free, mp_comm_null, mp_comm_type, mp_environ, mp_irecv, mp_isend, &
-        mp_isendrecv, mp_max, mp_min, mp_request_null, mp_sendrecv, mp_sum, mp_sync, mp_waitall, &
-        mp_waitany
+        mp_isendrecv, mp_max, mp_min, mp_request_null, mp_request_type, mp_sendrecv, mp_sum, &
+        mp_sync, mp_waitall, mp_waitany
    USE offload_api,                     ONLY: offload_buffer_type,&
                                               offload_create_buffer,&
                                               offload_free_buffer
@@ -822,8 +822,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: dir
 
       INTEGER                                            :: dest, i, ii, im, ip, ix, iy, iz, j, jm, &
-                                                            k, km, mepos, nma, nn, np, req(2), &
-                                                            s(3), source
+                                                            k, km, mepos, nma, nn, np, s(3), source
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rcount
       INTEGER, DIMENSION(3)                              :: lb, ub
       INTEGER, DIMENSION(:, :), POINTER                  :: pbo
@@ -831,6 +830,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: recvbuf, sendbuf, swapptr
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: grid
       TYPE(mp_comm_type)                                 :: group
+      TYPE(mp_request_type), DIMENSION(2)                :: req
 
       np = pw%pw_grid%para%group_size
       bo => pw%pw_grid%para%bo(1:2, 1:3, 0:np - 1, 1)
@@ -1005,19 +1005,19 @@ CONTAINS
       CHARACTER(LEN=200)                                 :: error_string
       INTEGER :: completed, dest_down, dest_up, i, idir, j, k, lb, my_id, my_pw_rank, my_rs_rank, &
          n_shifts, nn, num_threads, position, source_down, source_up, ub, x, y, z
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dshifts, recv_disps, recv_reqs, &
-                                                            recv_sizes, send_disps, send_reqs, &
-                                                            send_sizes, ushifts
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dshifts, recv_disps, recv_sizes, &
+                                                            send_disps, send_sizes, ushifts
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: bounds, recv_tasks, send_tasks
       INTEGER, DIMENSION(2)                              :: neighbours, pos
       INTEGER, DIMENSION(3) :: coords, lb_recv, lb_recv_down, lb_recv_up, lb_send, lb_send_down, &
          lb_send_up, ub_recv, ub_recv_down, ub_recv_up, ub_send, ub_send_down, ub_send_up
-      INTEGER, DIMENSION(4)                              :: req
       LOGICAL, DIMENSION(3)                              :: halo_swapped
       REAL(KIND=dp)                                      :: pw_sum, rs_sum
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: recv_buf_3d_down, recv_buf_3d_up, &
                                                             send_buf_3d_down, send_buf_3d_up
       TYPE(cp_1d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: recv_bufs, send_bufs
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_reqs, send_reqs
+      TYPE(mp_request_type), DIMENSION(4)                :: req
 
       num_threads = 1
       my_id = 0

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -26,8 +26,8 @@ MODULE realspace_grid_types
    USE machine,                         ONLY: m_memory
    USE mathlib,                         ONLY: det_3x3
    USE message_passing,                 ONLY: &
-        mp_comm_dup, mp_comm_free, mp_environ, mp_irecv, mp_isend, mp_isendrecv, mp_max, mp_min, &
-        mp_request_null, mp_sum, mp_sync, mp_waitall, mp_waitany
+        mp_comm_dup, mp_comm_free, mp_comm_null, mp_comm_type, mp_environ, mp_irecv, mp_isend, &
+        mp_isendrecv, mp_max, mp_min, mp_request_null, mp_sum, mp_sync, mp_waitall, mp_waitany
    USE offload_api,                     ONLY: offload_buffer_type,&
                                               offload_create_buffer,&
                                               offload_free_buffer
@@ -109,7 +109,7 @@ MODULE realspace_grid_types
       LOGICAL :: distributed ! whether the rs grid is distributed
       ! these MPI related quantities are only meaningful depending on how the grid has been laid out
       ! they are most useful for fully distributed grids, where they reflect the topology of the grid
-      INTEGER :: group
+      TYPE(mp_comm_type) :: group
       INTEGER :: my_pos
       LOGICAL :: group_head
       INTEGER :: group_size
@@ -253,7 +253,7 @@ CONTAINS
          END IF
          desc%parallel = .FALSE.
          desc%distributed = .FALSE.
-         desc%group = -1
+         CALL desc%group%set_handle(mp_comm_null)
          desc%group_size = 1
          desc%group_head = .TRUE.
          desc%group_dim = 1
@@ -820,15 +820,16 @@ CONTAINS
       TYPE(pw_type), INTENT(IN)                          :: pw
       INTEGER, INTENT(IN)                                :: dir
 
-      INTEGER                                            :: dest, group, i, ii, im, ip, ix, iy, iz, &
-                                                            j, jm, k, km, mepos, nma, nn, np, &
-                                                            req(2), s(3), source
+      INTEGER                                            :: dest, i, ii, im, ip, ix, iy, iz, j, jm, &
+                                                            k, km, mepos, nma, nn, np, req(2), &
+                                                            s(3), source
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rcount
       INTEGER, DIMENSION(3)                              :: lb, ub
       INTEGER, DIMENSION(:, :), POINTER                  :: pbo
       INTEGER, DIMENSION(:, :, :), POINTER               :: bo
       REAL(KIND=dp), DIMENSION(:), POINTER               :: recvbuf, sendbuf, swapptr
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: grid
+      TYPE(mp_comm_type)                                 :: group
 
       np = pw%pw_grid%para%group_size
       bo => pw%pw_grid%para%bo(1:2, 1:3, 0:np - 1, 1)

--- a/src/pw_env/gaussian_gridlevels.F
+++ b/src/pw_env/gaussian_gridlevels.F
@@ -21,7 +21,8 @@ MODULE gaussian_gridlevels
                                               section_vals_type
    USE kinds,                           ONLY: dp,&
                                               int_8
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -86,9 +87,10 @@ CONTAINS
       TYPE(gridlevel_info_type)                          :: gridlevel_info
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
 
-      INTEGER                                            :: group, i, output_unit
+      INTEGER                                            :: i, output_unit
       LOGICAL                                            :: do_io
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: group
 
       NULLIFY (logger)
       logger => cp_get_default_logger()

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -37,6 +37,7 @@ MODULE qmmm_gpw_forces
    USE message_passing,                 ONLY: mp_comm_type,&
                                               mp_irecv,&
                                               mp_isend,&
+                                              mp_request_type,&
                                               mp_sum,&
                                               mp_wait
    USE mm_collocate_potential,          ONLY: collocate_gf_rspace_NoPBC,&
@@ -425,12 +426,13 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'qmmm_forces_with_gaussian'
 
       INTEGER                                            :: handle, i, igrid, j, k, kind_interp, me, &
-                                                            ngrids, request, stat
+                                                            ngrids, stat
       INTEGER, DIMENSION(3)                              :: glb, gub, lb, ub
       INTEGER, DIMENSION(:), POINTER                     :: pos_of_x
       LOGICAL                                            :: shells
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: tmp
       TYPE(mp_comm_type)                                 :: group
+      TYPE(mp_request_type)                              :: request
       TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: grids
 
 ! Statements

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -34,7 +34,8 @@ MODULE qmmm_gpw_forces
                                               section_vals_type,&
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_irecv,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_irecv,&
                                               mp_isend,&
                                               mp_sum,&
                                               mp_wait
@@ -423,12 +424,13 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qmmm_forces_with_gaussian'
 
-      INTEGER                                            :: group, handle, i, igrid, j, k, &
-                                                            kind_interp, me, ngrids, request, stat
+      INTEGER                                            :: handle, i, igrid, j, k, kind_interp, me, &
+                                                            ngrids, request, stat
       INTEGER, DIMENSION(3)                              :: glb, gub, lb, ub
       INTEGER, DIMENSION(:), POINTER                     :: pos_of_x
       LOGICAL                                            :: shells
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: tmp
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: grids
 
 ! Statements

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -65,6 +65,7 @@ MODULE qs_active_space_methods
    USE mathconstants,                   ONLY: fourpi
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type,&
                                               mp_sum
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_list_types,             ONLY: particle_list_type
@@ -1011,7 +1012,7 @@ CONTAINS
          END IF
          nn1 = (n1*(n1 + 1))/2
          nn2 = (n2*(n2 + 1))/2
-         CALL dbcsr_csr_create(eri_mat, nn1, nn2, 0_int_8, 0, 0, para_env%group)
+         CALL dbcsr_csr_create(eri_mat, nn1, nn2, 0_int_8, 0, 0, para_env%group%get_handle())
          active_space_env%eri%norb = nmo
       END DO
 
@@ -1319,6 +1320,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mp_comm_type)                                 :: mp_group
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb_sub
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1465,7 +1467,8 @@ CONTAINS
       DO isp1 = 1, nspins
          CALL get_mo_set(mo_set=mos(isp1), nmo=nmo1)
          nmm = (nmo1*(nmo1 + 1))/2
-         irange = get_irange_csr(nmm, eri_env%eri(1)%csr_mat%mp_group)
+         CALL mp_group%set_handle(eri_env%eri(1)%csr_mat%mp_group)
+         irange = get_irange_csr(nmm, mp_group)
          DO i1 = 1, SIZE(orbitals, 1)
             iwa1 = orbitals(i1, isp1)
             IF (eri_env%eri_gpw%store_wfn) THEN
@@ -2201,11 +2204,13 @@ CONTAINS
                                                             irptr, m1, m2, nindex, nmo_total, norb
       INTEGER, DIMENSION(2)                              :: irange
       REAL(dp)                                           :: erint
+      TYPE(mp_comm_type)                                 :: mp_group
 
       norb = SIZE(active_orbitals, 1)
       nmo_total = SIZE(p_mat, 1)
       nindex = (nmo_total*(nmo_total + 1))/2
-      irange = get_irange_csr(nindex, eri%mp_group)
+      CALL mp_group%set_handle(eri%mp_group)
+      irange = get_irange_csr(nindex, mp_group)
       DO m1 = 1, norb
          i1 = active_orbitals(m1, 1)
          DO m2 = m1, norb
@@ -2253,7 +2258,7 @@ CONTAINS
             ks_ref(i2, i1) = ks_ref(i1, i2)
          END DO
       END DO
-      CALL mp_sum(ks_ref, eri%mp_group)
+      CALL mp_sum(ks_ref, mp_group)
 
    END SUBROUTINE build_subspace_fock_matrix
 
@@ -2279,11 +2284,13 @@ CONTAINS
                                                             norb, spin1, spin2
       INTEGER, DIMENSION(2)                              :: irange
       REAL(dp)                                           :: erint
+      TYPE(mp_comm_type)                                 :: mp_group
 
       norb = SIZE(active_orbitals, 1)
       nmo_total = SIZE(p_a_mat, 1)
       nindex = (nmo_total*(nmo_total + 1))/2
-      irange = get_irange_csr(nindex, eri_aa%mp_group)
+      CALL mp_group%set_handle(eri_aa%mp_group)
+      irange = get_irange_csr(nindex, mp_group)
       IF (tr_mixed_eri) THEN
          spin1 = 2
          spin2 = 1
@@ -2332,7 +2339,8 @@ CONTAINS
       END DO
       !
 
-      irange = get_irange_csr(nindex, eri_ab%mp_group)
+      CALL mp_group%set_handle(eri_ab%mp_group)
+      irange = get_irange_csr(nindex, mp_group)
       DO m1 = 1, norb
          i1 = active_orbitals(m1, 1)
          DO m2 = m1, norb
@@ -2365,7 +2373,8 @@ CONTAINS
             ks_a_ref(i2, i1) = ks_a_ref(i1, i2)
          END DO
       END DO
-      CALL mp_sum(ks_a_ref, eri_aa%mp_group)
+      CALL mp_group%set_handle(eri_aa%mp_group)
+      CALL mp_sum(ks_a_ref, mp_group)
 
    END SUBROUTINE build_subspace_spin_fock_matrix
 

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -21,6 +21,7 @@ MODULE qs_active_space_types
                                               dbcsr_p_type
    USE kinds,                           ONLY: default_path_length,&
                                               dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE qs_mo_types,                     ONLY: deallocate_mo_set,&
                                               mo_set_type
 #include "./base/base_uses.f90"
@@ -305,8 +306,9 @@ CONTAINS
 !>      04.2016 created [JGH]
 ! **************************************************************************************************
    FUNCTION get_irange_csr(nindex, mp_group) RESULT(irange)
-      USE message_passing, ONLY: mp_environ
-      INTEGER                                            :: nindex, mp_group
+      USE message_passing, ONLY: mp_environ, mp_comm_type
+      INTEGER, INTENT(IN)                                :: nindex
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
       INTEGER, DIMENSION(2)                              :: irange
 
       INTEGER                                            :: numtask, taskid
@@ -357,6 +359,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)       :: colind
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:) :: erival
       REAL(KIND=dp)                            :: erint
+      TYPE(mp_comm_type) :: mp_group
 
       IF (.NOT. PRESENT(spin1)) THEN
          spin1 = nspin
@@ -367,7 +370,8 @@ CONTAINS
 
       ASSOCIATE (eri => this%eri(nspin)%csr_mat, norb => this%norb)
          nindex = (norb*(norb + 1))/2
-         irange = get_irange_csr(nindex, eri%mp_group)
+         CALL mp_group%set_handle(eri%mp_group)
+         irange = get_irange_csr(nindex, mp_group)
          ALLOCATE (erival(nindex), colind(nindex))
 
          nmo = SIZE(active_orbitals, 1)
@@ -390,10 +394,10 @@ CONTAINS
                   nindex = 0
                END IF
 
-               CALL mp_sum(nindex, eri%mp_group)
-               CALL mp_sum(colind(1:nindex), eri%mp_group)
-               CALL mp_sum(erival(1:nindex), eri%mp_group)
-               CALL mp_sync(eri%mp_group)
+               CALL mp_sum(nindex, mp_group)
+               CALL mp_sum(colind(1:nindex), mp_group)
+               CALL mp_sum(erival(1:nindex), mp_group)
+               CALL mp_sync(mp_group)
 
                DO i34l = 1, nindex
                   i34 = colind(i34l)

--- a/src/qs_atomic_block.F
+++ b/src/qs_atomic_block.F
@@ -21,7 +21,8 @@ MODULE qs_atomic_block
         dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
         dbcsr_p_type, dbcsr_scale, dbcsr_set, dbcsr_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE particle_types,                  ONLY: particle_type
    USE qs_kind_types,                   ONLY: qs_kind_type
 #include "./base/base_uses.f90"
@@ -66,8 +67,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_atomic_block_dm'
 
-      INTEGER                                            :: blk, group, handle, icol, ikind, irow, &
-                                                            ispin, natom, nc, nkind, nocc(2)
+      INTEGER                                            :: blk, handle, icol, ikind, irow, ispin, &
+                                                            natom, nc, nkind, nocc(2)
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: nok
       REAL(dp), DIMENSION(:, :), POINTER                 :: pdata
@@ -76,6 +77,7 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_type), POINTER                          :: matrix_p
+      TYPE(mp_comm_type)                                 :: group
       TYPE(qs_kind_type), POINTER                        :: qs_kind
 
       CALL timeset(routineN, handle)

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -70,6 +70,7 @@ MODULE qs_collocate_density
                                               dp
    USE lri_environment_types,           ONLY: lri_kind_type
    USE memory_utilities,                ONLY: reallocate
+   USE message_passing,                 ONLY: mp_comm_type
    USE orbital_pointers,                ONLY: coset,&
                                               ncoset
    USE particle_types,                  ONLY: particle_type
@@ -1478,12 +1479,13 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_rho_elec'
 
       CHARACTER(LEN=default_string_length)               :: my_basis_type
-      INTEGER                                            :: ga_gb_function, group, handle, ilevel, &
-                                                            img, nimages, nlevels
+      INTEGER                                            :: ga_gb_function, handle, ilevel, img, &
+                                                            nimages, nlevels
       LOGICAL                                            :: any_distributed, my_compute_grad, &
                                                             my_compute_tau, my_soft_valid
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_images
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(realspace_grid_type), DIMENSION(:), POINTER   :: rs_rho
       TYPE(task_list_type), POINTER                      :: task_list
@@ -2413,8 +2415,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'collocate_single_gaussian'
 
       CHARACTER(LEN=default_string_length)               :: my_basis_type
-      INTEGER :: group, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, maxco, &
-         maxsgf_set, my_index, my_pos, na1, na2, natom, ncoa, nseta, offset, sgfa
+      INTEGER :: group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, maxco, maxsgf_set, &
+         my_index, my_pos, na1, na2, natom, ncoa, nseta, offset, sgfa
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: where_is_the_point
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nsgfa
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
@@ -2424,6 +2426,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: pab, sphi_a, zeta
       TYPE(gridlevel_info_type), POINTER                 :: gridlevel_info
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: mgrid_gspace, mgrid_rspace
       TYPE(realspace_grid_type), DIMENSION(:), POINTER   :: rs_rho
@@ -2607,8 +2610,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_wavefunction'
 
       CHARACTER(LEN=default_string_length)               :: my_basis_type
-      INTEGER :: group, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, maxco, &
-         maxsgf_set, my_pos, na1, na2, nao, natom, ncoa, nseta, offset, sgfa
+      INTEGER :: group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, maxco, maxsgf_set, &
+         my_pos, na1, na2, nao, natom, ncoa, nseta, offset, sgfa
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: where_is_the_point
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, npgfa, nsgfa
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
@@ -2619,6 +2622,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: pab, sphi_a, work, zeta
       TYPE(gridlevel_info_type), POINTER                 :: gridlevel_info
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_pool_p_type), DIMENSION(:), POINTER        :: pw_pools
       TYPE(pw_type), ALLOCATABLE, DIMENSION(:)           :: mgrid_gspace, mgrid_rspace
       TYPE(realspace_grid_type), DIMENSION(:), POINTER   :: rs_rho

--- a/src/qs_core_energies.F
+++ b/src/qs_core_energies.F
@@ -25,7 +25,8 @@ MODULE qs_core_energies
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: oorootpi,&
                                               twopi
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE particle_types,                  ONLY: particle_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -201,8 +202,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_ecore_overlap'
 
-      INTEGER                                            :: atom_a, atom_b, group, handle, iatom, &
-                                                            ikind, jatom, jkind, natom, nkind
+      INTEGER                                            :: atom_a, atom_b, handle, iatom, ikind, &
+                                                            jatom, jkind, natom, nkind
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind
       LOGICAL                                            :: atenergy, only_molecule, use_virial
       REAL(KIND=dp)                                      :: aab, dab, eab, ecore_overlap, f, fab, &
@@ -212,6 +213,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3)                     :: pv_loc
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(atprop_type), POINTER                         :: atprop
+      TYPE(mp_comm_type)                                 :: group
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: nl_iterator
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -50,7 +50,8 @@ MODULE qs_dcdr_utils
                                               default_string_length,&
                                               dp
    USE memory_utilities,                ONLY: reallocate
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE molecule_types,                  ONLY: molecule_type
    USE moments_utils,                   ONLY: get_reference_point
    USE parallel_gemm_api,               ONLY: parallel_gemm
@@ -146,15 +147,15 @@ CONTAINS
 
       CHARACTER(LEN=default_path_length)                 :: filename
       CHARACTER(LEN=default_string_length)               :: my_middle
-      INTEGER :: beta_tmp, group, handle, i, i_block, ia, ie, iostat, iounit, ispin, j, &
-         lambda_tmp, max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, &
-         rst_unit, source
+      INTEGER :: beta_tmp, handle, i, i_block, ia, ie, iostat, iounit, ispin, j, lambda_tmp, &
+         max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit, source
       LOGICAL                                            :: file_exists
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
+      TYPE(mp_comm_type)                                 :: group
       TYPE(section_vals_type), POINTER                   :: print_key
 
       file_exists = .FALSE.

--- a/src/qs_dispersion_pairpot.F
+++ b/src/qs_dispersion_pairpot.F
@@ -48,6 +48,7 @@ MODULE qs_dispersion_pairpot
    USE mathconstants,                   ONLY: twopi
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type,&
                                               mp_max,&
                                               mp_shift,&
                                               mp_sum
@@ -3357,11 +3358,11 @@ CONTAINS
       TYPE(dcnum_type), DIMENSION(:)                     :: dcnum
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
-      INTEGER                                            :: group, i, ia, ipe, jn, n, natom, ntmax, &
-                                                            ntot
+      INTEGER                                            :: i, ia, ipe, jn, n, natom, ntmax, ntot
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: list, nloc
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: dvals
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: rik
+      TYPE(mp_comm_type)                                 :: group
 
 ! we only have to do something if this is a parallel run
 

--- a/src/qs_epr_hyp.F
+++ b/src/qs_epr_hyp.F
@@ -27,7 +27,8 @@ MODULE qs_epr_hyp
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: fourpi
-   USE message_passing,                 ONLY: mp_sum,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum,&
                                               mp_sync
    USE particle_types,                  ONLY: particle_type
    USE periodic_table,                  ONLY: ptable
@@ -82,10 +83,10 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=2)                                   :: element_symbol
-      INTEGER                                            :: bo(2), group, ia, iat, iatom, idir1, &
-                                                            idir2, ig, ikind, ir, iso, jatom, &
-                                                            mepos, natom, natomkind, nkind, &
-                                                            num_pe, output_unit, z
+      INTEGER                                            :: bo(2), ia, iat, iatom, idir1, idir2, ig, &
+                                                            ikind, ir, iso, jatom, mepos, natom, &
+                                                            natomkind, nkind, num_pe, output_unit, &
+                                                            z
       INTEGER, DIMENSION(:), POINTER                     :: atom_list
       LOGICAL                                            :: lsd, paw_atom
       REAL(dp)                                           :: arg, esum, hard_radius, hypanisotemp, &
@@ -100,6 +101,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid

--- a/src/qs_external_density.F
+++ b/src/qs_external_density.F
@@ -20,7 +20,8 @@ MODULE qs_external_density
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE message_passing,                 ONLY: mp_recv,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_recv,&
                                               mp_send,&
                                               mp_sync
    USE pw_env_types,                    ONLY: pw_env_get,&
@@ -62,9 +63,9 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'external_read_density'
 
       CHARACTER(LEN=default_string_length)               :: filename
-      INTEGER                                            :: extunit, gid, handle, i, igrid_level, &
-                                                            ip, j, k, master, my_rank, nat, ndum, &
-                                                            num_pe, tag
+      INTEGER                                            :: extunit, handle, i, igrid_level, ip, j, &
+                                                            k, master, my_rank, nat, ndum, num_pe, &
+                                                            tag
       INTEGER, DIMENSION(3)                              :: lbounds, lbounds_local, npoints, &
                                                             npoints_local, ubounds, ubounds_local
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: buffer
@@ -73,6 +74,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(gridlevel_info_type), POINTER                 :: gridlevel_info
+      TYPE(mp_comm_type)                                 :: gid
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_type), DIMENSION(:), POINTER               :: rho_ext_g, rho_ext_r
       TYPE(qs_rho_type), POINTER                         :: rho_external

--- a/src/qs_external_potential.F
+++ b/src/qs_external_potential.F
@@ -30,7 +30,8 @@ MODULE qs_external_potential
                                               default_string_length,&
                                               dp
    USE maxwell_solver_interface,        ONLY: maxwell_solver
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE particle_types,                  ONLY: particle_type
    USE pw_grid_types,                   ONLY: PW_MODE_LOCAL
    USE pw_types,                        ONLY: pw_type
@@ -303,9 +304,9 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'interpolate_external_potential'
 
       INTEGER                                            :: buffer_i, buffer_j, buffer_k, &
-                                                            data_source, fd_extra_point, gid, &
-                                                            handle, i, i_pbc, ip, j, j_pbc, k, &
-                                                            k_pbc, my_rank, num_pe, tag
+                                                            data_source, fd_extra_point, handle, &
+                                                            i, i_pbc, ip, j, j_pbc, k, k_pbc, &
+                                                            my_rank, num_pe, tag
       INTEGER, DIMENSION(3)                              :: lbounds, lbounds_local, lower_inds, &
                                                             ubounds, ubounds_local, upper_inds
       LOGICAL                                            :: check, my_force
@@ -313,6 +314,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: grid_buffer
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: dgrid
       REAL(KIND=dp), DIMENSION(3)                        :: dr, subgrid_origin
+      TYPE(mp_comm_type)                                 :: gid
 
       CALL timeset(routineN, handle)
       my_force = .FALSE.
@@ -416,7 +418,7 @@ CONTAINS
 !> \param dr    step size for finite difference
 !> \param dgrid derivatives of grid
 ! **************************************************************************************************
-   SUBROUTINE d_finite_difference(grid, dr, dgrid)
+   PURE SUBROUTINE d_finite_difference(grid, dr, dgrid)
       REAL(KIND=dp), DIMENSION(0:, 0:, 0:), INTENT(IN)   :: grid
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: dr
       REAL(KIND=dp), DIMENSION(1:, 1:, 1:, :), &
@@ -444,10 +446,10 @@ CONTAINS
 !> \param dr          step size
 !> \return interpolated value of external potential
 ! **************************************************************************************************
-   FUNCTION trilinear_interpolation(r, subgrid, origin, dr) RESULT(value_at_r)
-      REAL(KIND=dp), DIMENSION(3)                        :: r
-      REAL(KIND=dp), DIMENSION(:, :, :)                  :: subgrid
-      REAL(KIND=dp), DIMENSION(3)                        :: origin, dr
+   PURE FUNCTION trilinear_interpolation(r, subgrid, origin, dr) RESULT(value_at_r)
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: r
+      REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: subgrid
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: origin, dr
       REAL(KIND=dp)                                      :: value_at_r
 
       REAL(KIND=dp), DIMENSION(3)                        :: norm_r, norm_r_rev
@@ -472,8 +474,9 @@ CONTAINS
 !> \param upbound ...
 !> \return ...
 ! **************************************************************************************************
-   FUNCTION pbc_index(i, lowbound, upbound)
-      INTEGER                                            :: i, lowbound, upbound, pbc_index
+   ELEMENTAL FUNCTION pbc_index(i, lowbound, upbound)
+      INTEGER, INTENT(IN)                                :: i, lowbound, upbound
+      INTEGER                                            :: pbc_index
 
       IF (i < lowbound) THEN
          pbc_index = upbound + i - lowbound + 1

--- a/src/qs_initial_guess.F
+++ b/src/qs_initial_guess.F
@@ -63,6 +63,7 @@ MODULE qs_initial_guess
    USE kpoint_io,                       ONLY: read_kpoints_restart
    USE kpoint_types,                    ONLY: kpoint_type
    USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type,&
                                               mp_sum
    USE particle_methods,                ONLY: get_particle_set
    USE particle_types,                  ONLY: particle_type
@@ -139,10 +140,10 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_first_density_matrix'
 
       CHARACTER(LEN=default_path_length)                 :: file_name, filename
-      INTEGER :: atom_a, blk, density_guess, group, handle, homo, i, iatom, ic, icol, id_nr, &
-         ikind, irow, iseed(4), ispin, istart_col, istart_row, j, last_read, n, n_cols, n_rows, &
-         nao, natom, natoms, natoms_tmp, nblocks, nelectron, nmo, nmo_tmp, not_read, nsgf, nspin, &
-         nvec, ounit, safe_density_guess, size_atomic_kind_set, z
+      INTEGER :: atom_a, blk, density_guess, handle, homo, i, iatom, ic, icol, id_nr, ikind, irow, &
+         iseed(4), ispin, istart_col, istart_row, j, last_read, n, n_cols, n_rows, nao, natom, &
+         natoms, natoms_tmp, nblocks, nelectron, nmo, nmo_tmp, not_read, nsgf, nspin, nvec, ounit, &
+         safe_density_guess, size_atomic_kind_set, z
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, kind_of, last_sgf
       INTEGER, DIMENSION(2)                              :: nelectron_spin
       INTEGER, DIMENSION(:), POINTER                     :: atom_list, elec_conf, nelec_kind, &
@@ -174,6 +175,7 @@ CONTAINS
       TYPE(hfx_type), DIMENSION(:, :), POINTER           :: x_data
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mo_array, mos_last_converged
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_kind_type), POINTER                        :: qs_kind
@@ -1171,10 +1173,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_mopac_dm'
 
-      INTEGER                                            :: atom_a, group, handle, iatom, ikind, &
-                                                            iset, isgf, isgfa, ishell, ispin, la, &
-                                                            maxl, maxll, na, nao, natom, ncount, &
-                                                            nset, nsgf, z
+      INTEGER                                            :: atom_a, handle, iatom, ikind, iset, &
+                                                            isgf, isgfa, ishell, ispin, la, maxl, &
+                                                            maxll, na, nao, natom, ncount, nset, &
+                                                            nsgf, z
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf
       INTEGER, DIMENSION(25)                             :: laox, naox
       INTEGER, DIMENSION(5)                              :: occupation
@@ -1189,6 +1191,7 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: matrix_p
       TYPE(gth_potential_type), POINTER                  :: gth_potential
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(sgp_potential_type), POINTER                  :: sgp_potential
       TYPE(xtb_atom_type), POINTER                       :: xtb_kind
 

--- a/src/qs_integrate_potential_product.F
+++ b/src/qs_integrate_potential_product.F
@@ -51,6 +51,7 @@ MODULE qs_integrate_potential_product
    USE input_constants,                 ONLY: do_admm_exch_scaling_merlot
    USE kinds,                           ONLY: default_string_length,&
                                               dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE orbital_pointers,                ONLY: ncoset
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
@@ -115,10 +116,10 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_v_dbasis'
 
-      INTEGER :: bcol, brow, group, handle, i, iatom, igrid_level, ikind, ikind_old, ilevel, img, &
-         ipair, ipgf, ipgf_new, iset, iset_new, iset_old, itask, ithread, jatom, jkind, jkind_old, &
-         jpgf, jpgf_new, jset, jset_new, jset_old, maxco, maxpgf, maxset, maxsgf_set, na1, na2, &
-         natom, nb1, nb2, ncoa, ncob, nimages, nkind, nseta, nsetb, nthread, sgfa, sgfb
+      INTEGER :: bcol, brow, handle, i, iatom, igrid_level, ikind, ikind_old, ilevel, img, ipair, &
+         ipgf, ipgf_new, iset, iset_new, iset_old, itask, ithread, jatom, jkind, jkind_old, jpgf, &
+         jpgf_new, jset, jset_new, jset_old, maxco, maxpgf, maxset, maxsgf_set, na1, na2, natom, &
+         nb1, nb2, ncoa, ncob, nimages, nkind, nseta, nsetb, nthread, sgfa, sgfb
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: block_touched
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, npgfa, &
                                                             npgfb, nsgfa, nsgfb
@@ -143,6 +144,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(gridlevel_info_type), POINTER                 :: gridlevel_info
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
@@ -597,9 +599,9 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_v_rspace'
 
       CHARACTER(len=default_string_length)               :: my_basis_type
-      INTEGER                                            :: atom_a, group, handle, iatom, &
-                                                            igrid_level, ikind, img, maxco, &
-                                                            maxsgf_set, natoms, nimages, nkind
+      INTEGER                                            :: atom_a, handle, iatom, igrid_level, &
+                                                            ikind, img, maxco, maxsgf_set, natoms, &
+                                                            nimages, nkind
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, kind_of
       LOGICAL                                            :: calculate_virial, distributed_grids, &
                                                             do_kp, my_compute_tau, my_force_adm, &
@@ -613,6 +615,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: deltap, dhmat
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(gridlevel_info_type), POINTER                 :: gridlevel_info
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -59,7 +59,8 @@ MODULE qs_linres_methods
                                               dp
    USE machine,                         ONLY: m_flush,&
                                               m_walltime
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE preconditioner,                  ONLY: apply_preconditioner,&
                                               make_preconditioner
@@ -919,7 +920,7 @@ CONTAINS
 
       CHARACTER(LEN=default_path_length)                 :: filename
       CHARACTER(LEN=default_string_length)               :: my_middle
-      INTEGER :: group, handle, i, i_block, ia, ie, iostat, iounit, ispin, iv, iv1, ivec_tmp, j, &
+      INTEGER :: handle, i, i_block, ia, ie, iostat, iounit, ispin, iv, iv1, ivec_tmp, j, &
          max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit, source
       LOGICAL                                            :: file_exists
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
@@ -927,6 +928,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
+      TYPE(mp_comm_type)                                 :: group
       TYPE(section_vals_type), POINTER                   :: print_key
 
       file_exists = .FALSE.

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -61,7 +61,8 @@ MODULE qs_loc_utils
    USE mathconstants,                   ONLY: pi,&
                                               twopi
    USE memory_utilities,                ONLY: reallocate
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE orbital_pointers,                ONLY: ncoset
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_types,                  ONLY: particle_type
@@ -1042,12 +1043,13 @@ CONTAINS
       CHARACTER(LEN=25)                                  :: fname_key
       CHARACTER(LEN=default_path_length)                 :: filename
       CHARACTER(LEN=default_string_length)               :: my_middle
-      INTEGER :: group, handle, homo_read, i, ispin, lfomo_read, max_nloc, n_rep_val, nao, &
+      INTEGER :: handle, homo_read, i, ispin, lfomo_read, max_nloc, n_rep_val, nao, &
          nelectron_read, nloc, nmo, nmo_read, nspin, output_unit, rst_unit, source
       LOGICAL                                            :: file_exists, my_do_mixed
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eig_read, occ_read
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: group
       TYPE(section_vals_type), POINTER                   :: print_key
 
       CALL timeset(routineN, handle)

--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -59,7 +59,8 @@ MODULE qs_mo_io
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               dp
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE orbital_pointers,                ONLY: indco,&
                                               nco,&
                                               nso
@@ -505,10 +506,11 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_mo_set_from_restart'
 
       CHARACTER(LEN=default_path_length)                 :: file_name
-      INTEGER                                            :: group, handle, ispin, natom, nspin, &
+      INTEGER                                            :: handle, ispin, natom, nspin, &
                                                             restart_unit, source
       LOGICAL                                            :: exist, my_cdft
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
@@ -594,10 +596,11 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_rt_mos_from_restart'
 
       CHARACTER(LEN=default_path_length)                 :: file_name
-      INTEGER                                            :: group, handle, ispin, natom, nspin, &
+      INTEGER                                            :: handle, ispin, natom, nspin, &
                                                             restart_unit, source
       LOGICAL                                            :: exist
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
@@ -668,7 +671,7 @@ CONTAINS
       TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: rt_mos
       LOGICAL, INTENT(OUT), OPTIONAL                     :: natom_mismatch
 
-      INTEGER :: group, homo, homo_read, i, iatom, ikind, imat, irow, iset, iset_read, ishell, &
+      INTEGER :: homo, homo_read, i, iatom, ikind, imat, irow, iset, iset_read, ishell, &
          ishell_read, iso, ispin, lfomo_read, lmax, lshell, my_mult, nao, nao_read, natom_read, &
          nelectron, nelectron_read, nmo, nmo_read, nnshell, nset, nset_max, nshell_max, nspin, &
          nspin_read, offset_read, source
@@ -680,6 +683,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer, vecbuffer_read
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(qs_dftb_atom_type), POINTER                   :: dftb_parameter
 
       logger => cp_get_default_logger()

--- a/src/qs_neighbor_lists.F
+++ b/src/qs_neighbor_lists.F
@@ -62,7 +62,8 @@ MODULE qs_neighbor_lists
                                               dp,&
                                               int_8
    USE kpoint_types,                    ONLY: kpoint_type
-   USE message_passing,                 ONLY: mp_max,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_max,&
                                               mp_sum
    USE molecule_types,                  ONLY: molecule_type
    USE particle_types,                  ONLY: particle_type
@@ -1634,12 +1635,13 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'write_neighbor_distribution'
       LOGICAL, PARAMETER                                 :: full_output = .FALSE.
 
-      INTEGER                                            :: group, handle, ikind, inode, ipe, jkind, &
-                                                            mype, n, nkind, nnode, npe
+      INTEGER                                            :: handle, ikind, inode, ipe, jkind, mype, &
+                                                            n, nkind, nnode, npe
       INTEGER(int_8)                                     :: nblock_max, nblock_sum, nelement_max, &
                                                             nelement_sum, tmp(2)
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: nblock, nelement, nnsgf
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+      TYPE(mp_comm_type)                                 :: group
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: nl_iterator
 

--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -27,7 +27,8 @@ MODULE qs_ot
         dbcsr_multiply, dbcsr_release, dbcsr_release_p, dbcsr_scale, dbcsr_scale_by_vector, &
         dbcsr_set, dbcsr_transposed, dbcsr_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE preconditioner,                  ONLY: apply_preconditioner
    USE preconditioner_types,            ONLY: preconditioner_type
    USE qs_ot_types,                     ONLY: qs_ot_type
@@ -113,13 +114,14 @@ CONTAINS
       INTEGER, PARAMETER                                 :: taylor_order = 50
       REAL(KIND=dp), PARAMETER                           :: alpha = 0.1_dp, f2_eps = 0.01_dp
 
-      INTEGER                                            :: blk, col, col_size, group, handle, i, k, &
-                                                            n, p, row, row_size
+      INTEGER                                            :: blk, col, col_size, group_handle, &
+                                                            handle, i, k, n, p, row, row_size
       REAL(dp), DIMENSION(:, :), POINTER                 :: DATA
       REAL(KIND=dp)                                      :: expfactor, f2, norm_fro, norm_gct, tmp
       TYPE(dbcsr_distribution_type)                      :: dist
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_type), POINTER                          :: C, Gp1, Gp2, GU, U
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
       !
@@ -151,7 +153,8 @@ CONTAINS
          END DO
       END DO
       CALL dbcsr_iterator_stop(iter)
-      CALL dbcsr_get_info(C, group=group)
+      CALL dbcsr_get_info(C, group=group_handle)
+      CALL group%set_handle(group_handle)
       CALL mp_sum(f2, group)
       !
       !

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -61,6 +61,7 @@ MODULE qs_resp
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_irecv,&
                                               mp_isend,&
+                                              mp_request_type,&
                                               mp_sum,&
                                               mp_wait
    USE particle_list_types,             ONLY: particle_list_type
@@ -1240,12 +1241,13 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: gbo(2, 3), handle, i, iatom, ip, jx, jy, &
                                                             jz, k, l, my_pos, nobjects, &
-                                                            output_unit, p, req(6)
+                                                            output_unit, p
       INTEGER, DIMENSION(:), POINTER                     :: tmp_npoints, tmp_size
       INTEGER, DIMENSION(:, :), POINTER                  :: tmp_points
       REAL(KIND=dp)                                      :: conv, dh(3, 3), r(3)
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_request_type), DIMENSION(6)                :: req
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_type), POINTER                             :: v_hartree_pw
       TYPE(section_vals_type), POINTER                   :: input, print_key, resp_section

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -95,7 +95,8 @@ MODULE qs_scf
    USE machine,                         ONLY: m_flush,&
                                               m_walltime
    USE mathlib,                         ONLY: invert_matrix
-   USE message_passing,                 ONLY: mp_send
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_send
    USE particle_types,                  ONLY: particle_type
    USE preconditioner,                  ONLY: prepare_preconditioner,&
                                               restart_preconditioner
@@ -343,8 +344,9 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'scf_env_do_scf'
 
       CHARACTER(LEN=default_string_length)               :: description, name
-      INTEGER :: ext_master_id, external_comm, handle, handle2, i_tmp, ic, ispin, iter_count, &
-         output_unit, scf_energy_message_tag, total_steps
+      INTEGER                                            :: ext_master_id, handle, handle2, i_tmp, &
+                                                            ic, ispin, iter_count, output_unit, &
+                                                            scf_energy_message_tag, total_steps
       LOGICAL :: diis_step, do_kpoints, energy_only, exit_inner_loop, exit_outer_loop, &
          inner_loop_converged, just_energy, outer_loop_converged
       REAL(KIND=dp)                                      :: t1, t2
@@ -358,6 +360,7 @@ CONTAINS
       TYPE(energy_correction_type), POINTER              :: ec_env
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos, mos_last_converged
+      TYPE(mp_comm_type)                                 :: external_comm
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(qs_charges_type), POINTER                     :: qs_charges
@@ -438,7 +441,7 @@ CONTAINS
                           " Trying to access result ("//TRIM(description)// &
                           ") which is not correctly stored.")
       END IF
-      external_comm = NINT(res_val_3(1))
+      CALL external_comm%set_handle(NINT(res_val_3(1)))
       ext_master_id = NINT(res_val_3(2))
       scf_energy_message_tag = NINT(res_val_3(3))
 

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -70,6 +70,7 @@ MODULE qs_tddfpt2_properties
    USE message_passing,                 ONLY: mp_comm_type,&
                                               mp_irecv,&
                                               mp_isend,&
+                                              mp_request_type,&
                                               mp_sum,&
                                               mp_wait
    USE molden_utils,                    ONLY: write_mos_molden
@@ -679,15 +680,16 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_print_excitation_analysis'
 
       CHARACTER(len=5)                                   :: spin_label
-      INTEGER :: handle, icol, iproc, irow, ispin, istate, nao, ncols_local, nrows_local, nspins, &
-         nstates, send_handler, send_handler2, state_spin
+      INTEGER                                            :: handle, icol, iproc, irow, ispin, &
+                                                            istate, nao, ncols_local, nrows_local, &
+                                                            nspins, nstates, state_spin
       INTEGER(kind=int_8)                                :: iexc, imo_occ, imo_virt, ind, nexcs, &
                                                             nexcs_local, nexcs_max_local, &
                                                             nmo_virt_occ, nmo_virt_occ_alpha
       INTEGER(kind=int_8), ALLOCATABLE, DIMENSION(:)     :: inds_local, inds_recv, nexcs_recv
       INTEGER(kind=int_8), DIMENSION(1)                  :: nexcs_send
       INTEGER(kind=int_8), DIMENSION(maxspins)           :: nmo_occ8, nmo_virt8
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: inds, recv_handlers, recv_handlers2
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: inds
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       INTEGER, DIMENSION(maxspins)                       :: nmo_occ, nmo_virt
       LOGICAL                                            :: do_exc_analysis
@@ -699,6 +701,8 @@ CONTAINS
       TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: S_mos_virt, weights_fm
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_request_type)                              :: send_handler, send_handler2
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_handlers, recv_handlers2
 
       CALL timeset(routineN, handle)
 

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -67,7 +67,8 @@ MODULE qs_tddfpt2_properties
    USE mathconstants,                   ONLY: twopi,&
                                               z_one,&
                                               z_zero
-   USE message_passing,                 ONLY: mp_irecv,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_irecv,&
                                               mp_isend,&
                                               mp_sum,&
                                               mp_wait
@@ -1227,16 +1228,18 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'vec_product'
 
-      INTEGER                                            :: blk, group, handle, icol, irow
+      INTEGER                                            :: blk, group_handle, handle, icol, irow
       LOGICAL                                            :: found
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vba, vbb
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
       res = 0.0_dp
 
-      CALL dbcsr_get_info(va, group=group)
+      CALL dbcsr_get_info(va, group=group_handle)
+      CALL group%set_handle(group_handle)
       CALL dbcsr_iterator_start(iter, va)
       DO WHILE (dbcsr_iterator_blocks_left(iter))
          CALL dbcsr_iterator_next_block(iter, irow, icol, vba, blk)

--- a/src/qs_tddfpt2_subgroups.F
+++ b/src/qs_tddfpt2_subgroups.F
@@ -55,7 +55,8 @@ MODULE qs_tddfpt2_subgroups
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE message_passing,                 ONLY: mp_comm_split
+   USE message_passing,                 ONLY: mp_comm_split,&
+                                              mp_comm_type
    USE molecule_kind_types,             ONLY: molecule_kind_type
    USE molecule_types,                  ONLY: molecule_type
    USE particle_types,                  ONLY: particle_type
@@ -110,7 +111,7 @@ MODULE qs_tddfpt2_subgroups
       !> can still be accessed; in this case they simply point to the corresponding global variables
       LOGICAL                                            :: is_split
       !> MPI communicator of the current parallel group
-      INTEGER                                            :: mpi_comm
+      TYPE(mp_comm_type)                                 :: mpi_comm
       !> number of parallel groups
       INTEGER                                            :: ngroups
       !> group_distribution(0:ngroups-1) : a process with rank 'i' belongs to the parallel group

--- a/src/qs_tensors_types.F
+++ b/src/qs_tensors_types.F
@@ -34,6 +34,7 @@ MODULE qs_tensors_types
                                               distribution_2d_type
    USE message_passing,                 ONLY: mp_cart_sub,&
                                               mp_comm_free,&
+                                              mp_comm_type,&
                                               mp_environ
    USE particle_types,                  ONLY: particle_type
    USE qs_neighbor_list_types,          ONLY: neighbor_list_iterator_p_type,&
@@ -58,7 +59,7 @@ MODULE qs_tensors_types
 
    TYPE distribution_3d_type
       TYPE(distribution_2d_type), POINTER :: dist_2d_1 => NULL(), dist_2d_2 => NULL()
-      INTEGER :: comm_3d, comm_2d_1, comm_2d_2
+      TYPE(mp_comm_type) :: comm_3d, comm_2d_1, comm_2d_2
       LOGICAL :: owns_comm
    END TYPE distribution_3d_type
 
@@ -94,15 +95,15 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: dist1, dist2, dist3
       INTEGER, INTENT(IN)                                :: nkind
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      INTEGER, INTENT(IN)                                :: mp_comm_3d
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm_3d
       LOGICAL, INTENT(IN), OPTIONAL                      :: own_comm
 
       CHARACTER(len=*), PARAMETER :: routineN = 'distribution_3d_create'
 
-      INTEGER                                            :: comm_2d_1, comm_2d_2, handle, nproc_1, &
-                                                            nproc_2
+      INTEGER                                            :: handle, nproc_1, nproc_2
       INTEGER, DIMENSION(2)                              :: mp_coor_1, mp_coor_2, mp_dims_1, &
                                                             mp_dims_2
+      TYPE(mp_comm_type)                                 :: comm_2d_1, comm_2d_2
 
       CALL timeset(routineN, handle)
 
@@ -168,7 +169,7 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: dist1, dist2
       INTEGER, INTENT(IN)                                :: nkind
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      INTEGER, INTENT(IN)                                :: mp_comm_2d
+      TYPE(mp_comm_type), INTENT(IN)                     :: mp_comm_2d
 
       CHARACTER(len=*), PARAMETER :: routineN = 'distribution_2d_create'
 

--- a/src/replica_methods.F
+++ b/src/replica_methods.F
@@ -133,7 +133,7 @@ CONTAINS
          WRITE (unit_nr, FMT="(T2,A,I0,A)") "REPLICA| ", para_env%num_pe - dims(1)*dims(2), " MPI process(es) will be idle"
       END IF
       CALL mp_cart_create(comm_old=para_env%group, ndims=2, dims=dims, pos=pos, comm_cart=comm_cart)
-      IF (comm_cart%get_handle() /= mp_comm_null%get_handle()) THEN
+      IF (comm_cart /= mp_comm_null) THEN
          CALL cp_cart_create(cart, comm_cart, ndims=2, owns_group=.TRUE.)
          NULLIFY (para_env_full)
          CALL cp_para_env_create(para_env_full, comm_cart, owns_group=.FALSE.)

--- a/src/replica_methods.F
+++ b/src/replica_methods.F
@@ -51,6 +51,7 @@ MODULE replica_methods
    USE message_passing,                 ONLY: mp_cart_create,&
                                               mp_cart_sub,&
                                               mp_comm_null,&
+                                              mp_comm_type,&
                                               mp_sum
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type,&
@@ -101,8 +102,9 @@ CONTAINS
       LOGICAL, INTENT(in), OPTIONAL                      :: sync_v, keep_wf_history, row_force
 
       CHARACTER(len=default_path_length)                 :: input_file_path, output_file_path
-      INTEGER :: comm_cart, comm_f, comm_inter_rep, forcedim, i, i0, ierr, ip, ir, irep, lp, &
-         my_prep, new_env_id, nparticle, nrep_local, unit_nr
+      INTEGER                                            :: forcedim, i, i0, ierr, ip, ir, irep, lp, &
+                                                            my_prep, new_env_id, nparticle, &
+                                                            nrep_local, unit_nr
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: gridinfo
       INTEGER, DIMENSION(2)                              :: dims, pos
       LOGICAL, DIMENSION(2)                              :: rdim
@@ -110,6 +112,7 @@ CONTAINS
       TYPE(cp_para_cart_type), POINTER                   :: cart
       TYPE(cp_para_env_type), POINTER                    :: para_env_f, para_env_full, &
                                                             para_env_inter_rep
+      TYPE(mp_comm_type)                                 :: comm_cart, comm_f, comm_inter_rep
 
       CPASSERT(.NOT. ASSOCIATED(rep_env))
       CPASSERT(ASSOCIATED(input_declaration))
@@ -130,7 +133,7 @@ CONTAINS
          WRITE (unit_nr, FMT="(T2,A,I0,A)") "REPLICA| ", para_env%num_pe - dims(1)*dims(2), " MPI process(es) will be idle"
       END IF
       CALL mp_cart_create(comm_old=para_env%group, ndims=2, dims=dims, pos=pos, comm_cart=comm_cart)
-      IF (comm_cart /= mp_comm_null) THEN
+      IF (comm_cart%get_handle() /= mp_comm_null) THEN
          CALL cp_cart_create(cart, comm_cart, ndims=2, owns_group=.TRUE.)
          NULLIFY (para_env_full)
          CALL cp_para_env_create(para_env_full, comm_cart, owns_group=.FALSE.)

--- a/src/replica_methods.F
+++ b/src/replica_methods.F
@@ -133,7 +133,7 @@ CONTAINS
          WRITE (unit_nr, FMT="(T2,A,I0,A)") "REPLICA| ", para_env%num_pe - dims(1)*dims(2), " MPI process(es) will be idle"
       END IF
       CALL mp_cart_create(comm_old=para_env%group, ndims=2, dims=dims, pos=pos, comm_cart=comm_cart)
-      IF (comm_cart%get_handle() /= mp_comm_null) THEN
+      IF (comm_cart%get_handle() /= mp_comm_null%get_handle()) THEN
          CALL cp_cart_create(cart, comm_cart, ndims=2, owns_group=.TRUE.)
          NULLIFY (para_env_full)
          CALL cp_para_env_create(para_env_full, comm_cart, owns_group=.FALSE.)

--- a/src/ri_environment_methods.F
+++ b/src/ri_environment_methods.F
@@ -38,7 +38,8 @@ MODULE ri_environment_methods
                                               lri_density_type,&
                                               lri_environment_type,&
                                               lri_kind_type
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE pw_types,                        ONLY: pw_type
    USE qs_collocate_density,            ONLY: calculate_lri_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -593,15 +594,17 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'ri_matvec'
 
       CHARACTER                                          :: matrix_type
-      INTEGER                                            :: group, handle, iatom, jatom, m1, m2, mb, &
-                                                            n1, n2, nb
+      INTEGER                                            :: group_handle, handle, iatom, jatom, m1, &
+                                                            m2, mb, n1, n2, nb
       LOGICAL                                            :: symm
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 
-      CALL dbcsr_get_info(mat, matrix_type=matrix_type, group=group)
+      CALL dbcsr_get_info(mat, matrix_type=matrix_type, group=group_handle)
+      CALL group%set_handle(group_handle)
 
       SELECT CASE (matrix_type)
       CASE (dbcsr_type_no_symmetry)

--- a/src/rpa_communication.F
+++ b/src/rpa_communication.F
@@ -40,6 +40,8 @@ MODULE rpa_communication
    USE message_passing,                 ONLY: mp_allgather,&
                                               mp_irecv,&
                                               mp_isend,&
+                                              mp_request_null,&
+                                              mp_request_type,&
                                               mp_sum,&
                                               mp_wait,&
                                               mp_waitall
@@ -99,8 +101,7 @@ CONTAINS
          number_of_send, proc_receive, proc_send, proc_shift, rec_counter, rec_iaia_end, &
          rec_iaia_size, rec_iaia_start, rec_pcol, rec_prow, ref_send_pcol, ref_send_prow, &
          send_counter, send_pcol, send_prow, size_rec_buffer, size_send_buffer
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii_vet, map_rec_size, map_send_size, &
-                                                            req_send
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iii_vet, map_rec_size, map_send_size
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: grid_2_mepos, grid_ref_2_send_pos, &
                                                             group_grid_2_mepos, indices_map_my, &
                                                             mepos_2_grid, mepos_2_grid_group
@@ -114,6 +115,7 @@ CONTAINS
       TYPE(index_map), ALLOCATABLE, DIMENSION(:)         :: indices_rec
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_send
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: req_send
 
       CALL timeset(routineN, handle)
 
@@ -372,7 +374,7 @@ CONTAINS
                   Gamma_2D(iaia - my_ia_start + 1, kkB)
             END IF
          END DO
-         req_send = 0
+         req_send = mp_request_null
          send_counter = 0
          DO proc_shift = 1, para_env_sub%num_pe - 1
             proc_send = MODULO(para_env_sub%mepos + proc_shift, para_env_sub%num_pe)
@@ -462,7 +464,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: num_entries_rec, num_entries_send
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:), INTENT(INOUT)                     :: buffer_rec, buffer_send
-      INTEGER, DIMENSION(:, :), POINTER                  :: req_array
+      TYPE(mp_request_type), DIMENSION(:, :), POINTER    :: req_array
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_indx, do_msg
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'communicate_buffer'

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -55,8 +55,8 @@ MODULE rpa_grad
                                               m_memory
    USE mathconstants,                   ONLY: pi
    USE message_passing,                 ONLY: &
-        mp_allgather, mp_alltoall, mp_irecv, mp_isend, mp_min, mp_recv, mp_request_null, mp_send, &
-        mp_sendrecv, mp_sum, mp_sync, mp_waitall, mp_waitany
+        mp_allgather, mp_alltoall, mp_irecv, mp_isend, mp_min, mp_recv, mp_request_null, &
+        mp_request_type, mp_send, mp_sendrecv, mp_sum, mp_sync, mp_waitall, mp_waitany
    USE mp2_laplace,                     ONLY: calc_fm_mat_s_laplace
    USE mp2_ri_grad_util,                ONLY: array2fm,&
                                               create_dbcsr_gamma,&
@@ -1024,7 +1024,7 @@ CONTAINS
          proc_i_recv, proc_i_send, proc_recv, proc_send, proc_shift, recv_a_end, recv_a_size, &
          recv_a_start, recv_i_end, recv_i_size, recv_i_start, tag
       INTEGER(KIND=int_8)                                :: mem, number_of_elements_per_blk
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: procs_recv, recv_requests, send_requests
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: procs_recv
       INTEGER, DIMENSION(:, :), POINTER                  :: blacs2mpi
       REAL(KIND=dp)                                      :: mem_per_block, mem_real
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: buffer_compens_1D
@@ -1032,6 +1032,7 @@ CONTAINS
       TYPE(cp_1d_r_cp_type), ALLOCATABLE, DIMENSION(:)   :: buffer_1D
       TYPE(cp_3d_r_cp_type), ALLOCATABLE, DIMENSION(:)   :: buffer_3D
       TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_requests, send_requests
 
       CALL timeset(routineN, handle)
 

--- a/src/rpa_gw_im_time_util.F
+++ b/src/rpa_gw_im_time_util.F
@@ -43,6 +43,7 @@ MODULE rpa_gw_im_time_util
                                               twopi
    USE message_passing,                 ONLY: mp_alltoall,&
                                               mp_dims_create,&
+                                              mp_request_type,&
                                               mp_sum
    USE mp2_types,                       ONLY: integ_mat_buffer_type
    USE particle_methods,                ONLY: get_particle_set
@@ -456,7 +457,6 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:) :: block_counter, entry_counter, image_atom, &
          num_blocks_rec, num_blocks_send, num_entries_rec, num_entries_send, sizes_rec, sizes_send
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
-      INTEGER, DIMENSION(:, :), POINTER                  :: req_array
       LOGICAL                                            :: found_image_atom
       REAL(KIND=dp)                                      :: avg_z_dist, delta, eps_dist2, &
                                                             min_z_dist, ra(3), rb(3), sum_z, &
@@ -466,6 +466,7 @@ CONTAINS
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(integ_mat_buffer_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: buffer_rec, buffer_send
+      TYPE(mp_request_type), DIMENSION(:, :), POINTER    :: req_array
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       CALL timeset(routineN, handle)

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -47,7 +47,8 @@ MODULE rpa_im_time
    USE machine,                         ONLY: m_flush,&
                                               m_walltime
    USE mathconstants,                   ONLY: twopi
-   USE message_passing,                 ONLY: mp_sync
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sync
    USE mp2_types,                       ONLY: mp2_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_types,                  ONLY: particle_type
@@ -178,9 +179,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_P_omega'
 
-      INTEGER :: comm_2d, handle, handle2, handle3, i, i_cell, i_cell_R_1, i_cell_R_1_minus_S, &
-         i_cell_R_1_minus_T, i_cell_R_2, i_cell_R_2_minus_S_minus_T, i_cell_S, i_cell_T, i_mem, &
-         iquad, j, j_mem, jquad, num_3c_repl, num_cells_dm, unit_nr_dbcsr
+      INTEGER :: comm_2d_handle, handle, handle2, handle3, i, i_cell, i_cell_R_1, &
+         i_cell_R_1_minus_S, i_cell_R_1_minus_T, i_cell_R_2, i_cell_R_2_minus_S_minus_T, i_cell_S, &
+         i_cell_T, i_mem, iquad, j, j_mem, jquad, num_3c_repl, num_cells_dm, unit_nr_dbcsr
       INTEGER(int_8)                                     :: nze, nze_dm_occ, nze_dm_virt, nze_M_occ, &
                                                             nze_M_virt, nze_O
       INTEGER(KIND=int_8)                                :: flops_1_occ, flops_1_virt, flops_2
@@ -206,6 +207,7 @@ CONTAINS
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_dm_occ, t_dm_virt
       TYPE(dbt_type), &
          DIMENSION(SIZE(t_3c_O, 1), SIZE(t_3c_O, 2))     :: t_3c_O_occ, t_3c_O_virt
+      TYPE(mp_comm_type)                                 :: comm_2d
 
       CALL timeset(routineN, handle)
 
@@ -251,7 +253,8 @@ CONTAINS
          ALLOCATE (t_dm_virt(num_cells_dm))
          ALLOCATE (t_dm_occ(num_cells_dm))
          CALL dbcsr_get_info(mat_P_global%matrix, distribution=dist_P)
-         CALL dbcsr_distribution_get(dist_P, group=comm_2d, nprows=pdims_2d(1), npcols=pdims_2d(2))
+         CALL dbcsr_distribution_get(dist_P, group=comm_2d_handle, nprows=pdims_2d(1), npcols=pdims_2d(2))
+         CALL comm_2d%set_handle(comm_2d_handle)
 
          pgrid_2d = dbt_nd_mp_comm(comm_2d, [1], [2], pdims_2d=pdims_2d)
          ALLOCATE (size_P(dbt_nblks_total(t_3c_M, 1)))

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -87,6 +87,7 @@ MODULE rpa_im_time_force_methods
                                               m_walltime
    USE mathconstants,                   ONLY: fourpi
    USE message_passing,                 ONLY: mp_cart_create,&
+                                              mp_comm_type,&
                                               mp_sum,&
                                               mp_sync
    USE mp2_eri,                         ONLY: integrate_set_2c
@@ -201,8 +202,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'init_im_time_forces'
 
       INTEGER                                            :: handle, i_mem, i_xyz, ibasis, ispin, &
-                                                            mp_comm_t3c, n_dependent, n_mem, &
-                                                            n_rep, natom, nkind, nspins
+                                                            n_dependent, n_mem, n_rep, natom, &
+                                                            nkind, nspins
       INTEGER(int_8)                                     :: nze, nze_tot
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist_AO_1, dist_AO_2, &
                                                             dist_RI, dummy_end, dummy_start, &
@@ -232,6 +233,7 @@ CONTAINS
          DIMENSION(:), TARGET                            :: basis_set_ao, basis_set_ri_aux
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
       TYPE(libint_potential_type)                        :: identity_pot
+      TYPE(mp_comm_type)                                 :: mp_comm_t3c
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: nl_2c
@@ -2660,7 +2662,7 @@ CONTAINS
          END DO
       END DO
 
-      CALL dbcsr_distribution_new(dbcsr_dist, group=para_env%group, pgrid=pgrid, row_dist=row_dist, col_dist=col_dist)
+      CALL dbcsr_distribution_new(dbcsr_dist, group=para_env%group%get_handle(), pgrid=pgrid, row_dist=row_dist, col_dist=col_dist)
 
       !The temporary DBCSR integrals and derivatives matrices in this flat distribution
       CALL dbcsr_create(tmp_G_PQ, template=G_PQ, matrix_type=dbcsr_type_no_symmetry, dist=dbcsr_dist)

--- a/src/sirius_interface.F
+++ b/src/sirius_interface.F
@@ -168,7 +168,7 @@ CONTAINS
 
       ! create context of simulation
       CALL pwdft_env_get(pwdft_env, para_env=para_env)
-      sirius_mpi_comm = para_env%group
+      sirius_mpi_comm = para_env%group%get_handle()
       CALL sirius_create_context(sirius_mpi_comm, sctx)
 
 !     the "fun" starts.

--- a/src/spme.F
+++ b/src/spme.F
@@ -27,6 +27,7 @@ MODULE spme
                                               ewald_pw_type
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: fourpi
+   USE message_passing,                 ONLY: mp_comm_type
    USE particle_types,                  ONLY: particle_type
    USE pme_tools,                       ONLY: get_center,&
                                               set_list
@@ -108,9 +109,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'spme_evaluate'
 
-      INTEGER                                            :: group, handle, i, ig, ipart, j, n, &
-                                                            ncore, npart, nshell, o_spline, p1, &
-                                                            p1_shell
+      INTEGER                                            :: handle, i, ig, ipart, j, n, ncore, &
+                                                            npart, nshell, o_spline, p1, p1_shell
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: center, core_center, shell_center
       INTEGER, DIMENSION(3)                              :: nd, npts
       LOGICAL                                            :: do_shell
@@ -120,6 +120,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: fat
       REAL(KIND=dp), DIMENSION(3, 3)                     :: f_stress, h_stress
       TYPE(greens_fn_type), POINTER                      :: green
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: grid_spme
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: pw_pool
@@ -479,14 +480,15 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'spme_potential'
 
-      INTEGER                                            :: group, handle, ipart, n, npart_a, &
-                                                            npart_b, o_spline, p1
+      INTEGER                                            :: handle, ipart, n, npart_a, npart_b, &
+                                                            o_spline, p1
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: center
       INTEGER, DIMENSION(3)                              :: npts
       REAL(KIND=dp)                                      :: alpha, dvols, fat1
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: delta
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: rhos
       TYPE(greens_fn_type), POINTER                      :: green
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: grid_spme
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: pw_pool
@@ -624,8 +626,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'spme_forces'
 
-      INTEGER                                            :: group, handle, i, ipart, n, npart_a, &
-                                                            npart_b, o_spline, p1
+      INTEGER                                            :: handle, i, ipart, n, npart_a, npart_b, &
+                                                            o_spline, p1
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: center
       INTEGER, DIMENSION(3)                              :: npts
       REAL(KIND=dp)                                      :: alpha, dvols
@@ -633,6 +635,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: rhos
       REAL(KIND=dp), DIMENSION(3)                        :: fat
       TYPE(greens_fn_type), POINTER                      :: green
+      TYPE(mp_comm_type)                                 :: group
       TYPE(pw_grid_type), POINTER                        :: grid_spme
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: pw_pool

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -109,8 +109,8 @@ MODULE cp2k_runs
    USE mc_run,                          ONLY: do_mon_car
    USE md_run,                          ONLY: qs_mol_dyn
    USE message_passing,                 ONLY: &
-        mp_any_source, mp_bcast, mp_comm_dup, mp_comm_free, mp_comm_split, mp_environ, mp_max, &
-        mp_recv, mp_send, mp_sum, mp_sync
+        mp_any_source, mp_bcast, mp_comm_dup, mp_comm_free, mp_comm_split, mp_comm_type, &
+        mp_environ, mp_max, mp_recv, mp_send, mp_sum, mp_sync
    USE mscfg_methods,                   ONLY: do_mol_loop,&
                                               loop_over_molecules
    USE neb_methods,                     ONLY: neb
@@ -177,7 +177,8 @@ CONTAINS
    RECURSIVE SUBROUTINE cp2k_run(input_declaration, input_file_name, output_unit, mpi_comm, initial_variables)
       TYPE(section_type), POINTER                        :: input_declaration
       CHARACTER(LEN=*), INTENT(IN)                       :: input_file_name
-      INTEGER, INTENT(IN)                                :: output_unit, mpi_comm
+      INTEGER, INTENT(IN)                                :: output_unit
+      TYPE(mp_comm_type)                                 :: mpi_comm
       CHARACTER(len=default_path_length), &
          DIMENSION(:, :), INTENT(IN)                     :: initial_variables
 
@@ -200,13 +201,13 @@ CONTAINS
 
 #if defined(__DBCSR_ACC)
       IF (offload_get_device_count() > 0) THEN
-         CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit, &
+         CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit, &
                              accdrv_active_device_id=offload_get_chosen_device())
       ELSE
-         CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
+         CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
       END IF
 #else
-      CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
+      CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
 #endif
 
       CALL pw_gpu_init()
@@ -284,13 +285,13 @@ CONTAINS
          CALL farming_run(input_declaration, root_section, para_env, initial_variables)
 #if defined(__DBCSR_ACC)
          IF (offload_get_device_count() > 0) THEN
-            CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit, &
+            CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit, &
                                 accdrv_active_device_id=offload_get_chosen_device())
          ELSE
-            CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
+            CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
          END IF
 #else
-         CALL dbcsr_init_lib(mpi_comm, io_unit=output_unit)
+         CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
 #endif
 
          CALL pw_gpu_init()
@@ -485,9 +486,9 @@ CONTAINS
       CHARACTER(LEN=default_path_length)       :: output_file
       CHARACTER(LEN=default_string_length)     :: str
       INTEGER :: dest, handle, i, i_job_to_restart, ierr, ijob, ijob_current, &
-                 ijob_end, ijob_start, iunit, n_jobs_to_run, new_group, new_output_unit, &
+                 ijob_end, ijob_start, iunit, n_jobs_to_run, new_output_unit, &
                  new_rank, new_size, ngroups, num_slaves, output_unit, primus_slave, &
-                 slave_group, slave_rank, source, tag, todo
+                 slave_rank, source, tag, todo
       INTEGER, DIMENSION(:), POINTER           :: group_distribution, &
                                                   master_slave_partition, &
                                                   slave_distribution, &
@@ -501,6 +502,7 @@ CONTAINS
       TYPE(farming_env_type), POINTER          :: farming_env
       TYPE(section_type), POINTER              :: g_section
       TYPE(section_vals_type), POINTER         :: g_data
+      TYPE(mp_comm_type) :: slave_group, new_group
 
       ! the primus of all slaves, talks to the master on topics concerning all slaves
       CALL timeset(routineN, handle)
@@ -971,7 +973,7 @@ CONTAINS
       CHARACTER(len=*), INTENT(in)                       :: input_file_path, output_file_path
       CHARACTER(len=default_path_length), &
          DIMENSION(:, :), INTENT(IN)                     :: initial_variables
-      INTEGER, INTENT(in), OPTIONAL                      :: mpi_comm
+      TYPE(mp_comm_type), INTENT(in), OPTIONAL           :: mpi_comm
 
       INTEGER                                            :: unit_nr
       TYPE(cp_para_env_type), POINTER                    :: para_env

--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -40,6 +40,7 @@ MODULE libcp2k
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE qs_active_space_types,           ONLY: eri_type_eri_element_func
    USE string_utilities,                ONLY: strlcpy_c2f
 #include "../base/base_uses.f90"
@@ -159,6 +160,7 @@ CONTAINS
 
       CHARACTER(LEN=default_path_length)                 :: ifp, ofp
       INTEGER                                            :: ierr, ncopied
+      TYPE(mp_comm_type)                                 :: my_mpi_comm
       TYPE(section_type), POINTER                        :: input_declaration
 
       ifp = " "; ofp = " "
@@ -167,7 +169,8 @@ CONTAINS
 
       NULLIFY (input_declaration)
       CALL create_cp2k_root_section(input_declaration)
-      CALL create_force_env(new_env_id, input_declaration, ifp, ofp, mpi_comm, ierr=ierr)
+      CALL my_mpi_comm%set_handle(INT(mpi_comm))
+      CALL create_force_env(new_env_id, input_declaration, ifp, ofp, my_mpi_comm, ierr=ierr)
       CALL section_release(input_declaration)
       CPASSERT(ierr == 0)
    END SUBROUTINE cp2k_create_force_env_comm
@@ -422,6 +425,7 @@ CONTAINS
 
       CHARACTER(LEN=default_path_length)                 :: ifp, ofp
       INTEGER                                            :: ncopied
+      TYPE(mp_comm_type)                                 :: my_mpi_comm
       TYPE(section_type), POINTER                        :: input_declaration
 
       ifp = " "; ofp = " "
@@ -430,7 +434,8 @@ CONTAINS
 
       NULLIFY (input_declaration)
       CALL create_cp2k_root_section(input_declaration)
-      CALL run_input(input_declaration, ifp, ofp, empty_initial_variables, mpi_comm)
+      CALL my_mpi_comm%set_handle(INT(mpi_comm))
+      CALL run_input(input_declaration, ifp, ofp, empty_initial_variables, my_mpi_comm)
       CALL section_release(input_declaration)
    END SUBROUTINE cp2k_run_input_comm
 

--- a/src/submatrix_dissection.F
+++ b/src/submatrix_dissection.F
@@ -51,7 +51,7 @@ MODULE submatrix_dissection
                               mp_irecv, &
                               mp_isend, &
                               mp_send, &
-                              mp_wait
+                              mp_wait, mp_comm_type
    USE kinds, ONLY: dp
    USE submatrix_types, ONLY: buffer_type, &
                               bufptr_type, &
@@ -72,7 +72,8 @@ MODULE submatrix_dissection
       TYPE(dbcsr_type)                                :: dbcsr_mat
       TYPE(dbcsr_distribution_type)                   :: dist
       LOGICAL                                         :: initialized = .FALSE.
-      INTEGER                                         :: numnodes, group, myrank, nblkcols, nblkrows, nblks, local_blocks, &
+      TYPE(mp_comm_type)                              :: group
+      INTEGER                                         :: numnodes, myrank, nblkcols, nblkrows, nblks, local_blocks, &
                                                          cols_per_sm, number_of_submatrices
       INTEGER, DIMENSION(:), POINTER                  :: row_blk_size, col_blk_size
       INTEGER, DIMENSION(:), ALLOCATABLE              :: coo_cols, coo_rows, coo_col_offsets, coo_cols_local, coo_rows_local, &
@@ -161,7 +162,7 @@ CONTAINS
       TYPE(intBuffer_type), DIMENSION(:), ALLOCATABLE  :: blocks_for_rank
 
       ! Additional structures for threaded parts
-      INTEGER                                          :: numthreads, mytid
+      INTEGER                                          :: numthreads, mytid, group_handle
       ! Indexing starts at 0 to match thread ids
       TYPE(setarray_type), DIMENSION(:), ALLOCATABLE   :: nonzero_rows_t
       TYPE(setarray_type), DIMENSION(:), ALLOCATABLE   :: result_blocks_from_rank_t, result_blocks_for_rank_t, &
@@ -178,8 +179,10 @@ CONTAINS
 
       this%dbcsr_mat = matrix_p
       CALL dbcsr_get_info(matrix=this%dbcsr_mat, nblkcols_total=this%nblkcols, nblkrows_total=this%nblkrows, &
-                          row_blk_size=this%row_blk_size, col_blk_size=this%col_blk_size, group=this%group, distribution=this%dist)
+                         row_blk_size=this%row_blk_size, col_blk_size=this%col_blk_size, group=group_handle, distribution=this%dist)
       CALL dbcsr_distribution_get(dist=this%dist, mynode=this%myrank, numnodes=this%numnodes)
+
+      CALL this%group%set_handle(group_handle)
 
       IF (this%nblkcols .NE. this%nblkrows) THEN
          CPABORT("Number of block rows and cols need to be identical")

--- a/src/submatrix_types.F
+++ b/src/submatrix_types.F
@@ -8,6 +8,8 @@
 MODULE submatrix_types
 
    USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_request_null,&
+                                              mp_request_type
    USE util,                            ONLY: sort
 
    IMPLICIT NONE
@@ -42,7 +44,7 @@ MODULE submatrix_types
       INTEGER, DIMENSION(:), POINTER                    :: data
       INTEGER                                           :: size = 0
       LOGICAL                                           :: allocated = .FALSE.
-      INTEGER                                           :: mpi_request = 0
+      TYPE(mp_request_type)                                           :: mpi_request = mp_request_null
    CONTAINS
       PROCEDURE :: alloc => intbuffer_alloc
       PROCEDURE :: dealloc => intbuffer_dealloc
@@ -53,7 +55,7 @@ MODULE submatrix_types
       REAL(KIND=dp), DIMENSION(:), POINTER     :: data
       INTEGER                                           :: size = 0
       LOGICAL                                           :: allocated = .FALSE.
-      INTEGER                                           :: mpi_request = 0
+      TYPE(mp_request_type)                                           :: mpi_request = mp_request_null
    CONTAINS
       PROCEDURE :: alloc => buffer_alloc
       PROCEDURE :: dealloc => buffer_dealloc

--- a/src/subsys/particle_types.F
+++ b/src/subsys/particle_types.F
@@ -19,7 +19,8 @@
 MODULE particle_types
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -120,7 +121,7 @@ CONTAINS
    SUBROUTINE update_particle_set(particle_set, int_group, pos, vel, for, add)
 
       TYPE(particle_type), INTENT(INOUT)                 :: particle_set(:)
-      INTEGER, INTENT(IN)                                :: int_group
+      TYPE(mp_comm_type), INTENT(IN)                     :: int_group
       REAL(KIND=dp), INTENT(INOUT), OPTIONAL             :: pos(:, :), vel(:, :), for(:, :)
       LOGICAL, INTENT(IN), OPTIONAL                      :: add
 

--- a/src/swarm/swarm_message.F
+++ b/src/swarm/swarm_message.F
@@ -21,7 +21,7 @@ MODULE swarm_message
    USE message_passing, ONLY: mp_bcast, &
                               mp_environ, &
                               mp_recv, &
-                              mp_send
+                              mp_send, mp_comm_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -184,7 +184,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_message_mpi_send(msg, group, dest, tag)
       TYPE(swarm_message_type), INTENT(IN)               :: msg
-      INTEGER, INTENT(IN)                                :: group, dest, tag
+      TYPE(mp_comm_type), INTENT(IN) :: group
+      INTEGER, INTENT(IN)                                :: dest, tag
 
       TYPE(message_entry_type), POINTER                  :: curr_entry
 
@@ -206,7 +207,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_message_mpi_recv(msg, group, src, tag)
       TYPE(swarm_message_type), INTENT(INOUT)            :: msg
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
       INTEGER, INTENT(INOUT)                             :: src, tag
 
       INTEGER                                            :: i, length
@@ -232,7 +233,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_message_mpi_bcast(msg, src, group)
       TYPE(swarm_message_type), INTENT(INOUT)            :: msg
-      INTEGER, INTENT(IN)                                :: src, group
+      INTEGER, INTENT(IN)                                :: src
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       INTEGER                                            :: i, length, mepos, num_pe
       TYPE(message_entry_type), POINTER                  :: curr_entry
@@ -439,7 +441,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_message_entry_mpi_send(ENTRY, group, dest, tag)
       TYPE(message_entry_type), INTENT(IN)               :: ENTRY
-      INTEGER, INTENT(IN)                                :: group, dest, tag
+      TYPE(mp_comm_type), INTENT(IN) :: group
+      INTEGER, INTENT(IN)                                :: dest, tag
 
       INTEGER, DIMENSION(default_string_length)          :: value_str_arr
       INTEGER, DIMENSION(key_length)                     :: key_arr
@@ -502,7 +505,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_message_entry_mpi_recv(ENTRY, group, src, tag)
       TYPE(message_entry_type), INTENT(INOUT)            :: ENTRY
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                                :: group
       INTEGER, INTENT(INOUT)                             :: src, tag
 
       INTEGER                                            :: datatype, s
@@ -562,7 +565,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE swarm_message_entry_mpi_bcast(ENTRY, src, group, mepos)
       TYPE(message_entry_type), INTENT(INOUT)            :: ENTRY
-      INTEGER, INTENT(IN)                                :: src, group, mepos
+      INTEGER, INTENT(IN)                                :: src, mepos
+      TYPE(mp_comm_type), INTENT(IN) :: group
 
       INTEGER                                            :: datasize, datatype
       INTEGER, DIMENSION(default_string_length)          :: value_str_arr

--- a/src/swarm/swarm_mpi.F
+++ b/src/swarm/swarm_mpi.F
@@ -29,14 +29,9 @@ MODULE swarm_mpi
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length
    USE machine,                         ONLY: default_output_unit
-   USE message_passing,                 ONLY: mp_any_source,&
-                                              mp_bcast,&
-                                              mp_comm_free,&
-                                              mp_comm_split,&
-                                              mp_comm_split_direct,&
-                                              mp_environ,&
-                                              mp_sum,&
-                                              mp_sync
+   USE message_passing,                 ONLY: &
+        mp_any_source, mp_bcast, mp_comm_free, mp_comm_split, mp_comm_split_direct, mp_comm_type, &
+        mp_environ, mp_sum, mp_sync
    USE swarm_message,                   ONLY: swarm_message_get,&
                                               swarm_message_mpi_bcast,&
                                               swarm_message_mpi_recv,&
@@ -82,12 +77,12 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: iw
 
       INTEGER                                            :: n_groups_created, pe_per_worker, &
-                                                            subgroup, subgroup_rank, &
-                                                            subgroup_size, worker_group
+                                                            subgroup_rank, subgroup_size
       LOGICAL                                            :: im_the_master
       INTEGER, DIMENSION(:), POINTER                     :: group_distribution_p
       INTEGER, DIMENSION(0:world_para_env%num_pe-2), &
          TARGET                                          :: group_distribution
+      TYPE(mp_comm_type)                                 :: subgroup, worker_group
 
 ! ====== Setup of MPI-Groups ======
 

--- a/src/task_list_methods.F
+++ b/src/task_list_methods.F
@@ -45,7 +45,7 @@ MODULE task_list_methods
                               mp_alltoall, &
                               mp_bcast, &
                               mp_sum, &
-                              mp_sum_partial
+                              mp_sum_partial, mp_comm_type
    USE particle_types, ONLY: particle_type
    USE particle_methods, ONLY: get_particle_set
    USE pw_env_types, ONLY: pw_env_get, &
@@ -1155,7 +1155,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE optimize_load_list(list, group, my_pos)
       INTEGER, DIMENSION(:, :, 0:)                       :: list
-      INTEGER, INTENT(IN)                                :: group, my_pos
+      TYPE(mp_comm_type), INTENT(IN) :: group
+      INTEGER, INTENT(IN)                                :: my_pos
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'optimize_load_list'
       INTEGER, PARAMETER                                 :: rank_of_root = 0
@@ -2523,7 +2524,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: src_matrices
       TYPE(offload_buffer_type), INTENT(INOUT)           :: dest_buffer
       TYPE(task_list_type), INTENT(IN)                   :: task_list
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rs_scatter_matrices'
 
@@ -2558,7 +2559,7 @@ CONTAINS
       TYPE(offload_buffer_type), INTENT(IN)              :: src_buffer
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT)    :: dest_matrices
       TYPE(task_list_type), INTENT(IN)                   :: task_list
-      INTEGER, INTENT(IN)                                :: group
+      TYPE(mp_comm_type), INTENT(IN)                     :: group
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'rs_gather_matrices'
 

--- a/src/tmc/tmc_messages.F
+++ b/src/tmc/tmc_messages.F
@@ -219,7 +219,7 @@ CONTAINS
             WRITE (*, *) "TMC|message: ID: ", para_env%mepos, &
             " send element info to   ", dest, " of stat ", m_send%info(1), &
             " with size int/real/char", m_send%info(2:), " with comm ", &
-            para_env%group, " and tag ", message_tag
+            para_env%group%get_handle(), " and tag ", message_tag
          IF (m_send%info(2) .GT. 0) DEALLOCATE (m_send%task_int)
          IF (m_send%info(3) .GT. 0) DEALLOCATE (m_send%task_real)
          IF (m_send%info(4) .GT. 0) DEALLOCATE (m_send%task_char)

--- a/src/tmc/tmc_setup.F
+++ b/src/tmc/tmc_setup.F
@@ -43,7 +43,8 @@ MODULE tmc_setup
    USE message_passing,                 ONLY: mp_bcast,&
                                               mp_comm_dup,&
                                               mp_comm_free,&
-                                              mp_comm_split_direct
+                                              mp_comm_split_direct,&
+                                              mp_comm_type
    USE parallel_rng_types,              ONLY: UNIFORM,&
                                               rng_stream_type
    USE physcon,                         ONLY: au2a => angstrom,&
@@ -356,9 +357,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'do_analyze_files'
 
-      INTEGER                                            :: comm, dir_ind, handle, my_mpi_world, &
-                                                            nr_dim, output_unit, temp
+      INTEGER                                            :: dir_ind, handle, nr_dim, output_unit, &
+                                                            temp
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: comm, my_mpi_world
       TYPE(tmc_ana_list_type), DIMENSION(:), POINTER     :: ana_list
       TYPE(tmc_env_type), POINTER                        :: tmc_env
       TYPE(tree_type), POINTER                           :: elem
@@ -809,10 +811,11 @@ CONTAINS
       INTEGER                                            :: ana_on_the_fly
       LOGICAL                                            :: success
 
-      INTEGER :: cc_group, cc_group_rank, comm_tmp, master_ana_group, master_ana_rank, &
+      INTEGER :: cc_group, cc_group_rank, master_ana_group, master_ana_rank, &
          master_first_e_worker_g, master_first_e_worker_r, master_worker_group, &
-         master_worker_rank, my_mpi_undefined, my_mpi_world, total_used
+         master_worker_rank, my_mpi_undefined, total_used
       LOGICAL                                            :: flag, master
+      TYPE(mp_comm_type)                                 :: comm_tmp, my_mpi_world
 
       CPASSERT(ASSOCIATED(tmc_comp_set))
       CPASSERT(ASSOCIATED(para_env))

--- a/src/tmc/tmc_worker.F
+++ b/src/tmc/tmc_worker.F
@@ -48,6 +48,7 @@ MODULE tmc_worker
                                               force_env_get_natom
    USE kinds,                           ONLY: default_string_length,&
                                               dp
+   USE message_passing,                 ONLY: mp_comm_type
    USE molecule_list_types,             ONLY: molecule_list_type
    USE particle_list_types,             ONLY: particle_list_type
    USE tmc_analysis,                    ONLY: analysis_init,&
@@ -855,7 +856,7 @@ CONTAINS
 !> \author Mandes 10.2013
 ! **************************************************************************************************
    SUBROUTINE set_intermediate_info_comm(comm, env_id)
-      INTEGER, INTENT(IN)                                :: comm
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
       INTEGER                                            :: env_id
 
       CHARACTER(LEN=default_string_length)               :: description
@@ -877,7 +878,7 @@ CONTAINS
                        "employing this force environment! ")
 
       ! set the information
-      values(1) = REAL(comm, KIND=dp)
+      values(1) = REAL(comm%get_handle(), KIND=dp)
       values(2) = REAL(MASTER_COMM_ID, KIND=dp)
       values(3) = REAL(TMC_STAT_SCF_STEP_ENER_RECEIVE, KIND=dp)
       description = "[EXT_SCF_ENER_COMM]"

--- a/src/transport.F
+++ b/src/transport.F
@@ -52,6 +52,7 @@ MODULE transport
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_allgather,&
+                                              mp_comm_type,&
                                               mp_environ
    USE particle_list_types,             ONLY: particle_list_type
    USE particle_methods,                ONLY: get_particle_set
@@ -300,9 +301,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'transport_initialize'
 
-      INTEGER                                            :: handle, mp_group, mynode, numnodes, &
-                                                            unit_nr
+      INTEGER                                            :: handle, mynode, numnodes, unit_nr
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mp_comm_type)                                 :: mp_group
 
       CALL timeset(routineN, handle)
 
@@ -453,7 +454,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'convert_dbcsr_to_csr_interop'
 
-      INTEGER                                  :: handle, mepos, num_pe, mp_group
+      INTEGER                                  :: handle, mepos, num_pe
+      TYPE(mp_comm_type) :: mp_group
       INTEGER, ALLOCATABLE, DIMENSION(:)       :: nrows_local_all, first_row_all
       INTEGER(C_INT), DIMENSION(:), POINTER    :: colind_local, rowptr_local, nzerow_local
       REAL(C_DOUBLE), DIMENSION(:), POINTER    :: nzvals_local

--- a/src/virial_methods.F
+++ b/src/virial_methods.F
@@ -22,7 +22,8 @@ MODULE virial_methods
    USE kinds,                           ONLY: dp
    USE mathlib,                         ONLY: det_3x3,&
                                               jacobi
-   USE message_passing,                 ONLY: mp_sum
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum
    USE particle_list_types,             ONLY: particle_list_type
    USE particle_types,                  ONLY: particle_type
    USE physcon,                         ONLY: pascal
@@ -82,7 +83,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(distribution_1d_type), POINTER                :: local_particles
       TYPE(virial_type), INTENT(INOUT)                   :: virial
-      INTEGER, INTENT(IN)                                :: igroup
+      TYPE(mp_comm_type), INTENT(IN)                     :: igroup
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'virial_evaluate'
 

--- a/src/voronoi_interface.F
+++ b/src/voronoi_interface.F
@@ -49,7 +49,7 @@ MODULE voronoi_interface
       file_amode_rdonly, file_offset, mp_bcast, mp_file_close, mp_file_descriptor_type, &
       mp_file_get_position, mp_file_open, mp_file_read_all_chv, mp_file_type_free, &
       mp_file_type_hindexed_make_chv, mp_file_type_set_view_chv, mp_file_write_all_chv, &
-      mp_file_write_at, mp_maxloc, mp_recv, mp_send, mp_sum, mp_sync, mpi_character_size
+      mp_file_write_at, mp_maxloc, mp_recv, mp_send, mp_sum, mp_sync, mpi_character_size, mp_comm_type
    USE input_constants, ONLY: &
       voro_radii_unity, voro_radii_vdw, voro_radii_cov, voro_radii_user, &
       bqb_opt_off, bqb_opt_quick, bqb_opt_normal, bqb_opt_patient, bqb_opt_exhaustive, do_method_gapw
@@ -326,10 +326,11 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'entry_voronoi_or_bqb'
       INTEGER                                            :: handle, iounit, L1, L2, L3, U1, U2, &
-                                                            U3, ret, i, my_rank, num_pe, gid, tag, &
+                                                            U3, ret, i, my_rank, num_pe, tag, &
                                                             nkind, natom, ikind, iat, ord, source, dest, &
                                                             ip, i1, i2, reffac, radius_type, bqb_optimize, &
                                                             bqb_history, nspins, jitter_seed
+      TYPE(mp_comm_type) :: gid
       LOGICAL                                            :: outemp, bqb_skip_first, voro_skip_first, &
                                                             bqb_store_step, bqb_check, voro_sanity, &
                                                             bqb_overwrite, vori_overwrite, ionode, molprop, &

--- a/src/xas_restart.F
+++ b/src/xas_restart.F
@@ -45,7 +45,8 @@ MODULE xas_restart
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               dp
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_types,                  ONLY: particle_type
    USE qs_density_matrices,             ONLY: calculate_density_matrix
@@ -113,7 +114,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'xas_read_restart'
 
       CHARACTER(LEN=default_path_length)                 :: filename
-      INTEGER :: group, handle, i, ia, ie, ispin, my_spin, nao, nao_read, nelectron, nexc_atoms, &
+      INTEGER :: handle, i, ia, ie, ispin, my_spin, nao, nao_read, nelectron, nexc_atoms, &
          nexc_atoms_read, nexc_search, nexc_search_read, nmo, nmo_read, output_unit, rst_unit, &
          source, xas_estate, xas_estate_read, xas_method_read
       LOGICAL                                            :: file_exists
@@ -127,6 +128,7 @@ CONTAINS
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
+      TYPE(mp_comm_type)                                 :: group
 
       CALL timeset(routineN, handle)
 

--- a/src/xas_tdp_atom.F
+++ b/src/xas_tdp_atom.F
@@ -62,6 +62,7 @@ MODULE xas_tdp_atom
                                               invmat_symm
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_comm_split_direct,&
+                                              mp_comm_type,&
                                               mp_irecv,&
                                               mp_isend,&
                                               mp_sum,&
@@ -669,9 +670,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'get_exat_ri_sinv'
 
-      INTEGER                                            :: blk, dest, group, handle, iat, ikind, &
-                                                            inb, ir, is, jat, jnb, natom, nnb, &
-                                                            npcols, nprows, source, tag
+      INTEGER                                            :: blk, dest, group_handle, handle, iat, &
+                                                            ikind, inb, ir, is, jat, jnb, natom, &
+                                                            nnb, npcols, nprows, source, tag
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: recv_req, send_req
       INTEGER, DIMENSION(:), POINTER                     :: col_dist, nsgf, row_dist
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
@@ -687,6 +688,7 @@ CONTAINS
       TYPE(dbcsr_distribution_type)                      :: sinv_dist
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       NULLIFY (pgrid, dbcsr_dist, row_dist, col_dist, nsgf, particle_set, block_whole, block_risinv)
@@ -707,7 +709,8 @@ CONTAINS
       END DO
 
       !Create the ri_sinv matrix based on some arbitrary dbcsr_dist
-      CALL dbcsr_distribution_get(dbcsr_dist, group=group, pgrid=pgrid, nprows=nprows, npcols=npcols)
+      CALL dbcsr_distribution_get(dbcsr_dist, group=group_handle, pgrid=pgrid, nprows=nprows, npcols=npcols)
+      CALL group%set_handle(group_handle)
 
       ALLOCATE (row_dist(nnb), col_dist(nnb))
       DO inb = 1, nnb
@@ -715,7 +718,7 @@ CONTAINS
          col_dist(inb) = MODULO(npcols - inb, npcols)
       END DO
 
-      CALL dbcsr_distribution_new(sinv_dist, group=group, pgrid=pgrid, row_dist=row_dist, &
+      CALL dbcsr_distribution_new(sinv_dist, group=group_handle, pgrid=pgrid, row_dist=row_dist, &
                                   col_dist=col_dist)
 
       CALL dbcsr_create(matrix=ri_sinv, name="RI_SINV", matrix_type=dbcsr_type_symmetric, &
@@ -1870,7 +1873,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_fxc_atoms'
 
       INTEGER :: batch_size, dir, er, ex_bo(2), handle, i, iatom, ibatch, iex, ikind, inb, ipe, &
-         mepos, na, natom, nb, nb_bo(2), nbatch, nbk, nex_atom, nr, num_pe, sr, subcomm
+         mepos, na, natom, nb, nb_bo(2), nbatch, nbk, nex_atom, nr, num_pe, sr
       INTEGER, DIMENSION(2, 3)                           :: bounds
       INTEGER, DIMENSION(:), POINTER                     :: exat_neighbors
       LOGICAL                                            :: do_gga, do_sc, do_sf
@@ -1878,6 +1881,7 @@ CONTAINS
       TYPE(cp_1d_r_p_type), DIMENSION(:, :), POINTER     :: ri_dcoeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mp_comm_type)                                 :: subcomm
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(section_vals_type), POINTER                   :: input, xc_functionals

--- a/src/xas_tdp_atom.F
+++ b/src/xas_tdp_atom.F
@@ -65,6 +65,7 @@ MODULE xas_tdp_atom
                                               mp_comm_type,&
                                               mp_irecv,&
                                               mp_isend,&
+                                              mp_request_type,&
                                               mp_sum,&
                                               mp_sync,&
                                               mp_waitall
@@ -673,7 +674,6 @@ CONTAINS
       INTEGER                                            :: blk, dest, group_handle, handle, iat, &
                                                             ikind, inb, ir, is, jat, jnb, natom, &
                                                             nnb, npcols, nprows, source, tag
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: recv_req, send_req
       INTEGER, DIMENSION(:), POINTER                     :: col_dist, nsgf, row_dist
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       LOGICAL                                            :: found_risinv, found_whole
@@ -689,6 +689,7 @@ CONTAINS
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(mp_comm_type)                                 :: group
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_req, send_req
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       NULLIFY (pgrid, dbcsr_dist, row_dist, col_dist, nsgf, particle_set, block_whole, block_risinv)

--- a/src/xas_tdp_correction.F
+++ b/src/xas_tdp_correction.F
@@ -1136,7 +1136,7 @@ CONTAINS
          CALL dbt_default_distvec(nblk_aos, SIZE(mat_pgrid, 1), ao_blk_size, ao_row_dist)
          CALL dbt_default_distvec(nblk_mos(ispin), SIZE(mat_pgrid, 2), mo_blk_size(ispin)%array, &
                                   mo_col_dist(ispin)%array)
-         CALL dbcsr_distribution_new(mat_dist, group=para_env%group, pgrid=mat_pgrid, &
+         CALL dbcsr_distribution_new(mat_dist, group=para_env%group%get_handle(), pgrid=mat_pgrid, &
                                      row_dist=ao_row_dist, col_dist=mo_col_dist(ispin)%array)
 
          CALL dbcsr_create(dbcsr_mo_coeffs, name="MO coeffs", matrix_type="N", dist=mat_dist, &

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -63,7 +63,8 @@ MODULE xas_tdp_integrals
                                               cp_libint_set_contrdepth,&
                                               cp_libint_t
    USE mathlib,                         ONLY: invmat_symm
-   USE message_passing,                 ONLY: mp_sum,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_sum,&
                                               mp_sync
    USE molecule_types,                  ONLY: molecule_type
    USE orbital_pointers,                ONLY: ncoset
@@ -136,9 +137,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'create_pqX_tensor'
 
-      INTEGER                                            :: A, b, group, handle, i, iatom, ikind, &
-                                                            jatom, katom, kkind, nblk, nblk_3, &
-                                                            nblk_per_thread, nkind
+      INTEGER                                            :: A, b, group_handle, handle, i, iatom, &
+                                                            ikind, jatom, katom, kkind, nblk, &
+                                                            nblk_3, nblk_per_thread, nkind
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: idx1, idx2, idx3
       INTEGER, DIMENSION(3)                              :: pdims
       INTEGER, DIMENSION(:), POINTER                     :: col_dist, row_dist
@@ -147,6 +148,7 @@ CONTAINS
       REAL(dp), DIMENSION(3)                             :: rab, rac, rbc
       TYPE(dbt_distribution_type)                        :: t_dist
       TYPE(dbt_pgrid_type)                               :: t_pgrid
+      TYPE(mp_comm_type)                                 :: group
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: ab_iter, ac_iter
 
@@ -161,8 +163,9 @@ CONTAINS
       CPASSERT(symmetric)
 
       !get 2D distribution info from matrix_dist
-      CALL dbcsr_distribution_get(matrix_dist, pgrid=mat_pgrid, group=group, &
+      CALL dbcsr_distribution_get(matrix_dist, pgrid=mat_pgrid, group=group_handle, &
                                   row_dist=row_dist, col_dist=col_dist)
+      CALL group%set_handle(group_handle)
 
       !create the corresponding tensor proc grid and dist
       pdims(1) = SIZE(mat_pgrid, 1); pdims(2) = SIZE(mat_pgrid, 2); pdims(3) = 1

--- a/src/xas_tdp_methods.F
+++ b/src/xas_tdp_methods.F
@@ -77,7 +77,8 @@ MODULE xas_tdp_methods
    USE machine,                         ONLY: m_flush
    USE mathlib,                         ONLY: get_diag
    USE memory_utilities,                ONLY: reallocate
-   USE message_passing,                 ONLY: mp_bcast
+   USE message_passing,                 ONLY: mp_bcast,&
+                                              mp_comm_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE parallel_rng_types,              ONLY: UNIFORM,&
                                               rng_stream_type
@@ -3336,7 +3337,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'read_donor_state_restart'
 
-      INTEGER                                            :: group, handle, ispin, nao, nex, nspins, &
+      INTEGER                                            :: handle, ispin, nao, nex, nspins, &
                                                             output_unit, read_params(7), rst_unit, &
                                                             source
       INTEGER, DIMENSION(:, :), POINTER                  :: mo_indices
@@ -3347,6 +3348,7 @@ CONTAINS
       TYPE(cp_fm_type), POINTER                          :: lr_coeffs
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
+      TYPE(mp_comm_type)                                 :: group
 
       NULLIFY (lr_evals, lr_coeffs, para_env, fm_struct, blacs_env, mos)
 

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -17,8 +17,7 @@ MODULE xc_derivative_set_types
                                               cp_sll_xc_deriv_next,&
                                               cp_sll_xc_deriv_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_comm_self,&
-                                              mp_comm_type
+   USE message_passing,                 ONLY: mp_comm_self
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
                                               pw_grid_release
@@ -121,7 +120,6 @@ CONTAINS
       TYPE(pw_pool_type), OPTIONAL, POINTER              :: pw_pool
       INTEGER, DIMENSION(2, 3), INTENT(IN), OPTIONAL     :: local_bounds
 
-      TYPE(mp_comm_type)                                 :: mp_comm
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
       NULLIFY (pw_grid)
@@ -137,8 +135,7 @@ CONTAINS
       ELSE
          !FM ugly hack, should be replaced by a pool only for 3d arrays
          CPASSERT(PRESENT(local_bounds))
-         CALL mp_comm%set_handle(mp_comm_self)
-         CALL pw_grid_create(pw_grid, mp_comm)
+         CALL pw_grid_create(pw_grid, mp_comm_self)
          pw_grid%bounds_local = local_bounds
          NULLIFY (derivative_set%pw_pool)
          CALL pw_pool_create(derivative_set%pw_pool, pw_grid)

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -17,7 +17,8 @@ MODULE xc_derivative_set_types
                                               cp_sll_xc_deriv_next,&
                                               cp_sll_xc_deriv_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_comm_self
+   USE message_passing,                 ONLY: mp_comm_self,&
+                                              mp_comm_type
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
                                               pw_grid_release
@@ -120,6 +121,7 @@ CONTAINS
       TYPE(pw_pool_type), OPTIONAL, POINTER              :: pw_pool
       INTEGER, DIMENSION(2, 3), INTENT(IN), OPTIONAL     :: local_bounds
 
+      TYPE(mp_comm_type)                                 :: mp_comm
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
       NULLIFY (pw_grid)
@@ -135,7 +137,8 @@ CONTAINS
       ELSE
          !FM ugly hack, should be replaced by a pool only for 3d arrays
          CPASSERT(PRESENT(local_bounds))
-         CALL pw_grid_create(pw_grid, mp_comm_self)
+         CALL mp_comm%set_handle(mp_comm_self)
+         CALL pw_grid_create(pw_grid, mp_comm)
          pw_grid%bounds_local = local_bounds
          NULLIFY (derivative_set%pw_pool)
          CALL pw_pool_create(derivative_set%pw_pool, pw_grid)

--- a/src/xray_diffraction.F
+++ b/src/xray_diffraction.F
@@ -29,7 +29,8 @@ MODULE xray_diffraction
    USE mathconstants,                   ONLY: pi,&
                                               twopi
    USE memory_utilities,                ONLY: reallocate
-   USE message_passing,                 ONLY: mp_gather,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_gather,&
                                               mp_gatherv
    USE orbital_pointers,                ONLY: indco,&
                                               nco,&
@@ -96,9 +97,9 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'xray_diffraction_spectrum'
       INTEGER, PARAMETER                                 :: nblock = 100
 
-      INTEGER                                            :: group, handle, i, ig, ig_shell, ipe, &
-                                                            ishell, jg, ng, npe, nshell, &
-                                                            nshell_gather, source
+      INTEGER                                            :: handle, i, ig, ig_shell, ipe, ishell, &
+                                                            jg, ng, npe, nshell, nshell_gather, &
+                                                            source
       INTEGER(KIND=int_8)                                :: ngpts
       INTEGER, DIMENSION(3)                              :: npts
       INTEGER, DIMENSION(:), POINTER                     :: aux_index, ng_shell, ng_shell_gather, &
@@ -111,6 +112,7 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mp_comm_type)                                 :: group
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool


### PR DESCRIPTION
This PR encapsulates all MPI handles used outside of the MPI wrapper module, i.e. communicators, requests, files, windows (the last one is not used in CP2K). File handles are only encapsulated as far as they are connected to the MPI module, otherwise, the ordinary Fortran integer handle will be used as in most parts of the code, the output is written to the regular output file. the status handles are not encapsulated as they are never used outside of the wrapper.

This PR prepares the introduction of the MPI-Fortran-2008 module.

I am open for comments.