### PR TITLE
Try DPC++/C++ Intel compiler (icpx/icx) as default

### DIFF
--- a/tests/QS/regtest-hfx-periodic/TEST_FILES
+++ b/tests/QS/regtest-hfx-periodic/TEST_FILES
@@ -12,5 +12,5 @@ CH3-coul-0.inp                                         1      9e-14            -
 h2o-respa.inp                                          1      6e-13            -76.023109187259081
 h2o-respa_restart.inp                                  1      5e-12            -76.022672170936700
 H2O-id-auto.inp                                        1      1e-10            -88.00800458674919
-graphene_periodic_XY.inp                               1      1e-10            -77.259924663247261
+graphene_periodic_XY.inp                               1      4e-09            -77.259924663247261
 #EOF

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -151,7 +151,7 @@ The --with-PKG options follow the rules:
   --with-intel            Use the Intel compiler to compile CP2K.
                           Default = system
   --with-intel-classic    Use the classic Intel compiler to compile CP2K.
-                          Default = yes
+                          Default = no
   --with-cmake            Cmake utilities
                           Default = install
   --with-openmpi          OpenMPI, important if you want a parallel version of CP2K.
@@ -340,7 +340,7 @@ enable_tsan="__FALSE__"
 enable_opencl="__FALSE__"
 enable_cuda="__FALSE__"
 enable_hip="__FALSE__"
-export intel_classic="yes"
+export intel_classic="no"
 export GPUVER="no"
 export MPICH_DEVICE="ch3"
 export TARGET_CPU="native"

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -129,7 +129,7 @@ if [ "${with_intel}" == "__DONTUSE__" ]; then
 else
   CXXFLAGS="IF_MPI(-cxx=${I_MPI_CXX}|) $G_CFLAGS -std=c11 -Wall \$(DFLAGS)"
   CFLAGS="IF_MPI(-cc=${I_MPI_CC}|) $G_CFLAGS -std=c11 -Wall \$(DFLAGS)"
-  FCFLAGS="IF_MPI(-fc=${I_MPI_FC}|) $FCFLAGS -diag-disable=8291 -diag-disable=8293 -fpp -free"
+  FCFLAGS="IF_MPI(-fc=${I_MPI_FC}|) $FCFLAGS -diag-disable=8291 -diag-disable=8293 -fpp -fpscomp logicals -free"
 fi
 
 # Linker flags


### PR DESCRIPTION
Intel suggests to switch to the new DPC++/C++ compiler:
`remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message.`
This is a test to see how that compiler works with CP2K.