### PR TITLE
small changes to install_libtorch.sh for gpu support and hfx_admm_utils.F for minimal build

### DIFF
--- a/src/hfx_admm_utils.F
+++ b/src/hfx_admm_utils.F
@@ -1053,7 +1053,9 @@ CONTAINS
       TYPE(admm_type), POINTER                           :: admm_env
 
       LOGICAL, PARAMETER                                 :: debug_functional = .FALSE.
+#if defined (__LIBXC)
       REAL(KIND=dp), PARAMETER :: x_factor_c = 0.930525736349100025_dp
+#endif
 
       CHARACTER(LEN=20)                                  :: name_x_func
       INTEGER                                            :: hfx_potential_type, ifun, iounit, nfun


### PR DESCRIPTION
- Included flags for gpu support in ```toolchain/scripts/stage7/install_libtorch.sh``` as in https://github.com/cp2k/cp2k/pull/2430, along with ```-Wl, --no-as-needed```
- Fix ```unused-parameter``` error for minimal build without libxc and libint in ```src/hfx_admm_utils.F```; The minimal build resulted from the following toolchain command: 
```
./install_cp2k_toolchain.sh --with-libtorch --with-quip=no --with-spglib=no --with-cosma=no --with-libxsmm=no --with-libvori=no --with-libxc=no --with-plumed=no --with-sirius=no  --with-elpa=no --with-libint=no  --with-libvdwxc=no --with-gsl=no --with-openmpi --with-gcc=install --with-cmake=install
```