### PR TITLE
Replace arrays of cp_fm_p_type with arrays of cp_fm_type

### DIFF
--- a/src/cp_control_types.F
+++ b/src/cp_control_types.F
@@ -10,8 +10,8 @@
 !>      settings for the DFT-based calculations.
 ! **************************************************************************************************
 MODULE cp_control_types
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
+                                              cp_fm_type
    USE input_constants,                 ONLY: do_full_density
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
@@ -391,7 +391,7 @@ MODULE cp_control_types
 !   TDDFPT operator without the perturbation kernel.
 ! **************************************************************************************************
    TYPE tddfpt_control_type
-      TYPE(cp_fm_p_type), DIMENSION(:), &
+      TYPE(cp_fm_type), DIMENSION(:), &
          POINTER                           :: lumos
       REAL(KIND=dp)                        :: tolerance
       INTEGER                              :: n_ev
@@ -869,19 +869,11 @@ CONTAINS
       TYPE(tddfpt_control_type), POINTER                 :: tddfpt_control
 
       INTEGER                                            :: ispin
-      LOGICAL                                            :: dummy
 
       IF (ASSOCIATED(tddfpt_control)) THEN
          IF (ASSOCIATED(tddfpt_control%lumos)) THEN
             DO ispin = 1, SIZE(tddfpt_control%lumos)
-               CALL cp_fm_release(tddfpt_control%lumos(ispin)%matrix)
-               DEALLOCATE (tddfpt_control%lumos(ispin)%matrix)
-               NULLIFY (tddfpt_control%lumos(ispin)%matrix)
-               !MK the following line just avoids a crash of TDDFT runs using
-               !MK the sdbg version compiled with the NAG compiler when
-               !MK tddfpt_control%lumos is deallocated. This is most likely a
-               !MK compiler bug and thus the line might become obsolete
-               dummy = ASSOCIATED(tddfpt_control%lumos(ispin)%matrix)
+               CALL cp_fm_release(tddfpt_control%lumos(ispin))
             END DO
             DEALLOCATE (tddfpt_control%lumos)
          END IF

--- a/src/dft_plus_u.F
+++ b/src/dft_plus_u.F
@@ -351,8 +351,8 @@ CONTAINS
       fm_work2_local_alloc = .FALSE.
 
       IF (ASSOCIATED(scf_env%scf_work1)) THEN
-         IF (ASSOCIATED(scf_env%scf_work1(1)%matrix)) THEN
-            fm_work1 => scf_env%scf_work1(1)%matrix
+         IF (ASSOCIATED(scf_env%scf_work1(1)%matrix_struct)) THEN
+            fm_work1 => scf_env%scf_work1(1)
          END IF
       END IF
 

--- a/src/ec_env_types.F
+++ b/src/ec_env_types.F
@@ -13,8 +13,6 @@
 ! **************************************************************************************************
 MODULE ec_env_types
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
    USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE dm_ls_scf_types,                 ONLY: ls_scf_env_type,&
                                               ls_scf_release
@@ -95,7 +93,6 @@ MODULE ec_env_types
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER        :: mao_coef
       ! CP equations
       TYPE(qs_p_env_type), POINTER                     :: p_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER        :: cpmos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER        :: matrix_hz, matrix_z, matrix_wz, z_admm
       ! Harris (rhoout), and response density (rhoz) on grid
       TYPE(pw_type), DIMENSION(:), POINTER           :: rhoout_r, rhoz_r
@@ -145,15 +142,6 @@ CONTAINS
          ! dispersion environment
          IF (ASSOCIATED(ec_env%dispersion_env)) THEN
             CALL qs_dispersion_release(ec_env%dispersion_env)
-         END IF
-         ! CP env
-         IF (ASSOCIATED(ec_env%cpmos)) THEN
-            DO iab = 1, SIZE(ec_env%cpmos)
-               CALL cp_fm_release(ec_env%cpmos(iab)%matrix)
-               DEALLOCATE (ec_env%cpmos(iab)%matrix)
-            END DO
-            DEALLOCATE (ec_env%cpmos)
-            NULLIFY (ec_env%cpmos)
          END IF
 
          IF (ASSOCIATED(ec_env%matrix_z)) CALL dbcsr_deallocate_matrix_set(ec_env%matrix_z)

--- a/src/ec_environment.F
+++ b/src/ec_environment.F
@@ -141,7 +141,6 @@ CONTAINS
       NULLIFY (ec_env%force)
       NULLIFY (ec_env%dispersion_env)
       NULLIFY (ec_env%xc_section)
-      NULLIFY (ec_env%cpmos)
       NULLIFY (ec_env%matrix_z)
       NULLIFY (ec_env%matrix_hz)
       NULLIFY (ec_env%matrix_wz)

--- a/src/et_coupling.F
+++ b/src/et_coupling.F
@@ -132,7 +132,7 @@ CONTAINS
 !   calculate MO-overlap
 
          CALL get_qs_env(qs_env, matrix_s=matrix_s)
-         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, qs_env%et_coupling%et_mo_coeff(i)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, qs_env%et_coupling%et_mo_coeff(i), &
                                       tmp2, nmo, 1.0_dp, 0.0_dp)
          CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
                             qs_env%mos(i)%mo_coeff, &
@@ -141,7 +141,7 @@ CONTAINS
 !    calculate the MO-representation of the restraint matrix A
 
          CALL cp_dbcsr_sm_fm_multiply(qs_env%et_coupling%rest_mat(1)%matrix, &
-                                      qs_env%et_coupling%et_mo_coeff(i)%matrix, &
+                                      qs_env%et_coupling%et_mo_coeff(i), &
                                       tmp2, nmo, 1.0_dp, 0.0_dp)
 
          CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
@@ -155,7 +155,7 @@ CONTAINS
                                       tmp2, nmo, 1.0_dp, 0.0_dp)
 
          CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
-                            qs_env%et_coupling%et_mo_coeff(i)%matrix, &
+                            qs_env%et_coupling%et_mo_coeff(i), &
                             tmp2, 0.0_dp, rest_MO(2))
 
          CALL cp_fm_invert(SMO, inverse_mat, S_det(i))

--- a/src/et_coupling.F
+++ b/src/et_coupling.F
@@ -21,7 +21,6 @@ MODULE et_coupling
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
@@ -74,10 +73,10 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: a, b, S_det
       REAL(KIND=dp), DIMENSION(2)                        :: eigenv
       REAL(KIND=dp), DIMENSION(2, 2)                     :: S_mat, tmp_mat, U, W_mat
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: rest_MO
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: mo_mo_fm_pools
       TYPE(cp_fm_struct_type), POINTER                   :: mo_mo_fmstruct
       TYPE(cp_fm_type)                                   :: inverse_mat, SMO, Tinverse, tmp2
+      TYPE(cp_fm_type), DIMENSION(2)                     :: rest_MO
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
@@ -85,7 +84,7 @@ CONTAINS
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(section_vals_type), POINTER                   :: et_coupling_section
 
-      NULLIFY (rest_MO, mo_mo_fmstruct, rest_MO, energy, matrix_s, dft_control, para_env)
+      NULLIFY (mo_mo_fmstruct, energy, matrix_s, dft_control, para_env)
 
       CALL timeset(routineN, handle)
 
@@ -99,7 +98,6 @@ CONTAINS
                                 extension=".log")
 
       is_spin_constraint = .FALSE.
-      ALLOCATE (rest_MO(2))
       ALLOCATE (a(dft_control%nspins))
       ALLOCATE (b(dft_control%nspins))
       ALLOCATE (S_det(dft_control%nspins))
@@ -126,8 +124,7 @@ CONTAINS
                            matrix_struct=mo_mo_fmstruct, &
                            name="ET_SMO"//TRIM(ADJUSTL(cp_to_string(1)))//"MATRIX")
          DO j = 1, 2
-            ALLOCATE (rest_MO(j)%matrix)
-            CALL cp_fm_create(matrix=rest_MO(j)%matrix, &
+            CALL cp_fm_create(matrix=rest_MO(j), &
                               matrix_struct=mo_mo_fmstruct, &
                               name="ET_rest_MO"//TRIM(ADJUSTL(cp_to_string(j)))//"MATRIX")
          END DO
@@ -149,7 +146,7 @@ CONTAINS
 
          CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
                             qs_env%mos(i)%mo_coeff, &
-                            tmp2, 0.0_dp, rest_MO(1)%matrix)
+                            tmp2, 0.0_dp, rest_MO(1))
 
 !    calculate the MO-representation of the restraint matrix D
 
@@ -159,7 +156,7 @@ CONTAINS
 
          CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
                             qs_env%et_coupling%et_mo_coeff(i)%matrix, &
-                            tmp2, 0.0_dp, rest_MO(2)%matrix)
+                            tmp2, 0.0_dp, rest_MO(2))
 
          CALL cp_fm_invert(SMO, inverse_mat, S_det(i))
 
@@ -169,7 +166,7 @@ CONTAINS
 
          DO j = 1, ncol_local
             DO k = 1, nrow_local
-               b(i) = b(i) + rest_MO(2)%matrix%local_data(k, j)*inverse_mat%local_data(k, j)
+               b(i) = b(i) + rest_MO(2)%local_data(k, j)*inverse_mat%local_data(k, j)
             END DO
          END DO
 
@@ -177,7 +174,7 @@ CONTAINS
          a(i) = 0.0_dp
          DO j = 1, ncol_local
             DO k = 1, nrow_local
-               a(i) = a(i) + rest_MO(1)%matrix%local_data(k, j)*Tinverse%local_data(k, j)
+               a(i) = a(i) + rest_MO(1)%local_data(k, j)*Tinverse%local_data(k, j)
             END DO
          END DO
          IF (is_spin_constraint) THEN
@@ -190,16 +187,12 @@ CONTAINS
 
          CALL cp_fm_release(tmp2)
          DO j = 1, 2
-         IF (ASSOCIATED(rest_MO(j)%matrix)) THEN
-            CALL cp_fm_release(rest_MO(j)%matrix)
-            DEALLOCATE (rest_MO(j)%matrix)
-         END IF
+            CALL cp_fm_release(rest_MO(j))
          END DO
          CALL cp_fm_release(SMO)
          CALL cp_fm_release(Tinverse)
          CALL cp_fm_release(inverse_mat)
       END DO
-      DEALLOCATE (rest_MO)
 
 !    solve eigenstates for the projector matrix
 

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -684,9 +684,9 @@ CONTAINS
       INTEGER                                            :: i, j, k, l, n_spins, spin
       REAL(KIND=dp), DIMENSION(:), POINTER               :: vec_e
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: dat
       TYPE(cp_fm_struct_type), POINTER                   :: fm_s
       TYPE(cp_fm_type)                                   :: mat_u
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: dat
       TYPE(cp_para_env_type), POINTER                    :: para_env
 
 ! Routine name for debug purposes
@@ -695,14 +695,13 @@ CONTAINS
       NULLIFY (blacs_env)
       NULLIFY (para_env)
       NULLIFY (fm_s)
-      NULLIFY (dat)
 
       ! Parallel environment
       CALL get_qs_env(qs_env, para_env=para_env, blacs_env=blacs_env)
 
       ! Storage for block sub-matrices
       ALLOCATE (dat(ec%n_blocks))
-      CPASSERT(ASSOCIATED(dat))
+      CPASSERT(ALLOCATED(dat))
 
       ! Storage for electronic states and couplings
       n_spins = SIZE(mat_h)
@@ -728,8 +727,7 @@ CONTAINS
             ! Memory allocation
             CALL cp_fm_struct_create(fmstruct=fm_s, para_env=para_env, context=blacs_env, &
                                      nrow_global=ec%block(i)%n_ao, ncol_global=ec%block(i)%n_ao)
-            ALLOCATE (dat(i)%matrix)
-            CALL cp_fm_create(matrix=dat(i)%matrix, matrix_struct=fm_s, &
+            CALL cp_fm_create(matrix=dat(i), matrix_struct=fm_s, &
                               name='H_KS DIAGONAL BLOCK')
 
             ALLOCATE (vec_e(ec%block(i)%n_ao))
@@ -737,13 +735,13 @@ CONTAINS
 
             ! Copy block data
             CALL cp_fm_to_fm_submat(mat_h(spin)%matrix, &
-                                    dat(i)%matrix, ec%block(i)%n_ao, &
+                                    dat(i), ec%block(i)%n_ao, &
                                     ec%block(i)%n_ao, j, j, 1, 1)
 
             ! Diagonalization
             CALL cp_fm_create(matrix=mat_u, matrix_struct=fm_s, name='UNITARY MATRIX')
-            CALL choose_eigv_solver(dat(i)%matrix, mat_u, vec_e)
-            CALL cp_fm_to_fm(mat_u, dat(i)%matrix)
+            CALL choose_eigv_solver(dat(i), mat_u, vec_e)
+            CALL cp_fm_to_fm(mat_u, dat(i))
 
             ! Save state energies / vectors
             CALL create_block_mo_set(qs_env, ec, i, spin, mat_u, vec_e)
@@ -780,9 +778,9 @@ CONTAINS
                   ! Transformation
                   CALL cp_fm_create(matrix=mat_u, matrix_struct=fm_s, name='FULL WORK MATRIX')
                   CALL parallel_gemm("T", "N", ec%block(i)%n_ao, ec%block(j)%n_ao, ec%block(i)%n_ao, &
-                                     1.0_dp, dat(i)%matrix, ec%block(i)%hab(spin, j)%matrix, 0.0_dp, mat_u)
+                                     1.0_dp, dat(i), ec%block(i)%hab(spin, j)%matrix, 0.0_dp, mat_u)
                   CALL parallel_gemm("N", "N", ec%block(i)%n_ao, ec%block(j)%n_ao, ec%block(j)%n_ao, &
-                                     1.0_dp, mat_u, dat(j)%matrix, 0.0_dp, ec%block(i)%hab(spin, j)%matrix)
+                                     1.0_dp, mat_u, dat(j), 0.0_dp, ec%block(i)%hab(spin, j)%matrix)
 
                   ! Clean memory
                   CALL cp_fm_struct_release(fmstruct=fm_s)
@@ -797,18 +795,15 @@ CONTAINS
          END DO
 
          ! Clean memory
-         IF (ASSOCIATED(dat)) THEN
+         IF (ALLOCATED(dat)) THEN
             DO i = 1, SIZE(dat)
-               IF (ASSOCIATED(dat(i)%matrix)) THEN
-                  CALL cp_fm_release(matrix=dat(i)%matrix)
-                  DEALLOCATE (dat(i)%matrix)
-               END IF
+               CALL cp_fm_release(dat(i))
             END DO
          END IF
       END DO
 
       ! Clean memory
-      IF (ASSOCIATED(dat)) &
+      IF (ALLOCATED(dat)) &
          DEALLOCATE (dat)
 
    END SUBROUTINE hamiltonian_block_diag

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -620,7 +620,8 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(et_cpl), POINTER                              :: ec
       TYPE(cp_fm_struct_type), POINTER                   :: fm_s
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mat_t
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: mat_t
       TYPE(cp_fm_type), INTENT(IN)                       :: mat_w
       INTEGER                                            :: n_ao, n_spins
 
@@ -633,7 +634,6 @@ CONTAINS
 
       ! Memory allocation
       ALLOCATE (mat_t(n_spins))
-      CPASSERT(ASSOCIATED(mat_t))
 
       ! KS Hamiltonian
       CALL get_qs_env(qs_env, matrix_ks=mat_h)
@@ -648,17 +648,16 @@ CONTAINS
       DO i = 1, n_spins
 
          ! Full-matrix format
-         ALLOCATE (mat_t(i)%matrix)
-         CALL cp_fm_create(matrix=mat_t(i)%matrix, matrix_struct=fm_s, &
+         CALL cp_fm_create(matrix=mat_t(i), matrix_struct=fm_s, &
                            name='KS HAMILTONIAN IN SEPARATED ORTHOGONALIZED BASIS SET')
-         CALL copy_dbcsr_to_fm(mat_h(i)%matrix, mat_t(i)%matrix)
+         CALL copy_dbcsr_to_fm(mat_h(i)%matrix, mat_t(i))
 
          ! Transform KS Hamiltonian to the orthogonalized AO basis set
-         CALL parallel_gemm("N", "N", n_ao, n_ao, n_ao, 1.0_dp, ec%m_transf, mat_t(i)%matrix, 0.0_dp, mat_w)
-         CALL parallel_gemm("N", "N", n_ao, n_ao, n_ao, 1.0_dp, mat_w, ec%m_transf, 0.0_dp, mat_t(i)%matrix)
+         CALL parallel_gemm("N", "N", n_ao, n_ao, n_ao, 1.0_dp, ec%m_transf, mat_t(i), 0.0_dp, mat_w)
+         CALL parallel_gemm("N", "N", n_ao, n_ao, n_ao, 1.0_dp, mat_w, ec%m_transf, 0.0_dp, mat_t(i))
 
          ! Reorder KS Hamiltonain elements to defined block structure
-         CALL reorder_hamiltonian_matrix(ec, mat_t(i)%matrix, mat_w)
+         CALL reorder_hamiltonian_matrix(ec, mat_t(i), mat_w)
 
       END DO
 
@@ -676,7 +675,7 @@ CONTAINS
       ! Routine arguments
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(et_cpl), POINTER                              :: ec
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mat_h
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mat_h
 
       INTEGER                                            :: i, j, k, l, n_spins, spin
       REAL(KIND=dp), DIMENSION(:), POINTER               :: vec_e
@@ -726,7 +725,7 @@ CONTAINS
             CPASSERT(ASSOCIATED(vec_e))
 
             ! Copy block data
-            CALL cp_fm_to_fm_submat(mat_h(spin)%matrix, &
+            CALL cp_fm_to_fm_submat(mat_h(spin), &
                                     dat(i), ec%block(i)%n_ao, &
                                     ec%block(i)%n_ao, j, j, 1, 1)
 
@@ -762,7 +761,7 @@ CONTAINS
                                     name='H_KS OFF-DIAGONAL BLOCK')
 
                   ! Copy block data
-                  CALL cp_fm_to_fm_submat(mat_h(spin)%matrix, &
+                  CALL cp_fm_to_fm_submat(mat_h(spin), &
                                           ec%block(i)%hab(spin, j), ec%block(i)%n_ao, &
                                           ec%block(j)%n_ao, k, l, 1, 1)
 
@@ -1743,9 +1742,9 @@ CONTAINS
       INTEGER                                            :: i, j, k, n_ao, n_atoms, output_unit
       LOGICAL                                            :: do_kp, master
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mat_h
       TYPE(cp_fm_struct_type), POINTER                   :: fm_s
       TYPE(cp_fm_type)                                   :: mat_w
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mat_h
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks, mo_der
@@ -1770,7 +1769,6 @@ CONTAINS
       NULLIFY (et_proj_sec)
 
       NULLIFY (fm_s)
-      NULLIFY (mat_h)
       NULLIFY (ks, mo_der)
 
       NULLIFY (ec)
@@ -1963,12 +1961,9 @@ CONTAINS
       ! Clean memory
       CALL cp_fm_struct_release(fmstruct=fm_s)
       CALL cp_fm_release(matrix=mat_w)
-      IF (ASSOCIATED(mat_h)) THEN
+      IF (ALLOCATED(mat_h)) THEN
          DO i = 1, SIZE(mat_h)
-            IF (ASSOCIATED(mat_h(i)%matrix)) THEN
-               CALL cp_fm_release(matrix=mat_h(i)%matrix)
-               DEALLOCATE (mat_h(i)%matrix)
-            END IF
+            CALL cp_fm_release(matrix=mat_h(i))
          END DO
          DEALLOCATE (mat_h)
       END IF

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -127,7 +127,7 @@ MODULE et_coupling_proj
       INTEGER                                            :: n_ao
       TYPE(et_cpl_atom), DIMENSION(:), POINTER           :: atom
       TYPE(mo_set_type), DIMENSION(:), POINTER         :: mo
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER        :: hab
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER        :: hab
    END TYPE et_cpl_block
 
    ! Electronic-coupling block-atom data
@@ -187,10 +187,7 @@ CONTAINS
                IF (ASSOCIATED(ec%block(i)%hab)) THEN
                   DO j = 1, SIZE(ec%block(i)%hab, 1)
                      DO k = 1, SIZE(ec%block(i)%hab, 2)
-                        IF (ASSOCIATED(ec%block(i)%hab(j, k)%matrix)) THEN
-                           CALL cp_fm_release(matrix=ec%block(i)%hab(j, k)%matrix)
-                           DEALLOCATE (ec%block(i)%hab(j, k)%matrix)
-                        END IF
+                        CALL cp_fm_release(matrix=ec%block(i)%hab(j, k))
                      END DO
                   END DO
                   DEALLOCATE (ec%block(i)%hab)
@@ -710,11 +707,6 @@ CONTAINS
          CPASSERT(ASSOCIATED(ec%block(i)%mo))
          ALLOCATE (ec%block(i)%hab(n_spins, ec%n_blocks))
          CPASSERT(ASSOCIATED(ec%block(i)%hab))
-         DO j = 1, n_spins
-            DO k = 1, ec%n_blocks
-               NULLIFY (ec%block(i)%hab(j, k)%matrix)
-            END DO
-         END DO
       END DO
 
       ! Spin components
@@ -766,21 +758,20 @@ CONTAINS
                   ! Memory allocation
                   CALL cp_fm_struct_create(fmstruct=fm_s, para_env=para_env, context=blacs_env, &
                                            nrow_global=ec%block(i)%n_ao, ncol_global=ec%block(j)%n_ao)
-                  ALLOCATE (ec%block(i)%hab(spin, j)%matrix)
-                  CALL cp_fm_create(matrix=ec%block(i)%hab(spin, j)%matrix, matrix_struct=fm_s, &
+                  CALL cp_fm_create(matrix=ec%block(i)%hab(spin, j), matrix_struct=fm_s, &
                                     name='H_KS OFF-DIAGONAL BLOCK')
 
                   ! Copy block data
                   CALL cp_fm_to_fm_submat(mat_h(spin)%matrix, &
-                                          ec%block(i)%hab(spin, j)%matrix, ec%block(i)%n_ao, &
+                                          ec%block(i)%hab(spin, j), ec%block(i)%n_ao, &
                                           ec%block(j)%n_ao, k, l, 1, 1)
 
                   ! Transformation
                   CALL cp_fm_create(matrix=mat_u, matrix_struct=fm_s, name='FULL WORK MATRIX')
                   CALL parallel_gemm("T", "N", ec%block(i)%n_ao, ec%block(j)%n_ao, ec%block(i)%n_ao, &
-                                     1.0_dp, dat(i), ec%block(i)%hab(spin, j)%matrix, 0.0_dp, mat_u)
+                                     1.0_dp, dat(i), ec%block(i)%hab(spin, j), 0.0_dp, mat_u)
                   CALL parallel_gemm("N", "N", ec%block(i)%n_ao, ec%block(j)%n_ao, ec%block(j)%n_ao, &
-                                     1.0_dp, mat_u, dat(j), 0.0_dp, ec%block(i)%hab(spin, j)%matrix)
+                                     1.0_dp, mat_u, dat(j), 0.0_dp, ec%block(i)%hab(spin, j))
 
                   ! Clean memory
                   CALL cp_fm_struct_release(fmstruct=fm_s)
@@ -1160,16 +1151,16 @@ CONTAINS
          DO i = 1, ec%n_blocks
             DO j = i + 1, ec%n_blocks
 
-               nr = ec%block(i)%hab(1, j)%matrix%matrix_struct%nrow_global
-               nc = ec%block(i)%hab(1, j)%matrix%matrix_struct%ncol_global
+               nr = ec%block(i)%hab(1, j)%matrix_struct%nrow_global
+               nc = ec%block(i)%hab(1, j)%matrix_struct%ncol_global
 
                ALLOCATE (w1(nr, nc))
                CPASSERT(ASSOCIATED(w1))
-               CALL get_fm_matrix_array(ec%block(i)%hab(1, j)%matrix, w1)
+               CALL get_fm_matrix_array(ec%block(i)%hab(1, j), w1)
                IF (nspins > 1) THEN
                   ALLOCATE (w2(nr, nc))
                   CPASSERT(ASSOCIATED(w2))
-                  CALL get_fm_matrix_array(ec%block(i)%hab(2, j)%matrix, w2)
+                  CALL get_fm_matrix_array(ec%block(i)%hab(2, j), w2)
                END IF
 
                IF (output_unit > 0) THEN
@@ -1249,10 +1240,10 @@ CONTAINS
 
                            WRITE (unit_nr, '(T3,I5,T13,I5,T22,E20.6)', ADVANCE='no') &
                               k, l, &
-                              ec%block(i)%hab(1, j)%matrix%local_data(k, l)*evolt*1000.0_dp
+                              ec%block(i)%hab(1, j)%local_data(k, l)*evolt*1000.0_dp
                            IF ((k <= n_states(2)) .AND. (l <= n_states(2))) THEN
                               WRITE (unit_nr, '(E20.6)') &
-                                 ec%block(i)%hab(2, j)%matrix%local_data(k, l)*evolt*1000.0_dp
+                                 ec%block(i)%hab(2, j)%local_data(k, l)*evolt*1000.0_dp
                            ELSE
                               WRITE (unit_nr, *)
                            END IF
@@ -1261,7 +1252,7 @@ CONTAINS
 
                            WRITE (unit_nr, '(T3,I5,T13,I5,T22,E20.6)') &
                               k, l, &
-                              ec%block(i)%hab(1, j)%matrix%local_data(k, l)*evolt*1000.0_dp
+                              ec%block(i)%hab(1, j)%local_data(k, l)*evolt*1000.0_dp
 
                         END IF
 

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -31,7 +31,6 @@ MODULE et_coupling_proj
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -901,7 +900,7 @@ CONTAINS
       INTEGER                                            :: j, k, l, m, n, n_ao, n_mo
       INTEGER, DIMENSION(:), POINTER                     :: list_at, list_mo
       REAL(KIND=dp)                                      :: c1, c2
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mat_w
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mat_w
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(section_vals_type), POINTER                   :: block_sec, print_sec
 
@@ -931,15 +930,13 @@ CONTAINS
 
          ! MOs in orthonormal basis set
          ALLOCATE (mat_w(n_spins))
-         CPASSERT(ASSOCIATED(mat_w))
          DO j = 1, n_spins
             n_mo = ec%block(blk)%n_ao
-            ALLOCATE (mat_w(j)%matrix)
-            CALL cp_fm_create(matrix=mat_w(j)%matrix, &
+            CALL cp_fm_create(matrix=mat_w(j), &
                               matrix_struct=ec%block(blk)%mo(j)%mo_coeff%matrix_struct, &
                               name='BLOCK MOs IN ORTHONORMAL BASIS SET')
             CALL parallel_gemm("N", "N", n_ao, n_mo, n_ao, 1.0_dp, ec%m_transf_inv, &
-                               ec%block(blk)%mo(j)%mo_coeff, 0.0_dp, mat_w(j)%matrix)
+                               ec%block(blk)%mo(j)%mo_coeff, 0.0_dp, mat_w(j))
          END DO
 
          DO j = 1, n
@@ -967,14 +964,14 @@ CONTAINS
                         DO l = 1, SIZE(list_mo)
 
                            IF (n_spins > 1) THEN
-                              c1 = get_mo_c2_sum(ec%block(blk)%atom, mat_w(1)%matrix, &
+                              c1 = get_mo_c2_sum(ec%block(blk)%atom, mat_w(1), &
                                                  list_mo(l), list_at)
-                              c2 = get_mo_c2_sum(ec%block(blk)%atom, mat_w(2)%matrix, &
+                              c2 = get_mo_c2_sum(ec%block(blk)%atom, mat_w(2), &
                                                  list_mo(l), list_at)
                               IF (output_unit > 0) &
                                  WRITE (output_unit, '(I5,A,I5,2F20.10)') j, ' /', list_mo(l), c1, c2
                            ELSE
-                              c1 = get_mo_c2_sum(ec%block(blk)%atom, mat_w(1)%matrix, &
+                              c1 = get_mo_c2_sum(ec%block(blk)%atom, mat_w(1), &
                                                  list_mo(l), list_at)
                               IF (output_unit > 0) &
                                  WRITE (output_unit, '(I5,A,I5,F20.10)') j, ' /', list_mo(l), c1
@@ -992,8 +989,7 @@ CONTAINS
 
          ! Clean memory
          DO j = 1, n_spins
-            CALL cp_fm_release(matrix=mat_w(j)%matrix)
-            DEALLOCATE (mat_w(j)%matrix)
+            CALL cp_fm_release(matrix=mat_w(j))
          END DO
          DEALLOCATE (mat_w)
 

--- a/src/et_coupling_types.F
+++ b/src/et_coupling_types.F
@@ -11,8 +11,8 @@
 ! **************************************************************************************************
 MODULE et_coupling_types
 
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
+                                              cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE kinds,                           ONLY: dp
 #include "./base/base_uses.f90"
@@ -39,7 +39,7 @@ MODULE et_coupling_types
 !> \author fschiff
 ! **************************************************************************************************
    TYPE et_coupling_type
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER           :: et_mo_coeff
+      TYPE(cp_fm_type), DIMENSION(:), POINTER           :: et_mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER     :: rest_mat
       LOGICAL                                            :: first_run
       LOGICAL                                            :: keep_matrix
@@ -73,8 +73,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_et_coupling_type(et_coupling, et_mo_coeff, rest_mat)
       TYPE(et_coupling_type), POINTER                    :: et_coupling
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: et_mo_coeff
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: et_mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: rest_mat
 
@@ -91,8 +90,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE set_et_coupling_type(et_coupling, et_mo_coeff, rest_mat)
       TYPE(et_coupling_type), POINTER                    :: et_coupling
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: et_mo_coeff
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: et_mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: rest_mat
 
@@ -112,9 +110,7 @@ CONTAINS
 
       IF (ASSOCIATED(et_coupling%et_mo_coeff)) THEN
          DO i = 1, SIZE(et_coupling%et_mo_coeff)
-            CALL cp_fm_release(et_coupling%et_mo_coeff(i)%matrix)
-            DEALLOCATE (et_coupling%et_mo_coeff(i)%matrix)
-            NULLIFY (et_coupling%et_mo_coeff(i)%matrix)
+            CALL cp_fm_release(et_coupling%et_mo_coeff(i))
          END DO
          DEALLOCATE (et_coupling%et_mo_coeff)
       END IF

--- a/src/exstates_types.F
+++ b/src/exstates_types.F
@@ -13,8 +13,7 @@
 ! **************************************************************************************************
 MODULE exstates_types
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release,&
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE input_constants,                 ONLY: xc_kernel_method_best
@@ -46,7 +45,7 @@ MODULE exstates_types
       INTEGER                                            :: state
       REAL(KIND=dp)                                      :: evalue
       INTEGER                                            :: xc_kernel_method
-      TYPE(cp_fm_p_type), POINTER, DIMENSION(:)          :: evect => NULL()
+      TYPE(cp_fm_type), POINTER, DIMENSION(:)          :: evect => NULL()
       TYPE(cp_fm_type), POINTER, DIMENSION(:)          :: cpmos => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_pe => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_hz => NULL()
@@ -80,8 +79,7 @@ CONTAINS
 
          IF (ASSOCIATED(ex_env%evect)) THEN
             DO is = 1, SIZE(ex_env%evect)
-               CALL cp_fm_release(ex_env%evect(is)%matrix)
-               DEALLOCATE (ex_env%evect(is)%matrix)
+               CALL cp_fm_release(ex_env%evect(is))
             END DO
             DEALLOCATE (ex_env%evect)
          END IF

--- a/src/exstates_types.F
+++ b/src/exstates_types.F
@@ -14,7 +14,8 @@
 MODULE exstates_types
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
    USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+                                              cp_fm_release,&
+                                              cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE input_constants,                 ONLY: xc_kernel_method_best
    USE input_section_types,             ONLY: section_vals_type,&
@@ -46,7 +47,7 @@ MODULE exstates_types
       REAL(KIND=dp)                                      :: evalue
       INTEGER                                            :: xc_kernel_method
       TYPE(cp_fm_p_type), POINTER, DIMENSION(:)          :: evect => NULL()
-      TYPE(cp_fm_p_type), POINTER, DIMENSION(:)          :: cpmos => NULL()
+      TYPE(cp_fm_type), POINTER, DIMENSION(:)          :: cpmos => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_pe => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_hz => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_pe_admm => NULL()
@@ -86,8 +87,7 @@ CONTAINS
          END IF
          IF (ASSOCIATED(ex_env%cpmos)) THEN
             DO is = 1, SIZE(ex_env%cpmos)
-               CALL cp_fm_release(ex_env%cpmos(is)%matrix)
-               DEALLOCATE (ex_env%cpmos(is)%matrix)
+               CALL cp_fm_release(ex_env%cpmos(is))
             END DO
             DEALLOCATE (ex_env%cpmos)
          END IF

--- a/src/fm/cp_fm_basic_linalg.F
+++ b/src/fm/cp_fm_basic_linalg.F
@@ -12,24 +12,24 @@
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
 MODULE cp_fm_basic_linalg
-   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
-   USE cp_fm_struct,                    ONLY: cp_fm_struct_equivalent
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_diag, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_p_type, &
-        cp_fm_release, cp_fm_set_all, cp_fm_set_element, cp_fm_set_submatrix, cp_fm_to_fm, &
-        cp_fm_type
-   USE cp_log_handling,                 ONLY: cp_logger_get_default_unit_nr,&
-                                              cp_to_string
-   USE kahan_sum,                       ONLY: accurate_dot_product,&
-                                              accurate_sum
-   USE kinds,                           ONLY: dp,&
-                                              int_8,&
-                                              sp
-   USE machine,                         ONLY: m_memory
-   USE mathlib,                         ONLY: get_pseudo_inverse_svd,&
-                                              invert_matrix
-   USE message_passing,                 ONLY: mp_comm_type,&
-                                              mp_sum
+   USE cp_blacs_env, ONLY: cp_blacs_env_type
+   USE cp_fm_struct, ONLY: cp_fm_struct_equivalent
+   USE cp_fm_types, ONLY: &
+      cp_fm_create, cp_fm_get_diag, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_p_type, &
+      cp_fm_release, cp_fm_set_all, cp_fm_set_element, cp_fm_set_submatrix, cp_fm_to_fm, &
+      cp_fm_type
+   USE cp_log_handling, ONLY: cp_logger_get_default_unit_nr, &
+                              cp_to_string
+   USE kahan_sum, ONLY: accurate_dot_product, &
+                        accurate_sum
+   USE kinds, ONLY: dp, &
+                    int_8, &
+                    sp
+   USE machine, ONLY: m_memory
+   USE mathlib, ONLY: get_pseudo_inverse_svd, &
+                      invert_matrix
+   USE message_passing, ONLY: mp_comm_type, &
+                              mp_sum
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -68,12 +68,19 @@ MODULE cp_fm_basic_linalg
 
    INTERFACE cp_fm_trace
       MODULE PROCEDURE cp_fm_trace_a0b0t0
-      MODULE PROCEDURE cp_fm_trace_a1b0t1
-      MODULE PROCEDURE cp_fm_trace_a1b1t1
+      MODULE PROCEDURE cp_fm_trace_a1b0t1_a
+      MODULE PROCEDURE cp_fm_trace_a1b0t1_p
+      MODULE PROCEDURE cp_fm_trace_a1b1t1_aa
+      MODULE PROCEDURE cp_fm_trace_a1b1t1_ap
+      MODULE PROCEDURE cp_fm_trace_a1b1t1_pa
+      MODULE PROCEDURE cp_fm_trace_a1b1t1_pp
    END INTERFACE cp_fm_trace
 
    INTERFACE cp_fm_contracted_trace
-      MODULE PROCEDURE cp_fm_contracted_trace_a2b2t2
+      MODULE PROCEDURE cp_fm_contracted_trace_a2b2t2_aa
+      MODULE PROCEDURE cp_fm_contracted_trace_a2b2t2_ap
+      MODULE PROCEDURE cp_fm_contracted_trace_a2b2t2_pa
+      MODULE PROCEDURE cp_fm_contracted_trace_a2b2t2_pp
    END INTERFACE cp_fm_contracted_trace
 CONTAINS
 
@@ -744,6 +751,10 @@ CONTAINS
 
    END SUBROUTINE cp_fm_trace_a0b0t0
 
+   #:mute
+      #:set types = [("cp_fm_type", "a", ""), ("cp_fm_p_type", "p","%matrix")]
+   #:endmute
+
 ! **************************************************************************************************
 !> \brief Compute trace(k) = Tr (matrix_a(k)^T matrix_b) for each pair of matrices A_k and B.
 !> \param matrix_a list of A matrices
@@ -762,61 +773,63 @@ CONTAINS
 !>      'matrix_b' is a single matrix.
 !>      \endparblock
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_trace_a1b0t1(matrix_a, matrix_b, trace)
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: matrix_a
-      TYPE(cp_fm_type), INTENT(IN)                       :: matrix_b
-      REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
+   #:for longname, shortname, appendix in types
+      SUBROUTINE cp_fm_trace_a1b0t1_${shortname}$ (matrix_a, matrix_b, trace)
+         TYPE(${longname}$), DIMENSION(:), INTENT(in)       :: matrix_a
+         TYPE(cp_fm_type), INTENT(IN)                       :: matrix_b
+         REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b0t1'
+         CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b0t1_${shortname}$'
 
-      INTEGER                                            :: handle, imatrix, n_matrices, &
-                                                            ncols_local, nrows_local
-      LOGICAL                                            :: use_sp_a, use_sp_b
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
-      REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
-      TYPE(mp_comm_type)                                 :: group
+         INTEGER                                            :: handle, imatrix, n_matrices, &
+                                                               ncols_local, nrows_local
+         LOGICAL                                            :: use_sp_a, use_sp_b
+         REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
+         REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
+         TYPE(mp_comm_type)                                 :: group
 
-      CALL timeset(routineN, handle)
+         CALL timeset(routineN, handle)
 
-      n_matrices = SIZE(trace)
-      CPASSERT(SIZE(matrix_a) == n_matrices)
+         n_matrices = SIZE(trace)
+         CPASSERT(SIZE(matrix_a) == n_matrices)
 
-      CALL cp_fm_get_info(matrix_b, nrow_local=nrows_local, ncol_local=ncols_local)
-      use_sp_b = matrix_b%use_sp
+         CALL cp_fm_get_info(matrix_b, nrow_local=nrows_local, ncol_local=ncols_local)
+         use_sp_b = matrix_b%use_sp
 
-      IF (use_sp_b) THEN
-         ldata_b_sp => matrix_b%local_data_sp(1:nrows_local, 1:ncols_local)
-      ELSE
-         ldata_b => matrix_b%local_data(1:nrows_local, 1:ncols_local)
-      END IF
+         IF (use_sp_b) THEN
+            ldata_b_sp => matrix_b%local_data_sp(1:nrows_local, 1:ncols_local)
+         ELSE
+            ldata_b => matrix_b%local_data(1:nrows_local, 1:ncols_local)
+         END IF
 
 !$OMP PARALLEL DO DEFAULT(NONE), &
 !$OMP             PRIVATE(imatrix, ldata_a, ldata_a_sp, use_sp_a), &
 !$OMP             SHARED(ldata_b, ldata_b_sp, matrix_a, matrix_b), &
 !$OMP             SHARED(ncols_local, nrows_local, n_matrices, trace, use_sp_b)
 
-      DO imatrix = 1, n_matrices
+         DO imatrix = 1, n_matrices
 
-         use_sp_a = matrix_a(imatrix)%matrix%use_sp
+            use_sp_a = matrix_a(imatrix) ${appendix}$%use_sp
 
-         ! assume that the matrices A(i) and B have identical shapes and distribution schemes
-         IF (use_sp_a .AND. use_sp_b) THEN
-            ldata_a_sp => matrix_a(imatrix)%matrix%local_data_sp(1:nrows_local, 1:ncols_local)
-            trace(imatrix) = accurate_dot_product(ldata_a_sp, ldata_b_sp)
-         ELSE IF (.NOT. use_sp_a .AND. .NOT. use_sp_b) THEN
-            ldata_a => matrix_a(imatrix)%matrix%local_data(1:nrows_local, 1:ncols_local)
-            trace(imatrix) = accurate_dot_product(ldata_a, ldata_b)
-         ELSE
-            CPABORT("Matrices A and B are of different types")
-         END IF
-      END DO
+            ! assume that the matrices A(i) and B have identical shapes and distribution schemes
+            IF (use_sp_a .AND. use_sp_b) THEN
+               ldata_a_sp => matrix_a(imatrix) ${appendix}$%local_data_sp(1:nrows_local, 1:ncols_local)
+               trace(imatrix) = accurate_dot_product(ldata_a_sp, ldata_b_sp)
+            ELSE IF (.NOT. use_sp_a .AND. .NOT. use_sp_b) THEN
+               ldata_a => matrix_a(imatrix) ${appendix}$%local_data(1:nrows_local, 1:ncols_local)
+               trace(imatrix) = accurate_dot_product(ldata_a, ldata_b)
+            ELSE
+               CPABORT("Matrices A and B are of different types")
+            END IF
+         END DO
 !$OMP END PARALLEL DO
 
-      group = matrix_b%matrix_struct%para_env%group
-      CALL mp_sum(trace, group)
+         group = matrix_b%matrix_struct%para_env%group
+         CALL mp_sum(trace, group)
 
-      CALL timestop(handle)
-   END SUBROUTINE cp_fm_trace_a1b0t1
+         CALL timestop(handle)
+      END SUBROUTINE cp_fm_trace_a1b0t1_${shortname}$
+   #:endfor
 
 ! **************************************************************************************************
 !> \brief Compute trace(k) = Tr (matrix_a(k)^T matrix_b(k)) for each pair of matrices A_k and B_k.
@@ -836,67 +849,72 @@ CONTAINS
 !>      all dummy variables (matrix_a, matrix_b, and trace) are 1-dimensional arrays.
 !>      \endparblock
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_trace_a1b1t1(matrix_a, matrix_b, trace, accurate)
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: matrix_a, matrix_b
-      REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
-      LOGICAL, INTENT(IN), OPTIONAL                      :: accurate
+   #:for longname1, shortname1, appendix1 in types
+      #:for longname2, shortname2, appendix2 in types
+         SUBROUTINE cp_fm_trace_a1b1t1_${shortname1}$${shortname2}$ (matrix_a, matrix_b, trace, accurate)
+            TYPE(${longname1}$), DIMENSION(:), INTENT(in)       :: matrix_a
+            TYPE(${longname2}$), DIMENSION(:), INTENT(in)       :: matrix_b
+            REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
+            LOGICAL, INTENT(IN), OPTIONAL                      :: accurate
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b1t1'
+            CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b1t1_${shortname1}$${shortname2}$'
 
-      INTEGER                                            :: handle, imatrix, n_matrices, &
-                                                            ncols_local, nrows_local
-      LOGICAL                                            :: use_accurate_sum, use_sp_a, use_sp_b
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
-      REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
-      TYPE(mp_comm_type)                                 :: group
+            INTEGER                                            :: handle, imatrix, n_matrices, &
+                                                                  ncols_local, nrows_local
+            LOGICAL                                            :: use_accurate_sum, use_sp_a, use_sp_b
+            REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
+            REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
+            TYPE(mp_comm_type)                                 :: group
 
-      CALL timeset(routineN, handle)
+            CALL timeset(routineN, handle)
 
-      n_matrices = SIZE(trace)
-      CPASSERT(SIZE(matrix_a) == n_matrices)
-      CPASSERT(SIZE(matrix_b) == n_matrices)
+            n_matrices = SIZE(trace)
+            CPASSERT(SIZE(matrix_a) == n_matrices)
+            CPASSERT(SIZE(matrix_b) == n_matrices)
 
-      use_accurate_sum = .TRUE.
-      IF (PRESENT(accurate)) use_accurate_sum = accurate
+            use_accurate_sum = .TRUE.
+            IF (PRESENT(accurate)) use_accurate_sum = accurate
 
 !$OMP PARALLEL DO DEFAULT(NONE), &
 !$OMP             PRIVATE(imatrix, ldata_a, ldata_a_sp, ldata_b, ldata_b_sp, ncols_local), &
 !$OMP             PRIVATE(nrows_local, use_sp_a, use_sp_b), &
 !$OMP             SHARED(matrix_a, matrix_b, n_matrices, trace, use_accurate_sum)
-      DO imatrix = 1, n_matrices
-         CALL cp_fm_get_info(matrix_a(imatrix)%matrix, nrow_local=nrows_local, ncol_local=ncols_local)
+            DO imatrix = 1, n_matrices
+               CALL cp_fm_get_info(matrix_a(imatrix) ${appendix1}$, nrow_local=nrows_local, ncol_local=ncols_local)
 
-         use_sp_a = matrix_a(imatrix)%matrix%use_sp
-         use_sp_b = matrix_b(imatrix)%matrix%use_sp
+               use_sp_a = matrix_a(imatrix) ${appendix1}$%use_sp
+               use_sp_b = matrix_b(imatrix) ${appendix2}$%use_sp
 
-         ! assume that the matrices A(i) and B(i) have identical shapes and distribution schemes
-         IF (use_sp_a .AND. use_sp_b) THEN
-            ldata_a_sp => matrix_a(imatrix)%matrix%local_data_sp(1:nrows_local, 1:ncols_local)
-            ldata_b_sp => matrix_b(imatrix)%matrix%local_data_sp(1:nrows_local, 1:ncols_local)
-            IF (use_accurate_sum) THEN
-               trace(imatrix) = accurate_dot_product(ldata_a_sp, ldata_b_sp)
-            ELSE
-               trace(imatrix) = SUM(ldata_a_sp*ldata_b_sp)
-            END IF
-         ELSE IF (.NOT. use_sp_a .AND. .NOT. use_sp_b) THEN
-            ldata_a => matrix_a(imatrix)%matrix%local_data(1:nrows_local, 1:ncols_local)
-            ldata_b => matrix_b(imatrix)%matrix%local_data(1:nrows_local, 1:ncols_local)
-            IF (use_accurate_sum) THEN
-               trace(imatrix) = accurate_dot_product(ldata_a, ldata_b)
-            ELSE
-               trace(imatrix) = SUM(ldata_a*ldata_b)
-            END IF
-         ELSE
-            CPABORT("Matrices A and B are of different types")
-         END IF
-      END DO
+               ! assume that the matrices A(i) and B(i) have identical shapes and distribution schemes
+               IF (use_sp_a .AND. use_sp_b) THEN
+                  ldata_a_sp => matrix_a(imatrix) ${appendix1}$%local_data_sp(1:nrows_local, 1:ncols_local)
+                  ldata_b_sp => matrix_b(imatrix) ${appendix2}$%local_data_sp(1:nrows_local, 1:ncols_local)
+                  IF (use_accurate_sum) THEN
+                     trace(imatrix) = accurate_dot_product(ldata_a_sp, ldata_b_sp)
+                  ELSE
+                     trace(imatrix) = SUM(ldata_a_sp*ldata_b_sp)
+                  END IF
+               ELSE IF (.NOT. use_sp_a .AND. .NOT. use_sp_b) THEN
+                  ldata_a => matrix_a(imatrix) ${appendix1}$%local_data(1:nrows_local, 1:ncols_local)
+                  ldata_b => matrix_b(imatrix) ${appendix2}$%local_data(1:nrows_local, 1:ncols_local)
+                  IF (use_accurate_sum) THEN
+                     trace(imatrix) = accurate_dot_product(ldata_a, ldata_b)
+                  ELSE
+                     trace(imatrix) = SUM(ldata_a*ldata_b)
+                  END IF
+               ELSE
+                  CPABORT("Matrices A and B are of different types")
+               END IF
+            END DO
 !$OMP END PARALLEL DO
 
-      group = matrix_a(1)%matrix%matrix_struct%para_env%group
-      CALL mp_sum(trace, group)
+            group = matrix_a(1) ${appendix1}$%matrix_struct%para_env%group
+            CALL mp_sum(trace, group)
 
-      CALL timestop(handle)
-   END SUBROUTINE cp_fm_trace_a1b1t1
+            CALL timestop(handle)
+         END SUBROUTINE cp_fm_trace_a1b1t1_${shortname1}$${shortname2}$
+      #:endfor
+   #:endfor
 
 ! **************************************************************************************************
 !> \brief Compute trace(i,j) = \sum_k Tr (matrix_a(k,i)^T matrix_b(k,j)).
@@ -905,85 +923,90 @@ CONTAINS
 !> \param trace    computed traces
 !> \param accurate ...
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_contracted_trace_a2b2t2(matrix_a, matrix_b, trace, accurate)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: matrix_a, matrix_b
-      REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: trace
-      LOGICAL, INTENT(IN), OPTIONAL                      :: accurate
+   #:for longname1, shortname1, appendix1 in types
+      #:for longname2, shortname2, appendix2 in types
+         SUBROUTINE cp_fm_contracted_trace_a2b2t2_${shortname1}$${shortname2}$ (matrix_a, matrix_b, trace, accurate)
+            TYPE(${longname1}$), DIMENSION(:, :), INTENT(in)       :: matrix_a
+            TYPE(${longname2}$), DIMENSION(:, :), INTENT(in)       :: matrix_b
+            REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: trace
+            LOGICAL, INTENT(IN), OPTIONAL                      :: accurate
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_contracted_trace_a2b2t2'
+            CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_contracted_trace_a2b2t2_${shortname1}$${shortname2}$'
 
-      INTEGER                                            :: handle, ia, ib, iz, na, nb, ncols_local, &
-                                                            nrows_local, nz
-      INTEGER(kind=int_8)                                :: ib8, itrace, na8, ntraces
-      LOGICAL                                            :: use_accurate_sum, use_sp_a, use_sp_b
-      REAL(kind=dp)                                      :: t
-      REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
-      REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
-      TYPE(mp_comm_type)                                 :: group
+            INTEGER                                            :: handle, ia, ib, iz, na, nb, ncols_local, &
+                                                                  nrows_local, nz
+            INTEGER(kind=int_8)                                :: ib8, itrace, na8, ntraces
+            LOGICAL                                            :: use_accurate_sum, use_sp_a, use_sp_b
+            REAL(kind=dp)                                      :: t
+            REAL(kind=dp), DIMENSION(:, :), POINTER            :: ldata_a, ldata_b
+            REAL(kind=sp), DIMENSION(:, :), POINTER            :: ldata_a_sp, ldata_b_sp
+            TYPE(mp_comm_type)                                 :: group
 
-      CALL timeset(routineN, handle)
+            CALL timeset(routineN, handle)
 
-      nz = SIZE(matrix_a, 1)
-      CPASSERT(SIZE(matrix_b, 1) == nz)
+            nz = SIZE(matrix_a, 1)
+            CPASSERT(SIZE(matrix_b, 1) == nz)
 
-      na = SIZE(matrix_a, 2)
-      nb = SIZE(matrix_b, 2)
-      CPASSERT(SIZE(trace, 1) == na)
-      CPASSERT(SIZE(trace, 2) == nb)
+            na = SIZE(matrix_a, 2)
+            nb = SIZE(matrix_b, 2)
+            CPASSERT(SIZE(trace, 1) == na)
+            CPASSERT(SIZE(trace, 2) == nb)
 
-      use_accurate_sum = .TRUE.
-      IF (PRESENT(accurate)) use_accurate_sum = accurate
+            use_accurate_sum = .TRUE.
+            IF (PRESENT(accurate)) use_accurate_sum = accurate
 
-      ! here we use one running index (itrace) instead of two (ia, ib) in order to
-      ! improve load balance between shared-memory threads
-      ntraces = na*nb
-      na8 = INT(na, kind=int_8)
+            ! here we use one running index (itrace) instead of two (ia, ib) in order to
+            ! improve load balance between shared-memory threads
+            ntraces = na*nb
+            na8 = INT(na, kind=int_8)
 
 !$OMP PARALLEL DO DEFAULT(NONE), &
 !$OMP             PRIVATE(ia, ib, ib8, itrace, iz, ldata_a, ldata_a_sp, ldata_b, ldata_b_sp, ncols_local), &
 !$OMP             PRIVATE(nrows_local, t, use_sp_a, use_sp_b), &
 !$OMP             SHARED(matrix_a, matrix_b, na, na8, nb, ntraces, nz, trace, use_accurate_sum)
-      DO itrace = 1, ntraces
-         ib8 = (itrace - 1)/na8
-         ia = INT(itrace - ib8*na8)
-         ib = INT(ib8) + 1
+            DO itrace = 1, ntraces
+               ib8 = (itrace - 1)/na8
+               ia = INT(itrace - ib8*na8)
+               ib = INT(ib8) + 1
 
-         t = 0.0_dp
-         DO iz = 1, nz
-            CALL cp_fm_get_info(matrix_a(iz, ia)%matrix, nrow_local=nrows_local, ncol_local=ncols_local)
-            use_sp_a = matrix_a(iz, ia)%matrix%use_sp
-            use_sp_b = matrix_b(iz, ib)%matrix%use_sp
+               t = 0.0_dp
+               DO iz = 1, nz
+                  CALL cp_fm_get_info(matrix_a(iz, ia) ${appendix1}$, nrow_local=nrows_local, ncol_local=ncols_local)
+                  use_sp_a = matrix_a(iz, ia) ${appendix1}$%use_sp
+                  use_sp_b = matrix_b(iz, ib) ${appendix2}$%use_sp
 
-            ! assume that the matrices A(iz, ia) and B(iz, ib) have identical shapes and distribution schemes
-            IF (.NOT. use_sp_a .AND. .NOT. use_sp_b) THEN
-               ldata_a => matrix_a(iz, ia)%matrix%local_data(1:nrows_local, 1:ncols_local)
-               ldata_b => matrix_b(iz, ib)%matrix%local_data(1:nrows_local, 1:ncols_local)
-               IF (use_accurate_sum) THEN
-                  t = t + accurate_dot_product(ldata_a, ldata_b)
-               ELSE
-                  t = t + SUM(ldata_a*ldata_b)
-               END IF
-            ELSE IF (use_sp_a .AND. use_sp_b) THEN
-               ldata_a_sp => matrix_a(iz, ia)%matrix%local_data_sp(1:nrows_local, 1:ncols_local)
-               ldata_b_sp => matrix_b(iz, ib)%matrix%local_data_sp(1:nrows_local, 1:ncols_local)
-               IF (use_accurate_sum) THEN
-                  t = t + accurate_dot_product(ldata_a_sp, ldata_b_sp)
-               ELSE
-                  t = t + SUM(ldata_a_sp*ldata_b_sp)
-               END IF
-            ELSE
-               CPABORT("Matrices A and B are of different types")
-            END IF
-         END DO
-         trace(ia, ib) = t
-      END DO
+                  ! assume that the matrices A(iz, ia) and B(iz, ib) have identical shapes and distribution schemes
+                  IF (.NOT. use_sp_a .AND. .NOT. use_sp_b) THEN
+                     ldata_a => matrix_a(iz, ia) ${appendix1}$%local_data(1:nrows_local, 1:ncols_local)
+                     ldata_b => matrix_b(iz, ib) ${appendix2}$%local_data(1:nrows_local, 1:ncols_local)
+                     IF (use_accurate_sum) THEN
+                        t = t + accurate_dot_product(ldata_a, ldata_b)
+                     ELSE
+                        t = t + SUM(ldata_a*ldata_b)
+                     END IF
+                  ELSE IF (use_sp_a .AND. use_sp_b) THEN
+                     ldata_a_sp => matrix_a(iz, ia) ${appendix1}$%local_data_sp(1:nrows_local, 1:ncols_local)
+                     ldata_b_sp => matrix_b(iz, ib) ${appendix2}$%local_data_sp(1:nrows_local, 1:ncols_local)
+                     IF (use_accurate_sum) THEN
+                        t = t + accurate_dot_product(ldata_a_sp, ldata_b_sp)
+                     ELSE
+                        t = t + SUM(ldata_a_sp*ldata_b_sp)
+                     END IF
+                  ELSE
+                     CPABORT("Matrices A and B are of different types")
+                  END IF
+               END DO
+               trace(ia, ib) = t
+            END DO
 !$OMP END PARALLEL DO
 
-      group = matrix_a(1, 1)%matrix%matrix_struct%para_env%group
-      CALL mp_sum(trace, group)
+            group = matrix_a(1, 1) ${appendix1}$%matrix_struct%para_env%group
+            CALL mp_sum(trace, group)
 
-      CALL timestop(handle)
-   END SUBROUTINE cp_fm_contracted_trace_a2b2t2
+            CALL timestop(handle)
+         END SUBROUTINE cp_fm_contracted_trace_a2b2t2_${shortname1}$${shortname2}$
+      #:endfor
+   #:endfor
 
 ! **************************************************************************************************
 !> \brief multiplies in place by a triangular matrix:
@@ -2299,8 +2322,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_Gram_Schmidt_orthonorm'
 
       INTEGER :: end_col_global, end_col_local, end_row_global, end_row_local, handle, i, j, &
-         j_col, ncol_global, ncol_local, nrow_global, nrow_local, start_col_global, &
-         start_col_local, start_row_global, start_row_local, this_col, unit_nr
+                 j_col, ncol_global, ncol_local, nrow_global, nrow_local, start_col_global, &
+                 start_col_local, start_row_global, start_row_local, this_col, unit_nr
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: my_do_norm, my_do_print
       REAL(KIND=dp)                                      :: norm

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -940,8 +940,9 @@ CONTAINS
       REAL(dp)                                           :: etmp, fac
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: occupied_evals
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff, occupied_orbs
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: occupied_orbs
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: homo_localized
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: my_ks_matrix, my_rho_ao
@@ -1040,7 +1041,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             IF (ri_data%do_loc) THEN
-               CALL copy_fm_to_dbcsr(moloc_coeff(ispin)%matrix, mo_coeff_b(ispin))
+               CALL copy_fm_to_dbcsr(moloc_coeff(ispin), mo_coeff_b(ispin))
             END IF
             CALL dbcsr_scale(mo_coeff_b(ispin), SQRT(mos(ispin)%maxocc))
             homo(ispin) = mos(ispin)%homo
@@ -2928,8 +2929,9 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: homo
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: occupied_evals
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff, occupied_orbs
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: occupied_orbs
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: homo_localized
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_type), DIMENSION(2)                     :: mo_coeff_b
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_b_tmp
@@ -2986,7 +2988,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             IF (ri_data%do_loc) THEN
-               CALL copy_fm_to_dbcsr(moloc_coeff(ispin)%matrix, mo_coeff_b(ispin))
+               CALL copy_fm_to_dbcsr(moloc_coeff(ispin), mo_coeff_b(ispin))
             END IF
             CALL dbcsr_scale(mo_coeff_b(ispin), SQRT(mos(ispin)%maxocc))
             homo(ispin) = mos(ispin)%homo

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -20,7 +20,6 @@ MODULE hfx_ri
                                               gto_basis_set_type
    USE cell_types,                      ONLY: cell_type,&
                                               real_to_scaled
-   USE cp_array_utils,                  ONLY: cp_1d_r_p_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cholesky,               ONLY: cp_dbcsr_cholesky_decompose,&
@@ -34,7 +33,6 @@ MODULE hfx_ri
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type,&
@@ -939,8 +937,6 @@ CONTAINS
       LOGICAL                                            :: is_antisymmetric
       REAL(dp)                                           :: etmp, fac
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
-      TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: occupied_evals
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: occupied_orbs
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: homo_localized
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
@@ -996,8 +992,6 @@ CONTAINS
          CALL timeset(routineN//"_MO", handle2)
 
          IF (ri_data%do_loc) THEN
-            ALLOCATE (occupied_orbs(nspins))
-            ALLOCATE (occupied_evals(nspins))
             ALLOCATE (homo_localized(nspins))
          END IF
          DO ispin = 1, nspins
@@ -1014,10 +1008,8 @@ CONTAINS
             END IF
 
             IF (ri_data%do_loc) THEN
-               occupied_orbs(ispin)%matrix => mo_coeff
-               occupied_evals(ispin)%array => mo_eigenvalues
-               CALL cp_fm_create(homo_localized(ispin), occupied_orbs(ispin)%matrix%matrix_struct)
-               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin))
+               CALL cp_fm_create(homo_localized(ispin), mo_coeff%matrix_struct)
+               CALL cp_fm_to_fm(mo_coeff, homo_localized(ispin))
             END IF
          END DO
 
@@ -1036,7 +1028,7 @@ CONTAINS
                CALL cp_fm_release(homo_localized(ispin))
             END DO
 
-            DEALLOCATE (occupied_orbs, occupied_evals, homo_localized)
+            DEALLOCATE (homo_localized)
          END IF
 
          DO ispin = 1, nspins
@@ -2928,8 +2920,6 @@ CONTAINS
       INTEGER                                            :: handle, ispin
       INTEGER, DIMENSION(2)                              :: homo
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
-      TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: occupied_evals
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: occupied_orbs
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: homo_localized
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
@@ -2942,8 +2932,6 @@ CONTAINS
       CASE (ri_mo)
 
          IF (ri_data%do_loc) THEN
-            ALLOCATE (occupied_orbs(nspins))
-            ALLOCATE (occupied_evals(nspins))
             ALLOCATE (homo_localized(nspins))
          END IF
          DO ispin = 1, nspins
@@ -2960,10 +2948,8 @@ CONTAINS
             END IF
 
             IF (ri_data%do_loc) THEN
-               occupied_orbs(ispin)%matrix => mo_coeff
-               occupied_evals(ispin)%array => mo_eigenvalues
-               CALL cp_fm_create(homo_localized(ispin), occupied_orbs(ispin)%matrix%matrix_struct)
-               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin))
+               CALL cp_fm_create(homo_localized(ispin), mo_coeff%matrix_struct)
+               CALL cp_fm_to_fm(mo_coeff, homo_localized(ispin))
             END IF
          END DO
 
@@ -2982,7 +2968,7 @@ CONTAINS
                CALL cp_fm_release(homo_localized(ispin))
             END DO
 
-            DEALLOCATE (occupied_orbs, occupied_evals, homo_localized)
+            DEALLOCATE (homo_localized)
 
          END IF
 

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -940,8 +940,8 @@ CONTAINS
       REAL(dp)                                           :: etmp, fac
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: occupied_evals
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: homo_localized, moloc_coeff, &
-                                                            occupied_orbs
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff, occupied_orbs
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: homo_localized
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: my_ks_matrix, my_rho_ao
@@ -1015,9 +1015,8 @@ CONTAINS
             IF (ri_data%do_loc) THEN
                occupied_orbs(ispin)%matrix => mo_coeff
                occupied_evals(ispin)%array => mo_eigenvalues
-               ALLOCATE (homo_localized(ispin)%matrix)
-               CALL cp_fm_create(homo_localized(ispin)%matrix, occupied_orbs(ispin)%matrix%matrix_struct)
-               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin)%matrix)
+               CALL cp_fm_create(homo_localized(ispin), occupied_orbs(ispin)%matrix%matrix_struct)
+               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin))
             END IF
          END DO
 
@@ -1028,13 +1027,12 @@ CONTAINS
             CALL qs_loc_init(qs_env, ri_data%qs_loc_env, ri_data%loc_subsection, homo_localized)
             DO ispin = 1, nspins
                CALL qs_loc_driver(qs_env, ri_data%qs_loc_env, ri_data%print_loc_subsection, ispin, &
-                                  ext_mo_coeff=homo_localized(ispin)%matrix)
+                                  ext_mo_coeff=homo_localized(ispin))
             END DO
             CALL get_qs_loc_env(qs_loc_env=ri_data%qs_loc_env, moloc_coeff=moloc_coeff)
 
             DO ispin = 1, nspins
-               CALL cp_fm_release(homo_localized(ispin)%matrix)
-               DEALLOCATE (homo_localized(ispin)%matrix)
+               CALL cp_fm_release(homo_localized(ispin))
             END DO
 
             DEALLOCATE (occupied_orbs, occupied_evals, homo_localized)
@@ -2930,8 +2928,8 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: homo
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: occupied_evals
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: homo_localized, moloc_coeff, &
-                                                            occupied_orbs
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff, occupied_orbs
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: homo_localized
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_type), DIMENSION(2)                     :: mo_coeff_b
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_b_tmp
@@ -2962,9 +2960,8 @@ CONTAINS
             IF (ri_data%do_loc) THEN
                occupied_orbs(ispin)%matrix => mo_coeff
                occupied_evals(ispin)%array => mo_eigenvalues
-               ALLOCATE (homo_localized(ispin)%matrix)
-               CALL cp_fm_create(homo_localized(ispin)%matrix, occupied_orbs(ispin)%matrix%matrix_struct)
-               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin)%matrix)
+               CALL cp_fm_create(homo_localized(ispin), occupied_orbs(ispin)%matrix%matrix_struct)
+               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin))
             END IF
          END DO
 
@@ -2975,13 +2972,12 @@ CONTAINS
             CALL qs_loc_init(qs_env, ri_data%qs_loc_env, ri_data%loc_subsection, homo_localized)
             DO ispin = 1, nspins
                CALL qs_loc_driver(qs_env, ri_data%qs_loc_env, ri_data%print_loc_subsection, ispin, &
-                                  ext_mo_coeff=homo_localized(ispin)%matrix)
+                                  ext_mo_coeff=homo_localized(ispin))
             END DO
             CALL get_qs_loc_env(qs_loc_env=ri_data%qs_loc_env, moloc_coeff=moloc_coeff)
 
             DO ispin = 1, nspins
-               CALL cp_fm_release(homo_localized(ispin)%matrix)
-               DEALLOCATE (homo_localized(ispin)%matrix)
+               CALL cp_fm_release(homo_localized(ispin))
             END DO
 
             DEALLOCATE (occupied_orbs, occupied_evals, homo_localized)

--- a/src/kpoint_io.F
+++ b/src/kpoint_io.F
@@ -19,8 +19,7 @@ MODULE kpoint_io
                                               copy_fm_to_dbcsr
    USE cp_files,                        ONLY: close_file,&
                                               open_file
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_read_unformatted,&
+   USE cp_fm_types,                     ONLY: cp_fm_read_unformatted,&
                                               cp_fm_type,&
                                               cp_fm_write_unformatted
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
@@ -120,7 +119,7 @@ CONTAINS
                   CALL get_kpoint_info(kpoint=kpoints, cell_to_index=cell_to_index)
                END IF
                CPASSERT(ASSOCIATED(scf_env%scf_work1))
-               fmat => scf_env%scf_work1(1)%matrix
+               fmat => scf_env%scf_work1(1)
 
                DO ispin = 1, nspin
                   IF (ires > 0) WRITE (ires) ispin, nspin, nimages
@@ -300,7 +299,7 @@ CONTAINS
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: denmat
       TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fmwork
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: fmwork
       INTEGER, INTENT(IN)                                :: natom
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: id_nr
@@ -339,10 +338,7 @@ CONTAINS
 
       END IF
 
-      CPASSERT(ASSOCIATED(fmwork))
-      CPASSERT(ASSOCIATED(fmwork(1)%matrix))
-
-      CALL read_kpoints_restart_low(denmat, kpoints, fmwork(1)%matrix, para_env, &
+      CALL read_kpoints_restart_low(denmat, kpoints, fmwork(1), para_env, &
                                     natom, restart_unit, natom_mismatch)
 
       ! only the io_node returns natom_mismatch, must broadcast it
@@ -373,7 +369,7 @@ CONTAINS
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: denmat
       TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(cp_fm_type), POINTER                          :: fmat
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: fmat
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: natom, rst_unit
       LOGICAL, INTENT(OUT)                               :: natom_mismatch

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -513,8 +513,7 @@ CONTAINS
                IF (ASSOCIATED(kp%pmat)) THEN
                   DO is = 1, SIZE(kp%pmat, 2)
                      DO ic = 1, SIZE(kp%pmat, 1)
-                        CALL cp_fm_release(kp%pmat(ic, is)%matrix)
-                        DEALLOCATE (kp%pmat(ic, is)%matrix)
+                        CALL cp_fm_release(kp%pmat(ic, is))
                      END DO
                   END DO
                   DEALLOCATE (kp%pmat)
@@ -522,16 +521,14 @@ CONTAINS
                ALLOCATE (kp%pmat(nc, nspin))
                DO is = 1, nspin
                   DO ic = 1, nc
-                     ALLOCATE (kp%pmat(ic, is)%matrix)
-                     CALL cp_fm_create(kp%pmat(ic, is)%matrix, matrix_struct)
+                     CALL cp_fm_create(kp%pmat(ic, is), matrix_struct)
                   END DO
                END DO
                ! energy weighted density matrix
                IF (ASSOCIATED(kp%wmat)) THEN
                   DO is = 1, SIZE(kp%wmat, 2)
                      DO ic = 1, SIZE(kp%wmat, 1)
-                        CALL cp_fm_release(kp%wmat(ic, is)%matrix)
-                        DEALLOCATE (kp%wmat(ic, is)%matrix)
+                        CALL cp_fm_release(kp%wmat(ic, is))
                      END DO
                   END DO
                   DEALLOCATE (kp%wmat)
@@ -539,8 +536,7 @@ CONTAINS
                ALLOCATE (kp%wmat(nc, nspin))
                DO is = 1, nspin
                   DO ic = 1, nc
-                     ALLOCATE (kp%wmat(ic, is)%matrix)
-                     CALL cp_fm_create(kp%wmat(ic, is)%matrix, matrix_struct)
+                     CALL cp_fm_create(kp%wmat(ic, is), matrix_struct)
                   END DO
                END DO
             END DO
@@ -979,9 +975,9 @@ CONTAINS
             END IF
             IF (kpoint%use_real_wfn) THEN
                IF (wtype) THEN
-                  pmat => kp%wmat(1, ispin)%matrix
+                  pmat => kp%wmat(1, ispin)
                ELSE
-                  pmat => kp%pmat(1, ispin)%matrix
+                  pmat => kp%pmat(1, ispin)
                END IF
                CALL get_mo_set(mo_set, occupation_numbers=occupation)
                CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
@@ -992,11 +988,11 @@ CONTAINS
                CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, mo_set%mo_coeff, fwork, 0.0_dp, pmat)
             ELSE
                IF (wtype) THEN
-                  rpmat => kp%wmat(1, ispin)%matrix
-                  cpmat => kp%wmat(2, ispin)%matrix
+                  rpmat => kp%wmat(1, ispin)
+                  cpmat => kp%wmat(2, ispin)
                ELSE
-                  rpmat => kp%pmat(1, ispin)%matrix
-                  cpmat => kp%pmat(2, ispin)%matrix
+                  rpmat => kp%pmat(1, ispin)
+                  cpmat => kp%pmat(2, ispin)
                END IF
                CALL get_mo_set(mo_set, occupation_numbers=occupation)
                CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
@@ -1117,9 +1113,9 @@ CONTAINS
                DO ic = 1, nc
                   indx = indx + 1
                   IF (wtype) THEN
-                     CALL cp_fm_start_copy_general(kp%wmat(ic, ispin)%matrix, fmwork(ic)%matrix, para_env, info(indx))
+                     CALL cp_fm_start_copy_general(kp%wmat(ic, ispin), fmwork(ic)%matrix, para_env, info(indx))
                   ELSE
-                     CALL cp_fm_start_copy_general(kp%pmat(ic, ispin)%matrix, fmwork(ic)%matrix, para_env, info(indx))
+                     CALL cp_fm_start_copy_general(kp%pmat(ic, ispin), fmwork(ic)%matrix, para_env, info(indx))
                   END IF
                END DO
             ELSE

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -28,8 +28,7 @@ MODULE kpoint_methods
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         copy_info_type, cp_fm_cleanup_copy_general, cp_fm_create, cp_fm_finish_copy_general, &
-        cp_fm_get_info, cp_fm_p_type, cp_fm_release, cp_fm_start_copy_general, cp_fm_to_fm, &
-        cp_fm_type
+        cp_fm_get_info, cp_fm_release, cp_fm_start_copy_general, cp_fm_to_fm, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE cp_para_env,                     ONLY: cp_cart_create,&
                                               cp_para_env_create,&
@@ -1042,7 +1041,7 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: tempmat
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_nl
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: fmwork
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fmwork
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_density_transform'
 
@@ -1113,15 +1112,15 @@ CONTAINS
                DO ic = 1, nc
                   indx = indx + 1
                   IF (wtype) THEN
-                     CALL cp_fm_start_copy_general(kp%wmat(ic, ispin), fmwork(ic)%matrix, para_env, info(indx))
+                     CALL cp_fm_start_copy_general(kp%wmat(ic, ispin), fmwork(ic), para_env, info(indx))
                   ELSE
-                     CALL cp_fm_start_copy_general(kp%pmat(ic, ispin), fmwork(ic)%matrix, para_env, info(indx))
+                     CALL cp_fm_start_copy_general(kp%pmat(ic, ispin), fmwork(ic), para_env, info(indx))
                   END IF
                END DO
             ELSE
                DO ic = 1, nc
                   indx = indx + 1
-                  CALL cp_fm_start_copy_general(fmdummy, fmwork(ic)%matrix, para_env, info(indx))
+                  CALL cp_fm_start_copy_general(fmdummy, fmwork(ic), para_env, info(indx))
                END DO
             END IF
          END DO
@@ -1133,16 +1132,16 @@ CONTAINS
          DO ik = 1, nkp
             DO ic = 1, nc
                indx = indx + 1
-               CALL cp_fm_finish_copy_general(fmwork(ic)%matrix, info(indx))
+               CALL cp_fm_finish_copy_general(fmwork(ic), info(indx))
             END DO
 
             ! reduce to dbcsr storage
             IF (real_only) THEN
-               CALL copy_fm_to_dbcsr(fmwork(1)%matrix, rpmat, keep_sparsity=.TRUE.)
+               CALL copy_fm_to_dbcsr(fmwork(1), rpmat, keep_sparsity=.TRUE.)
             ELSE
-               CALL copy_fm_to_dbcsr(fmwork(1)%matrix, rpmat, keep_sparsity=.TRUE.)
+               CALL copy_fm_to_dbcsr(fmwork(1), rpmat, keep_sparsity=.TRUE.)
                ! it seems this copy to a antisymmetric dbcsr matrix changes sign!
-               CALL copy_fm_to_dbcsr(fmwork(2)%matrix, cpmat, keep_sparsity=.TRUE.)
+               CALL copy_fm_to_dbcsr(fmwork(2), cpmat, keep_sparsity=.TRUE.)
             END IF
 
             ! symmetrization

--- a/src/kpoint_types.F
+++ b/src/kpoint_types.F
@@ -15,8 +15,8 @@
 MODULE kpoint_types
    USE cp_blacs_env,                    ONLY: cp_blacs_env_release,&
                                               cp_blacs_env_type
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
@@ -73,8 +73,8 @@ MODULE kpoint_types
       REAL(KIND=dp), DIMENSION(3)                       :: xkp
       LOGICAL                                           :: is_local
       TYPE(mo_set_type), DIMENSION(:, :), POINTER     :: mos
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER      :: pmat
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER      :: wmat
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER      :: pmat
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER      :: wmat
    END TYPE kpoint_env_type
 
    TYPE kpoint_env_p_type
@@ -705,8 +705,7 @@ CONTAINS
          IF (ASSOCIATED(kp_env%pmat)) THEN
             DO is = 1, SIZE(kp_env%pmat, 2)
                DO ic = 1, SIZE(kp_env%pmat, 1)
-                  CALL cp_fm_release(kp_env%pmat(ic, is)%matrix)
-                  DEALLOCATE (kp_env%pmat(ic, is)%matrix)
+                  CALL cp_fm_release(kp_env%pmat(ic, is))
                END DO
             END DO
             DEALLOCATE (kp_env%pmat)
@@ -715,8 +714,7 @@ CONTAINS
          IF (ASSOCIATED(kp_env%wmat)) THEN
             DO is = 1, SIZE(kp_env%wmat, 2)
                DO ic = 1, SIZE(kp_env%wmat, 1)
-                  CALL cp_fm_release(kp_env%wmat(ic, is)%matrix)
-                  DEALLOCATE (kp_env%wmat(ic, is)%matrix)
+                  CALL cp_fm_release(kp_env%wmat(ic, is))
                END DO
             END DO
             DEALLOCATE (kp_env%wmat)

--- a/src/localization_tb.F
+++ b/src/localization_tb.F
@@ -15,7 +15,6 @@ MODULE localization_tb
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
    USE cp_fm_vect,                      ONLY: cp_fm_vect_dealloc
@@ -91,8 +90,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: occupied_evals
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: homo_localized, mo_loc_history, &
-                                                            occupied_orbs
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: homo_localized, occupied_orbs
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: mo_loc_history
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -170,11 +169,10 @@ CONTAINS
             DO ispin = 1, nspins
                CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, &
                                eigenvalues=mo_eigenvalues)
-               occupied_orbs(ispin)%matrix => mo_coeff
+               occupied_orbs(ispin) = mo_coeff
                occupied_evals(ispin)%array => mo_eigenvalues
-               ALLOCATE (homo_localized(ispin)%matrix)
-               CALL cp_fm_create(homo_localized(ispin)%matrix, occupied_orbs(ispin)%matrix%matrix_struct)
-               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin)%matrix)
+               CALL cp_fm_create(homo_localized(ispin), occupied_orbs(ispin)%matrix_struct)
+               CALL cp_fm_to_fm(occupied_orbs(ispin), homo_localized(ispin))
             END DO
 
             CALL get_qs_env(qs_env, mo_loc_history=mo_loc_history)

--- a/src/ls_matrix_exp.F
+++ b/src/ls_matrix_exp.F
@@ -243,8 +243,8 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief subroutine for general complex matrix exponentials
-!>        on input a separate cp_fm_type for real and complex part
-!>        on output a size 2 cp_fm_p_type, first element is the real part of
+!>        on input a separate dbcsr_type for real and complex part
+!>        on output a size 2 dbcsr_p_type, first element is the real part of
 !>        the exponential second the imaginary
 !> \param exp_H ...
 !> \param re_part ...

--- a/src/matrix_exp.F
+++ b/src/matrix_exp.F
@@ -28,7 +28,6 @@ MODULE matrix_exp
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -157,7 +156,7 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief subroutine for general complex matrix exponentials
 !>        on input a separate cp_fm_type for real and complex part
-!>        on output a size 2 cp_fm_p_type, first element is the real part of
+!>        on output a size 2 cp_fm_type, first element is the real part of
 !>        the exponential second the imaginary
 !> \param exp_H ...
 !> \param re_part ...
@@ -590,9 +589,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: my_fac, scaleD, scaleN, square_fac
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          POINTER                                         :: local_data
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mult_p
-      TYPE(cp_fm_type)                                   :: Dpq
-      TYPE(cp_fm_type), POINTER                          :: fin_p
+      TYPE(cp_fm_type)                                   :: Dpq, fin_p
+      TYPE(cp_fm_type), DIMENSION(2)                     :: mult_p
       TYPE(cp_fm_type), TARGET                           :: Npq, T1, T2, Tres
 
       CALL timeset(routineN, handle)
@@ -601,7 +599,6 @@ CONTAINS
 
       CALL cp_fm_get_info(matrix, local_data=local_data, ncol_local=ldim, nrow_global=ndim)
       square_fac = 2.0_dp**REAL(nsquare, dp)
-      ALLOCATE (mult_p(2))
 
       CALL cp_fm_create(Dpq, &
                         matrix_struct=matrix%matrix_struct, &
@@ -636,36 +633,36 @@ CONTAINS
          Dpq%local_data(:, i) = Dpq%local_data(:, i) - 0.5_dp*local_data(:, i)
       END DO
 
-      mult_p(1)%matrix => T2
-      mult_p(2)%matrix => Tres
+      mult_p(1) = T2
+      mult_p(2) = Tres
 
       IF (npade .GE. 2) THEN
          DO j = 2, npade
             my_fac = (-1.0_dp)**j
             scaleN = fac(p + q - j)*fac(p)/(fac(p + q)*fac(j)*fac(p - j))
             scaleD = my_fac*fac(p + q - j)*fac(q)/(fac(p + q)*fac(j)*fac(q - j))
-            CALL parallel_gemm("N", "N", ndim, ndim, ndim, one, mult_p(MOD(j, 2) + 1)%matrix, T1, &
-                               zero, mult_p(MOD(j + 1, 2) + 1)%matrix)
+            CALL parallel_gemm("N", "N", ndim, ndim, ndim, one, mult_p(MOD(j, 2) + 1), T1, &
+                               zero, mult_p(MOD(j + 1, 2) + 1))
 
             DO k = 1, ldim
-               Npq%local_data(:, k) = Npq%local_data(:, k) + scaleN*mult_p(MOD(j + 1, 2) + 1)%matrix%local_data(:, k)
-               Dpq%local_data(:, k) = Dpq%local_data(:, k) + scaleD*mult_p(MOD(j + 1, 2) + 1)%matrix%local_data(:, k)
+               Npq%local_data(:, k) = Npq%local_data(:, k) + scaleN*mult_p(MOD(j + 1, 2) + 1)%local_data(:, k)
+               Dpq%local_data(:, k) = Dpq%local_data(:, k) + scaleD*mult_p(MOD(j + 1, 2) + 1)%local_data(:, k)
             END DO
          END DO
       END IF
 
       CALL cp_fm_solve(Dpq, Npq)
 
-      mult_p(2)%matrix => Npq
-      mult_p(1)%matrix => T1
+      mult_p(2) = Npq
+      mult_p(1) = T1
       IF (nsquare .GT. 0) THEN
          DO i = 1, nsquare
-            CALL parallel_gemm("N", "N", ndim, ndim, ndim, one, mult_p(MOD(i, 2) + 1)%matrix, mult_p(MOD(i, 2) + 1)%matrix, zero, &
-                               mult_p(MOD(i + 1, 2) + 1)%matrix)
+            CALL parallel_gemm("N", "N", ndim, ndim, ndim, one, mult_p(MOD(i, 2) + 1), mult_p(MOD(i, 2) + 1), zero, &
+                               mult_p(MOD(i + 1, 2) + 1))
          END DO
-         fin_p => mult_p(MOD(nsquare + 1, 2) + 1)%matrix
+         fin_p = mult_p(MOD(nsquare + 1, 2) + 1)
       ELSE
-         fin_p => Npq
+         fin_p = Npq
       END IF
 
       DO k = 1, ldim
@@ -677,7 +674,6 @@ CONTAINS
       CALL cp_fm_release(T1)
       CALL cp_fm_release(T2)
       CALL cp_fm_release(Tres)
-      DEALLOCATE (mult_p)
       CALL timestop(handle)
 
    END SUBROUTINE exp_pade_real
@@ -717,8 +713,8 @@ CONTAINS
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: D, mat1, mat2, mat3, N
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: H_approx, H_approx_save
       REAL(KIND=dp)                                      :: conv_norm, prefac, scaleD, scaleN
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: V_mats
       TYPE(cp_fm_struct_type), POINTER                   :: mo_struct, newstruct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: V_mats
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mp_comm_type)                                 :: col_group
 
@@ -744,19 +740,18 @@ CONTAINS
       H_approx_save = rzero
 
       DO i = 1, narnoldi + 1
-         ALLOCATE (V_mats(i)%matrix)
-         CALL cp_fm_create(V_mats(i)%matrix, matrix_struct=newstruct, &
+         CALL cp_fm_create(V_mats(i), matrix_struct=newstruct, &
                            name="V_mat"//cp_to_string(i))
       END DO
-      CALL cp_fm_get_info(V_mats(1)%matrix, ncol_global=newdim)
+      CALL cp_fm_get_info(V_mats(1), ncol_global=newdim)
 
       norm1 = 0.0_dp
 !$OMP PARALLEL DO PRIVATE(icol_local) DEFAULT(NONE) SHARED(V_mats,norm1,mos_old,ncol_local)
       DO icol_local = 1, ncol_local
-         V_mats(1)%matrix%local_data(:, icol_local) = mos_old(1)%local_data(:, icol_local)
-         V_mats(1)%matrix%local_data(:, icol_local + ncol_local) = mos_old(2)%local_data(:, icol_local)
-         norm1(icol_local) = SUM(V_mats(1)%matrix%local_data(:, icol_local)**2) &
-                             + SUM(V_mats(1)%matrix%local_data(:, icol_local + ncol_local)**2)
+         V_mats(1)%local_data(:, icol_local) = mos_old(1)%local_data(:, icol_local)
+         V_mats(1)%local_data(:, icol_local + ncol_local) = mos_old(2)%local_data(:, icol_local)
+         norm1(icol_local) = SUM(V_mats(1)%local_data(:, icol_local)**2) &
+                             + SUM(V_mats(1)%local_data(:, icol_local + ncol_local)**2)
       END DO
 
       CALL mp_sum(norm1, col_group)
@@ -765,33 +760,33 @@ CONTAINS
 
 !$OMP PARALLEL DO PRIVATE(icol_local) DEFAULT(NONE) SHARED(V_mats,norm1,ncol_local)
       DO icol_local = 1, ncol_local
-         V_mats(1)%matrix%local_data(:, icol_local) = V_mats(1)%matrix%local_data(:, icol_local)/norm1(icol_local)
-         V_mats(1)%matrix%local_data(:, icol_local + ncol_local) = &
-            V_mats(1)%matrix%local_data(:, icol_local + ncol_local)/norm1(icol_local)
+         V_mats(1)%local_data(:, icol_local) = V_mats(1)%local_data(:, icol_local)/norm1(icol_local)
+         V_mats(1)%local_data(:, icol_local + ncol_local) = &
+            V_mats(1)%local_data(:, icol_local + ncol_local)/norm1(icol_local)
       END DO
 
       ! arnoldi subspace procedure to get H_approx
       DO i = 2, narnoldi + 1
          !Be careful, imaginary matrix multiplied with complex. Unfortunately requires a swap of arrays afterwards
-         CALL parallel_gemm("N", "N", nao, newdim, nao, 1.0_dp, Him, V_mats(i - 1)%matrix, 0.0_dp, V_mats(i)%matrix)
+         CALL parallel_gemm("N", "N", nao, newdim, nao, 1.0_dp, Him, V_mats(i - 1), 0.0_dp, V_mats(i))
 
 !$OMP PARALLEL DO PRIVATE(icol_local) DEFAULT(NONE) SHARED(mos_new,V_mats,ncol_local,i)
          DO icol_local = 1, ncol_local
-            mos_new(1)%local_data(:, icol_local) = V_mats(i)%matrix%local_data(:, icol_local)
-            V_mats(i)%matrix%local_data(:, icol_local) = -V_mats(i)%matrix%local_data(:, icol_local + ncol_local)
-            V_mats(i)%matrix%local_data(:, icol_local + ncol_local) = mos_new(1)%local_data(:, icol_local)
+            mos_new(1)%local_data(:, icol_local) = V_mats(i)%local_data(:, icol_local)
+            V_mats(i)%local_data(:, icol_local) = -V_mats(i)%local_data(:, icol_local + ncol_local)
+            V_mats(i)%local_data(:, icol_local + ncol_local) = mos_new(1)%local_data(:, icol_local)
          END DO
 
          IF (PRESENT(Hre)) THEN
-            CALL parallel_gemm("N", "N", nao, newdim, nao, 1.0_dp, Hre, V_mats(i - 1)%matrix, 1.0_dp, V_mats(i)%matrix)
+            CALL parallel_gemm("N", "N", nao, newdim, nao, 1.0_dp, Hre, V_mats(i - 1), 1.0_dp, V_mats(i))
          END IF
 
          DO l = 1, i - 1
 !$OMP PARALLEL DO DEFAULT(NONE) SHARED(results,V_mats,ncol_local,l,i)
             DO icol_local = 1, ncol_local
-               results(icol_local) = SUM(V_mats(l)%matrix%local_data(:, icol_local)*V_mats(i)%matrix%local_data(:, icol_local)) + &
-                                     SUM(V_mats(l)%matrix%local_data(:, icol_local + ncol_local)* &
-                                         V_mats(i)%matrix%local_data(:, icol_local + ncol_local))
+               results(icol_local) = SUM(V_mats(l)%local_data(:, icol_local)*V_mats(i)%local_data(:, icol_local)) + &
+                                     SUM(V_mats(l)%local_data(:, icol_local + ncol_local)* &
+                                         V_mats(i)%local_data(:, icol_local + ncol_local))
             END DO
 
             CALL mp_sum(results, col_group)
@@ -799,18 +794,18 @@ CONTAINS
 !$OMP PARALLEL DO DEFAULT(NONE) SHARED(H_approx_save,V_mats,ncol_local,l,i,results)
             DO icol_local = 1, ncol_local
                H_approx_save(l, i - 1, icol_local) = results(icol_local)
-               V_mats(i)%matrix%local_data(:, icol_local) = V_mats(i)%matrix%local_data(:, icol_local) - &
-                                                            results(icol_local)*V_mats(l)%matrix%local_data(:, icol_local)
-               V_mats(i)%matrix%local_data(:, icol_local + ncol_local) = &
-                  V_mats(i)%matrix%local_data(:, icol_local + ncol_local) - &
-                  results(icol_local)*V_mats(l)%matrix%local_data(:, icol_local + ncol_local)
+               V_mats(i)%local_data(:, icol_local) = V_mats(i)%local_data(:, icol_local) - &
+                                                     results(icol_local)*V_mats(l)%local_data(:, icol_local)
+               V_mats(i)%local_data(:, icol_local + ncol_local) = &
+                  V_mats(i)%local_data(:, icol_local + ncol_local) - &
+                  results(icol_local)*V_mats(l)%local_data(:, icol_local + ncol_local)
             END DO
          END DO
 
 !$OMP PARALLEL DO DEFAULT(NONE) SHARED(ncol_local,V_mats,results,i)
          DO icol_local = 1, ncol_local
-            results(icol_local) = SUM(V_mats(i)%matrix%local_data(:, icol_local)**2) + &
-                                  SUM(V_mats(i)%matrix%local_data(:, icol_local + ncol_local)**2)
+            results(icol_local) = SUM(V_mats(i)%local_data(:, icol_local)**2) + &
+                                  SUM(V_mats(i)%local_data(:, icol_local + ncol_local)**2)
          END DO
 
          CALL mp_sum(results, col_group)
@@ -821,9 +816,9 @@ CONTAINS
             DO icol_local = 1, ncol_local
                H_approx_save(i, i - 1, icol_local) = SQRT(results(icol_local))
                last_norm(icol_local) = SQRT(results(icol_local))
-               V_mats(i)%matrix%local_data(:, icol_local) = V_mats(i)%matrix%local_data(:, icol_local)/SQRT(results(icol_local))
-               V_mats(i)%matrix%local_data(:, icol_local + ncol_local) = &
-                  V_mats(i)%matrix%local_data(:, icol_local + ncol_local)/SQRT(results(icol_local))
+               V_mats(i)%local_data(:, icol_local) = V_mats(i)%local_data(:, icol_local)/SQRT(results(icol_local))
+               V_mats(i)%local_data(:, icol_local + ncol_local) = &
+                  V_mats(i)%local_data(:, icol_local + ncol_local)/SQRT(results(icol_local))
             END DO
          ELSE
 !$OMP PARALLEL DO DEFAULT(NONE) SHARED(ncol_local,last_norm,results)
@@ -913,9 +908,9 @@ CONTAINS
                   DO idim = 1, mydim
                      prefac = H_approx(idim, 1, icol_local)*norm1(icol_local)
                      mos_new(1)%local_data(:, icol_local) = mos_new(1)%local_data(:, icol_local) + &
-                                                            V_mats(idim)%matrix%local_data(:, icol_local)*prefac
+                                                            V_mats(idim)%local_data(:, icol_local)*prefac
                      mos_new(2)%local_data(:, icol_local) = mos_new(2)%local_data(:, icol_local) + &
-                                                            V_mats(idim)%matrix%local_data(:, icol_local + ncol_local)*prefac
+                                                            V_mats(idim)%local_data(:, icol_local + ncol_local)*prefac
                   END DO
                END DO
 
@@ -940,10 +935,10 @@ CONTAINS
                         prefac = H_approx(idim, 1, icol_local)*norm1(icol_local)
                         mos_next(1)%local_data(:, icol_local) = &
                            mos_next(1)%local_data(:, icol_local) + &
-                           V_mats(idim)%matrix%local_data(:, icol_local)*prefac
+                           V_mats(idim)%local_data(:, icol_local)*prefac
                         mos_next(2)%local_data(:, icol_local) = &
                            mos_next(2)%local_data(:, icol_local) + &
-                           V_mats(idim)%matrix%local_data(:, icol_local + ncol_local)*prefac
+                           V_mats(idim)%local_data(:, icol_local + ncol_local)*prefac
                      END DO
                   END DO
                END IF
@@ -968,8 +963,7 @@ CONTAINS
       !deallocate all work matrices
 
       DO i = 1, SIZE(V_mats)
-         CALL cp_fm_release(V_mats(i)%matrix)
-         DEALLOCATE (V_mats(i)%matrix)
+         CALL cp_fm_release(V_mats(i))
       END DO
       CALL cp_fm_struct_release(newstruct)
       CALL mp_comm_free(col_group)

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -1177,10 +1177,10 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: a, b
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigval
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_overlap
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: mixed_mo_coeff
       TYPE(cp_fm_p_type), DIMENSION(:, :, :), POINTER    :: w_matrix_mo
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_mo, mo_mo_fmstruct
       TYPE(cp_fm_type)                                   :: inverse_mat, Tinverse, tmp2
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: mixed_mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: density_matrix, density_matrix_diff, &
                                                             w_matrix
@@ -1237,9 +1237,9 @@ CONTAINS
       ! Check that the number of MOs/AOs is equal in every CDFT state
       ALLOCATE (nrow_mo(nspins), ncol_mo(nspins))
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(mixed_mo_coeff(1, ispin)%matrix, ncol_global=check_mo(1), nrow_global=check_ao(1))
+         CALL cp_fm_get_info(mixed_mo_coeff(1, ispin), ncol_global=check_mo(1), nrow_global=check_ao(1))
          DO iforce_eval = 2, nforce_eval
-            CALL cp_fm_get_info(mixed_mo_coeff(iforce_eval, ispin)%matrix, ncol_global=check_mo(2), nrow_global=check_ao(2))
+            CALL cp_fm_get_info(mixed_mo_coeff(iforce_eval, ispin), ncol_global=check_mo(2), nrow_global=check_ao(2))
             IF (check_ao(1) /= check_ao(2)) &
                CALL cp_abort(__LOCATION__, &
                              "The number of atomic orbitals must be the same in every CDFT state.")
@@ -1291,7 +1291,7 @@ CONTAINS
          ! Create the MOxMO fm struct (mo_mo_fm_pools%struct)
          ! The number of MOs/AOs is equal to the number of columns/rows of mo_coeff(:,:)%matrix
          NULLIFY (fm_struct_mo, mo_mo_fmstruct)
-         CALL cp_fm_get_info(mixed_mo_coeff(1, ispin)%matrix, ncol_global=ncol_mo(ispin), nrow_global=nrow_mo(ispin))
+         CALL cp_fm_get_info(mixed_mo_coeff(1, ispin), ncol_global=ncol_mo(ispin), nrow_global=nrow_mo(ispin))
          nao = nrow_mo(ispin)
          IF (uniform_occupation) THEN
             nmo = ncol_mo(ispin)
@@ -1375,15 +1375,15 @@ CONTAINS
          ! Remove empty MOs and (possibly) scale rest with occupation numbers
          IF (.NOT. uniform_occupation) THEN
             DO iforce_eval = 1, nforce_eval
-               CALL cp_fm_to_fm(mixed_mo_coeff(iforce_eval, ispin)%matrix, tmp2, nmo, 1, 1)
-               CALL cp_fm_release(mixed_mo_coeff(iforce_eval, ispin)%matrix)
-               CALL cp_fm_create(mixed_mo_coeff(iforce_eval, ispin)%matrix, &
+               CALL cp_fm_to_fm(mixed_mo_coeff(iforce_eval, ispin), tmp2, nmo, 1, 1)
+               CALL cp_fm_release(mixed_mo_coeff(iforce_eval, ispin))
+               CALL cp_fm_create(mixed_mo_coeff(iforce_eval, ispin), &
                                  matrix_struct=tmp2%matrix_struct, &
                                  name="MO_COEFF_"//TRIM(ADJUSTL(cp_to_string(iforce_eval)))//"_" &
                                  //TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
-               CALL cp_fm_to_fm(tmp2, mixed_mo_coeff(iforce_eval, ispin)%matrix)
+               CALL cp_fm_to_fm(tmp2, mixed_mo_coeff(iforce_eval, ispin))
                IF (should_scale) &
-                  CALL cp_fm_column_scale(mixed_mo_coeff(iforce_eval, ispin)%matrix, &
+                  CALL cp_fm_column_scale(mixed_mo_coeff(iforce_eval, ispin), &
                                           mixed_cdft%occupations(iforce_eval, ispin)%array(1:nmo))
                DEALLOCATE (mixed_cdft%occupations(iforce_eval, ispin)%array)
             END DO
@@ -1393,10 +1393,10 @@ CONTAINS
          DO istate = 1, nforce_eval
             DO jstate = istate + 1, nforce_eval
                ipermutation = ipermutation + 1
-               CALL cp_dbcsr_sm_fm_multiply(mixed_matrix_s, mixed_mo_coeff(istate, ispin)%matrix, &
+               CALL cp_dbcsr_sm_fm_multiply(mixed_matrix_s, mixed_mo_coeff(istate, ispin), &
                                             tmp2, nmo, 1.0_dp, 0.0_dp)
                CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
-                                  mixed_mo_coeff(jstate, ispin)%matrix, &
+                                  mixed_mo_coeff(jstate, ispin), &
                                   tmp2, 0.0_dp, mo_overlap(ipermutation)%matrix)
                IF (print_mo) &
                   CALL cp_fm_write_formatted(mo_overlap(ipermutation)%matrix, mounit, &
@@ -1413,10 +1413,10 @@ CONTAINS
                   IF (istate == jstate) CYCLE
                   ! State i: (C_j)^T W_i C_i
                   CALL cp_dbcsr_sm_fm_multiply(w_matrix(istate, ivar)%matrix, &
-                                               mixed_mo_coeff(istate, ispin)%matrix, &
+                                               mixed_mo_coeff(istate, ispin), &
                                                tmp2, nmo, 1.0_dp, 0.0_dp)
                   CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
-                                     mixed_mo_coeff(jstate, ispin)%matrix, &
+                                     mixed_mo_coeff(jstate, ispin), &
                                      tmp2, 0.0_dp, w_matrix_mo(istate, jstate, ivar)%matrix)
                END DO
             END DO
@@ -2064,9 +2064,9 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: coupling_wfn
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: overlaps
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: mixed_mo_coeff
       TYPE(cp_fm_struct_type), POINTER                   :: mo_mo_fmstruct
       TYPE(cp_fm_type)                                   :: inverse_mat, mo_overlap_wfn, mo_tmp
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: mixed_mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys_mix
       TYPE(dbcsr_type), POINTER                          :: mixed_matrix_s
@@ -2104,7 +2104,7 @@ CONTAINS
          CALL set_mo_set(mo_set(ispin), uniform_occupation=.TRUE., homo=nmo)
          ALLOCATE (mo_set(ispin)%mo_coeff)
          CALL cp_fm_create(matrix=mo_set(ispin)%mo_coeff, &
-                           matrix_struct=mixed_mo_coeff(1, ispin)%matrix%matrix_struct, &
+                           matrix_struct=mixed_mo_coeff(1, ispin)%matrix_struct, &
                            name="GS_MO_COEFF"//TRIM(ADJUSTL(cp_to_string(ispin)))//"MATRIX")
          ALLOCATE (mo_set(ispin)%eigenvalues(nmo))
          ALLOCATE (mo_set(ispin)%occupation_numbers(nmo))
@@ -2160,7 +2160,7 @@ CONTAINS
                            name="INVERSE_MO_OVERLAP_MATRIX_WFN")
          CALL cp_fm_struct_release(mo_mo_fmstruct)
          CALL cp_fm_create(matrix=mo_tmp, &
-                           matrix_struct=mixed_mo_coeff(1, ispin)%matrix%matrix_struct, &
+                           matrix_struct=mixed_mo_coeff(1, ispin)%matrix_struct, &
                            name="OVERLAP_MO_COEFF_WFN")
          DO ipermutation = 1, npermutations
             CALL map_permutation_to_states(nforce_eval, ipermutation, istate, jstate)
@@ -2170,13 +2170,13 @@ CONTAINS
             ! C_i^T * (S*C_r)
             CALL cp_fm_set_all(mo_overlap_wfn, alpha=0.0_dp)
             CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
-                               mixed_mo_coeff(istate, ispin)%matrix, &
+                               mixed_mo_coeff(istate, ispin), &
                                mo_tmp, 0.0_dp, mo_overlap_wfn)
             CALL cp_fm_invert(mo_overlap_wfn, inverse_mat, overlaps(1, ipermutation, ispin), eps_svd=mixed_cdft%eps_svd)
             ! C_j^T * (S*C_r)
             CALL cp_fm_set_all(mo_overlap_wfn, alpha=0.0_dp)
             CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
-                               mixed_mo_coeff(jstate, ispin)%matrix, &
+                               mixed_mo_coeff(jstate, ispin), &
                                mo_tmp, 0.0_dp, mo_overlap_wfn)
             CALL cp_fm_invert(mo_overlap_wfn, inverse_mat, overlaps(2, ipermutation, ispin), eps_svd=mixed_cdft%eps_svd)
          END DO

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -31,7 +31,6 @@ MODULE mixed_cdft_methods
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -1176,10 +1175,10 @@ CONTAINS
                                                             W_diagonal, Wad, Wda
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: a, b
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigval
-      TYPE(cp_fm_type), DIMENSION(:), ALLOCATABLE        :: mo_overlap
-      TYPE(cp_fm_type), DIMENSION(:, :, :), ALLOCATABLE  :: w_matrix_mo
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_mo, mo_mo_fmstruct
       TYPE(cp_fm_type)                                   :: inverse_mat, Tinverse, tmp2
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_overlap
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :, :)  :: w_matrix_mo
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: mixed_mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: density_matrix, density_matrix_diff, &

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -1176,8 +1176,8 @@ CONTAINS
                                                             W_diagonal, Wad, Wda
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: a, b
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigval
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_overlap
-      TYPE(cp_fm_p_type), DIMENSION(:, :, :), POINTER    :: w_matrix_mo
+      TYPE(cp_fm_type), DIMENSION(:), ALLOCATABLE        :: mo_overlap
+      TYPE(cp_fm_type), DIMENSION(:, :, :), ALLOCATABLE  :: w_matrix_mo
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_mo, mo_mo_fmstruct
       TYPE(cp_fm_type)                                   :: inverse_mat, Tinverse, tmp2
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: mixed_mo_coeff
@@ -1195,8 +1195,8 @@ CONTAINS
 
       NULLIFY (force_env_section, print_section, mixed_cdft_section, &
                mixed_env, mixed_cdft, qs_env, dft_control, fm_struct_mo, &
-               density_matrix_diff, mo_mo_fmstruct, mo_overlap, &
-               w_matrix_mo, mixed_mo_coeff, mixed_matrix_s, &
+               density_matrix_diff, mo_mo_fmstruct, &
+               mixed_mo_coeff, mixed_matrix_s, &
                density_matrix, energy_qs, w_matrix, mo_eigval)
       logger => cp_get_default_logger()
       CPASSERT(ASSOCIATED(force_env))
@@ -1255,9 +1255,6 @@ CONTAINS
       ALLOCATE (a(nspins, nvar, npermutations), b(nspins, nvar, npermutations))
       a = 0.0_dp
       b = 0.0_dp
-      DO istate = 1, npermutations
-         NULLIFY (mo_overlap(istate)%matrix)
-      END DO
       IF (mixed_cdft%calculate_metric) THEN
          ALLOCATE (density_matrix_diff(npermutations, nspins))
          DO ispin = 1, nspins
@@ -1353,18 +1350,15 @@ CONTAINS
          CALL cp_fm_create(matrix=Tinverse, matrix_struct=mo_mo_fmstruct, &
                            name="T_INVERSE_"//TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
          DO istate = 1, npermutations
-            ALLOCATE (mo_overlap(istate)%matrix)
-            CALL cp_fm_create(matrix=mo_overlap(istate)%matrix, matrix_struct=mo_mo_fmstruct, &
+            CALL cp_fm_create(matrix=mo_overlap(istate), matrix_struct=mo_mo_fmstruct, &
                               name="MO_OVERLAP_"//TRIM(ADJUSTL(cp_to_string(istate)))//"_"// &
                               TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
          END DO
          DO ivar = 1, nvar
             DO istate = 1, nforce_eval
                DO jstate = 1, nforce_eval
-                  NULLIFY (w_matrix_mo(istate, jstate, ivar)%matrix)
                   IF (istate == jstate) CYCLE
-                  ALLOCATE (w_matrix_mo(istate, jstate, ivar)%matrix)
-                  CALL cp_fm_create(matrix=w_matrix_mo(istate, jstate, ivar)%matrix, matrix_struct=mo_mo_fmstruct, &
+                  CALL cp_fm_create(matrix=w_matrix_mo(istate, jstate, ivar), matrix_struct=mo_mo_fmstruct, &
                                     name="W_"//TRIM(ADJUSTL(cp_to_string(istate)))//"_"// &
                                     TRIM(ADJUSTL(cp_to_string(jstate)))//"_"// &
                                     TRIM(ADJUSTL(cp_to_string(ivar)))//"_MATRIX")
@@ -1397,9 +1391,9 @@ CONTAINS
                                             tmp2, nmo, 1.0_dp, 0.0_dp)
                CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
                                   mixed_mo_coeff(jstate, ispin), &
-                                  tmp2, 0.0_dp, mo_overlap(ipermutation)%matrix)
+                                  tmp2, 0.0_dp, mo_overlap(ipermutation))
                IF (print_mo) &
-                  CALL cp_fm_write_formatted(mo_overlap(ipermutation)%matrix, mounit, &
+                  CALL cp_fm_write_formatted(mo_overlap(ipermutation), mounit, &
                                              "# MO overlap matrix (step "//TRIM(ADJUSTL(cp_to_string(mixed_cdft%sim_step)))// &
                                              "): CDFT states "//TRIM(ADJUSTL(cp_to_string(istate)))//" and "// &
                                              TRIM(ADJUSTL(cp_to_string(jstate)))//" (spin "// &
@@ -1417,7 +1411,7 @@ CONTAINS
                                                tmp2, nmo, 1.0_dp, 0.0_dp)
                   CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, &
                                      mixed_mo_coeff(jstate, ispin), &
-                                     tmp2, 0.0_dp, w_matrix_mo(istate, jstate, ivar)%matrix)
+                                     tmp2, 0.0_dp, w_matrix_mo(istate, jstate, ivar))
                END DO
             END DO
          END DO
@@ -1426,7 +1420,7 @@ CONTAINS
             CALL map_permutation_to_states(nforce_eval, ipermutation, istate, jstate)
             IF (print_mo_eigval) THEN
                NULLIFY (mo_eigval)
-               CALL cp_fm_invert(mo_overlap(ipermutation)%matrix, inverse_mat, &
+               CALL cp_fm_invert(mo_overlap(ipermutation), inverse_mat, &
                                  S_det(ipermutation, ispin), eps_svd=mixed_cdft%eps_svd, &
                                  eigval=mo_eigval)
                IF (moeigvalunit > 0) THEN
@@ -1446,7 +1440,7 @@ CONTAINS
                END IF
                DEALLOCATE (mo_eigval)
             ELSE
-               CALL cp_fm_invert(mo_overlap(ipermutation)%matrix, inverse_mat, &
+               CALL cp_fm_invert(mo_overlap(ipermutation), inverse_mat, &
                                  S_det(ipermutation, ispin), eps_svd=mixed_cdft%eps_svd)
             END IF
             CALL cp_fm_get_info(inverse_mat, nrow_local=nrow_local, ncol_local=ncol_local)
@@ -1455,7 +1449,7 @@ CONTAINS
                DO k = 1, nrow_local
                   DO ivar = 1, nvar
                      b(ispin, ivar, ipermutation) = b(ispin, ivar, ipermutation) + &
-                                                    w_matrix_mo(jstate, istate, ivar)%matrix%local_data(k, j)* &
+                                                    w_matrix_mo(jstate, istate, ivar)%local_data(k, j)* &
                                                     inverse_mat%local_data(k, j)
                   END DO
                END DO
@@ -1466,7 +1460,7 @@ CONTAINS
                DO k = 1, nrow_local
                   DO ivar = 1, nvar
                      a(ispin, ivar, ipermutation) = a(ispin, ivar, ipermutation) + &
-                                                    w_matrix_mo(istate, jstate, ivar)%matrix%local_data(k, j)* &
+                                                    w_matrix_mo(istate, jstate, ivar)%local_data(k, j)* &
                                                     Tinverse%local_data(k, j)
                   END DO
                END DO
@@ -1516,14 +1510,12 @@ CONTAINS
             DO jstate = 1, nforce_eval
                DO istate = 1, nforce_eval
                   IF (istate == jstate) CYCLE
-                  CALL cp_fm_release(w_matrix_mo(istate, jstate, ivar)%matrix)
-                  DEALLOCATE (w_matrix_mo(istate, jstate, ivar)%matrix)
+                  CALL cp_fm_release(w_matrix_mo(istate, jstate, ivar))
                END DO
             END DO
          END DO
          DO ipermutation = 1, npermutations
-            CALL cp_fm_release(mo_overlap(ipermutation)%matrix)
-            DEALLOCATE (mo_overlap(ipermutation)%matrix)
+            CALL cp_fm_release(mo_overlap(ipermutation))
          END DO
          CALL cp_fm_release(Tinverse)
          CALL cp_fm_release(inverse_mat)

--- a/src/mixed_cdft_types.F
+++ b/src/mixed_cdft_types.F
@@ -15,8 +15,8 @@ MODULE mixed_cdft_types
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_release,&
                                               cp_blacs_env_type
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_p_type,&
                                               cp_logger_release
    USE dbcsr_api,                       ONLY: dbcsr_p_type,&
@@ -68,7 +68,7 @@ MODULE mixed_cdft_types
       ! AO overlap matrix
       TYPE(dbcsr_type), POINTER                          :: mixed_matrix_s
       ! MO coefficients of each CDFT state
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: mixed_mo_coeff
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: mixed_mo_coeff
       ! Density matrices of the CDFT states
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: density_matrix
    END TYPE mixed_cdft_work_type
@@ -617,8 +617,7 @@ CONTAINS
       IF (ASSOCIATED(matrix%mixed_mo_coeff)) THEN
          DO i = 1, SIZE(matrix%mixed_mo_coeff, 2)
             DO j = 1, SIZE(matrix%mixed_mo_coeff, 1)
-               CALL cp_fm_release(matrix%mixed_mo_coeff(j, i)%matrix)
-               DEALLOCATE (matrix%mixed_mo_coeff(j, i)%matrix)
+               CALL cp_fm_release(matrix%mixed_mo_coeff(j, i))
             END DO
          END DO
          DEALLOCATE (matrix%mixed_mo_coeff)

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -31,7 +31,6 @@ MODULE mixed_cdft_utils
    USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
                                               cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -1058,12 +1057,11 @@ CONTAINS
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: has_occupation_numbers
       TYPE(cp_1d_r_p_type), ALLOCATABLE, DIMENSION(:, :) :: occno_tmp
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: matrix_p_tmp, mixed_matrix_p_tmp, &
-                                                            mixed_wmat_tmp, mo_coeff_tmp, wmat_tmp
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_mo, fm_struct_overlap, &
                                                             fm_struct_tmp, fm_struct_wmat
-      TYPE(cp_fm_type)                                   :: fm_dummy, matrix_s_tmp, &
-                                                            mixed_matrix_s_tmp
+      TYPE(cp_fm_type)                                   :: matrix_s_tmp, mixed_matrix_s_tmp
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: matrix_p_tmp, mixed_matrix_p_tmp, &
+                                                            mixed_wmat_tmp, mo_coeff_tmp, wmat_tmp
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: mixed_mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: density_matrix, w_matrix
       TYPE(dbcsr_type)                                   :: desymm_tmp
@@ -1076,9 +1074,7 @@ CONTAINS
 
       NULLIFY (mixed_env, mixed_cdft, qs_env, dft_control, fm_struct_mo, &
                fm_struct_wmat, fm_struct_overlap, fm_struct_tmp, &
-               mixed_wmat_tmp, &
-               wmat_tmp, mixed_mo_coeff, matrix_p_tmp, mixed_matrix_p_tmp, &
-               mixed_matrix_s, density_matrix, blacs_env, w_matrix, force_env_qs)
+               mixed_mo_coeff, mixed_matrix_s, density_matrix, blacs_env, w_matrix, force_env_qs)
       CPASSERT(ASSOCIATED(force_env))
       mixed_env => force_env%mixed_env
       nforce_eval = SIZE(force_env%sub_force_env)
@@ -1161,16 +1157,10 @@ CONTAINS
       END IF
       DO iforce_eval = 1, nforce_eval
          ! Temporary arrays need to be nulled on every process
-         DO ivar = 1, nvar
-            NULLIFY (wmat_tmp(iforce_eval, ivar)%matrix)
-         END DO
          DO ispin = 1, nspins
-            NULLIFY (mo_coeff_tmp(iforce_eval, ispin)%matrix)
             ! Valgrind 3.12/gfortran 4.8.4 oddly complains here (unconditional jump)
             ! if mixed_cdft%calculate_metric = .FALSE. and the need to null the array
             ! is queried with IF (mixed_cdft%calculate_metric) &
-            IF (ASSOCIATED(matrix_p_tmp)) &
-               NULLIFY (matrix_p_tmp(iforce_eval, ispin)%matrix)
             IF (.NOT. uniform_occupation) &
                NULLIFY (occno_tmp(iforce_eval, ispin)%array)
          END DO
@@ -1193,13 +1183,12 @@ CONTAINS
          DO ispin = 1, nspins
             CALL cp_fm_get_info(dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix, &
                                 ncol_global=ncol_mo(ispin), nrow_global=nrow_mo(ispin))
-            ALLOCATE (mo_coeff_tmp(iforce_eval, ispin)%matrix)
-            CALL cp_fm_create(matrix=mo_coeff_tmp(iforce_eval, ispin)%matrix, &
+            CALL cp_fm_create(matrix=mo_coeff_tmp(iforce_eval, ispin), &
                               matrix_struct=dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix%matrix_struct, &
                               name="MO_COEFF_"//TRIM(ADJUSTL(cp_to_string(iforce_eval)))//"_" &
                               //TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
             CALL cp_fm_to_fm(dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix, &
-                             mo_coeff_tmp(iforce_eval, ispin)%matrix)
+                             mo_coeff_tmp(iforce_eval, ispin))
             CALL cp_fm_release(dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix)
             DEALLOCATE (dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix)
          END DO
@@ -1209,10 +1198,9 @@ CONTAINS
                                   para_env=force_env%sub_force_env(iforce_eval)%force_env%para_env, &
                                   square_blocks=.TRUE.)
          DO ivar = 1, nvar
-            ALLOCATE (wmat_tmp(iforce_eval, ivar)%matrix)
-            CALL cp_fm_create(wmat_tmp(iforce_eval, ivar)%matrix, fm_struct_tmp, name="w_matrix")
+            CALL cp_fm_create(wmat_tmp(iforce_eval, ivar), fm_struct_tmp, name="w_matrix")
             CALL dbcsr_desymmetrize(dft_control%qs_control%cdft_control%wmat(ivar)%matrix, desymm_tmp)
-            CALL copy_dbcsr_to_fm(desymm_tmp, wmat_tmp(iforce_eval, ivar)%matrix)
+            CALL copy_dbcsr_to_fm(desymm_tmp, wmat_tmp(iforce_eval, ivar))
             CALL dbcsr_release(desymm_tmp)
             CALL dbcsr_release_p(dft_control%qs_control%cdft_control%wmat(ivar)%matrix)
          END DO
@@ -1237,11 +1225,10 @@ CONTAINS
                CALL cp_fm_struct_create(fm_struct_tmp, nrow_global=ncol_overlap, &
                                         ncol_global=ncol_overlap, context=blacs_env, &
                                         para_env=force_env%sub_force_env(iforce_eval)%force_env%para_env)
-               ALLOCATE (matrix_p_tmp(iforce_eval, ispin)%matrix)
-               CALL cp_fm_create(matrix_p_tmp(iforce_eval, ispin)%matrix, fm_struct_tmp, name="dm_matrix")
+               CALL cp_fm_create(matrix_p_tmp(iforce_eval, ispin), fm_struct_tmp, name="dm_matrix")
                CALL cp_fm_struct_release(fm_struct_tmp)
                CALL dbcsr_desymmetrize(dft_control%qs_control%cdft_control%matrix_p(ispin)%matrix, desymm_tmp)
-               CALL copy_dbcsr_to_fm(desymm_tmp, matrix_p_tmp(iforce_eval, ispin)%matrix)
+               CALL copy_dbcsr_to_fm(desymm_tmp, matrix_p_tmp(iforce_eval, ispin))
                CALL dbcsr_release(desymm_tmp)
                CALL dbcsr_release_p(dft_control%qs_control%cdft_control%matrix_p(ispin)%matrix)
             END DO
@@ -1282,78 +1269,44 @@ CONTAINS
                               matrix_struct=fm_struct_mo, &
                               name="MO_COEFF_"//TRIM(ADJUSTL(cp_to_string(iforce_eval)))//"_" &
                               //TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
-            IF (ASSOCIATED(mo_coeff_tmp(iforce_eval, ispin)%matrix)) THEN
-               CALL cp_fm_copy_general(mo_coeff_tmp(iforce_eval, ispin)%matrix, &
-                                       mixed_mo_coeff(iforce_eval, ispin), &
-                                       mixed_cdft%blacs_env%para_env)
-            ELSE
-               CALL cp_fm_copy_general(fm_dummy, &
-                                       mixed_mo_coeff(iforce_eval, ispin), &
-                                       mixed_cdft%blacs_env%para_env)
-            END IF
-            IF (ASSOCIATED(mo_coeff_tmp(iforce_eval, ispin)%matrix)) THEN
-               CALL cp_fm_release(mo_coeff_tmp(iforce_eval, ispin)%matrix)
-               DEALLOCATE (mo_coeff_tmp(iforce_eval, ispin)%matrix)
-               NULLIFY (mo_coeff_tmp(iforce_eval, ispin)%matrix)
-            END IF
+            CALL cp_fm_copy_general(mo_coeff_tmp(iforce_eval, ispin), &
+                                    mixed_mo_coeff(iforce_eval, ispin), &
+                                    mixed_cdft%blacs_env%para_env)
+            CALL cp_fm_release(mo_coeff_tmp(iforce_eval, ispin))
             CALL cp_fm_struct_release(fm_struct_mo)
          END DO
          ! Weight
          DO ivar = 1, nvar
-            ALLOCATE (mixed_wmat_tmp(iforce_eval, ivar)%matrix)
             NULLIFY (w_matrix(iforce_eval, ivar)%matrix)
             CALL dbcsr_init_p(w_matrix(iforce_eval, ivar)%matrix)
-            CALL cp_fm_create(matrix=mixed_wmat_tmp(iforce_eval, ivar)%matrix, &
+            CALL cp_fm_create(matrix=mixed_wmat_tmp(iforce_eval, ivar), &
                               matrix_struct=fm_struct_wmat, &
                               name="WEIGHT_"//TRIM(ADJUSTL(cp_to_string(iforce_eval)))//"_MATRIX")
-            IF (ASSOCIATED(wmat_tmp(iforce_eval, ivar)%matrix)) THEN
-               CALL cp_fm_copy_general(wmat_tmp(iforce_eval, ivar)%matrix, &
-                                       mixed_wmat_tmp(iforce_eval, ivar)%matrix, &
-                                       mixed_cdft%blacs_env%para_env)
-            ELSE
-               CALL cp_fm_copy_general(fm_dummy, &
-                                       mixed_wmat_tmp(iforce_eval, ivar)%matrix, &
-                                       mixed_cdft%blacs_env%para_env)
-            END IF
-            IF (ASSOCIATED(wmat_tmp(iforce_eval, ivar)%matrix)) THEN
-               CALL cp_fm_release(wmat_tmp(iforce_eval, ivar)%matrix)
-               DEALLOCATE (wmat_tmp(iforce_eval, ivar)%matrix)
-               NULLIFY (wmat_tmp(iforce_eval, ivar)%matrix)
-            END IF
+            CALL cp_fm_copy_general(wmat_tmp(iforce_eval, ivar), &
+                                    mixed_wmat_tmp(iforce_eval, ivar), &
+                                    mixed_cdft%blacs_env%para_env)
+            CALL cp_fm_release(wmat_tmp(iforce_eval, ivar))
             ! (fm -> dbcsr)
-            CALL copy_fm_to_dbcsr_bc(mixed_wmat_tmp(iforce_eval, ivar)%matrix, &
+            CALL copy_fm_to_dbcsr_bc(mixed_wmat_tmp(iforce_eval, ivar), &
                                      w_matrix(iforce_eval, ivar)%matrix)
-            CALL cp_fm_release(mixed_wmat_tmp(iforce_eval, ivar)%matrix)
-            DEALLOCATE (mixed_wmat_tmp(iforce_eval, ivar)%matrix)
+            CALL cp_fm_release(mixed_wmat_tmp(iforce_eval, ivar))
          END DO
          ! Density matrix (fm -> dbcsr)
          IF (mixed_cdft%calculate_metric) THEN
             DO ispin = 1, nspins
-               ALLOCATE (mixed_matrix_p_tmp(iforce_eval, ispin)%matrix)
                NULLIFY (density_matrix(iforce_eval, ispin)%matrix)
                CALL dbcsr_init_p(density_matrix(iforce_eval, ispin)%matrix)
-               CALL cp_fm_create(matrix=mixed_matrix_p_tmp(iforce_eval, ispin)%matrix, &
+               CALL cp_fm_create(matrix=mixed_matrix_p_tmp(iforce_eval, ispin), &
                                  matrix_struct=fm_struct_overlap, &
                                  name="DENSITY_"//TRIM(ADJUSTL(cp_to_string(iforce_eval)))//"_"// &
                                  TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
-               IF (ASSOCIATED(matrix_p_tmp(iforce_eval, ispin)%matrix)) THEN
-                  CALL cp_fm_copy_general(matrix_p_tmp(iforce_eval, ispin)%matrix, &
-                                          mixed_matrix_p_tmp(iforce_eval, ispin)%matrix, &
-                                          mixed_cdft%blacs_env%para_env)
-               ELSE
-                  CALL cp_fm_copy_general(fm_dummy, &
-                                          mixed_matrix_p_tmp(iforce_eval, ispin)%matrix, &
-                                          mixed_cdft%blacs_env%para_env)
-               END IF
-               IF (ASSOCIATED(matrix_p_tmp(iforce_eval, ispin)%matrix)) THEN
-                  CALL cp_fm_release(matrix_p_tmp(iforce_eval, ispin)%matrix)
-                  DEALLOCATE (matrix_p_tmp(iforce_eval, ispin)%matrix)
-                  NULLIFY (matrix_p_tmp(iforce_eval, ispin)%matrix)
-               END IF
-               CALL copy_fm_to_dbcsr_bc(mixed_matrix_p_tmp(iforce_eval, ispin)%matrix, &
+               CALL cp_fm_copy_general(matrix_p_tmp(iforce_eval, ispin), &
+                                       mixed_matrix_p_tmp(iforce_eval, ispin), &
+                                       mixed_cdft%blacs_env%para_env)
+               CALL cp_fm_release(matrix_p_tmp(iforce_eval, ispin))
+               CALL copy_fm_to_dbcsr_bc(mixed_matrix_p_tmp(iforce_eval, ispin), &
                                         density_matrix(iforce_eval, ispin)%matrix)
-               CALL cp_fm_release(mixed_matrix_p_tmp(iforce_eval, ispin)%matrix)
-               DEALLOCATE (mixed_matrix_p_tmp(iforce_eval, ispin)%matrix)
+               CALL cp_fm_release(mixed_matrix_p_tmp(iforce_eval, ispin))
             END DO
          END IF
       END DO

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -1181,16 +1181,15 @@ CONTAINS
                              nfullrows_total=nrow_wmat, nfullcols_total=ncol_wmat)
          ! MO Coefficients
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix, &
+            CALL cp_fm_get_info(dft_control%qs_control%cdft_control%mo_coeff(ispin), &
                                 ncol_global=ncol_mo(ispin), nrow_global=nrow_mo(ispin))
             CALL cp_fm_create(matrix=mo_coeff_tmp(iforce_eval, ispin), &
-                              matrix_struct=dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix%matrix_struct, &
+                              matrix_struct=dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix_struct, &
                               name="MO_COEFF_"//TRIM(ADJUSTL(cp_to_string(iforce_eval)))//"_" &
                               //TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
-            CALL cp_fm_to_fm(dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix, &
+            CALL cp_fm_to_fm(dft_control%qs_control%cdft_control%mo_coeff(ispin), &
                              mo_coeff_tmp(iforce_eval, ispin))
-            CALL cp_fm_release(dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix)
-            DEALLOCATE (dft_control%qs_control%cdft_control%mo_coeff(ispin)%matrix)
+            CALL cp_fm_release(dft_control%qs_control%cdft_control%mo_coeff(ispin))
          END DO
          DEALLOCATE (dft_control%qs_control%cdft_control%mo_coeff)
          ! Matrix representation(s) of the weight function(s) (dbcsr -> fm)

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -1059,12 +1059,12 @@ CONTAINS
       TYPE(cp_1d_r_p_type), ALLOCATABLE, DIMENSION(:, :) :: occno_tmp
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: matrix_p_tmp, mixed_matrix_p_tmp, &
-                                                            mixed_mo_coeff, mixed_wmat_tmp, &
-                                                            mo_coeff_tmp, wmat_tmp
+                                                            mixed_wmat_tmp, mo_coeff_tmp, wmat_tmp
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_mo, fm_struct_overlap, &
                                                             fm_struct_tmp, fm_struct_wmat
       TYPE(cp_fm_type)                                   :: fm_dummy, matrix_s_tmp, &
                                                             mixed_matrix_s_tmp
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: mixed_mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: density_matrix, w_matrix
       TYPE(dbcsr_type)                                   :: desymm_tmp
       TYPE(dbcsr_type), POINTER                          :: mixed_matrix_s
@@ -1278,18 +1278,17 @@ CONTAINS
             NULLIFY (fm_struct_mo)
             CALL cp_fm_struct_create(fm_struct_mo, nrow_global=nrow_mo(ispin), ncol_global=ncol_mo(ispin), &
                                      context=mixed_cdft%blacs_env, para_env=force_env%para_env)
-            ALLOCATE (mixed_mo_coeff(iforce_eval, ispin)%matrix)
-            CALL cp_fm_create(matrix=mixed_mo_coeff(iforce_eval, ispin)%matrix, &
+            CALL cp_fm_create(matrix=mixed_mo_coeff(iforce_eval, ispin), &
                               matrix_struct=fm_struct_mo, &
                               name="MO_COEFF_"//TRIM(ADJUSTL(cp_to_string(iforce_eval)))//"_" &
                               //TRIM(ADJUSTL(cp_to_string(ispin)))//"_MATRIX")
             IF (ASSOCIATED(mo_coeff_tmp(iforce_eval, ispin)%matrix)) THEN
                CALL cp_fm_copy_general(mo_coeff_tmp(iforce_eval, ispin)%matrix, &
-                                       mixed_mo_coeff(iforce_eval, ispin)%matrix, &
+                                       mixed_mo_coeff(iforce_eval, ispin), &
                                        mixed_cdft%blacs_env%para_env)
             ELSE
                CALL cp_fm_copy_general(fm_dummy, &
-                                       mixed_mo_coeff(iforce_eval, ispin)%matrix, &
+                                       mixed_mo_coeff(iforce_eval, ispin), &
                                        mixed_cdft%blacs_env%para_env)
             END IF
             IF (ASSOCIATED(mo_coeff_tmp(iforce_eval, ispin)%matrix)) THEN

--- a/src/molecular_moments.F
+++ b/src/molecular_moments.F
@@ -21,7 +21,6 @@ MODULE molecular_moments
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -81,7 +80,7 @@ CONTAINS
    SUBROUTINE calculate_molecular_moments(qs_env, qs_loc_env, mo_local, loc_print_key, molecule_set)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_loc_env_type), INTENT(IN)                  :: qs_loc_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_local
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_local
       TYPE(section_vals_type), POINTER                   :: loc_print_key
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
 
@@ -167,7 +166,7 @@ CONTAINS
                END IF
                CALL mp_bcast(states, iproc, para_env%group)
                ! assemble local states for this molecule
-               ASSOCIATE (mo_localized => mo_local(ispin)%matrix)
+               ASSOCIATE (mo_localized => mo_local(ispin))
                   CALL cp_fm_get_info(mo_localized, ncol_global=ncol_global, nrow_global=nrow_global)
                   CALL cp_fm_struct_create(fm_struct, nrow_global=nrow_global, ncol_global=ns, &
                                            para_env=mo_localized%matrix_struct%para_env, &

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -17,7 +17,6 @@ MODULE negf_env_types
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
@@ -1233,7 +1232,7 @@ CONTAINS
       ! h_s
       IF (ALLOCATED(negf_env%h_s)) THEN
          DO ispin = SIZE(negf_env%h_s), 1, -1
-               CALL cp_fm_release(negf_env%h_s(ispin))
+            CALL cp_fm_release(negf_env%h_s(ispin))
          END DO
          DEALLOCATE (negf_env%h_s)
       END IF
@@ -1243,7 +1242,7 @@ CONTAINS
          nspins = SIZE(negf_env%h_sc, 1)
          DO icontact = SIZE(negf_env%h_sc, 2), 1, -1
             DO ispin = nspins, 1, -1
-                  CALL cp_fm_release(negf_env%h_sc(ispin, icontact))
+               CALL cp_fm_release(negf_env%h_sc(ispin, icontact))
             END DO
          END DO
          DEALLOCATE (negf_env%h_sc)
@@ -1259,7 +1258,7 @@ CONTAINS
       ! s_sc
       IF (ALLOCATED(negf_env%s_sc)) THEN
          DO icontact = SIZE(negf_env%s_sc), 1, -1
-               CALL cp_fm_release(negf_env%s_sc(icontact))
+            CALL cp_fm_release(negf_env%s_sc(icontact))
          END DO
          DEALLOCATE (negf_env%s_sc)
       END IF
@@ -1296,7 +1295,7 @@ CONTAINS
       ! h_00
       IF (ALLOCATED(contact_env%h_00)) THEN
          DO ispin = SIZE(contact_env%h_00), 1, -1
-               CALL cp_fm_release(contact_env%h_00(ispin))
+            CALL cp_fm_release(contact_env%h_00(ispin))
          END DO
          DEALLOCATE (contact_env%h_00)
       END IF
@@ -1304,7 +1303,7 @@ CONTAINS
       ! h_01
       IF (ALLOCATED(contact_env%h_01)) THEN
          DO ispin = SIZE(contact_env%h_01), 1, -1
-               CALL cp_fm_release(contact_env%h_01(ispin))
+            CALL cp_fm_release(contact_env%h_01(ispin))
          END DO
          DEALLOCATE (contact_env%h_01)
       END IF
@@ -1312,7 +1311,7 @@ CONTAINS
       ! rho_00
       IF (ALLOCATED(contact_env%rho_00)) THEN
          DO ispin = SIZE(contact_env%rho_00), 1, -1
-               CALL cp_fm_release(contact_env%rho_00(ispin))
+            CALL cp_fm_release(contact_env%rho_00(ispin))
          END DO
          DEALLOCATE (contact_env%rho_00)
       END IF
@@ -1320,7 +1319,7 @@ CONTAINS
       ! rho_01
       IF (ALLOCATED(contact_env%rho_01)) THEN
          DO ispin = SIZE(contact_env%rho_01), 1, -1
-               CALL cp_fm_release(contact_env%rho_01(ispin))
+            CALL cp_fm_release(contact_env%rho_01(ispin))
          END DO
          DEALLOCATE (contact_env%rho_01)
       END IF

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -107,9 +107,9 @@ MODULE negf_env_types
       REAL(kind=dp)                                      :: homo_energy
       !> diagonal (h_00) and off-diagonal (h_01) blocks of the contact Kohn-Sham matrix ([number_of_spins]).
       !> The matrix h_01 is of the shape [nao_cell0 x nao_cell1]
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: h_00, h_01
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)      :: h_00, h_01
       !> diagonal and off-diagonal blocks of the density matrix
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: rho_00, rho_01
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)      :: rho_00, rho_01
       !> diagonal and off-diagonal blocks of the overlap matrix
       TYPE(cp_fm_type), POINTER                          :: s_00 => null(), s_01 => null()
    END TYPE negf_env_contact_type
@@ -123,15 +123,15 @@ MODULE negf_env_types
       TYPE(negf_env_contact_type), ALLOCATABLE, &
          DIMENSION(:)                                     :: contacts
       !> Kohn-Sham matrix of the scattering region
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)       :: h_s
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)       :: h_s
       !> Kohn-Sham matrix of the scattering region -- contact interface ([nspins, ncontacts])
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)    :: h_sc
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)    :: h_sc
       !> overlap matrix of the scattering region
       TYPE(cp_fm_type), POINTER                           :: s_s => null()
       !> an external Hartree potential in atomic basis set representation
       TYPE(cp_fm_type), POINTER                           :: v_hartree_s => null()
       !> overlap matrix of the scattering region -- contact interface for every contact ([ncontacts])
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)       :: s_sc
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)       :: s_sc
       !> structure needed for density mixing
       TYPE(mixing_storage_type), POINTER                  :: mixing_storage
       !> density mixing method
@@ -468,15 +468,10 @@ CONTAINS
       ALLOCATE (contact_env%h_00(nspins), contact_env%h_01(nspins))
       ALLOCATE (contact_env%rho_00(nspins), contact_env%rho_01(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (contact_env%h_00(ispin)%matrix)
-         ALLOCATE (contact_env%h_01(ispin)%matrix)
-         ALLOCATE (contact_env%rho_00(ispin)%matrix)
-         ALLOCATE (contact_env%rho_01(ispin)%matrix)
-
-         CALL cp_fm_create(contact_env%h_00(ispin)%matrix, fm_struct)
-         CALL cp_fm_create(contact_env%h_01(ispin)%matrix, fm_struct)
-         CALL cp_fm_create(contact_env%rho_00(ispin)%matrix, fm_struct)
-         CALL cp_fm_create(contact_env%rho_01(ispin)%matrix, fm_struct)
+         CALL cp_fm_create(contact_env%h_00(ispin), fm_struct)
+         CALL cp_fm_create(contact_env%h_01(ispin), fm_struct)
+         CALL cp_fm_create(contact_env%rho_00(ispin), fm_struct)
+         CALL cp_fm_create(contact_env%rho_01(ispin), fm_struct)
       END DO
 
       CALL cp_fm_struct_release(fm_struct)
@@ -506,8 +501,8 @@ CONTAINS
 
       ! extract matrices: h_00, h_01, rho_00, rho_01
       DO ispin = 1, nspins
-         CALL negf_copy_contact_matrix(fm_cell0=contact_env%h_00(ispin)%matrix, &
-                                       fm_cell1=contact_env%h_01(ispin)%matrix, &
+         CALL negf_copy_contact_matrix(fm_cell0=contact_env%h_00(ispin), &
+                                       fm_cell1=contact_env%h_01(ispin), &
                                        direction_axis=contact_env%direction_axis, &
                                        matrix_kp=matrix_ks_kp(ispin, :), &
                                        index_to_cell=index_to_cell, &
@@ -515,8 +510,8 @@ CONTAINS
                                        subsys=subsys, mpi_comm_global=para_env%group, &
                                        is_same_cell=is_same_cell)
 
-         CALL negf_copy_contact_matrix(fm_cell0=contact_env%rho_00(ispin)%matrix, &
-                                       fm_cell1=contact_env%rho_01(ispin)%matrix, &
+         CALL negf_copy_contact_matrix(fm_cell0=contact_env%rho_00(ispin), &
+                                       fm_cell1=contact_env%rho_01(ispin), &
                                        direction_axis=contact_env%direction_axis, &
                                        matrix_kp=rho_ao_kp(ispin, :), &
                                        index_to_cell=index_to_cell, &
@@ -644,14 +639,10 @@ CONTAINS
       ALLOCATE (contact_env%h_00(nspins), contact_env%h_01(nspins))
       ALLOCATE (contact_env%rho_00(nspins), contact_env%rho_01(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (contact_env%h_00(ispin)%matrix)
-         ALLOCATE (contact_env%h_01(ispin)%matrix)
-         CALL cp_fm_create(contact_env%h_00(ispin)%matrix, fm_struct)
-         CALL cp_fm_create(contact_env%h_01(ispin)%matrix, fm_struct)
-         ALLOCATE (contact_env%rho_00(ispin)%matrix)
-         ALLOCATE (contact_env%rho_01(ispin)%matrix)
-         CALL cp_fm_create(contact_env%rho_00(ispin)%matrix, fm_struct)
-         CALL cp_fm_create(contact_env%rho_01(ispin)%matrix, fm_struct)
+         CALL cp_fm_create(contact_env%h_00(ispin), fm_struct)
+         CALL cp_fm_create(contact_env%h_01(ispin), fm_struct)
+         CALL cp_fm_create(contact_env%rho_00(ispin), fm_struct)
+         CALL cp_fm_create(contact_env%rho_01(ispin), fm_struct)
       END DO
       ALLOCATE (contact_env%s_00, contact_env%s_01)
       CALL cp_fm_create(contact_env%s_00, fm_struct)
@@ -660,26 +651,26 @@ CONTAINS
 
       DO ispin = 1, nspins
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=matrix_ks_kp(ispin, 1)%matrix, &
-                                               fm=contact_env%h_00(ispin)%matrix, &
+                                               fm=contact_env%h_00(ispin), &
                                                atomlist_row=contact_env%atomlist_cell0, &
                                                atomlist_col=contact_env%atomlist_cell0, &
                                                subsys=subsys, mpi_comm_global=para_env%group, &
                                                do_upper_diag=.TRUE., do_lower=.TRUE.)
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=matrix_ks_kp(ispin, 1)%matrix, &
-                                               fm=contact_env%h_01(ispin)%matrix, &
+                                               fm=contact_env%h_01(ispin), &
                                                atomlist_row=contact_env%atomlist_cell0, &
                                                atomlist_col=contact_env%atomlist_cell1, &
                                                subsys=subsys, mpi_comm_global=para_env%group, &
                                                do_upper_diag=.TRUE., do_lower=.TRUE.)
 
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=rho_ao_kp(ispin, 1)%matrix, &
-                                               fm=contact_env%rho_00(ispin)%matrix, &
+                                               fm=contact_env%rho_00(ispin), &
                                                atomlist_row=contact_env%atomlist_cell0, &
                                                atomlist_col=contact_env%atomlist_cell0, &
                                                subsys=subsys, mpi_comm_global=para_env%group, &
                                                do_upper_diag=.TRUE., do_lower=.TRUE.)
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=rho_ao_kp(ispin, 1)%matrix, &
-                                               fm=contact_env%rho_01(ispin)%matrix, &
+                                               fm=contact_env%rho_01(ispin), &
                                                atomlist_row=contact_env%atomlist_cell0, &
                                                atomlist_col=contact_env%atomlist_cell1, &
                                                subsys=subsys, mpi_comm_global=para_env%group, &
@@ -764,8 +755,7 @@ CONTAINS
          ALLOCATE (negf_env%s_s)
          CALL cp_fm_create(negf_env%s_s, fm_struct)
          DO ispin = 1, nspins
-            ALLOCATE (negf_env%h_s(ispin)%matrix)
-            CALL cp_fm_create(negf_env%h_s(ispin)%matrix, fm_struct)
+            CALL cp_fm_create(negf_env%h_s(ispin), fm_struct)
          END DO
          ALLOCATE (negf_env%v_hartree_s)
          CALL cp_fm_create(negf_env%v_hartree_s, fm_struct)
@@ -777,12 +767,10 @@ CONTAINS
             nao_c = number_of_atomic_orbitals(subsys, negf_env%contacts(icontact)%atomlist_cell0)
             CALL cp_fm_struct_create(fm_struct, nrow_global=nao_s, ncol_global=nao_c, context=sub_env%blacs_env)
 
-            ALLOCATE (negf_env%s_sc(icontact)%matrix)
-            CALL cp_fm_create(negf_env%s_sc(icontact)%matrix, fm_struct)
+            CALL cp_fm_create(negf_env%s_sc(icontact), fm_struct)
 
             DO ispin = 1, nspins
-               ALLOCATE (negf_env%h_sc(ispin, icontact)%matrix)
-               CALL cp_fm_create(negf_env%h_sc(ispin, icontact)%matrix, fm_struct)
+               CALL cp_fm_create(negf_env%h_sc(ispin, icontact), fm_struct)
             END DO
 
             CALL cp_fm_struct_release(fm_struct)
@@ -791,7 +779,7 @@ CONTAINS
          ! extract matrices: h_s, s_s
          DO ispin = 1, nspins
             CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=matrix_ks_kp(ispin, 1)%matrix, &
-                                                  fm=negf_env%h_s(ispin)%matrix, &
+                                                  fm=negf_env%h_s(ispin), &
                                                   atomlist_row=negf_control%atomlist_S_screening, &
                                                   atomlist_col=negf_control%atomlist_S_screening, &
                                                   subsys=subsys, mpi_comm_global=para_env%group, &
@@ -832,7 +820,7 @@ CONTAINS
          DO icontact = 1, ncontacts
             DO ispin = 1, nspins
                CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=matrix_ks_kp(ispin, 1)%matrix, &
-                                                     fm=negf_env%h_sc(ispin, icontact)%matrix, &
+                                                     fm=negf_env%h_sc(ispin, icontact), &
                                                      atomlist_row=negf_control%atomlist_S_screening, &
                                                      atomlist_col=negf_env%contacts(icontact)%atomlist_cell0, &
                                                      subsys=subsys, mpi_comm_global=para_env%group, &
@@ -840,7 +828,7 @@ CONTAINS
             END DO
 
             CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=matrix_s_kp(1, 1)%matrix, &
-                                                  fm=negf_env%s_sc(icontact)%matrix, &
+                                                  fm=negf_env%s_sc(icontact), &
                                                   atomlist_row=negf_control%atomlist_S_screening, &
                                                   atomlist_col=negf_env%contacts(icontact)%atomlist_cell0, &
                                                   subsys=subsys, mpi_comm_global=para_env%group, &
@@ -1245,10 +1233,7 @@ CONTAINS
       ! h_s
       IF (ALLOCATED(negf_env%h_s)) THEN
          DO ispin = SIZE(negf_env%h_s), 1, -1
-            IF (ASSOCIATED(negf_env%h_s(ispin)%matrix)) THEN
-               CALL cp_fm_release(negf_env%h_s(ispin)%matrix)
-               DEALLOCATE (negf_env%h_s(ispin)%matrix)
-            END IF
+               CALL cp_fm_release(negf_env%h_s(ispin))
          END DO
          DEALLOCATE (negf_env%h_s)
       END IF
@@ -1258,10 +1243,7 @@ CONTAINS
          nspins = SIZE(negf_env%h_sc, 1)
          DO icontact = SIZE(negf_env%h_sc, 2), 1, -1
             DO ispin = nspins, 1, -1
-               IF (ASSOCIATED(negf_env%h_sc(ispin, icontact)%matrix)) THEN
-                  CALL cp_fm_release(negf_env%h_sc(ispin, icontact)%matrix)
-                  DEALLOCATE (negf_env%h_sc(ispin, icontact)%matrix)
-               END IF
+                  CALL cp_fm_release(negf_env%h_sc(ispin, icontact))
             END DO
          END DO
          DEALLOCATE (negf_env%h_sc)
@@ -1277,10 +1259,7 @@ CONTAINS
       ! s_sc
       IF (ALLOCATED(negf_env%s_sc)) THEN
          DO icontact = SIZE(negf_env%s_sc), 1, -1
-            IF (ASSOCIATED(negf_env%s_sc(icontact)%matrix)) THEN
-               CALL cp_fm_release(negf_env%s_sc(icontact)%matrix)
-               DEALLOCATE (negf_env%s_sc(icontact)%matrix)
-            END IF
+               CALL cp_fm_release(negf_env%s_sc(icontact))
          END DO
          DEALLOCATE (negf_env%s_sc)
       END IF
@@ -1317,10 +1296,7 @@ CONTAINS
       ! h_00
       IF (ALLOCATED(contact_env%h_00)) THEN
          DO ispin = SIZE(contact_env%h_00), 1, -1
-            IF (ASSOCIATED(contact_env%h_00(ispin)%matrix)) THEN
-               CALL cp_fm_release(contact_env%h_00(ispin)%matrix)
-               DEALLOCATE (contact_env%h_00(ispin)%matrix)
-            END IF
+               CALL cp_fm_release(contact_env%h_00(ispin))
          END DO
          DEALLOCATE (contact_env%h_00)
       END IF
@@ -1328,10 +1304,7 @@ CONTAINS
       ! h_01
       IF (ALLOCATED(contact_env%h_01)) THEN
          DO ispin = SIZE(contact_env%h_01), 1, -1
-            IF (ASSOCIATED(contact_env%h_01(ispin)%matrix)) THEN
-               CALL cp_fm_release(contact_env%h_01(ispin)%matrix)
-               DEALLOCATE (contact_env%h_01(ispin)%matrix)
-            END IF
+               CALL cp_fm_release(contact_env%h_01(ispin))
          END DO
          DEALLOCATE (contact_env%h_01)
       END IF
@@ -1339,10 +1312,7 @@ CONTAINS
       ! rho_00
       IF (ALLOCATED(contact_env%rho_00)) THEN
          DO ispin = SIZE(contact_env%rho_00), 1, -1
-            IF (ASSOCIATED(contact_env%rho_00(ispin)%matrix)) THEN
-               CALL cp_fm_release(contact_env%rho_00(ispin)%matrix)
-               DEALLOCATE (contact_env%rho_00(ispin)%matrix)
-            END IF
+               CALL cp_fm_release(contact_env%rho_00(ispin))
          END DO
          DEALLOCATE (contact_env%rho_00)
       END IF
@@ -1350,10 +1320,7 @@ CONTAINS
       ! rho_01
       IF (ALLOCATED(contact_env%rho_01)) THEN
          DO ispin = SIZE(contact_env%rho_01), 1, -1
-            IF (ASSOCIATED(contact_env%rho_01(ispin)%matrix)) THEN
-               CALL cp_fm_release(contact_env%rho_01(ispin)%matrix)
-               DEALLOCATE (contact_env%rho_01(ispin)%matrix)
-            END IF
+               CALL cp_fm_release(contact_env%rho_01(ispin))
          END DO
          DEALLOCATE (contact_env%rho_01)
       END IF

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -32,7 +32,6 @@ MODULE negf_methods
    USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
                                               cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -672,9 +671,9 @@ CONTAINS
       REAL(kind=dp) :: mu_base, nelectrons_guess, nelectrons_max, nelectrons_min, nelectrons_ref, &
          t1, t2, temperature, trace, v_shift_guess, v_shift_max, v_shift_min
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: rho_ao_fm
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_dummy
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: rho_ao_fm
       TYPE(cp_fm_type), POINTER                          :: matrix_s_fm
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao_qs_kp
@@ -733,17 +732,16 @@ CONTAINS
       nelectrons_ref = 0.0_dp
       ALLOCATE (rho_ao_fm(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (rho_ao_fm(ispin)%matrix)
-         CALL cp_fm_create(rho_ao_fm(ispin)%matrix, fm_struct)
+         CALL cp_fm_create(rho_ao_fm(ispin), fm_struct)
 
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=rho_ao_qs_kp(ispin, 1)%matrix, &
-                                               fm=rho_ao_fm(ispin)%matrix, &
+                                               fm=rho_ao_fm(ispin), &
                                                atomlist_row=negf_control%atomlist_S_screening, &
                                                atomlist_col=negf_control%atomlist_S_screening, &
                                                subsys=subsys, mpi_comm_global=para_env%group, &
                                                do_upper_diag=.TRUE., do_lower=.TRUE.)
 
-         CALL cp_fm_trace(rho_ao_fm(ispin)%matrix, matrix_s_fm, trace)
+         CALL cp_fm_trace(rho_ao_fm(ispin), matrix_s_fm, trace)
          nelectrons_ref = nelectrons_ref + trace
       END DO
 
@@ -786,7 +784,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             ! closed contour: residuals
-            CALL negf_init_rho_equiv_residuals(rho_ao_fm=rho_ao_fm(ispin)%matrix, &
+            CALL negf_init_rho_equiv_residuals(rho_ao_fm=rho_ao_fm(ispin), &
                                                v_shift=v_shift_guess, &
                                                ignore_bias=.TRUE., &
                                                negf_env=negf_env, &
@@ -796,7 +794,7 @@ CONTAINS
                                                base_contact=base_contact)
 
             ! closed contour: C-path
-            CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_fm(ispin)%matrix, &
+            CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_fm(ispin), &
                                         stats=stats, &
                                         v_shift=v_shift_guess, &
                                         ignore_bias=.TRUE., &
@@ -814,7 +812,7 @@ CONTAINS
                CALL green_functions_cache_release(g_surf_circular(ispin))
 
             ! closed contour: L-path
-            CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_fm(ispin)%matrix, &
+            CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_fm(ispin), &
                                         stats=stats, &
                                         v_shift=v_shift_guess, &
                                         ignore_bias=.TRUE., &
@@ -834,13 +832,13 @@ CONTAINS
 
          IF (nspins > 1) THEN
             DO ispin = 2, nspins
-               CALL cp_fm_scale_and_add(1.0_dp, rho_ao_fm(1)%matrix, 1.0_dp, rho_ao_fm(ispin)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, rho_ao_fm(1), 1.0_dp, rho_ao_fm(ispin))
             END DO
          ELSE
-            CALL cp_fm_scale(2.0_dp, rho_ao_fm(1)%matrix)
+            CALL cp_fm_scale(2.0_dp, rho_ao_fm(1))
          END IF
 
-         CALL cp_fm_trace(rho_ao_fm(1)%matrix, matrix_s_fm, nelectrons_guess)
+         CALL cp_fm_trace(rho_ao_fm(1), matrix_s_fm, nelectrons_guess)
 
          t2 = m_walltime()
 
@@ -894,8 +892,7 @@ CONTAINS
       DEALLOCATE (g_surf_circular, g_surf_linear)
 
       DO ispin = nspins, 1, -1
-         CALL cp_fm_release(rho_ao_fm(ispin)%matrix)
-         DEALLOCATE (rho_ao_fm(ispin)%matrix)
+         CALL cp_fm_release(rho_ao_fm(ispin))
       END DO
       DEALLOCATE (rho_ao_fm)
 
@@ -939,9 +936,9 @@ CONTAINS
                                                             nelectrons_diff, t1, t2, temperature, &
                                                             trace, v_base, v_contact
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: rho_ao_delta_fm, rho_ao_new_fm
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_dummy
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: rho_ao_delta_fm, rho_ao_new_fm
       TYPE(cp_fm_type), POINTER                          :: matrix_s_fm
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_initial_kp, matrix_ks_qs_kp, &
@@ -1028,18 +1025,17 @@ CONTAINS
       nelectrons = 0.0_dp
       ALLOCATE (rho_ao_delta_fm(nspins), rho_ao_new_fm(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (rho_ao_delta_fm(ispin)%matrix, rho_ao_new_fm(ispin)%matrix)
-         CALL cp_fm_create(rho_ao_delta_fm(ispin)%matrix, fm_struct)
-         CALL cp_fm_create(rho_ao_new_fm(ispin)%matrix, fm_struct)
+         CALL cp_fm_create(rho_ao_delta_fm(ispin), fm_struct)
+         CALL cp_fm_create(rho_ao_new_fm(ispin), fm_struct)
 
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=rho_ao_qs_kp(ispin, 1)%matrix, &
-                                               fm=rho_ao_delta_fm(ispin)%matrix, &
+                                               fm=rho_ao_delta_fm(ispin), &
                                                atomlist_row=negf_control%atomlist_S_screening, &
                                                atomlist_col=negf_control%atomlist_S_screening, &
                                                subsys=subsys, mpi_comm_global=para_env%group, &
                                                do_upper_diag=.TRUE., do_lower=.TRUE.)
 
-         CALL cp_fm_trace(rho_ao_delta_fm(ispin)%matrix, matrix_s_fm, trace)
+         CALL cp_fm_trace(rho_ao_delta_fm(ispin), matrix_s_fm, trace)
          nelectrons = nelectrons + trace
       END DO
 
@@ -1085,7 +1081,7 @@ CONTAINS
 
                DO ispin = 1, nspins
                   ! closed contour: residuals
-                  CALL negf_init_rho_equiv_residuals(rho_ao_fm=rho_ao_new_fm(ispin)%matrix, &
+                  CALL negf_init_rho_equiv_residuals(rho_ao_fm=rho_ao_new_fm(ispin), &
                                                      v_shift=v_shift, &
                                                      ignore_bias=.FALSE., &
                                                      negf_env=negf_env, &
@@ -1095,7 +1091,7 @@ CONTAINS
                                                      base_contact=base_contact)
 
                   ! closed contour: C-path
-                  CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_new_fm(ispin)%matrix, &
+                  CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_new_fm(ispin), &
                                               stats=stats, &
                                               v_shift=v_shift, &
                                               ignore_bias=.FALSE., &
@@ -1113,7 +1109,7 @@ CONTAINS
                      CALL green_functions_cache_release(g_surf_circular(ispin))
 
                   ! closed contour: L-path
-                  CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_new_fm(ispin)%matrix, &
+                  CALL negf_add_rho_equiv_low(rho_ao_fm=rho_ao_new_fm(ispin), &
                                               stats=stats, &
                                               v_shift=v_shift, &
                                               ignore_bias=.FALSE., &
@@ -1133,7 +1129,7 @@ CONTAINS
                   ! non-equilibrium part
                   IF (ABS(negf_control%contacts(icontact)%v_external - &
                           negf_control%contacts(base_contact)%v_external) >= threshold) THEN
-                     CALL negf_add_rho_nonequiv(rho_ao_fm=rho_ao_new_fm(ispin)%matrix, &
+                     CALL negf_add_rho_nonequiv(rho_ao_fm=rho_ao_new_fm(ispin), &
                                                 stats=stats, &
                                                 v_shift=v_shift, &
                                                 negf_env=negf_env, &
@@ -1148,21 +1144,21 @@ CONTAINS
                   END IF
                END DO
 
-               IF (nspins == 1) CALL cp_fm_scale(2.0_dp, rho_ao_new_fm(1)%matrix)
+               IF (nspins == 1) CALL cp_fm_scale(2.0_dp, rho_ao_new_fm(1))
 
                nelectrons = 0.0_dp
                nelectrons_diff = 0.0_dp
                DO ispin = 1, nspins
-                  CALL cp_fm_trace(rho_ao_new_fm(ispin)%matrix, matrix_s_fm, trace)
+                  CALL cp_fm_trace(rho_ao_new_fm(ispin), matrix_s_fm, trace)
                   nelectrons = nelectrons + trace
 
                   ! rho_ao_delta_fm contains the original (non-mixed) density matrix from the previous iteration
-                  CALL cp_fm_scale_and_add(1.0_dp, rho_ao_delta_fm(ispin)%matrix, -1.0_dp, rho_ao_new_fm(ispin)%matrix)
-                  CALL cp_fm_trace(rho_ao_delta_fm(ispin)%matrix, matrix_s_fm, trace)
+                  CALL cp_fm_scale_and_add(1.0_dp, rho_ao_delta_fm(ispin), -1.0_dp, rho_ao_new_fm(ispin))
+                  CALL cp_fm_trace(rho_ao_delta_fm(ispin), matrix_s_fm, trace)
                   nelectrons_diff = nelectrons_diff + trace
 
                   ! rho_ao_new_fm -> rho_ao_delta_fm
-                  CALL cp_fm_to_fm(rho_ao_new_fm(ispin)%matrix, rho_ao_delta_fm(ispin)%matrix)
+                  CALL cp_fm_to_fm(rho_ao_new_fm(ispin), rho_ao_delta_fm(ispin))
                END DO
 
                t2 = m_walltime()
@@ -1187,7 +1183,7 @@ CONTAINS
                   END DO
 
                   DO ispin = 1, nspins
-                     CALL negf_copy_fm_submat_to_dbcsr(fm=rho_ao_new_fm(ispin)%matrix, &
+                     CALL negf_copy_fm_submat_to_dbcsr(fm=rho_ao_new_fm(ispin), &
                                                        matrix=rho_ao_new_kp(ispin, 1)%matrix, &
                                                        atomlist_row=negf_control%atomlist_S_screening, &
                                                        atomlist_col=negf_control%atomlist_S_screening, &
@@ -1213,7 +1209,7 @@ CONTAINS
                   END DO
 
                   DO ispin = 1, nspins
-                     CALL negf_copy_fm_submat_to_dbcsr(fm=rho_ao_new_fm(ispin)%matrix, &
+                     CALL negf_copy_fm_submat_to_dbcsr(fm=rho_ao_new_fm(ispin), &
                                                        matrix=rho_ao_qs_kp(ispin, 1)%matrix, &
                                                        atomlist_row=negf_control%atomlist_S_screening, &
                                                        atomlist_col=negf_control%atomlist_S_screening, &
@@ -1261,9 +1257,8 @@ CONTAINS
       END DO
 
       DO ispin = nspins, 1, -1
-         CALL cp_fm_release(rho_ao_new_fm(ispin)%matrix)
-         CALL cp_fm_release(rho_ao_delta_fm(ispin)%matrix)
-         DEALLOCATE (rho_ao_new_fm(ispin)%matrix, rho_ao_delta_fm(ispin)%matrix)
+         CALL cp_fm_release(rho_ao_new_fm(ispin))
+         CALL cp_fm_release(rho_ao_delta_fm(ispin))
       END DO
       DEALLOCATE (rho_ao_delta_fm, rho_ao_new_fm)
 
@@ -2571,7 +2566,7 @@ CONTAINS
 !> \param stats integration statistics
 !> \author Sergey Chulkov
 ! **************************************************************************************************
-   SUBROUTINE integration_status_reset(stats)
+   ELEMENTAL SUBROUTINE integration_status_reset(stats)
       TYPE(integration_status_type), INTENT(out)         :: stats
 
       stats%npoints = 0
@@ -2585,7 +2580,7 @@ CONTAINS
 !> \return description string
 !> \author Sergey Chulkov
 ! **************************************************************************************************
-   PURE FUNCTION get_method_description_string(stats, integration_method) RESULT(method_descr)
+   ELEMENTAL FUNCTION get_method_description_string(stats, integration_method) RESULT(method_descr)
       TYPE(integration_status_type), INTENT(in)          :: stats
       INTEGER, INTENT(in)                                :: integration_method
       CHARACTER(len=18)                                  :: method_descr

--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -486,7 +486,7 @@ CONTAINS
 
          nelectrons_qs_cell0 = 0.0_dp
          DO ispin = 1, nspins
-            CALL cp_fm_trace(negf_env%contacts(contact_id)%rho_00(ispin)%matrix, &
+            CALL cp_fm_trace(negf_env%contacts(contact_id)%rho_00(ispin), &
                              negf_env%contacts(contact_id)%s_00, trace)
             nelectrons_qs_cell0 = nelectrons_qs_cell0 + trace
          END DO
@@ -1230,7 +1230,7 @@ CONTAINS
                ! extract blocks from the updated Kohn-Sham matrix
                DO ispin = 1, nspins
                   CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=matrix_ks_qs_kp(ispin, 1)%matrix, &
-                                                        fm=negf_env%h_s(ispin)%matrix, &
+                                                        fm=negf_env%h_s(ispin), &
                                                         atomlist_row=negf_control%atomlist_S_screening, &
                                                         atomlist_col=negf_control%atomlist_S_screening, &
                                                         subsys=subsys, mpi_comm_global=para_env%group, &
@@ -1449,7 +1449,7 @@ CONTAINS
          END DO
       ELSE
          DO icontact = 1, ncontacts
-            CALL cp_fm_get_info(negf_env%s_sc(icontact)%matrix, matrix_struct=fm_struct)
+            CALL cp_fm_get_info(negf_env%s_sc(icontact), matrix_struct=fm_struct)
             ALLOCATE (zwork1_contacts(icontact)%matrix, zwork2_contacts(icontact)%matrix)
             CALL cp_cfm_create(zwork1_contacts(icontact)%matrix, fm_struct)
             CALL cp_cfm_create(zwork2_contacts(icontact)%matrix, fm_struct)
@@ -1559,7 +1559,7 @@ CONTAINS
                   CALL negf_contact_self_energy(self_energy_c=self_energy_contacts(icontact)%matrix, &
                                                 omega=omega(ipoint), &
                                                 g_surf_c=g_surf_contacts(icontact, ipoint)%matrix, &
-                                                h_sc0=negf_env%contacts(just_contact)%h_01(ispin)%matrix, &
+                                                h_sc0=negf_env%contacts(just_contact)%h_01(ispin), &
                                                 s_sc0=negf_env%contacts(just_contact)%s_01, &
                                                 zwork1=zwork1_contacts(icontact)%matrix, &
                                                 zwork2=zwork2_contacts(icontact)%matrix, &
@@ -1573,8 +1573,8 @@ CONTAINS
                   CALL negf_contact_self_energy(self_energy_c=self_energy_contacts(icontact)%matrix, &
                                                 omega=omega(ipoint) - v_external, &
                                                 g_surf_c=g_surf_contacts(icontact, ipoint)%matrix, &
-                                                h_sc0=negf_env%h_sc(ispin, icontact)%matrix, &
-                                                s_sc0=negf_env%s_sc(icontact)%matrix, &
+                                                h_sc0=negf_env%h_sc(ispin, icontact), &
+                                                s_sc0=negf_env%s_sc(icontact), &
                                                 zwork1=zwork1_contacts(icontact)%matrix, &
                                                 zwork2=zwork2_contacts(icontact)%matrix, &
                                                 transp=.FALSE.)
@@ -1600,19 +1600,19 @@ CONTAINS
                   CALL negf_retarded_green_function(g_ret_s=g_ret_s_group(ipoint)%matrix, &
                                                     omega=omega(ipoint) - v_shift, &
                                                     self_energy_ret_sum=self_energy_contacts(1)%matrix, &
-                                                    h_s=negf_env%contacts(just_contact)%h_00(ispin)%matrix, &
+                                                    h_s=negf_env%contacts(just_contact)%h_00(ispin), &
                                                     s_s=negf_env%contacts(just_contact)%s_00)
                ELSE IF (ignore_bias) THEN
                   CALL negf_retarded_green_function(g_ret_s=g_ret_s_group(ipoint)%matrix, &
                                                     omega=omega(ipoint) - v_shift, &
                                                     self_energy_ret_sum=self_energy_contacts(1)%matrix, &
-                                                    h_s=negf_env%h_s(ispin)%matrix, &
+                                                    h_s=negf_env%h_s(ispin), &
                                                     s_s=negf_env%s_s)
                ELSE
                   CALL negf_retarded_green_function(g_ret_s=g_ret_s_group(ipoint)%matrix, &
                                                     omega=omega(ipoint) - v_shift, &
                                                     self_energy_ret_sum=self_energy_contacts(1)%matrix, &
-                                                    h_s=negf_env%h_s(ispin)%matrix, &
+                                                    h_s=negf_env%h_s(ispin), &
                                                     s_s=negf_env%s_s, &
                                                     v_hartree_s=negf_env%v_hartree_s)
                END IF
@@ -1983,9 +1983,9 @@ CONTAINS
             DO icontact = 1, ncontacts
                CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, :), &
                                                       omega=omega(:), &
-                                                      h0=negf_env%contacts(just_contact)%h_00(ispin)%matrix, &
+                                                      h0=negf_env%contacts(just_contact)%h_00(ispin), &
                                                       s0=negf_env%contacts(just_contact)%s_00, &
-                                                      h1=negf_env%contacts(just_contact)%h_01(ispin)%matrix, &
+                                                      h1=negf_env%contacts(just_contact)%h_01(ispin), &
                                                       s1=negf_env%contacts(just_contact)%s_01, &
                                                       sub_env=sub_env, v_external=0.0_dp, &
                                                       conv=negf_control%conv_green, transp=(icontact == 1))
@@ -1996,9 +1996,9 @@ CONTAINS
 
                CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, :), &
                                                       omega=omega(:), &
-                                                      h0=negf_env%contacts(icontact)%h_00(ispin)%matrix, &
+                                                      h0=negf_env%contacts(icontact)%h_00(ispin), &
                                                       s0=negf_env%contacts(icontact)%s_00, &
-                                                      h1=negf_env%contacts(icontact)%h_01(ispin)%matrix, &
+                                                      h1=negf_env%contacts(icontact)%h_01(ispin), &
                                                       s1=negf_env%contacts(icontact)%s_01, &
                                                       sub_env=sub_env, &
                                                       v_external=v_external, &
@@ -2160,9 +2160,9 @@ CONTAINS
                   DO icontact = 1, ncontacts
                      CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, npoints_total + 1:), &
                                                             omega=xnodes(1:npoints), &
-                                                            h0=negf_env%contacts(just_contact)%h_00(ispin)%matrix, &
+                                                            h0=negf_env%contacts(just_contact)%h_00(ispin), &
                                                             s0=negf_env%contacts(just_contact)%s_00, &
-                                                            h1=negf_env%contacts(just_contact)%h_01(ispin)%matrix, &
+                                                            h1=negf_env%contacts(just_contact)%h_01(ispin), &
                                                             s1=negf_env%contacts(just_contact)%s_01, &
                                                             sub_env=sub_env, v_external=0.0_dp, &
                                                             conv=negf_control%conv_green, transp=(icontact == 1))
@@ -2173,9 +2173,9 @@ CONTAINS
 
                      CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, npoints_total + 1:), &
                                                             omega=xnodes(1:npoints), &
-                                                            h0=negf_env%contacts(icontact)%h_00(ispin)%matrix, &
+                                                            h0=negf_env%contacts(icontact)%h_00(ispin), &
                                                             s0=negf_env%contacts(icontact)%s_00, &
-                                                            h1=negf_env%contacts(icontact)%h_01(ispin)%matrix, &
+                                                            h1=negf_env%contacts(icontact)%h_01(ispin), &
                                                             s1=negf_env%contacts(icontact)%s_01, &
                                                             sub_env=sub_env, &
                                                             v_external=v_external, &
@@ -2293,9 +2293,9 @@ CONTAINS
                   DO icontact = 1, ncontacts
                      CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, npoints_total + 1:), &
                                                             omega=xnodes(1:npoints), &
-                                                            h0=negf_env%contacts(just_contact)%h_00(ispin)%matrix, &
+                                                            h0=negf_env%contacts(just_contact)%h_00(ispin), &
                                                             s0=negf_env%contacts(just_contact)%s_00, &
-                                                            h1=negf_env%contacts(just_contact)%h_01(ispin)%matrix, &
+                                                            h1=negf_env%contacts(just_contact)%h_01(ispin), &
                                                             s1=negf_env%contacts(just_contact)%s_01, &
                                                             sub_env=sub_env, v_external=0.0_dp, &
                                                             conv=negf_control%conv_green, transp=(icontact == 1))
@@ -2306,9 +2306,9 @@ CONTAINS
 
                      CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, npoints_total + 1:), &
                                                             omega=xnodes(1:npoints), &
-                                                            h0=negf_env%contacts(icontact)%h_00(ispin)%matrix, &
+                                                            h0=negf_env%contacts(icontact)%h_00(ispin), &
                                                             s0=negf_env%contacts(icontact)%s_00, &
-                                                            h1=negf_env%contacts(icontact)%h_01(ispin)%matrix, &
+                                                            h1=negf_env%contacts(icontact)%h_01(ispin), &
                                                             s1=negf_env%contacts(icontact)%s_01, &
                                                             sub_env=sub_env, &
                                                             v_external=v_external, &
@@ -2488,9 +2488,9 @@ CONTAINS
                   DO jcontact = 1, ncontacts
                      CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(jcontact, npoints_total + 1:), &
                                                             omega=xnodes(1:npoints), &
-                                                            h0=negf_env%contacts(jcontact)%h_00(ispin)%matrix, &
+                                                            h0=negf_env%contacts(jcontact)%h_00(ispin), &
                                                             s0=negf_env%contacts(jcontact)%s_00, &
-                                                            h1=negf_env%contacts(jcontact)%h_01(ispin)%matrix, &
+                                                            h1=negf_env%contacts(jcontact)%h_01(ispin), &
                                                             s1=negf_env%contacts(jcontact)%s_01, &
                                                             sub_env=sub_env, &
                                                             v_external=negf_control%contacts(jcontact)%v_external, &
@@ -2698,9 +2698,9 @@ CONTAINS
          DO icontact = 1, ncontacts
             CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, 1:npoints), &
                                                    omega=xnodes(1:npoints), &
-                                                   h0=negf_env%contacts(icontact)%h_00(ispin)%matrix, &
+                                                   h0=negf_env%contacts(icontact)%h_00(ispin), &
                                                    s0=negf_env%contacts(icontact)%s_00, &
-                                                   h1=negf_env%contacts(icontact)%h_01(ispin)%matrix, &
+                                                   h1=negf_env%contacts(icontact)%h_01(ispin), &
                                                    s1=negf_env%contacts(icontact)%s_01, &
                                                    sub_env=sub_env, &
                                                    v_external=negf_control%contacts(icontact)%v_external, &
@@ -2865,9 +2865,9 @@ CONTAINS
                DO icontact = 1, ncontacts
                   CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, :), &
                                                          omega=xnodes(1:npoints_bundle), &
-                                                         h0=negf_env%contacts(just_contact)%h_00(ispin)%matrix, &
+                                                         h0=negf_env%contacts(just_contact)%h_00(ispin), &
                                                          s0=negf_env%contacts(just_contact)%s_00, &
-                                                         h1=negf_env%contacts(just_contact)%h_01(ispin)%matrix, &
+                                                         h1=negf_env%contacts(just_contact)%h_01(ispin), &
                                                          s1=negf_env%contacts(just_contact)%s_01, &
                                                          sub_env=sub_env, v_external=0.0_dp, &
                                                          conv=negf_control%conv_green, transp=(icontact == 1))
@@ -2876,9 +2876,9 @@ CONTAINS
                DO icontact = 1, ncontacts
                   CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, :), &
                                                          omega=xnodes(1:npoints_bundle), &
-                                                         h0=negf_env%contacts(icontact)%h_00(ispin)%matrix, &
+                                                         h0=negf_env%contacts(icontact)%h_00(ispin), &
                                                          s0=negf_env%contacts(icontact)%s_00, &
-                                                         h1=negf_env%contacts(icontact)%h_01(ispin)%matrix, &
+                                                         h1=negf_env%contacts(icontact)%h_01(ispin), &
                                                          s1=negf_env%contacts(icontact)%s_01, &
                                                          sub_env=sub_env, &
                                                          v_external=negf_control%contacts(icontact)%v_external, &
@@ -3012,9 +3012,9 @@ CONTAINS
             DO icontact = 1, ncontacts
                CALL negf_surface_green_function_batch(g_surf=g_surf_cache%g_surf_contacts(icontact, :), &
                                                       omega=xnodes(1:npoints_bundle), &
-                                                      h0=negf_env%contacts(icontact)%h_00(ispin)%matrix, &
+                                                      h0=negf_env%contacts(icontact)%h_00(ispin), &
                                                       s0=negf_env%contacts(icontact)%s_00, &
-                                                      h1=negf_env%contacts(icontact)%h_01(ispin)%matrix, &
+                                                      h1=negf_env%contacts(icontact)%h_01(ispin), &
                                                       s1=negf_env%contacts(icontact)%s_01, &
                                                       sub_env=sub_env, &
                                                       v_external=negf_control%contacts(icontact)%v_external, &

--- a/src/qs_2nd_kernel_ao.F
+++ b/src/qs_2nd_kernel_ao.F
@@ -20,7 +20,6 @@ MODULE qs_2nd_kernel_ao
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_add,&
                                               dbcsr_copy,&
@@ -79,8 +78,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE build_dm_response(c0, c1, dm)
       !
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: c1
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0, c1
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT)    :: dm
 
       INTEGER                                            :: ispin, ncol, nspins
@@ -92,7 +90,7 @@ CONTAINS
          CALL cp_fm_get_info(c0(ispin), ncol_global=ncol)
          CALL cp_dbcsr_plus_fm_fm_t(dm(ispin)%matrix, &
                                     matrix_v=c0(ispin), &
-                                    matrix_g=c1(ispin)%matrix, &
+                                    matrix_g=c1(ispin), &
                                     ncol=ncol, alpha=2.0_dp, &
                                     keep_sparsity=.TRUE., &
                                     symmetry_mode=1)

--- a/src/qs_2nd_kernel_ao.F
+++ b/src/qs_2nd_kernel_ao.F
@@ -20,7 +20,8 @@ MODULE qs_2nd_kernel_ao
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
-                                              cp_fm_p_type
+                                              cp_fm_p_type,&
+                                              cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_add,&
                                               dbcsr_copy,&
                                               dbcsr_create,&
@@ -78,7 +79,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE build_dm_response(c0, c1, dm)
       !
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: c0, c1
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0
+      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: c1
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT)    :: dm
 
       INTEGER                                            :: ispin, ncol, nspins
@@ -87,9 +89,9 @@ CONTAINS
 
       DO ispin = 1, nspins
          CALL dbcsr_set(dm(ispin)%matrix, 0.0_dp)
-         CALL cp_fm_get_info(c0(ispin)%matrix, ncol_global=ncol)
+         CALL cp_fm_get_info(c0(ispin), ncol_global=ncol)
          CALL cp_dbcsr_plus_fm_fm_t(dm(ispin)%matrix, &
-                                    matrix_v=c0(ispin)%matrix, &
+                                    matrix_v=c0(ispin), &
                                     matrix_g=c1(ispin)%matrix, &
                                     ncol=ncol, alpha=2.0_dp, &
                                     keep_sparsity=.TRUE., &

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1152,8 +1152,7 @@ CONTAINS
       ! Kohn-Sham / Fock operator
       IF (ASSOCIATED(active_space_env%ks_sub)) THEN
          DO is = 1, SIZE(active_space_env%ks_sub)
-            CALL cp_fm_release(active_space_env%ks_sub(is)%matrix)
-            DEALLOCATE (active_space_env%ks_sub(is)%matrix)
+            CALL cp_fm_release(active_space_env%ks_sub(is))
          END DO
          DEALLOCATE (active_space_env%ks_sub)
       END IF
@@ -1164,15 +1163,13 @@ CONTAINS
       ALLOCATE (active_space_env%ks_sub(nspins))
       DO is = 1, nspins
          CALL get_mo_set(mo_set=mos(is), mo_coeff=mo_coeff, nmo=nmo)
-         IF (.NOT. ASSOCIATED(active_space_env%ks_sub(is)%matrix)) ALLOCATE (active_space_env%ks_sub(is)%matrix)
-         CALL subspace_operator(mo_coeff, nmo, ks_matrix(is, 1)%matrix, active_space_env%ks_sub(is)%matrix)
+         CALL subspace_operator(mo_coeff, nmo, ks_matrix(is, 1)%matrix, active_space_env%ks_sub(is))
       END DO
 
       ! Vxc matrix
       IF (ASSOCIATED(active_space_env%vxc_sub)) THEN
          DO is = 1, SIZE(active_space_env%vxc_sub)
-            CALL cp_fm_release(active_space_env%vxc_sub(is)%matrix)
-            DEALLOCATE (active_space_env%vxc_sub(is)%matrix)
+            CALL cp_fm_release(active_space_env%vxc_sub(is))
          END DO
          DEALLOCATE (active_space_env%vxc_sub)
       END IF
@@ -1182,16 +1179,14 @@ CONTAINS
          ALLOCATE (active_space_env%vxc_sub(nspins))
          DO is = 1, nspins
             CALL get_mo_set(mo_set=mos(is), mo_coeff=mo_coeff, nmo=nmo)
-            IF (.NOT. ASSOCIATED(active_space_env%vxc_sub(is)%matrix)) ALLOCATE (active_space_env%vxc_sub(is)%matrix)
-            CALL subspace_operator(mo_coeff, nmo, matrix_vxc(is)%matrix, active_space_env%vxc_sub(is)%matrix)
+            CALL subspace_operator(mo_coeff, nmo, matrix_vxc(is)%matrix, active_space_env%vxc_sub(is))
          END DO
       END IF
 
       ! Core Hamiltonian
       IF (ASSOCIATED(active_space_env%h_sub)) THEN
          DO is = 1, SIZE(active_space_env%h_sub)
-            CALL cp_fm_release(active_space_env%h_sub(is)%matrix)
-            DEALLOCATE (active_space_env%h_sub(is)%matrix)
+            CALL cp_fm_release(active_space_env%h_sub(is))
          END DO
          DEALLOCATE (active_space_env%h_sub)
       END IF
@@ -1203,8 +1198,7 @@ CONTAINS
       ALLOCATE (active_space_env%h_sub(nspins))
       DO is = 1, nspins
          CALL get_mo_set(mo_set=mos(is), mo_coeff=mo_coeff, nmo=nmo)
-         IF (.NOT. ASSOCIATED(active_space_env%h_sub(is)%matrix)) ALLOCATE (active_space_env%h_sub(is)%matrix)
-         CALL subspace_operator(mo_coeff, nmo, h_matrix(1, 1)%matrix, active_space_env%h_sub(is)%matrix)
+         CALL subspace_operator(mo_coeff, nmo, h_matrix(1, 1)%matrix, active_space_env%h_sub(is))
       END DO
 
       CALL timestop(handle)
@@ -1924,7 +1918,7 @@ CONTAINS
                nmo = active_space_env%eri%norb
                ALLOCATE (fmat(nmo, nmo))
                ! TODO: extend to arbitrary active orbitals
-               CALL replicate_and_symmetrize_matrix(nmo, active_space_env%fock_sub(1)%matrix, fmat)
+               CALL replicate_and_symmetrize_matrix(nmo, active_space_env%fock_sub(1), fmat)
                IF (iw > 0) THEN
                   i3 = 0; i4 = 0
                   DO m1 = 1, SIZE(active_space_env%active_orbitals, 1)
@@ -1978,7 +1972,7 @@ CONTAINS
                ! alpha
                nmo = active_space_env%eri%norb
                ALLOCATE (fmat(nmo, nmo))
-               CALL replicate_and_symmetrize_matrix(nmo, active_space_env%fock_sub(1)%matrix, fmat)
+               CALL replicate_and_symmetrize_matrix(nmo, active_space_env%fock_sub(1), fmat)
                IF (iw > 0) THEN
                   i3 = 0; i4 = 0
                   DO m1 = 1, norb
@@ -1993,7 +1987,7 @@ CONTAINS
                DEALLOCATE (fmat)
                ! beta
                ALLOCATE (fmat(nmo, nmo))
-               CALL replicate_and_symmetrize_matrix(nmo, active_space_env%fock_sub(2)%matrix, fmat)
+               CALL replicate_and_symmetrize_matrix(nmo, active_space_env%fock_sub(2), fmat)
                IF (iw > 0) THEN
                   i3 = 0; i4 = 0
                   DO m1 = 1, SIZE(active_space_env%active_orbitals, 1)
@@ -2081,7 +2075,7 @@ CONTAINS
          ks_ref = 0.0_dp
 
          CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(1), p_mat)
-         CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(1)%matrix, ks_mat)
+         CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(1), ks_mat)
          !
          !
          eri => active_space_env%eri%eri(1)%csr_mat
@@ -2097,19 +2091,17 @@ CONTAINS
          !
          IF (ASSOCIATED(active_space_env%fock_sub)) THEN
             DO is = 1, SIZE(active_space_env%fock_sub)
-               CALL cp_fm_release(active_space_env%fock_sub(is)%matrix)
-               DEALLOCATE (active_space_env%fock_sub(is)%matrix)
+               CALL cp_fm_release(active_space_env%fock_sub(is))
             END DO
             DEALLOCATE (active_space_env%fock_sub)
          END IF
          ALLOCATE (active_space_env%fock_sub(nspins))
          DO is = 1, nspins
-            matrix => active_space_env%ks_sub(is)%matrix
-            ALLOCATE (active_space_env%fock_sub(is)%matrix)
-            CALL cp_fm_create(active_space_env%fock_sub(is)%matrix, matrix%matrix_struct, &
+            matrix => active_space_env%ks_sub(is)
+            CALL cp_fm_create(active_space_env%fock_sub(is), matrix%matrix_struct, &
                               name="Active Fock operator")
          END DO
-         matrix => active_space_env%fock_sub(1)%matrix
+         matrix => active_space_env%fock_sub(1)
          DO i1 = 1, norb
             DO i2 = 1, norb
                mval = ks_mat(i1, i2)
@@ -2130,8 +2122,8 @@ CONTAINS
 
          CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(1), p_a_mat)
          CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(2), p_b_mat)
-         CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(1)%matrix, ks_a_mat)
-         CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(2)%matrix, ks_b_mat)
+         CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(1), ks_a_mat)
+         CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(2), ks_b_mat)
          !
          !
          eri_aa => active_space_env%eri%eri(1)%csr_mat
@@ -2153,27 +2145,25 @@ CONTAINS
          !
          IF (ASSOCIATED(active_space_env%fock_sub)) THEN
             DO is = 1, SIZE(active_space_env%fock_sub)
-               CALL cp_fm_release(active_space_env%fock_sub(is)%matrix)
-               DEALLOCATE (active_space_env%fock_sub(is)%matrix)
+               CALL cp_fm_release(active_space_env%fock_sub(is))
             END DO
             DEALLOCATE (active_space_env%fock_sub)
          END IF
          ALLOCATE (active_space_env%fock_sub(nspins))
          DO is = 1, nspins
-            matrix => active_space_env%ks_sub(is)%matrix
-            ALLOCATE (active_space_env%fock_sub(is)%matrix)
-            CALL cp_fm_create(active_space_env%fock_sub(is)%matrix, matrix%matrix_struct, &
+            matrix => active_space_env%ks_sub(is)
+            CALL cp_fm_create(active_space_env%fock_sub(is), matrix%matrix_struct, &
                               name="Active Fock operator")
          END DO
 
-         matrix => active_space_env%fock_sub(1)%matrix
+         matrix => active_space_env%fock_sub(1)
          DO i1 = 1, norb
             DO i2 = 1, norb
                mval = ks_a_mat(i1, i2)
                CALL cp_fm_set_element(matrix, i1, i2, mval)
             END DO
          END DO
-         matrix => active_space_env%fock_sub(2)%matrix
+         matrix => active_space_env%fock_sub(2)
          DO i1 = 1, norb
             DO i2 = 1, norb
                mval = ks_b_mat(i1, i2)

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1063,9 +1063,7 @@ CONTAINS
       DO isp = 1, nspins
          mo_set => active_space_env%mos_active(isp)
          CALL get_mo_set(mo_set, mo_coeff=mo_coeff, nmo=nmo)
-         NULLIFY (active_space_env%p_active(isp)%matrix)
-         ALLOCATE (active_space_env%p_active(isp)%matrix)
-         CALL create_subspace_matrix(mo_coeff, active_space_env%p_active(isp)%matrix, nmo)
+         CALL create_subspace_matrix(mo_coeff, active_space_env%p_active(isp), nmo)
       END DO
       SELECT CASE (mselect)
       CASE DEFAULT
@@ -1074,7 +1072,7 @@ CONTAINS
          focc = 2.0_dp
          IF (nspins == 2) focc = 1.0_dp
          DO isp = 1, nspins
-            fmat => active_space_env%p_active(isp)%matrix
+            fmat => active_space_env%p_active(isp)
             CALL cp_fm_set_all(fmat, alpha=0.0_dp)
             n1 = active_space_env%nelec_total(isp) - active_space_env%nelec_inactive_spinwise(isp)
             DO i = 1, nactive_orb(isp)
@@ -1089,7 +1087,7 @@ CONTAINS
          focc = 2.0_dp
          IF (nspins == 2) focc = 1.0_dp
          DO isp = 1, nspins
-            fmat => active_space_env%p_active(isp)%matrix
+            fmat => active_space_env%p_active(isp)
             CALL cp_fm_set_all(fmat, alpha=0.0_dp)
             n1 = active_space_env%nelec_total(isp) - active_space_env%nelec_inactive_spinwise(isp)
             DO i = 1, nactive_orb(isp)
@@ -2082,7 +2080,7 @@ CONTAINS
          ALLOCATE (ks_mat(norb, norb), ks_ref(norb, norb), p_mat(norb, norb))
          ks_ref = 0.0_dp
 
-         CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(1)%matrix, p_mat)
+         CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(1), p_mat)
          CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(1)%matrix, ks_mat)
          !
          !
@@ -2130,8 +2128,8 @@ CONTAINS
               &     p_a_mat(norb, norb), p_b_mat(norb, norb))
          ks_a_ref(:, :) = 0.0_dp; ks_b_ref(:, :) = 0.0_dp
 
-         CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(1)%matrix, p_a_mat)
-         CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(2)%matrix, p_b_mat)
+         CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(1), p_a_mat)
+         CALL replicate_and_symmetrize_matrix(norb, active_space_env%p_active(2), p_b_mat)
          CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(1)%matrix, ks_a_mat)
          CALL replicate_and_symmetrize_matrix(norb, active_space_env%ks_sub(2)%matrix, ks_b_mat)
          !
@@ -2456,8 +2454,8 @@ CONTAINS
 
       INTEGER                                            :: handle, ispin, nao, nmo, nspins
       LOGICAL                                            :: should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_ref
       TYPE(cp_fm_type)                                   :: lamat, vec
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: p_ref
       TYPE(cp_fm_type), POINTER                          :: fm_active, pmat
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
@@ -2479,7 +2477,7 @@ CONTAINS
          pinact => active_space_env%pmat_inactive(ispin)%matrix
          CALL dbcsr_copy(rho_ao(ispin)%matrix, pinact)
          ! create active density matrix in AO basis
-         pmat => p_ref(ispin)%matrix
+         pmat => p_ref(ispin)
 
          CALL cp_fm_create(lamat, pmat%matrix_struct)
          CALL cp_fm_to_fm(pmat, lamat)
@@ -2531,7 +2529,7 @@ CONTAINS
                pinact => active_space_env%pmat_inactive(ispin)%matrix
                CALL dbcsr_copy(rho_ao(ispin)%matrix, pinact)
                ! create active density matrix in AO basis
-               pmat => p_ref(ispin)%matrix
+               pmat => p_ref(ispin)
 
                CALL cp_fm_create(lamat, pmat%matrix_struct)
                CALL cp_fm_to_fm(pmat, lamat)
@@ -2683,7 +2681,7 @@ CONTAINS
 
       ! Find active DM dimensions
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(matrix=active_space_env%p_active(ispin)%matrix, ncol_global=nmo)
+         CALL cp_fm_get_info(matrix=active_space_env%p_active(ispin), ncol_global=nmo)
          nmos(ispin) = nmo
       END DO
 
@@ -2761,7 +2759,7 @@ CONTAINS
 
       DO ispin = 1, nspins
          ! Copy to fm_type structure
-         CALL cp_fm_get_info(matrix=active_space_env%p_active(ispin)%matrix, &
+         CALL cp_fm_get_info(matrix=active_space_env%p_active(ispin), &
                              nrow_local=nrow_local, &
                              ncol_local=ncol_local, &
                              col_indices=col_indices, &
@@ -2772,10 +2770,10 @@ CONTAINS
             DO MMM = 1, ncol_local
                m_global = col_indices(MMM)
                IF (ispin .EQ. 1) THEN
-                  active_space_env%p_active(ispin)%matrix%local_data(LLL, MMM) = &
+                  active_space_env%p_active(ispin)%local_data(LLL, MMM) = &
                      p_act(l_global, m_global)
                ELSE
-                  active_space_env%p_active(ispin)%matrix%local_data(LLL, MMM) = &
+                  active_space_env%p_active(ispin)%local_data(LLL, MMM) = &
                      p_act_beta(l_global, m_global)
                END IF
             END DO ! MMM

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -33,8 +33,8 @@ MODULE qs_active_space_methods
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_element, cp_fm_get_info, cp_fm_init_random, cp_fm_p_type, &
-        cp_fm_release, cp_fm_set_all, cp_fm_set_element, cp_fm_to_fm, cp_fm_type
+        cp_fm_create, cp_fm_get_element, cp_fm_get_info, cp_fm_init_random, cp_fm_release, &
+        cp_fm_set_all, cp_fm_set_element, cp_fm_to_fm, cp_fm_type
    USE cp_fm_vect,                      ONLY: cp_fm_vect_dealloc
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
@@ -212,9 +212,9 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: context
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mos_localized
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
       TYPE(cp_fm_type)                                   :: fm_dummy, mo_virt
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mos_localized
       TYPE(cp_fm_type), POINTER                          :: fm_ref, fm_target, fm_target_active, &
                                                             fm_target_inactive, fmat, mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -817,14 +817,12 @@ CONTAINS
          loc_section => section_vals_get_subs_vals(as_input, "LOCALIZE")
          CPASSERT(ASSOCIATED(loc_section))
          loc_print => section_vals_get_subs_vals(as_input, "LOCALIZE%PRINT")
-         NULLIFY (mos_localized)
          ALLOCATE (mos_localized(nspins))
          CALL get_qs_env(qs_env, mos=mos)
          DO ispin = 1, nspins
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-            ALLOCATE (mos_localized(ispin)%matrix)
-            CALL cp_fm_create(mos_localized(ispin)%matrix, mo_coeff%matrix_struct)
-            CALL cp_fm_to_fm(mo_coeff, mos_localized(ispin)%matrix)
+            CALL cp_fm_create(mos_localized(ispin), mo_coeff%matrix_struct)
+            CALL cp_fm_to_fm(mo_coeff, mos_localized(ispin))
          END DO
          ! occupied states
          NULLIFY (qs_loc_env_occ)
@@ -835,7 +833,7 @@ CONTAINS
                           mos_localized=mos_localized, do_homo=.TRUE.)
          DO ispin = 1, nspins
             CALL qs_loc_driver(qs_env, qs_loc_env_occ, loc_print, myspin=ispin, &
-                               ext_mo_coeff=mos_localized(ispin)%matrix)
+                               ext_mo_coeff=mos_localized(ispin))
          END DO
          ! virtual states
          NULLIFY (qs_loc_env_virt)
@@ -848,7 +846,7 @@ CONTAINS
                               loc_coeff=mos_localized)
          DO ispin = 1, nspins
             CALL qs_loc_driver(qs_env, qs_loc_env_virt, loc_print, myspin=ispin, &
-                               ext_mo_coeff=mos_localized(ispin)%matrix)
+                               ext_mo_coeff=mos_localized(ispin))
          END DO
          !
          ! get definition of subspace

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -15,7 +15,8 @@ MODULE qs_active_space_types
 
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
    USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+                                              cp_fm_release,&
+                                              cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_csr_destroy,&
                                               dbcsr_csr_p_type,&
                                               dbcsr_p_type
@@ -92,7 +93,7 @@ MODULE qs_active_space_types
       TYPE(mo_set_type), DIMENSION(:), POINTER  :: mos_active
       TYPE(mo_set_type), DIMENSION(:), POINTER  :: mos_inactive
       TYPE(eri_type)                :: eri
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: p_active
+      TYPE(cp_fm_type), DIMENSION(:), POINTER   :: p_active
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: ks_sub
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: vxc_sub
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: h_sub
@@ -180,8 +181,7 @@ CONTAINS
 
          IF (ASSOCIATED(active_space_env%p_active)) THEN
             DO isp = 1, SIZE(active_space_env%p_active)
-               CALL cp_fm_release(active_space_env%p_active(isp)%matrix)
-               DEALLOCATE (active_space_env%p_active(isp)%matrix)
+               CALL cp_fm_release(active_space_env%p_active(isp))
             END DO
             DEALLOCATE (active_space_env%p_active)
          END IF

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -14,8 +14,7 @@
 MODULE qs_active_space_types
 
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release,&
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_csr_destroy,&
                                               dbcsr_csr_p_type,&
@@ -94,10 +93,10 @@ MODULE qs_active_space_types
       TYPE(mo_set_type), DIMENSION(:), POINTER  :: mos_inactive
       TYPE(eri_type)                :: eri
       TYPE(cp_fm_type), DIMENSION(:), POINTER   :: p_active
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: ks_sub
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: vxc_sub
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: h_sub
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER   :: fock_sub
+      TYPE(cp_fm_type), DIMENSION(:), POINTER   :: ks_sub
+      TYPE(cp_fm_type), DIMENSION(:), POINTER   :: vxc_sub
+      TYPE(cp_fm_type), DIMENSION(:), POINTER   :: h_sub
+      TYPE(cp_fm_type), DIMENSION(:), POINTER   :: fock_sub
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER:: pmat_inactive
    END TYPE active_space_type
 
@@ -188,32 +187,28 @@ CONTAINS
 
          IF (ASSOCIATED(active_space_env%ks_sub)) THEN
             DO isp = 1, SIZE(active_space_env%ks_sub)
-               CALL cp_fm_release(active_space_env%ks_sub(isp)%matrix)
-               DEALLOCATE (active_space_env%ks_sub(isp)%matrix)
+               CALL cp_fm_release(active_space_env%ks_sub(isp))
             END DO
             DEALLOCATE (active_space_env%ks_sub)
          END IF
 
          IF (ASSOCIATED(active_space_env%vxc_sub)) THEN
             DO isp = 1, SIZE(active_space_env%vxc_sub)
-               CALL cp_fm_release(active_space_env%vxc_sub(isp)%matrix)
-               DEALLOCATE (active_space_env%vxc_sub(isp)%matrix)
+               CALL cp_fm_release(active_space_env%vxc_sub(isp))
             END DO
             DEALLOCATE (active_space_env%vxc_sub)
          END IF
 
          IF (ASSOCIATED(active_space_env%h_sub)) THEN
             DO isp = 1, SIZE(active_space_env%h_sub)
-               CALL cp_fm_release(active_space_env%h_sub(isp)%matrix)
-               DEALLOCATE (active_space_env%h_sub(isp)%matrix)
+               CALL cp_fm_release(active_space_env%h_sub(isp))
             END DO
             DEALLOCATE (active_space_env%h_sub)
          END IF
 
          IF (ASSOCIATED(active_space_env%fock_sub)) THEN
             DO isp = 1, SIZE(active_space_env%fock_sub)
-               CALL cp_fm_release(active_space_env%fock_sub(isp)%matrix)
-               DEALLOCATE (active_space_env%fock_sub(isp)%matrix)
+               CALL cp_fm_release(active_space_env%fock_sub(isp))
             END DO
             DEALLOCATE (active_space_env%fock_sub)
          END IF

--- a/src/qs_cdft_types.F
+++ b/src/qs_cdft_types.F
@@ -13,7 +13,7 @@
 ! **************************************************************************************************
 MODULE qs_cdft_types
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
-   USE cp_fm_types,                     ONLY: cp_fm_p_type
+   USE cp_fm_types,                     ONLY: cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE hirshfeld_types,                 ONLY: hirshfeld_type,&
                                               release_hirshfeld_type
@@ -243,7 +243,7 @@ MODULE qs_cdft_types
          DIMENSION(:)                      :: group
       TYPE(cp_1d_r_p_type), ALLOCATABLE, &
          DIMENSION(:)                      :: occupations
-      TYPE(cp_fm_p_type), DIMENSION(:), &
+      TYPE(cp_fm_type), DIMENSION(:), &
          POINTER                           :: mo_coeff
       TYPE(dbcsr_p_type)                   :: matrix_s
       TYPE(dbcsr_p_type), DIMENSION(:), &

--- a/src/qs_dcdr.F
+++ b/src/qs_dcdr.F
@@ -260,14 +260,15 @@ CONTAINS
 
       INTEGER                                            :: handle, output_unit
       LOGICAL                                            :: should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
+      TYPE(cp_fm_type), DIMENSION(1)                     :: h1_psi0
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(linres_control_type), POINTER                 :: linres_control
       TYPE(section_vals_type), POINTER                   :: lr_section
 
       CALL timeset(routineN, handle)
-      NULLIFY (linres_control, lr_section, logger, psi1, h1_psi0)
+      NULLIFY (linres_control, lr_section, logger, psi1)
 
       CALL get_qs_env(qs_env=qs_env, &
                       linres_control=linres_control)
@@ -283,13 +284,13 @@ CONTAINS
       END IF
 
       ! allocate the vectors
-      ALLOCATE (psi1(1), h1_psi0(1))
-      NULLIFY (psi1(1)%matrix, h1_psi0(1)%matrix)
+      ALLOCATE (psi1(1))
+      NULLIFY (psi1(1)%matrix)
 
       psi0_order(1:1) => dcdr_env%mo_coeff(1:1)
-      ALLOCATE (psi1(1)%matrix, h1_psi0(1)%matrix)
+      ALLOCATE (psi1(1)%matrix)
       CALL cp_fm_create(psi1(1)%matrix, dcdr_env%likemos_fm_struct)
-      CALL cp_fm_create(h1_psi0(1)%matrix, dcdr_env%likemos_fm_struct)
+      CALL cp_fm_create(h1_psi0(1), dcdr_env%likemos_fm_struct)
 
       ! Restart
       IF (linres_control%linres_restart) THEN
@@ -304,7 +305,7 @@ CONTAINS
             " displaced in "//ACHAR(dcdr_env%beta + 119)
       END IF
       CALL cp_fm_set_all(dcdr_env%dCR(1)%matrix, 0.0_dp)
-      CALL cp_fm_to_fm(dcdr_env%op_dR(1)%matrix, h1_psi0(1)%matrix)
+      CALL cp_fm_to_fm(dcdr_env%op_dR(1)%matrix, h1_psi0(1))
 
       linres_control%lr_triplet = .FALSE. ! we do singlet response
       linres_control%do_kernel = .TRUE.
@@ -326,9 +327,9 @@ CONTAINS
 
       ! clean up
       CALL cp_fm_release(psi1(1)%matrix)
-      CALL cp_fm_release(h1_psi0(1)%matrix)
-      DEALLOCATE (psi1(1)%matrix, h1_psi0(1)%matrix)
-      DEALLOCATE (psi1, h1_psi0)
+      CALL cp_fm_release(h1_psi0(1))
+      DEALLOCATE (psi1(1)%matrix)
+      DEALLOCATE (psi1)
       CALL cp_print_key_finished_output(output_unit, logger, lr_section, &
                                         "PRINT%PROGRAM_RUN_INFO")
 

--- a/src/qs_dcdr.F
+++ b/src/qs_dcdr.F
@@ -24,7 +24,6 @@ MODULE qs_dcdr
                                               cp_fm_trace
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_diag,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -260,15 +259,14 @@ CONTAINS
 
       INTEGER                                            :: handle, output_unit
       LOGICAL                                            :: should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
-      TYPE(cp_fm_type), DIMENSION(1)                     :: h1_psi0
+      TYPE(cp_fm_type), DIMENSION(1)                     :: h1_psi0, psi1
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(linres_control_type), POINTER                 :: linres_control
       TYPE(section_vals_type), POINTER                   :: lr_section
 
       CALL timeset(routineN, handle)
-      NULLIFY (linres_control, lr_section, logger, psi1)
+      NULLIFY (linres_control, lr_section, logger)
 
       CALL get_qs_env(qs_env=qs_env, &
                       linres_control=linres_control)
@@ -283,20 +281,15 @@ CONTAINS
             "*** Self consistent optimization of the response wavefunction ***"
       END IF
 
-      ! allocate the vectors
-      ALLOCATE (psi1(1))
-      NULLIFY (psi1(1)%matrix)
-
       psi0_order(1:1) => dcdr_env%mo_coeff(1:1)
-      ALLOCATE (psi1(1)%matrix)
-      CALL cp_fm_create(psi1(1)%matrix, dcdr_env%likemos_fm_struct)
+      CALL cp_fm_create(psi1(1), dcdr_env%likemos_fm_struct)
       CALL cp_fm_create(h1_psi0(1), dcdr_env%likemos_fm_struct)
 
       ! Restart
       IF (linres_control%linres_restart) THEN
          CALL dcdr_read_restart(qs_env, lr_section, psi1, dcdr_env%lambda, dcdr_env%beta, "dCdR")
       ELSE
-         CALL cp_fm_set_all(psi1(1)%matrix, 0.0_dp)
+         CALL cp_fm_set_all(psi1(1), 0.0_dp)
       END IF
 
       IF (output_unit > 0) THEN
@@ -318,7 +311,7 @@ CONTAINS
       ! psi0_order = the unperturbed wavefunction
       CALL linres_solver(p_env, qs_env, psi1, h1_psi0, psi0_order, &
                          output_unit, should_stop)
-      CALL cp_fm_to_fm(psi1(1)%matrix, dcdr_env%dCR(1)%matrix)
+      CALL cp_fm_to_fm(psi1(1), dcdr_env%dCR(1)%matrix)
 
       ! Write the new result to the restart file
       IF (linres_control%linres_restart) THEN
@@ -326,10 +319,8 @@ CONTAINS
       END IF
 
       ! clean up
-      CALL cp_fm_release(psi1(1)%matrix)
+      CALL cp_fm_release(psi1(1))
       CALL cp_fm_release(h1_psi0(1))
-      DEALLOCATE (psi1(1)%matrix)
-      DEALLOCATE (psi1)
       CALL cp_print_key_finished_output(output_unit, logger, lr_section, &
                                         "PRINT%PROGRAM_RUN_INFO")
 

--- a/src/qs_dcdr.F
+++ b/src/qs_dcdr.F
@@ -221,21 +221,21 @@ CONTAINS
       CALL dbcsr_add(dcdr_env%hamiltonian1(1)%matrix, dcdr_env%matrix_t1(dcdr_env%beta + 1)%matrix, one, one)
 
       CALL cp_dbcsr_sm_fm_multiply(dcdr_env%hamiltonian1(1)%matrix, dcdr_env%mo_coeff(1), &
-                                   dcdr_env%op_dR(1)%matrix, ncol=nmo)
+                                   dcdr_env%op_dR(1), ncol=nmo)
 
       ! The overlap derivative terms for the Sternheimer equation
       ! buf = mo * (-mo * matrix_ks * mo)
       CALL cp_fm_create(buf, dcdr_env%likemos_fm_struct)
       CALL parallel_gemm('N', 'N', nao, nmo, nmo, &
-                         -1.0_dp, dcdr_env%mo_coeff(1), dcdr_env%chc(1)%matrix, &
+                         -1.0_dp, dcdr_env%mo_coeff(1), dcdr_env%chc(1), &
                          0.0_dp, buf)
 
-      CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_s1(dcdr_env%beta + 1)%matrix, buf, dcdr_env%op_dR(1)%matrix, &
+      CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_s1(dcdr_env%beta + 1)%matrix, buf, dcdr_env%op_dR(1), &
                                    nmo, alpha=1.0_dp, beta=1.0_dp)
       CALL cp_fm_release(buf)
 
       ! SL multiply by -1 for response solver (H-S<H> C + dR_coupled= - (op_dR)
-      CALL cp_fm_scale(-1.0_dp, dcdr_env%op_dR(1)%matrix)
+      CALL cp_fm_scale(-1.0_dp, dcdr_env%op_dR(1))
 
       CALL dbcsr_deallocate_matrix_set(opdr_sym)
 
@@ -297,8 +297,8 @@ CONTAINS
             "Response to the perturbation operator referring to atom ", dcdr_env%lambda, &
             " displaced in "//ACHAR(dcdr_env%beta + 119)
       END IF
-      CALL cp_fm_set_all(dcdr_env%dCR(1)%matrix, 0.0_dp)
-      CALL cp_fm_to_fm(dcdr_env%op_dR(1)%matrix, h1_psi0(1))
+      CALL cp_fm_set_all(dcdr_env%dCR(1), 0.0_dp)
+      CALL cp_fm_to_fm(dcdr_env%op_dR(1), h1_psi0(1))
 
       linres_control%lr_triplet = .FALSE. ! we do singlet response
       linres_control%do_kernel = .TRUE.
@@ -311,7 +311,7 @@ CONTAINS
       ! psi0_order = the unperturbed wavefunction
       CALL linres_solver(p_env, qs_env, psi1, h1_psi0, psi0_order, &
                          output_unit, should_stop)
-      CALL cp_fm_to_fm(psi1(1), dcdr_env%dCR(1)%matrix)
+      CALL cp_fm_to_fm(psi1(1), dcdr_env%dCR(1))
 
       ! Write the new result to the restart file
       IF (linres_control%linres_restart) THEN
@@ -373,7 +373,7 @@ CONTAINS
 
       ! Compute S^(1,R)_(ij)
       CALL cp_fm_set_all(tmp_fm_like_mos, 0.0_dp)
-      CALL cp_fm_scale_and_add(0._dp, dcdr_env%dCR_prime(1)%matrix, 1._dp, dcdr_env%dCR(1)%matrix)
+      CALL cp_fm_scale_and_add(0._dp, dcdr_env%dCR_prime(1), 1._dp, dcdr_env%dCR(1))
       CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_s1(dcdr_env%beta + 1)%matrix, mo_coeff, &
                                    tmp_fm_like_mos, ncol=nmo)
       CALL parallel_gemm("T", "N", nmo, nmo, nao, &
@@ -385,7 +385,7 @@ CONTAINS
       !    And apply the constant correction due to the overlap derivative.
       CALL parallel_gemm("N", "N", nao, nmo, nmo, &
                          -0.5_dp, mo_coeff, overlap1_MO, &
-                         -1.0_dp, dcdr_env%dCR_prime(1)%matrix)
+                         -1.0_dp, dcdr_env%dCR_prime(1))
 
       DO alpha = 1, 3
          ! FIRST CONTRIBUTION: dCR * moments * mo
@@ -394,7 +394,7 @@ CONTAINS
          CALL dbcsr_desymmetrize(dcdr_env%moments(alpha)%matrix, dcdr_env%matrix_nosym_temp(2)%matrix)
          CALL dbcsr_add(dcdr_env%matrix_nosym_temp(1)%matrix, dcdr_env%matrix_nosym_temp(2)%matrix, &
                         -dcdr_env%ref_point(alpha), 1._dp)
-         CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_nosym_temp(1)%matrix, dcdr_env%dCR_prime(1)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_nosym_temp(1)%matrix, dcdr_env%dCR_prime(1), &
                                       tmp_fm_like_mos, ncol=nmo)
          CALL cp_fm_trace(mo_coeff, tmp_fm_like_mos, apt_coeff_derivative)
 
@@ -535,7 +535,7 @@ CONTAINS
 
       ! Build the full coefficient derivatives.
       CALL cp_fm_set_all(tmp_fm, 0.0_dp)
-      CALL cp_fm_scale_and_add(0._dp, dcdr_env%dCR_prime(1)%matrix, 1._dp, dcdr_env%dCR(1)%matrix)
+      CALL cp_fm_scale_and_add(0._dp, dcdr_env%dCR_prime(1), 1._dp, dcdr_env%dCR(1))
       CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_s1(dcdr_env%beta + 1)%matrix, mo_coeff, &
                                    tmp_fm, ncol=nmo)
       CALL parallel_gemm("T", "N", nmo, nmo, nao, &
@@ -545,7 +545,7 @@ CONTAINS
       !   C^1 <- -dCR - 0.5 * mo_coeff @ S1_ij
       CALL parallel_gemm("N", "N", nao, nmo, nmo, &
                          -0.5_dp, mo_coeff, tmp_fm_momo(1), &
-                         -1.0_dp, dcdr_env%dCR_prime(1)%matrix)
+                         -1.0_dp, dcdr_env%dCR_prime(1))
 
       ! FIRST CONTRIBUTION: dCR * moments * mo
       this_factor = -2._dp*f_spin
@@ -554,7 +554,7 @@ CONTAINS
             CALL build_local_moment_matrix(qs_env, dcdr_env%moments, 1, &
                                            ref_point=centers_set(1)%array(1:3, icenter))
             CALL multiply_localization(ao_matrix=dcdr_env%moments(alpha)%matrix, &
-                                       mo_coeff=dcdr_env%dCR_prime(1)%matrix, work=tmp_fm, nmo=nmo, &
+                                       mo_coeff=dcdr_env%dCR_prime(1), work=tmp_fm, nmo=nmo, &
                                        icenter=icenter, &
                                        res=tmp_fm_like_mos(alpha))
             CALL dbcsr_set(dcdr_env%moments(alpha)%matrix, 0.0_dp)

--- a/src/qs_dcdr.F
+++ b/src/qs_dcdr.F
@@ -12,7 +12,6 @@
 
 MODULE qs_dcdr
 
-!#include "./common/cp_common_uses.f90"
    USE atomic_kind_types,               ONLY: get_atomic_kind
    USE cell_types,                      ONLY: cell_type,&
                                               pbc
@@ -222,14 +221,14 @@ CONTAINS
       CALL dbcsr_desymmetrize(opdr_sym(1)%matrix, dcdr_env%hamiltonian1(1)%matrix)
       CALL dbcsr_add(dcdr_env%hamiltonian1(1)%matrix, dcdr_env%matrix_t1(dcdr_env%beta + 1)%matrix, one, one)
 
-      CALL cp_dbcsr_sm_fm_multiply(dcdr_env%hamiltonian1(1)%matrix, dcdr_env%mo_coeff(1)%matrix, &
+      CALL cp_dbcsr_sm_fm_multiply(dcdr_env%hamiltonian1(1)%matrix, dcdr_env%mo_coeff(1), &
                                    dcdr_env%op_dR(1)%matrix, ncol=nmo)
 
       ! The overlap derivative terms for the Sternheimer equation
       ! buf = mo * (-mo * matrix_ks * mo)
       CALL cp_fm_create(buf, dcdr_env%likemos_fm_struct)
       CALL parallel_gemm('N', 'N', nao, nmo, nmo, &
-                         -1.0_dp, dcdr_env%mo_coeff(1)%matrix, dcdr_env%chc(1)%matrix, &
+                         -1.0_dp, dcdr_env%mo_coeff(1), dcdr_env%chc(1)%matrix, &
                          0.0_dp, buf)
 
       CALL cp_dbcsr_sm_fm_multiply(dcdr_env%matrix_s1(dcdr_env%beta + 1)%matrix, buf, dcdr_env%op_dR(1)%matrix, &
@@ -261,7 +260,8 @@ CONTAINS
 
       INTEGER                                            :: handle, output_unit
       LOGICAL                                            :: should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi0_order, psi1
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(linres_control_type), POINTER                 :: linres_control
       TYPE(section_vals_type), POINTER                   :: lr_section
@@ -283,10 +283,10 @@ CONTAINS
       END IF
 
       ! allocate the vectors
-      ALLOCATE (psi0_order(1), psi1(1), h1_psi0(1))
+      ALLOCATE (psi1(1), h1_psi0(1))
       NULLIFY (psi1(1)%matrix, h1_psi0(1)%matrix)
 
-      psi0_order(1)%matrix => dcdr_env%mo_coeff(1)%matrix
+      psi0_order(1:1) => dcdr_env%mo_coeff(1:1)
       ALLOCATE (psi1(1)%matrix, h1_psi0(1)%matrix)
       CALL cp_fm_create(psi1(1)%matrix, dcdr_env%likemos_fm_struct)
       CALL cp_fm_create(h1_psi0(1)%matrix, dcdr_env%likemos_fm_struct)
@@ -328,7 +328,7 @@ CONTAINS
       CALL cp_fm_release(psi1(1)%matrix)
       CALL cp_fm_release(h1_psi0(1)%matrix)
       DEALLOCATE (psi1(1)%matrix, h1_psi0(1)%matrix)
-      DEALLOCATE (psi1, h1_psi0, psi0_order)
+      DEALLOCATE (psi1, h1_psi0)
       CALL cp_print_key_finished_output(output_unit, logger, lr_section, &
                                         "PRINT%PROGRAM_RUN_INFO")
 
@@ -370,7 +370,7 @@ CONTAINS
 
       nao = dcdr_env%nao
       nmo = dcdr_env%nmo
-      mo_coeff => dcdr_env%mo_coeff(1)%matrix
+      mo_coeff => dcdr_env%mo_coeff(1)
       apt_el => dcdr_env%apt_el_dcdr
       apt_nuc => dcdr_env%apt_nuc_dcdr
 
@@ -529,7 +529,7 @@ CONTAINS
 
       nao = dcdr_env%nao
       nmo = dcdr_env%nmo
-      mo_coeff => dcdr_env%mo_coeff(1)%matrix
+      mo_coeff => dcdr_env%mo_coeff(1)
       f_spin = 2._dp
 
       ALLOCATE (diagonal_elements(nmo))

--- a/src/qs_dcdr.F
+++ b/src/qs_dcdr.F
@@ -471,8 +471,8 @@ CONTAINS
       REAL(dp), DIMENSION(:, :, :, :), POINTER           :: apt_center, apt_subset
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: tmp_fm_like_mos, tmp_fm_momo
       TYPE(cp_fm_type)                                   :: tmp_fm
+      TYPE(cp_fm_type), DIMENSION(3)                     :: tmp_fm_like_mos, tmp_fm_momo
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -532,15 +532,13 @@ CONTAINS
       mo_coeff => dcdr_env%mo_coeff(1)%matrix
       f_spin = 2._dp
 
-      ALLOCATE (tmp_fm_momo(3), tmp_fm_like_mos(3))
       ALLOCATE (diagonal_elements(nmo))
 
       ! Allocate temporary matrices
       CALL cp_fm_create(tmp_fm, dcdr_env%likemos_fm_struct)
       DO i = 1, 3
-         ALLOCATE (tmp_fm_momo(i)%matrix, tmp_fm_like_mos(i)%matrix)
-         CALL cp_fm_create(tmp_fm_momo(i)%matrix, dcdr_env%momo_fm_struct)
-         CALL cp_fm_create(tmp_fm_like_mos(i)%matrix, dcdr_env%likemos_fm_struct)
+         CALL cp_fm_create(tmp_fm_momo(i), dcdr_env%momo_fm_struct)
+         CALL cp_fm_create(tmp_fm_like_mos(i), dcdr_env%likemos_fm_struct)
       END DO
 
       ! Build the full coefficient derivatives.
@@ -550,11 +548,11 @@ CONTAINS
                                    tmp_fm, ncol=nmo)
       CALL parallel_gemm("T", "N", nmo, nmo, nao, &
                          1.0_dp, mo_coeff, tmp_fm, &
-                         0.0_dp, tmp_fm_momo(1)%matrix)
+                         0.0_dp, tmp_fm_momo(1))
 
       !   C^1 <- -dCR - 0.5 * mo_coeff @ S1_ij
       CALL parallel_gemm("N", "N", nao, nmo, nmo, &
-                         -0.5_dp, mo_coeff, tmp_fm_momo(1)%matrix, &
+                         -0.5_dp, mo_coeff, tmp_fm_momo(1), &
                          -1.0_dp, dcdr_env%dCR_prime(1)%matrix)
 
       ! FIRST CONTRIBUTION: dCR * moments * mo
@@ -566,14 +564,14 @@ CONTAINS
             CALL multiply_localization(ao_matrix=dcdr_env%moments(alpha)%matrix, &
                                        mo_coeff=dcdr_env%dCR_prime(1)%matrix, work=tmp_fm, nmo=nmo, &
                                        icenter=icenter, &
-                                       res=tmp_fm_like_mos(alpha)%matrix)
+                                       res=tmp_fm_like_mos(alpha))
             CALL dbcsr_set(dcdr_env%moments(alpha)%matrix, 0.0_dp)
          END DO
 
          CALL parallel_gemm("T", "N", nmo, nmo, nao, &
-                            1.0_dp, mo_coeff, tmp_fm_like_mos(alpha)%matrix, &
-                            0.0_dp, tmp_fm_momo(alpha)%matrix)
-         CALL cp_fm_get_diag(tmp_fm_momo(alpha)%matrix, diagonal_elements)
+                            1.0_dp, mo_coeff, tmp_fm_like_mos(alpha), &
+                            0.0_dp, tmp_fm_momo(alpha))
+         CALL cp_fm_get_diag(tmp_fm_momo(alpha), diagonal_elements)
 
          DO icenter = 1, dcdr_env%nbr_center(1)
             map_atom = mapping_wannier_atom(icenter)
@@ -608,13 +606,13 @@ CONTAINS
             CALL multiply_localization(ao_matrix=dcdr_env%matrix_difdip(alpha, dcdr_env%beta)%matrix, &
                                        mo_coeff=mo_coeff, work=tmp_fm, nmo=nmo, &
                                        icenter=icenter, &
-                                       res=tmp_fm_like_mos(alpha)%matrix)
+                                       res=tmp_fm_like_mos(alpha))
          END DO ! icenter
 
          CALL parallel_gemm("T", "N", nmo, nmo, nao, &
-                            1.0_dp, mo_coeff, tmp_fm_like_mos(alpha)%matrix, &
-                            0.0_dp, tmp_fm_momo(alpha)%matrix)
-         CALL cp_fm_get_diag(tmp_fm_momo(alpha)%matrix, diagonal_elements)
+                            1.0_dp, mo_coeff, tmp_fm_like_mos(alpha), &
+                            0.0_dp, tmp_fm_momo(alpha))
+         CALL cp_fm_get_diag(tmp_fm_momo(alpha), diagonal_elements)
 
          DO icenter = 1, dcdr_env%nbr_center(1)
             map_atom = mapping_wannier_atom(icenter)
@@ -651,11 +649,9 @@ CONTAINS
       ! And deallocate all the things!
       CALL cp_fm_release(tmp_fm)
       DO i = 1, 3
-         CALL cp_fm_release(tmp_fm_like_mos(i)%matrix)
-         CALL cp_fm_release(tmp_fm_momo(i)%matrix)
-         DEALLOCATE (tmp_fm_like_mos(i)%matrix, tmp_fm_momo(i)%matrix)
+         CALL cp_fm_release(tmp_fm_like_mos(i))
+         CALL cp_fm_release(tmp_fm_momo(i))
       END DO
-      DEALLOCATE (tmp_fm_like_mos, tmp_fm_momo)
       DEALLOCATE (diagonal_elements)
 
       CALL timestop(handle)

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -178,7 +178,7 @@ CONTAINS
       END IF
 
       CALL parallel_gemm('N', 'T', dcdr_env%nao, dcdr_env%nao, dcdr_env%nmo, &
-                         1.0_dp, dcdr_env%mo_coeff(1)%matrix, dcdr_env%mo_coeff(1)%matrix, &
+                         1.0_dp, dcdr_env%mo_coeff(1), dcdr_env%mo_coeff(1), &
                          0.0_dp, rho_ao_fm)
 
       CALL parallel_gemm('N', 'N', dcdr_env%nao, dcdr_env%nao, dcdr_env%nao, &

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -855,18 +855,11 @@ CONTAINS
       ALLOCATE (dcdr_env%chc(nspins))
       ALLOCATE (dcdr_env%op_dR(nspins))
 
-      NULLIFY (dcdr_env%dCR(1)%matrix)
-      NULLIFY (dcdr_env%dCR_prime(1)%matrix)
-      NULLIFY (dcdr_env%chc(1)%matrix)
-      NULLIFY (dcdr_env%op_dR(1)%matrix)
-
-      ALLOCATE (dcdr_env%dCR(1)%matrix, dcdr_env%dCR_prime(1)%matrix, &
-                dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
-      CALL cp_fm_create(dcdr_env%dCR(1)%matrix, dcdr_env%likemos_fm_struct)
-      CALL cp_fm_create(dcdr_env%dCR_prime(1)%matrix, dcdr_env%likemos_fm_struct)
+      CALL cp_fm_create(dcdr_env%dCR(1), dcdr_env%likemos_fm_struct)
+      CALL cp_fm_create(dcdr_env%dCR_prime(1), dcdr_env%likemos_fm_struct)
       CALL cp_fm_create(dcdr_env%mo_coeff(1), dcdr_env%likemos_fm_struct)
-      CALL cp_fm_create(dcdr_env%chc(1)%matrix, dcdr_env%momo_fm_struct)
-      CALL cp_fm_create(dcdr_env%op_dR(1)%matrix, dcdr_env%likemos_fm_struct)
+      CALL cp_fm_create(dcdr_env%chc(1), dcdr_env%momo_fm_struct)
+      CALL cp_fm_create(dcdr_env%op_dR(1), dcdr_env%likemos_fm_struct)
 
       CALL cp_fm_to_fm(mo_coeff, dcdr_env%mo_coeff(1))
 
@@ -985,10 +978,10 @@ CONTAINS
       CALL cp_dbcsr_sm_fm_multiply(matrix_ks(1)%matrix, mo_coeff, buf, nmo)
       ! chc = mo * matrix_ks * mo
       CALL cp_fm_get_info(buf)
-      CALL cp_fm_get_info(dcdr_env%chc(1)%matrix)
+      CALL cp_fm_get_info(dcdr_env%chc(1))
       CALL parallel_gemm('T', 'N', nmo, nmo, nao, &
                          1.0_dp, mo_coeff, buf, &
-                         0.0_dp, dcdr_env%chc(1)%matrix)
+                         0.0_dp, dcdr_env%chc(1))
 
       CALL cp_fm_release(buf)
 
@@ -1047,15 +1040,11 @@ CONTAINS
       END IF
 
       ! Full matrices
-      CALL cp_fm_release(dcdr_env%dCR(1)%matrix)
-      CALL cp_fm_release(dcdr_env%dCR_prime(1)%matrix)
+      CALL cp_fm_release(dcdr_env%dCR(1))
+      CALL cp_fm_release(dcdr_env%dCR_prime(1))
       CALL cp_fm_release(dcdr_env%mo_coeff(1))
-      CALL cp_fm_release(dcdr_env%chc(1)%matrix)
-      CALL cp_fm_release(dcdr_env%op_dR(1)%matrix)
-      DEALLOCATE (dcdr_env%dCR(1)%matrix, dcdr_env%dCR_prime(1)%matrix, &
-                  dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
-      NULLIFY (dcdr_env%dCR(1)%matrix, dcdr_env%dCR_prime(1)%matrix, &
-               dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
+      CALL cp_fm_release(dcdr_env%chc(1))
+      CALL cp_fm_release(dcdr_env%op_dR(1))
 
       DEALLOCATE (dcdr_env%op_dR)
       DEALLOCATE (dcdr_env%dCR)

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -23,9 +23,14 @@ MODULE qs_dcdr_utils
                                               open_file
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_p_type, cp_fm_release, &
-        cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_info,&
+                                              cp_fm_get_submatrix,&
+                                              cp_fm_release,&
+                                              cp_fm_set_all,&
+                                              cp_fm_set_submatrix,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type,&
@@ -139,7 +144,7 @@ CONTAINS
    SUBROUTINE dcdr_read_restart(qs_env, linres_section, vec, lambda, beta, tag)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: linres_section
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: vec
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: vec
       INTEGER, INTENT(IN)                                :: lambda, beta
       CHARACTER(LEN=*)                                   :: tag
 
@@ -258,7 +263,7 @@ CONTAINS
                   IF (rst_unit > 0) READ (rst_unit) vecbuffer(1:nao, j)
                END DO
                CALL mp_bcast(vecbuffer, source, group)
-               CALL cp_fm_set_submatrix(vec(ispin)%matrix, vecbuffer, 1, i, nao, i_block)
+               CALL cp_fm_set_submatrix(vec(ispin), vecbuffer, 1, i, nao, i_block)
             END DO
          END DO
 
@@ -293,7 +298,7 @@ CONTAINS
    SUBROUTINE dcdr_write_restart(qs_env, linres_section, vec, lambda, beta, tag)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: linres_section
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: vec
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: vec
       INTEGER, INTENT(IN)                                :: lambda, beta
       CHARACTER(LEN=*)                                   :: tag
 
@@ -357,13 +362,13 @@ CONTAINS
          IF (rst_unit > 0) WRITE (rst_unit) lambda, beta, nspins, nao
 
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(vec(ispin)%matrix, ncol_global=nmo)
+            CALL cp_fm_get_info(vec(ispin), ncol_global=nmo)
 
             IF (rst_unit > 0) WRITE (rst_unit) nmo
 
             DO i = 1, nmo, MAX(max_block, 1)
                i_block = MIN(max_block, nmo - i + 1)
-               CALL cp_fm_get_submatrix(vec(ispin)%matrix, vecbuffer, 1, i, nao, i_block)
+               CALL cp_fm_get_submatrix(vec(ispin), vecbuffer, 1, i, nao, i_block)
                ! doing this in one write would increase efficiency, but breaks RESTART compatibility.
                ! to old ones, and in cases where max_block is different between runs, as might happen during
                ! restarts with a different number of CPUs

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -850,21 +850,20 @@ CONTAINS
       ALLOCATE (dcdr_env%chc(nspins))
       ALLOCATE (dcdr_env%op_dR(nspins))
 
-      NULLIFY (dcdr_env%mo_coeff(1)%matrix)
       NULLIFY (dcdr_env%dCR(1)%matrix)
       NULLIFY (dcdr_env%dCR_prime(1)%matrix)
       NULLIFY (dcdr_env%chc(1)%matrix)
       NULLIFY (dcdr_env%op_dR(1)%matrix)
 
       ALLOCATE (dcdr_env%dCR(1)%matrix, dcdr_env%dCR_prime(1)%matrix, &
-                dcdr_env%mo_coeff(1)%matrix, dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
+                dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
       CALL cp_fm_create(dcdr_env%dCR(1)%matrix, dcdr_env%likemos_fm_struct)
       CALL cp_fm_create(dcdr_env%dCR_prime(1)%matrix, dcdr_env%likemos_fm_struct)
-      CALL cp_fm_create(dcdr_env%mo_coeff(1)%matrix, dcdr_env%likemos_fm_struct)
+      CALL cp_fm_create(dcdr_env%mo_coeff(1), dcdr_env%likemos_fm_struct)
       CALL cp_fm_create(dcdr_env%chc(1)%matrix, dcdr_env%momo_fm_struct)
       CALL cp_fm_create(dcdr_env%op_dR(1)%matrix, dcdr_env%likemos_fm_struct)
 
-      CALL cp_fm_to_fm(mo_coeff, dcdr_env%mo_coeff(1)%matrix)
+      CALL cp_fm_to_fm(mo_coeff, dcdr_env%mo_coeff(1))
 
       ! DBCSR matrices
       NULLIFY (dcdr_env%hamiltonian1)
@@ -1045,13 +1044,13 @@ CONTAINS
       ! Full matrices
       CALL cp_fm_release(dcdr_env%dCR(1)%matrix)
       CALL cp_fm_release(dcdr_env%dCR_prime(1)%matrix)
-      CALL cp_fm_release(dcdr_env%mo_coeff(1)%matrix)
+      CALL cp_fm_release(dcdr_env%mo_coeff(1))
       CALL cp_fm_release(dcdr_env%chc(1)%matrix)
       CALL cp_fm_release(dcdr_env%op_dR(1)%matrix)
       DEALLOCATE (dcdr_env%dCR(1)%matrix, dcdr_env%dCR_prime(1)%matrix, &
-                  dcdr_env%mo_coeff(1)%matrix, dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
+                  dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
       NULLIFY (dcdr_env%dCR(1)%matrix, dcdr_env%dCR_prime(1)%matrix, &
-               dcdr_env%mo_coeff(1)%matrix, dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
+               dcdr_env%chc(1)%matrix, dcdr_env%op_dR(1)%matrix)
 
       DEALLOCATE (dcdr_env%op_dR)
       DEALLOCATE (dcdr_env%dCR)

--- a/src/qs_diis.F
+++ b/src/qs_diis.F
@@ -27,7 +27,6 @@ MODULE qs_diis
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_maxabsval,&
-                                              cp_fm_p_type,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -213,7 +212,7 @@ CONTAINS
 
       TYPE(qs_diis_buffer_type), POINTER                 :: diis_buffer
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mo_array
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: kc
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: kc
       TYPE(cp_fm_type), INTENT(IN)                       :: sc
       REAL(KIND=dp), INTENT(IN)                          :: delta
       REAL(KIND=dp), INTENT(OUT)                         :: error_max
@@ -268,7 +267,7 @@ CONTAINS
          RETURN
       END IF
 
-      CALL cp_fm_get_info(kc(1)%matrix, &
+      CALL cp_fm_get_info(kc(1), &
                           matrix_struct=matrix_struct)
       CALL qs_diis_b_check_i_alloc(diis_buffer, &
                                    matrix_struct=matrix_struct, &
@@ -296,7 +295,7 @@ CONTAINS
 
          ! Copy the Kohn-Sham matrix K to the DIIS buffer
 
-         CALL cp_fm_to_fm(kc(ispin)%matrix, parameters)
+         CALL cp_fm_to_fm(kc(ispin), parameters)
 
          IF (my_roks) THEN
 
@@ -313,7 +312,7 @@ CONTAINS
             CALL cp_fm_column_scale(sc, occ(1:homo))
 
             ! KC <- K*C
-            CALL cp_fm_symm("L", "U", nao, homo, 1.0_dp, parameters, sc, 0.0_dp, kc(ispin)%matrix)
+            CALL cp_fm_symm("L", "U", nao, homo, 1.0_dp, parameters, sc, 0.0_dp, kc(ispin))
 
             IF (PRESENT(s_matrix)) THEN
                CALL copy_dbcsr_to_fm(s_matrix(1)%matrix, new_errors)
@@ -325,15 +324,15 @@ CONTAINS
             ! new_errors <- KC*(SC)^T - (SC)*(KC)^T = K*P*S - S*P*K
             ! or for an orthogonal basis
             ! new_errors <- KC*C^T - C*(KC)^T = K*P - P*K with S = I
-            CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, sc, kc(ispin)%matrix, 0.0_dp, new_errors)
-            CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, kc(ispin)%matrix, sc, -1.0_dp, new_errors)
+            CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, sc, kc(ispin), 0.0_dp, new_errors)
+            CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, kc(ispin), sc, -1.0_dp, new_errors)
 
             DEALLOCATE (occ)
 
          ELSE
 
             ! KC <- K*C
-            CALL cp_fm_symm("L", "U", nao, homo, maxocc, parameters, c, 0.0_dp, kc(ispin)%matrix)
+            CALL cp_fm_symm("L", "U", nao, homo, maxocc, parameters, c, 0.0_dp, kc(ispin))
 
             IF (PRESENT(s_matrix)) THEN
                ! I guess that this copy can be avoided for LSD
@@ -341,12 +340,12 @@ CONTAINS
                ! sc <- S*C
                CALL cp_fm_symm("L", "U", nao, homo, 2.0_dp, new_errors, c, 0.0_dp, sc)
                ! new_errors <- KC*(SC)^T - (SC)*(KC)^T = K*P*S - S*P*K
-               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, sc, kc(ispin)%matrix, 0.0_dp, new_errors)
-               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, kc(ispin)%matrix, sc, -1.0_dp, new_errors)
+               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, sc, kc(ispin), 0.0_dp, new_errors)
+               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, kc(ispin), sc, -1.0_dp, new_errors)
             ELSE
                ! new_errors <- KC*(C)^T - C*(KC)^T = K*P - P*K
-               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, c, kc(ispin)%matrix, 0.0_dp, new_errors)
-               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, kc(ispin)%matrix, c, -1.0_dp, new_errors)
+               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, c, kc(ispin), 0.0_dp, new_errors)
+               CALL parallel_gemm("N", "T", nao, nao, homo, 1.0_dp, kc(ispin), c, -1.0_dp, new_errors)
             END IF
 
          END IF
@@ -464,10 +463,10 @@ CONTAINS
          ! Update Kohn-Sham matrix
 
          DO ispin = 1, nspin
-            CALL cp_fm_set_all(kc(ispin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(kc(ispin), 0.0_dp)
             DO jb = 1, nb
                parameters => diis_buffer%parameter(jb, ispin)%matrix
-               CALL cp_fm_scale_and_add(1.0_dp, kc(ispin)%matrix, -ev(jb), parameters)
+               CALL cp_fm_scale_and_add(1.0_dp, kc(ispin), -ev(jb), parameters)
             END DO
          END DO
 
@@ -479,7 +478,7 @@ CONTAINS
 
          DO ispin = 1, nspin
             parameters => diis_buffer%parameter(ib, ispin)%matrix
-            CALL cp_fm_to_fm(parameters, kc(ispin)%matrix)
+            CALL cp_fm_to_fm(parameters, kc(ispin))
          END DO
 
       END IF

--- a/src/qs_diis.F
+++ b/src/qs_diis.F
@@ -144,8 +144,7 @@ CONTAINS
 
          DO ispin = 1, nspin
             DO ibuffer = 1, nbuffer
-               ALLOCATE (diis_buffer%error(ibuffer, ispin)%matrix)
-               CALL cp_fm_create(diis_buffer%error(ibuffer, ispin)%matrix, &
+               CALL cp_fm_create(diis_buffer%error(ibuffer, ispin), &
                                  name="qs_diis_b%error("// &
                                  TRIM(ADJUSTL(cp_to_string(ibuffer)))//","// &
                                  TRIM(ADJUSTL(cp_to_string(ibuffer)))//")", &
@@ -159,8 +158,7 @@ CONTAINS
 
          DO ispin = 1, nspin
             DO ibuffer = 1, nbuffer
-               ALLOCATE (diis_buffer%parameter(ibuffer, ispin)%matrix)
-               CALL cp_fm_create(diis_buffer%parameter(ibuffer, ispin)%matrix, &
+               CALL cp_fm_create(diis_buffer%parameter(ibuffer, ispin), &
                                  name="qs_diis_b%parameter("// &
                                  TRIM(ADJUSTL(cp_to_string(ibuffer)))//","// &
                                  TRIM(ADJUSTL(cp_to_string(ibuffer)))//")", &
@@ -290,8 +288,8 @@ CONTAINS
                          occupation_numbers=occa, &
                          maxocc=maxocc)
 
-         new_errors => diis_buffer%error(ib, ispin)%matrix
-         parameters => diis_buffer%parameter(ib, ispin)%matrix
+         new_errors => diis_buffer%error(ib, ispin)
+         parameters => diis_buffer%parameter(ib, ispin)
 
          ! Copy the Kohn-Sham matrix K to the DIIS buffer
 
@@ -392,8 +390,8 @@ CONTAINS
          DO jb = 1, nb
             b(jb, ib) = 0.0_dp
             DO ispin = 1, nspin
-               old_errors => diis_buffer%error(jb, ispin)%matrix
-               new_errors => diis_buffer%error(ib, ispin)%matrix
+               old_errors => diis_buffer%error(jb, ispin)
+               new_errors => diis_buffer%error(ib, ispin)
                CALL cp_fm_trace(old_errors, new_errors, tmp)
                b(jb, ib) = b(jb, ib) + tmp
             END DO
@@ -465,7 +463,7 @@ CONTAINS
          DO ispin = 1, nspin
             CALL cp_fm_set_all(kc(ispin), 0.0_dp)
             DO jb = 1, nb
-               parameters => diis_buffer%parameter(jb, ispin)%matrix
+               parameters => diis_buffer%parameter(jb, ispin)
                CALL cp_fm_scale_and_add(1.0_dp, kc(ispin), -ev(jb), parameters)
             END DO
          END DO
@@ -477,7 +475,7 @@ CONTAINS
       ELSE
 
          DO ispin = 1, nspin
-            parameters => diis_buffer%parameter(ib, ispin)%matrix
+            parameters => diis_buffer%parameter(ib, ispin)
             CALL cp_fm_to_fm(parameters, kc(ispin))
          END DO
 

--- a/src/qs_diis_types.F
+++ b/src/qs_diis_types.F
@@ -12,8 +12,8 @@
 !> \author Matthias Krack
 ! **************************************************************************************************
 MODULE qs_diis_types
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
+                                              cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type,&
                                               dbcsr_release
    USE kinds,                           ONLY: dp
@@ -38,7 +38,7 @@ MODULE qs_diis_types
 ! **************************************************************************************************
    TYPE qs_diis_buffer_type
       INTEGER                                          :: nbuffer, ncall
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: error, PARAMETER
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: error, PARAMETER
       REAL(KIND=dp), DIMENSION(:, :), POINTER                :: b_matrix
    END TYPE qs_diis_buffer_type
 
@@ -90,9 +90,7 @@ CONTAINS
       IF (ASSOCIATED(diis_buffer%error)) THEN
          DO j = 1, SIZE(diis_buffer%error, 2)
             DO i = 1, SIZE(diis_buffer%error, 1)
-               CALL cp_fm_release(diis_buffer%error(i, j)%matrix)
-               DEALLOCATE (diis_buffer%error(i, j)%matrix)
-               NULLIFY (diis_buffer%error(i, j)%matrix)
+               CALL cp_fm_release(diis_buffer%error(i, j))
             END DO
          END DO
          DEALLOCATE (diis_buffer%error)
@@ -100,9 +98,7 @@ CONTAINS
       IF (ASSOCIATED(diis_buffer%parameter)) THEN
          DO j = 1, SIZE(diis_buffer%parameter, 2)
             DO i = 1, SIZE(diis_buffer%parameter, 1)
-               CALL cp_fm_release(diis_buffer%parameter(i, j)%matrix)
-               DEALLOCATE (diis_buffer%parameter(i, j)%matrix)
-               NULLIFY (diis_buffer%parameter(i, j)%matrix)
+               CALL cp_fm_release(diis_buffer%parameter(i, j))
             END DO
          END DO
          DEALLOCATE (diis_buffer%parameter)

--- a/src/qs_efield_berry.F
+++ b/src/qs_efield_berry.F
@@ -39,7 +39,6 @@ MODULE qs_efield_berry
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_type
@@ -211,9 +210,9 @@ CONTAINS
       TYPE(block_p_type), DIMENSION(3, 2)                :: dcost, dsint
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_cfm_p_type), DIMENSION(:), POINTER         :: eigrmat, inv_mat
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_coeff_tmp, mo_derivs_tmp
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: inv_work, op_fm_set, opvec
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_coeff_tmp, mo_derivs_tmp
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: inv_work, op_fm_set, opvec
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mo_derivs
@@ -320,19 +319,17 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nao=nao, nmo=nmo)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nmo, &
                                   ncol_global=nmo, para_env=para_env, context=mo_coeff%matrix_struct%context)
-         ALLOCATE (mo_derivs_tmp(ispin)%matrix, mo_coeff_tmp(ispin)%matrix)
-         CALL cp_fm_create(mo_derivs_tmp(ispin)%matrix, mo_coeff%matrix_struct)
-         CALL cp_fm_create(mo_coeff_tmp(ispin)%matrix, mo_coeff%matrix_struct)
-         CALL copy_dbcsr_to_fm(mo_derivs(ispin)%matrix, mo_derivs_tmp(ispin)%matrix)
+         CALL cp_fm_create(mo_derivs_tmp(ispin), mo_coeff%matrix_struct)
+         CALL cp_fm_create(mo_coeff_tmp(ispin), mo_coeff%matrix_struct)
+         CALL copy_dbcsr_to_fm(mo_derivs(ispin)%matrix, mo_derivs_tmp(ispin))
          DO i = 1, SIZE(op_fm_set, 1)
-            ALLOCATE (opvec(i, ispin)%matrix, op_fm_set(i, ispin)%matrix, inv_work(i, ispin)%matrix)
-            CALL cp_fm_create(opvec(i, ispin)%matrix, mo_coeff%matrix_struct)
-            CALL cp_fm_create(op_fm_set(i, ispin)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(inv_work(i, ispin)%matrix, op_fm_set(i, ispin)%matrix%matrix_struct)
+            CALL cp_fm_create(opvec(i, ispin), mo_coeff%matrix_struct)
+            CALL cp_fm_create(op_fm_set(i, ispin), tmp_fm_struct)
+            CALL cp_fm_create(inv_work(i, ispin), op_fm_set(i, ispin)%matrix_struct)
          END DO
          ALLOCATE (eigrmat(ispin)%matrix, inv_mat(ispin)%matrix)
-         CALL cp_cfm_create(eigrmat(ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
-         CALL cp_cfm_create(inv_mat(ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
+         CALL cp_cfm_create(eigrmat(ispin)%matrix, op_fm_set(1, ispin)%matrix_struct)
+         CALL cp_cfm_create(inv_mat(ispin)%matrix, op_fm_set(1, ispin)%matrix_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
       ! temp matrices for force calculation
@@ -371,22 +368,23 @@ CONTAINS
             DO ispin = 1, dft_control%nspins ! spin
                IF (mos(ispin)%use_mo_coeff_b) THEN
                   CALL get_mo_set(mo_set=mos(ispin), nao=nao, mo_coeff_b=mo_coeff_b, nmo=nmo)
-                  CALL copy_dbcsr_to_fm(mo_coeff_b, mo_coeff_tmp(ispin)%matrix)
+                  CALL copy_dbcsr_to_fm(mo_coeff_b, mo_coeff_tmp(ispin))
                ELSE
-                  CALL get_mo_set(mo_set=mos(ispin), nao=nao, mo_coeff=mo_coeff_tmp(ispin)%matrix, nmo=nmo)
+                  CALL get_mo_set(mo_set=mos(ispin), nao=nao, mo_coeff=mo_coeff, nmo=nmo)
+                  mo_coeff_tmp(ispin) = mo_coeff
                END IF
-               CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff_tmp(ispin)%matrix, opvec(1, ispin)%matrix, ncol=nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin)%matrix, opvec(1, ispin)%matrix, 0.0_dp, &
-                                  op_fm_set(1, ispin)%matrix)
-               CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff_tmp(ispin)%matrix, opvec(2, ispin)%matrix, ncol=nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin)%matrix, opvec(2, ispin)%matrix, 0.0_dp, &
-                                  op_fm_set(2, ispin)%matrix)
+               CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff_tmp(ispin), opvec(1, ispin), ncol=nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin), opvec(1, ispin), 0.0_dp, &
+                                  op_fm_set(1, ispin))
+               CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff_tmp(ispin), opvec(2, ispin), ncol=nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin), opvec(2, ispin), 0.0_dp, &
+                                  op_fm_set(2, ispin))
             END DO
             !second step invert C^T S_berry C
             zdet = z_one
             DO ispin = 1, dft_control%nspins
-               CALL cp_cfm_scale_and_add_fm(z_zero, eigrmat(ispin)%matrix, z_one, op_fm_set(1, ispin)%matrix)
-               CALL cp_cfm_scale_and_add_fm(z_one, eigrmat(ispin)%matrix, -gaussi, op_fm_set(2, ispin)%matrix)
+               CALL cp_cfm_scale_and_add_fm(z_zero, eigrmat(ispin)%matrix, z_one, op_fm_set(1, ispin))
+               CALL cp_cfm_scale_and_add_fm(z_one, eigrmat(ispin)%matrix, -gaussi, op_fm_set(2, ispin))
                CALL cp_cfm_set_all(inv_mat(ispin)%matrix, z_zero, z_one)
                CALL cp_cfm_solve(eigrmat(ispin)%matrix, inv_mat(ispin)%matrix, zdeta)
                zdet = zdet*zdeta
@@ -398,13 +396,13 @@ CONTAINS
                !compute the orbital derivative
                focc = fpolvec(idir)
                DO ispin = 1, dft_control%nspins
-                  inv_work(1, ispin)%matrix%local_data(:, :) = REAL(inv_mat(ispin)%matrix%local_data(:, :), dp)
-                  inv_work(2, ispin)%matrix%local_data(:, :) = AIMAG(inv_mat(ispin)%matrix%local_data(:, :))
+                  inv_work(1, ispin)%local_data(:, :) = REAL(inv_mat(ispin)%matrix%local_data(:, :), dp)
+                  inv_work(2, ispin)%local_data(:, :) = AIMAG(inv_mat(ispin)%matrix%local_data(:, :))
                   CALL get_mo_set(mo_set=mos(ispin), nao=nao, nmo=nmo)
-                  CALL parallel_gemm("N", "N", nao, nmo, nmo, focc, opvec(1, ispin)%matrix, inv_work(2, ispin)%matrix, &
-                                     1.0_dp, mo_derivs_tmp(ispin)%matrix)
-                  CALL parallel_gemm("N", "N", nao, nmo, nmo, -focc, opvec(2, ispin)%matrix, inv_work(1, ispin)%matrix, &
-                                     1.0_dp, mo_derivs_tmp(ispin)%matrix)
+                  CALL parallel_gemm("N", "N", nao, nmo, nmo, focc, opvec(1, ispin), inv_work(2, ispin), &
+                                     1.0_dp, mo_derivs_tmp(ispin))
+                  CALL parallel_gemm("N", "N", nao, nmo, nmo, -focc, opvec(2, ispin), inv_work(1, ispin), &
+                                     1.0_dp, mo_derivs_tmp(ispin))
                END DO
             END IF
 
@@ -420,14 +418,14 @@ CONTAINS
                   CALL dbcsr_set(tempmat(1, ispin)%matrix, 0.0_dp)
                   CALL dbcsr_set(tempmat(2, ispin)%matrix, 0.0_dp)
                   CALL get_mo_set(mo_set=mos(ispin), nao=nao, nmo=nmo)
-                CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin)%matrix, inv_work(1, ispin)%matrix, 0.0_dp, &
-                                     opvec(1, ispin)%matrix)
-                CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin)%matrix, inv_work(2, ispin)%matrix, 0.0_dp, &
-                                     opvec(2, ispin)%matrix)
+                  CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin), inv_work(1, ispin), 0.0_dp, &
+                                     opvec(1, ispin))
+                  CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin), inv_work(2, ispin), 0.0_dp, &
+                                     opvec(2, ispin))
                   CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=tempmat(1, ispin)%matrix, &
-                                             matrix_v=opvec(1, ispin)%matrix, matrix_g=mo_coeff_tmp(ispin)%matrix, ncol=nmo)
+                                             matrix_v=opvec(1, ispin), matrix_g=mo_coeff_tmp(ispin), ncol=nmo)
                   CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=tempmat(2, ispin)%matrix, &
-                                             matrix_v=opvec(2, ispin)%matrix, matrix_g=mo_coeff_tmp(ispin)%matrix, ncol=nmo)
+                                             matrix_v=opvec(2, ispin), matrix_g=mo_coeff_tmp(ispin), ncol=nmo)
                END DO
 
                ! Calculation of derivative integrals (da|eikr|b) and (a|eikr|db)
@@ -615,7 +613,7 @@ CONTAINS
       IF (.NOT. just_energy) THEN
          ! Add the result to mo_derivativs
          DO ispin = 1, dft_control%nspins
-            CALL copy_fm_to_dbcsr(mo_derivs_tmp(ispin)%matrix, mo_derivs(ispin)%matrix)
+            CALL copy_fm_to_dbcsr(mo_derivs_tmp(ispin), mo_derivs(ispin)%matrix)
          END DO
          IF (use_virial) THEN
             ti = 0.0_dp
@@ -636,14 +634,12 @@ CONTAINS
          CALL cp_cfm_release(eigrmat(ispin)%matrix)
          CALL cp_cfm_release(inv_mat(ispin)%matrix)
          DEALLOCATE (eigrmat(ispin)%matrix, inv_mat(ispin)%matrix)
-         CALL cp_fm_release(mo_derivs_tmp(ispin)%matrix)
-         CALL cp_fm_release(mo_coeff_tmp(ispin)%matrix)
-         DEALLOCATE (mo_derivs_tmp(ispin)%matrix, mo_coeff_tmp(ispin)%matrix)
+         CALL cp_fm_release(mo_derivs_tmp(ispin))
+         IF (mos(ispin)%use_mo_coeff_b) CALL cp_fm_release(mo_coeff_tmp(ispin))
          DO i = 1, SIZE(op_fm_set, 1)
-            CALL cp_fm_release(opvec(i, ispin)%matrix)
-            CALL cp_fm_release(op_fm_set(i, ispin)%matrix)
-            CALL cp_fm_release(inv_work(i, ispin)%matrix)
-            DEALLOCATE (opvec(i, ispin)%matrix, op_fm_set(i, ispin)%matrix, inv_work(i, ispin)%matrix)
+            CALL cp_fm_release(opvec(i, ispin))
+            CALL cp_fm_release(op_fm_set(i, ispin))
+            CALL cp_fm_release(inv_work(i, ispin))
          END DO
       END DO
       DEALLOCATE (inv_mat, inv_work, op_fm_set, opvec, eigrmat)
@@ -700,9 +696,9 @@ CONTAINS
       TYPE(block_p_type), DIMENSION(3, 2)                :: dcost, dsint
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_cfm_p_type), DIMENSION(:), POINTER         :: eigrmat, inv_mat
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_coeff_tmp
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: inv_work, mo_derivs_tmp, op_fm_set, opvec
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_coeff_tmp
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: inv_work, mo_derivs_tmp, op_fm_set, opvec
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, mo_derivs
@@ -808,22 +804,19 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nao=nao, nmo=nmo)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nmo, &
                                   ncol_global=nmo, para_env=para_env, context=mo_coeff%matrix_struct%context)
-         ALLOCATE (mo_coeff_tmp(ispin)%matrix)
-         CALL cp_fm_create(mo_coeff_tmp(ispin)%matrix, mo_coeff%matrix_struct)
+         CALL cp_fm_create(mo_coeff_tmp(ispin), mo_coeff%matrix_struct)
          DO i = 1, 3
-            ALLOCATE (mo_derivs_tmp(i, ispin)%matrix)
-            CALL cp_fm_create(mo_derivs_tmp(i, ispin)%matrix, mo_coeff%matrix_struct)
-            CALL cp_fm_set_all(matrix=mo_derivs_tmp(i, ispin)%matrix, alpha=0.0_dp)
+            CALL cp_fm_create(mo_derivs_tmp(i, ispin), mo_coeff%matrix_struct)
+            CALL cp_fm_set_all(matrix=mo_derivs_tmp(i, ispin), alpha=0.0_dp)
          END DO
          DO i = 1, SIZE(op_fm_set, 1)
-            ALLOCATE (opvec(i, ispin)%matrix, op_fm_set(i, ispin)%matrix, inv_work(i, ispin)%matrix)
-            CALL cp_fm_create(opvec(i, ispin)%matrix, mo_coeff%matrix_struct)
-            CALL cp_fm_create(op_fm_set(i, ispin)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(inv_work(i, ispin)%matrix, op_fm_set(i, ispin)%matrix%matrix_struct)
+            CALL cp_fm_create(opvec(i, ispin), mo_coeff%matrix_struct)
+            CALL cp_fm_create(op_fm_set(i, ispin), tmp_fm_struct)
+            CALL cp_fm_create(inv_work(i, ispin), op_fm_set(i, ispin)%matrix_struct)
          END DO
          ALLOCATE (eigrmat(ispin)%matrix, inv_mat(ispin)%matrix)
-         CALL cp_cfm_create(eigrmat(ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
-         CALL cp_cfm_create(inv_mat(ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
+         CALL cp_cfm_create(eigrmat(ispin)%matrix, op_fm_set(1, ispin)%matrix_struct)
+         CALL cp_cfm_create(inv_mat(ispin)%matrix, op_fm_set(1, ispin)%matrix_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
       ! temp matrices for force calculation
@@ -860,22 +853,23 @@ CONTAINS
          DO ispin = 1, dft_control%nspins ! spin
             IF (mos(ispin)%use_mo_coeff_b) THEN
                CALL get_mo_set(mo_set=mos(ispin), nao=nao, mo_coeff_b=mo_coeff_b, nmo=nmo)
-               CALL copy_dbcsr_to_fm(mo_coeff_b, mo_coeff_tmp(ispin)%matrix)
+               CALL copy_dbcsr_to_fm(mo_coeff_b, mo_coeff_tmp(ispin))
             ELSE
-               CALL get_mo_set(mo_set=mos(ispin), nao=nao, mo_coeff=mo_coeff_tmp(ispin)%matrix, nmo=nmo)
+               CALL get_mo_set(mo_set=mos(ispin), nao=nao, mo_coeff=mo_coeff, nmo=nmo)
+               mo_coeff_tmp(ispin) = mo_coeff
             END IF
-            CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff_tmp(ispin)%matrix, opvec(1, ispin)%matrix, ncol=nmo)
-            CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin)%matrix, opvec(1, ispin)%matrix, 0.0_dp, &
-                               op_fm_set(1, ispin)%matrix)
-            CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff_tmp(ispin)%matrix, opvec(2, ispin)%matrix, ncol=nmo)
-            CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin)%matrix, opvec(2, ispin)%matrix, 0.0_dp, &
-                               op_fm_set(2, ispin)%matrix)
+            CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff_tmp(ispin), opvec(1, ispin), ncol=nmo)
+            CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin), opvec(1, ispin), 0.0_dp, &
+                               op_fm_set(1, ispin))
+            CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff_tmp(ispin), opvec(2, ispin), ncol=nmo)
+            CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff_tmp(ispin), opvec(2, ispin), 0.0_dp, &
+                               op_fm_set(2, ispin))
          END DO
          !second step invert C^T S_berry C
          zdet = z_one
          DO ispin = 1, dft_control%nspins
-            CALL cp_cfm_scale_and_add_fm(z_zero, eigrmat(ispin)%matrix, z_one, op_fm_set(1, ispin)%matrix)
-            CALL cp_cfm_scale_and_add_fm(z_one, eigrmat(ispin)%matrix, -gaussi, op_fm_set(2, ispin)%matrix)
+            CALL cp_cfm_scale_and_add_fm(z_zero, eigrmat(ispin)%matrix, z_one, op_fm_set(1, ispin))
+            CALL cp_cfm_scale_and_add_fm(z_one, eigrmat(ispin)%matrix, -gaussi, op_fm_set(2, ispin))
             CALL cp_cfm_set_all(inv_mat(ispin)%matrix, z_zero, z_one)
             CALL cp_cfm_solve(eigrmat(ispin)%matrix, inv_mat(ispin)%matrix, zdeta)
             zdet = zdet*zdeta
@@ -886,15 +880,15 @@ CONTAINS
          IF (.NOT. just_energy) THEN
             !compute the orbital derivative
             DO ispin = 1, dft_control%nspins
-               inv_work(1, ispin)%matrix%local_data(:, :) = REAL(inv_mat(ispin)%matrix%local_data(:, :), dp)
-               inv_work(2, ispin)%matrix%local_data(:, :) = AIMAG(inv_mat(ispin)%matrix%local_data(:, :))
+               inv_work(1, ispin)%local_data(:, :) = REAL(inv_mat(ispin)%matrix%local_data(:, :), dp)
+               inv_work(2, ispin)%local_data(:, :) = AIMAG(inv_mat(ispin)%matrix%local_data(:, :))
                CALL get_mo_set(mo_set=mos(ispin), nao=nao, nmo=nmo)
                DO i = 1, 3
                   focc = hmat(idir, i)
-                  CALL parallel_gemm("N", "N", nao, nmo, nmo, focc, opvec(1, ispin)%matrix, inv_work(2, ispin)%matrix, &
-                                     1.0_dp, mo_derivs_tmp(idir, ispin)%matrix)
-                  CALL parallel_gemm("N", "N", nao, nmo, nmo, -focc, opvec(2, ispin)%matrix, inv_work(1, ispin)%matrix, &
-                                     1.0_dp, mo_derivs_tmp(idir, ispin)%matrix)
+                  CALL parallel_gemm("N", "N", nao, nmo, nmo, focc, opvec(1, ispin), inv_work(2, ispin), &
+                                     1.0_dp, mo_derivs_tmp(idir, ispin))
+                  CALL parallel_gemm("N", "N", nao, nmo, nmo, -focc, opvec(2, ispin), inv_work(1, ispin), &
+                                     1.0_dp, mo_derivs_tmp(idir, ispin))
                END DO
             END DO
          END IF
@@ -911,14 +905,14 @@ CONTAINS
                CALL dbcsr_set(tempmat(1, ispin)%matrix, 0.0_dp)
                CALL dbcsr_set(tempmat(2, ispin)%matrix, 0.0_dp)
                CALL get_mo_set(mo_set=mos(ispin), nao=nao, nmo=nmo)
-               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin)%matrix, inv_work(1, ispin)%matrix, 0.0_dp, &
-                                  opvec(1, ispin)%matrix)
-               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin)%matrix, inv_work(2, ispin)%matrix, 0.0_dp, &
-                                  opvec(2, ispin)%matrix)
+               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin), inv_work(1, ispin), 0.0_dp, &
+                                  opvec(1, ispin))
+               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, mo_coeff_tmp(ispin), inv_work(2, ispin), 0.0_dp, &
+                                  opvec(2, ispin))
                CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=tempmat(1, ispin)%matrix, &
-                                          matrix_v=opvec(1, ispin)%matrix, matrix_g=mo_coeff_tmp(ispin)%matrix, ncol=nmo)
+                                          matrix_v=opvec(1, ispin), matrix_g=mo_coeff_tmp(ispin), ncol=nmo)
                CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=tempmat(2, ispin)%matrix, &
-                                          matrix_v=opvec(2, ispin)%matrix, matrix_g=mo_coeff_tmp(ispin)%matrix, ncol=nmo)
+                                          matrix_v=opvec(2, ispin), matrix_g=mo_coeff_tmp(ispin), ncol=nmo)
             END DO
 
             ! Calculation of derivative integrals (da|eikr|b) and (a|eikr|db)
@@ -1112,14 +1106,14 @@ CONTAINS
          END DO
          ! Add the result to mo_derivativs
          DO ispin = 1, dft_control%nspins
-            CALL copy_dbcsr_to_fm(mo_derivs(ispin)%matrix, mo_coeff_tmp(ispin)%matrix)
+            CALL copy_dbcsr_to_fm(mo_derivs(ispin)%matrix, mo_coeff_tmp(ispin))
             DO idir = 1, 3
-               CALL cp_fm_scale_and_add(1.0_dp, mo_coeff_tmp(ispin)%matrix, di(idir), &
-                                        mo_derivs_tmp(idir, ispin)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, mo_coeff_tmp(ispin), di(idir), &
+                                        mo_derivs_tmp(idir, ispin))
             END DO
          END DO
          DO ispin = 1, dft_control%nspins
-            CALL copy_fm_to_dbcsr(mo_coeff_tmp(ispin)%matrix, mo_derivs(ispin)%matrix)
+            CALL copy_fm_to_dbcsr(mo_coeff_tmp(ispin), mo_derivs(ispin)%matrix)
          END DO
       END IF
 
@@ -1137,17 +1131,14 @@ CONTAINS
          CALL cp_cfm_release(eigrmat(ispin)%matrix)
          CALL cp_cfm_release(inv_mat(ispin)%matrix)
          DEALLOCATE (eigrmat(ispin)%matrix, inv_mat(ispin)%matrix)
-         CALL cp_fm_release(mo_coeff_tmp(ispin)%matrix)
-         DEALLOCATE (mo_coeff_tmp(ispin)%matrix)
+         IF (mos(ispin)%use_mo_coeff_b) CALL cp_fm_release(mo_coeff_tmp(ispin))
          DO i = 1, 3
-            CALL cp_fm_release(mo_derivs_tmp(i, ispin)%matrix)
-            DEALLOCATE (mo_derivs_tmp(i, ispin)%matrix)
+            CALL cp_fm_release(mo_derivs_tmp(i, ispin))
          END DO
          DO i = 1, SIZE(op_fm_set, 1)
-            CALL cp_fm_release(opvec(i, ispin)%matrix)
-            CALL cp_fm_release(op_fm_set(i, ispin)%matrix)
-            CALL cp_fm_release(inv_work(i, ispin)%matrix)
-            DEALLOCATE (opvec(i, ispin)%matrix, op_fm_set(i, ispin)%matrix, inv_work(i, ispin)%matrix)
+            CALL cp_fm_release(opvec(i, ispin))
+            CALL cp_fm_release(op_fm_set(i, ispin))
+            CALL cp_fm_release(inv_work(i, ispin))
          END DO
       END DO
       DEALLOCATE (inv_mat, inv_work, op_fm_set, opvec, eigrmat)

--- a/src/qs_energy_matrix_w.F
+++ b/src/qs_energy_matrix_w.F
@@ -17,7 +17,6 @@ MODULE qs_energy_matrix_w
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type,&
@@ -67,18 +66,11 @@ CONTAINS
 
       INTEGER                                            :: handle, is, ispin, nao, nspin
       LOGICAL                                            :: do_kpoints, has_unit_metric
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fmwork
-      TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_fmstruct
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s, matrix_w, &
                                                             mo_derivs, rho_ao
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrix_w_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(mo_set_type), POINTER                         :: mo_set
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_nl
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(scf_control_type), POINTER                    :: scf_control
 
@@ -91,37 +83,42 @@ CONTAINS
          CALL get_qs_env(qs_env, do_kpoints=do_kpoints)
 
          IF (do_kpoints) THEN
+            BLOCK
+               TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_fmstruct
+               TYPE(cp_fm_type), POINTER                          :: mo_coeff
+               TYPE(cp_fm_type), DIMENSION(2) :: fmwork
+               TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrix_w_kp
+               TYPE(kpoint_type), POINTER                         :: kpoints
+               TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+                  POINTER                                         :: sab_nl
 
-            CALL get_qs_env(qs_env, &
-                            matrix_w_kp=matrix_w_kp, &
-                            matrix_s_kp=matrix_s_kp, &
-                            sab_orb=sab_nl, &
-                            mos=mos, &
-                            kpoints=kpoints)
+               CALL get_qs_env(qs_env, &
+                               matrix_w_kp=matrix_w_kp, &
+                               matrix_s_kp=matrix_s_kp, &
+                               sab_orb=sab_nl, &
+                               mos=mos, &
+                               kpoints=kpoints)
 
-            CALL get_mo_set(mos(1), mo_coeff=mo_coeff, nao=nao)
-            CALL cp_fm_struct_create(fmstruct=ao_ao_fmstruct, nrow_global=nao, ncol_global=nao, &
-                                     template_fmstruct=mo_coeff%matrix_struct)
+               CALL get_mo_set(mos(1), mo_coeff=mo_coeff, nao=nao)
+               CALL cp_fm_struct_create(fmstruct=ao_ao_fmstruct, nrow_global=nao, ncol_global=nao, &
+                                        template_fmstruct=mo_coeff%matrix_struct)
 
-            ALLOCATE (fmwork(2))
-            DO is = 1, SIZE(fmwork)
-               ALLOCATE (fmwork(is)%matrix)
-               CALL cp_fm_create(fmwork(is)%matrix, matrix_struct=ao_ao_fmstruct)
-            END DO
-            CALL cp_fm_struct_release(ao_ao_fmstruct)
+               DO is = 1, SIZE(fmwork)
+                  CALL cp_fm_create(fmwork(is), matrix_struct=ao_ao_fmstruct)
+               END DO
+               CALL cp_fm_struct_release(ao_ao_fmstruct)
 
-            ! energy weighted density matrices in k-space
-            CALL kpoint_density_matrices(kpoints, energy_weighted=.TRUE.)
-            ! energy weighted density matrices in real space
-            CALL kpoint_density_transform(kpoints, matrix_w_kp, .TRUE., &
-                                          matrix_s_kp(1, 1)%matrix, sab_nl, fmwork)
+               ! energy weighted density matrices in k-space
+               CALL kpoint_density_matrices(kpoints, energy_weighted=.TRUE.)
+               ! energy weighted density matrices in real space
+               CALL kpoint_density_transform(kpoints, matrix_w_kp, .TRUE., &
+                                             matrix_s_kp(1, 1)%matrix, sab_nl, fmwork)
 
-            DO is = 1, SIZE(fmwork)
-               CALL cp_fm_release(fmwork(is)%matrix)
-               DEALLOCATE (fmwork(is)%matrix)
-            END DO
-            DEALLOCATE (fmwork)
+               DO is = 1, SIZE(fmwork)
+                  CALL cp_fm_release(fmwork(is))
+               END DO
 
+            END BLOCK
          ELSE
 
             NULLIFY (dft_control, rho_ao)

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -27,8 +27,8 @@ MODULE qs_environment_types
                                               cp_ddapc_ewald_type,&
                                               cp_ddapc_release,&
                                               cp_ddapc_type
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
+                                              cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE cp_result_types,                 ONLY: cp_result_type
    USE cp_subsys_types,                 ONLY: cp_subsys_type
@@ -233,7 +233,7 @@ MODULE qs_environment_types
       TYPE(transport_env_type), POINTER                     :: transport_env
       TYPE(cell_type), POINTER                              :: super_cell
       TYPE(mo_set_type), DIMENSION(:), POINTER            :: mos
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER             :: mo_loc_history
+      TYPE(cp_fm_type), DIMENSION(:), POINTER             :: mo_loc_history
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER             :: mo_derivs
       TYPE(scf_control_type), POINTER                       :: scf_control
       TYPE(rel_control_type), POINTER                       :: rel_control
@@ -570,8 +570,7 @@ CONTAINS
                                                             requires_mo_derivs
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: mo_derivs
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mo_loc_history
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: mo_loc_history
       INTEGER, OPTIONAL                                  :: nkind, natom, nelectron_total
       INTEGER, DIMENSION(2), OPTIONAL                    :: nelectron_spin
       TYPE(efield_berry_type), OPTIONAL, POINTER         :: efield
@@ -1052,8 +1051,7 @@ CONTAINS
       LOGICAL, OPTIONAL                                  :: has_unit_metric, requires_mo_derivs
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: mo_derivs
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mo_loc_history
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: mo_loc_history
       TYPE(efield_berry_type), OPTIONAL, POINTER         :: efield
       TYPE(linres_control_type), OPTIONAL, POINTER       :: linres_control
       TYPE(xas_environment_type), OPTIONAL, POINTER      :: xas_env
@@ -1373,8 +1371,7 @@ CONTAINS
       END IF
       IF (ASSOCIATED(qs_env%mo_loc_history)) THEN
          DO I = 1, SIZE(qs_env%mo_loc_history)
-            CALL cp_fm_release(qs_env%mo_loc_history(I)%matrix)
-            DEALLOCATE (qs_env%mo_loc_history(I)%matrix)
+            CALL cp_fm_release(qs_env%mo_loc_history(I))
          END DO
          DEALLOCATE (qs_env%mo_loc_history)
       END IF
@@ -1596,8 +1593,7 @@ CONTAINS
       END IF
       IF (ASSOCIATED(qs_env%mo_loc_history)) THEN
          DO I = 1, SIZE(qs_env%mo_loc_history)
-            CALL cp_fm_release(qs_env%mo_loc_history(I)%matrix)
-            DEALLOCATE (qs_env%mo_loc_history(I)%matrix)
+            CALL cp_fm_release(qs_env%mo_loc_history(I))
          END DO
          DEALLOCATE (qs_env%mo_loc_history)
       END IF

--- a/src/qs_fb_env_methods.F
+++ b/src/qs_fb_env_methods.F
@@ -198,7 +198,7 @@ CONTAINS
 
       DO ispin = 1, nspin
          CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, &
-                               scf_env%scf_work1(ispin)%matrix)
+                               scf_env%scf_work1(ispin))
       END DO
 
       eps_diis = scf_control%eps_diis

--- a/src/qs_initial_guess.F
+++ b/src/qs_initial_guess.F
@@ -28,8 +28,8 @@ MODULE qs_initial_guess
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_init_random, cp_fm_p_type, &
-        cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
+        cp_fm_create, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_init_random, cp_fm_release, &
+        cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type,&
@@ -158,9 +158,9 @@ CONTAINS
       TYPE(atom_matrix_type), DIMENSION(:), POINTER      :: pmat
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: work1
       TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_struct, ao_mo_struct
       TYPE(cp_fm_type)                                   :: sv
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: work1
       TYPE(cp_fm_type), POINTER                          :: mo_coeff, moa, mob, ortho, work2
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -558,9 +558,8 @@ CONTAINS
                                      ncol_global=nao, &
                                      template_fmstruct=ao_mo_struct)
             ALLOCATE (work1(1))
-            NULLIFY (work1(1)%matrix)
-            ALLOCATE (work1(1)%matrix, work2, ortho)
-            CALL cp_fm_create(work1(1)%matrix, ao_ao_struct)
+            ALLOCATE (work2, ortho)
+            CALL cp_fm_create(work1(1), ao_ao_struct)
             CALL cp_fm_create(work2, ao_ao_struct)
             CALL cp_fm_create(ortho, ao_ao_struct)
             CALL copy_dbcsr_to_fm(matrix_s_kp(1, 1)%matrix, ortho)
@@ -570,19 +569,19 @@ CONTAINS
 
          ispin = 1
          ! Load core Hamiltonian into work matrix
-         CALL copy_dbcsr_to_fm(h_core_sparse(1)%matrix, work1(ispin)%matrix)
+         CALL copy_dbcsr_to_fm(h_core_sparse(1)%matrix, work1(ispin))
 
          ! Diagonalize the core Hamiltonian matrix and retrieve a first set of
          ! molecular orbitals (MOs)
          IF (has_unit_metric) THEN
-            CALL eigensolver_simple(matrix_ks=work1(ispin)%matrix, &
+            CALL eigensolver_simple(matrix_ks=work1(ispin), &
                                     mo_set=mo_array(ispin), &
                                     work=work2, &
                                     do_level_shift=.FALSE., &
                                     level_shift=0.0_dp, &
                                     use_jacobi=.FALSE., jacobi_threshold=0._dp)
          ELSE
-            CALL eigensolver(matrix_ks_fm=work1(ispin)%matrix, &
+            CALL eigensolver(matrix_ks_fm=work1(ispin), &
                              mo_set=mo_array(ispin), &
                              ortho=ortho, &
                              work=work2, &
@@ -610,8 +609,8 @@ CONTAINS
          IF (need_wm) THEN
             CALL cp_fm_release(ortho)
             CALL cp_fm_release(work2)
-            CALL cp_fm_release(work1(1)%matrix)
-            DEALLOCATE (ortho, work2, work1(1)%matrix)
+            CALL cp_fm_release(work1(1))
+            DEALLOCATE (ortho, work2)
             DEALLOCATE (work1)
             NULLIFY (work1, work2, ortho)
          ELSE IF (owns_ortho) THEN

--- a/src/qs_ks_apply_restraints.F
+++ b/src/qs_ks_apply_restraints.F
@@ -13,7 +13,6 @@ MODULE qs_ks_apply_restraints
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               copy_fm_to_dbcsr
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type
@@ -195,7 +194,7 @@ CONTAINS
       LOGICAL, INTENT(in)                                :: calculate_forces, just_energy
 
       INTEGER                                            :: i
-      TYPE(cp_fm_type), DIMENSION(:), ALLOCATABLE        :: fm_mo_derivs
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_mo_derivs
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mo_derivs, smat
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mo_array

--- a/src/qs_ks_apply_restraints.F
+++ b/src/qs_ks_apply_restraints.F
@@ -195,12 +195,12 @@ CONTAINS
       LOGICAL, INTENT(in)                                :: calculate_forces, just_energy
 
       INTEGER                                            :: i
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_mo_derivs
+      TYPE(cp_fm_type), DIMENSION(:), ALLOCATABLE        :: fm_mo_derivs
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mo_derivs, smat
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mo_array
 
-      NULLIFY (fm_mo_derivs, mo_array, mo_coeff, mo_derivs)
+      NULLIFY (mo_array, mo_coeff, mo_derivs)
 
       IF (dft_control%qs_control%s2_restraint) THEN
          ! Test no k-points
@@ -216,9 +216,8 @@ CONTAINS
          ALLOCATE (fm_mo_derivs(SIZE(mo_derivs, 1))) !fm->dbcsr
          DO i = 1, SIZE(mo_derivs, 1) !fm->dbcsr
             CALL get_mo_set(mo_set=mo_array(i), mo_coeff=mo_coeff) !fm->dbcsr
-            ALLOCATE (fm_mo_derivs(i)%matrix)
-            CALL cp_fm_create(fm_mo_derivs(i)%matrix, mo_coeff%matrix_struct) !fm->dbcsr
-            CALL copy_dbcsr_to_fm(mo_derivs(i)%matrix, fm_mo_derivs(i)%matrix) !fm->dbcsr
+            CALL cp_fm_create(fm_mo_derivs(i), mo_coeff%matrix_struct) !fm->dbcsr
+            CALL copy_dbcsr_to_fm(mo_derivs(i)%matrix, fm_mo_derivs(i)) !fm->dbcsr
          END DO !fm->dbcsr
 
          smat => matrix_s(:, 1)
@@ -226,7 +225,7 @@ CONTAINS
                            dft_control%qs_control%s2_restraint_control, just_energy)
 
          DO i = 1, SIZE(mo_derivs, 1) !fm->dbcsr
-            CALL copy_fm_to_dbcsr(fm_mo_derivs(i)%matrix, mo_derivs(i)%matrix) !fm->dbcsr
+            CALL copy_fm_to_dbcsr(fm_mo_derivs(i), mo_derivs(i)%matrix) !fm->dbcsr
          END DO !fm->dbcsr
          DEALLOCATE (fm_mo_derivs) !fm->dbcsr
 

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -37,7 +37,6 @@ MODULE qs_ks_utils
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -411,9 +410,9 @@ CONTAINS
       REAL(KIND=dp)                                      :: ener, exc
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc_tmp
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_derivs_local
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
       TYPE(cp_fm_type)                                   :: matrix_hv, matrix_v
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_derivs_local
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type)                                 :: orb_density_matrix_p, orb_h_p
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mo_derivs, rho_ao, tmp_dbcsr
@@ -583,8 +582,7 @@ CONTAINS
       ALLOCATE (mo_derivs_local(SIZE(mo_array, 1)))
       DO I = 1, SIZE(mo_array, 1)
          CALL get_mo_set(mo_set=mo_array(i), mo_coeff=mo_coeff)
-         ALLOCATE (mo_derivs_local(I)%matrix)
-         CALL cp_fm_create(mo_derivs_local(I)%matrix, mo_coeff%matrix_struct)
+         CALL cp_fm_create(mo_derivs_local(I), mo_coeff%matrix_struct)
       END DO
 
       ALLOCATE (rho_r(2))
@@ -647,9 +645,9 @@ CONTAINS
             ! add this to the mo_derivs
             CALL cp_dbcsr_sm_fm_multiply(orb_h, matrix_v, matrix_hv, 1)
             ! silly trick, copy to an array of the right size and add to mo_derivs
-            CALL cp_fm_set_all(mo_derivs_local(sic_orbital_list(3, iorb))%matrix, 0.0_dp)
-            CALL cp_fm_to_fm(matrix_hv, mo_derivs_local(sic_orbital_list(3, iorb))%matrix, 1, 1, sic_orbital_list(2, iorb))
-            CALL copy_fm_to_dbcsr(mo_derivs_local(sic_orbital_list(3, iorb))%matrix, &
+            CALL cp_fm_set_all(mo_derivs_local(sic_orbital_list(3, iorb)), 0.0_dp)
+            CALL cp_fm_to_fm(matrix_hv, mo_derivs_local(sic_orbital_list(3, iorb)), 1, 1, sic_orbital_list(2, iorb))
+            CALL copy_fm_to_dbcsr(mo_derivs_local(sic_orbital_list(3, iorb)), &
                                   tmp_dbcsr(sic_orbital_list(3, iorb))%matrix)
             CALL dbcsr_add(mo_derivs(sic_orbital_list(3, iorb))%matrix, &
                            tmp_dbcsr(sic_orbital_list(3, iorb))%matrix, 1.0_dp, 1.0_dp)
@@ -675,8 +673,7 @@ CONTAINS
       CALL cp_fm_release(matrix_v)
       CALL cp_fm_release(matrix_hv)
       DO I = 1, SIZE(mo_derivs_local, 1)
-         CALL cp_fm_release(mo_derivs_local(I)%matrix)
-         DEALLOCATE (mo_derivs_local(I)%matrix)
+         CALL cp_fm_release(mo_derivs_local(I))
       END DO
       DEALLOCATE (mo_derivs_local)
       DEALLOCATE (rho_r)

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -2293,10 +2293,10 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_rxp, r_p1, r_p2
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: rr_p1, rr_p2, rr_rxp
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: psi0, psi_D, psi_p1, psi_p2, psi_rxp
+      TYPE(cp_fm_type), DIMENSION(3)                     :: p_rxp, r_p1, r_p2
+      TYPE(cp_fm_type), DIMENSION(9, 3)                  :: rr_p1, rr_p2, rr_rxp
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_D, psi1_p, psi1_rxp
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
@@ -2318,7 +2318,7 @@ CONTAINS
       !
       NULLIFY (dft_control, mos, para_env, mo_coeff, op_mom_ao, &
                op_mom_der_ao, center_list, centers_set, &
-               op_p_ao, psi1_p, psi1_rxp, psi1_D, p_rxp, r_p1, r_p2, rr_rxp, rr_p1, rr_p2, &
+               op_p_ao, psi1_p, psi1_rxp, psi1_D, &
                cell, particle_set, qs_kind_set)
 
       logger => cp_get_default_logger()
@@ -2434,20 +2434,17 @@ CONTAINS
       CALL cp_fm_create(psi_p2, tmp_fm_struct)
       CALL cp_fm_struct_release(tmp_fm_struct)
       !
-      ALLOCATE (p_rxp(3), r_p1(3), r_p2(3), rr_rxp(9, 3), rr_p1(9, 3), rr_p2(9, 3))
       CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                ncol_global=max_states, para_env=para_env, &
                                context=mo_coeff%matrix_struct%context)
       DO idir = 1, 3
-         ALLOCATE (p_rxp(idir)%matrix, r_p1(idir)%matrix, r_p2(idir)%matrix)
-         CALL cp_fm_create(p_rxp(idir)%matrix, tmp_fm_struct)
-         CALL cp_fm_create(r_p1(idir)%matrix, tmp_fm_struct)
-         CALL cp_fm_create(r_p2(idir)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(p_rxp(idir), tmp_fm_struct)
+         CALL cp_fm_create(r_p1(idir), tmp_fm_struct)
+         CALL cp_fm_create(r_p2(idir), tmp_fm_struct)
          DO idir2 = 1, 9
-            ALLOCATE (rr_rxp(idir2, idir)%matrix, rr_p1(idir2, idir)%matrix, rr_p2(idir2, idir)%matrix)
-            CALL cp_fm_create(rr_rxp(idir2, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(rr_p1(idir2, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(rr_p2(idir2, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(rr_rxp(idir2, idir), tmp_fm_struct)
+            CALL cp_fm_create(rr_p1(idir2, idir), tmp_fm_struct)
+            CALL cp_fm_create(rr_p2(idir2, idir), tmp_fm_struct)
          END DO
       END DO
       CALL cp_fm_struct_release(tmp_fm_struct)
@@ -2519,29 +2516,29 @@ CONTAINS
             DO idir = 1, 3
                CALL set_vecp(idir, ii, iii)
                CALL cp_dbcsr_sm_fm_multiply(op_p_ao(idir)%matrix, psi_rxp, &
-                                            p_rxp(idir)%matrix, ncol=nstate_loc, alpha=1.e0_dp)
+                                            p_rxp(idir), ncol=nstate_loc, alpha=1.e0_dp)
                IF (iiiB .EQ. iii .OR. iiiB .EQ. ii) THEN
                   CALL cp_dbcsr_sm_fm_multiply(op_mom_ao(idir)%matrix, psi_p1, &
-                                               r_p1(idir)%matrix, ncol=nstate_loc, alpha=1.e0_dp)
+                                               r_p1(idir), ncol=nstate_loc, alpha=1.e0_dp)
                END IF
                IF (iiB .EQ. iii .OR. iiB .EQ. ii) THEN
                   CALL cp_dbcsr_sm_fm_multiply(op_mom_ao(idir)%matrix, psi_p2, &
-                                               r_p2(idir)%matrix, ncol=nstate_loc, alpha=1.e0_dp)
+                                               r_p2(idir), ncol=nstate_loc, alpha=1.e0_dp)
                END IF
                DO idir2 = 1, 9
                   IF (idir2 .EQ. ii .OR. idir2 .EQ. iii) THEN
                      CALL cp_dbcsr_sm_fm_multiply(op_mom_der_ao(idir2, idir)%matrix, psi_rxp, &
-                                                  rr_rxp(idir2, idir)%matrix, ncol=nstate_loc, alpha=1.e0_dp)
+                                                  rr_rxp(idir2, idir), ncol=nstate_loc, alpha=1.e0_dp)
                   END IF
                   !
                   IF (idir2 .EQ. ind_m2(ii, iiiB) .OR. idir2 .EQ. ind_m2(iii, iiiB) .OR. idir2 .EQ. iiiB) THEN
                      CALL cp_dbcsr_sm_fm_multiply(op_mom_der_ao(idir2, idir)%matrix, psi_p1, &
-                                                  rr_p1(idir2, idir)%matrix, ncol=nstate_loc, alpha=1.e0_dp)
+                                                  rr_p1(idir2, idir), ncol=nstate_loc, alpha=1.e0_dp)
                   END IF
                   !
                   IF (idir2 .EQ. ind_m2(ii, iiB) .OR. idir2 .EQ. ind_m2(iii, iiB) .OR. idir2 .EQ. iiB) THEN
                      CALL cp_dbcsr_sm_fm_multiply(op_mom_der_ao(idir2, idir)%matrix, psi_p2, &
-                                                  rr_p2(idir2, idir)%matrix, ncol=nstate_loc, alpha=1.e0_dp)
+                                                  rr_p2(idir2, idir), ncol=nstate_loc, alpha=1.e0_dp)
                   END IF
                END DO
             END DO
@@ -2562,22 +2559,22 @@ CONTAINS
                ! term: 2[C0| (r-dk)_ii |d_iii(C1(rxp-D))]-2[C0| (r-dk)_iii |d_ii(C1(rxp-D))]
                ! the factor 2 should be already included in the matrix elements
                contrib = 0.0_dp
-               CALL cp_fm_trace(psi0, rr_rxp(ii, iii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_rxp(ii, iii), contrib)
                chi_tmp = chi_tmp + 2.0_dp*contrib
                !
                contrib = 0.0_dp
-               CALL cp_fm_trace(psi0, rr_rxp(iii, ii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_rxp(iii, ii), contrib)
                chi_tmp = chi_tmp - 2.0_dp*contrib
                !
                ! correction: dk_ii*2[C0| d_iii(C1(rxp-D))] - dk_iii*2[C0| d_ii(C1(rxp-D))]
                ! factor 2 not included in the matrix elements
                contrib = 0.0_dp
-               CALL cp_fm_trace(psi0, p_rxp(iii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, p_rxp(iii), contrib)
                IF (.NOT. chi_pbc) chi_tmp = chi_tmp + 2.0_dp*dk(ii)*contrib
                int_current_tmp = int_current_tmp + 2.0_dp*contrib
                !
                contrib2 = 0.0_dp
-               CALL cp_fm_trace(psi0, p_rxp(ii)%matrix, contrib2)
+               CALL cp_fm_trace(psi0, p_rxp(ii), contrib2)
                IF (.NOT. chi_pbc) chi_tmp = chi_tmp - 2.0_dp*dk(iii)*contrib2
                !
                ! term: -2[C0| (r-dk)_ii  (r-dk)_iiB | d_iii(C1(piiiB))] \
@@ -2585,21 +2582,21 @@ CONTAINS
                ! the factor 2 should be already included in the matrix elements
                contrib = 0.0_dp
                idir2 = ind_m2(ii, iiB)
-               CALL cp_fm_trace(psi0, rr_p2(idir2, iii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_p2(idir2, iii), contrib)
                chi_tmp = chi_tmp - 2.0_dp*contrib
                contrib2 = 0.0_dp
                IF (iiB == iii) THEN
-                  CALL cp_fm_trace(psi0, r_p2(ii)%matrix, contrib2)
+                  CALL cp_fm_trace(psi0, r_p2(ii), contrib2)
                   chi_tmp = chi_tmp - contrib2
                END IF
                !
                contrib = 0.0_dp
                idir2 = ind_m2(iii, iiB)
-               CALL cp_fm_trace(psi0, rr_p2(idir2, ii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_p2(idir2, ii), contrib)
                chi_tmp = chi_tmp + 2.0_dp*contrib
                contrib2 = 0.0_dp
                IF (iiB == ii) THEN
-                  CALL cp_fm_trace(psi0, r_p2(iii)%matrix, contrib2)
+                  CALL cp_fm_trace(psi0, r_p2(iii), contrib2)
                   chi_tmp = chi_tmp + contrib2
                END IF
                !
@@ -2608,12 +2605,12 @@ CONTAINS
                ! the factor 2 should be already included in the matrix elements
                ! no additional correction terms because of the orthogonality between C0 and C1
                contrib = 0.0_dp
-               CALL cp_fm_trace(psi0, rr_p2(iiB, iii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_p2(iiB, iii), contrib)
                IF (.NOT. chi_pbc) chi_tmp = chi_tmp - 2.0_dp*dk(ii)*contrib
                int_current_tmp = int_current_tmp - 2.0_dp*contrib
                !
                contrib2 = 0.0_dp
-               CALL cp_fm_trace(psi0, rr_p2(iiB, ii)%matrix, contrib2)
+               CALL cp_fm_trace(psi0, rr_p2(iiB, ii), contrib2)
                IF (.NOT. chi_pbc) chi_tmp = chi_tmp + 2.0_dp*dk(iii)*contrib2
                !
                ! term: +2[C0| (r-dk)_ii  (r-dk)_iiiB | d_iii(C1(piiB))] \
@@ -2621,21 +2618,21 @@ CONTAINS
                ! the factor 2 should be already included in the matrix elements
                contrib = 0.0_dp
                idir2 = ind_m2(ii, iiiB)
-               CALL cp_fm_trace(psi0, rr_p1(idir2, iii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_p1(idir2, iii), contrib)
                chi_tmp = chi_tmp + 2.0_dp*contrib
                contrib2 = 0.0_dp
                IF (iiiB == iii) THEN
-                  CALL cp_fm_trace(psi0, r_p1(ii)%matrix, contrib2)
+                  CALL cp_fm_trace(psi0, r_p1(ii), contrib2)
                   chi_tmp = chi_tmp + contrib2
                END IF
                !
                contrib = 0.0_dp
                idir2 = ind_m2(iii, iiiB)
-               CALL cp_fm_trace(psi0, rr_p1(idir2, ii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_p1(idir2, ii), contrib)
                chi_tmp = chi_tmp - 2.0_dp*contrib
                contrib2 = 0.0_dp
                IF (iiiB == ii) THEN
-                  CALL cp_fm_trace(psi0, r_p1(iii)%matrix, contrib2)
+                  CALL cp_fm_trace(psi0, r_p1(iii), contrib2)
                   chi_tmp = chi_tmp - contrib2
                END IF
                !
@@ -2643,12 +2640,12 @@ CONTAINS
                !             -dk_iii * 2[C0|(r-dk)_iiiB | d_ii(C1(piiB))]
                ! the factor 2 should be already included in the matrix elements
                contrib = 0.0_dp
-               CALL cp_fm_trace(psi0, rr_p1(iiiB, iii)%matrix, contrib)
+               CALL cp_fm_trace(psi0, rr_p1(iiiB, iii), contrib)
                IF (.NOT. chi_pbc) chi_tmp = chi_tmp + 2.0_dp*dk(ii)*contrib
                int_current_tmp = int_current_tmp + 2.0_dp*contrib
                !
                contrib2 = 0.0_dp
-               CALL cp_fm_trace(psi0, rr_p1(iiiB, ii)%matrix, contrib2)
+               CALL cp_fm_trace(psi0, rr_p1(iiiB, ii), contrib2)
                IF (.NOT. chi_pbc) chi_tmp = chi_tmp - 2.0_dp*dk(iii)*contrib2
                !
                ! accumulate
@@ -2682,18 +2679,15 @@ CONTAINS
       CALL cp_fm_release(psi_p1)
       CALL cp_fm_release(psi_p2)
       DO idir = 1, 3
-         CALL cp_fm_release(p_rxp(idir)%matrix)
-         CALL cp_fm_release(r_p1(idir)%matrix)
-         CALL cp_fm_release(r_p2(idir)%matrix)
-         DEALLOCATE (p_rxp(idir)%matrix, r_p1(idir)%matrix, r_p2(idir)%matrix)
+         CALL cp_fm_release(p_rxp(idir))
+         CALL cp_fm_release(r_p1(idir))
+         CALL cp_fm_release(r_p2(idir))
          DO idir2 = 1, 9
-            CALL cp_fm_release(rr_rxp(idir2, idir)%matrix)
-            CALL cp_fm_release(rr_p1(idir2, idir)%matrix)
-            CALL cp_fm_release(rr_p2(idir2, idir)%matrix)
-            DEALLOCATE (rr_rxp(idir2, idir)%matrix, rr_p1(idir2, idir)%matrix, rr_p2(idir2, idir)%matrix)
+            CALL cp_fm_release(rr_rxp(idir2, idir))
+            CALL cp_fm_release(rr_p1(idir2, idir))
+            CALL cp_fm_release(rr_p2(idir2, idir))
          END DO
       END DO
-      DEALLOCATE (p_rxp, r_p1, r_p2, rr_rxp, rr_p1, rr_p2)
 
       CALL timestop(handle)
 

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -201,8 +201,9 @@ CONTAINS
       REAL(dp), EXTERNAL                                 :: DDOT
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_psi1, psi0_order, psi1
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_psi1, psi1
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_D, psi1_p, psi1_rxp
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff, psi_a_iB, psi_buf
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -231,7 +232,7 @@ CONTAINS
                density_matrix_ii, density_matrix_iii, cell, dft_control, mos, &
                particle_set, pw_env, auxbas_rs_desc, auxbas_pw_pool, &
                para_env, center_list, mo_coeff, psi_a_iB, jrho1_r, jrho1_g, &
-               psi1, p_psi1, psi1_p, psi1_D, psi1_rxp, psi0_order, sab_all, qs_kind_set)
+               psi1, p_psi1, psi1_p, psi1_D, psi1_rxp, sab_all, qs_kind_set)
 
       logger => cp_get_default_logger()
       output_unit = cp_logger_get_default_io_unit(logger)
@@ -270,8 +271,8 @@ CONTAINS
       ALLOCATE (psi1(nspins), p_psi1(nspins))
       DO ispin = 1, nspins
          ALLOCATE (psi1(ispin)%matrix, p_psi1(ispin)%matrix)
-         CALL cp_fm_create(psi1(ispin)%matrix, psi0_order(ispin)%matrix%matrix_struct)
-         CALL cp_fm_create(p_psi1(ispin)%matrix, psi0_order(ispin)%matrix%matrix_struct)
+         CALL cp_fm_create(psi1(ispin)%matrix, psi0_order(ispin)%matrix_struct)
+         CALL cp_fm_create(p_psi1(ispin)%matrix, psi0_order(ispin)%matrix_struct)
          CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
          CALL cp_fm_set_all(p_psi1(ispin)%matrix, 0.0_dp)
       END DO
@@ -334,7 +335,7 @@ CONTAINS
       CALL set_vecp(iB, iiB, iiiB)
       DO ispin = 1, nspins
          nmo = nstates(ispin)
-         mo_coeff => psi0_order(ispin)%matrix
+         mo_coeff => psi0_order(ispin)
          !maxocc = max_occ(ispin)
          !
          CALL get_mo_set(mo_set=mos(ispin), maxocc=maxocc)
@@ -2292,11 +2293,12 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_rxp, psi0_order, r_p1, r_p2
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_rxp, r_p1, r_p2
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_D, psi1_p, psi1_rxp, rr_p1, rr_p2, &
                                                             rr_rxp
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: psi0, psi_D, psi_p1, psi_p2, psi_rxp
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -2317,7 +2319,7 @@ CONTAINS
       NULLIFY (dft_control, mos, para_env, mo_coeff, op_mom_ao, &
                op_mom_der_ao, center_list, centers_set, &
                op_p_ao, psi1_p, psi1_rxp, psi1_D, p_rxp, r_p1, r_p2, rr_rxp, rr_p1, rr_p2, &
-               cell, psi0_order, particle_set, qs_kind_set)
+               cell, particle_set, qs_kind_set)
 
       logger => cp_get_default_logger()
       output_unit = cp_logger_get_default_io_unit(logger)
@@ -2420,7 +2422,7 @@ CONTAINS
       !
       !
       ! Allocate full matrices for only one vector
-      mo_coeff => psi0_order(1)%matrix
+      mo_coeff => psi0_order(1)
       NULLIFY (tmp_fm_struct)
       CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                ncol_global=max_states, para_env=para_env, &
@@ -2463,7 +2465,7 @@ CONTAINS
          !
          ! get ground state MOS
          nmo = nstates(ispin)
-         mo_coeff => psi0_order(ispin)%matrix
+         mo_coeff => psi0_order(ispin)
          CALL get_mo_set(mo_set=mos(ispin), maxocc=maxocc)
          !
          ! Initialize the temporary vector chi
@@ -2721,9 +2723,9 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi0_order
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_p, psi1_rxp
       TYPE(cp_fm_type)                                   :: buf
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -2849,7 +2851,7 @@ CONTAINS
          !
          ! get ground state MOS
          nmo = nstates(ispin)
-         mo_coeff => psi0_order(ispin)%matrix
+         mo_coeff => psi0_order(ispin)
          CALL get_mo_set(mo_set=mos(ispin), maxocc=maxocc)
          !
          ! Create buffer matrix

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -35,7 +35,6 @@ MODULE qs_linres_current
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -201,10 +200,10 @@ CONTAINS
       REAL(dp), EXTERNAL                                 :: DDOT
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_psi1, psi1
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: p_psi1, psi1
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_D, psi1_p, psi1_rxp
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff, psi_a_iB, psi_buf
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
@@ -231,8 +230,8 @@ CONTAINS
       NULLIFY (logger, current_section, density_matrix0, density_matrix_a, &
                density_matrix_ii, density_matrix_iii, cell, dft_control, mos, &
                particle_set, pw_env, auxbas_rs_desc, auxbas_pw_pool, &
-               para_env, center_list, mo_coeff, psi_a_iB, jrho1_r, jrho1_g, &
-               psi1, p_psi1, psi1_p, psi1_D, psi1_rxp, sab_all, qs_kind_set)
+               para_env, center_list, mo_coeff, jrho1_r, jrho1_g, &
+               psi1_p, psi1_D, psi1_rxp, sab_all, qs_kind_set)
 
       logger => cp_get_default_logger()
       output_unit = cp_logger_get_default_io_unit(logger)
@@ -270,11 +269,10 @@ CONTAINS
       ! allocate temporary arrays
       ALLOCATE (psi1(nspins), p_psi1(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (psi1(ispin)%matrix, p_psi1(ispin)%matrix)
-         CALL cp_fm_create(psi1(ispin)%matrix, psi0_order(ispin)%matrix_struct)
-         CALL cp_fm_create(p_psi1(ispin)%matrix, psi0_order(ispin)%matrix_struct)
-         CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
-         CALL cp_fm_set_all(p_psi1(ispin)%matrix, 0.0_dp)
+         CALL cp_fm_create(psi1(ispin), psi0_order(ispin)%matrix_struct)
+         CALL cp_fm_create(p_psi1(ispin), psi0_order(ispin)%matrix_struct)
+         CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
+         CALL cp_fm_set_all(p_psi1(ispin), 0.0_dp)
       END DO
       !
       !
@@ -353,48 +351,48 @@ CONTAINS
          ! Construct the 3 density matrices for the field in direction iB
          !
          ! First the full matrix psi_a_iB
-         psi_a_iB => psi1(ispin)%matrix
-         psi_buf => p_psi1(ispin)%matrix
-         CALL cp_fm_set_all(psi_a_iB, 0.0_dp)
-         CALL cp_fm_set_all(psi_buf, 0.0_dp)
-         ! psi_a_iB = - (R_\nu-dk)_ii psi1_piiiB + (R_\nu-dk)_iii psi1_piiB
-         !
-         ! contributions from the response psi1_p_ii and psi1_p_iii
-         DO istate = 1, current_env%nbr_center(ispin)
-            dk(1:3) = current_env%centers_set(ispin)%array(1:3, istate)
+         ASSOCIATE (psi_a_iB => psi1(ispin), psi_buf => p_psi1(ispin))
+            CALL cp_fm_set_all(psi_a_iB, 0.0_dp)
+            CALL cp_fm_set_all(psi_buf, 0.0_dp)
+            ! psi_a_iB = - (R_\nu-dk)_ii psi1_piiiB + (R_\nu-dk)_iii psi1_piiB
             !
-            ! Copy the vector in the full matrix psi1
-            !nstate_loc = center_list(ispin)%array(1,icenter+1)-center_list(ispin)%array(1,icenter)
-            DO j = center_list(ispin)%array(1, istate), center_list(ispin)%array(1, istate + 1) - 1
-               jstate = center_list(ispin)%array(2, j)
-               CALL cp_fm_to_fm(psi1_p(ispin, iiB), psi_a_iB, 1, jstate, jstate)
-               CALL cp_fm_to_fm(psi1_p(ispin, iiiB), psi_buf, 1, jstate, jstate)
-               ddk(:, jstate) = dk(1:3)
-            END DO
-         END DO ! istate
-         CALL fm_scale_by_pbc_AC(psi_a_iB, current_env%basisfun_center, ddk, cell, iiiB)
-         CALL fm_scale_by_pbc_AC(psi_buf, current_env%basisfun_center, ddk, cell, iiB)
-         CALL cp_fm_scale_and_add(-1.0_dp, psi_a_iB, 1.0_dp, psi_buf)
-         !
-         !psi_a_iB = psi_a_iB + psi1_rxp
-         !
-         ! contribution from the response psi1_rxp
-         CALL cp_fm_scale_and_add(-1.0_dp, psi_a_iB, 1.0_dp, psi1_rxp(ispin, iB))
-         !
-         !psi_a_iB = psi_a_iB - psi1_D
-         IF (current_env%full) THEN
+            ! contributions from the response psi1_p_ii and psi1_p_iii
+            DO istate = 1, current_env%nbr_center(ispin)
+               dk(1:3) = current_env%centers_set(ispin)%array(1:3, istate)
+               !
+               ! Copy the vector in the full matrix psi1
+               !nstate_loc = center_list(ispin)%array(1,icenter+1)-center_list(ispin)%array(1,icenter)
+               DO j = center_list(ispin)%array(1, istate), center_list(ispin)%array(1, istate + 1) - 1
+                  jstate = center_list(ispin)%array(2, j)
+                  CALL cp_fm_to_fm(psi1_p(ispin, iiB), psi_a_iB, 1, jstate, jstate)
+                  CALL cp_fm_to_fm(psi1_p(ispin, iiiB), psi_buf, 1, jstate, jstate)
+                  ddk(:, jstate) = dk(1:3)
+               END DO
+            END DO ! istate
+            CALL fm_scale_by_pbc_AC(psi_a_iB, current_env%basisfun_center, ddk, cell, iiiB)
+            CALL fm_scale_by_pbc_AC(psi_buf, current_env%basisfun_center, ddk, cell, iiB)
+            CALL cp_fm_scale_and_add(-1.0_dp, psi_a_iB, 1.0_dp, psi_buf)
             !
-            ! contribution from the response psi1_D
-            CALL cp_fm_scale_and_add(1.0_dp, psi_a_iB, -1.0_dp, psi1_D(ispin, iB))
-         END IF
-         !
-         ! Multiply by the occupation number for the density matrix
-         !
-         ! Build the first density matrix
-         CALL dbcsr_set(density_matrix_a(ispin)%matrix, 0.0_dp)
-         CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=density_matrix_a(ispin)%matrix, &
-                                    matrix_v=mo_coeff, matrix_g=psi_a_iB, &
-                                    ncol=nmo, alpha=maxocc)
+            !psi_a_iB = psi_a_iB + psi1_rxp
+            !
+            ! contribution from the response psi1_rxp
+            CALL cp_fm_scale_and_add(-1.0_dp, psi_a_iB, 1.0_dp, psi1_rxp(ispin, iB))
+            !
+            !psi_a_iB = psi_a_iB - psi1_D
+            IF (current_env%full) THEN
+               !
+               ! contribution from the response psi1_D
+               CALL cp_fm_scale_and_add(1.0_dp, psi_a_iB, -1.0_dp, psi1_D(ispin, iB))
+            END IF
+            !
+            ! Multiply by the occupation number for the density matrix
+            !
+            ! Build the first density matrix
+            CALL dbcsr_set(density_matrix_a(ispin)%matrix, 0.0_dp)
+            CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=density_matrix_a(ispin)%matrix, &
+                                       matrix_v=mo_coeff, matrix_g=psi_a_iB, &
+                                       ncol=nmo, alpha=maxocc)
+         END ASSOCIATE
          !
          ! Build the second density matrix
          CALL dbcsr_set(density_matrix_iii(ispin)%matrix, 0.0_dp)
@@ -527,9 +525,8 @@ CONTAINS
       !
       ! Dellocate grids for the calculation of jrho and the shift
       DO ispin = 1, nspins
-         CALL cp_fm_release(psi1(ispin)%matrix)
-         CALL cp_fm_release(p_psi1(ispin)%matrix)
-         DEALLOCATE (psi1(ispin)%matrix, p_psi1(ispin)%matrix)
+         CALL cp_fm_release(psi1(ispin))
+         CALL cp_fm_release(p_psi1(ispin))
       END DO
       DEALLOCATE (psi1, p_psi1)
 

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -202,8 +202,8 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_psi1, psi1
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_D, psi1_p, psi1_rxp
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_D, psi1_p, psi1_rxp
       TYPE(cp_fm_type), POINTER                          :: mo_coeff, psi_a_iB, psi_buf
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -367,8 +367,8 @@ CONTAINS
             !nstate_loc = center_list(ispin)%array(1,icenter+1)-center_list(ispin)%array(1,icenter)
             DO j = center_list(ispin)%array(1, istate), center_list(ispin)%array(1, istate + 1) - 1
                jstate = center_list(ispin)%array(2, j)
-               CALL cp_fm_to_fm(psi1_p(ispin, iiB)%matrix, psi_a_iB, 1, jstate, jstate)
-               CALL cp_fm_to_fm(psi1_p(ispin, iiiB)%matrix, psi_buf, 1, jstate, jstate)
+               CALL cp_fm_to_fm(psi1_p(ispin, iiB), psi_a_iB, 1, jstate, jstate)
+               CALL cp_fm_to_fm(psi1_p(ispin, iiiB), psi_buf, 1, jstate, jstate)
                ddk(:, jstate) = dk(1:3)
             END DO
          END DO ! istate
@@ -379,13 +379,13 @@ CONTAINS
          !psi_a_iB = psi_a_iB + psi1_rxp
          !
          ! contribution from the response psi1_rxp
-         CALL cp_fm_scale_and_add(-1.0_dp, psi_a_iB, 1.0_dp, psi1_rxp(ispin, iB)%matrix)
+         CALL cp_fm_scale_and_add(-1.0_dp, psi_a_iB, 1.0_dp, psi1_rxp(ispin, iB))
          !
          !psi_a_iB = psi_a_iB - psi1_D
          IF (current_env%full) THEN
             !
             ! contribution from the response psi1_D
-            CALL cp_fm_scale_and_add(1.0_dp, psi_a_iB, -1.0_dp, psi1_D(ispin, iB)%matrix)
+            CALL cp_fm_scale_and_add(1.0_dp, psi_a_iB, -1.0_dp, psi1_D(ispin, iB))
          END IF
          !
          ! Multiply by the occupation number for the density matrix
@@ -399,13 +399,13 @@ CONTAINS
          ! Build the second density matrix
          CALL dbcsr_set(density_matrix_iii(ispin)%matrix, 0.0_dp)
          CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=density_matrix_iii(ispin)%matrix, &
-                                    matrix_v=mo_coeff, matrix_g=psi1_p(ispin, iiiB)%matrix, &
+                                    matrix_v=mo_coeff, matrix_g=psi1_p(ispin, iiiB), &
                                     ncol=nmo, alpha=maxocc)
          !
          ! Build the third density matrix
          CALL dbcsr_set(density_matrix_ii(ispin)%matrix, 0.0_dp)
          CALL cp_dbcsr_plus_fm_fm_t(sparse_matrix=density_matrix_ii(ispin)%matrix, &
-                                    matrix_v=mo_coeff, matrix_g=psi1_p(ispin, iiB)%matrix, &
+                                    matrix_v=mo_coeff, matrix_g=psi1_p(ispin, iiB), &
                                     ncol=nmo, alpha=maxocc)
          DO idir = 1, 3
             !
@@ -2294,11 +2294,11 @@ CONTAINS
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: p_rxp, r_p1, r_p2
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_D, psi1_p, psi1_rxp, rr_p1, rr_p2, &
-                                                            rr_rxp
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: rr_p1, rr_p2, rr_rxp
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: psi0, psi_D, psi_p1, psi_p2, psi_rxp
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_D, psi1_p, psi1_rxp
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -2503,12 +2503,12 @@ CONTAINS
                ! block the states that belong to this center
                CALL cp_fm_to_fm(mo_coeff, psi0, 1, istate, jstate)
                !
-               CALL cp_fm_to_fm(psi1_rxp(ispin, iB)%matrix, psi_rxp, 1, istate, jstate)
-               IF (current_env%full) CALL cp_fm_to_fm(psi1_D(ispin, iB)%matrix, psi_D, 1, istate, jstate)
+               CALL cp_fm_to_fm(psi1_rxp(ispin, iB), psi_rxp, 1, istate, jstate)
+               IF (current_env%full) CALL cp_fm_to_fm(psi1_D(ispin, iB), psi_D, 1, istate, jstate)
                !
                ! psi1_p_iiB_istate and psi1_p_iiiB_istate
-               CALL cp_fm_to_fm(psi1_p(ispin, iiB)%matrix, psi_p1, 1, istate, jstate)
-               CALL cp_fm_to_fm(psi1_p(ispin, iiiB)%matrix, psi_p2, 1, istate, jstate)
+               CALL cp_fm_to_fm(psi1_p(ispin, iiB), psi_p1, 1, istate, jstate)
+               CALL cp_fm_to_fm(psi1_p(ispin, iiiB), psi_p2, 1, istate, jstate)
                !
                jstate = jstate + 1
             END DO ! istate
@@ -2723,9 +2723,9 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_p, psi1_rxp
       TYPE(cp_fm_type)                                   :: buf
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_p, psi1_rxp
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -2894,7 +2894,7 @@ CONTAINS
                DO jdir = 1, 3
                   DO kdir = 1, 3
                      IF (Levi_Civita(kdir, jdir, idir) .EQ. 0.0_dp) CYCLE
-                     CALL cp_fm_trace(buf, psi1_rxp(ispin, iB)%matrix, contrib)
+                     CALL cp_fm_trace(buf, psi1_rxp(ispin, iB), contrib)
                      chi(kdir) = chi(kdir) - Levi_Civita(kdir, jdir, idir)*2.0_dp*dk(jdir)*contrib
                   END DO
                END DO
@@ -2914,7 +2914,7 @@ CONTAINS
                                             buf, ncol=nmo, alpha=1.e0_dp)
                DO kdir = 1, 3
                   IF (Levi_Civita(kdir, jdir, idir) .EQ. 0.0_dp) CYCLE
-                  CALL cp_fm_trace(buf, psi1_rxp(ispin, iB)%matrix, contrib)
+                  CALL cp_fm_trace(buf, psi1_rxp(ispin, iB), contrib)
                   chi(kdir) = chi(kdir) - Levi_Civita(kdir, jdir, idir)*2.0_dp*contrib
                END DO
                !
@@ -2923,7 +2923,7 @@ CONTAINS
                      DO jjdir = 1, 3
                         DO kdir = 1, 3
                            IF (Levi_Civita(kdir, jjdir, idir) .EQ. 0.0_dp) CYCLE
-                           CALL cp_fm_trace(buf, psi1_p(ispin, iiiB)%matrix, contrib)
+                           CALL cp_fm_trace(buf, psi1_p(ispin, iiiB), contrib)
                            chi(kdir) = chi(kdir) + Levi_Civita(kdir, jjdir, idir)*2.0_dp*dk(jjdir)*contrib
                         END DO
                      END DO
@@ -2933,7 +2933,7 @@ CONTAINS
                      DO jjdir = 1, 3
                         DO kdir = 1, 3
                            IF (Levi_Civita(kdir, jjdir, idir) .EQ. 0.0_dp) CYCLE
-                           CALL cp_fm_trace(buf, psi1_p(ispin, iiB)%matrix, contrib)
+                           CALL cp_fm_trace(buf, psi1_p(ispin, iiB), contrib)
                            chi(kdir) = chi(kdir) - Levi_Civita(kdir, jjdir, idir)*2.0_dp*dk(jjdir)*contrib
                         END DO
                      END DO
@@ -2954,7 +2954,7 @@ CONTAINS
                                             buf, ncol=nmo, alpha=1.e0_dp)
                DO kdir = 1, 3
                   IF (Levi_Civita(kdir, jdir, idir) .EQ. 0.0_dp) CYCLE
-                  CALL cp_fm_trace(buf, psi1_p(ispin, iiiB)%matrix, contrib)
+                  CALL cp_fm_trace(buf, psi1_p(ispin, iiiB), contrib)
                   chi(kdir) = chi(kdir) + Levi_Civita(kdir, jdir, idir)*2.0_dp*contrib
                END DO
                !
@@ -2962,7 +2962,7 @@ CONTAINS
                                             buf, ncol=nmo, alpha=1.e0_dp)
                DO kdir = 1, 3
                   IF (Levi_Civita(kdir, jdir, idir) .EQ. 0.0_dp) CYCLE
-                  CALL cp_fm_trace(buf, psi1_p(ispin, iiB)%matrix, contrib)
+                  CALL cp_fm_trace(buf, psi1_p(ispin, iiB), contrib)
                   chi(kdir) = chi(kdir) - Levi_Civita(kdir, jdir, idir)*2.0_dp*contrib
                END DO
             END DO
@@ -2980,7 +2980,7 @@ CONTAINS
                DO kdir = 1, 3
                   IF (Levi_Civita(kdir, idir, jdir) .EQ. 0.0_dp) CYCLE
                   IF (iiB == jdir) THEN
-                     CALL cp_fm_trace(buf, psi1_p(ispin, iiiB)%matrix, contrib)
+                     CALL cp_fm_trace(buf, psi1_p(ispin, iiiB), contrib)
                      chi(kdir) = chi(kdir) + Levi_Civita(kdir, idir, jdir)*contrib
                   END IF
                END DO
@@ -2990,7 +2990,7 @@ CONTAINS
                DO kdir = 1, 3
                   IF (Levi_Civita(kdir, idir, jdir) .EQ. 0.0_dp) CYCLE
                   IF (iiiB == jdir) THEN
-                     CALL cp_fm_trace(buf, psi1_p(ispin, iiB)%matrix, contrib)
+                     CALL cp_fm_trace(buf, psi1_p(ispin, iiB), contrib)
                      chi(kdir) = chi(kdir) - Levi_Civita(kdir, idir, jdir)*contrib
                   END IF
                   !

--- a/src/qs_linres_current_utils.F
+++ b/src/qs_linres_current_utils.F
@@ -36,7 +36,6 @@ MODULE qs_linres_current_utils
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -152,12 +151,11 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1, psi1_ptr
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_D, psi1_p, psi1_rxp
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_work_ii, fm_work_iii, h1_psi0
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_work_ii, fm_work_iii, h1_psi0, psi1
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: hpsi0_ptr, psi0_order
-      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: p_psi0, rxp_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: p_psi0, psi1_D, psi1_p, psi1_rxp, &
+                                                            rxp_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -175,7 +173,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       !
       NULLIFY (cell, dft_control, linres_control, lr_section, current_section, &
-               logger, mpools, psi1, mo_coeff, para_env, &
+               logger, mpools, mo_coeff, para_env, &
                tmp_fm_struct, &
                list_cubes, statetrueindex, centers_set, center_list, psi1_p, psi1_rxp, psi1_D, &
                p_psi0, rxp_psi0, psi0_order, op_p_ao, sab_orb, particle_set)
@@ -224,12 +222,11 @@ CONTAINS
          ALLOCATE (psi1(nspins), h1_psi0(nspins))
          DO ispin = 1, nspins
             mo_coeff => psi0_order(ispin)
-            NULLIFY (tmp_fm_struct, psi1(ispin)%matrix)
+            NULLIFY (tmp_fm_struct)
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                      ncol_global=nstates(ispin), &
                                      context=mo_coeff%matrix_struct%context)
-            ALLOCATE (psi1(ispin)%matrix)
-            CALL cp_fm_create(psi1(ispin)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(psi1(ispin), tmp_fm_struct)
             CALL cp_fm_create(h1_psi0(ispin), tmp_fm_struct)
             CALL cp_fm_struct_release(tmp_fm_struct)
          END DO
@@ -276,9 +273,9 @@ CONTAINS
       !
       DO idir = 1, 3
          DO ispin = 1, nspins
-            CALL cp_fm_set_all(psi1_p(ispin, idir)%matrix, 0.0_dp)
-            CALL cp_fm_set_all(psi1_rxp(ispin, idir)%matrix, 0.0_dp)
-            IF (current_env%full) CALL cp_fm_set_all(psi1_D(ispin, idir)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(psi1_p(ispin, idir), 0.0_dp)
+            CALL cp_fm_set_all(psi1_rxp(ispin, idir), 0.0_dp)
+            IF (current_env%full) CALL cp_fm_set_all(psi1_D(ispin, idir), 0.0_dp)
          END DO
       END DO
       !
@@ -290,11 +287,9 @@ CONTAINS
       IF (linres_control%linres_restart) THEN
          DO idir = 1, 3
             ! operator p
-            psi1_ptr => psi1_p(:, idir)
-            CALL linres_read_restart(qs_env, lr_section, psi1_ptr, idir, "nmr_p")
+            CALL linres_read_restart(qs_env, lr_section, psi1_p(:, idir), idir, "nmr_p")
             ! operator rxp
-            psi1_ptr => psi1_rxp(:, idir)
-            CALL linres_read_restart(qs_env, lr_section, psi1_ptr, idir, "nmr_rxp")
+            CALL linres_read_restart(qs_env, lr_section, psi1_rxp(:, idir), idir, "nmr_rxp")
          END DO
       END IF
       !
@@ -311,12 +306,11 @@ CONTAINS
          END IF
          !
          ! Initial guess for psi1
-         psi1_ptr => psi1_p(:, idir)
          hpsi0_ptr => p_psi0(:, idir)
          !
          !
          linres_control%converged = .FALSE.
-         CALL linres_solver(p_env, qs_env, psi1_ptr, hpsi0_ptr, psi0_order, output_unit, should_stop)
+         CALL linres_solver(p_env, qs_env, psi1_p(:, idir), hpsi0_ptr, psi0_order, output_unit, should_stop)
          !
          !
          ! print response functions
@@ -332,14 +326,14 @@ CONTAINS
             !
 
             DO ispin = 1, nspins
-               CALL qs_print_cubes(qs_env, psi1_ptr(ispin)%matrix, ncubes, list_cubes, &
+               CALL qs_print_cubes(qs_env, psi1_p(ispin, idir), ncubes, list_cubes, &
                                    centers_set(ispin)%array, print_key, 'psi1_p', &
                                    idir=idir, ispin=ispin, file_position=my_pos)
             END DO ! ispin
          END IF ! print response functions
          !
          ! write restart file
-         CALL linres_write_restart(qs_env, lr_section, psi1_ptr, idir, "nmr_p")
+         CALL linres_write_restart(qs_env, lr_section, psi1_p(:, idir), idir, "nmr_p")
       END DO ! idir
       !
       ! operator rxp
@@ -350,12 +344,11 @@ CONTAINS
          END IF
          !
          ! Initial guess for psi1
-         psi1_ptr => psi1_rxp(:, idir)
          hpsi0_ptr => rxp_psi0(:, idir)
          !
          !
          linres_control%converged = .FALSE.
-         CALL linres_solver(p_env, qs_env, psi1_ptr, hpsi0_ptr, psi0_order, output_unit, should_stop)
+         CALL linres_solver(p_env, qs_env, psi1_rxp(:, idir), hpsi0_ptr, psi0_order, output_unit, should_stop)
          !
          ! print response functions
          IF (BTEST(cp_print_key_should_output(logger%iter_info, current_section,&
@@ -364,14 +357,14 @@ CONTAINS
             print_key => section_vals_get_subs_vals(current_section, "PRINT%RESPONSE_FUNCTION_CUBES")
 
             DO ispin = 1, nspins
-               CALL qs_print_cubes(qs_env, psi1_ptr(ispin)%matrix, ncubes, list_cubes, &
+               CALL qs_print_cubes(qs_env, psi1_rxp(ispin, idir), ncubes, list_cubes, &
                                    centers_set(ispin)%array, print_key, 'psi1_rxp', &
                                    idir=idir, ispin=ispin, file_position=my_pos)
             END DO ! ispin
          END IF ! print response functions
          !
          ! write restart file
-         CALL linres_write_restart(qs_env, lr_section, psi1_ptr, idir, "nmr_rxp")
+         CALL linres_write_restart(qs_env, lr_section, psi1_rxp(:, idir), idir, "nmr_rxp")
       END DO ! idir
       IF (.NOT. should_stop) current_env%all_pert_op_done = .TRUE.
       !
@@ -381,7 +374,7 @@ CONTAINS
          !
          !
          DO ispin = 1, nspins
-            CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
          END DO
          !
          ! The correction is state depedent a loop over the states is necessary
@@ -410,12 +403,11 @@ CONTAINS
          DO idir = 1, 3
             IF (should_stop) EXIT
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(psi1_D(ispin, idir)%matrix, 0.0_dp)
+               CALL cp_fm_set_all(psi1_D(ispin, idir), 0.0_dp)
             END DO
             first_center = 0
             IF (linres_control%linres_restart) THEN
-               psi1_ptr => psi1_D(:, idir)
-               CALL linres_read_restart(qs_env, lr_section, psi1_ptr, idir, "nmr_dxp-", ind=first_center)
+               CALL linres_read_restart(qs_env, lr_section, psi1_D(:, idir), idir, "nmr_dxp-", ind=first_center)
             END IF
             IF (first_center > 0) THEN
                IF (output_unit > 0) THEN
@@ -446,7 +438,7 @@ CONTAINS
                         !
                         ! set h1_psi0 and psi1 to zero to avoid problems in linres_scf
                         CALL cp_fm_set_all(h1_psi0(ispin), 0.0_dp)
-                        CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
+                        CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
                         CYCLE
                      END IF
                      !
@@ -519,7 +511,7 @@ CONTAINS
                         istate = center_list(ispin)%array(2, i)
                         !
                         ! the optimized wfns are copied in the fm
-                        CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_D(ispin, idir)%matrix, 1, istate, istate)
+                        CALL cp_fm_to_fm(psi1(ispin), psi1_D(ispin, idir), 1, istate, istate)
                      END DO
                      current_env%full_done(idir*ispin, icenter) = .TRUE.
                   END DO ! ispin
@@ -529,8 +521,7 @@ CONTAINS
                      current_env%full_done(idir*ispin, icenter) = .TRUE.
                   END DO ! ispin
                END IF
-               psi1_ptr => psi1_D(:, idir)
-               CALL linres_write_restart(qs_env, lr_section, psi1_ptr, idir, "nmr_dxp-", ind=icenter)
+               CALL linres_write_restart(qs_env, lr_section, psi1_D(:, idir), idir, "nmr_dxp-", ind=icenter)
 
             END DO ! center
             !
@@ -540,7 +531,7 @@ CONTAINS
                ncubes = SIZE(list_cubes, 1)
                print_key => section_vals_get_subs_vals(current_section, "PRINT%RESPONSE_FUNCTION_CUBES")
                DO ispin = 1, nspins
-                  CALL qs_print_cubes(qs_env, psi1_D(ispin, idir)%matrix, &
+                  CALL qs_print_cubes(qs_env, psi1_D(ispin, idir), &
                                       ncubes, list_cubes, centers_set(ispin)%array, print_key, 'psi1_D', &
                                       idir=idir, ispin=ispin, file_position=my_pos)
                END DO
@@ -562,9 +553,8 @@ CONTAINS
       IF (current_env%full) THEN
          CALL dbcsr_deallocate_matrix_set(op_p_ao)
          DO ispin = 1, nspins
-            CALL cp_fm_release(psi1(ispin)%matrix)
+            CALL cp_fm_release(psi1(ispin))
             CALL cp_fm_release(h1_psi0(ispin))
-            DEALLOCATE (psi1(ispin)%matrix)
          END DO
          DEALLOCATE (psi1, h1_psi0)
       END IF
@@ -1265,14 +1255,12 @@ CONTAINS
                                   ncol_global=current_env%nstates(ispin), &
                                   context=mo_coeff%matrix_struct%context)
          DO idir = 1, 3
-            ALLOCATE (current_env%psi1_p(ispin, idir)%matrix, current_env%psi1_rxp(ispin, idir)%matrix)
-            CALL cp_fm_create(current_env%psi1_p(ispin, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(current_env%psi1_rxp(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(current_env%psi1_p(ispin, idir), tmp_fm_struct)
+            CALL cp_fm_create(current_env%psi1_rxp(ispin, idir), tmp_fm_struct)
             CALL cp_fm_create(current_env%p_psi0(ispin, idir), tmp_fm_struct)
             CALL cp_fm_create(current_env%rxp_psi0(ispin, idir), tmp_fm_struct)
             IF (current_env%full) THEN
-               ALLOCATE (current_env%psi1_D(ispin, idir)%matrix)
-               CALL cp_fm_create(current_env%psi1_D(ispin, idir)%matrix, tmp_fm_struct)
+               CALL cp_fm_create(current_env%psi1_D(ispin, idir), tmp_fm_struct)
             END IF
          END DO
          CALL cp_fm_struct_release(tmp_fm_struct)
@@ -1357,8 +1345,7 @@ CONTAINS
       IF (ASSOCIATED(current_env%psi1_p)) THEN
          DO idir = 1, SIZE(current_env%psi1_p, 2)
             DO ispin = 1, SIZE(current_env%psi1_p, 1)
-               CALL cp_fm_release(current_env%psi1_p(ispin, idir)%matrix)
-               DEALLOCATE (current_env%psi1_p(ispin, idir)%matrix)
+               CALL cp_fm_release(current_env%psi1_p(ispin, idir))
             END DO
          END DO
          DEALLOCATE (current_env%psi1_p)
@@ -1368,8 +1355,7 @@ CONTAINS
       IF (ASSOCIATED(current_env%psi1_rxp)) THEN
          DO idir = 1, SIZE(current_env%psi1_rxp, 2)
             DO ispin = 1, SIZE(current_env%psi1_rxp, 1)
-               CALL cp_fm_release(current_env%psi1_rxp(ispin, idir)%matrix)
-               DEALLOCATE (current_env%psi1_rxp(ispin, idir)%matrix)
+               CALL cp_fm_release(current_env%psi1_rxp(ispin, idir))
             END DO
          END DO
          DEALLOCATE (current_env%psi1_rxp)
@@ -1379,8 +1365,7 @@ CONTAINS
       IF (ASSOCIATED(current_env%psi1_D)) THEN
          DO idir = 1, SIZE(current_env%psi1_D, 2)
             DO ispin = 1, SIZE(current_env%psi1_D, 1)
-               CALL cp_fm_release(current_env%psi1_D(ispin, idir)%matrix)
-               DEALLOCATE (current_env%psi1_D(ispin, idir)%matrix)
+               CALL cp_fm_release(current_env%psi1_D(ispin, idir))
             END DO
          END DO
          DEALLOCATE (current_env%psi1_D)

--- a/src/qs_linres_current_utils.F
+++ b/src/qs_linres_current_utils.F
@@ -153,10 +153,11 @@ CONTAINS
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_work_ii, fm_work_iii, h1_psi0, &
-                                                            hpsi0_ptr, psi0_order, psi1, psi1_ptr
+                                                            hpsi0_ptr, psi1, psi1_ptr
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: p_psi0, psi1_D, psi1_p, psi1_rxp, &
                                                             rxp_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -222,7 +223,7 @@ CONTAINS
       IF (current_env%full) THEN
          ALLOCATE (psi1(nspins), h1_psi0(nspins))
          DO ispin = 1, nspins
-            mo_coeff => psi0_order(ispin)%matrix
+            mo_coeff => psi0_order(ispin)
             NULLIFY (tmp_fm_struct, psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                      ncol_global=nstates(ispin), &
@@ -393,7 +394,7 @@ CONTAINS
          !
          DO ispin = 1, nspins
             nmo = nstates(ispin)
-            mo_coeff => psi0_order(ispin)%matrix
+            mo_coeff => psi0_order(ispin)
             NULLIFY (tmp_fm_struct, fm_work_ii(ispin)%matrix, fm_work_iii(ispin)%matrix)
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                      ncol_global=nmo, para_env=para_env, &
@@ -439,7 +440,7 @@ CONTAINS
                   !
                   DO ispin = 1, nspins
                      nmo = nstates(ispin)
-                     mo_coeff => psi0_order(ispin)%matrix
+                     mo_coeff => psi0_order(ispin)
                      !
                      ! take care that no overflow can occur for uks
                      IF (icenter .GT. nbr_center(ispin)) THEN
@@ -1037,10 +1038,9 @@ CONTAINS
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                   ncol_global=nstate_list(ispin), para_env=para_env, &
                                   context=mo_coeff%matrix_struct%context)
-         ALLOCATE (current_env%psi0_order(ispin)%matrix)
-         CALL cp_fm_create(current_env%psi0_order(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(current_env%psi0_order(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
-         CALL cp_fm_set_all(current_env%psi0_order(ispin)%matrix, 0.0_dp)
+         CALL cp_fm_set_all(current_env%psi0_order(ispin), 0.0_dp)
       END DO
       !
       !
@@ -1058,10 +1058,10 @@ CONTAINS
                   ! the blocking works (so far) with all the precond except FULL_ALL
                   ! the center_list(ispin)%array(2,i) array is obsolete then
                   current_env%center_list(ispin)%array(2, i) = jstate
-                  CALL cp_fm_to_fm(mo_coeff, current_env%psi0_order(ispin)%matrix, 1, istate, jstate)
+                  CALL cp_fm_to_fm(mo_coeff, current_env%psi0_order(ispin), 1, istate, jstate)
                ELSE
                   ! for the moment we just copy them
-                  CALL cp_fm_to_fm(mo_coeff, current_env%psi0_order(ispin)%matrix, 1, istate, istate)
+                  CALL cp_fm_to_fm(mo_coeff, current_env%psi0_order(ispin), 1, istate, istate)
                END IF
             END DO
          END DO
@@ -1261,7 +1261,7 @@ CONTAINS
          ALLOCATE (current_env%psi1_D(nspins, 3))
       END IF
       DO ispin = 1, nspins
-         mo_coeff => current_env%psi0_order(ispin)%matrix
+         mo_coeff => current_env%psi0_order(ispin)
          NULLIFY (tmp_fm_struct)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                   ncol_global=current_env%nstates(ispin), &
@@ -1351,8 +1351,7 @@ CONTAINS
 
       IF (ASSOCIATED(current_env%psi0_order)) THEN
          DO ispin = 1, SIZE(current_env%psi0_order, 1)
-            CALL cp_fm_release(current_env%psi0_order(ispin)%matrix)
-            DEALLOCATE (current_env%psi0_order(ispin)%matrix)
+            CALL cp_fm_release(current_env%psi0_order(ispin))
          END DO
          DEALLOCATE (current_env%psi0_order)
       END IF

--- a/src/qs_linres_current_utils.F
+++ b/src/qs_linres_current_utils.F
@@ -147,16 +147,16 @@ CONTAINS
       INTEGER, DIMENSION(:, :, :), POINTER               :: statetrueindex
       LOGICAL                                            :: append_cube, should_stop
       REAL(dp)                                           :: dk(3), dkl(3), dl(3)
-      REAL(dp), DIMENSION(:), POINTER                    :: dkl_vec_ii, dkl_vec_iii
-      REAL(dp), DIMENSION(:, :), POINTER                 :: vecbuf_dklxp0
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: dkl_vec_ii, dkl_vec_iii
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: vecbuf_dklxp0
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fm_work_ii, fm_work_iii, h1_psi0, &
-                                                            hpsi0_ptr, psi1, psi1_ptr
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, hpsi0_ptr, psi1, psi1_ptr
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: p_psi0, psi1_D, psi1_p, psi1_rxp, &
                                                             rxp_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_work_ii, fm_work_iii
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -175,8 +175,8 @@ CONTAINS
       CALL timeset(routineN, handle)
       !
       NULLIFY (cell, dft_control, linres_control, lr_section, current_section, &
-               logger, mpools, psi1, h1_psi0, vecbuf_dklxp0, mo_coeff, para_env, &
-               fm_work_ii, fm_work_iii, tmp_fm_struct, dkl_vec_ii, dkl_vec_iii, &
+               logger, mpools, psi1, h1_psi0, mo_coeff, para_env, &
+               tmp_fm_struct, &
                list_cubes, statetrueindex, centers_set, center_list, psi1_p, psi1_rxp, psi1_D, &
                p_psi0, rxp_psi0, psi0_order, op_p_ao, sab_orb, particle_set)
 
@@ -395,16 +395,15 @@ CONTAINS
          DO ispin = 1, nspins
             nmo = nstates(ispin)
             mo_coeff => psi0_order(ispin)
-            NULLIFY (tmp_fm_struct, fm_work_ii(ispin)%matrix, fm_work_iii(ispin)%matrix)
+            NULLIFY (tmp_fm_struct)
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                      ncol_global=nmo, para_env=para_env, &
                                      context=mo_coeff%matrix_struct%context)
 
-            ALLOCATE (fm_work_ii(ispin)%matrix, fm_work_iii(ispin)%matrix)
-            CALL cp_fm_create(fm_work_ii(ispin)%matrix, tmp_fm_struct)
-            CALL cp_fm_set_all(fm_work_ii(ispin)%matrix, 0.0_dp)
-            CALL cp_fm_create(fm_work_iii(ispin)%matrix, tmp_fm_struct)
-            CALL cp_fm_set_all(fm_work_iii(ispin)%matrix, 0.0_dp)
+            CALL cp_fm_create(fm_work_ii(ispin), tmp_fm_struct)
+            CALL cp_fm_set_all(fm_work_ii(ispin), 0.0_dp)
+            CALL cp_fm_create(fm_work_iii(ispin), tmp_fm_struct)
+            CALL cp_fm_set_all(fm_work_iii(ispin), 0.0_dp)
             CALL cp_fm_struct_release(tmp_fm_struct)
          END DO ! ispin
          !
@@ -472,32 +471,32 @@ CONTAINS
                      !
                      ! First term
                      ! Rescale the ground state orbitals by (dk-dl)_ii
-                     CALL cp_fm_to_fm(mo_coeff, fm_work_ii(ispin)%matrix)
-                     CALL cp_fm_column_scale(fm_work_ii(ispin)%matrix, dkl_vec_ii(1:nmo))
+                     CALL cp_fm_to_fm(mo_coeff, fm_work_ii(ispin))
+                     CALL cp_fm_column_scale(fm_work_ii(ispin), dkl_vec_ii(1:nmo))
                      !
                      ! Apply the p_iii operator
                      ! fm_work_iii = -p_iii * (dk-dl)_ii * C0
-                     CALL cp_dbcsr_sm_fm_multiply(op_p_ao(iii)%matrix, fm_work_ii(ispin)%matrix, &
-                                                  fm_work_iii(ispin)%matrix, ncol=nmo, alpha=-1.0_dp)
+                     CALL cp_dbcsr_sm_fm_multiply(op_p_ao(iii)%matrix, fm_work_ii(ispin), &
+                                                  fm_work_iii(ispin), ncol=nmo, alpha=-1.0_dp)
                      !
                      ! Copy in h1_psi0
                      ! h1_psi0_i = fm_work_iii
-                     CALL cp_fm_to_fm(fm_work_iii(ispin)%matrix, h1_psi0(ispin)%matrix)
+                     CALL cp_fm_to_fm(fm_work_iii(ispin), h1_psi0(ispin)%matrix)
                      !
                      ! Second term
                      ! Rescale the ground state orbitals by (dk-dl)_iii
-                     CALL cp_fm_to_fm(mo_coeff, fm_work_iii(ispin)%matrix)
-                     CALL cp_fm_column_scale(fm_work_iii(ispin)%matrix, dkl_vec_iii(1:nmo))
+                     CALL cp_fm_to_fm(mo_coeff, fm_work_iii(ispin))
+                     CALL cp_fm_column_scale(fm_work_iii(ispin), dkl_vec_iii(1:nmo))
                      !
                      ! Apply the p_ii operator
                      ! fm_work_ii = -p_ii * (dk-dl)_iii * C0
-                     CALL cp_dbcsr_sm_fm_multiply(op_p_ao(ii)%matrix, fm_work_iii(ispin)%matrix, &
-                                                  fm_work_ii(ispin)%matrix, ncol=nmo, alpha=-1.0_dp)
+                     CALL cp_dbcsr_sm_fm_multiply(op_p_ao(ii)%matrix, fm_work_iii(ispin), &
+                                                  fm_work_ii(ispin), ncol=nmo, alpha=-1.0_dp)
                      !
                      ! Copy in h1_psi0
                      ! h1_psi0_i = fm_work_iii - fm_work_ii
                      CALL cp_fm_scale_and_add(1.0_dp, h1_psi0(ispin)%matrix,&
-                          &                  -1.0_dp, fm_work_ii(ispin)%matrix)
+                          &                  -1.0_dp, fm_work_ii(ispin))
                   END DO
 
                   !
@@ -552,9 +551,8 @@ CONTAINS
          !
          ! clean up
          DO ispin = 1, nspins
-            CALL cp_fm_release(fm_work_ii(ispin)%matrix)
-            CALL cp_fm_release(fm_work_iii(ispin)%matrix)
-            DEALLOCATE (fm_work_ii(ispin)%matrix, fm_work_iii(ispin)%matrix)
+            CALL cp_fm_release(fm_work_ii(ispin))
+            CALL cp_fm_release(fm_work_iii(ispin))
          END DO
          DEALLOCATE (fm_work_ii, fm_work_iii, dkl_vec_ii, dkl_vec_iii, vecbuf_dklxp0)
 

--- a/src/qs_linres_current_utils.F
+++ b/src/qs_linres_current_utils.F
@@ -152,12 +152,12 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, hpsi0_ptr, psi1, psi1_ptr
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: p_psi0, psi1_D, psi1_p, psi1_rxp, &
-                                                            rxp_psi0
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1, psi1_ptr
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_D, psi1_p, psi1_rxp
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_work_ii, fm_work_iii
-      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_work_ii, fm_work_iii, h1_psi0
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: hpsi0_ptr, psi0_order
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: p_psi0, rxp_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -175,7 +175,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       !
       NULLIFY (cell, dft_control, linres_control, lr_section, current_section, &
-               logger, mpools, psi1, h1_psi0, mo_coeff, para_env, &
+               logger, mpools, psi1, mo_coeff, para_env, &
                tmp_fm_struct, &
                list_cubes, statetrueindex, centers_set, center_list, psi1_p, psi1_rxp, psi1_D, &
                p_psi0, rxp_psi0, psi0_order, op_p_ao, sab_orb, particle_set)
@@ -224,13 +224,13 @@ CONTAINS
          ALLOCATE (psi1(nspins), h1_psi0(nspins))
          DO ispin = 1, nspins
             mo_coeff => psi0_order(ispin)
-            NULLIFY (tmp_fm_struct, psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+            NULLIFY (tmp_fm_struct, psi1(ispin)%matrix)
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                      ncol_global=nstates(ispin), &
                                      context=mo_coeff%matrix_struct%context)
-            ALLOCATE (psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+            ALLOCATE (psi1(ispin)%matrix)
             CALL cp_fm_create(psi1(ispin)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(h1_psi0(ispin)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(h1_psi0(ispin), tmp_fm_struct)
             CALL cp_fm_struct_release(tmp_fm_struct)
          END DO
          !
@@ -445,7 +445,7 @@ CONTAINS
                      IF (icenter .GT. nbr_center(ispin)) THEN
                         !
                         ! set h1_psi0 and psi1 to zero to avoid problems in linres_scf
-                        CALL cp_fm_set_all(h1_psi0(ispin)%matrix, 0.0_dp)
+                        CALL cp_fm_set_all(h1_psi0(ispin), 0.0_dp)
                         CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
                         CYCLE
                      END IF
@@ -481,7 +481,7 @@ CONTAINS
                      !
                      ! Copy in h1_psi0
                      ! h1_psi0_i = fm_work_iii
-                     CALL cp_fm_to_fm(fm_work_iii(ispin), h1_psi0(ispin)%matrix)
+                     CALL cp_fm_to_fm(fm_work_iii(ispin), h1_psi0(ispin))
                      !
                      ! Second term
                      ! Rescale the ground state orbitals by (dk-dl)_iii
@@ -495,7 +495,7 @@ CONTAINS
                      !
                      ! Copy in h1_psi0
                      ! h1_psi0_i = fm_work_iii - fm_work_ii
-                     CALL cp_fm_scale_and_add(1.0_dp, h1_psi0(ispin)%matrix,&
+                     CALL cp_fm_scale_and_add(1.0_dp, h1_psi0(ispin),&
                           &                  -1.0_dp, fm_work_ii(ispin))
                   END DO
 
@@ -563,8 +563,8 @@ CONTAINS
          CALL dbcsr_deallocate_matrix_set(op_p_ao)
          DO ispin = 1, nspins
             CALL cp_fm_release(psi1(ispin)%matrix)
-            CALL cp_fm_release(h1_psi0(ispin)%matrix)
-            DEALLOCATE (psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+            CALL cp_fm_release(h1_psi0(ispin))
+            DEALLOCATE (psi1(ispin)%matrix)
          END DO
          DEALLOCATE (psi1, h1_psi0)
       END IF
@@ -1266,11 +1266,10 @@ CONTAINS
                                   context=mo_coeff%matrix_struct%context)
          DO idir = 1, 3
             ALLOCATE (current_env%psi1_p(ispin, idir)%matrix, current_env%psi1_rxp(ispin, idir)%matrix)
-            ALLOCATE (current_env%p_psi0(ispin, idir)%matrix, current_env%rxp_psi0(ispin, idir)%matrix)
             CALL cp_fm_create(current_env%psi1_p(ispin, idir)%matrix, tmp_fm_struct)
             CALL cp_fm_create(current_env%psi1_rxp(ispin, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(current_env%p_psi0(ispin, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(current_env%rxp_psi0(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(current_env%p_psi0(ispin, idir), tmp_fm_struct)
+            CALL cp_fm_create(current_env%rxp_psi0(ispin, idir), tmp_fm_struct)
             IF (current_env%full) THEN
                ALLOCATE (current_env%psi1_D(ispin, idir)%matrix)
                CALL cp_fm_create(current_env%psi1_D(ispin, idir)%matrix, tmp_fm_struct)
@@ -1391,8 +1390,7 @@ CONTAINS
       IF (ASSOCIATED(current_env%p_psi0)) THEN
          DO idir = 1, SIZE(current_env%p_psi0, 2)
             DO ispin = 1, SIZE(current_env%p_psi0, 1)
-               CALL cp_fm_release(current_env%p_psi0(ispin, idir)%matrix)
-               DEALLOCATE (current_env%p_psi0(ispin, idir)%matrix)
+               CALL cp_fm_release(current_env%p_psi0(ispin, idir))
             END DO
          END DO
          DEALLOCATE (current_env%p_psi0)
@@ -1402,8 +1400,7 @@ CONTAINS
       IF (ASSOCIATED(current_env%rxp_psi0)) THEN
          DO idir = 1, SIZE(current_env%rxp_psi0, 2)
             DO ispin = 1, SIZE(current_env%rxp_psi0, 1)
-               CALL cp_fm_release(current_env%rxp_psi0(ispin, idir)%matrix)
-               DEALLOCATE (current_env%rxp_psi0(ispin, idir)%matrix)
+               CALL cp_fm_release(current_env%rxp_psi0(ispin, idir))
             END DO
          END DO
          DEALLOCATE (current_env%rxp_psi0)

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -112,11 +112,11 @@ CONTAINS
                                                             nmo, nspins, output_unit
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd, should_stop
       REAL(dp)                                           :: chk, fro
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, psi1_dso, psi1_efg, &
-                                                            psi1_pso, pso_psi0
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_dso, psi1_efg, psi1_pso
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order, psi1
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0, psi1_fc
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dso_psi0, efg_psi0, pso_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -208,7 +208,7 @@ CONTAINS
             !
             !DO scf cycle to optimize psi1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(efg_psi0(ispin, ijdir)%matrix, h1_psi0(ispin))
+               CALL cp_fm_to_fm(efg_psi0(ispin, ijdir), h1_psi0(ispin))
             END DO
             !
             !
@@ -266,7 +266,7 @@ CONTAINS
             !
             !DO scf cycle to optimize psi1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(pso_psi0(ispin, idir)%matrix, h1_psi0(ispin))
+               CALL cp_fm_to_fm(pso_psi0(ispin, idir), h1_psi0(ispin))
             END DO
             !
             !
@@ -380,7 +380,7 @@ CONTAINS
             !
             !DO scf cycle to optimize psi1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(dso_psi0(ispin, idir)%matrix, h1_psi0(ispin))
+               CALL cp_fm_to_fm(dso_psi0(ispin, idir), h1_psi0(ispin))
             END DO
             !
             !
@@ -915,17 +915,16 @@ CONTAINS
                                   ncol_global=m, &
                                   context=mo_coeff%matrix_struct%context)
          DO idir = 1, 6
-            ALLOCATE (issc_env%psi1_efg(ispin, idir)%matrix, issc_env%efg_psi0(ispin, idir)%matrix)
+            ALLOCATE (issc_env%psi1_efg(ispin, idir)%matrix, issc_env%efg_psi0(ispin, idir))
             CALL cp_fm_create(issc_env%psi1_efg(ispin, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(issc_env%efg_psi0(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(issc_env%efg_psi0(ispin, idir), tmp_fm_struct)
          END DO
          DO idir = 1, 3
-            ALLOCATE (issc_env%psi1_pso(ispin, idir)%matrix, issc_env%pso_psi0(ispin, idir)%matrix, &
-                      issc_env%psi1_dso(ispin, idir)%matrix, issc_env%dso_psi0(ispin, idir)%matrix)
+            ALLOCATE (issc_env%psi1_pso(ispin, idir)%matrix, issc_env%psi1_dso(ispin, idir)%matrix)
             CALL cp_fm_create(issc_env%psi1_pso(ispin, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(issc_env%pso_psi0(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(issc_env%pso_psi0(ispin, idir), tmp_fm_struct)
             CALL cp_fm_create(issc_env%psi1_dso(ispin, idir)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(issc_env%dso_psi0(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(issc_env%dso_psi0(ispin, idir), tmp_fm_struct)
          END DO
          CALL cp_fm_create(issc_env%psi1_fc(ispin), tmp_fm_struct)
          CALL cp_fm_create(issc_env%fc_psi0(ispin), tmp_fm_struct)
@@ -1054,8 +1053,7 @@ CONTAINS
       IF (ASSOCIATED(issc_env%efg_psi0)) THEN
          DO idir = 1, SIZE(issc_env%efg_psi0, 2)
             DO ispin = 1, SIZE(issc_env%efg_psi0, 1)
-               CALL cp_fm_release(issc_env%efg_psi0(ispin, idir)%matrix)
-               DEALLOCATE (issc_env%efg_psi0(ispin, idir)%matrix)
+               CALL cp_fm_release(issc_env%efg_psi0(ispin, idir))
             END DO
          END DO
          DEALLOCATE (issc_env%efg_psi0)
@@ -1066,8 +1064,7 @@ CONTAINS
       IF (ASSOCIATED(issc_env%pso_psi0)) THEN
          DO idir = 1, SIZE(issc_env%pso_psi0, 2)
             DO ispin = 1, SIZE(issc_env%pso_psi0, 1)
-               CALL cp_fm_release(issc_env%pso_psi0(ispin, idir)%matrix)
-               DEALLOCATE (issc_env%pso_psi0(ispin, idir)%matrix)
+               CALL cp_fm_release(issc_env%pso_psi0(ispin, idir))
             END DO
          END DO
          DEALLOCATE (issc_env%pso_psi0)
@@ -1078,8 +1075,7 @@ CONTAINS
       IF (ASSOCIATED(issc_env%dso_psi0)) THEN
          DO idir = 1, SIZE(issc_env%dso_psi0, 2)
             DO ispin = 1, SIZE(issc_env%dso_psi0, 1)
-               CALL cp_fm_release(issc_env%dso_psi0(ispin, idir)%matrix)
-               DEALLOCATE (issc_env%dso_psi0(ispin, idir)%matrix)
+               CALL cp_fm_release(issc_env%dso_psi0(ispin, idir))
             END DO
          END DO
          DEALLOCATE (issc_env%dso_psi0)

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -33,7 +33,6 @@ MODULE qs_linres_issc_utils
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -112,11 +111,11 @@ CONTAINS
                                                             nmo, nspins, output_unit
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd, should_stop
       REAL(dp)                                           :: chk, fro
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_dso, psi1_efg, psi1_pso
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order, psi1
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0, psi1_fc
-      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dso_psi0, efg_psi0, pso_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dso_psi0, efg_psi0, psi1_dso, psi1_efg, &
+                                                            psi1_pso, pso_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -193,7 +192,7 @@ CONTAINS
          DO jdir = idir, 3
             ijdir = ijdir + 1
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(psi1_efg(ispin, ijdir)%matrix, 0.0_dp)
+               CALL cp_fm_set_all(psi1_efg(ispin, ijdir), 0.0_dp)
             END DO
             IF (output_unit > 0) THEN
                WRITE (output_unit, "(T10,A)") "Response to the perturbation operator efg_"//ACHAR(idir + 119)//ACHAR(jdir + 119)
@@ -220,7 +219,7 @@ CONTAINS
             !
             ! copy the response
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1(ispin), psi1_efg(ispin, ijdir)%matrix)
+               CALL cp_fm_to_fm(psi1(ispin), psi1_efg(ispin, ijdir))
                fro = cp_fm_frobenius_norm(psi1(ispin))
                chk = chk + fro
             END DO
@@ -251,7 +250,7 @@ CONTAINS
       IF (do_pso) THEN
          DO idir = 1, 3
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(psi1_pso(ispin, idir)%matrix, 0.0_dp)
+               CALL cp_fm_set_all(psi1_pso(ispin, idir), 0.0_dp)
             END DO
             IF (output_unit > 0) THEN
                WRITE (output_unit, "(T10,A)") "Response to the perturbation operator pso_"//ACHAR(idir + 119)
@@ -278,7 +277,7 @@ CONTAINS
             !
             ! copy the response
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1(ispin), psi1_pso(ispin, idir)%matrix)
+               CALL cp_fm_to_fm(psi1(ispin), psi1_pso(ispin, idir))
                fro = cp_fm_frobenius_norm(psi1(ispin))
                chk = chk + fro
             END DO
@@ -365,7 +364,7 @@ CONTAINS
       IF (do_dso) THEN
          DO idir = 1, 3
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(psi1_dso(ispin, idir)%matrix, 0.0_dp)
+               CALL cp_fm_set_all(psi1_dso(ispin, idir), 0.0_dp)
             END DO
             IF (output_unit > 0) THEN
                WRITE (output_unit, "(T10,A)") "Response to the perturbation operator r_"//ACHAR(idir + 119)
@@ -392,7 +391,7 @@ CONTAINS
             !
             ! copy the response
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1(ispin), psi1_dso(ispin, idir)%matrix)
+               CALL cp_fm_to_fm(psi1(ispin), psi1_dso(ispin, idir))
                fro = cp_fm_frobenius_norm(psi1(ispin))
                chk = chk + fro
             END DO
@@ -464,8 +463,8 @@ CONTAINS
       REAL(dp), DIMENSION(3)                             :: r_i, r_j
       REAL(dp), DIMENSION(:, :, :, :, :), POINTER        :: issc
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_dso, psi1_efg, psi1_pso
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0, psi1_fc
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_dso, psi1_efg, psi1_pso
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_dso, matrix_efg, matrix_fc, &
                                                             matrix_pso
@@ -571,7 +570,7 @@ CONTAINS
                   CALL cp_fm_trace(fc_psi0(ispin), mo_coeff, buf)
                   WRITE (*, *) ' jatom', jatom, ixyz, 'tr(P*efg)=', buf
                   DO jxyz = 1, 6
-                     CALL cp_fm_trace(fc_psi0(ispin), psi1_efg(ispin, jxyz)%matrix, buf)
+                     CALL cp_fm_trace(fc_psi0(ispin), psi1_efg(ispin, jxyz), buf)
                      issc_sd = 2.0_dp*maxocc*facsd*buf
                      !issc(ixyz,jxyz,iatom,jatom) = issc_sd
                      !write(*,*) 'pso_',ixyz,jxyz,' iatom',iatom,'jatom',jatom,issc_pso
@@ -593,7 +592,7 @@ CONTAINS
                                          fc_psi0(ispin), ncol=nmo,& ! fc_psi0 a buffer
                        &                 alpha=1.0_dp, beta=0.0_dp)
                   DO jxyz = 1, 3
-                     CALL cp_fm_trace(fc_psi0(ispin), psi1_pso(ispin, jxyz)%matrix, buf)
+                     CALL cp_fm_trace(fc_psi0(ispin), psi1_pso(ispin, jxyz), buf)
                      issc_pso = -2.0_dp*maxocc*facpso*buf
                      issc(ixyz, jxyz, iatom, jatom, 3) = issc(ixyz, jxyz, iatom, jatom, 3) + issc_pso
                   END DO
@@ -630,7 +629,7 @@ CONTAINS
                                          fc_psi0(ispin), ncol=nmo,& ! fc_psi0 a buffer
                        &                 alpha=1.0_dp, beta=0.0_dp)
                   DO jxyz = 1, 3
-                     CALL cp_fm_trace(psi1_dso(ispin, jxyz)%matrix, fc_psi0(ispin), buf)
+                     CALL cp_fm_trace(psi1_dso(ispin, jxyz), fc_psi0(ispin), buf)
                      ! we save the polarizability for a checksum later on !
                      issc_dso = 2.0_dp*maxocc*buf
                      issc(ixyz, jxyz, iatom, jatom, 4) = issc(ixyz, jxyz, iatom, jatom, 4) + issc_dso
@@ -915,15 +914,13 @@ CONTAINS
                                   ncol_global=m, &
                                   context=mo_coeff%matrix_struct%context)
          DO idir = 1, 6
-            ALLOCATE (issc_env%psi1_efg(ispin, idir)%matrix, issc_env%efg_psi0(ispin, idir))
-            CALL cp_fm_create(issc_env%psi1_efg(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(issc_env%psi1_efg(ispin, idir), tmp_fm_struct)
             CALL cp_fm_create(issc_env%efg_psi0(ispin, idir), tmp_fm_struct)
          END DO
          DO idir = 1, 3
-            ALLOCATE (issc_env%psi1_pso(ispin, idir)%matrix, issc_env%psi1_dso(ispin, idir)%matrix)
-            CALL cp_fm_create(issc_env%psi1_pso(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(issc_env%psi1_pso(ispin, idir), tmp_fm_struct)
             CALL cp_fm_create(issc_env%pso_psi0(ispin, idir), tmp_fm_struct)
-            CALL cp_fm_create(issc_env%psi1_dso(ispin, idir)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(issc_env%psi1_dso(ispin, idir), tmp_fm_struct)
             CALL cp_fm_create(issc_env%dso_psi0(ispin, idir), tmp_fm_struct)
          END DO
          CALL cp_fm_create(issc_env%psi1_fc(ispin), tmp_fm_struct)
@@ -1095,8 +1092,7 @@ CONTAINS
       IF (ASSOCIATED(issc_env%psi1_efg)) THEN
          DO idir = 1, SIZE(issc_env%psi1_efg, 2)
             DO ispin = 1, SIZE(issc_env%psi1_efg, 1)
-               CALL cp_fm_release(issc_env%psi1_efg(ispin, idir)%matrix)
-               DEALLOCATE (issc_env%psi1_efg(ispin, idir)%matrix)
+               CALL cp_fm_release(issc_env%psi1_efg(ispin, idir))
             END DO
          END DO
          DEALLOCATE (issc_env%psi1_efg)
@@ -1107,8 +1103,7 @@ CONTAINS
       IF (ASSOCIATED(issc_env%psi1_pso)) THEN
          DO idir = 1, SIZE(issc_env%psi1_pso, 2)
             DO ispin = 1, SIZE(issc_env%psi1_pso, 1)
-               CALL cp_fm_release(issc_env%psi1_pso(ispin, idir)%matrix)
-               DEALLOCATE (issc_env%psi1_pso(ispin, idir)%matrix)
+               CALL cp_fm_release(issc_env%psi1_pso(ispin, idir))
             END DO
          END DO
          DEALLOCATE (issc_env%psi1_pso)
@@ -1119,8 +1114,7 @@ CONTAINS
       IF (ASSOCIATED(issc_env%psi1_dso)) THEN
          DO idir = 1, SIZE(issc_env%psi1_dso, 2)
             DO ispin = 1, SIZE(issc_env%psi1_dso, 1)
-               CALL cp_fm_release(issc_env%psi1_dso(ispin, idir)%matrix)
-               DEALLOCATE (issc_env%psi1_dso(ispin, idir)%matrix)
+               CALL cp_fm_release(issc_env%psi1_dso(ispin, idir))
             END DO
          END DO
          DEALLOCATE (issc_env%psi1_dso)

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -112,11 +112,11 @@ CONTAINS
                                                             nmo, nspins, output_unit
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd, should_stop
       REAL(dp)                                           :: chk, fro
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, psi1_dso, psi1_efg, &
                                                             psi1_pso, pso_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0_order
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0, psi1_fc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -130,7 +130,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       !
       NULLIFY (dft_control, linres_control, lr_section, issc_section)
-      NULLIFY (logger, mpools, psi1, h1_psi0, mo_coeff, para_env)
+      NULLIFY (logger, mpools, psi1, mo_coeff, para_env)
       NULLIFY (tmp_fm_struct, psi1_fc, psi1_efg, psi1_pso, pso_psi0, fc_psi0, efg_psi0)
 
       logger => cp_get_default_logger()
@@ -176,13 +176,13 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
          psi0_order(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, ncol_global=nmo, nrow_global=nao)
-         NULLIFY (tmp_fm_struct, psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+         NULLIFY (tmp_fm_struct, psi1(ispin)%matrix)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                   ncol_global=nmo, &
                                   context=mo_coeff%matrix_struct%context)
-         ALLOCATE (psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+         ALLOCATE (psi1(ispin)%matrix)
          CALL cp_fm_create(psi1(ispin)%matrix, tmp_fm_struct)
-         CALL cp_fm_create(h1_psi0(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(h1_psi0(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
       chk = 0.0_dp
@@ -210,7 +210,7 @@ CONTAINS
             !
             !DO scf cycle to optimize psi1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(efg_psi0(ispin, ijdir)%matrix, h1_psi0(ispin)%matrix)
+               CALL cp_fm_to_fm(efg_psi0(ispin, ijdir)%matrix, h1_psi0(ispin))
             END DO
             !
             !
@@ -268,7 +268,7 @@ CONTAINS
             !
             !DO scf cycle to optimize psi1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(pso_psi0(ispin, idir)%matrix, h1_psi0(ispin)%matrix)
+               CALL cp_fm_to_fm(pso_psi0(ispin, idir)%matrix, h1_psi0(ispin))
             END DO
             !
             !
@@ -324,7 +324,7 @@ CONTAINS
          !
          !DO scf cycle to optimize psi1
          DO ispin = 1, nspins
-            CALL cp_fm_to_fm(fc_psi0(ispin), h1_psi0(ispin)%matrix)
+            CALL cp_fm_to_fm(fc_psi0(ispin), h1_psi0(ispin))
          END DO
          !
          !
@@ -382,7 +382,7 @@ CONTAINS
             !
             !DO scf cycle to optimize psi1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(dso_psi0(ispin, idir)%matrix, h1_psi0(ispin)%matrix)
+               CALL cp_fm_to_fm(dso_psi0(ispin, idir)%matrix, h1_psi0(ispin))
             END DO
             !
             !
@@ -432,8 +432,8 @@ CONTAINS
       ! clean up
       DO ispin = 1, nspins
          CALL cp_fm_release(psi1(ispin)%matrix)
-         CALL cp_fm_release(h1_psi0(ispin)%matrix)
-         DEALLOCATE (psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+         CALL cp_fm_release(h1_psi0(ispin))
+         DEALLOCATE (psi1(ispin)%matrix)
       END DO
       DEALLOCATE (psi1, h1_psi0, psi0_order)
       !

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -112,11 +112,12 @@ CONTAINS
                                                             nmo, nspins, output_unit
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd, should_stop
       REAL(dp)                                           :: chk, fro
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fc_psi0, h1_psi0, psi1, psi1_fc
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1, psi1_fc
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, psi1_dso, psi1_efg, &
                                                             psi1_pso, pso_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0_order
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -323,7 +324,7 @@ CONTAINS
          !
          !DO scf cycle to optimize psi1
          DO ispin = 1, nspins
-            CALL cp_fm_to_fm(fc_psi0(ispin)%matrix, h1_psi0(ispin)%matrix)
+            CALL cp_fm_to_fm(fc_psi0(ispin), h1_psi0(ispin)%matrix)
          END DO
          !
          !
@@ -466,8 +467,9 @@ CONTAINS
       REAL(dp), DIMENSION(3)                             :: r_i, r_j
       REAL(dp), DIMENSION(:, :, :, :, :), POINTER        :: issc
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fc_psi0, psi1_fc
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1_fc
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_dso, psi1_efg, psi1_pso
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_dso, matrix_efg, matrix_fc, &
                                                             matrix_pso
@@ -541,13 +543,13 @@ CONTAINS
                CALL dbcsr_set(matrix_fc(1)%matrix, 0.0_dp)
                CALL build_fermi_contact_matrix(qs_env, matrix_fc, r_j)
                CALL cp_dbcsr_sm_fm_multiply(matrix_fc(1)%matrix, mo_coeff, &
-                                      fc_psi0(ispin)%matrix, ncol=nmo,& ! fc_psi0 a buffer
+                                      fc_psi0(ispin), ncol=nmo,& ! fc_psi0 a buffer
                     &                 alpha=1.0_dp)
 
-               CALL cp_fm_trace(fc_psi0(ispin)%matrix, mo_coeff, buf)
+               CALL cp_fm_trace(fc_psi0(ispin), mo_coeff, buf)
                WRITE (*, *) ' jatom', jatom, 'tr(P*fc)=', buf
 
-               CALL cp_fm_trace(fc_psi0(ispin)%matrix, psi1_fc(ispin)%matrix, buf)
+               CALL cp_fm_trace(fc_psi0(ispin), psi1_fc(ispin)%matrix, buf)
                issc_fc = 2.0_dp*2.0_dp*maxocc*facfc*buf
                issc(1, 1, iatom, jatom, 1) = issc(1, 1, iatom, jatom, 1) + issc_fc
                issc(2, 2, iatom, jatom, 1) = issc(2, 2, iatom, jatom, 1) + issc_fc
@@ -568,12 +570,12 @@ CONTAINS
                CALL build_efg_matrix(qs_env, matrix_efg, r_j)
                DO ixyz = 1, 6
                   CALL cp_dbcsr_sm_fm_multiply(matrix_efg(ixyz)%matrix, mo_coeff, &
-                                         fc_psi0(ispin)%matrix, ncol=nmo,& ! fc_psi0 a buffer
+                                         fc_psi0(ispin), ncol=nmo,& ! fc_psi0 a buffer
                        &                 alpha=1.0_dp, beta=0.0_dp)
-                  CALL cp_fm_trace(fc_psi0(ispin)%matrix, mo_coeff, buf)
+                  CALL cp_fm_trace(fc_psi0(ispin), mo_coeff, buf)
                   WRITE (*, *) ' jatom', jatom, ixyz, 'tr(P*efg)=', buf
                   DO jxyz = 1, 6
-                     CALL cp_fm_trace(fc_psi0(ispin)%matrix, psi1_efg(ispin, jxyz)%matrix, buf)
+                     CALL cp_fm_trace(fc_psi0(ispin), psi1_efg(ispin, jxyz)%matrix, buf)
                      issc_sd = 2.0_dp*maxocc*facsd*buf
                      !issc(ixyz,jxyz,iatom,jatom) = issc_sd
                      !write(*,*) 'pso_',ixyz,jxyz,' iatom',iatom,'jatom',jatom,issc_pso
@@ -592,10 +594,10 @@ CONTAINS
                CALL build_pso_matrix(qs_env, matrix_pso, r_j)
                DO ixyz = 1, 3
                   CALL cp_dbcsr_sm_fm_multiply(matrix_pso(ixyz)%matrix, mo_coeff, &
-                                         fc_psi0(ispin)%matrix, ncol=nmo,& ! fc_psi0 a buffer
+                                         fc_psi0(ispin), ncol=nmo,& ! fc_psi0 a buffer
                        &                 alpha=1.0_dp, beta=0.0_dp)
                   DO jxyz = 1, 3
-                     CALL cp_fm_trace(fc_psi0(ispin)%matrix, psi1_pso(ispin, jxyz)%matrix, buf)
+                     CALL cp_fm_trace(fc_psi0(ispin), psi1_pso(ispin, jxyz)%matrix, buf)
                      issc_pso = -2.0_dp*maxocc*facpso*buf
                      issc(ixyz, jxyz, iatom, jatom, 3) = issc(ixyz, jxyz, iatom, jatom, 3) + issc_pso
                   END DO
@@ -617,9 +619,9 @@ CONTAINS
                !CALL build_dso_matrix(qs_env,matrix_dso,r_i,r_j)
                !DO ixyz = 1,6
                !   CALL cp_sm_fm_multiply(matrix_dso(ixyz)%matrix,mo_coeff,&
-               !        &                 fc_psi0(ispin)%matrix,ncol=nmo,& ! fc_psi0 a buffer
+               !        &                 fc_psi0(ispin),ncol=nmo,& ! fc_psi0 a buffer
                !        &                 alpha=1.0_dp,beta=0.0_dp)
-               !   CALL cp_fm_trace(fc_psi0(ispin)%matrix,mo_coeff,buf)
+               !   CALL cp_fm_trace(fc_psi0(ispin),mo_coeff,buf)
                !   issc_dso = 2.0_dp * maxocc * facdso * buf
                !   issc(ixyz,jxyz,iatom,jatom,4) = issc_dso
                !ENDDO
@@ -629,10 +631,10 @@ CONTAINS
                !CALL rRc_xyz_ao(matrix_dso,qs_env,(/0.0_dp,0.0_dp,0.0_dp/),1)
                DO ixyz = 1, 3
                   CALL cp_dbcsr_sm_fm_multiply(matrix_dso(ixyz)%matrix, mo_coeff, &
-                                         fc_psi0(ispin)%matrix, ncol=nmo,& ! fc_psi0 a buffer
+                                         fc_psi0(ispin), ncol=nmo,& ! fc_psi0 a buffer
                        &                 alpha=1.0_dp, beta=0.0_dp)
                   DO jxyz = 1, 3
-                     CALL cp_fm_trace(psi1_dso(ispin, jxyz)%matrix, fc_psi0(ispin)%matrix, buf)
+                     CALL cp_fm_trace(psi1_dso(ispin, jxyz)%matrix, fc_psi0(ispin), buf)
                      ! we save the polarizability for a checksum later on !
                      issc_dso = 2.0_dp*maxocc*buf
                      issc(ixyz, jxyz, iatom, jatom, 4) = issc(ixyz, jxyz, iatom, jatom, 4) + issc_dso
@@ -929,9 +931,9 @@ CONTAINS
             CALL cp_fm_create(issc_env%psi1_dso(ispin, idir)%matrix, tmp_fm_struct)
             CALL cp_fm_create(issc_env%dso_psi0(ispin, idir)%matrix, tmp_fm_struct)
          END DO
-         ALLOCATE (issc_env%psi1_fc(ispin)%matrix, issc_env%fc_psi0(ispin)%matrix)
+         ALLOCATE (issc_env%psi1_fc(ispin)%matrix)
          CALL cp_fm_create(issc_env%psi1_fc(ispin)%matrix, tmp_fm_struct)
-         CALL cp_fm_create(issc_env%fc_psi0(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(issc_env%fc_psi0(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
       !
@@ -1092,8 +1094,7 @@ CONTAINS
       !fc_psi0
       IF (ASSOCIATED(issc_env%fc_psi0)) THEN
          DO ispin = 1, SIZE(issc_env%fc_psi0, 1)
-            CALL cp_fm_release(issc_env%fc_psi0(ispin)%matrix)
-            DEALLOCATE (issc_env%fc_psi0(ispin)%matrix)
+            CALL cp_fm_release(issc_env%fc_psi0(ispin))
          END DO
          DEALLOCATE (issc_env%fc_psi0)
          NULLIFY (issc_env%fc_psi0)

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -112,12 +112,12 @@ CONTAINS
                                                             nmo, nspins, output_unit
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd, should_stop
       REAL(dp)                                           :: chk, fro
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1, psi1_fc
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, psi1_dso, psi1_efg, &
                                                             psi1_pso, pso_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0_order
-      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0, psi1_fc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -309,7 +309,7 @@ CONTAINS
       ! operator fc
       IF (do_fc) THEN
          DO ispin = 1, nspins
-            CALL cp_fm_set_all(psi1_fc(ispin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(psi1_fc(ispin), 0.0_dp)
          END DO
          IF (output_unit > 0) THEN
             WRITE (output_unit, "(T10,A)") "Response to the perturbation operator fc"
@@ -336,7 +336,7 @@ CONTAINS
          !
          ! copy the response
          DO ispin = 1, nspins
-            CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_fc(ispin)%matrix)
+            CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_fc(ispin))
             fro = cp_fm_frobenius_norm(psi1(ispin)%matrix)
             chk = chk + fro
          END DO
@@ -467,9 +467,8 @@ CONTAINS
       REAL(dp), DIMENSION(3)                             :: r_i, r_j
       REAL(dp), DIMENSION(:, :, :, :, :), POINTER        :: issc
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1_fc
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: psi1_dso, psi1_efg, psi1_pso
-      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0, psi1_fc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_dso, matrix_efg, matrix_fc, &
                                                             matrix_pso
@@ -549,7 +548,7 @@ CONTAINS
                CALL cp_fm_trace(fc_psi0(ispin), mo_coeff, buf)
                WRITE (*, *) ' jatom', jatom, 'tr(P*fc)=', buf
 
-               CALL cp_fm_trace(fc_psi0(ispin), psi1_fc(ispin)%matrix, buf)
+               CALL cp_fm_trace(fc_psi0(ispin), psi1_fc(ispin), buf)
                issc_fc = 2.0_dp*2.0_dp*maxocc*facfc*buf
                issc(1, 1, iatom, jatom, 1) = issc(1, 1, iatom, jatom, 1) + issc_fc
                issc(2, 2, iatom, jatom, 1) = issc(2, 2, iatom, jatom, 1) + issc_fc
@@ -931,8 +930,7 @@ CONTAINS
             CALL cp_fm_create(issc_env%psi1_dso(ispin, idir)%matrix, tmp_fm_struct)
             CALL cp_fm_create(issc_env%dso_psi0(ispin, idir)%matrix, tmp_fm_struct)
          END DO
-         ALLOCATE (issc_env%psi1_fc(ispin)%matrix)
-         CALL cp_fm_create(issc_env%psi1_fc(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(issc_env%psi1_fc(ispin), tmp_fm_struct)
          CALL cp_fm_create(issc_env%fc_psi0(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
@@ -1139,8 +1137,7 @@ CONTAINS
       !psi1_fc
       IF (ASSOCIATED(issc_env%psi1_fc)) THEN
          DO ispin = 1, SIZE(issc_env%psi1_fc, 1)
-            CALL cp_fm_release(issc_env%psi1_fc(ispin)%matrix)
-            DEALLOCATE (issc_env%psi1_fc(ispin)%matrix)
+            CALL cp_fm_release(issc_env%psi1_fc(ispin))
          END DO
          DEALLOCATE (issc_env%psi1_fc)
          NULLIFY (issc_env%psi1_fc)

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -112,11 +112,11 @@ CONTAINS
                                                             nmo, nspins, output_unit
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd, should_stop
       REAL(dp)                                           :: chk, fro
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fc_psi0, h1_psi0, psi0_order, psi1, &
-                                                            psi1_fc
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fc_psi0, h1_psi0, psi1, psi1_fc
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, psi1_dso, psi1_efg, &
                                                             psi1_pso, pso_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -130,7 +130,7 @@ CONTAINS
       !
       NULLIFY (dft_control, linres_control, lr_section, issc_section)
       NULLIFY (logger, mpools, psi1, h1_psi0, mo_coeff, para_env)
-      NULLIFY (tmp_fm_struct, psi1_fc, psi1_efg, psi1_pso, pso_psi0, fc_psi0, efg_psi0, psi0_order)
+      NULLIFY (tmp_fm_struct, psi1_fc, psi1_efg, psi1_pso, pso_psi0, fc_psi0, efg_psi0)
 
       logger => cp_get_default_logger()
       lr_section => section_vals_get_subs_vals(qs_env%input, "PROPERTIES%LINRES")
@@ -173,7 +173,7 @@ CONTAINS
       ALLOCATE (psi1(nspins), h1_psi0(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-         psi0_order(ispin)%matrix => mo_coeff
+         psi0_order(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, ncol_global=nmo, nrow_global=nao)
          NULLIFY (tmp_fm_struct, psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -112,11 +112,10 @@ CONTAINS
                                                             nmo, nspins, output_unit
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd, should_stop
       REAL(dp)                                           :: chk, fro
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, psi1_dso, psi1_efg, &
                                                             psi1_pso, pso_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order, psi1
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0, psi1_fc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -130,7 +129,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       !
       NULLIFY (dft_control, linres_control, lr_section, issc_section)
-      NULLIFY (logger, mpools, psi1, mo_coeff, para_env)
+      NULLIFY (logger, mpools, mo_coeff, para_env)
       NULLIFY (tmp_fm_struct, psi1_fc, psi1_efg, psi1_pso, pso_psi0, fc_psi0, efg_psi0)
 
       logger => cp_get_default_logger()
@@ -176,12 +175,11 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
          psi0_order(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, ncol_global=nmo, nrow_global=nao)
-         NULLIFY (tmp_fm_struct, psi1(ispin)%matrix)
+         NULLIFY (tmp_fm_struct)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                   ncol_global=nmo, &
                                   context=mo_coeff%matrix_struct%context)
-         ALLOCATE (psi1(ispin)%matrix)
-         CALL cp_fm_create(psi1(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(psi1(ispin), tmp_fm_struct)
          CALL cp_fm_create(h1_psi0(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
@@ -203,9 +201,9 @@ CONTAINS
             !
             !Initial guess for psi1
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
-               !CALL cp_fm_to_fm(p_psi0(ispin,ijdir)%matrix, psi1(ispin)%matrix)
-               !CALL cp_fm_scale(-1.0_dp,psi1(ispin)%matrix)
+               CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
+               !CALL cp_fm_to_fm(p_psi0(ispin,ijdir)%matrix, psi1(ispin))
+               !CALL cp_fm_scale(-1.0_dp,psi1(ispin))
             END DO
             !
             !DO scf cycle to optimize psi1
@@ -222,8 +220,8 @@ CONTAINS
             !
             ! copy the response
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_efg(ispin, ijdir)%matrix)
-               fro = cp_fm_frobenius_norm(psi1(ispin)%matrix)
+               CALL cp_fm_to_fm(psi1(ispin), psi1_efg(ispin, ijdir)%matrix)
+               fro = cp_fm_frobenius_norm(psi1(ispin))
                chk = chk + fro
             END DO
             !
@@ -233,7 +231,7 @@ CONTAINS
             !   ncubes = SIZE(list_cubes,1)
             !   print_key => section_vals_get_subs_vals(issc_section,"PRINT%RESPONSE_FUNCTION_CUBES")
             !   DO ispin = 1,nspins
-            !      CALL qs_print_cubes(qs_env,psi1(ispin)%matrix,ncubes,list_cubes,&
+            !      CALL qs_print_cubes(qs_env,psi1(ispin),ncubes,list_cubes,&
             !            centers_set(ispin)%array,print_key,'psi1_efg',&
             !            idir=ijdir,ispin=ispin)
             !   ENDDO ! ispin
@@ -261,9 +259,9 @@ CONTAINS
             !
             !Initial guess for psi1
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
-               !CALL cp_fm_to_fm(rxp_psi0(ispin,idir)%matrix, psi1(ispin)%matrix)
-               !CALL cp_fm_scale(-1.0_dp,psi1(ispin)%matrix)
+               CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
+               !CALL cp_fm_to_fm(rxp_psi0(ispin,idir)%matrix, psi1(ispin))
+               !CALL cp_fm_scale(-1.0_dp,psi1(ispin))
             END DO
             !
             !DO scf cycle to optimize psi1
@@ -280,8 +278,8 @@ CONTAINS
             !
             ! copy the response
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_pso(ispin, idir)%matrix)
-               fro = cp_fm_frobenius_norm(psi1(ispin)%matrix)
+               CALL cp_fm_to_fm(psi1(ispin), psi1_pso(ispin, idir)%matrix)
+               fro = cp_fm_frobenius_norm(psi1(ispin))
                chk = chk + fro
             END DO
             !
@@ -291,7 +289,7 @@ CONTAINS
             !   ncubes = SIZE(list_cubes,1)
             !   print_key => section_vals_get_subs_vals(issc_section,"PRINT%RESPONSE_FUNCTION_CUBES")
             !   DO ispin = 1,nspins
-            !      CALL qs_print_cubes(qs_env,psi1(ispin)%matrix,ncubes,list_cubes,&
+            !      CALL qs_print_cubes(qs_env,psi1(ispin),ncubes,list_cubes,&
             !           centers_set(ispin)%array,print_key,'psi1_pso',&
             !           idir=idir,ispin=ispin)
             !   ENDDO ! ispin
@@ -317,9 +315,9 @@ CONTAINS
          !
          !Initial guess for psi1
          DO ispin = 1, nspins
-            CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
-            !CALL cp_fm_to_fm(rxp_psi0(ispin,idir)%matrix, psi1(ispin)%matrix)
-            !CALL cp_fm_scale(-1.0_dp,psi1(ispin)%matrix)
+            CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
+            !CALL cp_fm_to_fm(rxp_psi0(ispin,idir)%matrix, psi1(ispin))
+            !CALL cp_fm_scale(-1.0_dp,psi1(ispin))
          END DO
          !
          !DO scf cycle to optimize psi1
@@ -336,8 +334,8 @@ CONTAINS
          !
          ! copy the response
          DO ispin = 1, nspins
-            CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_fc(ispin))
-            fro = cp_fm_frobenius_norm(psi1(ispin)%matrix)
+            CALL cp_fm_to_fm(psi1(ispin), psi1_fc(ispin))
+            fro = cp_fm_frobenius_norm(psi1(ispin))
             chk = chk + fro
          END DO
          !
@@ -347,7 +345,7 @@ CONTAINS
          !   ncubes = SIZE(list_cubes,1)
          !   print_key => section_vals_get_subs_vals(issc_section,"PRINT%RESPONSE_FUNCTION_CUBES")
          !   DO ispin = 1,nspins
-         !      CALL qs_print_cubes(qs_env,psi1(ispin)%matrix,ncubes,list_cubes,&
+         !      CALL qs_print_cubes(qs_env,psi1(ispin),ncubes,list_cubes,&
          !           centers_set(ispin)%array,print_key,'psi1_pso',&
          !           idir=idir,ispin=ispin)
          !   ENDDO ! ispin
@@ -375,9 +373,9 @@ CONTAINS
             !
             !Initial guess for psi1
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
-               !CALL cp_fm_to_fm(rxp_psi0(ispin,idir)%matrix, psi1(ispin)%matrix)
-               !CALL cp_fm_scale(-1.0_dp,psi1(ispin)%matrix)
+               CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
+               !CALL cp_fm_to_fm(rxp_psi0(ispin,idir)%matrix, psi1(ispin))
+               !CALL cp_fm_scale(-1.0_dp,psi1(ispin))
             END DO
             !
             !DO scf cycle to optimize psi1
@@ -394,8 +392,8 @@ CONTAINS
             !
             ! copy the response
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_dso(ispin, idir)%matrix)
-               fro = cp_fm_frobenius_norm(psi1(ispin)%matrix)
+               CALL cp_fm_to_fm(psi1(ispin), psi1_dso(ispin, idir)%matrix)
+               fro = cp_fm_frobenius_norm(psi1(ispin))
                chk = chk + fro
             END DO
             !
@@ -405,7 +403,7 @@ CONTAINS
             !   ncubes = SIZE(list_cubes,1)
             !   print_key => section_vals_get_subs_vals(issc_section,"PRINT%RESPONSE_FUNCTION_CUBES")
             !   DO ispin = 1,nspins
-            !      CALL qs_print_cubes(qs_env,psi1(ispin)%matrix,ncubes,list_cubes,&
+            !      CALL qs_print_cubes(qs_env,psi1(ispin),ncubes,list_cubes,&
             !           centers_set(ispin)%array,print_key,'psi1_pso',&
             !           idir=idir,ispin=ispin)
             !   ENDDO ! ispin
@@ -431,9 +429,8 @@ CONTAINS
       !
       ! clean up
       DO ispin = 1, nspins
-         CALL cp_fm_release(psi1(ispin)%matrix)
+         CALL cp_fm_release(psi1(ispin))
          CALL cp_fm_release(h1_psi0(ispin))
-         DEALLOCATE (psi1(ispin)%matrix)
       END DO
       DEALLOCATE (psi1, h1_psi0, psi0_order)
       !

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -21,7 +21,6 @@ MODULE qs_linres_kernel
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type,&
@@ -140,8 +139,7 @@ CONTAINS
       !
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: Av
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0, Av
 
       INTEGER                                            :: ispin, ncol
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -164,7 +162,7 @@ CONTAINS
          CALL cp_fm_get_info(c0(ispin), ncol_global=ncol)
          CALL cp_dbcsr_sm_fm_multiply(p_env%kpp1(ispin)%matrix, &
                                       c0(ispin), &
-                                      Av(ispin)%matrix, &
+                                      Av(ispin), &
                                       ncol=ncol, alpha=1.0_dp, beta=1.0_dp)
       END DO
 

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -21,7 +21,8 @@ MODULE qs_linres_kernel
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
-                                              cp_fm_p_type
+                                              cp_fm_p_type,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type,&
                                               cp_to_string
@@ -139,7 +140,8 @@ CONTAINS
       !
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: c0, Av
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: Av
 
       INTEGER                                            :: ispin, ncol
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -159,9 +161,9 @@ CONTAINS
       END IF
 
       DO ispin = 1, SIZE(c0)
-         CALL cp_fm_get_info(c0(ispin)%matrix, ncol_global=ncol)
+         CALL cp_fm_get_info(c0(ispin), ncol_global=ncol)
          CALL cp_dbcsr_sm_fm_multiply(p_env%kpp1(ispin)%matrix, &
-                                      c0(ispin)%matrix, &
+                                      c0(ispin), &
                                       Av(ispin)%matrix, &
                                       ncol=ncol, alpha=1.0_dp, beta=1.0_dp)
       END DO

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -217,7 +217,8 @@ CONTAINS
    SUBROUTINE linres_solver(p_env, qs_env, psi1, h1_psi0, psi0_order, iounit, should_stop)
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: psi1, h1_psi0, psi0_order
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: psi1, h1_psi0
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: psi0_order
       INTEGER, INTENT(IN)                                :: iounit
       LOGICAL, INTENT(OUT)                               :: should_stop
 
@@ -263,7 +264,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL get_mo_set(mos(ispin), nmo=ncol)
          maxnmo = MAX(maxnmo, ncol)
-         CALL cp_fm_get_info(psi0_order(ispin)%matrix, ncol_global=ncol)
+         CALL cp_fm_get_info(psi0_order(ispin), ncol_global=ncol)
          maxnmo_o = MAX(maxnmo_o, ncol)
       END DO
       !
@@ -302,12 +303,13 @@ CONTAINS
       DO ispin = 1, nspins
          !
          ! C0_order' * H * C0_order
-         mo_coeff => psi0_order(ispin)%matrix
-         CALL cp_fm_create(buf, mo_coeff%matrix_struct)
-         CALL cp_fm_get_info(mo_coeff, ncol_global=ncol)
-         CALL cp_dbcsr_sm_fm_multiply(matrix_ks(ispin)%matrix, mo_coeff, buf, ncol)
-         CALL parallel_gemm('T', 'N', ncol, ncol, nao, -1.0_dp, mo_coeff, buf, 0.0_dp, chc(ispin)%matrix)
-         CALL cp_fm_release(buf)
+         ASSOCIATE (mo_coeff => psi0_order(ispin))
+            CALL cp_fm_create(buf, mo_coeff%matrix_struct)
+            CALL cp_fm_get_info(mo_coeff, ncol_global=ncol)
+            CALL cp_dbcsr_sm_fm_multiply(matrix_ks(ispin)%matrix, mo_coeff, buf, ncol)
+            CALL parallel_gemm('T', 'N', ncol, ncol, nao, -1.0_dp, mo_coeff, buf, 0.0_dp, chc(ispin)%matrix)
+            CALL cp_fm_release(buf)
+         END ASSOCIATE
          !
          ! S * C0
          CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
@@ -569,7 +571,8 @@ CONTAINS
       !
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: c0, v, Av, chc
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: v, Av, chc
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'apply_op'
 

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -26,7 +26,6 @@ MODULE qs_linres_methods
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_get_submatrix,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_submatrix,&
                                               cp_fm_to_fm,&
@@ -227,10 +226,9 @@ CONTAINS
       LOGICAL                                            :: restart
       REAL(dp)                                           :: alpha, beta, norm_res, t1, t2
       REAL(dp), DIMENSION(:), POINTER                    :: tr_pAp, tr_rz0, tr_rz00, tr_rz1
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: Ap, r
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: buf
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: chc, mo_coeff_array, p, z
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: Ap, chc, mo_coeff_array, p, r, z
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: Sc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -278,11 +276,10 @@ CONTAINS
       END DO
       !
       DO ispin = 1, nspins
-         ALLOCATE (r(ispin)%matrix, Ap(ispin)%matrix)
-         CALL cp_fm_create(r(ispin)%matrix, psi1(ispin)%matrix_struct)
+         CALL cp_fm_create(r(ispin), psi1(ispin)%matrix_struct)
          CALL cp_fm_create(p(ispin), psi1(ispin)%matrix_struct)
          CALL cp_fm_create(z(ispin), psi1(ispin)%matrix_struct)
-         CALL cp_fm_create(Ap(ispin)%matrix, psi1(ispin)%matrix_struct)
+         CALL cp_fm_create(Ap(ispin), psi1(ispin)%matrix_struct)
       END DO
       !
       ! compute S*C0, C0_order'*H*C0_order (this should be done once for all)
@@ -354,8 +351,8 @@ CONTAINS
       !
       ! r_0 = b - Ax0
       DO ispin = 1, nspins
-         CALL cp_fm_to_fm(h1_psi0(ispin), r(ispin)%matrix)
-         CALL cp_fm_scale_and_add(-1.0_dp, r(ispin)%matrix, -1.0_dp, Ap(ispin)%matrix)
+         CALL cp_fm_to_fm(h1_psi0(ispin), r(ispin))
+         CALL cp_fm_scale_and_add(-1.0_dp, r(ispin), -1.0_dp, Ap(ispin))
       END DO
       !
       ! proj r
@@ -367,14 +364,14 @@ CONTAINS
          !
          ! z_0 = r_0
          DO ispin = 1, nspins
-            CALL cp_fm_to_fm(r(ispin)%matrix, z(ispin))
+            CALL cp_fm_to_fm(r(ispin), z(ispin))
          END DO
          linres_control%flag = "CG"
       ELSE
          !
          ! z_0 = M * r_0
          DO ispin = 1, nspins
-            CALL apply_preconditioner(p_env%preconditioner(ispin), r(ispin)%matrix, &
+            CALL apply_preconditioner(p_env%preconditioner(ispin), r(ispin), &
                                       z(ispin))
          END DO
          linres_control%flag = "PCG"
@@ -386,7 +383,7 @@ CONTAINS
          CALL cp_fm_to_fm(z(ispin), p(ispin))
          !
          ! trace(r_0 * z_0)
-         CALL cp_fm_trace(r(ispin)%matrix, z(ispin), tr_rz0(ispin))
+         CALL cp_fm_trace(r(ispin), z(ispin), tr_rz0(ispin))
       END DO
       IF (SUM(tr_rz0) < 0.0_dp) CPABORT("tr(r_j*z_j) < 0")
       norm_res = ABS(SUM(tr_rz0))/SQRT(REAL(nspins*nao*maxnmo_o, dp))
@@ -445,7 +442,7 @@ CONTAINS
          DO ispin = 1, nspins
             !
             ! tr(Ap_j*p_j)
-            CALL cp_fm_trace(Ap(ispin)%matrix, p(ispin), tr_pAp(ispin))
+            CALL cp_fm_trace(Ap(ispin), p(ispin), tr_pAp(ispin))
          END DO
          !
          ! alpha = tr(r_j*z_j) / tr(Ap_j*p_j)
@@ -469,8 +466,8 @@ CONTAINS
             !
             DO ispin = 1, nspins
                CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
-               CALL cp_fm_to_fm(h1_psi0(ispin), r(ispin)%matrix)
-               CALL cp_fm_scale_and_add(-1.0_dp, r(ispin)%matrix, -1.0_dp, Ap(ispin)%matrix)
+               CALL cp_fm_to_fm(h1_psi0(ispin), r(ispin))
+               CALL cp_fm_scale_and_add(-1.0_dp, r(ispin), -1.0_dp, Ap(ispin))
             END DO
             CALL postortho(r, mo_coeff_array, Sc)
             !
@@ -481,7 +478,7 @@ CONTAINS
             !
             ! r_j+1 = r_j - alpha * Ap_j
             DO ispin = 1, nspins
-               CALL cp_fm_scale_and_add(1.0_dp, r(ispin)%matrix, -alpha, Ap(ispin)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, r(ispin), -alpha, Ap(ispin))
             END DO
             restart = .FALSE.
          END IF
@@ -492,14 +489,14 @@ CONTAINS
             !
             ! z_j+1 = r_j+1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(r(ispin)%matrix, z(ispin))
+               CALL cp_fm_to_fm(r(ispin), z(ispin))
             END DO
             linres_control%flag = "CG"
          ELSE
             !
             ! z_j+1 = M * r_j+1
             DO ispin = 1, nspins
-               CALL apply_preconditioner(p_env%preconditioner(ispin), r(ispin)%matrix, &
+               CALL apply_preconditioner(p_env%preconditioner(ispin), r(ispin), &
                                          z(ispin))
             END DO
             linres_control%flag = "PCG"
@@ -508,7 +505,7 @@ CONTAINS
          DO ispin = 1, nspins
             !
             ! tr(r_j+1*z_j+1)
-            CALL cp_fm_trace(r(ispin)%matrix, z(ispin), tr_rz1(ispin))
+            CALL cp_fm_trace(r(ispin), z(ispin), tr_rz1(ispin))
          END DO
          IF (SUM(tr_rz1) < 0.0_dp) CPABORT("tr(r_j+1*z_j+1) < 0")
          norm_res = SUM(tr_rz1)/SQRT(REAL(nspins*nao*maxnmo_o, dp))
@@ -539,14 +536,13 @@ CONTAINS
       !
       ! clean up
       DO ispin = 1, nspins
-         CALL cp_fm_release(r(ispin)%matrix)
+         CALL cp_fm_release(r(ispin))
          CALL cp_fm_release(p(ispin))
          CALL cp_fm_release(z(ispin))
-         CALL cp_fm_release(Ap(ispin)%matrix)
+         CALL cp_fm_release(Ap(ispin))
          !
          CALL cp_fm_release(Sc(ispin))
          CALL cp_fm_release(chc(ispin))
-         DEALLOCATE (r(ispin)%matrix, Ap(ispin)%matrix)
       END DO
       DEALLOCATE (tr_pAp, tr_rz0, tr_rz00, tr_rz1, r, p, z, Ap, Sc, chc, mo_coeff_array)
       !
@@ -567,9 +563,7 @@ CONTAINS
       !
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0, v
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: Av
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: chc
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0, v, Av, chc
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'apply_op'
 
@@ -593,7 +587,7 @@ CONTAINS
 
       ! apply the uncoupled operator
       DO ispin = 1, nspins
-         CALL apply_op_1(v(ispin), Av(ispin)%matrix, matrix_ks(ispin)%matrix, &
+         CALL apply_op_1(v(ispin), Av(ispin), matrix_ks(ispin)%matrix, &
                          matrix_s(1)%matrix, chc(ispin))
       END DO
 
@@ -740,8 +734,7 @@ CONTAINS
    SUBROUTINE postortho(v, psi0, S_psi0)
       !v = (I-SP)v
       !
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: v
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: psi0, S_psi0
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: v, psi0, S_psi0
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'postortho'
 
@@ -757,12 +750,12 @@ CONTAINS
       nspins = SIZE(v, 1)
       !
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(v(ispin)%matrix, ncol_global=mv, nrow_global=nv)
+         CALL cp_fm_get_info(v(ispin), ncol_global=mv, nrow_global=nv)
          CALL cp_fm_get_info(psi0(ispin), ncol_global=mp, nrow_global=np)
          !
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nv, ncol_global=mp, &
-                                  para_env=v(ispin)%matrix%matrix_struct%para_env, &
-                                  context=v(ispin)%matrix%matrix_struct%context)
+                                  para_env=v(ispin)%matrix_struct%para_env, &
+                                  context=v(ispin)%matrix_struct%context)
          CALL cp_fm_create(buf, tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
          !
@@ -773,9 +766,9 @@ CONTAINS
          CPASSERT(nt == nv)
          !
          ! buf = v' * psi0
-         CALL parallel_gemm('T', 'N', mv, mp, nv, 1.0_dp, v(ispin)%matrix, psi0(ispin), 0.0_dp, buf)
+         CALL parallel_gemm('T', 'N', mv, mp, nv, 1.0_dp, v(ispin), psi0(ispin), 0.0_dp, buf)
          ! v = v - S_psi0 * buf'
-         CALL parallel_gemm('N', 'T', nv, mv, mp, -1.0_dp, S_psi0(ispin), buf, 1.0_dp, v(ispin)%matrix)
+         CALL parallel_gemm('N', 'T', nv, mv, mp, -1.0_dp, S_psi0(ispin), buf, 1.0_dp, v(ispin))
          !
          CALL cp_fm_release(buf)
       END DO

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -123,7 +123,7 @@ CONTAINS
 
       INTEGER                                            :: iounit, ispin, istate, nmoloc(2)
       LOGICAL                                            :: my_centers_only
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mos_localized
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mos_localized
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(localized_wfn_control_type), POINTER          :: localized_wfn_control
@@ -142,7 +142,7 @@ CONTAINS
       my_centers_only = .FALSE.
       IF (PRESENT(centers_only)) my_centers_only = centers_only
 
-      NULLIFY (mos, mo_coeff, qs_loc_env, mos_localized)
+      NULLIFY (mos, mo_coeff, qs_loc_env)
       CALL get_qs_env(qs_env=qs_env, mos=mos)
       ALLOCATE (qs_loc_env)
       CALL qs_loc_env_create(qs_loc_env)
@@ -153,9 +153,8 @@ CONTAINS
       ALLOCATE (mos_localized(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-         ALLOCATE (mos_localized(ispin)%matrix)
-         CALL cp_fm_create(mos_localized(ispin)%matrix, mo_coeff%matrix_struct)
-         CALL cp_fm_to_fm(mo_coeff, mos_localized(ispin)%matrix)
+         CALL cp_fm_create(mos_localized(ispin), mo_coeff%matrix_struct)
+         CALL cp_fm_to_fm(mo_coeff, mos_localized(ispin))
       END DO
 
       nmoloc(1:2) = 0
@@ -171,9 +170,9 @@ CONTAINS
       ! The orbital centers are stored in linres_control%localized_wfn_control
       DO ispin = 1, nspins
          CALL qs_loc_driver(qs_env, qs_loc_env, loc_print_section, myspin=ispin, &
-                            ext_mo_coeff=mos_localized(ispin)%matrix)
+                            ext_mo_coeff=mos_localized(ispin))
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-         CALL cp_fm_to_fm(mos_localized(ispin)%matrix, mo_coeff)
+         CALL cp_fm_to_fm(mos_localized(ispin), mo_coeff)
       END DO
 
       CALL loc_write_restart(qs_loc_env, loc_print_section, mos, &

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -216,8 +216,8 @@ CONTAINS
    SUBROUTINE linres_solver(p_env, qs_env, psi1, h1_psi0, psi0_order, iounit, should_stop)
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: psi1, h1_psi0
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: psi0_order
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: psi1
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: h1_psi0, psi0_order
       INTEGER, INTENT(IN)                                :: iounit
       LOGICAL, INTENT(OUT)                               :: should_stop
 
@@ -356,7 +356,7 @@ CONTAINS
       !
       ! r_0 = b - Ax0
       DO ispin = 1, nspins
-         CALL cp_fm_to_fm(h1_psi0(ispin)%matrix, r(ispin)%matrix)
+         CALL cp_fm_to_fm(h1_psi0(ispin), r(ispin)%matrix)
          CALL cp_fm_scale_and_add(-1.0_dp, r(ispin)%matrix, -1.0_dp, Ap(ispin)%matrix)
       END DO
       !
@@ -471,7 +471,7 @@ CONTAINS
             !
             DO ispin = 1, nspins
                CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
-               CALL cp_fm_to_fm(h1_psi0(ispin)%matrix, r(ispin)%matrix)
+               CALL cp_fm_to_fm(h1_psi0(ispin), r(ispin)%matrix)
                CALL cp_fm_scale_and_add(-1.0_dp, r(ispin)%matrix, -1.0_dp, Ap(ispin)%matrix)
             END DO
             CALL postortho(r, mo_coeff_array, Sc)

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -227,10 +227,10 @@ CONTAINS
       LOGICAL                                            :: restart
       REAL(dp)                                           :: alpha, beta, norm_res, t1, t2
       REAL(dp), DIMENSION(:), POINTER                    :: tr_pAp, tr_rz0, tr_rz00, tr_rz1
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: Ap, chc, r, z
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: Ap, r
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: buf
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_coeff_array, p
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: chc, mo_coeff_array, p, z
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: Sc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -278,10 +278,10 @@ CONTAINS
       END DO
       !
       DO ispin = 1, nspins
-         ALLOCATE (r(ispin)%matrix, z(ispin)%matrix, Ap(ispin)%matrix)
+         ALLOCATE (r(ispin)%matrix, Ap(ispin)%matrix)
          CALL cp_fm_create(r(ispin)%matrix, psi1(ispin)%matrix_struct)
          CALL cp_fm_create(p(ispin), psi1(ispin)%matrix_struct)
-         CALL cp_fm_create(z(ispin)%matrix, psi1(ispin)%matrix_struct)
+         CALL cp_fm_create(z(ispin), psi1(ispin)%matrix_struct)
          CALL cp_fm_create(Ap(ispin)%matrix, psi1(ispin)%matrix_struct)
       END DO
       !
@@ -294,8 +294,7 @@ CONTAINS
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nmo, &
                                   ncol_global=nmo, para_env=para_env, &
                                   context=mo_coeff%matrix_struct%context)
-         ALLOCATE (chc(ispin)%matrix)
-         CALL cp_fm_create(chc(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(chc(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
       !
@@ -306,7 +305,7 @@ CONTAINS
             CALL cp_fm_create(buf, mo_coeff%matrix_struct)
             CALL cp_fm_get_info(mo_coeff, ncol_global=ncol)
             CALL cp_dbcsr_sm_fm_multiply(matrix_ks(ispin)%matrix, mo_coeff, buf, ncol)
-            CALL parallel_gemm('T', 'N', ncol, ncol, nao, -1.0_dp, mo_coeff, buf, 0.0_dp, chc(ispin)%matrix)
+            CALL parallel_gemm('T', 'N', ncol, ncol, nao, -1.0_dp, mo_coeff, buf, 0.0_dp, chc(ispin))
             CALL cp_fm_release(buf)
          END ASSOCIATE
          !
@@ -368,7 +367,7 @@ CONTAINS
          !
          ! z_0 = r_0
          DO ispin = 1, nspins
-            CALL cp_fm_to_fm(r(ispin)%matrix, z(ispin)%matrix)
+            CALL cp_fm_to_fm(r(ispin)%matrix, z(ispin))
          END DO
          linres_control%flag = "CG"
       ELSE
@@ -376,7 +375,7 @@ CONTAINS
          ! z_0 = M * r_0
          DO ispin = 1, nspins
             CALL apply_preconditioner(p_env%preconditioner(ispin), r(ispin)%matrix, &
-                                      z(ispin)%matrix)
+                                      z(ispin))
          END DO
          linres_control%flag = "PCG"
       END IF
@@ -384,10 +383,10 @@ CONTAINS
       DO ispin = 1, nspins
          !
          ! p_0 = z_0
-         CALL cp_fm_to_fm(z(ispin)%matrix, p(ispin))
+         CALL cp_fm_to_fm(z(ispin), p(ispin))
          !
          ! trace(r_0 * z_0)
-         CALL cp_fm_trace(r(ispin)%matrix, z(ispin)%matrix, tr_rz0(ispin))
+         CALL cp_fm_trace(r(ispin)%matrix, z(ispin), tr_rz0(ispin))
       END DO
       IF (SUM(tr_rz0) < 0.0_dp) CPABORT("tr(r_j*z_j) < 0")
       norm_res = ABS(SUM(tr_rz0))/SQRT(REAL(nspins*nao*maxnmo_o, dp))
@@ -493,7 +492,7 @@ CONTAINS
             !
             ! z_j+1 = r_j+1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(r(ispin)%matrix, z(ispin)%matrix)
+               CALL cp_fm_to_fm(r(ispin)%matrix, z(ispin))
             END DO
             linres_control%flag = "CG"
          ELSE
@@ -501,7 +500,7 @@ CONTAINS
             ! z_j+1 = M * r_j+1
             DO ispin = 1, nspins
                CALL apply_preconditioner(p_env%preconditioner(ispin), r(ispin)%matrix, &
-                                         z(ispin)%matrix)
+                                         z(ispin))
             END DO
             linres_control%flag = "PCG"
          END IF
@@ -509,7 +508,7 @@ CONTAINS
          DO ispin = 1, nspins
             !
             ! tr(r_j+1*z_j+1)
-            CALL cp_fm_trace(r(ispin)%matrix, z(ispin)%matrix, tr_rz1(ispin))
+            CALL cp_fm_trace(r(ispin)%matrix, z(ispin), tr_rz1(ispin))
          END DO
          IF (SUM(tr_rz1) < 0.0_dp) CPABORT("tr(r_j+1*z_j+1) < 0")
          norm_res = SUM(tr_rz1)/SQRT(REAL(nspins*nao*maxnmo_o, dp))
@@ -523,7 +522,7 @@ CONTAINS
          DO ispin = 1, nspins
             !
             ! p_j+1 = z_j+1 + beta * p_j
-            CALL cp_fm_scale_and_add(beta, p(ispin), 1.0_dp, z(ispin)%matrix)
+            CALL cp_fm_scale_and_add(beta, p(ispin), 1.0_dp, z(ispin))
             tr_rz00(ispin) = tr_rz0(ispin)
             tr_rz0(ispin) = tr_rz1(ispin)
          END DO
@@ -542,14 +541,12 @@ CONTAINS
       DO ispin = 1, nspins
          CALL cp_fm_release(r(ispin)%matrix)
          CALL cp_fm_release(p(ispin))
-         CALL cp_fm_release(z(ispin)%matrix)
+         CALL cp_fm_release(z(ispin))
          CALL cp_fm_release(Ap(ispin)%matrix)
          !
          CALL cp_fm_release(Sc(ispin))
-         CALL cp_fm_release(chc(ispin)%matrix)
-         DEALLOCATE (r(ispin)%matrix, &
-                     z(ispin)%matrix, Ap(ispin)%matrix, &
-                     chc(ispin)%matrix)
+         CALL cp_fm_release(chc(ispin))
+         DEALLOCATE (r(ispin)%matrix, Ap(ispin)%matrix)
       END DO
       DEALLOCATE (tr_pAp, tr_rz0, tr_rz00, tr_rz1, r, p, z, Ap, Sc, chc, mo_coeff_array)
       !
@@ -571,7 +568,8 @@ CONTAINS
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0, v
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: Av, chc
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: Av
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: chc
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'apply_op'
 
@@ -596,7 +594,7 @@ CONTAINS
       ! apply the uncoupled operator
       DO ispin = 1, nspins
          CALL apply_op_1(v(ispin), Av(ispin)%matrix, matrix_ks(ispin)%matrix, &
-                         matrix_s(1)%matrix, chc(ispin)%matrix)
+                         matrix_s(1)%matrix, chc(ispin))
       END DO
 
       IF (linres_control%do_kernel) THEN

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -216,8 +216,7 @@ CONTAINS
    SUBROUTINE linres_solver(p_env, qs_env, psi1, h1_psi0, psi0_order, iounit, should_stop)
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: psi1
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: h1_psi0, psi0_order
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: psi1, h1_psi0, psi0_order
       INTEGER, INTENT(IN)                                :: iounit
       LOGICAL, INTENT(OUT)                               :: should_stop
 
@@ -228,10 +227,10 @@ CONTAINS
       LOGICAL                                            :: restart
       REAL(dp)                                           :: alpha, beta, norm_res, t1, t2
       REAL(dp), DIMENSION(:), POINTER                    :: tr_pAp, tr_rz0, tr_rz00, tr_rz1
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: Ap, chc, p, r, z
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: Ap, chc, r, z
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: buf
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_coeff_array
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_coeff_array, p
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: Sc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -279,11 +278,11 @@ CONTAINS
       END DO
       !
       DO ispin = 1, nspins
-         ALLOCATE (r(ispin)%matrix, p(ispin)%matrix, z(ispin)%matrix, Ap(ispin)%matrix)
-         CALL cp_fm_create(r(ispin)%matrix, psi1(ispin)%matrix%matrix_struct)
-         CALL cp_fm_create(p(ispin)%matrix, psi1(ispin)%matrix%matrix_struct)
-         CALL cp_fm_create(z(ispin)%matrix, psi1(ispin)%matrix%matrix_struct)
-         CALL cp_fm_create(Ap(ispin)%matrix, psi1(ispin)%matrix%matrix_struct)
+         ALLOCATE (r(ispin)%matrix, z(ispin)%matrix, Ap(ispin)%matrix)
+         CALL cp_fm_create(r(ispin)%matrix, psi1(ispin)%matrix_struct)
+         CALL cp_fm_create(p(ispin), psi1(ispin)%matrix_struct)
+         CALL cp_fm_create(z(ispin)%matrix, psi1(ispin)%matrix_struct)
+         CALL cp_fm_create(Ap(ispin)%matrix, psi1(ispin)%matrix_struct)
       END DO
       !
       ! compute S*C0, C0_order'*H*C0_order (this should be done once for all)
@@ -385,7 +384,7 @@ CONTAINS
       DO ispin = 1, nspins
          !
          ! p_0 = z_0
-         CALL cp_fm_to_fm(z(ispin)%matrix, p(ispin)%matrix)
+         CALL cp_fm_to_fm(z(ispin)%matrix, p(ispin))
          !
          ! trace(r_0 * z_0)
          CALL cp_fm_trace(r(ispin)%matrix, z(ispin)%matrix, tr_rz0(ispin))
@@ -447,7 +446,7 @@ CONTAINS
          DO ispin = 1, nspins
             !
             ! tr(Ap_j*p_j)
-            CALL cp_fm_trace(Ap(ispin)%matrix, p(ispin)%matrix, tr_pAp(ispin))
+            CALL cp_fm_trace(Ap(ispin)%matrix, p(ispin), tr_pAp(ispin))
          END DO
          !
          ! alpha = tr(r_j*z_j) / tr(Ap_j*p_j)
@@ -459,7 +458,7 @@ CONTAINS
          DO ispin = 1, nspins
             !
             ! x_j+1 = x_j + alpha * p_j
-            CALL cp_fm_scale_and_add(1.0_dp, psi1(ispin)%matrix, alpha, p(ispin)%matrix)
+            CALL cp_fm_scale_and_add(1.0_dp, psi1(ispin), alpha, p(ispin))
          END DO
          !
          ! need to recompute the residue
@@ -524,7 +523,7 @@ CONTAINS
          DO ispin = 1, nspins
             !
             ! p_j+1 = z_j+1 + beta * p_j
-            CALL cp_fm_scale_and_add(beta, p(ispin)%matrix, 1.0_dp, z(ispin)%matrix)
+            CALL cp_fm_scale_and_add(beta, p(ispin), 1.0_dp, z(ispin)%matrix)
             tr_rz00(ispin) = tr_rz0(ispin)
             tr_rz0(ispin) = tr_rz1(ispin)
          END DO
@@ -542,13 +541,13 @@ CONTAINS
       ! clean up
       DO ispin = 1, nspins
          CALL cp_fm_release(r(ispin)%matrix)
-         CALL cp_fm_release(p(ispin)%matrix)
+         CALL cp_fm_release(p(ispin))
          CALL cp_fm_release(z(ispin)%matrix)
          CALL cp_fm_release(Ap(ispin)%matrix)
          !
          CALL cp_fm_release(Sc(ispin))
          CALL cp_fm_release(chc(ispin)%matrix)
-         DEALLOCATE (r(ispin)%matrix, p(ispin)%matrix, &
+         DEALLOCATE (r(ispin)%matrix, &
                      z(ispin)%matrix, Ap(ispin)%matrix, &
                      chc(ispin)%matrix)
       END DO
@@ -571,8 +570,8 @@ CONTAINS
       !
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: v, Av, chc
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: c0, v
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: Av, chc
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'apply_op'
 
@@ -596,7 +595,7 @@ CONTAINS
 
       ! apply the uncoupled operator
       DO ispin = 1, nspins
-         CALL apply_op_1(v(ispin)%matrix, Av(ispin)%matrix, matrix_ks(ispin)%matrix, &
+         CALL apply_op_1(v(ispin), Av(ispin)%matrix, matrix_ks(ispin)%matrix, &
                          matrix_s(1)%matrix, chc(ispin)%matrix)
       END DO
 
@@ -691,8 +690,7 @@ CONTAINS
    SUBROUTINE preortho(v, psi0, S_psi0)
       !v = (I-PS)v
       !
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: v
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: psi0, S_psi0
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: v, psi0, S_psi0
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'preortho'
 
@@ -708,12 +706,12 @@ CONTAINS
       nspins = SIZE(v, 1)
       !
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(v(ispin)%matrix, ncol_global=mv, nrow_global=nv)
+         CALL cp_fm_get_info(v(ispin), ncol_global=mv, nrow_global=nv)
          CALL cp_fm_get_info(psi0(ispin), ncol_global=mp, nrow_global=np)
          !
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nv, ncol_global=mp, &
-                                  para_env=v(ispin)%matrix%matrix_struct%para_env, &
-                                  context=v(ispin)%matrix%matrix_struct%context)
+                                  para_env=v(ispin)%matrix_struct%para_env, &
+                                  context=v(ispin)%matrix_struct%context)
          CALL cp_fm_create(buf, tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
          !
@@ -724,9 +722,9 @@ CONTAINS
          CPASSERT(nt == nv)
          !
          ! buf = v' * S_psi0
-         CALL parallel_gemm('T', 'N', mv, mp, nv, 1.0_dp, v(ispin)%matrix, S_psi0(ispin), 0.0_dp, buf)
+         CALL parallel_gemm('T', 'N', mv, mp, nv, 1.0_dp, v(ispin), S_psi0(ispin), 0.0_dp, buf)
          ! v = v - psi0 * buf'
-         CALL parallel_gemm('N', 'T', nv, mv, mp, -1.0_dp, psi0(ispin), buf, 1.0_dp, v(ispin)%matrix)
+         CALL parallel_gemm('N', 'T', nv, mv, mp, -1.0_dp, psi0(ispin), buf, 1.0_dp, v(ispin))
          !
          CALL cp_fm_release(buf)
       END DO
@@ -800,7 +798,7 @@ CONTAINS
    SUBROUTINE linres_write_restart(qs_env, linres_section, vec, ivec, tag, ind)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: linres_section
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: vec
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: vec
       INTEGER, INTENT(IN)                                :: ivec
       CHARACTER(LEN=*)                                   :: tag
       INTEGER, INTENT(IN), OPTIONAL                      :: ind
@@ -876,13 +874,13 @@ CONTAINS
          END IF
 
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(vec(ispin)%matrix, ncol_global=nmo)
+            CALL cp_fm_get_info(vec(ispin), ncol_global=nmo)
 
             IF (rst_unit > 0) WRITE (rst_unit) nmo
 
             DO i = 1, nmo, MAX(max_block, 1)
                i_block = MIN(max_block, nmo - i + 1)
-               CALL cp_fm_get_submatrix(vec(ispin)%matrix, vecbuffer, 1, i, nao, i_block)
+               CALL cp_fm_get_submatrix(vec(ispin), vecbuffer, 1, i, nao, i_block)
                ! doing this in one write would increase efficiency, but breaks RESTART compatibility.
                ! to old ones, and in cases where max_block is different between runs, as might happen during
                ! restarts with a different number of CPUs
@@ -914,7 +912,7 @@ CONTAINS
    SUBROUTINE linres_read_restart(qs_env, linres_section, vec, ivec, tag, ind)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: linres_section
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: vec
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: vec
       INTEGER, INTENT(IN)                                :: ivec
       CHARACTER(LEN=*)                                   :: tag
       INTEGER, INTENT(INOUT), OPTIONAL                   :: ind
@@ -1045,7 +1043,7 @@ CONTAINS
                   END DO
                   IF (iv .EQ. ivec_tmp) THEN
                      CALL mp_bcast(vecbuffer, source, group)
-                     CALL cp_fm_set_submatrix(vec(ispin)%matrix, vecbuffer, 1, i, nao, i_block)
+                     CALL cp_fm_set_submatrix(vec(ispin), vecbuffer, 1, i, nao, i_block)
                   END IF
                END DO
             END DO

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -228,9 +228,10 @@ CONTAINS
       LOGICAL                                            :: restart
       REAL(dp)                                           :: alpha, beta, norm_res, t1, t2
       REAL(dp), DIMENSION(:), POINTER                    :: tr_pAp, tr_rz0, tr_rz00, tr_rz1
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: Ap, chc, mo_coeff_array, p, r, z
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: Ap, chc, p, r, z
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: buf
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_coeff_array
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: Sc
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -274,7 +275,7 @@ CONTAINS
                 r(nspins), p(nspins), z(nspins), Ap(nspins), mo_coeff_array(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
-         mo_coeff_array(ispin)%matrix => mo_coeff
+         mo_coeff_array(ispin) = mo_coeff
       END DO
       !
       DO ispin = 1, nspins
@@ -690,8 +691,8 @@ CONTAINS
    SUBROUTINE preortho(v, psi0, S_psi0)
       !v = (I-PS)v
       !
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: v, psi0
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: S_psi0
+      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: v
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: psi0, S_psi0
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'preortho'
 
@@ -708,7 +709,7 @@ CONTAINS
       !
       DO ispin = 1, nspins
          CALL cp_fm_get_info(v(ispin)%matrix, ncol_global=mv, nrow_global=nv)
-         CALL cp_fm_get_info(psi0(ispin)%matrix, ncol_global=mp, nrow_global=np)
+         CALL cp_fm_get_info(psi0(ispin), ncol_global=mp, nrow_global=np)
          !
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nv, ncol_global=mp, &
                                   para_env=v(ispin)%matrix%matrix_struct%para_env, &
@@ -725,7 +726,7 @@ CONTAINS
          ! buf = v' * S_psi0
          CALL parallel_gemm('T', 'N', mv, mp, nv, 1.0_dp, v(ispin)%matrix, S_psi0(ispin), 0.0_dp, buf)
          ! v = v - psi0 * buf'
-         CALL parallel_gemm('N', 'T', nv, mv, mp, -1.0_dp, psi0(ispin)%matrix, buf, 1.0_dp, v(ispin)%matrix)
+         CALL parallel_gemm('N', 'T', nv, mv, mp, -1.0_dp, psi0(ispin), buf, 1.0_dp, v(ispin)%matrix)
          !
          CALL cp_fm_release(buf)
       END DO
@@ -743,8 +744,8 @@ CONTAINS
    SUBROUTINE postortho(v, psi0, S_psi0)
       !v = (I-SP)v
       !
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: v, psi0
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: S_psi0
+      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: v
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: psi0, S_psi0
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'postortho'
 
@@ -761,7 +762,7 @@ CONTAINS
       !
       DO ispin = 1, nspins
          CALL cp_fm_get_info(v(ispin)%matrix, ncol_global=mv, nrow_global=nv)
-         CALL cp_fm_get_info(psi0(ispin)%matrix, ncol_global=mp, nrow_global=np)
+         CALL cp_fm_get_info(psi0(ispin), ncol_global=mp, nrow_global=np)
          !
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nv, ncol_global=mp, &
                                   para_env=v(ispin)%matrix%matrix_struct%para_env, &
@@ -776,7 +777,7 @@ CONTAINS
          CPASSERT(nt == nv)
          !
          ! buf = v' * psi0
-         CALL parallel_gemm('T', 'N', mv, mp, nv, 1.0_dp, v(ispin)%matrix, psi0(ispin)%matrix, 0.0_dp, buf)
+         CALL parallel_gemm('T', 'N', mv, mp, nv, 1.0_dp, v(ispin)%matrix, psi0(ispin), 0.0_dp, buf)
          ! v = v - S_psi0 * buf'
          CALL parallel_gemm('N', 'T', nv, mv, mp, -1.0_dp, S_psi0(ispin), buf, 1.0_dp, v(ispin)%matrix)
          !

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -23,9 +23,9 @@ MODULE qs_linres_op
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_solve
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
-                                              cp_cfm_p_type,&
                                               cp_cfm_release,&
-                                              cp_cfm_set_all
+                                              cp_cfm_set_all,&
+                                              cp_cfm_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: cp_dbcsr_sm_fm_multiply,&
@@ -131,11 +131,11 @@ CONTAINS
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(3)                 :: vecbuf_RmdC0
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(3)                   :: fm_Rmd_mos
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi0_order
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: p_psi0, rxp_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: fm_work1
+      TYPE(cp_fm_type), DIMENSION(3)                     :: fm_Rmd_mos
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -369,8 +369,7 @@ CONTAINS
                                      ncol_global=nmo, para_env=para_env, &
                                      context=mo_coeff%matrix_struct%context)
             DO idir = 1, 3
-               ALLOCATE (fm_Rmd_mos(idir)%matrix)
-               CALL cp_fm_create(fm_Rmd_mos(idir)%matrix, tmp_fm_struct)
+               CALL cp_fm_create(fm_Rmd_mos(idir), tmp_fm_struct)
             END DO
             CALL cp_fm_create(fm_work1, tmp_fm_struct)
             CALL cp_fm_struct_release(tmp_fm_struct)
@@ -388,7 +387,7 @@ CONTAINS
                      ckdk = pbc(dk, ck, cell)
                      vecbuf_Rmdc0(idir)%array(1, iao) = vecbuf_c0(1, iao)*ckdk(idir)
                   END DO ! iao
-                  CALL cp_fm_set_submatrix(fm_Rmd_mos(idir)%matrix, vecbuf_Rmdc0(idir)%array, &
+                  CALL cp_fm_set_submatrix(fm_Rmd_mos(idir), vecbuf_Rmdc0(idir)%array, &
                                            1, istate, nao, 1, transpose=.TRUE.)
                END DO ! idir
             END DO ! istate
@@ -398,13 +397,13 @@ CONTAINS
 
                !Add the second term to the idir component
                CALL cp_fm_set_all(fm_work1, 0.0_dp)
-               CALL cp_dbcsr_sm_fm_multiply(op_ao(iii)%matrix, fm_Rmd_mos(ii)%matrix, &
+               CALL cp_dbcsr_sm_fm_multiply(op_ao(iii)%matrix, fm_Rmd_mos(ii), &
                                             fm_work1, ncol=nmo, alpha=-1.0_dp)
                CALL cp_fm_scale_and_add(1.0_dp, rxp_psi0(ispin, idir)%matrix, &
                                         1.0_dp, fm_work1)
 
                CALL cp_fm_set_all(fm_work1, 0.0_dp)
-               CALL cp_dbcsr_sm_fm_multiply(op_ao(ii)%matrix, fm_Rmd_mos(iii)%matrix, &
+               CALL cp_dbcsr_sm_fm_multiply(op_ao(ii)%matrix, fm_Rmd_mos(iii), &
                                             fm_work1, ncol=nmo, alpha=-1.0_dp)
                CALL cp_fm_scale_and_add(1.0_dp, rxp_psi0(ispin, idir)%matrix, &
                                         -1.0_dp, fm_work1)
@@ -412,8 +411,7 @@ CONTAINS
             END DO ! idir
 
             DO idir = 1, 3
-               CALL cp_fm_release(fm_Rmd_mos(idir)%matrix)
-               DEALLOCATE (fm_Rmd_mos(idir)%matrix)
+               CALL cp_fm_release(fm_Rmd_mos(idir))
             END DO
             CALL cp_fm_release(fm_work1)
 
@@ -690,11 +688,11 @@ CONTAINS
       LOGICAL                                            :: do_raman
       REAL(dp)                                           :: kvec(3), maxocc
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_cfm_p_type), DIMENSION(:), POINTER         :: eigrmat
-      TYPE(cp_cfm_p_type), DIMENSION(:, :), POINTER      :: inv_mat
+      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: eigrmat
+      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:, :)    :: inv_mat
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0, op_fm_set, opvec
-      TYPE(cp_fm_p_type), DIMENSION(:, :, :), POINTER    :: inv_work
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :, :)  :: inv_work
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
@@ -705,7 +703,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (dBerry_psi0, inv_work, op_fm_set, opvec, sinmat, cosmat)
+      NULLIFY (dBerry_psi0, op_fm_set, opvec, sinmat, cosmat)
       NULLIFY (polar_env)
 
       NULLIFY (cell, dft_control, mos, matrix_s)
@@ -749,15 +747,12 @@ CONTAINS
                CALL cp_fm_create(opvec(i, ispin)%matrix, mo_coeff%matrix_struct)
                CALL cp_fm_create(op_fm_set(i, ispin)%matrix, tmp_fm_struct)
             END DO
-            ALLOCATE (eigrmat(ispin)%matrix)
-            CALL cp_cfm_create(eigrmat(ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
+            CALL cp_cfm_create(eigrmat(ispin), op_fm_set(1, ispin)%matrix%matrix_struct)
             CALL cp_fm_struct_release(tmp_fm_struct)
             DO i = 1, 3
-               ALLOCATE (inv_work(2, i, ispin)%matrix, inv_work(1, i, ispin)%matrix)
-               ALLOCATE (inv_mat(i, ispin)%matrix)
-               CALL cp_cfm_create(inv_mat(i, ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
-               CALL cp_fm_create(inv_work(2, i, ispin)%matrix, op_fm_set(2, ispin)%matrix%matrix_struct)
-               CALL cp_fm_create(inv_work(1, i, ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
+               CALL cp_cfm_create(inv_mat(i, ispin), op_fm_set(1, ispin)%matrix%matrix_struct)
+               CALL cp_fm_create(inv_work(2, i, ispin), op_fm_set(2, ispin)%matrix%matrix_struct)
+               CALL cp_fm_create(inv_work(1, i, ispin), op_fm_set(1, ispin)%matrix%matrix_struct)
             END DO
          END DO
 
@@ -787,41 +782,38 @@ CONTAINS
             ! Second step invert C^T S_berry C
             zdet = one
             DO ispin = 1, dft_control%nspins
-               CALL cp_cfm_get_info(eigrmat(ispin)%matrix, ncol_local=tmp_dim)
+               CALL cp_cfm_get_info(eigrmat(ispin), ncol_local=tmp_dim)
                DO idim = 1, tmp_dim
-                  eigrmat(ispin)%matrix%local_data(:, idim) = &
+                  eigrmat(ispin)%local_data(:, idim) = &
                      CMPLX(op_fm_set(1, ispin)%matrix%local_data(:, idim), &
                            -op_fm_set(2, ispin)%matrix%local_data(:, idim), dp)
                END DO
-               CALL cp_cfm_set_all(inv_mat(i, ispin)%matrix, zero, one)
-               CALL cp_cfm_solve(eigrmat(ispin)%matrix, inv_mat(i, ispin)%matrix, zdeta)
+               CALL cp_cfm_set_all(inv_mat(i, ispin), zero, one)
+               CALL cp_cfm_solve(eigrmat(ispin), inv_mat(i, ispin), zdeta)
             END DO
 
             ! Compute the derivative and add the result to mo_derivatives
             DO ispin = 1, dft_control%nspins
-               CALL cp_cfm_get_info(eigrmat(ispin)%matrix, ncol_local=tmp_dim)
+               CALL cp_cfm_get_info(eigrmat(ispin), ncol_local=tmp_dim)
                CALL get_mo_set(mo_set=mos(ispin), nao=nao, nmo=nmo, maxocc=maxocc)
                DO z = 1, tmp_dim
-                  inv_work(1, i, ispin)%matrix%local_data(:, z) = REAL(inv_mat(i, ispin)%matrix%local_data(:, z), dp)
-                  inv_work(2, i, ispin)%matrix%local_data(:, z) = AIMAG(inv_mat(i, ispin)%matrix%local_data(:, z))
+                  inv_work(1, i, ispin)%local_data(:, z) = REAL(inv_mat(i, ispin)%local_data(:, z), dp)
+                  inv_work(2, i, ispin)%local_data(:, z) = AIMAG(inv_mat(i, ispin)%local_data(:, z))
                END DO
-               CALL parallel_gemm("N", "N", nao, nmo, nmo, -1.0_dp, opvec(1, ispin)%matrix, inv_work(2, i, ispin)%matrix, &
+               CALL parallel_gemm("N", "N", nao, nmo, nmo, -1.0_dp, opvec(1, ispin)%matrix, inv_work(2, i, ispin), &
                                   0.0_dp, dBerry_psi0(i, ispin)%matrix)
-               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, opvec(2, ispin)%matrix, inv_work(1, i, ispin)%matrix, &
+               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, opvec(2, ispin)%matrix, inv_work(1, i, ispin), &
                                   1.0_dp, dBerry_psi0(i, ispin)%matrix)
             END DO
          END DO !x/y/z-direction
          !SL we omit here the multiplication with hmat (this scaling back done at the end of the response calc)
 
          DO ispin = 1, dft_control%nspins
-            CALL cp_cfm_release(eigrmat(ispin)%matrix)
-            DEALLOCATE (eigrmat(ispin)%matrix)
+            CALL cp_cfm_release(eigrmat(ispin))
             DO i = 1, 3
-               CALL cp_cfm_release(inv_mat(i, ispin)%matrix)
-               DEALLOCATE (inv_mat(i, ispin)%matrix)
-               CALL cp_fm_release(inv_work(1, i, ispin)%matrix)
-               CALL cp_fm_release(inv_work(2, i, ispin)%matrix)
-               DEALLOCATE (inv_work(1, i, ispin)%matrix, inv_work(2, i, ispin)%matrix)
+               CALL cp_cfm_release(inv_mat(i, ispin))
+               CALL cp_fm_release(inv_work(1, i, ispin))
+               CALL cp_fm_release(inv_work(2, i, ispin))
             END DO
             CALL cp_fm_release(opvec(1, ispin)%matrix)
             CALL cp_fm_release(opvec(2, ispin)%matrix)

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -131,11 +131,11 @@ CONTAINS
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(3)                 :: vecbuf_RmdC0
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi0_order
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: p_psi0, rxp_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: fm_work1
       TYPE(cp_fm_type), DIMENSION(3)                     :: fm_Rmd_mos
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -245,7 +245,7 @@ CONTAINS
 
       chk(:) = 0.0_dp
       DO ispin = 1, nspins
-         mo_coeff => psi0_order(ispin)%matrix
+         mo_coeff => psi0_order(ispin)
          nmo = nstates(ispin)
          CALL cp_fm_set_all(p_psi0(ispin, 1)%matrix, 0.0_dp)
          CALL cp_fm_set_all(p_psi0(ispin, 2)%matrix, 0.0_dp)
@@ -323,7 +323,7 @@ CONTAINS
       ! Apply the p operator to the psi0
       DO idir = 1, 3
          DO ispin = 1, nspins
-            mo_coeff => psi0_order(ispin)%matrix
+            mo_coeff => psi0_order(ispin)
             nmo = nstates(ispin)
             CALL cp_fm_set_all(p_psi0(ispin, idir)%matrix, 0.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(op_ao(idir)%matrix, mo_coeff, &
@@ -362,7 +362,7 @@ CONTAINS
             !   Allocate full matrices as working storage in the calculation
             !   of the rxp operator matrix. 3 matrices for the 3 Cartesian direction
             !   plus one to apply the momentum oprator to the modified mos fm
-            mo_coeff => psi0_order(ispin)%matrix
+            mo_coeff => psi0_order(ispin)
             nmo = nstates(ispin)
             NULLIFY (tmp_fm_struct)
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
@@ -376,7 +376,7 @@ CONTAINS
 
             ! This part should be done better, using the full matrix distribution
             DO istate = 1, nmo
-               CALL cp_fm_get_submatrix(psi0_order(ispin)%matrix, vecbuf_c0, 1, istate, nao, 1, &
+               CALL cp_fm_get_submatrix(psi0_order(ispin), vecbuf_c0, 1, istate, nao, 1, &
                                         transpose=.TRUE.)
                !center of the localized psi0 state istate
                dk(1:3) = centers_set(ispin)%array(1:3, istate)

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -131,11 +131,11 @@ CONTAINS
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER        :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(3)                 :: vecbuf_RmdC0
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER        :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: p_psi0, rxp_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: fm_work1
       TYPE(cp_fm_type), DIMENSION(3)                     :: fm_Rmd_mos
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi0_order
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: p_psi0, rxp_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -247,9 +247,9 @@ CONTAINS
       DO ispin = 1, nspins
          mo_coeff => psi0_order(ispin)
          nmo = nstates(ispin)
-         CALL cp_fm_set_all(p_psi0(ispin, 1)%matrix, 0.0_dp)
-         CALL cp_fm_set_all(p_psi0(ispin, 2)%matrix, 0.0_dp)
-         CALL cp_fm_set_all(p_psi0(ispin, 3)%matrix, 0.0_dp)
+         CALL cp_fm_set_all(p_psi0(ispin, 1), 0.0_dp)
+         CALL cp_fm_set_all(p_psi0(ispin, 2), 0.0_dp)
+         CALL cp_fm_set_all(p_psi0(ispin, 3), 0.0_dp)
          DO icenter = 1, nbr_center(ispin)
             CALL dbcsr_set(op_ao(1)%matrix, 0.0_dp)
             CALL dbcsr_set(op_ao(2)%matrix, 0.0_dp)
@@ -264,21 +264,21 @@ CONTAINS
             chk(2) = chk(2) + dbcsr_checksum(op_ao(2)%matrix)
             chk(3) = chk(3) + dbcsr_checksum(op_ao(3)%matrix)
             DO idir = 1, 3
-               CALL cp_fm_set_all(rxp_psi0(ispin, idir)%matrix, 0.0_dp)
+               CALL cp_fm_set_all(rxp_psi0(ispin, idir), 0.0_dp)
                CALL cp_dbcsr_sm_fm_multiply(op_ao(idir)%matrix, mo_coeff, &
-                                            rxp_psi0(ispin, idir)%matrix, ncol=nmo, &
+                                            rxp_psi0(ispin, idir), ncol=nmo, &
                                             alpha=-1.0_dp)
                DO j = center_list(ispin)%array(1, icenter), center_list(ispin)%array(1, icenter + 1) - 1
                   istate = center_list(ispin)%array(2, j)
                   ! the p_psi0 fm is used as temporary matrix to store the results for the psi0 centered in dk
-                  CALL cp_fm_to_fm(rxp_psi0(ispin, idir)%matrix, &
-                                   p_psi0(ispin, idir)%matrix, 1, istate, istate)
+                  CALL cp_fm_to_fm(rxp_psi0(ispin, idir), &
+                                   p_psi0(ispin, idir), 1, istate, istate)
                END DO
             END DO
          END DO
-         CALL cp_fm_to_fm(p_psi0(ispin, 1)%matrix, rxp_psi0(ispin, 1)%matrix)
-         CALL cp_fm_to_fm(p_psi0(ispin, 2)%matrix, rxp_psi0(ispin, 2)%matrix)
-         CALL cp_fm_to_fm(p_psi0(ispin, 3)%matrix, rxp_psi0(ispin, 3)%matrix)
+         CALL cp_fm_to_fm(p_psi0(ispin, 1), rxp_psi0(ispin, 1))
+         CALL cp_fm_to_fm(p_psi0(ispin, 2), rxp_psi0(ispin, 2))
+         CALL cp_fm_to_fm(p_psi0(ispin, 3), rxp_psi0(ispin, 3))
       END DO
       !
       CALL dbcsr_deallocate_matrix_set(op_ao)
@@ -325,9 +325,9 @@ CONTAINS
          DO ispin = 1, nspins
             mo_coeff => psi0_order(ispin)
             nmo = nstates(ispin)
-            CALL cp_fm_set_all(p_psi0(ispin, idir)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(p_psi0(ispin, idir), 0.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(op_ao(idir)%matrix, mo_coeff, &
-                                         p_psi0(ispin, idir)%matrix, ncol=nmo, &
+                                         p_psi0(ispin, idir), ncol=nmo, &
                                          alpha=-1.0_dp)
          END DO
       END DO
@@ -348,9 +348,9 @@ CONTAINS
       !DO ispin = 1,nspins
       !  CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, nmo=nmo, homo=homo)
       !  DO idir = 1,3
-      !     CALL cp_fm_set_all(rxp_psi0(ispin,idir)%matrix,0.0_dp)
+      !     CALL cp_fm_set_all(rxp_psi0(ispin,idir),0.0_dp)
       !     CALL cp_sm_fm_multiply(op_rmd_ao(idir)%matrix,mo_coeff,&
-      !            rxp_psi0(ispin,idir)%matrix,ncol=nmo,alpha=-1.0_dp)
+      !            rxp_psi0(ispin,idir),ncol=nmo,alpha=-1.0_dp)
       !  END DO
       !END DO
 
@@ -399,13 +399,13 @@ CONTAINS
                CALL cp_fm_set_all(fm_work1, 0.0_dp)
                CALL cp_dbcsr_sm_fm_multiply(op_ao(iii)%matrix, fm_Rmd_mos(ii), &
                                             fm_work1, ncol=nmo, alpha=-1.0_dp)
-               CALL cp_fm_scale_and_add(1.0_dp, rxp_psi0(ispin, idir)%matrix, &
+               CALL cp_fm_scale_and_add(1.0_dp, rxp_psi0(ispin, idir), &
                                         1.0_dp, fm_work1)
 
                CALL cp_fm_set_all(fm_work1, 0.0_dp)
                CALL cp_dbcsr_sm_fm_multiply(op_ao(ii)%matrix, fm_Rmd_mos(iii), &
                                             fm_work1, ncol=nmo, alpha=-1.0_dp)
-               CALL cp_fm_scale_and_add(1.0_dp, rxp_psi0(ispin, idir)%matrix, &
+               CALL cp_fm_scale_and_add(1.0_dp, rxp_psi0(ispin, idir), &
                                         -1.0_dp, fm_work1)
 
             END DO ! idir

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -450,8 +450,8 @@ CONTAINS
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd
       REAL(dp)                                           :: chk(20), r_i(3)
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fc_psi0
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, pso_psi0
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -608,7 +608,7 @@ CONTAINS
          ! FC
          IF (do_fc) THEN
             CALL cp_dbcsr_sm_fm_multiply(matrix_fc(1)%matrix, mo_coeff, &
-                                         fc_psi0(ispin)%matrix, ncol=nmo, &
+                                         fc_psi0(ispin), ncol=nmo, &
                                          alpha=1.0_dp)
          END IF
          !

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -690,10 +690,10 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: eigrmat
       TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:, :)    :: inv_mat
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: op_fm_set, opvec
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :, :)  :: inv_work
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dBerry_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
@@ -726,7 +726,7 @@ CONTAINS
 
          DO i = 1, 3
             DO ispin = 1, nspins
-               CALL cp_fm_set_all(dBerry_psi0(i, ispin)%matrix, 0.0_dp)
+               CALL cp_fm_set_all(dBerry_psi0(i, ispin), 0.0_dp)
             END DO
          END DO
 
@@ -801,9 +801,9 @@ CONTAINS
                   inv_work(2, i, ispin)%local_data(:, z) = AIMAG(inv_mat(i, ispin)%local_data(:, z))
                END DO
                CALL parallel_gemm("N", "N", nao, nmo, nmo, -1.0_dp, opvec(1, ispin), inv_work(2, i, ispin), &
-                                  0.0_dp, dBerry_psi0(i, ispin)%matrix)
+                                  0.0_dp, dBerry_psi0(i, ispin))
                CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, opvec(2, ispin), inv_work(1, i, ispin), &
-                                  1.0_dp, dBerry_psi0(i, ispin)%matrix)
+                                  1.0_dp, dBerry_psi0(i, ispin))
             END DO
          END DO !x/y/z-direction
          !SL we omit here the multiplication with hmat (this scaling back done at the end of the response calc)
@@ -865,7 +865,7 @@ CONTAINS
       REAL(dp), DIMENSION(3, 3)                          :: hmat
       REAL(dp), DIMENSION(:, :), POINTER                 :: d_block, s_block
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dBerry_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: dipmat, matrix_s
@@ -924,7 +924,7 @@ CONTAINS
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
             DO i = 1, 3
                CALL cp_dbcsr_sm_fm_multiply(dipmat(i)%matrix, mo_coeff, &
-                                            dBerry_psi0(i, ispin)%matrix, ncol=nmo)
+                                            dBerry_psi0(i, ispin), ncol=nmo)
             END DO !x/y/z-direction
          END DO
 
@@ -958,7 +958,7 @@ CONTAINS
 
       INTEGER                                            :: handle, i, ispin, nmo, nspins
       LOGICAL                                            :: do_raman
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dBerry_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: dipmat, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -995,7 +995,7 @@ CONTAINS
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
             DO i = 1, 3
                CALL cp_dbcsr_sm_fm_multiply(dipmat(i)%matrix, mo_coeff, &
-                                            dBerry_psi0(i, ispin)%matrix, ncol=nmo)
+                                            dBerry_psi0(i, ispin), ncol=nmo)
             END DO !x/y/z-direction
          END DO
 
@@ -1034,7 +1034,7 @@ CONTAINS
       REAL(dp), DIMENSION(3)                             :: ria, rib
       REAL(dp), DIMENSION(:, :), POINTER                 :: d_block, s_block
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dBerry_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: dipmat, matrix_s
@@ -1086,7 +1086,7 @@ CONTAINS
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
             DO i = 1, 3
                CALL cp_dbcsr_sm_fm_multiply(dipmat(i)%matrix, mo_coeff, &
-                                            dBerry_psi0(i, ispin)%matrix, ncol=nmo)
+                                            dBerry_psi0(i, ispin), ncol=nmo)
             END DO !x/y/z-direction
          END DO
 

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -35,9 +35,14 @@ MODULE qs_linres_op
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_p_type, cp_fm_release, &
-        cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_info,&
+                                              cp_fm_get_submatrix,&
+                                              cp_fm_release,&
+                                              cp_fm_set_all,&
+                                              cp_fm_set_submatrix,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type,&
                                               cp_to_string
@@ -450,8 +455,8 @@ CONTAINS
       LOGICAL                                            :: do_dso, do_fc, do_pso, do_sd
       REAL(dp)                                           :: chk(20), r_i(3)
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dso_psi0, efg_psi0, pso_psi0
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fc_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dso_psi0, efg_psi0, pso_psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -591,7 +596,7 @@ CONTAINS
          IF (do_sd) THEN
             DO idir = 1, 6
                CALL cp_dbcsr_sm_fm_multiply(matrix_efg(idir)%matrix, mo_coeff, &
-                                            efg_psi0(ispin, idir)%matrix, ncol=nmo, &
+                                            efg_psi0(ispin, idir), ncol=nmo, &
                                             alpha=1.0_dp)
             END DO
          END IF
@@ -600,7 +605,7 @@ CONTAINS
          IF (do_pso) THEN
             DO idir = 1, 3
                CALL cp_dbcsr_sm_fm_multiply(matrix_pso(idir)%matrix, mo_coeff, &
-                                            pso_psi0(ispin, idir)%matrix, ncol=nmo, &
+                                            pso_psi0(ispin, idir), ncol=nmo, &
                                             alpha=-1.0_dp)
             END DO
          END IF
@@ -616,7 +621,7 @@ CONTAINS
          IF (do_dso) THEN
             DO idir = 1, 3
                CALL cp_dbcsr_sm_fm_multiply(matrix_dso(idir)%matrix, mo_coeff, &
-                                            dso_psi0(ispin, idir)%matrix, ncol=nmo, &
+                                            dso_psi0(ispin, idir), ncol=nmo, &
                                             alpha=-1.0_dp)
             END DO
          END IF

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -690,8 +690,9 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: eigrmat
       TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:, :)    :: inv_mat
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0, op_fm_set, opvec
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: op_fm_set, opvec
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :, :)  :: inv_work
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -703,7 +704,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (dBerry_psi0, op_fm_set, opvec, sinmat, cosmat)
+      NULLIFY (dBerry_psi0, sinmat, cosmat)
       NULLIFY (polar_env)
 
       NULLIFY (cell, dft_control, mos, matrix_s)
@@ -743,16 +744,15 @@ CONTAINS
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nmo, &
                                      ncol_global=nmo, para_env=para_env, context=mo_coeff%matrix_struct%context)
             DO i = 1, SIZE(op_fm_set, 1)
-               ALLOCATE (opvec(i, ispin)%matrix, op_fm_set(i, ispin)%matrix)
-               CALL cp_fm_create(opvec(i, ispin)%matrix, mo_coeff%matrix_struct)
-               CALL cp_fm_create(op_fm_set(i, ispin)%matrix, tmp_fm_struct)
+               CALL cp_fm_create(opvec(i, ispin), mo_coeff%matrix_struct)
+               CALL cp_fm_create(op_fm_set(i, ispin), tmp_fm_struct)
             END DO
-            CALL cp_cfm_create(eigrmat(ispin), op_fm_set(1, ispin)%matrix%matrix_struct)
+            CALL cp_cfm_create(eigrmat(ispin), op_fm_set(1, ispin)%matrix_struct)
             CALL cp_fm_struct_release(tmp_fm_struct)
             DO i = 1, 3
-               CALL cp_cfm_create(inv_mat(i, ispin), op_fm_set(1, ispin)%matrix%matrix_struct)
-               CALL cp_fm_create(inv_work(2, i, ispin), op_fm_set(2, ispin)%matrix%matrix_struct)
-               CALL cp_fm_create(inv_work(1, i, ispin), op_fm_set(1, ispin)%matrix%matrix_struct)
+               CALL cp_cfm_create(inv_mat(i, ispin), op_fm_set(1, ispin)%matrix_struct)
+               CALL cp_fm_create(inv_work(2, i, ispin), op_fm_set(2, ispin)%matrix_struct)
+               CALL cp_fm_create(inv_work(1, i, ispin), op_fm_set(1, ispin)%matrix_struct)
             END DO
          END DO
 
@@ -770,12 +770,12 @@ CONTAINS
             DO ispin = 1, dft_control%nspins ! spin
                CALL get_mo_set(mo_set=mos(ispin), nao=nao, mo_coeff=mo_coeff, nmo=nmo)
 
-               CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff, opvec(1, ispin)%matrix, ncol=nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(1, ispin)%matrix, 0.0_dp, &
-                                  op_fm_set(1, ispin)%matrix)
-               CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff, opvec(2, ispin)%matrix, ncol=nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(2, ispin)%matrix, 0.0_dp, &
-                                  op_fm_set(2, ispin)%matrix)
+               CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff, opvec(1, ispin), ncol=nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(1, ispin), 0.0_dp, &
+                                  op_fm_set(1, ispin))
+               CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff, opvec(2, ispin), ncol=nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(2, ispin), 0.0_dp, &
+                                  op_fm_set(2, ispin))
 
             END DO
 
@@ -785,8 +785,8 @@ CONTAINS
                CALL cp_cfm_get_info(eigrmat(ispin), ncol_local=tmp_dim)
                DO idim = 1, tmp_dim
                   eigrmat(ispin)%local_data(:, idim) = &
-                     CMPLX(op_fm_set(1, ispin)%matrix%local_data(:, idim), &
-                           -op_fm_set(2, ispin)%matrix%local_data(:, idim), dp)
+                     CMPLX(op_fm_set(1, ispin)%local_data(:, idim), &
+                           -op_fm_set(2, ispin)%local_data(:, idim), dp)
                END DO
                CALL cp_cfm_set_all(inv_mat(i, ispin), zero, one)
                CALL cp_cfm_solve(eigrmat(ispin), inv_mat(i, ispin), zdeta)
@@ -800,9 +800,9 @@ CONTAINS
                   inv_work(1, i, ispin)%local_data(:, z) = REAL(inv_mat(i, ispin)%local_data(:, z), dp)
                   inv_work(2, i, ispin)%local_data(:, z) = AIMAG(inv_mat(i, ispin)%local_data(:, z))
                END DO
-               CALL parallel_gemm("N", "N", nao, nmo, nmo, -1.0_dp, opvec(1, ispin)%matrix, inv_work(2, i, ispin), &
+               CALL parallel_gemm("N", "N", nao, nmo, nmo, -1.0_dp, opvec(1, ispin), inv_work(2, i, ispin), &
                                   0.0_dp, dBerry_psi0(i, ispin)%matrix)
-               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, opvec(2, ispin)%matrix, inv_work(1, i, ispin), &
+               CALL parallel_gemm("N", "N", nao, nmo, nmo, 1.0_dp, opvec(2, ispin), inv_work(1, i, ispin), &
                                   1.0_dp, dBerry_psi0(i, ispin)%matrix)
             END DO
          END DO !x/y/z-direction
@@ -815,12 +815,10 @@ CONTAINS
                CALL cp_fm_release(inv_work(1, i, ispin))
                CALL cp_fm_release(inv_work(2, i, ispin))
             END DO
-            CALL cp_fm_release(opvec(1, ispin)%matrix)
-            CALL cp_fm_release(opvec(2, ispin)%matrix)
-            CALL cp_fm_release(op_fm_set(2, ispin)%matrix)
-            CALL cp_fm_release(op_fm_set(1, ispin)%matrix)
-            DEALLOCATE (opvec(1, ispin)%matrix, opvec(2, ispin)%matrix, &
-                        op_fm_set(2, ispin)%matrix, op_fm_set(1, ispin)%matrix)
+            CALL cp_fm_release(opvec(1, ispin))
+            CALL cp_fm_release(opvec(2, ispin))
+            CALL cp_fm_release(op_fm_set(2, ispin))
+            CALL cp_fm_release(op_fm_set(1, ispin))
          END DO
 
          CALL dbcsr_deallocate_matrix(cosmat)

--- a/src/qs_linres_polar_utils.F
+++ b/src/qs_linres_polar_utils.F
@@ -168,9 +168,7 @@ CONTAINS
          ! Remove previous matrices
          DO ispin = 1, nspins
             DO idir = 1, 3
-               CALL cp_fm_release(polar_env%psi1_dBerry(idir, ispin)%matrix)
-               DEALLOCATE (polar_env%psi1_dBerry(idir, ispin)%matrix)
-               NULLIFY (polar_env%psi1_dBerry(idir, ispin)%matrix)
+               CALL cp_fm_release(polar_env%psi1_dBerry(idir, ispin))
             END DO
          END DO
       END IF
@@ -182,10 +180,9 @@ CONTAINS
                                   ncol_global=m, &
                                   context=mo_coeff%matrix_struct%context)
          DO idir = 1, 3
-            ALLOCATE (polar_env%dBerry_psi0(idir, ispin)%matrix, &
-                      polar_env%psi1_dBerry(idir, ispin)%matrix)
+            ALLOCATE (polar_env%dBerry_psi0(idir, ispin)%matrix)
             CALL cp_fm_create(polar_env%dBerry_psi0(idir, ispin)%matrix, tmp_fm_struct)
-            CALL cp_fm_create(polar_env%psi1_dBerry(idir, ispin)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(polar_env%psi1_dBerry(idir, ispin), tmp_fm_struct)
          END DO
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
@@ -214,7 +211,8 @@ CONTAINS
       REAL(dp)                                           :: ptmp
       REAL(dp), DIMENSION(:, :), POINTER                 :: polar, polar_tmp
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0, psi1_dBerry
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_dBerry
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
@@ -258,7 +256,7 @@ CONTAINS
                DO ispin = 1, dft_control%nspins
                   !SL compute trace
                   ptmp = 0.0_dp
-                  CALL cp_fm_trace(psi1_dBerry(i, ispin)%matrix, dBerry_psi0(z, ispin)%matrix, ptmp)
+                  CALL cp_fm_trace(psi1_dBerry(i, ispin), dBerry_psi0(z, ispin)%matrix, ptmp)
                   polar_tmp(i, z) = polar_tmp(i, z) - 2.0_dp*ptmp
                END DO
             END DO
@@ -392,10 +390,10 @@ CONTAINS
       INTEGER                                            :: handle, idir, iounit, ispin, nao, nmo, &
                                                             nspins
       LOGICAL                                            :: do_periodic, do_raman, should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1, psi1_ptr
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0, psi1_dBerry
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order, psi1
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_dBerry
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -409,7 +407,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (dft_control, linres_control, lr_section, polar_section)
-      NULLIFY (logger, mpools, psi1, mo_coeff, para_env)
+      NULLIFY (logger, mpools, mo_coeff, para_env)
       NULLIFY (tmp_fm_struct, psi1_dBerry, dBerry_psi0)
 
       logger => cp_get_default_logger()
@@ -443,12 +441,11 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
          psi0_order(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, ncol_global=nmo, nrow_global=nao)
-         NULLIFY (tmp_fm_struct, psi1(ispin)%matrix)
+         NULLIFY (tmp_fm_struct)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                   ncol_global=nmo, &
                                   context=mo_coeff%matrix_struct%context)
-         ALLOCATE (psi1(ispin)%matrix)
-         CALL cp_fm_create(psi1(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(psi1(ispin), tmp_fm_struct)
          CALL cp_fm_create(h1_psi0(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
@@ -460,13 +457,12 @@ CONTAINS
          ! Restart
          IF (linres_control%linres_restart) THEN
             DO idir = 1, 3
-               psi1_ptr => psi1_dBerry(idir, :)
-               CALL linres_read_restart(qs_env, lr_section, psi1_ptr, idir, "psi1_dBerry")
+               CALL linres_read_restart(qs_env, lr_section, psi1_dBerry(idir, :), idir, "psi1_dBerry")
             END DO
          ELSE
             DO idir = 1, 3
                DO ispin = 1, nspins
-                  CALL cp_fm_set_all(psi1_dBerry(idir, ispin)%matrix, 0.0_dp)
+                  CALL cp_fm_set_all(psi1_dBerry(idir, ispin), 0.0_dp)
                END DO
             END DO
          END IF
@@ -482,7 +478,7 @@ CONTAINS
             END IF
             ! Do scf cycle to optimize psi1
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1_dBerry(idir, ispin)%matrix, psi1(ispin)%matrix)
+               CALL cp_fm_to_fm(psi1_dBerry(idir, ispin), psi1(ispin))
                CALL cp_fm_to_fm(dBerry_psi0(idir, ispin)%matrix, h1_psi0(ispin))
             END DO
             !
@@ -493,13 +489,12 @@ CONTAINS
 
             ! Copy the response
             DO ispin = 1, nspins
-               CALL cp_fm_to_fm(psi1(ispin)%matrix, psi1_dBerry(idir, ispin)%matrix)
+               CALL cp_fm_to_fm(psi1(ispin), psi1_dBerry(idir, ispin))
             END DO
             !
             ! Write the new result to the restart file
             IF (linres_control%linres_restart) THEN
-               psi1_ptr => psi1_dBerry(idir, :)
-               CALL linres_write_restart(qs_env, lr_section, psi1_ptr, idir, "psi1_dBerry")
+               CALL linres_write_restart(qs_env, lr_section, psi1_dBerry(idir, :), idir, "psi1_dBerry")
             END IF
          END DO loop_idir
       END IF ! do_raman
@@ -508,9 +503,8 @@ CONTAINS
 
       ! Clean up
       DO ispin = 1, nspins
-         CALL cp_fm_release(psi1(ispin)%matrix)
+         CALL cp_fm_release(psi1(ispin))
          CALL cp_fm_release(h1_psi0(ispin))
-         DEALLOCATE (psi1(ispin)%matrix)
       END DO
       DEALLOCATE (psi1, h1_psi0, psi0_order)
 

--- a/src/qs_linres_polar_utils.F
+++ b/src/qs_linres_polar_utils.F
@@ -392,9 +392,10 @@ CONTAINS
       INTEGER                                            :: handle, idir, iounit, ispin, nao, nmo, &
                                                             nspins
       LOGICAL                                            :: do_periodic, do_raman, should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi0_order, psi1, psi1_ptr
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1, psi1_ptr
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0, psi1_dBerry
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -440,7 +441,7 @@ CONTAINS
       ALLOCATE (psi1(nspins), h1_psi0(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-         psi0_order(ispin)%matrix => mo_coeff
+         psi0_order(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, ncol_global=nmo, nrow_global=nao)
          NULLIFY (tmp_fm_struct, psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &

--- a/src/qs_linres_polar_utils.F
+++ b/src/qs_linres_polar_utils.F
@@ -25,7 +25,6 @@ MODULE qs_linres_polar_utils
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -156,9 +155,7 @@ CONTAINS
          ! Remove previous matrices
          DO ispin = 1, nspins
             DO idir = 1, 3
-               CALL cp_fm_release(polar_env%dBerry_psi0(idir, ispin)%matrix)
-               DEALLOCATE (polar_env%dBerry_psi0(idir, ispin)%matrix)
-               NULLIFY (polar_env%dBerry_psi0(idir, ispin)%matrix)
+               CALL cp_fm_release(polar_env%dBerry_psi0(idir, ispin))
             END DO
          END DO
       END IF
@@ -180,8 +177,7 @@ CONTAINS
                                   ncol_global=m, &
                                   context=mo_coeff%matrix_struct%context)
          DO idir = 1, 3
-            ALLOCATE (polar_env%dBerry_psi0(idir, ispin)%matrix)
-            CALL cp_fm_create(polar_env%dBerry_psi0(idir, ispin)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(polar_env%dBerry_psi0(idir, ispin), tmp_fm_struct)
             CALL cp_fm_create(polar_env%psi1_dBerry(idir, ispin), tmp_fm_struct)
          END DO
          CALL cp_fm_struct_release(tmp_fm_struct)
@@ -211,8 +207,7 @@ CONTAINS
       REAL(dp)                                           :: ptmp
       REAL(dp), DIMENSION(:, :), POINTER                 :: polar, polar_tmp
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
-      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_dBerry
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dBerry_psi0, psi1_dBerry
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
@@ -256,7 +251,7 @@ CONTAINS
                DO ispin = 1, dft_control%nspins
                   !SL compute trace
                   ptmp = 0.0_dp
-                  CALL cp_fm_trace(psi1_dBerry(i, ispin), dBerry_psi0(z, ispin)%matrix, ptmp)
+                  CALL cp_fm_trace(psi1_dBerry(i, ispin), dBerry_psi0(z, ispin), ptmp)
                   polar_tmp(i, z) = polar_tmp(i, z) - 2.0_dp*ptmp
                END DO
             END DO
@@ -390,10 +385,9 @@ CONTAINS
       INTEGER                                            :: handle, idir, iounit, ispin, nao, nmo, &
                                                             nspins
       LOGICAL                                            :: do_periodic, do_raman, should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order, psi1
-      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: psi1_dBerry
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: dBerry_psi0, psi1_dBerry
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -479,7 +473,7 @@ CONTAINS
             ! Do scf cycle to optimize psi1
             DO ispin = 1, nspins
                CALL cp_fm_to_fm(psi1_dBerry(idir, ispin), psi1(ispin))
-               CALL cp_fm_to_fm(dBerry_psi0(idir, ispin)%matrix, h1_psi0(ispin))
+               CALL cp_fm_to_fm(dBerry_psi0(idir, ispin), h1_psi0(ispin))
             END DO
             !
             linres_control%lr_triplet = .FALSE. ! we do singlet response

--- a/src/qs_linres_polar_utils.F
+++ b/src/qs_linres_polar_utils.F
@@ -392,10 +392,10 @@ CONTAINS
       INTEGER                                            :: handle, idir, iounit, ispin, nao, nmo, &
                                                             nspins
       LOGICAL                                            :: do_periodic, do_raman, should_stop
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: h1_psi0, psi1, psi1_ptr
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1, psi1_ptr
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: dBerry_psi0, psi1_dBerry
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0_order
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: h1_psi0, psi0_order
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -409,7 +409,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (dft_control, linres_control, lr_section, polar_section)
-      NULLIFY (logger, mpools, psi1, h1_psi0, mo_coeff, para_env)
+      NULLIFY (logger, mpools, psi1, mo_coeff, para_env)
       NULLIFY (tmp_fm_struct, psi1_dBerry, dBerry_psi0)
 
       logger => cp_get_default_logger()
@@ -443,13 +443,13 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
          psi0_order(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, ncol_global=nmo, nrow_global=nao)
-         NULLIFY (tmp_fm_struct, psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+         NULLIFY (tmp_fm_struct, psi1(ispin)%matrix)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                   ncol_global=nmo, &
                                   context=mo_coeff%matrix_struct%context)
-         ALLOCATE (psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+         ALLOCATE (psi1(ispin)%matrix)
          CALL cp_fm_create(psi1(ispin)%matrix, tmp_fm_struct)
-         CALL cp_fm_create(h1_psi0(ispin)%matrix, tmp_fm_struct)
+         CALL cp_fm_create(h1_psi0(ispin), tmp_fm_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
 
@@ -483,7 +483,7 @@ CONTAINS
             ! Do scf cycle to optimize psi1
             DO ispin = 1, nspins
                CALL cp_fm_to_fm(psi1_dBerry(idir, ispin)%matrix, psi1(ispin)%matrix)
-               CALL cp_fm_to_fm(dBerry_psi0(idir, ispin)%matrix, h1_psi0(ispin)%matrix)
+               CALL cp_fm_to_fm(dBerry_psi0(idir, ispin)%matrix, h1_psi0(ispin))
             END DO
             !
             linres_control%lr_triplet = .FALSE. ! we do singlet response
@@ -509,8 +509,8 @@ CONTAINS
       ! Clean up
       DO ispin = 1, nspins
          CALL cp_fm_release(psi1(ispin)%matrix)
-         CALL cp_fm_release(h1_psi0(ispin)%matrix)
-         DEALLOCATE (psi1(ispin)%matrix, h1_psi0(ispin)%matrix)
+         CALL cp_fm_release(h1_psi0(ispin))
+         DEALLOCATE (psi1(ispin)%matrix)
       END DO
       DEALLOCATE (psi1, h1_psi0, psi0_order)
 

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -126,8 +126,7 @@ MODULE qs_linres_types
    TYPE polar_env_type
       LOGICAL                                      :: do_raman, run_stopped, do_periodic
       REAL(dp), DIMENSION(:, :), POINTER           :: polar
-      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: psi1_dBerry
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: dBerry_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: psi1_dBerry, dBerry_psi0
    END TYPE polar_env_type
 ! *********************************************************************************************************
 
@@ -1350,7 +1349,7 @@ CONTAINS
 
       TYPE(polar_env_type), INTENT(IN)                   :: polar_env
       LOGICAL, OPTIONAL                                  :: do_raman, do_periodic
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: dBerry_psi0
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: polar
       TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
@@ -1381,7 +1380,7 @@ CONTAINS
 
       TYPE(polar_env_type), INTENT(INOUT)                :: polar_env
       LOGICAL, OPTIONAL                                  :: do_raman, do_periodic
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: dBerry_psi0
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: polar
       TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
@@ -1416,8 +1415,7 @@ CONTAINS
          IF (ASSOCIATED(polar_env%dBerry_psi0)) THEN
             DO idir = 1, SIZE(polar_env%dBerry_psi0, 1)
                DO ispin = 1, SIZE(polar_env%dBerry_psi0, 2)
-                  CALL cp_fm_release(polar_env%dBerry_psi0(idir, ispin)%matrix)
-                  DEALLOCATE (polar_env%dBerry_psi0(idir, ispin)%matrix)
+                  CALL cp_fm_release(polar_env%dBerry_psi0(idir, ispin))
                END DO
             END DO
             DEALLOCATE (polar_env%dBerry_psi0)

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -111,8 +111,8 @@ MODULE qs_linres_types
       REAL(dp), DIMENSION(:, :), POINTER           :: basisfun_center => NULL()
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER :: center_list => NULL()
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER :: centers_set => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_p => NULL(), psi1_rxp => NULL(), psi1_D => NULL(), &
-                                                      p_psi0 => NULL(), rxp_psi0 => NULL()
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_p => NULL(), psi1_rxp => NULL(), psi1_D => NULL()
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: p_psi0 => NULL(), rxp_psi0 => NULL()
       TYPE(jrho_atom_type), DIMENSION(:), POINTER :: jrho1_atom_set => NULL()
       TYPE(qs_rho_p_type), DIMENSION(:), POINTER :: jrho1_set => NULL()
       TYPE(realspace_grid_type), DIMENSION(:), POINTER :: rs_buf => NULL()
@@ -456,8 +456,9 @@ CONTAINS
       TYPE(cp_2d_r_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: centers_set
       TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: psi1_p, psi1_rxp, psi1_D, p_psi0, &
-                                                            rxp_psi0
+         POINTER                                         :: psi1_p, psi1_rxp, psi1_D
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: p_psi0, rxp_psi0
       TYPE(jrho_atom_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: jrho1_atom_set
       TYPE(qs_rho_p_type), DIMENSION(:), OPTIONAL, &

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -140,7 +140,7 @@ MODULE qs_linres_types
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_efg => NULL(), psi1_pso => NULL(), efg_psi0 => NULL(), &
                                                       pso_psi0 => NULL(), dso_psi0 => NULL(), psi1_dso => NULL()
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: psi1_fc => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: fc_psi0 => NULL()
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: fc_psi0 => NULL()
   TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: matrix_efg => NULL(), matrix_pso => NULL(), matrix_dso => NULL(), matrix_fc => NULL()
    END TYPE issc_env_type
 
@@ -589,8 +589,7 @@ CONTAINS
          POINTER                                         :: psi1_fc
       TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: efg_psi0, pso_psi0, dso_psi0
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: fc_psi0
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: fc_psi0
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: matrix_efg, matrix_pso, matrix_dso, &
                                                             matrix_fc

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -18,8 +18,7 @@ MODULE qs_linres_types
    USE cp_array_utils,                  ONLY: cp_2d_i_p_type,&
                                               cp_2d_r_p_type
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release,&
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type,&
                                               dbcsr_type
@@ -219,8 +218,8 @@ MODULE qs_linres_types
       REAL(dp), DIMENSION(:, :), POINTER :: deltaR => NULL(), delta_basis_function => NULL()
       REAL(dp), DIMENSION(:, :, :, :), POINTER :: apt_subset => NULL(), apt_at_dcdr_per_center => NULL()
       TYPE(cp_fm_type), DIMENSION(:), POINTER :: mo_coeff => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: dCR => NULL(), dCR_prime => NULL(), &
-                                                   op_dR => NULL(), chc => NULL()
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: dCR => NULL(), dCR_prime => NULL(), &
+                                                 op_dR => NULL(), chc => NULL()
 
       CHARACTER(LEN=30) :: orb_center_name
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER :: center_list => NULL()

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -19,7 +19,8 @@ MODULE qs_linres_types
                                               cp_2d_r_p_type
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+                                              cp_fm_release,&
+                                              cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type,&
                                               dbcsr_type
    USE kinds,                           ONLY: dp
@@ -117,7 +118,7 @@ MODULE qs_linres_types
       TYPE(realspace_grid_type), DIMENSION(:), POINTER :: rs_buf => NULL()
       TYPE(realspace_grid_type), DIMENSION(:, :), POINTER :: rs_gauge => NULL()
       !
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: psi0_order => NULL()
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: psi0_order => NULL()
    END TYPE current_env_type
 
 !*********************************************************************************************************
@@ -217,7 +218,8 @@ MODULE qs_linres_types
                                                       matrix_difdip => NULL()
       REAL(dp), DIMENSION(:, :), POINTER :: deltaR => NULL(), delta_basis_function => NULL()
       REAL(dp), DIMENSION(:, :, :, :), POINTER :: apt_subset => NULL(), apt_at_dcdr_per_center => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: mo_coeff => NULL(), dCR => NULL(), dCR_prime => NULL(), &
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: mo_coeff => NULL()
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: dCR => NULL(), dCR_prime => NULL(), &
                                                    op_dR => NULL(), chc => NULL()
 
       CHARACTER(LEN=30) :: orb_center_name
@@ -466,8 +468,7 @@ CONTAINS
       TYPE(realspace_grid_type), DIMENSION(:, :), &
          OPTIONAL, POINTER                               :: rs_gauge
       LOGICAL, OPTIONAL                                  :: use_old_gauge_atom, chi_pbc
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: psi0_order
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: psi0_order
 
       IF (PRESENT(simple_done)) simple_done(1:6) = current_env%simple_done(1:6)
       IF (PRESENT(simple_converged)) simple_converged(1:6) = current_env%simple_converged(1:6)

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -111,7 +111,7 @@ MODULE qs_linres_types
       REAL(dp), DIMENSION(:, :), POINTER           :: basisfun_center => NULL()
       TYPE(cp_2d_i_p_type), DIMENSION(:), POINTER :: center_list => NULL()
       TYPE(cp_2d_r_p_type), DIMENSION(:), POINTER :: centers_set => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_p => NULL(), psi1_rxp => NULL(), psi1_D => NULL()
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: psi1_p => NULL(), psi1_rxp => NULL(), psi1_D => NULL()
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: p_psi0 => NULL(), rxp_psi0 => NULL()
       TYPE(jrho_atom_type), DIMENSION(:), POINTER :: jrho1_atom_set => NULL()
       TYPE(qs_rho_p_type), DIMENSION(:), POINTER :: jrho1_set => NULL()
@@ -126,7 +126,8 @@ MODULE qs_linres_types
    TYPE polar_env_type
       LOGICAL                                      :: do_raman, run_stopped, do_periodic
       REAL(dp), DIMENSION(:, :), POINTER           :: polar
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_dBerry, dBerry_psi0
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: psi1_dBerry
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: dBerry_psi0
    END TYPE polar_env_type
 ! *********************************************************************************************************
 
@@ -455,10 +456,9 @@ CONTAINS
          POINTER                                         :: center_list
       TYPE(cp_2d_r_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: centers_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: psi1_p, psi1_rxp, psi1_D
       TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
-         POINTER                                         :: p_psi0, rxp_psi0
+         POINTER                                         :: psi1_p, psi1_rxp, psi1_D, p_psi0, &
+                                                            rxp_psi0
       TYPE(jrho_atom_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: jrho1_atom_set
       TYPE(qs_rho_p_type), DIMENSION(:), OPTIONAL, &
@@ -1353,7 +1353,7 @@ CONTAINS
       TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: dBerry_psi0
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: polar
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: psi1_dBerry
       LOGICAL, OPTIONAL                                  :: run_stopped
 
@@ -1384,7 +1384,7 @@ CONTAINS
       TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: dBerry_psi0
       REAL(dp), DIMENSION(:, :), OPTIONAL, POINTER       :: polar
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: psi1_dBerry
       LOGICAL, OPTIONAL                                  :: run_stopped
 
@@ -1425,8 +1425,7 @@ CONTAINS
          IF (ASSOCIATED(polar_env%psi1_dBerry)) THEN
             DO idir = 1, SIZE(polar_env%psi1_dBerry, 1)
                DO ispin = 1, SIZE(polar_env%psi1_dBerry, 2)
-                  CALL cp_fm_release(polar_env%psi1_dBerry(idir, ispin)%matrix)
-                  DEALLOCATE (polar_env%psi1_dBerry(idir, ispin)%matrix)
+                  CALL cp_fm_release(polar_env%psi1_dBerry(idir, ispin))
                END DO
             END DO
             DEALLOCATE (polar_env%psi1_dBerry)

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -137,8 +137,8 @@ MODULE qs_linres_types
       LOGICAL                             :: do_fc, do_sd, do_pso, do_dso
       REAL(dp)                            :: issc_gapw_radius, issc_factor, issc_factor_gapw
       REAL(dp), DIMENSION(:, :, :, :, :), POINTER :: issc => NULL(), issc_loc => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_efg => NULL(), psi1_pso => NULL(), efg_psi0 => NULL(), &
-                                                      pso_psi0 => NULL(), dso_psi0 => NULL(), psi1_dso => NULL()
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_efg => NULL(), psi1_pso => NULL(), psi1_dso => NULL()
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: efg_psi0 => NULL(), pso_psi0 => NULL(), dso_psi0 => NULL()
       TYPE(cp_fm_type), DIMENSION(:), POINTER :: psi1_fc => NULL()
       TYPE(cp_fm_type), DIMENSION(:), POINTER :: fc_psi0 => NULL()
   TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: matrix_efg => NULL(), matrix_pso => NULL(), matrix_dso => NULL(), matrix_fc => NULL()
@@ -586,7 +586,7 @@ CONTAINS
       TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: psi1_efg, psi1_pso, psi1_dso
       TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: psi1_fc
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: efg_psi0, pso_psi0, dso_psi0
       TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: fc_psi0
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -137,8 +137,8 @@ MODULE qs_linres_types
       LOGICAL                             :: do_fc, do_sd, do_pso, do_dso
       REAL(dp)                            :: issc_gapw_radius, issc_factor, issc_factor_gapw
       REAL(dp), DIMENSION(:, :, :, :, :), POINTER :: issc => NULL(), issc_loc => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_efg => NULL(), psi1_pso => NULL(), psi1_dso => NULL()
-      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: efg_psi0 => NULL(), pso_psi0 => NULL(), dso_psi0 => NULL()
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER :: psi1_efg => NULL(), psi1_pso => NULL(), psi1_dso => NULL(), &
+                                                    efg_psi0 => NULL(), pso_psi0 => NULL(), dso_psi0 => NULL()
       TYPE(cp_fm_type), DIMENSION(:), POINTER :: psi1_fc => NULL()
       TYPE(cp_fm_type), DIMENSION(:), POINTER :: fc_psi0 => NULL()
   TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: matrix_efg => NULL(), matrix_pso => NULL(), matrix_dso => NULL(), matrix_fc => NULL()
@@ -583,7 +583,7 @@ CONTAINS
       REAL(dp), DIMENSION(:, :, :, :, :), OPTIONAL, &
          POINTER                                         :: issc
       LOGICAL, OPTIONAL                                  :: interpolate_issc
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: psi1_efg, psi1_pso, psi1_dso
       TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: psi1_fc
       TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &

--- a/src/qs_linres_types.F
+++ b/src/qs_linres_types.F
@@ -139,7 +139,7 @@ MODULE qs_linres_types
       REAL(dp), DIMENSION(:, :, :, :, :), POINTER :: issc => NULL(), issc_loc => NULL()
       TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER :: psi1_efg => NULL(), psi1_pso => NULL(), efg_psi0 => NULL(), &
                                                       pso_psi0 => NULL(), dso_psi0 => NULL(), psi1_dso => NULL()
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: psi1_fc => NULL()
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: psi1_fc => NULL()
       TYPE(cp_fm_type), DIMENSION(:), POINTER :: fc_psi0 => NULL()
   TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: matrix_efg => NULL(), matrix_pso => NULL(), matrix_dso => NULL(), matrix_fc => NULL()
    END TYPE issc_env_type
@@ -585,8 +585,7 @@ CONTAINS
       LOGICAL, OPTIONAL                                  :: interpolate_issc
       TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: psi1_efg, psi1_pso, psi1_dso
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: psi1_fc
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: psi1_fc
       TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: efg_psi0, pso_psi0, dso_psi0
       TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: fc_psi0

--- a/src/qs_loc_methods.F
+++ b/src/qs_loc_methods.F
@@ -176,7 +176,7 @@ CONTAINS
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
       TYPE(cp_fm_type), INTENT(IN)                       :: vectors
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: op_sm_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: zij_fm_set
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: zij_fm_set
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(cell_type), POINTER                           :: cell
       REAL(dp), DIMENSION(:)                             :: weights
@@ -327,7 +327,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: method
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
       TYPE(cp_fm_type), INTENT(IN)                       :: vectors
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: zij_fm_set
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: zij_fm_set
       INTEGER, INTENT(IN)                                :: ispin
       TYPE(section_vals_type), POINTER                   :: print_loc_section
 
@@ -377,8 +377,8 @@ CONTAINS
 
       !   Compute zij here
       DO iatom = 1, natom
-         CALL cp_fm_set_all(zij_fm_set(iatom, 1)%matrix, 0.0_dp)
-         CALL cp_fm_get_info(zij_fm_set(iatom, 1)%matrix, ncol_global=ldz)
+         CALL cp_fm_set_all(zij_fm_set(iatom, 1), 0.0_dp)
+         CALL cp_fm_get_info(zij_fm_set(iatom, 1), ncol_global=ldz)
          isgf = first_sgf(iatom)
          ncol = nsgf(iatom)
 
@@ -387,14 +387,14 @@ CONTAINS
                             a_first_col=1, a_first_row=1, b_first_col=1, b_first_row=1)
 
          CALL parallel_gemm('T', 'N', nmoloc, nmoloc, ncol, 0.5_dp, vectors, opvec, &
-                            0.0_dp, zij_fm_set(iatom, 1)%matrix, &
+                            0.0_dp, zij_fm_set(iatom, 1), &
                             a_first_col=1, a_first_row=isgf, b_first_col=1, b_first_row=isgf)
 
          CALL parallel_gemm('N', 'N', nao, nmoloc, ncol, 1.0_dp, ov_fm, vectors, 0.0_dp, opvec, &
                             a_first_col=isgf, a_first_row=1, b_first_col=1, b_first_row=isgf)
 
          CALL parallel_gemm('T', 'N', nmoloc, nmoloc, nao, 0.5_dp, vectors, opvec, &
-                            1.0_dp, zij_fm_set(iatom, 1)%matrix, &
+                            1.0_dp, zij_fm_set(iatom, 1), &
                             a_first_col=1, a_first_row=1, b_first_col=1, b_first_row=1)
 
       END DO ! iatom
@@ -449,7 +449,7 @@ CONTAINS
    SUBROUTINE centers_spreads_berry(qs_loc_env, zij, nmoloc, cell, weights, ispin, &
                                     print_loc_section, only_initial_out)
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
-      TYPE(cp_fm_p_type), INTENT(INOUT)                  :: zij(:, :)
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: zij
       INTEGER, INTENT(IN)                                :: nmoloc
       TYPE(cell_type), POINTER                           :: cell
       REAL(dp), DIMENSION(:)                             :: weights
@@ -483,7 +483,7 @@ CONTAINS
       iter = cp_iter_string(logger%iter_info)
       IF (unit_out_s > 0 .AND. .NOT. my_only_init) WRITE (unit_out_s, '(i6,/,A)') nmoloc, TRIM(iter)
 
-      CALL cp_fm_get_info(zij(1, 1)%matrix, nrow_global=nstates)
+      CALL cp_fm_get_info(zij(1, 1), nrow_global=nstates)
       CPASSERT(nstates >= nmoloc)
 
       centers => qs_loc_env%localized_wfn_control%centers_set(ispin)%array
@@ -498,8 +498,8 @@ CONTAINS
          spread_i = 0.0_dp
          spread_ii = 0.0_dp
          DO jdir = 1, SIZE(zij, 2)
-            CALL cp_fm_get_element(zij(1, jdir)%matrix, istate, istate, realpart)
-            CALL cp_fm_get_element(zij(2, jdir)%matrix, istate, istate, imagpart)
+            CALL cp_fm_get_element(zij(1, jdir), istate, istate, realpart)
+            CALL cp_fm_get_element(zij(2, jdir), istate, istate, imagpart)
             z = CMPLX(realpart, imagpart, dp)
             spread_i = spread_i - weights(jdir)* &
                        LOG(realpart*realpart + imagpart*imagpart)/twopi/twopi
@@ -560,7 +560,7 @@ CONTAINS
                                     print_loc_section)
 
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: zij_fm_set
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: zij_fm_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       INTEGER, INTENT(IN)                                :: ispin
       TYPE(section_vals_type), POINTER                   :: print_loc_section
@@ -578,7 +578,7 @@ CONTAINS
       NULLIFY (centers, logger, print_key)
       logger => cp_get_default_logger()
 
-      CALL cp_fm_get_info(zij_fm_set(1, 1)%matrix, nrow_global=nstate)
+      CALL cp_fm_get_info(zij_fm_set(1, 1), nrow_global=nstate)
       natom = SIZE(zij_fm_set, 1)
 
       centers => qs_loc_env%localized_wfn_control%centers_set(ispin)%array
@@ -599,7 +599,7 @@ CONTAINS
 
       DO iatom = 1, natom
          DO istate = 1, nstate
-            CALL cp_fm_get_element(zij_fm_set(iatom, 1)%matrix, istate, istate, diag(istate, iatom))
+            CALL cp_fm_get_element(zij_fm_set(iatom, 1), istate, istate, diag(istate, iatom))
          END DO
       END DO
 
@@ -672,9 +672,9 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: op_fm_set
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: mos_guess, tmp_fm, tmp_fm_1, vectors_2
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: op_fm_set
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: p_rmpv
@@ -781,11 +781,10 @@ CONTAINS
             ALLOCATE (op_fm_set(2, dim_op))
             DO i = 1, dim_op
                DO j = 1, SIZE(op_fm_set, 1)
-                  ALLOCATE (op_fm_set(j, i)%matrix)
-                  CALL cp_fm_create(op_fm_set(j, i)%matrix, tmp_fm_struct)
-                  CALL cp_fm_get_info(op_fm_set(j, i)%matrix, nrow_global=nmosub)
+                  CALL cp_fm_create(op_fm_set(j, i), tmp_fm_struct)
+                  CALL cp_fm_get_info(op_fm_set(j, i), nrow_global=nmosub)
                   CPASSERT(nmo >= nmosub)
-                  CALL cp_fm_set_all(op_fm_set(j, i)%matrix, 0.0_dp)
+                  CALL cp_fm_set_all(op_fm_set(j, i), 0.0_dp)
                END DO
             END DO
             CALL cp_fm_struct_release(tmp_fm_struct)
@@ -904,8 +903,7 @@ CONTAINS
             IF (ASSOCIATED(op_fm_set)) THEN
                DO i = 1, dim_op
                   DO j = 1, SIZE(op_fm_set, 1)
-                     CALL cp_fm_release(op_fm_set(j, i)%matrix)
-                     DEALLOCATE (op_fm_set(j, i)%matrix)
+                     CALL cp_fm_release(op_fm_set(j, i))
                   END DO
                END DO
                DEALLOCATE (op_fm_set)

--- a/src/qs_loc_methods.F
+++ b/src/qs_loc_methods.F
@@ -38,7 +38,7 @@ MODULE qs_loc_methods
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         cp_fm_create, cp_fm_get_element, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_init_random, &
-        cp_fm_p_type, cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
+        cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type,&
                                               cp_to_string
@@ -671,9 +671,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: centers, tmp_mat, vecbuffer
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: mos_guess, tmp_fm, tmp_fm_1, vectors_2
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: op_fm_set
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -841,7 +841,7 @@ CONTAINS
                      ELSEIF (my_guess_wan) THEN
                         nguess = localized_wfn_control%nguess(ispin)
                         ALLOCATE (tmp_mat(nao, nguess))
-                        CALL cp_fm_get_submatrix(moloc_coeff(ispin)%matrix, tmp_mat, 1, 1, nao, nguess)
+                        CALL cp_fm_get_submatrix(moloc_coeff(ispin), tmp_mat, 1, 1, nao, nguess)
                         CALL cp_fm_set_submatrix(mos_guess, tmp_mat, 1, 1, nao, nguess)
                         DEALLOCATE (tmp_mat)
                         ngextra = nmosub - nguess
@@ -864,7 +864,7 @@ CONTAINS
                         END IF
                         ALLOCATE (tmp_mat(nao, nmosub))
                         CALL cp_fm_get_submatrix(mo_coeff, tmp_mat, 1, 1, nao, nmosub)
-                        CALL cp_fm_set_submatrix(moloc_coeff(ispin)%matrix, tmp_mat)
+                        CALL cp_fm_set_submatrix(moloc_coeff(ispin), tmp_mat)
                         DEALLOCATE (tmp_mat)
                      END IF
 
@@ -879,23 +879,23 @@ CONTAINS
                         END IF
                      END IF
 
-                     CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin)%matrix, op_sm_set, &
+                     CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin), op_sm_set, &
                                              op_fm_set, para_env, cell, weights, ispin, print_loc_section, &
                                              nextra=nextra, nmo=nmo, vectors_2=vectors_2, &
                                              guess_mos=mos_guess)
                      CALL cp_fm_release(mos_guess)
                   ELSE
-                     CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin)%matrix, op_sm_set, &
+                     CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin), op_sm_set, &
                                              op_fm_set, para_env, cell, weights, ispin, print_loc_section, &
                                              nextra=nextra, nmo=nmo, vectors_2=vectors_2)
                   END IF
                   CALL cp_fm_release(vectors_2)
                ELSE
-                  CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin)%matrix, op_sm_set, &
+                  CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin), op_sm_set, &
                                           op_fm_set, para_env, cell, weights, ispin, print_loc_section, nextra=0)
                END IF
             ELSE
-               CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin)%matrix, op_sm_set, &
+               CALL optimize_loc_berry(loc_method, qs_loc_env, moloc_coeff(ispin), op_sm_set, &
                                        op_fm_set, para_env, cell, weights, ispin, print_loc_section)
             END IF
 
@@ -914,7 +914,7 @@ CONTAINS
 
          CASE (op_loc_pipek)
 
-            CALL optimize_loc_pipek(qs_env, loc_method, qs_loc_env, moloc_coeff(ispin)%matrix, &
+            CALL optimize_loc_pipek(qs_env, loc_method, qs_loc_env, moloc_coeff(ispin), &
                                     op_fm_set, ispin, print_loc_section)
 
          END SELECT
@@ -937,7 +937,7 @@ CONTAINS
                ! Get the index in the full set
                imo = localized_wfn_control%loc_states(i, ispin)
 
-               CALL cp_fm_get_submatrix(moloc_coeff(ispin)%matrix, vecbuffer, 1, imoloc, &
+               CALL cp_fm_get_submatrix(moloc_coeff(ispin), vecbuffer, 1, imoloc, &
                                         nao, 1, transpose=.TRUE.)
                IF (PRESENT(ext_mo_coeff)) THEN
                   CALL cp_fm_set_submatrix(ext_mo_coeff, vecbuffer, 1, imo, &
@@ -952,9 +952,9 @@ CONTAINS
          ELSE
             nmosub = localized_wfn_control%nloc_states(ispin)
             IF (PRESENT(ext_mo_coeff)) THEN
-               CALL cp_fm_to_fm(moloc_coeff(ispin)%matrix, ext_mo_coeff, nmosub, 1, lb)
+               CALL cp_fm_to_fm(moloc_coeff(ispin), ext_mo_coeff, nmosub, 1, lb)
             ELSE
-               CALL cp_fm_to_fm(moloc_coeff(ispin)%matrix, mo_coeff, nmosub, 1, lb)
+               CALL cp_fm_to_fm(moloc_coeff(ispin), mo_coeff, nmosub, 1, lb)
             END IF
          END IF
 
@@ -1028,7 +1028,7 @@ CONTAINS
                my_pos = "APPEND"
             END IF
 
-            CALL qs_print_cubes(qs_env, moloc_coeff(ispin)%matrix, ncubes, list_cubes, centers, &
+            CALL qs_print_cubes(qs_env, moloc_coeff(ispin), ncubes, list_cubes, centers, &
                                 print_key, "loc"//TRIM(ADJUSTL(qs_loc_env%tag_mo)), &
                                 ispin=ispin, file_position=my_pos)
 
@@ -1341,17 +1341,13 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: moment_set
       REAL(KIND=dp), DIMENSION(3)                        :: rcc
       REAL(KIND=dp), DIMENSION(6)                        :: cov
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: momv, mvector, omvector
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: mo_localized
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, moments
-
-! two pointers, one to each spin channel's coeff. matrix, each nao x nmoloc
-!TYPE(localized_wfn_control_type), POINTER          :: localized_wfn_control
-!INTEGER, INTENT(IN)                                :: nmoloc
 
       logger => cp_get_default_logger()
 
@@ -1381,11 +1377,11 @@ CONTAINS
       !particle_set => qs_loc_env%particle_set
       para_env => qs_loc_env%para_env
 
-      CALL cp_fm_get_info(moloc_coeff(ispin)%matrix, ncol_global=nmoloc)
+      CALL cp_fm_get_info(moloc_coeff(ispin), ncol_global=nmoloc)
       ALLOCATE (moment_set(nm, nmoloc))
       moment_set = 0.0_dp
 
-      mo_localized => moloc_coeff(ispin)%matrix
+      mo_localized => moloc_coeff(ispin)
 
       DO istate = 1, nmoloc
          rcc = centers(1:3, istate)
@@ -1491,9 +1487,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: rcc
       REAL(KIND=dp), DIMENSION(6)                        :: cov
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: momv, mvector, omvector
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: mo_localized
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1533,12 +1529,12 @@ CONTAINS
 
       CALL get_qs_env(qs_env, matrix_s=matrix_s)
 
-      CALL cp_fm_get_info(moloc_coeff(ispin)%matrix, ncol_global=nmoloc)
+      CALL cp_fm_get_info(moloc_coeff(ispin), ncol_global=nmoloc)
 
       ALLOCATE (moment_set(nm, nmoloc))
       moment_set = 0.0_dp
 
-      mo_localized => moloc_coeff(ispin)%matrix
+      mo_localized => moloc_coeff(ispin)
 
       DO istate = 1, nmoloc
          rcc = centers(1:3, istate)

--- a/src/qs_loc_states.F
+++ b/src/qs_loc_states.F
@@ -11,7 +11,7 @@
 MODULE qs_loc_states
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
    USE cp_control_types,                ONLY: dft_control_type
-   USE cp_fm_types,                     ONLY: cp_fm_p_type
+   USE cp_fm_types,                     ONLY: cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type
@@ -71,11 +71,11 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
       TYPE(section_vals_type), POINTER                   :: loc_section
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_local
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_local
       TYPE(pw_type), INTENT(INOUT)                       :: wf_r
       TYPE(pw_type), INTENT(IN)                          :: wf_g
       TYPE(particle_list_type), POINTER                  :: particles
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: coeff
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: coeff
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: evals
       INTEGER, DIMENSION(:, :, :), POINTER               :: marked_states
 
@@ -135,7 +135,7 @@ CONTAINS
             scenter => qs_loc_env%localized_wfn_control%centers_set(ispin)%array
 
             CALL qs_loc_driver(qs_env, qs_loc_env, loc_print_section, &
-                               myspin=ispin, ext_mo_coeff=mo_local(ispin)%matrix)
+                               myspin=ispin, ext_mo_coeff=mo_local(ispin))
 
             ! maps wfc to molecules, and compute the molecular dipoles if required
             IF ((BTEST(cp_print_key_should_output(logger%iter_info, loc_print_section, &
@@ -158,7 +158,7 @@ CONTAINS
 
                wc(ispin)%centres(:, :) = scenter(1 + (ispin - 1)*3:ispin*3, :)
                lstates => qs_loc_env%localized_wfn_control%loc_states(:, ispin)
-               CALL construct_wannier_states(mo_local(ispin)%matrix, &
+               CALL construct_wannier_states(mo_local(ispin), &
                                              ks_rmpv(ispin)%matrix, qs_env, loc_print_section=loc_print_section, &
                                              WannierCentres=wc(ispin), ns=ns, states=lstates)
             END IF
@@ -166,7 +166,7 @@ CONTAINS
             IF (BTEST(cp_print_key_should_output(logger%iter_info, loc_print_section, &
                                                  "MOLECULAR_STATES"), cp_p_file)) THEN
                CALL construct_molecular_states( &
-                  molecule_set, mo_local(ispin)%matrix, coeff(ispin)%matrix, &
+                  molecule_set, mo_local(ispin), coeff(ispin), &
                   evals(ispin)%array, ks_rmpv(ispin)%matrix, matrix_s(1)%matrix, qs_env, wf_r, wf_g, &
                   loc_print_section=loc_print_section, particles=particles, tag=TRIM(qs_loc_env%tag_mo), &
                   marked_states=marked_states_spin, ispin=ispin)

--- a/src/qs_loc_types.F
+++ b/src/qs_loc_types.F
@@ -29,7 +29,8 @@ MODULE qs_loc_types
                                               cell_type
    USE cp_array_utils,                  ONLY: cp_2d_r_p_type
    USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release
+                                              cp_fm_release,&
+                                              cp_fm_type
    USE cp_para_env,                     ONLY: cp_para_env_release,&
                                               cp_para_env_retain
    USE cp_para_types,                   ONLY: cp_para_env_type
@@ -85,7 +86,7 @@ MODULE qs_loc_types
       TYPE(cp_para_env_type), POINTER          :: para_env
       TYPE(cp_fm_p_type), DIMENSION(:), &
          POINTER                                :: moloc_coeff
-      TYPE(cp_fm_p_type), DIMENSION(:, :), &
+      TYPE(cp_fm_type), DIMENSION(:, :), &
          POINTER                                :: op_fm_set
       TYPE(distribution_1d_type), POINTER         :: local_molecules
       TYPE(cell_type), POINTER                 :: cell
@@ -217,9 +218,7 @@ CONTAINS
       IF (ASSOCIATED(qs_loc_env%op_fm_set)) THEN
          DO i = 1, SIZE(qs_loc_env%op_fm_set, 2)
             DO j = 1, SIZE(qs_loc_env%op_fm_set, 1)
-               CALL cp_fm_release(qs_loc_env%op_fm_set(j, i)%matrix)
-               DEALLOCATE (qs_loc_env%op_fm_set(j, i)%matrix)
-               NULLIFY (qs_loc_env%op_fm_set(j, i)%matrix)
+               CALL cp_fm_release(qs_loc_env%op_fm_set(j, i))
             END DO
          END DO
          DEALLOCATE (qs_loc_env%op_fm_set)
@@ -336,7 +335,7 @@ CONTAINS
          POINTER                                         :: moloc_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: op_sm_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: op_fm_set
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &
@@ -387,7 +386,7 @@ CONTAINS
          POINTER                                         :: moloc_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: op_sm_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), OPTIONAL, &
+      TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: op_fm_set
       TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &

--- a/src/qs_loc_types.F
+++ b/src/qs_loc_types.F
@@ -28,8 +28,7 @@ MODULE qs_loc_types
                                               cell_retain,&
                                               cell_type
    USE cp_array_utils,                  ONLY: cp_2d_r_p_type
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release,&
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
                                               cp_fm_type
    USE cp_para_env,                     ONLY: cp_para_env_release,&
                                               cp_para_env_retain
@@ -84,7 +83,7 @@ MODULE qs_loc_types
       LOGICAL :: wannier_states
       CHARACTER(LEN=default_string_length)        :: tag_mo
       TYPE(cp_para_env_type), POINTER          :: para_env
-      TYPE(cp_fm_p_type), DIMENSION(:), &
+      TYPE(cp_fm_type), DIMENSION(:), &
          POINTER                                :: moloc_coeff
       TYPE(cp_fm_type), DIMENSION(:, :), &
          POINTER                                :: op_fm_set
@@ -208,9 +207,7 @@ CONTAINS
       IF (ASSOCIATED(qs_loc_env%moloc_coeff)) THEN
          DO i = 1, SIZE(qs_loc_env%moloc_coeff, 1)
             ii = LBOUND(qs_loc_env%moloc_coeff, 1) + i - 1
-            CALL cp_fm_release(qs_loc_env%moloc_coeff(ii)%matrix)
-            DEALLOCATE (qs_loc_env%moloc_coeff(ii)%matrix)
-            NULLIFY (qs_loc_env%moloc_coeff(ii)%matrix)
+            CALL cp_fm_release(qs_loc_env%moloc_coeff(ii))
          END DO
          DEALLOCATE (qs_loc_env%moloc_coeff)
       END IF
@@ -331,8 +328,7 @@ CONTAINS
       TYPE(distribution_1d_type), OPTIONAL, POINTER      :: local_molecules
       TYPE(localized_wfn_control_type), OPTIONAL, &
          POINTER                                         :: localized_wfn_control
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: moloc_coeff
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: moloc_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: op_sm_set
       TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
@@ -382,8 +378,7 @@ CONTAINS
       TYPE(distribution_1d_type), OPTIONAL, POINTER      :: local_molecules
       TYPE(localized_wfn_control_type), OPTIONAL, &
          POINTER                                         :: localized_wfn_control
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: moloc_coeff
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: moloc_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
          POINTER                                         :: op_sm_set
       TYPE(cp_fm_type), DIMENSION(:, :), OPTIONAL, &
@@ -423,9 +418,7 @@ CONTAINS
       IF (PRESENT(moloc_coeff)) THEN
          IF (ASSOCIATED(qs_loc_env%moloc_coeff)) THEN
             DO i = 1, SIZE(qs_loc_env%moloc_coeff, 1)
-               CALL cp_fm_release(qs_loc_env%moloc_coeff(i)%matrix)
-               DEALLOCATE (qs_loc_env%moloc_coeff(i)%matrix)
-               NULLIFY (qs_loc_env%moloc_coeff(i)%matrix)
+               CALL cp_fm_release(qs_loc_env%moloc_coeff(i))
             END DO
             DEALLOCATE (qs_loc_env%moloc_coeff)
          END IF

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -228,7 +228,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE jacobi_rotation_pipek(zij_fm_set, vectors, sweeps)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: zij_fm_set
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: zij_fm_set
       TYPE(cp_fm_type), INTENT(IN)                       :: vectors
       INTEGER                                            :: sweeps
 
@@ -237,7 +237,7 @@ CONTAINS
                                                             theta, tolerance
       TYPE(cp_fm_type)                                   :: rmat
 
-      CALL cp_fm_create(rmat, zij_fm_set(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(rmat, zij_fm_set(1, 1)%matrix_struct)
       CALL cp_fm_set_all(rmat, 0.0_dp, 1.0_dp)
 
       CALL cp_fm_get_info(rmat, nrow_global=nstate)
@@ -252,9 +252,9 @@ CONTAINS
                aij = 0.0_dp
                bij = 0.0_dp
                DO iatom = 1, natom
-                  CALL cp_fm_get_element(zij_fm_set(iatom, 1)%matrix, istate, istate, mii)
-                  CALL cp_fm_get_element(zij_fm_set(iatom, 1)%matrix, istate, jstate, mij)
-                  CALL cp_fm_get_element(zij_fm_set(iatom, 1)%matrix, jstate, jstate, mjj)
+                  CALL cp_fm_get_element(zij_fm_set(iatom, 1), istate, istate, mii)
+                  CALL cp_fm_get_element(zij_fm_set(iatom, 1), istate, jstate, mij)
+                  CALL cp_fm_get_element(zij_fm_set(iatom, 1), jstate, jstate, mjj)
                   aij = aij + mij*(mii - mjj)
                   bij = bij + mij*mij - 0.25_dp*(mii - mjj)*(mii - mjj)
 
@@ -339,8 +339,7 @@ CONTAINS
 
       INTEGER, INTENT(IN)                      :: istate, jstate
       REAL(dp), INTENT(IN)                     :: st, ct
-      TYPE(cp_fm_p_type), DIMENSION(:, :), &
-         POINTER                                :: zij
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN) :: zij
 
       INTEGER                                  :: iatom, natom, nstate
 #if defined(__SCALAPACK)
@@ -349,24 +348,24 @@ CONTAINS
       INTEGER                                  :: stride
 #endif
 
-      CALL cp_fm_get_info(zij(1, 1)%matrix, nrow_global=nstate)
+      CALL cp_fm_get_info(zij(1, 1), nrow_global=nstate)
 
       natom = SIZE(zij, 1)
       DO iatom = 1, natom
 #if defined(__SCALAPACK)
-         desc(:) = zij(iatom, 1)%matrix%matrix_struct%descriptor(:)
-         CALL pzrot(nstate, zij(iatom, 1)%matrix%local_data(1, 1), &
-                    1, istate, desc, 1, zij(iatom, 1)%matrix%local_data(1, 1), &
+         desc(:) = zij(iatom, 1)%matrix_struct%descriptor(:)
+         CALL pzrot(nstate, zij(iatom, 1)%local_data(1, 1), &
+                    1, istate, desc, 1, zij(iatom, 1)%local_data(1, 1), &
                     1, jstate, desc, nstate, ct, st)
-         CALL pzrot(nstate, zij(iatom, 1)%matrix%local_data(1, 1), &
-                    istate, 1, desc, 1, zij(iatom, 1)%matrix%local_data(1, 1), &
+         CALL pzrot(nstate, zij(iatom, 1)%local_data(1, 1), &
+                    istate, 1, desc, 1, zij(iatom, 1)%local_data(1, 1), &
                     jstate, 1, desc, nstate, ct, st)
 #else
-         CALL drot(nstate, zij(iatom, 1)%matrix%local_data(1, istate), &
-                   1, zij(iatom, 1)%matrix%local_data(1, jstate), 1, ct, st)
-         stride = SIZE(zij(iatom, 1)%matrix%local_data, 1)
-         CALL drot(nstate, zij(iatom, 1)%matrix%local_data(istate, 1), &
-                   stride, zij(iatom, 1)%matrix%local_data(jstate, 1), stride, ct, st)
+         CALL drot(nstate, zij(iatom, 1)%local_data(1, istate), &
+                   1, zij(iatom, 1)%local_data(1, jstate), 1, ct, st)
+         stride = SIZE(zij(iatom, 1)%local_data, 1)
+         CALL drot(nstate, zij(iatom, 1)%local_data(istate, 1), &
+                   stride, zij(iatom, 1)%local_data(jstate, 1), stride, ct, st)
 #endif
       END DO
 
@@ -382,7 +381,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE check_tolerance_real(zij_fm_set, tolerance)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: zij_fm_set
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: zij_fm_set
       REAL(dp), INTENT(OUT)                              :: tolerance
 
       INTEGER                                            :: iatom, istate, jstate, natom, &
@@ -394,17 +393,17 @@ CONTAINS
 
       NULLIFY (diag, col_indices, row_indices)
       natom = SIZE(zij_fm_set, 1)
-      CALL cp_fm_get_info(zij_fm_set(1, 1)%matrix, nrow_local=nrow_local, &
+      CALL cp_fm_get_info(zij_fm_set(1, 1), nrow_local=nrow_local, &
                           ncol_local=ncol_local, nrow_global=nrow_global, &
                           row_indices=row_indices, col_indices=col_indices)
       ALLOCATE (diag(nrow_global, natom))
 
-      CALL cp_fm_create(force, zij_fm_set(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(force, zij_fm_set(1, 1)%matrix_struct)
       CALL cp_fm_set_all(force, 0._dp)
 
       DO iatom = 1, natom
          DO istate = 1, nrow_global
-            CALL cp_fm_get_element(zij_fm_set(iatom, 1)%matrix, istate, istate, diag(istate, iatom))
+            CALL cp_fm_get_element(zij_fm_set(iatom, 1), istate, istate, diag(istate, iatom))
          END DO
       END DO
 
@@ -414,7 +413,7 @@ CONTAINS
             DO iatom = 1, natom
                zii = diag(istate, iatom)
                zjj = diag(jstate, iatom)
-               zij = zij_fm_set(iatom, 1)%matrix%local_data(istate, jstate)
+               zij = zij_fm_set(iatom, 1)%local_data(istate, jstate)
                grad_ij = grad_ij + 4.0_dp*zij*(zjj - zii)
             END DO
             force%local_data(istate, jstate) = grad_ij
@@ -613,13 +612,11 @@ CONTAINS
             DO ispin = 1, SIZE(qs_loc_env%op_fm_set, 2)
                CALL get_mo_set(mos(ispin), nmo=nmo)
                DO iatom = 1, natoms
-                  ALLOCATE (qs_loc_env%op_fm_set(iatom, ispin)%matrix)
+                  CALL cp_fm_create(qs_loc_env%op_fm_set(iatom, ispin), tmp_fm_struct)
 
-                  CALL cp_fm_create(qs_loc_env%op_fm_set(iatom, ispin)%matrix, tmp_fm_struct)
-
-                  CALL cp_fm_get_info(qs_loc_env%op_fm_set(iatom, ispin)%matrix, nrow_global=nmosub)
+                  CALL cp_fm_get_info(qs_loc_env%op_fm_set(iatom, ispin), nrow_global=nmosub)
                   CPASSERT(nmo >= nmosub)
-                  CALL cp_fm_set_all(qs_loc_env%op_fm_set(iatom, ispin)%matrix, 0.0_dp)
+                  CALL cp_fm_set_all(qs_loc_env%op_fm_set(iatom, ispin), 0.0_dp)
                END DO ! iatom
             END DO ! ispin
          ELSE

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -114,7 +114,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE retain_history(mo_loc_history, mo_loc)
 
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_loc_history, mo_loc
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: mo_loc_history
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_loc
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'retain_history'
 
@@ -125,16 +126,15 @@ CONTAINS
       IF (.NOT. ASSOCIATED(mo_loc_history)) THEN
          ALLOCATE (mo_loc_history(SIZE(mo_loc)))
          DO i = 1, SIZE(mo_loc_history)
-            ALLOCATE (mo_loc_history(i)%matrix)
-            CALL cp_fm_create(mo_loc_history(i)%matrix, mo_loc(i)%matrix%matrix_struct)
+            CALL cp_fm_create(mo_loc_history(i), mo_loc(i)%matrix_struct)
          END DO
       END IF
 
       DO i = 1, SIZE(mo_loc_history)
-         CALL cp_fm_get_info(mo_loc_history(i)%matrix, ncol_global=ncol_hist)
-         CALL cp_fm_get_info(mo_loc(i)%matrix, ncol_global=ncol_loc)
+         CALL cp_fm_get_info(mo_loc_history(i), ncol_global=ncol_hist)
+         CALL cp_fm_get_info(mo_loc(i), ncol_global=ncol_loc)
          CPASSERT(ncol_hist == ncol_loc)
-         CALL cp_fm_to_fm(mo_loc(i)%matrix, mo_loc_history(i)%matrix)
+         CALL cp_fm_to_fm(mo_loc(i), mo_loc_history(i))
       END DO
 
       CALL timestop(handle)
@@ -451,8 +451,9 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN), OPTIONAL                      :: myspin
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_localize
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: loc_coeff, mo_loc_history
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN), &
+         OPTIONAL                                        :: loc_coeff
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: mo_loc_history
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'qs_loc_env_init'
 
@@ -511,6 +512,8 @@ CONTAINS
          END DO ! ispin
          ! Copy the submatrix
 
+         IF (PRESENT(loc_coeff)) ALLOCATE (mat_ptr)
+
          DO ispin = s_spin, l_spin
             CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, &
                             occupation_numbers=occupations, nao=nao, nmo=nmo)
@@ -518,7 +521,7 @@ CONTAINS
             ub = localized_wfn_control%lu_bound_states(2, ispin)
 
             IF (PRESENT(loc_coeff)) THEN
-               mat_ptr => loc_coeff(ispin)%matrix
+               mat_ptr = loc_coeff(ispin)
             ELSE
                mat_ptr => mo_coeff
             END IF
@@ -570,11 +573,13 @@ CONTAINS
             IF (PRESENT(mo_loc_history)) THEN
                IF (localized_wfn_control%use_history .AND. ASSOCIATED(mo_loc_history)) THEN
                   CALL rotate_state_to_ref(moloc_coeff(ispin)%matrix, &
-                                           mo_loc_history(ispin)%matrix, matrix_s(1)%matrix)
+                                           mo_loc_history(ispin), matrix_s(1)%matrix)
                END IF
             END IF
 
          END DO
+
+         IF (PRESENT(loc_coeff)) DEALLOCATE (mat_ptr)
 
          CALL set_qs_loc_env(qs_loc_env=qs_loc_env, cell=cell, local_molecules=local_molecules, &
                              moloc_coeff=moloc_coeff, particle_set=particle_set, para_env=para_env, &
@@ -913,7 +918,7 @@ CONTAINS
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
       TYPE(section_vals_type), POINTER                   :: section
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mo_array
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: coeff_localized
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: coeff_localized
       LOGICAL, INTENT(IN)                                :: do_homo
       TYPE(cp_1d_r_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: evals
@@ -926,7 +931,6 @@ CONTAINS
       INTEGER                                            :: handle, ispin, max_block, nao, nloc, &
                                                             nmo, output_unit, rst_unit
       LOGICAL                                            :: my_do_mixed
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: print_key
 
@@ -976,25 +980,26 @@ CONTAINS
             END IF
 
             DO ispin = 1, SIZE(coeff_localized)
-               mo_coeff => coeff_localized(ispin)%matrix
-               CALL cp_fm_get_info(mo_coeff, nrow_global=nao, ncol_global=nmo, ncol_block=max_block)
-               nloc = qs_loc_env%localized_wfn_control%nloc_states(ispin)
-               IF (rst_unit > 0) THEN
-                  WRITE (rst_unit) qs_loc_env%localized_wfn_control%loc_states(1:nloc, ispin)
-                  IF (do_homo .OR. my_do_mixed) THEN
-                     WRITE (rst_unit) nmo, &
-                        mo_array(ispin)%homo, &
-                        mo_array(ispin)%lfomo, &
-                        mo_array(ispin)%nelectron
-                     WRITE (rst_unit) mo_array(ispin)%eigenvalues(1:nmo), &
-                        mo_array(ispin)%occupation_numbers(1:nmo)
-                  ELSE
-                     WRITE (rst_unit) nmo
-                     WRITE (rst_unit) evals(ispin)%array(1:nmo)
+               ASSOCIATE (mo_coeff => coeff_localized(ispin))
+                  CALL cp_fm_get_info(mo_coeff, nrow_global=nao, ncol_global=nmo, ncol_block=max_block)
+                  nloc = qs_loc_env%localized_wfn_control%nloc_states(ispin)
+                  IF (rst_unit > 0) THEN
+                     WRITE (rst_unit) qs_loc_env%localized_wfn_control%loc_states(1:nloc, ispin)
+                     IF (do_homo .OR. my_do_mixed) THEN
+                        WRITE (rst_unit) nmo, &
+                           mo_array(ispin)%homo, &
+                           mo_array(ispin)%lfomo, &
+                           mo_array(ispin)%nelectron
+                        WRITE (rst_unit) mo_array(ispin)%eigenvalues(1:nmo), &
+                           mo_array(ispin)%occupation_numbers(1:nmo)
+                     ELSE
+                        WRITE (rst_unit) nmo
+                        WRITE (rst_unit) evals(ispin)%array(1:nmo)
+                     END IF
                   END IF
-               END IF
 
-               CALL cp_fm_write_unformatted(mo_coeff, rst_unit)
+                  CALL cp_fm_write_unformatted(mo_coeff, rst_unit)
+               END ASSOCIATE
 
             END DO
 
@@ -1026,7 +1031,7 @@ CONTAINS
 
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mos_localized
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: mos_localized
       TYPE(section_vals_type), POINTER                   :: section, section2
       TYPE(cp_para_env_type), POINTER                    :: para_env
       LOGICAL, INTENT(IN)                                :: do_homo
@@ -1184,7 +1189,7 @@ CONTAINS
                   vecbuffer(1, :) = 0.0_dp
                END IF
                CALL mp_bcast(vecbuffer, source, group)
-               CALL cp_fm_set_submatrix(mos_localized(ispin)%matrix, &
+               CALL cp_fm_set_submatrix(mos_localized(ispin), &
                                         vecbuffer, 1, i, nao, 1, transpose=.TRUE.)
             END DO
          END DO
@@ -1265,10 +1270,9 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
       TYPE(section_vals_type), POINTER                   :: localize_section
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mos_localized
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: mos_localized
       LOGICAL, OPTIONAL                                  :: do_homo, do_mo_cubes
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mo_loc_history
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: mo_loc_history
       TYPE(cp_1d_r_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: evals
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: tot_zeff_corr

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -30,7 +30,7 @@ MODULE qs_loc_utils
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         cp_fm_create, cp_fm_get_element, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_maxabsval, &
-        cp_fm_p_type, cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type, &
+        cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type, &
         cp_fm_write_unformatted
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
@@ -464,8 +464,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: occupations
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: mat_ptr, mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
@@ -495,10 +495,9 @@ CONTAINS
             nmosub = localized_wfn_control%nloc_states(ispin)
             CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nao, &
                                      ncol_global=nmosub, para_env=para_env, context=mo_coeff%matrix_struct%context)
-            ALLOCATE (moloc_coeff(ispin)%matrix)
-            CALL cp_fm_create(moloc_coeff(ispin)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(moloc_coeff(ispin), tmp_fm_struct)
 
-            CALL cp_fm_get_info(moloc_coeff(ispin)%matrix, nrow_global=naosub, &
+            CALL cp_fm_get_info(moloc_coeff(ispin), nrow_global=naosub, &
                                 ncol_global=nmosub)
             CPASSERT(nao == naosub)
             IF ((localized_wfn_control%do_homo) .OR. &
@@ -507,7 +506,7 @@ CONTAINS
             ELSE
                CPASSERT(nao - nmo >= nmosub)
             END IF
-            CALL cp_fm_set_all(moloc_coeff(ispin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(moloc_coeff(ispin), 0.0_dp)
             CALL cp_fm_struct_release(tmp_fm_struct)
          END DO ! ispin
          ! Copy the submatrix
@@ -551,7 +550,7 @@ CONTAINS
                   ! Take the imo vector from the full set and copy in the imoloc vector of the subset
                   CALL cp_fm_get_submatrix(mat_ptr, vecbuffer, 1, imo, &
                                            nao, 1, transpose=.TRUE.)
-                  CALL cp_fm_set_submatrix(moloc_coeff(ispin)%matrix, vecbuffer, 1, imoloc, &
+                  CALL cp_fm_set_submatrix(moloc_coeff(ispin), vecbuffer, 1, imoloc, &
                                            nao, 1, transpose=.TRUE.)
                END DO
                DEALLOCATE (vecbuffer)
@@ -565,14 +564,14 @@ CONTAINS
                                    "cannot be rotated together")
                END IF
                nmosub = localized_wfn_control%nloc_states(ispin)
-               CALL cp_fm_to_fm(mat_ptr, moloc_coeff(ispin)%matrix, nmosub, lb, 1)
+               CALL cp_fm_to_fm(mat_ptr, moloc_coeff(ispin), nmosub, lb, 1)
             END IF
 
             ! we have the mo's to be localized now, see if we can rotate them according to the history
             ! only do that if we have a history of course. The history is filled
             IF (PRESENT(mo_loc_history)) THEN
                IF (localized_wfn_control%use_history .AND. ASSOCIATED(mo_loc_history)) THEN
-                  CALL rotate_state_to_ref(moloc_coeff(ispin)%matrix, &
+                  CALL rotate_state_to_ref(moloc_coeff(ispin), &
                                            mo_loc_history(ispin), matrix_s(1)%matrix)
                END IF
             END IF

--- a/src/qs_localization_methods.F
+++ b/src/qs_localization_methods.F
@@ -44,8 +44,8 @@ MODULE qs_localization_methods
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         cp_fm_create, cp_fm_get_element, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_init_random, &
-        cp_fm_maxabsrownorm, cp_fm_maxabsval, cp_fm_p_type, cp_fm_release, cp_fm_set_all, &
-        cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_to_fm_submat, cp_fm_type
+        cp_fm_maxabsrownorm, cp_fm_maxabsval, cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, &
+        cp_fm_to_fm, cp_fm_to_fm_submat, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit,&
                                               cp_logger_get_default_unit_nr
    USE cp_para_types,                   ONLY: cp_para_env_type
@@ -297,8 +297,7 @@ CONTAINS
                                eps_localization, sweeps, out_each, target_time, start_time)
 
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      TYPE(cp_fm_p_type), INTENT(INOUT)                  :: ZIJ(:, :)
-      TYPE(cp_fm_type), INTENT(IN)                       :: vectors
+      TYPE(cp_fm_type), INTENT(IN)                       :: zij(:, :), vectors
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: max_iter
       REAL(KIND=dp), INTENT(IN)                          :: eps_localization
@@ -329,8 +328,7 @@ CONTAINS
    SUBROUTINE jacobi_rotations_serial(weights, zij, vectors, max_iter, eps_localization, sweeps, &
                                       out_each)
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      TYPE(cp_fm_p_type), INTENT(INOUT)                  :: ZIJ(:, :)
-      TYPE(cp_fm_type), INTENT(IN)                       :: vectors
+      TYPE(cp_fm_type), INTENT(IN)                       :: zij(:, :), vectors
       INTEGER, INTENT(IN)                                :: max_iter
       REAL(KIND=dp), INTENT(IN)                          :: eps_localization
       INTEGER                                            :: sweeps
@@ -354,16 +352,16 @@ CONTAINS
       NULLIFY (mii, mij, mjj)
       ALLOCATE (mii(dim2), mij(dim2), mjj(dim2))
 
-      CALL cp_fm_create(rmat, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(rmat, zij(1, 1)%matrix_struct)
       CALL cp_fm_set_all(rmat, 0._dp, 1._dp)
 
-      CALL cp_cfm_create(c_rmat, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_cfm_create(c_rmat, zij(1, 1)%matrix_struct)
       CALL cp_cfm_set_all(c_rmat, (0._dp, 0._dp), (1._dp, 0._dp))
       DO idim = 1, dim2
          ALLOCATE (c_zij(idim)%matrix)
-         CALL cp_cfm_create(c_zij(idim)%matrix, zij(1, 1)%matrix%matrix_struct)
-         c_zij(idim)%matrix%local_data = CMPLX(zij(1, idim)%matrix%local_data, &
-                                               zij(2, idim)%matrix%local_data, dp)
+         CALL cp_cfm_create(c_zij(idim)%matrix, zij(1, 1)%matrix_struct)
+         c_zij(idim)%matrix%local_data = CMPLX(zij(1, idim)%local_data, &
+                                               zij(2, idim)%local_data, dp)
       END DO
 
       CALL cp_fm_get_info(rmat, nrow_global=nstate)
@@ -409,8 +407,8 @@ CONTAINS
       END DO
 
       DO idim = 1, dim2
-         zij(1, idim)%matrix%local_data = REAL(c_zij(idim)%matrix%local_data, dp)
-         zij(2, idim)%matrix%local_data = AIMAG(c_zij(idim)%matrix%local_data)
+         zij(1, idim)%local_data = REAL(c_zij(idim)%matrix%local_data, dp)
+         zij(2, idim)%local_data = AIMAG(c_zij(idim)%matrix%local_data)
          CALL cp_cfm_release(c_zij(idim)%matrix)
          DEALLOCATE (c_zij(idim)%matrix)
       END DO
@@ -591,8 +589,7 @@ CONTAINS
                                iter, out_each, nextra, do_cg, nmo, vectors_2, mos_guess)
       TYPE(cp_para_env_type), POINTER                    :: para_env
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      TYPE(cp_fm_p_type), INTENT(INOUT)                  :: zij(:, :)
-      TYPE(cp_fm_type), INTENT(IN)                       :: vectors
+      TYPE(cp_fm_type), INTENT(IN)                       :: zij(:, :), vectors
       INTEGER, INTENT(IN)                                :: max_iter
       REAL(KIND=dp), INTENT(IN)                          :: eps_localization
       INTEGER                                            :: iter
@@ -640,7 +637,7 @@ CONTAINS
 
       ALLOCATE (c_zij(dim2))
 
-      CALL cp_fm_get_info(zij(1, 1)%matrix, nrow_global=nstate)
+      CALL cp_fm_get_info(zij(1, 1), nrow_global=nstate)
 
       ALLOCATE (sum_spread(nstate))
       ALLOCATE (matrix_zii(nstate, dim2))
@@ -651,16 +648,16 @@ CONTAINS
       DO idim = 1, dim2
          alpha = alpha + weights(idim)
          ALLOCATE (c_zij(idim)%matrix)
-         CALL cp_cfm_create(c_zij(idim)%matrix, zij(1, 1)%matrix%matrix_struct)
-         c_zij(idim)%matrix%local_data = CMPLX(zij(1, idim)%matrix%local_data, &
-                                               zij(2, idim)%matrix%local_data, dp)
+         CALL cp_cfm_create(c_zij(idim)%matrix, zij(1, 1)%matrix_struct)
+         c_zij(idim)%matrix%local_data = CMPLX(zij(1, idim)%local_data, &
+                                               zij(2, idim)%local_data, dp)
       END DO
 
       NULLIFY (zij_0)
       ALLOCATE (zij_0(dim2))
 
-      CALL cp_cfm_create(U, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(matrix_U, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_cfm_create(U, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(matrix_U, zij(1, 1)%matrix_struct)
 
       CALL cp_cfm_set_all(U, czero, cone)
       CALL cp_fm_set_all(matrix_U, 0.0_dp, 1.0_dp)
@@ -688,7 +685,7 @@ CONTAINS
          nocc = nstate - nextra
          northo = nmo - nocc
          norextra = nmo - nstate
-         CALL cp_fm_struct_get(zij(1, 1)%matrix%matrix_struct, context=context)
+         CALL cp_fm_struct_get(zij(1, 1)%matrix_struct, context=context)
 
          ALLOCATE (tmp_cmat(nstate, nstate))
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nmo, ncol_global=nmo, &
@@ -862,10 +859,10 @@ CONTAINS
       ELSE
          DO idim = 1, dim2
             ALLOCATE (zij_0(idim)%matrix)
-            CALL cp_cfm_create(zij_0(idim)%matrix, zij(1, 1)%matrix%matrix_struct)
+            CALL cp_cfm_create(zij_0(idim)%matrix, zij(1, 1)%matrix_struct)
             CALL cp_cfm_to_cfm(c_zij(idim)%matrix, zij_0(idim)%matrix)
          END DO
-         CALL cp_fm_create(rmat, zij(1, 1)%matrix%matrix_struct)
+         CALL cp_fm_create(rmat, zij(1, 1)%matrix_struct)
          CALL cp_fm_set_all(rmat, 0._dp, 1._dp)
       END IF
 
@@ -896,8 +893,8 @@ CONTAINS
 
          IF (iter > 1) THEN
             ! comput U
-            CALL cp_cfm_create(tmp_cfm, zij(1, 1)%matrix%matrix_struct)
-            CALL cp_cfm_create(tmp_cfm_2, zij(1, 1)%matrix%matrix_struct)
+            CALL cp_cfm_create(tmp_cfm, zij(1, 1)%matrix_struct)
+            CALL cp_cfm_create(tmp_cfm_2, zij(1, 1)%matrix_struct)
             IF (para_env%num_pe == 1) THEN
                CALL jacobi_rotations_serial_1(weights, c_zij, 1, tmp_cfm_2, tol_out=tol)
             ELSE
@@ -945,9 +942,9 @@ CONTAINS
             CALL cp_cfm_create(tmp_cfm_1, V%matrix_struct)
             ndummy = nmo
          ELSE
-            CALL cp_cfm_create(tmp_cfm, zij(1, 1)%matrix%matrix_struct)
+            CALL cp_cfm_create(tmp_cfm, zij(1, 1)%matrix_struct)
             CALL cp_cfm_to_cfm(U, tmp_cfm)
-            CALL cp_cfm_create(tmp_cfm_1, zij(1, 1)%matrix%matrix_struct)
+            CALL cp_cfm_create(tmp_cfm_1, zij(1, 1)%matrix_struct)
             ndummy = nstate
          END IF
          ! update z_ij
@@ -1220,8 +1217,8 @@ CONTAINS
       DEALLOCATE (zij_0)
 
       DO idim = 1, dim2
-         zij(1, idim)%matrix%local_data = REAL(c_zij(idim)%matrix%local_data, dp)
-         zij(2, idim)%matrix%local_data = AIMAG(c_zij(idim)%matrix%local_data)
+         zij(1, idim)%local_data = REAL(c_zij(idim)%matrix%local_data, dp)
+         zij(2, idim)%local_data = AIMAG(c_zij(idim)%matrix%local_data)
          CALL cp_cfm_release(c_zij(idim)%matrix)
          DEALLOCATE (c_zij(idim)%matrix)
       END DO
@@ -1519,7 +1516,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE check_tolerance_new(weights, zij, tolerance, value)
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      TYPE(cp_fm_p_type), INTENT(IN)                     :: ZIJ(:, :)
+      TYPE(cp_fm_type), INTENT(IN)                       :: zij(:, :)
       REAL(KIND=dp)                                      :: tolerance, value
 
       COMPLEX(KIND=dp)                                   :: kii, kij, kjj
@@ -1530,15 +1527,15 @@ CONTAINS
       REAL(KIND=dp)                                      :: grad_ij, ra, rb
 
       NULLIFY (diag)
-      CALL cp_fm_get_info(zij(1, 1)%matrix, nrow_local=nrow_local, &
+      CALL cp_fm_get_info(zij(1, 1), nrow_local=nrow_local, &
                           ncol_local=ncol_local, nrow_global=nrow_global, &
                           row_indices=row_indices, col_indices=col_indices)
       ALLOCATE (diag(nrow_global, SIZE(zij, 2)))
       value = 0.0_dp
       DO idim = 1, SIZE(zij, 2)
          DO istate = 1, nrow_global
-            CALL cp_fm_get_element(zij(1, idim)%matrix, istate, istate, ra)
-            CALL cp_fm_get_element(zij(2, idim)%matrix, istate, istate, rb)
+            CALL cp_fm_get_element(zij(1, idim), istate, istate, ra)
+            CALL cp_fm_get_element(zij(2, idim), istate, istate, rb)
             diag(istate, idim) = CMPLX(ra, rb, dp)
             value = value + weights(idim) - weights(idim)*ABS(diag(istate, idim))**2
          END DO
@@ -1550,8 +1547,8 @@ CONTAINS
             DO idim = 1, SIZE(zij, 2)
                kii = diag(row_indices(istate), idim)
                kjj = diag(col_indices(jstate), idim)
-               ra = zij(1, idim)%matrix%local_data(istate, jstate)
-               rb = zij(2, idim)%matrix%local_data(istate, jstate)
+               ra = zij(1, idim)%local_data(istate, jstate)
+               rb = zij(2, idim)%local_data(istate, jstate)
                kij = CMPLX(ra, rb, dp)
                grad_ij = grad_ij + weights(idim)* &
                          REAL(4.0_dp*CONJG(kij)*(kjj - kii), dp)
@@ -1559,7 +1556,7 @@ CONTAINS
             tolerance = MAX(ABS(grad_ij), tolerance)
          END DO
       END DO
-      CALL mp_max(tolerance, zij(1, 1)%matrix%matrix_struct%para_env%group)
+      CALL mp_max(tolerance, zij(1, 1)%matrix_struct%para_env%group)
 
       DEALLOCATE (diag)
 
@@ -1582,8 +1579,7 @@ CONTAINS
    SUBROUTINE crazy_rotations(weights, zij, vectors, max_iter, max_crazy_angle, crazy_scale, crazy_use_diag, &
                               eps_localization, iterations, converged)
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      TYPE(cp_fm_p_type), INTENT(INOUT)                  :: ZIJ(:, :)
-      TYPE(cp_fm_type), INTENT(IN)                       :: vectors
+      TYPE(cp_fm_type), INTENT(IN)                       :: zij(:, :), vectors
       INTEGER, INTENT(IN)                                :: max_iter
       REAL(KIND=dp), INTENT(IN)                          :: max_crazy_angle
       REAL(KIND=dp)                                      :: crazy_scale
@@ -1613,7 +1609,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       NULLIFY (row_indices, col_indices)
-      CALL cp_fm_get_info(zij(1, 1)%matrix, nrow_global=nrow_global, &
+      CALL cp_fm_get_info(zij(1, 1), nrow_global=nrow_global, &
                           ncol_global=ncol_global, &
                           row_indices=row_indices, col_indices=col_indices, &
                           nrow_local=nrow_local, ncol_local=ncol_local)
@@ -1626,30 +1622,30 @@ CONTAINS
       ALLOCATE (evals(nrow_global))
       ALLOCATE (evals_exp(nrow_global))
 
-      CALL cp_cfm_create(cmat_A, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_R, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_t1, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_cfm_create(cmat_A, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_R, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_t1, zij(1, 1)%matrix_struct)
 
-      CALL cp_fm_create(mat_U, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(mat_t, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(mat_R, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(mat_U, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(mat_t, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(mat_R, zij(1, 1)%matrix_struct)
 
-      CALL cp_fm_create(mat_theta, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(mat_theta, zij(1, 1)%matrix_struct)
 
       CALL cp_fm_set_all(mat_R, 0.0_dp, 1.0_dp)
       CALL cp_fm_set_all(mat_t, 0.0_dp)
       ALLOCATE (mii(dim2), mij(dim2), mjj(dim2))
       DO idim = 1, dim2
-         CALL cp_fm_scale_and_add(1.0_dp, mat_t, weights(idim), zij(1, idim)%matrix)
-         CALL cp_fm_scale_and_add(1.0_dp, mat_t, weights(idim), zij(2, idim)%matrix)
+         CALL cp_fm_scale_and_add(1.0_dp, mat_t, weights(idim), zij(1, idim))
+         CALL cp_fm_scale_and_add(1.0_dp, mat_t, weights(idim), zij(2, idim))
       END DO
       CALL cp_fm_syevd(mat_t, mat_U, evals)
       DO idim = 1, dim2
          ! rotate z's
-         CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(1, idim)%matrix, mat_U, 0.0_dp, mat_t)
-         CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(1, idim)%matrix)
-         CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(2, idim)%matrix, mat_U, 0.0_dp, mat_t)
-         CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(2, idim)%matrix)
+         CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(1, idim), mat_U, 0.0_dp, mat_t)
+         CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(1, idim))
+         CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(2, idim), mat_U, 0.0_dp, mat_t)
+         CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(2, idim))
       END DO
       ! collect rotation matrix
       CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_R, mat_U, 0.0_dp, mat_t)
@@ -1669,16 +1665,16 @@ CONTAINS
          iterations = iterations + 1
          DO idim = 1, dim2
             DO i = 1, nrow_global
-               CALL cp_fm_get_element(zij(1, idim)%matrix, i, i, ra)
-               CALL cp_fm_get_element(zij(2, idim)%matrix, i, i, rb)
+               CALL cp_fm_get_element(zij(1, idim), i, i, ra)
+               CALL cp_fm_get_element(zij(2, idim), i, i, rb)
                diag_z(i, idim) = CMPLX(ra, rb, dp)
             END DO
          END DO
          DO irow = 1, nrow_local
             DO icol = 1, ncol_local
                DO idim = 1, dim2
-                  ra = zij(1, idim)%matrix%local_data(irow, icol)
-                  rb = zij(2, idim)%matrix%local_data(irow, icol)
+                  ra = zij(1, idim)%local_data(irow, icol)
+                  rb = zij(2, idim)%local_data(irow, icol)
                   mij(idim) = CMPLX(ra, rb, dp)
                   mii(idim) = diag_z(row_indices(irow), idim)
                   mjj(idim) = diag_z(col_indices(icol), idim)
@@ -1726,10 +1722,10 @@ CONTAINS
 
          DO idim = 1, dim2
             ! rotate z's
-            CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(1, idim)%matrix, mat_U, 0.0_dp, mat_t)
-            CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(1, idim)%matrix)
-            CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(2, idim)%matrix, mat_U, 0.0_dp, mat_t)
-            CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(2, idim)%matrix)
+            CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(1, idim), mat_U, 0.0_dp, mat_t)
+            CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(1, idim))
+            CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, zij(2, idim), mat_U, 0.0_dp, mat_t)
+            CALL parallel_gemm('T', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_U, mat_t, 0.0_dp, zij(2, idim))
          END DO
          ! collect rotation matrix
          CALL parallel_gemm('N', 'N', nrow_global, nrow_global, nrow_global, 1.0_dp, mat_R, mat_U, 0.0_dp, mat_t)
@@ -1781,8 +1777,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE direct_mini(weights, zij, vectors, max_iter, eps_localization, iterations)
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      TYPE(cp_fm_p_type), INTENT(INOUT)                  :: ZIJ(:, :)
-      TYPE(cp_fm_type), INTENT(IN)                       :: vectors
+      TYPE(cp_fm_type), INTENT(IN)                       :: zij(:, :), vectors
       INTEGER, INTENT(IN)                                :: max_iter
       REAL(KIND=dp), INTENT(IN)                          :: eps_localization
       INTEGER                                            :: iterations
@@ -1819,7 +1814,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       output_unit = cp_logger_get_default_io_unit()
 
-      n = zij(1, 1)%matrix%matrix_struct%nrow_global
+      n = zij(1, 1)%matrix_struct%nrow_global
       ndim = (SIZE(zij, 2))
 
       IF (output_unit > 0) THEN
@@ -1833,30 +1828,30 @@ CONTAINS
       ! create the three complex matrices Z
       DO idim = 1, ndim
          ALLOCATE (c_zij(idim)%matrix)
-         CALL cp_cfm_create(c_zij(idim)%matrix, zij(1, 1)%matrix%matrix_struct)
-         c_zij(idim)%matrix%local_data = CMPLX(zij(1, idim)%matrix%local_data, &
-                                               zij(2, idim)%matrix%local_data, dp)
+         CALL cp_cfm_create(c_zij(idim)%matrix, zij(1, 1)%matrix_struct)
+         c_zij(idim)%matrix%local_data = CMPLX(zij(1, idim)%local_data, &
+                                               zij(2, idim)%local_data, dp)
       END DO
 
-      CALL cp_fm_create(matrix_A, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(matrix_G, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(matrix_T, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(matrix_H, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(matrix_G_search, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(matrix_G_old, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_fm_create(matrix_R, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(matrix_A, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(matrix_G, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(matrix_T, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(matrix_H, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(matrix_G_search, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(matrix_G_old, zij(1, 1)%matrix_struct)
+      CALL cp_fm_create(matrix_R, zij(1, 1)%matrix_struct)
       CALL cp_fm_set_all(matrix_R, 0.0_dp, 1.0_dp)
 
       CALL cp_fm_set_all(matrix_A, 0.0_dp)
 !    CALL cp_fm_init_random ( matrix_A )
 
-      CALL cp_cfm_create(cmat_A, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_U, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_R, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_t1, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_t2, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_B, zij(1, 1)%matrix%matrix_struct)
-      CALL cp_cfm_create(cmat_M, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_cfm_create(cmat_A, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_U, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_R, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_t1, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_t2, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_B, zij(1, 1)%matrix_struct)
+      CALL cp_cfm_create(cmat_M, zij(1, 1)%matrix_struct)
 
       CALL cp_cfm_get_info(cmat_B, nrow_local=nrow_local, ncol_local=ncol_local, &
                            row_indices=row_indices, col_indices=col_indices)
@@ -2159,8 +2154,8 @@ CONTAINS
       DEALLOCATE (evals, evals_exp, fval, fvald)
 
       DO idim = 1, SIZE(c_zij)
-         zij(1, idim)%matrix%local_data = REAL(c_zij(idim)%matrix%local_data, dp)
-         zij(2, idim)%matrix%local_data = AIMAG(c_zij(idim)%matrix%local_data)
+         zij(1, idim)%local_data = REAL(c_zij(idim)%matrix%local_data, dp)
+         zij(2, idim)%local_data = AIMAG(c_zij(idim)%matrix%local_data)
          CALL cp_cfm_release(c_zij(idim)%matrix)
          DEALLOCATE (c_zij(idim)%matrix)
       END DO
@@ -2191,8 +2186,7 @@ CONTAINS
                               sweeps, out_each, target_time, start_time)
 
       REAL(KIND=dp), INTENT(IN)                          :: weights(:)
-      TYPE(cp_fm_p_type), INTENT(INOUT)                  :: ZIJ(:, :)
-      TYPE(cp_fm_type), INTENT(IN)                       :: vectors
+      TYPE(cp_fm_type), INTENT(IN)                       :: zij(:, :), vectors
       TYPE(cp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: max_iter
       REAL(KIND=dp), INTENT(IN)                          :: eps_localization
@@ -2219,7 +2213,7 @@ CONTAINS
 
       dim2 = SIZE(zij, 2)
 
-      CALL cp_fm_create(rmat, zij(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(rmat, zij(1, 1)%matrix_struct)
       CALL cp_fm_set_all(rmat, 0._dp, 1._dp)
 
       CALL cp_fm_get_info(rmat, nrow_global=nstate)
@@ -2244,8 +2238,8 @@ CONTAINS
       DO idim = 1, dim2
          DO ip = 0, para_env%num_pe - 1
             nblock = ns_bound(ip, 2) - ns_bound(ip, 1) + 1
-            CALL cp_fm_get_submatrix(zij(1, idim)%matrix, z_ij_loc_re, 1, ns_bound(ip, 1), nstate, nblock)
-            CALL cp_fm_get_submatrix(zij(2, idim)%matrix, z_ij_loc_im, 1, ns_bound(ip, 1), nstate, nblock)
+            CALL cp_fm_get_submatrix(zij(1, idim), z_ij_loc_re, 1, ns_bound(ip, 1), nstate, nblock)
+            CALL cp_fm_get_submatrix(zij(2, idim), z_ij_loc_im, 1, ns_bound(ip, 1), nstate, nblock)
             IF (para_env%mepos == ip) THEN
                ALLOCATE (cz_ij_loc(idim)%c_array(nstate, nblock))
                DO i = 1, nblock
@@ -2286,8 +2280,8 @@ CONTAINS
             END IF
             CALL mp_bcast(z_ij_loc_re, ip, para_env%group)
             CALL mp_bcast(z_ij_loc_im, ip, para_env%group)
-            CALL cp_fm_set_submatrix(zij(1, idim)%matrix, z_ij_loc_re, 1, ns_bound(ip, 1), nstate, nblock)
-            CALL cp_fm_set_submatrix(zij(2, idim)%matrix, z_ij_loc_im, 1, ns_bound(ip, 1), nstate, nblock)
+            CALL cp_fm_set_submatrix(zij(1, idim), z_ij_loc_re, 1, ns_bound(ip, 1), nstate, nblock)
+            CALL cp_fm_set_submatrix(zij(2, idim), z_ij_loc_im, 1, ns_bound(ip, 1), nstate, nblock)
          END DO ! ip
       END DO
 
@@ -2988,7 +2982,7 @@ CONTAINS
 
       TYPE(cp_fm_type), INTENT(IN)                       :: vectors
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: op_sm_set
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: zij_fm_set
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: zij_fm_set
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'zij_matrix'
 
@@ -3005,10 +2999,10 @@ CONTAINS
       ! Compute zij here
       DO i = 1, SIZE(zij_fm_set, 2)
          DO j = 1, SIZE(zij_fm_set, 1)
-            CALL cp_fm_set_all(zij_fm_set(j, i)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(zij_fm_set(j, i), 0.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(op_sm_set(j, i)%matrix, vectors, opvec, ncol=nmoloc)
             CALL parallel_gemm("T", "N", nmoloc, nmoloc, nao, 1.0_dp, vectors, opvec, 0.0_dp, &
-                               zij_fm_set(j, i)%matrix)
+                               zij_fm_set(j, i))
          END DO
       END DO
 

--- a/src/qs_matrix_w.F
+++ b/src/qs_matrix_w.F
@@ -17,7 +17,6 @@ MODULE qs_matrix_w
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type,&
@@ -67,18 +66,11 @@ CONTAINS
 
       INTEGER                                            :: handle, is, ispin, nao, nspin
       LOGICAL                                            :: do_kpoints, has_unit_metric
-      TYPE(cp_fm_p_type), DIMENSION(2)                   :: fmwork
-      TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_fmstruct
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s, matrix_w, &
                                                             mo_derivs, rho_ao
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrix_w_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(mo_set_type), POINTER                         :: mo_set
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_nl
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(scf_control_type), POINTER                    :: scf_control
 
@@ -91,35 +83,42 @@ CONTAINS
          CALL get_qs_env(qs_env, do_kpoints=do_kpoints)
 
          IF (do_kpoints) THEN
+            BLOCK
+               TYPE(cp_fm_type), DIMENSION(2)                   :: fmwork
+               TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_fmstruct
+               TYPE(cp_fm_type), POINTER                          :: mo_coeff
+               TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrix_w_kp
+               TYPE(kpoint_type), POINTER                         :: kpoints
+               TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+                  POINTER                                         :: sab_nl
 
-            CALL get_qs_env(qs_env, &
-                            matrix_w_kp=matrix_w_kp, &
-                            matrix_s_kp=matrix_s_kp, &
-                            sab_orb=sab_nl, &
-                            mos=mos, &
-                            kpoints=kpoints)
+               CALL get_qs_env(qs_env, &
+                               matrix_w_kp=matrix_w_kp, &
+                               matrix_s_kp=matrix_s_kp, &
+                               sab_orb=sab_nl, &
+                               mos=mos, &
+                               kpoints=kpoints)
 
-            CALL get_mo_set(mos(1), mo_coeff=mo_coeff, nao=nao)
-            CALL cp_fm_struct_create(fmstruct=ao_ao_fmstruct, nrow_global=nao, ncol_global=nao, &
-                                     template_fmstruct=mo_coeff%matrix_struct)
+               CALL get_mo_set(mos(1), mo_coeff=mo_coeff, nao=nao)
+               CALL cp_fm_struct_create(fmstruct=ao_ao_fmstruct, nrow_global=nao, ncol_global=nao, &
+                                        template_fmstruct=mo_coeff%matrix_struct)
 
-            DO is = 1, SIZE(fmwork)
-               ALLOCATE (fmwork(is)%matrix)
-               CALL cp_fm_create(fmwork(is)%matrix, matrix_struct=ao_ao_fmstruct)
-            END DO
-            CALL cp_fm_struct_release(ao_ao_fmstruct)
+               DO is = 1, SIZE(fmwork)
+                  CALL cp_fm_create(fmwork(is), matrix_struct=ao_ao_fmstruct)
+               END DO
+               CALL cp_fm_struct_release(ao_ao_fmstruct)
 
-            ! energy weighted density matrices in k-space
-            CALL kpoint_density_matrices(kpoints, energy_weighted=.TRUE.)
-            ! energy weighted density matrices in real space
-            CALL kpoint_density_transform(kpoints, matrix_w_kp, .TRUE., &
-                                          matrix_s_kp(1, 1)%matrix, sab_nl, fmwork)
+               ! energy weighted density matrices in k-space
+               CALL kpoint_density_matrices(kpoints, energy_weighted=.TRUE.)
+               ! energy weighted density matrices in real space
+               CALL kpoint_density_transform(kpoints, matrix_w_kp, .TRUE., &
+                                             matrix_s_kp(1, 1)%matrix, sab_nl, fmwork)
 
-            DO is = 1, SIZE(fmwork)
-               CALL cp_fm_release(fmwork(is)%matrix)
-               DEALLOCATE (fmwork(is)%matrix)
-            END DO
+               DO is = 1, SIZE(fmwork)
+                  CALL cp_fm_release(fmwork(is))
+               END DO
 
+            END BLOCK
          ELSE
 
             NULLIFY (dft_control, rho_ao)

--- a/src/qs_mom_methods.F
+++ b/src/qs_mom_methods.F
@@ -404,16 +404,15 @@ CONTAINS
          IF (.NOT. ASSOCIATED(scf_env%mom_ref_mo_coeff)) THEN
             ALLOCATE (scf_env%mom_ref_mo_coeff(nspins))
             DO ispin = 1, nspins
-               NULLIFY (ao_mo_fmstruct, scf_env%mom_ref_mo_coeff(ispin)%matrix)
+               NULLIFY (ao_mo_fmstruct)
                CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, occupation_numbers=occ_nums)
                CALL cp_fm_get_info(mo_coeff, matrix_struct=ao_mo_fmstruct)
-               ALLOCATE (scf_env%mom_ref_mo_coeff(ispin)%matrix)
-               CALL cp_fm_create(scf_env%mom_ref_mo_coeff(ispin)%matrix, ao_mo_fmstruct)
+               CALL cp_fm_create(scf_env%mom_ref_mo_coeff(ispin), ao_mo_fmstruct)
 
                ! Initial Maximum Overlap Method: keep initial molecular orbitals
                IF (scf_control%diagonalization%mom_type == momtype_imom) THEN
-                  CALL cp_fm_to_fm(mo_coeff, scf_env%mom_ref_mo_coeff(ispin)%matrix)
-                  CALL cp_fm_column_scale(scf_env%mom_ref_mo_coeff(ispin)%matrix, occ_nums)
+                  CALL cp_fm_to_fm(mo_coeff, scf_env%mom_ref_mo_coeff(ispin))
+                  CALL cp_fm_column_scale(scf_env%mom_ref_mo_coeff(ispin), occ_nums)
                END IF
             END DO
          END IF
@@ -422,12 +421,11 @@ CONTAINS
          IF (.NOT. ASSOCIATED(scf_env%mom_overlap)) THEN
             ALLOCATE (scf_env%mom_overlap(nspins))
             DO ispin = 1, nspins
-               NULLIFY (blacs_env, mo_mo_fmstruct, scf_env%mom_overlap(ispin)%matrix)
+               NULLIFY (blacs_env, mo_mo_fmstruct)
                CALL get_mo_set(mo_set=mos(ispin), nmo=nmo, mo_coeff=mo_coeff)
                CALL cp_fm_get_info(mo_coeff, context=blacs_env)
                CALL cp_fm_struct_create(mo_mo_fmstruct, nrow_global=nmo, ncol_global=nmo, context=blacs_env)
-               ALLOCATE (scf_env%mom_overlap(ispin)%matrix)
-               CALL cp_fm_create(scf_env%mom_overlap(ispin)%matrix, mo_mo_fmstruct)
+               CALL cp_fm_create(scf_env%mom_overlap(ispin), mo_mo_fmstruct)
                CALL cp_fm_struct_release(mo_mo_fmstruct)
             END DO
          END IF
@@ -436,11 +434,10 @@ CONTAINS
          IF (.NOT. ASSOCIATED(scf_env%mom_s_mo_coeff)) THEN
             ALLOCATE (scf_env%mom_s_mo_coeff(nspins))
             DO ispin = 1, nspins
-               NULLIFY (ao_mo_fmstruct, scf_env%mom_s_mo_coeff(ispin)%matrix)
+               NULLIFY (ao_mo_fmstruct)
                CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
                CALL cp_fm_get_info(mo_coeff, matrix_struct=ao_mo_fmstruct)
-               ALLOCATE (scf_env%mom_s_mo_coeff(ispin)%matrix)
-               CALL cp_fm_create(scf_env%mom_s_mo_coeff(ispin)%matrix, ao_mo_fmstruct)
+               CALL cp_fm_create(scf_env%mom_s_mo_coeff(ispin), ao_mo_fmstruct)
             END DO
          END IF
 
@@ -448,8 +445,8 @@ CONTAINS
          IF (scf_control%diagonalization%mom_type == momtype_mom) THEN
             DO ispin = 1, nspins
                CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, occupation_numbers=occ_nums)
-               CALL cp_fm_to_fm(mo_coeff, scf_env%mom_ref_mo_coeff(ispin)%matrix)
-               CALL cp_fm_column_scale(scf_env%mom_ref_mo_coeff(ispin)%matrix, occ_nums)
+               CALL cp_fm_to_fm(mo_coeff, scf_env%mom_ref_mo_coeff(ispin))
+               CALL cp_fm_column_scale(scf_env%mom_ref_mo_coeff(ispin), occ_nums)
             END DO
          END IF
       END IF
@@ -464,9 +461,9 @@ CONTAINS
             CALL get_mo_set(mo_set=mos(ispin), maxocc=maxocc, mo_coeff=mo_coeff, &
                             nao=nao, nmo=nmo, occupation_numbers=occ_nums)
 
-            mo_coeff_ref => scf_env%mom_ref_mo_coeff(ispin)%matrix
-            overlap => scf_env%mom_overlap(ispin)%matrix
-            svec => scf_env%mom_s_mo_coeff(ispin)%matrix
+            mo_coeff_ref => scf_env%mom_ref_mo_coeff(ispin)
+            overlap => scf_env%mom_overlap(ispin)
+            svec => scf_env%mom_s_mo_coeff(ispin)
 
             ! svec = S * C(new)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, mo_coeff, svec, nmo)

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -44,7 +44,6 @@ MODULE qs_moments
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_type
@@ -1255,9 +1254,9 @@ CONTAINS
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_cfm_p_type), DIMENSION(:), POINTER         :: eigrmat
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: opvec
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: op_fm_set
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: opvec
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: op_fm_set
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: mos_new
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1330,16 +1329,14 @@ CONTAINS
          NULLIFY (tmp_fm_struct, mo_coeff)
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nao=nao, nmo=nmo)
          nmotot = nmotot + nmo
-         ALLOCATE (opvec(ispin)%matrix)
-         CALL cp_fm_create(opvec(ispin)%matrix, mo_coeff%matrix_struct)
+         CALL cp_fm_create(opvec(ispin), mo_coeff%matrix_struct)
          CALL cp_fm_struct_create(tmp_fm_struct, nrow_global=nmo, &
                                   ncol_global=nmo, para_env=para_env, context=mo_coeff%matrix_struct%context)
          DO i = 1, SIZE(op_fm_set, 1)
-            ALLOCATE (op_fm_set(i, ispin)%matrix)
-            CALL cp_fm_create(op_fm_set(i, ispin)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(op_fm_set(i, ispin), tmp_fm_struct)
          END DO
          ALLOCATE (eigrmat(ispin)%matrix)
-         CALL cp_cfm_create(eigrmat(ispin)%matrix, op_fm_set(1, ispin)%matrix%matrix_struct)
+         CALL cp_cfm_create(eigrmat(ispin)%matrix, op_fm_set(1, ispin)%matrix_struct)
          CALL cp_fm_struct_release(tmp_fm_struct)
       END DO
 
@@ -1492,8 +1489,8 @@ CONTAINS
                   CALL cp_cfm_get_info(eigrmat(ispin)%matrix, ncol_local=tmp_dim)
                   DO idim = 1, tmp_dim
                      eigrmat(ispin)%matrix%local_data(:, idim) = &
-                        CMPLX(op_fm_set(1, ispin)%matrix%local_data(:, idim), &
-                              -op_fm_set(2, ispin)%matrix%local_data(:, idim), dp)
+                        CMPLX(op_fm_set(1, ispin)%local_data(:, idim), &
+                              -op_fm_set(2, ispin)%local_data(:, idim), dp)
                   END DO
                   CALL cp_cfm_lu_decompose(eigrmat(ispin)%matrix, zdeta)
                   zdet = zdet*zdeta
@@ -1523,8 +1520,8 @@ CONTAINS
                      CALL cp_cfm_get_info(eigrmat(ispin)%matrix, ncol_local=tmp_dim)
                      DO idim = 1, tmp_dim
                         eigrmat(ispin)%matrix%local_data(:, idim) = &
-                           CMPLX(op_fm_set(1, ispin)%matrix%local_data(:, idim), &
-                                 -op_fm_set(2, ispin)%matrix%local_data(:, idim), dp)
+                           CMPLX(op_fm_set(1, ispin)%local_data(:, idim), &
+                                 -op_fm_set(2, ispin)%local_data(:, idim), dp)
                      END DO
                      CALL cp_cfm_lu_decompose(eigrmat(ispin)%matrix, zdeta)
                      zdet = zdet*zdeta
@@ -1611,13 +1608,11 @@ CONTAINS
       CALL dbcsr_deallocate_matrix(sinmat)
 
       DO ispin = 1, dft_control%nspins
-         CALL cp_fm_release(opvec(ispin)%matrix)
-         DEALLOCATE (opvec(ispin)%matrix)
+         CALL cp_fm_release(opvec(ispin))
          CALL cp_cfm_release(eigrmat(ispin)%matrix)
          DEALLOCATE (eigrmat(ispin)%matrix)
          DO i = 1, SIZE(op_fm_set, 1)
-            CALL cp_fm_release(op_fm_set(i, ispin)%matrix)
-            DEALLOCATE (op_fm_set(i, ispin)%matrix)
+            CALL cp_fm_release(op_fm_set(i, ispin))
          END DO
       END DO
       DEALLOCATE (op_fm_set)
@@ -1639,21 +1634,21 @@ CONTAINS
    SUBROUTINE op_orbbas(cosmat, sinmat, mos, op_fm_set, opvec)
 
       TYPE(dbcsr_type), POINTER                          :: cosmat, sinmat
-      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: op_fm_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: opvec
+      TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: op_fm_set
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: opvec
 
       INTEGER                                            :: i, nao, nmo
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
 
       DO i = 1, SIZE(op_fm_set, 2) ! spin
          CALL get_mo_set(mo_set=mos(i), nao=nao, mo_coeff=mo_coeff, nmo=nmo)
-         CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff, opvec(i)%matrix, ncol=nmo)
-         CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(i)%matrix, 0.0_dp, &
-                            op_fm_set(1, i)%matrix)
-         CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff, opvec(i)%matrix, ncol=nmo)
-         CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(i)%matrix, 0.0_dp, &
-                            op_fm_set(2, i)%matrix)
+         CALL cp_dbcsr_sm_fm_multiply(cosmat, mo_coeff, opvec(i), ncol=nmo)
+         CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(i), 0.0_dp, &
+                            op_fm_set(1, i))
+         CALL cp_dbcsr_sm_fm_multiply(sinmat, mo_coeff, opvec(i), ncol=nmo)
+         CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, mo_coeff, opvec(i), 0.0_dp, &
+                            op_fm_set(2, i))
       END DO
 
    END SUBROUTINE op_orbbas
@@ -1669,8 +1664,8 @@ CONTAINS
    SUBROUTINE op_orbbas_rtp(cosmat, sinmat, mos, op_fm_set, mos_new)
 
       TYPE(dbcsr_type), POINTER                          :: cosmat, sinmat
-      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: op_fm_set
+      TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: op_fm_set
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: mos_new
 
       INTEGER                                            :: i, icol, lcol, nao, newdim, nmo
@@ -1713,8 +1708,8 @@ CONTAINS
          CALL cp_fm_release(work2)
 
          CALL cp_fm_struct_double(newstruct1, &
-                                  op_fm_set(1, i)%matrix%matrix_struct, &
-                                  op_fm_set(1, i)%matrix%matrix_struct%context, &
+                                  op_fm_set(1, i)%matrix_struct, &
+                                  op_fm_set(1, i)%matrix_struct%context, &
                                   double_col, &
                                   double_row)
 
@@ -1724,18 +1719,18 @@ CONTAINS
                             work, 0.0_dp, work1)
 
          DO icol = 1, lcol
-            op_fm_set(1, i)%matrix%local_data(:, icol) = work1%local_data(:, icol)
-            op_fm_set(2, i)%matrix%local_data(:, icol) = work1%local_data(:, icol + lcol)
+            op_fm_set(1, i)%local_data(:, icol) = work1%local_data(:, icol)
+            op_fm_set(2, i)%local_data(:, icol) = work1%local_data(:, icol + lcol)
          END DO
 
          CALL parallel_gemm("T", "N", nmo, newdim, nao, 1.0_dp, mos_new(2*i), &
                             work, 0.0_dp, work1)
 
          DO icol = 1, lcol
-            op_fm_set(1, i)%matrix%local_data(:, icol) = &
-               op_fm_set(1, i)%matrix%local_data(:, icol) + work1%local_data(:, icol + lcol)
-            op_fm_set(2, i)%matrix%local_data(:, icol) = &
-               op_fm_set(2, i)%matrix%local_data(:, icol) - work1%local_data(:, icol)
+            op_fm_set(1, i)%local_data(:, icol) = &
+               op_fm_set(1, i)%local_data(:, icol) + work1%local_data(:, icol + lcol)
+            op_fm_set(2, i)%local_data(:, icol) = &
+               op_fm_set(2, i)%local_data(:, icol) - work1%local_data(:, icol)
          END DO
 
          CALL cp_fm_release(work)

--- a/src/qs_p_env_methods.F
+++ b/src/qs_p_env_methods.F
@@ -40,7 +40,6 @@ MODULE qs_p_env_methods
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -680,7 +679,7 @@ CONTAINS
       ! argument
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: v
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(in)         :: v
       TYPE(cp_fm_type), DIMENSION(:), INTENT(inout)      :: res
 
       INTEGER                                            :: n_spins, spin
@@ -691,7 +690,7 @@ CONTAINS
 
       n_spins = dft_control%nspins
       DO spin = 1, n_spins
-         CALL p_op_l1_spin(p_env, qs_env, spin, v(spin)%matrix, &
+         CALL p_op_l1_spin(p_env, qs_env, spin, v(spin), &
                            res(spin))
       END DO
 
@@ -785,7 +784,7 @@ CONTAINS
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: p1
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: res
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: res
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: alpha, beta
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'p_op_l2'
@@ -841,7 +840,7 @@ CONTAINS
 
       DO ispin = 1, n_spins
          CALL cp_dbcsr_sm_fm_multiply(p_env%kpp1(ispin)%matrix, &
-                                      p_env%psi0d(ispin), res(ispin)%matrix, &
+                                      p_env%psi0d(ispin), res(ispin), &
                                       ncol=p_env%n_mo(ispin), &
                                       alpha=my_alpha, beta=my_beta)
       END DO

--- a/src/qs_p_env_methods.F
+++ b/src/qs_p_env_methods.F
@@ -865,7 +865,7 @@ CONTAINS
 
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(inout)    :: v
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(inout)      :: v
       INTEGER, DIMENSION(:), INTENT(in), OPTIONAL        :: n_cols
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'p_preortho'
@@ -894,7 +894,7 @@ CONTAINS
       ELSE
          max_cols = 0
          DO spin = 1, n_spins
-            CALL cp_fm_get_info(v(spin)%matrix, ncol_global=v_cols)
+            CALL cp_fm_get_info(v(spin), ncol_global=v_cols)
             max_cols = MAX(max_cols, v_cols)
          END DO
       END IF
@@ -909,7 +909,7 @@ CONTAINS
 
       DO spin = 1, n_spins
 
-         CALL cp_fm_get_info(v(spin)%matrix, &
+         CALL cp_fm_get_info(v(spin), &
                              nrow_global=v_rows, ncol_global=v_cols)
          CPASSERT(v_rows >= p_env%n_ao(spin))
          cols = v_cols
@@ -921,14 +921,14 @@ CONTAINS
 
          ! tmp_matrix = v^T (S psi0)
          CALL parallel_gemm(transa='T', transb='N', m=cols, n=p_env%n_mo(spin), &
-                            k=p_env%n_ao(spin), alpha=1.0_dp, matrix_a=v(spin)%matrix, &
+                            k=p_env%n_ao(spin), alpha=1.0_dp, matrix_a=v(spin), &
                             matrix_b=p_env%S_psi0(spin), beta=0.0_dp, &
                             matrix_c=tmp_matrix)
          ! v = v - psi0d tmp_matrix^T = v - psi0d psi0^T S v
          CALL parallel_gemm(transa='N', transb='T', m=p_env%n_ao(spin), n=cols, &
                             k=p_env%n_mo(spin), alpha=-1.0_dp, &
                             matrix_a=p_env%psi0d(spin), matrix_b=tmp_matrix, &
-                            beta=1.0_dp, matrix_c=v(spin)%matrix)
+                            beta=1.0_dp, matrix_c=v(spin))
 
       END DO
 

--- a/src/qs_p_env_methods.F
+++ b/src/qs_p_env_methods.F
@@ -681,7 +681,7 @@ CONTAINS
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: v
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(inout)    :: res
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(inout)      :: res
 
       INTEGER                                            :: n_spins, spin
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -692,7 +692,7 @@ CONTAINS
       n_spins = dft_control%nspins
       DO spin = 1, n_spins
          CALL p_op_l1_spin(p_env, qs_env, spin, v(spin)%matrix, &
-                           res(spin)%matrix)
+                           res(spin))
       END DO
 
    END SUBROUTINE p_op_l1
@@ -957,7 +957,7 @@ CONTAINS
 
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(inout)    :: v
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(inout)      :: v
       INTEGER, DIMENSION(:), INTENT(in), OPTIONAL        :: n_cols
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'p_postortho'
@@ -986,7 +986,7 @@ CONTAINS
       ELSE
          max_cols = 0
          DO spin = 1, n_spins
-            CALL cp_fm_get_info(v(spin)%matrix, ncol_global=v_cols)
+            CALL cp_fm_get_info(v(spin), ncol_global=v_cols)
             max_cols = MAX(max_cols, v_cols)
          END DO
       END IF
@@ -1001,7 +1001,7 @@ CONTAINS
 
       DO spin = 1, n_spins
 
-         CALL cp_fm_get_info(v(spin)%matrix, &
+         CALL cp_fm_get_info(v(spin), &
                              nrow_global=v_rows, ncol_global=v_cols)
          CPASSERT(v_rows >= p_env%n_ao(spin))
          cols = v_cols
@@ -1013,14 +1013,14 @@ CONTAINS
 
          ! tmp_matrix = v^T psi0d
          CALL parallel_gemm(transa='T', transb='N', m=cols, n=p_env%n_mo(spin), &
-                            k=p_env%n_ao(spin), alpha=1.0_dp, matrix_a=v(spin)%matrix, &
+                            k=p_env%n_ao(spin), alpha=1.0_dp, matrix_a=v(spin), &
                             matrix_b=p_env%psi0d(spin), beta=0.0_dp, &
                             matrix_c=tmp_matrix)
          ! v = v - (S psi0) tmp_matrix^T = v - S psi0 psi0d^T v
          CALL parallel_gemm(transa='N', transb='T', m=p_env%n_ao(spin), n=cols, &
                             k=p_env%n_mo(spin), alpha=-1.0_dp, &
                             matrix_a=p_env%S_psi0(spin), matrix_b=tmp_matrix, &
-                            beta=1.0_dp, matrix_c=v(spin)%matrix)
+                            beta=1.0_dp, matrix_c=v(spin))
 
       END DO
 

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -1111,12 +1111,11 @@ CONTAINS
          NULLIFY (cdft_control%mo_coeff)
          ALLOCATE (cdft_control%mo_coeff(dft_control%nspins))
          DO ispin = 1, dft_control%nspins
-            ALLOCATE (cdft_control%mo_coeff(ispin)%matrix)
-            CALL cp_fm_create(matrix=cdft_control%mo_coeff(ispin)%matrix, &
+            CALL cp_fm_create(matrix=cdft_control%mo_coeff(ispin), &
                               matrix_struct=qs_env%mos(ispin)%mo_coeff%matrix_struct, &
                               name="MO_COEFF_A"//TRIM(ADJUSTL(cp_to_string(ispin)))//"MATRIX")
             CALL cp_fm_to_fm(qs_env%mos(ispin)%mo_coeff, &
-                             cdft_control%mo_coeff(ispin)%matrix)
+                             cdft_control%mo_coeff(ispin))
          END DO
          ! Density matrix
          IF (cdft_control%calculate_metric) THEN

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -888,8 +888,7 @@ CONTAINS
       ! Release SCF work storage
       IF (ASSOCIATED(scf_env%scf_work1)) THEN
          DO ispin = 1, SIZE(scf_env%scf_work1)
-            CALL cp_fm_release(scf_env%scf_work1(ispin)%matrix)
-            DEALLOCATE (scf_env%scf_work1(ispin)%matrix)
+            CALL cp_fm_release(scf_env%scf_work1(ispin))
          END DO
          DEALLOCATE (scf_env%scf_work1)
       END IF

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -42,8 +42,8 @@ MODULE qs_scf_diagonalization
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         copy_info_type, cp_fm_add_to_element, cp_fm_cleanup_copy_general, cp_fm_create, &
-        cp_fm_finish_copy_general, cp_fm_get_info, cp_fm_p_type, cp_fm_release, &
-        cp_fm_start_copy_general, cp_fm_to_fm, cp_fm_type
+        cp_fm_finish_copy_general, cp_fm_get_info, cp_fm_release, cp_fm_start_copy_general, &
+        cp_fm_to_fm, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
@@ -160,7 +160,7 @@ CONTAINS
 
       DO ispin = 1, nspin
          CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, &
-                               scf_env%scf_work1(ispin)%matrix)
+                               scf_env%scf_work1(ispin))
       END DO
 
       eps_diis = scf_control%eps_diis
@@ -216,7 +216,7 @@ CONTAINS
       IF (scf_env%cholesky_method == cholesky_dbcsr) THEN
          ortho_dbcsr => scf_env%ortho_dbcsr
          DO ispin = 1, nspin
-            CALL eigensolver_dbcsr(matrix_ks=matrix_ks(ispin)%matrix, matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+            CALL eigensolver_dbcsr(matrix_ks=matrix_ks(ispin)%matrix, matrix_ks_fm=scf_env%scf_work1(ispin), &
                                    mo_set=mos(ispin), &
                                    ortho_dbcsr=ortho_dbcsr, &
                                    ksbuf1=scf_env%buf1_dbcsr, ksbuf2=scf_env%buf2_dbcsr)
@@ -237,7 +237,7 @@ CONTAINS
 
          DO ispin = 1, nspin
             IF (do_level_shift) THEN
-               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin), &
                                 mo_set=mos(ispin), &
                                 ortho=ortho, &
                                 work=scf_env%scf_work2, &
@@ -247,7 +247,7 @@ CONTAINS
                                 matrix_u_fm=scf_env%ortho, &
                                 use_jacobi=use_jacobi)
             ELSE
-               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin), &
                                 mo_set=mos(ispin), &
                                 ortho=ortho, &
                                 work=scf_env%scf_work2, &
@@ -270,7 +270,7 @@ CONTAINS
 
          IF (do_level_shift) THEN
          DO ispin = 1, nspin
-            CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+            CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin), &
                                   mo_set=mos(ispin), &
                                   ortho=ortho, &
                                   work=scf_env%scf_work2, &
@@ -282,7 +282,7 @@ CONTAINS
          END DO
          ELSE
          DO ispin = 1, nspin
-            CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin)%matrix, &
+            CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin), &
                                   mo_set=mos(ispin), &
                                   ortho=ortho, &
                                   work=scf_env%scf_work2, &
@@ -382,10 +382,10 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info
       TYPE(cp_cfm_type)                                  :: cksmat, cmos, csmat, cwork
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fmwork
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_ao_fm_pools
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct, mo_struct
       TYPE(cp_fm_type)                                   :: fmdummy, fmlocal, rksmat, rsmat
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fmwork
       TYPE(cp_fm_type), POINTER                          :: imos, mo_coeff, rmos
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_type), POINTER                          :: cmatrix, rmatrix, tmpmat
@@ -455,13 +455,13 @@ CONTAINS
                   CALL rskp_transform(rmatrix=rmatrix, rsmat=matrix_ks, ispin=ispin, &
                                       xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(1)%matrix)
+                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
                   ! s matrix is not spin dependent
                   CALL dbcsr_set(rmatrix, 0.0_dp)
                   CALL rskp_transform(rmatrix=rmatrix, rsmat=matrix_s, ispin=1, &
                                       xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(3)%matrix)
+                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
                ELSE
                   ! FT of matrices KS and S, then transfer to FM type
                   CALL dbcsr_set(rmatrix, 0.0_dp)
@@ -469,18 +469,18 @@ CONTAINS
                   CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=matrix_ks, ispin=ispin, &
                                       xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(1)%matrix)
+                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
                   CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(2)%matrix)
+                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
                   ! s matrix is not spin dependent, double the work
                   CALL dbcsr_set(rmatrix, 0.0_dp)
                   CALL dbcsr_set(cmatrix, 0.0_dp)
                   CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=matrix_s, ispin=1, &
                                       xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(3)%matrix)
+                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
                   CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(4)%matrix)
+                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(4))
                END IF
                ! transfer to kpoint group
                ! redistribution of matrices, new blacs environment
@@ -488,23 +488,23 @@ CONTAINS
                ! fmwork -> fmlocal -> rsmat/csmat
                IF (use_real_wfn) THEN
                   IF (my_kpgrp) THEN
-                     CALL cp_fm_start_copy_general(fmwork(1)%matrix, rksmat, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(3)%matrix, rsmat, para_env, info(indx, 2))
+                     CALL cp_fm_start_copy_general(fmwork(1), rksmat, para_env, info(indx, 1))
+                     CALL cp_fm_start_copy_general(fmwork(3), rsmat, para_env, info(indx, 2))
                   ELSE
-                     CALL cp_fm_start_copy_general(fmwork(1)%matrix, fmdummy, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(3)%matrix, fmdummy, para_env, info(indx, 2))
+                     CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
+                     CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 2))
                   END IF
                ELSE
                   IF (my_kpgrp) THEN
-                     CALL cp_fm_start_copy_general(fmwork(1)%matrix, fmlocal, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(2)%matrix, fmlocal, para_env, info(indx, 2))
-                     CALL cp_fm_start_copy_general(fmwork(3)%matrix, fmlocal, para_env, info(indx, 3))
-                     CALL cp_fm_start_copy_general(fmwork(4)%matrix, fmlocal, para_env, info(indx, 4))
+                     CALL cp_fm_start_copy_general(fmwork(1), fmlocal, para_env, info(indx, 1))
+                     CALL cp_fm_start_copy_general(fmwork(2), fmlocal, para_env, info(indx, 2))
+                     CALL cp_fm_start_copy_general(fmwork(3), fmlocal, para_env, info(indx, 3))
+                     CALL cp_fm_start_copy_general(fmwork(4), fmlocal, para_env, info(indx, 4))
                   ELSE
-                     CALL cp_fm_start_copy_general(fmwork(1)%matrix, fmdummy, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(2)%matrix, fmdummy, para_env, info(indx, 2))
-                     CALL cp_fm_start_copy_general(fmwork(3)%matrix, fmdummy, para_env, info(indx, 3))
-                     CALL cp_fm_start_copy_general(fmwork(4)%matrix, fmdummy, para_env, info(indx, 4))
+                     CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
+                     CALL cp_fm_start_copy_general(fmwork(2), fmdummy, para_env, info(indx, 2))
+                     CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 3))
+                     CALL cp_fm_start_copy_general(fmwork(4), fmdummy, para_env, info(indx, 4))
                   END IF
                END IF
             END DO
@@ -759,9 +759,9 @@ CONTAINS
                             mo_coeff=mo_coeff)
 
             !compute C'HC
-            chc => subspace_env%chc_mat(ispin)%matrix
-            evec => subspace_env%c_vec(ispin)%matrix
-            c0 => subspace_env%c0(ispin)%matrix
+            chc => subspace_env%chc_mat(ispin)
+            evec => subspace_env%c_vec(ispin)
+            c0 => subspace_env%c0(ispin)
             CALL cp_fm_to_fm(mo_coeff, c0)
             CALL cp_fm_create(work, c0%matrix_struct)
             CALL cp_dbcsr_sm_fm_multiply(matrix_ks(ispin)%matrix, c0, work, nmo)
@@ -887,15 +887,13 @@ CONTAINS
 
       DO ispin = 1, nspin
          CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
-         ALLOCATE (subspace_env%c0(ispin)%matrix)
-         CALL cp_fm_create(subspace_env%c0(ispin)%matrix, mo_coeff%matrix_struct)
+         CALL cp_fm_create(subspace_env%c0(ispin), mo_coeff%matrix_struct)
          NULLIFY (fm_struct_tmp)
          CALL cp_fm_struct_create(fm_struct_tmp, nrow_global=nmo, ncol_global=nmo, &
                                   para_env=mo_coeff%matrix_struct%para_env, &
                                   context=mo_coeff%matrix_struct%context)
-         ALLOCATE (subspace_env%chc_mat(ispin)%matrix, subspace_env%c_vec(ispin)%matrix)
-         CALL cp_fm_create(subspace_env%chc_mat(ispin)%matrix, fm_struct_tmp, "chc")
-         CALL cp_fm_create(subspace_env%c_vec(ispin)%matrix, fm_struct_tmp, "vec")
+         CALL cp_fm_create(subspace_env%chc_mat(ispin), fm_struct_tmp, "chc")
+         CALL cp_fm_create(subspace_env%c_vec(ispin), fm_struct_tmp, "vec")
          CALL cp_fm_struct_release(fm_struct_tmp)
       END DO
 
@@ -932,7 +930,7 @@ CONTAINS
       nspin = SIZE(matrix_ks)
 
       DO ispin = 1, nspin
-         CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, scf_env%scf_work1(ispin)%matrix)
+         CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, scf_env%scf_work1(ispin))
       END DO
       IF (scf_env%iter_count > 1 .AND. .NOT. scf_env%skip_diis) THEN
          CALL qs_diis_b_step(scf_env%scf_diis_buffer, mos, scf_env%scf_work1, &
@@ -978,7 +976,7 @@ CONTAINS
       scf_env%iter_delta = 0.0_dp
 
       DO ispin = 1, nspin
-         CALL eigensolver_simple(matrix_ks=scf_env%scf_work1(ispin)%matrix, &
+         CALL eigensolver_simple(matrix_ks=scf_env%scf_work1(ispin), &
                                  mo_set=mos(ispin), &
                                  work=scf_env%scf_work2, &
                                  do_level_shift=do_level_shift, &
@@ -1032,7 +1030,7 @@ CONTAINS
 
       DO ispin = 1, nspin
          CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, &
-                               scf_env%scf_work1(ispin)%matrix)
+                               scf_env%scf_work1(ispin))
       END DO
 
       IF ((scf_env%iter_count > 1) .AND. (.NOT. scf_env%skip_diis)) THEN
@@ -1050,7 +1048,7 @@ CONTAINS
          scf_env%iter_param = diis_error
          scf_env%iter_method = "DIIS/OTdiag"
          DO ispin = 1, nspin
-            CALL copy_fm_to_dbcsr(scf_env%scf_work1(ispin)%matrix, &
+            CALL copy_fm_to_dbcsr(scf_env%scf_work1(ispin), &
                                   matrix_ks(ispin)%matrix, keep_sparsity=.TRUE.)
          END DO
          eps_iter = MAX(eps_iter, scf_control%diagonalization%eps_adapt*diis_error)
@@ -1152,8 +1150,8 @@ CONTAINS
       END IF
       work => scf_env%scf_work2
 
-      ksa => scf_env%scf_work1(1)%matrix
-      ksb => scf_env%scf_work1(2)%matrix
+      ksa => scf_env%scf_work1(1)
+      ksb => scf_env%scf_work1(2)
 
       CALL copy_dbcsr_to_fm(matrix_ks(1)%matrix, ksa)
       CALL copy_dbcsr_to_fm(matrix_ks(2)%matrix, ksb)
@@ -1435,7 +1433,7 @@ CONTAINS
 
       DO ispin = 1, SIZE(matrix_ks)
          CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, &
-                               scf_env%scf_work1(ispin)%matrix)
+                               scf_env%scf_work1(ispin))
       END DO
 
       IF (scf_env%mixing_method == 1) THEN
@@ -1448,7 +1446,7 @@ CONTAINS
 
       DO ispin = 1, SIZE(matrix_ks)
 
-         ks => scf_env%scf_work1(ispin)%matrix
+         ks => scf_env%scf_work1(ispin)
          CALL cp_fm_upper_to_full(ks, work)
 
          CALL get_mo_set(mo_set=mos(ispin), &
@@ -1459,8 +1457,8 @@ CONTAINS
                          mo_coeff=mo_coeff)
 
          NULLIFY (c0, c1)
-         c0 => scf_env%krylov_space%mo_conv(ispin)%matrix
-         c1 => scf_env%krylov_space%mo_refine(ispin)%matrix
+         c0 => scf_env%krylov_space%mo_conv(ispin)
+         c1 => scf_env%krylov_space%mo_refine(ispin)
          SELECT CASE (scf_env%cholesky_method)
          CASE (cholesky_reduce)
             CALL cp_fm_cholesky_reduce(ks, ortho)
@@ -1539,15 +1537,15 @@ CONTAINS
             IF (.FALSE.) THEN
                !Re-orthogonalization
                NULLIFY (chc, evec)
-               chc => scf_env%krylov_space%chc_mat(ispin)%matrix
-               evec => scf_env%krylov_space%c_vec(ispin)%matrix
+               chc => scf_env%krylov_space%chc_mat(ispin)
+               evec => scf_env%krylov_space%c_vec(ispin)
                CALL parallel_gemm('N', 'N', nao, nmo, nao, rone, ks, c0, rzero, work)
                CALL parallel_gemm('T', 'N', nmo, nmo, nao, rone, c0, work, rzero, chc)
                !Diagonalize  (C^t)HC
                CALL choose_eigv_solver(chc, evec, mo_eigenvalues)
                !Rotate the C vectors
                CALL parallel_gemm('N', 'N', nao, nmo, nmo, rone, c0, evec, rzero, c1)
-               c0 => scf_env%krylov_space%mo_refine(ispin)%matrix
+               c0 => scf_env%krylov_space%mo_refine(ispin)
             END IF
 
             IF (scf_env%cholesky_method == cholesky_inverse) THEN

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -452,8 +452,7 @@ CONTAINS
             IF (do_kpoints) nw = 4
             ALLOCATE (scf_env%scf_work1(nw))
             DO is = 1, SIZE(scf_env%scf_work1)
-               ALLOCATE (scf_env%scf_work1(is)%matrix)
-               CALL cp_fm_create(scf_env%scf_work1(is)%matrix, &
+               CALL cp_fm_create(scf_env%scf_work1(is), &
                                  matrix_struct=ao_ao_fmstruct, &
                                  name="SCF-WORK_MATRIX-1-"//TRIM(ADJUSTL(cp_to_string(is))))
             END DO
@@ -517,8 +516,7 @@ CONTAINS
             nw = 4
             ALLOCATE (scf_env%scf_work1(nw))
             DO is = 1, SIZE(scf_env%scf_work1)
-               ALLOCATE (scf_env%scf_work1(is)%matrix)
-               CALL cp_fm_create(scf_env%scf_work1(is)%matrix, &
+               CALL cp_fm_create(scf_env%scf_work1(is), &
                                  matrix_struct=ao_ao_fmstruct, &
                                  name="SCF-WORK_MATRIX-1-"//TRIM(ADJUSTL(cp_to_string(is))))
             END DO

--- a/src/qs_scf_lanczos.F
+++ b/src/qs_scf_lanczos.F
@@ -24,9 +24,14 @@ MODULE qs_scf_lanczos
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_submatrix, cp_fm_p_type, cp_fm_release, cp_fm_set_all, &
-        cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type, cp_fm_vectorsnorm
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_submatrix,&
+                                              cp_fm_release,&
+                                              cp_fm_set_all,&
+                                              cp_fm_set_submatrix,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type,&
+                                              cp_fm_vectorsnorm
    USE cp_log_handling,                 ONLY: cp_to_string
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_sum
@@ -60,7 +65,7 @@ CONTAINS
 
    SUBROUTINE krylov_space_allocate(krylov_space, scf_control, mos)
 
-      TYPE(krylov_space_type), POINTER                   :: krylov_space
+      TYPE(krylov_space_type), INTENT(INOUT)             :: krylov_space
       TYPE(scf_control_type), POINTER                    :: scf_control
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
 
@@ -72,8 +77,6 @@ CONTAINS
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
 
       CALL timeset(routineN, handle)
-
-      CPASSERT(ASSOCIATED(krylov_space))
 
       IF (.NOT. ASSOCIATED(krylov_space%mo_conv)) THEN
          NULLIFY (fm_struct_tmp, mo_coeff)
@@ -92,16 +95,14 @@ CONTAINS
          max_nmo = 0
          DO ispin = 1, nspin
             CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, nao=nao, nmo=nmo)
-            ALLOCATE (krylov_space%mo_conv(ispin)%matrix, krylov_space%mo_refine(ispin)%matrix)
-            CALL cp_fm_create(krylov_space%mo_conv(ispin)%matrix, mo_coeff%matrix_struct)
-            CALL cp_fm_create(krylov_space%mo_refine(ispin)%matrix, mo_coeff%matrix_struct)
+            CALL cp_fm_create(krylov_space%mo_conv(ispin), mo_coeff%matrix_struct)
+            CALL cp_fm_create(krylov_space%mo_refine(ispin), mo_coeff%matrix_struct)
             NULLIFY (fm_struct_tmp)
             CALL cp_fm_struct_create(fm_struct_tmp, nrow_global=nmo, ncol_global=nmo, &
                                      para_env=mo_coeff%matrix_struct%para_env, &
                                      context=mo_coeff%matrix_struct%context)
-            ALLOCATE (krylov_space%chc_mat(ispin)%matrix, krylov_space%c_vec(ispin)%matrix)
-            CALL cp_fm_create(krylov_space%chc_mat(ispin)%matrix, fm_struct_tmp, "chc")
-            CALL cp_fm_create(krylov_space%c_vec(ispin)%matrix, fm_struct_tmp, "vec")
+            CALL cp_fm_create(krylov_space%chc_mat(ispin), fm_struct_tmp, "chc")
+            CALL cp_fm_create(krylov_space%c_vec(ispin), fm_struct_tmp, "vec")
             CALL cp_fm_struct_release(fm_struct_tmp)
             max_nmo = MAX(max_nmo, nmo)
          END DO
@@ -116,8 +117,7 @@ CONTAINS
                                   para_env=mo_coeff%matrix_struct%para_env, &
                                   context=mo_coeff%matrix_struct%context)
          DO ik = 1, nk
-            ALLOCATE (krylov_space%v_mat(ik)%matrix)
-            CALL cp_fm_create(krylov_space%v_mat(ik)%matrix, matrix_struct=fm_struct_tmp, &
+            CALL cp_fm_create(krylov_space%v_mat(ik), matrix_struct=fm_struct_tmp, &
                               name="v_mat_"//TRIM(ADJUSTL(cp_to_string(ik))))
          END DO
          ALLOCATE (krylov_space%tmp_mat)
@@ -202,9 +202,9 @@ CONTAINS
       REAL(dp)                                           :: max_norm, min_norm, vmax
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: q_mat, tblock, tvblock
       REAL(dp), DIMENSION(:), POINTER                    :: c_res, t_eval
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: v_mat
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
       TYPE(cp_fm_type)                                   :: c2_tmp, c3_tmp, c_tmp, hc
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: v_mat
       TYPE(cp_fm_type), POINTER                          :: a_mat, b2_mat, b_mat, chc, evec, t_mat, &
                                                             t_vec
 
@@ -220,8 +220,8 @@ CONTAINS
       my_check_moconv_only = .FALSE.
       IF (PRESENT(check_moconv_only)) my_check_moconv_only = check_moconv_only
 
-      chc => krylov_space%chc_mat(ispin)%matrix
-      evec => krylov_space%c_vec(ispin)%matrix
+      chc => krylov_space%chc_mat(ispin)
+      evec => krylov_space%c_vec(ispin)
       c_res => krylov_space%c_eval
       t_eval => krylov_space%t_eval
 
@@ -348,8 +348,7 @@ CONTAINS
                                         context=c0%matrix_struct%context)
                ALLOCATE (v_mat(krylov_space%nkrylov))
                DO ik = 1, krylov_space%nkrylov
-                  ALLOCATE (v_mat(ik)%matrix)
-                  CALL cp_fm_create(v_mat(ik)%matrix, matrix_struct=fm_struct_tmp, &
+                  CALL cp_fm_create(v_mat(ik), matrix_struct=fm_struct_tmp, &
                                     name="v_mat")
                END DO
                CALL cp_fm_struct_release(fm_struct_tmp)
@@ -368,16 +367,16 @@ CONTAINS
             CALL timeset(routineN//"_kry_loop", hand2)
             CALL cp_fm_set_all(b_mat, rzero)
             CALL cp_fm_set_all(t_mat, rzero)
-            CALL cp_fm_to_fm(c1, v_mat(1)%matrix, nmob, imo_low, 1)
+            CALL cp_fm_to_fm(c1, v_mat(1), nmob, imo_low, 1)
 
             !Compute A =(V^t)HV
-            CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(1)%matrix, rzero, hc)
-            CALL parallel_gemm('T', 'N', nmob, nmob, nao, rone, v_mat(1)%matrix, hc, &
+            CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(1), rzero, hc)
+            CALL parallel_gemm('T', 'N', nmob, nmob, nao, rone, v_mat(1), hc, &
                                rzero, a_mat)
 
             !Compute the residual matrix R for next
             !factorisation
-            CALL parallel_gemm('N', 'N', nao, nmob, nmob, rone, v_mat(1)%matrix, a_mat, &
+            CALL parallel_gemm('N', 'N', nao, nmob, nmob, rone, v_mat(1), a_mat, &
                                rzero, c_tmp)
             CALL cp_fm_scale_and_add(rmone, c_tmp, rone, hc)
 
@@ -389,21 +388,21 @@ CONTAINS
 
                ! Call lapack for QR factorization
                CALL cp_fm_set_all(b_mat, rzero)
-               CALL cp_fm_to_fm(c_tmp, v_mat(ik)%matrix, nmob, 1, 1)
+               CALL cp_fm_to_fm(c_tmp, v_mat(ik), nmob, 1, 1)
                CALL cp_fm_qr_factorization(c_tmp, b_mat, nao, nmob, 1, 1)
 
-               CALL cp_fm_triangular_multiply(b_mat, v_mat(ik)%matrix, side="R", invert_tr=.TRUE., &
+               CALL cp_fm_triangular_multiply(b_mat, v_mat(ik), side="R", invert_tr=.TRUE., &
                                               n_rows=nao, n_cols=nmob)
 
                !Compute A =(V^t)HV
-               CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(ik)%matrix, rzero, hc)
-               CALL parallel_gemm('T', 'N', nmob, nmob, nao, rone, v_mat(ik)%matrix, hc, rzero, a_mat)
+               CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(ik), rzero, hc)
+               CALL parallel_gemm('T', 'N', nmob, nmob, nao, rone, v_mat(ik), hc, rzero, a_mat)
 
                !Compute the !residual matrix R !for next !factorisation
-               CALL parallel_gemm('N', 'N', nao, nmob, nmob, rone, v_mat(ik)%matrix, a_mat, &
+               CALL parallel_gemm('N', 'N', nao, nmob, nmob, rone, v_mat(ik), a_mat, &
                                   rzero, c_tmp)
                CALL cp_fm_scale_and_add(rmone, c_tmp, rone, hc)
-               CALL cp_fm_to_fm(v_mat(ik - 1)%matrix, hc, nmob, 1, 1)
+               CALL cp_fm_to_fm(v_mat(ik - 1), hc, nmob, 1, 1)
                CALL cp_fm_triangular_multiply(b_mat, hc, side='R', transpose_tr=.TRUE., &
                                               n_rows=nao, n_cols=nmob, alpha=rmone)
                CALL cp_fm_scale_and_add(rone, c_tmp, rone, hc)
@@ -434,13 +433,13 @@ CONTAINS
             CALL cp_fm_set_all(c2_tmp, rzero)
             DO ik = 1, krylov_space%nkrylov
                jt = (ik - 1)*nmob
-               CALL parallel_gemm('N', 'N', nao, ndim, nmob, rone, v_mat(ik)%matrix, t_vec, rone, c2_tmp, &
+               CALL parallel_gemm('N', 'N', nao, ndim, nmob, rone, v_mat(ik), t_vec, rone, c2_tmp, &
                                   b_first_row=(jt + 1))
             END DO
             DEALLOCATE (tvblock)
 
             CALL cp_fm_set_all(c3_tmp, rzero)
-            CALL parallel_gemm('T', 'N', nmob, ndim, nao, rone, v_mat(1)%matrix, c2_tmp, rzero, c3_tmp)
+            CALL parallel_gemm('T', 'N', nmob, ndim, nao, rone, v_mat(1), c2_tmp, rzero, c3_tmp)
 
             !Try to avoid linear dependencies
             ALLOCATE (q_mat(nmob, ndim))
@@ -460,13 +459,13 @@ CONTAINS
                END DO
                itaken(ik) = 1
 
-               CALL cp_fm_to_fm(c2_tmp, v_mat(1)%matrix, 1, ik, it)
+               CALL cp_fm_to_fm(c2_tmp, v_mat(1), 1, ik, it)
             END DO
             DEALLOCATE (itaken)
             DEALLOCATE (q_mat)
 
             !Copy in the converged set to enlarge the converged subspace
-            CALL cp_fm_to_fm(v_mat(1)%matrix, c0, nmob, 1, (nmo_converged + imo_low))
+            CALL cp_fm_to_fm(v_mat(1), c0, nmob, 1, (nmo_converged + imo_low))
             CALL timestop(hand4)
 
             IF (nmob < nblock) THEN
@@ -477,8 +476,7 @@ CONTAINS
                CALL cp_fm_release(t_vec)
                DEALLOCATE (a_mat, b_mat, b2_mat, t_mat, t_vec)
                DO ik = 1, krylov_space%nkrylov
-                  CALL cp_fm_release(v_mat(ik)%matrix)
-                  DEALLOCATE (v_mat(ik)%matrix)
+                  CALL cp_fm_release(v_mat(ik))
                END DO
                DEALLOCATE (v_mat)
 
@@ -547,9 +545,9 @@ CONTAINS
       REAL(dp), DIMENSION(:), POINTER                    :: c_res, t_eval
       REAL(KIND=dp), DIMENSION(:), POINTER               :: work
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: a_loc, b_loc
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: v_mat
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
       TYPE(cp_fm_type)                                   :: b_mat, c2_tmp, c_tmp, hc, v_tmp
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: v_mat
       TYPE(cp_fm_type), POINTER                          :: chc, evec
 
       CALL timeset(routineN, handle)
@@ -557,15 +555,14 @@ CONTAINS
       NULLIFY (fm_struct_tmp)
       NULLIFY (chc, evec)
       NULLIFY (c_res, t_eval)
-      NULLIFY (v_mat)
       NULLIFY (b_loc, a_loc)
 
       nmo = SIZE(eval, 1)
       my_check_moconv_only = .FALSE.
       IF (PRESENT(check_moconv_only)) my_check_moconv_only = check_moconv_only
 
-      chc => krylov_space%chc_mat(ispin)%matrix
-      evec => krylov_space%c_vec(ispin)%matrix
+      chc => krylov_space%chc_mat(ispin)
+      evec => krylov_space%c_vec(ispin)
       c_res => krylov_space%c_eval
       t_eval => krylov_space%t_eval
 
@@ -680,8 +677,7 @@ CONTAINS
                                      context=c0%matrix_struct%context, &
                                      force_block=.TRUE.)
             DO ik = 1, krylov_space%nkrylov
-               ALLOCATE (v_mat(ik)%matrix)
-               CALL cp_fm_create(v_mat(ik)%matrix, matrix_struct=fm_struct_tmp, &
+               CALL cp_fm_create(v_mat(ik), matrix_struct=fm_struct_tmp, &
                                  name="v_mat")
             END DO
             CALL cp_fm_create(hc, matrix_struct=fm_struct_tmp, &
@@ -708,15 +704,15 @@ CONTAINS
             !End allocation
 
             CALL cp_fm_set_all(b_mat, rzero)
-            CALL cp_fm_to_fm(c1, v_mat(1)%matrix, nmob, imo_low, 1)
+            CALL cp_fm_to_fm(c1, v_mat(1), nmob, imo_low, 1)
 
             ! Here starts the construction of krylov space
             CALL timeset(routineN//"_kry_loop", hand2)
             !Compute A =(V^t)HV
-            CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(1)%matrix, rzero, hc)
+            CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(1), rzero, hc)
 
             a_block = 0.0_dp
-            a_loc => v_mat(1)%matrix%local_data
+            a_loc => v_mat(1)%local_data
             b_loc => hc%local_data
 
             IF (SIZE(hc%local_data, 2) == nmob) THEN
@@ -730,7 +726,6 @@ CONTAINS
             !factorisation
             c_tmp%local_data = 0.0_dp
             IF (SIZE(c_tmp%local_data, 2) == nmob) THEN
-               a_loc => v_mat(1)%matrix%local_data
                b_loc => c_tmp%local_data
                CALL dgemm('N', 'N', SIZE(c_tmp%local_data, 1), nmob, nmob, 1.0_dp, a_loc(1, 1), &
                           SIZE(c_tmp%local_data, 1), a_block(1, 1), nmob, 0.0_dp, &
@@ -747,20 +742,20 @@ CONTAINS
             DO ik = 2, krylov_space%nkrylov
                ! Call lapack for QR factorization
                CALL cp_fm_set_all(b_mat, rzero)
-               CALL cp_fm_to_fm(c_tmp, v_mat(ik)%matrix, nmob, 1, 1)
+               CALL cp_fm_to_fm(c_tmp, v_mat(ik), nmob, 1, 1)
                CALL cp_fm_qr_factorization(c_tmp, b_mat, nao, nmob, 1, 1)
 
-               CALL cp_fm_triangular_multiply(b_mat, v_mat(ik)%matrix, side="R", invert_tr=.TRUE., &
+               CALL cp_fm_triangular_multiply(b_mat, v_mat(ik), side="R", invert_tr=.TRUE., &
                                               n_rows=nao, n_cols=nmob)
 
                CALL cp_fm_get_submatrix(b_mat, b_block, 1, 1, nmob, nmob)
 
                !Compute A =(V^t)HV
-               CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(ik)%matrix, rzero, hc)
+               CALL parallel_gemm('N', 'N', nao, nmob, nao, rone, ks, v_mat(ik), rzero, hc)
 
                a_block = 0.0_dp
                IF (SIZE(hc%local_data, 2) == nmob) THEN
-                  a_loc => v_mat(ik)%matrix%local_data
+                  a_loc => v_mat(ik)%local_data
                   b_loc => hc%local_data
                   CALL dgemm('T', 'N', nmob, nmob, SIZE(hc%local_data, 1), 1.0_dp, a_loc(1, 1), &
                              SIZE(hc%local_data, 1), b_loc(1, 1), SIZE(hc%local_data, 1), 0.0_dp, a_block(1, 1), nmob)
@@ -771,7 +766,7 @@ CONTAINS
                !factorisation
                c_tmp%local_data = 0.0_dp
                IF (SIZE(c_tmp%local_data, 2) == nmob) THEN
-                  a_loc => v_mat(ik)%matrix%local_data
+                  a_loc => v_mat(ik)%local_data
                   b_loc => c_tmp%local_data
                   CALL dgemm('N', 'N', SIZE(c_tmp%local_data, 1), nmob, nmob, 1.0_dp, a_loc(1, 1), &
                              SIZE(c_tmp%local_data, 1), a_block(1, 1), nmob, 0.0_dp, &
@@ -780,7 +775,7 @@ CONTAINS
                CALL cp_fm_scale_and_add(rmone, c_tmp, rone, hc)
 
                IF (SIZE(c_tmp%local_data, 2) == nmob) THEN
-                  a_loc => v_mat(ik - 1)%matrix%local_data
+                  a_loc => v_mat(ik - 1)%local_data
                   DO j = 1, nmob
                      DO i = 1, j
                         DO ia = 1, SIZE(c_tmp%local_data, 1)
@@ -824,9 +819,9 @@ CONTAINS
             q_mat = 0.0_dp
             b_loc => c2_tmp%local_data
             DO ik = 1, krylov_space%nkrylov
-               CALL cp_fm_to_fm(v_mat(ik)%matrix, v_tmp, nmob, 1, 1)
+               CALL cp_fm_to_fm(v_mat(ik), v_tmp, nmob, 1, 1)
                IF (SIZE(c2_tmp%local_data, 2) == ndim) THEN
-!            a_loc => v_mat(ik)%matrix%local_data
+!            a_loc => v_mat(ik)%local_data
                   a_loc => v_tmp%local_data
                   it = (ik - 1)*nmob
                   CALL dgemm('N', 'N', SIZE(c2_tmp%local_data, 1), ndim, nmob, 1.0_dp, a_loc(1, 1), &
@@ -836,9 +831,9 @@ CONTAINS
             END DO !ik
 
             !Try to avoid linear dependencies
-            CALL cp_fm_to_fm(v_mat(1)%matrix, v_tmp, nmob, 1, 1)
+            CALL cp_fm_to_fm(v_mat(1), v_tmp, nmob, 1, 1)
             IF (SIZE(c2_tmp%local_data, 2) == ndim) THEN
-!          a_loc => v_mat(1)%matrix%local_data
+!          a_loc => v_mat(1)%local_data
                a_loc => v_tmp%local_data
                b_loc => c2_tmp%local_data
                CALL dgemm('T', 'N', nmob, ndim, SIZE(v_tmp%local_data, 1), 1.0_dp, a_loc(1, 1), &
@@ -860,13 +855,13 @@ CONTAINS
                END DO
                itaken(ik) = 1
 
-               CALL cp_fm_to_fm(c2_tmp, v_mat(1)%matrix, 1, ik, it)
+               CALL cp_fm_to_fm(c2_tmp, v_mat(1), 1, ik, it)
             END DO
             DEALLOCATE (itaken)
             DEALLOCATE (q_mat)
 
             !Copy in the converged set to enlarge the converged subspace
-            CALL cp_fm_to_fm(v_mat(1)%matrix, c0, nmob, 1, (nmo_converged + imo_low))
+            CALL cp_fm_to_fm(v_mat(1), c0, nmob, 1, (nmo_converged + imo_low))
             CALL timestop(hand4)
 
             CALL cp_fm_release(c2_tmp)
@@ -879,8 +874,7 @@ CONTAINS
             DEALLOCATE (a_block)
             DEALLOCATE (b_block)
             DO ik = 1, krylov_space%nkrylov
-               CALL cp_fm_release(v_mat(ik)%matrix)
-               DEALLOCATE (v_mat(ik)%matrix)
+               CALL cp_fm_release(v_mat(ik))
             END DO
             DEALLOCATE (v_mat)
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -37,7 +37,6 @@ MODULE qs_scf_post_gpw
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_init_random,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -1404,7 +1403,7 @@ CONTAINS
 
       INTEGER                                            :: handle, ispin
       LOGICAL                                            :: do_et
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: my_mos
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: my_mos
       TYPE(section_vals_type), POINTER                   :: et_section
 
       CALL timeset(routineN, handle)
@@ -1418,12 +1417,11 @@ CONTAINS
             ALLOCATE (my_mos(dft_control%nspins))
             ALLOCATE (qs_env%et_coupling%et_mo_coeff(dft_control%nspins))
             DO ispin = 1, dft_control%nspins
-               ALLOCATE (my_mos(ispin)%matrix)
-               CALL cp_fm_create(matrix=my_mos(ispin)%matrix, &
+               CALL cp_fm_create(matrix=my_mos(ispin), &
                                  matrix_struct=qs_env%mos(ispin)%mo_coeff%matrix_struct, &
                                  name="FIRST_RUN_COEFF"//TRIM(ADJUSTL(cp_to_string(ispin)))//"MATRIX")
                CALL cp_fm_to_fm(qs_env%mos(ispin)%mo_coeff, &
-                                my_mos(ispin)%matrix)
+                                my_mos(ispin))
             END DO
             CALL set_et_coupling_type(qs_env%et_coupling, et_mo_coeff=my_mos)
             DEALLOCATE (my_mos)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -258,9 +258,12 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: mixed_evals, occupied_evals, &
                                                             unoccupied_evals, unoccupied_evals_stm
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: homo_localized, lumo_localized, lumo_ptr, &
-         mixed_localized, mixed_orbs, mo_loc_history, occupied_orbs, unoccupied_orbs, &
-         unoccupied_orbs_stm
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mixed_orbs, occupied_orbs
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &
+         TARGET                                          :: homo_localized, lumo_localized, &
+                                                            mixed_localized
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: lumo_ptr, mo_loc_history, &
+                                                            unoccupied_orbs, unoccupied_orbs_stm
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_rmpv, matrix_p_mp2, matrix_s, &
@@ -309,11 +312,11 @@ CONTAINS
       my_localized_wfn = .FALSE.
       NULLIFY (admm_env, dft_control, pw_env, auxbas_pw_pool, pw_pools, mos, rho, &
                mo_coeff, ks_rmpv, matrix_s, qs_loc_env_homo, qs_loc_env_lumo, scf_control, &
-               unoccupied_orbs, unoccupied_orbs_stm, mo_eigenvalues, unoccupied_evals, &
+               unoccupied_orbs, mo_eigenvalues, unoccupied_evals, &
                unoccupied_evals_stm, molecule_set, mo_derivs, &
                subsys, particles, input, print_key, kinetic_m, marked_states, &
-               mixed_orbs, mixed_evals, qs_loc_env_mixed)
-      NULLIFY (homo_localized, lumo_localized, lumo_ptr, rho_ao, mixed_localized)
+               mixed_evals, qs_loc_env_mixed)
+      NULLIFY (lumo_ptr, rho_ao)
 
       has_homo = .FALSE.
       has_lumo = .FALSE.
@@ -513,11 +516,10 @@ CONTAINS
             DO ispin = 1, dft_control%nspins
                CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, &
                                eigenvalues=mo_eigenvalues)
-               occupied_orbs(ispin)%matrix => mo_coeff
+               occupied_orbs(ispin) = mo_coeff
                occupied_evals(ispin)%array => mo_eigenvalues
-               ALLOCATE (homo_localized(ispin)%matrix)
-               CALL cp_fm_create(homo_localized(ispin)%matrix, occupied_orbs(ispin)%matrix%matrix_struct)
-               CALL cp_fm_to_fm(occupied_orbs(ispin)%matrix, homo_localized(ispin)%matrix)
+               CALL cp_fm_create(homo_localized(ispin), occupied_orbs(ispin)%matrix_struct)
+               CALL cp_fm_to_fm(occupied_orbs(ispin), homo_localized(ispin))
             END DO
 
             CALL get_qs_env(qs_env, mo_loc_history=mo_loc_history)
@@ -618,7 +620,7 @@ CONTAINS
                   IF (p_loc_lumo .AND. nlumo .NE. -1) nlumos = MIN(nlumo, nlumos)
                   ! Prints the cube files of UNOCCUPIED ORBITALS
                   CALL qs_scf_post_unocc_cubes(input, dft_section, dft_control, logger, qs_env, &
-                                               unoccupied_orbs(ispin)%matrix, wf_g, wf_r, particles, nlumos, homo, ispin)
+                                               unoccupied_orbs(ispin), wf_g, wf_r, particles, nlumos, homo, ispin)
                END IF
             END DO
 
@@ -635,9 +637,8 @@ CONTAINS
             IF (p_loc_lumo) THEN
                ALLOCATE (lumo_localized(dft_control%nspins))
                DO ispin = 1, dft_control%nspins
-                  ALLOCATE (lumo_localized(ispin)%matrix)
-                  CALL cp_fm_create(lumo_localized(ispin)%matrix, unoccupied_orbs(ispin)%matrix%matrix_struct)
-                  CALL cp_fm_to_fm(unoccupied_orbs(ispin)%matrix, lumo_localized(ispin)%matrix)
+                  CALL cp_fm_create(lumo_localized(ispin), unoccupied_orbs(ispin)%matrix_struct)
+                  CALL cp_fm_to_fm(unoccupied_orbs(ispin), lumo_localized(ispin))
                END DO
                CALL qs_loc_init(qs_env, qs_loc_env_lumo, localize_section, lumo_localized, do_homo, do_mo_cubes, &
                                 evals=unoccupied_evals)
@@ -678,11 +679,10 @@ CONTAINS
             DO ispin = 1, dft_control%nspins
                CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, &
                                eigenvalues=mo_eigenvalues)
-               mixed_orbs(ispin)%matrix => mo_coeff
+               mixed_orbs(ispin) = mo_coeff
                mixed_evals(ispin)%array => mo_eigenvalues
-               ALLOCATE (mixed_localized(ispin)%matrix)
-               CALL cp_fm_create(mixed_localized(ispin)%matrix, mixed_orbs(ispin)%matrix%matrix_struct)
-               CALL cp_fm_to_fm(mixed_orbs(ispin)%matrix, mixed_localized(ispin)%matrix)
+               CALL cp_fm_create(mixed_localized(ispin), mixed_orbs(ispin)%matrix_struct)
+               CALL cp_fm_to_fm(mixed_orbs(ispin), mixed_localized(ispin))
             END DO
 
             CALL get_qs_env(qs_env, mo_loc_history=mo_loc_history)
@@ -697,7 +697,7 @@ CONTAINS
                              do_mixed=do_mixed)
 
             DO ispin = 1, dft_control%nspins
-               CALL cp_fm_get_info(mixed_localized(ispin)%matrix, ncol_global=nchk_nmoloc)
+               CALL cp_fm_get_info(mixed_localized(ispin), ncol_global=nchk_nmoloc)
             END DO
 
             CALL get_localization_info(qs_env, qs_loc_env_mixed, localize_section, mixed_localized, &
@@ -764,8 +764,7 @@ CONTAINS
             DO ispin = 1, dft_control%nspins
                DEALLOCATE (unoccupied_evals(ispin)%array)
                IF (.NOT. dft_control%do_tddfpt_calculation) THEN
-                  CALL cp_fm_release(unoccupied_orbs(ispin)%matrix)
-                  DEALLOCATE (unoccupied_orbs(ispin)%matrix)
+                  CALL cp_fm_release(unoccupied_orbs(ispin))
                END IF
             END DO
             DEALLOCATE (unoccupied_evals)
@@ -793,8 +792,7 @@ CONTAINS
             IF (nlumo_stm > 0) THEN
                DO ispin = 1, dft_control%nspins
                   DEALLOCATE (unoccupied_evals_stm(ispin)%array)
-                  CALL cp_fm_release(unoccupied_orbs_stm(ispin)%matrix)
-                  DEALLOCATE (unoccupied_orbs_stm(ispin)%matrix)
+                  CALL cp_fm_release(unoccupied_orbs_stm(ispin))
                END DO
                DEALLOCATE (unoccupied_evals_stm)
                DEALLOCATE (unoccupied_orbs_stm)
@@ -852,7 +850,7 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: unoccupied_orbs
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: unoccupied_orbs
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: unoccupied_evals
       INTEGER, INTENT(IN)                                :: nlumo
       INTEGER, INTENT(OUT)                               :: nlumos
@@ -890,7 +888,6 @@ CONTAINS
       output_unit = cp_logger_get_default_io_unit(logger)
 
       DO ispin = 1, dft_control%nspins
-         NULLIFY (unoccupied_orbs(ispin)%matrix)
          NULLIFY (unoccupied_evals(ispin)%array)
          ! Always write eigenvalues
          IF (output_unit > 0) WRITE (output_unit, *) " "
@@ -903,10 +900,9 @@ CONTAINS
          ALLOCATE (unoccupied_evals(ispin)%array(nlumos))
          CALL cp_fm_struct_create(fm_struct_tmp, para_env=para_env, context=blacs_env, &
                                   nrow_global=n, ncol_global=nlumos)
-         ALLOCATE (unoccupied_orbs(ispin)%matrix)
-         CALL cp_fm_create(unoccupied_orbs(ispin)%matrix, fm_struct_tmp, name="lumos")
+         CALL cp_fm_create(unoccupied_orbs(ispin), fm_struct_tmp, name="lumos")
          CALL cp_fm_struct_release(fm_struct_tmp)
-         CALL cp_fm_init_random(unoccupied_orbs(ispin)%matrix, nlumos)
+         CALL cp_fm_init_random(unoccupied_orbs(ispin), nlumos)
 
          ! the full_all preconditioner makes not much sense for lumos search
          NULLIFY (local_preconditioner)
@@ -924,14 +920,14 @@ CONTAINS
          END IF
 
          CALL ot_eigensolver(matrix_h=ks_rmpv(ispin)%matrix, matrix_s=matrix_s(1)%matrix, &
-                             matrix_c_fm=unoccupied_orbs(ispin)%matrix, &
+                             matrix_c_fm=unoccupied_orbs(ispin), &
                              matrix_orthogonal_space_fm=mo_coeff, &
                              eps_gradient=scf_control%eps_lumos, &
                              preconditioner=local_preconditioner, &
                              iter_max=scf_control%max_iter_lumos, &
                              size_ortho_space=nmo)
 
-         CALL calculate_subspace_eigenvalues(unoccupied_orbs(ispin)%matrix, ks_rmpv(ispin)%matrix, &
+         CALL calculate_subspace_eigenvalues(unoccupied_orbs(ispin), ks_rmpv(ispin)%matrix, &
                                              unoccupied_evals(ispin)%array, scr=output_unit, &
                                              ionode=output_unit > 0)
 

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -31,7 +31,6 @@ MODULE qs_scf_post_tb
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_init_random,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm_submat,&
                                               cp_fm_type
@@ -187,7 +186,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: charges
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: unoccupied_evals_stm
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: unoccupied_orbs_stm
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: unoccupied_orbs_stm
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -597,8 +596,7 @@ CONTAINS
                   IF (nlumo_stm > 0) THEN
                      DO ispin = 1, dft_control%nspins
                         DEALLOCATE (unoccupied_evals_stm(ispin)%array)
-                        CALL cp_fm_release(unoccupied_orbs_stm(ispin)%matrix)
-                        DEALLOCATE (unoccupied_orbs_stm(ispin)%matrix)
+                        CALL cp_fm_release(unoccupied_orbs_stm(ispin))
                      END DO
                      DEALLOCATE (unoccupied_evals_stm)
                      DEALLOCATE (unoccupied_orbs_stm)
@@ -801,9 +799,9 @@ CONTAINS
       INTEGER                                            :: iounit, ispin, nao, nmo
       REAL(dp), DIMENSION(:), POINTER                    :: mo_eigenvalues
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: lumos
       TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_fmstruct, ao_lumo_struct
       TYPE(cp_fm_type)                                   :: KS_tmp, MO_tmp, S_tmp, work
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: lumos
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
@@ -837,14 +835,13 @@ CONTAINS
          CALL cp_fm_struct_create(fmstruct=ao_lumo_struct, nrow_global=nao, ncol_global=nao - nmo, &
                                   template_fmstruct=mo_coeff%matrix_struct)
 
-         ALLOCATE (lumos(ispin)%matrix)
-         CALL cp_fm_create(lumos(ispin)%matrix, matrix_struct=ao_lumo_struct)
+         CALL cp_fm_create(lumos(ispin), matrix_struct=ao_lumo_struct)
          CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, KS_tmp)
          CALL cp_fm_cholesky_reduce(KS_tmp, S_tmp)
          CALL choose_eigv_solver(KS_tmp, work, mo_eigenvalues)
          CALL cp_fm_cholesky_restore(work, nao, S_tmp, MO_tmp, "SOLVE")
          CALL cp_fm_to_fm_submat(MO_tmp, mo_coeff, nao, nmo, 1, 1, 1, 1)
-         CALL cp_fm_to_fm_submat(MO_tmp, lumos(ispin)%matrix, nao, nao - nmo, 1, nmo + 1, 1, 1)
+         CALL cp_fm_to_fm_submat(MO_tmp, lumos(ispin), nao, nao - nmo, 1, nmo + 1, 1, 1)
 
          CALL cp_fm_struct_release(ao_lumo_struct)
       END DO
@@ -854,8 +851,7 @@ CONTAINS
                    lumos, scf_env, matrix_s, iounit)
 
       DO ispin = 1, SIZE(mos)
-         CALL cp_fm_release(lumos(ispin)%matrix)
-         DEALLOCATE (lumos(ispin)%matrix)
+         CALL cp_fm_release(lumos(ispin))
       END DO
       DEALLOCATE (lumos)
       CALL cp_fm_release(S_tmp)
@@ -879,8 +875,8 @@ CONTAINS
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: unoccupied_orbs
-      TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: unoccupied_evals
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: unoccupied_orbs
+      TYPE(cp_1d_r_p_type), DIMENSION(:), INTENT(INOUT)  :: unoccupied_evals
       INTEGER                                            :: nlumo
       INTEGER, INTENT(OUT)                               :: nlumos
 
@@ -910,7 +906,6 @@ CONTAINS
       iounit = cp_logger_get_default_io_unit(logger)
 
       DO ispin = 1, dft_control%nspins
-         NULLIFY (unoccupied_orbs(ispin)%matrix)
          NULLIFY (unoccupied_evals(ispin)%array)
          ! Always write eigenvalues
          IF (iounit > 0) WRITE (iounit, *) " "
@@ -923,10 +918,9 @@ CONTAINS
          ALLOCATE (unoccupied_evals(ispin)%array(nlumos))
          CALL cp_fm_struct_create(fm_struct_tmp, para_env=para_env, context=blacs_env, &
                                   nrow_global=n, ncol_global=nlumos)
-         ALLOCATE (unoccupied_orbs(ispin)%matrix)
-         CALL cp_fm_create(unoccupied_orbs(ispin)%matrix, fm_struct_tmp, name="lumos")
+         CALL cp_fm_create(unoccupied_orbs(ispin), fm_struct_tmp, name="lumos")
          CALL cp_fm_struct_release(fm_struct_tmp)
-         CALL cp_fm_init_random(unoccupied_orbs(ispin)%matrix, nlumos)
+         CALL cp_fm_init_random(unoccupied_orbs(ispin), nlumos)
 
          ! the full_all preconditioner makes not much sense for lumos search
          NULLIFY (local_preconditioner)
@@ -939,14 +933,14 @@ CONTAINS
          END IF
 
          CALL ot_eigensolver(matrix_h=ks_rmpv(ispin)%matrix, matrix_s=matrix_s(1)%matrix, &
-                             matrix_c_fm=unoccupied_orbs(ispin)%matrix, &
+                             matrix_c_fm=unoccupied_orbs(ispin), &
                              matrix_orthogonal_space_fm=mo_coeff, &
                              eps_gradient=scf_control%eps_lumos, &
                              preconditioner=local_preconditioner, &
                              iter_max=scf_control%max_iter_lumos, &
                              size_ortho_space=nmo)
 
-         CALL calculate_subspace_eigenvalues(unoccupied_orbs(ispin)%matrix, ks_rmpv(ispin)%matrix, &
+         CALL calculate_subspace_eigenvalues(unoccupied_orbs(ispin), ks_rmpv(ispin)%matrix, &
                                              unoccupied_evals(ispin)%array, scr=iounit, &
                                              ionode=iounit > 0)
 

--- a/src/qs_scf_types.F
+++ b/src/qs_scf_types.F
@@ -13,8 +13,7 @@
 ! **************************************************************************************************
 MODULE qs_scf_types
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
-   USE cp_fm_types,                     ONLY: cp_fm_p_type,&
-                                              cp_fm_release,&
+   USE cp_fm_types,                     ONLY: cp_fm_release,&
                                               cp_fm_type
    USE cp_fm_vect,                      ONLY: cp_fm_vect_dealloc
    USE dbcsr_api,                       ONLY: dbcsr_deallocate_matrix,&
@@ -74,11 +73,11 @@ MODULE qs_scf_types
       LOGICAL :: always_check_conv
       REAL(dp) :: eps_std_diag, eps_conv, eps_adapt, max_res_norm, min_res_norm
       REAL(dp), DIMENSION(:), POINTER :: c_eval, t_eval
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: v_mat, mo_conv, mo_refine
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: v_mat, mo_conv, mo_refine
       TYPE(cp_fm_type), POINTER ::  tmp_mat
       !NOTE: the following matrices are small and could be used as standard array rather than distributed fm
       TYPE(cp_fm_type), POINTER :: block1_mat, block2_mat, block3_mat, block4_mat, block5_mat
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER ::  c_vec, chc_mat
+      TYPE(cp_fm_type), DIMENSION(:), POINTER ::  c_vec, chc_mat
    END TYPE krylov_space_type
 
    TYPE subspace_env_type
@@ -86,14 +85,14 @@ MODULE qs_scf_types
       REAL(dp) :: eps_diag_sub, eps_ene, eps_adapt
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER :: p_matrix_store
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER :: p_matrix_mix
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: chc_mat, c_vec, c0
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: chc_mat, c_vec, c0
       TYPE(mixing_storage_type), POINTER :: mixing_store
    END TYPE subspace_env_type
 
    TYPE floating_basis_type
       REAL(KIND=dp), DIMENSION(:, :), POINTER :: gradient
    END TYPE floating_basis_type
-   ! **************************************************************************************************
+! **************************************************************************************************
    TYPE qs_scf_env_type
       TYPE(qs_outer_scf_type) :: outer_scf
       INTEGER :: iter_count
@@ -103,7 +102,7 @@ MODULE qs_scf_types
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER :: cc_buffer
       LOGICAL :: print_iter_line, skip_mixing, skip_diis, needs_ortho
       TYPE(mixing_storage_type), POINTER :: mixing_store
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER :: scf_work1
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: scf_work1
       TYPE(cp_fm_type), POINTER  :: scf_work2, ortho, ortho_m1, s_half, s_minus_one
       TYPE(krylov_space_type), POINTER :: krylov_space
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER :: p_delta, p_mix_new
@@ -116,9 +115,9 @@ MODULE qs_scf_types
       TYPE(fb_env_obj) :: filter_matrix_env
       TYPE(floating_basis_type) :: floating_basis
       !> reference molecular orbitals for the maximum overlap method
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mom_ref_mo_coeff
+      TYPE(cp_fm_type), DIMENSION(:), POINTER          :: mom_ref_mo_coeff
       !> MOM-related work matrices
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mom_overlap, mom_s_mo_coeff
+      TYPE(cp_fm_type), DIMENSION(:), POINTER          :: mom_overlap, mom_s_mo_coeff
    END TYPE qs_scf_env_type
 
 CONTAINS
@@ -213,8 +212,7 @@ CONTAINS
       END IF
       IF (ASSOCIATED(scf_env%mom_ref_mo_coeff)) THEN
          DO i = 1, SIZE(scf_env%mom_ref_mo_coeff)
-            CALL cp_fm_release(scf_env%mom_ref_mo_coeff(i)%matrix)
-            DEALLOCATE (scf_env%mom_ref_mo_coeff(i)%matrix)
+            CALL cp_fm_release(scf_env%mom_ref_mo_coeff(i))
          END DO
          DEALLOCATE (scf_env%mom_ref_mo_coeff)
       END IF
@@ -342,22 +340,19 @@ CONTAINS
       END IF
       IF (ASSOCIATED(scf_env%mom_ref_mo_coeff)) THEN
          DO i = 1, SIZE(scf_env%mom_ref_mo_coeff)
-            CALL cp_fm_release(scf_env%mom_ref_mo_coeff(i)%matrix)
-            DEALLOCATE (scf_env%mom_ref_mo_coeff(i)%matrix)
+            CALL cp_fm_release(scf_env%mom_ref_mo_coeff(i))
          END DO
          DEALLOCATE (scf_env%mom_ref_mo_coeff)
       END IF
       IF (ASSOCIATED(scf_env%mom_overlap)) THEN
          DO i = 1, SIZE(scf_env%mom_overlap)
-            CALL cp_fm_release(scf_env%mom_overlap(i)%matrix)
-            DEALLOCATE (scf_env%mom_overlap(i)%matrix)
+            CALL cp_fm_release(scf_env%mom_overlap(i))
          END DO
          DEALLOCATE (scf_env%mom_overlap)
       END IF
       IF (ASSOCIATED(scf_env%mom_s_mo_coeff)) THEN
          DO i = 1, SIZE(scf_env%mom_s_mo_coeff)
-            CALL cp_fm_release(scf_env%mom_s_mo_coeff(i)%matrix)
-            DEALLOCATE (scf_env%mom_s_mo_coeff(i)%matrix)
+            CALL cp_fm_release(scf_env%mom_s_mo_coeff(i))
          END DO
          DEALLOCATE (scf_env%mom_s_mo_coeff)
       END IF
@@ -425,31 +420,26 @@ CONTAINS
          DEALLOCATE (krylov_space%t_eval)
 
          DO i = 1, SIZE(krylov_space%v_mat)
-            CALL cp_fm_release(krylov_space%v_mat(i)%matrix)
-            DEALLOCATE (krylov_space%v_mat(i)%matrix)
+            CALL cp_fm_release(krylov_space%v_mat(i))
          END DO
          DEALLOCATE (krylov_space%v_mat)
 
          DO i = 1, SIZE(krylov_space%mo_conv)
-            CALL cp_fm_release(krylov_space%mo_conv(i)%matrix)
-            DEALLOCATE (krylov_space%mo_conv(i)%matrix)
+            CALL cp_fm_release(krylov_space%mo_conv(i))
          END DO
          DEALLOCATE (krylov_space%mo_conv)
 
          DO i = 1, SIZE(krylov_space%mo_refine)
-            CALL cp_fm_release(krylov_space%mo_refine(i)%matrix)
-            DEALLOCATE (krylov_space%mo_refine(i)%matrix)
+            CALL cp_fm_release(krylov_space%mo_refine(i))
          END DO
          DEALLOCATE (krylov_space%mo_refine)
 
          DO i = 1, SIZE(krylov_space%chc_mat)
-            CALL cp_fm_release(krylov_space%chc_mat(i)%matrix)
-            DEALLOCATE (krylov_space%chc_mat(i)%matrix)
+            CALL cp_fm_release(krylov_space%chc_mat(i))
          END DO
          DEALLOCATE (krylov_space%chc_mat)
          DO i = 1, SIZE(krylov_space%c_vec)
-            CALL cp_fm_release(krylov_space%c_vec(i)%matrix)
-            DEALLOCATE (krylov_space%c_vec(i)%matrix)
+            CALL cp_fm_release(krylov_space%c_vec(i))
          END DO
          DEALLOCATE (krylov_space%c_vec)
          IF (ASSOCIATED(krylov_space%tmp_mat)) THEN
@@ -558,18 +548,15 @@ CONTAINS
             CALL dbcsr_deallocate_matrix_set(subspace_env%p_matrix_store)
          END IF
          DO i = 1, SIZE(subspace_env%chc_mat)
-            CALL cp_fm_release(subspace_env%chc_mat(i)%matrix)
-            DEALLOCATE (subspace_env%chc_mat(i)%matrix)
+            CALL cp_fm_release(subspace_env%chc_mat(i))
          END DO
          DEALLOCATE (subspace_env%chc_mat)
          DO i = 1, SIZE(subspace_env%c_vec)
-            CALL cp_fm_release(subspace_env%c_vec(i)%matrix)
-            DEALLOCATE (subspace_env%c_vec(i)%matrix)
+            CALL cp_fm_release(subspace_env%c_vec(i))
          END DO
          DEALLOCATE (subspace_env%c_vec)
          DO i = 1, SIZE(subspace_env%c0)
-            CALL cp_fm_release(subspace_env%c0(i)%matrix)
-            DEALLOCATE (subspace_env%c0(i)%matrix)
+            CALL cp_fm_release(subspace_env%c0(i))
          END DO
          DEALLOCATE (subspace_env%c0)
 

--- a/src/qs_scf_wfn_mix.F
+++ b/src/qs_scf_wfn_mix.F
@@ -18,7 +18,6 @@ MODULE qs_scf_wfn_mix
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -67,7 +66,7 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: dft_section
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: unoccupied_orbs
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: unoccupied_orbs
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       INTEGER                                            :: output_unit
@@ -141,7 +140,7 @@ CONTAINS
                CALL cp_fm_to_fm(mos(orig_spin_index)%mo_coeff, matrix_x, 1, &
                                 mos(orig_spin_index)%nmo - orig_mo_index + 1, 1)
             ELSE
-               CALL cp_fm_to_fm(unoccupied_orbs(orig_spin_index)%matrix, matrix_x, 1, orig_mo_index, 1)
+               CALL cp_fm_to_fm(unoccupied_orbs(orig_spin_index), matrix_x, 1, orig_mo_index, 1)
             END IF
 
             ! now get a copy of the target

--- a/src/qs_tddfpt2_densities.F
+++ b/src/qs_tddfpt2_densities.F
@@ -86,13 +86,13 @@ CONTAINS
 
       nspins = SIZE(sub_env%mos_occ)
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(sub_env%mos_occ(ispin)%matrix, nrow_global=nao, ncol_global=nmo_occ(ispin))
+         CALL cp_fm_get_info(sub_env%mos_occ(ispin), nrow_global=nao, ncol_global=nmo_occ(ispin))
       END DO
 
       CALL qs_rho_get(rho_orb_struct, rho_ao=rho_ij_ao)
       DO ispin = 1, nspins
          CALL parallel_gemm('N', 'T', nao, nao, nmo_occ(ispin), 1.0_dp, &
-                            sub_env%mos_occ(ispin)%matrix, sub_env%mos_occ(ispin)%matrix, &
+                            sub_env%mos_occ(ispin), sub_env%mos_occ(ispin), &
                             0.0_dp, wfm_rho_orb)
 
          CALL copy_fm_to_dbcsr(wfm_rho_orb, rho_ij_ao(ispin)%matrix, keep_sparsity=.TRUE.)

--- a/src/qs_tddfpt2_eigensolver.F
+++ b/src/qs_tddfpt2_eigensolver.F
@@ -222,7 +222,7 @@ CONTAINS
    SUBROUTINE tddfpt_orthonormalize_psi1_psi1(evects, nvects_new, S_evects, matrix_s)
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       INTEGER, INTENT(in)                                :: nvects_new
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: S_evects
       TYPE(dbcsr_type), POINTER                          :: matrix_s
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_orthonormalize_psi1_psi1'
@@ -262,7 +262,7 @@ CONTAINS
 
          ! <psi1_j | psi1_j>
          DO ispin = 1, nspins
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect), S_evects(ispin, jvect)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect), S_evects(ispin, jvect), &
                                          ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
          END DO
 
@@ -273,7 +273,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             CALL cp_fm_scale(norm, evects(ispin, jvect))
-            CALL cp_fm_scale(norm, S_evects(ispin, jvect)%matrix)
+            CALL cp_fm_scale(norm, S_evects(ispin, jvect))
          END DO
       END DO
 
@@ -302,8 +302,7 @@ CONTAINS
                                         matrix_ks, qs_env, kernel_env, &
                                         sub_env, work_matrices)
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects, S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
@@ -685,7 +684,7 @@ CONTAINS
                                    tddfpt_print_section, work_matrices) RESULT(conv)
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(inout)   :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(inout)         :: evals
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(inout) :: S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(inout)   :: S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
@@ -709,8 +708,8 @@ CONTAINS
       REAL(kind=dp)                                      :: t1, t2
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: evals_last
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: Atilde
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_krylov, Aop_ritz, S_krylov
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: krylov_vects
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_krylov, Aop_ritz
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: krylov_vects, S_krylov
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
 
       CALL timeset(routineN, handle)
@@ -746,7 +745,7 @@ CONTAINS
                 S_krylov(nspins, max_krylov_vects))
       DO istate = 1, max_krylov_vects
          DO ispin = 1, nspins
-            NULLIFY (Aop_krylov(ispin, istate)%matrix, S_krylov(ispin, istate)%matrix)
+            NULLIFY (Aop_krylov(ispin, istate)%matrix)
          END DO
       END DO
 
@@ -755,9 +754,8 @@ CONTAINS
             CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, krylov_vects(ispin, istate))
             CALL cp_fm_to_fm(evects(ispin, istate), krylov_vects(ispin, istate))
 
-            ALLOCATE (S_krylov(ispin, istate)%matrix)
-            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate)%matrix)
-            CALL cp_fm_to_fm(S_evects(ispin, istate)%matrix, S_krylov(ispin, istate)%matrix)
+            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate))
+            CALL cp_fm_to_fm(S_evects(ispin, istate), S_krylov(ispin, istate))
 
             ALLOCATE (Aop_krylov(ispin, istate)%matrix)
             CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_krylov(ispin, istate)%matrix)
@@ -804,12 +802,11 @@ CONTAINS
             ! compute residual vectors for the next iteration
             DO istate = 1, nvects_new
                DO ispin = 1, nspins
-                  ALLOCATE (Aop_krylov(ispin, nvects_exist + istate)%matrix, &
-                            S_krylov(ispin, nvects_exist + istate)%matrix)
+                  ALLOCATE (Aop_krylov(ispin, nvects_exist + istate)%matrix)
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
                                          krylov_vects(ispin, nvects_exist + istate))
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
-                                         S_krylov(ispin, nvects_exist + istate)%matrix)
+                                         S_krylov(ispin, nvects_exist + istate))
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
                                          Aop_krylov(ispin, nvects_exist + istate)%matrix)
                END DO
@@ -875,8 +872,7 @@ CONTAINS
          DO ispin = nspins, 1, -1
             CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_krylov(ispin, istate)%matrix)
             DEALLOCATE (Aop_krylov(ispin, istate)%matrix)
-            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate)%matrix)
-            DEALLOCATE (S_krylov(ispin, istate)%matrix)
+            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate))
             CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, krylov_vects(ispin, istate))
          END DO
       END DO

--- a/src/qs_tddfpt2_eigensolver.F
+++ b/src/qs_tddfpt2_eigensolver.F
@@ -579,8 +579,8 @@ CONTAINS
       REAL(kind=dp)                                      :: e_occ_plus_lambda, eref, lambda
       REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
          POINTER                                         :: weights_ldata
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: awork, vomat
       TYPE(cp_fm_struct_type), POINTER                   :: ao_mo_struct, virt_mo_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: awork, vomat
 
       CALL timeset(routineN, handle)
 
@@ -595,13 +595,11 @@ CONTAINS
             !
             CALL cp_fm_get_info(matrix=ritz_vects(ispin, 1)%matrix, matrix_struct=ao_mo_struct, &
                                 ncol_global=nactive(ispin))
-            ALLOCATE (awork(ispin)%matrix)
-            CALL cp_fm_create(awork(ispin)%matrix, ao_mo_struct)
+            CALL cp_fm_create(awork(ispin), ao_mo_struct)
             !
             CALL cp_fm_struct_create(virt_mo_struct, nrow_global=nmo_virt(ispin), &
                                      ncol_global=nactive(ispin), template_fmstruct=ao_mo_struct)
-            ALLOCATE (vomat(ispin)%matrix)
-            CALL cp_fm_create(vomat(ispin)%matrix, virt_mo_struct)
+            CALL cp_fm_create(vomat(ispin), virt_mo_struct)
             CALL cp_fm_struct_release(virt_mo_struct)
          END DO
 
@@ -610,17 +608,17 @@ CONTAINS
             lambda = evals(irv)
 
             DO ispin = 1, nspins
-               CALL cp_fm_get_info(vomat(ispin)%matrix, nrow_local=nrows_local, &
+               CALL cp_fm_get_info(vomat(ispin), nrow_local=nrows_local, &
                                    ncol_local=ncols_local, row_indices=row_indices_local, &
                                    col_indices=col_indices_local, local_data=weights_ldata)
 
                ! awork := Ab(ispin, irv) - evals(irv) b(ispin, irv), where 'b' is a Ritz vector
-               CALL cp_dbcsr_sm_fm_multiply(matrix_s, ritz_vects(ispin, irv)%matrix, awork(ispin)%matrix, &
+               CALL cp_dbcsr_sm_fm_multiply(matrix_s, ritz_vects(ispin, irv)%matrix, awork(ispin), &
                                             ncol=nactive(ispin), alpha=-lambda, beta=0.0_dp)
-               CALL cp_fm_scale_and_add(1.0_dp, awork(ispin)%matrix, 1.0_dp, Aop_ritz(ispin, irv)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, awork(ispin), 1.0_dp, Aop_ritz(ispin, irv)%matrix)
                !
                CALL parallel_gemm('T', 'N', nmo_virt(ispin), nactive(ispin), nao, 1.0_dp, gs_mos(ispin)%mos_virt, &
-                                  awork(ispin)%matrix, 0.0_dp, vomat(ispin)%matrix)
+                                  awork(ispin), 0.0_dp, vomat(ispin))
 
                DO icol_local = 1, ncols_local
                   e_occ_plus_lambda = gs_mos(ispin)%evals_occ(col_indices_local(icol_local)) + lambda
@@ -638,14 +636,13 @@ CONTAINS
                END DO
 
                CALL parallel_gemm('N', 'N', nao, nactive(ispin), nmo_virt(ispin), 1.0_dp, gs_mos(ispin)%mos_virt, &
-                                  vomat(ispin)%matrix, 0.0_dp, residual_vects(ispin, irv)%matrix)
+                                  vomat(ispin), 0.0_dp, residual_vects(ispin, irv)%matrix)
             END DO
          END DO
          !
          DO ispin = 1, nspins
-            CALL cp_fm_release(awork(ispin)%matrix)
-            CALL cp_fm_release(vomat(ispin)%matrix)
-            DEALLOCATE (awork(ispin)%matrix, vomat(ispin)%matrix)
+            CALL cp_fm_release(awork(ispin))
+            CALL cp_fm_release(vomat(ispin))
          END DO
          DEALLOCATE (awork, vomat)
       END IF

--- a/src/qs_tddfpt2_eigensolver.F
+++ b/src/qs_tddfpt2_eigensolver.F
@@ -301,8 +301,7 @@ CONTAINS
    SUBROUTINE tddfpt_compute_Aop_evects(Aop_evects, evects, S_evects, gs_mos, tddfpt_control, &
                                         matrix_ks, qs_env, kernel_env, &
                                         sub_env, work_matrices)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects, S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: Aop_evects, evects, S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
@@ -385,7 +384,7 @@ CONTAINS
             ! No kernel
             DO ivect = 1, nvects
                DO ispin = 1, nspins
-                  CALL cp_fm_set_all(Aop_evects(ispin, ivect)%matrix, 0.0_dp)
+                  CALL cp_fm_set_all(Aop_evects(ispin, ivect), 0.0_dp)
                END DO
             END DO
          ELSE
@@ -397,14 +396,14 @@ CONTAINS
                DO ispin = 1, nspins
                   ASSOCIATE (Aop_evect => Aop_evects(ispin, ivect), &
                              work_matrix => work_matrices%Aop_evects_sub(ispin, ivect))
-                  IF (ASSOCIATED(Aop_evect%matrix)) THEN
-                  IF (ASSOCIATED(work_matrix%matrix)) THEN
-                     CALL cp_fm_copy_general(work_matrix%matrix, Aop_evect%matrix, para_env)
+                  IF (ASSOCIATED(Aop_evect%matrix_struct)) THEN
+                  IF (ASSOCIATED(work_matrix%matrix_struct)) THEN
+                     CALL cp_fm_copy_general(work_matrix, Aop_evect, para_env)
                   ELSE
-                     CALL cp_fm_copy_general(fm_dummy, Aop_evect%matrix, para_env)
+                     CALL cp_fm_copy_general(fm_dummy, Aop_evect, para_env)
                   END IF
-                  ELSE IF (ASSOCIATED(work_matrix%matrix)) THEN
-                  CALL cp_fm_copy_general(work_matrix%matrix, fm_dummy, para_env)
+                  ELSE IF (ASSOCIATED(work_matrix%matrix_struct)) THEN
+                  CALL cp_fm_copy_general(work_matrix, fm_dummy, para_env)
                   ELSE
                   CALL cp_fm_copy_general(fm_dummy, fm_dummy, para_env)
                   END IF
@@ -462,8 +461,7 @@ CONTAINS
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: ritz_vects
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_ritz
       REAL(kind=dp), DIMENSION(:), INTENT(out)           :: evals
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: krylov_vects
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_krylov
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: krylov_vects, Aop_krylov
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: Atilde
       INTEGER, INTENT(IN)                                :: nkvo, nkvn
 
@@ -538,7 +536,7 @@ CONTAINS
                CALL cp_fm_scale_and_add(1.0_dp, ritz_vects(ispin, irv), &
                                         act, krylov_vects(ispin, ikv))
                CALL cp_fm_scale_and_add(1.0_dp, Aop_ritz(ispin, irv)%matrix, &
-                                        act, Aop_krylov(ispin, ikv)%matrix)
+                                        act, Aop_krylov(ispin, ikv))
             END DO
          END DO
       END DO
@@ -708,8 +706,8 @@ CONTAINS
       REAL(kind=dp)                                      :: t1, t2
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: evals_last
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: Atilde
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_krylov, Aop_ritz
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: krylov_vects, S_krylov
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_ritz
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Aop_krylov, krylov_vects, S_krylov
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
 
       CALL timeset(routineN, handle)
@@ -743,11 +741,6 @@ CONTAINS
       ALLOCATE (evals_last(max_krylov_vects))
       ALLOCATE (Aop_krylov(nspins, max_krylov_vects), krylov_vects(nspins, max_krylov_vects), &
                 S_krylov(nspins, max_krylov_vects))
-      DO istate = 1, max_krylov_vects
-         DO ispin = 1, nspins
-            NULLIFY (Aop_krylov(ispin, istate)%matrix)
-         END DO
-      END DO
 
       DO istate = 1, nstates
          DO ispin = 1, nspins
@@ -757,8 +750,7 @@ CONTAINS
             CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate))
             CALL cp_fm_to_fm(S_evects(ispin, istate), S_krylov(ispin, istate))
 
-            ALLOCATE (Aop_krylov(ispin, istate)%matrix)
-            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_krylov(ispin, istate)%matrix)
+            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_krylov(ispin, istate))
          END DO
       END DO
 
@@ -802,13 +794,12 @@ CONTAINS
             ! compute residual vectors for the next iteration
             DO istate = 1, nvects_new
                DO ispin = 1, nspins
-                  ALLOCATE (Aop_krylov(ispin, nvects_exist + istate)%matrix)
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
                                          krylov_vects(ispin, nvects_exist + istate))
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
                                          S_krylov(ispin, nvects_exist + istate))
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
-                                         Aop_krylov(ispin, nvects_exist + istate)%matrix)
+                                         Aop_krylov(ispin, nvects_exist + istate))
                END DO
             END DO
 
@@ -870,8 +861,7 @@ CONTAINS
 
       DO istate = nvects_exist + nvects_new, 1, -1
          DO ispin = nspins, 1, -1
-            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_krylov(ispin, istate)%matrix)
-            DEALLOCATE (Aop_krylov(ispin, istate)%matrix)
+            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_krylov(ispin, istate))
             CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate))
             CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, krylov_vects(ispin, istate))
          END DO

--- a/src/qs_tddfpt2_eigensolver.F
+++ b/src/qs_tddfpt2_eigensolver.F
@@ -21,7 +21,7 @@ MODULE qs_tddfpt2_eigensolver
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         cp_fm_copy_general, cp_fm_create, cp_fm_get_info, cp_fm_get_submatrix, cp_fm_maxabsval, &
-        cp_fm_p_type, cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
+        cp_fm_release, cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_type
    USE cp_output_handling,              ONLY: cp_iterate
    USE cp_para_types,                   ONLY: cp_para_env_type
@@ -458,8 +458,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_compute_ritz_vects(ritz_vects, Aop_ritz, evals, krylov_vects, Aop_krylov, &
                                         Atilde, nkvo, nkvn)
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: ritz_vects
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_ritz
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: ritz_vects, Aop_ritz
       REAL(kind=dp), DIMENSION(:), INTENT(out)           :: evals
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: krylov_vects, Aop_krylov
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: Atilde
@@ -527,7 +526,7 @@ CONTAINS
       DO irv = 1, nrvs
          DO ispin = 1, nspins
             CALL cp_fm_set_all(ritz_vects(ispin, irv), 0.0_dp)
-            CALL cp_fm_set_all(Aop_ritz(ispin, irv)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(Aop_ritz(ispin, irv), 0.0_dp)
          END DO
 
          DO ikv = 1, nkvs
@@ -535,7 +534,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL cp_fm_scale_and_add(1.0_dp, ritz_vects(ispin, irv), &
                                         act, krylov_vects(ispin, ikv))
-               CALL cp_fm_scale_and_add(1.0_dp, Aop_ritz(ispin, irv)%matrix, &
+               CALL cp_fm_scale_and_add(1.0_dp, Aop_ritz(ispin, irv), &
                                         act, Aop_krylov(ispin, ikv))
             END DO
          END DO
@@ -564,8 +563,7 @@ CONTAINS
                                             matrix_s)
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: residual_vects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: ritz_vects
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_ritz
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: ritz_vects, Aop_ritz
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(dbcsr_type), POINTER                          :: matrix_s
@@ -617,7 +615,7 @@ CONTAINS
                ! awork := Ab(ispin, irv) - evals(irv) b(ispin, irv), where 'b' is a Ritz vector
                CALL cp_dbcsr_sm_fm_multiply(matrix_s, ritz_vects(ispin, irv), awork(ispin), &
                                             ncol=nactive(ispin), alpha=-lambda, beta=0.0_dp)
-               CALL cp_fm_scale_and_add(1.0_dp, awork(ispin), 1.0_dp, Aop_ritz(ispin, irv)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, awork(ispin), 1.0_dp, Aop_ritz(ispin, irv))
                !
                CALL parallel_gemm('T', 'N', nmo_virt(ispin), nactive(ispin), nao, 1.0_dp, gs_mos(ispin)%mos_virt, &
                                   awork(ispin), 0.0_dp, vomat(ispin))
@@ -706,8 +704,8 @@ CONTAINS
       REAL(kind=dp)                                      :: t1, t2
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: evals_last
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: Atilde
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_ritz
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Aop_krylov, krylov_vects, S_krylov
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Aop_krylov, Aop_ritz, krylov_vects, &
+                                                            S_krylov
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
 
       CALL timeset(routineN, handle)
@@ -733,8 +731,7 @@ CONTAINS
       ALLOCATE (Aop_ritz(nspins, nstates))
       DO istate = 1, nstates
          DO ispin = 1, nspins
-            ALLOCATE (Aop_ritz(ispin, istate)%matrix)
-            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_ritz(ispin, istate)%matrix)
+            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_ritz(ispin, istate))
          END DO
       END DO
 
@@ -871,8 +868,7 @@ CONTAINS
 
       DO istate = nstates, 1, -1
          DO ispin = nspins, 1, -1
-            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_ritz(ispin, istate)%matrix)
-            DEALLOCATE (Aop_ritz(ispin, istate)%matrix)
+            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, Aop_ritz(ispin, istate))
          END DO
       END DO
       DEALLOCATE (Aop_ritz)

--- a/src/qs_tddfpt2_eigensolver.F
+++ b/src/qs_tddfpt2_eigensolver.F
@@ -91,7 +91,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_orthogonalize_psi1_psi0(evects, S_C0_C0T)
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: S_C0_C0T
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(in)         :: S_C0_C0T
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_orthogonalize_psi1_psi0'
 
@@ -112,7 +112,7 @@ CONTAINS
             CALL cp_fm_create(evortho, matrix_struct)
             DO ivect = 1, nvects
                ! evortho: C0 * C0^T * S * C1 == (S * C0 * C0^T)^T * C1
-               CALL parallel_gemm('T', 'N', nao, nactive, nao, 1.0_dp, S_C0_C0T(ispin)%matrix, &
+               CALL parallel_gemm('T', 'N', nao, nactive, nao, 1.0_dp, S_C0_C0T(ispin), &
                                   evects(ispin, ivect)%matrix, 0.0_dp, evortho)
                CALL cp_fm_scale_and_add(1.0_dp, evects(ispin, ivect)%matrix, -1.0_dp, evortho)
             END DO
@@ -140,7 +140,7 @@ CONTAINS
    FUNCTION tddfpt_is_nonorthogonal_psi1_psi0(evects, S_C0, max_norm) &
       RESULT(is_nonortho)
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: S_C0
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(in)         :: S_C0
       REAL(kind=dp), INTENT(in)                          :: max_norm
       LOGICAL                                            :: is_nonortho
 
@@ -160,7 +160,7 @@ CONTAINS
       is_nonortho = .FALSE.
 
       loop: DO ispin = 1, nspins
-         CALL cp_fm_get_info(matrix=S_C0(ispin)%matrix, ncol_global=nocc)
+         CALL cp_fm_get_info(matrix=S_C0(ispin), ncol_global=nocc)
          CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, matrix_struct=matrix_struct, &
                              nrow_global=nao, ncol_global=nactive)
          CALL cp_fm_struct_create(matrix_struct_tmp, nrow_global=nocc, &
@@ -169,7 +169,7 @@ CONTAINS
          CALL cp_fm_struct_release(matrix_struct_tmp)
          DO ivect = 1, nvects
             ! aortho = S_0^T * S * C_1
-            CALL parallel_gemm('T', 'N', nocc, nactive, nao, 1.0_dp, S_C0(ispin)%matrix, &
+            CALL parallel_gemm('T', 'N', nocc, nactive, nao, 1.0_dp, S_C0(ispin), &
                                evects(ispin, ivect)%matrix, 0.0_dp, aortho)
             CALL cp_fm_maxabsval(aortho, maxabs_val)
             is_nonortho = maxabs_val > max_norm

--- a/src/qs_tddfpt2_eigensolver.F
+++ b/src/qs_tddfpt2_eigensolver.F
@@ -90,7 +90,7 @@ CONTAINS
 !>        the occupied MOs.
 ! **************************************************************************************************
    SUBROUTINE tddfpt_orthogonalize_psi1_psi0(evects, S_C0_C0T)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       TYPE(cp_fm_type), DIMENSION(:), INTENT(in)         :: S_C0_C0T
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_orthogonalize_psi1_psi0'
@@ -107,14 +107,14 @@ CONTAINS
 
       IF (nvects > 0) THEN
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, matrix_struct=matrix_struct, &
+            CALL cp_fm_get_info(matrix=evects(ispin, 1), matrix_struct=matrix_struct, &
                                 nrow_global=nao, ncol_global=nactive)
             CALL cp_fm_create(evortho, matrix_struct)
             DO ivect = 1, nvects
                ! evortho: C0 * C0^T * S * C1 == (S * C0 * C0^T)^T * C1
                CALL parallel_gemm('T', 'N', nao, nactive, nao, 1.0_dp, S_C0_C0T(ispin), &
-                                  evects(ispin, ivect)%matrix, 0.0_dp, evortho)
-               CALL cp_fm_scale_and_add(1.0_dp, evects(ispin, ivect)%matrix, -1.0_dp, evortho)
+                                  evects(ispin, ivect), 0.0_dp, evortho)
+               CALL cp_fm_scale_and_add(1.0_dp, evects(ispin, ivect), -1.0_dp, evortho)
             END DO
             CALL cp_fm_release(evortho)
          END DO
@@ -139,7 +139,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION tddfpt_is_nonorthogonal_psi1_psi0(evects, S_C0, max_norm) &
       RESULT(is_nonortho)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       TYPE(cp_fm_type), DIMENSION(:), INTENT(in)         :: S_C0
       REAL(kind=dp), INTENT(in)                          :: max_norm
       LOGICAL                                            :: is_nonortho
@@ -161,7 +161,7 @@ CONTAINS
 
       loop: DO ispin = 1, nspins
          CALL cp_fm_get_info(matrix=S_C0(ispin), ncol_global=nocc)
-         CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, matrix_struct=matrix_struct, &
+         CALL cp_fm_get_info(matrix=evects(ispin, 1), matrix_struct=matrix_struct, &
                              nrow_global=nao, ncol_global=nactive)
          CALL cp_fm_struct_create(matrix_struct_tmp, nrow_global=nocc, &
                                   ncol_global=nactive, template_fmstruct=matrix_struct)
@@ -170,7 +170,7 @@ CONTAINS
          DO ivect = 1, nvects
             ! aortho = S_0^T * S * C_1
             CALL parallel_gemm('T', 'N', nocc, nactive, nao, 1.0_dp, S_C0(ispin), &
-                               evects(ispin, ivect)%matrix, 0.0_dp, aortho)
+                               evects(ispin, ivect), 0.0_dp, aortho)
             CALL cp_fm_maxabsval(aortho, maxabs_val)
             is_nonortho = maxabs_val > max_norm
             IF (is_nonortho) THEN
@@ -220,7 +220,7 @@ CONTAINS
 !>       \endparblock
 ! **************************************************************************************************
    SUBROUTINE tddfpt_orthonormalize_psi1_psi1(evects, nvects_new, S_evects, matrix_s)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       INTEGER, INTENT(in)                                :: nvects_new
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
       TYPE(dbcsr_type), POINTER                          :: matrix_s
@@ -246,7 +246,7 @@ CONTAINS
       END IF
 
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, ncol_global=nactive(ispin))
+         CALL cp_fm_get_info(matrix=evects(ispin, 1), ncol_global=nactive(ispin))
       END DO
 
       DO jvect = nvects_old + 1, nvects_total
@@ -256,13 +256,13 @@ CONTAINS
             norm = SUM(weights(1:nspins))
 
             DO ispin = 1, nspins
-               CALL cp_fm_scale_and_add(1.0_dp, evects(ispin, jvect)%matrix, -norm, evects(ispin, ivect)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, evects(ispin, jvect), -norm, evects(ispin, ivect))
             END DO
          END DO
 
          ! <psi1_j | psi1_j>
          DO ispin = 1, nspins
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect)%matrix, S_evects(ispin, jvect)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect), S_evects(ispin, jvect)%matrix, &
                                          ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
          END DO
 
@@ -272,7 +272,7 @@ CONTAINS
          norm = 1.0_dp/SQRT(norm)
 
          DO ispin = 1, nspins
-            CALL cp_fm_scale(norm, evects(ispin, jvect)%matrix)
+            CALL cp_fm_scale(norm, evects(ispin, jvect))
             CALL cp_fm_scale(norm, S_evects(ispin, jvect)%matrix)
          END DO
       END DO
@@ -301,7 +301,9 @@ CONTAINS
    SUBROUTINE tddfpt_compute_Aop_evects(Aop_evects, evects, S_evects, gs_mos, tddfpt_control, &
                                         matrix_ks, qs_env, kernel_env, &
                                         sub_env, work_matrices)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects, evects, S_evects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
@@ -349,19 +351,19 @@ CONTAINS
       END DO
 
       IF (nvects > 0) THEN
-         CALL cp_fm_get_info(evects(1, 1)%matrix, para_env=para_env)
+         CALL cp_fm_get_info(evects(1, 1), para_env=para_env)
          IF (ALLOCATED(work_matrices%evects_sub)) THEN
             DO ivect = 1, nvects
                DO ispin = 1, nspins
                   ASSOCIATE (evect => evects(ispin, ivect), work_matrix => work_matrices%evects_sub(ispin, ivect))
-                  IF (ASSOCIATED(evect%matrix)) THEN
-                  IF (ASSOCIATED(work_matrix%matrix)) THEN
-                     CALL cp_fm_copy_general(evect%matrix, work_matrix%matrix, para_env)
+                  IF (ASSOCIATED(evect%matrix_struct)) THEN
+                  IF (ASSOCIATED(work_matrix%matrix_struct)) THEN
+                     CALL cp_fm_copy_general(evect, work_matrix, para_env)
                   ELSE
-                     CALL cp_fm_copy_general(evect%matrix, fm_dummy, para_env)
+                     CALL cp_fm_copy_general(evect, fm_dummy, para_env)
                   END IF
-                  ELSE IF (ASSOCIATED(work_matrix%matrix)) THEN
-                  CALL cp_fm_copy_general(fm_dummy, work_matrix%matrix, para_env)
+                  ELSE IF (ASSOCIATED(work_matrix%matrix_struct)) THEN
+                  CALL cp_fm_copy_general(fm_dummy, work_matrix, para_env)
                   ELSE
                   CALL cp_fm_copy_general(fm_dummy, fm_dummy, para_env)
                   END IF
@@ -458,9 +460,11 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_compute_ritz_vects(ritz_vects, Aop_ritz, evals, krylov_vects, Aop_krylov, &
                                         Atilde, nkvo, nkvn)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: ritz_vects, Aop_ritz
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: ritz_vects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_ritz
       REAL(kind=dp), DIMENSION(:), INTENT(out)           :: evals
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: krylov_vects, Aop_krylov
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: krylov_vects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_krylov
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: Atilde
       INTEGER, INTENT(IN)                                :: nkvo, nkvn
 
@@ -481,7 +485,7 @@ CONTAINS
       nrvs = SIZE(ritz_vects, 2)
       CPASSERT(nkvs == nkvo + nkvn)
 
-      CALL cp_fm_get_info(krylov_vects(1, 1)%matrix, context=blacs_env_global)
+      CALL cp_fm_get_info(krylov_vects(1, 1), context=blacs_env_global)
 
       CALL cp_fm_struct_create(fm_struct, nrow_global=nkvs, ncol_global=nkvs, context=blacs_env_global)
       CALL cp_fm_create(Atilde_fm, fm_struct)
@@ -525,15 +529,15 @@ CONTAINS
 !$OMP             SHARED(Aop_krylov, Aop_ritz, krylov_vects, evects_Atilde, nkvs, nrvs, nspins, ritz_vects)
       DO irv = 1, nrvs
          DO ispin = 1, nspins
-            CALL cp_fm_set_all(ritz_vects(ispin, irv)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(ritz_vects(ispin, irv), 0.0_dp)
             CALL cp_fm_set_all(Aop_ritz(ispin, irv)%matrix, 0.0_dp)
          END DO
 
          DO ikv = 1, nkvs
             act = evects_Atilde(ikv, irv)
             DO ispin = 1, nspins
-               CALL cp_fm_scale_and_add(1.0_dp, ritz_vects(ispin, irv)%matrix, &
-                                        act, krylov_vects(ispin, ikv)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, ritz_vects(ispin, irv), &
+                                        act, krylov_vects(ispin, ikv))
                CALL cp_fm_scale_and_add(1.0_dp, Aop_ritz(ispin, irv)%matrix, &
                                         act, Aop_krylov(ispin, ikv)%matrix)
             END DO
@@ -561,9 +565,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_compute_residual_vects(residual_vects, evals, ritz_vects, Aop_ritz, gs_mos, &
                                             matrix_s)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: residual_vects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: residual_vects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: ritz_vects, Aop_ritz
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: ritz_vects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_ritz
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(dbcsr_type), POINTER                          :: matrix_s
@@ -593,7 +598,7 @@ CONTAINS
          DO ispin = 1, nspins
             nmo_virt(ispin) = SIZE(gs_mos(ispin)%evals_virt)
             !
-            CALL cp_fm_get_info(matrix=ritz_vects(ispin, 1)%matrix, matrix_struct=ao_mo_struct, &
+            CALL cp_fm_get_info(matrix=ritz_vects(ispin, 1), matrix_struct=ao_mo_struct, &
                                 ncol_global=nactive(ispin))
             CALL cp_fm_create(awork(ispin), ao_mo_struct)
             !
@@ -613,7 +618,7 @@ CONTAINS
                                    col_indices=col_indices_local, local_data=weights_ldata)
 
                ! awork := Ab(ispin, irv) - evals(irv) b(ispin, irv), where 'b' is a Ritz vector
-               CALL cp_dbcsr_sm_fm_multiply(matrix_s, ritz_vects(ispin, irv)%matrix, awork(ispin), &
+               CALL cp_dbcsr_sm_fm_multiply(matrix_s, ritz_vects(ispin, irv), awork(ispin), &
                                             ncol=nactive(ispin), alpha=-lambda, beta=0.0_dp)
                CALL cp_fm_scale_and_add(1.0_dp, awork(ispin), 1.0_dp, Aop_ritz(ispin, irv)%matrix)
                !
@@ -636,7 +641,7 @@ CONTAINS
                END DO
 
                CALL parallel_gemm('N', 'N', nao, nactive(ispin), nmo_virt(ispin), 1.0_dp, gs_mos(ispin)%mos_virt, &
-                                  vomat(ispin), 0.0_dp, residual_vects(ispin, irv)%matrix)
+                                  vomat(ispin), 0.0_dp, residual_vects(ispin, irv))
             END DO
          END DO
          !
@@ -678,7 +683,7 @@ CONTAINS
                                    matrix_ks, qs_env, kernel_env, &
                                    sub_env, logger, iter_unit, energy_unit, &
                                    tddfpt_print_section, work_matrices) RESULT(conv)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(inout) :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(inout)   :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(inout)         :: evals
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(inout) :: S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
@@ -704,8 +709,8 @@ CONTAINS
       REAL(kind=dp)                                      :: t1, t2
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: evals_last
       REAL(kind=dp), DIMENSION(:, :), POINTER            :: Atilde
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_krylov, Aop_ritz, krylov_vects, &
-                                                            S_krylov
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_krylov, Aop_ritz, S_krylov
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: krylov_vects
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
 
       CALL timeset(routineN, handle)
@@ -741,16 +746,14 @@ CONTAINS
                 S_krylov(nspins, max_krylov_vects))
       DO istate = 1, max_krylov_vects
          DO ispin = 1, nspins
-            NULLIFY (Aop_krylov(ispin, istate)%matrix, krylov_vects(ispin, istate)%matrix, &
-                     S_krylov(ispin, istate)%matrix)
+            NULLIFY (Aop_krylov(ispin, istate)%matrix, S_krylov(ispin, istate)%matrix)
          END DO
       END DO
 
       DO istate = 1, nstates
          DO ispin = 1, nspins
-            ALLOCATE (krylov_vects(ispin, istate)%matrix)
-            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, krylov_vects(ispin, istate)%matrix)
-            CALL cp_fm_to_fm(evects(ispin, istate)%matrix, krylov_vects(ispin, istate)%matrix)
+            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, krylov_vects(ispin, istate))
+            CALL cp_fm_to_fm(evects(ispin, istate), krylov_vects(ispin, istate))
 
             ALLOCATE (S_krylov(ispin, istate)%matrix)
             CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate)%matrix)
@@ -802,10 +805,9 @@ CONTAINS
             DO istate = 1, nvects_new
                DO ispin = 1, nspins
                   ALLOCATE (Aop_krylov(ispin, nvects_exist + istate)%matrix, &
-                            krylov_vects(ispin, nvects_exist + istate)%matrix, &
                             S_krylov(ispin, nvects_exist + istate)%matrix)
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
-                                         krylov_vects(ispin, nvects_exist + istate)%matrix)
+                                         krylov_vects(ispin, nvects_exist + istate))
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
                                          S_krylov(ispin, nvects_exist + istate)%matrix)
                   CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, &
@@ -875,8 +877,7 @@ CONTAINS
             DEALLOCATE (Aop_krylov(ispin, istate)%matrix)
             CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_krylov(ispin, istate)%matrix)
             DEALLOCATE (S_krylov(ispin, istate)%matrix)
-            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, krylov_vects(ispin, istate)%matrix)
-            DEALLOCATE (krylov_vects(ispin, istate)%matrix)
+            CALL fm_pool_give_back_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, krylov_vects(ispin, istate))
          END DO
       END DO
       DEALLOCATE (Aop_krylov, krylov_vects, S_krylov)

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -15,7 +15,6 @@ MODULE qs_tddfpt2_fhxc
                                               cp_dbcsr_sm_fm_multiply
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
@@ -99,8 +98,7 @@ CONTAINS
    SUBROUTINE fhxc_kernel(Aop_evects, evects, is_rks_triplets, &
                           do_hfx, do_admm, qs_env, kernel_env, kernel_env_admm_aux, &
                           sub_env, work_matrices, admm_symm, admm_xc_correction, do_lrigpw)
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: Aop_evects
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: Aop_evects, evects
       LOGICAL, INTENT(in)                                :: is_rks_triplets, do_hfx, do_admm
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(full_kernel_env_type), POINTER                :: kernel_env, kernel_env_admm_aux
@@ -446,14 +444,14 @@ CONTAINS
             DO ispin = 1, nspins
                CALL cp_dbcsr_sm_fm_multiply(work_matrices%A_ia_munu_sub(ispin)%matrix, &
                                             sub_env%mos_occ(ispin)%matrix, &
-                                            work_matrices%Aop_evects_sub(ispin, ivect)%matrix, &
+                                            work_matrices%Aop_evects_sub(ispin, ivect), &
                                             ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
             END DO
          ELSE
             DO ispin = 1, nspins
                CALL cp_dbcsr_sm_fm_multiply(work_matrices%A_ia_munu_sub(ispin)%matrix, &
                                             sub_env%mos_occ(ispin)%matrix, &
-                                            Aop_evects(ispin, ivect)%matrix, &
+                                            Aop_evects(ispin, ivect), &
                                             ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
             END DO
          END IF
@@ -481,8 +479,7 @@ CONTAINS
                           qs_env, stda_control, stda_env, &
                           sub_env, work_matrices)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: Aop_evects
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: Aop_evects, evects
       LOGICAL, INTENT(in)                                :: is_rks_triplets
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(stda_control_type)                            :: stda_control

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -99,7 +99,8 @@ CONTAINS
    SUBROUTINE fhxc_kernel(Aop_evects, evects, is_rks_triplets, &
                           do_hfx, do_admm, qs_env, kernel_env, kernel_env_admm_aux, &
                           sub_env, work_matrices, admm_symm, admm_xc_correction, do_lrigpw)
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: Aop_evects, evects
+      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: Aop_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
       LOGICAL, INTENT(in)                                :: is_rks_triplets, do_hfx, do_admm
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(full_kernel_env_type), POINTER                :: kernel_env, kernel_env_admm_aux
@@ -143,9 +144,9 @@ CONTAINS
       gapw = dft_control%qs_control%gapw
       gapw_xc = dft_control%qs_control%gapw_xc
 
-      CALL cp_fm_get_info(evects(1, 1)%matrix, nrow_global=nao)
+      CALL cp_fm_get_info(evects(1, 1), nrow_global=nao)
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(evects(ispin, 1)%matrix, ncol_global=nactive(ispin))
+         CALL cp_fm_get_info(evects(ispin, 1), ncol_global=nactive(ispin))
       END DO
 
       CALL qs_rho_get(work_matrices%rho_orb_struct_sub, rho_ao=rho_ia_ao, &
@@ -159,12 +160,12 @@ CONTAINS
 
       DO ivect = 1, nvects
          IF (ALLOCATED(work_matrices%evects_sub)) THEN
-            IF (ASSOCIATED(work_matrices%evects_sub(1, ivect)%matrix)) THEN
+            IF (ASSOCIATED(work_matrices%evects_sub(1, ivect)%matrix_struct)) THEN
                DO ispin = 1, nspins
                   CALL dbcsr_set(rho_ia_ao(ispin)%matrix, 0.0_dp)
                   CALL cp_dbcsr_plus_fm_fm_t(rho_ia_ao(ispin)%matrix, &
                                              matrix_v=sub_env%mos_occ(ispin)%matrix, &
-                                             matrix_g=work_matrices%evects_sub(ispin, ivect)%matrix, &
+                                             matrix_g=work_matrices%evects_sub(ispin, ivect), &
                                              ncol=nactive(ispin), symmetry_mode=1)
                END DO
             ELSE
@@ -176,7 +177,7 @@ CONTAINS
                CALL dbcsr_set(rho_ia_ao(ispin)%matrix, 0.0_dp)
                CALL cp_dbcsr_plus_fm_fm_t(rho_ia_ao(ispin)%matrix, &
                                           matrix_v=sub_env%mos_occ(ispin)%matrix, &
-                                          matrix_g=evects(ispin, ivect)%matrix, &
+                                          matrix_g=evects(ispin, ivect), &
                                           ncol=nactive(ispin), symmetry_mode=1)
             END DO
          END IF
@@ -480,7 +481,8 @@ CONTAINS
                           qs_env, stda_control, stda_env, &
                           sub_env, work_matrices)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: Aop_evects, evects
+      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: Aop_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
       LOGICAL, INTENT(in)                                :: is_rks_triplets
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(stda_control_type)                            :: stda_control
@@ -498,7 +500,7 @@ CONTAINS
 
       DO ivect = 1, nvects
          IF (ALLOCATED(work_matrices%evects_sub)) THEN
-            IF (ASSOCIATED(work_matrices%evects_sub(1, ivect)%matrix)) THEN
+            IF (ASSOCIATED(work_matrices%evects_sub(1, ivect)%matrix_struct)) THEN
                CALL stda_calculate_kernel(qs_env, stda_control, stda_env, sub_env, work_matrices, &
                                           is_rks_triplets, work_matrices%evects_sub(:, ivect), &
                                           work_matrices%Aop_evects_sub(:, ivect))

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -162,7 +162,7 @@ CONTAINS
                DO ispin = 1, nspins
                   CALL dbcsr_set(rho_ia_ao(ispin)%matrix, 0.0_dp)
                   CALL cp_dbcsr_plus_fm_fm_t(rho_ia_ao(ispin)%matrix, &
-                                             matrix_v=sub_env%mos_occ(ispin)%matrix, &
+                                             matrix_v=sub_env%mos_occ(ispin), &
                                              matrix_g=work_matrices%evects_sub(ispin, ivect), &
                                              ncol=nactive(ispin), symmetry_mode=1)
                END DO
@@ -174,7 +174,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL dbcsr_set(rho_ia_ao(ispin)%matrix, 0.0_dp)
                CALL cp_dbcsr_plus_fm_fm_t(rho_ia_ao(ispin)%matrix, &
-                                          matrix_v=sub_env%mos_occ(ispin)%matrix, &
+                                          matrix_v=sub_env%mos_occ(ispin), &
                                           matrix_g=evects(ispin, ivect), &
                                           ncol=nactive(ispin), symmetry_mode=1)
             END DO
@@ -443,14 +443,14 @@ CONTAINS
          IF (ALLOCATED(work_matrices%evects_sub)) THEN
             DO ispin = 1, nspins
                CALL cp_dbcsr_sm_fm_multiply(work_matrices%A_ia_munu_sub(ispin)%matrix, &
-                                            sub_env%mos_occ(ispin)%matrix, &
+                                            sub_env%mos_occ(ispin), &
                                             work_matrices%Aop_evects_sub(ispin, ivect), &
                                             ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
             END DO
          ELSE
             DO ispin = 1, nspins
                CALL cp_dbcsr_sm_fm_multiply(work_matrices%A_ia_munu_sub(ispin)%matrix, &
-                                            sub_env%mos_occ(ispin)%matrix, &
+                                            sub_env%mos_occ(ispin), &
                                             Aop_evects(ispin, ivect), &
                                             ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
             END DO

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -181,9 +181,10 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: fodeb
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos, evect
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: evect
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct, fm_struct_mat
       TYPE(cp_fm_type)                                   :: cvcmat, vcvec
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos
       TYPE(cp_fm_type), POINTER                          :: mos
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1033,11 +1034,11 @@ CONTAINS
          !
          IF (.NOT. is_rks_triplets) THEN
             CALL cp_dbcsr_sm_fm_multiply(matrix_hx(ispin)%matrix, evect(ispin)%matrix, &
-                                         cpmos(ispin)%matrix, norb, alpha=focc, beta=1.0_dp)
+                                         cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_hx(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=0.0_dp)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, mos, vcvec, 0.0_dp, cvcmat)
             CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=-focc, beta=1.0_dp)
             !
             CALL cp_dbcsr_plus_fm_fm_t(matrix_wx1(ispin)%matrix, matrix_v=mos, matrix_g=vcvec, &
@@ -1046,18 +1047,18 @@ CONTAINS
          !
          IF (myfun /= xc_none) THEN
             CALL cp_dbcsr_sm_fm_multiply(matrix_fx(ispin)%matrix, evect(ispin)%matrix, &
-                                         cpmos(ispin)%matrix, norb, alpha=focc, beta=1.0_dp)
+                                         cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_fx(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=0.0_dp)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, mos, vcvec, 0.0_dp, cvcmat)
             CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=-focc, beta=1.0_dp)
             !
             CALL cp_dbcsr_plus_fm_fm_t(matrix_wx1(ispin)%matrix, matrix_v=mos, matrix_g=vcvec, &
                                        ncol=norb, alpha=2.0_dp, symmetry_mode=1)
             !
             CALL cp_dbcsr_sm_fm_multiply(matrix_gx(ispin)%matrix, mos, &
-                                         cpmos(ispin)%matrix, norb, alpha=focc, beta=1.0_dp)
+                                         cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             !
             CALL cp_dbcsr_sm_fm_multiply(matrix_gx(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=0.0_dp)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, mos, vcvec, 0.0_dp, cvcmat)
@@ -1068,15 +1069,15 @@ CONTAINS
          !
          IF (do_hfx) THEN
             CALL cp_dbcsr_sm_fm_multiply(matrix_hfx(ispin)%matrix, evect(ispin)%matrix, &
-                                         cpmos(ispin)%matrix, norb, alpha=focc, beta=1.0_dp)
+                                         cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_hfx(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=0.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_hfx_asymm(ispin)%matrix, evect(ispin)%matrix, &
-                                         cpmos(ispin)%matrix, norb, alpha=focc, beta=1.0_dp)
+                                         cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_hfx_asymm(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=1.0_dp)
             !
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, mos, vcvec, 0.0_dp, cvcmat)
             CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=-focc, beta=1.0_dp)
             !
             CALL cp_dbcsr_plus_fm_fm_t(matrix_wx1(ispin)%matrix, matrix_v=mos, matrix_g=vcvec, &
@@ -1144,10 +1145,11 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(atprop_type), POINTER                         :: atprop
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos, X, xtransformed
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: X, xtransformed
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct, fmstruct_mat, fmstructjspin
       TYPE(cp_fm_type)                                   :: cvcmat, cvec, cvecjspin, t0matrix, &
                                                             t1matrix, vcvec, xvec
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos
       TYPE(cp_fm_type), POINTER                          :: ct, ctjspin, ucmatrix, uxmatrix, xt
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1408,7 +1410,7 @@ CONTAINS
             xt => xtransformed(ispin)%matrix
             CALL cp_fm_to_fm(xt, cvec)
             CALL cp_fm_row_scale(cvec, tv)
-            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, cpmos(ispin)%matrix, norb, 2.0_dp*spinfac, 1.0_dp)
+            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, cpmos(ispin), norb, 2.0_dp*spinfac, 1.0_dp)
             ! CV(mu,i) = TV(mu)*CT(mu,i)
             ct => work%ctransformed(ispin)
             CALL cp_fm_to_fm(ct, cvec)
@@ -1423,7 +1425,7 @@ CONTAINS
             CALL cp_fm_struct_release(fmstruct_mat)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, gs_mos(ispin)%mos_occ, vcvec, 0.0_dp, cvcmat)
             CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, X(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          nactive(ispin), alpha=-2.0_dp*spinfac, beta=1.0_dp)
             ! wx1
             alpha = 2.0_dp
@@ -1549,7 +1551,7 @@ CONTAINS
             ! RHS contribution to response matrix
             ! CV(nu,i) = P(nu,mu)*XT(mu,i)
             CALL cp_dbcsr_sm_fm_multiply(ptrans, xt, cvec, norb, 1.0_dp, 0.0_dp)
-            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, cpmos(ispin)%matrix, norb, &
+            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, cpmos(ispin), norb, &
                                          alpha=-xfac, beta=1.0_dp)
             !
             CALL cp_fm_get_info(cvec, matrix_struct=fmstruct, nrow_global=nao)
@@ -1563,7 +1565,7 @@ CONTAINS
             CALL cp_fm_struct_release(fmstruct_mat)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, gs_mos(ispin)%mos_occ, vcvec, 0.0_dp, cvcmat)
             CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, X(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=xfac, beta=1.0_dp)
             ! wx1
             IF (nspins == 2) THEN

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -33,7 +33,6 @@ MODULE qs_tddfpt2_fhxc_forces
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type,&
@@ -1144,12 +1143,12 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(atprop_type), POINTER                         :: atprop
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: xtransformed
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct, fmstruct_mat, fmstructjspin
       TYPE(cp_fm_type)                                   :: cvcmat, cvec, cvecjspin, t0matrix, &
                                                             t1matrix, vcvec, xvec
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: xtransformed
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos, X
-      TYPE(cp_fm_type), POINTER                          :: ct, ctjspin, ucmatrix, uxmatrix, xt
+      TYPE(cp_fm_type), POINTER                          :: ct, ctjspin, ucmatrix, uxmatrix
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_iterator_type)                          :: iter
@@ -1223,8 +1222,7 @@ CONTAINS
          NULLIFY (fmstruct)
          ct => work%ctransformed(ispin)
          CALL cp_fm_get_info(ct, matrix_struct=fmstruct)
-         ALLOCATE (xtransformed(ispin)%matrix)
-         CALL cp_fm_create(matrix=xtransformed(ispin)%matrix, matrix_struct=fmstruct, name="XTRANSFORMED")
+         CALL cp_fm_create(matrix=xtransformed(ispin), matrix_struct=fmstruct, name="XTRANSFORMED")
       END DO
       CALL get_lowdin_x(work%shalf, X, xtransformed)
 
@@ -1262,12 +1260,11 @@ CONTAINS
             tcharge(:) = 0.0_dp
             DO jspin = 1, nspins
                ctjspin => work%ctransformed(jspin)
-               xt => xtransformed(jspin)%matrix
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin)
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin, nrow_global=nsgf)
                CALL cp_fm_create(cvecjspin, fmstructjspin)
                ! CV(mu,j) = CT(mu,j)*XT(mu,j)
-               CALL cp_fm_schur_product(ctjspin, xt, cvecjspin)
+               CALL cp_fm_schur_product(ctjspin, xtransformed(jspin), cvecjspin)
                ! TV(mu) = SUM_j CV(mu,j)
                CALL cp_fm_vectorssum(cvecjspin, tv, "R")
                ! contract charges
@@ -1384,8 +1381,7 @@ CONTAINS
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
                                X(ispin), 0.0_dp, uxmatrix)
             CALL parallel_gemm('N', 'T', nsgf, nsgf, norb, 1.0_dp, uxmatrix, ucmatrix, 0.0_dp, t0matrix)
-            xt => xtransformed(ispin)%matrix
-            CALL cp_fm_to_fm(xt, cvec)
+            CALL cp_fm_to_fm(xtransformed(ispin), cvec)
             CALL cp_fm_row_scale(cvec, tv)
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
                                cvec, 0.0_dp, uxmatrix)
@@ -1406,8 +1402,7 @@ CONTAINS
             CALL cp_fm_release(t1matrix)
             !
             ! CV(mu,i) = TV(mu)*XT(mu,i)
-            xt => xtransformed(ispin)%matrix
-            CALL cp_fm_to_fm(xt, cvec)
+            CALL cp_fm_to_fm(xtransformed(ispin), cvec)
             CALL cp_fm_row_scale(cvec, tv)
             CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, cpmos(ispin), norb, 2.0_dp*spinfac, 1.0_dp)
             ! CV(mu,i) = TV(mu)*CT(mu,i)
@@ -1452,9 +1447,8 @@ CONTAINS
             CALL dbcsr_create(pdens, template=tempmat, matrix_type=dbcsr_type_no_symmetry)
             ! P(nu,mu) = SUM_j XT(nu,j)*CT(mu,j)
             ct => work%ctransformed(ispin)
-            xt => xtransformed(ispin)%matrix
             CALL dbcsr_set(pdens, 0.0_dp)
-            CALL cp_dbcsr_plus_fm_fm_t(pdens, xt, ct, nactive(ispin), &
+            CALL cp_dbcsr_plus_fm_fm_t(pdens, xtransformed(ispin), ct, nactive(ispin), &
                                        1.0_dp, keep_sparsity=.FALSE.)
             CALL dbcsr_filter(pdens, stda_env%eps_td_filter)
             ! Apply PP*gab -> PP; gab = gamma_coulomb
@@ -1528,8 +1522,7 @@ CONTAINS
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
                                X(ispin), 0.0_dp, uxmatrix)
             CALL parallel_gemm('N', 'T', nsgf, nsgf, norb, 1.0_dp, uxmatrix, ucmatrix, 0.0_dp, t0matrix)
-            xt => xtransformed(ispin)%matrix
-            CALL cp_dbcsr_sm_fm_multiply(ptrans, xt, cvec, norb, 1.0_dp, 0.0_dp)
+            CALL cp_dbcsr_sm_fm_multiply(ptrans, xtransformed(ispin), cvec, norb, 1.0_dp, 0.0_dp)
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
                                cvec, 0.0_dp, uxmatrix)
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
@@ -1549,7 +1542,7 @@ CONTAINS
 
             ! RHS contribution to response matrix
             ! CV(nu,i) = P(nu,mu)*XT(mu,i)
-            CALL cp_dbcsr_sm_fm_multiply(ptrans, xt, cvec, norb, 1.0_dp, 0.0_dp)
+            CALL cp_dbcsr_sm_fm_multiply(ptrans, xtransformed(ispin), cvec, norb, 1.0_dp, 0.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, cpmos(ispin), norb, &
                                          alpha=-xfac, beta=1.0_dp)
             !
@@ -1595,8 +1588,7 @@ CONTAINS
       END DO
 
       DO ispin = 1, nspins
-         CALL cp_fm_release(matrix=xtransformed(ispin)%matrix)
-         DEALLOCATE (xtransformed(ispin)%matrix)
+         CALL cp_fm_release(matrix=xtransformed(ispin))
       END DO
       DEALLOCATE (xtransformed)
       DEALLOCATE (tcharge, gtcharge)

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -1220,7 +1220,7 @@ CONTAINS
       ALLOCATE (xtransformed(nspins))
       DO ispin = 1, nspins
          NULLIFY (fmstruct)
-         ct => work%ctransformed(ispin)%matrix
+         ct => work%ctransformed(ispin)
          CALL cp_fm_get_info(ct, matrix_struct=fmstruct)
          ALLOCATE (xtransformed(ispin)%matrix)
          CALL cp_fm_create(matrix=xtransformed(ispin)%matrix, matrix_struct=fmstruct, name="XTRANSFORMED")
@@ -1232,7 +1232,7 @@ CONTAINS
       cpmos => ex_env%cpmos
 
       DO ispin = 1, nspins
-         ct => work%ctransformed(ispin)%matrix
+         ct => work%ctransformed(ispin)
          CALL cp_fm_get_info(ct, matrix_struct=fmstruct, nrow_global=nsgf)
          ALLOCATE (tv(nsgf))
          CALL cp_fm_create(cvec, fmstruct)
@@ -1260,7 +1260,7 @@ CONTAINS
             !
             tcharge(:) = 0.0_dp
             DO jspin = 1, nspins
-               ctjspin => work%ctransformed(jspin)%matrix
+               ctjspin => work%ctransformed(jspin)
                xt => xtransformed(jspin)%matrix
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin)
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin, nrow_global=nsgf)
@@ -1368,14 +1368,14 @@ CONTAINS
             END IF
             norb = nactive(ispin)
             ! forces from Lowdin charge derivative
-            CALL cp_fm_get_info(work%S_C0_C0T(ispin)%matrix, matrix_struct=fmstruct)
+            CALL cp_fm_get_info(work%S_C0_C0T(ispin), matrix_struct=fmstruct)
             CALL cp_fm_create(t0matrix, matrix_struct=fmstruct, name="T0 SCRATCH")
             CALL cp_fm_create(t1matrix, matrix_struct=fmstruct, name="T1 SCRATCH")
             ALLOCATE (ucmatrix)
             CALL fm_pool_create_fm(work%fm_pool_ao_mo_occ(ispin)%pool, ucmatrix)
             ALLOCATE (uxmatrix)
             CALL fm_pool_create_fm(work%fm_pool_ao_mo_occ(ispin)%pool, uxmatrix)
-            ct => work%ctransformed(ispin)%matrix
+            ct => work%ctransformed(ispin)
             CALL cp_fm_to_fm(ct, cvec)
             CALL cp_fm_row_scale(cvec, tv)
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
@@ -1410,7 +1410,7 @@ CONTAINS
             CALL cp_fm_row_scale(cvec, tv)
             CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, cpmos(ispin)%matrix, norb, 2.0_dp*spinfac, 1.0_dp)
             ! CV(mu,i) = TV(mu)*CT(mu,i)
-            ct => work%ctransformed(ispin)%matrix
+            ct => work%ctransformed(ispin)
             CALL cp_fm_to_fm(ct, cvec)
             CALL cp_fm_row_scale(cvec, tv)
             ! Shalf(nu,mu)*CV(mu,i)
@@ -1450,7 +1450,7 @@ CONTAINS
             tempmat => work%shalf
             CALL dbcsr_create(pdens, template=tempmat, matrix_type=dbcsr_type_no_symmetry)
             ! P(nu,mu) = SUM_j XT(nu,j)*CT(mu,j)
-            ct => work%ctransformed(ispin)%matrix
+            ct => work%ctransformed(ispin)
             xt => xtransformed(ispin)%matrix
             CALL dbcsr_set(pdens, 0.0_dp)
             CALL cp_dbcsr_plus_fm_fm_t(pdens, xt, ct, nactive(ispin), &
@@ -1513,14 +1513,14 @@ CONTAINS
             CALL dbcsr_transposed(ptrans, pdens)
             !
             ! forces from Lowdin charge derivative
-            CALL cp_fm_get_info(work%S_C0_C0T(ispin)%matrix, matrix_struct=fmstruct)
+            CALL cp_fm_get_info(work%S_C0_C0T(ispin), matrix_struct=fmstruct)
             CALL cp_fm_create(t0matrix, matrix_struct=fmstruct, name="T0 SCRATCH")
             CALL cp_fm_create(t1matrix, matrix_struct=fmstruct, name="T1 SCRATCH")
             ALLOCATE (ucmatrix)
             CALL fm_pool_create_fm(work%fm_pool_ao_mo_occ(ispin)%pool, ucmatrix)
             ALLOCATE (uxmatrix)
             CALL fm_pool_create_fm(work%fm_pool_ao_mo_occ(ispin)%pool, uxmatrix)
-            ct => work%ctransformed(ispin)%matrix
+            ct => work%ctransformed(ispin)
             CALL cp_dbcsr_sm_fm_multiply(pdens, ct, cvec, norb, 1.0_dp, 0.0_dp)
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
                                cvec, 0.0_dp, ucmatrix)

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -181,10 +181,9 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: fodeb
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: evect
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct, fm_struct_mat
       TYPE(cp_fm_type)                                   :: cvcmat, vcvec
-      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos, evect
       TYPE(cp_fm_type), POINTER                          :: mos
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -249,17 +248,17 @@ CONTAINS
       IF (nspins == 2) focc = 0.5_dp
       DO ispin = 1, nspins
          CALL dbcsr_set(matrix_px1(ispin)%matrix, 0.0_dp)
-         CALL cp_fm_get_info(evect(ispin)%matrix, ncol_global=norb)
+         CALL cp_fm_get_info(evect(ispin), ncol_global=norb)
          CALL cp_dbcsr_plus_fm_fm_t(matrix_px1(ispin)%matrix, &
-                                    matrix_v=evect(ispin)%matrix, &
+                                    matrix_v=evect(ispin), &
                                     matrix_g=gs_mos(ispin)%mos_occ, &
                                     ncol=norb, alpha=2.0_dp*focc, symmetry_mode=1)
 
          CALL dbcsr_set(matrix_px1_asymm(ispin)%matrix, 0.0_dp)
-         CALL cp_fm_get_info(evect(ispin)%matrix, ncol_global=norb)
+         CALL cp_fm_get_info(evect(ispin), ncol_global=norb)
          CALL cp_dbcsr_plus_fm_fm_t(matrix_px1_asymm(ispin)%matrix, &
                                     matrix_v=gs_mos(ispin)%mos_occ, &
-                                    matrix_g=evect(ispin)%matrix, &
+                                    matrix_g=evect(ispin), &
                                     ncol=norb, alpha=2.0_dp*focc, &
                                     symmetry_mode=-1)
       END DO
@@ -1019,7 +1018,7 @@ CONTAINS
       IF (nspins == 2) focc = 1.0_dp
       DO ispin = 1, nspins
          mos => gs_mos(ispin)%mos_occ
-         CALL cp_fm_get_info(evect(ispin)%matrix, ncol_global=norb)
+         CALL cp_fm_get_info(evect(ispin), ncol_global=norb)
          CALL cp_fm_create(vcvec, mos%matrix_struct, "vcvec")
          CALL cp_fm_get_info(vcvec, matrix_struct=fm_struct, nrow_global=nao)
          CALL cp_fm_struct_create(fm_struct_mat, context=fm_struct%context, nrow_global=norb, &
@@ -1033,11 +1032,11 @@ CONTAINS
          CALL dbcsr_set(matrix_wx1(ispin)%matrix, 0.0_dp)
          !
          IF (.NOT. is_rks_triplets) THEN
-            CALL cp_dbcsr_sm_fm_multiply(matrix_hx(ispin)%matrix, evect(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_hx(ispin)%matrix, evect(ispin), &
                                          cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_hx(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=0.0_dp)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, mos, vcvec, 0.0_dp, cvcmat)
-            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
+            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin), cvcmat, 0.0_dp, vcvec)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=-focc, beta=1.0_dp)
             !
@@ -1046,11 +1045,11 @@ CONTAINS
          END IF
          !
          IF (myfun /= xc_none) THEN
-            CALL cp_dbcsr_sm_fm_multiply(matrix_fx(ispin)%matrix, evect(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_fx(ispin)%matrix, evect(ispin), &
                                          cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_fx(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=0.0_dp)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, mos, vcvec, 0.0_dp, cvcmat)
-            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
+            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin), cvcmat, 0.0_dp, vcvec)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=-focc, beta=1.0_dp)
             !
@@ -1068,15 +1067,15 @@ CONTAINS
          END IF
          !
          IF (do_hfx) THEN
-            CALL cp_dbcsr_sm_fm_multiply(matrix_hfx(ispin)%matrix, evect(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_hfx(ispin)%matrix, evect(ispin), &
                                          cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_hfx(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=0.0_dp)
-            CALL cp_dbcsr_sm_fm_multiply(matrix_hfx_asymm(ispin)%matrix, evect(ispin)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_hfx_asymm(ispin)%matrix, evect(ispin), &
                                          cpmos(ispin), norb, alpha=focc, beta=1.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(matrix_hfx_asymm(ispin)%matrix, mos, vcvec, norb, alpha=1.0_dp, beta=1.0_dp)
             !
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, mos, vcvec, 0.0_dp, cvcmat)
-            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
+            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, evect(ispin), cvcmat, 0.0_dp, vcvec)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=-focc, beta=1.0_dp)
             !
@@ -1145,11 +1144,11 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(atprop_type), POINTER                         :: atprop
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: X, xtransformed
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: xtransformed
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct, fmstruct_mat, fmstructjspin
       TYPE(cp_fm_type)                                   :: cvcmat, cvec, cvecjspin, t0matrix, &
                                                             t1matrix, vcvec, xvec
-      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos, X
       TYPE(cp_fm_type), POINTER                          :: ct, ctjspin, ucmatrix, uxmatrix, xt
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -1383,7 +1382,7 @@ CONTAINS
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
                                cvec, 0.0_dp, ucmatrix)
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
-                               X(ispin)%matrix, 0.0_dp, uxmatrix)
+                               X(ispin), 0.0_dp, uxmatrix)
             CALL parallel_gemm('N', 'T', nsgf, nsgf, norb, 1.0_dp, uxmatrix, ucmatrix, 0.0_dp, t0matrix)
             xt => xtransformed(ispin)%matrix
             CALL cp_fm_to_fm(xt, cvec)
@@ -1424,7 +1423,7 @@ CONTAINS
             CALL cp_fm_create(cvcmat, fmstruct_mat)
             CALL cp_fm_struct_release(fmstruct_mat)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, gs_mos(ispin)%mos_occ, vcvec, 0.0_dp, cvcmat)
-            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, X(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
+            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, X(ispin), cvcmat, 0.0_dp, vcvec)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          nactive(ispin), alpha=-2.0_dp*spinfac, beta=1.0_dp)
             ! wx1
@@ -1527,7 +1526,7 @@ CONTAINS
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
                                cvec, 0.0_dp, ucmatrix)
             CALL parallel_gemm('T', 'N', nsgf, norb, nsgf, 1.0_dp, work%S_eigenvectors, &
-                               X(ispin)%matrix, 0.0_dp, uxmatrix)
+                               X(ispin), 0.0_dp, uxmatrix)
             CALL parallel_gemm('N', 'T', nsgf, nsgf, norb, 1.0_dp, uxmatrix, ucmatrix, 0.0_dp, t0matrix)
             xt => xtransformed(ispin)%matrix
             CALL cp_dbcsr_sm_fm_multiply(ptrans, xt, cvec, norb, 1.0_dp, 0.0_dp)
@@ -1564,7 +1563,7 @@ CONTAINS
             CALL cp_fm_create(cvcmat, fmstruct_mat)
             CALL cp_fm_struct_release(fmstruct_mat)
             CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, gs_mos(ispin)%mos_occ, vcvec, 0.0_dp, cvcmat)
-            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, X(ispin)%matrix, cvcmat, 0.0_dp, vcvec)
+            CALL parallel_gemm("N", "N", nao, norb, norb, 1.0_dp, X(ispin), cvcmat, 0.0_dp, vcvec)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, vcvec, cpmos(ispin), &
                                          norb, alpha=xfac, beta=1.0_dp)
             ! wx1

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -26,7 +26,6 @@ MODULE qs_tddfpt2_forces
    USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
                                               cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_type
@@ -189,7 +188,7 @@ CONTAINS
       END IF
       ALLOCATE (ex_env%cpmos(nspins))
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(matrix=ex_env%evect(ispin)%matrix, matrix_struct=matrix_struct)
+         CALL cp_fm_get_info(matrix=ex_env%evect(ispin), matrix_struct=matrix_struct)
          CALL cp_fm_create(ex_env%cpmos(ispin), matrix_struct)
          CALL cp_fm_set_all(ex_env%cpmos(ispin), 0.0_dp)
       END DO
@@ -213,7 +212,7 @@ CONTAINS
                            matrix_type=dbcsr_type_antisymmetric)
          CALL dbcsr_complete_redistribute(ex_env%matrix_pe(ispin)%matrix, matrix_pe_asymm(ispin)%matrix)
 
-         CALL tddfpt_resvec1(ex_env%evect(ispin)%matrix, gs_mos(ispin)%mos_occ, &
+         CALL tddfpt_resvec1(ex_env%evect(ispin), gs_mos(ispin)%mos_occ, &
                              matrix_s(1)%matrix, ex_env%matrix_pe(ispin)%matrix)
       END DO
       !
@@ -390,7 +389,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: ftot1, ftot2
       REAL(KIND=dp), DIMENSION(3)                        :: fodeb
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: evect
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: evect
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s, matrix_wx1, &
@@ -438,13 +437,13 @@ CONTAINS
          CALL cp_dbcsr_alloc_block_from_nbl(matrix_wz(ispin)%matrix, sab_orb)
          CALL dbcsr_set(matrix_wz(ispin)%matrix, 0.0_dp)
          CALL cp_fm_get_info(gs_mos(ispin)%mos_occ, ncol_global=norb)
-         CALL cp_dbcsr_plus_fm_fm_t(matrix_wz(ispin)%matrix, matrix_v=evect(ispin)%matrix, ncol=norb)
+         CALL cp_dbcsr_plus_fm_fm_t(matrix_wz(ispin)%matrix, matrix_v=evect(ispin), ncol=norb)
          evalue = ex_env%evalue
          IF (tddfpt_control%oe_corr == oe_shift) THEN
             evalue = ex_env%evalue - tddfpt_control%ev_shift
          END IF
          CALL dbcsr_scale(matrix_wz(ispin)%matrix, evalue)
-         CALL calculate_wx_matrix(gs_mos(ispin)%mos_occ, evect(ispin)%matrix, matrix_ks(ispin)%matrix, &
+         CALL calculate_wx_matrix(gs_mos(ispin)%mos_occ, evect(ispin), matrix_ks(ispin)%matrix, &
                                   matrix_wz(ispin)%matrix)
       END DO
       IF (nspins == 2) THEN
@@ -480,7 +479,7 @@ CONTAINS
          IF (tddfpt_control%oe_corr == oe_shift) THEN
             evalue = ex_env%evalue - tddfpt_control%ev_shift
          END IF
-         CALL calculate_xwx_matrix(gs_mos(ispin)%mos_occ, evect(ispin)%matrix, matrix_s(1)%matrix, &
+         CALL calculate_xwx_matrix(gs_mos(ispin)%mos_occ, evect(ispin), matrix_s(1)%matrix, &
                                    matrix_ks(ispin)%matrix, matrix_wz(ispin)%matrix, evalue)
       END DO
       IF (nspins == 2) THEN

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -1256,7 +1256,7 @@ CONTAINS
       INTEGER                                            :: handle, ispin, nao, norb, nspins
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct
       TYPE(cp_fm_type)                                   :: cvec, umat
-      TYPE(cp_fm_type), POINTER                          :: omos, rvecs, scmat
+      TYPE(cp_fm_type), POINTER                          :: omos, rvecs
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
 
@@ -1267,7 +1267,6 @@ CONTAINS
 
       DO ispin = 1, nspins
          CALL get_mo_set(mos(ispin), mo_coeff=omos)
-         scmat => work%S_C0(ispin)%matrix
          rvecs => cpmos(ispin)%matrix
          CALL cp_fm_get_info(rvecs, nrow_global=nao, ncol_global=norb)
          CALL cp_fm_create(cvec, rvecs%matrix_struct, "cvec")
@@ -1276,7 +1275,7 @@ CONTAINS
          CALL cp_fm_create(umat, fmstruct, "umat")
          CALL cp_fm_struct_release(fmstruct)
          !
-         CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, omos, scmat, 0.0_dp, umat)
+         CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, omos, work%S_C0(ispin), 0.0_dp, umat)
          CALL cp_fm_copy_general(rvecs, cvec, rvecs%matrix_struct%para_env)
          CALL parallel_gemm("N", "T", nao, norb, norb, 1.0_dp, cvec, umat, 0.0_dp, rvecs)
          CALL cp_fm_release(cvec)

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -183,17 +183,15 @@ CONTAINS
       ! rhs of linres equation
       IF (ASSOCIATED(ex_env%cpmos)) THEN
          DO ispin = 1, SIZE(ex_env%cpmos)
-            CALL cp_fm_release(ex_env%cpmos(ispin)%matrix)
-            DEALLOCATE (ex_env%cpmos(ispin)%matrix)
+            CALL cp_fm_release(ex_env%cpmos(ispin))
          END DO
          DEALLOCATE (ex_env%cpmos)
       END IF
       ALLOCATE (ex_env%cpmos(nspins))
       DO ispin = 1, nspins
          CALL cp_fm_get_info(matrix=ex_env%evect(ispin)%matrix, matrix_struct=matrix_struct)
-         ALLOCATE (ex_env%cpmos(ispin)%matrix)
-         CALL cp_fm_create(ex_env%cpmos(ispin)%matrix, matrix_struct)
-         CALL cp_fm_set_all(ex_env%cpmos(ispin)%matrix, 0.0_dp)
+         CALL cp_fm_create(ex_env%cpmos(ispin), matrix_struct)
+         CALL cp_fm_set_all(ex_env%cpmos(ispin), 0.0_dp)
       END DO
       CALL get_qs_env(qs_env=qs_env, matrix_s=matrix_s)
       NULLIFY (matrix_pe_asymm, matrix_pe_symm)
@@ -650,7 +648,7 @@ CONTAINS
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          POINTER                                         :: gs_mos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_hz
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: cpmos
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'tddfpt_resvec2'
 
@@ -1122,7 +1120,7 @@ CONTAINS
       DO ispin = 1, nspins
          mos => gs_mos(ispin)%mos_occ
          CALL cp_fm_get_info(mos, ncol_global=norb)
-         CALL cp_dbcsr_sm_fm_multiply(matrix_hz(ispin)%matrix, mos, cpmos(ispin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(matrix_hz(ispin)%matrix, mos, cpmos(ispin), &
                                       norb, alpha=focc, beta=0.0_dp)
       END DO
 
@@ -1145,7 +1143,7 @@ CONTAINS
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          POINTER                                         :: gs_mos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_hz
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: cpmos
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_resvec2_xtb'
 
@@ -1231,7 +1229,7 @@ CONTAINS
       DO ispin = 1, nspins
          mos => gs_mos(ispin)%mos_occ
          CALL cp_fm_get_info(mos, ncol_global=norb)
-         CALL cp_dbcsr_sm_fm_multiply(matrix_hz(ispin)%matrix, mos, cpmos(ispin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(matrix_hz(ispin)%matrix, mos, cpmos(ispin), &
                                       norb, alpha=focc, beta=0.0_dp)
       END DO
 
@@ -1248,7 +1246,7 @@ CONTAINS
    SUBROUTINE tddfpt_resvec3(qs_env, cpmos, work)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: cpmos
       TYPE(tddfpt_work_matrices)                         :: work
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'tddfpt_resvec3'
@@ -1256,7 +1254,7 @@ CONTAINS
       INTEGER                                            :: handle, ispin, nao, norb, nspins
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct
       TYPE(cp_fm_type)                                   :: cvec, umat
-      TYPE(cp_fm_type), POINTER                          :: omos, rvecs
+      TYPE(cp_fm_type), POINTER                          :: omos
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
 
@@ -1267,17 +1265,18 @@ CONTAINS
 
       DO ispin = 1, nspins
          CALL get_mo_set(mos(ispin), mo_coeff=omos)
-         rvecs => cpmos(ispin)%matrix
-         CALL cp_fm_get_info(rvecs, nrow_global=nao, ncol_global=norb)
-         CALL cp_fm_create(cvec, rvecs%matrix_struct, "cvec")
-         CALL cp_fm_struct_create(fmstruct, context=rvecs%matrix_struct%context, nrow_global=norb, &
-                                  ncol_global=norb, para_env=rvecs%matrix_struct%para_env)
-         CALL cp_fm_create(umat, fmstruct, "umat")
-         CALL cp_fm_struct_release(fmstruct)
-         !
-         CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, omos, work%S_C0(ispin), 0.0_dp, umat)
-         CALL cp_fm_copy_general(rvecs, cvec, rvecs%matrix_struct%para_env)
-         CALL parallel_gemm("N", "T", nao, norb, norb, 1.0_dp, cvec, umat, 0.0_dp, rvecs)
+         ASSOCIATE (rvecs => cpmos(ispin))
+            CALL cp_fm_get_info(rvecs, nrow_global=nao, ncol_global=norb)
+            CALL cp_fm_create(cvec, rvecs%matrix_struct, "cvec")
+            CALL cp_fm_struct_create(fmstruct, context=rvecs%matrix_struct%context, nrow_global=norb, &
+                                     ncol_global=norb, para_env=rvecs%matrix_struct%para_env)
+            CALL cp_fm_create(umat, fmstruct, "umat")
+            CALL cp_fm_struct_release(fmstruct)
+            !
+            CALL parallel_gemm("T", "N", norb, norb, nao, 1.0_dp, omos, work%S_C0(ispin), 0.0_dp, umat)
+            CALL cp_fm_copy_general(rvecs, cvec, rvecs%matrix_struct%para_env)
+            CALL parallel_gemm("N", "T", nao, norb, norb, 1.0_dp, cvec, umat, 0.0_dp, rvecs)
+         END ASSOCIATE
          CALL cp_fm_release(cvec)
          CALL cp_fm_release(umat)
       END DO

--- a/src/qs_tddfpt2_fprint.F
+++ b/src/qs_tddfpt2_fprint.F
@@ -13,9 +13,9 @@ MODULE qs_tddfpt2_fprint
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
-                                              cp_fm_to_fm
+                                              cp_fm_to_fm,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type
@@ -100,7 +100,7 @@ CONTAINS
    SUBROUTINE tddfpt_print_forces(qs_env, evects, evals, ostrength, print_section, &
                                   gs_mos, kernel_env, sub_env, work_matrices)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals, ostrength
       TYPE(section_vals_type), POINTER                   :: print_section
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
@@ -207,17 +207,15 @@ CONTAINS
                ex_env%evalue = evals(istate)
                IF (ASSOCIATED(ex_env%evect)) THEN
                   DO ispin = 1, SIZE(ex_env%evect)
-                     CALL cp_fm_release(ex_env%evect(ispin)%matrix)
-                     DEALLOCATE (ex_env%evect(ispin)%matrix)
+                     CALL cp_fm_release(ex_env%evect(ispin))
                   END DO
                   DEALLOCATE (ex_env%evect)
                END IF
                ALLOCATE (ex_env%evect(nspins))
                DO ispin = 1, nspins
-                  CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, matrix_struct=matrix_struct)
-                  ALLOCATE (ex_env%evect(ispin)%matrix)
-                  CALL cp_fm_create(ex_env%evect(ispin)%matrix, matrix_struct)
-                  CALL cp_fm_to_fm(evects(ispin, istate)%matrix, ex_env%evect(ispin)%matrix)
+                  CALL cp_fm_get_info(matrix=evects(ispin, 1), matrix_struct=matrix_struct)
+                  CALL cp_fm_create(ex_env%evect(ispin), matrix_struct)
+                  CALL cp_fm_to_fm(evects(ispin, istate), ex_env%evect(ispin))
                END DO
                ! force array
                CALL zero_qs_force(td_force)

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -870,7 +870,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: dv
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: chr
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: charges
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi0
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_p1
@@ -891,7 +891,7 @@ CONTAINS
       ALLOCATE (psi0(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-         psi0(ispin)%matrix => mo_coeff
+         psi0(ispin) = mo_coeff
       END DO
       !
       IF (ASSOCIATED(fingerprint)) THEN

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -149,9 +149,9 @@ CONTAINS
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: my_mos, S_evects
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: my_mos
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dipole_op_mos_occ, evects
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dipole_op_mos_occ, evects, S_evects
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_oep, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -333,9 +333,7 @@ CONTAINS
       ALLOCATE (evects(nspins, nstates), S_evects(nspins, nstates))
       DO istate = 1, nstates
          DO ispin = 1, nspins
-            NULLIFY (S_evects(ispin, istate)%matrix)
-            ALLOCATE (S_evects(ispin, istate)%matrix)
-            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_evects(ispin, istate)%matrix)
+            CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_evects(ispin, istate))
          END DO
       END DO
 
@@ -535,8 +533,7 @@ CONTAINS
       DO istate = 1, SIZE(evects, 2)
          DO ispin = 1, nspins
             CALL cp_fm_release(evects(ispin, istate))
-            CALL cp_fm_release(S_evects(ispin, istate)%matrix)
-            DEALLOCATE (S_evects(ispin, istate)%matrix)
+            CALL cp_fm_release(S_evects(ispin, istate))
          END DO
       END DO
       DEALLOCATE (evects, S_evects, evals, ostrength)

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -149,9 +149,9 @@ CONTAINS
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: evects, S_evects
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: my_mos, S_evects
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dipole_op_mos_occ
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dipole_op_mos_occ, evects
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_oep, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -233,12 +233,12 @@ CONTAINS
       END IF
 
       ! split mpi communicator
-      ALLOCATE (evects(nspins, 1))
+      ALLOCATE (my_mos(nspins, 1))
       DO ispin = 1, nspins
-         evects(ispin, 1)%matrix => gs_mos(ispin)%mos_occ
+         my_mos(ispin, 1)%matrix => gs_mos(ispin)%mos_occ
       END DO
-      CALL tddfpt_sub_env_init(sub_env, qs_env, mos_occ=evects(:, 1), kernel=tddfpt_control%kernel)
-      DEALLOCATE (evects)
+      CALL tddfpt_sub_env_init(sub_env, qs_env, mos_occ=my_mos(:, 1), kernel=tddfpt_control%kernel)
+      DEALLOCATE (my_mos)
 
       IF (tddfpt_control%kernel == tddfpt_kernel_full) THEN
          ! create environment for Full Kernel
@@ -333,7 +333,7 @@ CONTAINS
       ALLOCATE (evects(nspins, nstates), S_evects(nspins, nstates))
       DO istate = 1, nstates
          DO ispin = 1, nspins
-            NULLIFY (evects(ispin, istate)%matrix, S_evects(ispin, istate)%matrix)
+            NULLIFY (S_evects(ispin, istate)%matrix)
             ALLOCATE (S_evects(ispin, istate)%matrix)
             CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, S_evects(ispin, istate)%matrix)
          END DO
@@ -506,17 +506,15 @@ CONTAINS
          ! excitation vector
          IF (ASSOCIATED(ex_env%evect)) THEN
             DO ispin = 1, SIZE(ex_env%evect)
-               CALL cp_fm_release(ex_env%evect(ispin)%matrix)
-               DEALLOCATE (ex_env%evect(ispin)%matrix)
+               CALL cp_fm_release(ex_env%evect(ispin))
             END DO
             DEALLOCATE (ex_env%evect)
          END IF
          ALLOCATE (ex_env%evect(nspins))
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, matrix_struct=matrix_struct)
-            ALLOCATE (ex_env%evect(ispin)%matrix)
-            CALL cp_fm_create(ex_env%evect(ispin)%matrix, matrix_struct)
-            CALL cp_fm_to_fm(evects(ispin, my_state)%matrix, ex_env%evect(ispin)%matrix)
+            CALL cp_fm_get_info(matrix=evects(ispin, 1), matrix_struct=matrix_struct)
+            CALL cp_fm_create(ex_env%evect(ispin), matrix_struct)
+            CALL cp_fm_to_fm(evects(ispin, my_state), ex_env%evect(ispin))
          END DO
 
          IF (log_unit > 0) THEN
@@ -536,9 +534,9 @@ CONTAINS
       ! clean up
       DO istate = 1, SIZE(evects, 2)
          DO ispin = 1, nspins
-            CALL cp_fm_release(evects(ispin, istate)%matrix)
+            CALL cp_fm_release(evects(ispin, istate))
             CALL cp_fm_release(S_evects(ispin, istate)%matrix)
-            DEALLOCATE (evects(ispin, istate)%matrix, S_evects(ispin, istate)%matrix)
+            DEALLOCATE (S_evects(ispin, istate)%matrix)
          END DO
       END DO
       DEALLOCATE (evects, S_evects, evals, ostrength)
@@ -858,7 +856,7 @@ CONTAINS
    SUBROUTINE assign_state(qs_env, matrix_s, evects, mos, fingerprint, my_state)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :)                  :: evects
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: fingerprint
       INTEGER, INTENT(INOUT)                             :: my_state

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -149,8 +149,9 @@ CONTAINS
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: dipole_op_mos_occ, evects, S_evects
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: evects, S_evects
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dipole_op_mos_occ
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_oep, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -564,8 +565,7 @@ CONTAINS
       IF (ALLOCATED(dipole_op_mos_occ)) THEN
          DO ispin = nspins, 1, -1
             DO istate = SIZE(dipole_op_mos_occ, 1), 1, -1
-               CALL cp_fm_release(dipole_op_mos_occ(istate, ispin)%matrix)
-               DEALLOCATE (dipole_op_mos_occ(istate, ispin)%matrix)
+               CALL cp_fm_release(dipole_op_mos_occ(istate, ispin))
             END DO
          END DO
          DEALLOCATE (dipole_op_mos_occ)

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -21,7 +21,6 @@ MODULE qs_tddfpt2_methods
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -149,8 +148,8 @@ CONTAINS
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: my_mos
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: my_mos
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dipole_op_mos_occ, evects, S_evects
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_ks_oep, matrix_s
@@ -233,11 +232,11 @@ CONTAINS
       END IF
 
       ! split mpi communicator
-      ALLOCATE (my_mos(nspins, 1))
+      ALLOCATE (my_mos(nspins))
       DO ispin = 1, nspins
-         my_mos(ispin, 1)%matrix => gs_mos(ispin)%mos_occ
+         my_mos(ispin) = gs_mos(ispin)%mos_occ
       END DO
-      CALL tddfpt_sub_env_init(sub_env, qs_env, mos_occ=my_mos(:, 1), kernel=tddfpt_control%kernel)
+      CALL tddfpt_sub_env_init(sub_env, qs_env, mos_occ=my_mos(:), kernel=tddfpt_control%kernel)
       DEALLOCATE (my_mos)
 
       IF (tddfpt_control%kernel == tddfpt_kernel_full) THEN

--- a/src/qs_tddfpt2_operators.F
+++ b/src/qs_tddfpt2_operators.F
@@ -87,7 +87,9 @@ CONTAINS
 !>       Thomas Chassaing on 08.2002.
 ! **************************************************************************************************
    SUBROUTINE tddfpt_apply_energy_diff(Aop_evects, evects, S_evects, gs_mos, matrix_ks)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects, evects, S_evects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(in)       :: matrix_ks
@@ -105,12 +107,12 @@ CONTAINS
       nvects = SIZE(evects, 2)
 
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, matrix_struct=matrix_struct, &
+         CALL cp_fm_get_info(matrix=evects(ispin, 1), matrix_struct=matrix_struct, &
                              nrow_global=nao, ncol_global=nactive)
          CALL cp_fm_create(hevec, matrix_struct)
 
          DO ivect = 1, nvects
-            CALL cp_dbcsr_sm_fm_multiply(matrix_ks(ispin)%matrix, evects(ispin, ivect)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_ks(ispin)%matrix, evects(ispin, ivect), &
                                          Aop_evects(ispin, ivect)%matrix, ncol=nactive, &
                                          alpha=1.0_dp, beta=1.0_dp)
 
@@ -438,7 +440,8 @@ CONTAINS
    SUBROUTINE tddfpt_apply_hfx(Aop_evects, evects, gs_mos, do_admm, qs_env, &
                                work_rho_ia_ao_symm, work_hmat_symm, work_rho_ia_ao_asymm, &
                                work_hmat_asymm, wfm_rho_orb)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects, evects
+      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       LOGICAL, INTENT(in)                                :: do_admm
@@ -480,7 +483,7 @@ CONTAINS
 
          CALL cp_fm_get_info(gs_mos(1)%mos_occ, nrow_global=nao)
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(evects(ispin, 1)%matrix, ncol_global=nactive(ispin))
+            CALL cp_fm_get_info(evects(ispin, 1), ncol_global=nactive(ispin))
          END DO
 
          IF (do_admm) THEN
@@ -499,10 +502,10 @@ CONTAINS
             DO ispin = 1, nspins
 
                !The symmetric density matrix
-               CALL parallel_gemm('N', 'T', nao, nao, nactive(ispin), 0.5_dp, evects(ispin, ivect)%matrix, &
+               CALL parallel_gemm('N', 'T', nao, nao, nactive(ispin), 0.5_dp, evects(ispin, ivect), &
                                   gs_mos(ispin)%mos_occ, 0.0_dp, wfm_rho_orb)
                CALL parallel_gemm('N', 'T', nao, nao, nactive(ispin), 0.5_dp, gs_mos(ispin)%mos_occ, &
-                                  evects(ispin, ivect)%matrix, 1.0_dp, wfm_rho_orb)
+                                  evects(ispin, ivect), 1.0_dp, wfm_rho_orb)
 
                CALL dbcsr_set(work_hmat_symm(ispin)%matrix, 0.0_dp)
                IF (do_admm) THEN
@@ -541,10 +544,10 @@ CONTAINS
             DO ispin = 1, nspins
 
                !The symmetric density matrix
-               CALL parallel_gemm('N', 'T', nao, nao, nactive(ispin), 0.5_dp, evects(ispin, ivect)%matrix, &
+               CALL parallel_gemm('N', 'T', nao, nao, nactive(ispin), 0.5_dp, evects(ispin, ivect), &
                                   gs_mos(ispin)%mos_occ, 0.0_dp, wfm_rho_orb)
                CALL parallel_gemm('N', 'T', nao, nao, nactive(ispin), -0.5_dp, gs_mos(ispin)%mos_occ, &
-                                  evects(ispin, ivect)%matrix, 1.0_dp, wfm_rho_orb)
+                                  evects(ispin, ivect), 1.0_dp, wfm_rho_orb)
 
                CALL dbcsr_set(work_hmat_asymm(ispin)%matrix, 0.0_dp)
                IF (do_admm) THEN

--- a/src/qs_tddfpt2_operators.F
+++ b/src/qs_tddfpt2_operators.F
@@ -14,7 +14,6 @@ MODULE qs_tddfpt2_operators
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -87,8 +86,7 @@ CONTAINS
 !>       Thomas Chassaing on 08.2002.
 ! **************************************************************************************************
    SUBROUTINE tddfpt_apply_energy_diff(Aop_evects, evects, S_evects, gs_mos, matrix_ks)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects, S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: Aop_evects, evects, S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(in)       :: matrix_ks
@@ -112,7 +110,7 @@ CONTAINS
 
          DO ivect = 1, nvects
             CALL cp_dbcsr_sm_fm_multiply(matrix_ks(ispin)%matrix, evects(ispin, ivect), &
-                                         Aop_evects(ispin, ivect)%matrix, ncol=nactive, &
+                                         Aop_evects(ispin, ivect), ncol=nactive, &
                                          alpha=1.0_dp, beta=1.0_dp)
 
             IF (ASSOCIATED(gs_mos(ispin)%evals_occ_matrix)) THEN
@@ -126,7 +124,7 @@ CONTAINS
             END IF
 
             ! KS * C1 - S * C1 * occupied_orbital_energies
-            CALL cp_fm_scale_and_add(1.0_dp, Aop_evects(ispin, ivect)%matrix, -1.0_dp, hevec)
+            CALL cp_fm_scale_and_add(1.0_dp, Aop_evects(ispin, ivect), -1.0_dp, hevec)
          END DO
          CALL cp_fm_release(hevec)
       END DO
@@ -439,8 +437,7 @@ CONTAINS
    SUBROUTINE tddfpt_apply_hfx(Aop_evects, evects, gs_mos, do_admm, qs_env, &
                                work_rho_ia_ao_symm, work_hmat_symm, work_rho_ia_ao_asymm, &
                                work_hmat_asymm, wfm_rho_orb)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: Aop_evects, evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       LOGICAL, INTENT(in)                                :: do_admm
@@ -529,12 +526,12 @@ CONTAINS
                                      admm_env%work_aux_orb, 0.0_dp, wfm_rho_orb)
 
                   CALL parallel_gemm('N', 'N', nao, nactive(ispin), nao, alpha, wfm_rho_orb, &
-                                     gs_mos(ispin)%mos_occ, 1.0_dp, Aop_evects(ispin, ivect)%matrix)
+                                     gs_mos(ispin)%mos_occ, 1.0_dp, Aop_evects(ispin, ivect))
                END DO
             ELSE
                DO ispin = 1, nspins
                   CALL cp_dbcsr_sm_fm_multiply(work_hmat_symm(ispin)%matrix, gs_mos(ispin)%mos_occ, &
-                                               Aop_evects(ispin, ivect)%matrix, ncol=nactive(ispin), &
+                                               Aop_evects(ispin, ivect), ncol=nactive(ispin), &
                                                alpha=alpha, beta=1.0_dp)
                END DO
             END IF
@@ -571,12 +568,12 @@ CONTAINS
                                      admm_env%work_aux_orb, 0.0_dp, wfm_rho_orb)
 
                   CALL parallel_gemm('N', 'N', nao, nactive(ispin), nao, alpha, wfm_rho_orb, &
-                                     gs_mos(ispin)%mos_occ, 1.0_dp, Aop_evects(ispin, ivect)%matrix)
+                                     gs_mos(ispin)%mos_occ, 1.0_dp, Aop_evects(ispin, ivect))
                END DO
             ELSE
                DO ispin = 1, nspins
                   CALL cp_dbcsr_sm_fm_multiply(work_hmat_asymm(ispin)%matrix, gs_mos(ispin)%mos_occ, &
-                                               Aop_evects(ispin, ivect)%matrix, ncol=nactive(ispin), &
+                                               Aop_evects(ispin, ivect), ncol=nactive(ispin), &
                                                alpha=alpha, beta=1.0_dp)
                END DO
             END IF

--- a/src/qs_tddfpt2_operators.F
+++ b/src/qs_tddfpt2_operators.F
@@ -88,8 +88,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_apply_energy_diff(Aop_evects, evects, S_evects, gs_mos, matrix_ks)
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: Aop_evects
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects, S_evects
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(in)       :: matrix_ks
@@ -119,10 +118,10 @@ CONTAINS
             IF (ASSOCIATED(gs_mos(ispin)%evals_occ_matrix)) THEN
                ! orbital energy correction: evals_occ_matrix is not a diagonal matrix
                CALL parallel_gemm('N', 'N', nao, nactive, nactive, 1.0_dp, &
-                                  S_evects(ispin, ivect)%matrix, gs_mos(ispin)%evals_occ_matrix, &
+                                  S_evects(ispin, ivect), gs_mos(ispin)%evals_occ_matrix, &
                                   0.0_dp, hevec)
             ELSE
-               CALL cp_fm_to_fm(S_evects(ispin, ivect)%matrix, hevec)
+               CALL cp_fm_to_fm(S_evects(ispin, ivect), hevec)
                CALL cp_fm_column_scale(hevec, gs_mos(ispin)%evals_occ)
             END IF
 

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -154,7 +154,7 @@ CONTAINS
 !>       \endparblock
 ! **************************************************************************************************
    SUBROUTINE tddfpt_dipole_operator(dipole_op_mos_occ, tddfpt_control, gs_mos, qs_env)
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :), &
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(inout)                                   :: dipole_op_mos_occ
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
@@ -206,8 +206,7 @@ CONTAINS
          CALL cp_fm_get_info(gs_mos(ispin)%mos_occ, matrix_struct=fm_struct)
 
          DO ideriv = 1, nderivs
-            ALLOCATE (dipole_op_mos_occ(ideriv, ispin)%matrix)
-            CALL cp_fm_create(dipole_op_mos_occ(ideriv, ispin)%matrix, fm_struct)
+            CALL cp_fm_create(dipole_op_mos_occ(ideriv, ispin), fm_struct)
          END DO
       END DO
 
@@ -334,14 +333,14 @@ CONTAINS
                ! dBerry_mos_occ is identical to dBerry_psi0 from qs_linres_op % polar_operators()
                CALL parallel_gemm("N", "N", nao, nmo_occ(ispin), nmo_occ(ispin), &
                                   1.0_dp, opvec(1, ispin)%matrix, gamma_real_imag(2, ispin)%matrix, &
-                                  0.0_dp, dipole_op_mos_occ(1, ispin)%matrix)
+                                  0.0_dp, dipole_op_mos_occ(1, ispin))
                CALL parallel_gemm("N", "N", nao, nmo_occ(ispin), nmo_occ(ispin), &
                                   -1.0_dp, opvec(2, ispin)%matrix, gamma_real_imag(1, ispin)%matrix, &
-                                  1.0_dp, dipole_op_mos_occ(1, ispin)%matrix)
+                                  1.0_dp, dipole_op_mos_occ(1, ispin))
 
                DO jderiv = 1, nderivs
                   CALL cp_fm_scale_and_add(1.0_dp, dBerry_mos_occ(jderiv, ispin)%matrix, &
-                                           cell%hmat(jderiv, ideriv), dipole_op_mos_occ(1, ispin)%matrix)
+                                           cell%hmat(jderiv, ideriv), dipole_op_mos_occ(1, ispin))
                END DO
             END DO
          END DO
@@ -387,7 +386,7 @@ CONTAINS
             DO ideriv = 1, nderivs
                CALL parallel_gemm('N', 'N', nao, nmo_occ(ispin), nao, &
                                   1.0_dp, wfm_ao_ao, dBerry_mos_occ(ideriv, ispin)%matrix, &
-                                  0.0_dp, dipole_op_mos_occ(ideriv, ispin)%matrix)
+                                  0.0_dp, dipole_op_mos_occ(ideriv, ispin))
             END DO
          END DO
 
@@ -446,7 +445,7 @@ CONTAINS
 
                CALL parallel_gemm('N', 'N', nao, nmo_occ(ispin), nao, &
                                   1.0_dp, wfm_ao_ao, rRc_mos_occ, &
-                                  0.0_dp, dipole_op_mos_occ(ideriv, ispin)%matrix)
+                                  0.0_dp, dipole_op_mos_occ(ideriv, ispin))
             END DO
 
             CALL cp_fm_release(rRc_mos_occ)
@@ -493,11 +492,11 @@ CONTAINS
             DO ideriv = 1, nderivs
                CALL cp_dbcsr_sm_fm_multiply(scrm(ideriv + 1)%matrix, &
                                             gs_mos(ispin)%mos_occ, &
-                                            dipole_op_mos_occ(ideriv, ispin)%matrix, &
+                                            dipole_op_mos_occ(ideriv, ispin), &
                                             ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
 
                CALL parallel_gemm('T', 'N', nmo_virt(ispin), nmo_occ(ispin), nao, &
-                                  1.0_dp, gs_mos(ispin)%mos_virt, dipole_op_mos_occ(ideriv, ispin)%matrix, &
+                                  1.0_dp, gs_mos(ispin)%mos_virt, dipole_op_mos_occ(ideriv, ispin), &
                                   0.0_dp, wfm_mo_virt_mo_occ)
 
                ! in-place element-wise (Schur) product;
@@ -516,7 +515,7 @@ CONTAINS
 
                CALL parallel_gemm('N', 'N', nao, nmo_occ(ispin), nmo_virt(ispin), &
                                   1.0_dp, S_mos_virt(ispin)%matrix, wfm_mo_virt_mo_occ, &
-                                  0.0_dp, dipole_op_mos_occ(ideriv, ispin)%matrix)
+                                  0.0_dp, dipole_op_mos_occ(ideriv, ispin))
             END DO
 
             CALL cp_fm_release(wfm_mo_virt_mo_occ)
@@ -569,7 +568,7 @@ CONTAINS
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
       REAL(kind=dp), DIMENSION(:), INTENT(inout)         :: ostrength
       INTEGER, INTENT(in)                                :: mult
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: dipole_op_mos_occ
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: dipole_op_mos_occ
       INTEGER, INTENT(in)                                :: dipole_form
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_print_summary'
@@ -622,7 +621,7 @@ CONTAINS
       IF (nspins > 1 .OR. mult == 1) THEN
          DO ispin = 1, nspins
             DO ideriv = 1, nderivs
-               CALL cp_fm_trace(evects(ispin, :), dipole_op_mos_occ(ideriv, ispin)%matrix, &
+               CALL cp_fm_trace(evects(ispin, :), dipole_op_mos_occ(ideriv, ispin), &
                                 trans_dipoles(:, ideriv, ispin))
             END DO
          END DO

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -35,7 +35,6 @@ MODULE qs_tddfpt2_properties
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -175,12 +174,11 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_cfm_p_type), ALLOCATABLE, DIMENSION(:)     :: gamma_00, gamma_inv_00
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: dBerry_mos_occ
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: ediff_inv, rRc_mos_occ, wfm_ao_ao, &
                                                             wfm_mo_virt_mo_occ
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: S_mos_virt
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: gamma_real_imag, opvec
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dBerry_mos_occ, gamma_real_imag, opvec
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: berry_cossin_xyz, matrix_s, rRc_xyz, scrm
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
@@ -284,9 +282,8 @@ CONTAINS
 
             ! dBerry * C_0
             DO ideriv = 1, nderivs
-               ALLOCATE (dBerry_mos_occ(ideriv, ispin)%matrix)
-               CALL cp_fm_create(dBerry_mos_occ(ideriv, ispin)%matrix, fm_struct)
-               CALL cp_fm_set_all(dBerry_mos_occ(ideriv, ispin)%matrix, 0.0_dp)
+               CALL cp_fm_create(dBerry_mos_occ(ideriv, ispin), fm_struct)
+               CALL cp_fm_set_all(dBerry_mos_occ(ideriv, ispin), 0.0_dp)
             END DO
          END DO
 
@@ -337,7 +334,7 @@ CONTAINS
                                   1.0_dp, dipole_op_mos_occ(1, ispin))
 
                DO jderiv = 1, nderivs
-                  CALL cp_fm_scale_and_add(1.0_dp, dBerry_mos_occ(jderiv, ispin)%matrix, &
+                  CALL cp_fm_scale_and_add(1.0_dp, dBerry_mos_occ(jderiv, ispin), &
                                            cell%hmat(jderiv, ideriv), dipole_op_mos_occ(1, ispin))
                END DO
             END DO
@@ -381,7 +378,7 @@ CONTAINS
 
             DO ideriv = 1, nderivs
                CALL parallel_gemm('N', 'N', nao, nmo_occ(ispin), nao, &
-                                  1.0_dp, wfm_ao_ao, dBerry_mos_occ(ideriv, ispin)%matrix, &
+                                  1.0_dp, wfm_ao_ao, dBerry_mos_occ(ideriv, ispin), &
                                   0.0_dp, dipole_op_mos_occ(ideriv, ispin))
             END DO
          END DO
@@ -390,8 +387,7 @@ CONTAINS
 
          DO ispin = nspins, 1, -1
             DO ideriv = SIZE(dBerry_mos_occ, 1), 1, -1
-               CALL cp_fm_release(dBerry_mos_occ(ideriv, ispin)%matrix)
-               DEALLOCATE (dBerry_mos_occ(ideriv, ispin)%matrix)
+               CALL cp_fm_release(dBerry_mos_occ(ideriv, ispin))
             END DO
          END DO
          DEALLOCATE (dBerry_mos_occ)
@@ -692,8 +688,8 @@ CONTAINS
       REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
          POINTER                                         :: local_data
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: S_mos_virt, weights_fm
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: S_mos_virt, weights_fm
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(mp_request_type)                              :: send_handler, send_handler2
       TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_handlers, recv_handlers2
@@ -736,25 +732,23 @@ CONTAINS
 
          ALLOCATE (S_mos_virt(nspins), weights_fm(nspins))
          DO ispin = 1, nspins
-            ALLOCATE (S_mos_virt(ispin)%matrix)
             CALL cp_fm_get_info(gs_mos(ispin)%mos_virt, matrix_struct=fm_struct)
-            CALL cp_fm_create(S_mos_virt(ispin)%matrix, fm_struct)
+            CALL cp_fm_create(S_mos_virt(ispin), fm_struct)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s, &
                                          gs_mos(ispin)%mos_virt, &
-                                         S_mos_virt(ispin)%matrix, &
+                                         S_mos_virt(ispin), &
                                          ncol=nmo_virt(ispin), alpha=1.0_dp, beta=0.0_dp)
 
-            NULLIFY (fm_struct, weights_fm(ispin)%matrix)
+            NULLIFY (fm_struct)
             CALL cp_fm_struct_create(fm_struct, nrow_global=nmo_virt(ispin), ncol_global=nmo_occ(ispin), &
                                      context=blacs_env)
-            ALLOCATE (weights_fm(ispin)%matrix)
-            CALL cp_fm_create(weights_fm(ispin)%matrix, fm_struct)
+            CALL cp_fm_create(weights_fm(ispin), fm_struct)
             CALL cp_fm_struct_release(fm_struct)
          END DO
 
          nexcs_max_local = 0
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(weights_fm(ispin)%matrix, nrow_local=nrows_local, ncol_local=ncols_local)
+            CALL cp_fm_get_info(weights_fm(ispin), nrow_local=nrows_local, ncol_local=ncols_local)
             nexcs_max_local = nexcs_max_local + INT(nrows_local, int_8)*INT(ncols_local, int_8)
          END DO
 
@@ -768,10 +762,10 @@ CONTAINS
             ! excitations to the master node for subsequent ordering
             DO ispin = 1, nspins
                ! compute excitation amplitudes
-               CALL parallel_gemm('T', 'N', nmo_virt(ispin), nmo_occ(ispin), nao, 1.0_dp, S_mos_virt(ispin)%matrix, &
-                                  evects(ispin, istate), 0.0_dp, weights_fm(ispin)%matrix)
+               CALL parallel_gemm('T', 'N', nmo_virt(ispin), nmo_occ(ispin), nao, 1.0_dp, S_mos_virt(ispin), &
+                                  evects(ispin, istate), 0.0_dp, weights_fm(ispin))
 
-               CALL cp_fm_get_info(weights_fm(ispin)%matrix, nrow_local=nrows_local, ncol_local=ncols_local, &
+               CALL cp_fm_get_info(weights_fm(ispin), nrow_local=nrows_local, ncol_local=ncols_local, &
                                    row_indices=row_indices, col_indices=col_indices, local_data=local_data)
 
                ! locate single excitations with significant amplitudes (>= min_amplitude)
@@ -907,9 +901,8 @@ CONTAINS
       END IF
 
       DO ispin = nspins, 1, -1
-         CALL cp_fm_release(weights_fm(ispin)%matrix)
-         CALL cp_fm_release(S_mos_virt(ispin)%matrix)
-         DEALLOCATE (weights_fm(ispin)%matrix, S_mos_virt(ispin)%matrix)
+         CALL cp_fm_release(weights_fm(ispin))
+         CALL cp_fm_release(S_mos_virt(ispin))
       END DO
       DEALLOCATE (S_mos_virt, weights_fm)
 
@@ -953,9 +946,9 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eigvals
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: eigenvalues
       REAL(KIND=dp), DIMENSION(ntomax)                   :: ia_eval
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: teig
       TYPE(cp_fm_struct_type), POINTER                   :: fm_mo_struct, fm_struct
       TYPE(cp_fm_type)                                   :: Sev, smat, tmat, wmat, work, wvec
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: teig
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(mo_set_type), ALLOCATABLE, DIMENSION(:)       :: nto_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1012,9 +1005,6 @@ CONTAINS
             END DO
             !
             ALLOCATE (teig(nspins))
-            DO ispin = 1, nspins
-               NULLIFY (teig(ispin)%matrix)
-            END DO
             ! hole states
             ! Diagonalize X(T)*S*X
             DO ispin = 1, nspins
@@ -1024,13 +1014,12 @@ CONTAINS
                   CALL cp_fm_struct_create(fmstruct=fm_mo_struct, template_fmstruct=fm_struct, &
                                            nrow_global=nmo, ncol_global=nmo)
                   CALL cp_fm_create(tmat, fm_mo_struct)
-                  ALLOCATE (teig(ispin)%matrix)
-                  CALL cp_fm_create(teig(ispin)%matrix, fm_mo_struct)
+                  CALL cp_fm_create(teig(ispin), fm_mo_struct)
                   CALL cp_dbcsr_sm_fm_multiply(matrix_s, ev, Sev, ncol=nmo, alpha=1.0_dp, beta=0.0_dp)
                   CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, ev, Sev, 0.0_dp, tmat)
                END ASSOCIATE
 
-               CALL choose_eigv_solver(tmat, teig(ispin)%matrix, eigenvalues(1:nmo, ispin))
+               CALL choose_eigv_solver(tmat, teig(ispin), eigenvalues(1:nmo, ispin))
 
                CALL cp_fm_struct_release(fm_mo_struct)
                CALL cp_fm_release(tmat)
@@ -1055,7 +1044,7 @@ CONTAINS
                ia = ia_index(1, i)
                ispin = ia_index(2, i)
                CALL cp_fm_get_info(gs_mos(ispin)%mos_occ, ncol_global=nmo)
-               CALL cp_fm_get_info(teig(ispin)%matrix, matrix_struct=fm_struct)
+               CALL cp_fm_get_info(teig(ispin), matrix_struct=fm_struct)
                CALL cp_fm_struct_create(fmstruct=fm_mo_struct, template_fmstruct=fm_struct, &
                                         nrow_global=nmo, ncol_global=1)
                CALL cp_fm_create(tmat, fm_mo_struct)
@@ -1065,7 +1054,7 @@ CONTAINS
                                         ncol_global=1)
                CALL cp_fm_create(wvec, fm_mo_struct)
                CALL cp_fm_struct_release(fm_mo_struct)
-               CALL cp_fm_to_fm(teig(ispin)%matrix, tmat, 1, ia, 1)
+               CALL cp_fm_to_fm(teig(ispin), tmat, 1, ia, 1)
                CALL parallel_gemm('N', 'N', nao, 1, nmo, 1.0_dp, gs_mos(ispin)%mos_occ, &
                                   tmat, 0.0_dp, wvec)
                CALL cp_fm_to_fm(wvec, nto_set(1)%mo_coeff, 1, 1, i)
@@ -1141,8 +1130,7 @@ CONTAINS
             !
             DEALLOCATE (eigenvalues)
             DO ispin = 1, nspins
-               CALL cp_fm_release(teig(ispin)%matrix)
-               DEALLOCATE (teig(ispin)%matrix)
+               CALL cp_fm_release(teig(ispin))
             END DO
             DEALLOCATE (teig)
             !

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -564,7 +564,7 @@ CONTAINS
    SUBROUTINE tddfpt_print_summary(log_unit, evects, evals, ostrength, mult, &
                                    dipole_op_mos_occ, dipole_form)
       INTEGER, INTENT(in)                                :: log_unit
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
       REAL(kind=dp), DIMENSION(:), INTENT(inout)         :: ostrength
       INTEGER, INTENT(in)                                :: mult
@@ -669,7 +669,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_print_excitation_analysis(log_unit, evects, evals, gs_mos, matrix_s, min_amplitude)
       INTEGER, INTENT(in)                                :: log_unit
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
@@ -774,7 +774,7 @@ CONTAINS
             DO ispin = 1, nspins
                ! compute excitation amplitudes
                CALL parallel_gemm('T', 'N', nmo_virt(ispin), nmo_occ(ispin), nao, 1.0_dp, S_mos_virt(ispin)%matrix, &
-                                  evects(ispin, istate)%matrix, 0.0_dp, weights_fm(ispin)%matrix)
+                                  evects(ispin, istate), 0.0_dp, weights_fm(ispin)%matrix)
 
                CALL cp_fm_get_info(weights_fm(ispin)%matrix, nrow_local=nrows_local, ncol_local=ncols_local, &
                                    row_indices=row_indices, col_indices=col_indices, local_data=local_data)
@@ -936,7 +936,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_print_nto_analysis(qs_env, evects, evals, gs_mos, matrix_s, print_section)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
@@ -961,7 +961,6 @@ CONTAINS
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: teig
       TYPE(cp_fm_struct_type), POINTER                   :: fm_mo_struct, fm_struct
       TYPE(cp_fm_type)                                   :: Sev, smat, tmat, wmat, work, wvec
-      TYPE(cp_fm_type), POINTER                          :: ev
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(mo_set_type), ALLOCATABLE, DIMENSION(:)       :: nto_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -996,8 +995,7 @@ CONTAINS
             END IF
             nmax = 0
             DO ispin = 1, nspins
-               ev => evects(ispin, istate)%matrix
-               CALL cp_fm_get_info(ev, matrix_struct=fm_struct, ncol_global=nmo)
+               CALL cp_fm_get_info(evects(ispin, istate), matrix_struct=fm_struct, ncol_global=nmo)
                nmax = MAX(nmax, nmo)
             END DO
             ALLOCATE (eigenvalues(nmax, nspins))
@@ -1009,8 +1007,7 @@ CONTAINS
             ALLOCATE (nto_set(2))
             DO i = 1, 2
                CALL allocate_mo_set(nto_set(i), nao, ntomax, 0, 0.0_dp, 1.0_dp, 0.0_dp)
-               ev => evects(1, istate)%matrix
-               CALL cp_fm_get_info(ev, matrix_struct=fm_struct)
+               CALL cp_fm_get_info(evects(1, istate), matrix_struct=fm_struct)
                CALL cp_fm_struct_create(fmstruct=fm_mo_struct, template_fmstruct=fm_struct, &
                                         ncol_global=ntomax)
                CALL cp_fm_create(tmat, fm_mo_struct)
@@ -1026,16 +1023,17 @@ CONTAINS
             ! hole states
             ! Diagonalize X(T)*S*X
             DO ispin = 1, nspins
-               ev => evects(ispin, istate)%matrix
-               CALL cp_fm_get_info(ev, matrix_struct=fm_struct, ncol_global=nmo)
-               CALL cp_fm_create(Sev, fm_struct)
-               CALL cp_fm_struct_create(fmstruct=fm_mo_struct, template_fmstruct=fm_struct, &
-                                        nrow_global=nmo, ncol_global=nmo)
-               CALL cp_fm_create(tmat, fm_mo_struct)
-               ALLOCATE (teig(ispin)%matrix)
-               CALL cp_fm_create(teig(ispin)%matrix, fm_mo_struct)
-               CALL cp_dbcsr_sm_fm_multiply(matrix_s, ev, Sev, ncol=nmo, alpha=1.0_dp, beta=0.0_dp)
-               CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, ev, Sev, 0.0_dp, tmat)
+               ASSOCIATE (ev => evects(ispin, istate))
+                  CALL cp_fm_get_info(ev, matrix_struct=fm_struct, ncol_global=nmo)
+                  CALL cp_fm_create(Sev, fm_struct)
+                  CALL cp_fm_struct_create(fmstruct=fm_mo_struct, template_fmstruct=fm_struct, &
+                                           nrow_global=nmo, ncol_global=nmo)
+                  CALL cp_fm_create(tmat, fm_mo_struct)
+                  ALLOCATE (teig(ispin)%matrix)
+                  CALL cp_fm_create(teig(ispin)%matrix, fm_mo_struct)
+                  CALL cp_dbcsr_sm_fm_multiply(matrix_s, ev, Sev, ncol=nmo, alpha=1.0_dp, beta=0.0_dp)
+                  CALL parallel_gemm('T', 'N', nmo, nmo, nao, 1.0_dp, ev, Sev, 0.0_dp, tmat)
+               END ASSOCIATE
 
                CALL choose_eigv_solver(tmat, teig(ispin)%matrix, eigenvalues(1:nmo, ispin))
 
@@ -1083,12 +1081,13 @@ CONTAINS
             ! Solve generalized eigenvalue equation:  (S*X)*(S*X)(T)*v = lambda*S*v
             CALL set_mo_set(nto_set(2), nmo=nnto)
             DO ispin = 1, nspins
-               ev => evects(ispin, istate)%matrix
-               CALL cp_fm_get_info(ev, matrix_struct=fm_struct, nrow_global=nao, ncol_global=nmo)
-               ALLOCATE (eigvals(nao))
-               eigvals = 0.0_dp
-               CALL cp_fm_create(Sev, fm_struct)
-               CALL cp_dbcsr_sm_fm_multiply(matrix_s, ev, Sev, ncol=nmo, alpha=1.0_dp, beta=0.0_dp)
+               ASSOCIATE (ev => evects(ispin, istate))
+                  CALL cp_fm_get_info(ev, matrix_struct=fm_struct, nrow_global=nao, ncol_global=nmo)
+                  ALLOCATE (eigvals(nao))
+                  eigvals = 0.0_dp
+                  CALL cp_fm_create(Sev, fm_struct)
+                  CALL cp_dbcsr_sm_fm_multiply(matrix_s, ev, Sev, ncol=nmo, alpha=1.0_dp, beta=0.0_dp)
+               END ASSOCIATE
                CALL cp_fm_struct_create(fmstruct=fm_mo_struct, template_fmstruct=fm_struct, &
                                         nrow_global=nao, ncol_global=nao)
                CALL cp_fm_create(tmat, fm_mo_struct)

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -175,11 +175,12 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_cfm_p_type), ALLOCATABLE, DIMENSION(:)     :: gamma_00, gamma_inv_00
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: S_mos_virt
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: dBerry_mos_occ, gamma_real_imag, opvec
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: dBerry_mos_occ
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: ediff_inv, rRc_mos_occ, wfm_ao_ao, &
                                                             wfm_mo_virt_mo_occ
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: S_mos_virt
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: gamma_real_imag, opvec
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: berry_cossin_xyz, matrix_s, rRc_xyz, scrm
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
@@ -213,12 +214,11 @@ CONTAINS
       ! +++ allocate work matrices
       ALLOCATE (S_mos_virt(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (S_mos_virt(ispin)%matrix)
          CALL cp_fm_get_info(gs_mos(ispin)%mos_virt, matrix_struct=fm_struct)
-         CALL cp_fm_create(S_mos_virt(ispin)%matrix, fm_struct)
+         CALL cp_fm_create(S_mos_virt(ispin), fm_struct)
          CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, &
                                       gs_mos(ispin)%mos_virt, &
-                                      S_mos_virt(ispin)%matrix, &
+                                      S_mos_virt(ispin), &
                                       ncol=nmo_virt(ispin), alpha=1.0_dp, beta=0.0_dp)
       END DO
 
@@ -272,16 +272,14 @@ CONTAINS
             CALL cp_cfm_create(gamma_inv_00(ispin)%matrix, fm_struct)
 
             DO i_cos_sin = 1, 2
-               ALLOCATE (gamma_real_imag(i_cos_sin, ispin)%matrix)
-               CALL cp_fm_create(gamma_real_imag(i_cos_sin, ispin)%matrix, fm_struct)
+               CALL cp_fm_create(gamma_real_imag(i_cos_sin, ispin), fm_struct)
             END DO
             CALL cp_fm_struct_release(fm_struct)
 
             ! G_real C_0, G_imag C_0
             CALL cp_fm_get_info(gs_mos(ispin)%mos_occ, matrix_struct=fm_struct)
             DO i_cos_sin = 1, 2
-               ALLOCATE (opvec(i_cos_sin, ispin)%matrix)
-               CALL cp_fm_create(opvec(i_cos_sin, ispin)%matrix, fm_struct)
+               CALL cp_fm_create(opvec(i_cos_sin, ispin), fm_struct)
             END DO
 
             ! dBerry * C_0
@@ -306,20 +304,20 @@ CONTAINS
                DO i_cos_sin = 1, 2
                   CALL cp_dbcsr_sm_fm_multiply(berry_cossin_xyz(i_cos_sin)%matrix, &
                                                gs_mos(ispin)%mos_occ, &
-                                               opvec(i_cos_sin, ispin)%matrix, &
+                                               opvec(i_cos_sin, ispin), &
                                                ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
                END DO
 
                CALL parallel_gemm('T', 'N', nmo_occ(ispin), nmo_occ(ispin), nao, &
-                                  1.0_dp, gs_mos(ispin)%mos_occ, opvec(1, ispin)%matrix, &
-                                  0.0_dp, gamma_real_imag(1, ispin)%matrix)
+                                  1.0_dp, gs_mos(ispin)%mos_occ, opvec(1, ispin), &
+                                  0.0_dp, gamma_real_imag(1, ispin))
 
                CALL parallel_gemm('T', 'N', nmo_occ(ispin), nmo_occ(ispin), nao, &
-                                  -1.0_dp, gs_mos(ispin)%mos_occ, opvec(2, ispin)%matrix, &
-                                  0.0_dp, gamma_real_imag(2, ispin)%matrix)
+                                  -1.0_dp, gs_mos(ispin)%mos_occ, opvec(2, ispin), &
+                                  0.0_dp, gamma_real_imag(2, ispin))
 
-               CALL cp_fm_to_cfm(msourcer=gamma_real_imag(1, ispin)%matrix, &
-                                 msourcei=gamma_real_imag(2, ispin)%matrix, &
+               CALL cp_fm_to_cfm(msourcer=gamma_real_imag(1, ispin), &
+                                 msourcei=gamma_real_imag(2, ispin), &
                                  mtarget=gamma_00(ispin)%matrix)
 
                ! gamma_inv_00 = Q = [C_0^T (gamma_real - i gamma_imag) C_0] ^ {-1}
@@ -327,15 +325,15 @@ CONTAINS
                CALL cp_cfm_solve(gamma_00(ispin)%matrix, gamma_inv_00(ispin)%matrix)
 
                CALL cp_cfm_to_fm(msource=gamma_inv_00(ispin)%matrix, &
-                                 mtargetr=gamma_real_imag(1, ispin)%matrix, &
-                                 mtargeti=gamma_real_imag(2, ispin)%matrix)
+                                 mtargetr=gamma_real_imag(1, ispin), &
+                                 mtargeti=gamma_real_imag(2, ispin))
 
                ! dBerry_mos_occ is identical to dBerry_psi0 from qs_linres_op % polar_operators()
                CALL parallel_gemm("N", "N", nao, nmo_occ(ispin), nmo_occ(ispin), &
-                                  1.0_dp, opvec(1, ispin)%matrix, gamma_real_imag(2, ispin)%matrix, &
+                                  1.0_dp, opvec(1, ispin), gamma_real_imag(2, ispin), &
                                   0.0_dp, dipole_op_mos_occ(1, ispin))
                CALL parallel_gemm("N", "N", nao, nmo_occ(ispin), nmo_occ(ispin), &
-                                  -1.0_dp, opvec(2, ispin)%matrix, gamma_real_imag(1, ispin)%matrix, &
+                                  -1.0_dp, opvec(2, ispin), gamma_real_imag(1, ispin), &
                                   1.0_dp, dipole_op_mos_occ(1, ispin))
 
                DO jderiv = 1, nderivs
@@ -348,13 +346,11 @@ CONTAINS
          ! --- release berry-phase-related work matrices
          DO ispin = nspins, 1, -1
             DO i_cos_sin = SIZE(opvec, 1), 1, -1
-               CALL cp_fm_release(opvec(i_cos_sin, ispin)%matrix)
-               DEALLOCATE (opvec(i_cos_sin, ispin)%matrix)
+               CALL cp_fm_release(opvec(i_cos_sin, ispin))
             END DO
 
             DO i_cos_sin = SIZE(gamma_real_imag, 1), 1, -1
-               CALL cp_fm_release(gamma_real_imag(i_cos_sin, ispin)%matrix)
-               DEALLOCATE (gamma_real_imag(i_cos_sin, ispin)%matrix)
+               CALL cp_fm_release(gamma_real_imag(i_cos_sin, ispin))
             END DO
 
             CALL cp_cfm_release(gamma_inv_00(ispin)%matrix)
@@ -380,7 +376,7 @@ CONTAINS
          DO ispin = 1, nspins
             ! wfm_ao_ao = S * mos_virt * mos_virt^T
             CALL parallel_gemm('N', 'T', nao, nao, nmo_virt(ispin), &
-                               1.0_dp/twopi, S_mos_virt(ispin)%matrix, gs_mos(ispin)%mos_virt, &
+                               1.0_dp/twopi, S_mos_virt(ispin), gs_mos(ispin)%mos_virt, &
                                0.0_dp, wfm_ao_ao)
 
             DO ideriv = 1, nderivs
@@ -434,7 +430,7 @@ CONTAINS
 
             ! wfm_ao_ao = S * mos_virt * mos_virt^T
             CALL parallel_gemm('N', 'T', nao, nao, nmo_virt(ispin), &
-                               1.0_dp, S_mos_virt(ispin)%matrix, gs_mos(ispin)%mos_virt, &
+                               1.0_dp, S_mos_virt(ispin), gs_mos(ispin)%mos_virt, &
                                0.0_dp, wfm_ao_ao)
 
             DO ideriv = 1, nderivs
@@ -514,7 +510,7 @@ CONTAINS
 !$OMP          END PARALLEL DO
 
                CALL parallel_gemm('N', 'N', nao, nmo_occ(ispin), nmo_virt(ispin), &
-                                  1.0_dp, S_mos_virt(ispin)%matrix, wfm_mo_virt_mo_occ, &
+                                  1.0_dp, S_mos_virt(ispin), wfm_mo_virt_mo_occ, &
                                   0.0_dp, dipole_op_mos_occ(ideriv, ispin))
             END DO
 
@@ -529,8 +525,7 @@ CONTAINS
 
       ! --- release work matrices
       DO ispin = nspins, 1, -1
-         CALL cp_fm_release(S_mos_virt(ispin)%matrix)
-         DEALLOCATE (S_mos_virt(ispin)%matrix)
+         CALL cp_fm_release(S_mos_virt(ispin))
       END DO
       DEALLOCATE (S_mos_virt)
 

--- a/src/qs_tddfpt2_restart.F
+++ b/src/qs_tddfpt2_restart.F
@@ -73,7 +73,7 @@ CONTAINS
 !>    * 08.2016 created [Sergey Chulkov]
 ! **************************************************************************************************
    SUBROUTINE tddfpt_write_restart(evects, evals, gs_mos, logger, tddfpt_print_section)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
@@ -125,11 +125,11 @@ CONTAINS
                ! coefficients of the reference ground-state wave function. To make the restart file
                ! transferable, TDDFPT wave functions are stored in assumption that all ground state
                ! MOs have a positive phase.
-               CALL cp_fm_column_scale(evects(ispin, istate)%matrix, gs_mos(ispin)%phases_occ)
+               CALL cp_fm_column_scale(evects(ispin, istate), gs_mos(ispin)%phases_occ)
 
-               CALL cp_fm_write_unformatted(evects(ispin, istate)%matrix, ounit)
+               CALL cp_fm_write_unformatted(evects(ispin, istate), ounit)
 
-               CALL cp_fm_column_scale(evects(ispin, istate)%matrix, gs_mos(ispin)%phases_occ)
+               CALL cp_fm_column_scale(evects(ispin, istate), gs_mos(ispin)%phases_occ)
             END DO
          END DO
 
@@ -158,7 +158,7 @@ CONTAINS
 ! **************************************************************************************************
    FUNCTION tddfpt_read_restart(evects, evals, gs_mos, logger, tddfpt_section, tddfpt_print_section, &
                                 fm_pool_ao_mo_occ, blacs_env_global) RESULT(nstates_read)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(inout) :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(inout)   :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(out)           :: evals
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
@@ -282,12 +282,11 @@ CONTAINS
       DO istate = 1, nstates_read
          DO ispin = 1, nspins
             IF (istate <= nstates) THEN
-               ALLOCATE (evects(ispin, istate)%matrix)
-               CALL fm_pool_create_fm(fm_pool_ao_mo_occ(ispin)%pool, evects(ispin, istate)%matrix)
+               CALL fm_pool_create_fm(fm_pool_ao_mo_occ(ispin)%pool, evects(ispin, istate))
 
-               CALL cp_fm_read_unformatted(evects(ispin, istate)%matrix, iunit)
+               CALL cp_fm_read_unformatted(evects(ispin, istate), iunit)
 
-               CALL cp_fm_column_scale(evects(ispin, istate)%matrix, gs_mos(ispin)%phases_occ)
+               CALL cp_fm_column_scale(evects(ispin, istate), gs_mos(ispin)%phases_occ)
             END IF
          END DO
       END DO
@@ -313,7 +312,7 @@ CONTAINS
    SUBROUTINE tddfpt_write_newtonx_output(evects, evals, gs_mos, logger, tddfpt_print_section, &
                                           matrix_s, S_evects, sub_env)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(in)            :: evals
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
@@ -377,7 +376,7 @@ CONTAINS
                   ALLOCATE (evects_mo(ispin, istate)%matrix)
                   CALL cp_fm_create(evects_mo(ispin, istate)%matrix, fmstruct)
                   CALL cp_fm_struct_release(fmstruct)
-                  CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, istate)%matrix, S_evects(ispin, istate)%matrix, &
+                  CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, istate), S_evects(ispin, istate)%matrix, &
                                                ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
                END DO
             END DO
@@ -400,12 +399,12 @@ CONTAINS
             DO ispin = 1, nspins
 
                IF (.NOT. print_virtuals) THEN
-                  CALL cp_fm_column_scale(evects(ispin, istate)%matrix, gs_mos(ispin)%phases_occ)
+                  CALL cp_fm_column_scale(evects(ispin, istate), gs_mos(ispin)%phases_occ)
                   IF (ounit > 0) THEN
                      WRITE (ounit, "(/,A)") "ES EIGENVECTORS SIZE"
-                     CALL cp_fm_write_info(evects(ispin, istate)%matrix, ounit)
+                     CALL cp_fm_write_info(evects(ispin, istate), ounit)
                   END IF
-                  CALL cp_fm_write_formatted(evects(ispin, istate)%matrix, ounit, "ES EIGENVECTORS")
+                  CALL cp_fm_write_formatted(evects(ispin, istate), ounit, "ES EIGENVECTORS")
                ELSE
                   CALL cp_fm_column_scale(evects_mo(ispin, istate)%matrix, gs_mos(ispin)%phases_occ)
                   IF (ounit > 0) THEN
@@ -421,7 +420,7 @@ CONTAINS
                IF (print_virtuals) THEN
                   CALL compute_phase_eigenvectors(evects_mo(ispin, istate)%matrix, phase_evects, sub_env)
                ELSE
-                  CALL compute_phase_eigenvectors(evects(ispin, istate)%matrix, phase_evects, sub_env)
+                  CALL compute_phase_eigenvectors(evects(ispin, istate), phase_evects, sub_env)
                END IF
                IF (ounit > 0) THEN
                   WRITE (ounit, "(/,A,/)") "PHASES ES EIGENVECTORS"
@@ -520,7 +519,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE tddfpt_check_orthonormality(evects, ounit, S_evects, matrix_s)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       INTEGER, INTENT(in)                                :: ounit
       TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
       TYPE(dbcsr_type), INTENT(in), POINTER              :: matrix_s
@@ -544,7 +543,7 @@ CONTAINS
       END IF
 
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(matrix=evects(ispin, 1)%matrix, ncol_global=nactive(ispin))
+         CALL cp_fm_get_info(matrix=evects(ispin, 1), ncol_global=nactive(ispin))
       END DO
 
       DO jvect = 1, nvects_total
@@ -554,13 +553,13 @@ CONTAINS
             norm = SUM(weights(1:nspins))
 
             DO ispin = 1, nspins
-               CALL cp_fm_scale_and_add(1.0_dp, evects(ispin, jvect)%matrix, -norm, evects(ispin, ivect)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, evects(ispin, jvect), -norm, evects(ispin, ivect))
             END DO
          END DO
 
          ! <psi1_j | psi1_j>
          DO ispin = 1, nspins
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect)%matrix, S_evects(ispin, jvect)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect), S_evects(ispin, jvect)%matrix, &
                                          ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
          END DO
 

--- a/src/qs_tddfpt2_restart.F
+++ b/src/qs_tddfpt2_restart.F
@@ -330,8 +330,8 @@ CONTAINS
       LOGICAL                                            :: print_phases, print_virtuals, &
                                                             scale_with_phases
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: phase_evects
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: evects_mo
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: evects_mo
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, tddfpt_print_section, "NAMD_PRINT"), cp_p_file)) THEN
          CALL timeset(routineN, handle)
@@ -372,9 +372,7 @@ CONTAINS
                   CALL cp_fm_struct_create(fmstruct, para_env=sub_env%para_env, &
                                            context=sub_env%blacs_env, &
                                            nrow_global=nmo_virt(ispin), ncol_global=nmo_occ(ispin))
-                  NULLIFY (evects_mo(ispin, istate)%matrix)
-                  ALLOCATE (evects_mo(ispin, istate)%matrix)
-                  CALL cp_fm_create(evects_mo(ispin, istate)%matrix, fmstruct)
+                  CALL cp_fm_create(evects_mo(ispin, istate), fmstruct)
                   CALL cp_fm_struct_release(fmstruct)
                   CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, istate), S_evects(ispin, istate)%matrix, &
                                                ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
@@ -390,7 +388,7 @@ CONTAINS
                                      gs_mos(ispin)%mos_virt, &
                                      S_evects(ispin, istate)%matrix, & !this also needs to be orthogonalized
                                      0.0_dp, &
-                                     evects_mo(ispin, istate)%matrix)
+                                     evects_mo(ispin, istate))
                END DO
             END DO
          END IF
@@ -406,19 +404,19 @@ CONTAINS
                   END IF
                   CALL cp_fm_write_formatted(evects(ispin, istate), ounit, "ES EIGENVECTORS")
                ELSE
-                  CALL cp_fm_column_scale(evects_mo(ispin, istate)%matrix, gs_mos(ispin)%phases_occ)
+                  CALL cp_fm_column_scale(evects_mo(ispin, istate), gs_mos(ispin)%phases_occ)
                   IF (ounit > 0) THEN
                      WRITE (ounit, "(/,A)") "ES EIGENVECTORS SIZE"
-                     CALL cp_fm_write_info(evects_mo(ispin, istate)%matrix, ounit)
+                     CALL cp_fm_write_info(evects_mo(ispin, istate), ounit)
                   END IF
-                  CALL cp_fm_write_formatted(evects_mo(ispin, istate)%matrix, ounit, "ES EIGENVECTORS")
+                  CALL cp_fm_write_formatted(evects_mo(ispin, istate), ounit, "ES EIGENVECTORS")
                END IF
 
                ! compute and print phase of eigenvectors
                nmo_occ(ispin) = SIZE(gs_mos(ispin)%evals_occ)
                ALLOCATE (phase_evects(nmo_occ(ispin)))
                IF (print_virtuals) THEN
-                  CALL compute_phase_eigenvectors(evects_mo(ispin, istate)%matrix, phase_evects, sub_env)
+                  CALL compute_phase_eigenvectors(evects_mo(ispin, istate), phase_evects, sub_env)
                ELSE
                   CALL compute_phase_eigenvectors(evects(ispin, istate), phase_evects, sub_env)
                END IF
@@ -434,11 +432,10 @@ CONTAINS
          END DO
 
          IF (print_virtuals) THEN
-            IF (ASSOCIATED(evects_mo)) THEN
+            IF (ALLOCATED(evects_mo)) THEN
                DO istate = 1, nstates
                   DO ispin = 1, nspins
-                     CALL cp_fm_release(matrix=evects_mo(ispin, istate)%matrix)
-                     DEALLOCATE (evects_mo(ispin, istate)%matrix)
+                     CALL cp_fm_release(matrix=evects_mo(ispin, istate))
                   END DO
                END DO
             END IF

--- a/src/qs_tddfpt2_restart.F
+++ b/src/qs_tddfpt2_restart.F
@@ -19,9 +19,14 @@ MODULE qs_tddfpt2_restart
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_info, cp_fm_p_type, cp_fm_read_unformatted, cp_fm_release, &
-        cp_fm_type, cp_fm_write_formatted, cp_fm_write_info, cp_fm_write_unformatted
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_info,&
+                                              cp_fm_read_unformatted,&
+                                              cp_fm_release,&
+                                              cp_fm_type,&
+                                              cp_fm_write_formatted,&
+                                              cp_fm_write_info,&
+                                              cp_fm_write_unformatted
    USE cp_log_handling,                 ONLY: cp_logger_type
    USE cp_output_handling,              ONLY: cp_p_file,&
                                               cp_print_key_finished_output,&
@@ -319,7 +324,7 @@ CONTAINS
       TYPE(cp_logger_type), INTENT(in), POINTER          :: logger
       TYPE(section_vals_type), INTENT(in), POINTER       :: tddfpt_print_section
       TYPE(dbcsr_type), INTENT(in), POINTER              :: matrix_s
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: S_evects
       TYPE(tddfpt_subgroup_env_type), INTENT(in)         :: sub_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_write_newtonx_output'
@@ -374,7 +379,7 @@ CONTAINS
                                            nrow_global=nmo_virt(ispin), ncol_global=nmo_occ(ispin))
                   CALL cp_fm_create(evects_mo(ispin, istate), fmstruct)
                   CALL cp_fm_struct_release(fmstruct)
-                  CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, istate), S_evects(ispin, istate)%matrix, &
+                  CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, istate), S_evects(ispin, istate), &
                                                ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
                END DO
             END DO
@@ -386,7 +391,7 @@ CONTAINS
                                      nao, &
                                      1.0_dp, &
                                      gs_mos(ispin)%mos_virt, &
-                                     S_evects(ispin, istate)%matrix, & !this also needs to be orthogonalized
+                                     S_evects(ispin, istate), & !this also needs to be orthogonalized
                                      0.0_dp, &
                                      evects_mo(ispin, istate))
                END DO
@@ -518,7 +523,7 @@ CONTAINS
 
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: evects
       INTEGER, INTENT(in)                                :: ounit
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(in)    :: S_evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(in)      :: S_evects
       TYPE(dbcsr_type), INTENT(in), POINTER              :: matrix_s
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_check_orthonormality'
@@ -556,7 +561,7 @@ CONTAINS
 
          ! <psi1_j | psi1_j>
          DO ispin = 1, nspins
-            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect), S_evects(ispin, jvect)%matrix, &
+            CALL cp_dbcsr_sm_fm_multiply(matrix_s, evects(ispin, jvect), S_evects(ispin, jvect), &
                                          ncol=nactive(ispin), alpha=1.0_dp, beta=0.0_dp)
          END DO
 

--- a/src/qs_tddfpt2_stda_utils.F
+++ b/src/qs_tddfpt2_stda_utils.F
@@ -465,8 +465,7 @@ CONTAINS
    SUBROUTINE get_lowdin_x(shalf, xvec, xt)
 
       TYPE(dbcsr_type)                                   :: shalf
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: xvec
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: xt
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: xvec, xt
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'get_lowdin_x'
 
@@ -478,9 +477,9 @@ CONTAINS
 
       ! Build Lowdin transformed tilde(X)= S^1/2 X for each spin
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(xt(ispin)%matrix, ncol_global=nactive)
+         CALL cp_fm_get_info(xt(ispin), ncol_global=nactive)
          CALL cp_dbcsr_sm_fm_multiply(shalf, xvec(ispin), &
-                                      xt(ispin)%matrix, nactive, alpha=1.0_dp, beta=0.0_dp)
+                                      xt(ispin), nactive, alpha=1.0_dp, beta=0.0_dp)
       END DO
 
       CALL timestop(handle)
@@ -530,10 +529,10 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(atprop_type), POINTER                         :: atprop
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: xtransformed
       TYPE(cp_fm_struct_type), POINTER                   :: fmstruct, fmstructjspin
       TYPE(cp_fm_type)                                   :: cvec, cvecjspin
-      TYPE(cp_fm_type), POINTER                          :: ct, ctjspin, xt
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: xtransformed
+      TYPE(cp_fm_type), POINTER                          :: ct, ctjspin
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_type)                                   :: pdens
@@ -576,8 +575,7 @@ CONTAINS
          NULLIFY (fmstruct)
          ct => work%ctransformed(ispin)
          CALL cp_fm_get_info(ct, matrix_struct=fmstruct)
-         ALLOCATE (xtransformed(ispin)%matrix)
-         CALL cp_fm_create(matrix=xtransformed(ispin)%matrix, matrix_struct=fmstruct, name="XTRANSFORMED")
+         CALL cp_fm_create(matrix=xtransformed(ispin), matrix_struct=fmstruct, name="XTRANSFORMED")
       END DO
       CALL get_lowdin_x(work%shalf, X, xtransformed)
 
@@ -599,12 +597,11 @@ CONTAINS
             tcharge(:) = 0.0_dp
             DO jspin = 1, nspins
                ctjspin => work%ctransformed(jspin)
-               xt => xtransformed(jspin)%matrix
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin)
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin, nrow_global=nsgf)
                CALL cp_fm_create(cvecjspin, fmstructjspin)
                ! CV(mu,j) = CT(mu,j)*XT(mu,j)
-               CALL cp_fm_schur_product(ctjspin, xt, cvecjspin)
+               CALL cp_fm_schur_product(ctjspin, xtransformed(jspin), cvecjspin)
                ! TV(mu) = SUM_j CV(mu,j)
                CALL cp_fm_vectorssum(cvecjspin, tv, "R")
                ! contract charges
@@ -690,9 +687,8 @@ CONTAINS
             CALL dbcsr_create(pdens, template=tempmat, matrix_type=dbcsr_type_no_symmetry)
             ! P(nu,mu) = SUM_j XT(nu,j)*CT(mu,j)
             ct => work%ctransformed(ispin)
-            xt => xtransformed(ispin)%matrix
             CALL dbcsr_set(pdens, 0.0_dp)
-            CALL cp_dbcsr_plus_fm_fm_t(pdens, xt, ct, nactive(ispin), &
+            CALL cp_dbcsr_plus_fm_fm_t(pdens, xtransformed(ispin), ct, nactive(ispin), &
                                        1.0_dp, keep_sparsity=.FALSE.)
             CALL dbcsr_filter(pdens, stda_env%eps_td_filter)
             ! Apply PP*gab -> PP; gab = gamma_coulomb
@@ -736,8 +732,7 @@ CONTAINS
       END DO
 
       DO ispin = 1, nspins
-         CALL cp_fm_release(matrix=xtransformed(ispin)%matrix)
-         DEALLOCATE (xtransformed(ispin)%matrix)
+         CALL cp_fm_release(matrix=xtransformed(ispin))
       END DO
       DEALLOCATE (xtransformed)
       DEALLOCATE (tcharge, gtcharge)

--- a/src/qs_tddfpt2_stda_utils.F
+++ b/src/qs_tddfpt2_stda_utils.F
@@ -465,7 +465,7 @@ CONTAINS
    SUBROUTINE get_lowdin_x(shalf, xvec, xt)
 
       TYPE(dbcsr_type)                                   :: shalf
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: xvec
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: xvec
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: xt
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'get_lowdin_x'
@@ -479,7 +479,7 @@ CONTAINS
       ! Build Lowdin transformed tilde(X)= S^1/2 X for each spin
       DO ispin = 1, nspins
          CALL cp_fm_get_info(xt(ispin)%matrix, ncol_global=nactive)
-         CALL cp_dbcsr_sm_fm_multiply(shalf, xvec(ispin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(shalf, xvec(ispin), &
                                       xt(ispin)%matrix, nactive, alpha=1.0_dp, beta=0.0_dp)
       END DO
 
@@ -509,7 +509,7 @@ CONTAINS
       TYPE(tddfpt_subgroup_env_type)                     :: sub_env
       TYPE(tddfpt_work_matrices)                         :: work
       LOGICAL, INTENT(IN)                                :: is_rks_triplets
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: X
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: X
       TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'stda_calculate_kernel'

--- a/src/qs_tddfpt2_stda_utils.F
+++ b/src/qs_tddfpt2_stda_utils.F
@@ -29,9 +29,14 @@ MODULE qs_tddfpt2_stda_utils
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_info, cp_fm_p_type, cp_fm_release, cp_fm_set_all, &
-        cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type, cp_fm_vectorssum
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_info,&
+                                              cp_fm_release,&
+                                              cp_fm_set_all,&
+                                              cp_fm_set_submatrix,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type,&
+                                              cp_fm_vectorssum
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type
@@ -508,8 +513,7 @@ CONTAINS
       TYPE(tddfpt_subgroup_env_type)                     :: sub_env
       TYPE(tddfpt_work_matrices)                         :: work
       LOGICAL, INTENT(IN)                                :: is_rks_triplets
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: X
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: res
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: X, res
 
       CHARACTER(len=*), PARAMETER :: routineN = 'stda_calculate_kernel'
 
@@ -582,7 +586,7 @@ CONTAINS
       ALLOCATE (tcharge(natom), gtcharge(natom, 1))
 
       DO ispin = 1, nspins
-         CALL cp_fm_set_all(res(ispin)%matrix, 0.0_dp)
+         CALL cp_fm_set_all(res(ispin), 0.0_dp)
       END DO
 
       DO ispin = 1, nspins
@@ -672,7 +676,7 @@ CONTAINS
             CALL cp_fm_to_fm(ct, cvec)
             CALL cp_fm_row_scale(cvec, tv)
             ! rho(nu,i) = rho(nu,i) + Shalf(nu,mu)*CV(mu,i)
-            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, res(ispin)%matrix, nactive(ispin), spinfac, 1.0_dp)
+            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, res(ispin), nactive(ispin), spinfac, 1.0_dp)
          END IF
          !
          ! *** Exchange contribution
@@ -721,7 +725,7 @@ CONTAINS
             ! CV(mu,i) = P(nu,mu)*CT(mu,i)
             CALL cp_dbcsr_sm_fm_multiply(pdens, ct, cvec, nactive(ispin), 1.0_dp, 0.0_dp)
             ! rho(nu,i) = rho(nu,i) + ShalfP(nu,mu)*CV(mu,i)
-            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, res(ispin)%matrix, nactive(ispin), -1.0_dp, 1.0_dp)
+            CALL cp_dbcsr_sm_fm_multiply(work%shalf, cvec, res(ispin), nactive(ispin), -1.0_dp, 1.0_dp)
             !
             CALL dbcsr_release(pdens)
             DEALLOCATE (kind_of)

--- a/src/qs_tddfpt2_stda_utils.F
+++ b/src/qs_tddfpt2_stda_utils.F
@@ -422,7 +422,7 @@ CONTAINS
 
       DO ispin = 1, nspins
          CALL cp_fm_get_info(work%ctransformed(ispin), ncol_global=nactive)
-         CALL cp_dbcsr_sm_fm_multiply(work%shalf, sub_env%mos_occ(ispin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(work%shalf, sub_env%mos_occ(ispin), &
                                       work%ctransformed(ispin), nactive, alpha=1.0_dp, beta=0.0_dp)
       END DO
 

--- a/src/qs_tddfpt2_stda_utils.F
+++ b/src/qs_tddfpt2_stda_utils.F
@@ -416,9 +416,9 @@ CONTAINS
       nspins = SIZE(sub_env%mos_occ)
 
       DO ispin = 1, nspins
-         CALL cp_fm_get_info(work%ctransformed(ispin)%matrix, ncol_global=nactive)
+         CALL cp_fm_get_info(work%ctransformed(ispin), ncol_global=nactive)
          CALL cp_dbcsr_sm_fm_multiply(work%shalf, sub_env%mos_occ(ispin)%matrix, &
-                                      work%ctransformed(ispin)%matrix, nactive, alpha=1.0_dp, beta=0.0_dp)
+                                      work%ctransformed(ispin), nactive, alpha=1.0_dp, beta=0.0_dp)
       END DO
 
       ! for Lowdin forces
@@ -574,7 +574,7 @@ CONTAINS
       ALLOCATE (xtransformed(nspins))
       DO ispin = 1, nspins
          NULLIFY (fmstruct)
-         ct => work%ctransformed(ispin)%matrix
+         ct => work%ctransformed(ispin)
          CALL cp_fm_get_info(ct, matrix_struct=fmstruct)
          ALLOCATE (xtransformed(ispin)%matrix)
          CALL cp_fm_create(matrix=xtransformed(ispin)%matrix, matrix_struct=fmstruct, name="XTRANSFORMED")
@@ -588,7 +588,7 @@ CONTAINS
       END DO
 
       DO ispin = 1, nspins
-         ct => work%ctransformed(ispin)%matrix
+         ct => work%ctransformed(ispin)
          CALL cp_fm_get_info(ct, matrix_struct=fmstruct, nrow_global=nsgf)
          ALLOCATE (tv(nsgf))
          CALL cp_fm_create(cvec, fmstruct)
@@ -598,7 +598,7 @@ CONTAINS
          IF (do_coulomb) THEN
             tcharge(:) = 0.0_dp
             DO jspin = 1, nspins
-               ctjspin => work%ctransformed(jspin)%matrix
+               ctjspin => work%ctransformed(jspin)
                xt => xtransformed(jspin)%matrix
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin)
                CALL cp_fm_get_info(ctjspin, matrix_struct=fmstructjspin, nrow_global=nsgf)
@@ -671,7 +671,7 @@ CONTAINS
                END DO
             END DO
             ! CV(mu,i) = TV(mu)*CV(mu,i)
-            ct => work%ctransformed(ispin)%matrix
+            ct => work%ctransformed(ispin)
             CALL cp_fm_to_fm(ct, cvec)
             CALL cp_fm_row_scale(cvec, tv)
             ! rho(nu,i) = rho(nu,i) + Shalf(nu,mu)*CV(mu,i)
@@ -689,7 +689,7 @@ CONTAINS
             tempmat => work%shalf
             CALL dbcsr_create(pdens, template=tempmat, matrix_type=dbcsr_type_no_symmetry)
             ! P(nu,mu) = SUM_j XT(nu,j)*CT(mu,j)
-            ct => work%ctransformed(ispin)%matrix
+            ct => work%ctransformed(ispin)
             xt => xtransformed(ispin)%matrix
             CALL dbcsr_set(pdens, 0.0_dp)
             CALL cp_dbcsr_plus_fm_fm_t(pdens, xt, ct, nactive(ispin), &

--- a/src/qs_tddfpt2_subgroups.F
+++ b/src/qs_tddfpt2_subgroups.F
@@ -123,7 +123,7 @@ MODULE qs_tddfpt2_subgroups
       TYPE(cp_para_env_type), POINTER                    :: para_env
       !> occupied MOs stored in a matrix form [nao x nmo_occ(spin)] distributed across processes
       !> in the parallel group
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: mos_occ
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)      :: mos_occ
       !> group-specific copy of the ADMM A matrix 'admm_type%A'
       TYPE(cp_fm_type), POINTER                          :: admm_A
       !
@@ -245,13 +245,12 @@ CONTAINS
          NULLIFY (fm_struct)
 
          DO ispin = 1, nspins
-            ALLOCATE (sub_env%mos_occ(ispin)%matrix)
             CALL cp_fm_get_info(mos_occ(ispin)%matrix, nrow_global=nao, ncol_global=nmo_occ)
             CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo_occ, context=sub_env%blacs_env)
-            CALL cp_fm_create(sub_env%mos_occ(ispin)%matrix, fm_struct)
+            CALL cp_fm_create(sub_env%mos_occ(ispin), fm_struct)
             CALL cp_fm_struct_release(fm_struct)
             CALL tddfpt_fm_replicate_across_subgroups(fm_src=mos_occ(ispin)%matrix, &
-                                                      fm_dest_sub=sub_env%mos_occ(ispin)%matrix, sub_env=sub_env)
+                                                      fm_dest_sub=sub_env%mos_occ(ispin), sub_env=sub_env)
          END DO
 
          IF (dft_control%do_admm) THEN
@@ -271,7 +270,7 @@ CONTAINS
          sub_env%blacs_env => blacs_env_global
 
          DO ispin = 1, nspins
-            sub_env%mos_occ(ispin)%matrix => mos_occ(ispin)%matrix
+            sub_env%mos_occ(ispin) = mos_occ(ispin)%matrix
          END DO
 
          IF (dft_control%do_admm) THEN
@@ -476,8 +475,7 @@ CONTAINS
 
       IF (sub_env%is_split) THEN
          DO i = SIZE(sub_env%mos_occ), 1, -1
-            CALL cp_fm_release(sub_env%mos_occ(i)%matrix)
-            DEALLOCATE (sub_env%mos_occ(i)%matrix)
+            CALL cp_fm_release(sub_env%mos_occ(i))
          END DO
       END IF
       DEALLOCATE (sub_env%mos_occ)

--- a/src/qs_tddfpt2_subgroups.F
+++ b/src/qs_tddfpt2_subgroups.F
@@ -27,7 +27,6 @@ MODULE qs_tddfpt2_subgroups
    USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
                                               cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_para_env,                     ONLY: cp_para_env_create,&
@@ -187,7 +186,7 @@ CONTAINS
    SUBROUTINE tddfpt_sub_env_init(sub_env, qs_env, mos_occ, kernel)
       TYPE(tddfpt_subgroup_env_type), INTENT(out)        :: sub_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(in)       :: mos_occ
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(in)         :: mos_occ
       INTEGER, INTENT(in)                                :: kernel
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'tddfpt_sub_env_init'
@@ -245,11 +244,11 @@ CONTAINS
          NULLIFY (fm_struct)
 
          DO ispin = 1, nspins
-            CALL cp_fm_get_info(mos_occ(ispin)%matrix, nrow_global=nao, ncol_global=nmo_occ)
+            CALL cp_fm_get_info(mos_occ(ispin), nrow_global=nao, ncol_global=nmo_occ)
             CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo_occ, context=sub_env%blacs_env)
             CALL cp_fm_create(sub_env%mos_occ(ispin), fm_struct)
             CALL cp_fm_struct_release(fm_struct)
-            CALL tddfpt_fm_replicate_across_subgroups(fm_src=mos_occ(ispin)%matrix, &
+            CALL tddfpt_fm_replicate_across_subgroups(fm_src=mos_occ(ispin), &
                                                       fm_dest_sub=sub_env%mos_occ(ispin), sub_env=sub_env)
          END DO
 
@@ -269,9 +268,7 @@ CONTAINS
          CALL cp_blacs_env_retain(blacs_env_global)
          sub_env%blacs_env => blacs_env_global
 
-         DO ispin = 1, nspins
-            sub_env%mos_occ(ispin) = mos_occ(ispin)%matrix
-         END DO
+         sub_env%mos_occ(:) = mos_occ(:)
 
          IF (dft_control%do_admm) THEN
             CALL get_qs_env(qs_env, admm_env=admm_env)

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -122,9 +122,9 @@ MODULE qs_tddfpt2_types
       !> used mainly to dynamically expand the list of trial vectors
       TYPE(cp_fm_pool_p_type), ALLOCATABLE, DIMENSION(:) :: fm_pool_ao_mo_occ
       !> S * mos_occ(spin)
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: S_C0
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)      :: S_C0
       !> S * \rho_0(spin)
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: S_C0_C0T
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)      :: S_C0_C0T
       !
       ! *** dense matrices distributed across parallel (sub)groups ***
       !
@@ -185,7 +185,7 @@ MODULE qs_tddfpt2_types
       ! Short-range gamma exchange matrix
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: gamma_exchange
       !Lowdin MO coefficients: NAO*NOCC
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: ctransformed
+      TYPE(cp_fm_type), DIMENSION(:), POINTER          :: ctransformed
       !S^1/2
       TYPE(dbcsr_type), POINTER                          :: shalf
       !Eigenvalues/eigenvectors of the overlap matrix, used in sTDA forces (Lowdin derivatives)
@@ -292,20 +292,18 @@ CONTAINS
       ALLOCATE (work_matrices%S_C0_C0T(nspins))
       CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nao, context=blacs_env)
       DO ispin = 1, nspins
-         ALLOCATE (work_matrices%S_C0_C0T(ispin)%matrix)
-         CALL cp_fm_create(work_matrices%S_C0_C0T(ispin)%matrix, fm_struct)
+         CALL cp_fm_create(work_matrices%S_C0_C0T(ispin), fm_struct)
       END DO
       CALL cp_fm_struct_release(fm_struct)
 
       ALLOCATE (work_matrices%S_C0(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (work_matrices%S_C0(ispin)%matrix)
-         CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, work_matrices%S_C0(ispin)%matrix)
+         CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, work_matrices%S_C0(ispin))
 
-         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, gs_mos(ispin)%mos_occ, work_matrices%S_C0(ispin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, gs_mos(ispin)%mos_occ, work_matrices%S_C0(ispin), &
                                       ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
-         CALL parallel_gemm('N', 'T', nao, nao, nmo_occ(ispin), 1.0_dp, work_matrices%S_C0(ispin)%matrix, &
-                            gs_mos(ispin)%mos_occ, 0.0_dp, work_matrices%S_C0_C0T(ispin)%matrix)
+         CALL parallel_gemm('N', 'T', nao, nao, nmo_occ(ispin), 1.0_dp, work_matrices%S_C0(ispin), &
+                            gs_mos(ispin)%mos_occ, 0.0_dp, work_matrices%S_C0_C0T(ispin))
       END DO
 
       IF (sub_env%is_split) THEN
@@ -568,20 +566,18 @@ CONTAINS
       ALLOCATE (work_matrices%S_C0_C0T(nspins))
       CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nao, context=blacs_env)
       DO ispin = 1, nspins
-         ALLOCATE (work_matrices%S_C0_C0T(ispin)%matrix)
-         CALL cp_fm_create(work_matrices%S_C0_C0T(ispin)%matrix, fm_struct)
+         CALL cp_fm_create(work_matrices%S_C0_C0T(ispin), fm_struct)
       END DO
       CALL cp_fm_struct_release(fm_struct)
 
       ALLOCATE (work_matrices%S_C0(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (work_matrices%S_C0(ispin)%matrix)
-         CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, work_matrices%S_C0(ispin)%matrix)
+         CALL fm_pool_create_fm(work_matrices%fm_pool_ao_mo_occ(ispin)%pool, work_matrices%S_C0(ispin))
 
-         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, gs_mos(ispin)%mos_occ, work_matrices%S_C0(ispin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, gs_mos(ispin)%mos_occ, work_matrices%S_C0(ispin), &
                                       ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
-         CALL parallel_gemm('N', 'T', nao, nao, nmo_occ(ispin), 1.0_dp, work_matrices%S_C0(ispin)%matrix, &
-                            gs_mos(ispin)%mos_occ, 0.0_dp, work_matrices%S_C0_C0T(ispin)%matrix)
+         CALL parallel_gemm('N', 'T', nao, nao, nmo_occ(ispin), 1.0_dp, work_matrices%S_C0(ispin), &
+                            gs_mos(ispin)%mos_occ, 0.0_dp, work_matrices%S_C0_C0T(ispin))
       END DO
 
       DO ispin = 1, nspins
@@ -615,8 +611,7 @@ CONTAINS
       ! sTDA specific work arrays
       ALLOCATE (work_matrices%ctransformed(nspins))
       DO ispin = 1, nspins
-         ALLOCATE (work_matrices%ctransformed(ispin)%matrix)
-         CALL cp_fm_create(work_matrices%ctransformed(ispin)%matrix, fm_struct_evects(ispin)%struct)
+         CALL cp_fm_create(work_matrices%ctransformed(ispin), fm_struct_evects(ispin)%struct)
       END DO
       NULLIFY (work_matrices%shalf)
       CALL dbcsr_init_p(work_matrices%shalf)
@@ -770,10 +765,8 @@ CONTAINS
       END IF
 
       DO ispin = SIZE(work_matrices%fm_pool_ao_mo_occ), 1, -1
-         CALL cp_fm_release(work_matrices%S_C0(ispin)%matrix)
-         DEALLOCATE (work_matrices%S_C0(ispin)%matrix)
-         CALL cp_fm_release(work_matrices%S_C0_C0T(ispin)%matrix)
-         DEALLOCATE (work_matrices%S_C0_C0T(ispin)%matrix)
+         CALL cp_fm_release(work_matrices%S_C0(ispin))
+         CALL cp_fm_release(work_matrices%S_C0_C0T(ispin))
       END DO
       DEALLOCATE (work_matrices%S_C0, work_matrices%S_C0_C0T)
 

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -24,7 +24,6 @@ MODULE qs_tddfpt2_types
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_fm_vect,                      ONLY: cp_fm_vect_dealloc
@@ -135,7 +134,7 @@ MODULE qs_tddfpt2_types
       !> evects_sub(spin, state) == null() means that the trial vector is assigned to a different (sub)group
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)   :: evects_sub
       !> action of TDDFPT operator on trial vectors distributed across parallel (sub)groups
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_evects_sub
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_evects_sub
       !> electron density expressed in terms of atomic orbitals using primary basis set
       TYPE(cp_fm_type), POINTER                          :: rho_ao_orb_fm_sub
       !
@@ -314,11 +313,6 @@ CONTAINS
          END DO
 
          ALLOCATE (work_matrices%evects_sub(nspins, nstates), work_matrices%Aop_evects_sub(nspins, nstates))
-         DO istate = 1, nstates
-            DO ispin = 1, nspins
-               NULLIFY (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
-            END DO
-         END DO
 
          CALL get_blacs_info(blacs_env, para_env=para_env)
          igroup = sub_env%group_distribution(para_env%mepos)
@@ -326,9 +320,8 @@ CONTAINS
 
          DO istate = ngroups - igroup, nstates, ngroups
             DO ispin = 1, nspins
-               ALLOCATE (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
                CALL cp_fm_create(work_matrices%evects_sub(ispin, istate), fm_struct_evects(ispin)%struct)
-               CALL cp_fm_create(work_matrices%Aop_evects_sub(ispin, istate)%matrix, fm_struct_evects(ispin)%struct)
+               CALL cp_fm_create(work_matrices%Aop_evects_sub(ispin, istate), fm_struct_evects(ispin)%struct)
             END DO
          END DO
 
@@ -586,11 +579,6 @@ CONTAINS
 
       IF (sub_env%is_split) THEN
          ALLOCATE (work_matrices%evects_sub(nspins, nstates), work_matrices%Aop_evects_sub(nspins, nstates))
-         DO istate = 1, nstates
-            DO ispin = 1, nspins
-               NULLIFY (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
-            END DO
-         END DO
 
          CALL get_blacs_info(blacs_env, para_env=para_env)
          igroup = sub_env%group_distribution(para_env%mepos)
@@ -598,9 +586,8 @@ CONTAINS
 
          DO istate = ngroups - igroup, nstates, ngroups
             DO ispin = 1, nspins
-               ALLOCATE (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
                CALL cp_fm_create(work_matrices%evects_sub(ispin, istate), fm_struct_evects(ispin)%struct)
-               CALL cp_fm_create(work_matrices%Aop_evects_sub(ispin, istate)%matrix, fm_struct_evects(ispin)%struct)
+               CALL cp_fm_create(work_matrices%Aop_evects_sub(ispin, istate), fm_struct_evects(ispin)%struct)
             END DO
          END DO
       END IF
@@ -748,9 +735,7 @@ CONTAINS
       IF (ALLOCATED(work_matrices%evects_sub)) THEN
          DO istate = SIZE(work_matrices%evects_sub, 2), 1, -1
             DO ispin = SIZE(work_matrices%evects_sub, 1), 1, -1
-               IF (ASSOCIATED(work_matrices%Aop_evects_sub(ispin, istate)%matrix)) THEN
-                  CALL cp_fm_release(work_matrices%Aop_evects_sub(ispin, istate)%matrix)
-               END IF
+               CALL cp_fm_release(work_matrices%Aop_evects_sub(ispin, istate))
                CALL cp_fm_release(work_matrices%evects_sub(ispin, istate))
             END DO
          END DO

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -133,7 +133,7 @@ MODULE qs_tddfpt2_types
       !> is typically much smaller than the total number of Krylov's vectors. Allocated only if
       !> the number of parallel groups > 1, otherwise we use the original globally distributed vectors.
       !> evects_sub(spin, state) == null() means that the trial vector is assigned to a different (sub)group
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: evects_sub
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)   :: evects_sub
       !> action of TDDFPT operator on trial vectors distributed across parallel (sub)groups
       TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:, :)   :: Aop_evects_sub
       !> electron density expressed in terms of atomic orbitals using primary basis set
@@ -316,7 +316,6 @@ CONTAINS
          ALLOCATE (work_matrices%evects_sub(nspins, nstates), work_matrices%Aop_evects_sub(nspins, nstates))
          DO istate = 1, nstates
             DO ispin = 1, nspins
-               NULLIFY (work_matrices%evects_sub(ispin, istate)%matrix)
                NULLIFY (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
             END DO
          END DO
@@ -327,9 +326,8 @@ CONTAINS
 
          DO istate = ngroups - igroup, nstates, ngroups
             DO ispin = 1, nspins
-               ALLOCATE (work_matrices%evects_sub(ispin, istate)%matrix, &
-                         work_matrices%Aop_evects_sub(ispin, istate)%matrix)
-               CALL cp_fm_create(work_matrices%evects_sub(ispin, istate)%matrix, fm_struct_evects(ispin)%struct)
+               ALLOCATE (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
+               CALL cp_fm_create(work_matrices%evects_sub(ispin, istate), fm_struct_evects(ispin)%struct)
                CALL cp_fm_create(work_matrices%Aop_evects_sub(ispin, istate)%matrix, fm_struct_evects(ispin)%struct)
             END DO
          END DO
@@ -590,7 +588,6 @@ CONTAINS
          ALLOCATE (work_matrices%evects_sub(nspins, nstates), work_matrices%Aop_evects_sub(nspins, nstates))
          DO istate = 1, nstates
             DO ispin = 1, nspins
-               NULLIFY (work_matrices%evects_sub(ispin, istate)%matrix)
                NULLIFY (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
             END DO
          END DO
@@ -601,8 +598,8 @@ CONTAINS
 
          DO istate = ngroups - igroup, nstates, ngroups
             DO ispin = 1, nspins
-               ALLOCATE (work_matrices%evects_sub(ispin, istate)%matrix, work_matrices%Aop_evects_sub(ispin, istate)%matrix)
-               CALL cp_fm_create(work_matrices%evects_sub(ispin, istate)%matrix, fm_struct_evects(ispin)%struct)
+               ALLOCATE (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
+               CALL cp_fm_create(work_matrices%evects_sub(ispin, istate), fm_struct_evects(ispin)%struct)
                CALL cp_fm_create(work_matrices%Aop_evects_sub(ispin, istate)%matrix, fm_struct_evects(ispin)%struct)
             END DO
          END DO
@@ -753,12 +750,8 @@ CONTAINS
             DO ispin = SIZE(work_matrices%evects_sub, 1), 1, -1
                IF (ASSOCIATED(work_matrices%Aop_evects_sub(ispin, istate)%matrix)) THEN
                   CALL cp_fm_release(work_matrices%Aop_evects_sub(ispin, istate)%matrix)
-                  DEALLOCATE (work_matrices%Aop_evects_sub(ispin, istate)%matrix)
                END IF
-               IF (ASSOCIATED(work_matrices%evects_sub(ispin, istate)%matrix)) THEN
-                  CALL cp_fm_release(work_matrices%evects_sub(ispin, istate)%matrix)
-                  DEALLOCATE (work_matrices%evects_sub(ispin, istate)%matrix)
-               END IF
+               CALL cp_fm_release(work_matrices%evects_sub(ispin, istate))
             END DO
          END DO
          DEALLOCATE (work_matrices%Aop_evects_sub, work_matrices%evects_sub)

--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -24,7 +24,6 @@ MODULE qs_tddfpt2_utils
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
@@ -937,7 +936,7 @@ CONTAINS
 !>       \endparblock
 ! **************************************************************************************************
    SUBROUTINE tddfpt_guess_vectors(evects, evals, gs_mos, log_unit)
-      TYPE(cp_fm_p_type), DIMENSION(:, :), INTENT(inout) :: evects
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(inout)   :: evects
       REAL(kind=dp), DIMENSION(:), INTENT(inout)         :: evals
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          INTENT(in)                                      :: gs_mos
@@ -1022,7 +1021,7 @@ CONTAINS
       END IF
 
       DO istate = 1, nstates
-         IF (ASSOCIATED(evects(1, istate)%matrix)) THEN
+         IF (ASSOCIATED(evects(1, istate)%matrix_struct)) THEN
             IF (log_unit > 0) &
                WRITE (log_unit, '(T7,I8,T28,A19,T60,F14.5)') &
                istate, "***  restarted  ***", evals(istate)*evolt
@@ -1048,13 +1047,12 @@ CONTAINS
                istate, imo_occ, spin_label, nmo_occ_avail(ispin) + imo_virt, spin_label, e_virt_minus_occ(istate)*evolt
 
             DO jspin = 1, nspins
-               ! .NOT. ASSOCIATED(evects(jspin, istate)%matrix))
-               ALLOCATE (evects(jspin, istate)%matrix)
-               CALL cp_fm_create(evects(jspin, istate)%matrix, fm_struct_evects(jspin)%struct)
-               CALL cp_fm_set_all(evects(jspin, istate)%matrix, 0.0_dp)
+               ! .NOT. ASSOCIATED(evects(jspin, istate)%matrix_struct))
+               CALL cp_fm_create(evects(jspin, istate), fm_struct_evects(jspin)%struct)
+               CALL cp_fm_set_all(evects(jspin, istate), 0.0_dp)
 
                IF (jspin == ispin) &
-                  CALL cp_fm_to_fm(gs_mos(ispin)%mos_virt, evects(ispin, istate)%matrix, &
+                  CALL cp_fm_to_fm(gs_mos(ispin)%mos_virt, evects(ispin, istate), &
                                    ncol=1, source_start=imo_virt, target_start=imo_occ)
             END DO
          END IF

--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -116,7 +116,8 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: evals_virt
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mos_virt
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &
+         TARGET                                          :: mos_virt
       TYPE(cp_fm_type), POINTER                          :: mos_virt_spin
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -143,7 +144,7 @@ CONTAINS
       ! when the number of unoccupied orbitals is limited and OT has been used
       ! for the ground-state DFT calculation,
       ! compute the missing unoccupied orbitals using OT as well.
-      NULLIFY (evals_virt, evals_virt_spin, mos_virt, mos_virt_spin)
+      NULLIFY (evals_virt, evals_virt_spin, mos_virt_spin)
       IF (ASSOCIATED(scf_env)) THEN
          IF ((scf_env%method == ot_method_nr .AND. tddfpt_control%nlumo > 0) .OR. &
              (scf_env%method == ot_method_nr .AND. print_virtuals_newtonx)) THEN
@@ -173,8 +174,8 @@ CONTAINS
          ELSE
             NULLIFY (evals_virt_spin)
          END IF
-         IF (ASSOCIATED(mos_virt)) THEN
-            mos_virt_spin => mos_virt(ispin)%matrix
+         IF (ALLOCATED(mos_virt)) THEN
+            mos_virt_spin => mos_virt(ispin)
          ELSE
             NULLIFY (mos_virt_spin)
          END IF
@@ -208,12 +209,9 @@ CONTAINS
          DEALLOCATE (evals_virt)
       END IF
 
-      IF (ASSOCIATED(mos_virt)) THEN
+      IF (ALLOCATED(mos_virt)) THEN
          DO ispin = 1, SIZE(mos_virt)
-            IF (ASSOCIATED(mos_virt(ispin)%matrix)) THEN
-               CALL cp_fm_release(mos_virt(ispin)%matrix)
-               DEALLOCATE (mos_virt(ispin)%matrix)
-            END IF
+            CALL cp_fm_release(mos_virt(ispin))
          END DO
          DEALLOCATE (mos_virt)
       END IF

--- a/src/qs_tddfpt_eigensolver.F
+++ b/src/qs_tddfpt_eigensolver.F
@@ -188,12 +188,12 @@ CONTAINS
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :)        :: evals
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: R, X
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: b, Sb
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: b
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools
       TYPE(cp_fm_struct_p_type), DIMENSION(:), POINTER   :: kv_fm_struct
       TYPE(cp_fm_struct_type), POINTER                   :: tilde_fm_struct
       TYPE(cp_fm_type)                                   :: Atilde, Us
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Ab
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Ab, Sb
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -203,7 +203,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (ao_mo_fm_pools, X, R, b, Sb, tddfpt_control, &
+      NULLIFY (ao_mo_fm_pools, X, R, b, tddfpt_control, &
                tilde_fm_struct, matrix_s, dft_control, &
                para_env, blacs_env)
 
@@ -264,7 +264,7 @@ CONTAINS
       END DO
       DO spin = 1, nspins
          DO i = 1, max_kv
-            NULLIFY (b(i, spin)%matrix, Sb(i, spin)%matrix)
+            NULLIFY (b(i, spin)%matrix)
          END DO
       END DO
 
@@ -282,7 +282,7 @@ CONTAINS
 
          CALL allocate_krylov_vectors(b, "b-", k + 1, n_kv, nspins, kv_fm_struct)
          CALL allocate_krylov_vectors_2(Ab, "Ab-", k + 1, n_kv, nspins, kv_fm_struct)
-         CALL allocate_krylov_vectors(Sb, "Sb-", k + 1, n_kv, nspins, kv_fm_struct)
+         CALL allocate_krylov_vectors_2(Sb, "Sb-", k + 1, n_kv, nspins, kv_fm_struct)
 
          DO i = 1, n_kv
             k = k + 1
@@ -319,7 +319,7 @@ CONTAINS
                      DO j = 1, k - i
                         CALL cp_fm_to_fm(Ab(j, spin), X(spin)%matrix)
                         CALL cp_fm_scale_and_add(1.0_dp, X(spin)%matrix, &
-                                                 -evals(iev, iter - 1), Sb(j, spin)%matrix)
+                                                 -evals(iev, iter - 1), Sb(j, spin))
                         CALL cp_fm_get_element(Us, j, iev, tmp)
                         CALL cp_fm_scale_and_add(1.0_dp, R(spin)%matrix, &
                                                  tmp, X(spin)%matrix)
@@ -377,7 +377,7 @@ CONTAINS
             DO spin = 1, nspins
                CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, &
                                             b(k, spin)%matrix, &
-                                            Sb(k, spin)%matrix, &
+                                            Sb(k, spin), &
                                             p_env%n_mo(spin))
             END DO
          END DO
@@ -504,10 +504,7 @@ CONTAINS
                DEALLOCATE (b(i, spin)%matrix)
             END IF
             CALL cp_fm_release(Ab(i, spin))
-            IF (ASSOCIATED(Sb(i, spin)%matrix)) THEN
-               CALL cp_fm_release(Sb(i, spin)%matrix)
-               DEALLOCATE (Sb(i, spin)%matrix)
-            END IF
+            CALL cp_fm_release(Sb(i, spin))
          END DO
       END DO
       DEALLOCATE (b, Ab, Sb, evals, evals_tmp, evals_difference, must_improve, kv_fm_struct)

--- a/src/qs_tddfpt_eigensolver.F
+++ b/src/qs_tddfpt_eigensolver.F
@@ -295,7 +295,7 @@ CONTAINS
                   DO spin = 1, nspins
                      IF (tddfpt_control%invert_S) THEN
                         CALL cp_fm_symm('L', 'U', p_env%n_ao(spin), p_env%n_mo(spin), &
-                                        1.0_dp, t_env%invS(spin)%matrix, Ab(k - 1, spin), &
+                                        1.0_dp, t_env%invS(spin), Ab(k - 1, spin), &
                                         0.0_dp, b(k, spin))
                      ELSE
                         CALL cp_fm_to_fm(Ab(k - 1, spin), b(k, spin))
@@ -320,7 +320,7 @@ CONTAINS
 
                      IF (tddfpt_control%invert_S) THEN
                         CALL cp_fm_symm('L', 'U', p_env%n_ao(spin), p_env%n_mo(spin), &
-                                        1.0_dp, t_env%invS(spin)%matrix, R(spin), &
+                                        1.0_dp, t_env%invS(spin), R(spin), &
                                         0.0_dp, X(spin))
                      ELSE
                         CALL cp_fm_to_fm(R(spin), X(spin))

--- a/src/qs_tddfpt_eigensolver.F
+++ b/src/qs_tddfpt_eigensolver.F
@@ -284,7 +284,7 @@ CONTAINS
 
                ! take the initial guess
                DO spin = 1, nspins
-                  CALL cp_fm_to_fm(t_env%evecs(k, spin)%matrix, b(k, spin))
+                  CALL cp_fm_to_fm(t_env%evecs(k, spin), b(k, spin))
                END DO
 
             ELSE
@@ -471,10 +471,10 @@ CONTAINS
 
       DO spin = 1, nspins
          DO j = 1, n_ev
-            CALL cp_fm_set_all(t_env%evecs(j, spin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(t_env%evecs(j, spin), 0.0_dp)
             DO i = 1, k
                CALL cp_fm_get_element(Us, i, j, tmp)
-               CALL cp_fm_scale_and_add(1.0_dp, t_env%evecs(j, spin)%matrix, &
+               CALL cp_fm_scale_and_add(1.0_dp, t_env%evecs(j, spin), &
                                         tmp, b(i, spin))
             END DO
          END DO

--- a/src/qs_tddfpt_eigensolver.F
+++ b/src/qs_tddfpt_eigensolver.F
@@ -188,12 +188,11 @@ CONTAINS
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :)        :: evals
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: R, X
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: b
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools
       TYPE(cp_fm_struct_p_type), DIMENSION(:), POINTER   :: kv_fm_struct
       TYPE(cp_fm_struct_type), POINTER                   :: tilde_fm_struct
       TYPE(cp_fm_type)                                   :: Atilde, Us
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Ab, Sb
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Ab, b, Sb
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -203,7 +202,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (ao_mo_fm_pools, X, R, b, tddfpt_control, &
+      NULLIFY (ao_mo_fm_pools, X, R, tddfpt_control, &
                tilde_fm_struct, matrix_s, dft_control, &
                para_env, blacs_env)
 
@@ -262,11 +261,6 @@ CONTAINS
          CALL cp_fm_struct_create(kv_fm_struct(spin)%struct, para_env, blacs_env, &
                                   p_env%n_ao(spin), p_env%n_mo(spin))
       END DO
-      DO spin = 1, nspins
-         DO i = 1, max_kv
-            NULLIFY (b(i, spin)%matrix)
-         END DO
-      END DO
 
       IF (output_unit > 0) THEN
          WRITE (output_unit, '(2X,A,T69,A)') &
@@ -281,8 +275,8 @@ CONTAINS
       iteration: DO
 
          CALL allocate_krylov_vectors(b, "b-", k + 1, n_kv, nspins, kv_fm_struct)
-         CALL allocate_krylov_vectors_2(Ab, "Ab-", k + 1, n_kv, nspins, kv_fm_struct)
-         CALL allocate_krylov_vectors_2(Sb, "Sb-", k + 1, n_kv, nspins, kv_fm_struct)
+         CALL allocate_krylov_vectors(Ab, "Ab-", k + 1, n_kv, nspins, kv_fm_struct)
+         CALL allocate_krylov_vectors(Sb, "Sb-", k + 1, n_kv, nspins, kv_fm_struct)
 
          DO i = 1, n_kv
             k = k + 1
@@ -291,7 +285,7 @@ CONTAINS
 
                ! take the initial guess
                DO spin = 1, nspins
-                  CALL cp_fm_to_fm(t_env%evecs(k, spin)%matrix, b(k, spin)%matrix)
+                  CALL cp_fm_to_fm(t_env%evecs(k, spin)%matrix, b(k, spin))
                END DO
 
             ELSE
@@ -303,9 +297,9 @@ CONTAINS
                      IF (tddfpt_control%invert_S) THEN
                         CALL cp_fm_symm('L', 'U', p_env%n_ao(spin), p_env%n_mo(spin), &
                                         1.0_dp, t_env%invS(spin)%matrix, Ab(k - 1, spin), &
-                                        0.0_dp, b(k, spin)%matrix)
+                                        0.0_dp, b(k, spin))
                      ELSE
-                        CALL cp_fm_to_fm(Ab(k - 1, spin), b(k, spin)%matrix)
+                        CALL cp_fm_to_fm(Ab(k - 1, spin), b(k, spin))
                      END IF
                   END DO
 
@@ -347,11 +341,11 @@ CONTAINS
                            tmp2 = MAX(tmp2, 100*EPSILON(1.0_dp))
                            DO row = 1, p_env%n_ao(spin)
                               CALL cp_fm_get_element(X(spin)%matrix, row, col, tmp)
-                              CALL cp_fm_set_element(b(k, spin)%matrix, row, col, tmp/tmp2)
+                              CALL cp_fm_set_element(b(k, spin), row, col, tmp/tmp2)
                            END DO
                         END DO
                      ELSE
-                        CALL cp_fm_to_fm(X(spin)%matrix, b(k, spin)%matrix)
+                        CALL cp_fm_to_fm(X(spin)%matrix, b(k, spin))
                      END IF
 
                   END DO
@@ -369,14 +363,14 @@ CONTAINS
             END DO
             CALL normalize(b(k, :), R, matrix_s) ! R is temp
             DO spin = 1, nspins
-               CALL cp_fm_to_fm(b(k, spin)%matrix, X(spin)%matrix)
+               CALL cp_fm_to_fm(b(k, spin), X(spin)%matrix)
             END DO
             CALL apply_op(X, Ab(k, :), p_env, qs_env, &
                           dft_control%tddfpt_control%do_kernel)
             CALL p_postortho(p_env, qs_env, Ab(k, :))
             DO spin = 1, nspins
                CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, &
-                                            b(k, spin)%matrix, &
+                                            b(k, spin), &
                                             Sb(k, spin), &
                                             p_env%n_mo(spin))
             END DO
@@ -407,7 +401,7 @@ CONTAINS
             DO j = 1, k
                Atilde_ij = 0.0_dp
                DO spin = 1, nspins
-                  CALL cp_fm_trace(b(i, spin)%matrix, Ab(j, spin), tmp)
+                  CALL cp_fm_trace(b(i, spin), Ab(j, spin), tmp)
                   Atilde_ij = Atilde_ij + tmp
                END DO
                CALL cp_fm_set_element(Atilde, i, j, Atilde_ij)
@@ -482,7 +476,7 @@ CONTAINS
             DO i = 1, k
                CALL cp_fm_get_element(Us, i, j, tmp)
                CALL cp_fm_scale_and_add(1.0_dp, t_env%evecs(j, spin)%matrix, &
-                                        tmp, b(i, spin)%matrix)
+                                        tmp, b(i, spin))
             END DO
          END DO
       END DO
@@ -499,10 +493,7 @@ CONTAINS
       DO spin = 1, nspins
          CALL cp_fm_struct_release(kv_fm_struct(spin)%struct)
          DO i = 1, max_kv
-            IF (ASSOCIATED(b(i, spin)%matrix)) THEN
-               CALL cp_fm_release(b(i, spin)%matrix)
-               DEALLOCATE (b(i, spin)%matrix)
-            END IF
+            CALL cp_fm_release(b(i, spin))
             CALL cp_fm_release(Ab(i, spin))
             CALL cp_fm_release(Sb(i, spin))
          END DO
@@ -595,50 +586,12 @@ CONTAINS
    SUBROUTINE allocate_krylov_vectors(vectors, vectors_name, &
                                       startv, n_v, nspins, fm_struct)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: vectors
-      CHARACTER(LEN=*), INTENT(IN)                       :: vectors_name
-      INTEGER, INTENT(IN)                                :: startv, n_v, nspins
-      TYPE(cp_fm_struct_p_type), DIMENSION(:), POINTER   :: fm_struct
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_krylov_vectors', &
-         routineP = moduleN//':'//routineN
-
-      CHARACTER(LEN=default_string_length)               :: mat_name
-      INTEGER                                            :: index, spin
-
-      DO spin = 1, nspins
-         DO index = startv, startv + n_v - 1
-            NULLIFY (vectors(index, spin)%matrix)
-            mat_name = routineP//vectors_name//TRIM(cp_to_string(index)) &
-                       //","//TRIM(cp_to_string(spin))
-            ALLOCATE (vectors(index, spin)%matrix)
-            CALL cp_fm_create(vectors(index, spin)%matrix, &
-                              fm_struct(spin)%struct, mat_name)
-            IF (.NOT. ASSOCIATED(vectors(index, spin)%matrix)) &
-               CPABORT("Could not allocate "//TRIM(mat_name)//".")
-         END DO
-      END DO
-
-   END SUBROUTINE allocate_krylov_vectors
-
-! **************************************************************************************************
-!> \brief ...
-!> \param vectors ...
-!> \param vectors_name ...
-!> \param startv ...
-!> \param n_v ...
-!> \param nspins ...
-!> \param fm_struct ...
-! **************************************************************************************************
-   SUBROUTINE allocate_krylov_vectors_2(vectors, vectors_name, &
-                                        startv, n_v, nspins, fm_struct)
-
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: vectors
       CHARACTER(LEN=*), INTENT(IN)                       :: vectors_name
       INTEGER, INTENT(IN)                                :: startv, n_v, nspins
       TYPE(cp_fm_struct_p_type), DIMENSION(:), POINTER   :: fm_struct
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_krylov_vectors_2', &
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_krylov_vectors', &
          routineP = moduleN//':'//routineN
 
       CHARACTER(LEN=default_string_length)               :: mat_name
@@ -655,6 +608,6 @@ CONTAINS
          END DO
       END DO
 
-   END SUBROUTINE allocate_krylov_vectors_2
+   END SUBROUTINE allocate_krylov_vectors
 
 END MODULE qs_tddfpt_eigensolver

--- a/src/qs_tddfpt_eigensolver.F
+++ b/src/qs_tddfpt_eigensolver.F
@@ -188,11 +188,12 @@ CONTAINS
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :)        :: evals
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: R, X
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: Ab, b, Sb
+      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: b, Sb
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools
       TYPE(cp_fm_struct_p_type), DIMENSION(:), POINTER   :: kv_fm_struct
       TYPE(cp_fm_struct_type), POINTER                   :: tilde_fm_struct
       TYPE(cp_fm_type)                                   :: Atilde, Us
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Ab
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -202,7 +203,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (ao_mo_fm_pools, X, R, b, Ab, Sb, tddfpt_control, &
+      NULLIFY (ao_mo_fm_pools, X, R, b, Sb, tddfpt_control, &
                tilde_fm_struct, matrix_s, dft_control, &
                para_env, blacs_env)
 
@@ -263,7 +264,7 @@ CONTAINS
       END DO
       DO spin = 1, nspins
          DO i = 1, max_kv
-            NULLIFY (b(i, spin)%matrix, Ab(i, spin)%matrix, Sb(i, spin)%matrix)
+            NULLIFY (b(i, spin)%matrix, Sb(i, spin)%matrix)
          END DO
       END DO
 
@@ -280,7 +281,7 @@ CONTAINS
       iteration: DO
 
          CALL allocate_krylov_vectors(b, "b-", k + 1, n_kv, nspins, kv_fm_struct)
-         CALL allocate_krylov_vectors(Ab, "Ab-", k + 1, n_kv, nspins, kv_fm_struct)
+         CALL allocate_krylov_vectors_2(Ab, "Ab-", k + 1, n_kv, nspins, kv_fm_struct)
          CALL allocate_krylov_vectors(Sb, "Sb-", k + 1, n_kv, nspins, kv_fm_struct)
 
          DO i = 1, n_kv
@@ -301,10 +302,10 @@ CONTAINS
                   DO spin = 1, nspins
                      IF (tddfpt_control%invert_S) THEN
                         CALL cp_fm_symm('L', 'U', p_env%n_ao(spin), p_env%n_mo(spin), &
-                                        1.0_dp, t_env%invS(spin)%matrix, Ab(k - 1, spin)%matrix, &
+                                        1.0_dp, t_env%invS(spin)%matrix, Ab(k - 1, spin), &
                                         0.0_dp, b(k, spin)%matrix)
                      ELSE
-                        CALL cp_fm_to_fm(Ab(k - 1, spin)%matrix, b(k, spin)%matrix)
+                        CALL cp_fm_to_fm(Ab(k - 1, spin), b(k, spin)%matrix)
                      END IF
                   END DO
 
@@ -316,7 +317,7 @@ CONTAINS
 
                      CALL cp_fm_set_all(R(spin)%matrix, 0.0_dp)
                      DO j = 1, k - i
-                        CALL cp_fm_to_fm(Ab(j, spin)%matrix, X(spin)%matrix)
+                        CALL cp_fm_to_fm(Ab(j, spin), X(spin)%matrix)
                         CALL cp_fm_scale_and_add(1.0_dp, X(spin)%matrix, &
                                                  -evals(iev, iter - 1), Sb(j, spin)%matrix)
                         CALL cp_fm_get_element(Us, j, iev, tmp)
@@ -406,7 +407,7 @@ CONTAINS
             DO j = 1, k
                Atilde_ij = 0.0_dp
                DO spin = 1, nspins
-                  CALL cp_fm_trace(b(i, spin)%matrix, Ab(j, spin)%matrix, tmp)
+                  CALL cp_fm_trace(b(i, spin)%matrix, Ab(j, spin), tmp)
                   Atilde_ij = Atilde_ij + tmp
                END DO
                CALL cp_fm_set_element(Atilde, i, j, Atilde_ij)
@@ -502,10 +503,7 @@ CONTAINS
                CALL cp_fm_release(b(i, spin)%matrix)
                DEALLOCATE (b(i, spin)%matrix)
             END IF
-            IF (ASSOCIATED(Ab(i, spin)%matrix)) THEN
-               CALL cp_fm_release(Ab(i, spin)%matrix)
-               DEALLOCATE (Ab(i, spin)%matrix)
-            END IF
+            CALL cp_fm_release(Ab(i, spin))
             IF (ASSOCIATED(Sb(i, spin)%matrix)) THEN
                CALL cp_fm_release(Sb(i, spin)%matrix)
                DEALLOCATE (Sb(i, spin)%matrix)
@@ -535,7 +533,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE apply_op(X, R, p_env, qs_env, do_kernel)
 
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: X, R
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: X
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: R
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN)                                :: do_kernel
@@ -578,7 +577,7 @@ CONTAINS
          CALL p_op_l2(p_env, qs_env, p_env%p1, X, &
                       alpha=1.0_dp, beta=0.0_dp) ! X = beta*X + alpha*K(P1)*C
          DO spin = 1, nspins
-            CALL cp_fm_scale_and_add(1.0_dp, R(spin)%matrix, &
+            CALL cp_fm_scale_and_add(1.0_dp, R(spin), &
                                      1.0_dp, X(spin)%matrix) ! add X to R
          END DO
       END IF
@@ -624,5 +623,41 @@ CONTAINS
       END DO
 
    END SUBROUTINE allocate_krylov_vectors
+
+! **************************************************************************************************
+!> \brief ...
+!> \param vectors ...
+!> \param vectors_name ...
+!> \param startv ...
+!> \param n_v ...
+!> \param nspins ...
+!> \param fm_struct ...
+! **************************************************************************************************
+   SUBROUTINE allocate_krylov_vectors_2(vectors, vectors_name, &
+                                        startv, n_v, nspins, fm_struct)
+
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: vectors
+      CHARACTER(LEN=*), INTENT(IN)                       :: vectors_name
+      INTEGER, INTENT(IN)                                :: startv, n_v, nspins
+      TYPE(cp_fm_struct_p_type), DIMENSION(:), POINTER   :: fm_struct
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'allocate_krylov_vectors_2', &
+         routineP = moduleN//':'//routineN
+
+      CHARACTER(LEN=default_string_length)               :: mat_name
+      INTEGER                                            :: index, spin
+
+      DO spin = 1, nspins
+         DO index = startv, startv + n_v - 1
+            mat_name = routineP//vectors_name//TRIM(cp_to_string(index)) &
+                       //","//TRIM(cp_to_string(spin))
+            CALL cp_fm_create(vectors(index, spin), &
+                              fm_struct(spin)%struct, mat_name)
+            IF (.NOT. ASSOCIATED(vectors(index, spin)%matrix_struct)) &
+               CPABORT("Could not allocate "//TRIM(mat_name)//".")
+         END DO
+      END DO
+
+   END SUBROUTINE allocate_krylov_vectors_2
 
 END MODULE qs_tddfpt_eigensolver

--- a/src/qs_tddfpt_eigensolver.F
+++ b/src/qs_tddfpt_eigensolver.F
@@ -25,7 +25,6 @@ MODULE qs_tddfpt_eigensolver
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_element,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_set_element,&
@@ -187,11 +186,11 @@ CONTAINS
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: evals_difference, evals_tmp
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :)        :: evals
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: R, X
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools
       TYPE(cp_fm_struct_p_type), DIMENSION(:), POINTER   :: kv_fm_struct
       TYPE(cp_fm_struct_type), POINTER                   :: tilde_fm_struct
       TYPE(cp_fm_type)                                   :: Atilde, Us
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: R, X
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: Ab, b, Sb
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
@@ -202,7 +201,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (ao_mo_fm_pools, X, R, tddfpt_control, &
+      NULLIFY (ao_mo_fm_pools, tddfpt_control, &
                tilde_fm_struct, matrix_s, dft_control, &
                para_env, blacs_env)
 
@@ -309,22 +308,22 @@ CONTAINS
                   ! create the new davidson vector
                   DO spin = 1, nspins
 
-                     CALL cp_fm_set_all(R(spin)%matrix, 0.0_dp)
+                     CALL cp_fm_set_all(R(spin), 0.0_dp)
                      DO j = 1, k - i
-                        CALL cp_fm_to_fm(Ab(j, spin), X(spin)%matrix)
-                        CALL cp_fm_scale_and_add(1.0_dp, X(spin)%matrix, &
+                        CALL cp_fm_to_fm(Ab(j, spin), X(spin))
+                        CALL cp_fm_scale_and_add(1.0_dp, X(spin), &
                                                  -evals(iev, iter - 1), Sb(j, spin))
                         CALL cp_fm_get_element(Us, j, iev, tmp)
-                        CALL cp_fm_scale_and_add(1.0_dp, R(spin)%matrix, &
-                                                 tmp, X(spin)%matrix)
+                        CALL cp_fm_scale_and_add(1.0_dp, R(spin), &
+                                                 tmp, X(spin))
                      END DO
 
                      IF (tddfpt_control%invert_S) THEN
                         CALL cp_fm_symm('L', 'U', p_env%n_ao(spin), p_env%n_mo(spin), &
-                                        1.0_dp, t_env%invS(spin)%matrix, R(spin)%matrix, &
-                                        0.0_dp, X(spin)%matrix)
+                                        1.0_dp, t_env%invS(spin)%matrix, R(spin), &
+                                        0.0_dp, X(spin))
                      ELSE
-                        CALL cp_fm_to_fm(R(spin)%matrix, X(spin)%matrix)
+                        CALL cp_fm_to_fm(R(spin), X(spin))
                      END IF
 
                      !----------------!
@@ -340,12 +339,12 @@ CONTAINS
                            ! protect against division by 0 by a introducing a cutoff.
                            tmp2 = MAX(tmp2, 100*EPSILON(1.0_dp))
                            DO row = 1, p_env%n_ao(spin)
-                              CALL cp_fm_get_element(X(spin)%matrix, row, col, tmp)
+                              CALL cp_fm_get_element(X(spin), row, col, tmp)
                               CALL cp_fm_set_element(b(k, spin), row, col, tmp/tmp2)
                            END DO
                         END DO
                      ELSE
-                        CALL cp_fm_to_fm(X(spin)%matrix, b(k, spin))
+                        CALL cp_fm_to_fm(X(spin), b(k, spin))
                      END IF
 
                   END DO
@@ -363,7 +362,7 @@ CONTAINS
             END DO
             CALL normalize(b(k, :), R, matrix_s) ! R is temp
             DO spin = 1, nspins
-               CALL cp_fm_to_fm(b(k, spin), X(spin)%matrix)
+               CALL cp_fm_to_fm(b(k, spin), X(spin))
             END DO
             CALL apply_op(X, Ab(k, :), p_env, qs_env, &
                           dft_control%tddfpt_control%do_kernel)
@@ -489,7 +488,6 @@ CONTAINS
       IF (ASSOCIATED(tilde_fm_struct)) CALL cp_fm_struct_release(tilde_fm_struct)
       CALL fm_pools_give_back_fm_vect(ao_mo_fm_pools, X)
       CALL fm_pools_give_back_fm_vect(ao_mo_fm_pools, R)
-      NULLIFY (X, R)
       DO spin = 1, nspins
          CALL cp_fm_struct_release(kv_fm_struct(spin)%struct)
          DO i = 1, max_kv
@@ -521,8 +519,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE apply_op(X, R, p_env, qs_env, do_kernel)
 
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: X
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: R
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: X, R
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
       LOGICAL, INTENT(IN)                                :: do_kernel
@@ -555,18 +552,18 @@ CONTAINS
             CALL dbcsr_set(p_env%p1(spin)%matrix, 0.0_dp) ! optimize?
             CALL cp_dbcsr_plus_fm_fm_t(p_env%p1(spin)%matrix, &
                                        matrix_v=p_env%psi0d(spin), &
-                                       matrix_g=X(spin)%matrix, &
+                                       matrix_g=X(spin), &
                                        ncol=p_env%n_mo(spin), &
                                        symmetry_mode=1)
          END DO
          DO spin = 1, nspins
-            CALL cp_fm_set_all(X(spin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(X(spin), 0.0_dp)
          END DO
          CALL p_op_l2(p_env, qs_env, p_env%p1, X, &
                       alpha=1.0_dp, beta=0.0_dp) ! X = beta*X + alpha*K(P1)*C
          DO spin = 1, nspins
             CALL cp_fm_scale_and_add(1.0_dp, R(spin), &
-                                     1.0_dp, X(spin)%matrix) ! add X to R
+                                     1.0_dp, X(spin)) ! add X to R
          END DO
       END IF
 

--- a/src/qs_tddfpt_types.F
+++ b/src/qs_tddfpt_types.F
@@ -16,7 +16,6 @@ MODULE qs_tddfpt_types
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
@@ -32,7 +31,7 @@ MODULE qs_tddfpt_types
 ! **************************************************************************************************
    TYPE tddfpt_env_type
       REAL(KIND=dp), DIMENSION(:), POINTER               :: evals ! eigenvalues
-      TYPE(cp_fm_p_type), DIMENSION(:, :), &
+      TYPE(cp_fm_type), DIMENSION(:, :), &
          POINTER                                       :: evecs ! eigenvectors
       TYPE(cp_fm_type), DIMENSION(:), POINTER          :: invS ! the inverse of the metric
       TYPE(cp_fm_pool_p_type), DIMENSION(:), &
@@ -86,9 +85,8 @@ CONTAINS
       ALLOCATE (t_env%evecs(n_ev, n_spins))
       DO spin = 1, n_spins
          DO i = 1, n_ev
-            ALLOCATE (t_env%evecs(i, spin)%matrix)
             CALL fm_pool_create_fm(t_env%ao_mo_fm_pools(spin)%pool, &
-                                   t_env%evecs(i, spin)%matrix)
+                                   t_env%evecs(i, spin))
          END DO
       END DO
 
@@ -119,8 +117,7 @@ CONTAINS
       DO spin = 1, SIZE(t_env%evecs, 2)
          DO i = 1, SIZE(t_env%evecs, 1)
             CALL fm_pool_give_back_fm(t_env%ao_mo_fm_pools(spin)%pool, &
-                                      t_env%evecs(i, spin)%matrix)
-            DEALLOCATE (t_env%evecs(i, spin)%matrix)
+                                      t_env%evecs(i, spin))
          END DO
       END DO
 

--- a/src/qs_tddfpt_types.F
+++ b/src/qs_tddfpt_types.F
@@ -17,7 +17,8 @@ MODULE qs_tddfpt_types
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_p_type,&
-                                              cp_fm_release
+                                              cp_fm_release,&
+                                              cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE kinds,                           ONLY: dp
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -33,7 +34,7 @@ MODULE qs_tddfpt_types
       REAL(KIND=dp), DIMENSION(:), POINTER               :: evals ! eigenvalues
       TYPE(cp_fm_p_type), DIMENSION(:, :), &
          POINTER                                       :: evecs ! eigenvectors
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: invS ! the inverse of the metric
+      TYPE(cp_fm_type), DIMENSION(:), POINTER          :: invS ! the inverse of the metric
       TYPE(cp_fm_pool_p_type), DIMENSION(:), &
          POINTER                                       :: ao_mo_fm_pools
    END TYPE tddfpt_env_type
@@ -99,8 +100,7 @@ CONTAINS
          NULLIFY (fm_struct)
          CALL cp_fm_struct_create(fm_struct, para_env, blacs_env, &
                                   p_env%n_ao(spin), p_env%n_ao(spin))
-         ALLOCATE (t_env%invS(spin)%matrix)
-         CALL cp_fm_create(t_env%invS(spin)%matrix, fm_struct, routineP//"invS")
+         CALL cp_fm_create(t_env%invS(spin), fm_struct, routineP//"invS")
          CALL cp_fm_struct_release(fm_struct)
       END DO
 
@@ -125,10 +125,7 @@ CONTAINS
       END DO
 
       DO spin = 1, SIZE(t_env%invS)
-         IF (ASSOCIATED(t_env%invS(spin)%matrix)) THEN
-            CALL cp_fm_release(t_env%invS(spin)%matrix)
-            DEALLOCATE (t_env%invS(spin)%matrix)
-         END IF
+         CALL cp_fm_release(t_env%invS(spin))
       END DO
       DEALLOCATE (t_env%invS, t_env%evecs, t_env%evals)
 

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -143,7 +143,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE co_initial_guess(matrices, energies, n_v, qs_env)
 
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: matrices
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER         :: matrices
       REAL(kind=DP), DIMENSION(:), INTENT(OUT)           :: energies
       INTEGER, INTENT(IN)                                :: n_v
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -173,11 +173,11 @@ CONTAINS
 
       DO spin = 1, n_spins
 
-         n_cols = matrices(1, spin)%matrix%matrix_struct%ncol_global
-         n_rows = matrices(1, spin)%matrix%matrix_struct%nrow_global
+         n_cols = matrices(1, spin)%matrix_struct%ncol_global
+         n_rows = matrices(1, spin)%matrix_struct%nrow_global
 
          DO i = 1, n_v
-            CALL cp_fm_set_all(matrices(i, spin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(matrices(i, spin), 0.0_dp)
          END DO
 
          CALL get_mo_set(qs_env%mos(spin), eigenvalues=orbital_eigenvalues)
@@ -235,13 +235,13 @@ CONTAINS
             guess(:, :) = 0.0_dp
             CALL dcopy(n_rows, lumos(:, sorter_iterator%lumo), 1, &
                        guess(:, sorter_iterator%orbit), 1)
-            CALL cp_fm_set_submatrix(matrices(i, spin)%matrix, guess)
+            CALL cp_fm_set_submatrix(matrices(i, spin), guess)
             energies(i) = energies(i) + sorter_iterator%value/REAL(n_spins, dp)
             sorter_iterator => sorter_iterator%next
          END DO
          IF (n_v > n_orbits*n_lumos) THEN
             DO i = n_orbits*n_lumos + 1, n_v
-               CALL cp_fm_init_random(matrices(i, spin)%matrix, n_orbits)
+               CALL cp_fm_init_random(matrices(i, spin), n_orbits)
                energies(i) = 1.0E38_dp
             END DO
          END IF
@@ -296,7 +296,7 @@ CONTAINS
 
       DO spin = 1, n_spins
          nrows(spin) = t_control%lumos(spin)%matrix_struct%nrow_global
-         nhomos(spin) = t_env%evecs(1, spin)%matrix%matrix_struct%ncol_global
+         nhomos(spin) = t_env%evecs(1, spin)%matrix_struct%ncol_global
          nlumos(spin) = t_control%lumos(spin)%matrix_struct%ncol_global
          ALLOCATE (S_lumos(spin)%matrix)
          CALL cp_fm_create(S_lumos(spin)%matrix, t_control%lumos(spin)%matrix_struct, &
@@ -322,7 +322,7 @@ CONTAINS
                END IF
             END IF
             searchloop: DO occ = nhomos(spin), 1, -1
-               CALL cp_fm_get_submatrix(t_env%evecs(i, spin)%matrix, homo_coeff_col, &
+               CALL cp_fm_get_submatrix(t_env%evecs(i, spin), homo_coeff_col, &
                                         1, occ, nrows(spin), 1)
                DO virt = 1, nlumos(spin)
                   CALL cp_fm_get_submatrix(S_lumos(spin)%matrix, lumo_coeff_col, &

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -187,7 +187,7 @@ CONTAINS
 
          CALL get_mo_set(qs_env%mos(spin), eigenvalues=orbital_eigenvalues)
 
-         n_lumos = tddfpt_control%lumos(spin)%matrix%matrix_struct%ncol_global
+         n_lumos = tddfpt_control%lumos(spin)%matrix_struct%ncol_global
 
          n_orbits = SIZE(orbital_eigenvalues)
 
@@ -229,7 +229,7 @@ CONTAINS
          END DO
 
          ALLOCATE (lumos(n_rows, n_lumos), guess(n_rows, n_orbits))
-         CALL cp_fm_get_submatrix(tddfpt_control%lumos(spin)%matrix, lumos, &
+         CALL cp_fm_get_submatrix(tddfpt_control%lumos(spin), lumos, &
                                   start_col=1, n_cols=n_lumos)
 
          !-------------------!
@@ -300,13 +300,13 @@ CONTAINS
       ALLOCATE (S_lumos(n_spins))
 
       DO spin = 1, n_spins
-         nrows(spin) = t_control%lumos(spin)%matrix%matrix_struct%nrow_global
+         nrows(spin) = t_control%lumos(spin)%matrix_struct%nrow_global
          nhomos(spin) = t_env%evecs(1, spin)%matrix%matrix_struct%ncol_global
-         nlumos(spin) = t_control%lumos(spin)%matrix%matrix_struct%ncol_global
+         nlumos(spin) = t_control%lumos(spin)%matrix_struct%ncol_global
          ALLOCATE (S_lumos(spin)%matrix)
-         CALL cp_fm_create(S_lumos(spin)%matrix, t_control%lumos(spin)%matrix%matrix_struct, &
+         CALL cp_fm_create(S_lumos(spin)%matrix, t_control%lumos(spin)%matrix_struct, &
                            "S times lumos")
-         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, t_control%lumos(spin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, t_control%lumos(spin), &
                                       S_lumos(spin)%matrix, nlumos(spin), 1.0_dp, 0.0_dp)
       END DO
 

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -111,9 +111,9 @@ CONTAINS
       n_spins = dft_control%nspins
       IF (dft_control%tddfpt_control%invert_S) THEN
          DO spin = 1, n_spins
-            CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, t_env%invS(spin)%matrix)
-            CALL cp_fm_cholesky_decompose(t_env%invS(spin)%matrix)
-            CALL cp_fm_cholesky_invert(t_env%invS(spin)%matrix)
+            CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, t_env%invS(spin))
+            CALL cp_fm_cholesky_decompose(t_env%invS(spin))
+            CALL cp_fm_cholesky_invert(t_env%invS(spin))
          END DO
       END IF
 

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -19,14 +19,9 @@ MODULE qs_tddfpt_utils
                                               cp_fm_trace
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert
-   USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_get_submatrix,&
-                                              cp_fm_init_random,&
-                                              cp_fm_p_type,&
-                                              cp_fm_release,&
-                                              cp_fm_set_all,&
-                                              cp_fm_set_submatrix,&
-                                              cp_fm_to_fm
+   USE cp_fm_types,                     ONLY: &
+        cp_fm_create, cp_fm_get_submatrix, cp_fm_init_random, cp_fm_p_type, cp_fm_release, &
+        cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE kinds,                           ONLY: dp
@@ -413,7 +408,8 @@ CONTAINS
    SUBROUTINE reorthogonalize(X, V_set, SV_set, work, n)
 
       TYPE(cp_fm_p_type), DIMENSION(:)                   :: X
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: V_set, SV_set
+      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: V_set
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: SV_set
       TYPE(cp_fm_p_type), DIMENSION(:)                   :: work
       INTEGER, INTENT(IN)                                :: n
 
@@ -434,7 +430,7 @@ CONTAINS
          DO i = 1, n
             dot_product = 0.0_dp
             DO spin = 1, n_spins
-               CALL cp_fm_trace(SV_set(i, spin)%matrix, work(spin)%matrix, tmp)
+               CALL cp_fm_trace(SV_set(i, spin), work(spin)%matrix, tmp)
                dot_product = dot_product + tmp
             END DO
             DO spin = 1, n_spins

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -367,7 +367,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE normalize(X, tmp_vec, metric)
 
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: x, tmp_vec
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: x
+      TYPE(cp_fm_p_type), DIMENSION(:)                   :: tmp_vec
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: metric
 
       INTEGER                                            :: n_spins, spin
@@ -378,17 +379,17 @@ CONTAINS
 
       DO spin = 1, n_spins
          tmp = 0.0_dp
-         CALL cp_dbcsr_sm_fm_multiply(metric(1)%matrix, X(spin)%matrix, &
+         CALL cp_dbcsr_sm_fm_multiply(metric(1)%matrix, X(spin), &
                                       tmp_vec(spin)%matrix, &
-                                      X(spin)%matrix%matrix_struct%ncol_global, &
+                                      X(spin)%matrix_struct%ncol_global, &
                                       1.0_dp, 0.0_dp)
-         CALL cp_fm_trace(X(spin)%matrix, tmp_vec(spin)%matrix, tmp)
+         CALL cp_fm_trace(X(spin), tmp_vec(spin)%matrix, tmp)
          norm = norm + tmp
       END DO
 
       norm = SQRT(norm)
       DO spin = 1, n_spins
-         CALL cp_fm_scale((1.0_dp/norm), X(spin)%matrix)
+         CALL cp_fm_scale((1.0_dp/norm), X(spin))
       END DO
 
    END SUBROUTINE normalize
@@ -407,8 +408,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE reorthogonalize(X, V_set, SV_set, work, n)
 
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: X
-      TYPE(cp_fm_p_type), DIMENSION(:, :)                :: V_set
+      TYPE(cp_fm_type), DIMENSION(:)                     :: X
+      TYPE(cp_fm_type), DIMENSION(:, :)                  :: V_set
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: SV_set
       TYPE(cp_fm_p_type), DIMENSION(:)                   :: work
       INTEGER, INTENT(IN)                                :: n
@@ -424,7 +425,7 @@ CONTAINS
 
          n_spins = SIZE(X)
          DO spin = 1, n_spins
-            CALL cp_fm_to_fm(X(spin)%matrix, work(spin)%matrix)
+            CALL cp_fm_to_fm(X(spin), work(spin)%matrix)
          END DO
 
          DO i = 1, n
@@ -434,8 +435,8 @@ CONTAINS
                dot_product = dot_product + tmp
             END DO
             DO spin = 1, n_spins
-               CALL cp_fm_scale_and_add(1.0_dp, X(spin)%matrix, &
-                                        -1.0_dp*dot_product, V_set(i, spin)%matrix)
+               CALL cp_fm_scale_and_add(1.0_dp, X(spin), &
+                                        -1.0_dp*dot_product, V_set(i, spin))
             END DO
          END DO
 

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -367,8 +367,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE normalize(X, tmp_vec, metric)
 
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: x
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: tmp_vec
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: x, tmp_vec
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: metric
 
       INTEGER                                            :: n_spins, spin
@@ -380,10 +379,10 @@ CONTAINS
       DO spin = 1, n_spins
          tmp = 0.0_dp
          CALL cp_dbcsr_sm_fm_multiply(metric(1)%matrix, X(spin), &
-                                      tmp_vec(spin)%matrix, &
+                                      tmp_vec(spin), &
                                       X(spin)%matrix_struct%ncol_global, &
                                       1.0_dp, 0.0_dp)
-         CALL cp_fm_trace(X(spin), tmp_vec(spin)%matrix, tmp)
+         CALL cp_fm_trace(X(spin), tmp_vec(spin), tmp)
          norm = norm + tmp
       END DO
 
@@ -408,10 +407,9 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE reorthogonalize(X, V_set, SV_set, work, n)
 
-      TYPE(cp_fm_type), DIMENSION(:)                     :: X
-      TYPE(cp_fm_type), DIMENSION(:, :)                  :: V_set
-      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: SV_set
-      TYPE(cp_fm_p_type), DIMENSION(:)                   :: work
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: X
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: V_set, SV_set
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: work
       INTEGER, INTENT(IN)                                :: n
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'reorthogonalize'
@@ -425,13 +423,13 @@ CONTAINS
 
          n_spins = SIZE(X)
          DO spin = 1, n_spins
-            CALL cp_fm_to_fm(X(spin), work(spin)%matrix)
+            CALL cp_fm_to_fm(X(spin), work(spin))
          END DO
 
          DO i = 1, n
             dot_product = 0.0_dp
             DO spin = 1, n_spins
-               CALL cp_fm_trace(SV_set(i, spin), work(spin)%matrix, tmp)
+               CALL cp_fm_trace(SV_set(i, spin), work(spin), tmp)
                dot_product = dot_product + tmp
             END DO
             DO spin = 1, n_spins

--- a/src/qs_tddfpt_utils.F
+++ b/src/qs_tddfpt_utils.F
@@ -19,9 +19,14 @@ MODULE qs_tddfpt_utils
                                               cp_fm_trace
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_create, cp_fm_get_submatrix, cp_fm_init_random, cp_fm_p_type, cp_fm_release, &
-        cp_fm_set_all, cp_fm_set_submatrix, cp_fm_to_fm, cp_fm_type
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_submatrix,&
+                                              cp_fm_init_random,&
+                                              cp_fm_release,&
+                                              cp_fm_set_all,&
+                                              cp_fm_set_submatrix,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE dbcsr_api,                       ONLY: dbcsr_p_type
    USE kinds,                           ONLY: dp
@@ -276,12 +281,12 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: nhomos, nlumos, nrows
       REAL(KIND=dp)                                      :: contribution, summed_contributions
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: homo_coeff_col, lumo_coeff_col
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: S_lumos
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: S_lumos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(tddfpt_control_type)                          :: t_control
 
-      NULLIFY (S_lumos, matrix_s, dft_control)
+      NULLIFY (matrix_s, dft_control)
       output_unit = cp_logger_get_default_io_unit()
       CALL get_qs_env(qs_env, matrix_s=matrix_s, dft_control=dft_control)
 
@@ -298,11 +303,10 @@ CONTAINS
          nrows(spin) = t_control%lumos(spin)%matrix_struct%nrow_global
          nhomos(spin) = t_env%evecs(1, spin)%matrix_struct%ncol_global
          nlumos(spin) = t_control%lumos(spin)%matrix_struct%ncol_global
-         ALLOCATE (S_lumos(spin)%matrix)
-         CALL cp_fm_create(S_lumos(spin)%matrix, t_control%lumos(spin)%matrix_struct, &
+         CALL cp_fm_create(S_lumos(spin), t_control%lumos(spin)%matrix_struct, &
                            "S times lumos")
          CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, t_control%lumos(spin), &
-                                      S_lumos(spin)%matrix, nlumos(spin), 1.0_dp, 0.0_dp)
+                                      S_lumos(spin), nlumos(spin), 1.0_dp, 0.0_dp)
       END DO
 
       ALLOCATE (homo_coeff_col(MAXVAL(nrows(1:n_spins)), 1), &
@@ -325,7 +329,7 @@ CONTAINS
                CALL cp_fm_get_submatrix(t_env%evecs(i, spin), homo_coeff_col, &
                                         1, occ, nrows(spin), 1)
                DO virt = 1, nlumos(spin)
-                  CALL cp_fm_get_submatrix(S_lumos(spin)%matrix, lumo_coeff_col, &
+                  CALL cp_fm_get_submatrix(S_lumos(spin), lumo_coeff_col, &
                                            1, virt, nrows(spin), 1)
                   contribution = 0.0_dp
                   DO j = 1, nrows(spin)
@@ -350,8 +354,7 @@ CONTAINS
       END IF
 
       DO spin = 1, n_spins
-         CALL cp_fm_release(S_lumos(spin)%matrix)
-         DEALLOCATE (S_lumos(spin)%matrix)
+         CALL cp_fm_release(S_lumos(spin))
       END DO
       DEALLOCATE (homo_coeff_col, lumo_coeff_col)
 

--- a/src/qs_wannier90.F
+++ b/src/qs_wannier90.F
@@ -29,7 +29,6 @@ MODULE qs_wannier90
    USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
                                               cp_fm_create,&
                                               cp_fm_get_element,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit,&
@@ -180,9 +179,9 @@ CONTAINS
       TYPE(berry_matrix_type), DIMENSION(:), POINTER     :: berry_matrix
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: fmk1, fmk2
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct_mmn, matrix_struct_work
       TYPE(cp_fm_type)                                   :: fm_tmp, mmn_imag, mmn_real
+      TYPE(cp_fm_type), DIMENSION(2)                     :: fmk1, fmk2
       TYPE(cp_fm_type), POINTER                          :: fmdummy, fmi, fmr
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_s
@@ -425,12 +424,10 @@ CONTAINS
                                ncol_global=nmo, &
                                para_env=para_env, &
                                context=blacs_env)
-      ALLOCATE (fmk1(2), fmk2(2))
       CALL cp_fm_create(fm_tmp, matrix_struct_work)
       DO i = 1, 2
-         ALLOCATE (fmk1(i)%matrix, fmk2(i)%matrix)
-         CALL cp_fm_create(fmk1(i)%matrix, matrix_struct_work)
-         CALL cp_fm_create(fmk2(i)%matrix, matrix_struct_work)
+         CALL cp_fm_create(fmk1(i), matrix_struct_work)
+         CALL cp_fm_create(fmk2(i), matrix_struct_work)
       END DO
       ! work matrices for Mmn(k,b) integrals
       NULLIFY (matrix_struct_mmn)
@@ -463,12 +460,12 @@ CONTAINS
                CPASSERT(SIZE(kp%mos, 1) == 2)
                fmr => kp%mos(1, ispin)%mo_coeff
                fmi => kp%mos(2, ispin)%mo_coeff
-               CALL cp_fm_copy_general(fmr, fmk1(1)%matrix, para_env)
-               CALL cp_fm_copy_general(fmi, fmk1(2)%matrix, para_env)
+               CALL cp_fm_copy_general(fmr, fmk1(1), para_env)
+               CALL cp_fm_copy_general(fmi, fmk1(2), para_env)
             ELSE
                NULLIFY (fmr, fmi, kp)
-               CALL cp_fm_copy_general(fmdummy, fmk1(1)%matrix, para_env)
-               CALL cp_fm_copy_general(fmdummy, fmk1(2)%matrix, para_env)
+               CALL cp_fm_copy_general(fmdummy, fmk1(1), para_env)
+               CALL cp_fm_copy_general(fmdummy, fmk1(2), para_env)
             END IF
             ! loop over all connected neighbors
             DO i = 1, nntot
@@ -481,12 +478,12 @@ CONTAINS
                   CPASSERT(SIZE(kp%mos, 1) == 2)
                   fmr => kp%mos(1, ispin)%mo_coeff
                   fmi => kp%mos(2, ispin)%mo_coeff
-                  CALL cp_fm_copy_general(fmr, fmk2(1)%matrix, para_env)
-                  CALL cp_fm_copy_general(fmi, fmk2(2)%matrix, para_env)
+                  CALL cp_fm_copy_general(fmr, fmk2(1), para_env)
+                  CALL cp_fm_copy_general(fmi, fmk2(2), para_env)
                ELSE
                   NULLIFY (fmr, fmi, kp)
-                  CALL cp_fm_copy_general(fmdummy, fmk2(1)%matrix, para_env)
-                  CALL cp_fm_copy_general(fmdummy, fmk2(2)%matrix, para_env)
+                  CALL cp_fm_copy_general(fmdummy, fmk2(1), para_env)
+                  CALL cp_fm_copy_general(fmdummy, fmk2(2), para_env)
                END IF
                !
                ! transfer realspace overlaps to connected k-point
@@ -503,18 +500,18 @@ CONTAINS
                                    is_complex=.TRUE., rs_sign=ksign)
                !
                ! calculate M_(mn)^(k,b)
-               CALL cp_dbcsr_sm_fm_multiply(rmatrix, fmk2(1)%matrix, fm_tmp, nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1)%matrix, fm_tmp, 0.0_dp, mmn_real)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2)%matrix, fm_tmp, 0.0_dp, mmn_imag)
-               CALL cp_dbcsr_sm_fm_multiply(rmatrix, fmk2(2)%matrix, fm_tmp, nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1)%matrix, fm_tmp, 1.0_dp, mmn_imag)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2)%matrix, fm_tmp, -1.0_dp, mmn_real)
-               CALL cp_dbcsr_sm_fm_multiply(cmatrix, fmk2(1)%matrix, fm_tmp, nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1)%matrix, fm_tmp, 1.0_dp, mmn_imag)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2)%matrix, fm_tmp, -1.0_dp, mmn_real)
-               CALL cp_dbcsr_sm_fm_multiply(cmatrix, fmk2(2)%matrix, fm_tmp, nmo)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1)%matrix, fm_tmp, -1.0_dp, mmn_real)
-               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2)%matrix, fm_tmp, -1.0_dp, mmn_imag)
+               CALL cp_dbcsr_sm_fm_multiply(rmatrix, fmk2(1), fm_tmp, nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1), fm_tmp, 0.0_dp, mmn_real)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2), fm_tmp, 0.0_dp, mmn_imag)
+               CALL cp_dbcsr_sm_fm_multiply(rmatrix, fmk2(2), fm_tmp, nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1), fm_tmp, 1.0_dp, mmn_imag)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2), fm_tmp, -1.0_dp, mmn_real)
+               CALL cp_dbcsr_sm_fm_multiply(cmatrix, fmk2(1), fm_tmp, nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1), fm_tmp, 1.0_dp, mmn_imag)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2), fm_tmp, -1.0_dp, mmn_real)
+               CALL cp_dbcsr_sm_fm_multiply(cmatrix, fmk2(2), fm_tmp, nmo)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(1), fm_tmp, -1.0_dp, mmn_real)
+               CALL parallel_gemm("T", "N", nmo, nmo, nao, 1.0_dp, fmk1(2), fm_tmp, -1.0_dp, mmn_imag)
                !
                ! write to output file
                IF (para_env%ionode) THEN
@@ -540,15 +537,13 @@ CONTAINS
       DEALLOCATE (berry_matrix)
       CALL cp_fm_struct_release(matrix_struct_work)
       DO i = 1, 2
-         CALL cp_fm_release(fmk1(i)%matrix)
-         CALL cp_fm_release(fmk2(i)%matrix)
-         DEALLOCATE (fmk1(i)%matrix, fmk2(i)%matrix)
+         CALL cp_fm_release(fmk1(i))
+         CALL cp_fm_release(fmk2(i))
       END DO
       CALL cp_fm_release(fm_tmp)
       CALL cp_fm_struct_release(matrix_struct_mmn)
       CALL cp_fm_release(mmn_real)
       CALL cp_fm_release(mmn_imag)
-      DEALLOCATE (fmk1, fmk2)
       CALL dbcsr_deallocate_matrix(rmatrix)
       CALL dbcsr_deallocate_matrix(cmatrix)
       !

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -638,15 +638,13 @@ CONTAINS
 !> \param p_env ...
 !> \param cpmos RHS of equation as Ax + b = 0 (sign of b)
 !> \param iounit ...
-!> \param p1_mat ...
 !> \param lr_section ...
 ! **************************************************************************************************
-   SUBROUTINE response_equation(qs_env, p_env, cpmos, iounit, p1_mat, lr_section)
+   SUBROUTINE response_equation(qs_env, p_env, cpmos, iounit, lr_section)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos
       INTEGER, INTENT(IN)                                :: iounit
-      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: p1_mat
       TYPE(section_vals_type), OPTIONAL, POINTER         :: lr_section
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'response_equation'
@@ -655,8 +653,7 @@ CONTAINS
       LOGICAL                                            :: should_stop
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0
-      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi1
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0, psi1
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s, matrix_s_aux
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -774,16 +771,10 @@ CONTAINS
          CALL calculate_wz_matrix(mos(ispin), psi1(ispin), matrix_ks(ispin)%matrix, &
                                   p_env%w1(ispin)%matrix)
       END DO
-      IF (PRESENT(p1_mat)) THEN
-         CPASSERT(.NOT. ASSOCIATED(p1_mat))
-         p1_mat => psi1
-      ELSE
-         DO ispin = 1, nspins
-            CALL cp_fm_release(psi1(ispin))
-         END DO
-         DEALLOCATE (psi1)
-      END IF
-      DEALLOCATE (psi0)
+      DO ispin = 1, nspins
+         CALL cp_fm_release(psi1(ispin))
+      END DO
+      DEALLOCATE (psi0, psi1)
 
       CALL timestop(handle)
 

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -187,9 +187,9 @@ CONTAINS
       REAL(KIND=dp)                                      :: focc
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: sv
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: cpmos
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_para_env_type), POINTER                    :: para_env
@@ -355,18 +355,17 @@ CONTAINS
          DO ispin = 1, nspins
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
             CALL cp_fm_get_info(mo_coeff, matrix_struct=fm_struct)
-            ALLOCATE (cpmos(ispin)%matrix)
-            CALL cp_fm_create(cpmos(ispin)%matrix, fm_struct)
-            CALL cp_fm_set_all(cpmos(ispin)%matrix, 0.0_dp)
+            CALL cp_fm_create(cpmos(ispin), fm_struct)
+            CALL cp_fm_set_all(cpmos(ispin), 0.0_dp)
          END DO
 
          focc = 2.0_dp
          IF (nspins == 1) focc = 4.0_dp
          DO ispin = 1, nspins
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
-            CALL cp_fm_set_all(cpmos(ispin)%matrix, 0.0_dp)
+            CALL cp_fm_set_all(cpmos(ispin), 0.0_dp)
             CALL cp_dbcsr_sm_fm_multiply(ec_env%matrix_hz(ispin)%matrix, mo_coeff, &
-                                         cpmos(ispin)%matrix, nmo, &
+                                         cpmos(ispin), nmo, &
                                          alpha=focc, beta=0.0_dp)
          END DO
 
@@ -380,10 +379,7 @@ CONTAINS
          END DO
 
          DO ispin = 1, nspins
-            IF (ASSOCIATED(cpmos(ispin)%matrix)) THEN
-               CALL cp_fm_release(cpmos(ispin)%matrix)
-               DEALLOCATE (cpmos(ispin)%matrix)
-            END IF
+            CALL cp_fm_release(cpmos(ispin))
          END DO
          DEALLOCATE (cpmos)
 
@@ -552,7 +548,7 @@ CONTAINS
    SUBROUTINE response_equation_new(qs_env, p_env, cpmos, iounit)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: cpmos
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: cpmos
       INTEGER, INTENT(IN)                                :: iounit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'response_equation_new'
@@ -628,9 +624,9 @@ CONTAINS
                                   p_env%w1(ispin)%matrix)
       END DO
       DO ispin = 1, nspins
-         CALL cp_fm_release(cpmos(ispin)%matrix)
+         CALL cp_fm_release(cpmos(ispin))
          CALL cp_fm_release(psi1(ispin)%matrix)
-         DEALLOCATE (cpmos(ispin)%matrix, psi1(ispin)%matrix)
+         DEALLOCATE (psi1(ispin)%matrix)
       END DO
       DEALLOCATE (psi0, psi1)
 
@@ -652,7 +648,7 @@ CONTAINS
    SUBROUTINE response_equation(qs_env, p_env, cpmos, iounit, p1_mat, lr_section)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos
       INTEGER, INTENT(IN)                                :: iounit
       TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: p1_mat

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -36,7 +36,6 @@ MODULE response_solver
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_init_random,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_type
@@ -556,9 +555,8 @@ CONTAINS
       INTEGER                                            :: handle, ispin, nao, nao_aux, nspins
       LOGICAL                                            :: should_stop
       TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0, psi1
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -566,7 +564,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (dft_control, matrix_ks, mo_coeff, mos, psi1)
+      NULLIFY (dft_control, matrix_ks, mo_coeff, mos)
 
       CALL get_qs_env(qs_env, dft_control=dft_control, matrix_ks=matrix_ks, &
                       matrix_s=matrix_s, mos=mos)
@@ -580,9 +578,8 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
          psi0(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, matrix_struct=fm_struct)
-         ALLOCATE (psi1(ispin)%matrix)
-         CALL cp_fm_create(psi1(ispin)%matrix, fm_struct)
-         CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
+         CALL cp_fm_create(psi1(ispin), fm_struct)
+         CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
       END DO
 
       should_stop = .FALSE.
@@ -620,13 +617,12 @@ CONTAINS
 
       ! Calculate Wz = 0.5*(psi1*eps*psi0^T + psi0*eps*psi1^T)
       DO ispin = 1, nspins
-         CALL calculate_wz_matrix(mos(ispin), psi1(ispin)%matrix, matrix_ks(ispin)%matrix, &
+         CALL calculate_wz_matrix(mos(ispin), psi1(ispin), matrix_ks(ispin)%matrix, &
                                   p_env%w1(ispin)%matrix)
       END DO
       DO ispin = 1, nspins
          CALL cp_fm_release(cpmos(ispin))
-         CALL cp_fm_release(psi1(ispin)%matrix)
-         DEALLOCATE (psi1(ispin)%matrix)
+         CALL cp_fm_release(psi1(ispin))
       END DO
       DEALLOCATE (psi0, psi1)
 
@@ -650,8 +646,7 @@ CONTAINS
       TYPE(qs_p_env_type)                                :: p_env
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: cpmos
       INTEGER, INTENT(IN)                                :: iounit
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: p1_mat
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, POINTER  :: p1_mat
       TYPE(section_vals_type), OPTIONAL, POINTER         :: lr_section
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'response_equation'
@@ -659,9 +654,9 @@ CONTAINS
       INTEGER                                            :: handle, ispin, nao, nao_aux, nspins
       LOGICAL                                            :: should_stop
       TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: psi1
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s, matrix_s_aux
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -715,9 +710,8 @@ CONTAINS
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
          psi0(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, matrix_struct=fm_struct)
-         ALLOCATE (psi1(ispin)%matrix)
-         CALL cp_fm_create(psi1(ispin)%matrix, fm_struct)
-         CALL cp_fm_set_all(psi1(ispin)%matrix, 0.0_dp)
+         CALL cp_fm_create(psi1(ispin), fm_struct)
+         CALL cp_fm_set_all(psi1(ispin), 0.0_dp)
       END DO
 
       should_stop = .FALSE.
@@ -777,7 +771,7 @@ CONTAINS
       ! Calculate Wz = 0.5*(psi1*eps*psi0^T + psi0*eps*psi1^T)
       CALL get_qs_env(qs_env, matrix_ks=matrix_ks)
       DO ispin = 1, nspins
-         CALL calculate_wz_matrix(mos(ispin), psi1(ispin)%matrix, matrix_ks(ispin)%matrix, &
+         CALL calculate_wz_matrix(mos(ispin), psi1(ispin), matrix_ks(ispin)%matrix, &
                                   p_env%w1(ispin)%matrix)
       END DO
       IF (PRESENT(p1_mat)) THEN
@@ -785,8 +779,7 @@ CONTAINS
          p1_mat => psi1
       ELSE
          DO ispin = 1, nspins
-            CALL cp_fm_release(psi1(ispin)%matrix)
-            DEALLOCATE (psi1(ispin)%matrix)
+            CALL cp_fm_release(psi1(ispin))
          END DO
          DEALLOCATE (psi1)
       END IF

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -560,8 +560,9 @@ CONTAINS
       INTEGER                                            :: handle, ispin, nao, nao_aux, nspins
       LOGICAL                                            :: should_stop
       TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi0, psi1
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -569,7 +570,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (dft_control, matrix_ks, mo_coeff, mos, psi0, psi1)
+      NULLIFY (dft_control, matrix_ks, mo_coeff, mos, psi1)
 
       CALL get_qs_env(qs_env, dft_control=dft_control, matrix_ks=matrix_ks, &
                       matrix_s=matrix_s, mos=mos)
@@ -581,7 +582,7 @@ CONTAINS
       ALLOCATE (psi0(nspins), psi1(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-         psi0(ispin)%matrix => mo_coeff
+         psi0(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, matrix_struct=fm_struct)
          ALLOCATE (psi1(ispin)%matrix)
          CALL cp_fm_create(psi1(ispin)%matrix, fm_struct)
@@ -662,8 +663,9 @@ CONTAINS
       INTEGER                                            :: handle, ispin, nao, nao_aux, nspins
       LOGICAL                                            :: should_stop
       TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi0, psi1
+      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: psi1
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: psi0
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s, matrix_s_aux
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -715,7 +717,7 @@ CONTAINS
       ALLOCATE (psi0(nspins), psi1(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
-         psi0(ispin)%matrix => mo_coeff
+         psi0(ispin) = mo_coeff
          CALL cp_fm_get_info(mo_coeff, matrix_struct=fm_struct)
          ALLOCATE (psi1(ispin)%matrix)
          CALL cp_fm_create(psi1(ispin)%matrix, fm_struct)

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -552,7 +552,7 @@ CONTAINS
    SUBROUTINE response_equation_new(qs_env, p_env, cpmos, iounit)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_p_env_type)                                :: p_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos
+      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(INOUT)    :: cpmos
       INTEGER, INTENT(IN)                                :: iounit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'response_equation_new'

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -5105,7 +5105,7 @@ CONTAINS
 
       nkp_Sigma = kpoints_Sigma%nkp
 
-      matrix_struct => kpoints_Sigma%kp_env(1)%kpoint_env%wmat(1, 1)%matrix%matrix_struct
+      matrix_struct => kpoints_Sigma%kp_env(1)%kpoint_env%wmat(1, 1)%matrix_struct
 
       CALL cp_cfm_create(ks_mat_ao_ao, matrix_struct)
       CALL cp_cfm_create(ks_mat_no_xc_ao_ao, matrix_struct)
@@ -5141,16 +5141,16 @@ CONTAINS
 
          CALL cp_fm_to_cfm(fm_tmp_re, fm_tmp_im, cfm_mo_coeff)
 
-         CALL cp_fm_to_cfm(kpoints_Sigma%kp_env(ikp)%kpoint_env%wmat(1, 1)%matrix, &
-                           kpoints_Sigma%kp_env(ikp)%kpoint_env%wmat(2, 1)%matrix, ks_mat_ao_ao)
+         CALL cp_fm_to_cfm(kpoints_Sigma%kp_env(ikp)%kpoint_env%wmat(1, 1), &
+                           kpoints_Sigma%kp_env(ikp)%kpoint_env%wmat(2, 1), ks_mat_ao_ao)
          ASSOCIATE (wmat => kpoints_Sigma_no_xc%kp_env(ikp)%kpoint_env%wmat)
-         IF (ASSOCIATED(wmat(1, 1)%matrix)) THEN
-            CALL cp_fm_copy_general(wmat(1, 1)%matrix, fm_tmp_re, para_env)
+         IF (ASSOCIATED(wmat(1, 1)%matrix_struct)) THEN
+            CALL cp_fm_copy_general(wmat(1, 1), fm_tmp_re, para_env)
          ELSE
             CALL cp_fm_copy_general(fm_dummy, fm_tmp_re, para_env)
          END IF
-         IF (ASSOCIATED(wmat(2, 1)%matrix)) THEN
-            CALL cp_fm_copy_general(wmat(2, 1)%matrix, fm_tmp_im, para_env)
+         IF (ASSOCIATED(wmat(2, 1)%matrix_struct)) THEN
+            CALL cp_fm_copy_general(wmat(2, 1), fm_tmp_im, para_env)
          ELSE
             CALL cp_fm_copy_general(fm_dummy, fm_tmp_im, para_env)
          END IF

--- a/src/rpa_gw_kpoints_util.F
+++ b/src/rpa_gw_kpoints_util.F
@@ -1720,7 +1720,7 @@ CONTAINS
 
       CALL get_kpoint_info(kpoints, nkp=nkp)
 
-      matrix_struct => kpoints%kp_env(1)%kpoint_env%wmat(1, 1)%matrix%matrix_struct
+      matrix_struct => kpoints%kp_env(1)%kpoint_env%wmat(1, 1)%matrix_struct
 
       CALL cp_cfm_create(cksmat, matrix_struct)
       CALL cp_cfm_create(csmat, matrix_struct)
@@ -1730,11 +1730,11 @@ CONTAINS
 
       DO ikp = 1, nkp
 
-         CALL copy_dbcsr_to_fm(mat_ks_kp(ikp, 1)%matrix, kpoints%kp_env(ikp)%kpoint_env%wmat(1, 1)%matrix)
-         CALL cp_cfm_scale_and_add_fm(czero, cksmat, cone, kpoints%kp_env(ikp)%kpoint_env%wmat(1, 1)%matrix)
+         CALL copy_dbcsr_to_fm(mat_ks_kp(ikp, 1)%matrix, kpoints%kp_env(ikp)%kpoint_env%wmat(1, 1))
+         CALL cp_cfm_scale_and_add_fm(czero, cksmat, cone, kpoints%kp_env(ikp)%kpoint_env%wmat(1, 1))
 
-         CALL copy_dbcsr_to_fm(mat_ks_kp(ikp, 2)%matrix, kpoints%kp_env(ikp)%kpoint_env%wmat(2, 1)%matrix)
-         CALL cp_cfm_scale_and_add_fm(cone, cksmat, ione, kpoints%kp_env(ikp)%kpoint_env%wmat(2, 1)%matrix)
+         CALL copy_dbcsr_to_fm(mat_ks_kp(ikp, 2)%matrix, kpoints%kp_env(ikp)%kpoint_env%wmat(2, 1))
+         CALL cp_cfm_scale_and_add_fm(cone, cksmat, ione, kpoints%kp_env(ikp)%kpoint_env%wmat(2, 1))
 
          CALL copy_dbcsr_to_fm(mat_s_kp(ikp, 1)%matrix, fm_work)
          CALL cp_cfm_scale_and_add_fm(czero, csmat, cone, fm_work)

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -917,8 +917,8 @@ CONTAINS
          DO ispin = 1, nspin
             mo_set => kp%mos(1, ispin)
             CALL get_mo_set(mo_set, eigenvalues=eigenvalues)
-            rpmat => kp%wmat(1, ispin)%matrix
-            cpmat => kp%wmat(2, ispin)%matrix
+            rpmat => kp%wmat(1, ispin)
+            cpmat => kp%wmat(2, ispin)
             CALL get_mo_set(mo_set, occupation_numbers=occupation)
             CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
 
@@ -1242,7 +1242,7 @@ CONTAINS
 
       NULLIFY (xkp, wkp)
 
-      CALL cp_fm_create(fm_mat_work, kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1)%matrix%matrix_struct)
+      CALL cp_fm_create(fm_mat_work, kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1)%matrix_struct)
       CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
 
       CALL get_kpoint_info(kpoints_G, nkp=nkp, xkp=xkp, wkp=wkp)
@@ -1258,7 +1258,7 @@ CONTAINS
 
       CALL get_atom_index_from_basis_function_index(qs_env, atom_from_ao_index, nao, "ORB")
 
-      CALL cp_fm_get_info(matrix=kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1)%matrix, &
+      CALL cp_fm_get_info(matrix=kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1), &
                           nrow_local=nrow_local, &
                           ncol_local=ncol_local, &
                           row_indices=row_indices, &
@@ -1278,8 +1278,8 @@ CONTAINS
          DO ik = 1, nkp
 
             kp => kpoints_G%kp_env(ik)%kpoint_env
-            rpmat => kp%wmat(1, ispin)%matrix
-            cpmat => kp%wmat(2, ispin)%matrix
+            rpmat => kp%wmat(1, ispin)
+            cpmat => kp%wmat(2, ispin)
 
             DO irow = 1, nrow_local
                DO jcol = 1, ncol_local
@@ -1381,8 +1381,8 @@ CONTAINS
          DO ik = 1, nkp
 
             kp => kpoints%kp_env(ik)%kpoint_env
-            rpmat => kp%wmat(1, ispin)%matrix
-            cpmat => kp%wmat(2, ispin)%matrix
+            rpmat => kp%wmat(1, ispin)
+            cpmat => kp%wmat(2, ispin)
 
             CALL copy_fm_to_dbcsr(rpmat, mat_work_re, keep_sparsity=.FALSE.)
             CALL copy_fm_to_dbcsr(cpmat, mat_work_im, keep_sparsity=.FALSE.)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2099,7 +2099,7 @@ CONTAINS
       LOGICAL                                            :: do_exx
       REAL(dp)                                           :: focc
       TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: cpmos
+      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: cpmos
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: dbcsr_p_work, matrix_p_mp2, &
@@ -2111,7 +2111,7 @@ CONTAINS
       TYPE(qs_p_env_type), POINTER                       :: p_env
       TYPE(section_vals_type), POINTER                   :: hfx_section, lr_section
 
-      NULLIFY (linres_control, p_env, dft_control, matrix_s, mos, cpmos, mo_coeff, fm_struct, lr_section, &
+      NULLIFY (linres_control, p_env, dft_control, matrix_s, mos, mo_coeff, fm_struct, lr_section, &
                dbcsr_p_work, YP_admm, matrix_p_mp2, admm_env, work_admm, matrix_s_aux, matrix_p_mp2_admm)
 
       CALL timeset(routineN, handle)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -37,7 +37,6 @@ MODULE rpa_im_time_force_methods
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_type
@@ -2099,8 +2098,8 @@ CONTAINS
       LOGICAL                                            :: do_exx
       REAL(dp)                                           :: focc
       TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: cpmos
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: cpmos
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: dbcsr_p_work, matrix_p_mp2, &
                                                             matrix_p_mp2_admm, matrix_s, &
@@ -2187,9 +2186,8 @@ CONTAINS
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff)
          CALL cp_fm_get_info(mo_coeff, matrix_struct=fm_struct)
-         ALLOCATE (cpmos(ispin)%matrix)
-         CALL cp_fm_create(cpmos(ispin)%matrix, fm_struct)
-         CALL cp_fm_set_all(cpmos(ispin)%matrix, 0.0_dp)
+         CALL cp_fm_create(cpmos(ispin), fm_struct)
+         CALL cp_fm_set_all(cpmos(ispin), 0.0_dp)
       END DO
 
       ! in case of EXX, need to add the HF Hamiltonian to the RHS of the Z-vector equation
@@ -2206,7 +2204,7 @@ CONTAINS
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, homo=nocc)
          CALL cp_dbcsr_sm_fm_multiply(force_data%sum_O_tau(ispin)%matrix, mo_coeff, &
-                                      cpmos(ispin)%matrix, nocc, &
+                                      cpmos(ispin), nocc, &
                                       alpha=focc, beta=0.0_dp)
       END DO
 
@@ -2256,10 +2254,7 @@ CONTAINS
       IF (dft_control%do_admm) CALL dbcsr_deallocate_matrix_set(YP_admm)
 
       DO ispin = 1, nspins
-         IF (ASSOCIATED(cpmos(ispin)%matrix)) THEN
-            CALL cp_fm_release(cpmos(ispin)%matrix)
-            DEALLOCATE (cpmos(ispin)%matrix)
-         END IF
+         CALL cp_fm_release(cpmos(ispin))
       END DO
       DEALLOCATE (cpmos)
       CALL p_env_release(p_env)

--- a/src/s_square_methods.F
+++ b/src/s_square_methods.F
@@ -69,8 +69,8 @@ CONTAINS
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       REAL(KIND=dp), INTENT(OUT)                         :: s_square, s_square_ideal
-      TYPE(cp_fm_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: mo_derivs
+      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, &
+         INTENT(INOUT)                                         :: mo_derivs
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: strength
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'compute_s_square'
@@ -147,14 +147,14 @@ CONTAINS
                CALL get_mo_set(mo_set=mos(2), uniform_occupation=has_uniform_occupation_beta)
                CPASSERT(has_uniform_occupation_beta)
                ! Add -strength*S*C(beta)*(C(alpha)^T*S*C(beta))^T to the alpha MO derivatives
-               CALL parallel_gemm('N', 'T', nao, nalpha, nbeta, -strength, scb, catscb, 1.0_dp, mo_derivs(1)%matrix)
+               CALL parallel_gemm('N', 'T', nao, nalpha, nbeta, -strength, scb, catscb, 1.0_dp, mo_derivs(1))
                ! Create S*C(alpha)
                CALL cp_fm_get_info(c_alpha, matrix_struct=fm_struct_tmp)
                CALL cp_fm_create(sca, fm_struct_tmp, name="S*C(alpha)")
                ! Compute S*C(alpha)
                CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, c_alpha, sca, nalpha)
                ! Add -strength*S*C(alpha)*C(alpha)^T*S*C(beta) to the beta MO derivatives
-               CALL parallel_gemm('N', 'N', nao, nbeta, nalpha, -strength, sca, catscb, 1.0_dp, mo_derivs(2)%matrix)
+               CALL parallel_gemm('N', 'N', nao, nbeta, nalpha, -strength, sca, catscb, 1.0_dp, mo_derivs(2))
                CALL cp_fm_release(sca)
             END IF
             CALL cp_fm_release(scb)
@@ -193,7 +193,7 @@ CONTAINS
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: mo_derivs
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)         :: mo_derivs
       REAL(kind=dp)                                      :: energy
       TYPE(s2_restraint_type), POINTER                   :: s2_restraint_control
       LOGICAL                                            :: just_energy

--- a/src/s_square_methods.F
+++ b/src/s_square_methods.F
@@ -22,7 +22,6 @@ MODULE s_square_methods
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_type
    USE cp_para_types,                   ONLY: cp_para_env_type
@@ -69,8 +68,8 @@ CONTAINS
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       REAL(KIND=dp), INTENT(OUT)                         :: s_square, s_square_ideal
-      TYPE(cp_fm_type), DIMENSION(:), OPTIONAL, &
-         INTENT(INOUT)                                         :: mo_derivs
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT), &
+         OPTIONAL                                        :: mo_derivs
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: strength
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'compute_s_square'
@@ -193,7 +192,7 @@ CONTAINS
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)         :: mo_derivs
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: mo_derivs
       REAL(kind=dp)                                      :: energy
       TYPE(s2_restraint_type), POINTER                   :: s2_restraint_control
       LOGICAL                                            :: just_energy

--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -539,7 +539,7 @@ CONTAINS
 
          DO i = 0, norb - 1
             DO j = 0, norb - 1
-               CALL cp_fm_get_element(active_space_env%fock_sub(1)%matrix, i + 1, j + 1, mval)
+               CALL cp_fm_get_element(active_space_env%fock_sub(1), i + 1, j + 1, mval)
                buf(norb*i + j) = mval
                buf(norb*j + i) = mval
             END DO

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -20,7 +20,6 @@ MODULE stm_images
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_p_type,&
                                               cp_fm_release,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
@@ -110,8 +109,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: efermi, ref_energy
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues, mo_occ, stm_biases
       TYPE(cp_1d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: evals, occupation
-      TYPE(cp_fm_p_type), ALLOCATABLE, DIMENSION(:)      :: mo_arrays
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: mo_arrays
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
@@ -183,7 +182,7 @@ CONTAINS
          IF (nadd_unocc(ispin) == 0) THEN
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, &
                             eigenvalues=mo_eigenvalues, nmo=nmo, mu=efermi, occupation_numbers=mo_occ)
-            mo_arrays(ispin)%matrix => mo_coeff
+            mo_arrays(ispin) = mo_coeff
             evals(ispin)%array => mo_eigenvalues
             occupation(ispin)%array => mo_occ
          ELSE
@@ -198,11 +197,10 @@ CONTAINS
             occupation(ispin)%array(1 + nmo:ndim) = 0.0_dp
             CALL cp_fm_struct_create(fm_struct_tmp, ncol_global=ndim, &
                                      template_fmstruct=mo_coeff%matrix_struct)
-            ALLOCATE (mo_arrays(ispin)%matrix)
-            CALL cp_fm_create(mo_arrays(ispin)%matrix, fm_struct_tmp, name="mo_arrays")
+            CALL cp_fm_create(mo_arrays(ispin), fm_struct_tmp, name="mo_arrays")
             CALL cp_fm_struct_release(fm_struct_tmp)
-            CALL cp_fm_to_fm(mo_coeff, mo_arrays(ispin)%matrix, nmo, 1, 1)
-            CALL cp_fm_to_fm(unoccupied_orbs(ispin), mo_arrays(ispin)%matrix, &
+            CALL cp_fm_to_fm(mo_coeff, mo_arrays(ispin), nmo, 1, 1)
+            CALL cp_fm_to_fm(unoccupied_orbs(ispin), mo_arrays(ispin), &
                              nadd_unocc(ispin), 1, nmo + 1)
          END IF
       END DO
@@ -215,8 +213,7 @@ CONTAINS
          IF (nadd_unocc(ispin) > 0) THEN
             DEALLOCATE (evals(ispin)%array)
             DEALLOCATE (occupation(ispin)%array)
-            CALL cp_fm_release(mo_arrays(ispin)%matrix)
-            DEALLOCATE (mo_arrays(ispin)%matrix)
+            CALL cp_fm_release(mo_arrays(ispin))
          END IF
       END DO
       DEALLOCATE (mo_arrays)
@@ -266,7 +263,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: stm_section
       TYPE(dbcsr_type), POINTER                          :: stm_density_ao
       TYPE(pw_type), INTENT(INOUT)                       :: wf_r, wf_g
-      TYPE(cp_fm_p_type), DIMENSION(:), INTENT(IN)       :: mo_arrays
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_arrays
       TYPE(cp_1d_r_p_type), DIMENSION(:), INTENT(IN)     :: evals, occupation
       REAL(KIND=dp)                                      :: efermi
       REAL(KIND=dp), DIMENSION(:), POINTER               :: stm_biases
@@ -339,7 +336,7 @@ CONTAINS
          IF (istates == 0) CYCLE
 
          CALL cp_fm_struct_create(fm_struct_tmp, ncol_global=istates, &
-                                  template_fmstruct=mo_arrays(1)%matrix%matrix_struct)
+                                  template_fmstruct=mo_arrays(1)%matrix_struct)
          CALL cp_fm_create(matrix_v, fm_struct_tmp, name="matrix_v")
          CALL cp_fm_create(matrix_vf, fm_struct_tmp, name="matrix_vf")
          CALL cp_fm_struct_release(fm_struct_tmp)
@@ -351,8 +348,8 @@ CONTAINS
          alpha = 1.0_dp
          IF (nspin == 1) alpha = 2.0_dp
          DO ispin = 1, nspin
-            CALL cp_fm_to_fm(mo_arrays(ispin)%matrix, matrix_v, nstates(ispin), state_start(ispin), istates + 1)
-            CALL cp_fm_to_fm(mo_arrays(ispin)%matrix, matrix_vf, nstates(ispin), state_start(ispin), istates + 1)
+            CALL cp_fm_to_fm(mo_arrays(ispin), matrix_v, nstates(ispin), state_start(ispin), istates + 1)
+            CALL cp_fm_to_fm(mo_arrays(ispin), matrix_vf, nstates(ispin), state_start(ispin), istates + 1)
             IF (stm_biases(ibias) < 0.0_dp) THEN
                occ_tot(istates + 1:istates + nstates(ispin)) = &
                   occupation(ispin)%array(state_start(ispin):state_start(ispin) - 1 + nstates(ispin))

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -97,7 +97,8 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: stm_section
       TYPE(particle_list_type), POINTER                  :: particles
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: unoccupied_orbs
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN), &
+         POINTER                                         :: unoccupied_orbs
       TYPE(cp_1d_r_p_type), DIMENSION(:), POINTER        :: unoccupied_evals
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'th_stm_image'
@@ -201,7 +202,7 @@ CONTAINS
             CALL cp_fm_create(mo_arrays(ispin)%matrix, fm_struct_tmp, name="mo_arrays")
             CALL cp_fm_struct_release(fm_struct_tmp)
             CALL cp_fm_to_fm(mo_coeff, mo_arrays(ispin)%matrix, nmo, 1, 1)
-            CALL cp_fm_to_fm(unoccupied_orbs(ispin)%matrix, mo_arrays(ispin)%matrix, &
+            CALL cp_fm_to_fm(unoccupied_orbs(ispin), mo_arrays(ispin)%matrix, &
                              nadd_unocc(ispin), 1, nmo + 1)
          END IF
       END DO

--- a/src/xas_tdp_methods.F
+++ b/src/xas_tdp_methods.F
@@ -40,8 +40,8 @@ MODULE xas_tdp_methods
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         cp_fm_copy_general, cp_fm_create, cp_fm_get_diag, cp_fm_get_info, cp_fm_get_submatrix, &
-        cp_fm_p_type, cp_fm_read_unformatted, cp_fm_release, cp_fm_set_all, cp_fm_to_fm, &
-        cp_fm_to_fm_submat, cp_fm_type, cp_fm_write_unformatted
+        cp_fm_read_unformatted, cp_fm_release, cp_fm_set_all, cp_fm_to_fm, cp_fm_to_fm_submat, &
+        cp_fm_type, cp_fm_write_unformatted
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
                                               cp_logger_type,&
@@ -1793,10 +1793,10 @@ CONTAINS
       REAL(dp), DIMENSION(6)                             :: weights
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: opvec
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: zij_fm_set
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: moloc_coeff
       TYPE(cp_fm_type), POINTER                          :: vectors
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: op_sm_set
@@ -1825,7 +1825,7 @@ CONTAINS
                           moloc_coeff=moloc_coeff)
 
 !  Prepare for zij
-      vectors => moloc_coeff(1)%matrix
+      vectors => moloc_coeff(1)
       CALL cp_fm_get_info(vectors, nrow_global=nao)
       CALL cp_fm_create(opvec, vectors%matrix_struct)
 
@@ -1849,7 +1849,7 @@ CONTAINS
 
       DO ispin = 1, nspins
 !     zij computation, copied from qs_loc_methods:optimize_loc_berry
-         vectors => moloc_coeff(ispin)%matrix
+         vectors => moloc_coeff(ispin)
          DO i = 1, dim_op
             DO j = 1, 2
                CALL cp_fm_set_all(zij_fm_set(j, i), 0.0_dp)

--- a/src/xas_tdp_methods.F
+++ b/src/xas_tdp_methods.F
@@ -1794,16 +1794,16 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_p_type), DIMENSION(:), POINTER          :: moloc_coeff
-      TYPE(cp_fm_p_type), DIMENSION(:, :), POINTER       :: zij_fm_set
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type)                                   :: opvec
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: zij_fm_set
       TYPE(cp_fm_type), POINTER                          :: vectors
       TYPE(cp_para_env_type), POINTER                    :: para_env
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: op_sm_set
       TYPE(qs_loc_env_type), POINTER                     :: qs_loc_env
       TYPE(section_vals_type), POINTER                   :: print_loc_section, prog_run_info
 
-      NULLIFY (qs_loc_env, zij_fm_set, cell, print_loc_section, op_sm_set, moloc_coeff, vectors)
+      NULLIFY (qs_loc_env, cell, print_loc_section, op_sm_set, moloc_coeff, vectors)
       NULLIFY (tmp_fm_struct, para_env, blacs_env, prog_run_info)
 
 !  Initialization
@@ -1840,8 +1840,7 @@ CONTAINS
       ALLOCATE (zij_fm_set(2, dim_op))
       DO i = 1, dim_op
          DO j = 1, 2
-            ALLOCATE (zij_fm_set(j, i)%matrix)
-            CALL cp_fm_create(zij_fm_set(j, i)%matrix, tmp_fm_struct)
+            CALL cp_fm_create(zij_fm_set(j, i), tmp_fm_struct)
          END DO
       END DO
 
@@ -1853,10 +1852,10 @@ CONTAINS
          vectors => moloc_coeff(ispin)%matrix
          DO i = 1, dim_op
             DO j = 1, 2
-               CALL cp_fm_set_all(zij_fm_set(j, i)%matrix, 0.0_dp)
+               CALL cp_fm_set_all(zij_fm_set(j, i), 0.0_dp)
                CALL cp_dbcsr_sm_fm_multiply(op_sm_set(j, i)%matrix, vectors, opvec, ncol=n_centers)
                CALL parallel_gemm("T", "N", n_centers, n_centers, nao, 1.0_dp, vectors, opvec, 0.0_dp, &
-                                  zij_fm_set(j, i)%matrix)
+                                  zij_fm_set(j, i))
             END DO
          END DO
 
@@ -1871,8 +1870,7 @@ CONTAINS
       CALL cp_fm_struct_release(tmp_fm_struct)
       DO i = 1, dim_op
          DO j = 1, 2
-            CALL cp_fm_release(zij_fm_set(j, i)%matrix)
-            DEALLOCATE (zij_fm_set(j, i)%matrix)
+            CALL cp_fm_release(zij_fm_set(j, i))
          END DO
       END DO
       DEALLOCATE (zij_fm_set)


### PR DESCRIPTION
This replacement improves the readibility and we lose a layer of pointers. In a few cases, the arrays can be allocated on the stack instead of the heap. In one case, I kept the cp_fm_p_type because pointers to mos are totally sufficient in that case and a copy of data was not intended.

I will squash all commits at the end.