### PR TITLE
Fix detection of system Open MPI

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -311,7 +311,7 @@ if (command -v mpiexec > /dev/null 2>&1); then
     echo "MPI is detected and it appears to be MPICH"
     export MPI_MODE="mpich"
     with_mpich="__SYSTEM__"
-  elif (mpiexec --version 2>&1 | grep -s -q "Open MPI"); then
+  elif (mpiexec --version 2>&1 | grep -s -q "OpenRTE"); then
     echo "MPI is detected and it appears to be OpenMPI"
     export MPI_MODE="openmpi"
     with_openmpi="__SYSTEM__"


### PR DESCRIPTION
The commands mpirun and mpiexec employ different runtime environments. The search string to determine the MPI flavor is based on the this very name in the case of OpenMPI. When switching to mpiexec, it was forgotten to adjust it accordingly. This issue is absent in case of IntelMPI because mpirun is a apparently a mere alias of mpiexec. I do not know about the respective differences in the case of MPICH which is not available on our cluster but mistakes here are not important anyways because the toolchain defaults to MPICH if the system MPI is neither IntelMPI nor Open MPI.