### PR TITLE
Try Intel Fortran compiler ifx instead of ifort

### DIFF
--- a/tools/docker/Dockerfile.prod_intel_psmp
+++ b/tools/docker/Dockerfile.prod_intel_psmp
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.prod_intel_psmp ../../
 #
 
-FROM intel/oneapi-hpckit:2023.0.0-devel-ubuntu22.04
+FROM intel/oneapi-hpckit:2023.1.0-devel-ubuntu22.04
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain

--- a/tools/docker/Dockerfile.test_intel-psmp
+++ b/tools/docker/Dockerfile.test_intel-psmp
@@ -3,7 +3,7 @@
 # Usage: docker build -f ./Dockerfile.test_intel-psmp ../../
 #
 
-FROM intel/oneapi-hpckit:2023.0.0-devel-ubuntu22.04
+FROM intel/oneapi-hpckit:2023.1.0-devel-ubuntu22.04
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -491,7 +491,7 @@ RUN ln -sf /usr/bin/gcc-{gcc_version}      /usr/local/bin/gcc  && \
 # ======================================================================================
 def toolchain_intel() -> str:
     return rf"""
-FROM intel/oneapi-hpckit:2023.0.0-devel-ubuntu22.04
+FROM intel/oneapi-hpckit:2023.1.0-devel-ubuntu22.04
 
 """ + install_toolchain(
         base_image="ubuntu",

--- a/tools/toolchain/scripts/stage0/install_intel.sh
+++ b/tools/toolchain/scripts/stage0/install_intel.sh
@@ -35,7 +35,7 @@ case "${with_intel}" in
     else
       check_command icx "intel" && CC="$(realpath $(command -v icx))" || exit 1
       check_command icpx "intel" && CXX="$(realpath $(command -v icpx))" || exit 1
-      check_command ifort "intel" && FC="$(realpath $(command -v ifort))" || exit 1
+      check_command ifx "intel" && FC="$(realpath $(command -v ifx))" || exit 1
     fi
     F90="${FC}"
     F77="${FC}"
@@ -56,7 +56,7 @@ case "${with_intel}" in
     else
       check_command ${pkg_install_dir}/bin/icx "intel" && CC="${pkg_install_dir}/bin/icx" || exit 1
       check_command ${pkg_install_dir}/bin/icpx "intel" && CXX="${pkg_install_dir}/bin/icpx" || exit 1
-      check_command ${pkg_install_dir}/bin/ifort "intel" && FC="${pkg_install_dir}/bin/ifort" || exit 1
+      check_command ${pkg_install_dir}/bin/ifx "intel" && FC="${pkg_install_dir}/bin/ifx" || exit 1
     fi
     F90="${FC}"
     F77="${FC}"

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -79,7 +79,7 @@ if [ "${with_intelmpi}" != "__DONTUSE__" ]; then
   else
     I_MPI_CXX="icpx"
     I_MPI_CC="icx"
-    I_MPI_FC="ifort"
+    I_MPI_FC="ifx"
   fi
   INTELMPI_LIBS="-lmpi -lmpicxx"
   echo "I_MPI_CXX is ${I_MPI_CXX}"


### PR DESCRIPTION
Switch completely from the Intel Classic compiler set icc/icpc/ifort to the new set icx/icpx/ifx provided by the Intel oneAPI HPC Toolkit 2023.0.0.