### PR TITLE
ci: use `GITHUB_ENV`

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set release tarball name
-        run: echo ::set-env name=TARBALL_NAME::$(echo cp2k-${GITHUB_REF##*/v}.tar.bz2)
+        run: echo "TARBALL_NAME=cp2k-${GITHUB_REF##*/v}.tar.bz2" >> $GITHUB_ENV
       - name: Install prerequisites
         run: |
           pip install git-archive-all


### PR DESCRIPTION
`set-env` is deprecated

- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable