### PR TITLE
Print only 1 instead of 3 backup copies by default

### DIFF
--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -2242,9 +2242,9 @@ CONTAINS
          filename="CHARGEMOL", &
          add_last=add_last_numeric)
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="PERIODIC", &
@@ -5104,9 +5104,9 @@ CONTAINS
                                        each_iter_names=s2a("QS_SCF"), each_iter_values=(/20/), &
                                        add_last=add_last_numeric, filename="RESTART")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(subsection, print_key)
@@ -5120,9 +5120,9 @@ CONTAINS
          each_iter_values=(/500, 500, 500, 500, 500, 500, 500/), &
          filename="RESTART")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(subsection, print_key)
@@ -8636,9 +8636,9 @@ CONTAINS
                                        each_iter_names=s2a("MD"), each_iter_values=(/20/), &
                                        add_last=add_last_numeric, filename="RESTART")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(print_section, print_key)
@@ -8652,9 +8652,9 @@ CONTAINS
                                        each_iter_values=(/500/), &
                                        filename="RESTART")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(print_section, print_key)
@@ -8681,7 +8681,7 @@ CONTAINS
                                        each_iter_values=(/20/), &
                                        filename="current")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
                           default_i_val=1)
       CALL section_add_keyword(print_key, keyword)

--- a/src/input_cp2k_motion_print.F
+++ b/src/input_cp2k_motion_print.F
@@ -213,7 +213,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
                           description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_properties_dft.F
+++ b/src/input_cp2k_properties_dft.F
@@ -1666,9 +1666,9 @@ CONTAINS
                                        each_iter_names=s2a("TDDFT_SCF"), each_iter_values=(/10/), &
                                        add_last=add_last_numeric, filename="RESTART")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(subsection, print_key)

--- a/src/input_optimize_input.F
+++ b/src/input_optimize_input.F
@@ -254,9 +254,9 @@ CONTAINS
                                        description="writes an input file that can be used to restart ", &
                                        print_level=low_print_level, filename="optimize", common_iter_levels=1)
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(subsubsection, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(section, subsubsection)

--- a/src/motion/input_cp2k_vib.F
+++ b/src/motion/input_cp2k_vib.F
@@ -203,9 +203,9 @@ CONTAINS
                                        add_last=add_last_numeric, &
                                        filename="VIBRATIONS")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(section, print_key)
@@ -216,9 +216,9 @@ CONTAINS
                                        print_level=debug_print_level + 1, add_last=add_last_numeric, &
                                        filename="FullNormalizedCartesian")
       CALL keyword_create(keyword, __LOCATION__, name="BACKUP_COPIES", &
-                          description="Specifies the maximum index of backup copies.", &
+                          description="Specifies the maximum number of backup copies.", &
                           usage="BACKUP_COPIES {int}", &
-                          default_i_val=3)
+                          default_i_val=1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(section, print_key)


### PR DESCRIPTION
This should save some disk space.