### PR TITLE
periodic GW: RI with truncated Coulomb metric and memory reduction

### DIFF
--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -27,10 +27,10 @@ MODULE input_cp2k_mp2
    USE input_constants,                 ONLY: &
         do_eri_gpw, do_eri_mme, do_eri_os, do_potential_coulomb, do_potential_id, &
         do_potential_long, do_potential_mix_cl, do_potential_short, do_potential_truncated, &
-        do_potential_tshpsc, eri_default, gaussian, gw_gf_gamma, gw_gf_mic, gw_no_print_exx, &
-        gw_pade_approx, gw_print_exx, gw_read_exx, gw_skip_for_regtest, gw_two_pole_model, &
-        kp_weights_W_auto, kp_weights_W_tailored, kp_weights_W_uniform, mp2_method_direct, &
-        mp2_method_gpw, mp2_method_none, numerical, ot_precond_full_all, ot_precond_full_kinetic, &
+        do_potential_tshpsc, eri_default, gaussian, gw_no_print_exx, gw_pade_approx, gw_print_exx, &
+        gw_read_exx, gw_skip_for_regtest, gw_two_pole_model, kp_weights_W_auto, &
+        kp_weights_W_tailored, kp_weights_W_uniform, mp2_method_direct, mp2_method_gpw, &
+        mp2_method_none, numerical, ot_precond_full_all, ot_precond_full_kinetic, &
         ot_precond_full_single, ot_precond_full_single_inverse, ot_precond_none, &
         ot_precond_s_inverse, ri_default, ri_rpa_g0w0_crossing_bisection, &
         ri_rpa_g0w0_crossing_newton, ri_rpa_g0w0_crossing_z_shot, wfc_mm_style_gemm, &
@@ -1269,18 +1269,6 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create( &
-         keyword, __LOCATION__, name="REL_CUTOFFS_CHI_W", &
-         description="For periodic calculations, the irreducible density reponse chi^0(r,r') and the screened "// &
-         "Coulomb interaction W(r,r') is truncated "// &
-         "in real space. No truncation of chi^0(r,r') and W(r,r') for |r-r'| < cutoff_1*(smallest lattice vector length), "// &
-         "chi^0(r,r') is set to zero for |r-r'| > cutoff_2*(smallest lattice vector length). Smooth transition "// &
-         "in between. For cutoff_1 = 0.5, and cutoff_2 = 0.5, we have the minimum image convention (that is also default).", &
-         usage="REL_CUTOFFS_CHI cutoff_1 cutoff_2", &
-         n_var=2, type_of_var=real_t, default_r_vals=(/0.5_dp, 0.5_dp/))
-      CALL section_add_keyword(section, keyword)
-      CALL keyword_release(keyword)
-
-      CALL keyword_create( &
          keyword, __LOCATION__, &
          name="REGULARIZATION_RI", &
          description="Parameter to reduce the expansion coefficients in RI for periodic GW. Larger parameter "// &
@@ -1303,12 +1291,35 @@ CONTAINS
 
       CALL keyword_create( &
          keyword, __LOCATION__, &
+         name="EPS_EIGVAL_S_GAMMA", &
+         description="Parameter to reduce the expansion coefficients in RI for periodic GW. Removes all "// &
+         "eigenvectors and eigenvalues of M_PQ(k=0) that are smaller than EPS_EIGVAL_S. ", &
+         usage="EPS_EIGVAL_S 1.0E-3", &
+         default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
          name="MAKE_CHI_POS_DEFINITE", &
          description="If true, makes eigenvalue decomposition of chi(iw,k) and removes negative "// &
          "eigenvalues. May increase computational cost significantly. Only recommended to try in case "// &
          "Cholesky decomposition of epsilon(iw,k) fails.", &
          usage="MAKE_CHI_POS_DEFINITE", &
          default_l_val=.TRUE., &
+         lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create( &
+         keyword, __LOCATION__, &
+         name="MAKE_OVERLAP_MAT_AO_POS_DEFINITE", &
+         description="If true, makes eigenvalue decomposition of S_mu,nu(k) and removes negative "// &
+         "eigenvalues. Slightly increases computational cost. Only recommended to try in case "// &
+         "Cholesky decomposition of S_mu,nu(k) fails (error message: Cholesky decompose failed: "// &
+         "matrix is not positive definite or ill-conditioned; when calling create_kp_and_calc_kp_orbitals).", &
+         usage="MAKE_OVERLAP_MAT_AO_POS_DEFINITE", &
+         default_l_val=.FALSE., &
          lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1366,22 +1377,6 @@ CONTAINS
          "the k-mesh for G. Example: factor 4, k-mesh for W: 4x4x1 -> k-mesh for G: 16x16x1 (z-dir. is "// &
          "non-periodic).", &
          default_i_val=1)
-      CALL section_add_keyword(section, keyword)
-      CALL keyword_release(keyword)
-
-      NULLIFY (keyword)
-      CALL keyword_create( &
-         keyword, __LOCATION__, &
-         name="GREENS_FUNCTION", &
-         description="Decides which scheme is used for the periodic Green's function "// &
-         "(only relevant for periodic GW calculations)."// &
-         "Both schemes are exact in the limit of large unit cells.", &
-         usage="GREENS_FUNCTION GAMMA", &
-         enum_c_vals=s2a("GAMMA", "MIC"), &
-         enum_i_vals=(/gw_gf_gamma, gw_gf_mic/), &
-         enum_desc=s2a("Use the Green's functions at the Gamma point. ", &
-                       "Use the minimum-image convention for the Green's function."), &
-         default_i_val=gw_gf_gamma)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -164,8 +164,9 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_sub, blacs_env_sub_mat_munu
       TYPE(cp_fm_type)                                   :: fm_matrix_PQ
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_coeff
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_RI_metric, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, fm_matrix_Minv, &
+                                                            fm_matrix_Minv_L_kpoints, &
+                                                            fm_matrix_Minv_Vtrunc_Minv
       TYPE(cp_fm_type), POINTER                          :: mo_coeff_ptr
       TYPE(cp_logger_type), POINTER                      :: logger, logger_sub
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub
@@ -381,8 +382,8 @@ CONTAINS
             CALL mp2_ri_gpw_compute_in( &
                BIb_C, BIb_C_gw, BIb_C_bse_ij, BIb_C_bse_ab, gd_array, gd_B_virtual, dimen_RI, dimen_RI_red, qs_env, &
                para_env, para_env_sub, color_sub, cell, particle_set, &
-               atomic_kind_set, qs_kind_set, mo_coeff, fm_matrix_PQ, fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &
-               nmo, homo, mat_munu, sab_orb_sub, &
+               atomic_kind_set, qs_kind_set, mo_coeff, fm_matrix_PQ, fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+               fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, nmo, homo, mat_munu, sab_orb_sub, &
                mo_coeff_o, mo_coeff_v, mo_coeff_all, mo_coeff_gw, &
                mp2_env%mp2_gpw%eps_filter, unit_nr, &
                mp2_env%mp2_memory, mp2_env%calc_PQ_cond_num, calc_forces, blacs_env_sub, my_do_gw .AND. .NOT. do_im_time, &
@@ -398,7 +399,8 @@ CONTAINS
                                        dimen_RI, dimen_RI_red, qs_env, para_env, para_env_sub, &
                                        color_sub, cell, particle_set, &
                                        atomic_kind_set, qs_kind_set, mo_coeff, fm_matrix_PQ, &
-                                       fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, nmo, homo, &
+                                       fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+                                       fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, nmo, homo, &
                                        mat_munu, sab_orb_sub, &
                                        mo_coeff_o, mo_coeff_v, mo_coeff_all, mo_coeff_gw, &
                                        mp2_env%mp2_gpw%eps_filter, unit_nr, &
@@ -537,7 +539,8 @@ CONTAINS
          CALL rpa_ri_compute_en(qs_env, Emp2, mp2_env, BIb_C, BIb_C_gw, BIb_C_bse_ij, BIb_C_bse_ab, &
                                 para_env, para_env_sub, color_sub, &
                                 gd_array, gd_B_virtual, gd_B_all, gd_B_occ_bse, gd_B_virt_bse, &
-                                mo_coeff, fm_matrix_PQ, fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, kpoints, &
+                                mo_coeff, fm_matrix_PQ, fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+                                fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, kpoints, &
                                 Eigenval, nmo, homo, dimen_RI, dimen_RI_red, gw_corr_lev_occ, gw_corr_lev_virt, &
                                 unit_nr, my_do_ri_sos_laplace_mp2, my_do_gw, do_im_time, do_bse, matrix_s, &
                                 mat_munu, mat_P_global, &
@@ -549,8 +552,10 @@ CONTAINS
             CALL rse_energy(qs_env, mp2_env, para_env, dft_control, mo_coeff, nmo, homo, Eigenval)
 
          IF (do_im_time) THEN
-            CALL dbcsr_release(mat_P_global%matrix)
-            DEALLOCATE (mat_P_global%matrix)
+            IF (ASSOCIATED(mat_P_global%matrix)) THEN
+               CALL dbcsr_release(mat_P_global%matrix)
+               DEALLOCATE (mat_P_global%matrix)
+            END IF
 
             CALL cp_libint_static_cleanup()
             IF (calc_forces) CALL cp_fm_release(fm_matrix_PQ)

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -145,8 +145,10 @@ CONTAINS
 !> \param qs_kind_set ...
 !> \param mo_coeff ...
 !> \param fm_matrix_PQ ...
-!> \param fm_matrix_L_RI_metric ...
-!> \param fm_matrix_Sinv_Vtrunc_Sinv ...
+!> \param fm_matrix_L_kpoints ...
+!> \param fm_matrix_Minv_L_kpoints ...
+!> \param fm_matrix_Minv ...
+!> \param fm_matrix_Minv_Vtrunc_Minv ...
 !> \param nmo ...
 !> \param homo ...
 !> \param mat_munu ...
@@ -185,7 +187,8 @@ CONTAINS
    SUBROUTINE mp2_ri_gpw_compute_in(BIb_C, BIb_C_gw, BIb_C_bse_ij, BIb_C_bse_ab, gd_array, gd_B_virtual, &
                                     dimen_RI, dimen_RI_red, qs_env, para_env, para_env_sub, color_sub, &
                                     cell, particle_set, atomic_kind_set, qs_kind_set, mo_coeff, &
-                                    fm_matrix_PQ, fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &
+                                    fm_matrix_PQ, fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+                                    fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                                     nmo, homo, mat_munu, &
                                     sab_orb_sub, mo_coeff_o, mo_coeff_v, mo_coeff_all, &
                                     mo_coeff_gw, eps_filter, unit_nr, &
@@ -214,8 +217,10 @@ CONTAINS
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_coeff
       TYPE(cp_fm_type), INTENT(OUT)                      :: fm_matrix_PQ
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_RI_metric, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, &
+                                                            fm_matrix_Minv_L_kpoints, &
+                                                            fm_matrix_Minv, &
+                                                            fm_matrix_Minv_Vtrunc_Minv
       INTEGER, INTENT(IN)                                :: nmo
       INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_munu
@@ -355,7 +360,7 @@ CONTAINS
                             kpoints, my_group_L_size, my_group_L_start, my_group_L_end, &
                             gd_array, calc_PQ_cond_num .AND. .NOT. do_svd, do_svd, &
                             qs_env%mp2_env%potential_parameter, ri_metric, &
-                            fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &
+                            fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                             do_im_time, do_kpoints_from_Gamma .OR. do_kpoints_cubic_RPA, qs_env%mp2_env%mp2_gpw%eps_pgf_orb_S, &
                             qs_kind_set, sab_orb_sub, calc_forces, unit_nr)
 
@@ -382,7 +387,7 @@ CONTAINS
                WRITE (unit_nr, FMT="(T3,A,T73,A)") &
                   "RI_INFO| RI metric: ", "OVERLAP"
             CASE (do_potential_truncated)
-               WRITE (unit_nr, FMT="(T3,A,T72,A)") &
+               WRITE (unit_nr, FMT="(T3,A,T64,A)") &
                   "RI_INFO| RI metric: ", "TRUNCATED COULOMB"
                rc_ang = cp_unit_from_cp2k(ri_metric%cutoff_radius, "angstrom")
                WRITE (unit_nr, '(T3,A,T61,F20.2)') &

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -39,6 +39,7 @@ MODULE mp2_ri_2c
                                               cp_fm_triangular_invert
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
    USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
+                                              cp_fm_power,&
                                               cp_fm_syevx
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
@@ -105,7 +106,7 @@ MODULE mp2_ri_2c
    USE qs_tensors,                      ONLY: build_2c_integrals,&
                                               build_2c_neighbor_lists
    USE rpa_communication,               ONLY: communicate_buffer
-   USE rpa_gw_kpoints_util,             ONLY: cp_cfm_matrix_exponential
+   USE rpa_gw_kpoints_util,             ONLY: cp_cfm_power
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num
 #include "./base/base_uses.f90"
@@ -116,7 +117,7 @@ MODULE mp2_ri_2c
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'mp2_ri_2c'
 
-   PUBLIC :: get_2c_integrals, setup_abs_cutoffs_chi_and_trunc_coulomb_potential
+   PUBLIC :: get_2c_integrals, setup_trunc_coulomb_potential_for_exchange_self_energy
 
 CONTAINS
 
@@ -144,8 +145,10 @@ CONTAINS
 !> \param do_svd ...
 !> \param potential ...
 !> \param ri_metric ...
-!> \param fm_matrix_L_RI_metric ...
-!> \param fm_matrix_Sinv_Vtrunc_Sinv ...
+!> \param fm_matrix_L_kpoints ...
+!> \param fm_matrix_Minv_L_kpoints ...
+!> \param fm_matrix_Minv ...
+!> \param fm_matrix_Minv_Vtrunc_Minv ...
 !> \param do_im_time ...
 !> \param do_kpoints ...
 !> \param mp2_eps_pgf_orb_S ...
@@ -157,9 +160,9 @@ CONTAINS
    SUBROUTINE get_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, mp2_memory, &
                                my_Lrows, my_Vrows, fm_matrix_PQ, ngroup, color_sub, dimen_RI, dimen_RI_red, &
                                kpoints, my_group_L_size, my_group_L_start, my_group_L_end, &
-                               gd_array, calc_PQ_cond_num, do_svd, &
-                               potential, ri_metric, &
-                               fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &
+                               gd_array, calc_PQ_cond_num, do_svd, potential, ri_metric, &
+                               fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+                               fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                                do_im_time, do_kpoints, mp2_eps_pgf_orb_S, qs_kind_set, sab_orb_sub, calc_forces, unit_nr)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -178,8 +181,10 @@ CONTAINS
       TYPE(group_dist_d1_type), INTENT(OUT)              :: gd_array
       LOGICAL, INTENT(IN)                                :: calc_PQ_cond_num, do_svd
       TYPE(libint_potential_type)                        :: potential, ri_metric
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_RI_metric, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, &
+                                                            fm_matrix_Minv_L_kpoints, &
+                                                            fm_matrix_Minv, &
+                                                            fm_matrix_Minv_Vtrunc_Minv
       LOGICAL, INTENT(IN)                                :: do_im_time, do_kpoints
       REAL(KIND=dp), INTENT(IN)                          :: mp2_eps_pgf_orb_S
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -190,39 +195,37 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'get_2c_integrals'
 
-      INTEGER                                            :: handle, i_real_imag, i_size, j_size, &
-                                                            num_small_eigen
+      INTEGER                                            :: handle, i_size, j_size, num_small_eigen
       REAL(KIND=dp)                                      :: cond_num, eps_pgf_orb_old
-      TYPE(cp_fm_type)                                   :: fm_matrix_L, fm_matrix_S_inv_work, &
+      TYPE(cp_fm_type)                                   :: fm_matrix_L_work, fm_matrix_M_inv_work, &
                                                             fm_matrix_V
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints
       TYPE(cp_para_env_type), POINTER                    :: para_env_L
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(libint_potential_type)                        :: trunc_coulomb
 
       CALL timeset(routineN, handle)
 
-      ! calculate V and store it in fm_matrix_L
+      ! calculate V and store it in fm_matrix_L_work
       CALL compute_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, para_env_L, mp2_memory, &
-                                fm_matrix_L, ngroup, color_sub, dimen_RI, &
+                                fm_matrix_L_work, ngroup, color_sub, dimen_RI, &
                                 my_group_L_size, my_group_L_start, my_group_L_end, &
                                 gd_array, calc_PQ_cond_num, cond_num, &
                                 num_small_eigen, potential, sab_orb_sub, do_im_time=do_im_time)
 
       IF (do_im_time .AND. calc_forces) THEN
          !need a copy of the (P|Q) integrals
-         CALL cp_fm_create(fm_matrix_PQ, fm_matrix_L%matrix_struct)
-         CALL cp_fm_to_fm(fm_matrix_L, fm_matrix_PQ)
+         CALL cp_fm_create(fm_matrix_PQ, fm_matrix_L_work%matrix_struct)
+         CALL cp_fm_to_fm(fm_matrix_L_work, fm_matrix_PQ)
       END IF
 
       dimen_RI_red = dimen_RI
 
       IF (compare_potential_types(ri_metric, potential) .AND. .NOT. do_im_time) THEN
-         CALL decomp_mat_L(fm_matrix_L, do_svd, num_small_eigen, cond_num, .TRUE., gd_array, ngroup, &
+         CALL decomp_mat_L(fm_matrix_L_work, do_svd, num_small_eigen, cond_num, .TRUE., gd_array, ngroup, &
                            dimen_RI, dimen_RI_red, para_env)
       ELSE
 
-         ! Obara-Saika overlap matrix
+         ! RI-metric matrix (depending on RI metric: Coulomb, overlap or truncated Coulomb)
          IF (do_im_time) THEN
             CALL get_qs_env(qs_env, dft_control=dft_control)
 
@@ -231,7 +234,7 @@ CONTAINS
             dft_control%qs_control%eps_pgf_orb = mp2_eps_pgf_orb_S
             CALL init_interaction_radii(dft_control%qs_control, qs_kind_set)
 
-            CALL RI_2c_integral_mat(qs_env, fm_matrix_L_RI_metric, fm_matrix_L, dimen_RI, ri_metric, &
+            CALL RI_2c_integral_mat(qs_env, fm_matrix_Minv_L_kpoints, fm_matrix_L_work, dimen_RI, ri_metric, &
                                     do_kpoints, kpoints, put_mat_KS_env=.TRUE.)
 
             ! re-init the radii to previous values
@@ -244,93 +247,88 @@ CONTAINS
             CALL cp_para_env_release(para_env_L)
             CALL release_group_dist(gd_array)
 
-            ALLOCATE (fm_matrix_L_RI_metric(1, 1))
+            ALLOCATE (fm_matrix_Minv_L_kpoints(1, 1))
 
-            ! Calculate matrix of RI operator (for overlap metric: S), store it in fm_matrix_L_RI_metric
+            ! Calculate matrix of RI operator (for overlap metric: S), store it in fm_matrix_Minv_L_kpoints
             CALL compute_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, para_env_L, mp2_memory, &
-                                      fm_matrix_L_RI_metric(1, 1), ngroup, color_sub, dimen_RI, &
+                                      fm_matrix_Minv_L_kpoints(1, 1), ngroup, color_sub, dimen_RI, &
                                       my_group_L_size, my_group_L_start, my_group_L_end, &
                                       gd_array, calc_PQ_cond_num, cond_num, &
                                       num_small_eigen, ri_metric, sab_orb_sub, &
-                                      fm_matrix_L_extern=fm_matrix_L)
+                                      fm_matrix_L_extern=fm_matrix_L_work)
 
          END IF
 
          IF (do_kpoints) THEN
 
-            CALL compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_L_RI_metric, kpoints)
+            ! k-dependent 1/r Coulomb matrix V_PQ(k)
+            CALL compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, kpoints)
 
-            CALL setup_abs_cutoffs_chi_and_trunc_coulomb_potential(qs_env, trunc_coulomb)
+            CALL inversion_of_M_and_mult_with_chol_dec_of_V(fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, &
+                                                            dimen_RI, kpoints, qs_env%mp2_env%ri_rpa_im_time%eps_eigval_S)
 
-            CALL RI_2c_integral_mat(qs_env, fm_matrix_Sinv_Vtrunc_Sinv, fm_matrix_L, dimen_RI, trunc_coulomb, &
-                                    do_kpoints, kpoints, put_mat_KS_env=.FALSE.)
+            CALL setup_trunc_coulomb_potential_for_exchange_self_energy(qs_env, trunc_coulomb)
 
-            CALL inversion_of_S_and_mult_with_chol_dec_of_V(fm_matrix_L_RI_metric, fm_matrix_L_kpoints, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv, dimen_RI, kpoints, &
-                                                            qs_env%mp2_env%ri_rpa_im_time%eps_eigval_S)
+            ! Gamma-only truncated Coulomb matrix V^tr with cutoff radius = half the unit cell size; for exchange self-energy
+            CALL RI_2c_integral_mat(qs_env, fm_matrix_Minv_Vtrunc_Minv, fm_matrix_L_work, dimen_RI, trunc_coulomb, &
+                                    do_kpoints=.FALSE., kpoints=kpoints, put_mat_KS_env=.FALSE.)
 
+            ! Gamma-only RI-metric matrix; for computing Gamma-only/MIC self-energy
+            CALL RI_2c_integral_mat(qs_env, fm_matrix_Minv, fm_matrix_L_work, dimen_RI, ri_metric, &
+                                    do_kpoints=.FALSE., kpoints=kpoints, put_mat_KS_env=.FALSE.)
+
+            CALL Gamma_only_inversion_of_M_and_mult_with_chol_dec_of_Vtrunc(fm_matrix_Minv_Vtrunc_Minv, &
+                                                                            fm_matrix_Minv, qs_env)
          ELSE
             IF (calc_forces .AND. (.NOT. do_im_time)) THEN
                ! For the gradients, we make a copy of the inverse root of L
-               CALL cp_fm_create(fm_matrix_V, fm_matrix_L%matrix_struct)
-               CALL cp_fm_to_fm(fm_matrix_L, fm_matrix_V)
+               CALL cp_fm_create(fm_matrix_V, fm_matrix_L_work%matrix_struct)
+               CALL cp_fm_to_fm(fm_matrix_L_work, fm_matrix_V)
 
                CALL decomp_mat_L(fm_matrix_V, do_svd, num_small_eigen, cond_num, .TRUE., gd_array, ngroup, &
                                  dimen_RI, dimen_RI_red, para_env)
             END IF
 
-            CALL decomp_mat_L(fm_matrix_L, do_svd, num_small_eigen, cond_num, .FALSE., gd_array, ngroup, &
+            CALL decomp_mat_L(fm_matrix_L_work, do_svd, num_small_eigen, cond_num, .FALSE., gd_array, ngroup, &
                               dimen_RI, dimen_RI_red, para_env)
 
-            CALL decomp_mat_L(fm_matrix_L_RI_metric(1, 1), .FALSE., num_small_eigen, cond_num, .TRUE., &
+            CALL decomp_mat_L(fm_matrix_Minv_L_kpoints(1, 1), .FALSE., num_small_eigen, cond_num, .TRUE., &
                               gd_array, ngroup, dimen_RI, dimen_RI_red, para_env)
 
-            CALL cp_fm_create(fm_matrix_S_inv_work, fm_matrix_L_RI_metric(1, 1)%matrix_struct)
-            CALL cp_fm_set_all(fm_matrix_S_inv_work, 0.0_dp)
+            CALL cp_fm_create(fm_matrix_M_inv_work, fm_matrix_Minv_L_kpoints(1, 1)%matrix_struct)
+            CALL cp_fm_set_all(fm_matrix_M_inv_work, 0.0_dp)
 
-            CALL parallel_gemm('N', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_matrix_L_RI_metric(1, 1), &
-                               fm_matrix_L_RI_metric(1, 1), 0.0_dp, fm_matrix_S_inv_work)
+            CALL parallel_gemm('N', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_matrix_Minv_L_kpoints(1, 1), &
+                               fm_matrix_Minv_L_kpoints(1, 1), 0.0_dp, fm_matrix_M_inv_work)
 
             IF (do_svd) THEN
-               ! We have to reset the size of fm_matrix_L_RI_metric
-               CALL reset_size_matrix(fm_matrix_L_RI_metric(1, 1), dimen_RI_red, fm_matrix_L%matrix_struct)
+               ! We have to reset the size of fm_matrix_Minv_L_kpoints
+               CALL reset_size_matrix(fm_matrix_Minv_L_kpoints(1, 1), dimen_RI_red, fm_matrix_L_work%matrix_struct)
 
-               ! L (=fm_matrix_L_RI_metric) = S^(-1)*chol_dec(V)
-               CALL parallel_gemm('T', 'N', dimen_RI, dimen_RI_red, dimen_RI, 1.0_dp, fm_matrix_S_inv_work, fm_matrix_L, &
-                                  0.0_dp, fm_matrix_L_RI_metric(1, 1))
+               ! L (=fm_matrix_Minv_L_kpoints) = S^(-1)*chol_dec(V)
+               CALL parallel_gemm('T', 'N', dimen_RI, dimen_RI_red, dimen_RI, 1.0_dp, fm_matrix_M_inv_work, &
+                                  fm_matrix_L_work, 0.0_dp, fm_matrix_Minv_L_kpoints(1, 1))
             ELSE
-               ! L (=fm_matrix_L_RI_metric) = S^(-1)*chol_dec(V)
-               CALL parallel_gemm('T', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_matrix_S_inv_work, fm_matrix_L, &
-                                  0.0_dp, fm_matrix_L_RI_metric(1, 1))
+               ! L (=fm_matrix_Minv_L_kpoints) = S^(-1)*chol_dec(V)
+               CALL parallel_gemm('T', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_matrix_M_inv_work, &
+                                  fm_matrix_L_work, 0.0_dp, fm_matrix_Minv_L_kpoints(1, 1))
             END IF
 
             ! clean the S_inv matrix
-            CALL cp_fm_release(fm_matrix_S_inv_work)
+            CALL cp_fm_release(fm_matrix_M_inv_work)
          END IF
 
          IF (.NOT. do_im_time) THEN
 
-            CALL cp_fm_to_fm(fm_matrix_L_RI_metric(1, 1), fm_matrix_L)
-            DO j_size = 1, SIZE(fm_matrix_L_RI_metric, 1)
-            DO i_size = 1, SIZE(fm_matrix_L_RI_metric, 2)
-               CALL cp_fm_release(fm_matrix_L_RI_metric(i_size, j_size))
+            CALL cp_fm_to_fm(fm_matrix_Minv_L_kpoints(1, 1), fm_matrix_L_work)
+            DO j_size = 1, SIZE(fm_matrix_Minv_L_kpoints, 1)
+            DO i_size = 1, SIZE(fm_matrix_Minv_L_kpoints, 2)
+               CALL cp_fm_release(fm_matrix_Minv_L_kpoints(i_size, j_size))
             END DO
             END DO
-            DEALLOCATE (fm_matrix_L_RI_metric)
+            DEALLOCATE (fm_matrix_Minv_L_kpoints)
 
          END IF
-
-      END IF
-
-      IF (do_kpoints) THEN
-
-         DO i_size = 1, SIZE(fm_matrix_L_kpoints, 1)
-         DO i_real_imag = 1, SIZE(fm_matrix_L_kpoints, 2)
-            CALL cp_fm_release(fm_matrix_L_kpoints(i_size, i_real_imag))
-         END DO
-         END DO
-
-         DEALLOCATE (fm_matrix_L_kpoints)
 
       END IF
 
@@ -351,13 +349,13 @@ CONTAINS
          END IF
 
          ! replicate the necessary row of the L^{-1} matrix on each proc
-         CALL grep_Lcols(fm_matrix_L, my_group_L_start, my_group_L_end, my_group_L_size, my_Lrows)
+         CALL grep_Lcols(fm_matrix_L_work, my_group_L_start, my_group_L_end, my_group_L_size, my_Lrows)
          IF (calc_forces .AND. .NOT. compare_potential_types(qs_env%mp2_env%ri_metric, &
                                                              qs_env%mp2_env%potential_parameter)) THEN
             CALL grep_Lcols(fm_matrix_V, my_group_L_start, my_group_L_end, my_group_L_size, my_Vrows)
          END IF
       END IF
-      CALL cp_fm_release(fm_matrix_L)
+      CALL cp_fm_release(fm_matrix_L_work)
       IF (calc_forces .AND. .NOT. (do_im_time .OR. compare_potential_types(qs_env%mp2_env%ri_metric, &
                                                                qs_env%mp2_env%potential_parameter))) CALL cp_fm_release(fm_matrix_V)
       CALL cp_para_env_release(para_env_L)
@@ -407,7 +405,7 @@ CONTAINS
          ! calculate Cholesky decomposition L (V=LL^T)
          CALL cholesky_decomp(fm_matrix_L, dimen_RI, do_inversion=do_inversion)
 
-         IF (do_inversion) CALL invert_L(fm_matrix_L)
+         IF (do_inversion) CALL invert_mat(fm_matrix_L)
       END IF
 
    END SUBROUTINE decomp_mat_L
@@ -416,13 +414,13 @@ CONTAINS
 !> \brief ...
 !> \param qs_env ...
 !> \param fm_matrix_L_kpoints ...
-!> \param fm_matrix_L_RI_metric ...
+!> \param fm_matrix_Minv_L_kpoints ...
 !> \param kpoints ...
 ! **************************************************************************************************
-   SUBROUTINE compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_L_RI_metric, kpoints)
+   SUBROUTINE compute_V_by_lattice_sum(qs_env, fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, kpoints)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, &
-                                                            fm_matrix_L_RI_metric
+                                                            fm_matrix_Minv_L_kpoints
       TYPE(kpoint_type), POINTER                         :: kpoints
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_V_by_lattice_sum'
@@ -461,7 +459,7 @@ CONTAINS
       DO ikp = 1, nkp
          DO i_real_imag = 1, 2
             CALL cp_fm_create(fm_matrix_L_kpoints(ikp, i_real_imag), &
-                              fm_matrix_L_RI_metric(1, i_real_imag)%matrix_struct)
+                              fm_matrix_Minv_L_kpoints(1, i_real_imag)%matrix_struct)
             CALL cp_fm_set_all(fm_matrix_L_kpoints(ikp, i_real_imag), 0.0_dp)
          END DO
       END DO
@@ -550,7 +548,7 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
-!> \param fm_matrix_L_RI_metric ...
+!> \param fm_matrix_Minv_L_kpoints ...
 !> \param fm_matrix_L ...
 !> \param dimen_RI ...
 !> \param ri_metric ...
@@ -558,11 +556,11 @@ CONTAINS
 !> \param kpoints ...
 !> \param put_mat_KS_env ...
 ! **************************************************************************************************
-   SUBROUTINE RI_2c_integral_mat(qs_env, fm_matrix_L_RI_metric, fm_matrix_L, dimen_RI, &
+   SUBROUTINE RI_2c_integral_mat(qs_env, fm_matrix_Minv_L_kpoints, fm_matrix_L, dimen_RI, &
                                  ri_metric, do_kpoints, kpoints, put_mat_KS_env)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_RI_metric
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_Minv_L_kpoints
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_matrix_L
       INTEGER, INTENT(IN)                                :: dimen_RI
       TYPE(libint_potential_type)                        :: ri_metric
@@ -669,11 +667,11 @@ CONTAINS
          n_real_imag = 1
       END IF
 
-      ALLOCATE (fm_matrix_L_RI_metric(nkp, n_real_imag))
+      ALLOCATE (fm_matrix_Minv_L_kpoints(nkp, n_real_imag))
       DO i_size = 1, nkp
          DO i_real_imag = 1, n_real_imag
-            CALL cp_fm_create(fm_matrix_L_RI_metric(i_size, i_real_imag), fm_matrix_L%matrix_struct)
-            CALL cp_fm_set_all(fm_matrix_L_RI_metric(i_size, i_real_imag), 0.0_dp)
+            CALL cp_fm_create(fm_matrix_Minv_L_kpoints(i_size, i_real_imag), fm_matrix_L%matrix_struct)
+            CALL cp_fm_set_all(fm_matrix_Minv_L_kpoints(i_size, i_real_imag), 0.0_dp)
          END DO
       END DO
 
@@ -710,14 +708,14 @@ CONTAINS
 
             CALL cp_fm_set_all(fm_matrix_S_global, 0.0_dp)
             CALL copy_dbcsr_to_fm(tmpmat, fm_matrix_S_global)
-            CALL cp_fm_copy_general(fm_matrix_S_global, fm_matrix_L_RI_metric(ikp, 1), para_env)
+            CALL cp_fm_copy_general(fm_matrix_S_global, fm_matrix_Minv_L_kpoints(ikp, 1), para_env)
 
             CALL dbcsr_set(tmpmat, 0.0_dp)
             CALL dbcsr_desymmetrize(cmatrix, tmpmat)
 
             CALL cp_fm_set_all(fm_matrix_S_global, 0.0_dp)
             CALL copy_dbcsr_to_fm(tmpmat, fm_matrix_S_global)
-            CALL cp_fm_copy_general(fm_matrix_S_global, fm_matrix_L_RI_metric(ikp, 2), para_env)
+            CALL cp_fm_copy_general(fm_matrix_S_global, fm_matrix_Minv_L_kpoints(ikp, 2), para_env)
 
          END DO
 
@@ -736,7 +734,7 @@ CONTAINS
 
          CALL copy_dbcsr_to_fm(matrix_s_RI_aux_desymm, fm_matrix_S_global)
 
-         CALL cp_fm_copy_general(fm_matrix_S_global, fm_matrix_L_RI_metric(1, 1), para_env)
+         CALL cp_fm_copy_general(fm_matrix_S_global, fm_matrix_Minv_L_kpoints(1, 1), para_env)
 
          CALL dbcsr_deallocate_matrix(matrix_s_RI_aux_desymm)
 
@@ -938,7 +936,6 @@ CONTAINS
       CALL cp_para_env_split(para_env_exchange, para_env_L, sub_sub_color)
 
       ! create the full matrix L defined in the L group
-
       CALL create_matrix_L(fm_matrix_L, blacs_env_L, dimen_RI, para_env_L, "fm_matrix_L", fm_matrix_L_extern)
 
       IF (my_do_im_time .AND. para_env%num_pe > 1) THEN
@@ -1450,41 +1447,36 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param fm_matrix_L_RI_metric ...
+!> \param fm_matrix_Minv_L_kpoints ...
 !> \param fm_matrix_L_kpoints ...
-!> \param fm_matrix_Sinv_Vtrunc_Sinv ...
 !> \param dimen_RI ...
 !> \param kpoints ...
 !> \param eps_eigval_S ...
 ! **************************************************************************************************
-   SUBROUTINE inversion_of_S_and_mult_with_chol_dec_of_V(fm_matrix_L_RI_metric, fm_matrix_L_kpoints, &
-                                                         fm_matrix_Sinv_Vtrunc_Sinv, dimen_RI, kpoints, &
-                                                         eps_eigval_S)
+   SUBROUTINE inversion_of_M_and_mult_with_chol_dec_of_V(fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, &
+                                                         dimen_RI, kpoints, eps_eigval_S)
 
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: fm_matrix_L_RI_metric, &
-                                                            fm_matrix_L_kpoints, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: fm_matrix_Minv_L_kpoints, &
+                                                            fm_matrix_L_kpoints
       INTEGER, INTENT(IN)                                :: dimen_RI
       TYPE(kpoint_type), POINTER                         :: kpoints
       REAL(KIND=dp), INTENT(IN)                          :: eps_eigval_S
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'inversion_of_S_and_mult_with_chol_dec_of_V'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'inversion_of_M_and_mult_with_chol_dec_of_V'
       COMPLEX(KIND=dp), PARAMETER :: cone = CMPLX(1.0_dp, 0.0_dp, KIND=dp), &
          czero = CMPLX(0.0_dp, 0.0_dp, KIND=dp), ione = CMPLX(0.0_dp, 1.0_dp, KIND=dp)
 
       INTEGER                                            :: handle, ikp, nkp
-      TYPE(cp_cfm_type)                                  :: cfm_matrix_K_tmp, cfm_matrix_L_tmp, &
-                                                            cfm_matrix_S_inv_tmp, &
-                                                            cfm_matrix_S_tmp, cfm_matrix_Vtrunc_tmp
+      TYPE(cp_cfm_type)                                  :: cfm_matrix_K_tmp, cfm_matrix_M_tmp, &
+                                                            cfm_matrix_V_tmp, cfm_matrix_Vtrunc_tmp
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
 
       CALL timeset(routineN, handle)
 
-      CALL cp_fm_get_info(fm_matrix_L_RI_metric(1, 1), matrix_struct=matrix_struct)
+      CALL cp_fm_get_info(fm_matrix_Minv_L_kpoints(1, 1), matrix_struct=matrix_struct)
 
-      CALL cp_cfm_create(cfm_matrix_S_tmp, matrix_struct)
-      CALL cp_cfm_create(cfm_matrix_S_inv_tmp, matrix_struct)
-      CALL cp_cfm_create(cfm_matrix_L_tmp, matrix_struct)
+      CALL cp_cfm_create(cfm_matrix_M_tmp, matrix_struct)
+      CALL cp_cfm_create(cfm_matrix_V_tmp, matrix_struct)
       CALL cp_cfm_create(cfm_matrix_K_tmp, matrix_struct)
       CALL cp_cfm_create(cfm_matrix_Vtrunc_tmp, matrix_struct)
 
@@ -1492,70 +1484,119 @@ CONTAINS
 
       DO ikp = 1, nkp
 
-         CALL cp_cfm_scale_and_add_fm(czero, cfm_matrix_S_tmp, cone, fm_matrix_L_RI_metric(ikp, 1))
-         CALL cp_cfm_scale_and_add_fm(cone, cfm_matrix_S_tmp, ione, fm_matrix_L_RI_metric(ikp, 2))
+         CALL cp_cfm_scale_and_add_fm(czero, cfm_matrix_M_tmp, cone, fm_matrix_Minv_L_kpoints(ikp, 1))
+         CALL cp_cfm_scale_and_add_fm(cone, cfm_matrix_M_tmp, ione, fm_matrix_Minv_L_kpoints(ikp, 2))
 
-         CALL cp_cfm_scale_and_add_fm(czero, cfm_matrix_L_tmp, cone, fm_matrix_L_kpoints(ikp, 1))
-         CALL cp_cfm_scale_and_add_fm(cone, cfm_matrix_L_tmp, ione, fm_matrix_L_kpoints(ikp, 2))
+         CALL cp_cfm_scale_and_add_fm(czero, cfm_matrix_V_tmp, cone, fm_matrix_L_kpoints(ikp, 1))
+         CALL cp_cfm_scale_and_add_fm(cone, cfm_matrix_V_tmp, ione, fm_matrix_L_kpoints(ikp, 2))
 
-         CALL cp_cfm_scale_and_add_fm(czero, cfm_matrix_Vtrunc_tmp, cone, fm_matrix_Sinv_Vtrunc_Sinv(ikp, 1))
-         CALL cp_cfm_scale_and_add_fm(cone, cfm_matrix_Vtrunc_tmp, ione, fm_matrix_Sinv_Vtrunc_Sinv(ikp, 2))
+         CALL cp_cfm_power(cfm_matrix_M_tmp, threshold=eps_eigval_S, exponent=-1.0_dp)
 
-         CALL cp_cfm_matrix_exponential(cfm_matrix_S_tmp, cfm_matrix_S_inv_tmp, threshold=eps_eigval_S, exponent=-0.5_dp)
+         CALL cp_cfm_power(cfm_matrix_V_tmp, threshold=0.0_dp, exponent=0.5_dp)
 
-         ! get S^(-1) = U^(-H)U^(-1)
-         CALL parallel_gemm("C", "N", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_tmp, cfm_matrix_S_tmp, &
-                            czero, cfm_matrix_S_inv_tmp)
+         ! save L(k) = SQRT(V(k))
+         CALL cp_cfm_to_fm(cfm_matrix_V_tmp, fm_matrix_L_kpoints(ikp, 1), fm_matrix_L_kpoints(ikp, 2))
 
-         CALL cp_cfm_matrix_exponential(cfm_matrix_L_tmp, cfm_matrix_S_tmp, threshold=0.0_dp, exponent=0.5_dp)
-
-         ! get K = S^(-1)*L, where L is the Cholesky decomposition of V = L^T*L
-         CALL parallel_gemm("N", "C", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_inv_tmp, cfm_matrix_L_tmp, &
+         ! get K = M^(-1)*L, where L is the Cholesky decomposition of V = L^T*L
+         CALL parallel_gemm("N", "C", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_M_tmp, cfm_matrix_V_tmp, &
                             czero, cfm_matrix_K_tmp)
 
          ! move
-         CALL cp_cfm_to_fm(cfm_matrix_K_tmp, fm_matrix_L_RI_metric(ikp, 1), fm_matrix_L_RI_metric(ikp, 2))
-
-         ! S^(-1)*V_trunc
-         CALL parallel_gemm("N", "C", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_Vtrunc_tmp, cfm_matrix_S_inv_tmp, &
-                            czero, cfm_matrix_K_tmp)
-
-         ! S^(-1)*V_trunc*S^{-1}
-         CALL parallel_gemm("N", "N", dimen_RI, dimen_RI, dimen_RI, cone, cfm_matrix_S_inv_tmp, cfm_matrix_K_tmp, &
-                            czero, cfm_matrix_Vtrunc_tmp)
-
-         ! move
-         CALL cp_cfm_to_fm(cfm_matrix_Vtrunc_tmp, fm_matrix_Sinv_Vtrunc_Sinv(ikp, 1), &
-                           fm_matrix_Sinv_Vtrunc_Sinv(ikp, 2))
+         CALL cp_cfm_to_fm(cfm_matrix_K_tmp, fm_matrix_Minv_L_kpoints(ikp, 1), fm_matrix_Minv_L_kpoints(ikp, 2))
 
       END DO
 
-      CALL cp_cfm_release(cfm_matrix_S_tmp)
-      CALL cp_cfm_release(cfm_matrix_S_inv_tmp)
-      CALL cp_cfm_release(cfm_matrix_L_tmp)
+      CALL cp_cfm_release(cfm_matrix_M_tmp)
+      CALL cp_cfm_release(cfm_matrix_V_tmp)
       CALL cp_cfm_release(cfm_matrix_K_tmp)
       CALL cp_cfm_release(cfm_matrix_Vtrunc_tmp)
 
       CALL timestop(handle)
 
-   END SUBROUTINE inversion_of_S_and_mult_with_chol_dec_of_V
+   END SUBROUTINE inversion_of_M_and_mult_with_chol_dec_of_V
+
+! **************************************************************************************************
+!> \brief ...
+!> \param fm_matrix_Minv_Vtrunc_Minv ...
+!> \param fm_matrix_Minv ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE Gamma_only_inversion_of_M_and_mult_with_chol_dec_of_Vtrunc(fm_matrix_Minv_Vtrunc_Minv, &
+                                                                         fm_matrix_Minv, qs_env)
+
+      TYPE(cp_fm_type), DIMENSION(:, :)                  :: fm_matrix_Minv_Vtrunc_Minv, &
+                                                            fm_matrix_Minv
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(LEN=*), PARAMETER :: &
+         routineN = 'Gamma_only_inversion_of_M_and_mult_with_chol_dec_of_Vtrunc'
+      COMPLEX(KIND=dp), PARAMETER :: cone = CMPLX(1.0_dp, 0.0_dp, KIND=dp), &
+         czero = CMPLX(0.0_dp, 0.0_dp, KIND=dp), ione = CMPLX(0.0_dp, 1.0_dp, KIND=dp)
+
+      INTEGER                                            :: dimen_RI, handle, ndep
+      REAL(KIND=dp)                                      :: eps_eigval_S_Gamma
+      TYPE(cp_fm_type)                                   :: fm_matrix_RI_metric_inv_work, fm_work
+
+      CALL timeset(routineN, handle)
+
+      CALL cp_fm_create(fm_work, fm_matrix_Minv(1, 1)%matrix_struct)
+      CALL cp_fm_set_all(fm_work, 0.0_dp)
+
+      CALL cp_fm_create(fm_matrix_RI_metric_inv_work, fm_matrix_Minv(1, 1)%matrix_struct)
+      CALL cp_fm_set_all(fm_matrix_RI_metric_inv_work, 0.0_dp)
+
+      CALL cp_fm_get_info(matrix=fm_matrix_Minv(1, 1), nrow_global=dimen_RI)
+
+      eps_eigval_S_Gamma = qs_env%mp2_env%ri_rpa_im_time%eps_eigval_S_Gamma
+
+      IF (eps_eigval_S_Gamma > 1.0E-18) THEN
+
+         ! remove small eigenvalues
+         CALL cp_fm_power(fm_matrix_Minv(1, 1), fm_matrix_RI_metric_inv_work, -0.5_dp, &
+                          eps_eigval_S_Gamma, ndep)
+
+      ELSE
+
+         CALL cholesky_decomp(fm_matrix_Minv(1, 1), dimen_RI, do_inversion=.TRUE.)
+
+         CALL invert_mat(fm_matrix_Minv(1, 1))
+
+      END IF
+
+      CALL parallel_gemm('N', 'T', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_matrix_Minv(1, 1), &
+                         fm_matrix_Minv(1, 1), 0.0_dp, fm_matrix_RI_metric_inv_work)
+
+      CALL cp_fm_to_fm(fm_matrix_RI_metric_inv_work, fm_matrix_Minv(1, 1))
+
+      CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_matrix_RI_metric_inv_work, &
+                         fm_matrix_Minv_Vtrunc_Minv(1, 1), 0.0_dp, fm_work)
+
+      CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_work, &
+                         fm_matrix_RI_metric_inv_work, 0.0_dp, fm_matrix_Minv_Vtrunc_Minv(1, 1))
+
+      CALL cp_fm_release(fm_work)
+      CALL cp_fm_release(fm_matrix_RI_metric_inv_work)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE Gamma_only_inversion_of_M_and_mult_with_chol_dec_of_Vtrunc
 
 ! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
 !> \param trunc_coulomb ...
 ! **************************************************************************************************
-   SUBROUTINE setup_abs_cutoffs_chi_and_trunc_coulomb_potential(qs_env, trunc_coulomb)
+   SUBROUTINE setup_trunc_coulomb_potential_for_exchange_self_energy(qs_env, trunc_coulomb)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(libint_potential_type), OPTIONAL              :: trunc_coulomb
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'setup_abs_cutoffs_chi_and_trunc_coulomb_potential'
+      CHARACTER(LEN=*), PARAMETER :: &
+         routineN = 'setup_trunc_coulomb_potential_for_exchange_self_energy'
 
       INTEGER                                            :: handle
       INTEGER, DIMENSION(3)                              :: periodic
       REAL(KIND=dp)                                      :: rel_cutoff_trunc_coulomb_ri_x, &
                                                             shortest_dist_cell_planes
-      REAL(KIND=dp), DIMENSION(2)                        :: abs_cutoffs_chi_W
       TYPE(cell_type), POINTER                           :: cell
 
       CALL timeset(routineN, handle)
@@ -1582,17 +1623,11 @@ CONTAINS
          END IF
       END IF
 
-      abs_cutoffs_chi_W(1:2) = qs_env%mp2_env%ri_rpa_im_time%rel_cutoffs_chi_W(1:2)* &
-                               shortest_dist_cell_planes
-
-      qs_env%mp2_env%ri_rpa_im_time%abs_cutoffs_chi_W(1:2) = abs_cutoffs_chi_W(1:2)
-
       rel_cutoff_trunc_coulomb_ri_x = qs_env%mp2_env%ri_rpa_im_time%rel_cutoff_trunc_coulomb_ri_x
 
       IF (PRESENT(trunc_coulomb)) THEN
          trunc_coulomb%potential_type = do_potential_truncated
-         trunc_coulomb%cutoff_radius = (abs_cutoffs_chi_W(1) + abs_cutoffs_chi_W(2))* &
-                                       rel_cutoff_trunc_coulomb_ri_x
+         trunc_coulomb%cutoff_radius = shortest_dist_cell_planes*rel_cutoff_trunc_coulomb_ri_x
          trunc_coulomb%filename = "t_c_g.dat"
          ! dummy
          trunc_coulomb%omega = 0.0_dp
@@ -1600,17 +1635,17 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE setup_abs_cutoffs_chi_and_trunc_coulomb_potential
+   END SUBROUTINE setup_trunc_coulomb_potential_for_exchange_self_energy
 
 ! **************************************************************************************************
 !> \brief ...
 !> \param fm_matrix_L ...
 ! **************************************************************************************************
-   SUBROUTINE invert_L(fm_matrix_L)
+   SUBROUTINE invert_mat(fm_matrix_L)
 
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_matrix_L
 
-      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'invert_L'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'invert_mat'
 
       INTEGER                                            :: handle, i_global, iiB, j_global, jjB, &
                                                             ncol_local, nrow_local
@@ -1636,7 +1671,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE invert_L
+   END SUBROUTINE invert_mat
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -247,14 +247,16 @@ CONTAINS
                                 i_val=mp2_env%ri_rpa_im_time%kpoint_weights_W_method)
       CALL section_vals_val_get(low_scaling_section, "EXPONENT_TAILORED_WEIGHTS", &
                                 r_val=mp2_env%ri_rpa_im_time%exp_tailored_weights)
-      CALL section_vals_val_get(low_scaling_section, "REL_CUTOFFS_CHI_W", &
-                                r_vals=mp2_env%ri_rpa_im_time%rel_cutoffs_chi_W)
       CALL section_vals_val_get(low_scaling_section, "REGULARIZATION_RI", &
                                 r_val=mp2_env%ri_rpa_im_time%regularization_RI)
       CALL section_vals_val_get(low_scaling_section, "EPS_EIGVAL_S", &
                                 r_val=mp2_env%ri_rpa_im_time%eps_eigval_S)
+      CALL section_vals_val_get(low_scaling_section, "EPS_EIGVAL_S_GAMMA", &
+                                r_val=mp2_env%ri_rpa_im_time%eps_eigval_S_Gamma)
       CALL section_vals_val_get(low_scaling_section, "MAKE_CHI_POS_DEFINITE", &
                                 l_val=mp2_env%ri_rpa_im_time%make_chi_pos_definite)
+      CALL section_vals_val_get(low_scaling_section, "MAKE_OVERLAP_MAT_AO_POS_DEFINITE", &
+                                l_val=mp2_env%ri_rpa_im_time%make_overlap_mat_ao_pos_definite)
       CALL section_vals_val_get(low_scaling_section, "TRUNC_COULOMB_RI_X", &
                                 l_val=mp2_env%ri_rpa_im_time%trunc_coulomb_ri_x)
       CALL section_vals_val_get(low_scaling_section, "DO_EXTRAPOLATE_KPOINTS", &
@@ -263,8 +265,6 @@ CONTAINS
                                 r_val=mp2_env%ri_rpa_im_time%rel_cutoff_trunc_coulomb_ri_x)
       CALL section_vals_val_get(low_scaling_section, "K_MESH_G_FACTOR", &
                                 i_val=mp2_env%ri_rpa_im_time%k_mesh_g_factor)
-      CALL section_vals_val_get(low_scaling_section, "GREENS_FUNCTION", &
-                                i_val=mp2_env%ri_rpa_im_time%periodic_gf)
 
       CALL section_vals_val_get(low_scaling_section, "KEEP_QUADRATURE", &
                                 l_val=mp2_env%ri_rpa_im_time%keep_quad)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -146,20 +146,20 @@ MODULE mp2_types
 
    TYPE ri_rpa_im_time_type
       INTEGER                  :: cut_memory
-      LOGICAL                  :: memory_info, make_chi_pos_definite, trunc_coulomb_ri_x, keep_quad, &
+      LOGICAL                  :: memory_info, make_chi_pos_definite, make_overlap_mat_ao_pos_definite, &
+                                  trunc_coulomb_ri_x, keep_quad, &
                                   do_kpoints_from_Gamma, do_extrapolate_kpoints
       REAL(KIND=dp)            :: eps_filter, &
                                   eps_filter_factor, eps_compress, exp_tailored_weights, regularization_RI, &
-                                  eps_eigval_S, rel_cutoff_trunc_coulomb_ri_x
-      REAL(KIND=dp), DIMENSION(:), POINTER :: rel_cutoffs_chi_W, tau_tj, tau_wj, tj, wj
+                                  eps_eigval_S, eps_eigval_S_Gamma, rel_cutoff_trunc_coulomb_ri_x
+      REAL(KIND=dp), DIMENSION(:), POINTER :: tau_tj, tau_wj, tj, wj
       REAL(KIND=dp), DIMENSION(:, :), POINTER :: weights_cos_tf_t_to_w, weights_cos_tf_w_to_t
-      REAL(KIND=dp), DIMENSION(2) :: abs_cutoffs_chi_W
       REAL(KIND=dp), DIMENSION(:), ALLOCATABLE :: Eigenval_Gamma, wkp_V
       INTEGER                  :: group_size_P, group_size_3c, kpoint_weights_W_method, k_mesh_g_factor
       INTEGER, DIMENSION(:), POINTER     :: kp_grid
       INTEGER, DIMENSION(3) ::  kp_grid_extra
       LOGICAL                  :: do_im_time_kpoints
-      INTEGER                  :: min_bsize, min_bsize_mo, periodic_gf, nkp_orig, nkp_extra
+      INTEGER                  :: min_bsize, min_bsize_mo, nkp_orig, nkp_extra
       TYPE(kpoint_type), POINTER :: kpoints_G, kpoints_Sigma, kpoints_Sigma_no_xc
       INTEGER, ALLOCATABLE, DIMENSION(:)      :: starts_array_mc_RI, ends_array_mc_RI, &
                                                  starts_array_mc_block_RI, &

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -644,15 +644,15 @@ CONTAINS
 !> \param t_3c_overl_nnP_ic ...
 !> \param t_3c_overl_nnP_ic_reflected ...
 !> \param mat_W ...
-!> \param ikp_local ...
 !> \param cfm_mat_W_kp_tau ...
+!> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE deallocate_matrices_gw_im_time(weights_cos_tf_w_to_t, weights_sin_tf_t_to_w, do_ic_model, do_kpoints_cubic_RPA, &
                                              fm_mat_W, &
                                              t_3c_overl_int_ao_mo, t_3c_O_mo_compressed, t_3c_O_mo_ind, &
                                              t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
                                              t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, mat_W, &
-                                             ikp_local, cfm_mat_W_kp_tau)
+                                             cfm_mat_W_kp_tau, qs_env)
 
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: weights_cos_tf_w_to_t, &
@@ -670,9 +670,9 @@ CONTAINS
                                                             t_3c_overl_nnP_ic, &
                                                             t_3c_overl_nnP_ic_reflected
       TYPE(dbcsr_type), POINTER                          :: mat_W
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: ikp_local
       TYPE(cp_cfm_p_type), ALLOCATABLE, &
          DIMENSION(:, :), INTENT(INOUT)                  :: cfm_mat_W_kp_tau
+      TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'deallocate_matrices_gw_im_time'
 
@@ -700,9 +700,10 @@ CONTAINS
       ELSE
          DO jquad = 1, SIZE(cfm_mat_W_kp_tau, 2)
             DO ikp = 1, SIZE(cfm_mat_W_kp_tau, 1)
-               IF (.NOT. (ANY(ikp_local(:) == ikp))) CYCLE
-               CALL cp_cfm_release(cfm_mat_W_kp_tau(ikp, jquad)%matrix)
-               DEALLOCATE (cfm_mat_W_kp_tau(ikp, jquad)%matrix)
+               IF (ASSOCIATED(cfm_mat_W_kp_tau(ikp, jquad)%matrix)) THEN
+                  CALL cp_cfm_release(cfm_mat_W_kp_tau(ikp, jquad)%matrix)
+                  DEALLOCATE (cfm_mat_W_kp_tau(ikp, jquad)%matrix)
+               END IF
             END DO
          END DO
          DEALLOCATE (cfm_mat_W_kp_tau)
@@ -722,13 +723,15 @@ CONTAINS
          DEALLOCATE (t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected)
       END IF
 
-      DO ispin = 1, nspins
-         DEALLOCATE (t_3c_O_mo_ind(ispin)%array)
-         CALL dealloc_containers(t_3c_O_mo_compressed(ispin), unused)
-      END DO
-      DEALLOCATE (t_3c_O_mo_ind, t_3c_O_mo_compressed)
+      IF (.NOT. qs_env%mp2_env%ri_g0w0%do_kpoints_Sigma) THEN
+         DO ispin = 1, nspins
+            DEALLOCATE (t_3c_O_mo_ind(ispin)%array)
+            CALL dealloc_containers(t_3c_O_mo_compressed(ispin), unused)
+         END DO
+         DEALLOCATE (t_3c_O_mo_ind, t_3c_O_mo_compressed)
 
-      CALL dbt_destroy(t_3c_overl_int_ao_mo)
+         CALL dbt_destroy(t_3c_overl_int_ao_mo)
+      END IF
 
       CALL timestop(handle)
 
@@ -1160,7 +1163,7 @@ CONTAINS
 !> \param para_env ...
 !> \param para_env_RPA ...
 !> \param mat_dm ...
-!> \param mat_SinvVSinv ...
+!> \param mat_MinvVMinv ...
 !> \param t_3c_O ...
 !> \param t_3c_M ...
 !> \param t_3c_overl_int_ao_mo ...
@@ -1194,7 +1197,7 @@ CONTAINS
                                   weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
                                   fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
                                   fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                  mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
+                                  mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
                                   t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, &
                                   t_3c_O_compressed, t_3c_O_mo_compressed, &
                                   t_3c_O_ind, t_3c_O_mo_ind, &
@@ -1238,7 +1241,7 @@ CONTAINS
                                                             fm_scaled_dm_virt_tau, mo_coeff
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mat_W
       TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_RPA
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_dm, mat_SinvVSinv
+      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_dm, mat_MinvVMinv
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_O
       TYPE(dbt_type)                                     :: t_3c_M, t_3c_overl_int_ao_mo
       TYPE(hfx_compression_type), ALLOCATABLE, &
@@ -1295,7 +1298,7 @@ CONTAINS
                                                  t_3c_overl_int_ao_mo, t_3c_O_mo_compressed(ispin), &
                                                  t_3c_O_mo_ind(ispin)%array, &
                                                  t_3c_overl_int_gw_RI(ispin), t_3c_overl_int_gw_AO(ispin), &
-                                                 mat_W, mat_SinvVSinv, mat_dm, &
+                                                 mat_W, mat_MinvVMinv, mat_dm, &
                                                  weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw(:, :, :, ispin), &
                                                  do_periodic, num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
                                                  mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
@@ -1312,7 +1315,7 @@ CONTAINS
                                                       count_ev_sc_GW, count_sc_GW0, &
                                                       t_3c_O, t_3c_M, t_3c_O_compressed, t_3c_O_ind, &
                                                       t_3c_overl_int_gw_RI(1), t_3c_overl_int_gw_AO(1), &
-                                                      mat_W, mat_SinvVSinv, &
+                                                      mat_W, mat_MinvVMinv, &
                                                       weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw(:, :, :, 1), &
                                                       qs_env, para_env, &
                                                       mp2_env, num_fit_points, mo_coeff, &
@@ -3990,15 +3993,28 @@ CONTAINS
 
       IF (unit_nr > 0) THEN
 
-         IF (do_closed_shell) THEN
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A,F57.3)') 'GW HOMO-LUMO gap (eV)', E_GAP_GW*evolt
-         ELSE IF (do_alpha) THEN
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A,F51.3)') 'Alpha GW HOMO-LUMO gap (eV)', E_GAP_GW*evolt
-         ELSE IF (do_beta) THEN
-            WRITE (unit_nr, '(T3,A)') ' '
-            WRITE (unit_nr, '(T3,A,F52.3)') 'Beta GW HOMO-LUMO gap (eV)', E_GAP_GW*evolt
+         IF (do_kpoints) THEN
+            IF (do_closed_shell) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F42.3)') 'GW direct gap at current kpoint (eV)', E_GAP_GW*evolt
+            ELSE IF (do_alpha) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F36.3)') 'Alpha GW direct gap at current kpoint (eV)', E_GAP_GW*evolt
+            ELSE IF (do_beta) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F37.3)') 'Beta GW direct gap at current kpoint (eV)', E_GAP_GW*evolt
+            END IF
+         ELSE
+            IF (do_closed_shell) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F57.3)') 'GW HOMO-LUMO gap (eV)', E_GAP_GW*evolt
+            ELSE IF (do_alpha) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F51.3)') 'Alpha GW HOMO-LUMO gap (eV)', E_GAP_GW*evolt
+            ELSE IF (do_beta) THEN
+               WRITE (unit_nr, '(T3,A)') ' '
+               WRITE (unit_nr, '(T3,A,F52.3)') 'Beta GW HOMO-LUMO gap (eV)', E_GAP_GW*evolt
+            END IF
          END IF
       END IF
 
@@ -4229,7 +4245,7 @@ CONTAINS
 !> \param t_3c_overl_int_gw_RI ...
 !> \param t_3c_overl_int_gw_AO ...
 !> \param mat_W ...
-!> \param mat_SinvVSinv ...
+!> \param mat_MinvVMinv ...
 !> \param mat_dm ...
 !> \param weights_cos_tf_t_to_w ...
 !> \param weights_sin_tf_t_to_w ...
@@ -4261,7 +4277,7 @@ CONTAINS
                                            count_ev_sc_GW, count_sc_GW0, &
                                            t_3c_overl_int_ao_mo, t_3c_O_mo_compressed, t_3c_O_mo_ind, &
                                            t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                           mat_W, mat_SinvVSinv, mat_dm, &
+                                           mat_W, mat_MinvVMinv, mat_dm, &
                                            weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, &
                                            do_periodic, num_points_corr, delta_corr, qs_env, para_env, para_env_RPA, &
                                            mp2_env, matrix_berry_re_mo_mo, matrix_berry_im_mo_mo, &
@@ -4286,7 +4302,7 @@ CONTAINS
       TYPE(dbt_type)                                     :: t_3c_overl_int_gw_RI, &
                                                             t_3c_overl_int_gw_AO
       TYPE(dbcsr_type), INTENT(INOUT), TARGET            :: mat_W
-      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv, mat_dm
+      TYPE(dbcsr_p_type)                                 :: mat_MinvVMinv, mat_dm
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
       COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)  :: vec_Sigma_c_gw
@@ -4530,7 +4546,7 @@ CONTAINS
          CALL create_2c_tensor(t_SinvVSinv, dist1, dist2, pgrid_2d, sizes_RI, sizes_RI, name="(RI|RI)")
          DEALLOCATE (dist1, dist2)
 
-         CALL dbt_copy_matrix_to_tensor(mat_SinvVSinv%matrix, t_RI_tmp)
+         CALL dbt_copy_matrix_to_tensor(mat_MinvVMinv%matrix, t_RI_tmp)
          CALL dbt_copy(t_RI_tmp, t_SinvVSinv)
 
          CALL dbt_batched_contract_init(t_3c_overl_int_gw_AO, batch_range_3=batch_range_mo)
@@ -4670,7 +4686,7 @@ CONTAINS
 !> \param t_3c_overl_int_gw_RI ...
 !> \param t_3c_overl_int_gw_AO ...
 !> \param mat_W ...
-!> \param mat_SinvVSinv ...
+!> \param mat_MinvVMinv ...
 !> \param weights_cos_tf_t_to_w ...
 !> \param weights_sin_tf_t_to_w ...
 !> \param vec_Sigma_c_gw ...
@@ -4693,7 +4709,7 @@ CONTAINS
                                                    count_ev_sc_GW, count_sc_GW0, &
                                                    t_3c_O, t_3c_M, t_3c_O_compressed, t_3c_O_ind, &
                                                    t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
-                                                   mat_W, mat_SinvVSinv, &
+                                                   mat_W, mat_MinvVMinv, &
                                                    weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, vec_Sigma_c_gw, &
                                                    qs_env, para_env, &
                                                    mp2_env, num_fit_points, fm_mo_coeff, &
@@ -4719,7 +4735,7 @@ CONTAINS
       TYPE(dbt_type)                                     :: t_3c_overl_int_gw_RI, &
                                                             t_3c_overl_int_gw_AO
       TYPE(dbcsr_type), INTENT(INOUT), TARGET            :: mat_W
-      TYPE(dbcsr_p_type)                                 :: mat_SinvVSinv
+      TYPE(dbcsr_p_type)                                 :: mat_MinvVMinv
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
       COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)  :: vec_Sigma_c_gw
@@ -4875,13 +4891,11 @@ CONTAINS
 
          CALL compute_periodic_dm(mat_p_greens_fct_occ, qs_env, &
                                   ispin, num_points, jquad, e_fermi, tau, &
-                                  remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=1, &
-                                  symmetrize=.TRUE.)
+                                  remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=1)
 
          CALL compute_periodic_dm(mat_p_greens_fct_virt, qs_env, &
                                   ispin, num_points, jquad, e_fermi, tau, &
-                                  remove_occ=.TRUE., remove_virt=.FALSE., first_jquad=1, &
-                                  symmetrize=.TRUE.)
+                                  remove_occ=.TRUE., remove_virt=.FALSE., first_jquad=1)
 
          CALL dbcsr_set(mat_greens_fct_occ, 0.0_dp)
          CALL dbcsr_copy(mat_greens_fct_occ, mat_p_greens_fct_occ(jquad, 1)%matrix)
@@ -4893,7 +4907,7 @@ CONTAINS
             CALL copy_fm_to_dbcsr(fm_mat_W(jquad), mat_W, keep_sparsity=.FALSE.)
             CALL dbt_copy_matrix_to_tensor(mat_W, t_RI_tmp)
          ELSE
-            CALL dbt_copy_matrix_to_tensor(mat_SinvVSinv%matrix, t_RI_tmp)
+            CALL dbt_copy_matrix_to_tensor(mat_MinvVMinv%matrix, t_RI_tmp)
          END IF
 
          CALL dbt_copy(t_RI_tmp, t_W)
@@ -5144,11 +5158,6 @@ CONTAINS
 
          CALL cp_fm_to_cfm(fm_tmp_re, fm_tmp_im, vxc_ao_ao)
 
-!         CALL cp_fm_to_cfm(fm_tmp_re, fm_tmp_im, ks_mat_no_xc_ao_ao)
-
-!         CALL cp_cfm_scale_and_add(z_one, ks_mat_ao_ao, -z_one, ks_mat_no_xc_ao_ao)
-!         CALL cp_cfm_to_cfm(ks_mat_ao_ao, vxc_ao_ao)
-
          CALL parallel_gemm('N', 'N', nmo, nmo, nmo, z_one, vxc_ao_ao, cfm_mo_coeff, z_zero, vxc_ao_mo)
          CALL parallel_gemm('C', 'N', nmo, nmo, nmo, z_one, cfm_mo_coeff, vxc_ao_mo, z_zero, vxc_mo_mo)
 
@@ -5156,7 +5165,6 @@ CONTAINS
 
          CALL cp_fm_get_diag(fm_Sigma_x_minus_vxc_mo_mo, diag_Sigma_x_minus_vxc_mo_mo)
 
-!         qs_env%mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp) = -diag_Sigma_x_minus_vxc_mo_mo(:)
          qs_env%mp2_env%ri_g0w0%vec_Sigma_x_minus_vxc_gw(:, 1, ikp) = diag_Sigma_x_minus_vxc_mo_mo(:)
 
       END DO
@@ -5379,7 +5387,7 @@ CONTAINS
 
       INTEGER                                            :: handle
       INTEGER, DIMENSION(2, 1)                           :: bounds_ao_j
-      INTEGER, DIMENSION(2, 2)                           :: bounds_RI_i_ao_j
+      INTEGER, DIMENSION(2, 2)                           :: bounds_ao_all_RI_i, bounds_RI_i_ao_j
       REAL(KIND=dp)                                      :: sign_self_energy
       TYPE(dbt_type)                                     :: t_3c_O_G, t_3c_O_G_tmp, t_self_energy, &
                                                             t_self_energy_tmp
@@ -5393,7 +5401,9 @@ CONTAINS
       CALL dbt_create(t_greens_fct, t_self_energy, name="(AO|AO)")
       CALL dbt_create(mat_self_energy_ao_ao, t_self_energy_tmp)
 
-      bounds_ao_j(:, 1) = bounds_ao_ao_j(:, 2)
+      bounds_ao_j(:, 1) = bounds_ao_ao_j(:, 1)
+      bounds_ao_all_RI_i(:, 1) = bounds_RI_i(:, 1)
+      bounds_ao_all_RI_i(:, 2) = bounds_ao_ao_j(:, 2)
 
       CALL dbt_contract(1.0_dp, t_greens_fct, t_3c_O_all, 0.0_dp, &
                         t_3c_O_G_tmp, &
@@ -5401,6 +5411,7 @@ CONTAINS
                         contract_2=[3], notcontract_2=[1, 2], &
                         map_1=[3], map_2=[1, 2], &
                         bounds_2=bounds_ao_j, &
+                        bounds_3=bounds_ao_all_RI_i, &
                         filter_eps=eps_filter, &
                         unit_nr=unit_nr)
 
@@ -5410,7 +5421,7 @@ CONTAINS
       IF (do_virt) sign_self_energy = 1.0_dp
 
       bounds_RI_i_ao_j(:, 1) = bounds_RI_i(:, 1)
-      bounds_RI_i_ao_j(:, 2) = bounds_ao_ao_j(:, 2)
+      bounds_RI_i_ao_j(:, 2) = bounds_ao_ao_j(:, 1)
 
       CALL dbt_contract(sign_self_energy, t_3c_O_W, t_3c_O_G, 0.0_dp, &
                         t_self_energy, &

--- a/src/rpa_gw_im_time_util.F
+++ b/src/rpa_gw_im_time_util.F
@@ -39,8 +39,7 @@ MODULE rpa_gw_im_time_util
                                               hfx_compression_type
    USE kinds,                           ONLY: dp,&
                                               int_8
-   USE mathconstants,                   ONLY: pi,&
-                                              twopi
+   USE mathconstants,                   ONLY: twopi
    USE message_passing,                 ONLY: mp_alltoall,&
                                               mp_dims_create,&
                                               mp_request_type,&
@@ -248,9 +247,11 @@ CONTAINS
                             sizes_RI_split, sizes_AO_split, sizes_AO_split, [1, 2], [3], name="(RI AO | AO)")
       DEALLOCATE (dist1, dist2, dist3)
 
-      CALL create_3c_tensor(t_3c_overl_int_ao_mo, dist1, dist2, dist3, pgrid_AO, &
-                            sizes_RI_split, sizes_AO_split, sizes_MO_1, [1, 2], [3], name="(RI AO | MO)")
-      DEALLOCATE (dist1, dist2, dist3)
+      IF (.NOT. qs_env%mp2_env%ri_g0w0%do_kpoints_Sigma) THEN
+         CALL create_3c_tensor(t_3c_overl_int_ao_mo, dist1, dist2, dist3, pgrid_AO, &
+                               sizes_RI_split, sizes_AO_split, sizes_MO_1, [1, 2], [3], name="(RI AO | MO)")
+         DEALLOCATE (dist1, dist2, dist3)
+      END IF
 
       CALL create_3c_tensor(t_3c_overl_int_gw_RI, dist1, dist2, dist3, pgrid_MO, &
                             sizes_RI_split, sizes_AO_split, sizes_MO, [1], [2, 3], name="(RI | AO MO)")
@@ -282,20 +283,22 @@ CONTAINS
 
       cut_memory = SIZE(starts_array_mc)
 
-      DO i_mem = 1, cut_memory
-         CALL decompress_tensor(t_3c_overl_int(1, 1), t_3c_O_ind(1, 1, i_mem)%ind, t_3c_O_compressed(1, 1, i_mem), &
-                                qs_env%mp2_env%ri_rpa_im_time%eps_compress)
+      IF (.NOT. qs_env%mp2_env%ri_g0w0%do_kpoints_Sigma) THEN
+         DO i_mem = 1, cut_memory
+            CALL decompress_tensor(t_3c_overl_int(1, 1), t_3c_O_ind(1, 1, i_mem)%ind, t_3c_O_compressed(1, 1, i_mem), &
+                                   qs_env%mp2_env%ri_rpa_im_time%eps_compress)
 
-         ibounds(:, 2) = [starts_array_mc(i_mem), ends_array_mc(i_mem)]
+            ibounds(:, 2) = [starts_array_mc(i_mem), ends_array_mc(i_mem)]
 
-         CALL dbt_copy(t_3c_overl_int(1, 1), t_3c_overl_int_ao_ao, move_data=.TRUE.)
+            CALL dbt_copy(t_3c_overl_int(1, 1), t_3c_overl_int_ao_ao, move_data=.TRUE.)
 
-         CALL dbt_contract(1.0_dp, mo_coeff_gw_t, t_3c_overl_int_ao_ao, 1.0_dp, &
-                           t_3c_overl_int_ao_mo, contract_1=[1], notcontract_1=[2], &
-                           contract_2=[3], notcontract_2=[1, 2], map_1=[3], map_2=[1, 2], &
-                           bounds_2=ibounds, move_data=.FALSE., unit_nr=unit_nr_prv)
+            CALL dbt_contract(1.0_dp, mo_coeff_gw_t, t_3c_overl_int_ao_ao, 1.0_dp, &
+                              t_3c_overl_int_ao_mo, contract_1=[1], notcontract_1=[2], &
+                              contract_2=[3], notcontract_2=[1, 2], map_1=[3], map_2=[1, 2], &
+                              bounds_2=ibounds, move_data=.FALSE., unit_nr=unit_nr_prv)
 
-      END DO
+         END DO
+      END IF
 
       CALL cp_fm_release(fm_mat_mo_coeff_gw)
 
@@ -403,22 +406,24 @@ CONTAINS
 
       END IF
 
-      CALL alloc_containers(t_3c_O_mo_compressed, 1)
-      CALL get_tensor_occupancy(t_3c_overl_int_ao_mo, nze, occ)
-      memory_3c = 0.0_dp
+      IF (.NOT. qs_env%mp2_env%ri_g0w0%do_kpoints_Sigma) THEN
+         CALL alloc_containers(t_3c_O_mo_compressed, 1)
+         CALL get_tensor_occupancy(t_3c_overl_int_ao_mo, nze, occ)
+         memory_3c = 0.0_dp
 
-      CALL compress_tensor(t_3c_overl_int_ao_mo, t_3c_O_mo_ind, t_3c_O_mo_compressed, &
-                           qs_env%mp2_env%ri_rpa_im_time%eps_compress, memory_3c)
+         CALL compress_tensor(t_3c_overl_int_ao_mo, t_3c_O_mo_ind, t_3c_O_mo_compressed, &
+                              qs_env%mp2_env%ri_rpa_im_time%eps_compress, memory_3c)
 
-      CALL mp_sum(memory_3c, para_env%group)
-      compression_factor = REAL(nze, dp)*1.0E-06*8.0_dp/memory_3c
+         CALL mp_sum(memory_3c, para_env%group)
+         compression_factor = REAL(nze, dp)*1.0E-06*8.0_dp/memory_3c
 
-      IF (unit_nr > 0) THEN
-         WRITE (UNIT=unit_nr, FMT="((T3,A,T66,F11.2,A4))") &
-            "MEMORY_INFO| Memory of MO-contracted tensor (compressed):", memory_3c, ' MiB'
+         IF (unit_nr > 0) THEN
+            WRITE (UNIT=unit_nr, FMT="((T3,A,T66,F11.2,A4))") &
+               "MEMORY_INFO| Memory of MO-contracted tensor (compressed):", memory_3c, ' MiB'
 
-         WRITE (UNIT=unit_nr, FMT="((T3,A,T60,F21.2))") &
-            "MEMORY_INFO| Compression factor:                  ", compression_factor
+            WRITE (UNIT=unit_nr, FMT="((T3,A,T60,F21.2))") &
+               "MEMORY_INFO| Compression factor:                  ", compression_factor
+         END IF
       END IF
 
       CALL dbcsr_release_p(mat_mo_coeff_gw)
@@ -787,14 +792,10 @@ CONTAINS
 !> \param index_to_cell ...
 !> \param hmat ...
 !> \param particle_set ...
-!> \param abs_cutoffs_chi_W ...
-!> \param symmetrize ...
-!> \param gamma_only ...
 ! **************************************************************************************************
    SUBROUTINE compute_weight_re_im(weight_re, weight_im, &
                                    num_cells, iatom, jatom, xkp, wkp_W, &
-                                   cell, index_to_cell, hmat, particle_set, abs_cutoffs_chi_W, &
-                                   symmetrize, gamma_only)
+                                   cell, index_to_cell, hmat, particle_set)
 
       REAL(KIND=dp)                                      :: weight_re, weight_im
       INTEGER                                            :: num_cells, iatom, jatom
@@ -804,25 +805,22 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
       REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      REAL(KIND=dp), DIMENSION(2)                        :: abs_cutoffs_chi_W
-      LOGICAL                                            :: symmetrize, gamma_only
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_weight_re_im'
 
-      INTEGER                                            :: handle, i_sym, icell, n_sym, xcell, &
-                                                            ycell, zcell
-      REAL(KIND=dp)                                      :: abs_rab_cell, arg, coskl, &
-                                                            dampening_function, first_cutoff, &
-                                                            second_cutoff, sinkl
+      INTEGER                                            :: handle, icell, n_equidistant_cells, &
+                                                            xcell, ycell, zcell
+      REAL(KIND=dp)                                      :: abs_rab_cell, abs_rab_cell_min, arg
       REAL(KIND=dp), DIMENSION(3)                        :: cell_vector, rab_cell_i
 
       CALL timeset(routineN, handle)
 
-      first_cutoff = abs_cutoffs_chi_W(1)
-      second_cutoff = abs_cutoffs_chi_W(2)
-
       weight_re = 0.0_dp
       weight_im = 0.0_dp
+
+      abs_rab_cell_min = 1.0E10_dp
+
+      n_equidistant_cells = 0
 
       DO icell = 1, num_cells
 
@@ -830,56 +828,47 @@ CONTAINS
          ycell = index_to_cell(2, icell)
          zcell = index_to_cell(3, icell)
 
-         IF (symmetrize .AND. (xcell .NE. 0 .OR. ycell .NE. 0 .OR. zcell .NE. 0)) THEN
-            n_sym = 2
-         ELSE
-            n_sym = 1
+         cell_vector(1:3) = MATMUL(hmat, REAL((/xcell, ycell, zcell/), dp))
+
+         rab_cell_i(1:3) = pbc(particle_set(iatom)%r(1:3), cell) - &
+                           (pbc(particle_set(jatom)%r(1:3), cell) + cell_vector(1:3))
+
+         abs_rab_cell = SQRT(rab_cell_i(1)**2 + rab_cell_i(2)**2 + rab_cell_i(3)**2)
+
+         IF (abs_rab_cell < abs_rab_cell_min) THEN
+            abs_rab_cell_min = abs_rab_cell
          END IF
-
-         DO i_sym = 1, n_sym
-
-            IF (n_sym == 2) THEN
-               xcell = -xcell
-               ycell = -ycell
-               zcell = -zcell
-            END IF
-
-            arg = REAL(xcell, dp)*xkp(1) + REAL(ycell, dp)*xkp(2) + REAL(zcell, dp)*xkp(3)
-
-            coskl = wkp_W*COS(twopi*arg)
-            sinkl = wkp_W*SIN(twopi*arg)
-
-            cell_vector(1:3) = MATMUL(hmat, REAL((/xcell, ycell, zcell/), dp))
-
-            rab_cell_i(1:3) = pbc(particle_set(iatom)%r(1:3), cell) - &
-                              (pbc(particle_set(jatom)%r(1:3), cell) + cell_vector(1:3))
-
-            abs_rab_cell = SQRT(rab_cell_i(1)**2 + rab_cell_i(2)**2 + rab_cell_i(3)**2)
-
-            ! smooth function that is only one if atoms are very close and becomes smoothly zero
-            ! for larger distances
-            IF (abs_rab_cell < first_cutoff) THEN
-               weight_re = 1.0_dp*coskl
-               weight_im = 1.0_dp*sinkl
-            ELSE IF (abs_rab_cell < second_cutoff) THEN
-               dampening_function = 0.5_dp*(COS(pi*(abs_rab_cell - first_cutoff)/ &
-                                                (second_cutoff - first_cutoff)) + 1.0_dp)
-               weight_re = dampening_function*coskl
-               weight_im = dampening_function*sinkl
-
-            END IF
-
-         END DO
 
       END DO
 
-      ! that is kind of a hack to get the same matrix format for GAMMA as for MIC
-      IF (gamma_only) THEN
-         IF (symmetrize .OR. iatom >= jatom) THEN
-            weight_re = 1.0_dp
-            weight_im = 0.0_dp
+      DO icell = 1, num_cells
+
+         xcell = index_to_cell(1, icell)
+         ycell = index_to_cell(2, icell)
+         zcell = index_to_cell(3, icell)
+
+         cell_vector(1:3) = MATMUL(hmat, REAL((/xcell, ycell, zcell/), dp))
+
+         rab_cell_i(1:3) = pbc(particle_set(iatom)%r(1:3), cell) - &
+                           (pbc(particle_set(jatom)%r(1:3), cell) + cell_vector(1:3))
+
+         abs_rab_cell = SQRT(rab_cell_i(1)**2 + rab_cell_i(2)**2 + rab_cell_i(3)**2)
+
+         IF (abs_rab_cell < abs_rab_cell_min + 0.1_dp) THEN
+
+            arg = REAL(xcell, dp)*xkp(1) + REAL(ycell, dp)*xkp(2) + REAL(zcell, dp)*xkp(3)
+
+            weight_re = weight_re + wkp_W*COS(twopi*arg)
+            weight_im = weight_im + wkp_W*SIN(twopi*arg)
+
+            n_equidistant_cells = n_equidistant_cells + 1
+
          END IF
-      END IF
+
+      END DO
+
+      weight_re = weight_re/REAL(n_equidistant_cells, KIND=dp)
+      weight_im = weight_im/REAL(n_equidistant_cells, KIND=dp)
 
       CALL timestop(handle)
 

--- a/src/rpa_gw_kpoints_util.F
+++ b/src/rpa_gw_kpoints_util.F
@@ -46,17 +46,14 @@ MODULE rpa_gw_kpoints_util
                                               cp_fm_type
    USE cp_para_env,                     ONLY: cp_para_env_retain
    USE cp_para_types,                   ONLY: cp_para_env_type
-   USE cp_units,                        ONLY: cp_unit_from_cp2k
    USE dbcsr_api,                       ONLY: &
-        dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_desymmetrize, &
-        dbcsr_filter, dbcsr_get_block_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
+        dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_desymmetrize, dbcsr_filter, &
+        dbcsr_get_block_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
         dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, &
         dbcsr_release, dbcsr_reserve_all_blocks, dbcsr_set, dbcsr_transposed, dbcsr_type, &
         dbcsr_type_no_symmetry
    USE hfx_types,                       ONLY: hfx_release
    USE input_constants,                 ONLY: cholesky_off,&
-                                              gw_gf_gamma,&
-                                              gw_gf_mic,&
                                               kp_weights_W_auto,&
                                               kp_weights_W_tailored,&
                                               kp_weights_W_uniform
@@ -67,8 +64,8 @@ MODULE rpa_gw_kpoints_util
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_env_type,&
                                               kpoint_type
+   USE machine,                         ONLY: m_walltime
    USE mathconstants,                   ONLY: gaussi,&
-                                              pi,&
                                               twopi,&
                                               z_one,&
                                               z_zero
@@ -94,7 +91,7 @@ MODULE rpa_gw_kpoints_util
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'rpa_gw_kpoints_util'
 
-   PUBLIC :: invert_eps_compute_W_and_Erpa_kp, cp_cfm_matrix_exponential, real_space_to_kpoint_transform_rpa, &
+   PUBLIC :: invert_eps_compute_W_and_Erpa_kp, cp_cfm_power, real_space_to_kpoint_transform_rpa, &
              get_mat_cell_T_from_mat_gamma, get_bandstruc_and_k_dependent_MOs, &
              compute_wkp_W
 
@@ -108,14 +105,12 @@ CONTAINS
 !> \param nkp ...
 !> \param count_ev_sc_GW ...
 !> \param para_env ...
-!> \param para_env_RPA ...
 !> \param Erpa ...
 !> \param tau_tj ...
 !> \param tj ...
 !> \param wj ...
 !> \param weights_cos_tf_w_to_t ...
 !> \param wkp_W ...
-!> \param wkp_V ...
 !> \param do_gw_im_time ...
 !> \param do_ri_Sigma_x ...
 !> \param do_kpoints_from_Gamma ...
@@ -129,55 +124,63 @@ CONTAINS
 !> \param eps_filter_im_time ...
 !> \param unit_nr ...
 !> \param kpoints ...
-!> \param fm_mat_L ...
+!> \param fm_mat_Minv_L_kpoints ...
+!> \param fm_matrix_L_kpoints ...
 !> \param fm_mat_W ...
 !> \param fm_mat_RI_global_work ...
-!> \param mat_SinvVSinv ...
-!> \param fm_mat_SiVtrSi ...
+!> \param mat_MinvVMinv ...
+!> \param fm_matrix_Minv ...
+!> \param fm_matrix_Minv_Vtrunc_Minv ...
 ! **************************************************************************************************
-   SUBROUTINE invert_eps_compute_W_and_Erpa_kp(dimen_RI, num_integ_points, jquad, nkp, count_ev_sc_GW, para_env, para_env_RPA, &
-                                               Erpa, tau_tj, tj, wj, weights_cos_tf_w_to_t, wkp_W, wkp_V, do_gw_im_time, &
+   SUBROUTINE invert_eps_compute_W_and_Erpa_kp(dimen_RI, num_integ_points, jquad, nkp, count_ev_sc_GW, para_env, &
+                                               Erpa, tau_tj, tj, wj, weights_cos_tf_w_to_t, wkp_W, do_gw_im_time, &
                                                do_ri_Sigma_x, do_kpoints_from_Gamma, do_kpoints_cubic_RPA, &
                                                cfm_mat_W_kp_tau, cfm_mat_Q, ikp_local, mat_P_omega, mat_P_omega_kp, &
-                                               qs_env, eps_filter_im_time, unit_nr, kpoints, fm_mat_L, fm_mat_W, &
-                                               fm_mat_RI_global_work, mat_SinvVSinv, fm_mat_SiVtrSi)
+                                               qs_env, eps_filter_im_time, unit_nr, kpoints, fm_mat_Minv_L_kpoints, &
+                                               fm_matrix_L_kpoints, fm_mat_W, &
+                                               fm_mat_RI_global_work, mat_MinvVMinv, fm_matrix_Minv, &
+                                               fm_matrix_Minv_Vtrunc_Minv)
 
       INTEGER, INTENT(IN)                                :: dimen_RI, num_integ_points, jquad, nkp, &
                                                             count_ev_sc_GW
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_RPA
       REAL(KIND=dp), INTENT(INOUT)                       :: Erpa
       REAL(KIND=dp), DIMENSION(0:num_integ_points), &
          INTENT(IN)                                      :: tau_tj
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tj, wj
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(IN)                                      :: weights_cos_tf_w_to_t
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wkp_W, wkp_V
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wkp_W
       LOGICAL, INTENT(IN)                                :: do_gw_im_time, do_ri_Sigma_x, &
                                                             do_kpoints_from_Gamma, &
                                                             do_kpoints_cubic_RPA
       TYPE(cp_cfm_p_type), ALLOCATABLE, &
          DIMENSION(:, :), INTENT(INOUT)                  :: cfm_mat_W_kp_tau
       TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: ikp_local
+      INTEGER, INTENT(IN)                                :: ikp_local
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(INOUT) :: mat_P_omega, mat_P_omega_kp
       TYPE(qs_environment_type), POINTER                 :: qs_env
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter_im_time
       INTEGER, INTENT(IN)                                :: unit_nr
       TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: fm_mat_L
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_Minv_L_kpoints, &
+                                                            fm_matrix_L_kpoints
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mat_W
       TYPE(cp_fm_type)                                   :: fm_mat_RI_global_work
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_SinvVSinv
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: fm_mat_SiVtrSi
+      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_MinvVMinv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_Minv, &
+                                                            fm_matrix_Minv_Vtrunc_Minv
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'invert_eps_compute_W_and_Erpa_kp'
 
       INTEGER                                            :: handle, ikp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: tau_tj_dummy, tj_dummy, trace_Qomega
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: weights_cos_tf_w_to_t_dummy
+      LOGICAL                                            :: do_this_ikp
+      REAL(KIND=dp)                                      :: t1, t2
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: trace_Qomega
 
       CALL timeset(routineN, handle)
+
+      t1 = m_walltime()
 
       IF (do_kpoints_cubic_RPA .AND. do_gw_im_time) THEN
          CALL allocate_Wc_kp_tau_GW(cfm_mat_W_kp_tau, cfm_mat_Q, num_integ_points, jquad, &
@@ -193,104 +196,121 @@ CONTAINS
 
       ALLOCATE (trace_Qomega(dimen_RI))
 
-      IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T69,I9,A,I2)') &
-         'GW_INFO| Computing chi and W for frequency point: ', jquad, '/', num_integ_points
+      IF (unit_nr > 0) WRITE (unit_nr, '(/T3,A,1X,I3)') &
+         'GW_INFO| Computing chi and W frequency point', jquad
 
       DO ikp = 1, nkp
 
          ! parallization, we either have all kpoints on all processors or a single kpoint per group
-         IF (ikp_local(ikp) .NE. ikp) CYCLE
+         do_this_ikp = (ikp_local == -1) .OR. (ikp_local == 0 .AND. ikp == 1) .OR. (ikp_local == ikp)
+         IF (.NOT. do_this_ikp) CYCLE
 
          ! 1. remove all spurious negative eigenvalues from P(iw,k), multiplication Q(iw,k) = K^H(k)P(iw,k)K(k)
          CALL compute_Q_kp_RPA(cfm_mat_Q, &
                                mat_P_omega_kp, &
-                               fm_mat_L(ikp, 1), &
-                               fm_mat_L(ikp, 2), &
+                               fm_mat_Minv_L_kpoints(ikp, 1), &
+                               fm_mat_Minv_L_kpoints(ikp, 2), &
                                fm_mat_RI_global_work, &
                                dimen_RI, ikp, nkp, ikp_local, para_env, &
                                qs_env%mp2_env%ri_rpa_im_time%make_chi_pos_definite)
 
          ! 2. Cholesky decomposition of Id + Q(iw,k)
-         CALL cholesky_decomp_Q(cfm_mat_Q, para_env_RPA, trace_Qomega, dimen_RI)
+         CALL cholesky_decomp_Q(cfm_mat_Q, para_env, trace_Qomega, dimen_RI)
 
          ! 3. Computing E_c^RPA = E_c^RPA + a_w/N_k*sum_k ln[det(1+Q(iw,k))-Tr(Q(iw,k))]
-         CALL frequency_and_kpoint_integration(Erpa, cfm_mat_Q, para_env_RPA, trace_Qomega, &
+         CALL frequency_and_kpoint_integration(Erpa, cfm_mat_Q, para_env, trace_Qomega, &
                                                dimen_RI, wj(jquad), kpoints%wkp(ikp))
 
          IF (do_gw_im_time) THEN
 
             ! compute S^-1*V*S^-1 for exchange part of the self-energy in real space as W in real space
-            IF (do_ri_Sigma_x .AND. jquad == 1 .AND. count_ev_sc_GW == 1 &
-                .AND. do_kpoints_from_Gamma) THEN
+            IF (do_ri_Sigma_x .AND. jquad == 1 .AND. count_ev_sc_GW == 1 .AND. do_kpoints_from_Gamma) THEN
 
-               CALL get_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
-
-               CALL compute_Wc_real_space_tau_GW(fm_mat_W, cfm_mat_Q, &
-                                                 fm_mat_L(ikp, 1), &
-                                                 fm_mat_L(ikp, 2), &
-                                                 dimen_RI, 1, 1, &
-                                                 ikp, tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy, &
-                                                 ikp_local, para_env, kpoints, qs_env, wkp_V, &
-                                                 mat_SinvVSinv, do_W_and_not_V=.FALSE., &
-                                                 fm_mat_SiVtrSi_re=fm_mat_SiVtrSi(ikp, 1), &
-                                                 fm_mat_SiVtrSi_im=fm_mat_SiVtrSi(ikp, 2))
-
-               CALL release_dummys(tj_dummy, tau_tj_dummy, weights_cos_tf_w_to_t_dummy)
+               CALL dbcsr_set(mat_MinvVMinv%matrix, 0.0_dp)
+               CALL copy_fm_to_dbcsr(fm_matrix_Minv_Vtrunc_Minv(1, 1), mat_MinvVMinv%matrix, keep_sparsity=.FALSE.)
 
             END IF
             IF (do_kpoints_from_Gamma) THEN
-
                CALL compute_Wc_real_space_tau_GW(fm_mat_W, cfm_mat_Q, &
-                                                 fm_mat_L(ikp, 1), &
-                                                 fm_mat_L(ikp, 2), &
+                                                 fm_matrix_L_kpoints(ikp, 1), &
+                                                 fm_matrix_L_kpoints(ikp, 2), &
                                                  dimen_RI, num_integ_points, jquad, &
                                                  ikp, tj, tau_tj, weights_cos_tf_w_to_t, &
-                                                 ikp_local, para_env, kpoints, qs_env, wkp_W, &
-                                                 mat_SinvVSinv, do_W_and_not_V=.TRUE.)
-
+                                                 ikp_local, para_env, kpoints, qs_env, wkp_W)
             END IF
 
-            IF (do_kpoints_cubic_RPA) THEN
-
-               CALL compute_Wc_kp_tau_GW(cfm_mat_W_kp_tau, cfm_mat_Q, &
-                                         fm_mat_L(ikp, 1), &
-                                         fm_mat_L(ikp, 2), &
-                                         dimen_RI, num_integ_points, jquad, &
-                                         ikp, tj, tau_tj, &
-                                         weights_cos_tf_w_to_t)
-
-            END IF
          END IF
       END DO
 
+      ! after the transform of (eps(iw)-1)^-1 from iw to it is done, multiply with V^1/2 to obtain W(it)
+      IF (do_gw_im_time .AND. do_kpoints_from_Gamma .AND. jquad == num_integ_points) THEN
+         CALL Wc_to_Minv_Wc_Minv(fm_mat_W, fm_matrix_Minv, para_env, dimen_RI, num_integ_points)
+         CALL deallocate_kp_matrices(fm_matrix_L_kpoints, fm_mat_Minv_L_kpoints)
+      END IF
+
       DEALLOCATE (trace_Qomega)
+
+      t2 = m_walltime()
+
+      IF (unit_nr > 0) WRITE (unit_nr, '(T6,A,T56,F25.1)') 'Execution time (s):', t2 - t1
 
       CALL timestop(handle)
 
    END SUBROUTINE invert_eps_compute_W_and_Erpa_kp
 
 ! **************************************************************************************************
-!> \brief Decomposition A = L^H*L of a Hermitian matrix A
+!> \brief ...
+!> \param fm_matrix_L_kpoints ...
+!> \param fm_mat_Minv_L_kpoints ...
+! **************************************************************************************************
+   SUBROUTINE deallocate_kp_matrices(fm_matrix_L_kpoints, fm_mat_Minv_L_kpoints)
+
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, &
+                                                            fm_mat_Minv_L_kpoints
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'deallocate_kp_matrices'
+
+      INTEGER                                            :: handle, i_size, j_size
+
+      CALL timeset(routineN, handle)
+
+      DO i_size = 1, SIZE(fm_mat_Minv_L_kpoints, 1)
+         DO j_size = 1, SIZE(fm_mat_Minv_L_kpoints, 2)
+            CALL cp_fm_release(fm_mat_Minv_L_kpoints(i_size, j_size))
+            CALL cp_fm_release(fm_matrix_L_kpoints(i_size, j_size))
+         END DO
+      END DO
+      DEALLOCATE (fm_mat_Minv_L_kpoints)
+      DEALLOCATE (fm_matrix_L_kpoints)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE deallocate_kp_matrices
+
+! **************************************************************************************************
+!> \brief ...
 !> \param matrix ...
-!> \param work ...
 !> \param threshold ...
 !> \param exponent ...
 !> \param min_eigval ...
-!> \author Jan Wilhelm, 07.2021
 ! **************************************************************************************************
-   SUBROUTINE cp_cfm_matrix_exponential(matrix, work, threshold, exponent, min_eigval)
-      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix, work
+   SUBROUTINE cp_cfm_power(matrix, threshold, exponent, min_eigval)
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: matrix
       REAL(KIND=dp)                                      :: threshold, exponent
       REAL(KIND=dp), OPTIONAL                            :: min_eigval
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_cfm_matrix_exponential'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cp_cfm_power'
       COMPLEX(KIND=dp), PARAMETER :: czero = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
 
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: eigenvalues_exponent
       INTEGER                                            :: handle, i, ncol_global, nrow_global
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eigenvalues
+      TYPE(cp_cfm_type)                                  :: cfm_work
 
       CALL timeset(routineN, handle)
+
+      CALL cp_cfm_create(cfm_work, matrix%matrix_struct)
+      CALL cp_cfm_set_all(cfm_work, z_zero)
 
       ! Test that matrix is square
       CALL cp_cfm_get_info(matrix, nrow_global=nrow_global, ncol_global=ncol_global)
@@ -301,11 +321,11 @@ CONTAINS
       eigenvalues_exponent(:) = czero
 
       ! Diagonalize matrix: get eigenvectors and eigenvalues
-      CALL cp_cfm_heevd(matrix, work, eigenvalues)
+      CALL cp_cfm_heevd(matrix, cfm_work, eigenvalues)
 
       DO i = 1, nrow_global
          IF (eigenvalues(i) > threshold) THEN
-            eigenvalues_exponent(i) = CMPLX((eigenvalues(i))**exponent, threshold, KIND=dp)
+            eigenvalues_exponent(i) = CMPLX((eigenvalues(i))**(0.5_dp*exponent), threshold, KIND=dp)
          ELSE
             IF (PRESENT(min_eigval)) THEN
                eigenvalues_exponent(i) = CMPLX(min_eigval, 0.0_dp, KIND=dp)
@@ -315,15 +335,18 @@ CONTAINS
          END IF
       END DO
 
-      CALL cp_cfm_column_scale(work, eigenvalues_exponent)
+      CALL cp_cfm_column_scale(cfm_work, eigenvalues_exponent)
 
-      CALL cp_cfm_transpose(work, 'C', matrix)
+      CALL parallel_gemm("N", "C", nrow_global, nrow_global, nrow_global, z_one, &
+                         cfm_work, cfm_work, z_zero, matrix)
 
       DEALLOCATE (eigenvalues, eigenvalues_exponent)
 
+      CALL cp_cfm_release(cfm_work)
+
       CALL timestop(handle)
 
-   END SUBROUTINE cp_cfm_matrix_exponential
+   END SUBROUTINE cp_cfm_power
 
 ! **************************************************************************************************
 !> \brief ...
@@ -343,12 +366,11 @@ CONTAINS
                                fm_mat_RI_global_work, dimen_RI, ikp, nkp, ikp_local, para_env, &
                                make_chi_pos_definite)
 
-      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
+      TYPE(cp_cfm_type)                                  :: cfm_mat_Q
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(INOUT) :: mat_P_omega_kp
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mat_L_re, fm_mat_L_im, &
+      TYPE(cp_fm_type)                                   :: fm_mat_L_re, fm_mat_L_im, &
                                                             fm_mat_RI_global_work
-      INTEGER, INTENT(IN)                                :: dimen_RI, ikp, nkp
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: ikp_local
+      INTEGER, INTENT(IN)                                :: dimen_RI, ikp, nkp, ikp_local
       TYPE(cp_para_env_type), POINTER                    :: para_env
       LOGICAL, INTENT(IN)                                :: make_chi_pos_definite
 
@@ -376,11 +398,7 @@ CONTAINS
 
       ! 2. Remove all negative eigenvalues from chi(k,iw)
       IF (make_chi_pos_definite) THEN
-         CALL cp_cfm_matrix_exponential(cfm_mat_Q, cfm_mat_work, threshold=0.0_dp, exponent=0.5_dp)
-         CALL parallel_gemm("C", "N", dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_Q, &
-                            z_zero, cfm_mat_work)
-         CALL cp_cfm_to_cfm(cfm_mat_work, cfm_mat_Q)
-
+         CALL cp_cfm_power(cfm_mat_Q, threshold=0.0_dp, exponent=1.0_dp)
       END IF
 
       ! 3. Copy fm_mat_L_re and fm_mat_L_re to cfm_mat_L
@@ -420,8 +438,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(INOUT) :: mat_P_omega_kp
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_mat_RI_global_work, fm_mat_work
       TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
-      INTEGER, INTENT(IN)                                :: ikp, nkp
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: ikp_local
+      INTEGER, INTENT(IN)                                :: ikp, nkp, ikp_local
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mat_P_to_subgroup'
@@ -432,7 +449,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      IF (SUM(ikp_local) > nkp) THEN
+      IF (ikp_local == -1) THEN
 
          mat_P_omega_re => mat_P_omega_kp(1, ikp)%matrix
          CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
@@ -446,6 +463,8 @@ CONTAINS
 
       ELSE
 
+         CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+
          DO jkp = 1, nkp
 
             mat_P_omega_re => mat_P_omega_kp(1, jkp)%matrix
@@ -453,30 +472,48 @@ CONTAINS
             CALL cp_fm_set_all(fm_mat_RI_global_work, 0.0_dp)
             CALL copy_dbcsr_to_fm(mat_P_omega_re, fm_mat_RI_global_work)
 
-            IF (ANY(ikp_local(:) == jkp)) THEN
-               CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+            CALL mp_sync(para_env%group)
+
+            IF (ikp_local == jkp) THEN
                CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_mat_work, para_env)
-               CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_Q, z_one, fm_mat_work)
             ELSE
                CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_dummy, para_env)
             END IF
+
+            CALL mp_sync(para_env%group)
+
+         END DO
+
+         CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_Q, z_one, fm_mat_work)
+
+         CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+
+         DO jkp = 1, nkp
 
             mat_P_omega_im => mat_P_omega_kp(2, jkp)%matrix
 
             CALL cp_fm_set_all(fm_mat_RI_global_work, 0.0_dp)
             CALL copy_dbcsr_to_fm(mat_P_omega_im, fm_mat_RI_global_work)
 
-            IF (ANY(ikp_local(:) == jkp)) THEN
-               CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+            CALL mp_sync(para_env%group)
+
+            IF (ikp_local == jkp) THEN
                CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_mat_work, para_env)
-               CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_Q, gaussi, fm_mat_work)
             ELSE
                CALL cp_fm_copy_general(fm_mat_RI_global_work, fm_dummy, para_env)
             END IF
 
+            CALL mp_sync(para_env%group)
+
          END DO
 
+         CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_Q, gaussi, fm_mat_work)
+
+         CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+
       END IF
+
+      CALL mp_sync(para_env%group)
 
       CALL mp_sync(para_env%group)
 
@@ -487,14 +524,14 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param cfm_mat_Q ...
-!> \param para_env_RPA ...
+!> \param para_env ...
 !> \param trace_Qomega ...
 !> \param dimen_RI ...
 ! **************************************************************************************************
-   SUBROUTINE cholesky_decomp_Q(cfm_mat_Q, para_env_RPA, trace_Qomega, dimen_RI)
+   SUBROUTINE cholesky_decomp_Q(cfm_mat_Q, para_env, trace_Qomega, dimen_RI)
 
       TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
-      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_RPA
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: trace_Qomega
       INTEGER, INTENT(IN)                                :: dimen_RI
 
@@ -534,7 +571,7 @@ CONTAINS
             END IF
          END DO
       END DO
-      CALL mp_sum(trace_Qomega, para_env_RPA%group)
+      CALL mp_sum(trace_Qomega, para_env%group)
 
       CALL cp_cfm_to_cfm(cfm_mat_Q, cfm_mat_Q_tmp)
 
@@ -553,18 +590,18 @@ CONTAINS
 !> \brief ...
 !> \param Erpa ...
 !> \param cfm_mat_Q ...
-!> \param para_env_RPA ...
+!> \param para_env ...
 !> \param trace_Qomega ...
 !> \param dimen_RI ...
 !> \param freq_weight ...
 !> \param kp_weight ...
 ! **************************************************************************************************
-   SUBROUTINE frequency_and_kpoint_integration(Erpa, cfm_mat_Q, para_env_RPA, trace_Qomega, &
+   SUBROUTINE frequency_and_kpoint_integration(Erpa, cfm_mat_Q, para_env, trace_Qomega, &
                                                dimen_RI, freq_weight, kp_weight)
 
       REAL(KIND=dp), INTENT(INOUT)                       :: Erpa
       TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
-      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_RPA
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: trace_Qomega
       INTEGER, INTENT(IN)                                :: dimen_RI
       REAL(KIND=dp), INTENT(IN)                          :: freq_weight, kp_weight
@@ -599,11 +636,11 @@ CONTAINS
             END IF
          END DO
       END DO
-      CALL mp_sum(Q_log, para_env_RPA%group)
+      CALL mp_sum(Q_log, para_env%group)
 
       FComega = 0.0_dp
       DO iiB = 1, dimen_RI
-         IF (MODULO(iiB, para_env_RPA%num_pe) /= para_env_RPA%mepos) CYCLE
+         IF (MODULO(iiB, para_env%num_pe) /= para_env%mepos) CYCLE
          ! FComega=FComega+(LOG(Q_log(iiB))-trace_Qomega(iiB))/2.0_dp
          FComega = FComega + (Q_log(iiB) - trace_Qomega(iiB))/2.0_dp
       END DO
@@ -689,12 +726,12 @@ CONTAINS
       TYPE(cp_cfm_p_type), ALLOCATABLE, &
          DIMENSION(:, :), INTENT(OUT)                    :: cfm_mat_W_kp_tau
       TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
-      INTEGER, INTENT(IN)                                :: num_integ_points, jquad, nkp
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: ikp_local
+      INTEGER, INTENT(IN)                                :: num_integ_points, jquad, nkp, ikp_local
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_Wc_kp_tau_GW'
 
       INTEGER                                            :: handle, iquad, jkp
+      LOGICAL                                            :: do_this_ikp
 
       CALL timeset(routineN, handle)
 
@@ -704,8 +741,12 @@ CONTAINS
          ALLOCATE (cfm_mat_W_kp_tau(nkp, num_integ_points))
          DO iquad = 1, num_integ_points
             DO jkp = 1, nkp
+
                NULLIFY (cfm_mat_W_kp_tau(jkp, iquad)%matrix)
-               IF (.NOT. (ANY(ikp_local(:) == jkp))) CYCLE
+
+               do_this_ikp = (ikp_local == -1) .OR. (ikp_local == jkp)
+               IF (.NOT. do_this_ikp) CYCLE
+
                ALLOCATE (cfm_mat_W_kp_tau(jkp, iquad)%matrix)
                CALL cp_cfm_create(cfm_mat_W_kp_tau(jkp, iquad)%matrix, cfm_mat_Q%matrix_struct)
                CALL cp_cfm_set_all(matrix=cfm_mat_W_kp_tau(jkp, iquad)%matrix, alpha=z_zero)
@@ -733,13 +774,14 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_mat_cell_T_from_mat_gamma'
 
-      INTEGER                                            :: col, handle, i_cell, i_dim, num_cells_P, &
-                                                            num_integ_points, row
+      INTEGER                                            :: col, handle, i_cell, i_dim, j_cell, &
+                                                            num_cells_P, num_integ_points, row
       INTEGER, DIMENSION(3)                              :: cell_grid_P, periodic
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_P
-      REAL(KIND=dp)                                      :: abs_rab_cell_i, first_cutoff, &
-                                                            second_cutoff, weight
-      REAL(KIND=dp), DIMENSION(3)                        :: cell_vector, rab_cell_i
+      LOGICAL :: i_cell_is_the_minimum_image_cell
+      REAL(KIND=dp)                                      :: abs_rab_cell_i, abs_rab_cell_j
+      REAL(KIND=dp), DIMENSION(3)                        :: cell_vector, cell_vector_j, rab_cell_i, &
+                                                            rab_cell_j
       REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
       TYPE(cell_type), POINTER                           :: cell
@@ -779,20 +821,7 @@ CONTAINS
                          mat_P_omega(1)%matrix)
       END DO
 
-      first_cutoff = qs_env%mp2_env%ri_rpa_im_time%abs_cutoffs_chi_W(1)
-      second_cutoff = qs_env%mp2_env%ri_rpa_im_time%abs_cutoffs_chi_W(2)
-
       IF (jquad == 1 .AND. unit_nr > 0) THEN
-         WRITE (unit_nr, '(T3,A,T72,F9.2)') 'GW_INFO| Relative cutoff 1: ', &
-            qs_env%mp2_env%ri_rpa_im_time%rel_cutoffs_chi_W(1)
-         WRITE (unit_nr, '(T3,A,T72,F9.2)') 'GW_INFO| Relative cutoff 2: ', &
-            qs_env%mp2_env%ri_rpa_im_time%rel_cutoffs_chi_W(2)
-         WRITE (unit_nr, '(T3,A,T72,F9.2)') 'GW_INFO| Cutoff radius 1 (Angstroem):', &
-            cp_unit_from_cp2k(first_cutoff, "Angstrom")
-         WRITE (unit_nr, '(T3,A,T72,F9.2)') 'GW_INFO| Cutoff radius 2 (Angstroem):', &
-            cp_unit_from_cp2k(second_cutoff, "Angstrom")
-         WRITE (unit_nr, '(T3,A,T72,F9.2)') &
-            'GW_INFO| If Cutoff radius 1 = Cutoff radius 2 = 0.5: minimum image convention.'
          WRITE (unit_nr, '(T3,A,T66,ES15.2)') 'GW_INFO| RI regularization parameter: ', &
             qs_env%mp2_env%ri_rpa_im_time%regularization_RI
          WRITE (unit_nr, '(T3,A,T66,ES15.2)') 'GW_INFO| eps_eigval_S: ', &
@@ -818,18 +847,22 @@ CONTAINS
                               (pbc(particle_set(col)%r(1:3), cell) + cell_vector(1:3))
             abs_rab_cell_i = SQRT(rab_cell_i(1)**2 + rab_cell_i(2)**2 + rab_cell_i(3)**2)
 
-            ! smooth function that is only one if atoms are very close and becomes smoothly zero
-            ! for larger distances
-            IF (abs_rab_cell_i < first_cutoff) THEN
-               weight = 1.0_dp
-            ELSE IF (abs_rab_cell_i < second_cutoff) THEN
-               weight = 0.5_dp*(COS(pi*(abs_rab_cell_i - first_cutoff)/ &
-                                    (second_cutoff - first_cutoff)) + 1.0_dp)
-            ELSE
-               weight = 0.0_dp
-            END IF
+            ! minimum image convention
+            i_cell_is_the_minimum_image_cell = .TRUE.
+            DO j_cell = 1, num_cells_P
+               cell_vector_j(1:3) = MATMUL(hmat, REAL(index_to_cell_P(1:3, j_cell), dp))
+               rab_cell_j(1:3) = pbc(particle_set(row)%r(1:3), cell) - &
+                                 (pbc(particle_set(col)%r(1:3), cell) + cell_vector_j(1:3))
+               abs_rab_cell_j = SQRT(rab_cell_j(1)**2 + rab_cell_j(2)**2 + rab_cell_j(3)**2)
 
-            data_block(:, :) = data_block(:, :)*weight
+               IF (abs_rab_cell_i > abs_rab_cell_j + 1.0E-6_dp) THEN
+                  i_cell_is_the_minimum_image_cell = .FALSE.
+               END IF
+            END DO
+
+            IF (.NOT. i_cell_is_the_minimum_image_cell) THEN
+               data_block(:, :) = data_block(:, :)*0.0_dp
+            END IF
 
          END DO
          CALL dbcsr_iterator_stop(iter)
@@ -1013,16 +1046,11 @@ CONTAINS
 !> \param kpoints ...
 !> \param qs_env ...
 !> \param wkp_W ...
-!> \param mat_SinvVSinv ...
-!> \param do_W_and_not_V ...
-!> \param fm_mat_SiVtrSi_re ...
-!> \param fm_mat_SiVtrSi_im ...
 ! **************************************************************************************************
    SUBROUTINE compute_Wc_real_space_tau_GW(fm_mat_W_tau, cfm_mat_Q, fm_mat_L_re, fm_mat_L_im, &
                                            dimen_RI, num_integ_points, jquad, &
                                            ikp, tj, tau_tj, weights_cos_tf_w_to_t, ikp_local, &
-                                           para_env, kpoints, qs_env, wkp_W, mat_SinvVSinv, do_W_and_not_V, &
-                                           fm_mat_SiVtrSi_re, fm_mat_SiVtrSi_im)
+                                           para_env, kpoints, qs_env, wkp_W)
 
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mat_W_tau
       TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
@@ -1032,14 +1060,11 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(0:num_integ_points), &
          INTENT(IN)                                      :: tau_tj
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: weights_cos_tf_w_to_t
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: ikp_local
+      INTEGER, INTENT(IN)                                :: ikp_local
       TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
       TYPE(kpoint_type), INTENT(IN), POINTER             :: kpoints
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: wkp_W
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_SinvVSinv
-      LOGICAL, INTENT(IN)                                :: do_W_and_not_V
-      TYPE(cp_fm_type), INTENT(IN), OPTIONAL             :: fm_mat_SiVtrSi_re, fm_mat_SiVtrSi_im
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Wc_real_space_tau_GW'
 
@@ -1048,10 +1073,8 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_from_RI_index
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
-      LOGICAL                                            :: do_V_and_not_W
       REAL(KIND=dp)                                      :: contribution, omega, tau, weight, &
                                                             weight_im, weight_re
-      REAL(KIND=dp), DIMENSION(2)                        :: abs_cutoffs_chi_W
       REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
@@ -1086,63 +1109,44 @@ CONTAINS
 
       CALL timestop(handle2)
 
-      IF (do_W_and_not_V) THEN
+      CALL timeset(routineN//"_2", handle2)
 
-         CALL timeset(routineN//"_2", handle2)
+      ! calculate [1+Q(iw')]^-1
+      CALL cp_cfm_cholesky_invert(cfm_mat_Q)
 
-         ! calculate [1+Q(iw')]^-1
-         CALL cp_cfm_cholesky_invert(cfm_mat_Q)
+      ! symmetrize the result
+      CALL own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
 
-         ! symmetrize the result
-         CALL own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
+      ! subtract exchange part by subtracing identity matrix from epsilon
+      CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
 
-         ! subtract exchange part by subtracing identity matrix from epsilon
-         CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
-                              nrow_local=nrow_local, &
-                              ncol_local=ncol_local, &
-                              row_indices=row_indices, &
-                              col_indices=col_indices)
-
-         DO jjB = 1, ncol_local
-            j_global = col_indices(jjB)
-            DO iiB = 1, nrow_local
-               i_global = row_indices(iiB)
-               IF (j_global == i_global .AND. i_global <= dimen_RI) THEN
-                  cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB) - z_one
-               END IF
-            END DO
+      DO jjB = 1, ncol_local
+         j_global = col_indices(jjB)
+         DO iiB = 1, nrow_local
+            i_global = row_indices(iiB)
+            IF (j_global == i_global .AND. i_global <= dimen_RI) THEN
+               cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB) - z_one
+            END IF
          END DO
+      END DO
 
-         CALL timestop(handle2)
+      CALL timestop(handle2)
 
-         CALL timeset(routineN//"_3.1", handle2)
+      CALL timeset(routineN//"_3", handle2)
 
-         ! work = epsilon(iw,k)*L^H(k)
-         CALL parallel_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
-                            z_zero, cfm_mat_work)
+      ! work = epsilon(iw,k)*V^1/2(k)
+      CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
+                         z_zero, cfm_mat_work)
 
-         ! W(iw,k) = L(k)*work
-         CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
-                            z_zero, cfm_mat_work_2)
+      ! W(iw,k) = V^1/2(k)*work
+      CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
+                         z_zero, cfm_mat_work_2)
 
-         CALL timestop(handle2)
-
-      ELSE
-
-         IF (qs_env%mp2_env%ri_rpa_im_time%trunc_coulomb_ri_x) THEN
-
-            ! Copy fm_mat_L_re and fm_mat_L_re to cfm_mat_L
-            CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_work_2, z_one, fm_mat_SiVtrSi_re)
-            CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_work_2, gaussi, fm_mat_SiVtrSi_im)
-
-         ELSE
-
-            ! S^-1(k)V(k)S^-1(k) = L(k)*L(k)^H
-            CALL parallel_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_L, &
-                               z_zero, cfm_mat_work_2)
-         END IF
-
-      END IF
+      CALL timestop(handle2)
 
       CALL timeset(routineN//"_4", handle2)
 
@@ -1150,7 +1154,6 @@ CONTAINS
       index_to_cell => kpoints%index_to_cell
       num_cells = SIZE(index_to_cell, 2)
 
-      abs_cutoffs_chi_W = qs_env%mp2_env%ri_rpa_im_time%abs_cutoffs_chi_W
       CALL cp_cfm_set_all(cfm_mat_work, z_zero)
 
       ALLOCATE (atom_from_RI_index(dimen_RI))
@@ -1180,8 +1183,7 @@ CONTAINS
                ! symmetrize=.FALSE. necessary since we already have a symmetrized index_to_cell
                CALL compute_weight_re_im(weight_re, weight_im, &
                                          num_cells, iatom, jatom, xkp(1:3, ikp), wkp_W(ikp), &
-                                         cell, index_to_cell, hmat, particle_set, abs_cutoffs_chi_W, &
-                                         symmetrize=.FALSE., gamma_only=.FALSE.)
+                                         cell, index_to_cell, hmat, particle_set)
 
                iatom_old = iatom
                jatom_old = jatom
@@ -1200,11 +1202,37 @@ CONTAINS
 
       CALL timeset(routineN//"_5", handle2)
 
-      IF (do_W_and_not_V) THEN
+      IF (ikp_local == -1) THEN
 
-         IF (SUM(ikp_local) > nkp) THEN
+         CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
 
-            CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
+         DO iquad = 1, num_integ_points
+
+            omega = tj(jquad)
+            tau = tau_tj(iquad)
+            weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
+
+            IF (jquad == 1 .AND. ikp == 1) THEN
+               CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad), alpha=0.0_dp)
+            END IF
+
+            CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad), beta=weight, matrix_b=fm_mat_work_global)
+
+         END DO
+
+      ELSE
+
+         DO jkp = 1, nkp
+
+            CALL mp_sync(para_env%group)
+
+            IF (ikp_local == jkp) THEN
+               CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
+            ELSE
+               CALL cp_fm_copy_general(fm_dummy, fm_mat_work_global, para_env)
+            END IF
+
+            CALL mp_sync(para_env%group)
 
             DO iquad = 1, num_integ_points
 
@@ -1212,61 +1240,17 @@ CONTAINS
                tau = tau_tj(iquad)
                weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
 
-               IF (jquad == 1 .AND. ikp == 1) THEN
+               IF (jquad == 1 .AND. jkp == 1) THEN
                   CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad), alpha=0.0_dp)
                END IF
 
-               CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad), beta=weight, matrix_b=fm_mat_work_global)
+               CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad), beta=weight, &
+                                        matrix_b=fm_mat_work_global)
 
             END DO
 
-         ELSE
+         END DO
 
-            DO jkp = 1, nkp
-
-               IF (ANY(ikp_local(:) == jkp)) THEN
-                  CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
-               ELSE
-                  CALL cp_fm_copy_general(fm_dummy, fm_mat_work_global, para_env)
-               END IF
-
-               DO iquad = 1, num_integ_points
-
-                  omega = tj(jquad)
-                  tau = tau_tj(iquad)
-                  weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
-
-                  IF (jquad == 1 .AND. jkp == 1) THEN
-                     CALL cp_fm_set_all(matrix=fm_mat_W_tau(iquad), alpha=0.0_dp)
-                  END IF
-
-                  CALL cp_fm_scale_and_add(alpha=1.0_dp, matrix_a=fm_mat_W_tau(iquad), beta=weight, &
-                                           matrix_b=fm_mat_work_global)
-
-               END DO
-
-            END DO
-
-         END IF
-
-      END IF
-
-      do_V_and_not_W = .NOT. do_W_and_not_V
-      IF (do_V_and_not_W) THEN
-
-         IF (SUM(ikp_local) > nkp) THEN
-            CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
-            CALL fm_mat_work_global_to_mat_SinvVSinv(mat_SinvVSinv, fm_mat_work_global)
-         ELSE
-            DO jkp = 1, nkp
-               IF (ANY(ikp_local(:) == jkp)) THEN
-                  CALL cp_fm_copy_general(fm_mat_work_local, fm_mat_work_global, para_env)
-               ELSE
-                  CALL cp_fm_copy_general(fm_dummy, fm_mat_work_global, para_env)
-               END IF
-               CALL fm_mat_work_global_to_mat_SinvVSinv(mat_SinvVSinv, fm_mat_work_global)
-            END DO
-         END IF
       END IF
 
       CALL cp_cfm_release(cfm_mat_work)
@@ -1274,6 +1258,7 @@ CONTAINS
       CALL cp_cfm_release(cfm_mat_L)
       CALL cp_fm_release(fm_mat_work_global)
       CALL cp_fm_release(fm_mat_work_local)
+
       DEALLOCATE (atom_from_RI_index)
 
       CALL timestop(handle2)
@@ -1284,132 +1269,44 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param mat_SinvVSinv ...
-!> \param fm_mat_work_global ...
-! **************************************************************************************************
-   SUBROUTINE fm_mat_work_global_to_mat_SinvVSinv(mat_SinvVSinv, fm_mat_work_global)
-
-      TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_SinvVSinv
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mat_work_global
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'fm_mat_work_global_to_mat_SinvVSinv'
-
-      INTEGER                                            :: handle
-      TYPE(dbcsr_p_type)                                 :: mat_work
-
-      CALL timeset(routineN, handle)
-
-      NULLIFY (mat_work%matrix)
-      ALLOCATE (mat_work%matrix)
-      CALL dbcsr_create(mat_work%matrix, template=mat_SinvVSinv%matrix)
-
-      CALL copy_fm_to_dbcsr(fm_mat_work_global, mat_work%matrix, keep_sparsity=.FALSE.)
-
-      CALL dbcsr_add(mat_SinvVSinv%matrix, mat_work%matrix, 1.0_dp, 1.0_dp)
-
-      CALL dbcsr_release(mat_work%matrix)
-      DEALLOCATE (mat_work%matrix)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE
-
-! **************************************************************************************************
-!> \brief ...
-!> \param cfm_mat_W_kp_tau ...
-!> \param cfm_mat_Q ...
-!> \param fm_mat_L_re ...
-!> \param fm_mat_L_im ...
+!> \param fm_mat_W ...
+!> \param fm_matrix_Minv ...
+!> \param para_env ...
 !> \param dimen_RI ...
 !> \param num_integ_points ...
-!> \param jquad ...
-!> \param ikp ...
-!> \param tj ...
-!> \param tau_tj ...
-!> \param weights_cos_tf_w_to_t ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Wc_kp_tau_GW(cfm_mat_W_kp_tau, cfm_mat_Q, fm_mat_L_re, fm_mat_L_im, &
-                                   dimen_RI, num_integ_points, jquad, &
-                                   ikp, tj, tau_tj, weights_cos_tf_w_to_t)
+   SUBROUTINE Wc_to_Minv_Wc_Minv(fm_mat_W, fm_matrix_Minv, para_env, dimen_RI, num_integ_points)
+      TYPE(cp_fm_type), DIMENSION(:)                     :: fm_mat_W
+      TYPE(cp_fm_type), DIMENSION(:, :)                  :: fm_matrix_Minv
+      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      INTEGER                                            :: dimen_RI, num_integ_points
 
-      TYPE(cp_cfm_p_type), DIMENSION(:, :), INTENT(IN)   :: cfm_mat_W_kp_tau
-      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mat_L_re, fm_mat_L_im
-      INTEGER, INTENT(IN)                                :: dimen_RI, num_integ_points, jquad, ikp
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tj
-      REAL(KIND=dp), DIMENSION(0:num_integ_points), &
-         INTENT(IN)                                      :: tau_tj
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: weights_cos_tf_w_to_t
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'Wc_to_Minv_Wc_Minv'
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Wc_kp_tau_GW'
-
-      INTEGER                                            :: handle, handle2, i_global, iiB, iquad, &
-                                                            j_global, jjB, ncol_local, nrow_local
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      REAL(KIND=dp)                                      :: omega, tau, weight
-      TYPE(cp_cfm_type)                                  :: cfm_mat_L, cfm_mat_work
+      INTEGER                                            :: handle, jquad
+      TYPE(cp_fm_type)                                   :: fm_work_Minv, fm_work_Minv_W
 
       CALL timeset(routineN, handle)
 
-      CALL cp_cfm_create(cfm_mat_work, fm_mat_L_re%matrix_struct)
-      CALL cp_cfm_set_all(cfm_mat_work, z_zero)
+      CALL cp_fm_create(fm_work_Minv, fm_mat_W(1)%matrix_struct)
+      CALL cp_fm_copy_general(fm_matrix_Minv(1, 1), fm_work_Minv, para_env)
 
-      CALL cp_cfm_create(cfm_mat_L, fm_mat_L_re%matrix_struct)
-      CALL cp_cfm_set_all(cfm_mat_L, z_zero)
+      CALL cp_fm_create(fm_work_Minv_W, fm_mat_W(1)%matrix_struct)
 
-      CALL timeset(routineN//"_cholesky_inv", handle2)
-
-      ! calculate [1+Q(iw')]^-1
-      CALL cp_cfm_cholesky_invert(cfm_mat_Q)
-
-      ! symmetrize the result
-      CALL own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
-
-      ! subtract exchange part by subtracing identity matrix from epsilon
-      CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
-                           nrow_local=nrow_local, &
-                           ncol_local=ncol_local, &
-                           row_indices=row_indices, &
-                           col_indices=col_indices)
-
-      DO jjB = 1, ncol_local
-         j_global = col_indices(jjB)
-         DO iiB = 1, nrow_local
-            i_global = row_indices(iiB)
-            IF (j_global == i_global .AND. i_global <= dimen_RI) THEN
-               cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB) - z_one
-            END IF
-         END DO
+      DO jquad = 1, num_integ_points
+         CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_work_Minv, fm_mat_W(jquad), &
+                            0.0_dp, fm_work_Minv_W)
+         CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, 1.0_dp, fm_work_Minv_W, fm_work_Minv, &
+                            0.0_dp, fm_mat_W(jquad))
       END DO
 
-      CALL timestop(handle2)
+      CALL cp_fm_release(fm_work_Minv)
 
-      ! Copy fm_mat_L_re and fm_mat_L_re to cfm_mat_L
-      CALL cp_cfm_scale_and_add_fm(z_zero, cfm_mat_L, z_one, fm_mat_L_re)
-      CALL cp_cfm_scale_and_add_fm(z_one, cfm_mat_L, gaussi, fm_mat_L_im)
-
-      ! work = epsilon(iw,k)*L^H(k)
-      CALL parallel_gemm('N', 'C', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_Q, cfm_mat_L, &
-                         z_zero, cfm_mat_work)
-
-      ! W(iw,k) = L(k)*work
-      CALL parallel_gemm('N', 'N', dimen_RI, dimen_RI, dimen_RI, z_one, cfm_mat_L, cfm_mat_work, &
-                         z_zero, cfm_mat_Q)
-
-      DO iquad = 1, num_integ_points
-         omega = tj(jquad)
-         tau = tau_tj(iquad)
-         weight = weights_cos_tf_w_to_t(iquad, jquad)*COS(tau*omega)
-         CALL cp_cfm_scale_and_add(alpha=z_one, matrix_a=cfm_mat_W_kp_tau(ikp, iquad)%matrix, &
-                                   beta=CMPLX(weight, KIND=dp), matrix_b=cfm_mat_Q)
-      END DO
-
-      CALL cp_cfm_release(cfm_mat_work)
-      CALL cp_cfm_release(cfm_mat_L)
+      CALL cp_fm_release(fm_work_Minv_W)
 
       CALL timestop(handle)
 
-   END SUBROUTINE
+   END SUBROUTINE Wc_to_Minv_Wc_Minv
 
 ! **************************************************************************************************
 !> \brief ...
@@ -1632,7 +1529,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_bandstruc_and_k_dependent_MOs'
 
-      INTEGER                                            :: handle, i_dim, ikp, n_spins, nmo
+      INTEGER                                            :: handle, ikp, n_spins, nmo
       INTEGER, DIMENSION(3)                              :: nkp_grid_G, nkp_grid_W
       REAL(KIND=dp), DIMENSION(:), POINTER               :: ev
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: kpgeneral
@@ -1647,20 +1544,7 @@ CONTAINS
                para_env)
 
       nkp_grid_W(1:3) = kpoints%nkp_grid(1:3)
-      SELECT CASE (qs_env%mp2_env%ri_rpa_im_time%periodic_gf)
-      CASE (gw_gf_mic)
-         DO i_dim = 1, 3
-            IF (nkp_grid_W(i_dim) == 1) THEN
-               nkp_grid_G(i_dim) = 1
-            ELSE
-               nkp_grid_G(i_dim) = nkp_grid_W(i_dim)*qs_env%mp2_env%ri_rpa_im_time%k_mesh_g_factor
-            END IF
-         END DO
-      CASE (gw_gf_gamma)
-         nkp_grid_G(1:3) = (/1, 1, 1/)
-      CASE DEFAULT
-         CPABORT("Not specified how to deal with periodic Green's function.")
-      END SELECT
+      nkp_grid_G(1:3) = (/1, 1, 1/)
 
       CALL get_qs_env(qs_env=qs_env, para_env=para_env)
 
@@ -1863,7 +1747,8 @@ CONTAINS
          CALL get_mo_set(kp%mos(1, 1), mo_coeff=rmos, eigenvalues=eigenvalues)
          CALL get_mo_set(kp%mos(2, 1), mo_coeff=imos)
 
-         IF (scf_env%cholesky_method == cholesky_off) THEN
+         IF (scf_env%cholesky_method == cholesky_off .OR. &
+             qs_env%mp2_env%ri_rpa_im_time%make_overlap_mat_ao_pos_definite) THEN
             CALL cp_cfm_geeig_canon(cksmat, csmat, cmos, eigenvalues, cwork, scf_control%eps_eigval)
          ELSE
             CALL cp_cfm_geeig(cksmat, csmat, cmos, eigenvalues, cwork)

--- a/src/rpa_gw_sigma_x.F
+++ b/src/rpa_gw_sigma_x.F
@@ -62,7 +62,7 @@ MODULE rpa_gw_sigma_x
    USE message_passing,                 ONLY: mp_sum,&
                                               mp_sync
    USE mp2_integrals,                   ONLY: compute_kpoints
-   USE mp2_ri_2c,                       ONLY: setup_abs_cutoffs_chi_and_trunc_coulomb_potential
+   USE mp2_ri_2c,                       ONLY: setup_trunc_coulomb_potential_for_exchange_self_energy
    USE mp2_types,                       ONLY: mp2_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE physcon,                         ONLY: evolt
@@ -612,7 +612,7 @@ CONTAINS
             CALL get_qs_env(qs_env=qs_env, &
                             kpoints=kpoints)
 
-            CALL setup_abs_cutoffs_chi_and_trunc_coulomb_potential(qs_env)
+            CALL setup_trunc_coulomb_potential_for_exchange_self_energy(qs_env)
 
             CALL compute_kpoints(qs_env, kpoints, unit_nr)
 

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -37,8 +37,6 @@ MODULE rpa_im_time
         dbt_get_info, dbt_nblks_total, dbt_nd_mp_comm, dbt_pgrid_destroy, dbt_pgrid_type, dbt_type
    USE hfx_types,                       ONLY: block_ind_type,&
                                               hfx_compression_type
-   USE input_constants,                 ONLY: gw_gf_gamma,&
-                                              gw_gf_mic
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE kpoint_types,                    ONLY: get_kpoint_info,&
@@ -721,13 +719,11 @@ CONTAINS
 
          CALL compute_periodic_dm(mat_dm_occ_global, qs_env, &
                                   ispin, num_integ_points, jquad, e_fermi, tau, &
-                                  remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=1, &
-                                  symmetrize=.FALSE.)
+                                  remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=1)
 
          CALL compute_periodic_dm(mat_dm_virt_global, qs_env, &
                                   ispin, num_integ_points, jquad, e_fermi, tau, &
-                                  remove_occ=.TRUE., remove_virt=.FALSE., first_jquad=1, &
-                                  symmetrize=.FALSE.)
+                                  remove_occ=.TRUE., remove_virt=.FALSE., first_jquad=1)
 
          num_cells_dm = 1
 
@@ -1131,17 +1127,15 @@ CONTAINS
 !> \param remove_occ ...
 !> \param remove_virt ...
 !> \param first_jquad ...
-!> \param symmetrize ...
 ! **************************************************************************************************
    SUBROUTINE compute_periodic_dm(mat_dm_global, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
-                                  remove_occ, remove_virt, first_jquad, symmetrize)
+                                  remove_occ, remove_virt, first_jquad)
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ispin, num_integ_points, jquad
       REAL(KIND=dp), INTENT(IN)                          :: e_fermi, tau
       LOGICAL, INTENT(IN)                                :: remove_occ, remove_virt
       INTEGER, INTENT(IN)                                :: first_jquad
-      LOGICAL, INTENT(IN)                                :: symmetrize
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_periodic_dm'
 
@@ -1201,15 +1195,7 @@ CONTAINS
       CALL kpoint_density_matrices_rpa(kpoints_G, tau, e_fermi, &
                                        remove_occ=remove_occ, remove_virt=remove_virt)
 
-      SELECT CASE (qs_env%mp2_env%ri_rpa_im_time%periodic_gf)
-      CASE (gw_gf_mic)
-         ! density matrices in real space, the cell vectors T for transforming are taken from kpoints%index_to_cell
-         ! (custom made for RPA) and not from sab_nl (which is symmetric and from SCF)
-         CALL density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env, symmetrize, gamma_only=.FALSE.)
-      CASE (gw_gf_gamma)
-         ! Gamma-only: take Gamma-k-point matrix
-         CALL density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env, symmetrize, gamma_only=.TRUE.)
-      END SELECT
+      CALL density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env)
 
       CALL dbcsr_copy(mat_dm_global(jquad, 1)%matrix, &
                       mat_dm_global_work(ispin, 1)%matrix)
@@ -1225,15 +1211,12 @@ CONTAINS
 !> \param kpoints_G ...
 !> \param mat_dm_global_work ...
 !> \param qs_env ...
-!> \param symmetrize ...
-!> \param gamma_only ...
 ! **************************************************************************************************
-   SUBROUTINE density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env, symmetrize, gamma_only)
+   SUBROUTINE density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env)
 
       TYPE(kpoint_type), POINTER                         :: kpoints_G
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL                                            :: symmetrize, gamma_only
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_from_kp_to_mic'
 
@@ -1245,7 +1228,6 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
       REAL(KIND=dp)                                      :: contribution, weight_im, weight_re
-      REAL(KIND=dp), DIMENSION(2)                        :: abs_cutoffs_chi_W
       REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
@@ -1267,8 +1249,6 @@ CONTAINS
       index_to_cell => kpoints_G%index_to_cell
       num_cells = SIZE(index_to_cell, 2)
 
-      abs_cutoffs_chi_W = qs_env%mp2_env%ri_rpa_im_time%abs_cutoffs_chi_W
-
       nspin = SIZE(mat_dm_global_work, 1)
 
       mo_set => kpoints_G%kp_env(1)%kpoint_env%mos(1, 1)
@@ -1287,8 +1267,6 @@ CONTAINS
       NULLIFY (cell, particle_set)
       CALL get_qs_env(qs_env, cell=cell, particle_set=particle_set)
       CALL get_cell(cell=cell, h=hmat)
-
-      abs_cutoffs_chi_W(1:2) = qs_env%mp2_env%ri_rpa_im_time%abs_cutoffs_chi_W(1:2)
 
       iatom_old = 0
       jatom_old = 0
@@ -1313,8 +1291,7 @@ CONTAINS
 
                      CALL compute_weight_re_im(weight_re, weight_im, &
                                                num_cells, iatom, jatom, xkp(1:3, ik), wkp(ik), &
-                                               cell, index_to_cell, hmat, particle_set, abs_cutoffs_chi_W, &
-                                               symmetrize, gamma_only)
+                                               cell, index_to_cell, hmat, particle_set)
 
                      iatom_old = iatom
                      jatom_old = jatom

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -143,8 +143,10 @@ CONTAINS
 !> \param gd_B_virt_bse ...
 !> \param mo_coeff ...
 !> \param fm_matrix_PQ ...
-!> \param fm_matrix_L_RI_metric ...
-!> \param fm_matrix_Sinv_Vtrunc_Sinv ...
+!> \param fm_matrix_L_kpoints ...
+!> \param fm_matrix_Minv_L_kpoints ...
+!> \param fm_matrix_Minv ...
+!> \param fm_matrix_Minv_Vtrunc_Minv ...
 !> \param kpoints ...
 !> \param Eigenval ...
 !> \param nmo ...
@@ -174,7 +176,8 @@ CONTAINS
    SUBROUTINE rpa_ri_compute_en(qs_env, Erpa, mp2_env, BIb_C, BIb_C_gw, BIb_C_bse_ij, BIb_C_bse_ab, &
                                 para_env, para_env_sub, color_sub, &
                                 gd_array, gd_B_virtual, gd_B_all, gd_B_occ_bse, gd_B_virt_bse, &
-                                mo_coeff, fm_matrix_PQ, fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, kpoints, &
+                                mo_coeff, fm_matrix_PQ, fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+                                fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, kpoints, &
                                 Eigenval, nmo, homo, dimen_RI, dimen_RI_red, gw_corr_lev_occ, gw_corr_lev_virt, &
                                 unit_nr, do_ri_sos_laplace_mp2, my_do_gw, do_im_time, do_bse, matrix_s, &
                                 mat_munu, mat_P_global, &
@@ -197,8 +200,10 @@ CONTAINS
       TYPE(group_dist_d1_type), INTENT(INOUT)            :: gd_B_all, gd_B_occ_bse, gd_B_virt_bse
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_coeff
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_matrix_PQ
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_RI_metric, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, &
+                                                            fm_matrix_Minv_L_kpoints, &
+                                                            fm_matrix_Minv, &
+                                                            fm_matrix_Minv_Vtrunc_Minv
       TYPE(kpoint_type), POINTER                         :: kpoints
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: Eigenval
@@ -619,7 +624,8 @@ CONTAINS
                        my_do_gw, do_bse, gw_corr_lev_occ, gw_corr_lev_virt, &
                        do_minimax_quad, &
                        do_im_time, mo_coeff, &
-                       fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &
+                       fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+                       fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                        mat_munu, mat_P_global, &
                        t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                        starts_array_mc, ends_array_mc, &
@@ -1023,8 +1029,10 @@ CONTAINS
 !> \param do_minimax_quad ...
 !> \param do_im_time ...
 !> \param mo_coeff ...
-!> \param fm_matrix_L_RI_metric ...
-!> \param fm_matrix_Sinv_Vtrunc_Sinv ...
+!> \param fm_matrix_L_kpoints ...
+!> \param fm_matrix_Minv_L_kpoints ...
+!> \param fm_matrix_Minv ...
+!> \param fm_matrix_Minv_Vtrunc_Minv ...
 !> \param mat_munu ...
 !> \param mat_P_global ...
 !> \param t_3c_M ...
@@ -1050,7 +1058,8 @@ CONTAINS
                           fm_mat_S_ij_bse, fm_mat_S_ab_bse, &
                           my_do_gw, do_bse, gw_corr_lev_occ, gw_corr_lev_virt, &
                           do_minimax_quad, do_im_time, mo_coeff, &
-                          fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, &
+                          fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
+                          fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                           mat_munu, mat_P_global, &
                           t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                           starts_array_mc, ends_array_mc, &
@@ -1080,8 +1089,10 @@ CONTAINS
       INTEGER, DIMENSION(:), INTENT(IN)                  :: gw_corr_lev_occ, gw_corr_lev_virt
       LOGICAL, INTENT(IN)                                :: do_minimax_quad, do_im_time
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_coeff
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_RI_metric, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, &
+                                                            fm_matrix_Minv_L_kpoints, &
+                                                            fm_matrix_Minv, &
+                                                            fm_matrix_Minv_Vtrunc_Minv
       TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_munu
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_P_global
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M
@@ -1106,11 +1117,10 @@ CONTAINS
       COMPLEX(KIND=dp), ALLOCATABLE, &
          DIMENSION(:, :, :, :)                           :: vec_Sigma_c_gw
       INTEGER :: count_ev_sc_GW, cut_memory, group_size_P, gw_corr_lev_tot, handle, handle3, i, &
-         ispin, iter_evGW, iter_sc_GW0, j, jquad, max_iter_bse, min_bsize, mm_style, nkp, &
-         nkp_self_energy, nmo, nspins, num_3c_repl, num_cells_dm, num_fit_points, num_Z_vectors, &
-         Pspin, Qspin, size_P
+         ikp_local, ispin, iter_evGW, iter_sc_GW0, j, jquad, max_iter_bse, min_bsize, mm_style, &
+         nkp, nkp_self_energy, nmo, nspins, num_3c_repl, num_cells_dm, num_fit_points, &
+         num_Z_vectors, Pspin, Qspin, size_P
       INTEGER(int_8)                                     :: dbcsr_nflop
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ikp_local
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, prim_blk_sizes, &
@@ -1124,7 +1134,7 @@ CONTAINS
          fermi_level_offset_input, my_flop_rate, omega, omega_max_fit, omega_old, tau, tau_old
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: delta_corr, e_fermi, tau_tj, tau_wj, tj, &
                                                             trace_Qomega, vec_omega_fit_gw, wj, &
-                                                            wkp_V, wkp_W
+                                                            wkp_W
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: vec_W_gw, weights_cos_tf_t_to_w, &
                                                             weights_cos_tf_w_to_t, &
                                                             weights_sin_tf_t_to_w
@@ -1137,10 +1147,9 @@ CONTAINS
          fm_scaled_dm_virt_tau
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_mat_S_gw_work, fm_mat_W, &
                                                             fm_mo_coeff_occ, fm_mo_coeff_virt
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_L, fm_mat_SiVtrSi
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_L_kpoints, fm_mat_Minv_L_kpoints
       TYPE(dbcsr_p_type)                                 :: mat_dm, mat_L, mat_M_P_munu_occ, &
-                                                            mat_M_P_munu_virt, mat_P_global_copy, &
-                                                            mat_SinvVSinv
+                                                            mat_M_P_munu_virt, mat_MinvVMinv
       TYPE(dbcsr_p_type), ALLOCATABLE, &
          DIMENSION(:, :, :)                              :: mat_P_omega
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_berry_im_mo_mo, &
@@ -1213,7 +1222,7 @@ CONTAINS
 
          CALL alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, &
                             num_integ_points, nspins, fm_mat_Q(1), fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                            fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, mat_P_global, &
+                            fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
                             cut_memory, nkp, num_cells_dm, num_3c_repl, &
                             size_P, ikp_local, &
@@ -1222,10 +1231,11 @@ CONTAINS
                             col_blk_size, &
                             do_ic_model, do_kpoints_cubic_RPA, &
                             do_kpoints_from_Gamma, do_ri_Sigma_x, my_open_shell, &
-                            has_mat_P_blocks, wkp_W, wkp_V, &
-                            cfm_mat_Q, fm_mat_L, fm_mat_SiVtrSi, fm_mat_RI_global_work, fm_mat_work, fm_mo_coeff_occ_scaled, &
-                            fm_mo_coeff_virt_scaled, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, mat_P_global_copy, &
-                            mat_SinvVSinv, mat_P_omega, mat_P_omega_kp, mat_work, mo_coeff, &
+                            has_mat_P_blocks, wkp_W, &
+                            cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
+                            fm_mat_RI_global_work, fm_mat_work, fm_mo_coeff_occ_scaled, &
+                            fm_mo_coeff_virt_scaled, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
+                            mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, mat_work, mo_coeff, &
                             fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, homo, nmo)
 
          IF (calc_forces) CALL init_im_time_forces(force_data, fm_matrix_PQ, t_3c_M, unit_nr, mp2_env, qs_env)
@@ -1454,7 +1464,7 @@ CONTAINS
                   DO ispin = 1, SIZE(mat_P_omega, 3)
                      CALL contract_P_omega_with_mat_L(mat_P_omega(jquad, 1, ispin)%matrix, mat_L%matrix, mat_work, &
                                                       eps_filter_im_time, fm_mat_work, dimen_RI, dimen_RI_red, &
-                                                      fm_mat_L(1, 1), fm_mat_Q(ispin))
+                                                      fm_mat_Minv_L_kpoints(1, 1), fm_mat_Q(ispin))
                   END DO
                END IF
 
@@ -1521,11 +1531,13 @@ CONTAINS
 
                IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
                   CALL invert_eps_compute_W_and_Erpa_kp(dimen_RI, num_integ_points, jquad, nkp, count_ev_sc_GW, para_env, &
-                                                        para_env_RPA, Erpa, tau_tj, tj, wj, weights_cos_tf_w_to_t, &
-                                                        wkp_W, wkp_V, do_gw_im_time, do_ri_Sigma_x, do_kpoints_from_Gamma, &
+                                                        Erpa, tau_tj, tj, wj, weights_cos_tf_w_to_t, &
+                                                        wkp_W, do_gw_im_time, do_ri_Sigma_x, do_kpoints_from_Gamma, &
                                                         do_kpoints_cubic_RPA, cfm_mat_W_kp_tau, cfm_mat_Q, ikp_local, &
                                                         mat_P_omega(:, :, 1), mat_P_omega_kp, qs_env, eps_filter_im_time, unit_nr, &
-                                                  kpoints, fm_mat_L, fm_mat_W, fm_mat_RI_global_work, mat_SinvVSinv, fm_mat_SiVtrSi)
+                                                        kpoints, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
+                                                        fm_mat_W, fm_mat_RI_global_work, mat_MinvVMinv, &
+                                                        fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv)
                ELSE
                   CALL compute_Erpa_by_freq_int(dimen_RI_red, trace_Qomega, fm_mat_Q(1), para_env_RPA, Erpa, wj(jquad))
                END IF
@@ -1549,7 +1561,7 @@ CONTAINS
                IF (do_im_time) THEN
                   ! only for molecules
                   IF (.NOT. (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma)) THEN
-                     CALL compute_W_cubic_GW(fm_mat_W, fm_mat_Q(1), fm_mat_work, dimen_RI, fm_mat_L, num_integ_points, &
+                    CALL compute_W_cubic_GW(fm_mat_W, fm_mat_Q(1), fm_mat_work, dimen_RI, fm_mat_Minv_L_kpoints, num_integ_points, &
                                              tj, tau_tj, weights_cos_tf_w_to_t, jquad, omega)
                   END IF
                ELSE
@@ -1640,7 +1652,7 @@ CONTAINS
          IF (do_im_time) THEN
 
             my_flop_rate = REAL(dbcsr_nflop, dp)/(1.0E09_dp*dbcsr_time)
-            IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T73,ES8.2)") &
+            IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(/T3,A,T73,ES8.2)") &
                "PERFORMANCE| DBCSR total number of flops:", REAL(dbcsr_nflop*para_env%num_pe, dp)
             IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T3,A,T66,F15.2)") &
                "PERFORMANCE| DBCSR total execution time:", dbcsr_time
@@ -1657,6 +1669,7 @@ CONTAINS
          ! for low-scaling and ordinary-scaling: analytic continuation from Sigma(iw) -> Sigma(w)
          !                                       and correction of quasiparticle energies e_n^GW
          IF (my_do_gw) THEN
+
             CALL compute_QP_energies(vec_Sigma_c_gw, count_ev_sc_GW, gw_corr_lev_occ, &
                                      gw_corr_lev_tot, gw_corr_lev_virt, homo, &
                                      nmo, num_fit_points, num_integ_points, &
@@ -1669,7 +1682,7 @@ CONTAINS
                                      weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
                                      fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
                                      fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                     mo_coeff(1), fm_mat_W, para_env, para_env_RPA, mat_dm, mat_SinvVSinv, &
+                                     mo_coeff(1), fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
                                      t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, t_3c_O_compressed, t_3c_O_mo_compressed, &
                                      t_3c_O_ind, t_3c_O_mo_ind, &
                                      t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
@@ -1688,13 +1701,13 @@ CONTAINS
 
          IF (my_open_shell) THEN
 
-            CALL calculate_ic_correction(Eigenval(:, 1, 1), mat_SinvVSinv%matrix, &
+            CALL calculate_ic_correction(Eigenval(:, 1, 1), mat_MinvVMinv%matrix, &
                                          t_3c_overl_nnP_ic(1), t_3c_overl_nnP_ic_reflected(1), &
                                          gw_corr_lev_tot, &
                                          gw_corr_lev_occ(1), gw_corr_lev_virt(1), homo(1), unit_nr, &
                                          print_ic_values, para_env, do_alpha=.TRUE.)
 
-            CALL calculate_ic_correction(Eigenval(:, 1, 2), mat_SinvVSinv%matrix, &
+            CALL calculate_ic_correction(Eigenval(:, 1, 2), mat_MinvVMinv%matrix, &
                                          t_3c_overl_nnP_ic(2), t_3c_overl_nnP_ic_reflected(2), &
                                          gw_corr_lev_tot, &
                                          gw_corr_lev_occ(2), gw_corr_lev_virt(2), homo(2), unit_nr, &
@@ -1702,7 +1715,7 @@ CONTAINS
 
          ELSE
 
-            CALL calculate_ic_correction(Eigenval(:, 1, 1), mat_SinvVSinv%matrix, &
+            CALL calculate_ic_correction(Eigenval(:, 1, 1), mat_MinvVMinv%matrix, &
                                          t_3c_overl_nnP_ic(1), t_3c_overl_nnP_ic_reflected(1), &
                                          gw_corr_lev_tot, &
                                          gw_corr_lev_occ(1), gw_corr_lev_virt(1), homo(1), unit_nr, &
@@ -1734,14 +1747,16 @@ CONTAINS
       END IF
 
       IF (do_im_time) THEN
+
          CALL dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, ikp_local, index_to_cell_3c, &
+                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &
-                              wkp_W, wkp_V, cfm_mat_Q, fm_mat_L, fm_mat_SiVtrSi, fm_mat_RI_global_work, fm_mat_work, &
+                              wkp_W, cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
+                              fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, fm_mat_RI_global_work, fm_mat_work, &
                               fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, mat_dm, mat_L, &
-                              mat_SinvVSinv, mat_P_omega, mat_P_omega_kp, &
+                              mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, &
                               t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, mat_work, qs_env)
 
          IF (my_do_gw) THEN
@@ -1750,7 +1765,7 @@ CONTAINS
                                                 t_3c_overl_int_ao_mo, t_3c_O_mo_compressed, t_3c_O_mo_ind, &
                                                 t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
                                                 t_3c_overl_nnP_ic, t_3c_overl_nnP_ic_reflected, &
-                                                mat_W, ikp_local, cfm_mat_W_kp_tau)
+                                                mat_W, cfm_mat_W_kp_tau, qs_env)
          END IF
 
       END IF

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -11,6 +11,7 @@
 !>      06.2019 Moved from rpa_ri_gpw.F [Frederick Stein]
 ! **************************************************************************************************
 MODULE rpa_util
+
    USE cell_types,                      ONLY: cell_type,&
                                               get_cell
    USE cp_blacs_env,                    ONLY: cp_blacs_env_create,&
@@ -84,8 +85,8 @@ CONTAINS
 !> \param fm_mat_Q ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_matrix_L_RI_metric ...
-!> \param fm_matrix_Sinv_Vtrunc_Sinv ...
+!> \param fm_matrix_Minv_L_kpoints ...
+!> \param fm_matrix_L_kpoints ...
 !> \param mat_P_global ...
 !> \param t_3c_O ...
 !> \param matrix_s ...
@@ -107,10 +108,9 @@ CONTAINS
 !> \param my_open_shell ...
 !> \param has_mat_P_blocks ...
 !> \param wkp_W ...
-!> \param wkp_V ...
 !> \param cfm_mat_Q ...
-!> \param fm_mat_L ...
-!> \param fm_mat_SiVtrSi ...
+!> \param fm_mat_Minv_L_kpoints ...
+!> \param fm_mat_L_kpoints ...
 !> \param fm_mat_RI_global_work ...
 !> \param fm_mat_work ...
 !> \param fm_mo_coeff_occ_scaled ...
@@ -119,8 +119,7 @@ CONTAINS
 !> \param mat_L ...
 !> \param mat_M_P_munu_occ ...
 !> \param mat_M_P_munu_virt ...
-!> \param mat_P_global_copy ...
-!> \param mat_SinvVSinv ...
+!> \param mat_MinvVMinv ...
 !> \param mat_P_omega ...
 !> \param mat_P_omega_kp ...
 !> \param mat_work ...
@@ -132,7 +131,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, num_integ_points, nspins, &
                             fm_mat_Q, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                            fm_matrix_L_RI_metric, fm_matrix_Sinv_Vtrunc_Sinv, mat_P_global, &
+                            fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
                             cut_memory, nkp, num_cells_dm, num_3c_repl, &
                             size_P, ikp_local, &
@@ -141,10 +140,11 @@ CONTAINS
                             col_blk_size, &
                             do_ic_model, do_kpoints_cubic_RPA, &
                             do_kpoints_from_Gamma, do_ri_Sigma_x, my_open_shell, &
-                            has_mat_P_blocks, wkp_W, wkp_V, &
-                            cfm_mat_Q, fm_mat_L, fm_mat_SiVtrSi, fm_mat_RI_global_work, fm_mat_work, fm_mo_coeff_occ_scaled, &
-                            fm_mo_coeff_virt_scaled, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, mat_P_global_copy, &
-                            mat_SinvVSinv, mat_P_omega, mat_P_omega_kp, &
+                            has_mat_P_blocks, wkp_W, &
+                            cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
+                            fm_mat_RI_global_work, fm_mat_work, fm_mo_coeff_occ_scaled, &
+                            fm_mo_coeff_virt_scaled, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
+                            mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, &
                             mat_work, mo_coeff, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, homo, nmo)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -153,8 +153,8 @@ CONTAINS
                                                             num_integ_points, nspins
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_mat_Q
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_mo_coeff_occ, fm_mo_coeff_virt
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_RI_metric, &
-                                                            fm_matrix_Sinv_Vtrunc_Sinv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_Minv_L_kpoints, &
+                                                            fm_matrix_L_kpoints
       TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_P_global
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: t_3c_O
@@ -162,8 +162,8 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter_im_time
       INTEGER, INTENT(IN)                                :: cut_memory
-      INTEGER, INTENT(OUT)                               :: nkp, num_cells_dm, num_3c_repl, size_P
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: ikp_local
+      INTEGER, INTENT(OUT)                               :: nkp, num_cells_dm, num_3c_repl, size_P, &
+                                                            ikp_local
       INTEGER, ALLOCATABLE, DIMENSION(:, :), INTENT(OUT) :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(OUT)                                     :: cell_to_index_3c
@@ -174,15 +174,14 @@ CONTAINS
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :), &
          INTENT(OUT)                                     :: has_mat_P_blocks
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(OUT)                                     :: wkp_W, wkp_V
+         INTENT(OUT)                                     :: wkp_W
       TYPE(cp_cfm_type), INTENT(OUT)                     :: cfm_mat_Q
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_L, fm_mat_SiVtrSi
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_Minv_L_kpoints, fm_mat_L_kpoints
       TYPE(cp_fm_type), INTENT(OUT)                      :: fm_mat_RI_global_work, fm_mat_work, &
                                                             fm_mo_coeff_occ_scaled, &
                                                             fm_mo_coeff_virt_scaled
       TYPE(dbcsr_p_type), INTENT(OUT)                    :: mat_dm, mat_L, mat_M_P_munu_occ, &
-                                                            mat_M_P_munu_virt, mat_P_global_copy, &
-                                                            mat_SinvVSinv
+                                                            mat_M_P_munu_virt, mat_MinvVMinv
       TYPE(dbcsr_p_type), ALLOCATABLE, &
          DIMENSION(:, :, :)                              :: mat_P_omega
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
@@ -199,6 +198,7 @@ CONTAINS
                                                             handle, i_dim, i_kp, ispin, jquad, &
                                                             nspins_P_omega, periodic(3)
       INTEGER, DIMENSION(:), POINTER                     :: row_blk_size
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: wkp_V
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct, fm_struct_sub_kp
 
@@ -244,8 +244,7 @@ CONTAINS
 
       IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
 
-         CALL get_sub_para_kp(fm_struct_sub_kp, para_env, kpoints%nkp, &
-                              dimen_RI, ikp_local, first_ikp_local)
+         CALL get_sub_para_kp(fm_struct_sub_kp, para_env, dimen_RI, ikp_local, first_ikp_local)
 
          CALL cp_cfm_create(cfm_mat_Q, fm_struct_sub_kp)
          CALL cp_cfm_set_all(cfm_mat_Q, z_zero)
@@ -265,6 +264,7 @@ CONTAINS
          ! compute k-point weights such that functions 1/k^2, 1/k and const function are
          ! integrated correctly
          CALL compute_wkp_W(qs_env, wkp_W, wkp_V, kpoints, cell%h_inv, periodic)
+         DEALLOCATE (wkp_V)
 
       ELSE
          nkp = 1
@@ -307,8 +307,8 @@ CONTAINS
       CALL cp_fm_set_all(matrix=fm_mo_coeff_virt_scaled, alpha=0.0_dp)
 
       IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
-         CALL cp_fm_create(fm_mat_RI_global_work, fm_matrix_L_RI_metric(1, 1)%matrix_struct)
-         CALL cp_fm_to_fm(fm_matrix_L_RI_metric(1, 1), fm_mat_RI_global_work)
+         CALL cp_fm_create(fm_mat_RI_global_work, fm_matrix_Minv_L_kpoints(1, 1)%matrix_struct)
+         CALL cp_fm_to_fm(fm_matrix_Minv_L_kpoints(1, 1), fm_mat_RI_global_work)
          CALL cp_fm_set_all(fm_mat_RI_global_work, 0.0_dp)
       END IF
 
@@ -316,16 +316,18 @@ CONTAINS
       has_mat_P_blocks = .TRUE.
 
       IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
-         CALL reorder_mat_L(fm_mat_L, fm_matrix_L_RI_metric, fm_mat_Q%matrix_struct, para_env, mat_L, &
-                            mat_P_global%matrix, dimen_RI, dimen_RI_red, first_ikp_local, .FALSE., ikp_local, fm_struct_sub_kp)
+         CALL reorder_mat_L(fm_mat_Minv_L_kpoints, fm_matrix_Minv_L_kpoints, fm_mat_Q%matrix_struct, para_env, mat_L, &
+                            mat_P_global%matrix, dimen_RI, dimen_RI_red, first_ikp_local, ikp_local, fm_struct_sub_kp, &
+                            allocate_mat_L=.FALSE.)
 
-         CALL reorder_mat_L(fm_mat_SiVtrSi, fm_matrix_Sinv_Vtrunc_Sinv, fm_mat_Q%matrix_struct, para_env, mat_L, &
-                            mat_P_global%matrix, dimen_RI, dimen_RI_red, first_ikp_local, .TRUE., ikp_local, fm_struct_sub_kp)
+         CALL reorder_mat_L(fm_mat_L_kpoints, fm_matrix_L_kpoints, fm_mat_Q%matrix_struct, para_env, mat_L, &
+                            mat_P_global%matrix, dimen_RI, dimen_RI_red, first_ikp_local, ikp_local, fm_struct_sub_kp)
 
          CALL cp_fm_struct_release(fm_struct_sub_kp)
+
       ELSE
-         CALL reorder_mat_L(fm_mat_L, fm_matrix_L_RI_metric, fm_mat_Q%matrix_struct, para_env, mat_L, &
-                            mat_P_global%matrix, dimen_RI, dimen_RI_red, first_ikp_local, .TRUE.)
+         CALL reorder_mat_L(fm_mat_Minv_L_kpoints, fm_matrix_Minv_L_kpoints, fm_mat_Q%matrix_struct, para_env, mat_L, &
+                            mat_P_global%matrix, dimen_RI, dimen_RI_red, first_ikp_local)
       END IF
 
       ! Create Scalapack working matrix for the contraction with the metric
@@ -358,17 +360,17 @@ CONTAINS
 
       IF (do_ri_Sigma_x .OR. do_ic_model) THEN
 
-         NULLIFY (mat_SinvVSinv%matrix)
-         ALLOCATE (mat_SinvVSinv%matrix)
-         CALL dbcsr_create(mat_SinvVSinv%matrix, template=mat_P_global%matrix)
-         CALL dbcsr_set(mat_SinvVSinv%matrix, 0.0_dp)
+         NULLIFY (mat_MinvVMinv%matrix)
+         ALLOCATE (mat_MinvVMinv%matrix)
+         CALL dbcsr_create(mat_MinvVMinv%matrix, template=mat_P_global%matrix)
+         CALL dbcsr_set(mat_MinvVMinv%matrix, 0.0_dp)
 
          ! for kpoints we compute SinvVSinv later with kpoints
          IF (.NOT. do_kpoints_from_Gamma) THEN
 
             !  get the Coulomb matrix for Sigma_x = G*V
             CALL dbcsr_multiply("T", "N", 1.0_dp, mat_L%matrix, mat_L%matrix, &
-                                0.0_dp, mat_SinvVSinv%matrix, filter_eps=eps_filter_im_time)
+                                0.0_dp, mat_MinvVMinv%matrix, filter_eps=eps_filter_im_time)
 
          END IF
 
@@ -469,7 +471,7 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param fm_mat_L ...
-!> \param fm_matrix_L_RI_metric ...
+!> \param fm_matrix_Minv_L_kpoints ...
 !> \param fm_struct_template ...
 !> \param para_env ...
 !> \param mat_L ...
@@ -477,27 +479,27 @@ CONTAINS
 !> \param dimen_RI ...
 !> \param dimen_RI_red ...
 !> \param first_ikp_local ...
-!> \param allocate_dbcsr_L ...
 !> \param ikp_local ...
 !> \param fm_struct_sub_kp ...
+!> \param allocate_mat_L ...
 ! **************************************************************************************************
-   SUBROUTINE reorder_mat_L(fm_mat_L, fm_matrix_L_RI_metric, fm_struct_template, para_env, mat_L, mat_template, &
-                            dimen_RI, dimen_RI_red, first_ikp_local, allocate_dbcsr_L, ikp_local, fm_struct_sub_kp)
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_L, fm_matrix_L_RI_metric
+   SUBROUTINE reorder_mat_L(fm_mat_L, fm_matrix_Minv_L_kpoints, fm_struct_template, para_env, mat_L, mat_template, &
+                            dimen_RI, dimen_RI_red, first_ikp_local, ikp_local, fm_struct_sub_kp, allocate_mat_L)
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_L, fm_matrix_Minv_L_kpoints
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_template
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), INTENT(OUT)                    :: mat_L
       TYPE(dbcsr_type), INTENT(IN)                       :: mat_template
       INTEGER, INTENT(IN)                                :: dimen_RI, dimen_RI_red, first_ikp_local
-      LOGICAL                                            :: allocate_dbcsr_L
-      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: ikp_local
+      INTEGER, OPTIONAL                                  :: ikp_local
       TYPE(cp_fm_struct_type), OPTIONAL, POINTER         :: fm_struct_sub_kp
+      LOGICAL, INTENT(IN), OPTIONAL                      :: allocate_mat_L
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'reorder_mat_L'
 
-      INTEGER                                            :: handle, i_size, j_size, nblk
+      INTEGER                                            :: handle, ikp, j_size, nblk
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, row_blk_size
-      LOGICAL                                            :: do_kpoints
+      LOGICAL                                            :: do_kpoints, my_allocate_mat_L
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_mat_L_transposed, fmdummy
@@ -519,17 +521,17 @@ CONTAINS
       END IF
 
       ! Start to allocate the new full matrix
-      ALLOCATE (fm_mat_L(SIZE(fm_matrix_L_RI_metric, 1), SIZE(fm_matrix_L_RI_metric, 2)))
-      DO i_size = 1, SIZE(fm_matrix_L_RI_metric, 1)
-         DO j_size = 1, SIZE(fm_matrix_L_RI_metric, 2)
+      ALLOCATE (fm_mat_L(SIZE(fm_matrix_Minv_L_kpoints, 1), SIZE(fm_matrix_Minv_L_kpoints, 2)))
+      DO ikp = 1, SIZE(fm_matrix_Minv_L_kpoints, 1)
+         DO j_size = 1, SIZE(fm_matrix_Minv_L_kpoints, 2)
             IF (do_kpoints) THEN
-               IF (ANY(ikp_local(:) == i_size)) THEN
-                  CALL cp_fm_create(fm_mat_L(i_size, j_size), fm_struct_sub_kp)
-                  CALL cp_fm_set_all(fm_mat_L(i_size, j_size), 0.0_dp)
+               IF (ikp == first_ikp_local .OR. ikp_local == -1) THEN
+                  CALL cp_fm_create(fm_mat_L(ikp, j_size), fm_struct_sub_kp)
+                  CALL cp_fm_set_all(fm_mat_L(ikp, j_size), 0.0_dp)
                END IF
             ELSE
-               CALL cp_fm_create(fm_mat_L(i_size, j_size), fm_struct)
-               CALL cp_fm_set_all(fm_mat_L(i_size, j_size), 0.0_dp)
+               CALL cp_fm_create(fm_mat_L(ikp, j_size), fm_struct)
+               CALL cp_fm_set_all(fm_mat_L(ikp, j_size), 0.0_dp)
             END IF
          END DO
       END DO
@@ -557,34 +559,36 @@ CONTAINS
       ! For k-points copy matrices of your group
       ! Without kpoints, transpose matrix
       ! without kpoints, the size of fm_mat_L is 1x1. with kpoints, the size is N_kpoints x 2 (2 for real/complex)
-      DO i_size = 1, SIZE(fm_matrix_L_RI_metric, 1)
-      DO j_size = 1, SIZE(fm_matrix_L_RI_metric, 2)
+      DO ikp = 1, SIZE(fm_matrix_Minv_L_kpoints, 1)
+      DO j_size = 1, SIZE(fm_matrix_Minv_L_kpoints, 2)
          IF (do_kpoints) THEN
-            IF (ANY(ikp_local(:) == i_size)) THEN
-               CALL cp_fm_copy_general(fm_matrix_L_RI_metric(i_size, j_size), fm_mat_L_transposed, para_env)
-               CALL cp_fm_to_fm(fm_mat_L_transposed, fm_mat_L(i_size, j_size))
+            IF (ikp_local == ikp .OR. ikp_local == -1) THEN
+               CALL cp_fm_copy_general(fm_matrix_Minv_L_kpoints(ikp, j_size), fm_mat_L_transposed, para_env)
+               CALL cp_fm_to_fm(fm_mat_L_transposed, fm_mat_L(ikp, j_size))
             ELSE
-               CALL cp_fm_copy_general(fm_matrix_L_RI_metric(i_size, j_size), fmdummy, para_env)
+               CALL cp_fm_copy_general(fm_matrix_Minv_L_kpoints(ikp, j_size), fmdummy, para_env)
             END IF
          ELSE
-            CALL cp_fm_copy_general(fm_matrix_L_RI_metric(i_size, j_size), fm_mat_L_transposed, blacs_env%para_env)
-            CALL cp_fm_transpose(fm_mat_L_transposed, fm_mat_L(i_size, j_size))
+            CALL cp_fm_copy_general(fm_matrix_Minv_L_kpoints(ikp, j_size), fm_mat_L_transposed, blacs_env%para_env)
+            CALL cp_fm_transpose(fm_mat_L_transposed, fm_mat_L(ikp, j_size))
          END IF
       END DO
       END DO
 
       ! Release old matrix
-      DO i_size = 1, SIZE(fm_matrix_L_RI_metric, 1)
-      DO j_size = 1, SIZE(fm_matrix_L_RI_metric, 2)
-         CALL cp_fm_release(fm_matrix_L_RI_metric(i_size, j_size))
+      DO ikp = 1, SIZE(fm_matrix_Minv_L_kpoints, 1)
+      DO j_size = 1, SIZE(fm_matrix_Minv_L_kpoints, 2)
+         CALL cp_fm_release(fm_matrix_Minv_L_kpoints(ikp, j_size))
       END DO
       END DO
-      DEALLOCATE (fm_matrix_L_RI_metric)
+      DEALLOCATE (fm_matrix_Minv_L_kpoints)
       ! Release buffer
       CALL cp_fm_release(fm_mat_L_transposed)
 
-      IF (allocate_dbcsr_L) THEN
+      my_allocate_mat_L = .TRUE.
+      IF (PRESENT(allocate_mat_L)) my_allocate_mat_L = allocate_mat_L
 
+      IF (my_allocate_mat_L) THEN
          ! Create sparse variant of L
          NULLIFY (mat_L%matrix)
          ALLOCATE (mat_L%matrix)
@@ -599,10 +603,11 @@ CONTAINS
 
             DEALLOCATE (row_blk_size)
          END IF
-      END IF
 
-      IF (.NOT. (do_kpoints)) THEN
-         CALL copy_fm_to_dbcsr(fm_mat_L(1, 1), mat_L%matrix)
+         IF (.NOT. (do_kpoints)) THEN
+            CALL copy_fm_to_dbcsr(fm_mat_L(1, 1), mat_L%matrix)
+         END IF
+
       END IF
 
       CALL timestop(handle)
@@ -1001,52 +1006,68 @@ CONTAINS
 !> \brief ...
 !> \param fm_struct_sub_kp ...
 !> \param para_env ...
-!> \param nkp ...
 !> \param dimen_RI ...
 !> \param ikp_local ...
 !> \param first_ikp_local ...
 ! **************************************************************************************************
-   SUBROUTINE get_sub_para_kp(fm_struct_sub_kp, para_env, nkp, dimen_RI, &
+   SUBROUTINE get_sub_para_kp(fm_struct_sub_kp, para_env, dimen_RI, &
                               ikp_local, first_ikp_local)
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_sub_kp
       TYPE(cp_para_env_type), POINTER                    :: para_env
-      INTEGER, INTENT(IN)                                :: nkp, dimen_RI
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: ikp_local
-      INTEGER, INTENT(OUT)                               :: first_ikp_local
+      INTEGER, INTENT(IN)                                :: dimen_RI
+      INTEGER, INTENT(OUT)                               :: ikp_local, first_ikp_local
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'get_sub_para_kp'
 
-      INTEGER                                            :: color_sub_kp, handle, ikp, &
-                                                            num_proc_per_kp
+      INTEGER                                            :: color_sub_kp, handle, num_proc_per_kp
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_sub_kp
       TYPE(cp_para_env_type), POINTER                    :: para_env_sub_kp
 
       CALL timeset(routineN, handle)
 
-      ! we use all processors for every k-point, a subgroup does not improve the
-      ! performance substantially
+      ! we use all processors for every k-point, subgroups for cp_cfm_heevd only seems to work for
+      ! very small subgroups with 1, 2, or 3 MPI ranks. For more MPI-ranks, eigenvalues and
+      ! eigenvectors coming out of cp_cfm_heevd are totally wrong unfortunately.
       num_proc_per_kp = para_env%num_pe
 
-      color_sub_kp = MOD(para_env%mepos/num_proc_per_kp, nkp)
+      ! IF(nkp > para_env%num_pe) THEN
+      !   num_proc_per_kp = para_env%num_pe
+      ! ELSE
+      !   num_proc_per_kp = para_env%num_pe/nkp
+      ! END IF
+
+      color_sub_kp = para_env%mepos/num_proc_per_kp
       CALL cp_para_env_split(para_env_sub_kp, para_env, color_sub_kp)
 
+      ! grid_2d(1) = 1
+      ! grid_2d(2) = para_env_sub_kp%num_pe
+
       NULLIFY (blacs_env_sub_kp)
+      ! CALL cp_blacs_env_create(blacs_env=blacs_env_sub_kp, para_env=para_env_sub_kp, grid_2d=grid_2d)
       CALL cp_blacs_env_create(blacs_env=blacs_env_sub_kp, para_env=para_env_sub_kp)
 
       NULLIFY (fm_struct_sub_kp)
       CALL cp_fm_struct_create(fm_struct_sub_kp, context=blacs_env_sub_kp, nrow_global=dimen_RI, &
                                ncol_global=dimen_RI, para_env=para_env_sub_kp)
 
-      CALL cp_para_env_release(para_env_sub_kp)
-
       CALL cp_blacs_env_release(blacs_env_sub_kp)
 
-      ALLOCATE (ikp_local(nkp))
-      ikp_local = 0
+      ! IF(nkp > para_env%num_pe) THEN
+      ! every processor has all ikp's
+      ikp_local = -1
       first_ikp_local = 1
-      DO ikp = 1, nkp
-         ikp_local(ikp) = ikp
-      END DO
+      ! ELSE
+      !    ikp_local = 0
+      !    first_ikp_local = 1
+      !    DO ikp = 1, nkp
+      !      IF(MOD(ikp-1, para_env%num_pe/num_proc_per_kp) == color_sub_kp) THEN
+      !        ikp_local = ikp
+      !        first_ikp_local = ikp
+      !      END IF
+      !    END DO
+      ! END IF
+
+      CALL cp_para_env_release(para_env_sub_kp)
 
       CALL timestop(handle)
 
@@ -1058,7 +1079,6 @@ CONTAINS
 !> \param fm_mo_coeff_virt ...
 !> \param fm_scaled_dm_occ_tau ...
 !> \param fm_scaled_dm_virt_tau ...
-!> \param ikp_local ...
 !> \param index_to_cell_3c ...
 !> \param cell_to_index_3c ...
 !> \param do_ic_model ...
@@ -1067,17 +1087,18 @@ CONTAINS
 !> \param do_ri_Sigma_x ...
 !> \param has_mat_P_blocks ...
 !> \param wkp_W ...
-!> \param wkp_V ...
 !> \param cfm_mat_Q ...
-!> \param fm_mat_L ...
-!> \param fm_mat_SiVtrSi ...
+!> \param fm_mat_Minv_L_kpoints ...
+!> \param fm_mat_L_kpoints ...
+!> \param fm_matrix_Minv ...
+!> \param fm_matrix_Minv_Vtrunc_Minv ...
 !> \param fm_mat_RI_global_work ...
 !> \param fm_mat_work ...
 !> \param fm_mo_coeff_occ_scaled ...
 !> \param fm_mo_coeff_virt_scaled ...
 !> \param mat_dm ...
 !> \param mat_L ...
-!> \param mat_SinvVSinv ...
+!> \param mat_MinvVMinv ...
 !> \param mat_P_omega ...
 !> \param mat_P_omega_kp ...
 !> \param t_3c_M ...
@@ -1088,21 +1109,21 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, ikp_local, index_to_cell_3c, &
+                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &
-                              wkp_W, wkp_V, cfm_mat_Q, fm_mat_L, fm_mat_SiVtrSi, &
+                              wkp_W, cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
+                              fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                               fm_mat_RI_global_work, fm_mat_work, &
                               fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, mat_dm, mat_L, &
-                              mat_SinvVSinv, mat_P_omega, mat_P_omega_kp, &
+                              mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, &
                               t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                               mat_work, qs_env)
 
       TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: fm_mo_coeff_occ, fm_mo_coeff_virt
       TYPE(cp_fm_type), INTENT(INOUT)                    :: fm_scaled_dm_occ_tau, &
                                                             fm_scaled_dm_virt_tau
-      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: ikp_local
       INTEGER, ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
@@ -1112,13 +1133,15 @@ CONTAINS
       LOGICAL, ALLOCATABLE, DIMENSION(:, :, :, :, :), &
          INTENT(INOUT)                                   :: has_mat_P_blocks
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
-         INTENT(INOUT)                                   :: wkp_W, wkp_V
+         INTENT(INOUT)                                   :: wkp_W
       TYPE(cp_cfm_type), INTENT(INOUT)                   :: cfm_mat_Q
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_L, fm_mat_SiVtrSi
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
+                                                            fm_matrix_Minv, &
+                                                            fm_matrix_Minv_Vtrunc_Minv
       TYPE(cp_fm_type), INTENT(INOUT)                    :: fm_mat_RI_global_work, fm_mat_work, &
                                                             fm_mo_coeff_occ_scaled, &
                                                             fm_mo_coeff_virt_scaled
-      TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_dm, mat_L, mat_SinvVSinv
+      TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_dm, mat_L, mat_MinvVMinv
       TYPE(dbcsr_p_type), ALLOCATABLE, &
          DIMENSION(:, :, :), INTENT(INOUT)               :: mat_P_omega
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
@@ -1151,20 +1174,31 @@ CONTAINS
       CALL cp_fm_release(fm_mo_coeff_occ_scaled)
       CALL cp_fm_release(fm_mo_coeff_virt_scaled)
 
-      DO i_size = 1, SIZE(fm_mat_L, 1)
-         DO j_size = 1, SIZE(fm_mat_L, 2)
-            IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
-               IF (ANY(ikp_local(:) == i_size)) THEN
-                  CALL cp_fm_release(fm_mat_L(i_size, j_size))
-                  CALL cp_fm_release(fm_mat_SiVtrSi(i_size, j_size))
-               END IF
-            ELSE
-               CALL cp_fm_release(fm_mat_L(i_size, j_size))
-            END IF
+      IF (ALLOCATED(fm_mat_Minv_L_kpoints)) THEN
+         DO i_size = 1, SIZE(fm_mat_Minv_L_kpoints, 1)
+            DO j_size = 1, SIZE(fm_mat_Minv_L_kpoints, 2)
+               CALL cp_fm_release(fm_mat_Minv_L_kpoints(i_size, j_size))
+            END DO
          END DO
-      END DO
-      DEALLOCATE (fm_mat_L)
-      IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) DEALLOCATE (fm_mat_SiVtrSi)
+         DEALLOCATE (fm_mat_Minv_L_kpoints)
+      END IF
+
+      IF (ALLOCATED(fm_mat_L_kpoints)) THEN
+         DO i_size = 1, SIZE(fm_mat_Minv_L_kpoints, 1)
+            DO j_size = 1, SIZE(fm_mat_Minv_L_kpoints, 2)
+               CALL cp_fm_release(fm_mat_L_kpoints(i_size, j_size))
+            END DO
+         END DO
+         DEALLOCATE (fm_mat_L_kpoints)
+      END IF
+
+      IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
+         CALL cp_fm_release(fm_matrix_Minv_Vtrunc_Minv(1, 1))
+         DEALLOCATE (fm_matrix_Minv_Vtrunc_Minv)
+         CALL cp_fm_release(fm_matrix_Minv(1, 1))
+         DEALLOCATE (fm_matrix_Minv)
+      END IF
+
       CALL cp_fm_release(fm_mat_work)
 
       IF (.NOT. (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma)) THEN
@@ -1173,11 +1207,11 @@ CONTAINS
       END IF
 
       CALL dbcsr_release(mat_L%matrix)
-
       DEALLOCATE (mat_L%matrix)
+
       IF (do_ri_Sigma_x .OR. do_ic_model) THEN
-         CALL dbcsr_release(mat_SinvVSinv%matrix)
-         DEALLOCATE (mat_SinvVSinv%matrix)
+         CALL dbcsr_release(mat_MinvVMinv%matrix)
+         DEALLOCATE (mat_MinvVMinv%matrix)
       END IF
       IF (do_ri_Sigma_x) THEN
          CALL dbcsr_release(mat_dm%matrix)
@@ -1186,14 +1220,16 @@ CONTAINS
 
       DEALLOCATE (index_to_cell_3c, cell_to_index_3c)
 
-      DO ispin = 1, SIZE(mat_P_omega, 3)
-         DO i_kp = 1, SIZE(mat_P_omega, 2)
-            DO jquad = 1, SIZE(mat_P_omega, 1)
-               CALL dbcsr_deallocate_matrix(mat_P_omega(jquad, i_kp, ispin)%matrix)
+      IF (ALLOCATED(mat_P_omega)) THEN
+         DO ispin = 1, SIZE(mat_P_omega, 3)
+            DO i_kp = 1, SIZE(mat_P_omega, 2)
+               DO jquad = 1, SIZE(mat_P_omega, 1)
+                  CALL dbcsr_deallocate_matrix(mat_P_omega(jquad, i_kp, ispin)%matrix)
+               END DO
             END DO
          END DO
-      END DO
-      DEALLOCATE (mat_P_omega)
+         DEALLOCATE (mat_P_omega)
+      END IF
 
       DO i_size = 1, SIZE(t_3c_O, 1)
          DO j_size = 1, SIZE(t_3c_O, 2)
@@ -1211,7 +1247,6 @@ CONTAINS
          CALL cp_fm_release(fm_mat_RI_global_work)
          CALL dbcsr_deallocate_matrix_set(mat_P_omega_kp)
          DEALLOCATE (wkp_W)
-         DEALLOCATE (wkp_V)
       END IF
 
       cut_memory = SIZE(t_3c_O_compressed, 3)

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -1184,8 +1184,8 @@ CONTAINS
       END IF
 
       IF (ALLOCATED(fm_mat_L_kpoints)) THEN
-         DO i_size = 1, SIZE(fm_mat_Minv_L_kpoints, 1)
-            DO j_size = 1, SIZE(fm_mat_Minv_L_kpoints, 2)
+         DO i_size = 1, SIZE(fm_mat_L_kpoints, 1)
+            DO j_size = 1, SIZE(fm_mat_L_kpoints, 2)
                CALL cp_fm_release(fm_mat_L_kpoints(i_size, j_size))
             END DO
          END DO

--- a/tests/QS/regtest-gw-kpoints/G0W0_kpoints_in_self_energy_RI_trunc_Coulomb_metric.inp
+++ b/tests/QS/regtest-gw-kpoints/G0W0_kpoints_in_self_energy_RI_trunc_Coulomb_metric.inp
@@ -1,0 +1,89 @@
+&GLOBAL
+  PROJECT  G0W0_kpoints_from_Gamma
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+  &TIMINGS
+     THRESHOLD 0.01
+  &END
+&END GLOBAL
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME  HFX_BASIS
+    SORT_BASIS EXP
+    POTENTIAL_FILE_NAME  GTH_POTENTIALS
+    &MGRID
+      CUTOFF  100
+      REL_CUTOFF  20
+    &END MGRID
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-15
+      EPS_PGF_ORB 1.0E-15
+    &END QS
+    &SCF
+      SCF_GUESS ATOMIC
+      EPS_SCF 1.0E-5
+      MAX_SCF 100
+      ADDED_MOS -1
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+      &WF_CORRELATION
+        &INTEGRALS
+          SIZE_LATTICE_SUM 3
+        &END INTEGRALS
+        &LOW_SCALING
+          KPOINTS 1 4 4
+          REGULARIZATION_RI 1.0E-3
+        &END LOW_SCALING
+        &RI
+          &RI_METRIC
+            POTENTIAL_TYPE TRUNCATED
+            CUTOFF_RADIUS  2.0
+          &END RI_METRIC
+        &END RI
+        &RI_RPA
+          RPA_NUM_QUAD_POINTS  6
+          &GW
+           CORR_OCC   1
+           CORR_VIRT  1
+           RI_SIGMA_X
+           KPOINTS_SELF_ENERGY 2 2 1
+           &KPOINT_SET
+             SPECIAL_POINT  0.5   0.0   0.0
+             SPECIAL_POINT  0.0   0.0   0.0
+             NPOINTS 3
+           &END
+          &END GW
+        &END RI_RPA
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom]  8.000   8.000  8.000
+      MULTIPLE_UNIT_CELL  1 1 1
+      PERIODIC YZ
+    &END CELL
+    &KIND H
+      BASIS_SET ORB        DZVP-GTH
+      BASIS_SET RI_AUX RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET ORB        DZVP-GTH
+      BASIS_SET RI_AUX RI_DZVP-GTH
+      POTENTIAL        GTH-PBE-q6
+    &END KIND
+    &TOPOLOGY
+      MULTIPLE_UNIT_CELL  1 1 1
+    &END TOPOLOGY
+    &COORD
+      H  0.0 -0.5 -4.5
+      O  0.5  0.0  4.5
+      H  0.0  0.5 -4.5
+    &END COORD
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-gw-kpoints/TEST_FILES
+++ b/tests/QS/regtest-gw-kpoints/TEST_FILES
@@ -1,7 +1,8 @@
 G0W0_kpoints_from_Gamma.inp                                       78      1e-05       15.316
-G0W0_kpoints_from_Gamma_RI_regularization_1E-3.inp                78      1e-05       15.231
-G0W0_kpoints_in_self_energy.inp                                   98      1e-05       12.586
-G0W0_kpoints_in_self_energy_at_HSE06.inp                          98      1e-05       13.097
+G0W0_kpoints_from_Gamma_RI_regularization_1E-3.inp                78      1e-05       15.216
+G0W0_kpoints_in_self_energy.inp                                   98      1e-05       12.562
+G0W0_kpoints_in_self_energy_at_HSE06.inp                          98      1e-05       13.073
+G0W0_kpoints_in_self_energy_RI_trunc_Coulomb_metric.inp           98      1e-05       12.869
 G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX.inp       98      1e-05       15.414
 G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX_ADMM.inp  98      1e-05       15.491
 #EOF


### PR DESCRIPTION
- RI with truncated Coulomb metric: much improved convergence with RI basis set size
- memory consumption of periodic GW is now reasonable, similar to Gamma-only low-scaling RPA