### PR TITLE
Reduce optimisation level for paw_basis_types.F

### DIFF
--- a/arch/Linux-intel-x86_64.psmp
+++ b/arch/Linux-intel-x86_64.psmp
@@ -13,7 +13,7 @@
 #        Optionally, the Intel compiler version can be specified as argument.
 #        Replace or adapt the "module add" commands below if needed.
 #
-# Author: Matthias Krack (12.01.2023)
+# Author: Matthias Krack (17.01.2023)
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -323,5 +323,8 @@ LIBS           += -lz -lstdc++
 # Required due to memory leak that occurs if high optimisations are used
 mp2_optimize_ri_basis.o: mp2_optimize_ri_basis.F
 	$(FC) -c $(subst O2,O0,$(FCFLAGS)) $<
+# Required due to SEGFAULTS occurring for higher optimisation levels
+paw_basis_types.o: paw_basis_types.F
+	$(FC) -c $(subst O2,O1,$(FCFLAGS)) $<
 
 # End


### PR DESCRIPTION
It seems that segfaults occur using the Intel compiler if paw_basis_types.F is compiled with an optimisation level higher than -O1.