### PR TITLE
Projection mo rtp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -248,6 +248,7 @@ list(
   input_cp2k_negf.F
   input_cp2k_nnp.F
   input_cp2k_poisson.F
+  input_cp2k_projection_rtp.F
   input_cp2k_properties_dft.F
   input_cp2k_pwdft.F
   input_cp2k_qmmm.F
@@ -926,6 +927,7 @@ list(
   emd/rt_delta_pulse.F
   emd/rt_hfx_utils.F
   emd/rt_make_propagators.F
+  emd/rt_projection_mo_utils.F
   emd/rt_propagation_methods.F
   emd/rt_propagation_output.F
   emd/rt_propagation_utils.F

--- a/src/cp_control_types.F
+++ b/src/cp_control_types.F
@@ -38,7 +38,24 @@ MODULE cp_control_types
       INTEGER, DIMENSION(2)                :: distribution_layout
       INTEGER                              :: blocked
    END TYPE pw_grid_option
+! **************************************************************************************************
+! \brief parameters for EMD/RTP calculations involving MO projections
+! **************************************************************************************************
+   TYPE proj_mo_type
+      INTEGER, DIMENSION(:), ALLOCATABLE         :: ref_mo_index
+      INTEGER                                    :: ref_mo_spin = 1
+      LOGICAL                                    :: sum_on_all_ref = .FALSE.
+      INTEGER, DIMENSION(:), ALLOCATABLE         :: td_mo_index
+      INTEGER                                    :: td_mo_spin = 1
+      LOGICAL                                    :: sum_on_all_td = .FALSE.
+      CHARACTER(LEN=default_path_length)         :: ref_mo_file_name = ""
+      TYPE(cp_fm_type), DIMENSION(:), &
+         ALLOCATABLE                       :: mo_ref
+   END TYPE proj_mo_type
 
+   TYPE proj_mo_p_type
+      TYPE(proj_mo_type), POINTER                :: proj_mo => NULL()
+   END TYPE proj_mo_p_type
 ! **************************************************************************************************
 ! \brief Control parameters for REAL_TIME_PROPAGATION calculations
 ! **************************************************************************************************
@@ -68,6 +85,9 @@ MODULE cp_control_types
       LOGICAL                              :: velocity_gauge
       REAL(KIND=dp), DIMENSION(3)          :: vec_pot
       LOGICAL                              :: nl_gauge_transform
+      LOGICAL                              :: is_proj_mo
+      TYPE(proj_mo_p_type), DIMENSION(:), &
+         POINTER                :: proj_mo_list => NULL()
    END TYPE rtp_control_type
 ! **************************************************************************************************
 ! \brief Control parameters for DFTB calculations
@@ -598,6 +618,7 @@ MODULE cp_control_types
              gapw_control_type, &
              tddfpt_control_type, &
              tddfpt2_control_type, &
+             proj_mo_type, &
              efield_type, &
              mulliken_restraint_type, &
              ddapc_restraint_type, &
@@ -775,6 +796,7 @@ CONTAINS
          DEALLOCATE (dft_control%period_efield)
       END IF
       IF (ASSOCIATED(dft_control%rtp_control)) THEN
+         CALL proj_mo_list_release(dft_control%rtp_control%proj_mo_list)
          DEALLOCATE (dft_control%rtp_control)
       END IF
 
@@ -930,6 +952,35 @@ CONTAINS
 
       CALL timestop(handle)
    END SUBROUTINE tddfpt2_control_release
+
+! **************************************************************************************************
+!> \brief ...
+!> \param proj_mo_list ...
+! **************************************************************************************************
+   SUBROUTINE proj_mo_list_release(proj_mo_list)
+      TYPE(proj_mo_p_type), DIMENSION(:), POINTER        :: proj_mo_list
+
+      INTEGER                                            :: i, mo_ref_nbr
+
+      IF (ASSOCIATED(proj_mo_list)) THEN
+         DO i = 1, SIZE(proj_mo_list)
+            IF (ASSOCIATED(proj_mo_list(i)%proj_mo)) THEN
+               IF (ALLOCATED(proj_mo_list(i)%proj_mo%ref_mo_index)) &
+                  DEALLOCATE (proj_mo_list(i)%proj_mo%ref_mo_index)
+               IF (ALLOCATED(proj_mo_list(i)%proj_mo%mo_ref)) THEN
+                  DO mo_ref_nbr = 1, SIZE(proj_mo_list(i)%proj_mo%mo_ref)
+                     CALL cp_fm_release(proj_mo_list(i)%proj_mo%mo_ref(mo_ref_nbr))
+                  END DO
+                  DEALLOCATE (proj_mo_list(i)%proj_mo%mo_ref)
+               END IF
+               IF (ALLOCATED(proj_mo_list(i)%proj_mo%td_mo_index)) &
+                  DEALLOCATE (proj_mo_list(i)%proj_mo%td_mo_index)
+               DEALLOCATE (proj_mo_list(i)%proj_mo)
+            END IF
+         END DO
+         DEALLOCATE (proj_mo_list)
+      END IF
+   END SUBROUTINE proj_mo_list_release
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -2234,6 +2234,8 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: rtp_section
 
       INTEGER, DIMENSION(:), POINTER                     :: tmp
+      LOGICAL                                            :: is_present
+      TYPE(section_vals_type), POINTER                   :: proj_mo_section
 
       ALLOCATE (dft_control%rtp_control)
       CALL section_vals_val_get(rtp_section, "MAX_ITER", &
@@ -2277,6 +2279,19 @@ CONTAINS
       dft_control%rtp_control%delta_pulse_direction = tmp
       CALL section_vals_val_get(rtp_section, "SC_CHECK_START", &
                                 i_val=dft_control%rtp_control%sc_check_start)
+      proj_mo_section => section_vals_get_subs_vals(rtp_section, "PRINT%PROJECTION_MO")
+      CALL section_vals_get(proj_mo_section, explicit=is_present)
+      IF (is_present) THEN
+         IF (dft_control%rtp_control%linear_scaling) &
+            CALL cp_abort(__LOCATION__, &
+                          "You have defined a time dependent projection of mos, but "// &
+                          " only the density matrix is propagated (DENSITY_PROPAGATION "// &
+                          ".TRUE.). Please either use MO-based real time DFT or do not "// &
+                          "define any PRINT%PROJECTION_MO section")
+         dft_control%rtp_control%is_proj_mo = .TRUE.
+      ELSE
+         dft_control%rtp_control%is_proj_mo = .FALSE.
+      END IF
 
    END SUBROUTINE read_rtp_section
 

--- a/src/emd/rt_projection_mo_utils.F
+++ b/src/emd/rt_projection_mo_utils.F
@@ -1,0 +1,567 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2023 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief Function related to MO projection in RTP calculations
+!> \author Guillaume Le Breton 04.2023
+! **************************************************************************************************
+MODULE rt_projection_mo_utils
+   USE cp_control_types,                ONLY: dft_control_type,&
+                                              proj_mo_type,&
+                                              rtp_control_type
+   USE cp_dbcsr_operations,             ONLY: cp_dbcsr_sm_fm_multiply
+   USE cp_files,                        ONLY: close_file,&
+                                              open_file
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_trace
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
+                                              cp_fm_struct_release,&
+                                              cp_fm_struct_type
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_release,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_type
+   USE cp_log_handling,                 ONLY: cp_get_default_logger,&
+                                              cp_logger_get_default_io_unit,&
+                                              cp_logger_type,&
+                                              cp_to_string
+   USE cp_output_handling,              ONLY: cp_p_file,&
+                                              cp_print_key_finished_output,&
+                                              cp_print_key_generate_filename,&
+                                              cp_print_key_should_output,&
+                                              cp_print_key_unit_nr
+   USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_constants,                 ONLY: proj_mo_ref_scf,&
+                                              proj_mo_ref_xas_tdp
+   USE input_section_types,             ONLY: section_vals_get,&
+                                              section_vals_get_subs_vals,&
+                                              section_vals_type,&
+                                              section_vals_val_get
+   USE kinds,                           ONLY: default_string_length,&
+                                              dp
+   USE message_passing,                 ONLY: mp_para_env_type
+   USE particle_types,                  ONLY: particle_type
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_kind_types,                   ONLY: qs_kind_type
+   USE qs_mo_io,                        ONLY: read_mos_restart_low
+   USE qs_mo_types,                     ONLY: deallocate_mo_set,&
+                                              duplicate_mo_set,&
+                                              mo_set_type
+#include "./../base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'rt_projection_mo_utils'
+
+   PUBLIC :: init_mo_projection, compute_and_write_proj_mo
+
+CONTAINS
+
+! **************************************************************************************************
+!> \brief Initialize the mo projection objects for time dependent run
+!> \param qs_env ...
+!> \param rtp_control ...
+!> \author Guillaume Le Breton (04.2023)
+! **************************************************************************************************
+   SUBROUTINE init_mo_projection(qs_env, rtp_control)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(rtp_control_type), POINTER                    :: rtp_control
+
+      INTEGER                                            :: i_rep, j_td, n_rep_val, nbr_mo_td_max, &
+                                                            nrep, reftype
+      INTEGER, DIMENSION(:), POINTER                     :: tmp_ints
+      TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
+      TYPE(proj_mo_type), POINTER                        :: proj_mo
+      TYPE(section_vals_type), POINTER                   :: input, print_key, proj_mo_section
+
+      NULLIFY (rtp_control%proj_mo_list, tmp_ints, proj_mo, logger, &
+               input, proj_mo_section, print_key, mos)
+
+      IF (.NOT. rtp_control%fixed_ions) &
+         CALL cp_abort(__LOCATION__, &
+                       "DFT%REAL_TIME_PROPAGATION%PRINT%PROJECTION_MO not implemented for EMD yet.")
+
+      CALL get_qs_env(qs_env, input=input, mos=mos)
+
+      proj_mo_section => section_vals_get_subs_vals(input, "DFT%REAL_TIME_PROPAGATION%PRINT%PROJECTION_MO")
+
+      ! Read the input section and load the reference MOs
+      CALL section_vals_get(proj_mo_section, n_repetition=nrep)
+      ALLOCATE (rtp_control%proj_mo_list(nrep))
+
+      DO i_rep = 1, nrep
+         NULLIFY (rtp_control%proj_mo_list(i_rep)%proj_mo)
+         ALLOCATE (rtp_control%proj_mo_list(i_rep)%proj_mo)
+         proj_mo => rtp_control%proj_mo_list(i_rep)%proj_mo
+
+         CALL section_vals_val_get(proj_mo_section, "REFERENCE_TYPE", i_rep_section=i_rep, &
+                                   i_val=reftype)
+
+         CALL section_vals_val_get(proj_mo_section, "REF_MO_FILE_NAME", i_rep_section=i_rep, &
+                                   c_val=proj_mo%ref_mo_file_name)
+
+         IF (reftype == proj_mo_ref_scf) THEN
+            ! If no reference .wfn is provided, using the restart SCF file:
+            IF (proj_mo%ref_mo_file_name == "DEFAULT") THEN
+               CALL section_vals_val_get(input, "DFT%WFN_RESTART_FILE_NAME", n_rep_val=n_rep_val)
+               IF (n_rep_val > 0) THEN
+                  CALL section_vals_val_get(input, "DFT%WFN_RESTART_FILE_NAME", c_val=proj_mo%ref_mo_file_name)
+               ELSE
+                  !try to read from the filename that is generated automatically from the printkey
+                  print_key => section_vals_get_subs_vals(input, "DFT%SCF%PRINT%RESTART")
+                  logger => cp_get_default_logger()
+                  proj_mo%ref_mo_file_name = cp_print_key_generate_filename(logger, print_key, &
+                                                                            extension=".wfn", my_local=.FALSE.)
+               END IF
+            END IF
+
+            CALL section_vals_val_get(proj_mo_section, "REF_MO_INDEX", i_rep_section=i_rep, &
+                                      i_vals=tmp_ints)
+            ALLOCATE (proj_mo%ref_mo_index, SOURCE=tmp_ints(:))
+            CALL section_vals_val_get(proj_mo_section, "REF_MO_SPIN", i_rep_section=i_rep, &
+                                      i_val=proj_mo%ref_mo_spin)
+
+            ! Read the SCF mos and store the one required
+            CALL read_reference_mo_from_wfn(qs_env, proj_mo)
+
+         ELSE IF (reftype == proj_mo_ref_xas_tdp) THEN
+            IF (proj_mo%ref_mo_file_name == "DEFAULT") THEN
+               CALL cp_abort(__LOCATION__, &
+                             "Input error in DFT%REAL_TIME_PROPAGATION%PRINT%PROJECTION_MO. "// &
+                             "For REFERENCE_TYPE XAS_TDP one must define the name "// &
+                             "of the .wfn file to read the reference MO from. Please define REF_MO_FILE_NAME.")
+            END IF
+            ALLOCATE (proj_mo%ref_mo_index(1))
+            ! XAS restart files contain only one excited state
+            proj_mo%ref_mo_index(1) = 1
+            proj_mo%ref_mo_spin = 1
+            ! Read XAS TDP mos
+            CALL read_reference_mo_from_wfn(qs_env, proj_mo, xas_ref=.TRUE.)
+
+         END IF
+
+         ! Initialize the other parameters related to the TD mos.
+         CALL section_vals_val_get(proj_mo_section, "SUM_ON_ALL_REF", i_rep_section=i_rep, &
+                                   l_val=proj_mo%sum_on_all_ref)
+
+         CALL section_vals_val_get(proj_mo_section, "TD_MO_SPIN", i_rep_section=i_rep, &
+                                   i_val=proj_mo%td_mo_spin)
+         IF (proj_mo%td_mo_spin > SIZE(mos)) &
+            CALL cp_abort(__LOCATION__, &
+                          "You asked to project the time dependent BETA spin while the "// &
+                          "real time DFT run has only one spin defined. "// &
+                          "Please set TD_MO_SPIN to 1 or use UKS.")
+
+         CALL section_vals_val_get(proj_mo_section, "TD_MO_INDEX", i_rep_section=i_rep, &
+                                   i_vals=tmp_ints)
+
+         ALLOCATE (proj_mo%td_mo_index, SOURCE=tmp_ints(:))
+         nbr_mo_td_max = mos(proj_mo%td_mo_spin)%mo_coeff%matrix_struct%ncol_global
+         IF (proj_mo%td_mo_index(1) == -1) THEN
+            DEALLOCATE (proj_mo%td_mo_index)
+            ALLOCATE (proj_mo%td_mo_index(nbr_mo_td_max))
+            DO j_td = 1, nbr_mo_td_max
+               proj_mo%td_mo_index(j_td) = j_td
+            END DO
+         ELSE
+            DO j_td = 1, SIZE(proj_mo%td_mo_index)
+               IF (proj_mo%td_mo_index(j_td) > nbr_mo_td_max) &
+                  CALL cp_abort(__LOCATION__, &
+                                "The MO number available in the Time Dependent run "// &
+                                "is smaller than the MO number you have required in TD_MO_INDEX.")
+            END DO
+         END IF
+
+         CALL section_vals_val_get(proj_mo_section, "SUM_ON_ALL_TD", i_rep_section=i_rep, &
+                                   l_val=proj_mo%sum_on_all_td)
+
+      END DO
+
+   END SUBROUTINE init_mo_projection
+
+! **************************************************************************************************
+!> \brief Read the MO from .wfn file and store the required mos for TD projections
+!> \param qs_env ...
+!> \param proj_mo ...
+!> \param xas_ref ...
+!> \author Guillaume Le Breton (04.2023)
+! **************************************************************************************************
+   SUBROUTINE read_reference_mo_from_wfn(qs_env, proj_mo, xas_ref)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(proj_mo_type), POINTER                        :: proj_mo
+      LOGICAL, OPTIONAL                                  :: xas_ref
+
+      INTEGER                                            :: i_ref, ispin, mo_index, natom, &
+                                                            nbr_mo_max, nbr_ref_mo, nspins, &
+                                                            real_mo_index, restart_unit
+      LOGICAL                                            :: is_file, my_xasref
+      TYPE(cp_fm_struct_type), POINTER                   :: mo_ref_fmstruct
+      TYPE(cp_fm_type)                                   :: mo_coeff_temp
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mo_qs, mo_ref_temp
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      NULLIFY (mo_qs, mo_ref_temp, qs_kind_set, particle_set, para_env, dft_control, &
+               mo_ref_fmstruct, matrix_s)
+
+      my_xasref = .FALSE.
+      IF (PRESENT(xas_ref)) my_xasref = xas_ref
+
+      CALL get_qs_env(qs_env, &
+                      qs_kind_set=qs_kind_set, &
+                      particle_set=particle_set, &
+                      dft_control=dft_control, &
+                      matrix_s_kp=matrix_s, &
+                      mos=mo_qs, &
+                      para_env=para_env)
+
+      natom = SIZE(particle_set, 1)
+
+      ! If the restart comes from DFT%XAS_TDP%PRINT%RESTART_WFN, then always 2 spins are saved
+      IF (my_xasref) THEN
+         nspins = 2
+         ALLOCATE (mo_ref_temp(nspins))
+         DO ispin = 1, nspins
+            CALL duplicate_mo_set(mo_ref_temp(ispin), mo_qs(1))
+         END DO
+      ELSE
+         nspins = SIZE(mo_qs)
+         ALLOCATE (mo_ref_temp(nspins))
+         DO ispin = 1, nspins
+            CALL duplicate_mo_set(mo_ref_temp(ispin), mo_qs(ispin))
+         END DO
+      END IF
+
+      IF (para_env%is_source()) THEN
+         INQUIRE (FILE=TRIM(proj_mo%ref_mo_file_name), exist=is_file)
+         IF (.NOT. is_file) &
+            CALL cp_abort(__LOCATION__, &
+                          "Reference file not found! Name of the file CP2K looked for: "//TRIM(proj_mo%ref_mo_file_name))
+
+         CALL open_file(file_name=proj_mo%ref_mo_file_name, &
+                        file_action="READ", &
+                        file_form="UNFORMATTED", &
+                        file_status="OLD", &
+                        unit_number=restart_unit)
+      END IF
+
+      CALL read_mos_restart_low(mo_ref_temp, para_env=para_env, qs_kind_set=qs_kind_set, &
+                                particle_set=particle_set, natom=natom, &
+                                rst_unit=restart_unit)
+
+      IF (para_env%is_source()) CALL close_file(unit_number=restart_unit)
+
+      IF (proj_mo%ref_mo_spin > SIZE(mo_ref_temp)) &
+         CALL cp_abort(__LOCATION__, &
+                       "You asked as reference spin the BETA one while the "// &
+                       "reference .wfn file has only one spin. Use a reference .wfn "// &
+                       "with 2 spins separated or set REF_MO_SPIN to 1")
+
+      ! Store only the mos required
+      nbr_mo_max = mo_ref_temp(proj_mo%ref_mo_spin)%mo_coeff%matrix_struct%ncol_global
+      IF (proj_mo%ref_mo_index(1) == -1) THEN
+         DEALLOCATE (proj_mo%ref_mo_index)
+         ALLOCATE (proj_mo%ref_mo_index(nbr_mo_max))
+         DO i_ref = 1, nbr_mo_max
+            proj_mo%ref_mo_index(i_ref) = i_ref
+         END DO
+      ELSE
+         DO i_ref = 1, SIZE(proj_mo%ref_mo_index)
+            IF (proj_mo%ref_mo_index(i_ref) > nbr_mo_max) &
+               CALL cp_abort(__LOCATION__, &
+                             "The MO number available in the Reference SCF "// &
+                             "is smaller than the MO number you have required in REF_MO_INDEX.")
+         END DO
+      END IF
+      nbr_ref_mo = SIZE(proj_mo%ref_mo_index)
+
+      IF (nbr_ref_mo > nbr_mo_max) &
+         CALL cp_abort(__LOCATION__, &
+                       "The number of reference mo is larger then the total number of available one in the .wfn file.")
+
+      ! Store
+      ALLOCATE (proj_mo%mo_ref(nbr_ref_mo))
+      CALL cp_fm_struct_create(mo_ref_fmstruct, &
+                               context=mo_ref_temp(proj_mo%ref_mo_spin)%mo_coeff%matrix_struct%context, &
+                               nrow_global=mo_ref_temp(proj_mo%ref_mo_spin)%mo_coeff%matrix_struct%nrow_global, &
+                               ncol_global=1)
+      CALL cp_fm_create(mo_coeff_temp, mo_ref_fmstruct, 'mo_ref')
+
+      DO mo_index = 1, nbr_ref_mo
+         real_mo_index = proj_mo%ref_mo_index(mo_index)
+         IF (real_mo_index > nbr_mo_max) &
+            CALL cp_abort(__LOCATION__, &
+                          "One of reference mo index is larger then the total number of available mo in the .wfn file.")
+
+         ! fill with the reference mo values
+         CALL cp_fm_create(proj_mo%mo_ref(mo_index), mo_ref_fmstruct, 'mo_ref')
+         CALL cp_fm_to_fm(mo_ref_temp(proj_mo%ref_mo_spin)%mo_coeff, mo_coeff_temp, &
+                          ncol=1, &
+                          source_start=real_mo_index, &
+                          target_start=1)
+
+         ! multiply with overlap matrix to save time later on
+         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1, 1)%matrix, mo_coeff_temp, proj_mo%mo_ref(mo_index), ncol=1)
+      END DO
+
+      ! Clean temporary variables
+      DO ispin = 1, nspins
+         CALL deallocate_mo_set(mo_ref_temp(ispin))
+      END DO
+      DEALLOCATE (mo_ref_temp)
+
+      CALL cp_fm_struct_release(mo_ref_fmstruct)
+      CALL cp_fm_release(mo_coeff_temp)
+
+   END SUBROUTINE read_reference_mo_from_wfn
+
+! **************************************************************************************************
+!> \brief Compute the projection of the current MO coefficients on reference ones
+!>        and write the results.
+!> \param qs_env ...
+!> \param mos_new ...
+!> \param proj_mo ...
+!> \param n_proj ...
+!> \author Guillaume Le Breton
+! **************************************************************************************************
+   SUBROUTINE compute_and_write_proj_mo(qs_env, mos_new, proj_mo, n_proj)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: mos_new
+      TYPE(proj_mo_type)                                 :: proj_mo
+      INTEGER                                            :: n_proj
+
+      INTEGER                                            :: i_ref, nbr_ref_mo, nbr_ref_td
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: phase, popu, sum_popu_ref
+      TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(section_vals_type), POINTER                   :: input, print_mo_section, proj_mo_section
+
+      NULLIFY (dft_control, input, proj_mo_section, print_mo_section, logger)
+
+      logger => cp_get_default_logger()
+
+      CALL get_qs_env(qs_env, &
+                      dft_control=dft_control, &
+                      input=input)
+
+      ! The general section
+      proj_mo_section => section_vals_get_subs_vals(input, "DFT%REAL_TIME_PROPAGATION%PRINT%PROJECTION_MO")
+      ! The section we are dealing in this particular subroutine call: n_proj.
+      print_mo_section => section_vals_get_subs_vals(proj_mo_section, "PRINT", i_rep_section=n_proj)
+
+      ! STOP if not the required time step
+      IF (.NOT. BTEST(cp_print_key_should_output(logger%iter_info, &
+                                                 print_mo_section, ""), &
+                      cp_p_file)) &
+         RETURN
+
+      IF (.NOT. dft_control%rtp_control%fixed_ions) &
+         CALL cp_abort(__LOCATION__, &
+                       "DFT%REAL_TIME_PROPAGATION%PRINT%PROJECTION_MO not implemented for EMD yet.")
+
+      nbr_ref_mo = SIZE(proj_mo%ref_mo_index)
+      nbr_ref_td = SIZE(proj_mo%td_mo_index)
+      ALLOCATE (popu(nbr_ref_td))
+      ALLOCATE (phase(nbr_ref_td))
+
+      IF (proj_mo%sum_on_all_ref) THEN
+         ALLOCATE (sum_popu_ref(nbr_ref_td))
+         sum_popu_ref(:) = 0.0_dp
+         DO i_ref = 1, nbr_ref_mo
+            CALL compute_proj_mo(popu, phase, mos_new, proj_mo, i_ref)
+            sum_popu_ref(:) = sum_popu_ref(:) + popu(:)
+         END DO
+         IF (proj_mo%sum_on_all_td) THEN
+            CALL write_proj_mo(qs_env, print_mo_section, proj_mo, popu_tot=SUM(sum_popu_ref), n_proj=n_proj)
+         ELSE
+            CALL write_proj_mo(qs_env, print_mo_section, proj_mo, popu=sum_popu_ref, n_proj=n_proj)
+         END IF
+         DEALLOCATE (sum_popu_ref)
+      ELSE
+         DO i_ref = 1, nbr_ref_mo
+            CALL compute_proj_mo(popu, phase, mos_new, proj_mo, i_ref)
+
+            IF (proj_mo%sum_on_all_td) THEN
+               CALL write_proj_mo(qs_env, print_mo_section, proj_mo, i_ref=i_ref, popu_tot=SUM(popu), n_proj=n_proj)
+            ELSE
+
+               CALL write_proj_mo(qs_env, print_mo_section, proj_mo, i_ref=i_ref, popu=popu, phase=phase, n_proj=n_proj)
+            END IF
+         END DO
+      END IF
+
+      DEALLOCATE (popu)
+      DEALLOCATE (phase)
+
+   END SUBROUTINE compute_and_write_proj_mo
+
+! **************************************************************************************************
+!> \brief Compute the projection of the current MO coefficients on reference ones
+!> \param popu ...
+!> \param phase ...
+!> \param mos_new ...
+!> \param proj_mo ...
+!> \param i_ref ...
+!> \author Guillaume Le Breton
+! **************************************************************************************************
+   SUBROUTINE compute_proj_mo(popu, phase, mos_new, proj_mo, i_ref)
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: popu, phase
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: mos_new
+      TYPE(proj_mo_type)                                 :: proj_mo
+      INTEGER                                            :: i_ref
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'compute_proj_mo'
+
+      INTEGER                                            :: handle, j_td, nbr_ref_td, spin_td
+      REAL(KIND=dp)                                      :: imag_proj, real_proj
+      TYPE(cp_fm_struct_type), POINTER                   :: mo_ref_fmstruct
+      TYPE(cp_fm_type)                                   :: mo_coeff_temp
+
+      CALL timeset(routineN, handle)
+
+      nbr_ref_td = SIZE(popu)
+      spin_td = proj_mo%td_mo_spin
+
+      CALL cp_fm_struct_create(mo_ref_fmstruct, &
+                               context=mos_new(1)%matrix_struct%context, &
+                               nrow_global=mos_new(1)%matrix_struct%nrow_global, &
+                               ncol_global=1)
+      CALL cp_fm_create(mo_coeff_temp, mo_ref_fmstruct, 'mo_temp')
+
+      DO j_td = 1, nbr_ref_td
+         ! Real part of the projection:
+         real_proj = 0.0_dp
+         CALL cp_fm_to_fm(mos_new(2*spin_td - 1), mo_coeff_temp, &
+                          ncol=1, &
+                          source_start=proj_mo%td_mo_index(j_td), &
+                          target_start=1)
+
+         CALL cp_fm_trace(mo_coeff_temp, proj_mo%mo_ref(i_ref), real_proj)
+
+         ! Imaginary part of the projection
+         imag_proj = 0.0_dp
+         CALL cp_fm_to_fm(mos_new(2*spin_td), mo_coeff_temp, &
+                          ncol=1, &
+                          source_start=proj_mo%td_mo_index(j_td), &
+                          target_start=1)
+
+         CALL cp_fm_trace(mo_coeff_temp, proj_mo%mo_ref(i_ref), imag_proj)
+
+         ! Store the result
+         phase(j_td) = ATAN2(imag_proj, real_proj) ! in radians
+         popu(j_td) = real_proj**2 + imag_proj**2
+
+      END DO
+
+      CALL cp_fm_struct_release(mo_ref_fmstruct)
+      CALL cp_fm_release(mo_coeff_temp)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE compute_proj_mo
+
+! **************************************************************************************************
+!> \brief Write in one file the projection of (all) the time-dependent MO coefficients
+!>        on one reference ones
+!> \param qs_env ...
+!> \param print_mo_section ...
+!> \param proj_mo ...
+!> \param i_ref ...
+!> \param popu ...
+!> \param phase ...
+!> \param popu_tot ...
+!> \param n_proj ...
+!> \author Guillaume Le Breton
+! **************************************************************************************************
+   SUBROUTINE write_proj_mo(qs_env, print_mo_section, proj_mo, i_ref, popu, phase, popu_tot, n_proj)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(section_vals_type), POINTER                   :: print_mo_section
+      TYPE(proj_mo_type)                                 :: proj_mo
+      INTEGER, OPTIONAL                                  :: i_ref
+      REAL(KIND=dp), DIMENSION(:), OPTIONAL              :: popu, phase
+      REAL(KIND=dp), OPTIONAL                            :: popu_tot
+      INTEGER, OPTIONAL                                  :: n_proj
+
+      CHARACTER(LEN=default_string_length)               :: ext, filename
+      INTEGER                                            :: j_td, output_unit, print_unit
+      TYPE(cp_logger_type), POINTER                      :: logger
+
+      NULLIFY (logger)
+
+      logger => cp_get_default_logger()
+      output_unit = cp_logger_get_default_io_unit(logger)
+
+      IF (.NOT. (output_unit > 0)) RETURN
+
+      IF (proj_mo%sum_on_all_ref) THEN
+         ext = "-"//TRIM(ADJUSTL(cp_to_string(n_proj)))//"-ALL_REF.dat"
+      ELSE
+         ! Filename is update wrt the reference MO number
+         ext = "-"//TRIM(ADJUSTL(cp_to_string(n_proj)))// &
+               "-REF-"// &
+               TRIM(ADJUSTL(cp_to_string(proj_mo%ref_mo_index(i_ref))))// &
+               ".dat"
+      END IF
+
+      print_unit = cp_print_key_unit_nr(logger, print_mo_section, "", &
+                                        extension=TRIM(ext))
+
+      IF (print_unit /= output_unit) THEN
+         INQUIRE (UNIT=print_unit, NAME=filename)
+         WRITE (UNIT=output_unit, FMT="(/,T2,A,2(/,T3,A),/)") &
+            "PROJECTION MO", "The projection of the TD MOs is done in the file:", &
+            TRIM(filename)
+         WRITE (UNIT=print_unit, FMT="(/,(T2,A,T40,I6))") &
+            "Real time propagation step:", qs_env%sim_step
+      ELSE
+         WRITE (UNIT=output_unit, FMT="(/,T2,A)") "PROJECTION MO"
+      END IF
+
+      IF (proj_mo%sum_on_all_ref) THEN
+         WRITE (print_unit, "(T3,A)") &
+            "Projection on all the required MO number from the reference file "// &
+            TRIM(proj_mo%ref_mo_file_name)
+         IF (proj_mo%sum_on_all_td) THEN
+            WRITE (print_unit, "(T3, A, E16.8)") &
+               "The sum over all the TD MOs population:", popu_tot
+         ELSE
+            WRITE (print_unit, "(T3,A)") &
+               "For each TD MOs required is printed: Population "
+            DO j_td = 1, SIZE(popu)
+               WRITE (print_unit, "(T5,1(E16.8, 1X))") popu(j_td)
+            END DO
+         END IF
+      ELSE
+         WRITE (print_unit, "(T3,A)") &
+            "Projection on the MO number "// &
+            TRIM(ADJUSTL(cp_to_string(proj_mo%ref_mo_index(i_ref))))// &
+            " from the reference file "// &
+            TRIM(proj_mo%ref_mo_file_name)
+
+         IF (proj_mo%sum_on_all_td) THEN
+            WRITE (print_unit, "(T3, A, E16.8)") &
+               "The sum over all the TD MOs population:", popu_tot
+         ELSE
+            WRITE (print_unit, "(T3,A)") &
+               "For each TD MOs required is printed: Population & Phase [rad] "
+            DO j_td = 1, SIZE(popu)
+               WRITE (print_unit, "(T5,2(E16.8, E16.8, 1X))") popu(j_td), phase(j_td)
+            END DO
+         END IF
+      END IF
+
+      CALL cp_print_key_finished_output(print_unit, logger, print_mo_section, "")
+
+   END SUBROUTINE write_proj_mo
+
+END MODULE rt_projection_mo_utils
+

--- a/src/emd/rt_propagation_output.F
+++ b/src/emd/rt_propagation_output.F
@@ -83,6 +83,7 @@ MODULE rt_propagation_output
    USE qs_scf_types,                    ONLY: qs_scf_env_type
    USE qs_subsys_types,                 ONLY: qs_subsys_get,&
                                               qs_subsys_type
+   USE rt_projection_mo_utils,          ONLY: compute_and_write_proj_mo
    USE rt_propagation_types,            ONLY: get_rtp,&
                                               rt_prop_type
    USE rt_propagation_utils,            ONLY: calculate_P_imaginary,&
@@ -115,7 +116,8 @@ CONTAINS
       INTEGER, INTENT(in)                                :: run_type
       REAL(dp), INTENT(in), OPTIONAL                     :: delta_iter, used_time
 
-      INTEGER                                            :: n_electrons, nspin, output_unit, spin
+      INTEGER                                            :: n_electrons, n_proj, nspin, output_unit, &
+                                                            spin
       REAL(dp)                                           :: orthonormality, tot_rho_r
       REAL(KIND=dp), DIMENSION(:), POINTER               :: qs_tot_rho_r
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -243,6 +245,12 @@ CONTAINS
                      CALL rt_current(qs_env, P_im(spin)%matrix, dft_section, spin, nspin)
                   END DO
                   CALL dbcsr_deallocate_matrix_set(P_im)
+               END IF
+               IF (dft_control%rtp_control%is_proj_mo) THEN
+                  DO n_proj = 1, SIZE(dft_control%rtp_control%proj_mo_list)
+                     CALL compute_and_write_proj_mo(qs_env, mos_new, &
+                                                    dft_control%rtp_control%proj_mo_list(n_proj)%proj_mo, n_proj)
+                  END DO
                END IF
             END IF
             CALL write_rt_mos_to_restart(qs_env%mos, mos_new, particle_set, &
@@ -860,6 +868,10 @@ CONTAINS
          WRITE (unit_nr, "(T5,3(A,A,E16.8,1X))") &
             (TRIM(rlab(i)), "=", to_write(i), i=1, 3)
       END IF
+
+      CALL cp_print_key_finished_output(unit_nr, logger, dft_section, &
+                                        "REAL_TIME_PROPAGATION%PRINT%FIELD")
+
    END SUBROUTINE print_field_applied
 
 END MODULE rt_propagation_output

--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -921,6 +921,9 @@ MODULE input_constants
                                                ramp_env = 3, &
                                                custom_env = 4
 
+   INTEGER, PARAMETER, PUBLIC               :: proj_mo_ref_scf = 1, &
+                                               proj_mo_ref_xas_tdp = 2
+
    ! how to solve polarizable force fields
    INTEGER, PARAMETER, PUBLIC               :: do_fist_pol_none = 1, &
                                                do_fist_pol_sc = 2, &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -120,6 +120,7 @@ MODULE input_cp2k_dft
    USE input_cp2k_mm,                   ONLY: create_dipoles_section,&
                                               create_neighbor_lists_section
    USE input_cp2k_poisson,              ONLY: create_poisson_section
+   USE input_cp2k_projection_rtp,       ONLY: create_projection_rtp_section
    USE input_cp2k_rsgrid,               ONLY: create_rsgrid_section
    USE input_cp2k_tb,                   ONLY: create_dftb_control_section,&
                                               create_xtb_control_section
@@ -8666,6 +8667,10 @@ CONTAINS
                                        each_iter_names=s2a("MD"), &
                                        each_iter_values=(/1/), &
                                        filename="applied_field")
+      CALL section_add_subsection(print_section, print_key)
+      CALL section_release(print_key)
+
+      CALL create_projection_rtp_section(print_key)
       CALL section_add_subsection(print_section, print_key)
       CALL section_release(print_key)
 

--- a/src/input_cp2k_field.F
+++ b/src/input_cp2k_field.F
@@ -110,8 +110,10 @@ CONTAINS
 
       CPASSERT(.NOT. ASSOCIATED(section))
       CALL section_create(section, __LOCATION__, name="EFIELD", &
-                          description="parameters for finite, time dependent, nonperiodic electric fields."// &
-                          " For static fields use EXTERNAL_POTENTIAL.", &
+                          description="Parameters for finite, time  dependent electric fields. "// &
+                          "For time dependent  propagation in periodic systems, set "// &
+                          "DFT%REAL_TIME_PROPAGATION%VELOCITY_GAUGE to true. "// &
+                          "For static fields use EXTERNAL_POTENTIAL.", &
                           n_keywords=6, n_subsections=1, repeats=.TRUE.)
 
       NULLIFY (keyword, subsection)

--- a/src/input_cp2k_projection_rtp.F
+++ b/src/input_cp2k_projection_rtp.F
@@ -1,0 +1,148 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2023 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief function that build the projection of MO in RTP section of the input
+!> \author Guillaume Le Breton 04.2023
+! **************************************************************************************************
+MODULE input_cp2k_projection_rtp
+   USE cp_output_handling,              ONLY: cp_print_key_section_create
+   USE input_constants,                 ONLY: proj_mo_ref_scf,&
+                                              proj_mo_ref_xas_tdp
+   USE input_keyword_types,             ONLY: keyword_create,&
+                                              keyword_release,&
+                                              keyword_type
+   USE input_section_types,             ONLY: section_add_keyword,&
+                                              section_add_subsection,&
+                                              section_create,&
+                                              section_release,&
+                                              section_type
+   USE input_val_types,                 ONLY: integer_t
+   USE string_utilities,                ONLY: s2a
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'input_cp2k_projection_rtp'
+
+   PUBLIC :: create_projection_rtp_section
+
+CONTAINS
+
+! **************************************************************************************************
+!> \brief creates the section for time dependent projection of the MOs
+!> \param section ...
+!> \author Guillaume Le Breton
+! **************************************************************************************************
+   SUBROUTINE create_projection_rtp_section(section)
+      TYPE(section_type), POINTER                        :: section
+
+      TYPE(keyword_type), POINTER                        :: keyword
+      TYPE(section_type), POINTER                        :: subsection
+
+      CPASSERT(.NOT. ASSOCIATED(section))
+      CALL section_create(section, __LOCATION__, name="PROJECTION_MO", &
+                          description="Projects the time dependent MO "// &
+                          "coefficients on reference ones. You can define "// &
+                          "several sections like this to project the TD-MOs "// &
+                          "on different reference MOs.", &
+                          n_keywords=7, n_subsections=1, &
+                          repeats=.TRUE.)
+
+      NULLIFY (keyword, subsection)
+      CALL keyword_create(keyword, __LOCATION__, name="REFERENCE_TYPE", &
+                          description="Type of the reference MO file provided in REF_MO_FILE_NAME.", &
+                          enum_c_vals=s2a("SCF", "XAS_TDP"), &
+                          usage="REFERENCE_TYPE SCF", &
+                          default_i_val=proj_mo_ref_scf, &
+                          enum_desc=s2a("The reference MO is from an SCF calculation.", &
+                                        "The reference MO is from an XAS_TDP analysis."), &
+                          enum_i_vals=(/proj_mo_ref_scf, proj_mo_ref_xas_tdp/))
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="REF_MO_FILE_NAME", &
+                          description="Name of the wavefunction file to read the reference MO form. "// &
+                          "For instance a restart wfn file from SCF calculation or an excited state from XAS_TDP calculation. "// &
+                          "If no file is specified, the default is to use DFT%WFN_RESTART_FILE_NAME.", &
+                          usage="REF_MO_FILE_NAME <FILENAME>", &
+                          default_lc_val="DEFAULT")
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="REF_MO_INDEX", &
+                          description="Indexes of the reference MO read from the .wfn reference file (see REF_MO_FILE_NAME). "// &
+                          "Use this keywork if REFERENCE_TYPE=SCF."// &
+                          "Set to -1 to project on all the MO available. "// &
+                          "One file will be generated per index defined.", &
+                          usage="MO_REF_INDEX 1 2", &
+                          default_i_vals=(/1/), &
+                          n_var=-1, type_of_var=integer_t, repeats=.FALSE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="REF_MO_SPIN", &
+                          description="Spin of the reference MOs to consider. "// &
+                          "1 for ALPHA and 2 for BETA spin respectively. "// &
+                          "If the reference MO is spin independent this key is not used.", &
+                          usage="MO_TD_SPIN 1", &
+                          default_i_val=1, &
+                          n_var=1, type_of_var=integer_t, repeats=.FALSE.)
+
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="SUM_ON_ALL_REF", &
+            description="Set to .TRUE. in order to sum all the projection done over the required MO_REF_INDEX for each TD MOs. "// &
+                          "Only one file will be generated containing the results for every MO_TD_INDEX.", &
+                          usage="SUM_ON_ALL_REF .TRUE.", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE., &
+                          repeats=.FALSE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="TD_MO_INDEX", &
+                          description="Indexes of the time dependent MOs to project on the reference MOs. "// &
+                          "Set to -1 to project on all the TD MOs.", &
+                          usage="MO_TD_INDEX 1 2", &
+                          default_i_vals=(/1/), &
+                          n_var=-1, type_of_var=integer_t, repeats=.FALSE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="TD_MO_SPIN", &
+                          description="Spin of the TD MOs to consider. 1 for ALPHA spin, 2 for BETA spin. "// &
+                          "If the TD calculation is spin independent this key is not used.", &
+                          usage="MO_TD_SPIN 1 2", &
+                          default_i_val=1, &
+                          n_var=1, type_of_var=integer_t)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="SUM_ON_ALL_TD", &
+               description="Set to .TRUE. in order to sum the projection done over all on TD MOs on the required MO_REF_INDEX. "// &
+                          "One file per MO_REF_INDEX will be generated."// &
+                          "Combining SUM_ON_ALL_TD and SUM_ON_ALL_REF lead to one file one projection: "// &
+                          "the population of all the defined TD_MO_INDEX over the reference MO_REF_INDEX per time step required.", &
+                          usage="SUM_ON_ALL_TD .TRUE.", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE., &
+                          repeats=.FALSE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      ! The results for different time step are stored in the same file by default:
+      CALL cp_print_key_section_create(subsection, __LOCATION__, name="PRINT", &
+                                       description="How to print the MO projection", &
+                                       common_iter_levels=999999999, &
+                                       filename="PROJ_MO")
+      CALL section_add_subsection(section, subsection)
+      CALL section_release(subsection)
+
+   END SUBROUTINE create_projection_rtp_section
+
+END MODULE input_cp2k_projection_rtp

--- a/src/motion/rt_propagation.F
+++ b/src/motion/rt_propagation.F
@@ -74,6 +74,7 @@ MODULE rt_propagation
                                               qs_rho_type
    USE rt_delta_pulse,                  ONLY: apply_delta_pulse
    USE rt_hfx_utils,                    ONLY: rtp_hfx_rebuild
+   USE rt_projection_mo_utils,          ONLY: init_mo_projection
    USE rt_propagation_methods,          ONLY: propagation_step
    USE rt_propagation_output,           ONLY: rt_prop_output
    USE rt_propagation_types,            ONLY: get_rtp,&
@@ -170,6 +171,9 @@ CONTAINS
       ! Hmm, not really like to initialize with the structure of S but I reckon it is
       ! done everywhere like this
       IF (rtp%do_hfx) CALL rtp_hfx_rebuild(qs_env)
+
+      ! Setup the MO projection environment if required
+      IF (rtp_control%is_proj_mo) CALL init_mo_projection(qs_env, rtp_control)
 
       CALL init_propagation_run(qs_env)
       IF (.NOT. rtp_control%fixed_ions) THEN

--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -90,6 +90,7 @@ MODULE qs_mo_io
              write_mo_set_to_output_unit, &
              write_mo_set_to_restart, &
              read_mo_set_from_restart, &
+             read_mos_restart_low, &
              write_mo_set_low
 
 CONTAINS

--- a/tests/QS/regtest-xastdp/H2O-B3LYP-full.inp
+++ b/tests/QS/regtest-xastdp/H2O-B3LYP-full.inp
@@ -51,6 +51,9 @@
       &END KERNEL
 
       &PRINT
+         &RESTART_WFN
+           EXCITED_STATE_INDEX 1
+         &END RESTART_WFN
          &RESTART
          &END RESTART
       &END PRINT

--- a/tests/QS/regtest-xastdp/H2O-projection-mo.inp
+++ b/tests/QS/regtest-xastdp/H2O-projection-mo.inp
@@ -1,0 +1,201 @@
+#CPQA DEPENDS wfn_mix_0.inp
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_SET
+    BASIS_SET_FILE_NAME EMSL_BASIS_SETS
+    POTENTIAL_FILE_NAME POTENTIAL
+    UKS
+    &REAL_TIME_PROPAGATION
+       MAX_ITER 10
+       MAT_EXP TAYLOR
+       EPS_ITER 1.0E-9
+       INITIAL_WFN SCF_WFN
+       &PRINT
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_INDEX 4 5
+           REF_MO_SPIN 1
+           SUM_ON_ALL_REF .FALSE.
+           TD_MO_INDEX 4 5
+           TD_MO_SPIN 1
+           SUM_ON_ALL_TD .FALSE.
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_INDEX 4 5
+           REF_MO_SPIN 2
+           SUM_ON_ALL_REF .FALSE.
+           TD_MO_INDEX 4 5
+           TD_MO_SPIN 1
+           SUM_ON_ALL_TD .FALSE.
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_INDEX 4 5
+           REF_MO_SPIN 1
+           SUM_ON_ALL_REF .FALSE.
+           TD_MO_INDEX 4 5
+           TD_MO_SPIN 2
+           SUM_ON_ALL_TD .FALSE.
+           &PRINT
+             &EACH
+               MD 2
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_INDEX 4 5 6
+           REF_MO_SPIN 2
+           SUM_ON_ALL_REF .FALSE.
+           TD_MO_INDEX 4 5 6
+           TD_MO_SPIN 2
+           SUM_ON_ALL_TD .FALSE.
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_INDEX -1
+           REF_MO_SPIN 1
+           SUM_ON_ALL_REF .FALSE.
+           TD_MO_INDEX -1
+           TD_MO_SPIN 1
+           SUM_ON_ALL_TD .TRUE.
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_INDEX -1
+           REF_MO_SPIN 2
+           SUM_ON_ALL_REF .TRUE.
+           TD_MO_INDEX -1
+           TD_MO_SPIN 1
+           SUM_ON_ALL_TD .FALSE.
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_INDEX -1
+           REF_MO_SPIN 1
+           SUM_ON_ALL_REF .TRUE.
+           TD_MO_INDEX -1
+           TD_MO_SPIN 2
+           SUM_ON_ALL_TD .TRUE.
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE SCF
+           REF_MO_FILE_NAME H2O-projection-mo-RESTART.wfn
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+         &PROJECTION_MO
+           REFERENCE_TYPE XAS_TDP
+           REF_MO_FILE_NAME H2O-B3LYP-full-xasat1_1s_singlet_idx1-1.wfn
+           TD_MO_INDEX -1
+           TD_MO_SPIN 1
+           SUM_ON_ALL_TD .TRUE.
+           &PRINT
+             &EACH
+               MD 1
+             &END EACH
+           &END PRINT
+         &END PROJECTION_MO
+       &END PRINT
+    &END REAL_TIME_PROPAGATION
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &SCF
+      ADDED_MOS 1
+    &END SCF
+    &QS
+      METHOD GAPW
+    &END QS
+    &XC
+      &XC_FUNCTIONAL
+         &HYB_GGA_XC_B3LYP5
+         &END HYB_GGA_XC_B3LYP5
+      &END XC_FUNCTIONAL
+      &HF
+         FRACTION 0.2
+      &END HF
+    &END XC
+  &END DFT
+  &SUBSYS
+    &KIND O
+      BASIS_SET Ahlrichs-def2-SVP
+      POTENTIAL ALL
+    &END KIND
+    &KIND H
+      BASIS_SET Ahlrichs-def2-SVP
+      POTENTIAL ALL
+    &END KIND
+    &CELL
+      ABC 5.0 5.0 5.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O          0.00000        0.00000        0.11779
+      H          0.00000        0.75545       -0.47116
+      H          0.00000       -0.75545       -0.47116
+    &END COORD
+    &TOPOLOGY
+      &CENTER_COORDINATES
+      &END CENTER_COORDINATES
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+  PROJECT H2O-projection-mo
+  RUN_TYPE RT_PROPAGATION
+  PRINT_LEVEL LOW
+&END GLOBAL
+&MOTION
+  &MD
+    ENSEMBLE NVE
+    STEPS 2
+    TIMESTEP [fs] 0.0005
+    TEMPERATURE 300.0
+  &END MD
+&END MOTION

--- a/tests/QS/regtest-xastdp/TEST_FILES
+++ b/tests/QS/regtest-xastdp/TEST_FILES
@@ -7,6 +7,8 @@ Ne-LDA-e_range.inp                                     88      1e-08           8
 H2O-B3LYP-full.inp                                     88      1e-08           519.822873
 #Checking the ability to restart for PDOS and CUBES
 H2O-B3LYP-full-restart.inp                             0
+#Checking the projection over MOs in RTP. This also include projection on excitated stated prediced in xas_tdp
+H2O-projection-mo.inp                                  0
 #Checking that 2 atoms of different kinds can be excited
 CO-PBE0.inp                                            88      1e-08           519.471902
 #Checking the non-zero RI_REGION for better density projection


### PR DESCRIPTION
Creates a print RTP routine to compute the projection of TD MO on reference one. 
The reference MOs can be from SCF calculation (by default the one from which the RTP starts) or XAS_TDP. 
A regtest has been added in the XAS_TDP folder in order to test the reading of .wfn obtained from XAS_TDP module as the reference MO to project on. 