### PR TITLE
Docker: Add cp2k-ci.conf

### DIFF
--- a/tests/SLOW_TESTS_SUPPRESSIONS
+++ b/tests/SLOW_TESTS_SUPPRESSIONS
@@ -20,6 +20,7 @@ Pimd/regtest-1/water-in-helium-restart.inp
 Pimd/regtest-2/water-micro-helium.inp
 Pimd/regtest-2/water-micro-helium-therminit.inp
 QMMM/SE/regtest-force-mixing/Lysozyme_small_NVT.inp
+QS/regtest-gpw-1/Li2-0-SCF-PBE.inp
 QS/regtest-admm-qps/O2-triplett-ADMMP-debug_forces.inp
 QS/regtest-almo-2/ion-pair.inp
 QS/regtest-almo-trustr/FHchain-dogleg.inp
@@ -66,6 +67,7 @@ QS/regtest-xastdp/CH3-PBE-uks.inp
 QS/regtest-p-efield/HF-field-debug.inp
 QS/regtest-admm-qps/H2O-ADMMQ_debug_forces.inp
 QS/regtest-ps-implicit-1-1/Ar_mixed_cuboidal.inp
+QS/regtest-ps-implicit-1-1/Ar_mixed_cylindrical.inp
 QS/regtest-embed/H2O_H2_pbe_FAB.inp
 QS/regtest-gapw-ext/H2S-e4.inp
 QS/regtest-rtp-5/si8-smearing-rtp-dens.inp

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -1,0 +1,249 @@
+[precommit]
+display_name: Precommit
+cpu:          2
+nodepools:    pool-t2d-4
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_precommit
+
+[python]
+display_name: Python
+cpu:          1
+nodepools:    pool-t2d-4
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_python
+
+#-------------------------------------------------------------------------------
+
+[sdbg]
+display_name: Regtest sdbg
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_sdbg
+
+[ssmp]
+display_name: Regtest ssmp
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_ssmp
+
+[pdbg]
+display_name: Regtest pdbg
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_pdbg
+
+[psmp]
+display_name: Regtest psmp
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_psmp
+
+[conventions]
+display_name: Conventions
+cpu:          16
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_conventions
+
+[manual]
+display_name: Manual generation
+cpu:          16
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_manual
+
+[ase]
+display_name: ASE
+cpu:          8
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_ase
+
+[i-pi]
+display_name: i-Pi
+cpu:          8
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_i-pi
+
+[aiida]
+display_name: AiiDA
+cpu:          8
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_aiida
+
+[gromacs]
+display_name: Gromacs
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gromacs
+
+[perf-openmp]
+display_name: Performance OpenMP
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_performance
+
+[minimal]
+display_name: Minimal arch file
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_minimal
+
+[cmake]
+display_name: CMake
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_cmake
+
+[coverage-pdbg]
+display_name: Coverage
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_coverage-pdbg
+
+[asan-psmp]
+display_name: Address Sanitizer
+cpu:          32
+nodepools:    pool-t2d-32
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_asan-psmp
+
+#-------------------------------------------------------------------------------
+
+[gcc7]
+display_name: Ubuntu, GCC 7 (ssmp)
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc7
+
+[gcc8]
+display_name: Ubuntu, GCC 8 (ssmp)
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc8
+
+[gcc9]
+display_name: Ubuntu, GCC 9 (ssmp)
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc9
+
+[gcc10]
+display_name: Ubuntu, GCC 10 (ssmp)
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc10
+
+#-------------------------------------------------------------------------------
+
+[perf-cuda-volta]
+display_name: Performance CUDA Volta
+cpu:          12
+gpu:          1
+nodepools:    pool-v100-skylake-12
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_performance_cuda_V100
+
+[doxygen]
+display_name: Doxygen generation
+cpu:          16
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_doxygen
+
+[openmpi-psmp]
+display_name: OpenMPI
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_openmpi-psmp
+
+[intel-psmp]
+display_name: Intel oneAPI
+cpu:          30
+nodepools:    pool-c2-30
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_intel-psmp
+
+[fedora-psmp]
+display_name: Fedora
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_fedora-psmp
+
+[generic-psmp]
+display_name: Generic
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_generic_psmp
+
+[cuda-pascal]
+display_name: CUDA Pascal Regtest
+cpu:          24
+gpu:          1
+nodepools:    pool-p4-skylake-24
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_cuda_P100
+
+[hip-pascal]
+display_name: HIP Pascal Regtest
+cpu:          24
+gpu:          1
+nodepools:    pool-p4-skylake-24
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_hip_cuda_P100
+
+[hip-rocm-build]
+display_name: HIP ROCm Build
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.build_hip_rocm_Mi100
+
+[i386]
+display_name: Debian i386 (ssmp)
+cpu:          32
+nodepools:    pool-t2d-32
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_i386
+
+[arm64-psmp]
+display_name: ARM64
+cpu:          16
+arch:         arm64
+nodepools:    pool-t2a-16
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_arm64-psmp
+
+#EOF


### PR DESCRIPTION
The `cp2k-ci.conf` used to live [here](https://github.com/cp2k/cp2k-ci/blob/master/backend/cp2k-ci.conf). Moving into our main repository will make it easier to experiment with it and also document any changes as part of our main commit history.