### PR TITLE
Use the Fortran 2003 wrapper to FFTW3

### DIFF
--- a/src/negf_integr_cc.F
+++ b/src/negf_integr_cc.F
@@ -25,7 +25,9 @@ MODULE negf_integr_cc
                                               cp_fm_get_info,&
                                               cp_fm_release,&
                                               cp_fm_type
-   USE fft_tools,                       ONLY: fft_fw1d
+   USE fft_tools,                       ONLY: fft_alloc,&
+                                              fft_dealloc,&
+                                              fft_fw1d
    USE kahan_sum,                       ONLY: accurate_sum
    USE kinds,                           ONLY: dp,&
                                               int_8
@@ -427,7 +429,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'ccquad_refine_integral'
 
-      COMPLEX(kind=dp), ALLOCATABLE, DIMENSION(:, :, :)  :: ztmp, ztmp_dct
+      COMPLEX(kind=dp), CONTIGUOUS, DIMENSION(:, :, :), &
+         POINTER                                         :: ztmp, ztmp_dct
       INTEGER :: handle, icol, ipoint, irow, ncols_local, nintervals, nintervals_half, &
          nintervals_half_plus_1, nintervals_half_plus_2, nintervals_plus_2, nrows_local, stat
       LOGICAL                                            :: equiv
@@ -484,8 +487,8 @@ CONTAINS
       ! 1.0 / nintervals
       rscale = 1.0_dp/rscale
 
-      ALLOCATE (ztmp(nintervals, nrows_local, ncols_local))
-      ALLOCATE (ztmp_dct(nintervals, nrows_local, ncols_local))
+      CALL fft_alloc(ztmp, [nintervals, nrows_local, ncols_local])
+      CALL fft_alloc(ztmp_dct, [nintervals, nrows_local, ncols_local])
 
 !$OMP PARALLEL DO DEFAULT(NONE), PRIVATE(icol, ipoint, irow), &
 !$OMP             SHARED(cc_env, ncols_local, nintervals_half, nintervals_half_plus_1, nintervals_half_plus_2, nrows_local, ztmp)
@@ -527,7 +530,8 @@ CONTAINS
       END DO
 !$OMP END PARALLEL DO
 
-      DEALLOCATE (ztmp, ztmp_dct)
+      CALL fft_dealloc(ztmp)
+      CALL fft_dealloc(ztmp_dct)
 
       CALL cp_fm_trace(cc_env%error_fm, cc_env%weights, cc_env%error)
 

--- a/src/pw/fft/fft_lib.F
+++ b/src/pw/fft/fft_lib.F
@@ -13,14 +13,10 @@ MODULE fft_lib
                                               fftsg_do_cleanup,&
                                               fftsg_do_init,&
                                               fftsg_get_lengths
-   USE fftw3_lib,                       ONLY: fftw31dm,&
-                                              fftw33d,&
-                                              fftw3_create_plan_1dm,&
-                                              fftw3_create_plan_3d,&
-                                              fftw3_destroy_plan,&
-                                              fftw3_do_cleanup,&
-                                              fftw3_do_init,&
-                                              fftw3_get_lengths
+   USE fftw3_lib,                       ONLY: &
+        fft_alloc => fftw_alloc, fft_dealloc => fftw_dealloc, fftw31dm, fftw33d, &
+        fftw3_create_plan_1dm, fftw3_create_plan_3d, fftw3_destroy_plan, fftw3_do_cleanup, &
+        fftw3_do_init, fftw3_get_lengths
 #include "../../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -30,6 +26,7 @@ MODULE fft_lib
 
    PUBLIC :: fft_do_cleanup, fft_do_init, fft_get_lengths, fft_create_plan_3d
    PUBLIC :: fft_create_plan_1dm, fft_1dm, fft_library, fft_3d, fft_destroy_plan
+   PUBLIC :: fft_alloc, fft_dealloc
 
 CONTAINS
 ! **************************************************************************************************

--- a/src/pw/fft/fft_plan.F
+++ b/src/pw/fft/fft_plan.F
@@ -16,7 +16,8 @@
 ! **************************************************************************************************
 
 MODULE fft_plan
-   USE ISO_C_BINDING,                   ONLY: C_PTR
+   USE ISO_C_BINDING,                   ONLY: C_NULL_PTR,&
+                                              C_PTR
 
    IMPLICIT NONE
    PRIVATE
@@ -25,24 +26,24 @@ MODULE fft_plan
 
    TYPE fft_plan_type
 
-      INTEGER                             :: fft_type
-      INTEGER                             :: fsign
-      LOGICAL                             :: trans, fft_in_place, valid, separated_plans
-      INTEGER                             :: n, m
-      INTEGER, DIMENSION(3)               :: n_3d
+      INTEGER                             :: fft_type = -1
+      INTEGER                             :: fsign = 0
+      LOGICAL                             :: trans = .FALSE., fft_in_place = .FALSE., valid = .FALSE., separated_plans = .FALSE.
+      INTEGER                             :: n = -1, m = -1
+      INTEGER, DIMENSION(3)               :: n_3d = -1
 
 !   Handle for the FFTW plan
-      TYPE(C_PTR)                         :: fftw_plan
+      TYPE(C_PTR)                         :: fftw_plan = C_NULL_PTR
 
 !   Plan for the remaining rows for 1D FFT when number of threads does not divide the number of rows exactly
-!$    TYPE(C_PTR)                         :: alt_fftw_plan
-!$    LOGICAL                             :: need_alt_plan
-!$    INTEGER                             :: num_threads_needed, num_rows, alt_num_rows
+!$    TYPE(C_PTR)                         :: alt_fftw_plan = C_NULL_PTR
+!$    LOGICAL                             :: need_alt_plan = .FALSE.
+!$    INTEGER                             :: num_threads_needed = -1, num_rows = -1, alt_num_rows = -1
 
 !   Individual plans (used by hand-optimised 3D FFT)
-      TYPE(C_PTR)                     :: fftw_plan_nx, fftw_plan_ny, fftw_plan_nz
+      TYPE(C_PTR)                     :: fftw_plan_nx = C_NULL_PTR, fftw_plan_ny = C_NULL_PTR, fftw_plan_nz = C_NULL_PTR
 !   Plans for the remaining rows (when the number of threads does not divide the number of rows exactly)
-      TYPE(C_PTR)                     :: fftw_plan_nx_r, fftw_plan_ny_r, fftw_plan_nz_r
+      TYPE(C_PTR)                     :: fftw_plan_nx_r = C_NULL_PTR, fftw_plan_ny_r = C_NULL_PTR, fftw_plan_nz_r = C_NULL_PTR
 
    END TYPE fft_plan_type
 

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -8,18 +8,20 @@ MODULE fftw3_lib
 
    USE ISO_C_BINDING, ONLY: C_ASSOCIATED, &
                             C_CHAR, &
+                            C_DOUBLE, &
+                            C_DOUBLE_COMPLEX, &
                             C_INT, &
                             C_PTR
 #if defined(__FFTW3)
-   USE ISO_C_BINDING, ONLY: C_DOUBLE, &
-                            C_DOUBLE_COMPLEX, &
-                            C_FLOAT, &
-                            C_FLOAT_COMPLEX, &
-                            C_FUNPTR, &
-                            C_INT32_T, &
-                            C_INTPTR_T, &
-                            C_NULL_CHAR, &
-                            C_SIZE_T
+   USE ISO_C_BINDING, ONLY: &
+      C_FLOAT, &
+      C_FLOAT_COMPLEX, &
+      C_FUNPTR, &
+      C_INT32_T, &
+      C_INTPTR_T, &
+      C_LOC, &
+      C_NULL_CHAR, &
+      C_SIZE_T
 #endif
    USE cp_files, ONLY: get_unit_number
    USE fft_kinds, ONLY: dp
@@ -39,7 +41,52 @@ MODULE fftw3_lib
 #include "fftw3.f03"
 #endif
 
+   INTERFACE fftw_alloc
+      MODULE PROCEDURE :: fftw_alloc_complex_1d
+      MODULE PROCEDURE :: fftw_alloc_complex_2d
+      MODULE PROCEDURE :: fftw_alloc_complex_3d
+   END INTERFACE
+
+   INTERFACE fftw_dealloc
+      MODULE PROCEDURE :: fftw_dealloc_complex_1d
+      MODULE PROCEDURE :: fftw_dealloc_complex_2d
+      MODULE PROCEDURE :: fftw_dealloc_complex_3d
+   END INTERFACE
+
 CONTAINS
+
+   #:set maxdim = 3
+   #:for dim in range(1, maxdim+1)
+! Concatenate the components of the dimensions passed to this function to use it if FFTW3 is not used
+      #:set dim_extended = ", ".join(["n("+str(i)+")" for i in range(1, dim+1)])
+      SUBROUTINE fftw_alloc_complex_${dim}$d(array, n)
+         COMPLEX(C_DOUBLE_COMPLEX), DIMENSION(:${", :"*(dim-1)}$), CONTIGUOUS, POINTER, INTENT(OUT) :: array
+         INTEGER, DIMENSION(${dim}$), INTENT(IN) :: n
+
+#if defined(__FFTW3)
+         TYPE(C_PTR) :: data_ptr
+         data_ptr = fftw_alloc_complex(INT(PRODUCT(n), KIND=C_SIZE_T))
+         CALL C_F_POINTER(data_ptr, array, n)
+#else
+! Just allocate the array
+         ALLOCATE (array(${dim_extended}$))
+#endif
+
+      END SUBROUTINE fftw_alloc_complex_${dim}$d
+
+      SUBROUTINE fftw_dealloc_complex_${dim}$d(array)
+         COMPLEX(C_DOUBLE_COMPLEX), DIMENSION(:${", :"*(dim-1)}$), CONTIGUOUS, POINTER, INTENT(INOUT) :: array
+
+#if defined(__FFTW3)
+         CALL fftw_free(C_LOC(array))
+         NULLIFY (array)
+#else
+! Just deallocate the array
+         DEALLOCATE (array)
+#endif
+
+      END SUBROUTINE fftw_dealloc_complex_${dim}$d
+   #:endfor
 
 #if defined ( __FFTW3 )
 ! **************************************************************************************************

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -21,7 +21,7 @@ MODULE fftw3_lib
       C_INTPTR_T, &
       C_LOC, &
       C_NULL_CHAR, &
-      C_SIZE_T
+      C_SIZE_T, C_F_POINTER
 #endif
    USE cp_files, ONLY: get_unit_number
    USE fft_kinds, ONLY: dp
@@ -36,6 +36,7 @@ MODULE fftw3_lib
 
    PUBLIC :: fftw3_do_init, fftw3_do_cleanup, fftw3_get_lengths, fftw33d, fftw31dm
    PUBLIC :: fftw3_destroy_plan, fftw3_create_plan_1dm, fftw3_create_plan_3d
+   PUBLIC :: fftw_alloc, fftw_dealloc
 
 #if defined ( __FFTW3 )
 #include "fftw3.f03"

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -4,21 +4,26 @@
 !                                                                                                  !
 !   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
 !--------------------------------------------------------------------------------------------------!
-#define XFFTW_PLAN_WITH_NTHREADS dfftw_plan_with_nthreads
-#define XFFTW_PLAN_DFT_3D dfftw_plan_dft_3d
-#define XFFTW_PLAN_GURU_DFT dfftw_plan_guru_dft
-#define XFFTW_EXECUTE_DFT dfftw_execute_dft
-#define XFFTW_DESTROY_PLAN dfftw_destroy_plan
-
 MODULE fftw3_lib
 
-   USE ISO_C_BINDING,                   ONLY: C_ASSOCIATED,&
-                                              C_CHAR,&
-                                              C_INT,&
-                                              C_PTR
-   USE cp_files,                        ONLY: get_unit_number
-   USE fft_kinds,                       ONLY: dp
-   USE fft_plan,                        ONLY: fft_plan_type
+   USE ISO_C_BINDING, ONLY: C_ASSOCIATED, &
+                            C_CHAR, &
+                            C_INT, &
+                            C_PTR
+#if defined(__FFTW3)
+   USE ISO_C_BINDING, ONLY: C_DOUBLE, &
+                            C_DOUBLE_COMPLEX, &
+                            C_FLOAT, &
+                            C_FLOAT_COMPLEX, &
+                            C_FUNPTR, &
+                            C_INT32_T, &
+                            C_INTPTR_T, &
+                            C_NULL_CHAR, &
+                            C_SIZE_T
+#endif
+   USE cp_files, ONLY: get_unit_number
+   USE fft_kinds, ONLY: dp
+   USE fft_plan, ONLY: fft_plan_type
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num, omp_get_num_threads
 
@@ -31,11 +36,7 @@ MODULE fftw3_lib
    PUBLIC :: fftw3_destroy_plan, fftw3_create_plan_1dm, fftw3_create_plan_3d
 
 #if defined ( __FFTW3 )
-#include "fftw3.f"
-   INTERFACE
-      SUBROUTINE fftw_cleanup() BIND(C, name="fftw_cleanup")
-      END SUBROUTINE
-   END INTERFACE
+#include "fftw3.f03"
 #endif
 
 CONTAINS
@@ -96,13 +97,16 @@ CONTAINS
 
 #if defined ( __FFTW3 )
       INTEGER                                  :: iunit, istat
+      INTEGER(KIND=C_INT)                      :: isuccess
       ! Write out FFTW3 wisdom to file (if we can)
       ! only the ionode updates the wisdom
       IF (ionode) THEN
          iunit = get_unit_number()
          OPEN (UNIT=iunit, FILE=wisdom_file, STATUS="UNKNOWN", FORM="FORMATTED", ACTION="WRITE", IOSTAT=istat)
          IF (istat == 0) THEN
-            CALL fftw_export_wisdom_to_file(iunit)
+            isuccess = fftw_export_wisdom_to_filename(wisdom_file//C_NULL_CHAR)
+            IF (isuccess == 0) &
+               CPABORT("Error exporting wisdom to file "//wisdom_file)
             CLOSE (iunit)
          END IF
       END IF
@@ -124,7 +128,8 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)             :: wisdom_file
 
 #if defined ( __FFTW3 )
-      INTEGER                                  :: istat, isuccess, iunit
+      INTEGER                                  :: istat, iunit
+      INTEGER(KIND=C_INT) :: isuccess
       LOGICAL                                  :: exist
 
 !$    LOGICAL                                  :: mkl_is_safe
@@ -158,7 +163,9 @@ CONTAINS
          OPEN (UNIT=iunit, FILE=wisdom_file, STATUS="OLD", FORM="FORMATTED", POSITION="REWIND", &
                ACTION="READ", IOSTAT=istat)
          IF (istat == 0) THEN
-            CALL fftw_import_wisdom_from_file(isuccess, iunit)
+            isuccess = fftw_import_wisdom_from_filename(wisdom_file//C_NULL_CHAR)
+            IF (isuccess == 0) &
+               CPABORT("Error importing wisdom from file "//wisdom_file)
             ! write(*,*) "FFTW3 import wisdom from file ....",MERGE((/"OK    "/),(/"NOT OK"/),(/isuccess==1/))
             CLOSE (iunit)
          END IF
@@ -436,20 +443,25 @@ CONTAINS
       IMPLICIT NONE
 
       TYPE(C_PTR), INTENT(INOUT)                         :: plan
-      COMPLEX(KIND=dp), DIMENSION(*), INTENT(IN)         :: zin
-      COMPLEX(KIND=dp), DIMENSION(*), INTENT(IN)         :: zout
+      COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT)      :: zin, zout
       INTEGER, INTENT(IN) :: dim_n(2), dim_istride(2), dim_ostride(2), &
                              hm_n(2), hm_istride(2), hm_ostride(2), fft_rank, &
                              fft_direction, fftw_plan_type, hm_rank
       LOGICAL, INTENT(OUT)                               :: valid
 
 #if defined (__FFTW3)
+      TYPE(fftw_iodim) :: dim(2), hm(2)
+      INTEGER :: i
 
-      CALL XFFTW_PLAN_GURU_DFT(plan, fft_rank, &
-                               dim_n, dim_istride, dim_ostride, &
-                               hm_rank, hm_n, hm_istride, hm_ostride, &
-                               zin, zout, &
-                               fft_direction, fftw_plan_type)
+      DO i = 1, 2
+         DIM(i) = fftw_iodim(dim_n(i), dim_istride(i), dim_ostride(i))
+         hm(i) = fftw_iodim(hm_n(i), hm_istride(i), hm_ostride(i))
+      END DO
+
+      plan = fftw_plan_guru_dft(fft_rank, &
+                                dim, hm_rank, hm, &
+                                zin, zout, &
+                                fft_direction, fftw_plan_type)
 
       valid = C_ASSOCIATED(plan)
 
@@ -510,7 +522,7 @@ CONTAINS
                                   zin, zin, &
                                   FFTW_FORWARD, FFTW_ESTIMATE, guru_supported)
       IF (guru_supported) THEN
-         CALL XFFTW_DESTROY_PLAN(test_plan)
+         CALL fftw_destroy_plan(test_plan)
          is_mkl = .FALSE.
       ELSE
          is_mkl = .TRUE.
@@ -687,12 +699,12 @@ CONTAINS
          ! so plan a single 3D FFT which will execute using all the threads
 
          plan%separated_plans = .FALSE.
-!$       CALL XFFTW_PLAN_WITH_NTHREADS(nt)
+!$       CALL fftw_plan_with_nthreads(nt)
 
          IF (plan%fft_in_place) THEN
-            CALL XFFTW_PLAN_DFT_3D(plan%fftw_plan, n1, n2, n3, zin, zin, fft_direction, fftw_plan_type)
+            plan%fftw_plan = fftw_plan_dft_3d(n3, n2, n1, zin, zin, fft_direction, fftw_plan_type)
          ELSE
-            CALL XFFTW_PLAN_DFT_3D(plan%fftw_plan, n1, n2, n3, zin, zout, fft_direction, fftw_plan_type)
+            plan%fftw_plan = fftw_plan_dft_3d(n3, n2, n1, zin, zout, fft_direction, fftw_plan_type)
          END IF
       ELSE
          ALLOCATE (tmp(n1*n2*n3))
@@ -829,8 +841,8 @@ CONTAINS
             i_off = (tid)*(istride*(rows_per_thread)) + 1
             o_off = (tid)*(ostride*(rows_per_thread)) + 1
             IF (rows_per_thread .GT. 0) THEN
-               CALL XFFTW_EXECUTE_DFT(plan, input(i_off), &
-                                      output(o_off))
+               CALL fftw_execute_dft(plan, input(i_off), &
+                                     output(o_off))
             END IF
          ELSE IF ((tid - th_planA) < th_planB) THEN
 
@@ -839,16 +851,16 @@ CONTAINS
             o_off = (th_planA)*ostride*(rows_per_thread) + &
                     (tid - th_planA)*ostride*(rows_per_thread_r) + 1
 
-            CALL XFFTW_EXECUTE_DFT(plan_r, input(i_off), &
-                                   output(o_off))
+            CALL fftw_execute_dft(plan_r, input(i_off), &
+                                  output(o_off))
          END IF
 
       ELSE
          i_off = (tid)*(istride*(rows_per_thread)) + 1
          o_off = (tid)*(ostride*(rows_per_thread)) + 1
 
-         CALL XFFTW_EXECUTE_DFT(plan, input(i_off), &
-                                output(o_off))
+         CALL fftw_execute_dft(plan, input(i_off), &
+                               output(o_off))
 
       END IF
 #else
@@ -904,7 +916,7 @@ CONTAINS
 
       ! Either compute the full 3D FFT using a multithreaded plan
       IF (.NOT. plan%separated_plans) THEN
-         CALL XFFTW_EXECUTE_DFT(plan%fftw_plan, zin, xout)
+         CALL fftw_execute_dft(plan%fftw_plan, zin, xout)
       ELSE
          ! Or use the 3 stage FFT scheme described in fftw3_create_plan_3d
          ALLOCATE (tmp1(n1*n2*n3))   ! Temporary vector used for transpositions
@@ -1068,20 +1080,20 @@ CONTAINS
 
 #if defined ( __FFTW3 )
 !$    IF (plan%need_alt_plan) THEN
-!$       CALL XFFTW_DESTROY_PLAN(plan%alt_fftw_plan)
+!$       CALL fftw_destroy_plan(plan%alt_fftw_plan)
 !$    END IF
 
       IF (.NOT. plan%separated_plans) THEN
-         CALL XFFTW_DESTROY_PLAN(plan%fftw_plan)
+         CALL fftw_destroy_plan(plan%fftw_plan)
       ELSE
          ! If it is a separated plan then we have to destroy
          ! each dim plan individually
-         CALL XFFTW_DESTROY_PLAN(plan%fftw_plan_nx)
-         CALL XFFTW_DESTROY_PLAN(plan%fftw_plan_ny)
-         CALL XFFTW_DESTROY_PLAN(plan%fftw_plan_nz)
-         CALL XFFTW_DESTROY_PLAN(plan%fftw_plan_nx_r)
-         CALL XFFTW_DESTROY_PLAN(plan%fftw_plan_ny_r)
-         CALL XFFTW_DESTROY_PLAN(plan%fftw_plan_nz_r)
+         CALL fftw_destroy_plan(plan%fftw_plan_nx)
+         CALL fftw_destroy_plan(plan%fftw_plan_ny)
+         CALL fftw_destroy_plan(plan%fftw_plan_nz)
+         CALL fftw_destroy_plan(plan%fftw_plan_nx_r)
+         CALL fftw_destroy_plan(plan%fftw_plan_ny_r)
+         CALL fftw_destroy_plan(plan%fftw_plan_nz_r)
       END IF
 
 #else
@@ -1171,115 +1183,5 @@ CONTAINS
 !$OMP END PARALLEL
 
       END SUBROUTINE fftw31dm
-
-!     Copyright (c) 2003, 2006 Matteo Frigo
-!     Copyright (c) 2003, 2006 Massachusetts Institute of Technology
-!
-!     This program is free software; you can redistribute it and/or modify
-!     it under the terms of the GNU General Public License as published by
-!     the Free Software Foundation; either version 2 of the License, or
-!     (at your option) any later version.
-!
-!     This program is distributed in the hope that it will be useful,
-!     but WITHOUT ANY WARRANTY; without even the implied warranty of
-!     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-!     GNU General Public License for more details.
-!
-!     You should have received a copy of the GNU General Public License
-!     along with this program; if not, write to the Free Software
-!     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-!
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!
-!     This is an example implementation of Fortran wisdom export/import
-!     to/from a Fortran unit (file), exploiting the generic
-!     dfftw_export_wisdom/dfftw_import_wisdom functions.
-!
-!     We cannot compile this file into the FFTW library itself, lest all
-!     FFTW-calling programs be required to link to the Fortran I/O
-!     libraries.
-!
-!     adapted to become more standard Fortran 90 [2007-10] Joost VandeVondele
-!     and added some namespacing
-!
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-! **************************************************************************************************
-!> \brief ...
-!> \param c ...
-!> \param iunit ...
-! **************************************************************************************************
-      SUBROUTINE fftw_write_char(c, iunit) BIND(C, name="fftw_write_char")
-      CHARACTER(KIND=C_CHAR)                             :: c
-      INTEGER(KIND=C_INT)                                :: iunit
-
-         WRITE (iunit, '(a)', ADVANCE="NO") c
-      END SUBROUTINE
-
-! **************************************************************************************************
-!> \brief ...
-!> \param iunit ...
-! **************************************************************************************************
-      SUBROUTINE fftw_export_wisdom_to_file(iunit)
-         INTEGER                                  :: iunit
-
-#if defined ( __FFTW3 )
-         CALL dfftw_export_wisdom(fftw_write_char, iunit)
-#else
-         MARK_USED(iunit)
-#endif
-      END SUBROUTINE
-
-!     Fortran 77 does not have any portable way to read an arbitrary
-!     file one character at a time [needs to wait for stream IO of F2003].
-!     The best alternative seems to be to
-!     read a whole line into a buffer, since for fftw-exported wisdom we
-!     can bound the line length.  (If the file contains longer lines,
-!     then the lines will be truncated and the wisdom import should
-!     simply fail.)  Ugh (and not thread safe).
-
-! **************************************************************************************************
-!> \brief ...
-!> \param ic ...
-!> \param iunit ...
-! **************************************************************************************************
-      SUBROUTINE fftw_read_char(ic, iunit) BIND(C, name="fftw_read_char")
-      INTEGER(KIND=C_INT)                                :: ic, iunit
-
-      CHARACTER(LEN=256)                                 :: buf
-
-         SAVE buf
-         INTEGER ibuf
-         DATA ibuf/257/
-         SAVE ibuf
-         IF (ibuf .LT. 257) THEN
-            ic = ICHAR(buf(ibuf:ibuf))
-            ibuf = ibuf + 1
-            RETURN
-         END IF
-         READ (iunit, 123, END=666) buf
-         ic = ICHAR(buf(1:1))
-         ibuf = 2
-         RETURN
-666      ic = -1
-         ibuf = 257
-123      FORMAT(a256)
-      END SUBROUTINE
-
-! **************************************************************************************************
-!> \brief ...
-!> \param isuccess ...
-!> \param iunit ...
-! **************************************************************************************************
-      SUBROUTINE fftw_import_wisdom_from_file(isuccess, iunit)
-      INTEGER                                            :: isuccess, iunit
-
-         isuccess = 0
-#if defined ( __FFTW3 )
-         CALL dfftw_import_wisdom(isuccess, fftw_read_char, iunit)
-#else
-         MARK_USED(iunit)
-#endif
-      END SUBROUTINE
 
    END MODULE

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -85,23 +85,23 @@ MODULE fft_tools
       TYPE(mp_cart_type), DIMENSION(2)     :: cart_sub_comm = mp_cart_type()
       INTEGER, DIMENSION(2)                :: dim = -1, pos = -1
       ! to be used in fft3d_s
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER &
+      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER, CONTIGUOUS &
          :: ziptr => NULL(), zoptr => NULL()
       ! to be used in fft3d_ps : block distribution
       COMPLEX(KIND=dp), DIMENSION(:, :), CONTIGUOUS, POINTER &
          :: p1buf => NULL(), p2buf => NULL(), p3buf => NULL(), p4buf => NULL(), &
             p5buf => NULL(), p6buf => NULL(), p7buf => NULL()
       ! to be used in fft3d_ps : plane distribution
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER, CONTIGUOUS &
          :: r1buf => NULL(), r2buf => NULL()
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER &
+      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER, CONTIGUOUS &
          :: tbuf => NULL()
       ! to be used in fft3d_pb
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
          :: a1buf => NULL(), a2buf => NULL(), a3buf => NULL(), &
             a4buf => NULL(), a5buf => NULL(), a6buf => NULL()
       ! to be used in communication routines
-      INTEGER, DIMENSION(:), POINTER       :: scount => NULL(), rcount => NULL(), sdispl => NULL(), rdispl => NULL()
+      INTEGER, DIMENSION(:), CONTIGUOUS, POINTER       :: scount => NULL(), rcount => NULL(), sdispl => NULL(), rdispl => NULL()
       INTEGER, DIMENSION(:, :), POINTER     :: pgcube => NULL()
       INTEGER, DIMENSION(:), POINTER       :: xzcount => NULL(), yzcount => NULL(), xzdispl => NULL(), yzdispl => NULL()
       INTEGER                              :: in = -1, mip = -1
@@ -382,8 +382,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'fft3d_s'
 
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
+         POINTER                                         :: zoptr
       COMPLEX(KIND=dp), DIMENSION(1, 1, 1), TARGET       :: zdum
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER      :: zoptr
       INTEGER                                            :: handle, ld(3), lo(3), output_unit, sign, &
                                                             stat
       LOGICAL                                            :: fft_in_place, test
@@ -2612,10 +2613,10 @@ CONTAINS
 
       ! deallocate structures
       IF (ASSOCIATED(fft_scratch%ziptr)) THEN
-         DEALLOCATE (fft_scratch%ziptr)
+         CALL fft_dealloc(fft_scratch%ziptr)
       END IF
       IF (ASSOCIATED(fft_scratch%zoptr)) THEN
-         DEALLOCATE (fft_scratch%zoptr)
+         CALL fft_dealloc(fft_scratch%zoptr)
       END IF
       IF (ASSOCIATED(fft_scratch%p1buf)) THEN
          CALL fft_dealloc(fft_scratch%p1buf)
@@ -2660,7 +2661,7 @@ CONTAINS
          dummy_ptr_z => fft_scratch%p7buf(1, 1)
          ierr = offload_free_pinned_mem(c_loc(dummy_ptr_z))
 #else
-         DEALLOCATE (fft_scratch%p7buf)
+         CALL fft_dealloc(fft_scratch%p7buf)
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%r1buf)) THEN
@@ -2668,18 +2669,18 @@ CONTAINS
          dummy_ptr_z => fft_scratch%r1buf(1, 1)
          ierr = offload_free_pinned_mem(c_loc(dummy_ptr_z))
 #else
-         DEALLOCATE (fft_scratch%r1buf)
+         CALL fft_dealloc(fft_scratch%r1buf)
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%r2buf)) THEN
-         DEALLOCATE (fft_scratch%r2buf)
+         CALL fft_dealloc(fft_scratch%r2buf)
       END IF
       IF (ASSOCIATED(fft_scratch%tbuf)) THEN
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
          dummy_ptr_z => fft_scratch%tbuf(1, 1, 1)
          ierr = offload_free_pinned_mem(c_loc(dummy_ptr_z))
 #else
-         DEALLOCATE (fft_scratch%tbuf)
+         CALL fft_dealloc(fft_scratch%tbuf)
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%a1buf)) THEN
@@ -3116,11 +3117,11 @@ CONTAINS
                CPASSERT(ierr == 0)
                CALL c_f_pointer(cptr_tbuf, fft_scratch_new%fft_scratch%tbuf, (/MAX(ny, 1), MAX(nz, 1), MAX(nx, 1)/))
 #else
-               ALLOCATE (fft_scratch_new%fft_scratch%r1buf(mmax, lmax))
-               ALLOCATE (fft_scratch_new%fft_scratch%tbuf(ny, nz, nx))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%r1buf, [mmax, lmax])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%tbuf, [ny, nz, nx])
 #endif
                fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
-               ALLOCATE (fft_scratch_new%fft_scratch%r2buf(lg, mg))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%r2buf, [lg, mg])
                nm = nmray*mx2
                IF (alltoall_sgl) THEN
                   ALLOCATE (fft_scratch_new%fft_scratch%ss(mmax, lmax))
@@ -3186,7 +3187,7 @@ CONTAINS
                CALL fft_alloc(fft_scratch_new%fft_scratch%p3buf, [mx2*mz2, n(2)])
                CALL fft_alloc(fft_scratch_new%fft_scratch%p4buf, [n(2), mx2*mz2])
                CALL fft_alloc(fft_scratch_new%fft_scratch%p5buf, [nyzray, n(1)])
-               ALLOCATE (fft_scratch_new%fft_scratch%p7buf(mg, lg))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%p7buf, [mg, lg])
 #endif
                IF (alltoall_sgl) THEN
                   ALLOCATE (fft_scratch_new%fft_scratch%yzbuf_sgl(mg*lg))
@@ -3256,8 +3257,8 @@ CONTAINS
 
             CASE (400) ! serial FFT
                np = 0
-               ALLOCATE (fft_scratch_new%fft_scratch%ziptr(n(1), n(2), n(3)))
-               ALLOCATE (fft_scratch_new%fft_scratch%zoptr(n(1), n(2), n(3)))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%ziptr, n)
+               CALL fft_alloc(fft_scratch_new%fft_scratch%zoptr, n)
 
                !in place plans
                CALL fft_create_plan_3d(fft_scratch_new%fft_scratch%fft_plan(1), fft_type, .TRUE., FWFFT, n, &

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -33,8 +33,8 @@ MODULE fft_tools
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE fast,                            ONLY: zero_c
    USE fft_lib,                         ONLY: &
-        fft_1dm, fft_3d, fft_create_plan_1dm, fft_create_plan_3d, fft_destroy_plan, &
-        fft_do_cleanup, fft_do_init, fft_get_lengths, fft_library
+        fft_1dm, fft_3d, fft_alloc, fft_create_plan_1dm, fft_create_plan_3d, fft_dealloc, &
+        fft_destroy_plan, fft_do_cleanup, fft_do_init, fft_get_lengths, fft_library
    USE fft_plan,                        ONLY: fft_plan_type
    USE kinds,                           ONLY: dp,&
                                               dp_size,&
@@ -69,59 +69,62 @@ MODULE fft_tools
       INTEGER                              :: lg = 0, mg = 0
       INTEGER                              :: nbx = 0, nbz = 0
       INTEGER                              :: nmray = 0, nyzray = 0
-      TYPE(mp_comm_type)                   :: gs_group
-      TYPE(mp_cart_type)                   :: rs_group
+      TYPE(mp_comm_type)                   :: gs_group = mp_comm_type()
+      TYPE(mp_cart_type)                   :: rs_group = mp_cart_type()
       INTEGER, DIMENSION(2)                :: g_pos = 0, r_pos = 0, r_dim = 0
       INTEGER                              :: numtask = 0
    END TYPE fft_scratch_sizes
 
    TYPE fft_scratch_type
-      INTEGER                              :: fft_scratch_id
-      INTEGER                              :: tf_type
-      LOGICAL                              :: in_use
-      TYPE(mp_comm_type)                   :: group
-      INTEGER, DIMENSION(3)                :: nfft
+      INTEGER                              :: fft_scratch_id = -1
+      INTEGER                              :: tf_type = -1
+      LOGICAL                              :: in_use = .FALSE.
+      TYPE(mp_comm_type)                   :: group = mp_comm_type()
+      INTEGER, DIMENSION(3)                :: nfft = -1
       ! to be used in cube_transpose_* routines
-      TYPE(mp_cart_type), DIMENSION(2)     :: cart_sub_comm
-      INTEGER, DIMENSION(2)                :: dim, pos
+      TYPE(mp_cart_type), DIMENSION(2)     :: cart_sub_comm = mp_cart_type()
+      INTEGER, DIMENSION(2)                :: dim = -1, pos = -1
       ! to be used in fft3d_s
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER &
-         :: ziptr, zoptr
+         :: ziptr => NULL(), zoptr => NULL()
       ! to be used in fft3d_ps : block distribution
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
-         :: p1buf, p2buf, p3buf, p4buf, p5buf, p6buf, p7buf
+         :: p1buf => NULL(), p2buf => NULL(), p3buf => NULL(), p4buf => NULL(), &
+            p5buf => NULL(), p6buf => NULL(), p7buf => NULL()
       ! to be used in fft3d_ps : plane distribution
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
-         :: r1buf, r2buf
+         :: r1buf => NULL(), r2buf => NULL()
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER &
-         :: tbuf
+         :: tbuf => NULL()
       ! to be used in fft3d_pb
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
-         :: a1buf, a2buf, a3buf, a4buf, a5buf, a6buf
+         :: a1buf => NULL(), a2buf => NULL(), a3buf => NULL(), &
+            a4buf => NULL(), a5buf => NULL(), a6buf => NULL()
       ! to be used in communication routines
-      INTEGER, DIMENSION(:), POINTER       :: scount, rcount, sdispl, rdispl
-      INTEGER, DIMENSION(:, :), POINTER     :: pgcube
-      INTEGER, DIMENSION(:), POINTER       :: xzcount, yzcount, xzdispl, yzdispl
-      INTEGER                              :: in, mip
-      REAL(KIND=dp)                        :: rsratio
+      INTEGER, DIMENSION(:), POINTER       :: scount => NULL(), rcount => NULL(), sdispl => NULL(), rdispl => NULL()
+      INTEGER, DIMENSION(:, :), POINTER     :: pgcube => NULL()
+      INTEGER, DIMENSION(:), POINTER       :: xzcount => NULL(), yzcount => NULL(), xzdispl => NULL(), yzdispl => NULL()
+      INTEGER                              :: in = -1, mip = -1
+      REAL(KIND=dp)                        :: rsratio = 0.0_dp
       COMPLEX(KIND=dp), DIMENSION(:), POINTER &
-         :: xzbuf, yzbuf
+         :: xzbuf => NULL(), yzbuf => NULL()
       COMPLEX(KIND=sp), DIMENSION(:), POINTER &
-         :: xzbuf_sgl, yzbuf_sgl
+         :: xzbuf_sgl => NULL(), yzbuf_sgl => NULL()
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
-         :: rbuf1, rbuf2, rbuf3, rbuf4, rbuf5, rbuf6, rr
+         :: rbuf1 => NULL(), rbuf2 => NULL(), rbuf3 => NULL(), rbuf4 => NULL(), &
+            rbuf5 => NULL(), rbuf6 => NULL(), rr => NULL()
       COMPLEX(KIND=sp), DIMENSION(:, :), POINTER &
-         :: ss, tt
-      INTEGER, DIMENSION(:, :), POINTER     :: pgrid
-      INTEGER, DIMENSION(:), POINTER       :: xcor, zcor, pzcoord
-      TYPE(fft_scratch_sizes)              :: sizes
-      TYPE(fft_plan_type), DIMENSION(6)   :: fft_plan
-      INTEGER                              :: last_tick
+         :: ss => NULL(), tt => NULL()
+      INTEGER, DIMENSION(:, :), POINTER     :: pgrid => NULL()
+      INTEGER, DIMENSION(:), POINTER       :: xcor => NULL(), zcor => NULL(), pzcoord => NULL()
+      TYPE(fft_scratch_sizes)              :: sizes = fft_scratch_sizes()
+      TYPE(fft_plan_type), DIMENSION(6)   :: fft_plan = fft_plan_type()
+      INTEGER                              :: last_tick = -1
    END TYPE fft_scratch_type
 
    TYPE fft_scratch_pool_type
-      TYPE(fft_scratch_type), POINTER       :: fft_scratch
-      TYPE(fft_scratch_pool_type), POINTER  :: fft_scratch_next
+      TYPE(fft_scratch_type), POINTER       :: fft_scratch => NULL()
+      TYPE(fft_scratch_pool_type), POINTER  :: fft_scratch_next => NULL()
    END TYPE fft_scratch_pool_type
 
    INTEGER, SAVE                           :: init_fft_pool = 0
@@ -134,6 +137,7 @@ MODULE fft_tools
 
    PRIVATE
    PUBLIC :: init_fft, fft3d, finalize_fft
+   PUBLIC :: fft_alloc, fft_dealloc
    PUBLIC :: fft_radix_operations, fft_fw1d
    PUBLIC :: FWFFT, BWFFT
    PUBLIC :: FFT_RADIX_CLOSEST, FFT_RADIX_NEXT

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -97,7 +97,7 @@ MODULE fft_tools
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER, CONTIGUOUS &
          :: tbuf => NULL()
       ! to be used in fft3d_pb
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER, CONTIGUOUS &
          :: a1buf => NULL(), a2buf => NULL(), a3buf => NULL(), &
             a4buf => NULL(), a5buf => NULL(), a6buf => NULL()
       ! to be used in communication routines
@@ -2684,22 +2684,22 @@ CONTAINS
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%a1buf)) THEN
-         DEALLOCATE (fft_scratch%a1buf)
+         CALL fft_dealloc(fft_scratch%a1buf)
       END IF
       IF (ASSOCIATED(fft_scratch%a2buf)) THEN
-         DEALLOCATE (fft_scratch%a2buf)
+         CALL fft_dealloc(fft_scratch%a2buf)
       END IF
       IF (ASSOCIATED(fft_scratch%a3buf)) THEN
-         DEALLOCATE (fft_scratch%a3buf)
+         CALL fft_dealloc(fft_scratch%a3buf)
       END IF
       IF (ASSOCIATED(fft_scratch%a4buf)) THEN
-         DEALLOCATE (fft_scratch%a4buf)
+         CALL fft_dealloc(fft_scratch%a4buf)
       END IF
       IF (ASSOCIATED(fft_scratch%a5buf)) THEN
-         DEALLOCATE (fft_scratch%a5buf)
+         CALL fft_dealloc(fft_scratch%a5buf)
       END IF
       IF (ASSOCIATED(fft_scratch%a6buf)) THEN
-         DEALLOCATE (fft_scratch%a6buf)
+         CALL fft_dealloc(fft_scratch%a6buf)
       END IF
       IF (ASSOCIATED(fft_scratch%scount)) THEN
          DEALLOCATE (fft_scratch%scount, fft_scratch%rcount, &
@@ -3007,12 +3007,12 @@ CONTAINS
                mz2 = fft_sizes%mz2
                my3 = fft_sizes%my3
                mz3 = fft_sizes%mz3
-               ALLOCATE (fft_scratch_new%fft_scratch%a1buf(mx1*my1, n(3)))
-               ALLOCATE (fft_scratch_new%fft_scratch%a2buf(n(3), mx1*my1))
-               ALLOCATE (fft_scratch_new%fft_scratch%a3buf(mx2*mz2, n(2)))
-               ALLOCATE (fft_scratch_new%fft_scratch%a4buf(n(2), mx2*mz2))
-               ALLOCATE (fft_scratch_new%fft_scratch%a5buf(my3*mz3, n(1)))
-               ALLOCATE (fft_scratch_new%fft_scratch%a6buf(n(1), my3*mz3))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a1buf, [mx1*my1, n(3)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a2buf, [n(3), mx1*my1])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a3buf, [mx2*mz2, n(2)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a4buf, [n(2), mx2*mz2])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a5buf, [my3*mz3, n(1)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a6buf, [n(1), my3*mz3])
                fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
 
                dim = fft_sizes%rs_group%num_pe_cart
@@ -3064,13 +3064,13 @@ CONTAINS
                mz1 = fft_sizes%mz1
                my3 = fft_sizes%my3
                mz3 = fft_sizes%mz3
-               ALLOCATE (fft_scratch_new%fft_scratch%a1buf(mx1*my1, n(3)))
-               ALLOCATE (fft_scratch_new%fft_scratch%a2buf(n(3), mx1*my1))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a1buf, [mx1*my1, n(3)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a2buf, [n(3), mx1*my1])
                fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
-               ALLOCATE (fft_scratch_new%fft_scratch%a3buf(mx1*mz1, n(2)))
-               ALLOCATE (fft_scratch_new%fft_scratch%a4buf(n(2), mx1*mz1))
-               ALLOCATE (fft_scratch_new%fft_scratch%a5buf(my3*mz3, n(1)))
-               ALLOCATE (fft_scratch_new%fft_scratch%a6buf(n(1), my3*mz3))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a3buf, [mx1*mz1, n(2)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a4buf, [n(2), mx1*mz1])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a5buf, [my3*mz3, n(1)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%a6buf, [n(1), my3*mz3])
 
                dim = fft_sizes%rs_group%num_pe_cart
                pos = fft_sizes%rs_group%mepos_cart

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -113,7 +113,7 @@ MODULE fft_tools
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
          :: rbuf1 => NULL(), rbuf2 => NULL(), rbuf3 => NULL(), rbuf4 => NULL(), &
             rbuf5 => NULL(), rbuf6 => NULL(), rr => NULL()
-      COMPLEX(KIND=sp), DIMENSION(:, :), POINTER &
+      COMPLEX(KIND=sp), DIMENSION(:, :), POINTER, CONTIGUOUS &
          :: ss => NULL(), tt => NULL()
       INTEGER, DIMENSION(:, :), POINTER     :: pgrid => NULL()
       INTEGER, DIMENSION(:), POINTER       :: xcor => NULL(), zcor => NULL(), pzcoord => NULL()
@@ -1373,21 +1373,24 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE x_to_yz(sb, group, my_pos, p2p, yzp, nray, bo, tb, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: sb
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: sb
       TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), &
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: tb
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'x_to_yz'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rr
-      COMPLEX(KIND=sp), DIMENSION(:, :), POINTER         :: ss, tt
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: rr
+      COMPLEX(KIND=sp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: ss, tt
       INTEGER                                            :: handle, ip, ir, ix, ixx, iy, iz, mpr, &
                                                             nm, np, nr, nx
       INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
@@ -1483,23 +1486,27 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE yz_to_x(tb, group, my_pos, p2p, yzp, nray, bo, sb, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(IN)   :: tb
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
+         INTENT(IN)                                      :: tb
       TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: sb
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: sb
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'yz_to_x'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rr
-      COMPLEX(KIND=sp), DIMENSION(:, :), POINTER         :: ss, tt
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: rr
+      COMPLEX(KIND=sp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: ss, tt
       INTEGER                                            :: handle, ip, ir, ix, ixx, iy, iz, mpr, &
                                                             nm, np, nr, nx
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
+      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
 
       CALL timeset(routineN, handle)
 
@@ -1594,7 +1601,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE yz_to_xz(sb, group, dims, my_pos, p2p, yzp, nray, bo, tb, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: sb
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: sb
 
       CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(2), INTENT(IN)                  :: dims
@@ -1603,18 +1611,18 @@ CONTAINS
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: tb
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT), CONTIGUOUS   :: tb
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'yz_to_xz'
 
-      COMPLEX(KIND=dp), DIMENSION(:), POINTER            :: xzbuf, yzbuf
-      COMPLEX(KIND=sp), DIMENSION(:), POINTER            :: xzbuf_sgl, yzbuf_sgl
+      COMPLEX(KIND=dp), DIMENSION(:), POINTER, CONTIGUOUS            :: xzbuf, yzbuf
+      COMPLEX(KIND=sp), DIMENSION(:), POINTER, CONTIGUOUS            :: xzbuf_sgl, yzbuf_sgl
       INTEGER                                            :: handle, icrs, ip, ipl, ipr, ir, ix, iz, &
                                                             jj, jx, jy, jz, myx, myz, np, npx, &
                                                             npz, nx, nz, rs_pos
-      INTEGER, DIMENSION(:), POINTER                     :: pzcoord, rcount, rdispl, scount, sdispl, &
-                                                            xcor, zcor
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS                     :: pzcoord, rcount, rdispl, scount, sdispl, &
+                                                                        xcor, zcor
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
 
       CALL timeset(routineN, handle)
@@ -1803,7 +1811,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE xz_to_yz(sb, group, dims, my_pos, p2p, yzp, nray, bo, tb, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: sb
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: sb
 
       CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(2), INTENT(IN)                  :: dims
@@ -1812,18 +1821,18 @@ CONTAINS
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
       INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: tb
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT), CONTIGUOUS   :: tb
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xz_to_yz'
 
-      COMPLEX(KIND=dp), DIMENSION(:), POINTER            :: xzbuf, yzbuf
-      COMPLEX(KIND=sp), DIMENSION(:), POINTER            :: xzbuf_sgl, yzbuf_sgl
+      COMPLEX(KIND=dp), DIMENSION(:), POINTER, CONTIGUOUS            :: xzbuf, yzbuf
+      COMPLEX(KIND=sp), DIMENSION(:), POINTER, CONTIGUOUS            :: xzbuf_sgl, yzbuf_sgl
       INTEGER                                            :: handle, icrs, ip, ipl, ir, ix, ixx, iz, &
                                                             jj, jx, jy, jz, mp, myx, myz, np, npx, &
                                                             npz, nx, nz
-      INTEGER, DIMENSION(:), POINTER                     :: pzcoord, rcount, rdispl, scount, sdispl, &
-                                                            xcor, zcor
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS                     :: pzcoord, rcount, rdispl, scount, sdispl, &
+                                                                        xcor, zcor
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
 
       CALL timeset(routineN, handle)
@@ -1996,18 +2005,21 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_transpose_1(cin, boin, boout, sout, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_1'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, is, ixy, iz, mip, &
                                                             mz, np, nx, ny, nz
+      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
 
       CALL timeset(routineN, handle)
@@ -2082,18 +2094,21 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_transpose_2(cin, boin, boout, sout, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_2'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, ixy, iz, mip, mz, &
                                                             np, nx, ny, nz
+      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       TYPE(mp_comm_type)                                 :: sub_group
 
@@ -2168,19 +2183,22 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_transpose_3(cin, boin, boout, sout, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_3'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, is, ixz, iy, lb, &
                                                             mip, my, my_id, np, num_threads, nx, &
                                                             ny, nz, ub
+      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       TYPE(mp_comm_type)                                 :: sub_group
 
@@ -2269,19 +2287,22 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_transpose_4(cin, boin, boout, sout, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: cin
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_4'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: rbuf
       INTEGER                                            :: handle, ip, ipl, ir, iy, izx, lb, mip, &
                                                             my, my_id, np, num_threads, nx, ny, &
                                                             nz, ub
+      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       TYPE(mp_comm_type)                                 :: sub_group
 
@@ -2367,20 +2388,21 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_transpose_5(cin, group, boin, boout, sout, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: cin
 
       CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT), CONTIGUOUS     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_5'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER, CONTIGUOUS         :: rbuf
       INTEGER                                            :: handle, ip, ir, is, ixz, iy, lb, mip, &
                                                             my, my_id, np, num_threads, nx, ny, &
                                                             nz, ub
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS                     :: rcount, rdispl, scount, sdispl
 
       CALL timeset(routineN, handle)
 
@@ -2461,19 +2483,20 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cube_transpose_6(cin, group, boin, boout, sout, fft_scratch)
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: cin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(IN)                                      :: cin
 
       CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: sout
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT), CONTIGUOUS     :: sout
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_6'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: rbuf
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER, CONTIGUOUS         :: rbuf
       INTEGER                                            :: handle, ip, ir, iy, izx, lb, mip, my, &
                                                             my_id, np, num_threads, nx, ny, nz, ub
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS                     :: rcount, rdispl, scount, sdispl
 
       CALL timeset(routineN, handle)
 

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -76,9 +76,9 @@ MODULE fft_tools
    END TYPE fft_scratch_sizes
 
    TYPE fft_scratch_type
-      INTEGER                              :: fft_scratch_id = -1
+      INTEGER                              :: fft_scratch_id = 0
       INTEGER                              :: tf_type = -1
-      LOGICAL                              :: in_use = .FALSE.
+      LOGICAL                              :: in_use = .TRUE.
       TYPE(mp_comm_type)                   :: group = mp_comm_type()
       INTEGER, DIMENSION(3)                :: nfft = -1
       ! to be used in cube_transpose_* routines
@@ -102,21 +102,21 @@ MODULE fft_tools
             a4buf => NULL(), a5buf => NULL(), a6buf => NULL()
       ! to be used in communication routines
       INTEGER, DIMENSION(:), CONTIGUOUS, POINTER       :: scount => NULL(), rcount => NULL(), sdispl => NULL(), rdispl => NULL()
-      INTEGER, DIMENSION(:, :), POINTER     :: pgcube => NULL()
-      INTEGER, DIMENSION(:), POINTER       :: xzcount => NULL(), yzcount => NULL(), xzdispl => NULL(), yzdispl => NULL()
-      INTEGER                              :: in = -1, mip = -1
-      REAL(KIND=dp)                        :: rsratio = 0.0_dp
-      COMPLEX(KIND=dp), DIMENSION(:), POINTER &
+      INTEGER, DIMENSION(:, :), CONTIGUOUS, POINTER     :: pgcube => NULL()
+      INTEGER, DIMENSION(:), CONTIGUOUS, POINTER       :: xzcount => NULL(), yzcount => NULL(), xzdispl => NULL(), yzdispl => NULL()
+      INTEGER                              :: in = 0, mip = -1
+      REAL(KIND=dp)                        :: rsratio = 1.0_dp
+      COMPLEX(KIND=dp), DIMENSION(:), POINTER, CONTIGUOUS &
          :: xzbuf => NULL(), yzbuf => NULL()
-      COMPLEX(KIND=sp), DIMENSION(:), POINTER &
+      COMPLEX(KIND=sp), DIMENSION(:), POINTER, CONTIGUOUS &
          :: xzbuf_sgl => NULL(), yzbuf_sgl => NULL()
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER, CONTIGUOUS &
          :: rbuf1 => NULL(), rbuf2 => NULL(), rbuf3 => NULL(), rbuf4 => NULL(), &
             rbuf5 => NULL(), rbuf6 => NULL(), rr => NULL()
       COMPLEX(KIND=sp), DIMENSION(:, :), POINTER, CONTIGUOUS &
          :: ss => NULL(), tt => NULL()
-      INTEGER, DIMENSION(:, :), POINTER     :: pgrid => NULL()
-      INTEGER, DIMENSION(:), POINTER       :: xcor => NULL(), zcor => NULL(), pzcoord => NULL()
+      INTEGER, DIMENSION(:, :), POINTER, CONTIGUOUS     :: pgrid => NULL()
+      INTEGER, DIMENSION(:), POINTER, CONTIGUOUS       :: xcor => NULL(), zcor => NULL(), pzcoord => NULL()
       TYPE(fft_scratch_sizes)              :: sizes = fft_scratch_sizes()
       TYPE(fft_plan_type), DIMENSION(6)   :: fft_plan = fft_plan_type()
       INTEGER                              :: last_tick = -1
@@ -372,9 +372,9 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: fsign
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: n
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), &
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: zin
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), &
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(INOUT), OPTIONAL, TARGET                 :: zout
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
       INTEGER, INTENT(OUT), OPTIONAL                     :: status
@@ -500,22 +500,27 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: fsign
       INTEGER, DIMENSION(:), INTENT(IN)                  :: n
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), &
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: cin
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: gin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: gin
       TYPE(mp_comm_type), INTENT(IN)                     :: gs_group
       TYPE(mp_cart_type), INTENT(IN)                     :: rs_group
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: nyzray
-      INTEGER, DIMENSION(:, :, 0:, :), INTENT(IN)        :: bo
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: yzp
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: nyzray
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:, :), &
+         INTENT(IN)                                      :: bo
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
       INTEGER, INTENT(OUT), OPTIONAL                     :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'fft3d_ps'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: pbuf, qbuf, rbuf, sbuf
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER      :: tbuf
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: pbuf, qbuf, rbuf, sbuf
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
+         POINTER                                         :: tbuf
       INTEGER :: g_pos, handle, lg, lmax, mcx2, mcz1, mcz2, mg, mmax, mx1, mx2, my1, mz2, n1, n2, &
          nmax, numtask, numtask_g, numtask_r, nx, ny, nz, output_unit, r_dim(2), r_pos(2), rp, &
          sign, stat
@@ -947,18 +952,21 @@ CONTAINS
 
       INTEGER, INTENT(IN)                                :: fsign
       INTEGER, DIMENSION(3), INTENT(IN)                  :: n
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), &
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: zin
-      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)   :: gin
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         INTENT(INOUT)                                   :: gin
       TYPE(mp_cart_type), INTENT(IN)                     :: group
-      INTEGER, DIMENSION(:, :, 0:, :), INTENT(IN)        :: bo
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:, :), &
+         INTENT(IN)                                      :: bo
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
       INTEGER, INTENT(OUT), OPTIONAL                     :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'fft3d_pb'
 
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: abuf, bbuf
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: abuf, bbuf
       INTEGER                                            :: handle, lg(2), lz(3), mcx2, mcy3, mcz1, &
                                                             mcz2, mx1, mx2, mx3, my1, my2, my3, &
                                                             my_pos, mz1, mz2, mz3, output_unit, &
@@ -1377,13 +1385,15 @@ CONTAINS
          INTENT(IN)                                      :: sb
       TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, INTENT(IN)                                :: my_pos
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: p2p
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: yzp
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: nray
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: bo
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(INOUT)                                   :: tb
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'x_to_yz'
 
@@ -1393,7 +1403,7 @@ CONTAINS
          POINTER                                         :: ss, tt
       INTEGER                                            :: handle, ip, ir, ix, ixx, iy, iz, mpr, &
                                                             nm, np, nr, nx
-      INTEGER, DIMENSION(:), POINTER                     :: rcount, rdispl, scount, sdispl
+      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
 
       CALL timeset(routineN, handle)
 
@@ -1490,13 +1500,14 @@ CONTAINS
          INTENT(IN)                                      :: tb
       TYPE(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, INTENT(IN)                                :: my_pos
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: p2p
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: yzp
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: nray
       INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: sb
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'yz_to_x'
 
@@ -1607,12 +1618,12 @@ CONTAINS
       CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(2), INTENT(IN)                  :: dims
       INTEGER, INTENT(IN)                                :: my_pos
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)                 :: p2p
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)                 :: nray
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT), CONTIGUOUS   :: tb
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(INOUT)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'yz_to_xz'
 
@@ -1623,7 +1634,7 @@ CONTAINS
                                                             npz, nx, nz, rs_pos
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS                     :: pzcoord, rcount, rdispl, scount, sdispl, &
                                                                         xcor, zcor
-      INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
+      INTEGER, DIMENSION(:, :), CONTIGUOUS, POINTER                  :: pgrid
 
       CALL timeset(routineN, handle)
 
@@ -1817,12 +1828,12 @@ CONTAINS
       CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, DIMENSION(2), INTENT(IN)                  :: dims
       INTEGER, INTENT(IN)                                :: my_pos
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: p2p
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
-      INTEGER, DIMENSION(0:), INTENT(IN)                 :: nray
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)                 :: p2p
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), INTENT(IN)           :: yzp
+      INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)                 :: nray
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), INTENT(IN)           :: bo
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT), CONTIGUOUS   :: tb
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(INOUT)              :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'xz_to_yz'
 
@@ -1833,7 +1844,7 @@ CONTAINS
                                                             npz, nx, nz
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS                     :: pzcoord, rcount, rdispl, scount, sdispl, &
                                                                         xcor, zcor
-      INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
+      INTEGER, DIMENSION(:, :), CONTIGUOUS, POINTER                  :: pgrid
 
       CALL timeset(routineN, handle)
 
@@ -2007,10 +2018,11 @@ CONTAINS
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(IN)                                      :: cin
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: boin, boout
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(OUT)                                     :: sout
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_1'
 
@@ -2019,8 +2031,8 @@ CONTAINS
       INTEGER                                            :: handle, ip, ipl, ir, is, ixy, iz, mip, &
                                                             mz, np, nx, ny, nz
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
+      INTEGER, CONTIGUOUS, DIMENSION(:, :), POINTER      :: pgrid
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
 
       CALL timeset(routineN, handle)
 
@@ -2096,10 +2108,11 @@ CONTAINS
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(IN)                                      :: cin
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: boin, boout
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(OUT)                                     :: sout
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_2'
 
@@ -2108,8 +2121,8 @@ CONTAINS
       INTEGER                                            :: handle, ip, ipl, ir, ixy, iz, mip, mz, &
                                                             np, nx, ny, nz
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
+      INTEGER, CONTIGUOUS, DIMENSION(:, :), POINTER      :: pgrid
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       TYPE(mp_comm_type)                                 :: sub_group
 
       CALL timeset(routineN, handle)
@@ -2185,10 +2198,11 @@ CONTAINS
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(IN)                                      :: cin
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: boin, boout
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(OUT)                                     :: sout
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_3'
 
@@ -2198,8 +2212,8 @@ CONTAINS
                                                             mip, my, my_id, np, num_threads, nx, &
                                                             ny, nz, ub
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
+      INTEGER, CONTIGUOUS, DIMENSION(:, :), POINTER      :: pgrid
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       TYPE(mp_comm_type)                                 :: sub_group
 
       CALL timeset(routineN, handle)
@@ -2289,10 +2303,11 @@ CONTAINS
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(IN)                                      :: cin
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
+         INTENT(IN)                                      :: boin, boout
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(OUT)                                     :: sout
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_4'
 
@@ -2302,8 +2317,8 @@ CONTAINS
                                                             my, my_id, np, num_threads, nx, ny, &
                                                             nz, ub
       INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: rcount, rdispl, scount, sdispl
+      INTEGER, CONTIGUOUS, DIMENSION(:, :), POINTER      :: pgrid
       INTEGER, DIMENSION(2)                              :: dim, pos
-      INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       TYPE(mp_comm_type)                                 :: sub_group
 
       CALL timeset(routineN, handle)
@@ -2392,9 +2407,9 @@ CONTAINS
          INTENT(IN)                                      :: cin
 
       CLASS(mp_comm_type), INTENT(IN)                     :: group
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT), CONTIGUOUS     :: sout
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_5'
 
@@ -2487,9 +2502,9 @@ CONTAINS
          INTENT(IN)                                      :: cin
 
       CLASS(mp_comm_type), INTENT(IN)                     :: group
-      INTEGER, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
+      INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), INTENT(IN)           :: boin, boout
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT), CONTIGUOUS     :: sout
-      TYPE(fft_scratch_type), POINTER                    :: fft_scratch
+      TYPE(fft_scratch_type), INTENT(IN)                 :: fft_scratch
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cube_transpose_6'
 
@@ -2567,54 +2582,11 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE init_fft_scratch_pool()
 
-      INTEGER                                            :: i
-
       CALL release_fft_scratch_pool()
 
       ! Allocate first scratch and mark it as used
       ALLOCATE (fft_scratch_first)
       ALLOCATE (fft_scratch_first%fft_scratch)
-      NULLIFY (fft_scratch_first%fft_scratch_next)
-      fft_scratch_first%fft_scratch%fft_scratch_id = 0
-      fft_scratch_first%fft_scratch%in_use = .TRUE.
-      NULLIFY (fft_scratch_first%fft_scratch%ziptr)
-      NULLIFY (fft_scratch_first%fft_scratch%zoptr)
-      NULLIFY (fft_scratch_first%fft_scratch%p1buf)
-      NULLIFY (fft_scratch_first%fft_scratch%p2buf)
-      NULLIFY (fft_scratch_first%fft_scratch%p3buf)
-      NULLIFY (fft_scratch_first%fft_scratch%p4buf)
-      NULLIFY (fft_scratch_first%fft_scratch%p5buf)
-      NULLIFY (fft_scratch_first%fft_scratch%p6buf)
-      NULLIFY (fft_scratch_first%fft_scratch%p7buf)
-      NULLIFY (fft_scratch_first%fft_scratch%r1buf)
-      NULLIFY (fft_scratch_first%fft_scratch%r2buf)
-      NULLIFY (fft_scratch_first%fft_scratch%tbuf)
-      NULLIFY (fft_scratch_first%fft_scratch%a1buf)
-      NULLIFY (fft_scratch_first%fft_scratch%a2buf)
-      NULLIFY (fft_scratch_first%fft_scratch%a3buf)
-      NULLIFY (fft_scratch_first%fft_scratch%a4buf)
-      NULLIFY (fft_scratch_first%fft_scratch%a5buf)
-      NULLIFY (fft_scratch_first%fft_scratch%a6buf)
-      NULLIFY (fft_scratch_first%fft_scratch%scount, fft_scratch_first%fft_scratch%rcount, &
-               fft_scratch_first%fft_scratch%sdispl, fft_scratch_first%fft_scratch%rdispl)
-      NULLIFY (fft_scratch_first%fft_scratch%rr, &
-               fft_scratch_first%fft_scratch%ss, fft_scratch_first%fft_scratch%tt)
-      NULLIFY (fft_scratch_first%fft_scratch%xzbuf, fft_scratch_first%fft_scratch%yzbuf, &
-               fft_scratch_first%fft_scratch%xzbuf_sgl, fft_scratch_first%fft_scratch%yzbuf_sgl)
-      NULLIFY (fft_scratch_first%fft_scratch%pgrid)
-      NULLIFY (fft_scratch_first%fft_scratch%pgcube)
-      NULLIFY (fft_scratch_first%fft_scratch%xcor, fft_scratch_first%fft_scratch%zcor)
-      NULLIFY (fft_scratch_first%fft_scratch%pzcoord)
-      NULLIFY (fft_scratch_first%fft_scratch%xzcount, fft_scratch_first%fft_scratch%yzcount, &
-               fft_scratch_first%fft_scratch%xzdispl, fft_scratch_first%fft_scratch%yzdispl)
-      NULLIFY (fft_scratch_first%fft_scratch%rbuf1, fft_scratch_first%fft_scratch%rbuf2, &
-               fft_scratch_first%fft_scratch%rbuf3, fft_scratch_first%fft_scratch%rbuf4)
-      NULLIFY (fft_scratch_first%fft_scratch%rbuf5, fft_scratch_first%fft_scratch%rbuf6)
-      fft_scratch_first%fft_scratch%in = 0
-      fft_scratch_first%fft_scratch%rsratio = 1._dp
-      DO i = 1, 6
-         fft_scratch_first%fft_scratch%fft_plan(i)%valid = .FALSE.
-      END DO
       ! this is a very special scratch, it seems, we always keep it 'most - recent' so we will never delete it
       fft_scratch_first%fft_scratch%last_tick = HUGE(fft_scratch_first%fft_scratch%last_tick)
 
@@ -2973,44 +2945,6 @@ CONTAINS
             ! Generate a new scratch set
             ALLOCATE (fft_scratch_new)
             ALLOCATE (fft_scratch_new%fft_scratch)
-            NULLIFY (fft_scratch_new%fft_scratch%ziptr)
-            NULLIFY (fft_scratch_new%fft_scratch%zoptr)
-            NULLIFY (fft_scratch_new%fft_scratch%p1buf)
-            NULLIFY (fft_scratch_new%fft_scratch%p2buf)
-            NULLIFY (fft_scratch_new%fft_scratch%p3buf)
-            NULLIFY (fft_scratch_new%fft_scratch%p4buf)
-            NULLIFY (fft_scratch_new%fft_scratch%p5buf)
-            NULLIFY (fft_scratch_new%fft_scratch%p6buf)
-            NULLIFY (fft_scratch_new%fft_scratch%p7buf)
-            NULLIFY (fft_scratch_new%fft_scratch%r1buf)
-            NULLIFY (fft_scratch_new%fft_scratch%r2buf)
-            NULLIFY (fft_scratch_new%fft_scratch%tbuf)
-            NULLIFY (fft_scratch_new%fft_scratch%a1buf)
-            NULLIFY (fft_scratch_new%fft_scratch%a2buf)
-            NULLIFY (fft_scratch_new%fft_scratch%a3buf)
-            NULLIFY (fft_scratch_new%fft_scratch%a4buf)
-            NULLIFY (fft_scratch_new%fft_scratch%a5buf)
-            NULLIFY (fft_scratch_new%fft_scratch%a6buf)
-            NULLIFY (fft_scratch_new%fft_scratch%scount, fft_scratch_new%fft_scratch%rcount, &
-                     fft_scratch_new%fft_scratch%sdispl, fft_scratch_new%fft_scratch%rdispl)
-            NULLIFY (fft_scratch_new%fft_scratch%rr, &
-                     fft_scratch_new%fft_scratch%ss, fft_scratch_new%fft_scratch%tt)
-            NULLIFY (fft_scratch_new%fft_scratch%xzbuf, fft_scratch_new%fft_scratch%yzbuf, &
-                     fft_scratch_new%fft_scratch%xzbuf_sgl, fft_scratch_new%fft_scratch%yzbuf_sgl)
-            NULLIFY (fft_scratch_new%fft_scratch%pgcube)
-            NULLIFY (fft_scratch_new%fft_scratch%pgrid)
-            NULLIFY (fft_scratch_new%fft_scratch%xcor, fft_scratch_new%fft_scratch%zcor)
-            NULLIFY (fft_scratch_new%fft_scratch%pzcoord)
-            NULLIFY (fft_scratch_new%fft_scratch%xzcount, fft_scratch_new%fft_scratch%yzcount)
-            NULLIFY (fft_scratch_new%fft_scratch%xzdispl, fft_scratch_new%fft_scratch%yzdispl)
-            NULLIFY (fft_scratch_new%fft_scratch%rbuf1, fft_scratch_new%fft_scratch%rbuf2, &
-                     fft_scratch_new%fft_scratch%rbuf3, fft_scratch_new%fft_scratch%rbuf4)
-            NULLIFY (fft_scratch_new%fft_scratch%rbuf5, fft_scratch_new%fft_scratch%rbuf6)
-            fft_scratch_new%fft_scratch%in = 0
-            fft_scratch_new%fft_scratch%rsratio = 1._dp
-            DO i = 1, 6
-               fft_scratch_new%fft_scratch%fft_plan(i)%valid = .FALSE.
-            END DO
 
             IF (tf_type .NE. 400) THEN
                fft_scratch_new%fft_scratch%sizes = fft_sizes
@@ -3227,8 +3161,6 @@ CONTAINS
                          fft_scratch_new%fft_scratch%yzcount(0:np - 1))
                ALLOCATE (fft_scratch_new%fft_scratch%xzdispl(0:np - 1), &
                          fft_scratch_new%fft_scratch%yzdispl(0:np - 1))
-               fft_scratch_new%fft_scratch%in = 0
-               fft_scratch_new%fft_scratch%rsratio = 1._dp
                fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
 
                dim = fft_sizes%rs_group%num_pe_cart

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -88,7 +88,7 @@ MODULE fft_tools
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER &
          :: ziptr => NULL(), zoptr => NULL()
       ! to be used in fft3d_ps : block distribution
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER &
+      COMPLEX(KIND=dp), DIMENSION(:, :), CONTIGUOUS, POINTER &
          :: p1buf => NULL(), p2buf => NULL(), p3buf => NULL(), p4buf => NULL(), &
             p5buf => NULL(), p6buf => NULL(), p7buf => NULL()
       ! to be used in fft3d_ps : plane distribution
@@ -2618,14 +2618,14 @@ CONTAINS
          DEALLOCATE (fft_scratch%zoptr)
       END IF
       IF (ASSOCIATED(fft_scratch%p1buf)) THEN
-         DEALLOCATE (fft_scratch%p1buf)
+         CALL fft_dealloc(fft_scratch%p1buf)
       END IF
       IF (ASSOCIATED(fft_scratch%p2buf)) THEN
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
          dummy_ptr_z => fft_scratch%p2buf(1, 1)
          ierr = offload_free_pinned_mem(c_loc(dummy_ptr_z))
 #else
-         DEALLOCATE (fft_scratch%p2buf)
+         CALL fft_dealloc(fft_scratch%p2buf)
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%p3buf)) THEN
@@ -2633,7 +2633,7 @@ CONTAINS
          dummy_ptr_z => fft_scratch%p3buf(1, 1)
          ierr = offload_free_pinned_mem(c_loc(dummy_ptr_z))
 #else
-         DEALLOCATE (fft_scratch%p3buf)
+         CALL fft_dealloc(fft_scratch%p3buf)
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%p4buf)) THEN
@@ -2641,7 +2641,7 @@ CONTAINS
          dummy_ptr_z => fft_scratch%p4buf(1, 1)
          ierr = offload_free_pinned_mem(c_loc(dummy_ptr_z))
 #else
-         DEALLOCATE (fft_scratch%p4buf)
+         CALL fft_dealloc(fft_scratch%p4buf)
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%p5buf)) THEN
@@ -2649,11 +2649,11 @@ CONTAINS
          dummy_ptr_z => fft_scratch%p5buf(1, 1)
          ierr = offload_free_pinned_mem(c_loc(dummy_ptr_z))
 #else
-         DEALLOCATE (fft_scratch%p5buf)
+         CALL fft_dealloc(fft_scratch%p5buf)
 #endif
       END IF
       IF (ASSOCIATED(fft_scratch%p6buf)) THEN
-         DEALLOCATE (fft_scratch%p6buf)
+         CALL fft_dealloc(fft_scratch%p6buf)
       END IF
       IF (ASSOCIATED(fft_scratch%p7buf)) THEN
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
@@ -3158,8 +3158,8 @@ CONTAINS
                m2 = fft_sizes%r_dim(2)
                nbx = fft_sizes%nbx
                nbz = fft_sizes%nbz
-               ALLOCATE (fft_scratch_new%fft_scratch%p1buf(mx1*my1, n(3)))
-               ALLOCATE (fft_scratch_new%fft_scratch%p6buf(lg, mg))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%p1buf, [mx1*my1, n(3)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%p6buf, [lg, mg])
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
                length = INT(2*dp_size*MAX(n(3), 1)*MAX(mx1*my1, 1), KIND=C_SIZE_T)
                ierr = offload_malloc_pinned_mem(cptr_p2buf, length)
@@ -3182,10 +3182,10 @@ CONTAINS
                CPASSERT(ierr == 0)
                CALL c_f_pointer(cptr_p7buf, fft_scratch_new%fft_scratch%p7buf, (/MAX(mg, 1), MAX(lg, 1)/))
 #else
-               ALLOCATE (fft_scratch_new%fft_scratch%p2buf(n(3), mx1*my1))
-               ALLOCATE (fft_scratch_new%fft_scratch%p3buf(mx2*mz2, n(2)))
-               ALLOCATE (fft_scratch_new%fft_scratch%p4buf(n(2), mx2*mz2))
-               ALLOCATE (fft_scratch_new%fft_scratch%p5buf(nyzray, n(1)))
+               CALL fft_alloc(fft_scratch_new%fft_scratch%p2buf, [n(3), mx1*my1])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%p3buf, [mx2*mz2, n(2)])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%p4buf, [n(2), mx2*mz2])
+               CALL fft_alloc(fft_scratch_new%fft_scratch%p5buf, [nyzray, n(1)])
                ALLOCATE (fft_scratch_new%fft_scratch%p7buf(mg, lg))
 #endif
                IF (alltoall_sgl) THEN

--- a/src/pw/pw_grid_types.F
+++ b/src/pw/pw_grid_types.F
@@ -87,7 +87,7 @@ MODULE pw_grid_types
       INTEGER, DIMENSION(:), POINTER :: gidx ! ref grid index
       INTEGER :: ref_count ! reference count
       LOGICAL :: spherical ! spherical cutoff?
-      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER :: grays ! used by parallel 3D FFT routine
+      COMPLEX(KIND=dp), DIMENSION(:, :), CONTIGUOUS, POINTER :: grays ! used by parallel 3D FFT routine
    END TYPE pw_grid_type
 
 END MODULE pw_grid_types

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -1663,7 +1663,7 @@ CONTAINS
 
       CHARACTER(LEN=9)                                   :: mode
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: grays
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER      :: c_in, c_out
+      COMPLEX(KIND=dp), DIMENSION(:, :, :), CONTIGUOUS, POINTER      :: c_in, c_out
       INTEGER                                            :: dir, handle, handle2, my_pos, nrays, &
                                                             out_space, out_unit
       INTEGER, DIMENSION(3)                              :: nloc

--- a/tests/SLOW_TESTS_SUPPRESSIONS
+++ b/tests/SLOW_TESTS_SUPPRESSIONS
@@ -76,5 +76,6 @@ QS/regtest-sccs-1/H2O_sccs_td_cd5_fg.inp
 QS/regtest-sccs-3/H2O_sccs_td_cd5_geo_opt.inp
 QS/regtest-sccs-2/H2O_sccs_otdiis_cd5.inp
 QS/regtest-lsroks/ch2o_rs.inp
+QS/regtest-rtp-5/H2O-wfn-mix-dens-pulse-1.inp
 
 #EOF

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -233,6 +233,10 @@ farming_methods.F: Found CLOSE statement in procedure "farming_parse_input" http
 farming_methods.F: Found OPEN statement in procedure "farming_parse_input" https://cp2k.org/conv#c203
 farming_types.F: Found type farming_env_type without initializer https://cp2k.org/conv#c016
 farming_types.F: Found type job_type without initializer https://cp2k.org/conv#c016
+fftw3_lib.F: 'dim_istride' is used uninitialized [-Wuninitialized]
+fftw3_lib.F: 'dim_n' is used uninitialized [-Wuninitialized]
+fftw3_lib.F: 'dim_ostride' is used uninitialized [-Wuninitialized]
+fftw3_lib.F: Same actual argument associated with INTENT(OUT) argument 'in' and INTENT(OUT) argument 'out' at (1)
 fft_plan.F: Found type fft_plan_type without initializer https://cp2k.org/conv#c016
 fft_tools.F: Found type fft_scratch_pool_type without initializer https://cp2k.org/conv#c016
 fft_tools.F: Found type fft_scratch_type without initializer https://cp2k.org/conv#c016


### PR DESCRIPTION
This PR
- upgrades our FFTW3 wrapper to its Fortran-2003-equivalent,
- uses FFTW3 to allocate aligned memory for the grids
- makes some arrays contiguous
- adds a few more initializers

This should reduce some of the of overhead to call FFTW and to carry out FFTs in general.

This PR was tested with H2O-512 on Daint (64 nodes). This PR should also work with Intel/MKL (Tested locally with Intel Parallel Studio 20.4).

Closes #2533 .