### PR TITLE
Fixed virial bug in sparse tensor methods

### DIFF
--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -98,8 +98,8 @@ MODULE hfx_ri
                                               qs_rho_type
    USE qs_tensors,                      ONLY: &
         build_2c_derivatives, build_2c_integrals, build_2c_neighbor_lists, build_3c_derivatives, &
-        build_3c_integrals, build_3c_neighbor_lists, compress_tensor, decompress_tensor, &
-        get_tensor_occupancy, neighbor_list_3c_destroy
+        build_3c_integrals, build_3c_neighbor_lists, calc_2c_virial, calc_3c_virial, &
+        compress_tensor, decompress_tensor, get_tensor_occupancy, neighbor_list_3c_destroy
    USE qs_tensors_types,                ONLY: create_2c_tensor,&
                                               create_3c_tensor,&
                                               create_tensor_batches,&
@@ -205,8 +205,8 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(dbcsr_type), DIMENSION(1) :: dbcsr_work_1, dbcsr_work_2, t_2c_int_mat, t_2c_op_pot, &
          t_2c_op_pot_sqrt, t_2c_op_pot_sqrt_inv, t_2c_op_RI, t_2c_op_RI_inv
-      TYPE(dbt_type), DIMENSION(1)                       :: t_2c_int, t_2c_work
-      TYPE(dbt_type), DIMENSION(1, 1)                    :: t_3c_int
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_2c_int, t_2c_work
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_int
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
       CALL timeset(routineN, handle)
@@ -218,6 +218,7 @@ CONTAINS
 
       CALL timeset(routineN//"_int", handle2)
 
+      ALLOCATE (t_2c_int(1), t_2c_work(1), t_3c_int(1, 1))
       CALL hfx_ri_pre_scf_calc_tensors(qs_env, ri_data, t_2c_op_RI, t_2c_op_pot, t_3c_int)
 
       CALL timestop(handle2)
@@ -453,7 +454,7 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbt_type)                                     :: t_3c_tmp
-      TYPE(dbt_type), DIMENSION(1, 1)                    :: t_3c_int_batched
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_int_batched
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_2d_type), POINTER                :: dist_2d
       TYPE(distribution_3d_type)                         :: dist_3d
@@ -499,6 +500,7 @@ CONTAINS
 
       DEALLOCATE (starts_array_mc_int, ends_array_mc_int)
 
+      ALLOCATE (t_3c_int_batched(1, 1))
       CALL create_3c_tensor(t_3c_int_batched(1, 1), dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid, &
                             sizes_RI, sizes_AO, sizes_AO, map1=[1], map2=[2, 3], &
                             name="(RI | AO AO)")
@@ -661,8 +663,8 @@ CONTAINS
       TYPE(dbcsr_type), DIMENSION(1)                     :: t_2c_int_mat, t_2c_op_pot, t_2c_op_RI, &
                                                             t_2c_tmp, t_2c_tmp_2
       TYPE(dbt_type)                                     :: t_3c_2
-      TYPE(dbt_type), DIMENSION(1)                       :: t_2c_int, t_2c_work
-      TYPE(dbt_type), DIMENSION(1, 1)                    :: t_3c_int_1
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_2c_int, t_2c_work
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_int_1
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
       CALL timeset(routineN, handle)
@@ -674,6 +676,7 @@ CONTAINS
 
       CALL timeset(routineN//"_int", handle2)
 
+      ALLOCATE (t_2c_int(1), t_2c_work(1), t_3c_int_1(1, 1))
       CALL hfx_ri_pre_scf_calc_tensors(qs_env, ri_data, t_2c_op_RI, t_2c_op_pot, t_3c_int_1)
 
       CALL dbt_copy(t_3c_int_1(1, 1), ri_data%t_3c_int_ctr_3(1, 1), order=[1, 2, 3], move_data=.TRUE.)
@@ -1092,7 +1095,7 @@ CONTAINS
       TYPE(dbt_pgrid_type)                               :: pgrid, pgrid_2d
       TYPE(dbt_type)                                     :: ks_t, ks_t_mat, mo_coeff_t, &
                                                             mo_coeff_t_split
-      TYPE(dbt_type), DIMENSION(1, 1)                    :: t_3c_int_mo_1, t_3c_int_mo_2
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_int_mo_1, t_3c_int_mo_2
       TYPE(mp_comm_type)                                 :: comm_2d
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
@@ -1149,6 +1152,7 @@ CONTAINS
       CALL para_env%sync()
       t1 = m_walltime()
 
+      ALLOCATE (t_3c_int_mo_1(1, 1), t_3c_int_mo_2(1, 1))
       DO ispin = 1, nspins
 
          CALL dbcsr_get_info(mo_coeff(ispin), nfullcols_total=n_mos)
@@ -1661,8 +1665,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_ri_forces_mo'
 
-      INTEGER :: dummy_int, handle, i_mem, i_xyz, ispin, j_mem, j_xyz, k_mem, k_xyz, n_mem, &
-         n_mem_input, n_mem_input_RI, n_mem_RI, n_mem_RI_fit, n_mos, natom, unit_nr_dbcsr
+      INTEGER :: dummy_int, handle, i_mem, i_xyz, ibasis, ispin, j_mem, k_mem, n_mem, n_mem_input, &
+         n_mem_input_RI, n_mem_RI, n_mem_RI_fit, n_mos, natom, nkind, unit_nr_dbcsr
       INTEGER(int_8)                                     :: nflop
       INTEGER, ALLOCATABLE, DIMENSION(:) :: atom_of_kind, batch_blk_end, batch_blk_start, &
          batch_end, batch_end_RI, batch_end_RI_fit, batch_ranges, batch_ranges_RI, &
@@ -1673,7 +1677,6 @@ CONTAINS
       INTEGER, DIMENSION(3)                              :: pdims
       LOGICAL                                            :: use_virial_prv
       REAL(dp)                                           :: pref, spin_fac, t1, t2
-      REAL(dp), DIMENSION(3, 3)                          :: work_virial
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(block_ind_type), ALLOCATABLE, DIMENSION(:, :) :: t_3c_der_AO_ind, t_3c_der_RI_ind
       TYPE(cell_type), POINTER                           :: cell
@@ -1683,14 +1686,19 @@ CONTAINS
          t_3c_2, t_3c_3, t_3c_4, t_3c_5, t_3c_6, t_3c_ao_ri_ao, t_3c_ao_ri_mo, t_3c_desymm, &
          t_3c_mo_ri_ao, t_3c_mo_ri_mo, t_3c_ri_ao_ao, t_3c_RI_ctr, t_3c_ri_mo_mo, &
          t_3c_ri_mo_mo_fit, t_3c_work, t_mo_coeff, t_mo_cpy
-      TYPE(dbt_type), DIMENSION(3) :: t_2c_der_metric, t_2c_der_RI, t_2c_MO_AO, t_2c_MO_AO_ctr, &
-         t_3c_der_AO, t_3c_der_AO_ctr_1, t_3c_der_RI, t_3c_der_RI_ctr_1, t_3c_der_RI_ctr_2
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:) :: t_2c_der_metric, t_2c_der_RI, t_2c_MO_AO, &
+         t_2c_MO_AO_ctr, t_3c_der_AO, t_3c_der_AO_ctr_1, t_3c_der_RI, t_3c_der_RI_ctr_1, &
+         t_3c_der_RI_ctr_2
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
       TYPE(hfx_compression_type), ALLOCATABLE, &
          DIMENSION(:, :)                                 :: t_3c_der_AO_comp, t_3c_der_RI_comp
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
-      TYPE(virial_type), POINTER                         :: virial
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
       ! 1) Precompute the derivatives that are needed (3c, 3c RI and metric)
       ! 2) Go over batched of occupied MOs so as to save memory and optimize contractions
@@ -1703,13 +1711,16 @@ CONTAINS
 
       use_virial_prv = .FALSE.
       IF (PRESENT(use_virial)) use_virial_prv = use_virial
+      IF (use_virial_prv) THEN
+         CPABORT("Stress tensor with RI-HFX MO flavor not implemented.")
+      END IF
 
       unit_nr_dbcsr = ri_data%unit_nr_dbcsr
 
-      CALL get_qs_env(qs_env, natom=natom, particle_set=particle_set, &
-                      atomic_kind_set=atomic_kind_set, virial=virial, &
-                      cell=cell, force=force, matrix_s=matrix_s, &
-                      para_env=para_env)
+      CALL get_qs_env(qs_env, natom=natom, particle_set=particle_set, nkind=nkind, &
+                      atomic_kind_set=atomic_kind_set, cell=cell, force=force, &
+                      matrix_s=matrix_s, para_env=para_env, dft_control=dft_control, &
+                      qs_kind_set=qs_kind_set)
 
       pdims(:) = 0
       CALL dbt_pgrid_create(para_env, pdims, pgrid_1, tensor_dims=[SIZE(ri_data%bsizes_AO_split), &
@@ -1729,9 +1740,33 @@ CONTAINS
                             [1], [2, 3], name="(RI | AO AO)")
       DEALLOCATE (dist1, dist2, dist3)
 
+      ALLOCATE (basis_set_RI(nkind), basis_set_AO(nkind))
+      CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
+      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_RI)
+      CALL basis_set_list_setup(basis_set_AO, ri_data%orb_basis_type, qs_kind_set)
+      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_AO)
+
+      DO ibasis = 1, SIZE(basis_set_AO)
+         orb_basis => basis_set_AO(ibasis)%gto_basis_set
+         CALL init_interaction_radii_orb_basis(orb_basis, ri_data%eps_pgf_orb)
+         ri_basis => basis_set_RI(ibasis)%gto_basis_set
+         CALL init_interaction_radii_orb_basis(ri_basis, ri_data%eps_pgf_orb)
+      END DO
+
+      ALLOCATE (t_2c_der_metric(3), t_2c_der_RI(3), t_2c_MO_AO(3), t_2c_MO_AO_ctr(3), t_3c_der_AO(3), &
+                t_3c_der_AO_ctr_1(3), t_3c_der_RI(3), t_3c_der_RI_ctr_1(3), t_3c_der_RI_ctr_2(3))
+
       ! 1) Precompute the derivatives
       CALL precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
-                               t_2c_der_RI, t_2c_der_metric, t_3c_ri_ao_ao, ri_data, qs_env)
+                               t_2c_der_RI, t_2c_der_metric, t_3c_ri_ao_ao, &
+                               basis_set_AO, basis_set_RI, ri_data, qs_env)
+
+      DO ibasis = 1, SIZE(basis_set_AO)
+         orb_basis => basis_set_AO(ibasis)%gto_basis_set
+         ri_basis => basis_set_RI(ibasis)%gto_basis_set
+         CALL init_interaction_radii_orb_basis(orb_basis, dft_control%qs_control%eps_pgf_orb)
+         CALL init_interaction_radii_orb_basis(ri_basis, dft_control%qs_control%eps_pgf_orb)
+      END DO
 
       n_mem = SIZE(t_3c_der_RI_comp, 1)
       DO i_xyz = 1, 3
@@ -1828,7 +1863,6 @@ CONTAINS
       DEALLOCATE (batch_blk_start, batch_blk_end)
 
       DO ispin = 1, nspins
-         work_virial = 0.0_dp
 
          ! 2 )Prepare the batches for this spin
          CALL dbcsr_get_info(mo_coeff(ispin), nfullcols_total=n_mos)
@@ -2160,13 +2194,8 @@ CONTAINS
                CALL timeset(routineN//"_3c_RI", handle)
                pref = -0.5_dp*2.0_dp*hf_fraction*spin_fac
                CALL dbt_copy(t_3c_4, t_3c_RI_ctr, move_data=.TRUE.)
-               IF (use_virial_prv) THEN
-                  CALL get_force_from_3c_trace(force, t_3c_RI_ctr, t_3c_der_RI_ctr_2, atom_of_kind, kind_of, &
-                                               idx_to_at_RI, pref, work_virial, cell, particle_set)
-               ELSE
-                  CALL get_force_from_3c_trace(force, t_3c_RI_ctr, t_3c_der_RI_ctr_2, atom_of_kind, kind_of, &
-                                               idx_to_at_RI, pref)
-               END IF
+               CALL get_force_from_3c_trace(force, t_3c_RI_ctr, t_3c_der_RI_ctr_2, atom_of_kind, kind_of, &
+                                            idx_to_at_RI, pref)
                CALL timestop(handle)
 
                ! (a'b|P) Note that derivative remains in AO rep until the actual force evaluation,
@@ -2230,12 +2259,7 @@ CONTAINS
          pref = -0.5_dp*4.0_dp*hf_fraction*spin_fac
          DO i_xyz = 1, 3
             CALL dbt_copy(t_2c_MO_AO_ctr(i_xyz), t_2c_MO_AO(i_xyz), move_data=.TRUE.) !ensures matching distributions
-            IF (use_virial_prv) THEN
-               CALL get_mo_ao_force(force, t_mo_cpy, t_2c_MO_AO(i_xyz), atom_of_kind, kind_of, idx_to_at_AO, pref, &
-                                    i_xyz, work_virial, cell, particle_set)
-            ELSE
-               CALL get_mo_ao_force(force, t_mo_cpy, t_2c_MO_AO(i_xyz), atom_of_kind, kind_of, idx_to_at_AO, pref, i_xyz)
-            END IF
+            CALL get_mo_ao_force(force, t_mo_cpy, t_2c_MO_AO(i_xyz), atom_of_kind, kind_of, idx_to_at_AO, pref, i_xyz)
             CALL dbt_clear(t_2c_MO_AO(i_xyz))
          END DO
 
@@ -2245,14 +2269,8 @@ CONTAINS
 
          !Making sure dists of the t_2c_RI tensors match
          CALL dbt_copy(t_2c_RI_PQ, t_2c_RI, move_data=.TRUE.)
-         IF (use_virial_prv) THEN
-            CALL get_2c_der_force(force, t_2c_RI, t_2c_der_RI, atom_of_kind, &
-                                  kind_of, idx_to_at_RI, pref, work_virial, cell, particle_set)
-         ELSE
-            CALL get_2c_der_force(force, t_2c_RI, t_2c_der_RI, atom_of_kind, &
-                                  kind_of, idx_to_at_RI, pref)
-
-         END IF
+         CALL get_2c_der_force(force, t_2c_RI, t_2c_der_RI, atom_of_kind, &
+                               kind_of, idx_to_at_RI, pref)
          CALL dbt_clear(t_2c_RI)
 
          !Force contribution due to the inverse metric
@@ -2260,25 +2278,9 @@ CONTAINS
             pref = 0.5_dp*2.0_dp*hf_fraction*spin_fac
 
             CALL dbt_copy(t_2c_RI_met, t_2c_RI, move_data=.TRUE.)
-            IF (use_virial_prv) THEN
-               CALL get_2c_der_force(force, t_2c_RI, t_2c_der_metric, atom_of_kind, &
-                                     kind_of, idx_to_at_RI, pref, work_virial, cell, particle_set)
-            ELSE
-               CALL get_2c_der_force(force, t_2c_RI, t_2c_der_metric, atom_of_kind, &
-                                     kind_of, idx_to_at_RI, pref)
-            END IF
+            CALL get_2c_der_force(force, t_2c_RI, t_2c_der_metric, atom_of_kind, &
+                                  kind_of, idx_to_at_RI, pref)
             CALL dbt_clear(t_2c_RI)
-         END IF
-
-         IF (use_virial_prv) THEN
-            DO k_xyz = 1, 3
-               DO j_xyz = 1, 3
-                  DO i_xyz = 1, 3
-                     virial%pv_fock_4c(i_xyz, j_xyz) = virial%pv_fock_4c(i_xyz, j_xyz) &
-                                                       + work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
-                  END DO
-               END DO
-            END DO
          END IF
 
          CALL dbt_destroy(t_3c_0)
@@ -2358,8 +2360,9 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_ri_forces_Pmat'
 
       INTEGER                                            :: dummy_int, handle, i_mem, i_spin, i_xyz, &
-                                                            j_mem, j_xyz, k_mem, k_xyz, n_mem, &
-                                                            n_mem_RI, natom, unit_nr_dbcsr
+                                                            ibasis, j_mem, j_xyz, k_mem, k_xyz, &
+                                                            n_mem, n_mem_RI, natom, nkind, &
+                                                            unit_nr_dbcsr
       INTEGER(int_8)                                     :: nflop
       INTEGER, ALLOCATABLE, DIMENSION(:) :: atom_of_kind, batch_end, batch_end_RI, batch_ranges, &
          batch_ranges_RI, batch_start, batch_start_RI, dist1, dist2, dist3, idx_to_at_AO, &
@@ -2367,23 +2370,33 @@ CONTAINS
       INTEGER, DIMENSION(2, 1)                           :: ibounds, jbounds, kbounds
       INTEGER, DIMENSION(2, 2)                           :: ijbounds
       INTEGER, DIMENSION(2, 3)                           :: bounds_cpy
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       LOGICAL                                            :: do_resp, resp_only_prv, use_virial_prv
       REAL(dp)                                           :: pref, spin_fac, t1, t2
       REAL(dp), DIMENSION(3, 3)                          :: work_virial
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(block_ind_type), ALLOCATABLE, DIMENSION(:, :) :: t_3c_der_AO_ind, t_3c_der_RI_ind
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(dbcsr_type)                                   :: dbcsr_tmp
-      TYPE(dbt_type) :: rho_ao_1, rho_ao_2, t_2c_RI, t_2c_RI_tmp, t_2c_tmp, t_3c_1, t_3c_2, &
-         t_3c_3, t_3c_4, t_3c_5, t_3c_ao_ri_ao, t_3c_help_1, t_3c_help_2, t_3c_int, t_3c_int_2, &
-         t_3c_ri_ao_ao, t_3c_sparse, t_R, t_SVS
-      TYPE(dbt_type), DIMENSION(3)                       :: t_2c_der_metric, t_2c_der_RI, &
+      TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
+      TYPE(dbcsr_type)                                   :: dbcsr_tmp, virial_trace
+      TYPE(dbt_type) :: rho_ao_1, rho_ao_2, t_2c_RI, t_2c_RI_tmp, t_2c_tmp, t_2c_virial, t_3c_1, &
+         t_3c_2, t_3c_3, t_3c_4, t_3c_5, t_3c_ao_ri_ao, t_3c_help_1, t_3c_help_2, t_3c_int, &
+         t_3c_int_2, t_3c_ri_ao_ao, t_3c_sparse, t_3c_virial, t_R, t_SVS
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_2c_der_metric, t_2c_der_RI, &
                                                             t_3c_der_AO, t_3c_der_RI
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
       TYPE(hfx_compression_type), ALLOCATABLE, &
          DIMENSION(:, :)                                 :: t_3c_der_AO_comp, t_3c_der_RI_comp
       TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_3c_type)                        :: nl_3c
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: nl_2c_met, nl_2c_pot
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(virial_type), POINTER                         :: virial
 
       !The idea is the following: we need to compute the gradients
@@ -2398,7 +2411,8 @@ CONTAINS
       !    Potential: [S^-1*R*S^-1]_QR d/dx (Q|R)
       !    Metric:    [S^-1*R*S^-1*(Q|R)*S^-1]_UV d/dx S_UV
 
-      NULLIFY (particle_set, virial, cell, force, atomic_kind_set)
+      NULLIFY (particle_set, virial, cell, force, atomic_kind_set, nl_2c_pot, nl_2c_met)
+      NULLIFY (orb_basis, ri_basis, qs_kind_set, particle_set, dft_control, dbcsr_dist)
 
       use_virial_prv = .FALSE.
       IF (PRESENT(use_virial)) use_virial_prv = use_virial
@@ -2413,9 +2427,10 @@ CONTAINS
 
       unit_nr_dbcsr = ri_data%unit_nr_dbcsr
 
-      CALL get_qs_env(qs_env, natom=natom, particle_set=particle_set, &
+      CALL get_qs_env(qs_env, natom=natom, particle_set=particle_set, nkind=nkind, &
                       atomic_kind_set=atomic_kind_set, virial=virial, &
-                      cell=cell, force=force, para_env=para_env)
+                      cell=cell, force=force, para_env=para_env, dft_control=dft_control, &
+                      qs_kind_set=qs_kind_set, dbcsr_dist=dbcsr_dist)
 
       CALL create_3c_tensor(t_3c_ao_ri_ao, dist1, dist2, dist3, ri_data%pgrid_1, &
                             ri_data%bsizes_AO_split, ri_data%bsizes_RI_split, ri_data%bsizes_AO_split, &
@@ -2427,9 +2442,39 @@ CONTAINS
                             [1], [2, 3], name="(RI | AO AO)")
       DEALLOCATE (dist1, dist2, dist3)
 
+      ALLOCATE (basis_set_RI(nkind), basis_set_AO(nkind))
+      CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
+      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_RI)
+      CALL basis_set_list_setup(basis_set_AO, ri_data%orb_basis_type, qs_kind_set)
+      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_AO)
+
+      DO ibasis = 1, SIZE(basis_set_AO)
+         orb_basis => basis_set_AO(ibasis)%gto_basis_set
+         CALL init_interaction_radii_orb_basis(orb_basis, ri_data%eps_pgf_orb)
+         ri_basis => basis_set_RI(ibasis)%gto_basis_set
+         CALL init_interaction_radii_orb_basis(ri_basis, ri_data%eps_pgf_orb)
+      END DO
+
       ! Precompute the derivatives
-      CALL precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
-                               t_2c_der_RI, t_2c_der_metric, t_3c_ri_ao_ao, ri_data, qs_env)
+      ALLOCATE (t_2c_der_metric(3), t_2c_der_RI(3), t_3c_der_AO(3), t_3c_der_RI(3))
+      IF (use_virial) THEN
+         CALL precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
+                                  t_2c_der_RI, t_2c_der_metric, t_3c_ri_ao_ao, &
+                                  basis_set_AO, basis_set_RI, ri_data, qs_env, &
+                                  nl_2c_pot=nl_2c_pot, nl_2c_met=nl_2c_met, &
+                                  nl_3c_out=nl_3c, t_3c_virial=t_3c_virial)
+
+         ALLOCATE (col_bsize(natom), row_bsize(natom))
+         col_bsize(:) = ri_data%bsizes_RI
+         row_bsize(:) = ri_data%bsizes_RI
+         CALL dbcsr_create(virial_trace, "virial_trace", dbcsr_dist, dbcsr_type_no_symmetry, row_bsize, col_bsize)
+         CALL dbt_create(virial_trace, t_2c_virial)
+         DEALLOCATE (col_bsize, row_bsize)
+      ELSE
+         CALL precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
+                                  t_2c_der_RI, t_2c_der_metric, t_3c_ri_ao_ao, &
+                                  basis_set_AO, basis_set_RI, ri_data, qs_env)
+      END IF
 
       ! Keep track of derivative sparsity to be able to use retain_sparsity in contraction
       CALL dbt_create(t_3c_ri_ao_ao, t_3c_sparse)
@@ -2664,13 +2709,8 @@ CONTAINS
                   CALL decompress_tensor(t_3c_der_RI(i_xyz), t_3c_der_RI_ind(k_mem, i_xyz)%ind, &
                                          t_3c_der_RI_comp(k_mem, i_xyz), ri_data%filter_eps_storage)
                END DO
-               IF (use_virial_prv) THEN
-                  CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_RI, atom_of_kind, kind_of, &
-                                               idx_to_at_RI, pref, work_virial, cell, particle_set)
-               ELSE
-                  CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_RI, atom_of_kind, kind_of, &
-                                               idx_to_at_RI, pref)
-               END IF
+               CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_RI, atom_of_kind, kind_of, &
+                                            idx_to_at_RI, pref)
             END DO
 
             pref = -0.5_dp*4.0_dp*hf_fraction*spin_fac
@@ -2685,25 +2725,26 @@ CONTAINS
                   CALL decompress_tensor(t_3c_der_AO(i_xyz), t_3c_der_AO_ind(k_mem, i_xyz)%ind, &
                                          t_3c_der_AO_comp(k_mem, i_xyz), ri_data%filter_eps_storage)
                END DO
-
-               IF (use_virial_prv) THEN
-                  CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_AO, atom_of_kind, kind_of, &
-                                               idx_to_at_AO, pref, work_virial, cell, particle_set, deriv_dim=2)
-               ELSE
-                  CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_AO, atom_of_kind, kind_of, &
-                                               idx_to_at_AO, pref, deriv_dim=2)
-               END IF
+               CALL get_force_from_3c_trace(force, t_3c_help_1, t_3c_der_AO, atom_of_kind, kind_of, &
+                                            idx_to_at_AO, pref, deriv_dim=2)
 
                IF (do_resp) THEN
-                  IF (use_virial_prv) THEN
-                     CALL get_force_from_3c_trace(force, t_3c_help_2, t_3c_der_AO, atom_of_kind, kind_of, &
-                                                  idx_to_at_AO, pref, work_virial, cell, particle_set, deriv_dim=2)
-                  ELSE
-                     CALL get_force_from_3c_trace(force, t_3c_help_2, t_3c_der_AO, atom_of_kind, kind_of, &
-                                                  idx_to_at_AO, pref, deriv_dim=2)
-                  END IF
+                  CALL get_force_from_3c_trace(force, t_3c_help_2, t_3c_der_AO, atom_of_kind, kind_of, &
+                                               idx_to_at_AO, pref, deriv_dim=2)
                END IF
             END DO
+
+            !The 3c virial contribution. Note: only fraction of integrals correspondig to i_mem calculated
+            IF (use_virial) THEN
+               pref = -0.5_dp*2.0_dp*hf_fraction*spin_fac
+               CALL dbt_copy(t_3c_help_1, t_3c_virial, move_data=.TRUE.)
+               CALL calc_3c_virial(work_virial, t_3c_virial, pref, qs_env, nl_3c, basis_set_RI, &
+                                   basis_set_AO, basis_set_AO, ri_data%ri_metric, &
+                                   der_eps=ri_data%eps_schwarz_forces, op_pos=1)
+
+               CALL dbt_clear(t_3c_virial)
+            END IF
+
             CALL dbt_clear(t_3c_help_1)
             CALL dbt_clear(t_3c_help_2)
          END DO !i_mem
@@ -2731,13 +2772,14 @@ CONTAINS
          !Calculate the potential contribution to the force: [S^-1*R*S^-1]_QR d/dx (Q|R)
          pref = 0.5_dp*hf_fraction*spin_fac
          IF (.NOT. ri_data%same_op) pref = -pref
-         IF (use_virial_prv) THEN
-            CALL get_2c_der_force(force, t_2c_RI, t_2c_der_RI, atom_of_kind, &
-                                  kind_of, idx_to_at_RI, pref, work_virial, cell, particle_set)
-         ELSE
-            CALL get_2c_der_force(force, t_2c_RI, t_2c_der_RI, atom_of_kind, &
-                                  kind_of, idx_to_at_RI, pref)
+         CALL get_2c_der_force(force, t_2c_RI, t_2c_der_RI, atom_of_kind, kind_of, idx_to_at_RI, pref)
 
+         !Calculate the contribution to the virial on the fly
+         IF (use_virial_prv) THEN
+            CALL dbt_copy(t_2c_RI, t_2c_virial)
+            CALL dbt_copy_tensor_to_matrix(t_2c_virial, virial_trace)
+            CALL calc_2c_virial(work_virial, virial_trace, pref, qs_env, nl_2c_pot, &
+                                basis_set_RI, basis_set_RI, ri_data%hfx_pot)
          END IF
 
          !And that from the metric: [S^-1*R*S^-1*(Q|R)*S^-1]_UV d/dx S_UV
@@ -2757,12 +2799,13 @@ CONTAINS
             ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
 
             pref = 0.5_dp*2.0_dp*hf_fraction*spin_fac
+            CALL get_2c_der_force(force, t_2c_RI, t_2c_der_metric, atom_of_kind, kind_of, idx_to_at_RI, pref)
+
             IF (use_virial_prv) THEN
-               CALL get_2c_der_force(force, t_2c_RI, t_2c_der_metric, atom_of_kind, &
-                                     kind_of, idx_to_at_RI, pref, work_virial, cell, particle_set)
-            ELSE
-               CALL get_2c_der_force(force, t_2c_RI, t_2c_der_metric, atom_of_kind, &
-                                     kind_of, idx_to_at_RI, pref)
+               CALL dbt_copy(t_2c_RI, t_2c_virial)
+               CALL dbt_copy_tensor_to_matrix(t_2c_virial, virial_trace)
+               CALL calc_2c_virial(work_virial, virial_trace, pref, qs_env, nl_2c_met, &
+                                   basis_set_RI, basis_set_RI, ri_data%ri_metric)
             END IF
          END IF
          CALL dbt_clear(t_2c_RI)
@@ -2832,6 +2875,22 @@ CONTAINS
          END DO
       END DO
       DEALLOCATE (t_3c_der_AO_ind, t_3c_der_RI_ind)
+
+      DO ibasis = 1, SIZE(basis_set_AO)
+         orb_basis => basis_set_AO(ibasis)%gto_basis_set
+         ri_basis => basis_set_RI(ibasis)%gto_basis_set
+         CALL init_interaction_radii_orb_basis(orb_basis, dft_control%qs_control%eps_pgf_orb)
+         CALL init_interaction_radii_orb_basis(ri_basis, dft_control%qs_control%eps_pgf_orb)
+      END DO
+
+      IF (use_virial) THEN
+         CALL release_neighbor_list_sets(nl_2c_met)
+         CALL release_neighbor_list_sets(nl_2c_pot)
+         CALL neighbor_list_3c_destroy(nl_3c)
+         CALL dbcsr_release(virial_trace)
+         CALL dbt_destroy(t_2c_virial)
+         CALL dbt_destroy(t_3c_virial)
+      END IF
 
    END SUBROUTINE hfx_ri_forces_Pmat
 
@@ -2915,24 +2974,37 @@ CONTAINS
 !> \param t_2c_der_RI format based on standard atomic block sizes
 !> \param t_2c_der_metric format based on standard atomic block sizes
 !> \param ri_ao_ao_template ...
+!> \param basis_set_AO ...
+!> \param basis_set_RI ...
 !> \param ri_data ...
 !> \param qs_env ...
+!> \param nl_2c_pot ...
+!> \param nl_2c_met ...
+!> \param nl_3c_out ...
+!> \param t_3c_virial ...
 ! **************************************************************************************************
    SUBROUTINE precalc_derivatives(t_3c_der_RI_comp, t_3c_der_AO_comp, t_3c_der_RI_ind, t_3c_der_AO_ind, &
-                                  t_2c_der_RI, t_2c_der_metric, ri_ao_ao_template, ri_data, qs_env)
+                                  t_2c_der_RI, t_2c_der_metric, ri_ao_ao_template, &
+                                  basis_set_AO, basis_set_RI, ri_data, qs_env, &
+                                  nl_2c_pot, nl_2c_met, nl_3c_out, t_3c_virial)
 
       TYPE(hfx_compression_type), ALLOCATABLE, &
          DIMENSION(:, :), INTENT(INOUT)                  :: t_3c_der_RI_comp, t_3c_der_AO_comp
       TYPE(block_ind_type), ALLOCATABLE, DIMENSION(:, :) :: t_3c_der_RI_ind, t_3c_der_AO_ind
       TYPE(dbt_type), DIMENSION(3), INTENT(OUT)          :: t_2c_der_RI, t_2c_der_metric
       TYPE(dbt_type), INTENT(INOUT)                      :: ri_ao_ao_template
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
       TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
       TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         OPTIONAL, POINTER                               :: nl_2c_pot, nl_2c_met
+      TYPE(neighbor_list_3c_type), OPTIONAL              :: nl_3c_out
+      TYPE(dbt_type), INTENT(INOUT), OPTIONAL            :: t_3c_virial
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'precalc_derivatives'
 
-      INTEGER                                            :: handle, i_mem, i_xyz, ibasis, n_mem, &
-                                                            nkind
+      INTEGER                                            :: handle, i_mem, i_xyz, n_mem, nkind
       INTEGER(int_8)                                     :: nze, nze_tot
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist_AO_1, dist_AO_2, &
                                                             dist_RI, dummy_end, dummy_start, &
@@ -2943,14 +3015,11 @@ CONTAINS
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbcsr_type), DIMENSION(1, 3)                  :: t_2c_der_metric_prv, t_2c_der_RI_prv
       TYPE(dbt_type)                                     :: t_2c_template, t_2c_tmp, t_3c_template
-      TYPE(dbt_type), DIMENSION(1, 1, 3)                 :: t_3c_der_AO_prv, t_3c_der_RI_prv
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :, :)    :: t_3c_der_AO_prv, t_3c_der_RI_prv
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_2d_type), POINTER                :: dist_2d
-      TYPE(distribution_3d_type)                         :: dist_3d
-      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
-         DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
-      TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
-      TYPE(mp_cart_type)                                 :: mp_comm_t3c
+      TYPE(distribution_3d_type)                         :: dist_3d, dist_3d_out
+      TYPE(mp_cart_type)                                 :: mp_comm_t3c, mp_comm_t3c_out
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
@@ -2958,25 +3027,12 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
-      NULLIFY (qs_kind_set, orb_basis, dist_2d, nl_2c, particle_set, dft_control, para_env)
+      NULLIFY (qs_kind_set, dist_2d, nl_2c, particle_set, dft_control, para_env)
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, nkind=nkind, qs_kind_set=qs_kind_set, distribution_2d=dist_2d, &
                       particle_set=particle_set, dft_control=dft_control, para_env=para_env)
-
-      ALLOCATE (basis_set_RI(nkind), basis_set_AO(nkind))
-      CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
-      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_RI)
-      CALL basis_set_list_setup(basis_set_AO, ri_data%orb_basis_type, qs_kind_set)
-      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_AO)
-
-      DO ibasis = 1, SIZE(basis_set_AO)
-         orb_basis => basis_set_AO(ibasis)%gto_basis_set
-         CALL init_interaction_radii_orb_basis(orb_basis, ri_data%eps_pgf_orb)
-         ri_basis => basis_set_RI(ibasis)%gto_basis_set
-         CALL init_interaction_radii_orb_basis(ri_basis, ri_data%eps_pgf_orb)
-      END DO
 
       !Dealing with the 3c derivatives
       CALL create_3c_tensor(t_3c_template, dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid, &
@@ -2984,20 +3040,33 @@ CONTAINS
                             map1=[1], map2=[2, 3], &
                             name="der (RI AO | AO)")
 
+      ALLOCATE (t_3c_der_AO_prv(1, 1, 3), t_3c_der_RI_prv(1, 1, 3))
       DO i_xyz = 1, 3
          CALL dbt_create(t_3c_template, t_3c_der_RI_prv(1, 1, i_xyz))
          CALL dbt_create(t_3c_template, t_3c_der_AO_prv(1, 1, i_xyz))
       END DO
+      IF (PRESENT(t_3c_virial)) THEN
+         CALL dbt_create(t_3c_template, t_3c_virial)
+      END IF
       CALL dbt_destroy(t_3c_template)
 
       CALL dbt_mp_environ_pgrid(ri_data%pgrid, pdims, pcoord)
       CALL mp_comm_t3c%create(ri_data%pgrid%mp_comm_2d, 3, pdims)
       CALL distribution_3d_create(dist_3d, dist_RI, dist_AO_1, dist_AO_2, &
                                   nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
-      DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
 
       CALL build_3c_neighbor_lists(nl_3c, basis_set_RI, basis_set_AO, basis_set_AO, dist_3d, ri_data%ri_metric, &
                                    "HFX_3c_nl", qs_env, op_pos=1, sym_jk=.TRUE., own_dist=.TRUE.)
+
+      IF (PRESENT(nl_3c_out)) THEN
+         CALL mp_comm_t3c_out%create(ri_data%pgrid%mp_comm_2d, 3, pdims)
+         CALL distribution_3d_create(dist_3d_out, dist_RI, dist_AO_1, dist_AO_2, &
+                                     nkind, particle_set, mp_comm_t3c_out, own_comm=.TRUE.)
+         CALL build_3c_neighbor_lists(nl_3c_out, basis_set_RI, basis_set_AO, basis_set_AO, dist_3d_out, &
+                                      ri_data%ri_metric, "HFX_3c_nl", qs_env, op_pos=1, sym_jk=.FALSE., &
+                                      own_dist=.TRUE.)
+      END IF
+      DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
 
       n_mem = ri_data%n_mem
       CALL create_tensor_batches(ri_data%bsizes_RI, n_mem, dummy_start, dummy_end, &
@@ -3074,6 +3143,12 @@ CONTAINS
                                 basis_set_RI, ri_data%hfx_pot)
       CALL release_neighbor_list_sets(nl_2c)
 
+      IF (PRESENT(nl_2c_pot)) THEN
+         NULLIFY (nl_2c_pot)
+         CALL build_2c_neighbor_lists(nl_2c_pot, basis_set_RI, basis_set_RI, ri_data%hfx_pot, &
+                                      "HFX_2c_nl_pot", qs_env, sym_ij=.FALSE., dist_2d=dist_2d)
+      END IF
+
       !copy 2c derivative tensor into the standard format
       CALL create_2c_tensor(t_2c_template, dist1, dist2, ri_data%pgrid_2d, ri_data%bsizes_RI_split, &
                             ri_data%bsizes_RI_split, name='(RI| RI)')
@@ -3105,6 +3180,12 @@ CONTAINS
                                    basis_set_RI, basis_set_RI, ri_data%ri_metric)
          CALL release_neighbor_list_sets(nl_2c)
 
+         IF (PRESENT(nl_2c_met)) THEN
+            NULLIFY (nl_2c_met)
+            CALL build_2c_neighbor_lists(nl_2c_met, basis_set_RI, basis_set_RI, ri_data%ri_metric, &
+                                         "HFX_2c_nl_RI", qs_env, sym_ij=.FALSE., dist_2d=dist_2d)
+         END IF
+
          DO i_xyz = 1, 3
             CALL dbt_create(t_2c_der_metric_prv(1, i_xyz), t_2c_tmp)
             CALL dbt_copy_matrix_to_tensor(t_2c_der_metric_prv(1, i_xyz), t_2c_tmp)
@@ -3121,13 +3202,6 @@ CONTAINS
       CALL dbt_destroy(t_2c_template)
       CALL dbcsr_distribution_release(dbcsr_dist)
       DEALLOCATE (row_bsize, col_bsize)
-
-      DO ibasis = 1, SIZE(basis_set_AO)
-         orb_basis => basis_set_AO(ibasis)%gto_basis_set
-         ri_basis => basis_set_RI(ibasis)%gto_basis_set
-         CALL init_interaction_radii_orb_basis(orb_basis, dft_control%qs_control%eps_pgf_orb)
-         CALL init_interaction_radii_orb_basis(ri_basis, dft_control%qs_control%eps_pgf_orb)
-      END DO
 
       CALL timestop(handle)
 
@@ -3682,7 +3756,7 @@ CONTAINS
       TYPE(dbt_type)                                     :: density_coeffs_t, density_tmp, rho_ao_t, &
                                                             rho_ao_t_3d, rho_ao_tmp, t2c_ri_ints, &
                                                             t2c_ri_inv, t2c_ri_tmp
-      TYPE(dbt_type), DIMENSION(1, 1)                    :: t_3c_int_batched
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_int_batched
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_3d_type)                         :: dist_nl3c
       TYPE(mp_cart_type)                                 :: mp_comm_t3c
@@ -3854,6 +3928,7 @@ CONTAINS
       CALL dbt_get_info(ri_data%t_3c_int_ctr_3(1, 1), nfull_total=dims_3c)
 
       ! The 3c integrals tensor, in case we compute them here
+      ALLOCATE (t_3c_int_batched(1, 1))
       CALL create_3c_tensor(t_3c_int_batched(1, 1), dist1, dist2, dist3, ri_data%pgrid, &
                             ri_data%bsizes_RI, ri_data%bsizes_AO, ri_data%bsizes_AO, map1=[1], map2=[2, 3], &
                             name="(RI | AO AO)")

--- a/src/qs_tensors.F
+++ b/src/qs_tensors.F
@@ -19,7 +19,8 @@ MODULE qs_tensors
                                               gto_basis_set_p_type,&
                                               gto_basis_set_type
    USE block_p_types,                   ONLY: block_p_type
-   USE cell_types,                      ONLY: cell_type
+   USE cell_types,                      ONLY: cell_type,&
+                                              real_to_scaled
    USE cp_array_utils,                  ONLY: cp_2d_r_p_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
@@ -112,7 +113,7 @@ MODULE qs_tensors
              neighbor_list_3c_iterator_destroy, get_3c_iterator_info, build_3c_integrals, &
              build_2c_neighbor_lists, build_2c_integrals, cutoff_screen_factor, &
              get_tensor_occupancy, compress_tensor, decompress_tensor, &
-             build_3c_derivatives, build_2c_derivatives
+             build_3c_derivatives, build_2c_derivatives, calc_2c_virial, calc_3c_virial
 
    TYPE one_dim_int_array
       INTEGER, DIMENSION(:), ALLOCATABLE    :: array
@@ -1725,7 +1726,503 @@ CONTAINS
       CALL timestop(handle)
    END SUBROUTINE build_3c_derivatives
 
-   ! **************************************************************************************************
+! **************************************************************************************************
+!> \brief Calculates the 3c virial contributions on the fly
+!> \param work_virial ...
+!> \param t3c_trace the tensor with which the trace should be taken
+!> \param pref ...
+!> \param qs_env ...
+!> \param nl_3c 3-center neighborlist, with a distribution matching that of t3c_trace
+!> \param basis_i ...
+!> \param basis_j ...
+!> \param basis_k ...
+!> \param potential_parameter ...
+!> \param der_eps neglect integrals smaller than der_eps
+!> \param op_pos operator position.
+!>        1: calculate (i|jk) integrals,
+!>        2: calculate (ij|k) integrals
+!> this routine requires that libint has been static initialised somewhere else
+! **************************************************************************************************
+   SUBROUTINE calc_3c_virial(work_virial, t3c_trace, pref, qs_env, &
+                             nl_3c, basis_i, basis_j, basis_k, &
+                             potential_parameter, der_eps, op_pos)
+
+      REAL(dp), DIMENSION(3, 3), INTENT(INOUT)           :: work_virial
+      TYPE(dbt_type), INTENT(INOUT)                      :: t3c_trace
+      REAL(KIND=dp), INTENT(IN)                          :: pref
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(neighbor_list_3c_type), INTENT(INOUT)         :: nl_3c
+      TYPE(gto_basis_set_p_type), DIMENSION(:)           :: basis_i, basis_j, basis_k
+      TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: der_eps
+      INTEGER, INTENT(IN), OPTIONAL                      :: op_pos
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'calc_3c_virial'
+
+      INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
+         block_start_k, egfi, handle, i, i_xyz, iatom, ibasis, ikind, ilist, imax, iset, j_xyz, &
+         jatom, jkind, jset, katom, kkind, kset, m_max, max_ncoi, max_ncoj, max_ncok, max_nset, &
+         max_nsgfi, max_nsgfj, max_nsgfk, maxli, maxlj, maxlk, mepos, natom, nbasis, ncoi, ncoj, &
+         ncok, nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
+      INTEGER, DIMENSION(2)                              :: bo
+      INTEGER, DIMENSION(3)                              :: blk_size, sp
+      INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmax_k, lmin_i, lmin_j, &
+                                                            lmin_k, npgfi, npgfj, npgfk, nsgfi, &
+                                                            nsgfj, nsgfk
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_i, first_sgf_j, first_sgf_k
+      LOGICAL                                            :: found, skip
+      LOGICAL, DIMENSION(3)                              :: block_j_not_zero, block_k_not_zero, &
+                                                            der_j_zero, der_k_zero
+      REAL(dp)                                           :: force
+      REAL(dp), DIMENSION(3)                             :: der_ext_i, der_ext_j, der_ext_k
+      REAL(KIND=dp)                                      :: dij, dik, djk, dr_ij, dr_ik, dr_jk, &
+                                                            kind_radius_i, kind_radius_j, &
+                                                            kind_radius_k
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: ccp_buffer, cpp_buffer, &
+                                                            max_contraction_i, max_contraction_j, &
+                                                            max_contraction_k
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ablock, dijk_contr, tmp_block
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: block_t_i, block_t_j, block_t_k, dijk_j, &
+                                                            dijk_k
+      REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rik, rj, rjk, rk, scoord
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_i, set_radius_j, set_radius_k
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgf_i, rpgf_j, rpgf_k, sphi_i, sphi_j, &
+                                                            sphi_k, zeti, zetj, zetk
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_2d_r_p_type), DIMENSION(:, :), POINTER     :: spi, spk, tspj
+      TYPE(cp_libint_t)                                  :: lib
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_type), POINTER                  :: basis_set
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_3c_iterator_type)               :: nl_3c_iter
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      CALL timeset(routineN, handle)
+
+      op_ij = do_potential_id; op_jk = do_potential_id
+
+      IF (PRESENT(op_pos)) THEN
+         op_pos_prv = op_pos
+      ELSE
+         op_pos_prv = 1
+      END IF
+      CPASSERT(op_pos == 1)
+      CPASSERT(.NOT. nl_3c%sym == symmetric_jk)
+
+      SELECT CASE (op_pos_prv)
+      CASE (1)
+         op_ij = potential_parameter%potential_type
+      CASE (2)
+         op_jk = potential_parameter%potential_type
+      END SELECT
+
+      dr_ij = 0.0_dp; dr_jk = 0.0_dp; dr_ik = 0.0_dp
+
+      IF (op_ij == do_potential_truncated .OR. op_ij == do_potential_short) THEN
+         dr_ij = potential_parameter%cutoff_radius*cutoff_screen_factor
+         dr_ik = potential_parameter%cutoff_radius*cutoff_screen_factor
+      ELSEIF (op_ij == do_potential_coulomb) THEN
+         dr_ij = 1000000.0_dp
+         dr_ik = 1000000.0_dp
+      END IF
+
+      IF (op_jk == do_potential_truncated .OR. op_jk == do_potential_short) THEN
+         dr_jk = potential_parameter%cutoff_radius*cutoff_screen_factor
+         dr_ik = potential_parameter%cutoff_radius*cutoff_screen_factor
+      ELSEIF (op_jk == do_potential_coulomb) THEN
+         dr_jk = 1000000.0_dp
+         dr_ik = 1000000.0_dp
+      END IF
+
+      NULLIFY (qs_kind_set, atomic_kind_set)
+
+      ! get stuff
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
+                      natom=natom, dft_control=dft_control, para_env=para_env, &
+                      particle_set=particle_set, cell=cell)
+
+      !Need the max l for each basis for libint and max nset, nco and nsgf for LIBXSMM contraction
+      nbasis = SIZE(basis_i)
+      max_nsgfi = 0
+      max_ncoi = 0
+      max_nset = 0
+      maxli = 0
+      DO ibasis = 1, nbasis
+         CALL get_gto_basis_set(gto_basis_set=basis_i(ibasis)%gto_basis_set, maxl=imax, &
+                                nset=iset, nsgf_set=nsgfi, npgf=npgfi)
+         maxli = MAX(maxli, imax)
+         max_nset = MAX(max_nset, iset)
+         max_nsgfi = MAX(max_nsgfi, MAXVAL(nsgfi))
+         max_ncoi = MAX(max_ncoi, MAXVAL(npgfi)*ncoset(maxli))
+      END DO
+      max_nsgfj = 0
+      max_ncoj = 0
+      maxlj = 0
+      DO ibasis = 1, nbasis
+         CALL get_gto_basis_set(gto_basis_set=basis_j(ibasis)%gto_basis_set, maxl=imax, &
+                                nset=jset, nsgf_set=nsgfj, npgf=npgfj)
+         maxlj = MAX(maxlj, imax)
+         max_nset = MAX(max_nset, jset)
+         max_nsgfj = MAX(max_nsgfj, MAXVAL(nsgfj))
+         max_ncoj = MAX(max_ncoj, MAXVAL(npgfj)*ncoset(maxlj))
+      END DO
+      max_nsgfk = 0
+      max_ncok = 0
+      maxlk = 0
+      DO ibasis = 1, nbasis
+         CALL get_gto_basis_set(gto_basis_set=basis_k(ibasis)%gto_basis_set, maxl=imax, &
+                                nset=kset, nsgf_set=nsgfk, npgf=npgfk)
+         maxlk = MAX(maxlk, imax)
+         max_nset = MAX(max_nset, kset)
+         max_nsgfk = MAX(max_nsgfk, MAXVAL(nsgfk))
+         max_ncok = MAX(max_ncok, MAXVAL(npgfk)*ncoset(maxlk))
+      END DO
+      m_max = maxli + maxlj + maxlk + 1
+
+      !To minimize expensive memory opsand generally optimize contraction, pre-allocate
+      !contiguous sphi arrays (and transposed in the cas of sphi_i)
+
+      NULLIFY (tspj, spi, spk)
+      ALLOCATE (spi(max_nset, nbasis), tspj(max_nset, nbasis), spk(max_nset, nbasis))
+
+      DO ibasis = 1, nbasis
+         DO iset = 1, max_nset
+            NULLIFY (spi(iset, ibasis)%array)
+            NULLIFY (tspj(iset, ibasis)%array)
+
+            NULLIFY (spk(iset, ibasis)%array)
+         END DO
+      END DO
+
+      DO ilist = 1, 3
+         DO ibasis = 1, nbasis
+            IF (ilist == 1) basis_set => basis_i(ibasis)%gto_basis_set
+            IF (ilist == 2) basis_set => basis_j(ibasis)%gto_basis_set
+            IF (ilist == 3) basis_set => basis_k(ibasis)%gto_basis_set
+
+            DO iset = 1, basis_set%nset
+
+               ncoi = basis_set%npgf(iset)*ncoset(basis_set%lmax(iset))
+               sgfi = basis_set%first_sgf(1, iset)
+               egfi = sgfi + basis_set%nsgf_set(iset) - 1
+
+               IF (ilist == 1) THEN
+                  ALLOCATE (spi(iset, ibasis)%array(ncoi, basis_set%nsgf_set(iset)))
+                  spi(iset, ibasis)%array(:, :) = basis_set%sphi(1:ncoi, sgfi:egfi)
+
+               ELSE IF (ilist == 2) THEN
+                  ALLOCATE (tspj(iset, ibasis)%array(basis_set%nsgf_set(iset), ncoi))
+                  tspj(iset, ibasis)%array(:, :) = TRANSPOSE(basis_set%sphi(1:ncoi, sgfi:egfi))
+
+               ELSE
+                  ALLOCATE (spk(iset, ibasis)%array(ncoi, basis_set%nsgf_set(iset)))
+                  spk(iset, ibasis)%array(:, :) = basis_set%sphi(1:ncoi, sgfi:egfi)
+               END IF
+
+            END DO !iset
+         END DO !ibasis
+      END DO !ilist
+
+      !Init the truncated Coulomb operator
+      IF (op_ij == do_potential_truncated .OR. op_jk == do_potential_truncated) THEN
+
+         IF (m_max > get_lmax_init()) THEN
+            IF (para_env%mepos == 0) THEN
+               CALL open_file(unit_number=unit_id, file_name=potential_parameter%filename)
+            END IF
+            CALL init(m_max, unit_id, para_env%mepos, para_env)
+            IF (para_env%mepos == 0) THEN
+               CALL close_file(unit_id)
+            END IF
+         END IF
+      END IF
+
+      CALL init_md_ftable(nmax=m_max)
+
+      nthread = 1
+!$    nthread = omp_get_max_threads()
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED (nthread,maxli,maxlk,maxlj,i,work_virial,pref,&
+!$OMP         basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,&
+!$OMP         potential_parameter,der_eps,tspj,spi,spk,max_ncoi,max_nsgfk,&
+!$OMP         max_nsgfj,max_ncok,natom,nl_3c,t3c_trace,cell,particle_set) &
+!$OMP PRIVATE (lib,nl_3c_iter,ikind,jkind,kkind,iatom,jatom,katom,rij,rjk,rik,i_xyz,j_xyz,&
+!$OMP          first_sgf_i,lmax_i,lmin_i,npgfi,nseti,nsgfi,rpgf_i,set_radius_i,&
+!$OMP          sphi_i,zeti,kind_radius_i,first_sgf_j,lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,&
+!$OMP          set_radius_j,sphi_j,zetj,kind_radius_j,first_sgf_k,lmax_k,lmin_k,npgfk,nsetk,nsgfk,&
+!$OMP          rpgf_k,set_radius_k,sphi_k,zetk,kind_radius_k,djk,dij,dik,ncoi,ncoj,ncok,sgfi,sgfj,&
+!$OMP          sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,tmp_block,&
+!$OMP          max_contraction_k,iset,jset,kset,block_t_i,blk_size,dijk_contr,cpp_buffer,ccp_buffer,&
+!$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,found,&
+!$OMP          sp,mepos,bo,block_t_k,der_ext_i,der_ext_j,der_ext_k,ablock,force,scoord,&
+!$OMP          block_k_not_zero,der_k_zero,skip,der_j_zero,block_t_j,block_j_not_zero)
+
+      mepos = 0
+!$    mepos = omp_get_thread_num()
+
+      CALL cp_libint_init_3eri1(lib, MAX(maxli, maxlj, maxlk))
+      CALL cp_libint_set_contrdepth(lib, 1)
+
+      !pre-allocate contraction buffers
+      ALLOCATE (cpp_buffer(max_nsgfj*max_ncok), ccp_buffer(max_nsgfj*max_nsgfk*max_ncoi))
+
+      CALL neighbor_list_3c_iterator_create(nl_3c_iter, nl_3c)
+
+      !We split the provided bounds among the threads such that each threads works on a different set of atoms
+
+      bo = get_limit(natom, nthread, mepos)
+      CALL nl_3c_iter_set_bounds(nl_3c_iter, bounds_i=bo)
+
+      skip = .FALSE.
+      IF (bo(1) > bo(2)) skip = .TRUE.
+
+      DO WHILE (neighbor_list_3c_iterate(nl_3c_iter) == 0)
+         CALL get_3c_iterator_info(nl_3c_iter, ikind=ikind, jkind=jkind, kkind=kkind, &
+                                   iatom=iatom, jatom=jatom, katom=katom, &
+                                   rij=rij, rjk=rjk, rik=rik)
+         IF (skip) EXIT
+
+         CALL dbt_get_block(t3c_trace, [iatom, jatom, katom], tmp_block, found)
+         IF (.NOT. found) CYCLE
+
+         CALL get_gto_basis_set(basis_i(ikind)%gto_basis_set, first_sgf=first_sgf_i, lmax=lmax_i, lmin=lmin_i, &
+                                npgf=npgfi, nset=nseti, nsgf_set=nsgfi, pgf_radius=rpgf_i, set_radius=set_radius_i, &
+                                sphi=sphi_i, zet=zeti, kind_radius=kind_radius_i)
+
+         CALL get_gto_basis_set(basis_j(jkind)%gto_basis_set, first_sgf=first_sgf_j, lmax=lmax_j, lmin=lmin_j, &
+                                npgf=npgfj, nset=nsetj, nsgf_set=nsgfj, pgf_radius=rpgf_j, set_radius=set_radius_j, &
+                                sphi=sphi_j, zet=zetj, kind_radius=kind_radius_j)
+
+         CALL get_gto_basis_set(basis_k(kkind)%gto_basis_set, first_sgf=first_sgf_k, lmax=lmax_k, lmin=lmin_k, &
+                                npgf=npgfk, nset=nsetk, nsgf_set=nsgfk, pgf_radius=rpgf_k, set_radius=set_radius_k, &
+                                sphi=sphi_k, zet=zetk, kind_radius=kind_radius_k)
+
+         djk = NORM2(rjk)
+         dij = NORM2(rij)
+         dik = NORM2(rik)
+
+         IF (kind_radius_j + kind_radius_i + dr_ij < dij) CYCLE
+         IF (kind_radius_j + kind_radius_k + dr_jk < djk) CYCLE
+         IF (kind_radius_k + kind_radius_i + dr_ik < dik) CYCLE
+
+         ALLOCATE (max_contraction_i(nseti))
+         max_contraction_i = 0.0_dp
+         DO iset = 1, nseti
+            sgfi = first_sgf_i(1, iset)
+            max_contraction_i(iset) = MAXVAL((/(SUM(ABS(sphi_i(:, i))), i=sgfi, sgfi + nsgfi(iset) - 1)/))
+         END DO
+
+         ALLOCATE (max_contraction_j(nsetj))
+         max_contraction_j = 0.0_dp
+         DO jset = 1, nsetj
+            sgfj = first_sgf_j(1, jset)
+            max_contraction_j(jset) = MAXVAL((/(SUM(ABS(sphi_j(:, i))), i=sgfj, sgfj + nsgfj(jset) - 1)/))
+         END DO
+
+         ALLOCATE (max_contraction_k(nsetk))
+         max_contraction_k = 0.0_dp
+         DO kset = 1, nsetk
+            sgfk = first_sgf_k(1, kset)
+            max_contraction_k(kset) = MAXVAL((/(SUM(ABS(sphi_k(:, i))), i=sgfk, sgfk + nsgfk(kset) - 1)/))
+         END DO
+
+         CALL dbt_blk_sizes(t3c_trace, [iatom, jatom, katom], blk_size)
+
+         ALLOCATE (block_t_i(blk_size(2), blk_size(3), blk_size(1), 3))
+         ALLOCATE (block_t_j(blk_size(2), blk_size(3), blk_size(1), 3))
+         ALLOCATE (block_t_k(blk_size(2), blk_size(3), blk_size(1), 3))
+
+         ALLOCATE (ablock(blk_size(2), blk_size(3), blk_size(1)))
+         DO i = 1, blk_size(1)
+            ablock(:, :, i) = tmp_block(i, :, :)
+         END DO
+         DEALLOCATE (tmp_block)
+
+         block_t_i = 0.0_dp
+         block_t_j = 0.0_dp
+         block_t_k = 0.0_dp
+         block_j_not_zero = .FALSE.
+         block_k_not_zero = .FALSE.
+
+         DO iset = 1, nseti
+
+            DO jset = 1, nsetj
+
+               IF (set_radius_j(jset) + set_radius_i(iset) + dr_ij < dij) CYCLE
+
+               DO kset = 1, nsetk
+
+                  IF (set_radius_j(jset) + set_radius_k(kset) + dr_jk < djk) CYCLE
+                  IF (set_radius_k(kset) + set_radius_i(iset) + dr_ik < dik) CYCLE
+
+                  ncoi = npgfi(iset)*ncoset(lmax_i(iset))
+                  ncoj = npgfj(jset)*ncoset(lmax_j(jset))
+                  ncok = npgfk(kset)*ncoset(lmax_k(kset))
+
+                  sgfi = first_sgf_i(1, iset)
+                  sgfj = first_sgf_j(1, jset)
+                  sgfk = first_sgf_k(1, kset)
+
+                  IF (ncoj*ncok*ncoi > 0) THEN
+                     ALLOCATE (dijk_j(ncoj, ncok, ncoi, 3))
+                     ALLOCATE (dijk_k(ncoj, ncok, ncoi, 3))
+                     dijk_j(:, :, :, :) = 0.0_dp
+                     dijk_k(:, :, :, :) = 0.0_dp
+
+                     der_j_zero = .FALSE.
+                     der_k_zero = .FALSE.
+
+                     !need positions for libint. Only relative positions are needed => set ri to 0.0
+                     ri = 0.0_dp
+                     rj = rij ! ri + rij
+                     rk = rik ! ri + rik
+
+                     CALL eri_3center_derivs(dijk_j, dijk_k, &
+                                             lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
+                                             lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
+                                             lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
+                                             djk, dij, dik, lib, potential_parameter, &
+                                             der_abc_1_ext=der_ext_j, der_abc_2_ext=der_ext_k)
+
+                     IF (PRESENT(der_eps)) THEN
+                        DO i_xyz = 1, 3
+                           IF (der_eps > der_ext_j(i_xyz)*(max_contraction_i(iset)* &
+                                                           max_contraction_j(jset)* &
+                                                           max_contraction_k(kset))) THEN
+                              der_j_zero(i_xyz) = .TRUE.
+                           END IF
+                        END DO
+
+                        DO i_xyz = 1, 3
+                           IF (der_eps > der_ext_k(i_xyz)*(max_contraction_i(iset)* &
+                                                           max_contraction_j(jset)* &
+                                                           max_contraction_k(kset))) THEN
+                              der_k_zero(i_xyz) = .TRUE.
+                           END IF
+                        END DO
+                        IF (ALL(der_j_zero) .AND. ALL(der_k_zero)) THEN
+                           DEALLOCATE (dijk_j, dijk_k)
+                           CYCLE
+                        END IF
+                     END IF
+
+                     ALLOCATE (dijk_contr(nsgfj(jset), nsgfk(kset), nsgfi(iset)))
+
+                     block_start_j = sgfj
+                     block_end_j = sgfj + nsgfj(jset) - 1
+                     block_start_k = sgfk
+                     block_end_k = sgfk + nsgfk(kset) - 1
+                     block_start_i = sgfi
+                     block_end_i = sgfi + nsgfi(iset) - 1
+
+                     DO i_xyz = 1, 3
+                        IF (der_j_zero(i_xyz)) CYCLE
+
+                        block_j_not_zero(i_xyz) = .TRUE.
+                        CALL libxsmm_abc_contract(dijk_contr, dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                                                  spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                                  ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                                  nsgfi(iset), cpp_buffer, ccp_buffer)
+
+                        block_t_j(block_start_j:block_end_j, &
+                                  block_start_k:block_end_k, &
+                                  block_start_i:block_end_i, i_xyz) = &
+                           block_t_j(block_start_j:block_end_j, &
+                                     block_start_k:block_end_k, &
+                                     block_start_i:block_end_i, i_xyz) + &
+                           dijk_contr(:, :, :)
+
+                     END DO
+
+                     DO i_xyz = 1, 3
+                        IF (der_k_zero(i_xyz)) CYCLE
+
+                        block_k_not_zero(i_xyz) = .TRUE.
+                        CALL libxsmm_abc_contract(dijk_contr, dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                                                  spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                                  ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                                  nsgfi(iset), cpp_buffer, ccp_buffer)
+
+                        block_t_k(block_start_j:block_end_j, &
+                                  block_start_k:block_end_k, &
+                                  block_start_i:block_end_i, i_xyz) = &
+                           block_t_k(block_start_j:block_end_j, &
+                                     block_start_k:block_end_k, &
+                                     block_start_i:block_end_i, i_xyz) + &
+                           dijk_contr(:, :, :)
+
+                     END DO
+
+                     DEALLOCATE (dijk_j, dijk_k, dijk_contr)
+                  END IF ! number of triples > 0
+               END DO
+            END DO
+         END DO
+
+         !We obtain the derivative wrt to first center using translational invariance
+         DO i_xyz = 1, 3
+            block_t_i(:, :, :, i_xyz) = -block_t_j(:, :, :, i_xyz) - block_t_k(:, :, :, i_xyz)
+         END DO
+
+         !virial contribution coming from deriv wrt to first center
+         DO i_xyz = 1, 3
+            force = pref*SUM(ablock(:, :, :)*block_t_i(:, :, :, i_xyz))
+            CALL real_to_scaled(scoord, particle_set(iatom)%r, cell)
+            DO j_xyz = 1, 3
+!$OMP ATOMIC
+               work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + force*scoord(j_xyz)
+            END DO
+         END DO
+
+         !second center
+         DO i_xyz = 1, 3
+            force = pref*SUM(ablock(:, :, :)*block_t_j(:, :, :, i_xyz))
+            CALL real_to_scaled(scoord, particle_set(iatom)%r + rij, cell)
+            DO j_xyz = 1, 3
+!$OMP ATOMIC
+               work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + force*scoord(j_xyz)
+            END DO
+         END DO
+
+         !third center
+         DO i_xyz = 1, 3
+            force = pref*SUM(ablock(:, :, :)*block_t_k(:, :, :, i_xyz))
+            CALL real_to_scaled(scoord, particle_set(iatom)%r + rik, cell)
+            DO j_xyz = 1, 3
+!$OMP ATOMIC
+               work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + force*scoord(j_xyz)
+            END DO
+         END DO
+
+         DEALLOCATE (block_t_i)
+         DEALLOCATE (block_t_j)
+         DEALLOCATE (block_t_k)
+
+         DEALLOCATE (max_contraction_i, max_contraction_j, max_contraction_k, ablock)
+      END DO
+
+      CALL cp_libint_cleanup_3eri1(lib)
+      CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
+!$OMP END PARALLEL
+
+      DO iset = 1, max_nset
+         DO ibasis = 1, nbasis
+            IF (ASSOCIATED(spi(iset, ibasis)%array)) DEALLOCATE (spi(iset, ibasis)%array)
+            IF (ASSOCIATED(tspj(iset, ibasis)%array)) DEALLOCATE (tspj(iset, ibasis)%array)
+
+            IF (ASSOCIATED(spk(iset, ibasis)%array)) DEALLOCATE (spk(iset, ibasis)%array)
+         END DO
+      END DO
+
+      DEALLOCATE (spi, tspj, spk)
+
+      CALL timestop(handle)
+   END SUBROUTINE calc_3c_virial
+
+! **************************************************************************************************
 !> \brief Build 3-center integral tensor
 !> \param t3c empty DBCSR tensor
 !>            Should be of shape (1,1) if no kpoints are used and of shape (nimages, nimages)
@@ -2508,6 +3005,180 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE build_2c_derivatives
+
+! **************************************************************************************************
+!> \brief Calculates the virial coming from 2c derivatives on the fly
+!> \param work_virial ...
+!> \param t2c_trace the 2c tensor that we should trace with the derivatives
+!> \param pref ...
+!> \param qs_env ...
+!> \param nl_2c 2-center neighborlist. Assumed to have compatible distribution with t2c_trace,
+!>              and to be non-symmetric
+!> \param basis_i ...
+!> \param basis_j ...
+!> \param potential_parameter ...
+! **************************************************************************************************
+   SUBROUTINE calc_2c_virial(work_virial, t2c_trace, pref, qs_env, nl_2c, basis_i, basis_j, potential_parameter)
+      REAL(dp), DIMENSION(3, 3), INTENT(INOUT)           :: work_virial
+      TYPE(dbcsr_type), INTENT(INOUT)                    :: t2c_trace
+      REAL(KIND=dp), INTENT(IN)                          :: pref
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: nl_2c
+      TYPE(gto_basis_set_p_type), DIMENSION(:)           :: basis_i, basis_j
+      TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'calc_2c_virial'
+
+      INTEGER :: handle, i_xyz, iatom, ibasis, ikind, imax, iset, j_xyz, jatom, jkind, jset, &
+         m_max, maxli, maxlj, natom, ncoi, ncoj, nseti, nsetj, op_prv, sgfi, sgfj, unit_id
+      INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmin_i, lmin_j, npgfi, &
+                                                            npgfj, nsgfi, nsgfj
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_i, first_sgf_j
+      LOGICAL                                            :: do_symmetric, found
+      REAL(dp)                                           :: force
+      REAL(dp), DIMENSION(:, :), POINTER                 :: pblock
+      REAL(KIND=dp)                                      :: dab
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: dij_contr
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: dij
+      REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rj, scoord
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_i, set_radius_j
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgf_i, rpgf_j, sphi_i, sphi_j, zeti, &
+                                                            zetj
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_libint_t)                                  :: lib
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      CALL timeset(routineN, handle)
+
+      op_prv = potential_parameter%potential_type
+
+      NULLIFY (qs_kind_set, atomic_kind_set, pblock, particle_set, cell)
+
+      ! get stuff
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
+                      natom=natom, dft_control=dft_control, para_env=para_env, &
+                      particle_set=particle_set, cell=cell)
+
+      ! check for symmetry
+      CPASSERT(SIZE(nl_2c) > 0)
+      CALL get_neighbor_list_set_p(neighbor_list_sets=nl_2c, symmetric=do_symmetric)
+      CPASSERT(.NOT. do_symmetric)
+
+      maxli = 0
+      DO ibasis = 1, SIZE(basis_i)
+         CALL get_gto_basis_set(gto_basis_set=basis_i(ibasis)%gto_basis_set, maxl=imax)
+         maxli = MAX(maxli, imax)
+      END DO
+      maxlj = 0
+      DO ibasis = 1, SIZE(basis_j)
+         CALL get_gto_basis_set(gto_basis_set=basis_j(ibasis)%gto_basis_set, maxl=imax)
+         maxlj = MAX(maxlj, imax)
+      END DO
+
+      m_max = maxli + maxlj + 1
+
+      !Init the truncated Coulomb operator
+      IF (op_prv == do_potential_truncated) THEN
+
+         IF (m_max > get_lmax_init()) THEN
+            IF (para_env%mepos == 0) THEN
+               CALL open_file(unit_number=unit_id, file_name=potential_parameter%filename)
+            END IF
+            CALL init(m_max, unit_id, para_env%mepos, para_env)
+            IF (para_env%mepos == 0) THEN
+               CALL close_file(unit_id)
+            END IF
+         END IF
+      END IF
+
+      CALL init_md_ftable(nmax=m_max)
+
+      CALL cp_libint_init_2eri1(lib, MAX(maxli, maxlj))
+      CALL cp_libint_set_contrdepth(lib, 1)
+
+      CALL neighbor_list_iterator_create(nl_iterator, nl_2c)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+
+         CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, &
+                                iatom=iatom, jatom=jatom, r=rij)
+
+         CALL get_gto_basis_set(basis_i(ikind)%gto_basis_set, first_sgf=first_sgf_i, lmax=lmax_i, lmin=lmin_i, &
+                                npgf=npgfi, nset=nseti, nsgf_set=nsgfi, pgf_radius=rpgf_i, set_radius=set_radius_i, &
+                                sphi=sphi_i, zet=zeti)
+
+         CALL get_gto_basis_set(basis_j(jkind)%gto_basis_set, first_sgf=first_sgf_j, lmax=lmax_j, lmin=lmin_j, &
+                                npgf=npgfj, nset=nsetj, nsgf_set=nsgfj, pgf_radius=rpgf_j, set_radius=set_radius_j, &
+                                sphi=sphi_j, zet=zetj)
+
+         dab = NORM2(rij)
+
+         CALL dbcsr_get_block_p(t2c_trace, iatom, jatom, pblock, found)
+         IF (.NOT. found) CYCLE
+
+         DO iset = 1, nseti
+
+            ncoi = npgfi(iset)*ncoset(lmax_i(iset))
+            sgfi = first_sgf_i(1, iset)
+
+            DO jset = 1, nsetj
+
+               ncoj = npgfj(jset)*ncoset(lmax_j(jset))
+               sgfj = first_sgf_j(1, jset)
+
+               IF (ncoi*ncoj > 0) THEN
+                  ALLOCATE (dij_contr(nsgfi(iset), nsgfj(jset)))
+                  ALLOCATE (dij(ncoi, ncoj, 3))
+                  dij(:, :, :) = 0.0_dp
+
+                  ri = 0.0_dp
+                  rj = rij
+
+                  CALL eri_2center_derivs(dij, lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), &
+                                          rpgf_i(:, iset), ri, lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), &
+                                          rpgf_j(:, jset), rj, dab, lib, potential_parameter)
+
+                  DO i_xyz = 1, 3
+
+                     dij_contr(:, :) = 0.0_dp
+                     CALL ab_contract(dij_contr, dij(:, :, i_xyz), &
+                                      sphi_i(:, sgfi:), sphi_j(:, sgfj:), &
+                                      ncoi, ncoj, nsgfi(iset), nsgfj(jset))
+
+                     force = SUM(pblock(sgfi:sgfi + nsgfi(iset) - 1, sgfj:sgfj + nsgfj(jset) - 1)*dij_contr(:, :))
+                     force = pref*force
+
+                     !iatom virial
+                     CALL real_to_scaled(scoord, particle_set(iatom)%r, cell)
+                     DO j_xyz = 1, 3
+                        work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + force*scoord(j_xyz)
+                     END DO
+
+                     !jatom virial
+                     CALL real_to_scaled(scoord, particle_set(iatom)%r + rij, cell)
+                     DO j_xyz = 1, 3
+                        work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) - force*scoord(j_xyz)
+                     END DO
+                  END DO
+
+                  DEALLOCATE (dij, dij_contr)
+               END IF
+            END DO
+         END DO
+      END DO
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+      CALL cp_libint_cleanup_2eri1(lib)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE calc_2c_virial
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -202,8 +202,7 @@ CONTAINS
                                                             t_3c_M_virt_tmp, t_dm, t_dm_tmp, t_P, &
                                                             t_P_tmp
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_dm_occ, t_dm_virt
-      TYPE(dbt_type), &
-         DIMENSION(SIZE(t_3c_O, 1), SIZE(t_3c_O, 2))     :: t_3c_O_occ, t_3c_O_virt
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_O_occ, t_3c_O_virt
       TYPE(mp_comm_type)                                 :: comm_2d
 
       CALL timeset(routineN, handle)
@@ -220,6 +219,7 @@ CONTAINS
       num_3c_repl = MAXVAL(cell_to_index_3c)
 
       first_cycle_im_time = .TRUE.
+      ALLOCATE (t_3c_O_occ(SIZE(t_3c_O, 1), SIZE(t_3c_O, 2)), t_3c_O_virt(SIZE(t_3c_O, 1), SIZE(t_3c_O, 2)))
       DO i = 1, SIZE(t_3c_O, 1)
          DO j = 1, SIZE(t_3c_O, 2)
             CALL dbt_create(t_3c_O(i, j), t_3c_O_occ(i, j))

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -147,8 +147,8 @@ MODULE rpa_im_time_force_methods
                                               qs_rho_type
    USE qs_tensors,                      ONLY: &
         build_2c_derivatives, build_2c_integrals, build_2c_neighbor_lists, build_3c_derivatives, &
-        build_3c_neighbor_lists, compress_tensor, decompress_tensor, get_tensor_occupancy, &
-        neighbor_list_3c_destroy
+        build_3c_neighbor_lists, calc_2c_virial, calc_3c_virial, compress_tensor, &
+        decompress_tensor, get_tensor_occupancy, neighbor_list_3c_destroy
    USE qs_tensors_types,                ONLY: create_2c_tensor,&
                                               create_3c_tensor,&
                                               create_tensor_batches,&
@@ -208,7 +208,7 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: pdims_t2c
       INTEGER, DIMENSION(3)                              :: nblks_total, pcoord, pdims, pdims_t3c
       INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
-      LOGICAL                                            :: do_periodic
+      LOGICAL                                            :: do_periodic, use_virial
       REAL(dp)                                           :: compression_factor, eps_pgf_orb, &
                                                             eps_pgf_orb_old, memory, occ
       TYPE(cell_type), POINTER                           :: cell
@@ -220,15 +220,15 @@ CONTAINS
       TYPE(dbcsr_type), DIMENSION(1, 3)                  :: t_2c_der_tmp
       TYPE(dbt_pgrid_type)                               :: pgrid_t2c, pgrid_t3c
       TYPE(dbt_type)                                     :: t_2c_template, t_2c_tmp, t_3c_template
-      TYPE(dbt_type), DIMENSION(1, 1, 3)                 :: t_3c_der_AO_prv, t_3c_der_RI_prv
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :, :)    :: t_3c_der_AO_prv, t_3c_der_RI_prv
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_2d_type), POINTER                :: dist_2d
-      TYPE(distribution_3d_type)                         :: dist_3d
+      TYPE(distribution_3d_type)                         :: dist_3d, dist_vir
       TYPE(gto_basis_set_p_type), ALLOCATABLE, &
          DIMENSION(:), TARGET                            :: basis_set_ao, basis_set_ri_aux
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
       TYPE(libint_potential_type)                        :: identity_pot
-      TYPE(mp_cart_type)                                 :: mp_comm_t3c
+      TYPE(mp_cart_type)                                 :: mp_comm_t3c, mp_comm_vir
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
@@ -237,17 +237,28 @@ CONTAINS
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: qs_section
+      TYPE(virial_type), POINTER                         :: virial
 
       NULLIFY (dft_control, para_env, particle_set, qs_kind_set, dist_2d, nl_2c, blacs_env, matrix_s, &
-               rho, rho_ao, cell, qs_section, orb_basis, ri_basis)
+               rho, rho_ao, cell, qs_section, orb_basis, ri_basis, virial)
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, natom=natom, nkind=nkind, dft_control=dft_control, para_env=para_env, &
-                      particle_set=particle_set, qs_kind_set=qs_kind_set, cell=cell)
+                      particle_set=particle_set, qs_kind_set=qs_kind_set, cell=cell, virial=virial)
       IF (dft_control%qs_control%gapw) THEN
          CPABORT("Low-scaling RPA/SOS-MP2 forces only available with GPW")
       END IF
+
+      use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
+
+      do_periodic = .FALSE.
+      IF (ANY(cell%perd == 1)) do_periodic = .TRUE.
+      force_data%do_periodic = do_periodic
+
+      !Dealing with the 3-center derivatives
+      pdims_t3c = 0
+      CALL dbt_pgrid_create(para_env, pdims_t3c, pgrid_t3c)
 
       !Make sure we use the proper QS EPS_PGF_ORB values
       qs_section => section_vals_get_subs_vals(qs_env%input, "DFT%QS")
@@ -259,14 +270,6 @@ CONTAINS
          eps_pgf_orb = SQRT(eps_pgf_orb)
       END IF
       eps_pgf_orb_old = dft_control%qs_control%eps_pgf_orb
-
-      do_periodic = .FALSE.
-      IF (ANY(cell%perd == 1)) do_periodic = .TRUE.
-      force_data%do_periodic = do_periodic
-
-      !Dealing with the 3-center derivatives
-      pdims_t3c = 0
-      CALL dbt_pgrid_create(para_env, pdims_t3c, pgrid_t3c)
 
       ALLOCATE (sizes_RI(natom), sizes_AO(natom))
       ALLOCATE (basis_set_ri_aux(nkind), basis_set_ao(nkind))
@@ -285,21 +288,39 @@ CONTAINS
       CALL create_3c_tensor(t_3c_template, dist_RI, dist_AO_1, dist_AO_2, pgrid_t3c, &
                             sizes_RI, sizes_AO, sizes_AO, map1=[1], map2=[2, 3], name="der (RI AO | AO)")
 
+      ALLOCATE (t_3c_der_RI_prv(1, 1, 3), t_3c_der_AO_prv(1, 1, 3))
       DO i_xyz = 1, 3
          CALL dbt_create(t_3c_template, t_3c_der_RI_prv(1, 1, i_xyz))
          CALL dbt_create(t_3c_template, t_3c_der_AO_prv(1, 1, i_xyz))
       END DO
+
+      IF (use_virial) THEN
+         ALLOCATE (force_data%t_3c_virial, force_data%t_3c_virial_split)
+         CALL dbt_create(t_3c_template, force_data%t_3c_virial)
+         CALL dbt_create(t_3c_M, force_data%t_3c_virial_split)
+      END IF
       CALL dbt_destroy(t_3c_template)
 
       CALL dbt_mp_environ_pgrid(pgrid_t3c, pdims, pcoord)
       CALL mp_comm_t3c%create(pgrid_t3c%mp_comm_2d, 3, pdims)
       CALL distribution_3d_create(dist_3d, dist_RI, dist_AO_1, dist_AO_2, &
                                   nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
-      DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
+
+      !In case of virial, we need to store the 3c_nl
+      IF (use_virial) THEN
+         ALLOCATE (force_data%nl_3c)
+         CALL mp_comm_vir%create(pgrid_t3c%mp_comm_2d, 3, pdims)
+         CALL distribution_3d_create(dist_vir, dist_RI, dist_AO_1, dist_AO_2, &
+                                     nkind, particle_set, mp_comm_vir, own_comm=.TRUE.)
+         CALL build_3c_neighbor_lists(force_data%nl_3c, basis_set_ri_aux, basis_set_ao, basis_set_ao, &
+                                      dist_vir, mp2_env%ri_metric, "RPA_3c_nl", qs_env, op_pos=1, &
+                                      sym_jk=.FALSE., own_dist=.TRUE.)
+      END IF
 
       CALL build_3c_neighbor_lists(nl_3c, basis_set_ri_aux, basis_set_ao, basis_set_ao, dist_3d, &
                                    mp2_env%ri_metric, "RPA_3c_nl", qs_env, op_pos=1, sym_jk=.TRUE., &
                                    own_dist=.TRUE.)
+      DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
 
       !Prepare the resulting 3c tensors in the format of t_3c_M for compatible traces: (RI|AO AO), split blocks
       CALL dbt_get_info(t_3c_M, nblks_total=nblks_total)
@@ -390,6 +411,14 @@ CONTAINS
                            dbcsr_type_antisymmetric, row_bsize, col_bsize)
       END DO
 
+      IF (use_virial) THEN
+         ALLOCATE (force_data%RI_virial_pot, force_data%RI_virial_met)
+         CALL dbcsr_create(force_data%RI_virial_pot, "RI_virial", dbcsr_dist, &
+                           dbcsr_type_no_symmetry, row_bsize, col_bsize)
+         CALL dbcsr_create(force_data%RI_virial_met, "RI_virial", dbcsr_dist, &
+                           dbcsr_type_no_symmetry, row_bsize, col_bsize)
+      END IF
+
       ! Main (P|Q) integrals and derivatives
       ! Integrals are passed as a full matrix => convert to DBCSR
       CALL dbcsr_create(dbcsr_work, template=t_2c_int_tmp(1))
@@ -435,6 +464,12 @@ CONTAINS
             CALL dbt_destroy(t_2c_tmp)
             CALL dbcsr_clear(t_2c_der_tmp(1, i_xyz))
          END DO
+
+         IF (use_virial) THEN
+            CALL build_2c_neighbor_lists(force_data%nl_2c_pot, basis_set_ri_aux, basis_set_ri_aux, &
+                                         mp2_env%potential_parameter, "RPA_2c_nl_pot", qs_env, &
+                                         sym_ij=.FALSE., dist_2d=dist_2d)
+         END IF
       END IF
       ! Create a G_PQ matrix to collect the terms for the force trace in the periodic case
       CALL dbcsr_create(force_data%G_PQ, "G_PQ", dbcsr_dist, dbcsr_type_no_symmetry, row_bsize, col_bsize)
@@ -447,6 +482,12 @@ CONTAINS
       CALL build_2c_derivatives(t_2c_der_tmp, mp2_env%ri_rpa_im_time%eps_filter, qs_env, nl_2c, &
                                 basis_set_ri_aux, basis_set_ri_aux, mp2_env%ri_metric)
       CALL release_neighbor_list_sets(nl_2c)
+
+      IF (use_virial) THEN
+         CALL build_2c_neighbor_lists(force_data%nl_2c_met, basis_set_ri_aux, basis_set_ri_aux, &
+                                      mp2_env%ri_metric, "RPA_2c_nl_metric", qs_env, sym_ij=.FALSE., &
+                                      dist_2d=dist_2d)
+      END IF
 
       CALL dbcsr_copy(dbcsr_work, t_2c_int_tmp(1))
       CALL cp_dbcsr_cholesky_decompose(dbcsr_work, para_env=para_env, blacs_env=blacs_env)
@@ -508,6 +549,11 @@ CONTAINS
       CALL build_2c_derivatives(t_2c_der_tmp, mp2_env%ri_rpa_im_time%eps_filter, qs_env, nl_2c, &
                                 basis_set_ao, basis_set_ao, identity_pot)
       CALL release_neighbor_list_sets(nl_2c)
+
+      IF (use_virial) THEN
+         CALL build_2c_neighbor_lists(force_data%nl_2c_ovlp, basis_set_ao, basis_set_ao, identity_pot, &
+                                      "RPA_2c_nl_metric", qs_env, sym_ij=.FALSE., dist_2d=dist_2d)
+      END IF
 
       CALL dbcsr_create(force_data%inv_ovlp, template=matrix_s(1)%matrix)
       CALL dbcsr_copy(force_data%inv_ovlp, matrix_s(1)%matrix)
@@ -648,9 +694,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_laplace_loop_forces'
 
-      INTEGER                                            :: dummy_int, handle, handle2, i_mem, &
-                                                            i_xyz, ispin, j_xyz, jquad, k_xyz, &
-                                                            n_mem_RI, natom, nspins, unit_nr_dbcsr
+      INTEGER :: dummy_int, handle, handle2, i_mem, i_xyz, ibasis, ispin, j_xyz, jquad, k_xyz, &
+         n_mem_RI, n_rep, natom, nkind, nspins, unit_nr_dbcsr
       INTEGER(int_8)                                     :: flop, nze, nze_ddint, nze_der_AO, &
                                                             nze_der_RI, nze_KQK
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, batch_blk_end, &
@@ -659,7 +704,8 @@ CONTAINS
                                                             mc_ranges_RI
       INTEGER, DIMENSION(:, :), POINTER                  :: dummy_ptr
       LOGICAL                                            :: memory_info, use_virial
-      REAL(dp)                                           :: eps_filter, fac, occ, occ_ddint, &
+      REAL(dp)                                           :: eps_filter, eps_pgf_orb, &
+                                                            eps_pgf_orb_old, fac, occ, occ_ddint, &
                                                             occ_der_AO, occ_der_RI, occ_KQK, &
                                                             omega, pref, t1, t2, tau
       REAL(dp), DIMENSION(3, 3)                          :: work_virial, work_virial_ovlp
@@ -668,26 +714,34 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ, mat_dm_virt
       TYPE(dbcsr_type)                                   :: dbcsr_work1, dbcsr_work2, dbcsr_work3, &
-                                                            exp_occ, exp_virt, R_occ, R_virt, Y_1, &
-                                                            Y_2
+                                                            exp_occ, exp_virt, R_occ, R_virt, &
+                                                            virial_ovlp, Y_1, Y_2
       TYPE(dbt_type) :: t_2c_AO, t_2c_RI, t_2c_RI_2, t_2c_tmp, t_3c_0, t_3c_1, t_3c_3, t_3c_4, &
          t_3c_5, t_3c_6, t_3c_7, t_3c_8, t_3c_help_1, t_3c_help_2, t_3c_ints, t_3c_sparse, &
          t_3c_work, t_dm_occ, t_dm_virt, t_KQKT, t_M_occ, t_M_virt, t_Q, t_R_occ, t_R_virt
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_P
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_ao, basis_set_ri_aux
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
+      TYPE(libint_potential_type)                        :: identity_pot
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(section_vals_type), POINTER                   :: qs_section
       TYPE(virial_type), POINTER                         :: virial
 
       NULLIFY (matrix_s, dummy_ptr, atomic_kind_set, force, matrix_s, matrix_ks, mat_dm_occ, mat_dm_virt)
-      NULLIFY (dft_control, virial, particle_set, cell, para_env)
+      NULLIFY (dft_control, virial, particle_set, cell, para_env, orb_basis, ri_basis, qs_section)
+      NULLIFY (qs_kind_set)
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, matrix_s=matrix_s, natom=natom, atomic_kind_set=atomic_kind_set, &
                       force=force, matrix_ks=matrix_ks, dft_control=dft_control, virial=virial, &
-                      particle_set=particle_set, cell=cell, para_env=para_env)
+                      particle_set=particle_set, cell=cell, para_env=para_env, nkind=nkind, &
+                      qs_kind_set=qs_kind_set)
       eps_filter = mp2_env%ri_rpa_im_time%eps_filter
       nspins = dft_control%nspins
 
@@ -701,6 +755,29 @@ CONTAINS
       use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
 
       IF (use_virial) virial%pv_calculate = .TRUE.
+
+      IF (use_virial) THEN
+         qs_section => section_vals_get_subs_vals(qs_env%input, "DFT%QS")
+         CALL section_vals_val_get(qs_section, "EPS_PGF_ORB", n_rep_val=n_rep)
+         IF (n_rep /= 0) THEN
+            CALL section_vals_val_get(qs_section, "EPS_PGF_ORB", r_val=eps_pgf_orb)
+         ELSE
+            CALL section_vals_val_get(qs_section, "EPS_DEFAULT", r_val=eps_pgf_orb)
+            eps_pgf_orb = SQRT(eps_pgf_orb)
+         END IF
+         eps_pgf_orb_old = dft_control%qs_control%eps_pgf_orb
+
+         ALLOCATE (basis_set_ri_aux(nkind), basis_set_ao(nkind))
+         CALL basis_set_list_setup(basis_set_ri_aux, "RI_AUX", qs_kind_set)
+         CALL basis_set_list_setup(basis_set_ao, "ORB", qs_kind_set)
+
+         DO ibasis = 1, SIZE(basis_set_ao)
+            orb_basis => basis_set_ao(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(orb_basis, eps_pgf_orb)
+            ri_basis => basis_set_ri_aux(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(ri_basis, eps_pgf_orb)
+         END DO
+      END IF
 
       !We follow the general logic of the compute_mat_P_omega routine
       ALLOCATE (t_P(nspins))
@@ -787,6 +864,7 @@ CONTAINS
       CALL dbcsr_create(dbcsr_work3, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(exp_occ, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(exp_virt, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
+      IF (use_virial) CALL dbcsr_create(virial_ovlp, template=dbcsr_work1)
 
       CALL dbt_batched_contract_init(t_3c_0, batch_range_2=mc_ranges, batch_range_3=mc_ranges)
       CALL dbt_batched_contract_init(t_3c_1, batch_range_2=mc_ranges, batch_range_3=mc_ranges)
@@ -810,14 +888,14 @@ CONTAINS
       CALL dbt_batched_contract_init(t_3c_sparse, batch_range_1=mc_ranges_RI, batch_range_2=mc_ranges, &
                                      batch_range_3=mc_ranges)
 
+      work_virial = 0.0_dp
+      work_virial_ovlp = 0.0_dp
       DO jquad = 1, num_integ_points
          tau = tau_tj(jquad)
          omega = tau_wj(jquad)
          fac = -2.0_dp*omega*mp2_env%scale_S
          IF (open_shell) fac = 0.5_dp*fac
          occ_ddint = 0; nze_ddint = 0
-         work_virial = 0.0_dp
-         work_virial_ovlp = 0.0_dp
 
          CALL para_env%sync()
          t1 = m_walltime()
@@ -847,9 +925,8 @@ CONTAINS
          dbcsr_nflop = dbcsr_nflop + flop
          CALL dbt_clear(t_2c_RI)
 
-         CALL perform_2c_ops(force, work_virial, t_KQKT, force_data, fac, t_Q, t_P(Pspin), t_2c_RI, &
-                             t_2c_RI_2, use_virial, cell, particle_set, atom_of_kind, kind_of, &
-                             eps_filter, dbcsr_nflop, unit_nr_dbcsr)
+         CALL perform_2c_ops(force, t_KQKT, force_data, fac, t_Q, t_P(Pspin), t_2c_RI, t_2c_RI_2, &
+                             use_virial, atom_of_kind, kind_of, eps_filter, dbcsr_nflop, unit_nr_dbcsr)
          CALL get_tensor_occupancy(t_KQKT, nze_KQK, occ_KQK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
@@ -873,11 +950,11 @@ CONTAINS
          CALL dbt_destroy(t_2c_tmp)
 
          !Deal with the 3-center quantities.
-         CALL perform_3c_ops(force, work_virial, t_R_occ, t_R_virt, force_data, fac, cut_memory, n_mem_RI, &
+         CALL perform_3c_ops(force, t_R_occ, t_R_virt, force_data, fac, cut_memory, n_mem_RI, &
                              t_KQKT, t_dm_occ, t_dm_virt, t_3c_O, t_3c_M, t_M_occ, t_M_virt, t_3c_0, t_3c_1, &
                              t_3c_3, t_3c_4, t_3c_5, t_3c_6, t_3c_7, t_3c_8, t_3c_sparse, t_3c_help_1, t_3c_help_2, &
                              t_3c_ints, t_3c_work, starts_array_mc, ends_array_mc, batch_start_RI, &
-                             batch_end_RI, t_3c_O_compressed, t_3c_O_ind, use_virial, cell, particle_set, &
+                             batch_end_RI, t_3c_O_compressed, t_3c_O_ind, use_virial, &
                              atom_of_kind, kind_of, eps_filter, occ_ddint, nze_ddint, dbcsr_nflop, &
                              unit_nr_dbcsr, mp2_env)
 
@@ -918,14 +995,10 @@ CONTAINS
          CALL dbt_copy(t_2c_tmp, t_2c_AO, move_data=.TRUE.)
 
          pref = -1.0_dp*fac
-         IF (use_virial) THEN
-            CALL get_2c_der_force(force, t_2c_AO, force_data%t_2c_der_ovlp, atom_of_kind, &
-                                  kind_of, force_data%idx_to_at_AO, pref, work_virial_ovlp, cell, &
-                                  particle_set, do_ovlp=.TRUE.)
-         ELSE
-            CALL get_2c_der_force(force, t_2c_AO, force_data%t_2c_der_ovlp, atom_of_kind, &
-                                  kind_of, force_data%idx_to_at_AO, pref, do_ovlp=.TRUE.)
-         END IF
+         CALL get_2c_der_force(force, t_2c_AO, force_data%t_2c_der_ovlp, atom_of_kind, &
+                               kind_of, force_data%idx_to_at_AO, pref, do_ovlp=.TRUE.)
+
+         IF (use_virial) CALL dbcsr_add(virial_ovlp, dbcsr_work2, 1.0_dp, pref)
 
          !The final contribution from Tr[(tau*Y_1*P_occ - tau*Y_2*P_virt) * der_F]
          CALL dbcsr_multiply('N', 'N', tau*fac, Y_1, force_data%P_occ(Pspin)%matrix, 1.0_dp, &
@@ -945,22 +1018,6 @@ CONTAINS
                              force_data%sum_O_tau(Pspin)%matrix, retain_sparsity=.TRUE.)
 
          CALL timestop(handle2)
-
-         IF (use_virial) THEN
-            DO k_xyz = 1, 3
-               DO j_xyz = 1, 3
-                  DO i_xyz = 1, 3
-                     virial%pv_mp2(i_xyz, j_xyz) = virial%pv_mp2(i_xyz, j_xyz) &
-                                                   - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
-                     virial%pv_overlap(i_xyz, j_xyz) = virial%pv_overlap(i_xyz, j_xyz) &
-                                                       - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
-                     virial%pv_virial(i_xyz, j_xyz) = virial%pv_virial(i_xyz, j_xyz) &
-                                                      - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz) &
-                                                      - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
-                  END DO
-               END DO
-            END DO
-         END IF
 
          !Print some info
          CALL para_env%sync()
@@ -1005,6 +1062,43 @@ CONTAINS
       CALL dbt_batched_contract_finalize(t_3c_8)
       CALL dbt_batched_contract_finalize(t_3c_sparse)
 
+      !Calculate the 2c and 3c contributions to the virial
+      IF (use_virial) THEN
+         CALL dbt_copy(force_data%t_3c_virial_split, force_data%t_3c_virial, move_data=.TRUE.)
+         CALL calc_3c_virial(work_virial, force_data%t_3c_virial, 1.0_dp, qs_env, force_data%nl_3c, &
+                             basis_set_ri_aux, basis_set_ao, basis_set_ao, mp2_env%ri_metric, &
+                             der_eps=mp2_env%ri_rpa_im_time%eps_filter, op_pos=1)
+
+         CALL calc_2c_virial(work_virial, force_data%RI_virial_met, 1.0_dp, qs_env, force_data%nl_2c_met, &
+                             basis_set_ri_aux, basis_set_ri_aux, mp2_env%ri_metric)
+         CALL dbcsr_clear(force_data%RI_virial_met)
+
+         IF (.NOT. force_data%do_periodic) THEN
+            CALL calc_2c_virial(work_virial, force_data%RI_virial_pot, 1.0_dp, qs_env, force_data%nl_2c_pot, &
+                                basis_set_ri_aux, basis_set_ri_aux, mp2_env%potential_parameter)
+            CALL dbcsr_clear(force_data%RI_virial_pot)
+         END IF
+
+         identity_pot%potential_type = do_potential_id
+         CALL calc_2c_virial(work_virial_ovlp, virial_ovlp, 1.0_dp, qs_env, force_data%nl_2c_ovlp, &
+                             basis_set_ao, basis_set_ao, identity_pot)
+         CALL dbcsr_release(virial_ovlp)
+
+         DO k_xyz = 1, 3
+            DO j_xyz = 1, 3
+               DO i_xyz = 1, 3
+                  virial%pv_mp2(i_xyz, j_xyz) = virial%pv_mp2(i_xyz, j_xyz) &
+                                                - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
+                  virial%pv_overlap(i_xyz, j_xyz) = virial%pv_overlap(i_xyz, j_xyz) &
+                                                    - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
+                  virial%pv_virial(i_xyz, j_xyz) = virial%pv_virial(i_xyz, j_xyz) &
+                                                   - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz) &
+                                                   - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
+               END DO
+            END DO
+         END DO
+      END IF
+
       !Calculate the periodic contributions of (P|Q) to the force and the virial
       work_virial = 0.0_dp
       IF (force_data%do_periodic) THEN
@@ -1023,6 +1117,13 @@ CONTAINS
          virial%pv_mp2 = virial%pv_mp2 + work_virial
          virial%pv_virial = virial%pv_virial + work_virial
          virial%pv_calculate = .FALSE.
+
+         DO ibasis = 1, SIZE(basis_set_ao)
+            orb_basis => basis_set_ao(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(orb_basis, eps_pgf_orb_old)
+            ri_basis => basis_set_ri_aux(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(ri_basis, eps_pgf_orb_old)
+         END DO
       END IF
 
       !clean-up
@@ -1148,9 +1249,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_rpa_loop_forces'
 
-      INTEGER                                            :: dummy_int, handle, handle2, i_mem, &
-                                                            i_xyz, iquad, j_xyz, jquad, k_xyz, &
-                                                            n_mem_RI, natom, nspins, unit_nr_dbcsr
+      INTEGER :: dummy_int, handle, handle2, i_mem, i_xyz, ibasis, iquad, j_xyz, jquad, k_xyz, &
+         n_mem_RI, n_rep, natom, nkind, nspins, unit_nr_dbcsr
       INTEGER(int_8)                                     :: flop, nze, nze_ddint, nze_der_AO, &
                                                             nze_der_RI, nze_KBK
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, batch_blk_end, &
@@ -1159,10 +1259,8 @@ CONTAINS
                                                             mc_ranges_RI
       INTEGER, DIMENSION(:, :), POINTER                  :: dummy_ptr
       LOGICAL                                            :: memory_info, use_virial
-      REAL(dp)                                           :: eps_filter, fac, occ, occ_ddint, &
-                                                            occ_der_AO, occ_der_RI, occ_KBK, &
-                                                            omega, pref, spin_fac, t1, t2, tau, &
-                                                            weight
+      REAL(dp) :: eps_filter, eps_pgf_orb, eps_pgf_orb_old, fac, occ, occ_ddint, occ_der_AO, &
+         occ_der_RI, occ_KBK, omega, pref, spin_fac, t1, t2, tau, weight
       REAL(dp), DIMENSION(3, 3)                          :: work_virial, work_virial_ovlp
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
@@ -1171,25 +1269,33 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ, mat_dm_virt
       TYPE(dbcsr_type)                                   :: dbcsr_work1, dbcsr_work2, dbcsr_work3, &
                                                             dbcsr_work_symm, exp_occ, exp_virt, &
-                                                            R_occ, R_virt, Y_1, Y_2
+                                                            R_occ, R_virt, virial_ovlp, Y_1, Y_2
       TYPE(dbt_type) :: t_2c_AO, t_2c_RI, t_2c_RI_2, t_2c_tmp, t_3c_0, t_3c_1, t_3c_3, t_3c_4, &
          t_3c_5, t_3c_6, t_3c_7, t_3c_8, t_3c_help_1, t_3c_help_2, t_3c_ints, t_3c_sparse, &
          t_3c_work, t_dm_occ, t_dm_virt, t_KBKT, t_M_occ, t_M_virt, t_P, t_R_occ, t_R_virt
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_B
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_ao, basis_set_ri_aux
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
+      TYPE(libint_potential_type)                        :: identity_pot
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(section_vals_type), POINTER                   :: qs_section
       TYPE(virial_type), POINTER                         :: virial
 
       NULLIFY (matrix_s, dummy_ptr, atomic_kind_set, force, matrix_s, matrix_ks, mat_dm_occ, mat_dm_virt)
-      NULLIFY (dft_control, virial, particle_set, cell, blacs_env, para_env)
+      NULLIFY (dft_control, virial, particle_set, cell, blacs_env, para_env, orb_basis, ri_basis)
+      NULLIFY (qs_kind_set)
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, matrix_s=matrix_s, natom=natom, atomic_kind_set=atomic_kind_set, &
                       force=force, matrix_ks=matrix_ks, dft_control=dft_control, virial=virial, &
-                      particle_set=particle_set, cell=cell, blacs_env=blacs_env, para_env=para_env)
+                      particle_set=particle_set, cell=cell, blacs_env=blacs_env, para_env=para_env, &
+                      qs_kind_set=qs_kind_set, nkind=nkind)
       eps_filter = mp2_env%ri_rpa_im_time%eps_filter
       nspins = dft_control%nspins
 
@@ -1203,6 +1309,29 @@ CONTAINS
       use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
 
       IF (use_virial) virial%pv_calculate = .TRUE.
+
+      IF (use_virial) THEN
+         qs_section => section_vals_get_subs_vals(qs_env%input, "DFT%QS")
+         CALL section_vals_val_get(qs_section, "EPS_PGF_ORB", n_rep_val=n_rep)
+         IF (n_rep /= 0) THEN
+            CALL section_vals_val_get(qs_section, "EPS_PGF_ORB", r_val=eps_pgf_orb)
+         ELSE
+            CALL section_vals_val_get(qs_section, "EPS_DEFAULT", r_val=eps_pgf_orb)
+            eps_pgf_orb = SQRT(eps_pgf_orb)
+         END IF
+         eps_pgf_orb_old = dft_control%qs_control%eps_pgf_orb
+
+         ALLOCATE (basis_set_ri_aux(nkind), basis_set_ao(nkind))
+         CALL basis_set_list_setup(basis_set_ri_aux, "RI_AUX", qs_kind_set)
+         CALL basis_set_list_setup(basis_set_ao, "ORB", qs_kind_set)
+
+         DO ibasis = 1, SIZE(basis_set_ao)
+            orb_basis => basis_set_ao(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(orb_basis, eps_pgf_orb)
+            ri_basis => basis_set_ri_aux(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(ri_basis, eps_pgf_orb)
+         END DO
+      END IF
 
       !We follow the general logic of the compute_mat_P_omega routine
       CALL dbt_create(force_data%t_2c_K, t_2c_RI)
@@ -1363,6 +1492,7 @@ CONTAINS
       CALL dbcsr_create(dbcsr_work3, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(exp_occ, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(exp_virt, template=matrix_s(1)%matrix, matrix_type=dbcsr_type_no_symmetry)
+      IF (use_virial) CALL dbcsr_create(virial_ovlp, template=dbcsr_work1)
 
       CALL dbt_batched_contract_init(t_3c_0, batch_range_2=mc_ranges, batch_range_3=mc_ranges)
       CALL dbt_batched_contract_init(t_3c_1, batch_range_2=mc_ranges, batch_range_3=mc_ranges)
@@ -1389,11 +1519,11 @@ CONTAINS
       fac = 1.0_dp/fourpi*mp2_env%ri_rpa%scale_rpa
       IF (open_shell) fac = 0.5_dp*fac
 
+      work_virial = 0.0_dp
+      work_virial_ovlp = 0.0_dp
       DO jquad = 1, num_integ_points
          tau = tau_tj(jquad)
          occ_ddint = 0; nze_ddint = 0
-         work_virial = 0.0_dp
-         work_virial_ovlp = 0.0_dp
 
          CALL para_env%sync()
          t1 = m_walltime()
@@ -1406,9 +1536,8 @@ CONTAINS
          CALL dbt_filter(t_P, eps_filter)
          CALL dbt_destroy(t_2c_tmp)
 
-         CALL perform_2c_ops(force, work_virial, t_KBKT, force_data, fac, t_B(jquad), t_P, t_2c_RI, &
-                             t_2c_RI_2, use_virial, cell, particle_set, atom_of_kind, kind_of, &
-                             eps_filter, dbcsr_nflop, unit_nr_dbcsr)
+         CALL perform_2c_ops(force, t_KBKT, force_data, fac, t_B(jquad), t_P, t_2c_RI, t_2c_RI_2, &
+                             use_virial, atom_of_kind, kind_of, eps_filter, dbcsr_nflop, unit_nr_dbcsr)
          CALL get_tensor_occupancy(t_KBKT, nze_KBK, occ_KBK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
@@ -1432,11 +1561,11 @@ CONTAINS
          CALL dbt_destroy(t_2c_tmp)
 
          !Deal with the 3-center quantities.
-         CALL perform_3c_ops(force, work_virial, t_R_occ, t_R_virt, force_data, fac, cut_memory, n_mem_RI, &
+         CALL perform_3c_ops(force, t_R_occ, t_R_virt, force_data, fac, cut_memory, n_mem_RI, &
                              t_KBKT, t_dm_occ, t_dm_virt, t_3c_O, t_3c_M, t_M_occ, t_M_virt, t_3c_0, t_3c_1, &
                              t_3c_3, t_3c_4, t_3c_5, t_3c_6, t_3c_7, t_3c_8, t_3c_sparse, t_3c_help_1, t_3c_help_2, &
                              t_3c_ints, t_3c_work, starts_array_mc, ends_array_mc, batch_start_RI, &
-                             batch_end_RI, t_3c_O_compressed, t_3c_O_ind, use_virial, cell, particle_set, &
+                             batch_end_RI, t_3c_O_compressed, t_3c_O_ind, use_virial, &
                              atom_of_kind, kind_of, eps_filter, occ_ddint, nze_ddint, dbcsr_nflop, &
                              unit_nr_dbcsr, mp2_env)
 
@@ -1481,14 +1610,10 @@ CONTAINS
          CALL dbt_copy(t_2c_tmp, t_2c_AO, move_data=.TRUE.)
 
          pref = -1.0_dp*fac
-         IF (use_virial) THEN
-            CALL get_2c_der_force(force, t_2c_AO, force_data%t_2c_der_ovlp, atom_of_kind, &
-                                  kind_of, force_data%idx_to_at_AO, pref, work_virial_ovlp, cell, &
-                                  particle_set, do_ovlp=.TRUE.)
-         ELSE
-            CALL get_2c_der_force(force, t_2c_AO, force_data%t_2c_der_ovlp, atom_of_kind, &
-                                  kind_of, force_data%idx_to_at_AO, pref, do_ovlp=.TRUE.)
-         END IF
+         CALL get_2c_der_force(force, t_2c_AO, force_data%t_2c_der_ovlp, atom_of_kind, &
+                               kind_of, force_data%idx_to_at_AO, pref, do_ovlp=.TRUE.)
+
+         IF (use_virial) CALL dbcsr_add(virial_ovlp, dbcsr_work2, 1.0_dp, pref)
 
          !The final contribution from Tr[(tau*Y_1*P_occ - tau*Y_2*P_virt) * der_F]
          CALL dbcsr_multiply('N', 'N', fac*tau, Y_1, force_data%P_occ(ispin)%matrix, 1.0_dp, &
@@ -1509,22 +1634,6 @@ CONTAINS
                              force_data%sum_O_tau(ispin)%matrix, retain_sparsity=.TRUE.)
 
          CALL timestop(handle2)
-
-         IF (use_virial) THEN
-            DO k_xyz = 1, 3
-               DO j_xyz = 1, 3
-                  DO i_xyz = 1, 3
-                     virial%pv_mp2(i_xyz, j_xyz) = virial%pv_mp2(i_xyz, j_xyz) &
-                                                   - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
-                     virial%pv_overlap(i_xyz, j_xyz) = virial%pv_overlap(i_xyz, j_xyz) &
-                                                       - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
-                     virial%pv_virial(i_xyz, j_xyz) = virial%pv_virial(i_xyz, j_xyz) &
-                                                      - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz) &
-                                                      - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
-                  END DO
-               END DO
-            END DO
-         END IF
 
          !Print some info
          CALL para_env%sync()
@@ -1570,6 +1679,43 @@ CONTAINS
       CALL dbt_batched_contract_finalize(t_3c_8)
       CALL dbt_batched_contract_finalize(t_3c_sparse)
 
+      !Calculate the 2c and 3c contributions to the virial
+      IF (use_virial) THEN
+         CALL dbt_copy(force_data%t_3c_virial_split, force_data%t_3c_virial, move_data=.TRUE.)
+         CALL calc_3c_virial(work_virial, force_data%t_3c_virial, 1.0_dp, qs_env, force_data%nl_3c, &
+                             basis_set_ri_aux, basis_set_ao, basis_set_ao, mp2_env%ri_metric, &
+                             der_eps=mp2_env%ri_rpa_im_time%eps_filter, op_pos=1)
+
+         CALL calc_2c_virial(work_virial, force_data%RI_virial_met, 1.0_dp, qs_env, force_data%nl_2c_met, &
+                             basis_set_ri_aux, basis_set_ri_aux, mp2_env%ri_metric)
+         CALL dbcsr_clear(force_data%RI_virial_met)
+
+         IF (.NOT. force_data%do_periodic) THEN
+            CALL calc_2c_virial(work_virial, force_data%RI_virial_pot, 1.0_dp, qs_env, force_data%nl_2c_pot, &
+                                basis_set_ri_aux, basis_set_ri_aux, mp2_env%potential_parameter)
+            CALL dbcsr_clear(force_data%RI_virial_pot)
+         END IF
+
+         identity_pot%potential_type = do_potential_id
+         CALL calc_2c_virial(work_virial_ovlp, virial_ovlp, 1.0_dp, qs_env, force_data%nl_2c_ovlp, &
+                             basis_set_ao, basis_set_ao, identity_pot)
+         CALL dbcsr_release(virial_ovlp)
+
+         DO k_xyz = 1, 3
+            DO j_xyz = 1, 3
+               DO i_xyz = 1, 3
+                  virial%pv_mp2(i_xyz, j_xyz) = virial%pv_mp2(i_xyz, j_xyz) &
+                                                - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
+                  virial%pv_overlap(i_xyz, j_xyz) = virial%pv_overlap(i_xyz, j_xyz) &
+                                                    - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
+                  virial%pv_virial(i_xyz, j_xyz) = virial%pv_virial(i_xyz, j_xyz) &
+                                                   - work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz) &
+                                                   - work_virial_ovlp(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
+               END DO
+            END DO
+         END DO
+      END IF
+
       !Calculate the periodic contributions of (P|Q) to the force and the virial
       work_virial = 0.0_dp
       IF (force_data%do_periodic) THEN
@@ -1588,6 +1734,13 @@ CONTAINS
          virial%pv_mp2 = virial%pv_mp2 + work_virial
          virial%pv_virial = virial%pv_virial + work_virial
          virial%pv_calculate = .FALSE.
+
+         DO ibasis = 1, SIZE(basis_set_ao)
+            orb_basis => basis_set_ao(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(orb_basis, eps_pgf_orb_old)
+            ri_basis => basis_set_ri_aux(ibasis)%gto_basis_set
+            CALL init_interaction_radii_orb_basis(ri_basis, eps_pgf_orb_old)
+         END DO
       END IF
 
       !clean-up
@@ -1640,7 +1793,6 @@ CONTAINS
 !> \brief This subroutines performs the 2c tensor operations that are common accros low-scaling RPA
 !>        and SOS-MP2, including forces and virial
 !> \param force ...
-!> \param work_virial ...
 !> \param t_KBKT returns the 2c tensor product of K*B*K^T
 !> \param force_data ...
 !> \param fac ...
@@ -1649,27 +1801,21 @@ CONTAINS
 !> \param t_2c_RI ...
 !> \param t_2c_RI_2 ...
 !> \param use_virial ...
-!> \param cell ...
-!> \param particle_set ...
 !> \param atom_of_kind ...
 !> \param kind_of ...
 !> \param eps_filter ...
 !> \param dbcsr_nflop ...
 !> \param unit_nr_dbcsr ...
 ! **************************************************************************************************
-   SUBROUTINE perform_2c_ops(force, work_virial, t_KBKT, force_data, fac, t_B, t_P, t_2c_RI, t_2c_RI_2, &
-                             use_virial, cell, particle_set, atom_of_kind, kind_of, eps_filter, &
-                             dbcsr_nflop, unit_nr_dbcsr)
+   SUBROUTINE perform_2c_ops(force, t_KBKT, force_data, fac, t_B, t_P, t_2c_RI, t_2c_RI_2, use_virial, &
+                             atom_of_kind, kind_of, eps_filter, dbcsr_nflop, unit_nr_dbcsr)
 
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
-      REAL(dp), DIMENSION(3, 3), INTENT(INOUT)           :: work_virial
       TYPE(dbt_type), INTENT(INOUT)                      :: t_KBKT
       TYPE(im_time_force_type), INTENT(INOUT)            :: force_data
       REAL(dp), INTENT(IN)                               :: fac
       TYPE(dbt_type), INTENT(INOUT)                      :: t_B, t_P, t_2c_RI, t_2c_RI_2
       LOGICAL, INTENT(IN)                                :: use_virial
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of
       REAL(dp), INTENT(IN)                               :: eps_filter
       INTEGER(int_8), INTENT(INOUT)                      :: dbcsr_nflop
@@ -1680,9 +1826,11 @@ CONTAINS
       INTEGER                                            :: handle
       INTEGER(int_8)                                     :: flop
       REAL(dp)                                           :: pref
-      TYPE(dbt_type)                                     :: t_2c_tmp
+      TYPE(dbt_type)                                     :: t_2c_tmp, t_2c_virial
 
       CALL timeset(routineN, handle)
+
+      IF (use_virial) CALL dbt_create(force_data%RI_virial_pot, t_2c_virial)
 
       !P^T*K*B + P*K*B^T (note we calculate and save K*B*K^T for later, and P=P^T)
       CALL dbt_contract(1.0_dp, force_data%t_2c_K, t_B, 0.0_dp, t_2c_RI, &
@@ -1725,13 +1873,13 @@ CONTAINS
 
       !Here we do the trace for the force
       pref = -1.0_dp*fac
+      CALL get_2c_der_force(force, t_2c_RI_2, force_data%t_2c_der_metric, atom_of_kind, &
+                            kind_of, force_data%idx_to_at_RI, pref, do_mp2=.TRUE.)
       IF (use_virial) THEN
-         CALL get_2c_der_force(force, t_2c_RI_2, force_data%t_2c_der_metric, atom_of_kind, &
-                               kind_of, force_data%idx_to_at_RI, pref, work_virial, cell, &
-                               particle_set, do_mp2=.TRUE.)
-      ELSE
-         CALL get_2c_der_force(force, t_2c_RI_2, force_data%t_2c_der_metric, atom_of_kind, &
-                               kind_of, force_data%idx_to_at_RI, pref, do_mp2=.TRUE.)
+         CALL dbt_copy(t_2c_RI_2, t_2c_virial)
+         CALL dbt_scale(t_2c_virial, pref)
+         CALL dbt_copy_tensor_to_matrix(t_2c_virial, force_data%RI_virial_met, summation=.TRUE.)
+         CALL dbt_clear(t_2c_virial)
       END IF
 
       !For the potential contribution, we need S^-1*(P^T*K*B + P*K*B^T)*V^-0.5
@@ -1752,18 +1900,21 @@ CONTAINS
          CALL dbt_copy_tensor_to_matrix(t_2c_tmp, force_data%G_PQ, summation=.TRUE.)
          CALL dbt_destroy(t_2c_tmp)
       ELSE
+         CALL get_2c_der_force(force, t_2c_RI_2, force_data%t_2c_der_pot, atom_of_kind, &
+                               kind_of, force_data%idx_to_at_RI, pref, do_mp2=.TRUE.)
+
          IF (use_virial) THEN
-            CALL get_2c_der_force(force, t_2c_RI_2, force_data%t_2c_der_pot, atom_of_kind, &
-                                  kind_of, force_data%idx_to_at_RI, pref, work_virial, cell, &
-                                  particle_set, do_mp2=.TRUE.)
-         ELSE
-            CALL get_2c_der_force(force, t_2c_RI_2, force_data%t_2c_der_pot, atom_of_kind, &
-                                  kind_of, force_data%idx_to_at_RI, pref, do_mp2=.TRUE.)
+            CALL dbt_copy(t_2c_RI_2, t_2c_virial)
+            CALL dbt_scale(t_2c_virial, pref)
+            CALL dbt_copy_tensor_to_matrix(t_2c_virial, force_data%RI_virial_pot, summation=.TRUE.)
+            CALL dbt_clear(t_2c_virial)
          END IF
       END IF
 
       CALL dbt_clear(t_2c_RI)
       CALL dbt_clear(t_2c_RI_2)
+
+      IF (use_virial) CALL dbt_destroy(t_2c_virial)
 
       CALL timestop(handle)
 
@@ -1773,7 +1924,6 @@ CONTAINS
 !> \brief This subroutines performs the 3c tensor operations that are common accros low-scaling RPA
 !>        and SOS-MP2, including forces and virial
 !> \param force ...
-!> \param work_virial ...
 !> \param t_R_occ ...
 !> \param t_R_virt ...
 !> \param force_data ...
@@ -1807,8 +1957,6 @@ CONTAINS
 !> \param t_3c_O_compressed ...
 !> \param t_3c_O_ind ...
 !> \param use_virial ...
-!> \param cell ...
-!> \param particle_set ...
 !> \param atom_of_kind ...
 !> \param kind_of ...
 !> \param eps_filter ...
@@ -1818,16 +1966,15 @@ CONTAINS
 !> \param unit_nr_dbcsr ...
 !> \param mp2_env ...
 ! **************************************************************************************************
-   SUBROUTINE perform_3c_ops(force, work_virial, t_R_occ, t_R_virt, force_data, fac, cut_memory, n_mem_RI, &
+   SUBROUTINE perform_3c_ops(force, t_R_occ, t_R_virt, force_data, fac, cut_memory, n_mem_RI, &
                              t_KBKT, t_dm_occ, t_dm_virt, t_3c_O, t_3c_M, t_M_occ, t_M_virt, t_3c_0, t_3c_1, &
                              t_3c_3, t_3c_4, t_3c_5, t_3c_6, t_3c_7, t_3c_8, t_3c_sparse, t_3c_help_1, t_3c_help_2, &
                              t_3c_ints, t_3c_work, starts_array_mc, ends_array_mc, batch_start_RI, &
-                             batch_end_RI, t_3c_O_compressed, t_3c_O_ind, use_virial, cell, particle_set, &
+                             batch_end_RI, t_3c_O_compressed, t_3c_O_ind, use_virial, &
                              atom_of_kind, kind_of, eps_filter, occ_ddint, nze_ddint, dbcsr_nflop, &
                              unit_nr_dbcsr, mp2_env)
 
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
-      REAL(dp), DIMENSION(3, 3), INTENT(INOUT)           :: work_virial
       TYPE(dbt_type), INTENT(INOUT)                      :: t_R_occ, t_R_virt
       TYPE(im_time_force_type), INTENT(INOUT)            :: force_data
       REAL(dp), INTENT(IN)                               :: fac
@@ -1840,8 +1987,6 @@ CONTAINS
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
       LOGICAL, INTENT(IN)                                :: use_virial
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of
       REAL(dp), INTENT(IN)                               :: eps_filter
       REAL(dp), INTENT(INOUT)                            :: occ_ddint
@@ -1996,7 +2141,7 @@ CONTAINS
                CALL dbt_contract(1.0_dp, t_KBKT, t_3c_6, 0.0_dp, t_3c_7, &
                                  contract_1=[2], notcontract_1=[1], &
                                  contract_2=[1], notcontract_2=[2, 3], &
-                                 map_1=[1], map_2=[2, 3], filter_eps=eps_filter, &
+                                 map_1=[1], map_2=[2, 3], &
                                  retain_sparsity=.TRUE., flop=flop, unit_nr=unit_nr_dbcsr)
                dbcsr_nflop = dbcsr_nflop + flop
                CALL timestop(handle2)
@@ -2009,53 +2154,34 @@ CONTAINS
          CALL dbt_copy(t_3c_8, t_3c_help_1, move_data=.TRUE.)
 
          pref = 1.0_dp*fac
+         DO k_mem = 1, cut_memory
+            DO i_xyz = 1, 3
+               CALL dbt_clear(force_data%t_3c_der_RI(i_xyz))
+               CALL decompress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(k_mem, i_xyz)%ind, &
+                                      force_data%t_3c_der_RI_comp(k_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            END DO
+            CALL get_force_from_3c_trace(force, t_3c_help_1, force_data%t_3c_der_RI, atom_of_kind, kind_of, &
+                                         force_data%idx_to_at_RI, pref, do_mp2=.TRUE., deriv_dim=1)
+         END DO
+
          IF (use_virial) THEN
-            DO k_mem = 1, cut_memory
-               DO i_xyz = 1, 3
-                  CALL dbt_clear(force_data%t_3c_der_RI(i_xyz))
-                  CALL decompress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(k_mem, i_xyz)%ind, &
-                                         force_data%t_3c_der_RI_comp(k_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
-               END DO
-               CALL get_force_from_3c_trace(force, t_3c_help_1, force_data%t_3c_der_RI, atom_of_kind, kind_of, &
-                                            force_data%idx_to_at_RI, pref, work_virial, cell, particle_set, &
-                                            do_mp2=.TRUE., deriv_dim=1)
-            END DO
-
             CALL dbt_copy(t_3c_help_1, t_3c_help_2)
-            CALL dbt_copy(t_3c_help_1, t_3c_help_2, order=[1, 3, 2], move_data=.TRUE., summation=.TRUE.)
-            DO k_mem = 1, cut_memory
-               DO i_xyz = 1, 3
-                  CALL dbt_clear(force_data%t_3c_der_AO(i_xyz))
-                  CALL decompress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(k_mem, i_xyz)%ind, &
-                                         force_data%t_3c_der_AO_comp(k_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
-               END DO
-               CALL get_force_from_3c_trace(force, t_3c_help_2, force_data%t_3c_der_AO, atom_of_kind, kind_of, &
-                                            force_data%idx_to_at_AO, pref, work_virial, cell, particle_set, &
-                                            do_mp2=.TRUE., deriv_dim=3)
-            END DO
-         ELSE
-            DO k_mem = 1, cut_memory
-               DO i_xyz = 1, 3
-                  CALL dbt_clear(force_data%t_3c_der_RI(i_xyz))
-                  CALL decompress_tensor(force_data%t_3c_der_RI(i_xyz), force_data%t_3c_der_RI_ind(k_mem, i_xyz)%ind, &
-                                         force_data%t_3c_der_RI_comp(k_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
-               END DO
-               CALL get_force_from_3c_trace(force, t_3c_help_1, force_data%t_3c_der_RI, atom_of_kind, kind_of, &
-                                            force_data%idx_to_at_RI, pref, do_mp2=.TRUE., deriv_dim=1)
-            END DO
-
-            CALL dbt_copy(t_3c_help_1, t_3c_help_2)
-            CALL dbt_copy(t_3c_help_1, t_3c_help_2, order=[1, 3, 2], move_data=.TRUE., summation=.TRUE.)
-            DO k_mem = 1, cut_memory
-               DO i_xyz = 1, 3
-                  CALL dbt_clear(force_data%t_3c_der_AO(i_xyz))
-                  CALL decompress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(k_mem, i_xyz)%ind, &
-                                         force_data%t_3c_der_AO_comp(k_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
-               END DO
-               CALL get_force_from_3c_trace(force, t_3c_help_2, force_data%t_3c_der_AO, atom_of_kind, kind_of, &
-                                            force_data%idx_to_at_AO, pref, do_mp2=.TRUE., deriv_dim=3)
-            END DO
+            CALL dbt_scale(t_3c_help_2, pref)
+            CALL dbt_copy(t_3c_help_2, force_data%t_3c_virial_split, summation=.TRUE., move_data=.TRUE.)
          END IF
+
+         CALL dbt_copy(t_3c_help_1, t_3c_help_2)
+         CALL dbt_copy(t_3c_help_1, t_3c_help_2, order=[1, 3, 2], move_data=.TRUE., summation=.TRUE.)
+         DO k_mem = 1, cut_memory
+            DO i_xyz = 1, 3
+               CALL dbt_clear(force_data%t_3c_der_AO(i_xyz))
+               CALL decompress_tensor(force_data%t_3c_der_AO(i_xyz), force_data%t_3c_der_AO_ind(k_mem, i_xyz)%ind, &
+                                      force_data%t_3c_der_AO_comp(k_mem, i_xyz), mp2_env%ri_rpa_im_time%eps_compress)
+            END DO
+            CALL get_force_from_3c_trace(force, t_3c_help_2, force_data%t_3c_der_AO, atom_of_kind, kind_of, &
+                                         force_data%idx_to_at_AO, pref, do_mp2=.TRUE., deriv_dim=3)
+         END DO
+
          CALL dbt_clear(t_3c_help_2)
       END DO !i_mem
       CALL dbt_batched_contract_finalize(t_KBKT)

--- a/src/rpa_im_time_force_types.F
+++ b/src/rpa_im_time_force_types.F
@@ -19,6 +19,10 @@ MODULE rpa_im_time_force_types
    USE hfx_types,                       ONLY: block_ind_type,&
                                               dealloc_containers,&
                                               hfx_compression_type
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type,&
+                                              release_neighbor_list_sets
+   USE qs_tensors,                      ONLY: neighbor_list_3c_destroy
+   USE qs_tensors_types,                ONLY: neighbor_list_3c_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -64,6 +68,16 @@ MODULE rpa_im_time_force_types
 
       !Is it a periodic calculation
       LOGICAL :: do_periodic
+
+      !Necessary stuff for the on-the fly calculation of the virial
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), POINTER :: nl_2c_ovlp => Null(), &
+                                                               nl_2c_met => Null(), &
+                                                               nl_2c_pot => Null()
+      TYPE(neighbor_list_3c_type), POINTER                  :: nl_3c => Null()
+      TYPE(dbcsr_type), POINTER                             :: RI_virial_pot => Null(), &
+                                                               RI_virial_met => Null()
+      TYPE(dbt_type), POINTER                               :: t_3c_virial => Null(), &
+                                                               t_3c_virial_split => Null()
 
    END TYPE im_time_force_type
 
@@ -114,6 +128,43 @@ CONTAINS
          END DO
       END DO
       DEALLOCATE (force_data%t_3c_der_AO_ind, force_data%t_3c_der_RI_ind)
+
+      IF (ASSOCIATED(force_data%nl_2c_ovlp)) THEN
+         CALL release_neighbor_list_sets(force_data%nl_2c_ovlp)
+      END IF
+
+      IF (ASSOCIATED(force_data%nl_2c_pot)) THEN
+         CALL release_neighbor_list_sets(force_data%nl_2c_pot)
+      END IF
+
+      IF (ASSOCIATED(force_data%nl_2c_met)) THEN
+         CALL release_neighbor_list_sets(force_data%nl_2c_met)
+      END IF
+
+      IF (ASSOCIATED(force_data%nl_3c)) THEN
+         CALL neighbor_list_3c_destroy(force_data%nl_3c)
+         DEALLOCATE (force_data%nl_3c)
+      END IF
+
+      IF (ASSOCIATED(force_data%RI_virial_pot)) THEN
+         CALL dbcsr_release(force_data%RI_virial_pot)
+         DEALLOCATE (force_data%RI_virial_pot)
+      END IF
+
+      IF (ASSOCIATED(force_data%RI_virial_met)) THEN
+         CALL dbcsr_release(force_data%RI_virial_met)
+         DEALLOCATE (force_data%RI_virial_met)
+      END IF
+
+      IF (ASSOCIATED(force_data%t_3c_virial)) THEN
+         CALL dbt_destroy(force_data%t_3c_virial)
+         DEALLOCATE (force_data%t_3c_virial)
+      END IF
+
+      IF (ASSOCIATED(force_data%t_3c_virial_split)) THEN
+         CALL dbt_destroy(force_data%t_3c_virial_split)
+         DEALLOCATE (force_data%t_3c_virial_split)
+      END IF
 
    END SUBROUTINE im_time_force_release
 

--- a/src/xas_tdp_correction.F
+++ b/src/xas_tdp_correction.F
@@ -694,8 +694,8 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: mo_blk_size
       REAL(dp)                                           :: c_os, c_ss, dg, diff, ds1, ds2, eps_I, &
                                                             eps_iter, g, omega_k, parts(4), s1, s2
-      TYPE(dbt_type)                                     :: aj_Ib, aj_Ib_diff, aj_X(2), ja_Ik, &
-                                                            ja_Ik_diff
+      TYPE(dbt_type)                                     :: aj_Ib, aj_Ib_diff, ja_Ik, ja_Ik_diff
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: aj_X
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
       CALL timeset(routineN, handle)
@@ -721,6 +721,7 @@ CONTAINS
       !g(omega) = eps_I - omega + mp2 terms, dg(omega) = -1 + d/d_omega (mp2 terms)
       !We simply compute at each iteration: omega_k+1 = omega_k - g(omega_k)/dg(omega_k)
 
+      ALLOCATE (aj_X(2))
       DO ispin = 1, nspins
 
          !need transposed tensor of (ja|X) for optimal contraction scheme,

--- a/tests/QS/regtest-hfx-ri-2/H2O-hfx-stress-identity.inp
+++ b/tests/QS/regtest-hfx-ri-2/H2O-hfx-stress-identity.inp
@@ -26,7 +26,7 @@
             &END XC_FUNCTIONAL
             &HF
                 &RI
-                   RI_FLAVOR MO
+                   RI_FLAVOR RHO
                    EPS_FILTER 1.0E-12
                 &END
                 &INTERACTION_POTENTIAL

--- a/tests/QS/regtest-hfx-ri-2/TEST_FILES
+++ b/tests/QS/regtest-hfx-ri-2/TEST_FILES
@@ -4,6 +4,6 @@ CH-hfx-ri-mo.inp                                       11    1.0E-9             
 Ne-hfx-pbc-metric-rho.inp                              11    1.0E-9            -636.720103843241191
 Ne-hfx-pbc-metric-mo.inp                               11    1.0E-9            -635.511722336957519
 CH3-b3lyp-ADMM.inp                                     11    1.0E-9              -7.347189043204780
-H2O-pbe0-stress-truncated.inp                          31    1.0E-8               1.08502858250E+00
-H2O-hfx-stress-identity.inp                            31    1.0E-8               7.88736348016E-01
+H2O-pbe0-stress-truncated.inp                          31    1.0E-8               1.10578148678E+00
+H2O-hfx-stress-identity.inp                            31    1.0E-8               7.89429744040E-01
 #EOF

--- a/tests/QS/regtest-ri-laplace-mp2-cubic-2/TEST_FILES
+++ b/tests/QS/regtest-ri-laplace-mp2-cubic-2/TEST_FILES
@@ -2,6 +2,6 @@ H2O_md.inp                                                11      5e-10         
 H2O_md_periodic.inp                                       11      5e-10            -17.072819522507213
 H2O_dh_admm.inp                                           11      1e-8             -17.374161321018438
 H2O_dh_meta.inp                                           11      1e-8             -17.098390868336434 
-H2O_dh_stress.inp                                         31      1e-5              -1.06050039000E+01
+H2O_dh_stress.inp                                         31      1e-5              -1.06027699558E+01
 CH3_md.inp                                                11      5e-10             -7.305999437581916
 #EOF

--- a/tests/QS/regtest-rpa-cubic-scaling-2/TEST_FILES
+++ b/tests/QS/regtest-rpa-cubic-scaling-2/TEST_FILES
@@ -2,7 +2,7 @@ H2O_md.inp                                                11      5e-10         
 H2O_md_periodic.inp                                       11      5e-10            -17.152310315201596
 H2O_dh_admm.inp                                           11      1e-8             -17.396989904939694
 H2O_dh_meta.inp                                           11      1e-8             -17.170279631316898 
-H2O_dh_stress.inp                                         31      1e-5               2.47225995573E+01
+H2O_dh_stress.inp                                         31      1e-5               2.47151346061E+01
 CH3_md_admm.inp                                           11      5e-10             -7.358442900231783
 CH3_md_periodic.inp                                       11      5e-8              -6.826364548206040
 H2O_added_mos.inp                                          0


### PR DESCRIPTION
There was a bug in the calculation of the stress tensor in the methods relying on sparse tensor contractions (RI-HFX, low-scaling RPA and SOS-MP2), which this PR fixes. The reference values in concerned regtests were adapted.

Additionally, some clean-up was done regarding `uninitialized variable` compilation warnings concerning the same DBT based methods.