### PR TITLE
[grid] reduce shared memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,13 +148,13 @@ if(NOT ${CP2K_SCALAPACK_VENDOR} IN_LIST CP2K_SCALAPACK_VENDOR_LIST)
   message(FATAL_ERROR "Invalid scalapack vendor backend")
 endif()
 
-set(CP2K_BUILD_OPTIONS_LIST "DEFAULT" "MINIMAL" "FULL" "SERIAL")
+set(CP2K_BUILD_OPTIONS_LIST "CUSTOM" "DEFAULT" "MINIMAL" "FULL" "SERIAL")
 
 set(CP2K_BUILD_OPTIONS
-    "DEFAULT"
+    "CUSTOM"
     CACHE
       STRING
-      "Build cp2k with a predefined set of dependencies. The default is full user control"
+      "Build cp2k with a predefined set of dependencies. The default setting is full user control"
 )
 set_property(CACHE CP2K_BUILD_OPTIONS PROPERTY STRINGS
                                                ${CP2K_BUILD_OPTIONS_LIST})
@@ -206,6 +206,16 @@ if(${cp2k_build_options_up} STREQUAL "SERIAL")
   set(CP2K_USE_QUIP ON)
   set(CP2K_USE_PEXSI ON)
   set(CP2K_USE_SUPERLU ON)
+endif()
+
+if(${cp2k_build_options_up} STREQUAL "DEFAULT")
+  set(CP2K_USE_FFTW3 ON)
+  set(CP2K_USE_MPI ON)
+  set(CP2K_USE_COSMA ON)
+  set(CP2K_USE_LIBXSMM ON)
+  set(CP2K_USE_LIBXC ON)
+  set(CP2K_USE_LIBINT2 ON)
+  set(CP2K_USE_SPGLIB ON)
 endif()
 
 # ##############################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1425,6 +1425,22 @@ if(CP2K_USE_HIP)
                                                 hip::host)
 endif()
 
+add_library(cp2k_linalg_libs INTERFACE)
+target_link_libraries(
+  cp2k_linalg_libs
+  INTERFACE CP2K::LAPACK::lapack
+            $<$<BOOL:${CP2K_USE_LIBXSMM}>:CP2K::LibXSMM::libxsmmf>
+            $<$<BOOL:${CP2K_USE_LIBXSMM}>:CP2K::LibXSMM::libxsmmext>
+            CP2K::BLAS::blas
+            $<$<BOOL:${CP2K_USE_CUDA}>:cp2k_cuda_libs>
+            $<$<BOOL:${CP2K_USE_HIP}>:cp2k_hip_libs>
+            $<$<BOOL:${CP2K_USE_MPI}>:MPI::MPI_Fortran>
+            $<$<BOOL:${CP2K_USE_MPI}>:MPI::MPI_C>
+            $<$<BOOL:${CP2K_USE_MPI}>:MPI::MPI_CXX>
+            OpenMP::OpenMP_Fortran
+            OpenMP::OpenMP_C
+            OpenMP::OpenMP_CXX)
+
 set(CP2K_GPU_DFLAGS
     $<$<BOOL:${CP2K_USE_HIP}>:__HIP_PLATFORM_AMD__
     __OFFLOAD_HIP>
@@ -1521,19 +1537,7 @@ target_link_libraries(
     $<$<BOOL:${CP2K_USE_COSMA}>:cosma::cosma>
     DBCSR::dbcsr
     $<$<BOOL:${CP2K_USE_MPI}>:CP2K::SCALAPACK::scalapack>
-    CP2K::LAPACK::lapack
-    $<$<BOOL:${CP2K_USE_MPI}>:MPI::MPI_C>
-    $<$<BOOL:${CP2K_USE_LIBXSMM}>:CP2K::LibXSMM::libxsmmf>
-    $<$<BOOL:${CP2K_USE_LIBXSMM}>:CP2K::LibXSMM::libxsmmext>
-    CP2K::BLAS::blas
-    $<$<BOOL:${CP2K_USE_CUDA}>:cp2k_cuda_libs>
-    $<$<BOOL:${CP2K_USE_HIP}>:cp2k_hip_libs>
-    $<$<BOOL:${CP2K_USE_MPI}>:MPI::MPI_Fortran>
-    $<$<BOOL:${CP2K_USE_MPI}>:MPI::MPI_C>
-    $<$<BOOL:${CP2K_USE_MPI}>:MPI::MPI_CXX>
-    OpenMP::OpenMP_Fortran
-    OpenMP::OpenMP_C
-    OpenMP::OpenMP_CXX)
+    cp2k_linalg_libs)
 
 string(TIMESTAMP CP2K_TIMESTAMP "%Y-%m-%d %H:%M:%S")
 
@@ -1641,8 +1645,8 @@ foreach(_app ${__CP2K_APPS})
 
   target_compile_features(${_app} PUBLIC c_std_99)
   if(CP2K_USE_ACCEL MATCHES HIP)
-    set_target_properties(${_app} PROPERTIES HIP_ARCHITECTURES
-                                             ${CMAKE_HIP_ARCHITECTURES})
+    set_property(TARGET ${_app} PROPERTY HIP_ARCHITECTURES
+                                         ${CMAKE_HIP_ARCHITECTURES})
   endif()
 
   target_link_libraries(${_app} PUBLIC cp2k)
@@ -1701,8 +1705,8 @@ foreach(__app grid_miniapp grid_unittest dbm_miniapp)
                OUTPUT_NAME "${__app}.${__cp2k_ext}")
 
   if(CP2K_USE_HIP)
-    set_target_properties(${__app} PROPERTIES HIP_ARCHITECTURES
-                                              ${CMAKE_HIP_ARCHITECTURES})
+    set_property(TARGET ${__app} PROPERTY HIP_ARCHITECTURES
+                                          ${CMAKE_HIP_ARCHITECTURES})
   endif()
 
   if(CP2K_USE_CUDA)
@@ -1721,7 +1725,7 @@ foreach(__app grid_miniapp grid_unittest dbm_miniapp)
            $<$<BOOL:${CP2K_USE_CUDA}>:${CMAKE_CUDA_INCLUDE_DIRECTORIES}>
            $<$<BOOL:${CP2K_USE_HIP}>:${CMAKE_HIP_INCLUDE_DIRECTORIES}>)
 
-  target_link_libraries(${__app} PUBLIC cp2k_link_libs m)
+  target_link_libraries(${__app} PUBLIC cp2k_linalg_libs m)
 endforeach()
 
 # ##############################################################################
@@ -1741,7 +1745,7 @@ install(DIRECTORY "${CMAKE_SOURCE_DIR}/data"
 # cp2kConfig.cmake, etc...
 # ##############################################################################
 
-set(cp2k_export_libs cp2k cp2k_link_libs)
+set(cp2k_export_libs cp2k cp2k_link_libs cp2k_linalg_libs)
 if(CP2K_USE_CUDA)
   list(APPEND cp2k_export_libs cp2k_cuda_libs)
 endif()

--- a/src/grid/grid_unittest.c
+++ b/src/grid/grid_unittest.c
@@ -88,14 +88,7 @@ int main(int argc, char *argv[]) {
   errors += run_test(argv[1], "ortho_density_l2200.task");
   errors += run_test(argv[1], "ortho_density_l3300.task");
   errors += run_test(argv[1], "ortho_density_l3333.task");
-
-#if defined(__OFFLOAD_HIP)
-  printf("\nSkipping ortho_density_l0505.task for HIP backend "
-         "because of shared memory limits.\n\n");
-#else
   errors += run_test(argv[1], "ortho_density_l0505.task");
-#endif
-
   errors += run_test(argv[1], "ortho_non_periodic.task");
   errors += run_test(argv[1], "ortho_tau.task");
   errors += run_test(argv[1], "general_density.task");

--- a/src/grid/hip/grid_hip_collocate.cu
+++ b/src/grid/hip/grid_hip_collocate.cu
@@ -92,7 +92,6 @@ __global__ void calculate_coefficients(const kernel_params dev_) {
   T *smem_alpha = &shared_memory[dev_.smem_alpha_offset];
   T *coef_ =
       &dev_.ptr_dev[2][dev_.tasks[dev_.first_task + blockIdx.x].coef_offset];
-  T *coefs_ = &shared_memory[0];
 
   for (int z = tid; z < task.n1 * task.n2;
        z += blockDim.x * blockDim.y * blockDim.z)
@@ -103,12 +102,7 @@ __global__ void calculate_coefficients(const kernel_params dev_) {
   __syncthreads();
   compute_alpha(task, smem_alpha);
   __syncthreads();
-  cab_to_cxyz(task, smem_alpha, smem_cab, coefs_);
-  __syncthreads();
-
-  for (int z = tid; z < ncoset(task.lp);
-       z += blockDim.x * blockDim.y * blockDim.z)
-    coef_[z] = coefs_[z];
+  cab_to_cxyz(task, smem_alpha, smem_cab, coef_);
 }
 
 /*
@@ -171,9 +165,8 @@ __launch_bounds__(64) void collocate_kernel(const kernel_params dev_) {
   }
 
   __syncthreads();
-  for (int i = tid; i < ncoset(task.lp);
-       i += blockDim.x * blockDim.y * blockDim.z)
-    coefs_[i] = coef_[i];
+  if (tid < ncoset(4))
+    coefs_[tid] = coef_[tid];
 
   if (tid == 0) {
     // the cube center is initialy expressed in lattice coordinates but we
@@ -360,10 +353,11 @@ __launch_bounds__(64) void collocate_kernel(const kernel_params dev_) {
           res += coefs_[34] * r3z2 * r3z2;
         }
 
+        // beware it is coef_ (global memory) here not coefs_ (shared memory)
         if (task.lp > 4) {
           for (int ic = 35; ic < ncoset(task.lp); ic++) {
             auto &co = coset_inv[ic];
-            T tmp = coefs_[ic];
+            T tmp = coef_[ic];
             for (int po = 0; po < co.l[2]; po++)
               tmp *= r3.z;
             for (int po = 0; po < co.l[1]; po++)
@@ -423,24 +417,20 @@ void context_info::collocate_one_grid_level(const int level,
     if (grid_[level].is_orthorhombic())
       collocate_kernel<double, double3, true, true>
           <<<number_of_tasks_per_level_[level], threads_per_block,
-             smem_params.cxyz_len() * sizeof(double), level_streams[level]>>>(
-              params);
+             ncoset(4) * sizeof(double), level_streams[level]>>>(params);
     else
       collocate_kernel<double, double3, true, false>
           <<<number_of_tasks_per_level_[level], threads_per_block,
-             smem_params.cxyz_len() * sizeof(double), level_streams[level]>>>(
-              params);
+             ncoset(4) * sizeof(double), level_streams[level]>>>(params);
   } else {
     if (grid_[level].is_orthorhombic())
       collocate_kernel<double, double3, false, true>
           <<<number_of_tasks_per_level_[level], threads_per_block,
-             smem_params.cxyz_len() * sizeof(double), level_streams[level]>>>(
-              params);
+             ncoset(4) * sizeof(double), level_streams[level]>>>(params);
     else
       collocate_kernel<double, double3, false, false>
           <<<number_of_tasks_per_level_[level], threads_per_block,
-             smem_params.cxyz_len() * sizeof(double), level_streams[level]>>>(
-              params);
+             ncoset(4) * sizeof(double), level_streams[level]>>>(params);
   }
 }
 } // namespace rocm_backend

--- a/src/grid/hip/grid_hip_collocate.cu
+++ b/src/grid/hip/grid_hip_collocate.cu
@@ -88,11 +88,12 @@ __global__ void calculate_coefficients(const kernel_params dev_) {
 
   fill_smem_task_coef(dev_, dev_.first_task + blockIdx.x, task);
   extern __shared__ T shared_memory[];
-  T *smem_cab = &shared_memory[dev_.smem_cab_offset];
+  // T *smem_cab = &shared_memory[dev_.smem_cab_offset];
   T *smem_alpha = &shared_memory[dev_.smem_alpha_offset];
   T *coef_ =
       &dev_.ptr_dev[2][dev_.tasks[dev_.first_task + blockIdx.x].coef_offset];
-
+  T *smem_cab =
+      &dev_.ptr_dev[6][dev_.tasks[dev_.first_task + blockIdx.x].cab_offset];
   for (int z = tid; z < task.n1 * task.n2;
        z += blockDim.x * blockDim.y * blockDim.z)
     smem_cab[z] = 0.0;

--- a/src/grid/hip/grid_hip_context.h
+++ b/src/grid/hip/grid_hip_context.h
@@ -279,6 +279,7 @@ struct task_info {
   double rab[3];
   int lp_max{0};
   size_t coef_offset{0};
+  size_t cab_offset{0};
   int la_max, lb_max, la_min, lb_min, first_coseta, first_cosetb, ncoseta,
       ncosetb, nsgfa, nsgfb, nsgf_seta, nsgf_setb, maxcoa, maxcob;
   int sgfa, sgfb, subblock_offset;
@@ -313,7 +314,8 @@ struct kernel_params {
   char la_max_diff{0};
   char lb_max_diff{0};
   enum grid_func func;
-  double *ptr_dev[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  double *ptr_dev[7] = {nullptr, nullptr, nullptr, nullptr,
+                        nullptr, nullptr, nullptr};
   double **sphi_dev{nullptr};
   int ntasks{0};
   int *task_sorted_by_blocks_dev{nullptr};
@@ -342,6 +344,7 @@ public:
   // from them
   gpu_vector<int> block_offsets_dev;
   gpu_vector<double> coef_dev_;
+  gpu_vector<double> cab_dev_;
   gpu_vector<double> pab_block_;
   gpu_vector<double> hab_block_;
   gpu_vector<double> forces_;
@@ -373,6 +376,7 @@ public:
     tasks_dev.reset();
     block_offsets_dev.reset();
     coef_dev_.reset();
+    cab_dev_.reset();
     task_sorted_by_blocks_dev.reset();
     sorted_blocks_offset_dev.reset();
     sphi_dev.reset();

--- a/src/grid/hip/grid_hip_integrate.cu
+++ b/src/grid/hip/grid_hip_integrate.cu
@@ -73,7 +73,7 @@ template <typename T, typename T3, bool COMPUTE_TAU, bool CALCULATE_FORCES>
 __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
   // Copy task from global to shared memory and precompute some stuff.
   extern __shared__ T shared_memory[];
-  T *smem_cab = &shared_memory[dev_.smem_cab_offset];
+  // T *smem_cab = &shared_memory[dev_.smem_cab_offset];
   T *smem_alpha = &shared_memory[dev_.smem_alpha_offset];
   const int tid =
       threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
@@ -111,6 +111,7 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
     fill_smem_task_coef(dev_, task_id, task);
 
     T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+    T *smem_cab = &dev_.ptr_dev[6][dev_.tasks[task_id].cab_offset];
 
     compute_alpha(task, smem_alpha);
     __syncthreads();
@@ -650,6 +651,7 @@ context_info::set_kernel_parameters(const int level,
   params.ptr_dev[3] = hab_block_.data();
   params.ptr_dev[4] = forces_.data();
   params.ptr_dev[5] = virial_.data();
+  params.ptr_dev[6] = this->cab_dev_.data();
   params.sphi_dev = this->sphi_dev.data();
   return params;
 }

--- a/src/grid/hip/grid_hip_internal_header.h
+++ b/src/grid/hip/grid_hip_internal_header.h
@@ -804,8 +804,7 @@ public:
     smem_per_block_ = std::max(cab_len_ + alpha_len_, 64) * sizeof(double);
 
     if (smem_per_block_ > 64 * 1024) {
-      fprintf(stderr,
-              q "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
+      fprintf(stderr, "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
       fprintf(stderr, "cab_len: %i, ", cab_len_);
       fprintf(stderr, "alpha_len: %i, ", alpha_len_);
       fprintf(stderr, "total smem_per_block: %f kb\n\n",

--- a/src/grid/hip/grid_hip_internal_header.h
+++ b/src/grid/hip/grid_hip_internal_header.h
@@ -646,7 +646,6 @@ cxyz_to_cab(const smem_task<T> &task, const T *__restrict__ alpha,
       cab[jco * task.n1 + ico] = reg; // partial loop coverage -> zero it
     }
   }
-  __syncthreads(); // because of concurrent writes to cxyz / cab
 }
 
 /*******************************************************************************
@@ -801,10 +800,11 @@ public:
 
     cab_len_ = ncoset(lb_max_) * ncoset(la_max_);
     alpha_len_ = 3 * (lb_max_ + 1) * (la_max_ + 1) * (lp_max_ + 1);
-    smem_per_block_ = std::max(cab_len_ + alpha_len_, 64) * sizeof(double);
+    smem_per_block_ = std::max(alpha_len_, 64) * sizeof(double);
 
     if (smem_per_block_ > 64 * 1024) {
-      fprintf(stderr, "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
+      fprintf(stderr,
+              "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
       fprintf(stderr, "cab_len: %i, ", cab_len_);
       fprintf(stderr, "alpha_len: %i, ", alpha_len_);
       fprintf(stderr, "total smem_per_block: %f kb\n\n",

--- a/src/grid/hip/grid_hip_internal_header.h
+++ b/src/grid/hip/grid_hip_internal_header.h
@@ -124,15 +124,10 @@ template <typename T> struct smem_task {
  * \brief data needed for collocate and integrate kernels
  ******************************************************************************/
 template <typename T, typename T3> struct smem_task_reduced {
-  // bool block_transposed;
   T radius, discrete_radius;
   int3 cube_center, lb_cube, cube_size, window_size, window_shift;
   T3 roffset;
   T zetp;
-  // char la_max;
-  // char lb_max;
-  // char la_min;
-  // char lb_min;
   char lp;
   bool apply_border_mask;
 };
@@ -790,7 +785,6 @@ private:
   int la_max_{-1};
   int lb_max_{-1};
   int smem_per_block_{0};
-  int cxyz_len_{-1};
   int alpha_len_{-1};
   int cab_len_{-1};
   int lp_max_{-1};
@@ -807,16 +801,13 @@ public:
 
     cab_len_ = ncoset(lb_max_) * ncoset(la_max_);
     alpha_len_ = 3 * (lb_max_ + 1) * (la_max_ + 1) * (lp_max_ + 1);
-    cxyz_len_ = ncoset(lp_max_);
-    smem_per_block_ =
-        std::max(cab_len_ + alpha_len_ + cxyz_len_, 64) * sizeof(double);
+    smem_per_block_ = std::max(cab_len_ + alpha_len_, 64) * sizeof(double);
 
     if (smem_per_block_ > 64 * 1024) {
       fprintf(stderr,
-              "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
+              q "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
       fprintf(stderr, "cab_len: %i, ", cab_len_);
       fprintf(stderr, "alpha_len: %i, ", alpha_len_);
-      fprintf(stderr, "cxyz_len: %i, ", cxyz_len_);
       fprintf(stderr, "total smem_per_block: %f kb\n\n",
               smem_per_block_ / 1024.0);
       abort();
@@ -827,11 +818,11 @@ public:
 
   // copy and move are trivial
 
-  inline int smem_cab_offset() const { return cxyz_len_; }
+  inline int smem_alpha_offset() const { return 0; }
 
-  inline int smem_alpha_offset() const { return cab_len_ + cxyz_len_; }
+  inline int smem_cab_offset() const { return alpha_len_; }
 
-  inline int smem_cxyz_offset() const { return 0; }
+  inline int smem_cxyz_offset() const { return alpha_len_ + cab_len_; }
 
   inline int smem_per_block() const { return smem_per_block_; }
 
@@ -841,7 +832,7 @@ public:
 
   inline int lp_max() const { return lp_max_; }
 
-  inline int cxyz_len() const { return cxyz_len_; }
+  inline int cxyz_len() const { return ncoset(lp_max_); }
 };
 
 } // namespace rocm_backend


### PR DESCRIPTION
- the coefficients are now read directly from global memory when lp_max > 4 instead of storing them in shared memory. This reduce shared memory usage for large l
- grid_miniapp seems unhappy and trigger a race condition when hab coefficients are calculated. So add an atomicAdd.
- minor changes in the cmake build system.