### PR TITLE
Docker: Fix typo in cmake variable and add check for warnings

### DIFF
--- a/tools/docker/Dockerfile.test_cmake
+++ b/tools/docker/Dockerfile.test_cmake
@@ -78,7 +78,8 @@ WORKDIR ./build
 RUN /bin/bash -c " \
     echo 'Compiling cp2k...' && \
     source /opt/cp2k-toolchain/install/setup && \
-    cmake -DCP2K_USE_VORI=ON -DCP2K_USE_COSMA=NO -DCP2K_USE_LIBXSMM=ON -DCP2K_BLAS_VENDOR=OpenBLAS -DCP2K_USE_SPGLIB=ON -DCP2K_USE_LIBINT2=ON -DCP2K_USE_LIBXC=ON -DCP2k_USE_LIBTORCH=ON .. && \
+    cmake -Werror=dev -DCP2K_USE_VORI=ON -DCP2K_USE_COSMA=NO -DCP2K_USE_LIBXSMM=ON -DCP2K_BLAS_VENDOR=OpenBLAS -DCP2K_USE_SPGLIB=ON -DCP2K_USE_LIBINT2=ON -DCP2K_USE_LIBXC=ON -DCP2K_USE_LIBTORCH=OFF .. |& tee ./cmake.log && \
+    ! grep -A5 'CMake Warning' ./cmake.log && \
     make -j"
 COPY ./data ./data
 COPY ./tests ./tests

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -402,7 +402,8 @@ WORKDIR ./build
 RUN /bin/bash -c " \
     echo 'Compiling cp2k...' && \
     source /opt/cp2k-toolchain/install/setup && \
-    cmake -DCP2K_USE_VORI=ON -DCP2K_USE_COSMA=NO -DCP2K_USE_LIBXSMM=ON -DCP2K_BLAS_VENDOR=OpenBLAS -DCP2K_USE_SPGLIB=ON -DCP2K_USE_LIBINT2=ON -DCP2K_USE_LIBXC=ON -DCP2k_USE_LIBTORCH=ON .. && \
+    cmake -Werror=dev -DCP2K_USE_VORI=ON -DCP2K_USE_COSMA=NO -DCP2K_USE_LIBXSMM=ON -DCP2K_BLAS_VENDOR=OpenBLAS -DCP2K_USE_SPGLIB=ON -DCP2K_USE_LIBINT2=ON -DCP2K_USE_LIBXC=ON -DCP2K_USE_LIBTORCH=OFF .. |& tee ./cmake.log && \
+    ! grep -A5 'CMake Warning' ./cmake.log && \
     make -j"
 COPY ./data ./data
 COPY ./tests ./tests

--- a/tools/docker/scripts/install_dbcsr.sh
+++ b/tools/docker/scripts/install_dbcsr.sh
@@ -35,7 +35,7 @@ else
   if [ -f dbcsr-${DBCSR_ver}.tar.gz ]; then
     echo "dbcsr-${DBCSR_ver}.tar.gz is found"
   else
-    wget "https://github.com/cp2k/dbcsr/archive/refs/tags/v${DBCSR_ver}.tar.gz" -O "dbcsr-${DBCSR_ver}.tar.gz"
+    wget -q "https://github.com/cp2k/dbcsr/archive/refs/tags/v${DBCSR_ver}.tar.gz" -O "dbcsr-${DBCSR_ver}.tar.gz"
   fi
   echo "Installing from scratch into ${pkg_install_dir}"
   [ -d dbcsr-${DBCSR_ver} ] && rm -rf dbcsr-${DBCSR_ver}


### PR DESCRIPTION
While looking through CMake's output I noticed:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    CP2k_USE_LIBTORCH
```

... ie. lower case `k` instead of capital `K`.

Unfortunately, fixing the typo broke the build and I couldn't immediately figure out why. So, I've disable libtorch for now.

Since there [seems to be no way](https://gitlab.kitware.com/cmake/cmake/-/issues/21412) to turn those warnings into errors, I've added a simple check via `grep` afterward.

