### PR TITLE
Conventions: Make default initializers mandatory

### DIFF
--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -1,5 +1,51 @@
+admm_types.F: Found type admm_type with partial initializer https://cp2k.org/conv#c017
+admm_types.F: Found type eigvals_p_type without initializer https://cp2k.org/conv#c016
+admm_types.F: Found type eigvals_type without initializer https://cp2k.org/conv#c016
+almo_scf_diis_types.F: Found type almo_scf_diis_type with partial initializer https://cp2k.org/conv#c017
 almo_scf.F: Found WRITE statement with hardcoded unit in "almo_scf_init" https://cp2k.org/conv#c012
+almo_scf_lbfgs_types.F: Found type lbfgs_history_type with partial initializer https://cp2k.org/conv#c017
+almo_scf_types.F: Found type almo_analysis_type without initializer https://cp2k.org/conv#c016
+almo_scf_types.F: Found type almo_scf_env_type with partial initializer https://cp2k.org/conv#c017
+almo_scf_types.F: Found type almo_scf_history_type with partial initializer https://cp2k.org/conv#c017
+almo_scf_types.F: Found type optimizer_options_type with partial initializer https://cp2k.org/conv#c017
+almo_scf_types.F: Found type penalty_type without initializer https://cp2k.org/conv#c016
 al_system_dynamics.F: Found WRITE statement with hardcoded unit in "dump_vel" https://cp2k.org/conv#c012
+al_system_types.F: Found type al_system_type without initializer https://cp2k.org/conv#c016
+al_system_types.F: Found type al_thermo_type without initializer https://cp2k.org/conv#c016
+arnoldi_types.F: Found type arnoldi_control_type with partial initializer https://cp2k.org/conv#c017
+arnoldi_types.F: Found type arnoldi_data_c_type without initializer https://cp2k.org/conv#c016
+arnoldi_types.F: Found type arnoldi_data_d_type without initializer https://cp2k.org/conv#c016
+arnoldi_types.F: Found type arnoldi_data_s_type without initializer https://cp2k.org/conv#c016
+arnoldi_types.F: Found type arnoldi_data_type with partial initializer https://cp2k.org/conv#c017
+arnoldi_types.F: Found type arnoldi_data_z_type without initializer https://cp2k.org/conv#c016
+atom_fit.F: Found type wfn_init without initializer https://cp2k.org/conv#c016
+atom_grb.F: Found type basis_p_type without initializer https://cp2k.org/conv#c016
+atomic_kind_list_types.F: Found type atomic_kind_list_p_type without initializer https://cp2k.org/conv#c016
+atomic_kind_list_types.F: Found type atomic_kind_list_type without initializer https://cp2k.org/conv#c016
+atomic_kind_types.F: Found type atomic_kind_p_type without initializer https://cp2k.org/conv#c016
+atom_optimization.F: Found type atom_history_type without initializer https://cp2k.org/conv#c016
+atom_optimization.F: Found type hmat_type without initializer https://cp2k.org/conv#c016
+atom_sgp.F: Found type atom_sgp_potential_type with partial initializer https://cp2k.org/conv#c017
+atom_types.F: Found type atom_basis_type without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type atom_ecppot_type without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type atom_energy_type without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type atom_gthpot_type without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type atom_hfx_type with partial initializer https://cp2k.org/conv#c017
+atom_types.F: Found type atom_integrals with partial initializer https://cp2k.org/conv#c017
+atom_types.F: Found type atom_optimization_type without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type atom_orbitals without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type atom_potential_type with partial initializer https://cp2k.org/conv#c017
+atom_types.F: Found type atom_p_type without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type atom_sgppot_type with partial initializer https://cp2k.org/conv#c017
+atom_types.F: Found type atom_state with partial initializer https://cp2k.org/conv#c017
+atom_types.F: Found type atom_type with partial initializer https://cp2k.org/conv#c017
+atom_types.F: Found type eri without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type opgrid_type without initializer https://cp2k.org/conv#c016
+atom_types.F: Found type opmat_type without initializer https://cp2k.org/conv#c016
+atom_upf.F: Found type atom_upfpot_type with partial initializer https://cp2k.org/conv#c017
+atprop_types.F: Found type atprop_type without initializer https://cp2k.org/conv#c016
+averages_types.F: Found type average_quantities_type without initializer https://cp2k.org/conv#c016
+barostat_types.F: Found type barostat_type without initializer https://cp2k.org/conv#c016
 base_hooks.F: Found CALL m_abort in procedure "cp_abort" https://cp2k.org/conv#c008
 base_hooks.F: Found STOP statement in procedure "cp_abort" https://cp2k.org/conv#c011
 base_hooks.F: Found STOP statement in procedure "cp__a" https://cp2k.org/conv#c011
@@ -7,9 +53,70 @@ base_hooks.F: Found STOP statement in procedure "cp__b" https://cp2k.org/conv#c0
 base_hooks.F: Found WRITE statement with hardcoded unit in "cp_abort" https://cp2k.org/conv#c012
 base_hooks.F: Found WRITE statement with hardcoded unit in "cp_hint" https://cp2k.org/conv#c012
 base_hooks.F: Found WRITE statement with hardcoded unit in "cp_warn" https://cp2k.org/conv#c012
+basis_set_types.F: Found type gto_basis_set_p_type without initializer https://cp2k.org/conv#c016
+basis_set_types.F: Found type gto_basis_set_type with partial initializer https://cp2k.org/conv#c017
+basis_set_types.F: Found type sto_basis_set_type without initializer https://cp2k.org/conv#c016
 beta_gamma_psi.F: Found GOTO statement in procedure "bratio" https://cp2k.org/conv#c011
 bfgs_optimizer.F: Found GOTO statement in procedure "rat_fun_opt" https://cp2k.org/conv#c011
+block_p_types.F: Found type block_p_type without initializer https://cp2k.org/conv#c016
+callgraph.F: Found type callgraph_item_type without initializer https://cp2k.org/conv#c016
+callgraph.F: Found type private_item_type with partial initializer https://cp2k.org/conv#c017
+cell_opt_types.F: Found type cell_opt_env_type without initializer https://cp2k.org/conv#c016
+cell_types.F: Found type cell_p_type without initializer https://cp2k.org/conv#c016
+cell_types.F: Found type cell_type without initializer https://cp2k.org/conv#c016
 cg_test.F: Found WRITE statement with hardcoded unit in "clebsch_gordon_test" https://cp2k.org/conv#c012
+colvar_types.F: Found type acid_hyd_dist_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type acid_hyd_shell_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type angle_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type colvar_counters without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type colvar_p_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type combine_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type coord_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type dfunct_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type dist_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type gyration_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type hbp_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type hydronium_dist_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type hydronium_shell_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type mindist_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type plane_def_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type plane_distance_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type plane_plane_angle_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type point_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type population_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type qparm_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type reaction_path_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type ring_puckering_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type rmsd_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type rotation_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type torsion_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type u_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type wc_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type xyz_diag_colvar_type without initializer https://cp2k.org/conv#c016
+colvar_types.F: Found type xyz_outerdiag_colvar_type without initializer https://cp2k.org/conv#c016
+cp2k_shell.F: Found type cp2k_shell_type with partial initializer https://cp2k.org/conv#c017
+cp_blacs_env.F: Found type cp_blacs_env_type with partial initializer https://cp2k.org/conv#c017
+cp_control_types.F: Found type admm_control_type with partial initializer https://cp2k.org/conv#c017
+cp_control_types.F: Found type ddapc_restraint_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type dftb_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type dft_control_type with partial initializer https://cp2k.org/conv#c017
+cp_control_types.F: Found type efield_p_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type efield_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type expot_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type gapw_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type maxwell_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type mulliken_restraint_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type period_efield_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type pw_grid_option without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type qs_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type rtp_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type s2_restraint_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type semi_empirical_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type stda_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type tddfpt2_control_type with partial initializer https://cp2k.org/conv#c017
+cp_control_types.F: Found type tddfpt_control_type without initializer https://cp2k.org/conv#c016
+cp_control_types.F: Found type xtb_control_type without initializer https://cp2k.org/conv#c016
 cp_dbcsr_cholesky.F: Procedure 'pdcopy' called with an implicit interface at (1) [-Wimplicit-interface]
 cp_dbcsr_cholesky.F: Procedure 'pdpotrf' called with an implicit interface at (1) [-Wimplicit-interface]
 cp_dbcsr_cholesky.F: Procedure 'pdpotri' called with an implicit interface at (1) [-Wimplicit-interface]
@@ -24,14 +131,25 @@ cp_dbcsr_operations.F: Found CALL cp_fm_gemm in procedure "cp_dbcsr_plus_fm_fm_t
 cp_dbcsr_operations.F: Found WRITE statement with hardcoded unit in "cp_dbcsr_plus_fm_fm_t" https://cp2k.org/conv#c012
 cp_dbcsr_operations.F: Found WRITE statement with hardcoded unit in "create_bl_distribution" https://cp2k.org/conv#c012
 cp_dbcsr_operations.F: Found WRITE statement with hardcoded unit in "dbcsr_create_dist_block_cyclic" https://cp2k.org/conv#c012
+cp_ddapc_types.F: Found type cp_ddapc_ewald_type without initializer https://cp2k.org/conv#c016
+cp_ddapc_types.F: Found type cp_ddapc_type without initializer https://cp2k.org/conv#c016
 cp_ddapc_util.F: Found WRITE statement with hardcoded unit in "debug_charge" https://cp2k.org/conv#c012
 cp_ddapc_util.F: Found WRITE statement with hardcoded unit in "debug_der_a_matrix" https://cp2k.org/conv#c012
 cp_ddapc_util.F: Found WRITE statement with hardcoded unit in "debug_der_b_vector" https://cp2k.org/conv#c012
+cp_eri_mme_interface.F: Found type cp_eri_mme_param with partial initializer https://cp2k.org/conv#c017
 cp_error_handling.F: Found CALL mp_abort in procedure "cp_abort_handler" https://cp2k.org/conv#c008
 cp_files.F: Found CLOSE statement in procedure "close_file" https://cp2k.org/conv#c011
 cp_files.F: Found OPEN statement in procedure "open_file" https://cp2k.org/conv#c011
+cp_files.F: Found type preconnection_type without initializer https://cp2k.org/conv#c016
 cp_fm_basic_linalg.F: Found CALL cp_fm_gemm in procedure "cp_complex_fm_gemm" https://cp2k.org/conv#c008
 cp_fm_diag.F: Found CALL cp_fm_gemm in procedure "cp_fm_geeig_canon" https://cp2k.org/conv#c008
+cp_fm_diag_utils.F: Found type cp_fm_redistribute_info without initializer https://cp2k.org/conv#c016
+cp_fm_diag_utils.F: Found type cp_fm_redistribute_type with partial initializer https://cp2k.org/conv#c017
+cp_fm_pool_types.F: Found type cp_fm_pool_p_type without initializer https://cp2k.org/conv#c016
+cp_fm_pool_types.F: Found type cp_fm_pool_type without initializer https://cp2k.org/conv#c016
+cp_fm_struct.F: Found type cp_fm_struct_p_type without initializer https://cp2k.org/conv#c016
+cp_fm_struct.F: Found type cp_fm_struct_type without initializer https://cp2k.org/conv#c016
+cp_iter_types.F: Found type cp_iteration_info_type without initializer https://cp2k.org/conv#c016
 cp_lbfgs.F: Found WRITE statement with hardcoded unit in "active" https://cp2k.org/conv#c012
 cp_lbfgs.F: Found WRITE statement with hardcoded unit in "cauchy" https://cp2k.org/conv#c012
 cp_lbfgs.F: Found WRITE statement with hardcoded unit in "freev" https://cp2k.org/conv#c012
@@ -41,38 +159,218 @@ cp_lbfgs.F: Found WRITE statement with hardcoded unit in "prn1lb" https://cp2k.o
 cp_lbfgs.F: Found WRITE statement with hardcoded unit in "prn2lb" https://cp2k.org/conv#c012
 cp_lbfgs.F: Found WRITE statement with hardcoded unit in "prn3lb" https://cp2k.org/conv#c012
 cp_lbfgs.F: Found WRITE statement with hardcoded unit in "subsm" https://cp2k.org/conv#c012
+cp_lbfgs_optimizer_gopt.F: Found type cp_lbfgs_opt_gopt_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_fm.F: Found type cp_sll_fm_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_fm.F: Found type cp_sll_fm_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_char_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_char_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_int_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_int_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_logical_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_logical_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_real_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_real_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_val_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_input.F: Found type cp_sll_val_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_pw.F: Found type cp_sll_3d_r_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_pw.F: Found type cp_sll_3d_r_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_pw.F: Found type cp_sll_pw_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_pw.F: Found type cp_sll_pw_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_pw.F: Found type cp_sll_rs_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_pw.F: Found type cp_sll_rs_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_xc_deriv.F: Found type cp_sll_xc_deriv_p_type without initializer https://cp2k.org/conv#c016
+cp_linked_list_xc_deriv.F: Found type cp_sll_xc_deriv_type without initializer https://cp2k.org/conv#c016
+cp_log_handling.F: Found type cp_logger_type without initializer https://cp2k.org/conv#c016
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_int_to_string" https://cp2k.org/conv#c012
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_logger_get_default_unit_nr" https://cp2k.org/conv#c012
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_real_dp_to_string" https://cp2k.org/conv#c012
+cp_min_heap.F: Found type cp_heap_node_e without initializer https://cp2k.org/conv#c016
+cp_min_heap.F: Found type cp_heap_node without initializer https://cp2k.org/conv#c016
+cp_min_heap.F: Found type cp_heap_type without initializer https://cp2k.org/conv#c016
+cp_output_handling.F: Found type cp_out_flags_type without initializer https://cp2k.org/conv#c016
+cp_para_types.F: Found type cp_para_cart_type with partial initializer https://cp2k.org/conv#c017
+cp_para_types.F: Found type cp_para_env_p_type without initializer https://cp2k.org/conv#c016
+cp_para_types.F: Found type cp_para_env_type with partial initializer https://cp2k.org/conv#c017
+cp_parser_buffer_types.F: Found type buffer_type without initializer https://cp2k.org/conv#c016
+cp_parser_ilist_types.F: Found type ilist_type without initializer https://cp2k.org/conv#c016
 cp_parser_inpp_methods.F: Found READ with unchecked STAT in "inpp_process_directive" https://cp2k.org/conv#c001
+cp_parser_inpp_types.F: Found type inpp_type without initializer https://cp2k.org/conv#c016
+cp_parser_status_types.F: Found type status_type without initializer https://cp2k.org/conv#c016
+cp_parser_types.F: Found type cp_parser_type without initializer https://cp2k.org/conv#c016
+cp_result_types.F: Found type cp_result_p_type without initializer https://cp2k.org/conv#c016
+cp_result_types.F: Found type cp_result_type without initializer https://cp2k.org/conv#c016
+cp_result_types.F: Found type cp_result_value_p_type without initializer https://cp2k.org/conv#c016
+cp_result_types.F: Found type cp_result_value_type without initializer https://cp2k.org/conv#c016
+cp_subsys_types.F: Found type cp_subsys_p_type without initializer https://cp2k.org/conv#c016
+cp_subsys_types.F: Found type cp_subsys_type with partial initializer https://cp2k.org/conv#c017
+cp_units.F: Found type cp_unit_p_type without initializer https://cp2k.org/conv#c016
+cp_units.F: Found type cp_unit_set_type without initializer https://cp2k.org/conv#c016
+cp_units.F: Found type cp_unit_type without initializer https://cp2k.org/conv#c016
+cryssym.F: Found type csym_type with partial initializer https://cp2k.org/conv#c017
+csvr_system_types.F: Found type csvr_system_type without initializer https://cp2k.org/conv#c016
+csvr_system_types.F: Found type csvr_thermo_type with partial initializer https://cp2k.org/conv#c017
+ct_types.F: Found type ct_step_env_type with partial initializer https://cp2k.org/conv#c017
+cube_utils.F: Found type cube_info_type without initializer https://cp2k.org/conv#c016
+cube_utils.F: Found type cube_ptr without initializer https://cp2k.org/conv#c016
 cube_utils.F: Found WRITE statement with hardcoded unit in "return_cube_nonortho" https://cp2k.org/conv#c012
 d3_poly.F: Found CALL RANDOM_NUMBER in procedure "poly_random" https://cp2k.org/conv#c009
+damping_dipole_types.F: Found type damping_info_type without initializer https://cp2k.org/conv#c016
+damping_dipole_types.F: Found type damping_p_type without initializer https://cp2k.org/conv#c016
+damping_dipole_types.F: Found type damping_type without initializer https://cp2k.org/conv#c016
+dbcsr_vector.F: Found type block_ptr_c with partial initializer https://cp2k.org/conv#c017
+dbcsr_vector.F: Found type block_ptr_d with partial initializer https://cp2k.org/conv#c017
+dbcsr_vector.F: Found type block_ptr_s with partial initializer https://cp2k.org/conv#c017
+dbcsr_vector.F: Found type block_ptr_z with partial initializer https://cp2k.org/conv#c017
+dbcsr_vector.F: Found type fast_vec_access_type with partial initializer https://cp2k.org/conv#c017
+dbcsr_vector.F: Found type hash_table_type with partial initializer https://cp2k.org/conv#c017
+dbt_index.F: Found type nd_to_2d_mapping with partial initializer https://cp2k.org/conv#c017
+dbt_tas_global.F: Found type dbt_tas_blk_size_arb with partial initializer https://cp2k.org/conv#c017
+dbt_tas_global.F: Found type dbt_tas_blk_size_one without initializer https://cp2k.org/conv#c016
+dbt_tas_global.F: Found type dbt_tas_blk_size_repl with partial initializer https://cp2k.org/conv#c017
+dbt_tas_global.F: Found type dbt_tas_dist_arb with partial initializer https://cp2k.org/conv#c017
+dbt_tas_global.F: Found type dbt_tas_dist_cyclic without initializer https://cp2k.org/conv#c016
+dbt_tas_global.F: Found type dbt_tas_dist_repl with partial initializer https://cp2k.org/conv#c017
+dbt_tas_types.F: Found type dbt_tas_distribution_type with partial initializer https://cp2k.org/conv#c017
+dbt_tas_types.F: Found type dbt_tas_split_info with partial initializer https://cp2k.org/conv#c017
+dbt_tas_types.F: Found type dbt_tas_type with partial initializer https://cp2k.org/conv#c017
+dbt_types.F: Found type dbt_contraction_storage with partial initializer https://cp2k.org/conv#c017
+dbt_types.F: Found type dbt_distribution_type with partial initializer https://cp2k.org/conv#c017
+dbt_types.F: Found type dbt_pgrid_type with partial initializer https://cp2k.org/conv#c017
+dbt_types.F: Found type dbt_tas_blk_size_t with partial initializer https://cp2k.org/conv#c017
+dbt_types.F: Found type dbt_tas_dist_t with partial initializer https://cp2k.org/conv#c017
+dbt_types.F: Found type dbt_type with partial initializer https://cp2k.org/conv#c017
+dct.F: Found type dct_type with partial initializer https://cp2k.org/conv#c017
+dgemm_counter_types.F: Found type dgemm_counter_type without initializer https://cp2k.org/conv#c016
+dg_rho0_types.F: Found type dg_rho0_type without initializer https://cp2k.org/conv#c016
+dg_types.F: Found type dg_p_type without initializer https://cp2k.org/conv#c016
+dg_types.F: Found type dg_type without initializer https://cp2k.org/conv#c016
+dielectric_types.F: Found type dielectric_parameters with partial initializer https://cp2k.org/conv#c017
+dielectric_types.F: Found type dielectric_type with partial initializer https://cp2k.org/conv#c017
+dimer_types.F: Found type dimer_cg_rot_type without initializer https://cp2k.org/conv#c016
+dimer_types.F: Found type dimer_env_type without initializer https://cp2k.org/conv#c016
+dimer_types.F: Found type dimer_rotational_type without initializer https://cp2k.org/conv#c016
+dimer_types.F: Found type dimer_translational_type without initializer https://cp2k.org/conv#c016
+dirichlet_bc_types.F: Found type dirichlet_bc_parameters with partial initializer https://cp2k.org/conv#c017
+dirichlet_bc_types.F: Found type dirichlet_bc_p_type without initializer https://cp2k.org/conv#c016
+dirichlet_bc_types.F: Found type dirichlet_bc_type with partial initializer https://cp2k.org/conv#c017
+dirichlet_bc_types.F: Found type tile_p_type without initializer https://cp2k.org/conv#c016
+dirichlet_bc_types.F: Found type tile_type with partial initializer https://cp2k.org/conv#c017
+distribution_1d_types.F: Found type distribution_1d_type without initializer https://cp2k.org/conv#c016
+distribution_1d_types.F: Found type local_particle_type without initializer https://cp2k.org/conv#c016
+distribution_2d_types.F: Found type distribution_2d_type without initializer https://cp2k.org/conv#c016
 dkh_main.F: Found WRITE statement with hardcoded unit in "kintegral_a" https://cp2k.org/conv#c012
 dkh_main.F: Found WRITE statement with hardcoded unit in "kintegral" https://cp2k.org/conv#c012
+dm_ls_scf_types.F: Found type chebyshev_type with partial initializer https://cp2k.org/conv#c017
+dm_ls_scf_types.F: Found type ls_mat_history_type with partial initializer https://cp2k.org/conv#c017
+dm_ls_scf_types.F: Found type ls_mstruct_type with partial initializer https://cp2k.org/conv#c017
+dm_ls_scf_types.F: Found type ls_scf_curvy_type with partial initializer https://cp2k.org/conv#c017
+dm_ls_scf_types.F: Found type ls_scf_env_type with partial initializer https://cp2k.org/conv#c017
 domain_submatrix_methods.F: Found WRITE statement with hardcoded unit in "print_submatrices" https://cp2k.org/conv#c012
+domain_submatrix_types.F: Found type domain_submatrix_type with partial initializer https://cp2k.org/conv#c017
 dumpdcd.F: Found CLOSE statement in procedure "dumpdcd" https://cp2k.org/conv#c011
 dumpdcd.F: Found OPEN statement in procedure "dumpdcd" https://cp2k.org/conv#c011
 dumpdcd.F: Found STOP statement in procedure "abort_program" https://cp2k.org/conv#c011
 dumpdcd.F: Found STOP statement in procedure "dumpdcd" https://cp2k.org/conv#c011
 dumpdcd.F: Found WRITE statement with hardcoded unit in "abort_program" https://cp2k.org/conv#c012
 dumpdcd.F: Found WRITE statement with hardcoded unit in "print_help" https://cp2k.org/conv#c012
+ec_env_types.F: Found type energy_correction_type with partial initializer https://cp2k.org/conv#c017
+eip_environment_types.F: Found type eip_environment_type without initializer https://cp2k.org/conv#c016
 eip_silicon.F: Found OPEN statement in procedure "eip_bazant_silicon" https://cp2k.org/conv#c011
 eip_silicon.F: Found OPEN statement in procedure "eip_lenosky_silicon" https://cp2k.org/conv#c011
 eip_silicon.F: Found WRITE statement with hardcoded unit in "eip_bazant_silicon" https://cp2k.org/conv#c012
 eip_silicon.F: Found WRITE statement with hardcoded unit in "eip_lenosky_silicon" https://cp2k.org/conv#c012
 eip_silicon.F: Found WRITE statement with hardcoded unit in "subfeniat_b" https://cp2k.org/conv#c012
 eip_silicon.F: Found WRITE statement with hardcoded unit in "subfeniat_l" https://cp2k.org/conv#c012
+embed_types.F: Found type embed_env_type with partial initializer https://cp2k.org/conv#c017
+embed_types.F: Found type opt_dmfet_pot_type with partial initializer https://cp2k.org/conv#c017
+embed_types.F: Found type opt_embed_pot_type with partial initializer https://cp2k.org/conv#c017
+eri_mme_types.F: Found type eri_mme_param with partial initializer https://cp2k.org/conv#c017
+eri_mme_types.F: Found type minimax_grid with partial initializer https://cp2k.org/conv#c017
+et_coupling_proj.F: Found type et_cpl_atom without initializer https://cp2k.org/conv#c016
+et_coupling_proj.F: Found type et_cpl_block without initializer https://cp2k.org/conv#c016
+et_coupling_proj.F: Found type et_cpl without initializer https://cp2k.org/conv#c016
 et_coupling_proj.F: Procedure 'infog2l' called with an implicit interface at (1) [-Wimplicit-interface]
+et_coupling_types.F: Found type et_coupling_type without initializer https://cp2k.org/conv#c016
+ewald_environment_types.F: Found type ewald_environment_type with partial initializer https://cp2k.org/conv#c017
+ewald_pw_types.F: Found type ewald_pw_type without initializer https://cp2k.org/conv#c016
+exclusion_types.F: Found type exclusion_type without initializer https://cp2k.org/conv#c016
+exstates_types.F: Found type excited_energy_type with partial initializer https://cp2k.org/conv#c017
 extended_system_init.F: Found WRITE statement with hardcoded unit in "init_barostat_variables" https://cp2k.org/conv#c012
+extended_system_types.F: Found type lnhc_parameters_type without initializer https://cp2k.org/conv#c016
+extended_system_types.F: Found type map_info_type without initializer https://cp2k.org/conv#c016
+extended_system_types.F: Found type nhc_info_type without initializer https://cp2k.org/conv#c016
+extended_system_types.F: Found type npt_info_type without initializer https://cp2k.org/conv#c016
+extended_system_types.F: Found type point_info_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type all_potential_p_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type all_potential_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type fist_potential_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type gth_potential_p_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type gth_potential_type with partial initializer https://cp2k.org/conv#c017
+external_potential_types.F: Found type local_potential_p_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type local_potential_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type sgp_potential_p_type without initializer https://cp2k.org/conv#c016
+external_potential_types.F: Found type sgp_potential_type with partial initializer https://cp2k.org/conv#c017
+f77_interface.F: Found type f_env_p_type without initializer https://cp2k.org/conv#c016
+f77_interface.F: Found type f_env_type without initializer https://cp2k.org/conv#c016
 farming_methods.F: Found CLOSE statement in procedure "farming_parse_input" https://cp2k.org/conv#c011
 farming_methods.F: Found OPEN statement in procedure "farming_parse_input" https://cp2k.org/conv#c011
+farming_types.F: Found type farming_env_type without initializer https://cp2k.org/conv#c016
+farming_types.F: Found type job_type without initializer https://cp2k.org/conv#c016
+fft_plan.F: Found type fft_plan_type without initializer https://cp2k.org/conv#c016
+fft_tools.F: Found type fft_scratch_pool_type without initializer https://cp2k.org/conv#c016
+fft_tools.F: Found type fft_scratch_type with partial initializer https://cp2k.org/conv#c017
+fist_efield_types.F: Found type fist_efield_type with partial initializer https://cp2k.org/conv#c017
+fist_energy_types.F: Found type fist_energy_type without initializer https://cp2k.org/conv#c016
+fist_environment_types.F: Found type fist_environment_type without initializer https://cp2k.org/conv#c016
+fist_force.F: Found type debug_variables_type without initializer https://cp2k.org/conv#c016
+fist_neighbor_lists.F: Found type local_atoms_type without initializer https://cp2k.org/conv#c016
+fist_neighbor_list_types.F: Found type fist_neighbor_type without initializer https://cp2k.org/conv#c016
+fist_neighbor_list_types.F: Found type neighbor_kind_pairs_type without initializer https://cp2k.org/conv#c016
+fist_nonbond_env_types.F: Found type eam_type without initializer https://cp2k.org/conv#c016
+fist_nonbond_env_types.F: Found type fist_nonbond_env_type without initializer https://cp2k.org/conv#c016
+fist_nonbond_env_types.F: Found type nequip_data_type with partial initializer https://cp2k.org/conv#c017
+fist_nonbond_env_types.F: Found type pos_type without initializer https://cp2k.org/conv#c016
+fist_nonbond_env_types.F: Found type quip_data_type without initializer https://cp2k.org/conv#c016
+force_env_types.F: Found type force_env_p_type without initializer https://cp2k.org/conv#c016
+force_env_types.F: Found type force_env_type without initializer https://cp2k.org/conv#c016
+force_field_kind_types.F: Found type bend_kind_type without initializer https://cp2k.org/conv#c016
+force_field_kind_types.F: Found type bond_kind_type without initializer https://cp2k.org/conv#c016
+force_field_kind_types.F: Found type impr_kind_type without initializer https://cp2k.org/conv#c016
+force_field_kind_types.F: Found type legendre_data_type without initializer https://cp2k.org/conv#c016
+force_field_kind_types.F: Found type opbend_kind_type without initializer https://cp2k.org/conv#c016
+force_field_kind_types.F: Found type torsion_kind_type without initializer https://cp2k.org/conv#c016
+force_field_kind_types.F: Found type ub_kind_type without initializer https://cp2k.org/conv#c016
+force_field_types.F: Found type amber_info_type without initializer https://cp2k.org/conv#c016
+force_field_types.F: Found type charmm_info_type without initializer https://cp2k.org/conv#c016
+force_field_types.F: Found type force_field_type without initializer https://cp2k.org/conv#c016
+force_field_types.F: Found type gromos_info_type without initializer https://cp2k.org/conv#c016
+force_field_types.F: Found type input_info_type without initializer https://cp2k.org/conv#c016
+fparser.F: Found type tcomp without initializer https://cp2k.org/conv#c016
 fparser.F: Found WRITE statement with hardcoded unit in "parseerrmsg" https://cp2k.org/conv#c012
+fp_types.F: Found type fp_type without initializer https://cp2k.org/conv#c016
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_norm_sc" https://cp2k.org/conv#c012
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_norm_sc_low" https://cp2k.org/conv#c012
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_trend" https://cp2k.org/conv#c012
+free_energy_types.F: Found type free_energy_type without initializer https://cp2k.org/conv#c016
+free_energy_types.F: Found type statistical_type without initializer https://cp2k.org/conv#c016
+free_energy_types.F: Found type ui_conv_type without initializer https://cp2k.org/conv#c016
+free_energy_types.F: Found type ui_var_type without initializer https://cp2k.org/conv#c016
+gaussian_gridlevels.F: Found type gridlevel_info_type without initializer https://cp2k.org/conv#c016
 glbopt_history.F: Found WRITE statement with hardcoded unit in "verify_history_lookup" https://cp2k.org/conv#c012
+glbopt_master.F: Found type glbopt_master_type with partial initializer https://cp2k.org/conv#c017
+glbopt_mincrawl.F: Found type mincrawl_type with partial initializer https://cp2k.org/conv#c017
 glbopt_mincrawl.F: Found WRITE statement with hardcoded unit in "print_tempdist" https://cp2k.org/conv#c012
+glbopt_worker.F: Found type glbopt_worker_type with partial initializer https://cp2k.org/conv#c017
+gle_system_types.F: Found type gle_thermo_type with partial initializer https://cp2k.org/conv#c017
+gle_system_types.F: Found type gle_type without initializer https://cp2k.org/conv#c016
+gopt_f_types.F: Found type gopt_f_type without initializer https://cp2k.org/conv#c016
+gopt_param_types.F: Found type cg_ls_param_type without initializer https://cp2k.org/conv#c016
+gopt_param_types.F: Found type gopt_param_type without initializer https://cp2k.org/conv#c016
 graphcon.F: Found GOTO statement in procedure "all_permutations" https://cp2k.org/conv#c011
+graphcon.F: Found type class without initializer https://cp2k.org/conv#c016
+graphcon.F: Found type graph_type without initializer https://cp2k.org/conv#c016
+graphcon.F: Found type superclass without initializer https://cp2k.org/conv#c016
+graphcon.F: Found type vertex without initializer https://cp2k.org/conv#c016
 graphcon.F: Found WRITE statement with hardcoded unit in "reorder_graph" https://cp2k.org/conv#c012
 graph.F: Found CALL RANDOM_SEED in procedure "graph" https://cp2k.org/conv#c010
 graph.F: Found WRITE statement with hardcoded unit in "graph" https://cp2k.org/conv#c012
@@ -80,16 +378,110 @@ graph_methods.F: Found OPEN statement in procedure "fes_cube_write" https://cp2k
 graph_methods.F: Found WRITE statement with hardcoded unit in "fes_cube_write" https://cp2k.org/conv#c012
 graph_methods.F: Found WRITE statement with hardcoded unit in "fes_min" https://cp2k.org/conv#c012
 graph_methods.F: Found WRITE statement with hardcoded unit in "fes_path" https://cp2k.org/conv#c012
+graph_utils.F: Found type mep_input_data_type without initializer https://cp2k.org/conv#c016
 graph_utils.F: Found WRITE statement with hardcoded unit in "get_val_res" https://cp2k.org/conv#c012
+group_dist_types.F: Found type group_dist_d0_type without initializer https://cp2k.org/conv#c016
+hartree_local_types.F: Found type ecoul_1center_type without initializer https://cp2k.org/conv#c016
+hartree_local_types.F: Found type hartree_local_type without initializer https://cp2k.org/conv#c016
+helium_types.F: Found type density_properties_type without initializer https://cp2k.org/conv#c016
+helium_types.F: Found type helium_solvent_p_type with partial initializer https://cp2k.org/conv#c017
+helium_types.F: Found type helium_solvent_type without initializer https://cp2k.org/conv#c016
+helium_types.F: Found type helium_vector_type without initializer https://cp2k.org/conv#c016
+helium_types.F: Found type int_arr_ptr without initializer https://cp2k.org/conv#c016
+helium_types.F: Found type real_arr_ptr without initializer https://cp2k.org/conv#c016
 hfx_compression_methods.F: Found READ with unchecked STAT in "hfx_decompress_cache" https://cp2k.org/conv#c001
 hfx_energy_potential.F: Found WRITE statement with hardcoded unit in "print_integrals" https://cp2k.org/conv#c012
+hfx_types.F: Found type hfx_2d_map without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_basis_info_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_basis_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_block_range_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_cache_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_cell_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_compression_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_container_node without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_container_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_distribution without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_general_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_load_balance_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_memory_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_periodic_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_pgf_image without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_pgf_list without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_pgf_product_list without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_p_kind without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_potential_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_ri_type with partial initializer https://cp2k.org/conv#c017
+hfx_types.F: Found type hfx_screen_coeff_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_screening_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_task_list_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type hfx_type with partial initializer https://cp2k.org/conv#c017
+hfx_types.F: Found type pair_list_element_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type pair_list_type without initializer https://cp2k.org/conv#c016
+hfx_types.F: Found type pair_set_list_type without initializer https://cp2k.org/conv#c016
+hirshfeld_types.F: Found type hirshfeld_type without initializer https://cp2k.org/conv#c016
+hirshfeld_types.F: Found type shape_fn without initializer https://cp2k.org/conv#c016
+input_enumeration_types.F: Found type enumeration_type with partial initializer https://cp2k.org/conv#c017
 input_enumeration_types.F: Found WRITE statement with hardcoded unit in "enum_i2c" https://cp2k.org/conv#c012
+input_keyword_types.F: Found type keyword_p_type without initializer https://cp2k.org/conv#c016
+input_keyword_types.F: Found type keyword_type with partial initializer https://cp2k.org/conv#c017
 input_parsing.F: Found WRITE statement with hardcoded unit in "section_vals_parse" https://cp2k.org/conv#c012
+input_section_types.F: Found type section_p_type without initializer https://cp2k.org/conv#c016
+input_section_types.F: Found type section_type with partial initializer https://cp2k.org/conv#c017
+input_section_types.F: Found type section_vals_p_type without initializer https://cp2k.org/conv#c016
+input_section_types.F: Found type section_vals_type without initializer https://cp2k.org/conv#c016
+input_val_types.F: Found type val_p_type without initializer https://cp2k.org/conv#c016
+input_val_types.F: Found type val_type without initializer https://cp2k.org/conv#c016
+integration_grid_types.F: Found type grid_batch_info_type with partial initializer https://cp2k.org/conv#c017
+integration_grid_types.F: Found type grid_batch_val_1d_type with partial initializer https://cp2k.org/conv#c017
+integration_grid_types.F: Found type grid_batch_val_2d_type with partial initializer https://cp2k.org/conv#c017
+integration_grid_types.F: Found type integration_grid_type with partial initializer https://cp2k.org/conv#c017
+integration_grid_types.F: Found type integration_grid_value_type with partial initializer https://cp2k.org/conv#c017
+integrator_utils.F: Found type old_variables_type without initializer https://cp2k.org/conv#c016
+integrator_utils.F: Found type tmp_variables_type without initializer https://cp2k.org/conv#c016
+kg_environment_types.F: Found type energy_correction_type without initializer https://cp2k.org/conv#c016
+kg_environment_types.F: Found type kg_environment_type with partial initializer https://cp2k.org/conv#c017
+kg_environment_types.F: Found type subset_type without initializer https://cp2k.org/conv#c016
+kg_vertex_coloring_methods.F: Found type vertex_p_type without initializer https://cp2k.org/conv#c016
+kg_vertex_coloring_methods.F: Found type vertex with partial initializer https://cp2k.org/conv#c017
+kpoint_types.F: Found type kpoint_env_p_type without initializer https://cp2k.org/conv#c016
+kpoint_types.F: Found type kpoint_env_type without initializer https://cp2k.org/conv#c016
+kpoint_types.F: Found type kpoint_sym_p_type without initializer https://cp2k.org/conv#c016
+kpoint_types.F: Found type kpoint_sym_type without initializer https://cp2k.org/conv#c016
+kpoint_types.F: Found type kpoint_type with partial initializer https://cp2k.org/conv#c017
+lebedev.F: Found type oh_grid with partial initializer https://cp2k.org/conv#c017
+libcp2k.F: Found type eri2array with partial initializer https://cp2k.org/conv#c017
+libint_2c_3c.F: Found type libint_potential_type without initializer https://cp2k.org/conv#c016
+libint_2c_3c.F: Found type params_2c without initializer https://cp2k.org/conv#c016
+libint_2c_3c.F: Found type params_3c without initializer https://cp2k.org/conv#c016
 library_tests.F: Found CALL RANDOM_NUMBER in procedure "copy_test" https://cp2k.org/conv#c009
 library_tests.F: Found CALL RANDOM_NUMBER in procedure "cp_fm_gemm_test" https://cp2k.org/conv#c009
 library_tests.F: Found CALL RANDOM_NUMBER in procedure "fft_test" https://cp2k.org/conv#c009
 library_tests.F: Found CALL RANDOM_NUMBER in procedure "rs_pw_transfer_test" https://cp2k.org/conv#c009
 library_tests.F: Procedure 'pilaenv' called with an implicit interface at (1) [-Wimplicit-interface]
+list_callstackentry.F: Found type private_item_type_callstackentry without initializer https://cp2k.org/conv#c016
+list_routinereport.F: Found type private_item_type_routinereport without initializer https://cp2k.org/conv#c016
+list_routinestat.F: Found type private_item_type_routinestat without initializer https://cp2k.org/conv#c016
+list_timerenv.F: Found type private_item_type_timerenv without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type carray without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type int_container without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_bas_type with partial initializer https://cp2k.org/conv#c017
+lri_environment_types.F: Found type lri_clebsch_gordon_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_environment_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_force_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_int_rho_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_int_type with partial initializer https://cp2k.org/conv#c017
+lri_environment_types.F: Found type lri_kind_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_ppl_int_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_ppl_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_rhoab_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type lri_spin_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type ri_fit_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type stat_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type wbas_type without initializer https://cp2k.org/conv#c016
+lri_environment_types.F: Found type wmat_type without initializer https://cp2k.org/conv#c016
+lri_optimize_ri_basis_types.F: Found type lri_gcc_p_type without initializer https://cp2k.org/conv#c016
+lri_optimize_ri_basis_types.F: Found type lri_opt_type without initializer https://cp2k.org/conv#c016
+lri_optimize_ri_basis_types.F: Found type lri_subset_type without initializer https://cp2k.org/conv#c016
 machine.F: Found CALL m_abort in procedure "m_getcwd" https://cp2k.org/conv#c008
 machine.F: Found CALL m_abort in procedure "m_hostnm" https://cp2k.org/conv#c008
 machine.F: Found CALL m_abort in procedure "m_mov" https://cp2k.org/conv#c008
@@ -100,9 +492,26 @@ machine.F: Found OPEN statement in procedure "m_memory" https://cp2k.org/conv#c0
 machine.F: Found WRITE statement with hardcoded unit in "m_getcwd" https://cp2k.org/conv#c012
 machine.F: Found WRITE statement with hardcoded unit in "m_hostnm" https://cp2k.org/conv#c012
 machine.F: Found WRITE statement with hardcoded unit in "m_mov" https://cp2k.org/conv#c012
+mao_methods.F: Found type mblocks without initializer https://cp2k.org/conv#c016
+mao_types.F: Found type mao_type without initializer https://cp2k.org/conv#c016
 mathlib.F: Found WRITE statement with hardcoded unit in "diag" https://cp2k.org/conv#c012
 mc_coordinates.F: Found WRITE statement with hardcoded unit in "generate_cbmc_swap_config" https://cp2k.org/conv#c012
+mc_environment_types.F: Found type mc_environment_p_type without initializer https://cp2k.org/conv#c016
+mc_environment_types.F: Found type mc_environment_type without initializer https://cp2k.org/conv#c016
 mc_move_control.F: Found WRITE statement with hardcoded unit in "mc_move_update" https://cp2k.org/conv#c012
+mc_types.F: Found type accattempt without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_averages_p_type without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_averages_type without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_ekin_type without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_input_file_type without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_molecule_info_type without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_moves_p_type without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_moves_type without initializer https://cp2k.org/conv#c016
+mc_types.F: Found type mc_simpar_type with partial initializer https://cp2k.org/conv#c017
+mc_types.F: Found type mc_simulation_parameters_p_type without initializer https://cp2k.org/conv#c016
+mdctrl_types.F: Found type glbopt_mdctrl_data_type with partial initializer https://cp2k.org/conv#c017
+md_ener_types.F: Found type md_ener_type without initializer https://cp2k.org/conv#c016
+md_environment_types.F: Found type md_environment_type with partial initializer https://cp2k.org/conv#c017
 memory_utilities_unittest.F: Found WRITE statement with hardcoded unit in "check_real_rank1_allocated" https://cp2k.org/conv#c012
 memory_utilities_unittest.F: Found WRITE statement with hardcoded unit in "check_real_rank1_unallocated" https://cp2k.org/conv#c012
 memory_utilities_unittest.F: Found WRITE statement with hardcoded unit in "check_real_rank2_allocated" https://cp2k.org/conv#c012
@@ -113,6 +522,12 @@ message_passing.F: Found CALL m_abort in procedure "mp_abort" https://cp2k.org/c
 message_passing.F: Found CLOSE statement in procedure "mp_file_close" https://cp2k.org/conv#c011
 message_passing.F: Found OPEN statement in procedure "mp_file_open" https://cp2k.org/conv#c011
 message_passing.F: Found STOP statement in procedure "mp_abort" https://cp2k.org/conv#c011
+message_passing.F: Found type mp_file_descriptor_type with partial initializer https://cp2k.org/conv#c017
+message_passing.F: Found type mp_file_indexing_meta_type without initializer https://cp2k.org/conv#c016
+message_passing.F: Found type mp_indexing_meta_type without initializer https://cp2k.org/conv#c016
+message_passing.F: Found type mp_perf_env_type without initializer https://cp2k.org/conv#c016
+message_passing.F: Found type mp_perf_type without initializer https://cp2k.org/conv#c016
+message_passing.F: Found type mp_type_descriptor_type without initializer https://cp2k.org/conv#c016
 message_passing.F: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
 message_passing.F: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/INTEGER(4)).
 message_passing.F: USE statement at (1) has no ONLY qualifier [-Wuse-without-only]
@@ -121,20 +536,154 @@ message_passing.fypp: Rank mismatch between actual argument at (1) and actual ar
 message_passing.fypp: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-3)
 message_passing.fypp: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-4)
 message_passing.fypp: Type mismatch between actual argument at (1) and actual argument at (2) (COMPLEX(8)/COMPLEX(4)).
+metadynamics_types.F: Found type hills_env_type without initializer https://cp2k.org/conv#c016
+metadynamics_types.F: Found type meta_env_type with partial initializer https://cp2k.org/conv#c017
+metadynamics_types.F: Found type metavar_type without initializer https://cp2k.org/conv#c016
+metadynamics_types.F: Found type multiple_walkers_type without initializer https://cp2k.org/conv#c016
+metadynamics_types.F: Found type wall_type without initializer https://cp2k.org/conv#c016
+mixed_cdft_types.F: Found type buffers without initializer https://cp2k.org/conv#c016
+mixed_cdft_types.F: Found type mixed_cdft_dlb_type without initializer https://cp2k.org/conv#c016
+mixed_cdft_types.F: Found type mixed_cdft_settings_type without initializer https://cp2k.org/conv#c016
+mixed_cdft_types.F: Found type mixed_cdft_type with partial initializer https://cp2k.org/conv#c017
+mixed_cdft_types.F: Found type mixed_cdft_work_type without initializer https://cp2k.org/conv#c016
+mixed_cdft_types.F: Found type p_buffers without initializer https://cp2k.org/conv#c016
+mixed_cdft_types.F: Found type repl_info without initializer https://cp2k.org/conv#c016
+mixed_energy_types.F: Found type mixed_energy_type without initializer https://cp2k.org/conv#c016
+mixed_energy_types.F: Found type mixed_force_type without initializer https://cp2k.org/conv#c016
+mixed_environment_types.F: Found type mixed_environment_type with partial initializer https://cp2k.org/conv#c017
 mltfftsg_tools.F: Found WRITE statement with hardcoded unit in "ctrig" https://cp2k.org/conv#c012
+mm_mapping_library.F: Found type ff_map_type without initializer https://cp2k.org/conv#c016
 mode_selective.F: Found READ with unchecked STAT in "bfgs_guess" https://cp2k.org/conv#c001
+mode_selective.F: Found type ms_vib_type without initializer https://cp2k.org/conv#c016
+molecule_kind_list_types.F: Found type molecule_kind_list_p_type without initializer https://cp2k.org/conv#c016
+molecule_kind_list_types.F: Found type molecule_kind_list_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type atom_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type bend_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type bond_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type colvar_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type fixd_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type g3x3_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type g4x6_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type impr_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type local_fixd_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type molecule_kind_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type opbend_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type restraint_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type shell_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type torsion_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type ub_type without initializer https://cp2k.org/conv#c016
+molecule_kind_types.F: Found type vsite_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_list_types.F: Found type molecule_list_p_type without initializer https://cp2k.org/conv#c016
+molecule_list_types.F: Found type molecule_list_type without initializer https://cp2k.org/conv#c016
+molecule_types.F: Found type global_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_types.F: Found type local_colvar_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_types.F: Found type local_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_types.F: Found type local_g3x3_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_types.F: Found type local_g4x6_constraint_type without initializer https://cp2k.org/conv#c016
+molecule_types.F: Found type local_states_type without initializer https://cp2k.org/conv#c016
+molecule_types.F: Found type molecule_type without initializer https://cp2k.org/conv#c016
+molsym.F: Found type molsym_type without initializer https://cp2k.org/conv#c016
+mp2_integrals.F: Found type intermediate_matrix_type with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type grad_util with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type integ_mat_buffer_type_2d with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type integ_mat_buffer_type with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type mp2_direct_type without initializer https://cp2k.org/conv#c016
+mp2_types.F: Found type mp2_gpw_type without initializer https://cp2k.org/conv#c016
+mp2_types.F: Found type mp2_laplace_type without initializer https://cp2k.org/conv#c016
+mp2_types.F: Found type mp2_type with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type pair_list_type_mp2 with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type ri_basis_opt with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type ri_g0w0_type with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type ri_mp2_type without initializer https://cp2k.org/conv#c016
+mp2_types.F: Found type ri_rpa_im_time_type with partial initializer https://cp2k.org/conv#c017
+mp2_types.F: Found type ri_rpa_type with partial initializer https://cp2k.org/conv#c017
+mscfg_types.F: Found type molecular_scf_guess_env_type with partial initializer https://cp2k.org/conv#c017
+multipole_types.F: Found type multipole_type without initializer https://cp2k.org/conv#c016
+neb_types.F: Found type neb_type without initializer https://cp2k.org/conv#c016
+neb_types.F: Found type neb_var_type without initializer https://cp2k.org/conv#c016
+negf_atom_map.F: Found type negf_atom_map_type without initializer https://cp2k.org/conv#c016
+negf_control_types.F: Found type negf_control_contact_type with partial initializer https://cp2k.org/conv#c017
+negf_control_types.F: Found type negf_control_type with partial initializer https://cp2k.org/conv#c017
+negf_env_types.F: Found type negf_env_contact_type with partial initializer https://cp2k.org/conv#c017
+negf_env_types.F: Found type negf_env_type with partial initializer https://cp2k.org/conv#c017
+negf_green_methods.F: Found type sancho_work_matrices_type without initializer https://cp2k.org/conv#c016
+negf_integr_cc.F: Found type ccquad_type with partial initializer https://cp2k.org/conv#c017
+negf_integr_simpson.F: Found type simpsonrule_subinterval_type with partial initializer https://cp2k.org/conv#c017
+negf_integr_simpson.F: Found type simpsonrule_type with partial initializer https://cp2k.org/conv#c017
 negf_methods.F: Found CALL with NULL() as argument in procedure "converge_density" https://cp2k.org/conv#c007
 negf_methods.F: Found CALL with NULL() as argument in procedure "guess_fermi_level" https://cp2k.org/conv#c007
 negf_methods.F: Found CALL with NULL() as argument in procedure "shift_potential" https://cp2k.org/conv#c007
+negf_methods.F: Found type integration_status_type without initializer https://cp2k.org/conv#c016
+negf_subgroup_types.F: Found type negf_subgroup_env_type with partial initializer https://cp2k.org/conv#c017
 nequip_unittest.F: Found WRITE statement with hardcoded unit in "nequip_unittest" https://cp2k.org/conv#c012
+nnp_environment_types.F: Found type nnp_acsf_ang_type with partial initializer https://cp2k.org/conv#c017
+nnp_environment_types.F: Found type nnp_acsf_rad_type with partial initializer https://cp2k.org/conv#c017
+nnp_environment_types.F: Found type nnp_arc_type with partial initializer https://cp2k.org/conv#c017
+nnp_environment_types.F: Found type nnp_neighbor_type with partial initializer https://cp2k.org/conv#c017
+nnp_environment_types.F: Found type nnp_symfgrp_type with partial initializer https://cp2k.org/conv#c017
+nnp_environment_types.F: Found type nnp_type with partial initializer https://cp2k.org/conv#c017
+optimize_basis_types.F: Found type basis_optimization_type with partial initializer https://cp2k.org/conv#c017
+optimize_basis_types.F: Found type derived_basis_info with partial initializer https://cp2k.org/conv#c017
+optimize_basis_types.F: Found type exp_constraint_type without initializer https://cp2k.org/conv#c016
+optimize_basis_types.F: Found type flex_basis_type with partial initializer https://cp2k.org/conv#c017
+optimize_basis_types.F: Found type kind_basis_type with partial initializer https://cp2k.org/conv#c017
+optimize_basis_types.F: Found type subset_type with partial initializer https://cp2k.org/conv#c017
+optimize_input.F: Found type fm_env_type without initializer https://cp2k.org/conv#c016
+optimize_input.F: Found type oi_env_type with partial initializer https://cp2k.org/conv#c017
+optimize_input.F: Found type variable_type without initializer https://cp2k.org/conv#c016
+orbital_transformation_matrices.F: Found type orbtramat_type without initializer https://cp2k.org/conv#c016
+outer_scf_control_types.F: Found type outer_scf_control_type without initializer https://cp2k.org/conv#c016
+outer_scf_control_types.F: Found type qs_outer_scf_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type buck4ran_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type buckmorse_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type eam_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type ftd_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type ft_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type gal21_pot_type with partial initializer https://cp2k.org/conv#c017
+pair_potential_types.F: Found type gal_pot_type with partial initializer https://cp2k.org/conv#c017
+pair_potential_types.F: Found type goodwin_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type gp_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type ipbv_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type lj_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type nequip_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type pair_potential_pp_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type pair_potential_p_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type pair_potential_single_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type pair_potential_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type pot_set_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type quip_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type siepmann_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type tab_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type tersoff_pot_type without initializer https://cp2k.org/conv#c016
+pair_potential_types.F: Found type williams_pot_type without initializer https://cp2k.org/conv#c016
 pao_param_exp.F: Found lossy conversion real_4_r8 without KIND argument in "zheevd_wrapper" https://cp2k.org/conv#c015
+pao_types.F: Found type filename_type without initializer https://cp2k.org/conv#c016
 parallel_gemm_api.F: Found CALL cp_fm_gemm in procedure "parallel_gemm_fm" https://cp2k.org/conv#c008
+parallel_rng_types.F: Found type rng_stream_p_type without initializer https://cp2k.org/conv#c016
+parallel_rng_types.F: Found type rng_stream_type with partial initializer https://cp2k.org/conv#c017
 parallel_rng_types_unittest.F: Found WRITE statement with hardcoded unit in "dump_reload_check" https://cp2k.org/conv#c012
 parallel_rng_types_unittest.F: Found WRITE statement with hardcoded unit in "parallel_rng_types_test" https://cp2k.org/conv#c012
 parallel_rng_types_unittest.F: Found WRITE statement with hardcoded unit in "shuffle_check" https://cp2k.org/conv#c012
+particle_list_types.F: Found type particle_list_p_type without initializer https://cp2k.org/conv#c016
+particle_list_types.F: Found type particle_list_type without initializer https://cp2k.org/conv#c016
+paw_proj_set_types.F: Found type paw_proj_set_type without initializer https://cp2k.org/conv#c016
+periodic_table.F: Found type atom without initializer https://cp2k.org/conv#c016
+pexsi_types.F: Found type lib_pexsi_env with partial initializer https://cp2k.org/conv#c017
+pint_types.F: Found type normalmode_env_type without initializer https://cp2k.org/conv#c016
+pint_types.F: Found type piglet_therm_type with partial initializer https://cp2k.org/conv#c017
+pint_types.F: Found type pile_therm_type with partial initializer https://cp2k.org/conv#c017
+pint_types.F: Found type pint_env_type with partial initializer https://cp2k.org/conv#c017
+pint_types.F: Found type pint_propagator_type without initializer https://cp2k.org/conv#c016
+pint_types.F: Found type qtb_therm_type with partial initializer https://cp2k.org/conv#c017
+pint_types.F: Found type staging_env_type without initializer https://cp2k.org/conv#c016
 powell.F: Found GOTO statement in procedure "newuob" https://cp2k.org/conv#c011
+powell.F: Found type opt_state_type without initializer https://cp2k.org/conv#c016
 preconditioner_makes.F: Found WRITE statement with hardcoded unit in "make_full_all" https://cp2k.org/conv#c012
 preconditioner_makes.F: Found WRITE statement with hardcoded unit in "make_full_all_ortho" https://cp2k.org/conv#c012
+preconditioner_types.F: Found type preconditioner_p_type without initializer https://cp2k.org/conv#c016
+preconditioner_types.F: Found type preconditioner_type without initializer https://cp2k.org/conv#c016
+ps_implicit_types.F: Found type ps_implicit_parameters without initializer https://cp2k.org/conv#c016
+ps_implicit_types.F: Found type ps_implicit_type with partial initializer https://cp2k.org/conv#c017
 ps_wavelet_base.F: Found WRITE statement with hardcoded unit in "f_poissonsolver" https://cp2k.org/conv#c012
 ps_wavelet_base.F: Found WRITE statement with hardcoded unit in "p_poissonsolver" https://cp2k.org/conv#c012
 ps_wavelet_base.F: Found WRITE statement with hardcoded unit in "s_poissonsolver" https://cp2k.org/conv#c012
@@ -144,30 +693,220 @@ ps_wavelet_kernel.F: Found WRITE statement with hardcoded unit in "indices" http
 ps_wavelet_scaling_function.F: Found WRITE statement with hardcoded unit in "ftest" https://cp2k.org/conv#c012
 ps_wavelet_scaling_function.F: Found WRITE statement with hardcoded unit in "scaling_function" https://cp2k.org/conv#c012
 ps_wavelet_scaling_function.F: Found WRITE statement with hardcoded unit in "wavelet_function" https://cp2k.org/conv#c012
+ps_wavelet_types.F: Found type ps_wavelet_type without initializer https://cp2k.org/conv#c016
 ps_wavelet_util.F: Found WRITE statement with hardcoded unit in "p_fft_dimensions" https://cp2k.org/conv#c012
 ps_wavelet_util.F: Found WRITE statement with hardcoded unit in "s_fft_dimensions" https://cp2k.org/conv#c012
+pwdft_environment_types.F: Found type pwdft_energy_type without initializer https://cp2k.org/conv#c016
+pwdft_environment_types.F: Found type pwdft_environment_type with partial initializer https://cp2k.org/conv#c017
+pw_env_types.F: Found type pw_env_type with partial initializer https://cp2k.org/conv#c017
 pw_grids.F: Found WRITE statement with hardcoded unit in "pw_grid_sort" https://cp2k.org/conv#c012
+pw_grid_types.F: Found type map_pn without initializer https://cp2k.org/conv#c016
+pw_grid_types.F: Found type pw_grid_type with partial initializer https://cp2k.org/conv#c017
+pw_grid_types.F: Found type pw_para_type with partial initializer https://cp2k.org/conv#c017
+pw_poisson_types.F: Found type greens_fn_type with partial initializer https://cp2k.org/conv#c017
+pw_poisson_types.F: Found type pw_poisson_parameter_type with partial initializer https://cp2k.org/conv#c017
+pw_poisson_types.F: Found type pw_poisson_type with partial initializer https://cp2k.org/conv#c017
+pw_pool_types.F: Found type pw_pool_p_type without initializer https://cp2k.org/conv#c016
+pw_pool_types.F: Found type pw_pool_type without initializer https://cp2k.org/conv#c016
+pw_spline_utils.F: Found type pw_spline_precond_type without initializer https://cp2k.org/conv#c016
+qmmm_gaussian_types.F: Found type qmmm_gaussian_p_type without initializer https://cp2k.org/conv#c016
+qmmm_gaussian_types.F: Found type qmmm_gaussian_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type add_env_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type add_set_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type add_shell_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type gridlevel_info_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type image_charge_type with partial initializer https://cp2k.org/conv#c017
+qmmm_types_low.F: Found type qmmm_env_mm_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_env_qm_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_imomm_link_p_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_imomm_link_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_links_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_per_pot_p_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_per_pot_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_pot_p_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_pot_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_pseudo_link_p_type without initializer https://cp2k.org/conv#c016
+qmmm_types_low.F: Found type qmmm_pseudo_link_type without initializer https://cp2k.org/conv#c016
+qs_active_space_methods.F: Found type eri_fcidump_checksum with partial initializer https://cp2k.org/conv#c017
+qs_active_space_methods.F: Found type eri_fcidump_print without initializer https://cp2k.org/conv#c016
+qs_active_space_types.F: Found type active_space_type with partial initializer https://cp2k.org/conv#c017
+qs_active_space_types.F: Found type eri_gpw_type without initializer https://cp2k.org/conv#c016
+qs_active_space_types.F: Found type eri_type with partial initializer https://cp2k.org/conv#c017
+qs_atomic_block.F: Found type atom_matrix_type without initializer https://cp2k.org/conv#c016
+qs_block_davidson_types.F: Found type davidson_type without initializer https://cp2k.org/conv#c016
+qs_cdft_opt_types.F: Found type cdft_opt_type with partial initializer https://cp2k.org/conv#c017
+qs_cdft_types.F: Found type becke_constraint_type with partial initializer https://cp2k.org/conv#c017
+qs_cdft_types.F: Found type becke_vector_buffer with partial initializer https://cp2k.org/conv#c017
+qs_cdft_types.F: Found type cdft_control_type with partial initializer https://cp2k.org/conv#c017
+qs_cdft_types.F: Found type cdft_group_type with partial initializer https://cp2k.org/conv#c017
+qs_cdft_types.F: Found type hirshfeld_constraint_type without initializer https://cp2k.org/conv#c016
+qs_charges_types.F: Found type qs_charges_type without initializer https://cp2k.org/conv#c016
+qs_density_mixing_types.F: Found type cp_1d_z_p_type without initializer https://cp2k.org/conv#c016
+qs_density_mixing_types.F: Found type mixing_storage_type without initializer https://cp2k.org/conv#c016
+qs_dftb_types.F: Found type qs_dftb_atom_type without initializer https://cp2k.org/conv#c016
+qs_dftb_types.F: Found type qs_dftb_pairpot_type without initializer https://cp2k.org/conv#c016
+qs_diis_types.F: Found type qs_diis_buffer_p_type_sparse without initializer https://cp2k.org/conv#c016
+qs_diis_types.F: Found type qs_diis_buffer_p_type without initializer https://cp2k.org/conv#c016
+qs_diis_types.F: Found type qs_diis_buffer_type_sparse without initializer https://cp2k.org/conv#c016
+qs_diis_types.F: Found type qs_diis_buffer_type without initializer https://cp2k.org/conv#c016
+qs_dispersion_pairpot.F: Found type dcnum_type without initializer https://cp2k.org/conv#c016
+qs_dispersion_types.F: Found type cn_atom_list without initializer https://cp2k.org/conv#c016
+qs_dispersion_types.F: Found type cn_kind_list without initializer https://cp2k.org/conv#c016
+qs_dispersion_types.F: Found type qs_atom_dispersion_type without initializer https://cp2k.org/conv#c016
+qs_dispersion_types.F: Found type qs_dispersion_type without initializer https://cp2k.org/conv#c016
+qs_energy_types.F: Found type qs_energy_type with partial initializer https://cp2k.org/conv#c017
+qs_environment_types.F: Found type qs_environment_type with partial initializer https://cp2k.org/conv#c017
 qs_external_density.F: Found WRITE statement with hardcoded unit in "external_read_density" https://cp2k.org/conv#c012
+qs_fb_atomic_halo_types.F: Found type fb_atomic_halo_data without initializer https://cp2k.org/conv#c016
+qs_fb_atomic_halo_types.F: Found type fb_atomic_halo_list_data without initializer https://cp2k.org/conv#c016
+qs_fb_atomic_halo_types.F: Found type fb_atomic_halo_list_obj without initializer https://cp2k.org/conv#c016
+qs_fb_atomic_halo_types.F: Found type fb_atomic_halo_obj without initializer https://cp2k.org/conv#c016
+qs_fb_buffer_types.F: Found type fb_buffer_d_data without initializer https://cp2k.org/conv#c016
+qs_fb_buffer_types.F: Found type fb_buffer_i_data without initializer https://cp2k.org/conv#c016
+qs_fb_com_tasks_types.F: Found type fb_com_atom_pairs_data without initializer https://cp2k.org/conv#c016
+qs_fb_com_tasks_types.F: Found type fb_com_atom_pairs_obj without initializer https://cp2k.org/conv#c016
+qs_fb_com_tasks_types.F: Found type fb_com_tasks_data without initializer https://cp2k.org/conv#c016
+qs_fb_com_tasks_types.F: Found type fb_com_tasks_obj without initializer https://cp2k.org/conv#c016
+qs_fb_distribution_methods.F: Found type fb_distribution_element without initializer https://cp2k.org/conv#c016
+qs_fb_distribution_methods.F: Found type fb_distribution_list with partial initializer https://cp2k.org/conv#c017
+qs_fb_distribution_methods.F: Found type fb_preferred_procs_list with partial initializer https://cp2k.org/conv#c017
 qs_fb_env_methods.F: Found CALL cp_fm_gemm in procedure "fb_env_do_diag" https://cp2k.org/conv#c008
+qs_fb_env_types.F: Found type fb_env_data without initializer https://cp2k.org/conv#c016
+qs_fb_env_types.F: Found type fb_env_obj without initializer https://cp2k.org/conv#c016
 qs_fb_filter_matrix_methods.F: Found WRITE statement with hardcoded unit in "fb_fltrmat_build_atomic_fltrmat" https://cp2k.org/conv#c012
+qs_fb_hash_table_types.F: Found type fb_hash_table_data with partial initializer https://cp2k.org/conv#c017
+qs_fb_hash_table_types.F: Found type fb_hash_table_element without initializer https://cp2k.org/conv#c016
+qs_fb_matrix_data_types.F: Found type fb_matrix_data_data with partial initializer https://cp2k.org/conv#c017
+qs_fb_trial_fns_types.F: Found type fb_trial_fns_data without initializer https://cp2k.org/conv#c016
+qs_fb_trial_fns_types.F: Found type fb_trial_fns_obj without initializer https://cp2k.org/conv#c016
+qs_force_types.F: Found type qs_force_type without initializer https://cp2k.org/conv#c016
+qs_gcp_types.F: Found type qs_gcp_kind_type without initializer https://cp2k.org/conv#c016
+qs_gcp_types.F: Found type qs_gcp_type with partial initializer https://cp2k.org/conv#c017
+qs_grid_atom.F: Found type atom_integration_grid_type with partial initializer https://cp2k.org/conv#c017
+qs_grid_atom.F: Found type grid_atom_type without initializer https://cp2k.org/conv#c016
+qs_grid_atom.F: Found type grid_batch_type with partial initializer https://cp2k.org/conv#c017
 qs_gspace_mixing.F: Found WRITE statement with hardcoded unit in "broyden_mixing_new" https://cp2k.org/conv#c012
+qs_harmonics_atom.F: Found type harmonics_atom_type without initializer https://cp2k.org/conv#c016
+qs_initial_guess.F: Found type atom_matrix_type without initializer https://cp2k.org/conv#c016
 qs_initial_guess.F: Found WRITE statement with hardcoded unit in "calculate_first_density_matrix" https://cp2k.org/conv#c012
+qs_kernel_types.F: Found type full_kernel_env_type with partial initializer https://cp2k.org/conv#c017
+qs_kind_types.F: Found type dft_plus_u_type with partial initializer https://cp2k.org/conv#c017
+qs_kind_types.F: Found type qs_kind_p_type without initializer https://cp2k.org/conv#c016
+qs_ks_qmmm_types.F: Found type qs_ks_qmmm_env_type with partial initializer https://cp2k.org/conv#c017
 qs_linres_atom_current.F: Found WRITE statement with hardcoded unit in "calculate_jrho_atom_rad" https://cp2k.org/conv#c012
+qs_linres_current.F: Found type box_type without initializer https://cp2k.org/conv#c016
 qs_linres_current.F: Found WRITE statement with hardcoded unit in "box_atoms" https://cp2k.org/conv#c012
 qs_linres_current.F: Found WRITE statement with hardcoded unit in "box_atoms_new" https://cp2k.org/conv#c012
 qs_linres_current.F: Found WRITE statement with hardcoded unit in "calculate_jrho_resp" https://cp2k.org/conv#c012
 qs_linres_current.F: Found WRITE statement with hardcoded unit in "collocate_gauge_new" https://cp2k.org/conv#c012
 qs_linres_issc_utils.F: Found WRITE statement with hardcoded unit in "issc_issc" https://cp2k.org/conv#c012
 qs_linres_op.F: Procedure 'indxl2g' called with an implicit interface at (1) [-Wimplicit-interface]
+qs_linres_types.F: Found type current_env_type with partial initializer https://cp2k.org/conv#c017
+qs_linres_types.F: Found type dcdr_env_type with partial initializer https://cp2k.org/conv#c017
+qs_linres_types.F: Found type epr_env_type with partial initializer https://cp2k.org/conv#c017
+qs_linres_types.F: Found type issc_env_type with partial initializer https://cp2k.org/conv#c017
+qs_linres_types.F: Found type linres_control_type without initializer https://cp2k.org/conv#c016
+qs_linres_types.F: Found type nmr_env_type with partial initializer https://cp2k.org/conv#c017
+qs_linres_types.F: Found type polar_env_type without initializer https://cp2k.org/conv#c016
+qs_localization_methods.F: Found type set_c_1d_type without initializer https://cp2k.org/conv#c016
+qs_localization_methods.F: Found type set_c_2d_type without initializer https://cp2k.org/conv#c016
 qs_localization_methods.F: Procedure 'pzrot' called with an implicit interface at (1) [-Wimplicit-interface]
+qs_local_rho_types.F: Found type local_rho_type without initializer https://cp2k.org/conv#c016
+qs_local_rho_types.F: Found type rhoz_type without initializer https://cp2k.org/conv#c016
+qs_loc_types.F: Found type localized_wfn_control_type with partial initializer https://cp2k.org/conv#c017
+qs_loc_types.F: Found type qs_loc_env_type without initializer https://cp2k.org/conv#c016
 qs_loc_utils.F: Procedure 'pzrot' called with an implicit interface at (1) [-Wimplicit-interface]
+qs_matrix_pools.F: Found type qs_matrix_pools_type without initializer https://cp2k.org/conv#c016
+qs_mo_types.F: Found type mo_set_p_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_lists.F: Found type local_atoms_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type list_search_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_list_iterator_p_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_list_iterator_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_list_p_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_list_set_p_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_list_set_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_list_task_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_list_type without initializer https://cp2k.org/conv#c016
+qs_neighbor_list_types.F: Found type neighbor_node_type without initializer https://cp2k.org/conv#c016
+qs_nl_hash_table_types.F: Found type nl_hash_table_data with partial initializer https://cp2k.org/conv#c017
+qs_nl_hash_table_types.F: Found type nl_hash_table_element without initializer https://cp2k.org/conv#c016
+qs_o3c_types.F: Found type o3c_container_type without initializer https://cp2k.org/conv#c016
+qs_o3c_types.F: Found type o3c_int_type without initializer https://cp2k.org/conv#c016
+qs_o3c_types.F: Found type o3c_iterator_type without initializer https://cp2k.org/conv#c016
+qs_o3c_types.F: Found type o3c_pair_type without initializer https://cp2k.org/conv#c016
+qs_o3c_types.F: Found type o3c_vec_type without initializer https://cp2k.org/conv#c016
+qs_oce_types.F: Found type oce_matrix_type without initializer https://cp2k.org/conv#c016
+qs_oce_types.F: Found type qlist_type without initializer https://cp2k.org/conv#c016
 qs_ot.F: Found WRITE statement with hardcoded unit in "qs_ot_generate_rotation" https://cp2k.org/conv#c012
+qs_ot_types.F: Found type qs_ot_settings_type without initializer https://cp2k.org/conv#c016
+qs_ot_types.F: Found type qs_ot_type without initializer https://cp2k.org/conv#c016
+qs_pdos.F: Found type ldos_p_type without initializer https://cp2k.org/conv#c016
+qs_pdos.F: Found type ldos_type without initializer https://cp2k.org/conv#c016
+qs_pdos.F: Found type r_ldos_p_type without initializer https://cp2k.org/conv#c016
+qs_pdos.F: Found type r_ldos_type without initializer https://cp2k.org/conv#c016
+qs_p_env_types.F: Found type qs_p_env_type with partial initializer https://cp2k.org/conv#c017
+qs_period_efield_types.F: Found type efield_berry_type without initializer https://cp2k.org/conv#c016
+qs_resp.F: Found type resp_p_type without initializer https://cp2k.org/conv#c016
+qs_resp.F: Found type resp_type without initializer https://cp2k.org/conv#c016
+qs_rho0_types.F: Found type mpole_gau_overlap without initializer https://cp2k.org/conv#c016
+qs_rho0_types.F: Found type mpole_rho_atom without initializer https://cp2k.org/conv#c016
+qs_rho0_types.F: Found type rho0_atom_type without initializer https://cp2k.org/conv#c016
+qs_rho0_types.F: Found type rho0_mpole_type without initializer https://cp2k.org/conv#c016
 qs_rho_atom_methods.F: Found WRITE statement with hardcoded unit in "init_rho_atom" https://cp2k.org/conv#c012
+qs_rho_atom_types.F: Found type rho_atom_coeff without initializer https://cp2k.org/conv#c016
+qs_rho_atom_types.F: Found type rho_atom_p_type without initializer https://cp2k.org/conv#c016
+qs_rho_atom_types.F: Found type rho_atom_type without initializer https://cp2k.org/conv#c016
+qs_rho_types.F: Found type qs_rho_p_type without initializer https://cp2k.org/conv#c016
+qs_scf_types.F: Found type floating_basis_type without initializer https://cp2k.org/conv#c016
+qs_scf_types.F: Found type krylov_space_type without initializer https://cp2k.org/conv#c016
+qs_scf_types.F: Found type qs_scf_env_type without initializer https://cp2k.org/conv#c016
+qs_scf_types.F: Found type subspace_env_type without initializer https://cp2k.org/conv#c016
+qs_tddfpt2_stda_types.F: Found type stda_env_type without initializer https://cp2k.org/conv#c016
+qs_tddfpt2_stda_types.F: Found type stda_kind_p_type without initializer https://cp2k.org/conv#c016
+qs_tddfpt2_stda_types.F: Found type stda_kind_type without initializer https://cp2k.org/conv#c016
+qs_tddfpt2_subgroups.F: Found type tddfpt_subgroup_env_type with partial initializer https://cp2k.org/conv#c017
+qs_tddfpt2_types.F: Found type tddfpt_ground_state_mos with partial initializer https://cp2k.org/conv#c017
+qs_tddfpt2_types.F: Found type tddfpt_work_matrices with partial initializer https://cp2k.org/conv#c017
+qs_tddfpt_types.F: Found type tddfpt_env_type without initializer https://cp2k.org/conv#c016
+qs_tddfpt_utils.F: Found type simple_solution_sorter without initializer https://cp2k.org/conv#c016
+qs_tensors_types.F: Found type distribution_3d_type with partial initializer https://cp2k.org/conv#c017
+qs_tensors_types.F: Found type neighbor_list_3c_iterator_type with partial initializer https://cp2k.org/conv#c017
+qs_tensors_types.F: Found type neighbor_list_3c_type with partial initializer https://cp2k.org/conv#c017
+qs_wannier90.F: Found type berry_matrix_type without initializer https://cp2k.org/conv#c016
+qs_wf_history_types.F: Found type qs_wf_history_p_type without initializer https://cp2k.org/conv#c016
+qs_wf_history_types.F: Found type qs_wf_history_type without initializer https://cp2k.org/conv#c016
+qs_wf_history_types.F: Found type qs_wf_snapshot_p_type without initializer https://cp2k.org/conv#c016
+qs_wf_history_types.F: Found type qs_wf_snapshot_type without initializer https://cp2k.org/conv#c016
+realspace_grid_types.F: Found type realspace_grid_desc_p_type without initializer https://cp2k.org/conv#c016
+realspace_grid_types.F: Found type realspace_grid_desc_type with partial initializer https://cp2k.org/conv#c017
+realspace_grid_types.F: Found type realspace_grid_input_type without initializer https://cp2k.org/conv#c016
+realspace_grid_types.F: Found type realspace_grid_p_type without initializer https://cp2k.org/conv#c016
+reference_manager.F: Found type reference_p_type without initializer https://cp2k.org/conv#c016
+reference_manager.F: Found type reference_type without initializer https://cp2k.org/conv#c016
+reftraj_types.F: Found type reftraj_info_type without initializer https://cp2k.org/conv#c016
+reftraj_types.F: Found type reftraj_msd_type without initializer https://cp2k.org/conv#c016
+reftraj_types.F: Found type reftraj_type without initializer https://cp2k.org/conv#c016
+rel_control_types.F: Found type rel_control_type without initializer https://cp2k.org/conv#c016
+replica_types.F: Found type replica_env_p_type without initializer https://cp2k.org/conv#c016
+replica_types.F: Found type replica_env_type without initializer https://cp2k.org/conv#c016
+routine_map.F: Found type private_item_type with partial initializer https://cp2k.org/conv#c017
+routine_map.F: Found type routine_map_item_type without initializer https://cp2k.org/conv#c016
+rpa_grad.F: Found type rpa_grad_type with partial initializer https://cp2k.org/conv#c017
+rpa_grad.F: Found type rpa_grad_work_type with partial initializer https://cp2k.org/conv#c017
+rpa_im_time_force_types.F: Found type im_time_force_type with partial initializer https://cp2k.org/conv#c017
+sap_kind_types.F: Found type alist_type without initializer https://cp2k.org/conv#c016
+sap_kind_types.F: Found type clist_type without initializer https://cp2k.org/conv#c016
+sap_kind_types.F: Found type sap_int_type without initializer https://cp2k.org/conv#c016
+scf_control_types.F: Found type diagonalization_type without initializer https://cp2k.org/conv#c016
+scf_control_types.F: Found type scf_control_type without initializer https://cp2k.org/conv#c016
+scf_control_types.F: Found type smear_type without initializer https://cp2k.org/conv#c016
 se_core_matrix.F: Found WRITE statement with hardcoded unit in "aa" https://cp2k.org/conv#c012
 se_core_matrix.F: Found WRITE statement with hardcoded unit in "makeds" https://cp2k.org/conv#c012
 se_core_matrix.F: Found WRITE statement with hardcoded unit in "makes" https://cp2k.org/conv#c012
 se_fock_matrix_coulomb.F: Found WRITE statement with hardcoded unit in "build_fock_matrix_coulomb_lr" https://cp2k.org/conv#c012
 se_fock_matrix_dbg.F: Found WRITE statement with hardcoded unit in "dbg_energy_coulomb_lr" https://cp2k.org/conv#c012
+semi_empirical_expns3_types.F: Found type semi_empirical_expns3_p_type without initializer https://cp2k.org/conv#c016
+semi_empirical_expns3_types.F: Found type semi_empirical_expns3_type without initializer https://cp2k.org/conv#c016
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_dcorecore_ana" https://cp2k.org/conv#c012
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_dcore_nucint_ana" https://cp2k.org/conv#c012
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_drotnuc_ana" https://cp2k.org/conv#c012
@@ -179,21 +918,81 @@ semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "check_
 semi_empirical_int_debug.F: Found WRITE statement with hardcoded unit in "rot_2el_2c_first_debug" https://cp2k.org/conv#c012
 semi_empirical_int_debug.F: Procedure 'check_value' called with an implicit interface at (1) [-Wimplicit-interface]
 semi_empirical_mpole_methods.F: Found WRITE statement with hardcoded unit in "semi_empirical_mpole_p_setup" https://cp2k.org/conv#c012
+semi_empirical_mpole_types.F: Found type nddo_mpole_type without initializer https://cp2k.org/conv#c016
+semi_empirical_mpole_types.F: Found type semi_empirical_mpole_p_type without initializer https://cp2k.org/conv#c016
+semi_empirical_mpole_types.F: Found type semi_empirical_mpole_type without initializer https://cp2k.org/conv#c016
+semi_empirical_store_int_types.F: Found type semi_empirical_si_type without initializer https://cp2k.org/conv#c016
+semi_empirical_types.F: Found type ewald_gks_type without initializer https://cp2k.org/conv#c016
+semi_empirical_types.F: Found type rotmat_type without initializer https://cp2k.org/conv#c016
+semi_empirical_types.F: Found type se_int_control_type without initializer https://cp2k.org/conv#c016
+semi_empirical_types.F: Found type se_int_screen_type without initializer https://cp2k.org/conv#c016
+semi_empirical_types.F: Found type semi_empirical_p_type without initializer https://cp2k.org/conv#c016
+semi_empirical_types.F: Found type semi_empirical_type without initializer https://cp2k.org/conv#c016
+semi_empirical_types.F: Found type se_taper_type without initializer https://cp2k.org/conv#c016
+shell_potential_types.F: Found type shell_kind_type without initializer https://cp2k.org/conv#c016
+shell_potential_types.F: Found type shell_p_type without initializer https://cp2k.org/conv#c016
+simpar_types.F: Found type simpar_type without initializer https://cp2k.org/conv#c016
 spherical_harmonics.F: Found WRITE statement with hardcoded unit in "cgc" https://cp2k.org/conv#c012
 spherical_harmonics.F: Found WRITE statement with hardcoded unit in "get_factor" https://cp2k.org/conv#c012
+splines_types.F: Found type spline_data_pp_type without initializer https://cp2k.org/conv#c016
+splines_types.F: Found type spline_data_p_type without initializer https://cp2k.org/conv#c016
+splines_types.F: Found type spline_data_type without initializer https://cp2k.org/conv#c016
+splines_types.F: Found type spline_environment_type without initializer https://cp2k.org/conv#c016
+splines_types.F: Found type spline_factor_type without initializer https://cp2k.org/conv#c016
 statistical_methods.F: Found WRITE statement with hardcoded unit in "tests" https://cp2k.org/conv#c012
+structure_factor_types.F: Found type structure_factor_type without initializer https://cp2k.org/conv#c016
+subcell_types.F: Found type subcell_type without initializer https://cp2k.org/conv#c016
+submatrix_dissection.F: Found type submatrix_dissection_type with partial initializer https://cp2k.org/conv#c017
+submatrix_types.F: Found type buffer_type with partial initializer https://cp2k.org/conv#c017
+submatrix_types.F: Found type intbuffer_type with partial initializer https://cp2k.org/conv#c017
+swarm_master.F: Found type swarm_master_type with partial initializer https://cp2k.org/conv#c017
+swarm_message.F: Found type message_entry_type with partial initializer https://cp2k.org/conv#c017
 swarm_mpi.F: Found CLOSE statement in procedure "logger_init_master" https://cp2k.org/conv#c011
 swarm_mpi.F: Found OPEN statement in procedure "logger_finalize" https://cp2k.org/conv#c011
+taper_types.F: Found type taper_type without initializer https://cp2k.org/conv#c016
 task_list_methods.F: Found WRITE statement with hardcoded unit in "generate_qs_task_list" https://cp2k.org/conv#c012
+task_list_types.F: Found type task_list_type with partial initializer https://cp2k.org/conv#c017
+thermal_region_types.F: Found type thermal_regions_type without initializer https://cp2k.org/conv#c016
+thermal_region_types.F: Found type thermal_region_type without initializer https://cp2k.org/conv#c016
+thermostat_types.F: Found type thermostat_info_type without initializer https://cp2k.org/conv#c016
+thermostat_types.F: Found type thermostats_type without initializer https://cp2k.org/conv#c016
+thermostat_types.F: Found type thermostat_type without initializer https://cp2k.org/conv#c016
+timings_base_type.F: Found type callstack_entry_type without initializer https://cp2k.org/conv#c016
+timings_base_type.F: Found type call_stat_type without initializer https://cp2k.org/conv#c016
+timings_base_type.F: Found type routine_report_type with partial initializer https://cp2k.org/conv#c017
+timings_base_type.F: Found type routine_stat_type without initializer https://cp2k.org/conv#c016
 timings.F: Found WRITE statement with hardcoded unit in "timestop_handler" https://cp2k.org/conv#c012
+timings_types.F: Found type timer_env_type with partial initializer https://cp2k.org/conv#c017
+tip_scan_types.F: Found type scanning_type with partial initializer https://cp2k.org/conv#c017
 tmc_analysis.F: Found WRITE statement with hardcoded unit in "print_average_displacement" https://cp2k.org/conv#c012
 tmc_analysis.F: Found WRITE statement with hardcoded unit in "print_dipole_moment" https://cp2k.org/conv#c012
 tmc_analysis.F: Found WRITE statement with hardcoded unit in "print_paircorrelation" https://cp2k.org/conv#c012
+tmc_analysis_types.F: Found type atom_pairs_type with partial initializer https://cp2k.org/conv#c017
+tmc_analysis_types.F: Found type density_3d_type without initializer https://cp2k.org/conv#c016
+tmc_analysis_types.F: Found type dipole_analysis_type with partial initializer https://cp2k.org/conv#c017
+tmc_analysis_types.F: Found type dipole_moment_type with partial initializer https://cp2k.org/conv#c017
+tmc_analysis_types.F: Found type displacement_type without initializer https://cp2k.org/conv#c016
+tmc_analysis_types.F: Found type pair_correl_type without initializer https://cp2k.org/conv#c016
+tmc_analysis_types.F: Found type tmc_analysis_env with partial initializer https://cp2k.org/conv#c017
 tmc_cancelation.F: Found WRITE statement with hardcoded unit in "add_to_canceling_list" https://cp2k.org/conv#c012
 tmc_dot_tree.F: Found WRITE statement with hardcoded unit in "create_dot_color" https://cp2k.org/conv#c012
 tmc_dot_tree.F: Found WRITE statement with hardcoded unit in "create_global_tree_dot_color" https://cp2k.org/conv#c012
+tmc_messages.F: Found type message_send with partial initializer https://cp2k.org/conv#c017
 tmc_messages.F: Found WRITE statement with hardcoded unit in "read_energy_result_message" https://cp2k.org/conv#c012
 tmc_messages.F: Found WRITE statement with hardcoded unit in "tmc_message" https://cp2k.org/conv#c012
+tmc_move_types.F: Found type list_atoms without initializer https://cp2k.org/conv#c016
+tmc_move_types.F: Found type tmc_move_type with partial initializer https://cp2k.org/conv#c017
+tmc_tree_types.F: Found type elem_array_type with partial initializer https://cp2k.org/conv#c017
+tmc_tree_types.F: Found type elem_list_type with partial initializer https://cp2k.org/conv#c017
+tmc_tree_types.F: Found type global_tree_type with partial initializer https://cp2k.org/conv#c017
+tmc_tree_types.F: Found type tree_type with partial initializer https://cp2k.org/conv#c017
+tmc_types.F: Found type master_env_type without initializer https://cp2k.org/conv#c016
+tmc_types.F: Found type prior_estimate_acceptance_type without initializer https://cp2k.org/conv#c016
+tmc_types.F: Found type tmc_atom_type without initializer https://cp2k.org/conv#c016
+tmc_types.F: Found type tmc_comp_set_type without initializer https://cp2k.org/conv#c016
+tmc_types.F: Found type tmc_env_type with partial initializer https://cp2k.org/conv#c017
+tmc_types.F: Found type tmc_param_type without initializer https://cp2k.org/conv#c016
+tmc_types.F: Found type worker_env_type without initializer https://cp2k.org/conv#c016
 topology_constraint_util.F: Found WRITE statement with hardcoded unit in "setup_lcolv" https://cp2k.org/conv#c012
 topology_constraint_util.F: Found WRITE statement with hardcoded unit in "setup_lg3x3" https://cp2k.org/conv#c012
 topology_constraint_util.F: Found WRITE statement with hardcoded unit in "setup_lg4x6" https://cp2k.org/conv#c012
@@ -202,12 +1001,38 @@ topology_generate_util.F: Found WRITE statement with hardcoded unit in "generate
 topology_generate_util.F: Found WRITE statement with hardcoded unit in "topology_generate_molecule" https://cp2k.org/conv#c012
 topology_gromos.F: Found READ with unchecked STAT in "read_topology_gromos" https://cp2k.org/conv#c001
 topology_pdb.F: Found READ with unchecked STAT in "read_coordinate_pdb" https://cp2k.org/conv#c001
+topology_types.F: Found type atom_info_type without initializer https://cp2k.org/conv#c016
+topology_types.F: Found type connectivity_info_type without initializer https://cp2k.org/conv#c016
+topology_types.F: Found type constraint_info_type without initializer https://cp2k.org/conv#c016
+topology_types.F: Found type constr_list_type without initializer https://cp2k.org/conv#c016
+topology_types.F: Found type topology_parameters_type without initializer https://cp2k.org/conv#c016
+transport_env_types.F: Found type cp2k_csr_interop_type without initializer https://cp2k.org/conv#c016
+transport_env_types.F: Found type cp2k_transport_parameters without initializer https://cp2k.org/conv#c016
+transport_env_types.F: Found type transport_env_type with partial initializer https://cp2k.org/conv#c017
+virial_types.F: Found type virial_p_type without initializer https://cp2k.org/conv#c016
+virial_types.F: Found type virial_type with partial initializer https://cp2k.org/conv#c017
+xas_control.F: Found type xas_control_type without initializer https://cp2k.org/conv#c016
+xas_env_types.F: Found type xas_environment_type without initializer https://cp2k.org/conv#c016
+xas_tdp_types.F: Found type batch_info_type with partial initializer https://cp2k.org/conv#c017
+xas_tdp_types.F: Found type donor_state_type without initializer https://cp2k.org/conv#c016
+xas_tdp_types.F: Found type grid_atom_p_type without initializer https://cp2k.org/conv#c016
+xas_tdp_types.F: Found type harmonics_atom_p_type without initializer https://cp2k.org/conv#c016
+xas_tdp_types.F: Found type xas_atom_env_type without initializer https://cp2k.org/conv#c016
+xas_tdp_types.F: Found type xas_tdp_control_type without initializer https://cp2k.org/conv#c016
+xas_tdp_types.F: Found type xas_tdp_env_type without initializer https://cp2k.org/conv#c016
+xas_tdp_utils.F: Found type dbcsr_soc_package_type without initializer https://cp2k.org/conv#c016
+xc_derivative_set_types.F: Found type xc_derivative_set_type without initializer https://cp2k.org/conv#c016
+xc_derivative_types.F: Found type xc_derivative_p_type without initializer https://cp2k.org/conv#c016
 xc.F: Found CLOSE statement in procedure "xc_vxc_pw_create_debug" https://cp2k.org/conv#c011
 xc.F: Found CLOSE statement in procedure "xc_vxc_pw_create_test_lsd" https://cp2k.org/conv#c011
 xc.F: Found OPEN statement in procedure "xc_vxc_pw_create_debug" https://cp2k.org/conv#c011
 xc.F: Found OPEN statement in procedure "xc_vxc_pw_create_test_lsd" https://cp2k.org/conv#c011
 xc.F: Found WRITE statement with hardcoded unit in "xc_vxc_pw_create_debug" https://cp2k.org/conv#c012
 xc.F: Found WRITE statement with hardcoded unit in "xc_vxc_pw_create_test_lsd" https://cp2k.org/conv#c012
+xc_rho_cflags_types.F: Found type xc_rho_cflags_type without initializer https://cp2k.org/conv#c016
+xc_rho_set_types.F: Found type xc_rho_set_type with partial initializer https://cp2k.org/conv#c017
+xtb_matrices.F: Found type neighbor_atoms_type without initializer https://cp2k.org/conv#c016
+xtb_types.F: Found type xtb_atom_type without initializer https://cp2k.org/conv#c016
 xyz2dcd.F: Found CLOSE statement in procedure "xyz2dcd" https://cp2k.org/conv#c011
 xyz2dcd.F: Found OPEN statement in procedure "xyz2dcd" https://cp2k.org/conv#c011
 xyz2dcd.F: Found STOP statement in procedure "abort_program" https://cp2k.org/conv#c011


### PR DESCRIPTION
I think we should start using [default initializers](https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/language-reference/data-types-constants-and-variables/derived-data-types/default-initialization.html) for all derived types. It will allow us to simplify and often entirely remove our usual create routines and it will eliminate many problems with uninitialized memory.

After a bit of tinkering I managed to detect missing and incomplete initializers as part of our conventions check.