### PR TITLE
New Keyword: MIN_PAIR_LIST_RADIUS can be used to force non-zero blocks

### DIFF
--- a/src/cp_control_types.F
+++ b/src/cp_control_types.F
@@ -330,6 +330,7 @@ MODULE cp_control_types
       INTEGER                              :: wf_interpolation_method_nr
       INTEGER                              :: wf_extrapolation_order
       INTEGER                              :: periodicity
+      REAL(KIND=dp)                        :: pairlist_radius
       REAL(KIND=dp)                        :: cutoff
       REAL(KIND=dp), DIMENSION(:), POINTER :: e_cutoff
       TYPE(mulliken_restraint_type), &

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -754,6 +754,8 @@ CONTAINS
       CALL section_vals_val_get(qs_section, "FORCE_PAW", l_val=qs_control%gapw_control%force_paw)
       CALL section_vals_val_get(qs_section, "MAX_RAD_LOCAL", r_val=qs_control%gapw_control%max_rad_local)
 
+      CALL section_vals_val_get(qs_section, "MIN_PAIR_LIST_RADIUS", r_val=qs_control%pairlist_radius)
+
       CALL section_vals_val_get(qs_section, "LS_SCF", l_val=qs_control%do_ls_scf)
       CALL section_vals_val_get(qs_section, "ALMO_SCF", l_val=qs_control%do_almo_scf)
       CALL section_vals_val_get(qs_section, "KG_METHOD", l_val=qs_control%do_kg)

--- a/src/hfx_admm_utils.F
+++ b/src/hfx_admm_utils.F
@@ -26,9 +26,11 @@ MODULE hfx_admm_utils
    USE basis_set_types,                 ONLY: copy_gto_basis_set,&
                                               get_gto_basis_set,&
                                               gto_basis_set_type
-   USE cell_types,                      ONLY: cell_type
+   USE cell_types,                      ONLY: cell_type,&
+                                              plane_distance
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
+   USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: cp_dbcsr_m_by_n_from_row_template,&
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
@@ -390,7 +392,7 @@ CONTAINS
       INTEGER                                            :: handle, ikind, nkind
       LOGICAL                                            :: mic, molecule_only
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: aux_fit_present, orb_present
-      REAL(dp)                                           :: subcells
+      REAL(dp)                                           :: pdist, subcells
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: aux_fit_radius, orb_radius
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -431,6 +433,8 @@ CONTAINS
          mic = .TRUE.
       END IF
 
+      pdist = dft_control%qs_control%pairlist_radius
+
       CALL section_vals_val_get(qs_env%input, "DFT%SUBCELLS", r_val=subcells)
       neighbor_list_section => section_vals_get_subs_vals(qs_env%input, "DFT%PRINT%NEIGHBOR_LISTS")
 
@@ -456,7 +460,12 @@ CONTAINS
          END IF
       END DO
 
-      CALL pair_radius_setup(aux_fit_present, aux_fit_present, aux_fit_radius, aux_fit_radius, pair_radius)
+      IF (pdist < 0.0_dp) THEN
+         pdist = MAX(plane_distance(1, 0, 0, cell), &
+                     plane_distance(0, 1, 0, cell), &
+                     plane_distance(0, 0, 1, cell))
+      END IF
+      CALL pair_radius_setup(aux_fit_present, aux_fit_present, aux_fit_radius, aux_fit_radius, pair_radius, pdist)
       CALL build_neighbor_lists(admm_env%sab_aux_fit, particle_set, atom2d, cell, pair_radius, &
                                 mic=mic, molecular=molecule_only, subcells=subcells, nlname="sab_aux_fit")
       CALL build_neighbor_lists(admm_env%sab_aux_fit_asymm, particle_set, atom2d, cell, pair_radius, &
@@ -671,7 +680,7 @@ CONTAINS
          ALLOCATE (admm_env%matrix_ks_aux_fit(ispin)%matrix)
          CALL dbcsr_create(admm_env%matrix_ks_aux_fit(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
                            name="KOHN-SHAM_MATRIX for ADMM")
-         CALL dbcsr_copy(admm_env%matrix_ks_aux_fit(ispin)%matrix, matrix_s_aux_fit(1)%matrix)
+         CALL cp_dbcsr_alloc_block_from_nbl(admm_env%matrix_ks_aux_fit(ispin)%matrix, admm_env%sab_aux_fit)
          CALL dbcsr_set(admm_env%matrix_ks_aux_fit(ispin)%matrix, 0.0_dp)
       END DO
 
@@ -681,7 +690,7 @@ CONTAINS
          ALLOCATE (admm_env%matrix_ks_aux_fit_dft(ispin)%matrix)
          CALL dbcsr_create(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
                            name="KOHN-SHAM_MATRIX for ADMM")
-         CALL dbcsr_copy(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, matrix_s_aux_fit(1)%matrix)
+         CALL cp_dbcsr_alloc_block_from_nbl(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, admm_env%sab_aux_fit)
          CALL dbcsr_set(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, 0.0_dp)
       END DO
 
@@ -691,7 +700,7 @@ CONTAINS
          ALLOCATE (admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix)
          CALL dbcsr_create(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
                            name="KOHN-SHAM_MATRIX for ADMM")
-         CALL dbcsr_copy(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, matrix_s_aux_fit(1)%matrix)
+         CALL cp_dbcsr_alloc_block_from_nbl(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, admm_env%sab_aux_fit)
          CALL dbcsr_set(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, 0.0_dp)
       END DO
 

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -2881,6 +2881,14 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="MIN_PAIR_LIST_RADIUS", &
+                          description="Set the minimum value [Bohr] for the overlap pair list radius."// &
+                          " Default is 0.0 Bohr, negative values are changed to the cell size."// &
+                          " This allows to control the sparsity of the KS matrix for HFX calculations.", &
+                          usage="MIN_PAIR_LIST_RADIUS real", default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
       ! Logicals
       CALL keyword_create(keyword, __LOCATION__, name="LS_SCF", &
                           description="Perform a linear scaling SCF", &

--- a/src/qs_neighbor_lists.F
+++ b/src/qs_neighbor_lists.F
@@ -309,8 +309,8 @@ CONTAINS
       LOGICAL, ALLOCATABLE, DIMENSION(:) :: all_present, aux_fit_present, aux_present, &
          core_present, default_present, nonbond1_atom, nonbond2_atom, oce_present, orb_present, &
          ppl_present, ppnl_present, ri_present, xb1_atom, xb2_atom
-      REAL(dp)                                           :: almo_rcov, almo_rvdw, rcut, roperator, &
-                                                            subcells
+      REAL(dp)                                           :: almo_rcov, almo_rvdw, pdist, rcut, &
+                                                            roperator, subcells
       REAL(dp), ALLOCATABLE, DIMENSION(:) :: all_pot_rad, aux_fit_radius, c_radius, calpha, &
          core_radius, oce_radius, orb_radius, ppl_radius, ppnl_radius, ri_radius, zeff
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius
@@ -432,6 +432,7 @@ CONTAINS
          ! enforce MIC for interaction lists in SE
          mic = .TRUE.
       END IF
+      pdist = dft_control%qs_control%pairlist_radius
 
       hfx_sections => section_vals_get_subs_vals(qs_env%input, "DFT%XC%HF")
       CALL section_vals_get(hfx_sections, explicit=do_hfx)
@@ -581,7 +582,12 @@ CONTAINS
       END DO
 
       ! Build the orbital-orbital overlap neighbor lists
-      CALL pair_radius_setup(orb_present, orb_present, orb_radius, orb_radius, pair_radius)
+      IF (pdist < 0.0_dp) THEN
+         pdist = MAX(plane_distance(1, 0, 0, cell), &
+                     plane_distance(0, 1, 0, cell), &
+                     plane_distance(0, 0, 1, cell))
+      END IF
+      CALL pair_radius_setup(orb_present, orb_present, orb_radius, orb_radius, pair_radius, pdist)
       CALL build_neighbor_lists(sab_orb, particle_set, atom2d, cell, pair_radius, &
                                 mic=mic, subcells=subcells, molecular=molecule_only, nlname="sab_orb")
       CALL set_ks_env(ks_env=ks_env, sab_orb=sab_orb)
@@ -1593,23 +1599,30 @@ CONTAINS
 !> \param radius_a ...
 !> \param radius_b ...
 !> \param pair_radius ...
+!> \param prmin ...
 ! **************************************************************************************************
-   SUBROUTINE pair_radius_setup(present_a, present_b, radius_a, radius_b, pair_radius)
+   SUBROUTINE pair_radius_setup(present_a, present_b, radius_a, radius_b, pair_radius, prmin)
       LOGICAL, DIMENSION(:), INTENT(IN)                  :: present_a, present_b
       REAL(dp), DIMENSION(:), INTENT(IN)                 :: radius_a, radius_b
       REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: pair_radius
+      REAL(dp), INTENT(IN), OPTIONAL                     :: prmin
 
       INTEGER                                            :: i, j, nkind
+      REAL(dp)                                           :: rrmin
 
       nkind = SIZE(present_a)
 
       pair_radius = 0._dp
+
+      rrmin = 0.0_dp
+      IF (PRESENT(prmin)) rrmin = prmin
 
       DO i = 1, nkind
          IF (.NOT. present_a(i)) CYCLE
          DO j = 1, nkind
             IF (.NOT. present_b(j)) CYCLE
             pair_radius(i, j) = radius_a(i) + radius_b(j)
+            pair_radius(i, j) = MAX(pair_radius(i, j), rrmin)
          END DO
       END DO
 

--- a/tests/QS/regtest-hfx/H2-ADMM-full.inp
+++ b/tests/QS/regtest-hfx/H2-ADMM-full.inp
@@ -1,0 +1,78 @@
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_SET
+    BASIS_SET_FILE_NAME BASIS_ADMM
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &MGRID
+      CUTOFF 100
+      REL_CUTOFF 30
+    &END MGRID
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-08
+      MIN_PAIR_LIST_RADIUS  -1.0
+    &END QS
+    &AUXILIARY_DENSITY_MATRIX_METHOD
+      METHOD BASIS_PROJECTION
+      ADMM_PURIFICATION_METHOD NONE
+      EXCH_CORRECTION_FUNC  NONE
+    &END
+    &SCF
+      EPS_SCF 1.0E-8
+      SCF_GUESS ATOMIC
+      MAX_SCF 4
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL NONE
+      &END XC_FUNCTIONAL
+      &HF
+        &SCREENING
+          EPS_SCHWARZ 1.0E-6
+          SCREEN_ON_INITIAL_P FALSE
+        &END
+        &MEMORY
+          MAX_MEMORY 200
+          EPS_STORAGE_SCALING 0.1
+        &END
+        &INTERACTION_POTENTIAL
+          POTENTIAL_TYPE COULOMB
+        &END
+        FRACTION 1.00
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 20.0 20.0 20.0
+    &END CELL
+    &COORD
+      H   0.00  0.00  0.36
+      H   0.00  0.00 -0.36
+      H   2.50  2.50  0.36
+      H   2.50  2.50 -0.36
+      H   5.00  5.00  0.36
+      H   5.00  5.00 -0.36
+      H   7.50  7.50  0.36
+      H   7.50  7.50 -0.36
+      H  10.00 10.00  0.36
+      H  10.00 10.00 -0.36
+      H  12.50 12.50  0.36
+      H  12.50 12.50 -0.36
+      H  15.00 15.00  0.36
+      H  15.00 15.00 -0.36
+      H  17.50 17.50  0.36
+      H  17.50 17.50 -0.36
+    &END COORD
+    &KIND H
+      BASIS_SET DZVP-GTH-PADE
+      BASIS_SET AUX_FIT cfit3
+      POTENTIAL GTH-PADE-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+  PROJECT H2-full
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-hfx/H2-full.inp
+++ b/tests/QS/regtest-hfx/H2-full.inp
@@ -1,0 +1,72 @@
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_SET
+    BASIS_SET_FILE_NAME BASIS_ADMM
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &MGRID
+      CUTOFF 100
+      REL_CUTOFF 30
+    &END MGRID
+    &QS
+      METHOD GPW
+      EPS_DEFAULT 1.0E-08
+      MIN_PAIR_LIST_RADIUS  -1.0
+    &END QS
+    &SCF
+      EPS_SCF 1.0E-8
+      SCF_GUESS ATOMIC
+      MAX_SCF 4
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL NONE
+      &END XC_FUNCTIONAL
+      &HF
+        &SCREENING
+          EPS_SCHWARZ 1.0E-6
+          SCREEN_ON_INITIAL_P FALSE
+        &END
+        &MEMORY
+          MAX_MEMORY 200
+          EPS_STORAGE_SCALING 0.1
+        &END
+        &INTERACTION_POTENTIAL
+          POTENTIAL_TYPE COULOMB
+        &END
+        FRACTION 1.00
+      &END
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 20.0 20.0 20.0
+    &END CELL
+    &COORD
+      H   0.00  0.00  0.36
+      H   0.00  0.00 -0.36
+      H   2.50  2.50  0.36
+      H   2.50  2.50 -0.36
+      H   5.00  5.00  0.36
+      H   5.00  5.00 -0.36
+      H   7.50  7.50  0.36
+      H   7.50  7.50 -0.36
+      H  10.00 10.00  0.36
+      H  10.00 10.00 -0.36
+      H  12.50 12.50  0.36
+      H  12.50 12.50 -0.36
+      H  15.00 15.00  0.36
+      H  15.00 15.00 -0.36
+      H  17.50 17.50  0.36
+      H  17.50 17.50 -0.36
+    &END COORD
+    &KIND H
+      BASIS_SET DZVP-GTH-PADE
+      POTENTIAL GTH-PADE-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+  PROJECT H2-full
+  PRINT_LEVEL MEDIUM
+  RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-hfx/TEST_FILES
+++ b/tests/QS/regtest-hfx/TEST_FILES
@@ -23,4 +23,7 @@ H2O-hfx-ls-rtp.inp                                     1    1.0e-12             
 H2O-hfx-ls-rtp-bch.inp                                 1    1.0e-12             -16.83980778496808
 H2O-hfx-ls-emd-bch.inp                                 2    1.0E-14            -0.168398023991E+02
 H2O-hfx-ls-emd-ngs.inp                                 2    1.0E-14            -0.167496522883E+02
+#
+H2-full.inp                                            1    1.0E-13              -8.52236909125538  
+H2-ADMM-full.inp                                       1    1.0E-13              -8.85571255294376  
 #EOF


### PR DESCRIPTION
New Keyword: MIN_PAIR_LIST_RADIUS can be used to force non-zero blocks in overlap and KS matrix.
