### PR TITLE
Exclude grid_unittest from keepalive mode

### DIFF
--- a/tools/regtesting/do_regtest.py
+++ b/tools/regtesting/do_regtest.py
@@ -37,6 +37,7 @@ KEEPALIVE_SKIP_DIRS = [
     "QS/regtest-gpw-1",
     "QS/regtest-mp2-grad-1",
     "QS/regtest-mp2-grad-2",
+    "UNIT/grid_unittest",
 ]
 
 


### PR DESCRIPTION
Intel oneAPI returns an error for the grid_unittest with --keepalive