### PR TITLE
Add a CP2K_BUILD_OPTIONS with some default dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,11 +148,16 @@ if(NOT ${CP2K_SCALAPACK_VENDOR} IN_LIST CP2K_SCALAPACK_VENDOR_LIST)
   message(FATAL_ERROR "Invalid scalapack vendor backend")
 endif()
 
-
 set(CP2K_BUILD_OPTIONS_LIST "DEFAULT" "MINIMAL" "FULL" "SERIAL")
 
-set(CP2K_BUILD_OPTIONS "DEFAULT" CACHE STRING "Build cp2k with a predefined set of dependencies. The default is full user control")
-set_property(CACHE CP2K_BUILD_OPTIONS PROPERTY STRINGS ${CP2K_BUILD_OPTIONS_LIST})
+set(CP2K_BUILD_OPTIONS
+    "DEFAULT"
+    CACHE
+      STRING
+      "Build cp2k with a predefined set of dependencies. The default is full user control"
+)
+set_property(CACHE CP2K_BUILD_OPTIONS PROPERTY STRINGS
+                                               ${CP2K_BUILD_OPTIONS_LIST})
 
 string(TOUPPER ${CP2K_BUILD_OPTIONS} cp2k_build_options_up)
 
@@ -160,12 +165,12 @@ if(NOT ${cp2k_build_options_up} IN_LIST CP2K_BUILD_OPTIONS_LIST)
   message(FATAL_ERROR "Invalid value for cp2k build options")
 endif()
 
-if (${cp2k_build_options_up} STREQUAL "MINIMAL")
+if(${cp2k_build_options_up} STREQUAL "MINIMAL")
   set(CP2K_USE_FFTW3 ON)
   set(CP2K_USE_MPI ON)
 endif()
 
-if (${cp2k_build_options_up} STREQUAL "FULL")
+if(${cp2k_build_options_up} STREQUAL "FULL")
   set(CP2K_USE_FFTW3 ON)
   set(CP2K_USE_MPI ON)
   set(CP2K_USE_SIRIUS ON)
@@ -184,7 +189,7 @@ if (${cp2k_build_options_up} STREQUAL "FULL")
   set(CP2K_USE_SUPERLU ON)
 endif()
 
-if (${cp2k_build_options_up} STREQUAL "SERIAL")
+if(${cp2k_build_options_up} STREQUAL "SERIAL")
   set(CP2K_USE_FFTW3 ON)
   set(CP2K_USE_MPI OFF)
   set(CP2K_USE_SIRIUS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ option(CP2K_USE_METIS "enable metis library support" OFF)
 option(CP2K_USE_LIBXSMM "Use libxsmm for small gemms (supports x86 platforms)"
        OFF)
 option(CP2K_BUILD_DBCSR "Duild dbcsr at the same time than cp2k." OFF)
+option(CMAKE_BUILD_SHARED "Build cp2k shared library" OFF)
 
 cmake_dependent_option(CP2K_ENABLE_ELPA_OPENMP_SUPPORT
                        "Enable elpa openmp support" ON "CP2K_USE_ELPA" OFF)
@@ -145,6 +146,61 @@ set_property(CACHE CP2K_SCALAPACK_VENDOR PROPERTY STRINGS
 
 if(NOT ${CP2K_SCALAPACK_VENDOR} IN_LIST CP2K_SCALAPACK_VENDOR_LIST)
   message(FATAL_ERROR "Invalid scalapack vendor backend")
+endif()
+
+
+set(CP2K_BUILD_OPTIONS_LIST "DEFAULT" "MINIMAL" "FULL" "SERIAL")
+
+set(CP2K_BUILD_OPTIONS "DEFAULT" CACHE STRING "Build cp2k with a predefined set of dependencies. The default is full user control")
+set_property(CACHE CP2K_BUILD_OPTIONS PROPERTY STRINGS ${CP2K_BUILD_OPTIONS_LIST})
+
+string(TOUPPER ${CP2K_BUILD_OPTIONS} cp2k_build_options_up)
+
+if(NOT ${cp2k_build_options_up} IN_LIST CP2K_BUILD_OPTIONS_LIST)
+  message(FATAL_ERROR "Invalid value for cp2k build options")
+endif()
+
+if (${cp2k_build_options_up} STREQUAL "MINIMAL")
+  set(CP2K_USE_FFTW3 ON)
+  set(CP2K_USE_MPI ON)
+endif()
+
+if (${cp2k_build_options_up} STREQUAL "FULL")
+  set(CP2K_USE_FFTW3 ON)
+  set(CP2K_USE_MPI ON)
+  set(CP2K_USE_SIRIUS ON)
+  set(CP2K_USE_LIBXSMM ON)
+  set(CP2K_USE_VORI ON)
+  set(CP2K_USE_COSMA ON)
+  set(CP2K_USE_SPLA ON)
+  set(CP2K_USE_LIBXC ON)
+  set(CP2K_USE_LIBINT2 ON)
+  set(CP2K_USE_ELPA ON)
+  set(CP2K_USE_SPGLIB ON)
+  set(CP2K_USE_LIBTORCH ON)
+  set(CP2K_USE_METIS ON)
+  set(CP2K_USE_QUIP ON)
+  set(CP2K_USE_PEXSI ON)
+  set(CP2K_USE_SUPERLU ON)
+endif()
+
+if (${cp2k_build_options_up} STREQUAL "SERIAL")
+  set(CP2K_USE_FFTW3 ON)
+  set(CP2K_USE_MPI OFF)
+  set(CP2K_USE_SIRIUS ON)
+  set(CP2K_USE_LIBXSMM ON)
+  set(CP2K_USE_VORI ON)
+  set(CP2K_USE_COSMA ON)
+  set(CP2K_USE_SPLA ON)
+  set(CP2K_USE_LIBXC ON)
+  set(CP2K_USE_LIBINT2 ON)
+  set(CP2K_USE_ELPA ON)
+  set(CP2K_USE_SPGLIB ON)
+  set(CP2K_USE_LIBTORCH ON)
+  set(CP2K_USE_METIS ON)
+  set(CP2K_USE_QUIP ON)
+  set(CP2K_USE_PEXSI ON)
+  set(CP2K_USE_SUPERLU ON)
 endif()
 
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ option(CP2K_USE_METIS "enable metis library support" OFF)
 option(CP2K_USE_LIBXSMM "Use libxsmm for small gemms (supports x86 platforms)"
        OFF)
 option(CP2K_BUILD_DBCSR "Duild dbcsr at the same time than cp2k." OFF)
-option(CMAKE_BUILD_SHARED "Build cp2k shared library" OFF)
+option(BUILD_SHARED_LIBS "Build cp2k shared library" ON)
 
 cmake_dependent_option(CP2K_ENABLE_ELPA_OPENMP_SUPPORT
                        "Enable elpa openmp support" ON "CP2K_USE_ELPA" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1449,10 +1449,10 @@ endforeach()
 
 if(CP2K_USE_LIBTORCH)
   add_library(
-    cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED>
+    cp2k $<$<BOOL:${BUILD_SHARED_LIBS}>:SHARED>
          "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
 else()
-  add_library(cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED>
+  add_library(cp2k $<$<BOOL:${BUILD_SHARED_LIBRARIES}>:SHARED>
                    "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1448,10 +1448,10 @@ foreach(cp2k_src ${CP2K_SRCS})
 endforeach()
 
 if(CP2K_USE_LIBTORCH)
-  add_library(cp2k
+  add_library(cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED>
               "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
 else()
-  add_library(cp2k "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
+  add_library(cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED> "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
 endif()
 
 target_compile_features(cp2k PUBLIC cxx_std_14)
@@ -1756,7 +1756,7 @@ install(
   NAMESPACE cp2k::
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cp2k")
 
-install(FILES src/start/libcp2k.h
+install(FILES start/libcp2k.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cp2k")
 
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1449,11 +1449,9 @@ endforeach()
 
 if(CP2K_USE_LIBTORCH)
   add_library(
-    cp2k $<$<BOOL:${BUILD_SHARED_LIBS}>:SHARED>
-         "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
+    cp2k "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
 else()
-  add_library(cp2k $<$<BOOL:${BUILD_SHARED_LIBRARIES}>:SHARED>
-                   "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
+  add_library(cp2k "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
 endif()
 
 target_compile_features(cp2k PUBLIC cxx_std_14)
@@ -1461,8 +1459,11 @@ target_compile_features(cp2k PUBLIC c_std_99)
 target_compile_features(cp2k PUBLIC cuda_std_11)
 target_include_directories(cp2k PUBLIC $<INSTALL_INTERFACE:include/cp2k>)
 
-set_target_properties(cp2k PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "CXX")
-set_target_properties(cp2k PROPERTIES Fortran_MODULE_DIRECTORY mod_files)
+set_target_properties(cp2k PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+				      Fortran_MODULE_DIRECTORY mod_files
+			              POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
+			              VERSION ${cp2k_VERSION}
+			      	      SOVERSION ${cp2k_APIVERSION})
 
 if(CP2K_USE_ACCEL MATCHES "CUDA")
   set_property(TARGET cp2k PROPERTY CUDA_ARCHITECTURES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1448,10 +1448,12 @@ foreach(cp2k_src ${CP2K_SRCS})
 endforeach()
 
 if(CP2K_USE_LIBTORCH)
-  add_library(cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED>
-              "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
+  add_library(
+    cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED>
+         "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
 else()
-  add_library(cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED> "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
+  add_library(cp2k $<$<BOOL:${CMAKE_BUILD_SHARED}>:SHARED>
+                   "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
 endif()
 
 target_compile_features(cp2k PUBLIC cxx_std_14)
@@ -1756,8 +1758,7 @@ install(
   NAMESPACE cp2k::
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cp2k")
 
-install(FILES start/libcp2k.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cp2k")
+install(FILES start/libcp2k.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/cp2k")
 
 install(
   DIRECTORY "${PROJECT_BINARY_DIR}/src/mod_files"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1448,8 +1448,8 @@ foreach(cp2k_src ${CP2K_SRCS})
 endforeach()
 
 if(CP2K_USE_LIBTORCH)
-  add_library(
-    cp2k "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
+  add_library(cp2k
+              "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU};${CP2K_SRCS_CPP}")
 else()
   add_library(cp2k "${CP2K_SRCS};${CP2K_SRCS_C};${CP2K_SRCS_GPU}")
 endif()
@@ -1459,11 +1459,13 @@ target_compile_features(cp2k PUBLIC c_std_99)
 target_compile_features(cp2k PUBLIC cuda_std_11)
 target_include_directories(cp2k PUBLIC $<INSTALL_INTERFACE:include/cp2k>)
 
-set_target_properties(cp2k PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
-				      Fortran_MODULE_DIRECTORY mod_files
-			              POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
-			              VERSION ${cp2k_VERSION}
-			      	      SOVERSION ${cp2k_APIVERSION})
+set_target_properties(
+  cp2k
+  PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+             Fortran_MODULE_DIRECTORY mod_files
+             POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
+             VERSION ${cp2k_VERSION}
+             SOVERSION ${cp2k_APIVERSION})
 
 if(CP2K_USE_ACCEL MATCHES "CUDA")
   set_property(TARGET cp2k PROPERTY CUDA_ARCHITECTURES


### PR DESCRIPTION
- Add -DCP2K_BUILD_OPTIONS=DEFAULT,MINIMAL,SERIAL,FULL to avoid specifying which dependency should be included in the build. The default behavior (when the argument is not speficied) lets the user decide what to include.
- Fix the installation of the libcp2k.h header file
- Add option to compile libcp2k shared version