### PR TITLE
Fix conventions in file src/negf_methods.F

### DIFF
--- a/src/negf_methods.F
+++ b/src/negf_methods.F
@@ -1392,7 +1392,6 @@ CONTAINS
                                                             just_contact
 
       CHARACTER(len=*), PARAMETER :: routineN = 'negf_retarded_green_function_batch'
-      TYPE(cp_cfm_type), PARAMETER                       :: cfm_dummy = cp_cfm_type()
 
       INTEGER                                            :: handle, icontact, igroup, ipoint, &
                                                             ncontacts, npoints, nrows
@@ -1697,27 +1696,9 @@ CONTAINS
 
                DO ipoint = 1, npoints
                   DO icontact = 1, ncontacts
-                     IF (ASSOCIATED(gret_gamma_gadv(icontact, ipoint)%matrix_struct)) THEN
-                        IF (ASSOCIATED(gret_gamma_gadv_group(icontact, ipoint)%matrix_struct)) THEN
-                           CALL cp_cfm_start_copy_general(gret_gamma_gadv_group(icontact, ipoint), &
-                                                          gret_gamma_gadv(icontact, ipoint), &
-                                                          para_env, info2(icontact, ipoint))
-                        ELSE
-                           CALL cp_cfm_start_copy_general(cfm_dummy, &
-                                                          gret_gamma_gadv(icontact, ipoint), &
-                                                          para_env, info2(icontact, ipoint))
-                        END IF
-                     ELSE
-                        IF (ASSOCIATED(gret_gamma_gadv_group(icontact, ipoint)%matrix_struct)) THEN
-                           CALL cp_cfm_start_copy_general(gret_gamma_gadv_group(icontact, ipoint), &
-                                                          cfm_dummy, &
-                                                          para_env, info2(icontact, ipoint))
-                        ELSE
-                           CALL cp_cfm_start_copy_general(cfm_dummy, &
-                                                          cfm_dummy, &
-                                                          para_env, info2(icontact, ipoint))
-                        END IF
-                     END IF
+                     CALL cp_cfm_start_copy_general(gret_gamma_gadv_group(icontact, ipoint), &
+                                                    gret_gamma_gadv(icontact, ipoint), &
+                                                    para_env, info2(icontact, ipoint))
                   END DO
                END DO
 

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -123,6 +123,9 @@ message_passing.fypp: Rank mismatch between actual argument at (1) and actual ar
 message_passing.fypp: Type mismatch between actual argument at (1) and actual argument at (2) (COMPLEX(8)/COMPLEX(4)).
 mltfftsg_tools.F: Found WRITE statement with hardcoded unit in "ctrig" https://cp2k.org/conv#c012
 mode_selective.F: Found READ with unchecked STAT in "bfgs_guess" https://cp2k.org/conv#c001
+negf_methods.F: Found CALL with NULL() as argument in procedure "converge_density" https://cp2k.org/conv#c007
+negf_methods.F: Found CALL with NULL() as argument in procedure "guess_fermi_level" https://cp2k.org/conv#c007
+negf_methods.F: Found CALL with NULL() as argument in procedure "shift_potential" https://cp2k.org/conv#c007
 nequip_unittest.F: Found WRITE statement with hardcoded unit in "nequip_unittest" https://cp2k.org/conv#c012
 pao_param_exp.F: Found lossy conversion real_4_r8 without KIND argument in "zheevd_wrapper" https://cp2k.org/conv#c015
 parallel_gemm_api.F: Found CALL cp_fm_gemm in procedure "parallel_gemm_fm" https://cp2k.org/conv#c008


### PR DESCRIPTION
This is a follow-up to #2555 . I introduced the removed branches to simplify the refactoring but I forgot to remove them afterwards. The left-over issues are added to the suppression file.