### PR TITLE
Use the standard conforming wrappers mpifort and mpiexec

### DIFF
--- a/arch/Darwin-gfortran.psmp
+++ b/arch/Darwin-gfortran.psmp
@@ -3,8 +3,8 @@
 # libxc is installed in LIBXC_INCLUDE_DIR / LIBXC_LIB_DIR
 # libint is installed in LIBINT_INCLUDE_DIR / LIBINT_LIB_DIR
 CC       = gcc
-FC       = mpif90
-LD       = mpif90
+FC       = mpifort
+LD       = mpifort
 AR       = ar -r
 RANLIB   = ranlib
 CFLAGS   = -O2 -fopenmp -g

--- a/arch/Darwin-gnu-arm64.psmp
+++ b/arch/Darwin-gnu-arm64.psmp
@@ -66,8 +66,8 @@ LMAX           := 5
 MAX_CONTR      := 4
 
 CC             := mpicc
-FC             := mpif90
-LD             := mpif90
+FC             := mpifort
+LD             := mpifort
 AR             := ar -r -s
 
 CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)

--- a/arch/FreeBSD-gfortran.psmp
+++ b/arch/FreeBSD-gfortran.psmp
@@ -1,6 +1,6 @@
 CC       = gcc
-FC       = mpif90
-LD       = mpif90
+FC       = mpifort
+LD       = mpifort
 AR       = ar -r
 DFLAGS   = -D__FFTW3 -D__NO_STATM_ACCESS -D__parallel -D__SCALAPACK
 FCFLAGS  = -O2 -fopenmp -funroll-loops -ftree-vectorize -march=native -ffree-form $(DFLAGS)

--- a/arch/Linux-gnu-aarch64.psmp
+++ b/arch/Linux-gnu-aarch64.psmp
@@ -68,8 +68,8 @@ LMAX           := 5
 MAX_CONTR      := 4
 
 CC             := mpicc
-FC             := mpif90
-LD             := mpif90
+FC             := mpifort
+LD             := mpifort
 AR             := ar -r
 
 CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)

--- a/arch/Linux-gnu-x86_64.psmp
+++ b/arch/Linux-gnu-x86_64.psmp
@@ -84,8 +84,8 @@ LMAX           := 5
 MAX_CONTR      := 4
 
 CC             := mpicc
-FC             := mpif90
-LD             := mpif90
+FC             := mpifort
+LD             := mpifort
 AR             := ar -r
 
 CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g -mtune=$(TARGET_CPU)

--- a/arch/Linux-x86-64-gfortran-opencl.psmp
+++ b/arch/Linux-x86-64-gfortran-opencl.psmp
@@ -3,8 +3,8 @@
 #              PLUMED 2.7.2, LIBXSMM
 
 CC          = mpicc
-FC          = mpif90
-LD          = mpif90
+FC          = mpifort
+LD          = mpifort
 AR          = gcc-ar -r
 
 GPUVER      = P100

--- a/tests/SLOW_TESTS_SUPPRESSIONS
+++ b/tests/SLOW_TESTS_SUPPRESSIONS
@@ -43,5 +43,13 @@ QS/regtest-rel/Hg_rel.inp
 xTB/regtest-5/AdeThyvdW.inp
 xTB/regtest-5/ef_stress1.inp
 xTB/regtest-5/ef_stress3.inp
+QS/regtest-admm-qps/CH4-ADMMS-stress-tensor-numerical.inp
+QS/regtest-xc/3H2_PBE.inp
+QS/regtest-xc/3H2_PBEsol.inp
+QS/regtest-nmr-1/H2O-NMR-1-postgeo.inp
+Fist/regtest-5-vib/N3dye_geoopt.inp
+QS/regtest-rel/h2o-4.inp
+QS/regtest-ps-implicit-1-3/Ar_mixed_aa_planar.inp
+QS/regtest-ps-implicit-1-2/Ar_neumann.inp
 
 #EOF

--- a/tools/docker/scripts/test_aiida.sh
+++ b/tools/docker/scripts/test_aiida.sh
@@ -45,7 +45,7 @@ adduser --disabled-password --gecos "" ubuntu
 echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # link mpi executables into path
-MPI_INSTALL_DIR=$(dirname "$(command -v mpirun)")
+MPI_INSTALL_DIR=$(dirname "$(command -v mpiexec)")
 for i in "${MPI_INSTALL_DIR}"/*; do ln -sf "$i" /usr/bin/; done
 
 echo -e "\n========== Installing AiiDA-CP2K plugin =========="

--- a/tools/plan_mpi_omp/README.md
+++ b/tools/plan_mpi_omp/README.md
@@ -26,7 +26,7 @@ be better for performance (`16x6`). To easily place the ranks, Intel MPI
 is used:
 
 ```bash
-mpirun -np 16 \
+mpiexec -np 16 \
   -genv I_MPI_PIN_DOMAIN=auto -genv I_MPI_PIN_ORDER=bunch \
   -genv OMP_PLACES=threads -genv OMP_PROC_BIND=SPREAD \
   -genv OMP_NUM_THREADS=6 \
@@ -49,7 +49,7 @@ elements (`PE`). By default, execution slots are counted in number of physical
 cores which yields `--map-by slot:PE=3` for the same system (mentioned above).
 
 ```bash
-mpirun -np 16 --map-by slot:PE=3 \
+mpiexec -np 16 --map-by slot:PE=3 \
   -x OMP_PLACES=threads -x OMP_PROC_BIND=SPREAD \
   -x OMP_NUM_THREADS=6 \
   exe/Linux-x86-64-intelx/cp2k.psmp workload.inp
@@ -59,7 +59,7 @@ mpirun -np 16 --map-by slot:PE=3 \
 ranks between sockets (see above) appears hard to achieve with OpenMPI
 therefore an undersubscribed system may not be recommended. To display and
 to log the pinning and thread affinization at the startup of an application,
-`mpirun --report-bindings` can be used.
+`mpiexec --report-bindings` can be used.
 
 The end of the next section continues with our example and extends execution
 to multiple nodes of the above-mentioned system.
@@ -105,30 +105,30 @@ filling each node). For the given example, 8 ranks per node with
 12 threads per rank is chosen (`8x12`) and MPI-executed:
 
 ```bash
-mpirun -perhost 8 -host node1,node2,node3,node4,node5,node6,node7,node8 \
+mpiexec -perhost 8 -host node1,node2,node3,node4,node5,node6,node7,node8 \
   -genv I_MPI_PIN_DOMAIN=auto -genv I_MPI_PIN_ORDER=bunch -genv I_MPI_DEBUG=4 \
   -genv OMP_PLACES=threads -genv OMP_PROC_BIND=SPREAD -genv OMP_NUM_THREADS=12 \
   exe/Linux-x86-64-intelx/cp2k.psmp workload.inp
 ```
 
-**NOTE**: For Intel MPI as well as OpenMPI, mpirun's host-list (`mpirun -host`) is setup with unique node-names, and this is the only style that is
+**NOTE**: For Intel MPI as well as OpenMPI, mpiexec's host-list (`mpiexec -host`) is setup with unique node-names, and this is the only style that is
 explained in this article. There is a competing style where nodes names are
 duplicated for the sake of enumerating available ranks (or "execution slots"
 in case of OpenMPI), which is not exercised in this article.
 
 For OpenMPI, the quantity (per node) of the previously mentioned "execution
 slots" (measured in number of physical cores) are sometimes not known to
-OpenMPI (depends on cluster/scheduler setup). For instance, `mpirun` may be
+OpenMPI (depends on cluster/scheduler setup). For instance, `mpiexec` may be
 complaining about an attempt to use too many execution slots simply because
 OpenMPI believes all systems represent a single such slot (instead of 2x24
 cores it only "sees" a single core per system). In such case, it is not
 recommended to "oversubscribe" the system because rank/thread affinity will
-likely be wrong (`mpirun --oversubscribe`). Instead, the list of unique nodes
+likely be wrong (`mpiexec --oversubscribe`). Instead, the list of unique nodes
 names (`-host`) may be augmented with the number of physical cores on each of
 the nodes (e.g., ":48" in our case).
 
 ```bash
-mpirun -npernode 8 -host
+mpiexec -npernode 8 -host
 node1:48,node2:48,node3:48,node4:48,node5:48,node6:48,node7:48,node8:48 \
   --map-by slot:PE=6 --report-bindings \
   -x OMP_PLACES=threads -x OMP_PROC_BIND=SPREAD -x OMP_NUM_THREADS=12 \
@@ -136,9 +136,9 @@ node1:48,node2:48,node3:48,node4:48,node5:48,node6:48,node7:48,node8:48 \
 ```
 
 **NOTE**: It can be still insufficient to augment the nodes with the expected
-number of slots (`:48`). If OpenMPI's mpirun is still complaining, it might
+number of slots (`:48`). If OpenMPI's mpiexec is still complaining, it might
 be caused and solved by the job scheduler. For example, `qsub` (PBS) may be
-instructed with `-l select=8:mpiprocs=48` in the above case (`mpirun` in this
+instructed with `-l select=8:mpiprocs=48` in the above case (`mpiexec` in this
 job can use less than 48 ranks per node).
 
 The plan-script also suggests close-by configurations (lower and higher

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -836,7 +836,7 @@ if [ "${ENABLE_CRAY}" = "__TRUE__" ]; then
   export MPICC="${CC}"
   export MPICXX="${CXX}"
   export MPIFC="${FC}"
-  export MPIF90="${MPIFC}"
+  export MPIFORT="${MPIFC}"
   export MPIF77="${MPIFC}"
   # CRAY libsci should contains core math libraries, scalapack
   # doesn't need LDFLAGS or CFLAGS, nor do the one need to

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -305,17 +305,17 @@ with_cosma="__INSTALL__"
 with_libvori="__INSTALL__"
 with_libtorch="__DONTUSE__"
 # for MPI, we try to detect system MPI variant
-if (command -v mpirun > /dev/null 2>&1); then
+if (command -v mpiexec > /dev/null 2>&1); then
   # check if we are dealing with openmpi, mpich or intelmpi
-  if (mpirun --version 2>&1 | grep -s -q "HYDRA"); then
+  if (mpiexec --version 2>&1 | grep -s -q "HYDRA"); then
     echo "MPI is detected and it appears to be MPICH"
     export MPI_MODE="mpich"
     with_mpich="__SYSTEM__"
-  elif (mpirun --version 2>&1 | grep -s -q "Open MPI"); then
+  elif (mpiexec --version 2>&1 | grep -s -q "Open MPI"); then
     echo "MPI is detected and it appears to be OpenMPI"
     export MPI_MODE="openmpi"
     with_openmpi="__SYSTEM__"
-  elif (mpirun --version 2>&1 | grep -s -q "Intel"); then
+  elif (mpiexec --version 2>&1 | grep -s -q "Intel"); then
     echo "MPI is detected and it appears to be Intel MPI"
     with_gcc="__DONTUSE__"
     with_intel="__SYSTEM__"

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -29,7 +29,7 @@ case "${with_intelmpi}" in
     ;;
   __SYSTEM__)
     echo "==================== Finding Intel MPI from system paths ===================="
-    check_command mpirun "intelmpi" && MPIRUN="$(command -v mpirun)" || exit 1
+    check_command mpiexec "intelmpi" && MPIRUN="$(command -v mpiexec)" || exit 1
     if [ "${with_intel}" != "__DONTUSE__" ]; then
       check_command mpiicc "intelmpi" && MPICC="$(command -v mpiicc)" || exit 1
       check_command mpiicpc "intelmpi" && MPICXX="$(command -v mpiicpc)" || exit 1
@@ -56,7 +56,7 @@ case "${with_intelmpi}" in
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    check_command ${pkg_install_dir}/bin/mpirun "intel" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
+    check_command ${pkg_install_dir}/bin/mpiexec "intel" && MPIRUN="${pkg_install_dir}/bin/mpiexec" || exit 1
     if [ "${with_intel}" != "__DONTUSE__" ]; then
       check_command ${pkg_install_dir}/bin/mpiicc "intel" && MPICC="${pkg_install_dir}/bin/mpiicc" || exit 1
       check_command ${pkg_install_dir}/bin/mpiicpc "intel" && MPICXX="${pkg_install_dir}/bin/mpiicpc" || exit 1

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -37,9 +37,9 @@ case "${with_intelmpi}" in
     else
       check_command mpicc "intelmpi" && MPICC="$(command -v mpicc)" || exit 1
       check_command mpicxx "intelmpi" && MPICXX="$(command -v mpicxx)" || exit 1
-      check_command mpif90 "intelmpi" && MPIFC="$(command -v mpif90)" || exit 1
+      check_command mpifort "intelmpi" && MPIFC="$(command -v mpifort)" || exit 1
     fi
-    MPIF90="${MPIFC}"
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     # include path is already handled by compiler wrapper scripts (can cause wrong mpi.mod with GNU Fortran)
     # add_include_from_paths INTELMPI_CFLAGS "mpi.h" $INCLUDE_PATHS
@@ -64,9 +64,9 @@ case "${with_intelmpi}" in
     else
       check_command ${pkg_install_dir}/bin/mpicc "intel" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
       check_command ${pkg_install_dir}/bin/mpicxx "intel" && MPICXX="${pkg_install_dir}/bin/mpicxx" || exit 1
-      check_command ${pkg_install_dir}/bin/mpif90 "intel" && MPIFC="${pkg_install_dir}/bin/mpif90" || exit 1
+      check_command ${pkg_install_dir}/bin/mpifort "intel" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
     fi
-    MPIF90="${MPIFC}"
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     # include path is already handled by compiler wrapper scripts (can cause wrong mpi.mod with GNU Fortran)
     #INTELMPI_CFLAGS="-I'${pkg_install_dir}/include'"
@@ -81,7 +81,7 @@ export MPIRUN="${MPIRUN}"
 export MPICC="${MPICC}"
 export MPICXX="${MPICXX}"
 export MPIFC="${MPIFC}"
-export MPIF90="${MPIF90}"
+export MPIFORT="${MPIFORT}"
 export MPIF77="${MPIF77}"
 export INTELMPI_CFLAGS="${INTELMPI_CFLAGS}"
 export INTELMPI_LDFLAGS="${INTELMPI_LDFLAGS}"

--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -71,8 +71,8 @@ case "${with_mpich}" in
     check_install ${pkg_install_dir}/bin/mpirun "mpich" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
     check_install ${pkg_install_dir}/bin/mpicc "mpich" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_install ${pkg_install_dir}/bin/mpicxx "mpich" && MPICXX="${pkg_install_dir}/bin/mpicxx" || exit 1
-    check_install ${pkg_install_dir}/bin/mpif90 "mpich" && MPIFC="${pkg_install_dir}/bin/mpif90" || exit 1
-    MPIF90="${MPIFC}"
+    check_install ${pkg_install_dir}/bin/mpifort "mpich" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     MPICH_CFLAGS="-I'${pkg_install_dir}/include'"
     MPICH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
@@ -86,8 +86,8 @@ case "${with_mpich}" in
     else
       check_command mpicxx "mpich" && MPICXX="$(command -v mpicxx)" || exit 1
     fi
-    check_command mpif90 "mpich" && MPIFC="$(command -v mpif90)" || exit 1
-    MPIF90="${MPIFC}"
+    check_command mpifort "mpich" && MPIFC="$(command -v mpifort)" || exit 1
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     check_lib -lmpifort "mpich"
     check_lib -lmpicxx "mpich"
@@ -107,8 +107,8 @@ case "${with_mpich}" in
     check_command ${pkg_install_dir}/bin/mpirun "mpich" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
     check_command ${pkg_install_dir}/bin/mpicc "mpich" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_command ${pkg_install_dir}/bin/mpicxx "mpich" && MPICXX="${pkg_install_dir}/bin/mpicxx" || exit 1
-    check_command ${pkg_install_dir}/bin/mpif90 "mpich" && MPIFC="${pkg_install_dir}/bin/mpif90" || exit 1
-    MPIF90="${MPIFC}"
+    check_command ${pkg_install_dir}/bin/mpifort "mpich" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     MPICH_CFLAGS="-I'${pkg_install_dir}/include'"
     MPICH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
@@ -127,7 +127,7 @@ export MPIRUN="${MPIRUN}"
 export MPICC="${MPICC}"
 export MPICXX="${MPICXX}"
 export MPIFC="${MPIFC}"
-export MPIF90="${MPIF90}"
+export MPIFORT="${MPIFORT}"
 export MPIF77="${MPIF77}"
 export MPICH_CFLAGS="${MPICH_CFLAGS}"
 export MPICH_LDFLAGS="${MPICH_LDFLAGS}"

--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -68,7 +68,7 @@ case "${with_mpich}" in
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    check_install ${pkg_install_dir}/bin/mpirun "mpich" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
+    check_install ${pkg_install_dir}/bin/mpiexec "mpich" && MPIRUN="${pkg_install_dir}/bin/mpiexec" || exit 1
     check_install ${pkg_install_dir}/bin/mpicc "mpich" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_install ${pkg_install_dir}/bin/mpicxx "mpich" && MPICXX="${pkg_install_dir}/bin/mpicxx" || exit 1
     check_install ${pkg_install_dir}/bin/mpifort "mpich" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
@@ -79,7 +79,7 @@ case "${with_mpich}" in
     ;;
   __SYSTEM__)
     echo "==================== Finding MPICH from system paths ===================="
-    check_command mpirun "mpich" && MPIRUN="$(command -v mpirun)" || exit 1
+    check_command mpiexec "mpich" && MPIRUN="$(command -v mpiexec)" || exit 1
     check_command mpicc "mpich" && MPICC="$(command -v mpicc)" || exit 1
     if [ $(command -v mpic++ > /dev/null 2>&1) ]; then
       check_command mpic++ "mpich" && MPICXX="$(command -v mpic++)" || exit 1
@@ -104,7 +104,7 @@ case "${with_mpich}" in
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    check_command ${pkg_install_dir}/bin/mpirun "mpich" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
+    check_command ${pkg_install_dir}/bin/mpiexec "mpich" && MPIRUN="${pkg_install_dir}/bin/mpiexec" || exit 1
     check_command ${pkg_install_dir}/bin/mpicc "mpich" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_command ${pkg_install_dir}/bin/mpicxx "mpich" && MPICXX="${pkg_install_dir}/bin/mpicxx" || exit 1
     check_command ${pkg_install_dir}/bin/mpifort "mpich" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
@@ -116,9 +116,9 @@ case "${with_mpich}" in
 esac
 if [ "${with_mpich}" != "__DONTUSE__" ]; then
   if [ "${with_mpich}" != "__SYSTEM__" ]; then
-    mpi_bin="${pkg_install_dir}/bin/mpirun"
+    mpi_bin="${pkg_install_dir}/bin/mpiexec"
   else
-    mpi_bin="mpirun"
+    mpi_bin="mpiexec"
   fi
   MPICH_LIBS="-lmpifort -lmpicxx -lmpi"
   cat << EOF > "${BUILDDIR}/setup_mpich"

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -76,7 +76,7 @@ case "${with_openmpi}" in
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    check_install ${pkg_install_dir}/bin/mpirun "openmpi" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
+    check_install ${pkg_install_dir}/bin/mpiexec "openmpi" && MPIRUN="${pkg_install_dir}/bin/mpiexec" || exit 1
     check_install ${pkg_install_dir}/bin/mpicc "openmpi" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_install ${pkg_install_dir}/bin/mpicxx "openmpi" && MPICXX="${pkg_install_dir}/bin/mpicxx" || exit 1
     check_install ${pkg_install_dir}/bin/mpifort "openmpi" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
@@ -87,7 +87,7 @@ case "${with_openmpi}" in
     ;;
   __SYSTEM__)
     echo "==================== Finding OpenMPI from system paths ===================="
-    check_command mpirun "openmpi" && MPIRUN="$(command -v mpirun)" || exit 1
+    check_command mpiexec "openmpi" && MPIRUN="$(command -v mpiexec)" || exit 1
     check_command mpicc "openmpi" && MPICC="$(command -v mpicc)" || exit 1
     check_command mpic++ "openmpi" && MPICXX="$(command -v mpic++)" || exit 1
     check_command mpifort "openmpi" && MPIFC="$(command -v mpifort)" || exit 1
@@ -107,7 +107,7 @@ case "${with_openmpi}" in
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    check_command ${pkg_install_dir}/bin/mpirun "openmpi" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
+    check_command ${pkg_install_dir}/bin/mpiexec "openmpi" && MPIRUN="${pkg_install_dir}/bin/mpiexec" || exit 1
     check_command ${pkg_install_dir}/bin/mpicc "openmpi" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_command ${pkg_install_dir}/bin/mpic++ "openmpi" && MPICXX="${pkg_install_dir}/bin/mpic++" || exit 1
     check_command ${pkg_install_dir}/bin/mpifort "openmpi" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
@@ -119,13 +119,13 @@ case "${with_openmpi}" in
 esac
 if [ "${with_openmpi}" != "__DONTUSE__" ]; then
   if [ "${with_openmpi}" != "__SYSTEM__" ]; then
-    mpi_bin="${pkg_install_dir}/bin/mpirun"
+    mpi_bin="${pkg_install_dir}/bin/mpiexec"
     mpicxx_bin="${pkg_install_dir}/bin/mpicxx"
   else
-    mpi_bin="mpirun"
+    mpi_bin="mpiexec"
     mpicxx_bin="mpicxx"
   fi
-  # check openmpi version as reported by mpirun
+  # check openmpi version as reported by mpiexec
   raw_version=$(${mpi_bin} --version 2>&1 |
     grep "(Open MPI)" | awk '{print $4}')
   major_version=$(echo ${raw_version} | cut -d '.' -f 1)

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -79,8 +79,8 @@ case "${with_openmpi}" in
     check_install ${pkg_install_dir}/bin/mpirun "openmpi" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
     check_install ${pkg_install_dir}/bin/mpicc "openmpi" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_install ${pkg_install_dir}/bin/mpicxx "openmpi" && MPICXX="${pkg_install_dir}/bin/mpicxx" || exit 1
-    check_install ${pkg_install_dir}/bin/mpif90 "openmpi" && MPIFC="${pkg_install_dir}/bin/mpif90" || exit 1
-    MPIF90="${MPIFC}"
+    check_install ${pkg_install_dir}/bin/mpifort "openmpi" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     OPENMPI_CFLAGS="-I'${pkg_install_dir}/include'"
     OPENMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
@@ -90,8 +90,8 @@ case "${with_openmpi}" in
     check_command mpirun "openmpi" && MPIRUN="$(command -v mpirun)" || exit 1
     check_command mpicc "openmpi" && MPICC="$(command -v mpicc)" || exit 1
     check_command mpic++ "openmpi" && MPICXX="$(command -v mpic++)" || exit 1
-    check_command mpif90 "openmpi" && MPIFC="$(command -v mpif90)" || exit 1
-    MPIF90="${MPIFC}"
+    check_command mpifort "openmpi" && MPIFC="$(command -v mpifort)" || exit 1
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     # Fortran code in CP2K is built via the mpifort wrapper, but we may need additional
     # libraries and linker flags for C/C++-based MPI codepaths, pull them in at this point.
@@ -110,8 +110,8 @@ case "${with_openmpi}" in
     check_command ${pkg_install_dir}/bin/mpirun "openmpi" && MPIRUN="${pkg_install_dir}/bin/mpirun" || exit 1
     check_command ${pkg_install_dir}/bin/mpicc "openmpi" && MPICC="${pkg_install_dir}/bin/mpicc" || exit 1
     check_command ${pkg_install_dir}/bin/mpic++ "openmpi" && MPICXX="${pkg_install_dir}/bin/mpic++" || exit 1
-    check_command ${pkg_install_dir}/bin/mpif90 "openmpi" && MPIFC="${pkg_install_dir}/bin/mpif90" || exit 1
-    MPIF90="${MPIFC}"
+    check_command ${pkg_install_dir}/bin/mpifort "openmpi" && MPIFC="${pkg_install_dir}/bin/mpifort" || exit 1
+    MPIFORT="${MPIFC}"
     MPIF77="${MPIFC}"
     OPENMPI_CFLAGS="-I'${pkg_install_dir}/include'"
     OPENMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
@@ -143,7 +143,7 @@ export MPIRUN="${MPIRUN}"
 export MPICC="${MPICC}"
 export MPICXX="${MPICXX}"
 export MPIFC="${MPIFC}"
-export MPIF90="${MPIF90}"
+export MPIFORT="${MPIFORT}"
 export MPIF77="${MPIF77}"
 export OPENMPI_CFLAGS="${OPENMPI_CFLAGS}"
 export OPENMPI_LDFLAGS="${OPENMPI_LDFLAGS}"


### PR DESCRIPTION
We currently employ the MPI compiler wrapper mpif90 and the MPI execution script mpirun which are both not standardized. This PR will replace both of them with mpifort and mpiexec respectively which are required by the MPI standard 2.0.