### PR TITLE
Stay with gcc version 12 (instead of 13.1)

### DIFF
--- a/arch/Darwin-gnu-arm64.psmp
+++ b/arch/Darwin-gnu-arm64.psmp
@@ -26,7 +26,7 @@
    if $(command -v brew >/dev/null 2>&1); then \
       brew install cmake; \
       brew install coreutils; \
-      brew install gcc; \
+      brew install gcc@12; \
       brew install gsed; \
       brew install pkg-config; \
       brew install wget; \


### PR DESCRIPTION
The SpLA build fails with the new default gcc version 13.1 installed by brew under macOS (arm64).