### PR TITLE
 SIGN option in DISTANCE CV

### DIFF
--- a/src/colvar_methods.F
+++ b/src/colvar_methods.F
@@ -250,6 +250,7 @@ CONTAINS
          colvar%dist_param%i_at = iatms(1)
          colvar%dist_param%j_at = iatms(2)
          CALL section_vals_val_get(distance_section, "AXIS", i_val=colvar%dist_param%axis_id)
+         CALL section_vals_val_get(distance_section, "SIGN", l_val=colvar%dist_param%sign_d)
       ELSE IF (my_subsection(2)) THEN
          ! Angle
          wrk_section => angle_section
@@ -2902,7 +2903,22 @@ CONTAINS
       END SELECT
       r12 = SQRT(xij(1)**2 + xij(2)**2 + xij(3)**2)
 
-      colvar%ss = r12
+      IF(colvar%dist_param%sign_d) THEN
+        SELECT CASE (colvar%dist_param%axis_id)
+        CASE (do_clv_x)
+           colvar%ss = xij(1)
+        CASE (do_clv_y)
+           colvar%ss = xij(2)
+        CASE (do_clv_z)
+           colvar%ss = xij(3)
+        CASE DEFAULT
+           !do_clv_xyz
+        END SELECT
+
+      ELSE
+        colvar%ss = r12
+      ENDIF
+
       fi(:) = xij/r12
       fj(:) = -xij/r12
 

--- a/src/input_cp2k_colvar.F
+++ b/src/input_cp2k_colvar.F
@@ -810,6 +810,16 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="SIGN", &
+                          description="Whether the distance along one Cartesian axiz has to be considered with sign. "// &
+                          " Yhis option is valid only if only one dimension is selected.", &
+                          usage="SIGN", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+
+
       ! Must be present in each colvar and handled properly
       CALL create_point_section(subsection)
       CALL section_add_subsection(section, subsection)

--- a/src/subsys/colvar_types.F
+++ b/src/subsys/colvar_types.F
@@ -89,6 +89,7 @@ MODULE colvar_types
 ! **************************************************************************************************
    TYPE dist_colvar_type
       INTEGER       :: i_at, j_at, axis_id
+      LOGICAL       :: sign_d
    END TYPE dist_colvar_type
 
 ! **************************************************************************************************
@@ -461,6 +462,7 @@ CONTAINS
       CASE (dist_colvar_id)
          ALLOCATE (colvar%dist_param)
          colvar%dist_param%axis_id = do_clv_xyz
+         colvar%dist_param%sign_d = .false.
       CASE (coord_colvar_id)
          ALLOCATE (colvar%coord_param)
       CASE (population_colvar_id)
@@ -1398,6 +1400,7 @@ CONTAINS
          colvar_out%dist_param%i_at = colvar_in%dist_param%i_at + my_offset
          colvar_out%dist_param%j_at = colvar_in%dist_param%j_at + my_offset
          colvar_out%dist_param%axis_id = colvar_in%dist_param%axis_id
+         colvar_out%dist_param%sign_d = colvar_in%dist_param%sign_d
       CASE (coord_colvar_id)
          colvar_out%coord_param%n_atoms_to = colvar_in%coord_param%n_atoms_to
          colvar_out%coord_param%n_atoms_to_b = colvar_in%coord_param%n_atoms_to_b


### PR DESCRIPTION
The distance colvar can be used with sign if defined for only one component.

 This is useful to work with vector products