### PR TITLE
Further refactoring of message_passing module

### DIFF
--- a/src/almo_scf_lbfgs_types.F
+++ b/src/almo_scf_lbfgs_types.F
@@ -150,7 +150,7 @@ CONTAINS
       INTEGER                                            :: ispin, istore
 
       !logger => cp_get_default_logger()
-      !IF (logger%para_env%mepos == logger%para_env%source) THEN
+      !IF (logger%para_env%is_source()) THEN
       !   unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       !ELSE
       !   unit_nr = -1
@@ -191,7 +191,7 @@ CONTAINS
       INTEGER                                            :: ispin, istore
 
       !logger => cp_get_default_logger()
-      !IF (logger%para_env%mepos == logger%para_env%source) THEN
+      !IF (logger%para_env%is_source()) THEN
       !   unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       !ELSE
       !   unit_nr = -1
@@ -252,7 +252,7 @@ CONTAINS
       TYPE(dbcsr_type)                                   :: q
 
       !logger => cp_get_default_logger()
-      !IF (logger%para_env%mepos == logger%para_env%source) THEN
+      !IF (logger%para_env%is_source()) THEN
       !   unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       !ELSE
       !   unit_nr = -1

--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -2053,7 +2053,7 @@ CONTAINS
 
       ! get a useful output_unit
       logger => cp_get_default_logger()
-      IF (logger%para_env%mepos == logger%para_env%source) THEN
+      IF (logger%para_env%is_source()) THEN
          unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       ELSE
          unit_nr = -1
@@ -5402,7 +5402,7 @@ CONTAINS
 !
 !    ! get a useful output_unit
 !    logger => cp_get_default_logger()
-!    IF (logger%para_env%mepos==logger%para_env%source) THEN
+!    IF (logger%para_env%is_source()) THEN
 !       unit_nr=cp_logger_get_default_unit_nr(logger,local=.TRUE.)
 !    ELSE
 !       unit_nr=-1

--- a/src/common/cp_log_handling.F
+++ b/src/common/cp_log_handling.F
@@ -612,7 +612,7 @@ CONTAINS
                lggr%close_global_unit_on_dealloc = .FALSE.
             END IF
          END IF
-         IF ((lggr%para_env%mepos /= lggr%para_env%source) .AND. (.NOT. skip)) THEN
+         IF (.NOT. (lggr%para_env%is_source() .OR. skip)) THEN
             WRITE (UNIT=lggr%default_global_unit_nr, FMT='(/,T2,A)', IOSTAT=iostat) &
                ' *** WARNING non ionode asked for global logger ***'
             IF (iostat /= 0) THEN

--- a/src/common/cp_para_types.F
+++ b/src/common/cp_para_types.F
@@ -44,7 +44,6 @@ MODULE cp_para_types
       PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: mp_comm_init => cp_para_env_init
       PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: mp_comm_free => cp_para_env_free
       PROCEDURE, PUBLIC, PASS(para_env), NON_OVERRIDABLE :: retain => cp_para_env_retain
-      PROCEDURE, PUBLIC, PASS(para_env), NON_OVERRIDABLE :: is_source => cp_para_env_is_source
       PROCEDURE, PUBLIC, PASS(para_env), NON_OVERRIDABLE :: is_valid => cp_para_env_is_valid
    END TYPE cp_para_env_type
 
@@ -103,18 +102,6 @@ CONTAINS
       comm%ref_count = 1
 
    END SUBROUTINE cp_para_env_init
-
-! **************************************************************************************************
-!> \brief check whether the local process is the source process
-!> \param para_env ...
-!> \return ...
-! **************************************************************************************************
-   ELEMENTAL LOGICAL FUNCTION cp_para_env_is_source(para_env)
-      CLASS(cp_para_env_type), INTENT(IN) :: para_env
-
-      cp_para_env_is_source = para_env%source == para_env%mepos
-
-   END FUNCTION cp_para_env_is_source
 
 ! **************************************************************************************************
 !> \brief check whether the environment exists

--- a/src/common/parallel_rng_types_unittest.F
+++ b/src/common/parallel_rng_types_unittest.F
@@ -22,7 +22,7 @@ PROGRAM parallel_rng_types_TEST
 
    IMPLICIT NONE
 
-   INTEGER                          :: i, nsamples, nargs, stat, mepos
+   INTEGER                          :: i, nsamples, nargs, stat
    LOGICAL                          :: ionode
    REAL(KIND=dp)                    :: t, tend, tmax, tmin, tstart, tsum, tsum2
    TYPE(mp_comm_type) :: mpi_comm
@@ -43,8 +43,7 @@ PROGRAM parallel_rng_types_TEST
    END IF
 
    CALL mp_world_init(mpi_comm)
-   mepos = mpi_comm%mepos
-   ionode = mepos == 0
+   ionode = mpi_comm%is_source()
 
    CALL check_rng(default_output_unit, ionode)
 

--- a/src/cp_ddapc_methods.F
+++ b/src/cp_ddapc_methods.F
@@ -623,7 +623,7 @@ CONTAINS
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE ewald_ddapc_pot(cp_para_env, coeff, factor, cell, multipole_section, &
                                         particle_set, M, radii)
-      TYPE(cp_para_env_type), POINTER                    :: cp_para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: cp_para_env
       TYPE(pw_type), INTENT(IN), POINTER                 :: coeff
       REAL(KIND=dp), INTENT(IN)                          :: factor
       TYPE(cell_type), POINTER                           :: cell

--- a/src/cp_eri_mme_interface.F
+++ b/src/cp_eri_mme_interface.F
@@ -348,7 +348,7 @@ CONTAINS
          POINTER                                         :: qs_kind_set
       CHARACTER(len=*), INTENT(IN)                       :: basis_type_1
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: basis_type_2
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER, INTENT(IN), OPTIONAL                      :: potential
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pot_par
 
@@ -390,7 +390,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: is_ortho
       REAL(KIND=dp), INTENT(IN)                          :: zet_min, zet_max
       INTEGER, INTENT(IN)                                :: l_max_zet, l_max
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER, INTENT(IN), OPTIONAL                      :: potential
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pot_par
 
@@ -707,7 +707,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_eri_mme_update_local_counts(param, para_env, G_count_2c, R_count_2c, GG_count_3c, GR_count_3c, RR_count_3c)
       TYPE(cp_eri_mme_param), INTENT(INOUT)              :: param
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER, INTENT(INOUT), OPTIONAL                   :: G_count_2c, R_count_2c, GG_count_3c, &
                                                             GR_count_3c, RR_count_3c
 
@@ -745,7 +745,7 @@ CONTAINS
 !> \param eri_mme_test_section ...
 ! **************************************************************************************************
    SUBROUTINE cp_eri_mme_perf_acc_test(para_env, iw, eri_mme_test_section)
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER, INTENT(IN)                                :: iw
       TYPE(section_vals_type), POINTER                   :: eri_mme_test_section
 

--- a/src/cp_external_control.F
+++ b/src/cp_external_control.F
@@ -223,7 +223,7 @@ CONTAINS
             END IF
          END IF
       END IF
-      CALL logger%para_env%bcast(should_stop, logger%para_env%source)
+      CALL logger%para_env%bcast(should_stop)
 
       check_always = should_stop
 

--- a/src/dbm/dbm_tests.F
+++ b/src/dbm/dbm_tests.F
@@ -65,7 +65,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'dbm_run_tests'
 
-      INTEGER                                            :: bmax, bmin, handle, numnodes
+      INTEGER                                            :: bmax, bmin, handle
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_dist_a, col_dist_b, col_dist_c, &
                                                             row_dist_a, row_dist_b, row_dist_c, &
                                                             sizes_k, sizes_m, sizes_n
@@ -77,9 +77,8 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       ! Create MPI processor grid.
-      numnodes = mp_group%num_pe
       npdims(:) = 0
-      CALL mp_dims_create(numnodes, npdims)
+      CALL mp_dims_create(mp_group%num_pe, npdims)
       CALL cart_group%create(mp_group, 2, npdims)
       npdims = cart_group%num_pe_cart
 
@@ -214,50 +213,50 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'run_multiply_test'
 
-      INTEGER                                            :: handle, loop_iter, numnodes
+      INTEGER                                            :: handle, loop_iter
       INTEGER(kind=int_8)                                :: flop
       REAL(kind=dp)                                      :: cs, duration, flops_all, time_start
       TYPE(dbm_type)                                     :: matrix_c_orig
 
       CALL timeset(routineN, handle)
 
-      numnodes = group%num_pe
-
       CALL dbm_create_from_template(matrix_c_orig, "Original Matrix C", matrix_c)
       CALL dbm_copy(matrix_c_orig, matrix_c)
 
-      DO loop_iter = 1, n_loops
-         CALL group%sync()
-         time_start = omp_get_wtime()
-         IF (eps < -0.0_dp) THEN
-            CALL dbm_multiply(transa, transb, alpha, matrix_a, matrix_b, beta, matrix_c, &
-                              retain_sparsity=retain_sparsity, flop=flop)
-         ELSE
-            CALL dbm_multiply(transa, transb, alpha, matrix_a, matrix_b, beta, matrix_c, &
-                              retain_sparsity=retain_sparsity, flop=flop, filter_eps=eps)
-         END IF
-         duration = omp_get_wtime() - time_start
-
-         CALL group%max(duration)
-         CALL group%sum(flop)
-         duration = MAX(duration, EPSILON(duration))  ! avoid division by zero
-         flops_all = REAL(flop, KIND=dp)/duration/numnodes/(1024*1024)
-         IF (io_unit .GT. 0) THEN
-            WRITE (io_unit, '(A,I5,A,I5,A,F12.3,A,I9,A)') &
-               " loop ", loop_iter, " with ", numnodes, " MPI ranks: using ", &
-               duration, "s ", INT(flops_all), " Mflops/rank"
-            CALL m_flush(io_unit)
-         END IF
-
-         IF (loop_iter .EQ. n_loops .OR. always_checksum) THEN
-            cs = dbm_checksum(matrix_c)
-            IF (io_unit > 0) THEN
-               WRITE (io_unit, *) "Final checksums", cs
+      ASSOCIATE (numnodes => group%num_pe)
+         DO loop_iter = 1, n_loops
+            CALL group%sync()
+            time_start = omp_get_wtime()
+            IF (eps < -0.0_dp) THEN
+               CALL dbm_multiply(transa, transb, alpha, matrix_a, matrix_b, beta, matrix_c, &
+                                 retain_sparsity=retain_sparsity, flop=flop)
+            ELSE
+               CALL dbm_multiply(transa, transb, alpha, matrix_a, matrix_b, beta, matrix_c, &
+                                 retain_sparsity=retain_sparsity, flop=flop, filter_eps=eps)
             END IF
-         END IF
+            duration = omp_get_wtime() - time_start
 
-         CALL dbm_copy(matrix_c, matrix_c_orig)
-      END DO
+            CALL group%max(duration)
+            CALL group%sum(flop)
+            duration = MAX(duration, EPSILON(duration))  ! avoid division by zero
+            flops_all = REAL(flop, KIND=dp)/duration/numnodes/(1024*1024)
+            IF (io_unit .GT. 0) THEN
+               WRITE (io_unit, '(A,I5,A,I5,A,F12.3,A,I9,A)') &
+                  " loop ", loop_iter, " with ", numnodes, " MPI ranks: using ", &
+                  duration, "s ", INT(flops_all), " Mflops/rank"
+               CALL m_flush(io_unit)
+            END IF
+
+            IF (loop_iter .EQ. n_loops .OR. always_checksum) THEN
+               cs = dbm_checksum(matrix_c)
+               IF (io_unit > 0) THEN
+                  WRITE (io_unit, *) "Final checksums", cs
+               END IF
+            END IF
+
+            CALL dbm_copy(matrix_c, matrix_c_orig)
+         END DO
+      END ASSOCIATE
 
       CALL dbm_release(matrix_c_orig)
       CALL timestop(handle)
@@ -277,7 +276,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'fill_matrix'
 
-      INTEGER                                            :: block_node, col, handle, mynode, ncol, &
+      INTEGER                                            :: block_node, col, handle, ncol, &
                                                             nrow, row
       INTEGER(KIND=int_8)                                :: counter, ele, increment, nmax
       INTEGER, DIMENSION(4)                              :: iseed, jseed
@@ -287,8 +286,6 @@ CONTAINS
       REAL(kind=dp), DIMENSION(1)                        :: value
 
       CALL timeset(routineN, handle)
-
-      mynode = group%mepos
 
       ! Check that the counter was initialised (or has not overflowed)
       CPASSERT(randmat_counter .NE. 0)
@@ -310,32 +307,34 @@ CONTAINS
       counter = 0
       jseed = generate_larnv_seed(7, 42, 3, 42, randmat_counter)
 
-      DO
-         ! find the next block to add, this is given by a geometrically distributed variable
-         ! we number the blocks of the matrix and jump to the next one
-         CALL dlarnv(1, jseed, 1, value)
-         IF (my_sparsity > 0) THEN
-            increment = 1 + FLOOR(LOG(value(1))/LOG(my_sparsity), KIND=int_8)
-         ELSE
-            increment = 1
-         END IF
-         ele = ele + increment
-         IF (ele >= nmax) EXIT
-         counter = counter + 1
-         row = INT(ele/ncol) + 1
-         col = INT(MOD(ele, INT(ncol, KIND=KIND(ele)))) + 1
+      ASSOCIATE (mynode => group%mepos)
+         DO
+            ! find the next block to add, this is given by a geometrically distributed variable
+            ! we number the blocks of the matrix and jump to the next one
+            CALL dlarnv(1, jseed, 1, value)
+            IF (my_sparsity > 0) THEN
+               increment = 1 + FLOOR(LOG(value(1))/LOG(my_sparsity), KIND=int_8)
+            ELSE
+               increment = 1
+            END IF
+            ele = ele + increment
+            IF (ele >= nmax) EXIT
+            counter = counter + 1
+            row = INT(ele/ncol) + 1
+            col = INT(MOD(ele, INT(ncol, KIND=KIND(ele)))) + 1
 
-         ! Only deal with the local blocks.
-         CALL dbm_get_stored_coordinates(matrix, row, col, block_node)
-         IF (block_node == mynode) THEN
-            ! fill based on a block based seed, makes this the same values in parallel
-            iseed = generate_larnv_seed(row, nrow, col, ncol, randmat_counter)
-            ALLOCATE (block(row_block_sizes(row), col_block_sizes(col)))
-            CALL dlarnv(1, iseed, SIZE(block), block)
-            CALL dbm_put_block(matrix, row, col, block)
-            DEALLOCATE (block)
-         END IF
-      END DO
+            ! Only deal with the local blocks.
+            CALL dbm_get_stored_coordinates(matrix, row, col, block_node)
+            IF (block_node == mynode) THEN
+               ! fill based on a block based seed, makes this the same values in parallel
+               iseed = generate_larnv_seed(row, nrow, col, ncol, randmat_counter)
+               ALLOCATE (block(row_block_sizes(row), col_block_sizes(col)))
+               CALL dlarnv(1, iseed, SIZE(block), block)
+               CALL dbm_put_block(matrix, row, col, block)
+               DEALLOCATE (block)
+            END IF
+         END DO
+      END ASSOCIATE
 
       CALL timestop(handle)
    END SUBROUTINE fill_matrix

--- a/src/eri_mme/eri_mme_error_control.F
+++ b/src/eri_mme/eri_mme_error_control.F
@@ -72,7 +72,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: l_max_zet, n_minimax
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_l, cutoff_r, tol, delta
       REAL(KIND=dp), INTENT(OUT)                         :: cutoff, err_mm, err_c, C_mm
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       LOGICAL, INTENT(IN)                                :: print_calib
       INTEGER, INTENT(IN)                                :: unit_nr
 
@@ -209,7 +209,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: l_max_zet, n_minimax
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: minimax_aw
       REAL(KIND=dp), INTENT(OUT)                         :: err_mm, err_ctff, C_mm
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
 
       REAL(KIND=dp)                                      :: delta_mm
 
@@ -290,7 +290,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: l_max_zet, n_minimax
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: minimax_aw
       REAL(KIND=dp), INTENT(OUT)                         :: err_ctff, C_mm
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
 
       INTEGER                                            :: i_aw, iG, iter, max_iter, nG
       REAL(KIND=dp) :: C, dG, eps_zet, err0, err1, err_c, err_ctff_curr, err_ctff_prev, err_d, G, &
@@ -399,7 +399,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: l_max_zet
       REAL(KIND=dp), INTENT(IN)                          :: zet_max, C_mm
       REAL(KIND=dp), INTENT(OUT)                         :: err_c
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
 
       INTEGER                                            :: ax, ay, az, G_l, G_u, Gl_first, Gl_last, &
                                                             Gu_first, Gu_last, i_xyz, l, my_p, &

--- a/src/eri_mme/eri_mme_test.F
+++ b/src/eri_mme/eri_mme_test.F
@@ -64,7 +64,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: rabc
       INTEGER, INTENT(IN)                                :: nrep
       LOGICAL, INTENT(INOUT)                             :: test_accuracy
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER, INTENT(IN)                                :: iw
       INTEGER, INTENT(IN), OPTIONAL                      :: potential
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pot_par
@@ -192,7 +192,7 @@ CONTAINS
          INTENT(IN)                                      :: rabc
       INTEGER, INTENT(IN)                                :: nrep
       INTEGER, INTENT(IN), OPTIONAL                      :: nsample
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER, INTENT(IN)                                :: iw
       INTEGER, INTENT(IN), OPTIONAL                      :: potential
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pot_par

--- a/src/eri_mme/eri_mme_types.F
+++ b/src/eri_mme/eri_mme_types.F
@@ -177,8 +177,7 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: is_ortho
       REAL(KIND=dp), INTENT(IN)                          :: zet_min, zet_max
       INTEGER, INTENT(IN)                                :: l_max_zet, l_max
-      TYPE(cp_para_env_type), INTENT(IN), OPTIONAL, &
-         POINTER                                         :: para_env
+      TYPE(cp_para_env_type), INTENT(IN), OPTIONAL       :: para_env
       INTEGER, INTENT(IN), OPTIONAL                      :: potential
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: pot_par
 

--- a/src/farming_methods.F
+++ b/src/farming_methods.F
@@ -310,7 +310,7 @@ CONTAINS
          CALL cp_print_key_finished_output(output_unit, logger, farming_section, &
                                            "PROGRAM_RUN_INFO")
       END IF
-      CALL para_env%bcast(farming_env%restart_n, para_env%source)
+      CALL para_env%bcast(farming_env%restart_n)
 
    END SUBROUTINE
 

--- a/src/fist_neighbor_lists.F
+++ b/src/fist_neighbor_lists.F
@@ -650,18 +650,16 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)                       :: name, unit_str
 
       CHARACTER(LEN=default_string_length)               :: string
-      INTEGER                                            :: atom_a, atom_b, iab, ilist, mype, &
-                                                            nneighbor
+      INTEGER                                            :: atom_a, atom_b, iab, ilist, nneighbor
       LOGICAL                                            :: print_headline
       REAL(dp)                                           :: conv, dab
       REAL(dp), DIMENSION(3)                             :: cell_v, ra, rab, rb
       TYPE(neighbor_kind_pairs_type), POINTER            :: neighbor_kind_pair
 
-      mype = para_env%mepos
       ! Print headline
       string = ""
       WRITE (UNIT=string, FMT="(A,I5,A)") &
-         TRIM(name)//" IN "//TRIM(unit_str)//" (PROCESS", mype, ")"
+         TRIM(name)//" IN "//TRIM(unit_str)//" (PROCESS", para_env%mepos, ")"
       CALL compress(string)
       IF (output_unit > 0) WRITE (UNIT=output_unit, FMT="(/,/,T2,A)") TRIM(string)
 
@@ -710,7 +708,7 @@ CONTAINS
 
       string = ""
       WRITE (UNIT=string, FMT="(A,I12,A,I12)") &
-         "Total number of neighbor interactions for process", mype, ":", &
+         "Total number of neighbor interactions for process", para_env%mepos, ":", &
          nneighbor
       CALL compress(string)
       IF (output_unit > 0) WRITE (UNIT=output_unit, FMT="(/,T2,A)") TRIM(string)

--- a/src/fm/cp_blacs_types.F
+++ b/src/fm/cp_blacs_types.F
@@ -49,6 +49,8 @@ MODULE cp_blacs_types
 
       PROCEDURE, PRIVATE, PASS(this), NON_OVERRIDABLE :: cp_context_is_not_equal
       GENERIC, PUBLIC :: OPERATOR(/=) => cp_context_is_not_equal
+
+      PROCEDURE, PUBLIC, PASS(this), NON_OVERRIDABLE :: interconnect => cp_blacs_interconnect
    END TYPE
 
 !***
@@ -303,5 +305,24 @@ CONTAINS
       cp_context_is_not_equal = .FALSE.
 #endif
    END FUNCTION cp_context_is_not_equal
+
+! **************************************************************************************************
+!> \brief ...
+!> \param this ...
+!> \param comm_super ...
+!> \return ...
+! **************************************************************************************************
+   TYPE(mp_comm_type) FUNCTION cp_blacs_interconnect(this, comm_super)
+      CLASS(cp_blacs_type), INTENT(IN) :: this
+      CLASS(mp_comm_type), INTENT(IN) :: comm_super
+
+      INTEGER :: blacs_coord
+
+! We enumerate the processes within the process grid in a linear fashion
+      blacs_coord = this%mepos(1)*this%num_pe(2) + this%mepos(2)
+
+      CALL cp_blacs_interconnect%from_split(comm_super, blacs_coord)
+
+   END FUNCTION cp_blacs_interconnect
 
 END MODULE cp_blacs_types

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -1037,7 +1037,7 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER :: context
 
       INTEGER :: myprow, mypcol, nprow, npcol, block_dim_row, block_dim_col, &
-                 info, ev_row_block_size, iam, source, mynumrows, mype, npe, &
+                 info, ev_row_block_size, iam, mynumrows, mype, npe, &
                  q_loc
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE :: a_loc, ev_loc
       INTEGER, DIMENSION(9)                        :: desca, descz, desc_a_block, &
@@ -1053,7 +1053,6 @@ CONTAINS
 
 #if defined(__SCALAPACK)
       context => matrix%matrix_struct%context
-      source = matrix%matrix_struct%para_env%source
       allgrp = matrix%matrix_struct%para_env
 
       myprow = context%mepos(1)

--- a/src/fm/cp_fm_elpa.F
+++ b/src/fm/cp_fm_elpa.F
@@ -395,7 +395,7 @@ CONTAINS
       IF (use_qr .AND. elpa_qr_unsafe .AND. elpa_should_print) &
          check_eigenvalues = .TRUE.
 
-      CALL matrix%matrix_struct%para_env%bcast(check_eigenvalues, matrix%matrix_struct%para_env%source)
+      CALL matrix%matrix_struct%para_env%bcast(check_eigenvalues)
 
       IF (check_eigenvalues) THEN
          ! Allocate and initialize needed temporaries to compute eigenvalues without ELPA QR

--- a/src/group_dist_types.F
+++ b/src/group_dist_types.F
@@ -12,7 +12,7 @@
 !> \author Frederick Stein
 ! **************************************************************************************************
 MODULE group_dist_types
-   USE cp_para_types,                   ONLY: cp_para_env_type
+   USE message_passing,                 ONLY: mp_comm_type
    USE util,                            ONLY: get_limit
 #include "./base/base_uses.f90"
 
@@ -129,12 +129,13 @@ CONTAINS
 !> \param starts ...
 !> \param ends ...
 !> \param sizes ...
-!> \param para_env ...
+!> \param comm ...
 ! **************************************************************************************************
-   SUBROUTINE create_group_dist_d1_i3(this, starts, ends, sizes, para_env)
+   SUBROUTINE create_group_dist_d1_i3(this, starts, ends, sizes, comm)
       TYPE(group_dist_d1_type), INTENT(INOUT)            :: this
       INTEGER, INTENT(IN)                                :: starts, ends, sizes
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+
+      CLASS(mp_comm_type), INTENT(IN)                    :: comm
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_group_dist_d1_i3'
 
@@ -142,13 +143,13 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      ALLOCATE (this%starts(0:para_env%num_pe - 1))
-      ALLOCATE (this%ends(0:para_env%num_pe - 1))
-      ALLOCATE (this%sizes(0:para_env%num_pe - 1))
+      ALLOCATE (this%starts(0:comm%num_pe - 1))
+      ALLOCATE (this%ends(0:comm%num_pe - 1))
+      ALLOCATE (this%sizes(0:comm%num_pe - 1))
 
-      CALL para_env%allgather(starts, this%starts)
-      CALL para_env%allgather(ends, this%ends)
-      CALL para_env%allgather(sizes, this%sizes)
+      CALL comm%allgather(starts, this%starts)
+      CALL comm%allgather(ends, this%ends)
+      CALL comm%allgather(sizes, this%sizes)
 
       CALL timestop(handle)
 
@@ -158,12 +159,13 @@ CONTAINS
 !> \brief ...
 !> \param this ...
 !> \param group_dist_ext ...
-!> \param para_env ...
+!> \param comm ...
 ! **************************************************************************************************
-   SUBROUTINE create_group_dist_d1_gd(this, group_dist_ext, para_env)
+   SUBROUTINE create_group_dist_d1_gd(this, group_dist_ext, comm)
       TYPE(group_dist_d1_type), INTENT(INOUT)            :: this
       TYPE(group_dist_d0_type), INTENT(IN)               :: group_dist_ext
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+
+      CLASS(mp_comm_type), INTENT(IN)                    :: comm
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_group_dist_d1_gd'
 
@@ -171,13 +173,13 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      ALLOCATE (this%starts(0:para_env%num_pe - 1))
-      ALLOCATE (this%ends(0:para_env%num_pe - 1))
-      ALLOCATE (this%sizes(0:para_env%num_pe - 1))
+      ALLOCATE (this%starts(0:comm%num_pe - 1))
+      ALLOCATE (this%ends(0:comm%num_pe - 1))
+      ALLOCATE (this%sizes(0:comm%num_pe - 1))
 
-      CALL para_env%allgather(group_dist_ext%starts, this%starts)
-      CALL para_env%allgather(group_dist_ext%ends, this%ends)
-      CALL para_env%allgather(group_dist_ext%sizes, this%sizes)
+      CALL comm%allgather(group_dist_ext%starts, this%starts)
+      CALL comm%allgather(group_dist_ext%ends, this%ends)
+      CALL comm%allgather(group_dist_ext%sizes, this%sizes)
 
       CALL timestop(handle)
 

--- a/src/hfx_load_balance_methods.F
+++ b/src/hfx_load_balance_methods.F
@@ -925,7 +925,7 @@ CONTAINS
       REAL(dp)                                           :: pmax_blocks
       TYPE(cell_type), INTENT(IN), POINTER               :: cell
       TYPE(hfx_type), INTENT(IN), POINTER                :: x_data
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)        :: para_env
       REAL(dp), DIMENSION(:, :), INTENT(IN), POINTER     :: pmax_block
       LOGICAL, INTENT(IN)                                :: do_p_screening
       INTEGER, DIMENSION(:), INTENT(IN), POINTER         :: map_atom_to_kind_atom
@@ -1235,7 +1235,7 @@ CONTAINS
       REAL(dp)                                           :: pmax_blocks
       TYPE(cell_type), POINTER                           :: cell
       TYPE(hfx_type), POINTER                            :: x_data
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       REAL(dp), DIMENSION(:, :), POINTER                 :: pmax_block
       LOGICAL, INTENT(IN)                                :: do_p_screening
       INTEGER, DIMENSION(:), POINTER                     :: map_atom_to_kind_atom
@@ -1482,7 +1482,7 @@ CONTAINS
                                       i_thread, n_threads, eval_type)
 
       TYPE(hfx_type), POINTER                            :: x_data
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       TYPE(hfx_load_balance_type)                        :: load_balance_parameter
       INTEGER, INTENT(IN)                                :: i_thread, n_threads, eval_type
 
@@ -2253,7 +2253,7 @@ CONTAINS
                           atomic_pair_list)
 
       INTEGER, INTENT(IN)                                :: nkind
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       INTEGER                                            :: natom, block_size, nblock
       TYPE(hfx_block_range_type), DIMENSION(1:nblock)    :: blocks
       TYPE(pair_list_type)                               :: list_ij, list_kl
@@ -2327,7 +2327,7 @@ CONTAINS
    SUBROUTINE collect_load_balance_info(para_env, x_data, iw, n_threads, i_thread, &
                                         eval_type)
 
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       TYPE(hfx_type), POINTER                            :: x_data
       INTEGER, INTENT(IN)                                :: iw, n_threads, i_thread, eval_type
 

--- a/src/hfx_load_balance_methods.F
+++ b/src/hfx_load_balance_methods.F
@@ -2418,7 +2418,7 @@ CONTAINS
          buffer_in(2*i) = shm_cost_vector(2*i)
       END DO
 
-      CALL para_env%gatherv(buffer_in, buffer_out, bins_per_rank, rdispl, para_env%source)
+      CALL para_env%gatherv(buffer_in, buffer_out, bins_per_rank, rdispl)
 
       IF (iw > 0) THEN
 

--- a/src/input/cp_parser_methods.F
+++ b/src/input/cp_parser_methods.F
@@ -345,12 +345,12 @@ CONTAINS
 
       para_env => parser%para_env
       IF (para_env%num_pe > 1) THEN
-         CALL para_env%bcast(parser%buffer%buffer_id, para_env%source)
-         CALL para_env%bcast(parser%buffer%present_line_number, para_env%source)
-         CALL para_env%bcast(parser%buffer%last_line_number, para_env%source)
-         CALL para_env%bcast(parser%buffer%istat, para_env%source)
-         CALL para_env%bcast(parser%buffer%input_line_numbers, para_env%source)
-         CALL para_env%bcast(parser%buffer%input_lines, para_env%source)
+         CALL para_env%bcast(parser%buffer%buffer_id)
+         CALL para_env%bcast(parser%buffer%present_line_number)
+         CALL para_env%bcast(parser%buffer%last_line_number)
+         CALL para_env%bcast(parser%buffer%istat)
+         CALL para_env%bcast(parser%buffer%input_line_numbers)
+         CALL para_env%bcast(parser%buffer%input_lines)
       END IF
 
       CALL timestop(handle)

--- a/src/input_cp2k_binary_restarts.F
+++ b/src/input_cp2k_binary_restarts.F
@@ -140,12 +140,12 @@ CONTAINS
          END IF
       END IF
 
-      CALL para_env%bcast(natomkind, para_env%source)
-      CALL para_env%bcast(natom, para_env%source)
-      CALL para_env%bcast(ncore, para_env%source)
-      CALL para_env%bcast(nshell, para_env%source)
-      CALL para_env%bcast(nmoleculekind, para_env%source)
-      CALL para_env%bcast(nmolecule, para_env%source)
+      CALL para_env%bcast(natomkind)
+      CALL para_env%bcast(natom)
+      CALL para_env%bcast(ncore)
+      CALL para_env%bcast(nshell)
+      CALL para_env%bcast(nmoleculekind)
+      CALL para_env%bcast(nmolecule)
 
       ALLOCATE (id_name(natomkind))
       ! Read atomic kind names
@@ -156,7 +156,7 @@ CONTAINS
                                            TRIM(ADJUSTL(cp_to_string(istat)))//")", &
                                            input_unit)
          END IF
-         CALL para_env%bcast(string, para_env%source)
+         CALL para_env%bcast(string)
          id_name(ikind) = str2id(string)
       END DO
 
@@ -191,7 +191,7 @@ CONTAINS
                                         TRIM(ADJUSTL(cp_to_string(istat)))//")", &
                                         input_unit)
       END IF
-      CALL para_env%bcast(ibuf, para_env%source)
+      CALL para_env%bcast(ibuf)
       DO iatom = 1, natom
          ikind = ibuf(iatom)
          atom_info%id_atmname(iatom) = id_name(ikind)
@@ -206,7 +206,7 @@ CONTAINS
                                         TRIM(ADJUSTL(cp_to_string(istat)))//")", &
                                         input_unit)
       END IF
-      CALL para_env%bcast(atom_info%r, para_env%source)
+      CALL para_env%bcast(atom_info%r)
 
       ! Read molecule information if available
       IF (nmolecule > 0) THEN
@@ -219,7 +219,7 @@ CONTAINS
                                               TRIM(ADJUSTL(cp_to_string(istat)))//")", &
                                               input_unit)
             END IF
-            CALL para_env%bcast(string, para_env%source)
+            CALL para_env%bcast(string)
             id_name(ikind) = str2id(string)
          END DO
          ! Read molecule kind numbers
@@ -229,7 +229,7 @@ CONTAINS
                                            TRIM(ADJUSTL(cp_to_string(istat)))//")", &
                                            input_unit)
          END IF
-         CALL para_env%bcast(ibuf, para_env%source)
+         CALL para_env%bcast(ibuf)
          DO iatom = 1, natom
             ikind = ibuf(iatom)
             atom_info%id_molname(iatom) = id_name(ikind)
@@ -242,7 +242,7 @@ CONTAINS
                                            TRIM(ADJUSTL(cp_to_string(istat)))//")", &
                                            input_unit)
          END IF
-         CALL para_env%bcast(atom_info%resid, para_env%source)
+         CALL para_env%bcast(atom_info%resid)
          DO iatom = 1, natom
             atom_info%id_resname(iatom) = str2id(s2s(cp_to_string(atom_info%resid(iatom))))
          END DO
@@ -403,7 +403,7 @@ CONTAINS
          END IF
       END IF
 
-      CALL para_env%bcast(exit_routine, para_env%source)
+      CALL para_env%bcast(exit_routine)
       IF (exit_routine) THEN
          IF (para_env%is_source()) CALL close_file(unit_number=input_unit, &
                                                    keep_preconnection=.TRUE.)
@@ -422,7 +422,7 @@ CONTAINS
                                         TRIM(ADJUSTL(cp_to_string(istat)))//")", &
                                         input_unit)
       END IF
-      CALL para_env%bcast(rbuf, para_env%source)
+      CALL para_env%bcast(rbuf)
 
       DO iparticle = 1, nparticle
          particle_set(iparticle)%r(1:3) = rbuf(1:3, iparticle)
@@ -440,7 +440,7 @@ CONTAINS
                                         input_unit)
       END IF
 
-      CALL para_env%bcast(ibuf, para_env%source)
+      CALL para_env%bcast(ibuf)
 
       DO iparticle = 1, nparticle
          particle_set(iparticle)%atom_index = ibuf(iparticle)
@@ -593,8 +593,8 @@ CONTAINS
          END DO
       END IF
 
-      CALL para_env%bcast(nbuf, para_env%source)
-      CALL para_env%bcast(have_velocities, para_env%source)
+      CALL para_env%bcast(nbuf)
+      CALL para_env%bcast(have_velocities)
 
       IF (have_velocities) THEN
 
@@ -609,7 +609,7 @@ CONTAINS
          END IF
 
          IF (nbuf == nparticle) THEN
-            CALL para_env%bcast(rbuf, para_env%source)
+            CALL para_env%bcast(rbuf)
             DO iparticle = 1, nparticle
                particle_set(iparticle)%v(1:3) = rbuf(1:3, iparticle)
             END DO
@@ -738,7 +738,7 @@ CONTAINS
          END IF
       END IF
 
-      CALL para_env%bcast(nhc_size, para_env%source)
+      CALL para_env%bcast(nhc_size)
 
       IF (nhc_size > 0) THEN
 
@@ -756,7 +756,7 @@ CONTAINS
                   "&COORD", rbuf(1:nhc_size)
             END IF
          END IF
-         CALL para_env%bcast(rbuf, para_env%source)
+         CALL para_env%bcast(rbuf)
          DO i = 1, SIZE(nhc%nvt, 2)
             idx = (nhc%map_info%index(i) - 1)*nhc%nhc_len
             DO j = 1, SIZE(nhc%nvt, 1)
@@ -776,7 +776,7 @@ CONTAINS
                   "&VELOCITY", rbuf(1:nhc_size)
             END IF
          END IF
-         CALL para_env%bcast(rbuf, para_env%source)
+         CALL para_env%bcast(rbuf)
          DO i = 1, SIZE(nhc%nvt, 2)
             idx = (nhc%map_info%index(i) - 1)*nhc%nhc_len
             DO j = 1, SIZE(nhc%nvt, 1)
@@ -796,7 +796,7 @@ CONTAINS
                   "&MASS:", rbuf(1:nhc_size)
             END IF
          END IF
-         CALL para_env%bcast(rbuf, para_env%source)
+         CALL para_env%bcast(rbuf)
          DO i = 1, SIZE(nhc%nvt, 2)
             idx = (nhc%map_info%index(i) - 1)*nhc%nhc_len
             DO j = 1, SIZE(nhc%nvt, 1)
@@ -816,7 +816,7 @@ CONTAINS
                   "&FORCE", rbuf(1:nhc_size)
             END IF
          END IF
-         CALL para_env%bcast(rbuf, para_env%source)
+         CALL para_env%bcast(rbuf)
          DO i = 1, SIZE(nhc%nvt, 2)
             idx = (nhc%map_info%index(i) - 1)*nhc%nhc_len
             DO j = 1, SIZE(nhc%nvt, 1)

--- a/src/ipi_driver.F
+++ b/src/ipi_driver.F
@@ -408,7 +408,7 @@ CONTAINS
 
          CALL para_env%sync()
 
-         CALL para_env%bcast(header, para_env%source)
+         CALL para_env%bcast(header)
 
          IF (output_unit > 0) WRITE (output_unit, *) " @ DRIVER MODE: Message from server: ", TRIM(header)
          IF (TRIM(header) == "STATUS") THEN
@@ -432,12 +432,12 @@ CONTAINS
                cellh = TRANSPOSE(cellh)
                cellih = TRANSPOSE(cellih)
             END IF
-            CALL para_env%bcast(cellh, para_env%source)
-            CALL para_env%bcast(cellih, para_env%source)
-            CALL para_env%bcast(nat, para_env%source)
+            CALL para_env%bcast(cellh)
+            CALL para_env%bcast(cellih)
+            CALL para_env%bcast(nat)
             IF (.NOT. ALLOCATED(combuf)) ALLOCATE (combuf(3*nat))
             IF (ionode) CALL readbuffer(socket, combuf, nat*3)
-            CALL para_env%bcast(combuf, para_env%source)
+            CALL para_env%bcast(combuf)
 
             CALL force_env_get(force_env, subsys=subsys)
             IF (nat /= subsys%particles%n_els) &

--- a/src/kg_environment.F
+++ b/src/kg_environment.F
@@ -649,7 +649,7 @@ CONTAINS
 
       msg_gather = 0
 
-      CALL para_env%gather(pairs, msg_gather, para_env%source)
+      CALL para_env%gather(pairs, msg_gather)
 
       DEALLOCATE (pairs)
 

--- a/src/kg_environment.F
+++ b/src/kg_environment.F
@@ -653,7 +653,7 @@ CONTAINS
 
       DEALLOCATE (pairs)
 
-      IF (para_env%source .EQ. para_env%mepos) THEN
+      IF (para_env%is_source()) THEN
 
          ! shift all non-zero entries to the beginning of the array and count the number of actual pairs
          npairs = 0
@@ -695,12 +695,12 @@ CONTAINS
       !WRITE(*,'(A27,40X,I6,1X,A6)') ' KG| Vertex coloring result', ncolors, 'colors'
 
       ! broadcast the number of colors to all nodes
-      CALL para_env%bcast(ncolors, para_env%source)
+      CALL para_env%bcast(ncolors)
 
       IF (.NOT. ALLOCATED(color_of_node)) ALLOCATE (color_of_node(nmol))
 
       ! broadcast the resulting coloring to all nodes.....
-      CALL para_env%bcast(color_of_node, para_env%source)
+      CALL para_env%bcast(color_of_node)
 
       IF ((kg_env%nsubsets .NE. 0) .AND. (ncolors .NE. kg_env%nsubsets)) THEN
          ! number of subsets has changed

--- a/src/kpoint_io.F
+++ b/src/kpoint_io.F
@@ -307,7 +307,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_kpoints_restart'
 
       CHARACTER(LEN=default_path_length)                 :: file_name
-      INTEGER                                            :: handle, restart_unit, source
+      INTEGER                                            :: handle, restart_unit
       LOGICAL                                            :: exist
       TYPE(cp_logger_type), POINTER                      :: logger
 
@@ -315,8 +315,6 @@ CONTAINS
       logger => cp_get_default_logger()
 
       restart_unit = -1
-
-      source = para_env%source
 
       IF (para_env%is_source()) THEN
 
@@ -338,7 +336,7 @@ CONTAINS
                                     natom, restart_unit, natom_mismatch)
 
       ! only the io_node returns natom_mismatch, must broadcast it
-      CALL para_env%bcast(natom_mismatch, source)
+      CALL para_env%bcast(natom_mismatch)
 
       ! Close restart file
       IF (para_env%is_source()) CALL close_file(unit_number=restart_unit)
@@ -372,13 +370,11 @@ CONTAINS
 
       INTEGER                                            :: ic, image, ispin, nao, nao_read, &
                                                             natom_read, ni, nimages, nset_max, &
-                                                            nshell_max, nspin, nspin_read, source, &
+                                                            nshell_max, nspin, nspin_read, &
                                                             version_read
       INTEGER, DIMENSION(3)                              :: cell
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: natom_match
-
-      source = para_env%source
 
       CPASSERT(ASSOCIATED(denmat))
       CALL dbcsr_get_info(denmat(1, 1)%matrix, nfullrows_total=nao)
@@ -410,7 +406,7 @@ CONTAINS
       END IF
 
       ! make natom_match and natom_mismatch uniform across all nodes
-      CALL para_env%bcast(natom_match, source)
+      CALL para_env%bcast(natom_match)
       natom_mismatch = .NOT. natom_match
       ! handle natom_match false
       IF (natom_mismatch) THEN
@@ -423,9 +419,9 @@ CONTAINS
             IF (para_env%is_source()) THEN
                READ (rst_unit) ispin, nspin_read, ni
             END IF
-            CALL para_env%bcast(ispin, source)
-            CALL para_env%bcast(nspin_read, source)
-            CALL para_env%bcast(ni, source)
+            CALL para_env%bcast(ispin)
+            CALL para_env%bcast(nspin_read)
+            CALL para_env%bcast(ni)
             IF (nspin_read /= nspin) THEN
                CALL cp_abort(__LOCATION__, &
                              " READ RESTART : Different spin polarisation not supported")
@@ -434,8 +430,8 @@ CONTAINS
                IF (para_env%is_source()) THEN
                   READ (rst_unit) image, cell
                END IF
-               CALL para_env%bcast(image, source)
-               CALL para_env%bcast(cell, source)
+               CALL para_env%bcast(image)
+               CALL para_env%bcast(cell)
                !
                CALL cp_fm_read_unformatted(fmat, rst_unit)
                !

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -1153,7 +1153,7 @@ CONTAINS
                   READ (UNIT=unit_number, FMT=*) buffer(1, 1:n)
                END SELECT
             END IF
-            CALL para_env%bcast(buffer, para_env%source)
+            CALL para_env%bcast(buffer)
             SELECT CASE (init_method)
             CASE (do_mat_random)
                CALL cp_fm_set_submatrix(fm=matrix, &

--- a/src/maxwell_solver_interface.F
+++ b/src/maxwell_solver_interface.F
@@ -148,27 +148,11 @@ CONTAINS
       END IF
 
       ! The following code block is copied from src/pw/realspace_grid_cube.F
+      CALL gid%bcast(buffer(lbounds(3):ubounds(3)), 0)
 
       !master sends all data to everyone
       DO i = lbounds(1), ubounds(1)
          DO j = lbounds(2), ubounds(2)
-
-            IF (my_rank == 0) THEN
-               !buffer(lbounds(3)) = 23.0;
-               !buffer(lbounds(3)+1) = 42.0;
-               !buffer(lbounds(3)+2) = 69.0;
-               res = libcp2kmw_getzrow(buffer, i - lbounds(1) + 1, j - lbounds(2) + 1, 1, ubounds(3) - lbounds(3) + 1)
-               IF (num_pe > 1) THEN
-                  DO ip = 1, num_pe - 1
-                     CALL gid%send(buffer(lbounds(3):ubounds(3)), ip, tag)
-                  END DO
-               END IF
-            ELSE
-               master = 0
-               CALL gid%recv(buffer(lbounds(3):ubounds(3)), master, tag)
-            END IF
-
-            CALL gid%sync()
 
             !only use data that is local to me - i.e. in slice of pencil I own
             IF ((lbounds_local(1) <= i) .AND. (i <= ubounds_local(1)) .AND. &

--- a/src/metadynamics_utils.F
+++ b/src/metadynamics_utils.F
@@ -575,7 +575,7 @@ CONTAINS
             IF (para_env%is_source()) THEN
                INQUIRE (FILE=TRIM(filename), EXIST=exist)
             END IF
-            CALL para_env%bcast(exist, para_env%source)
+            CALL para_env%bcast(exist)
             DO WHILE (exist)
                ! Read information from the walker's file
                ! We shouldn't care too much about the concurrency of these I/O instructions..
@@ -592,7 +592,7 @@ CONTAINS
                   IF (hills_env%wtcontrol) READ (unit_nr, *) delta_s_ss0_buf(2, 0)
                   CALL close_file(unit_nr)
                END IF
-               CALL para_env%bcast(delta_s_ss0_buf, para_env%source)
+               CALL para_env%bcast(delta_s_ss0_buf)
                ww = delta_s_ss0_buf(1, 0)
                IF (hills_env%wtcontrol) invdt = delta_s_ss0_buf(2, 0)
                DO ih = 1, n_colvar
@@ -613,7 +613,7 @@ CONTAINS
                IF (para_env%is_source()) THEN
                   INQUIRE (FILE=TRIM(filename), EXIST=exist)
                END IF
-               CALL para_env%bcast(exist, para_env%source)
+               CALL para_env%bcast(exist)
             END DO
 
             delta_hills = i_hills - 1 - multiple_walkers%walkers_status(i)

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -1563,8 +1563,7 @@ CONTAINS
             CALL force_env_get(force_env%sub_force_env(iforce_eval)%force_env, qs_env=qs_env)
          END IF
          CALL get_qs_env(qs_env, energy=energy_qs, dft_control=dft_control)
-         IF (force_env%sub_force_env(iforce_eval)%force_env%para_env%mepos == &
-             force_env%sub_force_env(iforce_eval)%force_env%para_env%source) THEN
+         IF (force_env%sub_force_env(iforce_eval)%force_env%para_env%is_source()) THEN
             W_diagonal(:, iforce_eval) = dft_control%qs_control%cdft_control%value(:)
             energy(iforce_eval) = energy_qs%total
          END IF
@@ -2106,8 +2105,8 @@ CONTAINS
       CPASSERT(ASSOCIATED(mixed_cdft%qs_kind_set))
       IF (force_env%para_env%is_source()) &
          CALL wfn_restart_file_name(file_name, exist, mixed_cdft_section, logger)
-      CALL force_env%para_env%bcast(exist, force_env%para_env%source)
-      CALL force_env%para_env%bcast(file_name, force_env%para_env%source)
+      CALL force_env%para_env%bcast(exist)
+      CALL force_env%para_env%bcast(file_name)
       IF (.NOT. exist) &
          CALL cp_abort(__LOCATION__, &
                        "User requested to restart the wavefunction from the file named: "// &

--- a/src/mode_selective.F
+++ b/src/mode_selective.F
@@ -421,8 +421,8 @@ CONTAINS
          CALL molden_guess(ms_vib_section, input, para_env, ms_vib, mass, ncoord, nrep, logger)
          ms_vib%mat_size = 0
       END SELECT
-      CALL para_env%bcast(ms_vib%b_vec, para_env%source)
-      CALL para_env%bcast(ms_vib%delta_vec, para_env%source)
+      CALL para_env%bcast(ms_vib%b_vec)
+      CALL para_env%bcast(ms_vib%delta_vec)
       DO i = 1, nrep
          ms_vib%step_r(i) = dx/SQRT(DOT_PRODUCT(ms_vib%delta_vec(:, i), ms_vib%delta_vec(:, i)))
          ms_vib%step_b(i) = SQRT(DOT_PRODUCT(ms_vib%step_r(i)*ms_vib%b_vec(:, i), ms_vib%step_r(i)*ms_vib%b_vec(:, i)))
@@ -527,8 +527,8 @@ CONTAINS
          DEALLOCATE (tmplist)
       END IF
 
-      CALL para_env%bcast(ms_vib%b_vec, para_env%source)
-      CALL para_env%bcast(ms_vib%delta_vec, para_env%source)
+      CALL para_env%bcast(ms_vib%b_vec)
+      CALL para_env%bcast(ms_vib%delta_vec)
 
       DEALLOCATE (ms_vib%hes_bfgs)
       DEALLOCATE (ms_vib%eig_bfgs)
@@ -589,7 +589,7 @@ CONTAINS
          CPASSERT(stat == 0)
          ms_vib%mat_size = mat
       END IF
-      CALL para_env%bcast(ms_vib%mat_size, para_env%source)
+      CALL para_env%bcast(ms_vib%mat_size)
       ALLOCATE (ms_vib%b_mat(ncoord, ms_vib%mat_size))
       ALLOCATE (ms_vib%s_mat(ncoord, ms_vib%mat_size))
       IF (calc_intens) THEN
@@ -611,9 +611,9 @@ CONTAINS
             END IF
          END IF
       END IF
-      CALL para_env%bcast(ms_vib%b_mat, para_env%source)
-      CALL para_env%bcast(ms_vib%s_mat, para_env%source)
-      IF (calc_intens) CALL para_env%bcast(ms_vib%dip_deriv, para_env%source)
+      CALL para_env%bcast(ms_vib%b_mat)
+      CALL para_env%bcast(ms_vib%s_mat)
+      IF (calc_intens) CALL para_env%bcast(ms_vib%dip_deriv)
       ALLOCATE (approx_H(ms_vib%mat_size, ms_vib%mat_size))
       ALLOCATE (eigenval(ms_vib%mat_size))
       ALLOCATE (ind(ms_vib%mat_size))
@@ -797,8 +797,8 @@ CONTAINS
          DEALLOCATE (tmplist)
 
       END IF
-      CALL para_env%bcast(ms_vib%b_vec, para_env%source)
-      CALL para_env%bcast(ms_vib%delta_vec, para_env%source)
+      CALL para_env%bcast(ms_vib%b_vec)
+      CALL para_env%bcast(ms_vib%delta_vec)
 
       IF (ms_filename == "") CALL cp_print_key_finished_output(output_molden, logger, input, &
                                                                "VIBRATIONAL_ANALYSIS%PRINT%MOLDEN_VIB")

--- a/src/motion/bfgs_optimizer.F
+++ b/src/motion/bfgs_optimizer.F
@@ -145,7 +145,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       CALL section_vals_val_get(geo_section, "BFGS%TRUST_RADIUS", r_val=rad)
       print_key => section_vals_get_subs_vals(geo_section, "BFGS%RESTART")
-      ionode = para_env%mepos == para_env%source
+      ionode = para_env%is_source()
       maxiter = gopt_param%max_iter
       conv = .FALSE.
       rat = 0.0_dp

--- a/src/motion/helium_io.F
+++ b/src/motion/helium_io.F
@@ -1893,8 +1893,7 @@ CONTAINS
 
          ! pass the message from all processors to logger%para_env%source
          helium%rtmp_p_ndim_np_1d(:) = 0.0_dp
-         CALL logger%para_env%gather(helium%rtmp_p_ndim_1d, helium%rtmp_p_ndim_np_1d, &
-                                     logger%para_env%source)
+         CALL logger%para_env%gather(helium%rtmp_p_ndim_1d, helium%rtmp_p_ndim_np_1d)
 
          IF (logger%para_env%is_source()) THEN
 

--- a/src/motion/helium_sampling.F
+++ b/src/motion/helium_sampling.F
@@ -119,8 +119,8 @@ CONTAINS
       END IF
 
       ! Distribute steps for processors without helium_env
-      CALL logger%para_env%bcast(num_steps, logger%para_env%source)
-      CALL logger%para_env%bcast(tot_steps, logger%para_env%source)
+      CALL logger%para_env%bcast(num_steps)
+      CALL logger%para_env%bcast(tot_steps)
 
       DO step = 1, num_steps
 

--- a/src/motion/md_util.F
+++ b/src/motion/md_util.F
@@ -148,9 +148,9 @@ CONTAINS
       END IF
       ! broadcast to all compulational nodes. note that it is assumed
       ! that source is the ionode
-      CALL para_env%bcast(dof, para_env%source)
-      CALL para_env%bcast(eigenvalues, para_env%source)
-      CALL para_env%bcast(eigenvectors, para_env%source)
+      CALL para_env%bcast(dof)
+      CALL para_env%bcast(eigenvalues)
+      CALL para_env%bcast(eigenvectors)
       ! close file
       IF (para_env%is_source()) THEN
          CALL close_file(unit_number=unit_nr)

--- a/src/motion/pint_methods.F
+++ b/src/motion/pint_methods.F
@@ -1506,8 +1506,7 @@ CONTAINS
                CALL pint_x2u(pint_env, ux=pint_env%uv, x=pint_env%v)
             END IF
             ! Broadcast updated velocities to other nodes
-            CALL pint_env%logger%para_env%bcast(pint_env%uv, &
-                                                pint_env%logger%para_env%source)
+            CALL pint_env%logger%para_env%bcast(pint_env%uv)
             ! Centroid constraints
          ELSE
             ! Transform positions and velocities to Cartesian coordinates:
@@ -1532,8 +1531,7 @@ CONTAINS
                                    local_particles)
             END IF
             ! Broadcast updated velocities to other nodes
-            CALL pint_env%logger%para_env%bcast(vel, &
-                                                pint_env%logger%para_env%source)
+            CALL pint_env%logger%para_env%bcast(vel)
             ! Transform back to normal modes
             DO i = 1, nparticle
                DO j = 1, 3
@@ -1686,8 +1684,7 @@ CONTAINS
          IF (logger%para_env%is_source()) THEN
             pint_env%f(:, :) = pint_env%f(:, :) + helium_env(1)%helium%force_avrg(:, :)
          END IF
-         CALL logger%para_env%bcast(pint_env%f, &
-                                    logger%para_env%source)
+         CALL logger%para_env%bcast(pint_env%f)
       END IF
       CALL pint_f2uf(pint_env)
 
@@ -2126,10 +2123,8 @@ CONTAINS
                                      mp_comm_self, local_particles)
                END IF
                ! Positions and velocities of centroid were constrained by SHAKE
-               CALL pint_env%logger%para_env%bcast(pos, &
-                                                   pint_env%logger%para_env%source)
-               CALL pint_env%logger%para_env%bcast(vel, &
-                                                   pint_env%logger%para_env%source)
+               CALL pint_env%logger%para_env%bcast(pos)
+               CALL pint_env%logger%para_env%bcast(vel)
                ! Transform back to normal modes:
                DO i = 1, nparticle
                   DO j = 1, 3
@@ -2161,8 +2156,7 @@ CONTAINS
                   IF (pint_env%logger%para_env%is_source()) THEN
                      pint_env%f(:, :) = pint_env%f(:, :) + helium_env(1)%helium%force_avrg(:, :)
                   END IF
-                  CALL pint_env%logger%para_env%bcast(pint_env%f, &
-                                                      pint_env%logger%para_env%source)
+                  CALL pint_env%logger%para_env%bcast(pint_env%f)
                END IF
 
                CALL pint_f2uf(pint_env)
@@ -2309,8 +2303,7 @@ CONTAINS
                   END IF
                   ! Velocities of centroid were constrained by RATTLE
                   ! Broadcast updated velocities to other nodes
-                  CALL pint_env%logger%para_env%bcast(vel, &
-                                                      pint_env%logger%para_env%source)
+                  CALL pint_env%logger%para_env%bcast(vel)
 
                   DO i = 1, nparticle
                      DO j = 1, 3
@@ -2438,10 +2431,8 @@ CONTAINS
                   CALL pint_x2u(pint_env, ux=pint_env%uv_t, x=pint_env%v)
                END IF
                ! Broadcast positions and velocities to all nodes
-               CALL pint_env%logger%para_env%bcast(pint_env%ux_t, &
-                                                   pint_env%logger%para_env%source)
-               CALL pint_env%logger%para_env%bcast(pint_env%uv_t, &
-                                                   pint_env%logger%para_env%source)
+               CALL pint_env%logger%para_env%bcast(pint_env%ux_t)
+               CALL pint_env%logger%para_env%bcast(pint_env%uv_t)
                ! Centroid constraints
             ELSE
                IF (pint_env%logger%para_env%is_source()) THEN
@@ -2465,10 +2456,8 @@ CONTAINS
                                      mp_comm_self, local_particles)
                END IF
                ! Broadcast positions and velocities to all nodes
-               CALL pint_env%logger%para_env%bcast(pos, &
-                                                   pint_env%logger%para_env%source)
-               CALL pint_env%logger%para_env%bcast(vel, &
-                                                   pint_env%logger%para_env%source)
+               CALL pint_env%logger%para_env%bcast(pos)
+               CALL pint_env%logger%para_env%bcast(vel)
                ! Transform back to normal modes:
                DO i = 1, nparticle
                   DO j = 1, 3
@@ -2493,8 +2482,7 @@ CONTAINS
             IF (pint_env%logger%para_env%is_source()) THEN
                pint_env%f(:, :) = pint_env%f(:, :) + helium_env(1)%helium%force_avrg(:, :)
             END IF
-            CALL pint_env%logger%para_env%bcast(pint_env%f, &
-                                                pint_env%logger%para_env%source)
+            CALL pint_env%logger%para_env%bcast(pint_env%f)
          END IF
          CALL pint_f2uf(pint_env)
          ! set the centroid forces to 0 if FIX_CENTROID_POS
@@ -2563,8 +2551,7 @@ CONTAINS
                   ! Transform back to normal modes:
                   CALL pint_x2u(pint_env, ux=pint_env%uv, x=pint_env%v)
                END IF
-               CALL pint_env%logger%para_env%bcast(pint_env%uv, &
-                                                   pint_env%logger%para_env%source)
+               CALL pint_env%logger%para_env%bcast(pint_env%uv)
                ! Centroid constraints
             ELSE
                IF (pint_env%logger%para_env%is_source()) THEN
@@ -2587,8 +2574,7 @@ CONTAINS
                END IF
                ! Velocities of centroid were constrained by RATTLE
                ! Broadcast updated velocities to other nodes
-               CALL pint_env%logger%para_env%bcast(vel, &
-                                                   pint_env%logger%para_env%source)
+               CALL pint_env%logger%para_env%bcast(vel)
 
                ! Transform back to normal modes:
                ! Multiply with SQRT(n_beads) due to normal mode transformation

--- a/src/motion/pint_qtb.F
+++ b/src/motion/pint_qtb.F
@@ -386,8 +386,8 @@ CONTAINS
          IF (p > 1) DEALLOCATE (fp1)
       END IF
 
-      CALL para_env%bcast(qtb_therm%h, para_env%source)
-      CALL para_env%bcast(qtb_therm%step, para_env%source)
+      CALL para_env%bcast(qtb_therm%h)
+      CALL para_env%bcast(qtb_therm%step)
 
       ALLOCATE (qtb_therm%r(nf, p, ndim))
       ALLOCATE (qtb_therm%cpt(p))

--- a/src/motion/reftraj_util.F
+++ b/src/motion/reftraj_util.F
@@ -204,7 +204,7 @@ CONTAINS
       ALLOCATE (msd%ref0_pos(3, reftraj%natom))
       msd%ref0_pos = 0.0_dp
 
-      IF (para_env%mepos == para_env%source) THEN
+      IF (para_env%is_source()) THEN
          REWIND (msd%ref0_unit)
          READ (msd%ref0_unit, *, ERR=999, END=998) natom_read
          IF (natom_read /= reftraj%natom) THEN
@@ -242,9 +242,9 @@ CONTAINS
       END IF
       CALL close_file(unit_number=msd%ref0_unit)
 
-      CALL para_env%bcast(msd%total_mass, para_env%source)
-      CALL para_env%bcast(msd%ref0_pos, para_env%source)
-      CALL para_env%bcast(msd%ref0_com, para_env%source)
+      CALL para_env%bcast(msd%total_mass)
+      CALL para_env%bcast(msd%ref0_pos)
+      CALL para_env%bcast(msd%ref0_com)
 
       CALL section_vals_val_get(msd_section, "MSD_PER_KIND", l_val=msd%msd_kind)
       CALL section_vals_val_get(msd_section, "MSD_PER_MOLKIND", l_val=msd%msd_molecule)

--- a/src/mp2_eri.F
+++ b/src/mp2_eri.F
@@ -120,7 +120,7 @@ CONTAINS
                                    reflection_z_a, reflection_z_b, do_reflection_a, do_reflection_b)
       TYPE(cp_eri_mme_param), INTENT(INOUT)              :: param
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)        :: para_env
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       CHARACTER(len=*), INTENT(IN), OPTIONAL             :: basis_type_a, basis_type_b
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: hab
@@ -621,7 +621,7 @@ CONTAINS
                                    mat_dabc, mat_adbc, mat_abdc)
       TYPE(cp_eri_mme_param), INTENT(INOUT)              :: param
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)        :: para_env
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       INTEGER, INTENT(IN)                                :: first_c, last_c
       TYPE(dbcsr_p_type), DIMENSION(last_c - first_c + 1), &

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -1108,7 +1108,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: e_cutoff_old
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_old, relative_cutoff_old
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_sub
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
       TYPE(task_list_type), POINTER                      :: task_list_sub
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: auxbas_pw_pool

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -24,7 +24,6 @@ MODULE mp2_gpw_method
                                               cp_fm_get_info,&
                                               cp_fm_release,&
                                               cp_fm_type
-   USE cp_para_env,                     ONLY: cp_para_env_release
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dbcsr_api,                       ONLY: &
         dbcsr_create, dbcsr_get_info, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
@@ -37,6 +36,7 @@ MODULE mp2_gpw_method
    USE kinds,                           ONLY: dp,&
                                               int_8
    USE machine,                         ONLY: m_memory
+   USE message_passing,                 ONLY: mp_comm_type
    USE mp2_eri_gpw,                     ONLY: calc_potential_gpw,&
                                               cleanup_gpw,&
                                               prepare_gpw
@@ -136,13 +136,12 @@ CONTAINS
       INTEGER :: a, a_group_counter, b, b_global, b_group_counter, blk, col, col_offset, col_size, &
          color_counter, EX_end, EX_end_send, EX_start, EX_start_send, group_counter, handle, &
          handle2, handle3, i, i_counter, i_group_counter, index_proc_shift, j, max_b_size, &
-         max_batch_size_A, max_batch_size_I, max_row_col_local, mepos_in_EX_group, &
-         my_A_batch_size, my_A_virtual_end, my_A_virtual_start, my_B_size, my_B_virtual_end, &
-         my_B_virtual_start, my_I_batch_size, my_I_occupied_end, my_I_occupied_start, &
-         my_q_position, ncol_local, nfullcols_total, nfullrows_total, ngroup, nrow_local, p, p_best
-      INTEGER :: proc_receive, proc_send, q, q_best, row, row_offset, row_size, size_EX, &
-         size_EX_send, size_of_exchange_group, sub_sub_color, virtual, virtual_beta, wfn_calc, &
-         wfn_calc_best
+         max_batch_size_A, max_batch_size_I, max_row_col_local, my_A_batch_size, my_A_virtual_end, &
+         my_A_virtual_start, my_B_size, my_B_virtual_end, my_B_virtual_start, my_I_batch_size, &
+         my_I_occupied_end, my_I_occupied_start, my_q_position, ncol_local, nfullcols_total, &
+         nfullrows_total, ngroup, nrow_local, p, p_best, proc_receive, proc_send, q
+      INTEGER :: q_best, row, row_offset, row_size, size_EX, size_EX_send, sub_sub_color, virtual, &
+         virtual_beta, wfn_calc, wfn_calc_best
       INTEGER(KIND=int_8)                                :: mem
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: vector_B_sizes, &
                                                             vector_batch_A_size_group, &
@@ -158,12 +157,12 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_BIb_jb
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_type)                                   :: matrix_ia_jb, matrix_ia_jb_beta, &
                                                             matrix_ia_jnu, matrix_ia_jnu_beta
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(group_dist_d1_type)                           :: gd_exchange
+      TYPE(mp_comm_type)                                 :: comm_exchange
       TYPE(pw_env_type), POINTER                         :: pw_env_sub
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
@@ -376,14 +375,10 @@ CONTAINS
 
       ! now create a group that contains all the proc that have the same 2 virtual starting points
       ! in this way it is possible to sum the common integrals needed for the full MP2 energy
-      ALLOCATE (para_env_exchange)
-      CALL para_env_exchange%from_split(para_env, sub_sub_color)
+      CALL comm_exchange%from_split(para_env, sub_sub_color)
 
       ! create an array containing the information for communication
-      CALL create_group_dist(gd_exchange, my_I_occupied_start, my_I_occupied_end, my_I_batch_size, para_env_exchange)
-
-      mepos_in_EX_group = para_env_exchange%mepos
-      size_of_exchange_group = para_env_exchange%num_pe
+      CALL create_group_dist(gd_exchange, my_I_occupied_start, my_I_occupied_end, my_I_batch_size, comm_exchange)
 
       ALLOCATE (psi_i(my_I_occupied_start:my_I_occupied_end))
       DO i = my_I_occupied_start, my_I_occupied_end
@@ -496,54 +491,57 @@ CONTAINS
          END DO
 
          IF (calc_ex) THEN
-            CALL timeset(routineN//"_E_Ex_2", handle3)
-            ! calculate the contribution to MP2 energy for my local data
-            DO i = 1, my_I_batch_size
-               DO j = my_I_occupied_start, my_I_occupied_end
-                  DO b = 1, my_B_size
-                     b_global = b - 1 + my_B_virtual_start
-                     Emp2_EX = Emp2_EX + BIb_C(b, j, i)*BIb_C(b, i + my_I_occupied_start - 1, j - my_I_occupied_start + 1) &
-                               /(Eigenval(a) + Eigenval(homo + b_global) - Eigenval(i + my_I_occupied_start - 1) - Eigenval(j))
-                  END DO
-               END DO
-            END DO
 
-            ! start communicating and collecting exchange contributions from
-            ! other processes in my exchange group
-            DO index_proc_shift = 1, size_of_exchange_group - 1
-               proc_send = MODULO(mepos_in_EX_group + index_proc_shift, size_of_exchange_group)
-               proc_receive = MODULO(mepos_in_EX_group - index_proc_shift, size_of_exchange_group)
-
-               CALL get_group_dist(gd_exchange, proc_receive, EX_start, EX_end, size_EX)
-
-               ALLOCATE (BIb_EX(my_B_size, my_I_batch_size, size_EX))
-               BIb_EX = 0.0_dp
-
-               CALL get_group_dist(gd_exchange, proc_send, EX_start_send, EX_end_send, size_EX_send)
-
-               ALLOCATE (BIb_send(my_B_size, size_EX_send, my_I_batch_size))
-               BIb_send(1:my_B_size, 1:size_EX_send, 1:my_I_batch_size) = &
-                  BIb_C(1:my_B_size, EX_start_send:EX_end_send, 1:my_I_batch_size)
-
-               ! send and receive the exchange array
-               CALL para_env_exchange%sendrecv(BIb_send, proc_send, BIb_EX, proc_receive)
-
+            ASSOCIATE (mepos_in_EX_group => comm_exchange%mepos, size_of_exchange_group => comm_exchange%num_pe)
+               CALL timeset(routineN//"_E_Ex_2", handle3)
+               ! calculate the contribution to MP2 energy for my local data
                DO i = 1, my_I_batch_size
-                  DO j = 1, size_EX
+                  DO j = my_I_occupied_start, my_I_occupied_end
                      DO b = 1, my_B_size
                         b_global = b - 1 + my_B_virtual_start
-                        Emp2_EX = Emp2_EX + BIb_C(b, j + EX_start - 1, i)*BIb_EX(b, i, j) &
-                                  /(Eigenval(a) + Eigenval(homo + b_global) - Eigenval(i + my_I_occupied_start - 1) &
-                                    - Eigenval(j + EX_start - 1))
+                        Emp2_EX = Emp2_EX + BIb_C(b, j, i)*BIb_C(b, i + my_I_occupied_start - 1, j - my_I_occupied_start + 1) &
+                                  /(Eigenval(a) + Eigenval(homo + b_global) - Eigenval(i + my_I_occupied_start - 1) - Eigenval(j))
                      END DO
                   END DO
                END DO
 
-               DEALLOCATE (BIb_EX)
-               DEALLOCATE (BIb_send)
+               ! start communicating and collecting exchange contributions from
+               ! other processes in my exchange group
+               DO index_proc_shift = 1, size_of_exchange_group - 1
+                  proc_send = MODULO(mepos_in_EX_group + index_proc_shift, size_of_exchange_group)
+                  proc_receive = MODULO(mepos_in_EX_group - index_proc_shift, size_of_exchange_group)
 
-            END DO
-            CALL timestop(handle3)
+                  CALL get_group_dist(gd_exchange, proc_receive, EX_start, EX_end, size_EX)
+
+                  ALLOCATE (BIb_EX(my_B_size, my_I_batch_size, size_EX))
+                  BIb_EX = 0.0_dp
+
+                  CALL get_group_dist(gd_exchange, proc_send, EX_start_send, EX_end_send, size_EX_send)
+
+                  ALLOCATE (BIb_send(my_B_size, size_EX_send, my_I_batch_size))
+                  BIb_send(1:my_B_size, 1:size_EX_send, 1:my_I_batch_size) = &
+                     BIb_C(1:my_B_size, EX_start_send:EX_end_send, 1:my_I_batch_size)
+
+                  ! send and receive the exchange array
+                  CALL comm_exchange%sendrecv(BIb_send, proc_send, BIb_EX, proc_receive)
+
+                  DO i = 1, my_I_batch_size
+                     DO j = 1, size_EX
+                        DO b = 1, my_B_size
+                           b_global = b - 1 + my_B_virtual_start
+                           Emp2_EX = Emp2_EX + BIb_C(b, j + EX_start - 1, i)*BIb_EX(b, i, j) &
+                                     /(Eigenval(a) + Eigenval(homo + b_global) - Eigenval(i + my_I_occupied_start - 1) &
+                                       - Eigenval(j + EX_start - 1))
+                        END DO
+                     END DO
+                  END DO
+
+                  DEALLOCATE (BIb_EX)
+                  DEALLOCATE (BIb_send)
+
+               END DO
+               CALL timestop(handle3)
+            END ASSOCIATE
          END IF
 
       END DO
@@ -564,7 +562,7 @@ CONTAINS
       END IF
       CALL release_group_dist(gd_exchange)
 
-      CALL cp_para_env_release(para_env_exchange)
+      CALL comm_exchange%free()
 
       CALL dbcsr_release(matrix_ia_jnu)
       CALL dbcsr_release(matrix_ia_jb)

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -911,8 +911,7 @@ CONTAINS
       LOGICAL, PARAMETER                                 :: debug = .FALSE.
 
       INTEGER                                            :: check_proc, handle, i, iend, ii, ioff, &
-                                                            iproc, iproc_glob, istart, loc_a, &
-                                                            loc_P, nblk_per_thread, nproc
+                                                            istart, loc_a, loc_P, nblk_per_thread
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: block_ind_L_P, block_ind_L_R
       INTEGER, DIMENSION(1)                              :: dist_B_i, map_B_1, map_L_1, map_L_2, &
                                                             sizes_i
@@ -930,109 +929,106 @@ CONTAINS
 
       sizes_i(1) = SIZE(BIb_C, 3)
 
-      nproc = para_env_sub%num_pe ! number of processes per subgroup (Nw)
-      iproc = para_env_sub%mepos ! subgroup-local process ID
+      ASSOCIATE (nproc => para_env_sub%num_pe, iproc => para_env_sub%mepos, iproc_glob => mp_comm%mepos)
 
-      ! Total number of processes and global process ID
-      iproc_glob = mp_comm%mepos
+         ! local block index for R/P and a
+         loc_P = igroup + 1; loc_a = iproc + 1
 
-      ! local block index for R/P and a
-      loc_P = igroup + 1; loc_a = iproc + 1
+         CPASSERT(SIZE(sizes_L) .EQ. ngroup)
+         CPASSERT(SIZE(sizes_B) .EQ. nproc)
+         CPASSERT(sizes_L(loc_P) .EQ. SIZE(BIb_C, 1))
+         CPASSERT(sizes_L(loc_P) .EQ. SIZE(my_Lrows, 2))
+         CPASSERT(sizes_B(loc_a) .EQ. SIZE(BIb_C, 2))
 
-      CPASSERT(SIZE(sizes_L) .EQ. ngroup)
-      CPASSERT(SIZE(sizes_B) .EQ. nproc)
-      CPASSERT(sizes_L(loc_P) .EQ. SIZE(BIb_C, 1))
-      CPASSERT(sizes_L(loc_P) .EQ. SIZE(my_Lrows, 2))
-      CPASSERT(sizes_B(loc_a) .EQ. SIZE(BIb_C, 2))
+         ! Tensor distributions as follows:
+         ! Process grid NG x Nw
+         ! Each process has coordinates (np, nw)
+         ! tB_in: (R|ai): R distributed (np), a distributed (nw)
+         ! tB_out: (P|ai): P distributed (np), a distributed (nw)
+         ! tL: (R|P): R distributed (nw), P distributed (np)
 
-      ! Tensor distributions as follows:
-      ! Process grid NG x Nw
-      ! Each process has coordinates (np, nw)
-      ! tB_in: (R|ai): R distributed (np), a distributed (nw)
-      ! tB_out: (P|ai): P distributed (np), a distributed (nw)
-      ! tL: (R|P): R distributed (nw), P distributed (np)
+         ! define mappings between tensor index and matrix index:
+         ! (R|ai) and (P|ai):
+         map_B_1 = [1] ! index 1 (R or P) maps to 1st matrix index (np distributed)
+         map_B_2 = [2, 3] ! indices 2, 3 (a, i) map to 2nd matrix index (nw distributed)
+         ! (R|P):
+         map_L_1 = [2] ! index 2 (P) maps to 1st matrix index (np distributed)
+         map_L_2 = [1] ! index 1 (R) maps to 2nd matrix index (nw distributed)
 
-      ! define mappings between tensor index and matrix index:
-      ! (R|ai) and (P|ai):
-      map_B_1 = [1] ! index 1 (R or P) maps to 1st matrix index (np distributed)
-      map_B_2 = [2, 3] ! indices 2, 3 (a, i) map to 2nd matrix index (nw distributed)
-      ! (R|P):
-      map_L_1 = [2] ! index 2 (P) maps to 1st matrix index (np distributed)
-      map_L_2 = [1] ! index 1 (R) maps to 2nd matrix index (nw distributed)
+         ! derive nd process grid that is compatible with distributions and 2d process grid
+         ! (R|ai) / (P|ai) on process grid NG x Nw x 1
+         ! (R|P) on process grid NG x Nw
+         pdims_B = [ngroup, nproc, 1]
+         pdims_L = [nproc, ngroup]
 
-      ! derive nd process grid that is compatible with distributions and 2d process grid
-      ! (R|ai) / (P|ai) on process grid NG x Nw x 1
-      ! (R|P) on process grid NG x Nw
-      pdims_B = [ngroup, nproc, 1]
-      pdims_L = [nproc, ngroup]
+         CALL dbt_pgrid_create(mp_comm, pdims_B, mp_comm_B)
+         CALL dbt_pgrid_create(mp_comm, pdims_L, mp_comm_L)
 
-      CALL dbt_pgrid_create(mp_comm, pdims_B, mp_comm_B)
-      CALL dbt_pgrid_create(mp_comm, pdims_L, mp_comm_L)
+         ! setup distribution vectors such that distribution matches parallel data layout of BIb_C and my_Lrows
+         dist_B_i = [0]
+         dist_B_a = (/(i, i=0, nproc - 1)/)
+         dist_L_R = (/(MODULO(i, nproc), i=0, ngroup - 1)/) ! R index is replicated in my_Lrows, we impose a cyclic distribution
+         dist_L_P = (/(i, i=0, ngroup - 1)/)
 
-      ! setup distribution vectors such that distribution matches parallel data layout of BIb_C and my_Lrows
-      dist_B_i = [0]
-      dist_B_a = (/(i, i=0, nproc - 1)/)
-      dist_L_R = (/(MODULO(i, nproc), i=0, ngroup - 1)/) ! R index is replicated in my_Lrows, we impose a cyclic distribution
-      dist_L_P = (/(i, i=0, ngroup - 1)/)
+         ! create distributions and tensors
+         CALL dbt_distribution_new(dist_B, mp_comm_B, dist_L_P, dist_B_a, dist_B_i)
+         CALL dbt_distribution_new(dist_L, mp_comm_L, dist_L_R, dist_L_P)
 
-      ! create distributions and tensors
-      CALL dbt_distribution_new(dist_B, mp_comm_B, dist_L_P, dist_B_a, dist_B_i)
-      CALL dbt_distribution_new(dist_L, mp_comm_L, dist_L_R, dist_L_P)
+         CALL dbt_create(tB_in, "(R|ai)", dist_B, map_B_1, map_B_2, sizes_L, sizes_B, sizes_i)
+         CALL dbt_create(tB_out, "(P|ai)", dist_B, map_B_1, map_B_2, sizes_L, sizes_B, sizes_i)
+         CALL dbt_create(tL, "(R|P)", dist_L, map_L_1, map_L_2, sizes_L, sizes_L)
 
-      CALL dbt_create(tB_in, "(R|ai)", dist_B, map_B_1, map_B_2, sizes_L, sizes_B, sizes_i)
-      CALL dbt_create(tB_out, "(P|ai)", dist_B, map_B_1, map_B_2, sizes_L, sizes_B, sizes_i)
-      CALL dbt_create(tL, "(R|P)", dist_L, map_L_1, map_L_2, sizes_L, sizes_L)
+         IF (debug) THEN
+            ! check that tensor distribution is correct
+            CALL dbt_get_stored_coordinates(tB_in, [loc_P, loc_a, 1], check_proc)
+            CPASSERT(check_proc .EQ. iproc_glob)
+         END IF
 
-      IF (debug) THEN
-         ! check that tensor distribution is correct
-         CALL dbt_get_stored_coordinates(tB_in, [loc_P, loc_a, 1], check_proc)
-         CPASSERT(check_proc .EQ. iproc_glob)
-      END IF
-
-      ! reserve (R|ai) block
+         ! reserve (R|ai) block
 !$OMP PARALLEL DEFAULT(NONE) SHARED(tB_in,loc_P,loc_a)
-      CALL dbt_reserve_blocks(tB_in, [loc_P], [loc_a], [1])
+         CALL dbt_reserve_blocks(tB_in, [loc_P], [loc_a], [1])
 !$OMP END PARALLEL
 
-      ! reserve (R|P) blocks
-      ! in my_Lrows, R index is replicated. For (R|P), we distribute quadratic blocks cyclically over
-      ! the processes in a subgroup.
-      ! There are NG blocks, so each process holds at most NG/Nw+1 blocks.
-      ALLOCATE (block_ind_L_R(ngroup/nproc + 1))
-      ALLOCATE (block_ind_L_P(ngroup/nproc + 1))
-      block_ind_L_R(:) = 0; block_ind_L_P(:) = 0
-      ii = 0
-      DO i = 1, ngroup
-         CALL dbt_get_stored_coordinates(tL, [i, loc_P], check_proc)
-         IF (check_proc == iproc_glob) THEN
-            ii = ii + 1
-            block_ind_L_R(ii) = i
-            block_ind_L_P(ii) = loc_P
-         END IF
-      END DO
+         ! reserve (R|P) blocks
+         ! in my_Lrows, R index is replicated. For (R|P), we distribute quadratic blocks cyclically over
+         ! the processes in a subgroup.
+         ! There are NG blocks, so each process holds at most NG/Nw+1 blocks.
+         ALLOCATE (block_ind_L_R(ngroup/nproc + 1))
+         ALLOCATE (block_ind_L_P(ngroup/nproc + 1))
+         block_ind_L_R(:) = 0; block_ind_L_P(:) = 0
+         ii = 0
+         DO i = 1, ngroup
+            CALL dbt_get_stored_coordinates(tL, [i, loc_P], check_proc)
+            IF (check_proc == iproc_glob) THEN
+               ii = ii + 1
+               block_ind_L_R(ii) = i
+               block_ind_L_P(ii) = loc_P
+            END IF
+         END DO
 
 !TODO: Parallelize creation of block list.
 !$OMP PARALLEL DEFAULT(NONE) SHARED(tL,block_ind_L_R,block_ind_L_P,ii) &
 !$OMP PRIVATE(nblk_per_thread,istart,iend)
-      nblk_per_thread = ii/omp_get_num_threads() + 1
-      istart = omp_get_thread_num()*nblk_per_thread + 1
-      iend = MIN(istart + nblk_per_thread, ii)
-      CALL dbt_reserve_blocks(tL, block_ind_L_R(istart:iend), block_ind_L_P(istart:iend))
+         nblk_per_thread = ii/omp_get_num_threads() + 1
+         istart = omp_get_thread_num()*nblk_per_thread + 1
+         iend = MIN(istart + nblk_per_thread, ii)
+         CALL dbt_reserve_blocks(tL, block_ind_L_R(istart:iend), block_ind_L_P(istart:iend))
 !$OMP END PARALLEL
 
-      ! insert (R|ai) block
-      CALL dbt_put_block(tB_in, [loc_P, loc_a, 1], SHAPE(BIb_C), BIb_C)
+         ! insert (R|ai) block
+         CALL dbt_put_block(tB_in, [loc_P, loc_a, 1], SHAPE(BIb_C), BIb_C)
 
-      ! insert (R|P) blocks
-      ioff = 0
-      DO i = 1, ngroup
-         istart = ioff + 1; iend = ioff + sizes_L(i)
-         ioff = ioff + sizes_L(i)
-         CALL dbt_get_stored_coordinates(tL, [i, loc_P], check_proc)
-         IF (check_proc == iproc_glob) THEN
-            CALL dbt_put_block(tL, [i, loc_P], [sizes_L(i), sizes_L(loc_P)], my_Lrows(istart:iend, :))
-         END IF
-      END DO
+         ! insert (R|P) blocks
+         ioff = 0
+         DO i = 1, ngroup
+            istart = ioff + 1; iend = ioff + sizes_L(i)
+            ioff = ioff + sizes_L(i)
+            CALL dbt_get_stored_coordinates(tL, [i, loc_P], check_proc)
+            IF (check_proc == iproc_glob) THEN
+               CALL dbt_put_block(tL, [i, loc_P], [sizes_L(i), sizes_L(loc_P)], my_Lrows(istart:iend, :))
+            END IF
+         END DO
+      END ASSOCIATE
 
       CALL dbt_split_blocks(tB_in, tB_in_split, [blk_size(2), blk_size(1), blk_size(1)])
       CALL dbt_split_blocks(tL, tL_split, [blk_size(2), blk_size(2)])

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -994,7 +994,7 @@ CONTAINS
       ! create the new group for the sum of the local data over all processes
       BLOCK
          TYPE(mp_comm_type) :: comm_exchange
-         CALL comm_exchange%from_split(para_env, para_env_L%mepos)
+         comm_exchange = fm_matrix_L%matrix_struct%context%interconnect(para_env)
          CALL comm_exchange%sum(fm_matrix_L%local_data)
          CALL comm_exchange%free()
       END BLOCK
@@ -1055,7 +1055,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: num_eval
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: evals
       TYPE(cp_fm_type)                                   :: evecs
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange
+      TYPE(mp_comm_type)                                 :: comm_exchange
 
       CALL timeset(routineN, handle)
 
@@ -1098,11 +1098,10 @@ CONTAINS
       ! Step 1: Get a communicator connecting processes with same id within subgroups
       ! use that group_size_L is divisible by the total number of processes (see above)
       group_size_L = para_env%num_pe/matrix%matrix_struct%para_env%num_pe
-      ALLOCATE (para_env_exchange)
-      CALL para_env_exchange%from_split(para_env, matrix%matrix_struct%para_env%mepos)
+      comm_exchange = matrix%matrix_struct%context%interconnect(para_env)
 
       ALLOCATE (num_eval(0:group_size_L - 1))
-      CALL para_env_exchange%allgather(num_small_evals, num_eval)
+      CALL comm_exchange%allgather(num_small_evals, num_eval)
 
       num_small_evals = MINVAL(num_eval)
 
@@ -1113,13 +1112,13 @@ CONTAINS
          needed_evals = nrow - num_small_evals
 
          ! Step 3: Broadcast your local data to all other processes
-         CALL para_env_exchange%bcast(evecs%local_data, pos_max(1))
-         CALL para_env_exchange%bcast(cond_num, pos_max(1))
+         CALL comm_exchange%bcast(evecs%local_data, pos_max(1))
+         CALL comm_exchange%bcast(cond_num, pos_max(1))
       END IF
 
       DEALLOCATE (num_eval)
 
-      CALL cp_para_env_release(para_env_exchange)
+      CALL comm_exchange%free()
 
       CALL reset_size_matrix(matrix, needed_evals, matrix%matrix_struct)
 

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -80,7 +80,8 @@ MODULE mp2_ri_2c
                                               libint_potential_type
    USE machine,                         ONLY: m_flush,&
                                               m_walltime
-   USE message_passing,                 ONLY: mp_request_type
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_request_type
    USE mp2_eri,                         ONLY: mp2_eri_2c_integrate
    USE mp2_eri_gpw,                     ONLY: mp2_eri_2c_integrate_gpw
    USE mp2_types,                       ONLY: integ_mat_buffer_type
@@ -805,7 +806,7 @@ CONTAINS
       INTEGER :: best_group_size, color_L, group_size, handle, handle2, i_global, iatom, iiB, &
          ikind, iproc, j_global, jjB, natom, ncol_local, nkind, nrow_local, nsgf, potential_type, &
          proc_receive, proc_receive_static, proc_send_static, proc_shift, rec_L_end, rec_L_size, &
-         rec_L_start, strat_group_size, sub_sub_color
+         rec_L_start, strat_group_size
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: my_do_im_time
@@ -815,7 +816,6 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_L
       TYPE(cp_fm_type)                                   :: fm_matrix_L_diag
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange
       TYPE(group_dist_d1_type)                           :: gd_sub_array
       TYPE(gto_basis_set_type), POINTER                  :: basis_set_a
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -924,12 +924,6 @@ CONTAINS
       NULLIFY (blacs_env_L)
       CALL cp_blacs_env_create(blacs_env=blacs_env_L, para_env=para_env_L)
 
-      ! now create the exchange group (for communication only between members not belonging to the
-      ! same group
-      sub_sub_color = para_env_sub%mepos
-      ALLOCATE (para_env_exchange)
-      CALL para_env_exchange%from_split(para_env_L, sub_sub_color)
-
       ! create the full matrix L defined in the L group
       CALL create_matrix_L(fm_matrix_L, blacs_env_L, dimen_RI, para_env_L, "fm_matrix_L", fm_matrix_L_extern)
 
@@ -940,69 +934,70 @@ CONTAINS
                                                 dimen_RI)
 
       ELSE
+         BLOCK
+            TYPE(mp_comm_type) :: comm_exchange
 
-         CALL create_group_dist(gd_sub_array, my_group_L_start, &
-                                my_group_L_end, my_group_L_size, para_env_exchange)
+            CALL comm_exchange%from_split(para_env_L, para_env_sub%mepos)
 
-         CALL cp_fm_get_info(matrix=fm_matrix_L, &
-                             nrow_local=nrow_local, &
-                             ncol_local=ncol_local, &
-                             row_indices=row_indices, &
-                             col_indices=col_indices)
+            CALL create_group_dist(gd_sub_array, my_group_L_start, &
+                                   my_group_L_end, my_group_L_size, comm_exchange)
 
-         DO jjB = 1, ncol_local
-            j_global = col_indices(jjB)
-            IF (j_global >= my_group_L_start .AND. j_global <= my_group_L_end) THEN
-               DO iiB = 1, nrow_local
-                  i_global = row_indices(iiB)
-                  fm_matrix_L%local_data(iiB, jjB) = L_local_col(i_global, j_global - my_group_L_start + 1)
-               END DO
-            END IF
-         END DO
-
-         proc_send_static = MODULO(para_env_exchange%mepos + 1, para_env_exchange%num_pe)
-         proc_receive_static = MODULO(para_env_exchange%mepos - 1, para_env_exchange%num_pe)
-
-         DO proc_shift = 1, para_env_exchange%num_pe - 1
-            proc_receive = MODULO(para_env_exchange%mepos - proc_shift, para_env_exchange%num_pe)
-
-            CALL get_group_dist(gd_sub_array, proc_receive, rec_L_start, rec_L_end, rec_L_size)
-
-            ALLOCATE (L_external_col(dimen_RI, rec_L_size))
-            L_external_col = 0.0_dp
-
-            CALL para_env_exchange%sendrecv(L_local_col, proc_send_static, L_external_col, proc_receive_static)
+            CALL cp_fm_get_info(matrix=fm_matrix_L, &
+                                nrow_local=nrow_local, &
+                                ncol_local=ncol_local, &
+                                row_indices=row_indices, &
+                                col_indices=col_indices)
 
             DO jjB = 1, ncol_local
                j_global = col_indices(jjB)
-               IF (j_global >= rec_L_start .AND. j_global <= rec_L_end) THEN
+               IF (j_global >= my_group_L_start .AND. j_global <= my_group_L_end) THEN
                   DO iiB = 1, nrow_local
                      i_global = row_indices(iiB)
-                     fm_matrix_L%local_data(iiB, jjB) = L_external_col(i_global, j_global - rec_L_start + 1)
+                     fm_matrix_L%local_data(iiB, jjB) = L_local_col(i_global, j_global - my_group_L_start + 1)
                   END DO
                END IF
             END DO
 
-            CALL MOVE_ALLOC(L_external_col, L_local_col)
-         END DO
+            proc_send_static = MODULO(comm_exchange%mepos + 1, comm_exchange%num_pe)
+            proc_receive_static = MODULO(comm_exchange%mepos - 1, comm_exchange%num_pe)
 
-         CALL release_group_dist(gd_sub_array)
+            DO proc_shift = 1, comm_exchange%num_pe - 1
+               proc_receive = MODULO(comm_exchange%mepos - proc_shift, comm_exchange%num_pe)
 
+               CALL get_group_dist(gd_sub_array, proc_receive, rec_L_start, rec_L_end, rec_L_size)
+
+               ALLOCATE (L_external_col(dimen_RI, rec_L_size))
+               L_external_col = 0.0_dp
+
+               CALL comm_exchange%sendrecv(L_local_col, proc_send_static, L_external_col, proc_receive_static)
+
+               DO jjB = 1, ncol_local
+                  j_global = col_indices(jjB)
+                  IF (j_global >= rec_L_start .AND. j_global <= rec_L_end) THEN
+                     DO iiB = 1, nrow_local
+                        i_global = row_indices(iiB)
+                        fm_matrix_L%local_data(iiB, jjB) = L_external_col(i_global, j_global - rec_L_start + 1)
+                     END DO
+                  END IF
+               END DO
+
+               CALL MOVE_ALLOC(L_external_col, L_local_col)
+            END DO
+
+            CALL release_group_dist(gd_sub_array)
+            CALL comm_exchange%free()
+         END BLOCK
       END IF
 
       DEALLOCATE (L_local_col)
 
-      ! free the old exchange group stuff
-      CALL cp_para_env_release(para_env_exchange)
-
       ! create the new group for the sum of the local data over all processes
-      sub_sub_color = para_env_L%mepos
-      ALLOCATE (para_env_exchange)
-      CALL para_env_exchange%from_split(para_env, sub_sub_color)
-
-      CALL para_env_exchange%sum(fm_matrix_L%local_data)
-
-      CALL cp_para_env_release(para_env_exchange)
+      BLOCK
+         TYPE(mp_comm_type) :: comm_exchange
+         CALL comm_exchange%from_split(para_env, para_env_L%mepos)
+         CALL comm_exchange%sum(fm_matrix_L%local_data)
+         CALL comm_exchange%free()
+      END BLOCK
 
       cond_num = 1.0_dp
       num_small_eigen = 0

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -15,7 +15,6 @@ MODULE mp2_ri_gpw
    USE ISO_C_BINDING,                   ONLY: C_NULL_PTR,&
                                               c_associated
    USE cp_log_handling,                 ONLY: cp_to_string
-   USE cp_para_env,                     ONLY: cp_para_env_release
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dgemm_counter_types,             ONLY: dgemm_counter_init,&
                                               dgemm_counter_start,&
@@ -83,7 +82,7 @@ CONTAINS
       TYPE(three_dim_real_array), DIMENSION(:), &
          INTENT(INOUT)                                   :: BIb_C
       TYPE(mp2_type)                                     :: mp2_env
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env, para_env_sub
       INTEGER, INTENT(IN)                                :: color_sub
       TYPE(group_dist_d1_type), INTENT(INOUT)            :: gd_array
       INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
@@ -120,8 +119,8 @@ CONTAINS
          POINTER                                         :: external_ab, external_i_aL
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: BI_C_rec
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_rep
       TYPE(dgemm_counter_type)                           :: dgemm_counter
+      TYPE(mp_comm_type)                                 :: comm_exchange, comm_rep
       TYPE(three_dim_real_array), ALLOCATABLE, &
          DIMENSION(:)                                    :: B_ia_Q
 
@@ -163,14 +162,14 @@ CONTAINS
          integ_group_size, my_group_L_end, &
          my_group_L_size, my_group_L_size_orig, my_group_L_start, my_new_group_L_size, &
          integ_group_pos2color_sub, sizes_array_orig, &
-         ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
+         ranges_info_array, comm_exchange, comm_rep, num_integ_group)
 
       ! We cannot fix the tag because of the recv routine
       tag = 42
 
       DO jspin = 1, nspins
 
-         CALL replicate_iaK_2intgroup(BIb_C(jspin)%array, para_env_exchange, para_env_rep, &
+         CALL replicate_iaK_2intgroup(BIb_C(jspin)%array, comm_exchange, comm_rep, &
                                       homo(jspin), gd_array%sizes, my_B_size(jspin), &
                                       my_group_L_size, ranges_info_array)
 
@@ -225,8 +224,8 @@ CONTAINS
             CALL mp2_ri_communication(my_alpha_beta_case, total_ij_pairs, homo(ispin), homo(jspin), &
                                       block_size, ngroup, ij_map, color_sub, my_ij_pairs, my_open_shell_SS, unit_nr)
 
-            ALLOCATE (num_ij_pairs(0:para_env_exchange%num_pe - 1))
-            CALL para_env_exchange%allgather(my_ij_pairs, num_ij_pairs)
+            ALLOCATE (num_ij_pairs(0:comm_exchange%num_pe - 1))
+            CALL comm_exchange%allgather(my_ij_pairs, num_ij_pairs)
 
             max_ij_pairs = MAXVAL(num_ij_pairs)
 
@@ -265,18 +264,18 @@ CONTAINS
                   my_block_size = ij_map(3, ij_counter)
 
                   local_i_aL = 0.0_dp
-                  CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
+                  CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, comm_exchange%mepos), &
                                        BIb_C(ispin)%array(:, :, my_i:my_i + my_block_size - 1))
 
                   local_j_aL = 0.0_dp
-                  CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
+                  CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, comm_exchange%mepos), &
                                        BIb_C(jspin)%array(:, :, my_j:my_j + my_block_size - 1))
 
                   ! collect data from other proc
                   CALL timeset(routineN//"_comm", handle3)
-                  DO proc_shift = 1, para_env_exchange%num_pe - 1
-                     proc_send = MODULO(para_env_exchange%mepos + proc_shift, para_env_exchange%num_pe)
-                     proc_receive = MODULO(para_env_exchange%mepos - proc_shift, para_env_exchange%num_pe)
+                  DO proc_shift = 1, comm_exchange%num_pe - 1
+                     proc_send = MODULO(comm_exchange%mepos + proc_shift, comm_exchange%num_pe)
+                     proc_receive = MODULO(comm_exchange%mepos - proc_shift, comm_exchange%num_pe)
 
                      send_ij_index = num_ij_pairs(proc_send)
 
@@ -292,8 +291,8 @@ CONTAINS
                         BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:my_block_size) => &
                            buffer_1D(1:rec_L_size*my_B_size(ispin)*my_block_size)
                         BI_C_rec = 0.0_dp
-                        CALL para_env_exchange%sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + my_block_size - 1), &
-                                                        proc_send, BI_C_rec, proc_receive, tag)
+                        CALL comm_exchange%sendrecv(BIb_C(ispin)%array(:, :, send_i:send_i + my_block_size - 1), &
+                                                    proc_send, BI_C_rec, proc_receive, tag)
 
                         CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
                                              BI_C_rec(:, 1:my_B_size(ispin), :))
@@ -302,8 +301,8 @@ CONTAINS
                         BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:my_block_size) => &
                            buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*my_block_size)
                         BI_C_rec = 0.0_dp
-                        CALL para_env_exchange%sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + my_block_size - 1), &
-                                                        proc_send, BI_C_rec, proc_receive, tag)
+                        CALL comm_exchange%sendrecv(BIb_C(jspin)%array(:, :, send_j:send_j + my_block_size - 1), &
+                                                    proc_send, BI_C_rec, proc_receive, tag)
 
                         CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
                                              BI_C_rec(:, 1:my_B_size(jspin), :))
@@ -315,7 +314,7 @@ CONTAINS
                         BI_C_rec(1:rec_L_size, 1:my_B_size(ispin), 1:my_block_size) => &
                            buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(ispin)*my_block_size)
                         BI_C_rec = 0.0_dp
-                        CALL para_env_exchange%recv(BI_C_rec, proc_receive, tag)
+                        CALL comm_exchange%recv(BI_C_rec, proc_receive, tag)
 
                         CALL fill_local_i_aL(local_i_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
                                              BI_C_rec(:, 1:my_B_size(ispin), 1:my_block_size))
@@ -324,7 +323,7 @@ CONTAINS
                         BI_C_rec(1:rec_L_size, 1:my_B_size(jspin), 1:my_block_size) => &
                            buffer_1D(1:INT(rec_L_size, int_8)*my_B_size(jspin)*my_block_size)
                         BI_C_rec = 0.0_dp
-                        CALL para_env_exchange%recv(BI_C_rec, proc_receive, tag)
+                        CALL comm_exchange%recv(BI_C_rec, proc_receive, tag)
 
                         CALL fill_local_i_aL(local_j_aL(:, :, 1:my_block_size), ranges_info_array(:, :, proc_receive), &
                                              BI_C_rec(:, 1:my_B_size(jspin), 1:my_block_size))
@@ -495,9 +494,9 @@ CONTAINS
                   CALL timeset(routineN//"_comm", handle3)
                   ! No work to do and we know that we have to receive nothing, but send something
                   ! send data to other proc
-                  DO proc_shift = 1, para_env_exchange%num_pe - 1
-                     proc_send = MODULO(para_env_exchange%mepos + proc_shift, para_env_exchange%num_pe)
-                     proc_receive = MODULO(para_env_exchange%mepos - proc_shift, para_env_exchange%num_pe)
+                  DO proc_shift = 1, comm_exchange%num_pe - 1
+                     proc_send = MODULO(comm_exchange%mepos + proc_shift, comm_exchange%num_pe)
+                     proc_receive = MODULO(comm_exchange%mepos - proc_shift, comm_exchange%num_pe)
 
                      send_ij_index = num_ij_pairs(proc_send)
 
@@ -509,11 +508,11 @@ CONTAINS
                         send_j = ij_map(2, ij_counter_send)
 
                         ! occupied i
-                        CALL para_env_exchange%send(BIb_C(ispin)%array(:, :, send_i:send_i + my_block_size - 1), &
-                                                    proc_send, tag)
+                        CALL comm_exchange%send(BIb_C(ispin)%array(:, :, send_i:send_i + my_block_size - 1), &
+                                                proc_send, tag)
                         ! occupied j
-                        CALL para_env_exchange%send(BIb_C(jspin)%array(:, :, send_j:send_j + my_block_size - 1), &
-                                                    proc_send, tag)
+                        CALL comm_exchange%send(BIb_C(jspin)%array(:, :, send_j:send_j + my_block_size - 1), &
+                                                proc_send, tag)
                      END IF
                   END DO
                   CALL timestop(handle3)
@@ -524,12 +523,12 @@ CONTAINS
                   CALL mp2_redistribute_gamma(mp2_env%ri_grad%Gamma_P_ia(ispin)%array, ij_index, my_B_size(ispin), &
                                               my_block_size, my_group_L_size, my_i, my_ij_pairs, ngroup, &
                                               num_integ_group, integ_group_pos2color_sub, num_ij_pairs, &
-                                              ij_map, ranges_info_array, Y_i_aP(:, :, 1:my_block_size), para_env_exchange, &
+                                              ij_map, ranges_info_array, Y_i_aP(:, :, 1:my_block_size), comm_exchange, &
                                               gd_array%sizes, 1, buffer_1D)
                   CALL mp2_redistribute_gamma(mp2_env%ri_grad%Gamma_P_ia(jspin)%array, ij_index, my_B_size(jspin), &
                                               my_block_size, my_group_L_size, my_j, my_ij_pairs, ngroup, &
                                               num_integ_group, integ_group_pos2color_sub, num_ij_pairs, &
-                                              ij_map, ranges_info_array, Y_j_aP(:, :, 1:my_block_size), para_env_exchange, &
+                                              ij_map, ranges_info_array, Y_j_aP(:, :, 1:my_block_size), comm_exchange, &
                                               gd_array%sizes, 2, buffer_1D)
                END IF
 
@@ -561,7 +560,7 @@ CONTAINS
                   mp2_env, Eigenval(:, ispin:jspin), homo(ispin:jspin), virtual(ispin:jspin), my_open_shell_ss, &
                   my_beta_beta_case, Bib_C(ispin:jspin), unit_nr, dimen_RI, &
                   my_B_size(ispin:jspin), ngroup, my_group_L_size, &
-                  color_sub, ranges_info_array, para_env_exchange, para_env_sub, para_env, &
+                  color_sub, ranges_info_array, comm_exchange, para_env_sub, para_env, &
                   my_B_virtual_start(ispin:jspin), my_B_virtual_end(ispin:jspin), gd_array%sizes, gd_B_virtual(ispin:jspin), &
                   integ_group_pos2color_sub, dgemm_counter, buffer_1D)
 
@@ -586,16 +585,16 @@ CONTAINS
 
                ! sum Gamma and dereplicate
                ALLOCATE (BIb_C(ispin)%array(my_B_size(ispin), homo(ispin), my_group_L_size_orig))
-               DO proc_shift = 1, para_env_rep%num_pe - 1
+               DO proc_shift = 1, comm_rep%num_pe - 1
                   ! invert order
-                  proc_send = MODULO(para_env_rep%mepos - proc_shift, para_env_rep%num_pe)
-                  proc_receive = MODULO(para_env_rep%mepos + proc_shift, para_env_rep%num_pe)
+                  proc_send = MODULO(comm_rep%mepos - proc_shift, comm_rep%num_pe)
+                  proc_receive = MODULO(comm_rep%mepos + proc_shift, comm_rep%num_pe)
 
-                  start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
-                  end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
+                  start_point = ranges_info_array(3, proc_shift, comm_exchange%mepos)
+                  end_point = ranges_info_array(4, proc_shift, comm_exchange%mepos)
 
-                  CALL para_env_rep%sendrecv(mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, start_point:end_point), &
-                                             proc_send, BIb_C(ispin)%array, proc_receive, tag)
+                  CALL comm_rep%sendrecv(mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, start_point:end_point), &
+                                         proc_send, BIb_C(ispin)%array, proc_receive, tag)
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) &
 !$OMP          SHARED(mp2_env,BIb_C,ispin,homo,my_B_size,my_group_L_size_orig)
                   mp2_env%ri_grad%Gamma_P_ia(ispin)%array(:, :, 1:my_group_L_size_orig) = &
@@ -636,8 +635,8 @@ CONTAINS
       DEALLOCATE (integ_group_pos2color_sub)
       DEALLOCATE (ranges_info_array)
 
-      CALL cp_para_env_release(para_env_exchange)
-      CALL cp_para_env_release(para_env_rep)
+      CALL comm_exchange%free()
+      CALL comm_rep%free()
 
       IF (calc_forces) THEN
          ! recover original information (before replication)
@@ -766,19 +765,19 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param BIb_C ...
-!> \param para_env_exchange ...
-!> \param para_env_rep ...
+!> \param comm_exchange ...
+!> \param comm_rep ...
 !> \param homo ...
 !> \param sizes_array ...
 !> \param my_B_size ...
 !> \param my_group_L_size ...
 !> \param ranges_info_array ...
 ! **************************************************************************************************
-   SUBROUTINE replicate_iaK_2intgroup(BIb_C, para_env_exchange, para_env_rep, homo, sizes_array, my_B_size, &
+   SUBROUTINE replicate_iaK_2intgroup(BIb_C, comm_exchange, comm_rep, homo, sizes_array, my_B_size, &
                                       my_group_L_size, ranges_info_array)
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: BIb_C
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_exchange, para_env_rep
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange, comm_rep
       INTEGER, INTENT(IN)                                :: homo
       INTEGER, DIMENSION(:), INTENT(IN)                  :: sizes_array
       INTEGER, INTENT(IN)                                :: my_B_size, my_group_L_size
@@ -803,10 +802,10 @@ CONTAINS
 
       DEALLOCATE (BIb_C)
 
-      ALLOCATE (BIb_C_gather(max_L_size, my_B_size, homo, 0:para_env_rep%num_pe - 1))
+      ALLOCATE (BIb_C_gather(max_L_size, my_B_size, homo, 0:comm_rep%num_pe - 1))
       BIb_C_gather = 0.0_dp
 
-      CALL para_env_rep%allgather(BIb_C_copy, BIb_C_gather)
+      CALL comm_rep%allgather(BIb_C_copy, BIb_C_gather)
 
       DEALLOCATE (BIb_C_copy)
 
@@ -814,11 +813,11 @@ CONTAINS
       BIb_C = 0.0_dp
 
       ! reorder data
-      DO proc_shift = 0, para_env_rep%num_pe - 1
-         proc_receive = MODULO(para_env_rep%mepos - proc_shift, para_env_rep%num_pe)
+      DO proc_shift = 0, comm_rep%num_pe - 1
+         proc_receive = MODULO(comm_rep%mepos - proc_shift, comm_rep%num_pe)
 
-         start_point = ranges_info_array(3, proc_shift, para_env_exchange%mepos)
-         end_point = ranges_info_array(4, proc_shift, para_env_exchange%mepos)
+         start_point = ranges_info_array(3, proc_shift, comm_exchange%mepos)
+         end_point = ranges_info_array(4, proc_shift, comm_exchange%mepos)
 
          BIb_C(start_point:end_point, 1:my_B_size, 1:homo) = &
             BIb_C_gather(1:end_point - start_point + 1, 1:my_B_size, 1:homo, proc_receive)
@@ -1179,8 +1178,8 @@ CONTAINS
 !> \param integ_group_pos2color_sub ...
 !> \param sizes_array_orig ...
 !> \param ranges_info_array ...
-!> \param para_env_exchange ...
-!> \param para_env_rep ...
+!> \param comm_exchange ...
+!> \param comm_rep ...
 !> \param num_integ_group ...
 ! **************************************************************************************************
    SUBROUTINE mp2_ri_create_group(para_env, para_env_sub, color_sub, &
@@ -1188,7 +1187,7 @@ CONTAINS
                                   integ_group_size, my_group_L_end, &
                                   my_group_L_size, my_group_L_size_orig, my_group_L_start, my_new_group_L_size, &
                                   integ_group_pos2color_sub, &
-                                  sizes_array_orig, ranges_info_array, para_env_exchange, para_env_rep, num_integ_group)
+                                  sizes_array_orig, ranges_info_array, comm_exchange, comm_rep, num_integ_group)
       TYPE(cp_para_env_type), INTENT(IN)                 :: para_env, para_env_sub
       INTEGER, INTENT(IN)                                :: color_sub
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(INOUT)  :: sizes_array
@@ -1202,7 +1201,7 @@ CONTAINS
                                                             sizes_array_orig
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(OUT)                                     :: ranges_info_array
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_rep
+      TYPE(mp_comm_type), INTENT(OUT)                    :: comm_exchange, comm_rep
       INTEGER, INTENT(IN)                                :: num_integ_group
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mp2_ri_create_group'
@@ -1216,38 +1215,36 @@ CONTAINS
       CALL timeset(routineN, handle)
       !
       sub_sub_color = para_env_sub%mepos*num_integ_group + color_sub/integ_group_size
-      ALLOCATE (para_env_exchange)
-      CALL para_env_exchange%from_split(para_env, sub_sub_color)
+      CALL comm_exchange%from_split(para_env, sub_sub_color)
 
       ! create the replication group
-      sub_sub_color = para_env_sub%mepos*para_env_exchange%num_pe + para_env_exchange%mepos
-      ALLOCATE (para_env_rep)
-      CALL para_env_rep%from_split(para_env, sub_sub_color)
+      sub_sub_color = para_env_sub%mepos*comm_exchange%num_pe + comm_exchange%mepos
+      CALL comm_rep%from_split(para_env, sub_sub_color)
 
       ! create the new limits for K according to the size
       ! of the integral group
 
       ! info array for replication
-      ALLOCATE (rep_ends_array(0:para_env_rep%num_pe - 1))
-      ALLOCATE (rep_starts_array(0:para_env_rep%num_pe - 1))
-      ALLOCATE (rep_sizes_array(0:para_env_rep%num_pe - 1))
+      ALLOCATE (rep_ends_array(0:comm_rep%num_pe - 1))
+      ALLOCATE (rep_starts_array(0:comm_rep%num_pe - 1))
+      ALLOCATE (rep_sizes_array(0:comm_rep%num_pe - 1))
 
-      CALL para_env_rep%allgather(my_group_L_size, rep_sizes_array)
-      CALL para_env_rep%allgather(my_group_L_start, rep_starts_array)
-      CALL para_env_rep%allgather(my_group_L_end, rep_ends_array)
+      CALL comm_rep%allgather(my_group_L_size, rep_sizes_array)
+      CALL comm_rep%allgather(my_group_L_start, rep_starts_array)
+      CALL comm_rep%allgather(my_group_L_end, rep_ends_array)
 
       ! calculate my_new_group_L_size according to sizes_array
       my_new_group_L_size = my_group_L_size
 
       ! Info of this process
-      ALLOCATE (my_info(4, 0:para_env_rep%num_pe - 1))
+      ALLOCATE (my_info(4, 0:comm_rep%num_pe - 1))
       my_info(1, 0) = my_group_L_start
       my_info(2, 0) = my_group_L_end
       my_info(3, 0) = 1
       my_info(4, 0) = my_group_L_size
 
-      DO proc_shift = 1, para_env_rep%num_pe - 1
-         proc_receive = MODULO(para_env_rep%mepos - proc_shift, para_env_rep%num_pe)
+      DO proc_shift = 1, comm_rep%num_pe - 1
+         proc_receive = MODULO(comm_rep%mepos - proc_shift, comm_rep%num_pe)
 
          my_new_group_L_size = my_new_group_L_size + rep_sizes_array(proc_receive)
 
@@ -1258,17 +1255,17 @@ CONTAINS
 
       END DO
 
-      ALLOCATE (new_sizes_array(0:para_env_exchange%num_pe - 1))
-      ALLOCATE (ranges_info_array(4, 0:para_env_rep%num_pe - 1, 0:para_env_exchange%num_pe - 1))
-      CALL para_env_exchange%allgather(my_new_group_L_size, new_sizes_array)
-      CALL para_env_exchange%allgather(my_info, ranges_info_array)
+      ALLOCATE (new_sizes_array(0:comm_exchange%num_pe - 1))
+      ALLOCATE (ranges_info_array(4, 0:comm_rep%num_pe - 1, 0:comm_exchange%num_pe - 1))
+      CALL comm_exchange%allgather(my_new_group_L_size, new_sizes_array)
+      CALL comm_exchange%allgather(my_info, ranges_info_array)
 
       DEALLOCATE (rep_sizes_array)
       DEALLOCATE (rep_starts_array)
       DEALLOCATE (rep_ends_array)
 
-      ALLOCATE (integ_group_pos2color_sub(0:para_env_exchange%num_pe - 1))
-      CALL para_env_exchange%allgather(color_sub, integ_group_pos2color_sub)
+      ALLOCATE (integ_group_pos2color_sub(0:comm_exchange%num_pe - 1))
+      CALL comm_exchange%allgather(color_sub, integ_group_pos2color_sub)
 
       IF (calc_forces) THEN
          iiB = SIZE(sizes_array)
@@ -1919,7 +1916,7 @@ CONTAINS
 !> \param ij_map ...
 !> \param ranges_info_array ...
 !> \param Y_i_aP ...
-!> \param para_env_exchange ...
+!> \param comm_exchange ...
 !> \param sizes_array ...
 !> \param spin ...
 !> \param buffer_1D ...
@@ -1927,7 +1924,7 @@ CONTAINS
    SUBROUTINE mp2_redistribute_gamma(Gamma_P_ia, ij_index, my_B_size, &
                                      my_block_size, my_group_L_size, my_i, my_ij_pairs, ngroup, &
                                      num_integ_group, integ_group_pos2color_sub, num_ij_pairs, &
-                                     ij_map, ranges_info_array, Y_i_aP, para_env_exchange, &
+                                     ij_map, ranges_info_array, Y_i_aP, comm_exchange, &
                                      sizes_array, spin, buffer_1D)
 
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(INOUT)   :: Gamma_P_ia
@@ -1939,7 +1936,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(IN)                                      :: ranges_info_array
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: Y_i_aP
-      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_exchange
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: sizes_array
       INTEGER, INTENT(IN)                                :: spin
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:), TARGET    :: buffer_1D
@@ -1963,9 +1960,9 @@ CONTAINS
          ! start with myself
          CALL timeset(routineN//"_comm2_w", handle2)
          DO irep = 0, num_integ_group - 1
-            Lstart_pos = ranges_info_array(1, irep, para_env_exchange%mepos)
-            start_point = ranges_info_array(3, irep, para_env_exchange%mepos)
-            end_point = ranges_info_array(4, irep, para_env_exchange%mepos)
+            Lstart_pos = ranges_info_array(1, irep, comm_exchange%mepos)
+            start_point = ranges_info_array(3, irep, comm_exchange%mepos)
+            end_point = ranges_info_array(4, irep, comm_exchange%mepos)
 !$OMP       PARALLEL DO DEFAULT(NONE) PRIVATE(kkk,lll,iiB) &
 !$OMP                                 SHARED(start_point,end_point,Lstart_pos,my_block_size,&
 !$OMP                                        Gamma_P_ia,my_i,my_B_size,Y_i_aP)
@@ -1983,9 +1980,9 @@ CONTAINS
 
          ! Y_i_aP(my_B_size,dimen_RI,block_size)
 
-         DO proc_shift = 1, para_env_exchange%num_pe - 1
-            proc_send = MODULO(para_env_exchange%mepos + proc_shift, para_env_exchange%num_pe)
-            proc_receive = MODULO(para_env_exchange%mepos - proc_shift, para_env_exchange%num_pe)
+         DO proc_shift = 1, comm_exchange%num_pe - 1
+            proc_send = MODULO(comm_exchange%mepos + proc_shift, comm_exchange%num_pe)
+            proc_receive = MODULO(comm_exchange%mepos - proc_shift, comm_exchange%num_pe)
 
             send_L_size = sizes_array(proc_send)
             BI_C_send(1:my_B_size, 1:my_block_size, 1:send_L_size) => &
@@ -2025,13 +2022,13 @@ CONTAINS
                   buffer_1D(offset + 1:offset + INT(my_B_size, int_8)*my_block_size*my_group_L_size)
                BI_C_rec = 0.0_dp
 
-               CALL para_env_exchange%sendrecv(BI_C_send, proc_send, &
-                                               BI_C_rec, proc_receive, tag)
+               CALL comm_exchange%sendrecv(BI_C_send, proc_send, &
+                                           BI_C_rec, proc_receive, tag)
 
                CALL timeset(routineN//"_comm2_w", handle2)
                DO irep = 0, num_integ_group - 1
-                  start_point = ranges_info_array(3, irep, para_env_exchange%mepos)
-                  end_point = ranges_info_array(4, irep, para_env_exchange%mepos)
+                  start_point = ranges_info_array(3, irep, comm_exchange%mepos)
+                  end_point = ranges_info_array(4, irep, comm_exchange%mepos)
 !$OMP             PARALLEL WORKSHARE DEFAULT(NONE) SHARED(start_point,end_point,my_block_size,&
 !$OMP                                           Gamma_P_ia,rec_i,iiB,my_B_size,BI_C_rec)
                   Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) = &
@@ -2043,7 +2040,7 @@ CONTAINS
 
             ELSE
                ! we have something to send but nothing to receive
-               CALL para_env_exchange%send(BI_C_send, proc_send, tag)
+               CALL comm_exchange%send(BI_C_send, proc_send, tag)
 
             END IF
 
@@ -2051,9 +2048,9 @@ CONTAINS
 
       ELSE
          ! noting to send check if we have to receive
-         DO proc_shift = 1, para_env_exchange%num_pe - 1
-            proc_send = MODULO(para_env_exchange%mepos + proc_shift, para_env_exchange%num_pe)
-            proc_receive = MODULO(para_env_exchange%mepos - proc_shift, para_env_exchange%num_pe)
+         DO proc_shift = 1, comm_exchange%num_pe - 1
+            proc_send = MODULO(comm_exchange%mepos + proc_shift, comm_exchange%num_pe)
+            proc_receive = MODULO(comm_exchange%mepos - proc_shift, comm_exchange%num_pe)
             rec_ij_index = num_ij_pairs(proc_receive)
 
             IF (ij_index <= rec_ij_index) THEN
@@ -2068,12 +2065,12 @@ CONTAINS
 
                BI_C_rec = 0.0_dp
 
-               CALL para_env_exchange%recv(BI_C_rec, proc_receive, tag)
+               CALL comm_exchange%recv(BI_C_rec, proc_receive, tag)
 
                CALL timeset(routineN//"_comm2_w", handle2)
                DO irep = 0, num_integ_group - 1
-                  start_point = ranges_info_array(3, irep, para_env_exchange%mepos)
-                  end_point = ranges_info_array(4, irep, para_env_exchange%mepos)
+                  start_point = ranges_info_array(3, irep, comm_exchange%mepos)
+                  end_point = ranges_info_array(4, irep, comm_exchange%mepos)
 !$OMP             PARALLEL WORKSHARE DEFAULT(NONE) SHARED(start_point,end_point,my_block_size,&
 !$OMP                                           Gamma_P_ia,rec_i,iiB,my_B_size,BI_C_rec)
                   Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) = &
@@ -2107,7 +2104,7 @@ CONTAINS
 !> \param my_group_L_size ...
 !> \param color_sub ...
 !> \param ranges_info_array ...
-!> \param para_env_exchange ...
+!> \param comm_exchange ...
 !> \param para_env_sub ...
 !> \param para_env ...
 !> \param my_B_virtual_start ...
@@ -2121,7 +2118,7 @@ CONTAINS
    SUBROUTINE quasi_degenerate_P_ij(mp2_env, Eigenval, homo, virtual, open_shell, &
                                     beta_beta, Bib_C, unit_nr, dimen_RI, &
                                     my_B_size, ngroup, my_group_L_size, &
-                                    color_sub, ranges_info_array, para_env_exchange, para_env_sub, para_env, &
+                                    color_sub, ranges_info_array, comm_exchange, para_env_sub, para_env, &
                                     my_B_virtual_start, my_B_virtual_end, sizes_array, gd_B_virtual, &
                                     integ_group_pos2color_sub, dgemm_counter, buffer_1D)
       TYPE(mp2_type)                                     :: mp2_env
@@ -2135,7 +2132,8 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: ngroup, my_group_L_size, color_sub
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(IN)                                      :: ranges_info_array
-      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_exchange, para_env_sub, para_env
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub, para_env
       INTEGER, DIMENSION(:), INTENT(IN)                  :: my_B_virtual_start, my_B_virtual_end
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(IN)     :: sizes_array
       TYPE(group_dist_d1_type), DIMENSION(:), INTENT(IN) :: gd_B_virtual
@@ -2175,7 +2173,7 @@ CONTAINS
       amp_fac = mp2_env%scale_S + mp2_env%scale_T
       IF (open_shell) amp_fac = mp2_env%scale_T
 
-      ALLOCATE (send_last_k(2, para_env_exchange%num_pe - 1))
+      ALLOCATE (send_last_k(2, comm_exchange%num_pe - 1))
 
       ! Loop(s) over orbital triplets
       DO ispin = 1, nspins
@@ -2190,7 +2188,7 @@ CONTAINS
          ! Find the number of quasi-degenerate orbitals and orbital triplets
 
          CALL Find_quasi_degenerate_ij(my_ijk, homo(ispin), homo(kspin), Eigenval(:, ispin), mp2_env, ijk_map, unit_nr, ngroup, &
-                                       .NOT. beta_beta .AND. ispin /= 2, para_env_exchange, num_ijk, max_ijk, color_sub, &
+                                       .NOT. beta_beta .AND. ispin /= 2, comm_exchange, num_ijk, max_ijk, color_sub, &
                                        SIZE(buffer_1D), my_group_L_size, size_B_k, para_env, virtual(ispin), size_B_i)
 
          my_virtual = virtual(ispin)
@@ -2239,26 +2237,26 @@ CONTAINS
 
                local_aL_i = 0.0_dp
                IF (do_recv_i) THEN
-                  CALL fill_local_i_aL_2D(local_al_i, ranges_info_array(:, :, para_env_exchange%mepos), &
+                  CALL fill_local_i_aL_2D(local_al_i, ranges_info_array(:, :, comm_exchange%mepos), &
                                           BIb_C(ispin)%array(:, :, my_i))
                END IF
 
                local_aL_j = 0.0_dp
                IF (do_recv_j) THEN
-                  CALL fill_local_i_aL_2D(local_al_j, ranges_info_array(:, :, para_env_exchange%mepos), &
+                  CALL fill_local_i_aL_2D(local_al_j, ranges_info_array(:, :, comm_exchange%mepos), &
                                           BIb_C(ispin)%array(:, :, my_j))
                END IF
 
                IF (do_recv_k) THEN
                   local_aL_k = 0.0_dp
-                  CALL fill_local_i_aL(local_aL_k(:, :, 1:block_size), ranges_info_array(:, :, para_env_exchange%mepos), &
+                  CALL fill_local_i_aL(local_aL_k(:, :, 1:block_size), ranges_info_array(:, :, comm_exchange%mepos), &
                                        BIb_C(kspin)%array(:, :, my_k:my_k + block_size - 1))
                END IF
 
                CALL timeset(routineN//"_comm", handle2)
-               DO proc_shift = 1, para_env_exchange%num_pe - 1
-                  proc_send = MODULO(para_env_exchange%mepos + proc_shift, para_env_exchange%num_pe)
-                  proc_receive = MODULO(para_env_exchange%mepos - proc_shift, para_env_exchange%num_pe)
+               DO proc_shift = 1, comm_exchange%num_pe - 1
+                  proc_send = MODULO(comm_exchange%mepos + proc_shift, comm_exchange%num_pe)
+                  proc_receive = MODULO(comm_exchange%mepos - proc_shift, comm_exchange%num_pe)
 
                   send_ijk_index = num_ijk(proc_send)
 
@@ -2287,13 +2285,13 @@ CONTAINS
                   BI_C_rec = 0.0_dp
                   IF (do_send_i) THEN
                   IF (do_recv_i) THEN
-                     CALL para_env_exchange%sendrecv(BIb_C(ispin)%array(:, :, send_i), proc_send, &
-                                                     BI_C_rec, proc_receive, tag)
+                     CALL comm_exchange%sendrecv(BIb_C(ispin)%array(:, :, send_i), proc_send, &
+                                                 BI_C_rec, proc_receive, tag)
                   ELSE
-                     CALL para_env_exchange%send(BIb_C(ispin)%array(:, :, send_i), proc_send, tag)
+                     CALL comm_exchange%send(BIb_C(ispin)%array(:, :, send_i), proc_send, tag)
                   END IF
                   ELSE IF (do_recv_i) THEN
-                  CALL para_env_exchange%recv(BI_C_rec, proc_receive, tag)
+                  CALL comm_exchange%recv(BI_C_rec, proc_receive, tag)
                   END IF
                   IF (do_recv_i) THEN
                      CALL fill_local_i_aL_2D(local_al_i, ranges_info_array(:, :, proc_receive), BI_C_rec)
@@ -2303,13 +2301,13 @@ CONTAINS
                   BI_C_rec = 0.0_dp
                   IF (do_send_j) THEN
                   IF (do_recv_j) THEN
-                     CALL para_env_exchange%sendrecv(BIb_C(ispin)%array(:, :, send_j), proc_send, &
-                                                     BI_C_rec, proc_receive, tag)
+                     CALL comm_exchange%sendrecv(BIb_C(ispin)%array(:, :, send_j), proc_send, &
+                                                 BI_C_rec, proc_receive, tag)
                   ELSE
-                     CALL para_env_exchange%send(BIb_C(ispin)%array(:, :, send_j), proc_send, tag)
+                     CALL comm_exchange%send(BIb_C(ispin)%array(:, :, send_j), proc_send, tag)
                   END IF
                   ELSE IF (do_recv_j) THEN
-                  CALL para_env_exchange%recv(BI_C_rec, proc_receive, tag)
+                  CALL comm_exchange%recv(BI_C_rec, proc_receive, tag)
                   END IF
                   IF (do_recv_j) THEN
                      CALL fill_local_i_aL_2D(local_al_j, ranges_info_array(:, :, proc_receive), BI_C_rec)
@@ -2320,13 +2318,13 @@ CONTAINS
                      buffer_1D(1:INT(rec_L_size, KIND=int_8)*size_B_k*block_size)
                   IF (do_send_k) THEN
                   IF (do_recv_k) THEN
-                     CALL para_env_exchange%sendrecv(BIb_C(kspin)%array(:, :, send_k:send_k + block_size - 1), proc_send, &
-                                                     BI_C_rec_3D, proc_receive, tag)
+                     CALL comm_exchange%sendrecv(BIb_C(kspin)%array(:, :, send_k:send_k + block_size - 1), proc_send, &
+                                                 BI_C_rec_3D, proc_receive, tag)
                   ELSE
-                     CALL para_env_exchange%send(BI_C_rec, proc_receive, tag)
+                     CALL comm_exchange%send(BI_C_rec, proc_receive, tag)
                   END IF
                   ELSE IF (do_recv_k) THEN
-                  CALL para_env_exchange%recv(BI_C_rec_3D, proc_receive, tag)
+                  CALL comm_exchange%recv(BI_C_rec_3D, proc_receive, tag)
                   END IF
                   IF (do_recv_k) THEN
                      CALL fill_local_i_aL(local_al_k(:, :, 1:block_size), ranges_info_array(:, :, proc_receive), BI_C_rec_3D)
@@ -2355,8 +2353,8 @@ CONTAINS
 
                      external_aL(1:dimen_RI, 1:rec_B_size) => buffer_1D(1:INT(dimen_RI, KIND=int_8)*rec_B_size)
 
-                     CALL para_env_exchange%sendrecv(local_aL_i, proc_send, &
-                                                     external_aL, proc_receive, tag)
+                     CALL comm_exchange%sendrecv(local_aL_i, proc_send, &
+                                                 external_aL, proc_receive, tag)
 
                      CALL local_gemm('T', 'N', rec_B_size, size_B_k, dimen_RI, 1.0_dp, &
                                      external_aL, dimen_RI, local_aL_k(:, :, kkB), dimen_RI, &
@@ -2432,8 +2430,8 @@ CONTAINS
 
                      external_aL(1:dimen_RI, 1:rec_B_size) => buffer_1D(1:INT(dimen_RI, KIND=int_8)*rec_B_size)
 
-                     CALL para_env_exchange%sendrecv(local_aL_j, proc_send, &
-                                                     external_aL, proc_receive, tag)
+                     CALL comm_exchange%sendrecv(local_aL_j, proc_send, &
+                                                 external_aL, proc_receive, tag)
                      CALL local_gemm('T', 'N', rec_B_size, size_B_k, dimen_RI, 1.0_dp, &
                                      external_aL, dimen_RI, local_aL_k(:, :, kkB), dimen_RI, &
                                      0.0_dp, local_ab(rec_B_virtual_start:rec_B_virtual_end, 1:size_B_k), rec_B_size, &
@@ -2470,9 +2468,9 @@ CONTAINS
             ELSE
                CALL timeset(routineN//"_comm", handle2)
                ! no work to be done, possible messeges to be exchanged
-               DO proc_shift = 1, para_env_exchange%num_pe - 1
-                  proc_send = MODULO(para_env_exchange%mepos + proc_shift, para_env_exchange%num_pe)
-                  proc_receive = MODULO(para_env_exchange%mepos - proc_shift, para_env_exchange%num_pe)
+               DO proc_shift = 1, comm_exchange%num_pe - 1
+                  proc_send = MODULO(comm_exchange%mepos + proc_shift, comm_exchange%num_pe)
+                  proc_receive = MODULO(comm_exchange%mepos - proc_shift, comm_exchange%num_pe)
 
                   send_ijk_index = num_ijk(proc_send)
 
@@ -2489,14 +2487,14 @@ CONTAINS
                      do_send_j = (ispin /= kspin) .OR. send_j < send_k .OR. send_j > send_k + block_size - 1
                      ! occupied i
                      IF (do_send_i) THEN
-                        CALL para_env_exchange%send(BIb_C(ispin)%array(:, :, send_i), proc_send, tag)
+                        CALL comm_exchange%send(BIb_C(ispin)%array(:, :, send_i), proc_send, tag)
                      END IF
                      ! occupied j
                      IF (do_send_j) THEN
-                        CALL para_env_exchange%send(BIb_C(ispin)%array(:, :, send_j), proc_send, tag)
+                        CALL comm_exchange%send(BIb_C(ispin)%array(:, :, send_j), proc_send, tag)
                      END IF
                      ! occupied k
-                     CALL para_env_exchange%send(BIb_C(kspin)%array(:, :, send_k:send_k + block_size - 1), proc_send, tag)
+                     CALL comm_exchange%send(BIb_C(kspin)%array(:, :, send_k:send_k + block_size - 1), proc_send, tag)
                   END IF
 
                END DO ! proc loop
@@ -2524,7 +2522,7 @@ CONTAINS
 !> \param unit_nr ...
 !> \param ngroup ...
 !> \param do_print_alpha ...
-!> \param para_env_exchange ...
+!> \param comm_exchange ...
 !> \param num_ijk ...
 !> \param max_ijk ...
 !> \param color_sub ...
@@ -2536,7 +2534,7 @@ CONTAINS
 !> \param B_size_i ...
 ! **************************************************************************************************
    SUBROUTINE Find_quasi_degenerate_ij(my_ijk, homo, homo_beta, Eigenval, mp2_env, ijk_map, unit_nr, ngroup, &
-                                       do_print_alpha, para_env_exchange, num_ijk, max_ijk, color_sub, &
+                                       do_print_alpha, comm_exchange, num_ijk, max_ijk, color_sub, &
                                        buffer_size, my_group_L_size, B_size_k, para_env, virtual, B_size_i)
 
       INTEGER, INTENT(OUT)                               :: my_ijk
@@ -2546,7 +2544,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :), INTENT(OUT) :: ijk_map
       INTEGER, INTENT(IN)                                :: unit_nr, ngroup
       LOGICAL, INTENT(IN)                                :: do_print_alpha
-      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_exchange
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange
       INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: num_ijk
       INTEGER, INTENT(OUT)                               :: max_ijk
       INTEGER, INTENT(IN)                                :: color_sub, buffer_size, my_group_L_size, &
@@ -2560,7 +2558,7 @@ CONTAINS
       INTEGER(KIND=int_8)                                :: mem
       LOGICAL, ALLOCATABLE, DIMENSION(:, :)              :: ijk_marker
 
-      ALLOCATE (num_ijk(0:para_env_exchange%num_pe - 1))
+      ALLOCATE (num_ijk(0:comm_exchange%num_pe - 1))
 
       num_sing_ij = 0
       DO iiB = 1, homo
@@ -2671,7 +2669,7 @@ CONTAINS
 
       DEALLOCATE (ijk_marker)
 
-      CALL para_env_exchange%allgather(my_ijk, num_ijk)
+      CALL comm_exchange%allgather(my_ijk, num_ijk)
       max_ijk = MAXVAL(num_ijk)
 
    END SUBROUTINE Find_quasi_degenerate_ij

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -37,6 +37,7 @@ MODULE mp2_ri_gpw
    USE machine,                         ONLY: m_flush,&
                                               m_memory,&
                                               m_walltime
+   USE message_passing,                 ONLY: mp_comm_type
    USE mp2_ri_grad_util,                ONLY: complete_gamma
    USE mp2_types,                       ONLY: mp2_type,&
                                               three_dim_real_array
@@ -101,7 +102,7 @@ CONTAINS
          my_group_L_start, my_i, my_ij_pairs, my_j, my_new_group_L_size, ngroup, nspins, &
          num_integ_group, proc_receive, proc_send, proc_shift, rec_B_size, rec_B_virtual_end, &
          rec_B_virtual_start, rec_L_size, send_B_size, send_B_virtual_end, send_B_virtual_start, &
-         send_i, send_ij_index, send_j, start_point, sub_P_color, tag, total_ij_pairs
+         send_i, send_ij_index, send_j, start_point, tag, total_ij_pairs
       INTEGER, ALLOCATABLE, DIMENSION(:) :: integ_group_pos2color_sub, my_B_size, &
          my_B_virtual_end, my_B_virtual_start, num_ij_pairs, sizes_array_orig, virtual
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: ij_map
@@ -119,8 +120,7 @@ CONTAINS
          POINTER                                         :: external_ab, external_i_aL
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: BI_C_rec
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_P, &
-                                                            para_env_rep
+      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange, para_env_rep
       TYPE(dgemm_counter_type)                           :: dgemm_counter
       TYPE(three_dim_real_array), ALLOCATABLE, &
          DIMENSION(:)                                    :: B_ia_Q
@@ -662,15 +662,17 @@ CONTAINS
          DEALLOCATE (B_ia_Q)
 
          IF (nspins == 1) mp2_env%ri_grad%P_ab(1)%array(:, :) = mp2_env%ri_grad%P_ab(1)%array(:, :)*2.0_dp
-         sub_P_color = para_env_sub%mepos
-         ALLOCATE (para_env_P)
-         CALL para_env_P%from_split(para_env, sub_P_color)
-         DO ispin = 1, nspins
-            CALL para_env_P%sum(mp2_env%ri_grad%P_ab(ispin)%array)
-            CALL para_env%sum(mp2_env%ri_grad%P_ij(ispin)%array)
-         END DO
-         ! release para_env_P
-         CALL cp_para_env_release(para_env_P)
+         BLOCK
+            TYPE(mp_comm_type) :: comm
+            CALL comm%from_split(para_env, para_env_sub%mepos)
+            DO ispin = 1, nspins
+               ! P_ab is only replicated over all subgroups
+               CALL comm%sum(mp2_env%ri_grad%P_ab(ispin)%array)
+               ! P_ij is replicated over all processes
+               CALL para_env%sum(mp2_env%ri_grad%P_ij(ispin)%array)
+            END DO
+            CALL comm%free()
+         END BLOCK
       END IF
 
       CALL release_group_dist(gd_array)

--- a/src/mp2_ri_grad_util.F
+++ b/src/mp2_ri_grad_util.F
@@ -86,7 +86,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: B_ia_Q
       INTEGER, INTENT(IN)                                :: dimen_RI, homo, virtual
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env, para_env_sub
       INTEGER, INTENT(IN)                                :: ngroup, my_group_L_size, &
                                                             my_group_L_start, my_group_L_end, &
                                                             my_B_size, my_B_virtual_start
@@ -343,7 +343,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: homo, my_B_size, virtual, &
                                                             my_B_virtual_start, my_ia_start, &
                                                             my_ia_end, my_ia_size, my_group_L_size
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_sub
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_B_virtual
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mat_3d_to_2d'
@@ -418,7 +418,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: homo, my_B_size, virtual, &
                                                             my_B_virtual_start, my_ia_start, &
                                                             my_ia_end, my_ia_size, my_group_L_size
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_sub
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env_sub
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_B_virtual
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mat_3d_to_2d_gamma'
@@ -1253,7 +1253,7 @@ CONTAINS
                                  gd_ia, dbcsr_Gamma, mo_coeff_o)
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: Gamma_2D
       INTEGER, INTENT(IN)                                :: homo, virtual, dimen_ia
-      TYPE(cp_para_env_type), POINTER                    :: para_env_sub
+      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env_sub
       INTEGER, INTENT(IN)                                :: my_ia_start, my_ia_end, my_group_L_size
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_ia
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(INOUT)    :: dbcsr_Gamma

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -880,7 +880,7 @@ MODULE message_passing
    INTEGER, PARAMETER :: max_stack_size = 10
    INTEGER            :: stack_pointer = 0
    ! target attribute needed as a hack around ifc 7.1 bug
-   TYPE(mp_perf_env_p_type), DIMENSION(max_stack_size), TARGET, SAVE :: mp_perf_stack
+   TYPE(mp_perf_env_p_type), DIMENSION(max_stack_size), SAVE :: mp_perf_stack
 
    CHARACTER(LEN=20), PARAMETER :: sname(MAX_PERF) = &
                                    (/"MP_Group            ", "MP_Bcast            ", "MP_Allreduce        ", &

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -211,14 +211,28 @@ MODULE message_passing
          mp_bcast_d, mp_bcast_dv, mp_bcast_dm, mp_bcast_d3, &
          mp_bcast_c, mp_bcast_cv, mp_bcast_cm, mp_bcast_c3, &
          mp_bcast_z, mp_bcast_zv, mp_bcast_zm, mp_bcast_z3, &
-         mp_bcast_b, mp_bcast_bv, mp_bcast_av, mp_bcast_am
+         mp_bcast_b, mp_bcast_bv, mp_bcast_av, mp_bcast_am, &
+         mp_bcast_i_src, mp_bcast_iv_src, mp_bcast_im_src, mp_bcast_i3_src, &
+         mp_bcast_l_src, mp_bcast_lv_src, mp_bcast_lm_src, mp_bcast_l3_src, &
+         mp_bcast_r_src, mp_bcast_rv_src, mp_bcast_rm_src, mp_bcast_r3_src, &
+         mp_bcast_d_src, mp_bcast_dv_src, mp_bcast_dm_src, mp_bcast_d3_src, &
+         mp_bcast_c_src, mp_bcast_cv_src, mp_bcast_cm_src, mp_bcast_c3_src, &
+         mp_bcast_z_src, mp_bcast_zv_src, mp_bcast_zm_src, mp_bcast_z3_src, &
+         mp_bcast_b_src, mp_bcast_bv_src, mp_bcast_av_src, mp_bcast_am_src
       GENERIC, PUBLIC :: bcast => mp_bcast_i, mp_bcast_iv, mp_bcast_im, mp_bcast_i3, &
          mp_bcast_l, mp_bcast_lv, mp_bcast_lm, mp_bcast_l3, &
          mp_bcast_r, mp_bcast_rv, mp_bcast_rm, mp_bcast_r3, &
          mp_bcast_d, mp_bcast_dv, mp_bcast_dm, mp_bcast_d3, &
          mp_bcast_c, mp_bcast_cv, mp_bcast_cm, mp_bcast_c3, &
          mp_bcast_z, mp_bcast_zv, mp_bcast_zm, mp_bcast_z3, &
-         mp_bcast_b, mp_bcast_bv, mp_bcast_av, mp_bcast_am
+         mp_bcast_b, mp_bcast_bv, mp_bcast_av, mp_bcast_am, &
+         mp_bcast_i_src, mp_bcast_iv_src, mp_bcast_im_src, mp_bcast_i3_src, &
+         mp_bcast_l_src, mp_bcast_lv_src, mp_bcast_lm_src, mp_bcast_l3_src, &
+         mp_bcast_r_src, mp_bcast_rv_src, mp_bcast_rm_src, mp_bcast_r3_src, &
+         mp_bcast_d_src, mp_bcast_dv_src, mp_bcast_dm_src, mp_bcast_d3_src, &
+         mp_bcast_c_src, mp_bcast_cv_src, mp_bcast_cm_src, mp_bcast_c3_src, &
+         mp_bcast_z_src, mp_bcast_zv_src, mp_bcast_zm_src, mp_bcast_z3_src, &
+         mp_bcast_b_src, mp_bcast_bv_src, mp_bcast_av_src, mp_bcast_am_src
 
       PROCEDURE, PRIVATE, PASS(comm), NON_OVERRIDABLE :: mp_ibcast_i, mp_ibcast_iv, &
          mp_ibcast_l, mp_ibcast_lv, mp_ibcast_r, mp_ibcast_rv, &
@@ -520,6 +534,7 @@ MODULE message_passing
       PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: get_size => mp_comm_size
       PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: get_rank => mp_comm_rank
       PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: get_ndims => mp_comm_get_ndims
+      PROCEDURE, PUBLIC, PASS(comm), NON_OVERRIDABLE :: is_source => mp_comm_is_source
 
       PROCEDURE, PRIVATE, PASS(sub_comm), NON_OVERRIDABLE :: mp_comm_split, mp_comm_split_direct
       GENERIC, PUBLIC :: from_split => mp_comm_split, mp_comm_split_direct
@@ -1751,6 +1766,18 @@ CONTAINS
       END SUBROUTINE
 
 ! **************************************************************************************************
+!> \brief check whether the local process is the source process
+!> \param para_env ...
+!> \return ...
+! **************************************************************************************************
+      ELEMENTAL LOGICAL FUNCTION mp_comm_is_source(comm)
+         CLASS(mp_comm_type), INTENT(IN) :: comm
+
+         mp_comm_is_source = comm%source == comm%mepos
+
+      END FUNCTION mp_comm_is_source
+
+! **************************************************************************************************
 !> \brief Initializes the communicator (mostly relevant for its derived classes)
 !> \param comm ...
 ! **************************************************************************************************
@@ -2552,6 +2579,37 @@ CONTAINS
 !> \param source ...
 !> \param comm ...
 ! **************************************************************************************************
+      SUBROUTINE mp_bcast_b_src(msg, comm)
+         LOGICAL, INTENT(INOUT)                                            :: msg
+         CLASS(mp_comm_type), INTENT(IN) :: comm
+
+         CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_b_src'
+
+         INTEGER                                            :: handle
+#if defined(__parallel)
+         INTEGER :: ierr, msglen
+#endif
+
+         CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+         msglen = 1
+         CALL mpi_bcast(msg, msglen, MPI_LOGICAL, comm%source, comm%handle, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+         CALL add_perf(perf_id=2, count=1, msg_size=msglen*loglen)
+#else
+         MARK_USED(msg)
+         MARK_USED(comm)
+#endif
+         CALL mp_timestop(handle)
+      END SUBROUTINE mp_bcast_b_src
+
+! **************************************************************************************************
+!> \brief ...
+!> \param msg ...
+!> \param source ...
+!> \param comm ...
+! **************************************************************************************************
       SUBROUTINE mp_bcast_bv(msg, source, comm)
          LOGICAL, CONTIGUOUS, INTENT(INOUT)                 :: msg(:)
          INTEGER, INTENT(IN)                                            :: source
@@ -2578,6 +2636,36 @@ CONTAINS
 #endif
          CALL mp_timestop(handle)
       END SUBROUTINE mp_bcast_bv
+
+! **************************************************************************************************
+!> \brief ...
+!> \param msg ...
+!> \param comm ...
+! **************************************************************************************************
+      SUBROUTINE mp_bcast_bv_src(msg, comm)
+         LOGICAL, CONTIGUOUS, INTENT(INOUT)                 :: msg(:)
+         CLASS(mp_comm_type), INTENT(IN) :: comm
+
+         CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_bv_src'
+
+         INTEGER                                            :: handle
+#if defined(__parallel)
+         INTEGER :: ierr, msglen
+#endif
+
+         CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+         msglen = SIZE(msg)
+         CALL mpi_bcast(msg, msglen, MPI_LOGICAL, comm%source, comm%handle, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+         CALL add_perf(perf_id=2, count=1, msg_size=msglen*loglen)
+#else
+         MARK_USED(msg)
+         MARK_USED(comm)
+#endif
+         CALL mp_timestop(handle)
+      END SUBROUTINE mp_bcast_bv_src
 
 ! **************************************************************************************************
 !> \brief Non-blocking send of logical vector data
@@ -2839,7 +2927,7 @@ CONTAINS
 
          INTEGER                                  :: handle
 #if defined(__parallel)
-         INTEGER                                  :: i, ierr, msglen, taskid
+         INTEGER                                  :: i, ierr, msglen
          INTEGER, DIMENSION(:), ALLOCATABLE       :: imsg
 #endif
 
@@ -2847,8 +2935,7 @@ CONTAINS
 
 #if defined(__parallel)
 
-         CALL comm%get_rank(taskid)
-         IF (taskid == source) msglen = LEN_TRIM(msg)
+         IF (comm%mepos == source) msglen = LEN_TRIM(msg)
 
          CALL comm%bcast(msglen, source)
          ! this is a workaround to avoid problems on the T3E
@@ -2879,6 +2966,54 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param msg ...
+!> \param comm ...
+! **************************************************************************************************
+      SUBROUTINE mp_bcast_av_src(msg, comm)
+         CHARACTER(LEN=*), INTENT(INOUT)          :: msg
+         CLASS(mp_comm_type), INTENT(IN) :: comm
+
+         CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_av_src'
+
+         INTEGER                                  :: handle
+#if defined(__parallel)
+         INTEGER                                  :: i, ierr, msglen
+         INTEGER, DIMENSION(:), ALLOCATABLE       :: imsg
+#endif
+
+         CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+
+         IF (comm%is_source()) msglen = LEN_TRIM(msg)
+
+         CALL comm%bcast(msglen, comm%source)
+         ! this is a workaround to avoid problems on the T3E
+         ! at the moment we have a data alignment error when trying to
+         ! broadcast characters on the T3E (not always!)
+         ! JH 19/3/99 on galileo
+         ! CALL mpi_bcast(msg,msglen,MPI_CHARACTER,source,gid%handle,ierr)
+         ALLOCATE (imsg(1:msglen))
+         DO i = 1, msglen
+            imsg(i) = ICHAR(msg(i:i))
+         END DO
+         CALL mpi_bcast(imsg, msglen, MPI_INTEGER, comm%source, comm%handle, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+         msg = ""
+         DO i = 1, msglen
+            msg(i:i) = CHAR(imsg(i))
+         END DO
+         DEALLOCATE (imsg)
+         CALL add_perf(perf_id=2, count=1, msg_size=msglen*charlen)
+#else
+         MARK_USED(msg)
+         MARK_USED(comm)
+#endif
+         CALL mp_timestop(handle)
+      END SUBROUTINE mp_bcast_av_src
+
+! **************************************************************************************************
+!> \brief ...
+!> \param msg ...
 !> \param source ...
 !> \param comm ...
 ! **************************************************************************************************
@@ -2891,21 +3026,21 @@ CONTAINS
 
          INTEGER                                  :: handle
 #if defined(__parallel)
-         INTEGER                                  :: i, ierr, j, k, msglen, msgsiz, &
-                                                     taskid
+         INTEGER                                  :: i, ierr, j, k, msglen, msgsiz
          INTEGER, ALLOCATABLE                     :: imsg(:), imsglen(:)
 #endif
 
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
-         CALL comm%get_rank(taskid)
          msgsiz = SIZE(msg)
          ! Determine size of the minimum array of integers to broadcast the string
          ALLOCATE (imsglen(1:msgsiz))
-         DO j = 1, msgsiz
-            IF (taskid == source) imsglen(j) = LEN_TRIM(msg(j))
-         END DO
+         IF (comm%mepos == source) THEN
+            DO j = 1, msgsiz
+               imsglen(j) = LEN_TRIM(msg(j))
+            END DO
+         END IF
          CALL comm%bcast(imsglen, source)
          msglen = SUM(imsglen)
          ! this is a workaround to avoid problems on the T3E
@@ -2940,6 +3075,61 @@ CONTAINS
 #endif
          CALL mp_timestop(handle)
       END SUBROUTINE mp_bcast_am
+
+      SUBROUTINE mp_bcast_am_src(msg, comm)
+         CHARACTER(LEN=*), CONTIGUOUS, INTENT(INOUT)      :: msg(:)
+         CLASS(mp_comm_type), INTENT(IN) :: comm
+
+         CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_am_src'
+
+         INTEGER                                  :: handle
+#if defined(__parallel)
+         INTEGER                                  :: i, ierr, j, k, msglen, msgsiz
+         INTEGER, ALLOCATABLE                     :: imsg(:), imsglen(:)
+#endif
+
+         CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+         msgsiz = SIZE(msg)
+         ! Determine size of the minimum array of integers to broadcast the string
+         ALLOCATE (imsglen(1:msgsiz))
+         DO j = 1, msgsiz
+            imsglen(j) = LEN_TRIM(msg(j))
+         END DO
+         CALL comm%bcast(imsglen, comm%source)
+         msglen = SUM(imsglen)
+         ! this is a workaround to avoid problems on the T3E
+         ! at the moment we have a data alignment error when trying to
+         ! broadcast characters on the T3E (not always!)
+         ! JH 19/3/99 on galileo
+         ALLOCATE (imsg(1:msglen))
+         k = 0
+         DO j = 1, msgsiz
+            DO i = 1, imsglen(j)
+               k = k + 1
+               imsg(k) = ICHAR(msg(j) (i:i))
+            END DO
+         END DO
+         CALL mpi_bcast(imsg, msglen, MPI_INTEGER, comm%source, comm%handle, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+         msg = ""
+         k = 0
+         DO j = 1, msgsiz
+            DO i = 1, imsglen(j)
+               k = k + 1
+               msg(j) (i:i) = CHAR(imsg(k))
+            END DO
+         END DO
+         DEALLOCATE (imsg)
+         DEALLOCATE (imsglen)
+         CALL add_perf(perf_id=2, count=1, msg_size=msglen*charlen*msgsiz)
+#else
+         MARK_USED(msg)
+         MARK_USED(comm)
+#endif
+         CALL mp_timestop(handle)
+      END SUBROUTINE mp_bcast_am_src
 
 ! **************************************************************************************************
 !> \brief Finds the location of the minimal element in a vector.
@@ -4599,9 +4789,9 @@ CONTAINS
          ! set system sizes !
          ngrid = 10**npow
 
-         CALL mpi_comm_rank(comm%handle, taskid, ierror)
-         CALL mpi_comm_size(comm%handle, Nprocs, ierror)
-         ionode = (taskid == 0)
+         taskid = comm%mepos
+         nprocs = comm%num_pe
+         ionode = comm%is_source()
          IF (ionode .AND. output_unit > 0) THEN
             WRITE (output_unit, *) "Running with ", nprocs
             WRITE (output_unit, *) "running messages with npow = ", npow

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -305,22 +305,40 @@ MODULE message_passing
          mp_gather_r, mp_gather_rv, mp_gather_rm, &
          mp_gather_d, mp_gather_dv, mp_gather_dm, &
          mp_gather_c, mp_gather_cv, mp_gather_cm, &
-         mp_gather_z, mp_gather_zv, mp_gather_zm
+         mp_gather_z, mp_gather_zv, mp_gather_zm, &
+         mp_gather_i_src, mp_gather_iv_src, mp_gather_im_src, &
+         mp_gather_l_src, mp_gather_lv_src, mp_gather_lm_src, &
+         mp_gather_r_src, mp_gather_rv_src, mp_gather_rm_src, &
+         mp_gather_d_src, mp_gather_dv_src, mp_gather_dm_src, &
+         mp_gather_c_src, mp_gather_cv_src, mp_gather_cm_src, &
+         mp_gather_z_src, mp_gather_zv_src, mp_gather_zm_src
       GENERIC, PUBLIC :: gather => mp_gather_i, mp_gather_iv, mp_gather_im, &
          mp_gather_l, mp_gather_lv, mp_gather_lm, &
          mp_gather_r, mp_gather_rv, mp_gather_rm, &
          mp_gather_d, mp_gather_dv, mp_gather_dm, &
          mp_gather_c, mp_gather_cv, mp_gather_cm, &
-         mp_gather_z, mp_gather_zv, mp_gather_zm
+         mp_gather_z, mp_gather_zv, mp_gather_zm, &
+         mp_gather_i_src, mp_gather_iv_src, mp_gather_im_src, &
+         mp_gather_l_src, mp_gather_lv_src, mp_gather_lm_src, &
+         mp_gather_r_src, mp_gather_rv_src, mp_gather_rm_src, &
+         mp_gather_d_src, mp_gather_dv_src, mp_gather_dm_src, &
+         mp_gather_c_src, mp_gather_cv_src, mp_gather_cm_src, &
+         mp_gather_z_src, mp_gather_zv_src, mp_gather_zm_src
 
       PROCEDURE, PRIVATE, PASS(comm), NON_OVERRIDABLE :: mp_gatherv_iv, &
          mp_gatherv_lv, mp_gatherv_rv, mp_gatherv_dv, &
          mp_gatherv_cv, mp_gatherv_zv, mp_gatherv_lm2, mp_gatherv_rm2, &
-         mp_gatherv_dm2, mp_gatherv_cm2, mp_gatherv_zm2
+         mp_gatherv_dm2, mp_gatherv_cm2, mp_gatherv_zm2, mp_gatherv_iv_src, &
+         mp_gatherv_lv_src, mp_gatherv_rv_src, mp_gatherv_dv_src, &
+         mp_gatherv_cv_src, mp_gatherv_zv_src, mp_gatherv_lm2_src, mp_gatherv_rm2_src, &
+         mp_gatherv_dm2_src, mp_gatherv_cm2_src, mp_gatherv_zm2_src
       GENERIC, PUBLIC :: gatherv => mp_gatherv_iv, &
          mp_gatherv_lv, mp_gatherv_rv, mp_gatherv_dv, &
          mp_gatherv_cv, mp_gatherv_zv, mp_gatherv_lm2, mp_gatherv_rm2, &
-         mp_gatherv_dm2, mp_gatherv_cm2, mp_gatherv_zm2
+         mp_gatherv_dm2, mp_gatherv_cm2, mp_gatherv_zm2, mp_gatherv_iv_src, &
+         mp_gatherv_lv_src, mp_gatherv_rv_src, mp_gatherv_dv_src, &
+         mp_gatherv_cv_src, mp_gatherv_zv_src, mp_gatherv_lm2_src, mp_gatherv_rm2_src, &
+         mp_gatherv_dm2_src, mp_gatherv_cm2_src, mp_gatherv_zm2_src
 
       PROCEDURE, PRIVATE, PASS(comm), NON_OVERRIDABLE :: mp_igatherv_iv, &
          mp_igatherv_lv, mp_igatherv_rv, mp_igatherv_dv, &

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -1963,6 +1963,41 @@
    END SUBROUTINE mp_gather_${nametype1}$
 
 ! **************************************************************************************************
+!> \brief Gathers a datum from all processes to one, uses the source process of comm
+!> \param[in] msg             Datum to send to root
+!> \param[out] msg_gather     Received data (on root)
+!> \param[in] comm            Message passing environment identifier
+!> \par MPI mapping
+!>      mpi_gather
+! **************************************************************************************************
+   SUBROUTINE mp_gather_${nametype1}$_src(msg, msg_gather, comm)
+      ${type1}$, INTENT(IN)                      :: msg
+      ${type1}$, CONTIGUOUS, INTENT(OUT)                     :: msg_gather(:)
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER :: ierr, msglen
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      msglen = 1
+      CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
+                      msglen, ${mpi_type1}$, comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
+      CALL add_perf(perf_id=4, count=1, msg_size=msglen*${bytes1}$)
+#else
+      MARK_USED(comm)
+      msg_gather(1) = msg
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_gather_${nametype1}$_src
+
+! **************************************************************************************************
 !> \brief Gathers data from all processes to one
 !> \param[in] msg             Datum to send to root
 !> \param msg_gather ...
@@ -2004,6 +2039,44 @@
    END SUBROUTINE mp_gather_${nametype1}$v
 
 ! **************************************************************************************************
+!> \brief Gathers data from all processes to one. Gathers from comm%source
+!> \param[in] msg             Datum to send to root
+!> \param msg_gather ...
+!> \param comm ...
+!> \par Data length
+!>      All data (msg) is equal-sized
+!> \par MPI mapping
+!>      mpi_gather
+!> \note see mp_gather_${nametype1}$
+! **************************************************************************************************
+   SUBROUTINE mp_gather_${nametype1}$v_src(msg, msg_gather, comm)
+      ${type1}$, CONTIGUOUS, INTENT(IN)                      :: msg(:)
+      ${type1}$, CONTIGUOUS, INTENT(OUT)                     :: msg_gather(:)
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$v_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER :: ierr, msglen
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      msglen = SIZE(msg)
+      CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
+                      msglen, ${mpi_type1}$, comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
+      CALL add_perf(perf_id=4, count=1, msg_size=msglen*${bytes1}$)
+#else
+      MARK_USED(comm)
+      msg_gather = msg
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_gather_${nametype1}$v_src
+
+! **************************************************************************************************
 !> \brief Gathers data from all processes to one
 !> \param[in] msg             Datum to send to root
 !> \param msg_gather ...
@@ -2043,6 +2116,44 @@
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_gather_${nametype1}$m
+
+! **************************************************************************************************
+!> \brief Gathers data from all processes to one. Gathers from comm%source
+!> \param[in] msg             Datum to send to root
+!> \param msg_gather ...
+!> \param comm ...
+!> \par Data length
+!>      All data (msg) is equal-sized
+!> \par MPI mapping
+!>      mpi_gather
+!> \note see mp_gather_${nametype1}$
+! **************************************************************************************************
+   SUBROUTINE mp_gather_${nametype1}$m_src(msg, msg_gather, comm)
+      ${type1}$, CONTIGUOUS, INTENT(IN)                      :: msg(:, :)
+      ${type1}$, CONTIGUOUS, INTENT(OUT)                     :: msg_gather(:, :)
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_gather_${nametype1}$m_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER :: ierr, msglen
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      msglen = SIZE(msg)
+      CALL mpi_gather(msg, msglen, ${mpi_type1}$, msg_gather, &
+                      msglen, ${mpi_type1}$, comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gather @ "//routineN)
+      CALL add_perf(perf_id=4, count=1, msg_size=msglen*${bytes1}$)
+#else
+      MARK_USED(comm)
+      msg_gather = msg
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_gather_${nametype1}$m_src
 
 ! **************************************************************************************************
 !> \brief Gathers data from all processes to one.
@@ -2095,6 +2206,53 @@
    END SUBROUTINE mp_gatherv_${nametype1}$v
 
 ! **************************************************************************************************
+!> \brief Gathers data from all processes to one. Gathers from comm%source
+!> \param[in] sendbuf         Data to send to root
+!> \param[out] recvbuf        Received data (on root)
+!> \param[in] recvcounts      Sizes of data received from processes
+!> \param[in] displs          Offsets of data received from processes
+!> \param[in] comm            Message passing environment identifier
+!> \par Data length
+!>      Data can have different lengths
+!> \par Offsets
+!>      Offsets start at 0
+!> \par MPI mapping
+!>      mpi_gather
+! **************************************************************************************************
+   SUBROUTINE mp_gatherv_${nametype1}$v_src(sendbuf, recvbuf, recvcounts, displs, comm)
+
+      ${type1}$, DIMENSION(:), CONTIGUOUS, INTENT(IN)        :: sendbuf
+      ${type1}$, DIMENSION(:), CONTIGUOUS, INTENT(OUT)       :: recvbuf
+      INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(IN)        :: recvcounts, displs
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_gatherv_${nametype1}$v_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER                                  :: ierr, sendcount
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      sendcount = SIZE(sendbuf)
+      CALL mpi_gatherv(sendbuf, sendcount, ${mpi_type1}$, &
+                       recvbuf, recvcounts, displs, ${mpi_type1}$, &
+                       comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gatherv @ "//routineN)
+      CALL add_perf(perf_id=4, &
+                    count=1, &
+                    msg_size=sendcount*${bytes1}$)
+#else
+      MARK_USED(recvcounts)
+      MARK_USED(comm)
+      recvbuf(1 + displs(1):) = sendbuf
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_gatherv_${nametype1}$v_src
+
+! **************************************************************************************************
 !> \brief Gathers data from all processes to one.
 !> \param[in] sendbuf         Data to send to root
 !> \param[out] recvbuf        Received data (on root)
@@ -2143,6 +2301,53 @@
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_gatherv_${nametype1}$m2
+
+! **************************************************************************************************
+!> \brief Gathers data from all processes to one.
+!> \param[in] sendbuf         Data to send to root
+!> \param[out] recvbuf        Received data (on root)
+!> \param[in] recvcounts      Sizes of data received from processes
+!> \param[in] displs          Offsets of data received from processes
+!> \param[in] comm            Message passing environment identifier
+!> \par Data length
+!>      Data can have different lengths
+!> \par Offsets
+!>      Offsets start at 0
+!> \par MPI mapping
+!>      mpi_gather
+! **************************************************************************************************
+   SUBROUTINE mp_gatherv_${nametype1}$m2_src(sendbuf, recvbuf, recvcounts, displs, comm)
+
+      ${type1}$, DIMENSION(:, :), CONTIGUOUS, INTENT(IN)        :: sendbuf
+      ${type1}$, DIMENSION(:, :), CONTIGUOUS, INTENT(OUT)       :: recvbuf
+      INTEGER, DIMENSION(:), CONTIGUOUS, INTENT(IN)        :: recvcounts, displs
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_gatherv_${nametype1}$m2_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER                                  :: ierr, sendcount
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      sendcount = SIZE(sendbuf)
+      CALL mpi_gatherv(sendbuf, sendcount, ${mpi_type1}$, &
+                       recvbuf, recvcounts, displs, ${mpi_type1}$, &
+                       comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_gatherv @ "//routineN)
+      CALL add_perf(perf_id=4, &
+                    count=1, &
+                    msg_size=sendcount*${bytes1}$)
+#else
+      MARK_USED(recvcounts)
+      MARK_USED(comm)
+      recvbuf(:, 1 + displs(1):) = sendbuf
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_gatherv_${nametype1}$m2_src
 
 ! **************************************************************************************************
 !> \brief Gathers data from all processes to one.

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -763,11 +763,16 @@
 
 #if defined(__parallel)
       msglen = 1
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
-      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
-      CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
-      source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
-      tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      IF (source /= mp_any_source .AND. tag /= mp_any_tag) THEN
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, MPI_STATUS_IGNORE, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+      ELSE
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+         CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
+         source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
+         tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      END IF
 #else
       MARK_USED(msg)
       MARK_USED(source)
@@ -804,11 +809,16 @@
 
 #if defined(__parallel)
       msglen = SIZE(msg)
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
-      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
-      CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
-      source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
-      tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      IF (source /= mp_any_source .AND. tag /= mp_any_tag) THEN
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, MPI_STATUS_IGNORE, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+      ELSE
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+         CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
+         source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
+         tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      END IF
 #else
       MARK_USED(msg)
       MARK_USED(source)
@@ -845,11 +855,16 @@
 
 #if defined(__parallel)
       msglen = SIZE(msg)
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
-      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
-      CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
-      source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
-      tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      IF (source /= mp_any_source .AND. tag /= mp_any_tag) THEN
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, MPI_STATUS_IGNORE, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+      ELSE
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+         CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
+         source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
+         tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      END IF
 #else
       MARK_USED(msg)
       MARK_USED(source)
@@ -886,11 +901,16 @@
 
 #if defined(__parallel)
       msglen = SIZE(msg)
-      CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
-      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
-      CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
-      source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
-      tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      IF (source /= mp_any_source .AND. tag /= mp_any_tag) THEN
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, MPI_STATUS_IGNORE, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+      ELSE
+         CALL mpi_recv(msg, msglen, ${mpi_type1}$, source, tag, comm%handle, status, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_recv @ "//routineN)
+         CALL add_perf(perf_id=14, count=1, msg_size=msglen*${bytes1}$)
+         source = status MPI_STATUS_EXTRACT(MPI_SOURCE)
+         tag = status MPI_STATUS_EXTRACT(MPI_TAG)
+      END IF
 #else
       MARK_USED(msg)
       MARK_USED(source)

--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -938,6 +938,38 @@
    END SUBROUTINE mp_bcast_${nametype1}$
 
 ! **************************************************************************************************
+!> \brief Broadcasts a datum to all processes. Convenience function using the source of the communicator
+!> \param[in] msg             Datum to broadcast
+!> \param[in] comm             Message passing environment identifier
+!> \par MPI mapping
+!>      mpi_bcast
+! **************************************************************************************************
+   SUBROUTINE mp_bcast_${nametype1}$_src(msg, comm)
+      ${type1}$, INTENT(INOUT)                                  :: msg
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER :: ierr, msglen
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      msglen = 1
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+      CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
+#else
+      MARK_USED(msg)
+      MARK_USED(comm)
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_bcast_${nametype1}$_src
+
+! **************************************************************************************************
 !> \brief Broadcasts a datum to all processes.
 !> \param[in] msg             Datum to broadcast
 !> \param[in] source          Processes which broadcasts
@@ -1009,6 +1041,37 @@
    END SUBROUTINE mp_bcast_${nametype1}$v
 
 ! **************************************************************************************************
+!> \brief Broadcasts rank-1 data to all processes, uses the source of the communicator, convenience function
+!> \param[in] msg             Data to broadcast
+!> \param comm ...
+!> \note see mp_bcast_${nametype1}$1
+! **************************************************************************************************
+   SUBROUTINE mp_bcast_${nametype1}$v_src(msg, comm)
+      ${type1}$, CONTIGUOUS, INTENT(INOUT)                                  :: msg(:)
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$v_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER :: ierr, msglen
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      msglen = SIZE(msg)
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+      CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
+#else
+      MARK_USED(msg)
+      MARK_USED(comm)
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_bcast_${nametype1}$v_src
+
+! **************************************************************************************************
 !> \brief Broadcasts rank-1 data to all processes
 !> \param[in] msg             Data to broadcast
 !> \param source ...
@@ -1059,7 +1122,7 @@
       INTEGER, INTENT(IN)                                  :: source
       CLASS(mp_comm_type), INTENT(IN) :: comm
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_im'
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$m'
 
       INTEGER                                  :: handle
 #if defined(__parallel)
@@ -1080,6 +1143,38 @@
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_bcast_${nametype1}$m
+
+! **************************************************************************************************
+!> \brief Broadcasts rank-2 data to all processes
+!> \param[in] msg             Data to broadcast
+!> \param source ...
+!> \param comm ...
+!> \note see mp_bcast_${nametype1}$1
+! **************************************************************************************************
+   SUBROUTINE mp_bcast_${nametype1}$m_src(msg, comm)
+      ${type1}$, CONTIGUOUS, INTENT(INOUT)                                  :: msg(:, :)
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$m_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER :: ierr, msglen
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      msglen = SIZE(msg)
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+      CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
+#else
+      MARK_USED(msg)
+      MARK_USED(comm)
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_bcast_${nametype1}$m_src
 
 ! **************************************************************************************************
 !> \brief Broadcasts rank-3 data to all processes
@@ -1114,6 +1209,38 @@
 #endif
       CALL mp_timestop(handle)
    END SUBROUTINE mp_bcast_${nametype1}$3
+
+! **************************************************************************************************
+!> \brief Broadcasts rank-3 data to all processes. Uses the source of the communicator for convenience
+!> \param[in] msg             Data to broadcast
+!> \param source ...
+!> \param comm ...
+!> \note see mp_bcast_${nametype1}$1
+! **************************************************************************************************
+   SUBROUTINE mp_bcast_${nametype1}$3_src(msg, comm)
+      ${type1}$, CONTIGUOUS                                  :: msg(:, :, :)
+      CLASS(mp_comm_type), INTENT(IN) :: comm
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'mp_bcast_${nametype1}$3_src'
+
+      INTEGER                                  :: handle
+#if defined(__parallel)
+      INTEGER :: ierr, msglen
+#endif
+
+      CALL mp_timeset(routineN, handle)
+
+#if defined(__parallel)
+      msglen = SIZE(msg)
+      CALL mpi_bcast(msg, msglen, ${mpi_type1}$, comm%source, comm%handle, ierr)
+      IF (ierr /= 0) CALL mp_stop(ierr, "mpi_bcast @ "//routineN)
+      CALL add_perf(perf_id=2, count=1, msg_size=msglen*${bytes1}$)
+#else
+      MARK_USED(msg)
+      MARK_USED(comm)
+#endif
+      CALL mp_timestop(handle)
+   END SUBROUTINE mp_bcast_${nametype1}$3_src
 
 ! **************************************************************************************************
 !> \brief Sums a datum from all processes with result left on all processes.

--- a/src/nnp_model.F
+++ b/src/nnp_model.F
@@ -44,7 +44,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE nnp_write_arc(nnp, para_env)
       TYPE(nnp_type), INTENT(IN)                         :: nnp
-      TYPE(cp_para_env_type), INTENT(IN), POINTER        :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
 
       CHARACTER(len=default_string_length)               :: my_label
       INTEGER                                            :: i, j, unit_nr

--- a/src/optimize_basis.F
+++ b/src/optimize_basis.F
@@ -198,8 +198,8 @@ CONTAINS
                                        para_env_top, para_env, iopt)
          IF (para_env_top%is_source()) &
             CALL powell_optimize(opt_bas%powell_param%nvar, opt_bas%x_opt, opt_bas%powell_param)
-         CALL para_env_top%bcast(opt_bas%powell_param%state, para_env_top%source)
-         CALL para_env_top%bcast(opt_bas%x_opt, para_env_top%source)
+         CALL para_env_top%bcast(opt_bas%powell_param%state)
+         CALL para_env_top%bcast(opt_bas%x_opt)
          CALL update_free_vars(opt_bas)
          write_basis = MOD(iopt, opt_bas%write_frequency) == 0
          CALL update_derived_basis_sets(opt_bas, write_basis, opt_bas%output_basis_file, &
@@ -213,7 +213,7 @@ CONTAINS
          CALL powell_optimize(opt_bas%powell_param%nvar, opt_bas%x_opt, opt_bas%powell_param)
       END IF
 
-      CALL para_env_top%bcast(opt_bas%x_opt, para_env_top%source)
+      CALL para_env_top%bcast(opt_bas%x_opt)
       CALL update_free_vars(opt_bas)
       CALL update_derived_basis_sets(opt_bas, .TRUE., opt_bas%output_basis_file, &
                                      para_env_top)
@@ -369,7 +369,7 @@ CONTAINS
       ELSE
          f_vec = 0.0_dp; cond_vec = 0.0_dp; my_time = 0.0_dp; energy = 0.0_dp
       END IF
-      CALL para_env_top%bcast(opt_bas%powell_param%f, para_env_top%source)
+      CALL para_env_top%bcast(opt_bas%powell_param%f)
 
       ! output info if required
       CALL output_opt_info(f_vec, cond_vec, my_time, tot_time, opt_bas, iopt, para_env_top)

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -823,7 +823,7 @@ CONTAINS
       END IF
 
       ! Broadcast the coefficients on all processes
-      CALL para_env%bcast(coef, para_env%source)
+      CALL para_env%bcast(coef)
 
       ! Copy to fm_type structure
       ! Information about full matrix gradient

--- a/src/optimize_input.F
+++ b/src/optimize_input.F
@@ -304,7 +304,7 @@ CONTAINS
 
          ! globalize the state
          IF (para_env%is_source()) state = ostate%state
-         CALL para_env%bcast(state, para_env%source)
+         CALL para_env%bcast(state)
 
          ! if required get the energy of this set of params
          IF (state == 2) THEN
@@ -451,7 +451,7 @@ CONTAINS
          IF (para_env%is_source()) THEN
             CALL powell_optimize(ostate%nvar, free_vars, ostate)
          END IF
-         CALL para_env%bcast(free_vars, para_env%source)
+         CALL para_env%bcast(free_vars)
 
       END DO
 
@@ -460,7 +460,7 @@ CONTAINS
          ostate%state = 8
          CALL powell_optimize(ostate%nvar, free_vars, ostate)
       END IF
-      CALL para_env%bcast(free_vars, para_env%source)
+      CALL para_env%bcast(free_vars)
       DO i_free_var = 1, n_free_var
          WRITE (initial_variables(2, free_var_index(i_free_var)), *) free_vars(i_free_var)
          oi_env%variables(free_var_index(i_free_var))%value = free_vars(i_free_var)

--- a/src/pao_io.F
+++ b/src/pao_io.F
@@ -157,7 +157,7 @@ CONTAINS
             CPASSERT(col_blk_sizes(iatom) == SIZE(xblocks(iatom)%p, 2))
             buffer = xblocks(iatom)%p
          END IF
-         CALL para_env%bcast(buffer, para_env%source)
+         CALL para_env%bcast(buffer)
          CALL dbcsr_get_block_p(matrix=pao%matrix_X, row=iatom, col=iatom, block=block_X, found=found)
          IF (ASSOCIATED(block_X)) &
             block_X = buffer

--- a/src/pao_ml.F
+++ b/src/pao_ml.F
@@ -176,19 +176,19 @@ CONTAINS
       END IF
 
       ! broadcast parsed raw training data
-      CALL para_env%bcast(nkinds, para_env%source)
-      CALL para_env%bcast(natoms, para_env%source)
+      CALL para_env%bcast(nkinds)
+      CALL para_env%bcast(natoms)
       IF (.NOT. para_env%is_source()) THEN
          ALLOCATE (hmat(3, 3))
          ALLOCATE (kindsmap(nkinds))
          ALLOCATE (positions(natoms, 3))
          ALLOCATE (atom2kind(natoms))
       END IF
-      CALL para_env%bcast(hmat, para_env%source)
-      CALL para_env%bcast(kindsmap, para_env%source)
-      CALL para_env%bcast(atom2kind, para_env%source)
-      CALL para_env%bcast(positions, para_env%source)
-      CALL para_env%bcast(ml_range, para_env%source)
+      CALL para_env%bcast(hmat)
+      CALL para_env%bcast(kindsmap)
+      CALL para_env%bcast(atom2kind)
+      CALL para_env%bcast(positions)
+      CALL para_env%bcast(ml_range)
 
       IF (ml_range(1) /= 1 .OR. ml_range(2) /= natoms) &
          CPWARN("Skipping some atoms for PAO-ML training.")

--- a/src/pexsi_types.F
+++ b/src/pexsi_types.F
@@ -125,8 +125,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'lib_pexsi_init'
 
-      INTEGER                                            :: handle, ispin, mynode, npSymbFact, &
-                                                            numnodes, unit_nr
+      INTEGER                                            :: handle, ispin, npSymbFact, &
+                                                            unit_nr
       TYPE(cp_logger_type), POINTER                      :: logger
 
       logger => cp_get_default_logger()
@@ -142,46 +142,46 @@ CONTAINS
       CALL cite_reference(Lin2013)
 
       pexsi_env%mp_group = mp_group
-      numnodes = pexsi_env%mp_group%num_pe
-      mynode = pexsi_env%mp_group%mepos
+      ASSOCIATE (numnodes => pexsi_env%mp_group%num_pe, mynode => pexsi_env%mp_group%mepos)
 
-      ! Use all nodes available per pole by default or if the user tries to use
-      ! more nodes than MPI size
-      IF ((pexsi_env%num_ranks_per_pole .GT. numnodes) &
-          .OR. (pexsi_env%num_ranks_per_pole .EQ. 0)) THEN
-         pexsi_env%num_ranks_per_pole = numnodes
-      END IF
+         ! Use all nodes available per pole by default or if the user tries to use
+         ! more nodes than MPI size
+         IF ((pexsi_env%num_ranks_per_pole .GT. numnodes) &
+             .OR. (pexsi_env%num_ranks_per_pole .EQ. 0)) THEN
+            pexsi_env%num_ranks_per_pole = numnodes
+         END IF
 
-      ! Find num_ranks_per_pole from user input MIN_RANKS_PER_POLE s.t. num_ranks_per_pole
-      ! is the smallest number greater or equal to min_ranks_per_pole that divides
-      ! MPI size without remainder.
-      DO WHILE (MOD(numnodes, pexsi_env%num_ranks_per_pole) .NE. 0)
-         pexsi_env%num_ranks_per_pole = pexsi_env%num_ranks_per_pole + 1
-      END DO
+         ! Find num_ranks_per_pole from user input MIN_RANKS_PER_POLE s.t. num_ranks_per_pole
+         ! is the smallest number greater or equal to min_ranks_per_pole that divides
+         ! MPI size without remainder.
+         DO WHILE (MOD(numnodes, pexsi_env%num_ranks_per_pole) .NE. 0)
+            pexsi_env%num_ranks_per_pole = pexsi_env%num_ranks_per_pole + 1
+         END DO
 
-      CALL cp_pexsi_get_options(pexsi_env%options, npSymbFact=npSymbFact)
-      IF ((npSymbFact .GT. pexsi_env%num_ranks_per_pole) .OR. (npSymbFact .EQ. 0)) THEN
-         ! Use maximum possible number of ranks for symbolic factorization
-         CALL cp_pexsi_set_options(pexsi_env%options, npSymbFact=pexsi_env%num_ranks_per_pole)
-      END IF
+         CALL cp_pexsi_get_options(pexsi_env%options, npSymbFact=npSymbFact)
+         IF ((npSymbFact .GT. pexsi_env%num_ranks_per_pole) .OR. (npSymbFact .EQ. 0)) THEN
+            ! Use maximum possible number of ranks for symbolic factorization
+            CALL cp_pexsi_set_options(pexsi_env%options, npSymbFact=pexsi_env%num_ranks_per_pole)
+         END IF
 
-      ! Create dimensions for MPI cartesian grid for PEXSI
-      pexsi_env%mp_dims = 0
-      CALL mp_dims_create(pexsi_env%num_ranks_per_pole, pexsi_env%mp_dims)
+         ! Create dimensions for MPI cartesian grid for PEXSI
+         pexsi_env%mp_dims = 0
+         CALL mp_dims_create(pexsi_env%num_ranks_per_pole, pexsi_env%mp_dims)
 
-      ! allocations with nspin
-      pexsi_env%nspin = nspin
-      ALLOCATE (pexsi_env%kTS(nspin))
-      pexsi_env%kTS(:) = 0.0_dp
-      ALLOCATE (pexsi_env%max_ev_vector(nspin))
-      ALLOCATE (pexsi_env%matrix_w(nspin))
-      DO ispin = 1, pexsi_env%nspin
-         ALLOCATE (pexsi_env%matrix_w(ispin)%matrix)
-      END DO
+         ! allocations with nspin
+         pexsi_env%nspin = nspin
+         ALLOCATE (pexsi_env%kTS(nspin))
+         pexsi_env%kTS(:) = 0.0_dp
+         ALLOCATE (pexsi_env%max_ev_vector(nspin))
+         ALLOCATE (pexsi_env%matrix_w(nspin))
+         DO ispin = 1, pexsi_env%nspin
+            ALLOCATE (pexsi_env%matrix_w(ispin)%matrix)
+         END DO
 
-      ! Initialize PEXSI
-      pexsi_env%plan = cp_pexsi_plan_initialize(pexsi_env%mp_group, pexsi_env%mp_dims(1), &
-                                                pexsi_env%mp_dims(2), mynode)
+         ! Initialize PEXSI
+         pexsi_env%plan = cp_pexsi_plan_initialize(pexsi_env%mp_group, pexsi_env%mp_dims(1), &
+                                                   pexsi_env%mp_dims(2), mynode)
+      END ASSOCIATE
 
       pexsi_env%do_adaptive_tol_nel = .FALSE.
 

--- a/src/pw/realspace_grid_cube.F
+++ b/src/pw/realspace_grid_cube.F
@@ -245,10 +245,9 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_to_pw'
       INTEGER, PARAMETER                                 :: entry_len = 13, num_entries_line = 6
 
-      INTEGER                                            :: extunit, handle, i, ip, j, k, master, &
-                                                            msglen, my_rank, nat, ndum, &
-                                                            num_linebreak, num_pe, output_unit, &
-                                                            size_of_z, tag
+      INTEGER                                            :: extunit, handle, i, j, k, msglen, &
+                                                            my_rank, nat, ndum, num_linebreak, &
+                                                            num_pe, output_unit, size_of_z, tag
       INTEGER, DIMENSION(3)                              :: lbounds, lbounds_local, npoints, &
                                                             npoints_local, ubounds, ubounds_local
       LOGICAL                                            :: be_silent
@@ -323,16 +322,8 @@ CONTAINS
             DO j = lbounds(2), ubounds(2)
                IF (my_rank .EQ. 0) THEN
                   READ (extunit, *) (buffer(k), k=lbounds(3), ubounds(3))
-                  IF (num_pe .GT. 1) THEN
-                     DO ip = 1, num_pe - 1
-                        CALL gid%send(buffer(lbounds(3):ubounds(3)), ip, tag)
-                     END DO
-                  END IF
-               ELSE
-                  master = 0
-                  CALL gid%recv(buffer(lbounds(3):ubounds(3)), master, tag)
                END IF
-               CALL gid%sync()
+               CALL gid%bcast(buffer(lbounds(3):ubounds(3)), 0)
 
                !only use data that is local to me - i.e. in slice of pencil I own
                IF ((lbounds_local(1) .LE. i) .AND. (i .LE. ubounds_local(1)) .AND. (lbounds_local(2) .LE. j) &
@@ -391,8 +382,8 @@ CONTAINS
       INTEGER(kind=file_offset), ALLOCATABLE, &
          DIMENSION(:), TARGET                            :: displacements
       INTEGER(kind=file_offset)                          :: BOF
-      INTEGER :: extunit_handle, i, ientry, ip, islice, j, k, master, my_rank, nat, ndum, nslices, &
-         num_pe, offset_global, output_unit, pos, readstat, size_of_z, tag
+      INTEGER :: extunit_handle, i, ientry, islice, j, k, my_rank, nat, ndum, nslices, num_pe, &
+         offset_global, output_unit, pos, readstat, size_of_z, tag
       CHARACTER(LEN=msglen), ALLOCATABLE, DIMENSION(:)   :: readbuffer
       CHARACTER(LEN=msglen)                              :: tmp
       LOGICAL                                            :: be_silent, should_read(2)
@@ -593,16 +584,8 @@ CONTAINS
             DO j = lbounds(2), ubounds(2)
                IF (my_rank .EQ. 0) THEN
                   READ (extunit_handle, *) (buffer(k), k=lbounds(3), ubounds(3))
-                  IF (num_pe .GT. 1) THEN
-                     DO ip = 1, num_pe - 1
-                        CALL gid%send(buffer(lbounds(3):ubounds(3)), ip, tag)
-                     END DO
-                  END IF
-               ELSE
-                  master = 0
-                  CALL gid%recv(buffer(lbounds(3):ubounds(3)), master, tag)
                END IF
-               CALL gid%sync()
+               CALL gid%bcast(buffer(lbounds(3):ubounds(3)), 0)
 
                !only use data that is local to me - i.e. in slice of pencil I own
                IF ((lbounds_local(1) .LE. i) .AND. (i .LE. ubounds_local(1)) .AND. (lbounds_local(2) .LE. j) &

--- a/src/pw_env/gaussian_gridlevels.F
+++ b/src/pw_env/gaussian_gridlevels.F
@@ -84,7 +84,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE destroy_gaussian_gridlevel(gridlevel_info, para_env)
       TYPE(gridlevel_info_type)                          :: gridlevel_info
-      TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
+      TYPE(cp_para_env_type), INTENT(IN), OPTIONAL       :: para_env
 
       INTEGER                                            :: i, output_unit
       LOGICAL                                            :: do_io

--- a/src/pw_env/pw_env_types.F
+++ b/src/pw_env/pw_env_types.F
@@ -177,7 +177,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_env_release(pw_env, para_env)
       TYPE(pw_env_type), POINTER                         :: pw_env
-      TYPE(cp_para_env_type), OPTIONAL, POINTER          :: para_env
+      TYPE(cp_para_env_type), INTENT(IN), OPTIONAL       :: para_env
 
       INTEGER                                            :: i, igrid_level
 

--- a/src/pw_env_methods.F
+++ b/src/pw_env_methods.F
@@ -156,7 +156,8 @@ CONTAINS
    SUBROUTINE pw_env_rebuild(pw_env, qs_env, external_para_env)
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      TYPE(cp_para_env_type), OPTIONAL, POINTER          :: external_para_env
+      TYPE(cp_para_env_type), INTENT(IN), OPTIONAL, &
+         TARGET                                          :: external_para_env
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_env_rebuild'
 

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -1091,7 +1091,7 @@ CONTAINS
             READ (rst_unit) qs_env%image_matrix
          END IF
 
-         CALL para_env%bcast(qs_env%image_matrix, para_env%source)
+         CALL para_env%bcast(qs_env%image_matrix)
 
          IF (para_env%is_source()) CALL close_file(unit_number=rst_unit)
 

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -306,28 +306,27 @@ CONTAINS
       TYPE(mp_comm_type), INTENT(IN)                     :: mp_group
       INTEGER, DIMENSION(2)                              :: irange
 
-      INTEGER                                            :: numtask, taskid
       REAL(KIND=dp)                                      :: rat
 
-      numtask = mp_group%num_pe
-      taskid = mp_group%mepos
+      ASSOCIATE (numtask => mp_group%num_pe, taskid => mp_group%mepos)
 
-      IF (numtask == 1 .AND. taskid == 0) THEN
-         irange(1) = 1
-         irange(2) = nindex
-      ELSEIF (numtask >= nindex) THEN
-         IF (taskid >= nindex) THEN
+         IF (numtask == 1 .AND. taskid == 0) THEN
             irange(1) = 1
-            irange(2) = 0
+            irange(2) = nindex
+         ELSEIF (numtask >= nindex) THEN
+            IF (taskid >= nindex) THEN
+               irange(1) = 1
+               irange(2) = 0
+            ELSE
+               irange(1) = taskid + 1
+               irange(2) = taskid + 1
+            END IF
          ELSE
-            irange(1) = taskid + 1
-            irange(2) = taskid + 1
+            rat = REAL(nindex, KIND=dp)/REAL(numtask, KIND=dp)
+            irange(1) = NINT(rat*taskid) + 1
+            irange(2) = NINT(rat*taskid + rat)
          END IF
-      ELSE
-         rat = REAL(nindex, KIND=dp)/REAL(numtask, KIND=dp)
-         irange(1) = NINT(rat*taskid) + 1
-         irange(2) = NINT(rat*taskid + rat)
-      END IF
+      END ASSOCIATE
 
    END FUNCTION get_irange_csr
 

--- a/src/qs_dcdr_utils.F
+++ b/src/qs_dcdr_utils.F
@@ -156,7 +156,7 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename
       CHARACTER(LEN=default_string_length)               :: my_middle
       INTEGER :: beta_tmp, handle, i, i_block, ia, ie, iostat, iounit, ispin, j, lambda_tmp, &
-         max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit, source
+         max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit
       LOGICAL                                            :: file_exists
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
@@ -180,7 +180,6 @@ CONTAINS
                       mos=mos)
 
       nspins = SIZE(mos)
-      source = para_env%source !ionode???
 
       rst_unit = -1
       IF (para_env%is_source()) THEN
@@ -220,7 +219,7 @@ CONTAINS
          END IF
       END IF
 
-      CALL para_env%bcast(file_exists, source)
+      CALL para_env%bcast(file_exists)
 
       IF (file_exists) THEN
 
@@ -231,11 +230,11 @@ CONTAINS
          !
          ! read headers
          IF (rst_unit > 0) READ (rst_unit, IOSTAT=iostat) lambda_tmp, beta_tmp, nspins_tmp, nao_tmp
-         CALL para_env%bcast(iostat, source)
-         CALL para_env%bcast(beta_tmp, source)
-         CALL para_env%bcast(lambda_tmp, source)
-         CALL para_env%bcast(nspins_tmp, source)
-         CALL para_env%bcast(nao_tmp, source)
+         CALL para_env%bcast(iostat)
+         CALL para_env%bcast(beta_tmp)
+         CALL para_env%bcast(lambda_tmp)
+         CALL para_env%bcast(nspins_tmp)
+         CALL para_env%bcast(nao_tmp)
 
          ! check that the number nao, nmo and nspins are
          ! the same as in the current mos
@@ -253,7 +252,7 @@ CONTAINS
             CALL cp_fm_get_info(mo_coeff, ncol_global=nmo)
             !
             IF (rst_unit > 0) READ (rst_unit) nmo_tmp
-            CALL para_env%bcast(nmo_tmp, source)
+            CALL para_env%bcast(nmo_tmp)
             IF (nmo_tmp .NE. nmo) CPABORT("nmo not consistent")
             !
             ! read the response
@@ -262,7 +261,7 @@ CONTAINS
                DO j = 1, i_block
                   IF (rst_unit > 0) READ (rst_unit) vecbuffer(1:nao, j)
                END DO
-               CALL para_env%bcast(vecbuffer, source)
+               CALL para_env%bcast(vecbuffer)
                CALL cp_fm_set_submatrix(vec(ispin), vecbuffer, 1, i, nao, i_block)
             END DO
          END DO

--- a/src/qs_dftb_parameters.F
+++ b/src/qs_dftb_parameters.F
@@ -262,15 +262,15 @@ CONTAINS
             IF (n_urpoly < 2) n_urpoly = 0
          END IF
 
-         CALL para_env%bcast(n_urpoly, para_env%source)
-         CALL para_env%bcast(uwork, para_env%source)
-         CALL para_env%bcast(ngrd, para_env%source)
-         CALL para_env%bcast(dgrd, para_env%source)
+         CALL para_env%bcast(n_urpoly)
+         CALL para_env%bcast(uwork)
+         CALL para_env%bcast(ngrd)
+         CALL para_env%bcast(dgrd)
 
-         CALL para_env%bcast(skself, para_env%source)
-         CALL para_env%bcast(energy, para_env%source)
-         CALL para_env%bcast(eta, para_env%source)
-         CALL para_env%bcast(occupation, para_env%source)
+         CALL para_env%bcast(skself)
+         CALL para_env%bcast(energy)
+         CALL para_env%bcast(eta)
+         CALL para_env%bcast(occupation)
 
          CALL set_dftb_atom_param(dftb_parameter=dftb_atom_a, &
                                   z=z, zeff=SUM(occupation), defined=.TRUE., &
@@ -286,8 +286,8 @@ CONTAINS
                smat(k, 1:10) = swork(1:10)
             END DO
          END IF
-         CALL para_env%bcast(fmat, para_env%source)
-         CALL para_env%bcast(smat, para_env%source)
+         CALL para_env%bcast(fmat)
+         CALL para_env%bcast(smat)
 
          !
          ! Determine lmax for atom type.
@@ -362,17 +362,17 @@ CONTAINS
             CALL close_file(unit_number=runit)
          END IF
 
-         CALL para_env%bcast(spdim, para_env%source)
+         CALL para_env%bcast(spdim)
          IF (spdim > 0 .AND. (.NOT. para_env%is_source())) THEN
             ALLOCATE (spxr(spdim, 2))
             ALLOCATE (scoeff(spdim, 4))
          END IF
          IF (spdim > 0) THEN
-            CALL para_env%bcast(spxr, para_env%source)
-            CALL para_env%bcast(scoeff, para_env%source)
-            CALL para_env%bcast(surr, para_env%source)
-            CALL para_env%bcast(srep, para_env%source)
-            CALL para_env%bcast(s_cut, para_env%source)
+            CALL para_env%bcast(spxr)
+            CALL para_env%bcast(scoeff)
+            CALL para_env%bcast(surr)
+            CALL para_env%bcast(srep)
+            CALL para_env%bcast(s_cut)
          END IF
 
          ! store potential data
@@ -475,10 +475,10 @@ CONTAINS
                IF (n_urpoly < 2) n_urpoly = 0
             END IF
 
-            CALL para_env%bcast(n_urpoly, para_env%source)
-            CALL para_env%bcast(uwork, para_env%source)
-            CALL para_env%bcast(ngrd, para_env%source)
-            CALL para_env%bcast(dgrd, para_env%source)
+            CALL para_env%bcast(n_urpoly)
+            CALL para_env%bcast(uwork)
+            CALL para_env%bcast(ngrd)
+            CALL para_env%bcast(dgrd)
 
             ! Slater-Koster table
             ALLOCATE (fmat(ngrd, 10))
@@ -490,8 +490,8 @@ CONTAINS
                   smat(k, 1:10) = swork(1:10)
                END DO
             END IF
-            CALL para_env%bcast(fmat, para_env%source)
-            CALL para_env%bcast(smat, para_env%source)
+            CALL para_env%bcast(fmat)
+            CALL para_env%bcast(smat)
 
             spdim = 0
             IF (n_urpoly == 0) THEN
@@ -523,17 +523,17 @@ CONTAINS
                CALL close_file(unit_number=runit)
             END IF
 
-            CALL para_env%bcast(spdim, para_env%source)
+            CALL para_env%bcast(spdim)
             IF (spdim > 0 .AND. (.NOT. para_env%is_source())) THEN
                ALLOCATE (spxr(spdim, 2))
                ALLOCATE (scoeff(spdim, 4))
             END IF
             IF (spdim > 0) THEN
-               CALL para_env%bcast(spxr, para_env%source)
-               CALL para_env%bcast(scoeff, para_env%source)
-               CALL para_env%bcast(surr, para_env%source)
-               CALL para_env%bcast(srep, para_env%source)
-               CALL para_env%bcast(s_cut, para_env%source)
+               CALL para_env%bcast(spxr)
+               CALL para_env%bcast(scoeff)
+               CALL para_env%bcast(surr)
+               CALL para_env%bcast(srep)
+               CALL para_env%bcast(s_cut)
             END IF
 
             ! store potential data

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -102,9 +102,9 @@ CONTAINS
             READ (funit, *) nqs, nr_points
             READ (funit, *) dispersion_env%r_max
          END IF
-         CALL para_env%bcast(nqs, para_env%source)
-         CALL para_env%bcast(nr_points, para_env%source)
-         CALL para_env%bcast(dispersion_env%r_max, para_env%source)
+         CALL para_env%bcast(nqs)
+         CALL para_env%bcast(nr_points)
+         CALL para_env%bcast(dispersion_env%r_max)
          ALLOCATE (dispersion_env%q_mesh(nqs), dispersion_env%kernel(0:nr_points, nqs, nqs), &
                    dispersion_env%d2phi_dk2(0:nr_points, nqs, nqs))
          dispersion_env%nqs = nqs
@@ -133,9 +133,9 @@ CONTAINS
             END DO
             CALL close_file(unit_number=funit)
          END IF
-         CALL para_env%bcast(dispersion_env%q_mesh, para_env%source)
-         CALL para_env%bcast(dispersion_env%kernel, para_env%source)
-         CALL para_env%bcast(dispersion_env%d2phi_dk2, para_env%source)
+         CALL para_env%bcast(dispersion_env%q_mesh)
+         CALL para_env%bcast(dispersion_env%kernel)
+         CALL para_env%bcast(dispersion_env%d2phi_dk2)
          ! 2nd derivates for interpolation
          ALLOCATE (dispersion_env%d2y_dx2(nqs, nqs))
          CALL initialize_spline_interpolation(dispersion_env%q_mesh, dispersion_env%d2y_dx2)

--- a/src/qs_dispersion_pairpot.F
+++ b/src/qs_dispersion_pairpot.F
@@ -2267,14 +2267,14 @@ CONTAINS
          CALL open_file(file_name=filename, unit_number=funit, file_form="FORMATTED")
          READ (funit, *) nl, nlines
       END IF
-      CALL para_env%bcast(nl, para_env%source)
-      CALL para_env%bcast(nlines, para_env%source)
+      CALL para_env%bcast(nl)
+      CALL para_env%bcast(nlines)
       ALLOCATE (pars(nl))
       IF (para_env%is_source()) THEN
          READ (funit, *) pars(1:nl)
          CALL close_file(unit_number=funit)
       END IF
-      CALL para_env%bcast(pars, para_env%source)
+      CALL para_env%bcast(pars)
 
       ! Store C6AB coefficients in an array
       c6ab = -1._dp

--- a/src/qs_external_density.F
+++ b/src/qs_external_density.F
@@ -59,8 +59,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'external_read_density'
 
       CHARACTER(LEN=default_string_length)               :: filename
-      INTEGER                                            :: extunit, handle, i, igrid_level, ip, j, &
-                                                            k, master, nat, ndum, tag
+      INTEGER                                            :: extunit, handle, i, igrid_level, j, k, &
+                                                            nat, ndum, tag
       INTEGER, DIMENSION(3)                              :: lbounds, lbounds_local, npoints, &
                                                             npoints_local, ubounds, ubounds_local
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: buffer
@@ -169,19 +169,8 @@ CONTAINS
                   DO j = lbounds(2), ubounds(2)
                      IF (my_rank .EQ. 0) THEN
                         READ (extunit, *) (buffer(k), k=lbounds(3), ubounds(3))
-                        IF (num_pe .GT. 1) THEN
-                           DO ip = 1, num_pe - 1
-                              CALL gid%send(buffer(lbounds(3):ubounds(3)), ip, tag)
-!                  WRITE(*,*) my_rank," sending to : ",ip
-                           END DO
-!                CALL gid%sync()
-                        END IF
-                     ELSE
-                        master = 0
-                        CALL gid%recv(buffer(lbounds(3):ubounds(3)), master, tag)
-!               WRITE(*,*) my_rank," receiving from master"
                      END IF
-                     CALL gid%sync()
+                     CALL gid%bcast(buffer(lbounds(3):ubounds(3)), 0)
 
                      IF ((lbounds_local(1) .LE. i) .AND. (i .LE. ubounds_local(1)) .AND. (lbounds_local(2) .LE. j) &
                          .AND. (j .LE. ubounds_local(2))) THEN

--- a/src/qs_fb_atomic_matrix_methods.F
+++ b/src/qs_fb_atomic_matrix_methods.F
@@ -436,8 +436,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_atmatrix_generate_com_pairs'
 
-      INTEGER :: counter, dest, handle, iatom, iatom_global, itask, jatom, jatom_global, &
-         natoms_in_halo, nblkrows_total, nencode, ntasks_recv, ntasks_send, src
+      INTEGER :: counter, handle, iatom, iatom_global, itask, jatom, jatom_global, natoms_in_halo, &
+         nblkrows_total, nencode, ntasks_recv, ntasks_send, src
       INTEGER(KIND=int_8)                                :: pair
       INTEGER(KIND=int_8), DIMENSION(:, :), POINTER      :: tasks_recv, tasks_send
       INTEGER, DIMENSION(:), POINTER                     :: halo_atoms
@@ -473,9 +473,6 @@ CONTAINS
       CALL dbcsr_get_info(matrix=dbcsr_mat, &
                           nblkrows_total=nblkrows_total)
 
-      ! destination proc is always the local processor
-      dest = para_env%mepos ! my MPI rank
-
       ! generate recv task list (tasks_recv)
 
       ! a recv task corresponds to the copying or transferring of a
@@ -487,40 +484,43 @@ CONTAINS
 
       ALLOCATE (tasks_recv(TASK_N_RECORDS, ntasks_recv))
 
-      ! now that tasks_recv has been allocated, generate the tasks
-      itask = 1
-      DO iatom = 1, natoms_in_halo
-         iatom_global = halo_atoms(iatom)
-         DO jatom = 1, natoms_in_halo
-            jatom_global = halo_atoms(jatom)
-            ! atomic matrix is symmetric, and only upper triangular part
-            ! is stored in DBCSR matrix
-            IF (jatom_global .GE. iatom_global) THEN
-               ! find the source proc that supposed to own the block
-               ! (iatom_global, jatom_global)
-               CALL dbcsr_get_stored_coordinates(dbcsr_mat, &
-                                                 iatom_global, &
-                                                 jatom_global, &
-                                                 processor=src)
-               ! we must encode the global atom indices rather the halo
-               ! atomic indices in each task, because halo atomic
-               ! indices are local to each halo, and each processor is
-               ! working on a different halo local to them. So one
-               ! processor would not have the information about the halo
-               ! on another processor, rendering the halo atomic indices
-               ! rather useless outside the local processor.
-               tasks_recv(TASK_DEST, itask) = dest
-               tasks_recv(TASK_SRC, itask) = src
+      ! destination proc is always the local processor
+      ASSOCIATE (dest => para_env%mepos)
+         ! now that tasks_recv has been allocated, generate the tasks
+         itask = 1
+         DO iatom = 1, natoms_in_halo
+            iatom_global = halo_atoms(iatom)
+            DO jatom = 1, natoms_in_halo
+               jatom_global = halo_atoms(jatom)
+               ! atomic matrix is symmetric, and only upper triangular part
+               ! is stored in DBCSR matrix
+               IF (jatom_global .GE. iatom_global) THEN
+                  ! find the source proc that supposed to own the block
+                  ! (iatom_global, jatom_global)
+                  CALL dbcsr_get_stored_coordinates(dbcsr_mat, &
+                                                    iatom_global, &
+                                                    jatom_global, &
+                                                    processor=src)
+                  ! we must encode the global atom indices rather the halo
+                  ! atomic indices in each task, because halo atomic
+                  ! indices are local to each halo, and each processor is
+                  ! working on a different halo local to them. So one
+                  ! processor would not have the information about the halo
+                  ! on another processor, rendering the halo atomic indices
+                  ! rather useless outside the local processor.
+                  tasks_recv(TASK_DEST, itask) = dest
+                  tasks_recv(TASK_SRC, itask) = src
 
-               CALL fb_com_tasks_encode_pair(tasks_recv(TASK_PAIR, itask), &
-                                             iatom_global, jatom_global, &
-                                             nblkrows_total)
-               ! calculation of cost not implemented at the moment
-               tasks_recv(TASK_COST, itask) = 0
-               itask = itask + 1
-            END IF
-         END DO ! jatom
-      END DO ! iatom
+                  CALL fb_com_tasks_encode_pair(tasks_recv(TASK_PAIR, itask), &
+                                                iatom_global, jatom_global, &
+                                                nblkrows_total)
+                  ! calculation of cost not implemented at the moment
+                  tasks_recv(TASK_COST, itask) = 0
+                  itask = itask + 1
+               END IF
+            END DO ! jatom
+         END DO ! iatom
+      END ASSOCIATE
 
       ! get the actual number of tasks
       ntasks_recv = itask - 1
@@ -630,7 +630,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_atmatrix_generate_com_pairs_2'
 
-      INTEGER :: counter, dest, handle, iatom, iatom_global, ihalo, itask, jatom, jatom_global, &
+      INTEGER :: counter, handle, iatom, iatom_global, ihalo, itask, jatom, jatom_global, &
          natoms_in_halo, nblkrows_total, nencode, nhalos, ntasks_recv, ntasks_send, src
       INTEGER(KIND=int_8)                                :: pair
       INTEGER(KIND=int_8), DIMENSION(:, :), POINTER      :: tasks_recv, tasks_send
@@ -679,44 +679,45 @@ CONTAINS
       ! now that tasks_recv has been allocated, generate the tasks
 
       ! destination proc is always the local process
-      dest = para_env%mepos
-      itask = 1
-      DO ihalo = 1, nhalos
-         CALL fb_atomic_halo_get(atomic_halo=halos(ihalo), &
-                                 natoms=natoms_in_halo, &
-                                 halo_atoms=halo_atoms)
-         DO iatom = 1, natoms_in_halo
-            iatom_global = halo_atoms(iatom)
-            DO jatom = 1, natoms_in_halo
-               jatom_global = halo_atoms(jatom)
-               ! atomic matrices are always symmetric, treat it as such.
-               ! so only deal with upper triangular parts
-               IF (jatom_global .GE. iatom_global) THEN
-                  ! find the source proc that supposed to own the block
-                  ! (iatom_global, jatom_global)
-                  CALL dbcsr_get_stored_coordinates(dbcsr_mat, &
-                                                    iatom_global, &
-                                                    jatom_global, &
-                                                    processor=src)
-                  ! we must encode the global atom indices rather the halo
-                  ! atomic indices in each task, because halo atomic indices
-                  ! are local to each halo, and each processor is working on a
-                  ! different halo local to them. So one processor would not
-                  ! have the information about the halo on another processor,
-                  ! rendering the halo atomic indices rather useless outside
-                  ! the local processor.
-                  tasks_recv(TASK_DEST, itask) = dest
-                  tasks_recv(TASK_SRC, itask) = src
-                  CALL fb_com_tasks_encode_pair(tasks_recv(TASK_PAIR, itask), &
-                                                iatom_global, jatom_global, &
-                                                nblkrows_total)
-                  ! calculation of cost not implemented at the moment
-                  tasks_recv(TASK_COST, itask) = 0
-                  itask = itask + 1
-               END IF
-            END DO ! jatom
-         END DO ! iatom
-      END DO ! ihalo
+      ASSOCIATE (dest => para_env%mepos)
+         itask = 1
+         DO ihalo = 1, nhalos
+            CALL fb_atomic_halo_get(atomic_halo=halos(ihalo), &
+                                    natoms=natoms_in_halo, &
+                                    halo_atoms=halo_atoms)
+            DO iatom = 1, natoms_in_halo
+               iatom_global = halo_atoms(iatom)
+               DO jatom = 1, natoms_in_halo
+                  jatom_global = halo_atoms(jatom)
+                  ! atomic matrices are always symmetric, treat it as such.
+                  ! so only deal with upper triangular parts
+                  IF (jatom_global .GE. iatom_global) THEN
+                     ! find the source proc that supposed to own the block
+                     ! (iatom_global, jatom_global)
+                     CALL dbcsr_get_stored_coordinates(dbcsr_mat, &
+                                                       iatom_global, &
+                                                       jatom_global, &
+                                                       processor=src)
+                     ! we must encode the global atom indices rather the halo
+                     ! atomic indices in each task, because halo atomic indices
+                     ! are local to each halo, and each processor is working on a
+                     ! different halo local to them. So one processor would not
+                     ! have the information about the halo on another processor,
+                     ! rendering the halo atomic indices rather useless outside
+                     ! the local processor.
+                     tasks_recv(TASK_DEST, itask) = dest
+                     tasks_recv(TASK_SRC, itask) = src
+                     CALL fb_com_tasks_encode_pair(tasks_recv(TASK_PAIR, itask), &
+                                                   iatom_global, jatom_global, &
+                                                   nblkrows_total)
+                     ! calculation of cost not implemented at the moment
+                     tasks_recv(TASK_COST, itask) = 0
+                     itask = itask + 1
+                  END IF
+               END DO ! jatom
+            END DO ! iatom
+         END DO ! ihalo
+      END ASSOCIATE
 
       ! set the actual number of tasks obtained
       ntasks_recv = itask - 1

--- a/src/qs_fb_filter_matrix_methods.F
+++ b/src/qs_fb_filter_matrix_methods.F
@@ -980,7 +980,7 @@ CONTAINS
       INTEGER                                            :: dest, handle, iatom_global, &
                                                             iatom_in_halo, itask, jatom_global, &
                                                             natoms_in_halo, nblkrows_total, &
-                                                            ntasks_send, src
+                                                            ntasks_send
       INTEGER(KIND=int_8), DIMENSION(:, :), POINTER      :: tasks_send
       INTEGER, DIMENSION(:), POINTER                     :: halo_atoms
       TYPE(fb_com_tasks_obj)                             :: com_tasks_recv, com_tasks_send
@@ -1002,9 +1002,6 @@ CONTAINS
       ELSE
          CALL fb_com_atom_pairs_create(atom_pairs_recv)
       END IF
-
-      ! source is always the local processor
-      src = para_env%mepos
 
       ! The total number of filter matrix blocks each processor is going
       ! to construct equals to the total number of halo atoms in all of
@@ -1038,25 +1035,28 @@ CONTAINS
       CALL dbcsr_get_info(filter_mat, &
                           nblkrows_total=nblkrows_total)
 
-      ! construct send tasks
-      itask = 1
-      DO iatom_in_halo = 1, natoms_in_halo
-         iatom_global = halo_atoms(iatom_in_halo)
-         ! find where the constructed block of filter matrix belongs to
-         CALL dbcsr_get_stored_coordinates(filter_mat, &
-                                           iatom_global, &
-                                           jatom_global, &
-                                           processor=dest)
-         ! create the send tasks
-         tasks_send(TASK_DEST, itask) = dest
-         tasks_send(TASK_SRC, itask) = src
-         CALL fb_com_tasks_encode_pair(tasks_send(TASK_PAIR, itask), &
-                                       iatom_global, jatom_global, &
-                                       nblkrows_total)
-         ! calculation of cost not implemented at the moment
-         tasks_send(TASK_COST, itask) = 0
-         itask = itask + 1
-      END DO ! iatom_in_halo
+      ! source is always the local processor
+      ASSOCIATE (src => para_env%mepos)
+         ! construct send tasks
+         itask = 1
+         DO iatom_in_halo = 1, natoms_in_halo
+            iatom_global = halo_atoms(iatom_in_halo)
+            ! find where the constructed block of filter matrix belongs to
+            CALL dbcsr_get_stored_coordinates(filter_mat, &
+                                              iatom_global, &
+                                              jatom_global, &
+                                              processor=dest)
+            ! create the send tasks
+            tasks_send(TASK_DEST, itask) = dest
+            tasks_send(TASK_SRC, itask) = src
+            CALL fb_com_tasks_encode_pair(tasks_send(TASK_PAIR, itask), &
+                                          iatom_global, jatom_global, &
+                                          nblkrows_total)
+            ! calculation of cost not implemented at the moment
+            tasks_send(TASK_COST, itask) = 0
+            itask = itask + 1
+         END DO ! iatom_in_halo
+      END ASSOCIATE
 
       CALL fb_com_tasks_create(com_tasks_recv)
       CALL fb_com_tasks_create(com_tasks_send)
@@ -1116,7 +1116,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'fb_fltrmat_generate_com_pairs_2'
 
       INTEGER :: dest, handle, iatom_global, iatom_in_halo, iatom_stored, ihalo, itask, &
-         jatom_global, jatom_stored, natoms_in_halo, nblkrows_total, nhalos, ntasks_send, src
+         jatom_global, jatom_stored, natoms_in_halo, nblkrows_total, nhalos, ntasks_send
       INTEGER(KIND=int_8), DIMENSION(:, :), POINTER      :: tasks_send
       INTEGER, DIMENSION(:), POINTER                     :: halo_atoms
       LOGICAL                                            :: transpose
@@ -1140,9 +1140,6 @@ CONTAINS
       ELSE
          CALL fb_com_atom_pairs_create(atom_pairs_recv)
       END IF
-
-      ! source is always the local processor
-      src = para_env%mepos
 
       ! The col atom block index for each filter matrix block are the
       ! owner atom of each halo. The row atom block index for each
@@ -1175,34 +1172,37 @@ CONTAINS
       CALL dbcsr_get_info(filter_mat, &
                           nblkrows_total=nblkrows_total)
 
-      ! construct send tasks
-      itask = 1
-      DO ihalo = 1, nhalos
-         CALL fb_atomic_halo_get(atomic_halo=halos(ihalo), &
-                                 owner_atom=jatom_global, &
-                                 natoms=natoms_in_halo, &
-                                 halo_atoms=halo_atoms)
-         DO iatom_in_halo = 1, natoms_in_halo
-            iatom_global = halo_atoms(iatom_in_halo)
-            iatom_stored = iatom_global
-            jatom_stored = jatom_global
-            transpose = .FALSE.
-            ! find where the constructed block of filter matrix belongs to
-            CALL dbcsr_get_stored_coordinates(filter_mat, &
-                                              iatom_stored, &
-                                              jatom_stored, &
-                                              processor=dest)
-            ! create the send tasks
-            tasks_send(TASK_DEST, itask) = dest
-            tasks_send(TASK_SRC, itask) = src
-            CALL fb_com_tasks_encode_pair(tasks_send(TASK_PAIR, itask), &
-                                          iatom_global, jatom_global, &
-                                          nblkrows_total)
-            ! calculation of cost not implemented at the moment
-            tasks_send(TASK_COST, itask) = 0
-            itask = itask + 1
-         END DO ! iatom_in_halo
-      END DO ! ihalo
+      ! source is always the local processor
+      ASSOCIATE (src => para_env%mepos)
+         ! construct send tasks
+         itask = 1
+         DO ihalo = 1, nhalos
+            CALL fb_atomic_halo_get(atomic_halo=halos(ihalo), &
+                                    owner_atom=jatom_global, &
+                                    natoms=natoms_in_halo, &
+                                    halo_atoms=halo_atoms)
+            DO iatom_in_halo = 1, natoms_in_halo
+               iatom_global = halo_atoms(iatom_in_halo)
+               iatom_stored = iatom_global
+               jatom_stored = jatom_global
+               transpose = .FALSE.
+               ! find where the constructed block of filter matrix belongs to
+               CALL dbcsr_get_stored_coordinates(filter_mat, &
+                                                 iatom_stored, &
+                                                 jatom_stored, &
+                                                 processor=dest)
+               ! create the send tasks
+               tasks_send(TASK_DEST, itask) = dest
+               tasks_send(TASK_SRC, itask) = src
+               CALL fb_com_tasks_encode_pair(tasks_send(TASK_PAIR, itask), &
+                                             iatom_global, jatom_global, &
+                                             nblkrows_total)
+               ! calculation of cost not implemented at the moment
+               tasks_send(TASK_COST, itask) = 0
+               itask = itask + 1
+            END DO ! iatom_in_halo
+         END DO ! ihalo
+      END ASSOCIATE
 
       ! get the actual number of tasks
       ntasks_send = itask - 1

--- a/src/qs_initial_guess.F
+++ b/src/qs_initial_guess.F
@@ -299,8 +299,8 @@ CONTAINS
                CALL wfn_restart_file_name(file_name, exist, dft_section, logger)
             END IF
          END IF
-         CALL para_env%bcast(exist, para_env%source)
-         CALL para_env%bcast(file_name, para_env%source)
+         CALL para_env%bcast(exist)
+         CALL para_env%bcast(file_name)
          IF (.NOT. exist) THEN
             CALL cp_warn(__LOCATION__, &
                          "User requested to restart the wavefunction from the file named: "// &
@@ -315,8 +315,8 @@ CONTAINS
          END IF
          IF (para_env%is_source()) &
             CALL wfn_restart_file_name(file_name, exist, dft_section, logger)
-         CALL para_env%bcast(exist, para_env%source)
-         CALL para_env%bcast(file_name, para_env%source)
+         CALL para_env%bcast(exist)
+         CALL para_env%bcast(file_name)
          nvec = qs_env%wf_history%memory_depth
          not_read = nvec + 1
          ! At this level we read the saved backup RESTART files..
@@ -326,7 +326,7 @@ CONTAINS
             IF (j /= 0) filename = TRIM(file_name)//".bak-"//ADJUSTL(cp_to_string(j))
             IF (para_env%is_source()) &
                INQUIRE (FILE=filename, exist=exist)
-            CALL para_env%bcast(exist, para_env%source)
+            CALL para_env%bcast(exist)
             IF ((.NOT. exist) .AND. (i < not_read)) THEN
                not_read = i
             END IF
@@ -335,7 +335,7 @@ CONTAINS
             density_guess = restart_guess
             filename = TRIM(file_name)
             IF (para_env%is_source()) INQUIRE (FILE=filename, exist=exist)
-            CALL para_env%bcast(exist, para_env%source)
+            CALL para_env%bcast(exist)
             IF (.NOT. exist) THEN
                CALL cp_warn(__LOCATION__, &
                             "User requested to restart the wavefunction from a series of restart files named: "// &

--- a/src/qs_ks_atom.F
+++ b/src/qs_ks_atom.F
@@ -120,9 +120,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'update_ks_atom'
 
       INTEGER :: bo(2), handle, ia_kind, iac, iat, iatom, ibc, ikind, img, ip, ispin, ja_kind, &
-         jatom, jkind, ka_kind, kac, katom, kbc, kkind, ldCPC, max_gau, max_nsgf, mepos, n_cont_a, &
-         n_cont_b, nat, natom, nimages, nkind, nl_table_num_slots, nsoctot, nspins, num_pe, &
-         slot_num
+         jatom, jkind, ka_kind, kac, katom, kbc, kkind, ldCPC, max_gau, max_nsgf, n_cont_a, &
+         n_cont_b, nat, natom, nimages, nkind, nl_table_num_slots, nsoctot, nspins, slot_num
       INTEGER(KIND=int_8)                                :: nl_table_key
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind
       INTEGER, DIMENSION(3)                              :: cell_b
@@ -227,8 +226,7 @@ CONTAINS
 
       nkind = SIZE(my_kind_set, 1)
       ! Collect the local potential contributions from all the processors
-      mepos = para_env%mepos
-      num_pe = para_env%num_pe
+      ASSOCIATE (mepos => para_env%mepos, num_pe => para_env%num_pe)
       DO ikind = 1, nkind
          NULLIFY (atom_list)
          CALL get_atomic_kind(atomic_kind_set(ikind), atom_list=atom_list, natom=nat)
@@ -258,6 +256,7 @@ CONTAINS
             END DO
          END IF
       END DO
+      END ASSOCIATE
 
       ALLOCATE (basis_set_list(nkind))
       DO ikind = 1, nkind

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -911,7 +911,7 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename
       CHARACTER(LEN=default_string_length)               :: my_middle
       INTEGER :: handle, i, i_block, ia, ie, iostat, iounit, ispin, iv, iv1, ivec_tmp, j, &
-         max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit, source
+         max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit
       LOGICAL                                            :: file_exists
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
@@ -935,7 +935,6 @@ CONTAINS
                       mos=mos)
 
       nspins = SIZE(mos)
-      source = para_env%source !ionode???
 
       rst_unit = -1
       IF (para_env%is_source()) THEN
@@ -978,7 +977,7 @@ CONTAINS
          END IF
       END IF
 
-      CALL para_env%bcast(file_exists, source)
+      CALL para_env%bcast(file_exists)
 
       IF (file_exists) THEN
 
@@ -997,17 +996,17 @@ CONTAINS
 
             IF (PRESENT(ind)) THEN
                IF (rst_unit > 0) READ (rst_unit, IOSTAT=iostat) ind, ivec_tmp, nspins_tmp, nao_tmp
-               CALL para_env%bcast(iostat, source)
-               CALL para_env%bcast(ind, source)
+               CALL para_env%bcast(iostat)
+               CALL para_env%bcast(ind)
             ELSE
                IF (rst_unit > 0) READ (rst_unit, IOSTAT=iostat) ivec_tmp, nspins_tmp, nao_tmp
-               CALL para_env%bcast(iostat, source)
+               CALL para_env%bcast(iostat)
             END IF
 
             IF (iostat .NE. 0) EXIT
-            CALL para_env%bcast(ivec_tmp, source)
-            CALL para_env%bcast(nspins_tmp, source)
-            CALL para_env%bcast(nao_tmp, source)
+            CALL para_env%bcast(ivec_tmp)
+            CALL para_env%bcast(nspins_tmp)
+            CALL para_env%bcast(nao_tmp)
 
             ! check that the number nao, nmo and nspins are
             ! the same as in the current mos
@@ -1019,7 +1018,7 @@ CONTAINS
                CALL cp_fm_get_info(mo_coeff, ncol_global=nmo)
                !
                IF (rst_unit > 0) READ (rst_unit) nmo_tmp
-               CALL para_env%bcast(nmo_tmp, source)
+               CALL para_env%bcast(nmo_tmp)
                IF (nmo_tmp .NE. nmo) CPABORT("nmo not consistent")
                !
                ! read the response
@@ -1029,7 +1028,7 @@ CONTAINS
                      IF (rst_unit > 0) READ (rst_unit) vecbuffer(1:nao, j)
                   END DO
                   IF (iv .EQ. ivec_tmp) THEN
-                     CALL para_env%bcast(vecbuffer, source)
+                     CALL para_env%bcast(vecbuffer)
                      CALL cp_fm_set_submatrix(vec(ispin), vecbuffer, 1, i, nao, i_block)
                   END IF
                END DO

--- a/src/qs_linres_nmr_shift.F
+++ b/src/qs_linres_nmr_shift.F
@@ -259,8 +259,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'nmr_shift_gapw'
 
-      INTEGER :: handle, ia, iat, iatom, idir2_1, idir3_1, ikind, ir, ira, ispin, j, jatom, mepos, &
-         n_nics, na, natom, natom_local, natom_tot, nkind, nnics_local, nr, nra, nspins, num_pe, &
+      INTEGER :: handle, ia, iat, iatom, idir2_1, idir3_1, ikind, ir, ira, ispin, j, jatom, &
+         n_nics, na, natom, natom_local, natom_tot, nkind, nnics_local, nr, nra, nspins, &
          output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: list_j, list_nics_j
       INTEGER, DIMENSION(2)                              :: bo
@@ -364,9 +364,7 @@ CONTAINS
          IF (paw_atom) THEN
             !
             ! Distribute the atoms of this kind
-            num_pe = para_env%num_pe
-            mepos = para_env%mepos
-            bo = get_limit(natom, num_pe, mepos)
+            bo = get_limit(natom, para_env%num_pe, para_env%mepos)
             !
             DO iat = bo(1), bo(2)
                iatom = atom_list(iat)

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -1110,91 +1110,89 @@ CONTAINS
          IF (output_unit > 0) WRITE (output_unit, "(/,T10,A)") &
             "Restart file not available filename=<"//TRIM(filename)//'>'
       END IF
-      ASSOCIATE (source => para_env%source)
-         CALL para_env%bcast(file_exists, source)
+      CALL para_env%bcast(file_exists)
 
-         IF (file_exists) THEN
-            restart_found = .TRUE.
+      IF (file_exists) THEN
+         restart_found = .TRUE.
 
-            CALL para_env%bcast(qs_loc_env%localized_wfn_control%set_of_states, source)
-            CALL para_env%bcast(qs_loc_env%localized_wfn_control%lu_bound_states, source)
-            CALL para_env%bcast(qs_loc_env%localized_wfn_control%nloc_states, source)
+         CALL para_env%bcast(qs_loc_env%localized_wfn_control%set_of_states)
+         CALL para_env%bcast(qs_loc_env%localized_wfn_control%lu_bound_states)
+         CALL para_env%bcast(qs_loc_env%localized_wfn_control%nloc_states)
 
-            max_nloc = MAXVAL(qs_loc_env%localized_wfn_control%nloc_states(:))
+         max_nloc = MAXVAL(qs_loc_env%localized_wfn_control%nloc_states(:))
 
-            ALLOCATE (vecbuffer(1, nao))
-            IF (ASSOCIATED(qs_loc_env%localized_wfn_control%loc_states)) THEN
-               DEALLOCATE (qs_loc_env%localized_wfn_control%loc_states)
-            END IF
-            ALLOCATE (qs_loc_env%localized_wfn_control%loc_states(max_nloc, 2))
-            qs_loc_env%localized_wfn_control%loc_states = 0
-
-            DO ispin = 1, nspin
-               IF (do_homo .OR. do_mixed) THEN
-                  nmo = mos(ispin)%nmo
-               ELSE
-                  nmo = SIZE(evals(ispin)%array, 1)
-               END IF
-               IF (para_env%is_source() .AND. (nmo > 0)) THEN
-                  nloc = qs_loc_env%localized_wfn_control%nloc_states(ispin)
-                  READ (rst_unit) qs_loc_env%localized_wfn_control%loc_states(1:nloc, ispin)
-                  IF (do_homo .OR. do_mixed) THEN
-                     READ (rst_unit) nmo_read, homo_read, lfomo_read, nelectron_read
-                     ALLOCATE (eig_read(nmo_read), occ_read(nmo_read))
-                     eig_read = 0.0_dp
-                     occ_read = 0.0_dp
-                     READ (rst_unit) eig_read(1:nmo_read), occ_read(1:nmo_read)
-                  ELSE
-                     READ (rst_unit) nmo_read
-                     ALLOCATE (eig_read(nmo_read))
-                     eig_read = 0.0_dp
-                     READ (rst_unit) eig_read(1:nmo_read)
-                  END IF
-                  IF (nmo_read < nmo) &
-                     CALL cp_warn(__LOCATION__, &
-                                  "The number of MOs on the restart unit is smaller than the number of "// &
-                                  "the allocated MOs. ")
-                  IF (nmo_read > nmo) &
-                     CALL cp_warn(__LOCATION__, &
-                                  "The number of MOs on the restart unit is greater than the number of "// &
-                                  "the allocated MOs. The read MO set will be truncated!")
-
-                  nmo = MIN(nmo, nmo_read)
-                  IF (do_homo .OR. do_mixed) THEN
-                     mos(ispin)%eigenvalues(1:nmo) = eig_read(1:nmo)
-                     mos(ispin)%occupation_numbers(1:nmo) = occ_read(1:nmo)
-                     DEALLOCATE (eig_read, occ_read)
-                  ELSE
-                     evals(ispin)%array(1:nmo) = eig_read(1:nmo)
-                     DEALLOCATE (eig_read)
-                  END IF
-
-               END IF
-               IF (do_homo .OR. do_mixed) THEN
-                  CALL para_env%bcast(mos(ispin)%eigenvalues, source)
-                  CALL para_env%bcast(mos(ispin)%occupation_numbers, source)
-               ELSE
-                  CALL para_env%bcast(evals(ispin)%array, source)
-               END IF
-
-               DO i = 1, nmo
-                  IF (para_env%is_source()) THEN
-                     READ (rst_unit) vecbuffer
-                  ELSE
-                     vecbuffer(1, :) = 0.0_dp
-                  END IF
-                  CALL para_env%bcast(vecbuffer, source)
-                  CALL cp_fm_set_submatrix(mos_localized(ispin), &
-                                           vecbuffer, 1, i, nao, 1, transpose=.TRUE.)
-               END DO
-            END DO
-
-            CALL para_env%bcast(qs_loc_env%localized_wfn_control%loc_states, source)
-
-            DEALLOCATE (vecbuffer)
-
+         ALLOCATE (vecbuffer(1, nao))
+         IF (ASSOCIATED(qs_loc_env%localized_wfn_control%loc_states)) THEN
+            DEALLOCATE (qs_loc_env%localized_wfn_control%loc_states)
          END IF
-      END ASSOCIATE
+         ALLOCATE (qs_loc_env%localized_wfn_control%loc_states(max_nloc, 2))
+         qs_loc_env%localized_wfn_control%loc_states = 0
+
+         DO ispin = 1, nspin
+            IF (do_homo .OR. do_mixed) THEN
+               nmo = mos(ispin)%nmo
+            ELSE
+               nmo = SIZE(evals(ispin)%array, 1)
+            END IF
+            IF (para_env%is_source() .AND. (nmo > 0)) THEN
+               nloc = qs_loc_env%localized_wfn_control%nloc_states(ispin)
+               READ (rst_unit) qs_loc_env%localized_wfn_control%loc_states(1:nloc, ispin)
+               IF (do_homo .OR. do_mixed) THEN
+                  READ (rst_unit) nmo_read, homo_read, lfomo_read, nelectron_read
+                  ALLOCATE (eig_read(nmo_read), occ_read(nmo_read))
+                  eig_read = 0.0_dp
+                  occ_read = 0.0_dp
+                  READ (rst_unit) eig_read(1:nmo_read), occ_read(1:nmo_read)
+               ELSE
+                  READ (rst_unit) nmo_read
+                  ALLOCATE (eig_read(nmo_read))
+                  eig_read = 0.0_dp
+                  READ (rst_unit) eig_read(1:nmo_read)
+               END IF
+               IF (nmo_read < nmo) &
+                  CALL cp_warn(__LOCATION__, &
+                               "The number of MOs on the restart unit is smaller than the number of "// &
+                               "the allocated MOs. ")
+               IF (nmo_read > nmo) &
+                  CALL cp_warn(__LOCATION__, &
+                               "The number of MOs on the restart unit is greater than the number of "// &
+                               "the allocated MOs. The read MO set will be truncated!")
+
+               nmo = MIN(nmo, nmo_read)
+               IF (do_homo .OR. do_mixed) THEN
+                  mos(ispin)%eigenvalues(1:nmo) = eig_read(1:nmo)
+                  mos(ispin)%occupation_numbers(1:nmo) = occ_read(1:nmo)
+                  DEALLOCATE (eig_read, occ_read)
+               ELSE
+                  evals(ispin)%array(1:nmo) = eig_read(1:nmo)
+                  DEALLOCATE (eig_read)
+               END IF
+
+            END IF
+            IF (do_homo .OR. do_mixed) THEN
+               CALL para_env%bcast(mos(ispin)%eigenvalues)
+               CALL para_env%bcast(mos(ispin)%occupation_numbers)
+            ELSE
+               CALL para_env%bcast(evals(ispin)%array)
+            END IF
+
+            DO i = 1, nmo
+               IF (para_env%is_source()) THEN
+                  READ (rst_unit) vecbuffer
+               ELSE
+                  vecbuffer(1, :) = 0.0_dp
+               END IF
+               CALL para_env%bcast(vecbuffer)
+               CALL cp_fm_set_submatrix(mos_localized(ispin), &
+                                        vecbuffer, 1, i, nao, 1, transpose=.TRUE.)
+            END DO
+         END DO
+
+         CALL para_env%bcast(qs_loc_env%localized_wfn_control%loc_states)
+
+         DEALLOCATE (vecbuffer)
+
+      END IF
 
       ! Close restart file
       IF (para_env%is_source()) THEN

--- a/src/qs_localization_methods.F
+++ b/src/qs_localization_methods.F
@@ -361,7 +361,7 @@ CONTAINS
 
       sweeps = 0
       unit_nr = -1
-      IF (rmat%matrix_struct%para_env%mepos .EQ. rmat%matrix_struct%para_env%source) THEN
+      IF (rmat%matrix_struct%para_env%is_source()) THEN
          unit_nr = cp_logger_get_default_unit_nr()
          WRITE (unit_nr, '(T4,A )') " Localization by iterative Jacobi rotation"
       END IF
@@ -472,7 +472,7 @@ CONTAINS
       sweeps = 0
       IF (PRESENT(out_each)) THEN
          unit_nr = -1
-         IF (c_rmat_local%matrix_struct%para_env%mepos .EQ. c_rmat_local%matrix_struct%para_env%source) THEN
+         IF (c_rmat_local%matrix_struct%para_env%is_source()) THEN
             unit_nr = cp_logger_get_default_unit_nr()
          END IF
          alpha = 0.0_dp
@@ -850,7 +850,7 @@ CONTAINS
       END IF
 
       unit_nr = -1
-      IF (rmat%matrix_struct%para_env%mepos .EQ. rmat%matrix_struct%para_env%source) THEN
+      IF (rmat%matrix_struct%para_env%is_source()) THEN
          unit_nr = cp_logger_get_default_unit_nr()
          WRITE (unit_nr, '(T4,A )') " Localization by combined Jacobi rotations and Non-Linear Conjugate Gradient"
       END IF
@@ -1632,7 +1632,7 @@ CONTAINS
       CALL cp_fm_to_fm(mat_t, mat_R)
 
       unit_nr = -1
-      IF (cmat_A%matrix_struct%para_env%mepos .EQ. cmat_A%matrix_struct%para_env%source) THEN
+      IF (cmat_A%matrix_struct%para_env%is_source()) THEN
          unit_nr = cp_logger_get_default_unit_nr()
          WRITE (unit_nr, '(T2,A7,A6,1X,A20,A12,A12,A12)') &
             "CRAZY| ", "Iter", "value    ", "gradient", "Max. eval", "limit"
@@ -1974,8 +1974,7 @@ CONTAINS
                CALL cp_fm_scale_and_add(beta_pr, matrix_G_search, -1.0_dp, matrix_G_old)
                CALL cp_fm_trace(matrix_G_search, matrix_G_old, normg_cross)
                IF (normg_cross .GE. 0) THEN ! back to SD
-                  IF (matrix_A%matrix_struct%para_env%mepos .EQ. &
-                      matrix_A%matrix_struct%para_env%source) THEN
+                  IF (matrix_A%matrix_struct%para_env%is_source()) THEN
                      WRITE (cp_logger_get_default_unit_nr(), *) "!"
                   END IF
                   beta_pr = 0.0_dp

--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -504,8 +504,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_mo_set_from_restart'
 
       CHARACTER(LEN=default_path_length)                 :: file_name
-      INTEGER                                            :: handle, ispin, natom, nspin, &
-                                                            restart_unit, source
+      INTEGER                                            :: handle, ispin, natom, nspin, restart_unit
       LOGICAL                                            :: exist, my_cdft
       TYPE(cp_logger_type), POINTER                      :: logger
 
@@ -516,8 +515,6 @@ CONTAINS
 
       nspin = SIZE(mo_array)
       restart_unit = -1
-
-      source = para_env%source
 
       IF (para_env%is_source()) THEN
 
@@ -542,7 +539,7 @@ CONTAINS
 
       IF (PRESENT(natom_mismatch)) THEN
          ! read_mos_restart_low only the io_node returns natom_mismatch, must broadcast it
-         CALL para_env%bcast(natom_mismatch, source)
+         CALL para_env%bcast(natom_mismatch)
          IF (natom_mismatch) THEN
             IF (para_env%is_source()) CALL close_file(unit_number=restart_unit)
             CALL timestop(handle)
@@ -592,8 +589,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_rt_mos_from_restart'
 
       CHARACTER(LEN=default_path_length)                 :: file_name
-      INTEGER                                            :: handle, ispin, natom, nspin, &
-                                                            restart_unit, source
+      INTEGER                                            :: handle, ispin, natom, nspin, restart_unit
       LOGICAL                                            :: exist
       TYPE(cp_logger_type), POINTER                      :: logger
 
@@ -602,8 +598,6 @@ CONTAINS
 
       nspin = SIZE(mo_array)
       restart_unit = -1
-
-      source = para_env%source
 
       IF (para_env%is_source()) THEN
 
@@ -668,7 +662,7 @@ CONTAINS
       INTEGER :: homo, homo_read, i, iatom, ikind, imat, irow, iset, iset_read, ishell, &
          ishell_read, iso, ispin, lfomo_read, lmax, lshell, my_mult, nao, nao_read, natom_read, &
          nelectron, nelectron_read, nmo, nmo_read, nnshell, nset, nset_max, nshell_max, nspin, &
-         nspin_read, offset_read, source
+         nspin_read, offset_read
       INTEGER, DIMENSION(:), POINTER                     :: nset_info, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l, nshell_info
       INTEGER, DIMENSION(:, :, :), POINTER               :: nso_info, offset_info
@@ -686,7 +680,6 @@ CONTAINS
       nao = mos(1)%nao
       my_mult = 0
       IF (PRESENT(multiplicity)) my_mult = multiplicity
-      source = para_env%source
 
       IF (para_env%is_source()) THEN
          READ (rst_unit) natom_read, nspin_read, nao_read, nset_max, nshell_max
@@ -743,7 +736,7 @@ CONTAINS
       END IF ! ionode
 
       ! make natom_match and natom_mismatch uniform across all nodes
-      CALL para_env%bcast(natom_match, source)
+      CALL para_env%bcast(natom_match)
       IF (PRESENT(natom_mismatch)) natom_mismatch = .NOT. natom_match
       ! handle natom_match false
       IF (.NOT. natom_match) THEN
@@ -756,7 +749,7 @@ CONTAINS
          END IF
       END IF
 
-      CALL para_env%bcast(nspin_read, source)
+      CALL para_env%bcast(nspin_read)
 
       ALLOCATE (vecbuffer(1, nao))
 
@@ -806,13 +799,13 @@ CONTAINS
             END IF
          END IF
 
-         CALL para_env%bcast(nmo, source)
-         CALL para_env%bcast(mos(ispin)%homo, source)
-         CALL para_env%bcast(mos(ispin)%lfomo, source)
-         CALL para_env%bcast(mos(ispin)%nelectron, source)
-         CALL para_env%bcast(mos(ispin)%eigenvalues, source)
-         CALL para_env%bcast(mos(ispin)%uniform_occupation, source)
-         CALL para_env%bcast(mos(ispin)%occupation_numbers, source)
+         CALL para_env%bcast(nmo)
+         CALL para_env%bcast(mos(ispin)%homo)
+         CALL para_env%bcast(mos(ispin)%lfomo)
+         CALL para_env%bcast(mos(ispin)%nelectron)
+         CALL para_env%bcast(mos(ispin)%eigenvalues)
+         CALL para_env%bcast(mos(ispin)%uniform_occupation)
+         CALL para_env%bcast(mos(ispin)%occupation_numbers)
 
          IF (PRESENT(rt_mos)) THEN
             DO imat = 2*ispin - 1, 2*ispin
@@ -822,7 +815,7 @@ CONTAINS
                   ELSE
                      vecbuffer(1, :) = 0.0_dp
                   END IF
-                  CALL para_env%bcast(vecbuffer, source)
+                  CALL para_env%bcast(vecbuffer)
                   CALL cp_fm_set_submatrix(rt_mos(imat), &
                                            vecbuffer, 1, i, nao, 1, transpose=.TRUE.)
                END DO
@@ -906,7 +899,7 @@ CONTAINS
 
                END IF
 
-               CALL para_env%bcast(vecbuffer, source)
+               CALL para_env%bcast(vecbuffer)
                CALL cp_fm_set_submatrix(mos(ispin)%mo_coeff, &
                                         vecbuffer, 1, i, nao, 1, transpose=.TRUE.)
             END DO

--- a/src/qs_neighbor_lists.F
+++ b/src/qs_neighbor_lists.F
@@ -1756,8 +1756,7 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)                       :: nl_type, middle_name, nlname
 
       CHARACTER(LEN=default_string_length)               :: string, unit_str
-      INTEGER                                            :: iatom, inode, iw, jatom, mype, &
-                                                            nneighbor, nnode
+      INTEGER                                            :: iatom, inode, iw, jatom, nneighbor, nnode
       INTEGER, DIMENSION(3)                              :: cell_b
       REAL(dp)                                           :: dab, unit_conv
       REAL(dp), DIMENSION(3)                             :: ra, rab, rb
@@ -1778,49 +1777,50 @@ CONTAINS
                                    local=.TRUE., &
                                    log_filename=.FALSE., &
                                    file_position="REWIND")
-         mype = para_env%mepos
-         CALL section_vals_val_get(neighbor_list_section, "UNIT", c_val=unit_str)
-         unit_conv = cp_unit_from_cp2k(1.0_dp, TRIM(unit_str))
+         ASSOCIATE (mype => para_env%mepos)
+            CALL section_vals_val_get(neighbor_list_section, "UNIT", c_val=unit_str)
+            unit_conv = cp_unit_from_cp2k(1.0_dp, TRIM(unit_str))
 
-         ! Print headline
-         string = ""
-         WRITE (UNIT=string, FMT="(A,I5,A)") &
-            TRIM(nlname)//" IN "//TRIM(unit_str)//" (PROCESS", mype, ")"
-         CALL compress(string)
-         IF (iw > 0) WRITE (UNIT=iw, FMT="(/,/,T2,A)") TRIM(string)
+            ! Print headline
+            string = ""
+            WRITE (UNIT=string, FMT="(A,I5,A)") &
+               TRIM(nlname)//" IN "//TRIM(unit_str)//" (PROCESS", mype, ")"
+            CALL compress(string)
+            IF (iw > 0) WRITE (UNIT=iw, FMT="(/,/,T2,A)") TRIM(string)
 
-         nneighbor = 0
+            nneighbor = 0
 
-         CALL neighbor_list_iterator_create(nl_iterator, ab)
-         DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
-            CALL get_iterator_info(nl_iterator, inode=inode, nnode=nnode, &
-                                   iatom=iatom, jatom=jatom, cell=cell_b, r=rab)
-            nneighbor = nneighbor + 1
-            ra(:) = pbc(particle_set(iatom)%r, cell)
-            rb(:) = ra(:) + rab(:)
-            dab = SQRT(rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3))
-            IF (iw > 0) THEN
-               IF (inode == 1) THEN
-                  WRITE (UNIT=iw, FMT="(/,T2,I5,3X,I6,3X,3F12.6)") &
-                     iatom, nnode, ra(1:3)*unit_conv
+            CALL neighbor_list_iterator_create(nl_iterator, ab)
+            DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+               CALL get_iterator_info(nl_iterator, inode=inode, nnode=nnode, &
+                                      iatom=iatom, jatom=jatom, cell=cell_b, r=rab)
+               nneighbor = nneighbor + 1
+               ra(:) = pbc(particle_set(iatom)%r, cell)
+               rb(:) = ra(:) + rab(:)
+               dab = SQRT(rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3))
+               IF (iw > 0) THEN
+                  IF (inode == 1) THEN
+                     WRITE (UNIT=iw, FMT="(/,T2,I5,3X,I6,3X,3F12.6)") &
+                        iatom, nnode, ra(1:3)*unit_conv
+                  END IF
+                  WRITE (UNIT=iw, FMT="(T10,I6,3X,3I4,3F12.6,2X,F12.6)") &
+                     jatom, cell_b(1:3), rb(1:3)*unit_conv, dab*unit_conv
                END IF
-               WRITE (UNIT=iw, FMT="(T10,I6,3X,3I4,3F12.6,2X,F12.6)") &
-                  jatom, cell_b(1:3), rb(1:3)*unit_conv, dab*unit_conv
-            END IF
-         END DO
-         CALL neighbor_list_iterator_release(nl_iterator)
+            END DO
+            CALL neighbor_list_iterator_release(nl_iterator)
 
-         string = ""
-         WRITE (UNIT=string, FMT="(A,I12,A,I12)") &
-            "Total number of neighbor interactions for process", mype, ":", &
-            nneighbor
-         CALL compress(string)
-         IF (iw > 0) WRITE (UNIT=iw, FMT="(/,T2,A)") TRIM(string)
-         CALL cp_print_key_finished_output(unit_nr=iw, &
-                                           logger=logger, &
-                                           basis_section=neighbor_list_section, &
-                                           print_key_path=TRIM(nl_type), &
-                                           local=.TRUE.)
+            string = ""
+            WRITE (UNIT=string, FMT="(A,I12,A,I12)") &
+               "Total number of neighbor interactions for process", mype, ":", &
+               nneighbor
+            CALL compress(string)
+            IF (iw > 0) WRITE (UNIT=iw, FMT="(/,T2,A)") TRIM(string)
+            CALL cp_print_key_finished_output(unit_nr=iw, &
+                                              logger=logger, &
+                                              basis_section=neighbor_list_section, &
+                                              print_key_path=TRIM(nl_type), &
+                                              local=.TRUE.)
+         END ASSOCIATE
       END IF
 
    END SUBROUTINE write_neighbor_lists

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -706,7 +706,7 @@ CONTAINS
 
       ! *** excitation analysis ***
       IF (do_exc_analysis) THEN
-         CPASSERT(log_unit <= 0 .OR. para_env%mepos == para_env%source)
+         CPASSERT(log_unit <= 0 .OR. para_env%is_source())
          nmo_virt_occ_alpha = INT(nmo_virt(1), int_8)*INT(nmo_occ(1), int_8)
 
          IF (log_unit > 0) THEN
@@ -780,7 +780,7 @@ CONTAINS
                nmo_virt_occ = nmo_virt_occ + nmo_virt8(ispin)*nmo_occ8(ispin)
             END DO
 
-            IF (para_env%mepos == para_env%source) THEN
+            IF (para_env%is_source()) THEN
                ! master node
                ALLOCATE (nexcs_recv(para_env%num_pe), recv_handlers(para_env%num_pe), recv_handlers2(para_env%num_pe))
 
@@ -855,7 +855,7 @@ CONTAINS
 
             ! sort non-negligible excitations on the master node according to their amplitudes,
             ! uncompress indices and print summary information
-            IF (para_env%mepos == para_env%source .AND. log_unit > 0) THEN
+            IF (para_env%is_source() .AND. log_unit > 0) THEN
                weights_neg_abs_recv(:) = -ABS(weights_recv)
                CALL sort(weights_neg_abs_recv, INT(nexcs), inds)
 
@@ -883,7 +883,7 @@ CONTAINS
             END IF
 
             ! deallocate temporary arrays
-            IF (para_env%mepos == para_env%source) &
+            IF (para_env%is_source()) &
                DEALLOCATE (weights_recv, weights_neg_abs_recv, inds_recv, inds)
          END DO
 

--- a/src/qs_tddfpt2_restart.F
+++ b/src/qs_tddfpt2_restart.F
@@ -203,7 +203,7 @@ CONTAINS
 
          IF (.NOT. file_exists) THEN
             nstates_read = 0
-            CALL para_env_global%bcast(nstates_read, para_env_global%source)
+            CALL para_env_global%bcast(nstates_read)
 
             CALL cp_warn(__LOCATION__, &
                          "User requested to restart the TDDFPT wave functions from the file '"//TRIM(filename)// &
@@ -260,7 +260,7 @@ CONTAINS
                          " excited states were requested.")
          END IF
       END IF
-      CALL para_env_global%bcast(nstates_read, para_env_global%source)
+      CALL para_env_global%bcast(nstates_read)
 
       ! exit if restart file does not exist
       IF (nstates_read <= 0) THEN
@@ -278,7 +278,7 @@ CONTAINS
          END IF
          DEALLOCATE (evals_read)
       END IF
-      CALL para_env_global%bcast(evals, para_env_global%source)
+      CALL para_env_global%bcast(evals)
 
       DO istate = 1, nstates_read
          DO ispin = 1, nspins

--- a/src/qs_vcd_utils.F
+++ b/src/qs_vcd_utils.F
@@ -528,7 +528,7 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename
       CHARACTER(LEN=default_string_length)               :: my_middle
       INTEGER :: beta_tmp, handle, i, i_block, ia, ie, iostat, iounit, ispin, j, lambda_tmp, &
-         max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit, source
+         max_block, n_rep_val, nao, nao_tmp, nmo, nmo_tmp, nspins, nspins_tmp, rst_unit
       LOGICAL                                            :: file_exists
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
@@ -552,7 +552,6 @@ CONTAINS
                       mos=mos)
 
       nspins = SIZE(mos)
-      source = para_env%source !ionode???
 
       rst_unit = -1
       IF (para_env%is_source()) THEN
@@ -592,7 +591,7 @@ CONTAINS
          END IF
       END IF
 
-      CALL para_env%bcast(file_exists, source)
+      CALL para_env%bcast(file_exists)
 
       IF (file_exists) THEN
 
@@ -603,12 +602,12 @@ CONTAINS
          !
          ! read headers
          IF (rst_unit > 0) READ (rst_unit, IOSTAT=iostat) lambda_tmp, beta_tmp, nspins_tmp, nao_tmp
-         CALL para_env%bcast(iostat, source)
+         CALL para_env%bcast(iostat)
 
-         CALL para_env%bcast(beta_tmp, source)
-         CALL para_env%bcast(lambda_tmp, source)
-         CALL para_env%bcast(nspins_tmp, source)
-         CALL para_env%bcast(nao_tmp, source)
+         CALL para_env%bcast(beta_tmp)
+         CALL para_env%bcast(lambda_tmp)
+         CALL para_env%bcast(nspins_tmp)
+         CALL para_env%bcast(nao_tmp)
 
          ! check that the number nao, nmo and nspins are
          ! the same as in the current mos
@@ -626,7 +625,7 @@ CONTAINS
             CALL cp_fm_get_info(mo_coeff, ncol_global=nmo)
             !
             IF (rst_unit > 0) READ (rst_unit) nmo_tmp
-            CALL para_env%bcast(nmo_tmp, source)
+            CALL para_env%bcast(nmo_tmp)
             IF (nmo_tmp .NE. nmo) CPABORT("nmo not consistent")
             !
             ! read the response
@@ -635,7 +634,7 @@ CONTAINS
                DO j = 1, i_block
                   IF (rst_unit > 0) READ (rst_unit) vecbuffer(1:nao, j)
                END DO
-               CALL para_env%bcast(vecbuffer, source)
+               CALL para_env%bcast(vecbuffer)
                CALL cp_fm_set_submatrix(vec(ispin), vecbuffer, 1, i, nao, i_block)
             END DO
          END DO

--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -99,8 +99,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_vxc_atom'
 
       INTEGER                                            :: bo(2), handle, ia, iat, iatom, idir, &
-                                                            ikind, ir, ispin, mepos, myfun, na, &
-                                                            natom, nr, nspins, num_pe
+                                                            ikind, ir, ispin, myfun, na, natom, &
+                                                            nr, nspins, num_pe
       INTEGER, DIMENSION(2, 3)                           :: bounds
       INTEGER, DIMENSION(:), POINTER                     :: atom_list
       LOGICAL                                            :: donlcc, epr_xc, gradient_f, lsd, nlcc, &
@@ -278,8 +278,7 @@ CONTAINS
             ! Distribute the atoms of this kind
 
             num_pe = para_env%num_pe
-            mepos = para_env%mepos
-            bo = get_limit(natom, num_pe, mepos)
+            bo = get_limit(natom, para_env%num_pe, para_env%mepos)
 
             DO iat = bo(1), bo(2)
                iatom = atom_list(iat)
@@ -774,8 +773,8 @@ CONTAINS
       REAL(KIND=dp), PARAMETER                           :: epsrho = 5.e-4_dp
 
       INTEGER                                            :: bo(2), handle, iat, iatom, ikind, ir, &
-                                                            istep, mepos, myfun, na, natom, nf, &
-                                                            nr, ns, nspins, nstep, num_pe
+                                                            istep, myfun, na, natom, nf, nr, ns, &
+                                                            nspins, nstep, num_pe
       INTEGER, DIMENSION(2, 3)                           :: bounds
       INTEGER, DIMENSION(:), POINTER                     :: atom_list
       LOGICAL                                            :: donlcc, gradient_f, lsd, nlcc, paw_atom, &
@@ -918,8 +917,7 @@ CONTAINS
 
             ! Distribute the atoms of this kind
             num_pe = para_env%num_pe
-            mepos = para_env%mepos
-            bo = get_limit(natom, num_pe, mepos)
+            bo = get_limit(natom, num_pe, para_env%mepos)
 
             DO iat = bo(1), bo(2)
                iatom = atom_list(iat)

--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -469,7 +469,7 @@ CONTAINS
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom_set, rho1_atom_set
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: xc_section
-      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(cp_para_env_type), INTENT(IN)                 :: para_env
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_tddft, do_tddfpt2, do_triplet
       TYPE(qs_kind_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: kind_set_external

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -28,7 +28,6 @@ MODULE rpa_grad
    USE cp_fm_types,                     ONLY: &
         cp_fm_create, cp_fm_get_info, cp_fm_indxg2l, cp_fm_indxg2p, cp_fm_release, cp_fm_set_all, &
         cp_fm_to_fm, cp_fm_to_fm_submat_general, cp_fm_type
-   USE cp_para_env,                     ONLY: cp_para_env_release
    USE cp_para_types,                   ONLY: cp_para_env_type
    USE dgemm_counter_types,             ONLY: dgemm_counter_start,&
                                               dgemm_counter_stop,&
@@ -52,7 +51,8 @@ MODULE rpa_grad
    USE machine,                         ONLY: m_flush,&
                                               m_memory
    USE mathconstants,                   ONLY: pi
-   USE message_passing,                 ONLY: mp_request_null,&
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_request_null,&
                                               mp_request_type,&
                                               mp_waitall,&
                                               mp_waitany
@@ -465,7 +465,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, ncol_locals
       INTEGER, DIMENSION(:, :), POINTER                  :: blacs2mpi
       TYPE(cp_blacs_env_type), POINTER                   :: context
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_exchange
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_comm_type)                                 :: comm_exchange
 
       CALL timeset(routineN, handle)
 
@@ -489,8 +490,7 @@ CONTAINS
 
       IF (num_ij_pairs > 0) THEN
 
-         ALLOCATE (para_env_exchange)
-         CALL para_env_exchange%from_split(para_env, my_prow)
+         CALL comm_exchange%from_split(para_env, my_prow)
 
          data2send = 0
          data2recv = 0
@@ -523,7 +523,7 @@ CONTAINS
             data2send(pcol_send) = counter
          END DO
 
-         CALL para_env_exchange%alltoall(data2send, data2recv, 1)
+         CALL comm_exchange%alltoall(data2send, data2recv, 1)
 
          DO proc_shift = 0, num_pe_col - 1
             pcol_send = MODULO(my_pcol + proc_shift, num_pe_col)
@@ -570,7 +570,7 @@ CONTAINS
             END DO
          END DO
 
-         CALL cp_para_env_release(para_env_exchange)
+         CALL comm_exchange%free()
       END IF
 
       DEALLOCATE (data2send, data2recv)
@@ -599,7 +599,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, ncol_locals
       INTEGER, DIMENSION(:, :), POINTER                  :: blacs2mpi
       TYPE(cp_blacs_env_type), POINTER                   :: context
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_exchange
+      TYPE(cp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_comm_type)                                 :: comm_exchange
 
       CALL timeset(routineN, handle)
 
@@ -619,8 +620,7 @@ CONTAINS
                           blacs2mpi=blacs2mpi)
          first_p_pos_col = first_p_pos(2)
 
-         ALLOCATE (para_env_exchange)
-         CALL para_env_exchange%from_split(para_env, my_prow)
+         CALL comm_exchange%from_split(para_env, my_prow)
 
          ALLOCATE (data2send(0:num_pe_col - 1))
          ALLOCATE (data2recv(0:num_pe_col - 1))
@@ -656,7 +656,7 @@ CONTAINS
             data2send(pcol_send) = counter
          END DO
 
-         CALL para_env_exchange%alltoall(data2send, data2recv, 1)
+         CALL comm_exchange%alltoall(data2send, data2recv, 1)
 
          DO proc_shift = 0, num_pe_col - 1
             pcol_send = MODULO(my_pcol + proc_shift, num_pe_col)
@@ -703,7 +703,7 @@ CONTAINS
             END DO
          END DO
 
-         CALL cp_para_env_release(para_env_exchange)
+         CALL comm_exchange%free()
          DEALLOCATE (data2send, data2recv)
 
       END IF
@@ -2426,7 +2426,6 @@ CONTAINS
          send_a_size, send_a_start, send_end, send_start, size_recv_buffer, size_send_buffer
       REAL(KIND=dp)                                      :: my_scale
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: buffer_recv, buffer_send
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange
       TYPE(group_dist_d1_type)                           :: gd_a_sub, gd_virtual_sub
 
       CALL timeset(routineN, handle)
@@ -2541,10 +2540,12 @@ CONTAINS
 
          CALL release_group_dist(gd_a_sub)
 
-         ALLOCATE (para_env_exchange)
-         CALL para_env_exchange%from_split(para_env, para_env_sub%mepos)
-         CALL para_env_exchange%sum(mp2_env%ri_grad%P_ab(ispin)%array)
-         CALL cp_para_env_release(para_env_exchange)
+         BLOCK
+            TYPE(mp_comm_type) :: comm_exchange
+            CALL comm_exchange%from_split(para_env, para_env_sub%mepos)
+            CALL comm_exchange%sum(mp2_env%ri_grad%P_ab(ispin)%array)
+            CALL comm_exchange%free()
+         END BLOCK
 
          ! Symmetrize P_ab
          IF (para_env_sub%num_pe > 1) THEN
@@ -2624,7 +2625,7 @@ CONTAINS
                                                             mpi2blacs_global, mpi2blacs_sub
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), TARGET   :: recv_buffer_1D, send_buffer_1D
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: recv_buffer, send_buffer
-      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_exchange, para_env_sub
+      TYPE(cp_para_env_type), POINTER                    :: para_env, para_env_sub
       TYPE(one_dim_int_array), ALLOCATABLE, DIMENSION(:) :: index2recv_col, index2recv_row, &
                                                             index2send_col, index2send_row
 
@@ -2652,12 +2653,12 @@ CONTAINS
       CALL fm_global%matrix_struct%context%get(blacs2mpi=blacs2mpi_global, mpi2blacs=mpi2blacs_global)
 
       IF (para_env%num_pe /= para_env_sub%num_pe) THEN
-         CALL timeset(routineN//"_exchange", handle2)
-         ALLOCATE (para_env_exchange)
-         CALL para_env_exchange%from_split(para_env, para_env_sub%mepos)
-         CALL para_env_exchange%sum(fm_sub%local_data)
-         CALL cp_para_env_release(para_env_exchange)
-         CALL timestop(handle2)
+         BLOCK
+            TYPE(mp_comm_type) :: comm_exchange
+            comm_exchange = fm_sub%matrix_struct%context%interconnect(para_env)
+            CALL comm_exchange%sum(fm_sub%local_data)
+            CALL comm_exchange%free()
+         END BLOCK
       END IF
 
       ALLOCATE (subgroup2mepos(0:para_env_sub%num_pe - 1))

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -60,6 +60,7 @@ MODULE rpa_main
                                               m_memory
    USE mathconstants,                   ONLY: pi,&
                                               z_zero
+   USE message_passing,                 ONLY: mp_comm_type
    USE minimax_exp,                     ONLY: check_exp_minimax_range
    USE mp2_grids,                       ONLY: get_clenshaw_grid,&
                                               get_minimax_grid
@@ -827,13 +828,12 @@ CONTAINS
 
       INTEGER                                            :: col_row_proc_ratio, grid_2D(2), handle, &
                                                             iproc, iproc_col, iproc_row, ispin, &
-                                                            mepos_in_RPA_group, sub_sub_color
+                                                            mepos_in_RPA_group
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: group_grid_2_mepos
       LOGICAL                                            :: my_blacs_ext, my_blacs_S_ext, &
                                                             my_do_im_time
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env, blacs_env_Q
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
-      TYPE(cp_para_env_type), POINTER                    :: para_env_exchange
       TYPE(group_dist_d1_type)                           :: gd_ia, gd_L
 
       CALL timeset(routineN, handle)
@@ -938,11 +938,12 @@ CONTAINS
 
             ! sum the local data across processes belonging to different RPA group.
             IF (para_env_RPA%num_pe /= para_env%num_pe) THEN
-               sub_sub_color = para_env_RPA%mepos
-               ALLOCATE (para_env_exchange)
-               CALL para_env_exchange%from_split(para_env, sub_sub_color)
-               CALL para_env_exchange%sum(fm_mat_S(ispin)%local_data)
-               CALL cp_para_env_release(para_env_exchange)
+               BLOCK
+                  TYPE(mp_comm_type) :: comm_exchange
+                  comm_exchange = fm_mat_S(ispin)%matrix_struct%context%interconnect(para_env)
+                  CALL comm_exchange%sum(fm_mat_S(ispin)%local_data)
+                  CALL comm_exchange%free()
+               END BLOCK
             END IF
          END DO
       END IF

--- a/src/start/cp2k_shell.F
+++ b/src/start/cp2k_shell.F
@@ -198,9 +198,9 @@ CONTAINS
             success = .FALSE. ! EOF
          END IF
       END IF
-      CALL shell%para_env%bcast(success, shell%para_env%source)
+      CALL shell%para_env%bcast(success)
       IF (.NOT. success) RETURN
-      CALL shell%para_env%bcast(line, shell%para_env%source)
+      CALL shell%para_env%bcast(line)
 
       ! extract command
       line = TRIM(line)
@@ -578,7 +578,7 @@ CONTAINS
          CALL uppercase(line)
          IF (.NOT. my_assert(TRIM(line) == '*END', 'missing *END', shell)) RETURN
       END IF
-      CALL shell%para_env%bcast(pos, shell%para_env%source)
+      CALL shell%para_env%bcast(pos)
       CALL get_pos(shell%env_id, old_pos, n_el=3*n_atom, ierr=ierr)
       IF (.NOT. my_assert(ierr == 0, 'get_pos error', shell)) RETURN
       CALL set_pos(shell%env_id, new_pos=pos, n_el=3*n_atom, ierr=ierr)
@@ -612,7 +612,7 @@ CONTAINS
          IF (.NOT. my_assert(iostat == 0, 'setcell read failed', shell)) RETURN
          cell(:, :) = cell(:, :)/shell%pos_fact
       END IF
-      CALL shell%para_env%bcast(cell, shell%para_env%source)
+      CALL shell%para_env%bcast(cell)
       CALL set_cell(shell%env_id, new_cell=cell, ierr=ierr)
       IF (.NOT. my_assert(ierr == 0, 'set_cell failed', shell)) RETURN
    END SUBROUTINE set_cell_command

--- a/src/swarm/swarm_message.F
+++ b/src/swarm/swarm_message.F
@@ -233,29 +233,30 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: src
       CLASS(mp_comm_type), INTENT(IN) :: group
 
-      INTEGER                                            :: i, length, mepos
+      INTEGER                                            :: i, length
       TYPE(message_entry_type), POINTER                  :: curr_entry
 
-      mepos = group%mepos
+      ASSOCIATE (mepos => group%mepos)
 
-      IF (mepos /= src .AND. ASSOCIATED(msg%root)) CPABORT("message not empty")
-      length = swarm_message_length(msg)
-      CALL group%bcast(length, src)
+         IF (mepos /= src .AND. ASSOCIATED(msg%root)) CPABORT("message not empty")
+         length = swarm_message_length(msg)
+         CALL group%bcast(length, src)
 
-      IF (mepos == src) curr_entry => msg%root
+         IF (mepos == src) curr_entry => msg%root
 
-      DO i = 1, length
-         IF (mepos /= src) ALLOCATE (curr_entry)
+         DO i = 1, length
+            IF (mepos /= src) ALLOCATE (curr_entry)
 
-         CALL swarm_message_entry_mpi_bcast(curr_entry, src, group, mepos)
+            CALL swarm_message_entry_mpi_bcast(curr_entry, src, group, mepos)
 
-         IF (mepos == src) THEN
-            curr_entry => curr_entry%next
-         ELSE
-            curr_entry%next => msg%root
-            msg%root => curr_entry
-         END IF
-      END DO
+            IF (mepos == src) THEN
+               curr_entry => curr_entry%next
+            ELSE
+               curr_entry%next => msg%root
+               msg%root => curr_entry
+            END IF
+         END DO
+      END ASSOCIATE
 
    END SUBROUTINE swarm_message_mpi_bcast
 

--- a/src/swarm/swarm_mpi.F
+++ b/src/swarm/swarm_mpi.F
@@ -166,7 +166,7 @@ CONTAINS
             CLOSE (output_unit)
       END IF
 
-      CALL swarm_mpi%world%bcast(swarm_mpi%master_output_path, swarm_mpi%world%source)
+      CALL swarm_mpi%world%bcast(swarm_mpi%master_output_path)
 
       IF (ASSOCIATED(swarm_mpi%master)) &
          CALL error_add_new_logger(swarm_mpi%master, swarm_mpi%master_output_path)

--- a/src/swarm/swarm_mpi.F
+++ b/src/swarm/swarm_mpi.F
@@ -289,7 +289,6 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: root_section
 
       INTEGER                                            :: output_unit
-      LOGICAL                                            :: I_am_rank0
       TYPE(cp_logger_type), POINTER                      :: logger, old_logger
 
       NULLIFY (logger, old_logger)
@@ -308,8 +307,7 @@ CONTAINS
       CALL swarm_mpi%world%sync()
 
       ! do this only on master's rank 0
-      I_am_rank0 = swarm_mpi%world%mepos == swarm_mpi%world%source
-      IF (I_am_rank0 .AND. output_unit /= default_output_unit) THEN
+      IF (swarm_mpi%world%is_source() .AND. output_unit /= default_output_unit) THEN
          output_unit = old_logger%default_local_unit_nr
          OPEN (unit=output_unit, file=swarm_mpi%master_output_path, &
                status="UNKNOWN", action="WRITE", position="APPEND")

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -292,8 +292,8 @@ CONTAINS
          CALL close_file(unit_number=extunit)
       END IF
 
-      CALL para_env%bcast(npts, para_env%source)
-      CALL para_env%bcast(dcell, para_env%source)
+      CALL para_env%bcast(npts)
+      CALL para_env%bcast(dcell)
 
       NULLIFY (pw_grid)
       CALL pw_grid_create(pw_grid, para_env)

--- a/src/tmc/tmc_setup.F
+++ b/src/tmc/tmc_setup.F
@@ -140,7 +140,7 @@ CONTAINS
          WRITE (UNIT=output_unit, FMT="(/,T2,A)") REPEAT("-", 79)
       END IF
       bcast_output_unit = output_unit
-      CALL para_env%bcast(bcast_output_unit, para_env%source)
+      CALL para_env%bcast(bcast_output_unit)
 
       ! create tmc_env
       CALL tmc_env_create(tmc_env)

--- a/src/xas_restart.F
+++ b/src/xas_restart.F
@@ -114,7 +114,7 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER :: handle, i, ia, ie, ispin, my_spin, nao, nao_read, nelectron, nexc_atoms, &
          nexc_atoms_read, nexc_search, nexc_search_read, nmo, nmo_read, output_unit, rst_unit, &
-         source, xas_estate, xas_estate_read, xas_method_read
+         xas_estate, xas_estate_read, xas_method_read
       LOGICAL                                            :: file_exists
       REAL(dp)                                           :: occ_estate, occ_estate_read, &
                                                             xas_nelectron, xas_nelectron_read
@@ -140,7 +140,6 @@ CONTAINS
                                          "PRINT%PROGRAM_RUN_INFO", extension=".Log")
 
       CALL get_qs_env(qs_env=qs_env, para_env=para_env)
-      source = para_env%source
 
       IF (para_env%is_source()) THEN
          CALL wfn_restart_file_name(filename, file_exists, xas_section, logger, &
@@ -170,7 +169,7 @@ CONTAINS
                " not available. Initialization done with GS orbitals"
          END IF
       END IF
-      CALL para_env%bcast(file_exists, source)
+      CALL para_env%bcast(file_exists)
 
       CALL get_xas_env(xas_env=xas_env, occ_estate=occ_estate, xas_estate=xas_estate, &
                        xas_nelectron=xas_nelectron, nexc_search=nexc_search, &
@@ -192,7 +191,7 @@ CONTAINS
                              " is not possible. Start instead a new XAS run with the new set of atoms. ")
          END IF
 
-         CALL para_env%bcast(xas_estate_read, source)
+         CALL para_env%bcast(xas_estate_read)
          CALL set_xas_env(xas_env=xas_env, xas_estate=xas_estate_read)
          estate = xas_estate_read
 
@@ -225,8 +224,8 @@ CONTAINS
                END IF
                DEALLOCATE (eig_read, occ_read)
             END IF
-            CALL para_env%bcast(eigenvalues, source)
-            CALL para_env%bcast(occupation_numbers, source)
+            CALL para_env%bcast(eigenvalues)
+            CALL para_env%bcast(occupation_numbers)
 
             DO i = 1, nmo
                IF (para_env%is_source()) THEN
@@ -234,7 +233,7 @@ CONTAINS
                ELSE
                   vecbuffer(1, :) = 0.0_dp
                END IF
-               CALL para_env%bcast(vecbuffer, source)
+               CALL para_env%bcast(vecbuffer)
                CALL cp_fm_set_submatrix(mo_coeff, &
                                         vecbuffer, 1, i, nao, 1, transpose=.TRUE.)
             END DO

--- a/src/xas_tdp_methods.F
+++ b/src/xas_tdp_methods.F
@@ -3335,8 +3335,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'read_donor_state_restart'
 
       INTEGER                                            :: handle, ispin, nao, nex, nspins, &
-                                                            output_unit, read_params(7), rst_unit, &
-                                                            source
+                                                            output_unit, read_params(7), rst_unit
       INTEGER, DIMENSION(:, :), POINTER                  :: mo_indices
       LOGICAL                                            :: file_exists
       REAL(dp), DIMENSION(:), POINTER                    :: lr_evals
@@ -3355,7 +3354,6 @@ CONTAINS
       CPASSERT(ASSOCIATED(donor_state))
       CALL get_qs_env(qs_env, para_env=para_env, blacs_env=blacs_env)
       group = para_env
-      source = para_env%source
 
       file_exists = .FALSE.
       rst_unit = -1
@@ -3380,7 +3378,7 @@ CONTAINS
          READ (rst_unit) read_params(1:4)
          READ (rst_unit) read_params(5:7)
       END IF
-      CALL group%bcast(read_params, source)
+      CALL group%bcast(read_params)
       donor_state%at_index = read_params(1)
       donor_state%state_type = read_params(2)
       donor_state%ndo_mo = read_params(3)
@@ -3393,13 +3391,13 @@ CONTAINS
       IF (rst_unit > 0) THEN
          READ (rst_unit) mo_indices(1:donor_state%ndo_mo, 1:nspins)
       END IF
-      CALL group%bcast(mo_indices, source)
+      CALL group%bcast(mo_indices)
       donor_state%mo_indices => mo_indices
 
       !read evals
       ALLOCATE (lr_evals(nex))
       IF (rst_unit > 0) READ (rst_unit) lr_evals(1:nex)
-      CALL group%bcast(lr_evals, source)
+      CALL group%bcast(lr_evals)
 
       !read evecs
       CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=para_env, &

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -505,8 +505,8 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: oe_corr
 
-      INTEGER                                            :: ia, iat, iatom, ikind, ir, ispin, mepos, &
-                                                            na, natom, nr, ns, nspins, num_pe, orb
+      INTEGER                                            :: ia, iat, iatom, ikind, ir, ispin, na, &
+                                                            natom, nr, ns, nspins, orb
       INTEGER, DIMENSION(2)                              :: bo, homo, ncol, nrow
       INTEGER, DIMENSION(2, 3)                           :: bounds
       INTEGER, DIMENSION(:), POINTER                     :: atom_list
@@ -676,9 +676,7 @@ CONTAINS
          ALLOCATE (drho_h(1:4, 1:na, 1:nr, 1:nspins), drho_s(1:4, 1:na, 1:nr, 1:nspins))
 
          ! Distribute the atoms of this kind
-         num_pe = para_env%num_pe
-         mepos = para_env%mepos
-         bo = get_limit(natom, num_pe, mepos)
+         bo = get_limit(natom, para_env%num_pe, para_env%mepos)
 
          DO iat = 1, natom !bo(1),bo(2)
             iatom = atom_list(iat)

--- a/src/xray_diffraction.F
+++ b/src/xray_diffraction.F
@@ -94,8 +94,7 @@ CONTAINS
       INTEGER, PARAMETER                                 :: nblock = 100
 
       INTEGER                                            :: handle, i, ig, ig_shell, ipe, ishell, &
-                                                            jg, ng, npe, nshell, nshell_gather, &
-                                                            source
+                                                            jg, ng, npe, nshell, nshell_gather
       INTEGER(KIND=int_8)                                :: ngpts
       INTEGER, DIMENSION(3)                              :: npts
       INTEGER, DIMENSION(:), POINTER                     :: aux_index, ng_shell, ng_shell_gather, &
@@ -161,7 +160,6 @@ CONTAINS
                       auxbas_pw_pool=auxbas_pw_pool)
 
       npe = para_env%num_pe
-      source = para_env%source
 
       ! Plane waves grid to assemble the total electronic density
 
@@ -261,7 +259,7 @@ CONTAINS
 
       ! Root (source) process gathers the number of shell of each process
 
-      CALL para_env%gather(nshell, nshell_pe, source)
+      CALL para_env%gather(nshell, nshell_pe)
 
       ! Only the root process which has to print the full spectrum has to
       ! allocate here the receive buffers with their real sizes
@@ -284,13 +282,13 @@ CONTAINS
       CALL reallocate(f2sum_gather, 1, nshell_gather)
       CALL reallocate(f4sum_gather, 1, nshell_gather)
 
-      CALL para_env%gatherv(q_shell, q_shell_gather, nshell_pe, offset_pe, source)
-      CALL para_env%gatherv(ng_shell, ng_shell_gather, nshell_pe, offset_pe, source)
-      CALL para_env%gatherv(fmax, fmax_gather, nshell_pe, offset_pe, source)
-      CALL para_env%gatherv(fmin, fmin_gather, nshell_pe, offset_pe, source)
-      CALL para_env%gatherv(fsum, fsum_gather, nshell_pe, offset_pe, source)
-      CALL para_env%gatherv(f2sum, f2sum_gather, nshell_pe, offset_pe, source)
-      CALL para_env%gatherv(f4sum, f4sum_gather, nshell_pe, offset_pe, source)
+      CALL para_env%gatherv(q_shell, q_shell_gather, nshell_pe, offset_pe)
+      CALL para_env%gatherv(ng_shell, ng_shell_gather, nshell_pe, offset_pe)
+      CALL para_env%gatherv(fmax, fmax_gather, nshell_pe, offset_pe)
+      CALL para_env%gatherv(fmin, fmin_gather, nshell_pe, offset_pe)
+      CALL para_env%gatherv(fsum, fsum_gather, nshell_pe, offset_pe)
+      CALL para_env%gatherv(f2sum, f2sum_gather, nshell_pe, offset_pe)
+      CALL para_env%gatherv(f4sum, f4sum_gather, nshell_pe, offset_pe)
 
       IF (ASSOCIATED(offset_pe)) THEN
          DEALLOCATE (offset_pe)


### PR DESCRIPTION
This PR
- adds convenience functions to broadcast/gather on the source of a given communicator (not implemented for wrappers to mpi_scatter, mpi_reduce, non-blocking calls because they are not used)
- replaces local cp_para_env_types with simple communicators
- replaces some send/recv calls with bcast