### PR TITLE
Regtesting: Introduce tests/UNIT_TESTS file

### DIFF
--- a/src/nequip_unittest.F
+++ b/src/nequip_unittest.F
@@ -23,10 +23,6 @@ PROGRAM nequip_unittest
 
    IMPLICIT NONE
 
-#if !defined(__LIBTORCH)
-   WRITE (*, *) "CP2K compiled without the Torch library - skipping NequIP unittest."
-
-#else
    CHARACTER(LEN=default_path_length) :: filename, cutoff_str, nequip_version
    REAL(dp) :: cutoff
 
@@ -237,7 +233,5 @@ CONTAINS
          END DO
       END DO
    END SUBROUTINE neighbor_search
-
-#endif
 
 END PROGRAM nequip_unittest

--- a/tests/UNIT_TESTS
+++ b/tests/UNIT_TESTS
@@ -1,0 +1,12 @@
+# Binaries listed in this file will be executed as part of cp2k's regression testing.
+# The binary name can be followed by required flags as reported by `cp2k --version`.
+
+dbt_tas_unittest
+dbt_unittest
+grid_unittest
+libcp2k_unittest
+memory_utilities_unittest
+nequip_unittest                                          libtorch
+parallel_rng_types_unittest
+
+#EOF


### PR DESCRIPTION
Follow up to #2534.
Closes #1350.

An explicit list of unit tests allows us to gate them on feature flags. Furthermore, it ensures that we're not accidentally losing a test because it failed to build for some reason