### PR TITLE
grid: For GPU backend store large Cab in global memory

### DIFF
--- a/src/grid/common/PACKAGE
+++ b/src/grid/common/PACKAGE
@@ -1,5 +1,5 @@
 {
     "description": "Common parts shared by the grid backends",
-    "requires": [],
+    "requires": ["../../offload"],
     "archive": "libcp2kgridcommon",
 }

--- a/src/grid/gpu/grid_gpu_collocate.cu
+++ b/src/grid/gpu/grid_gpu_collocate.cu
@@ -282,18 +282,24 @@ __device__ static void collocate_kernel(const kernel_params *params) {
   double *smem_alpha = &shared_memory[params->smem_alpha_offset];
   double *smem_cxyz = &shared_memory[params->smem_cxyz_offset];
 
-  // For large basis sets the Cab matrix does not fit into shared memory.
-  // Therefore, we're doing multiple passes while masking different parts.
-  compute_alpha(&task, smem_alpha);
-  for (int lb = 0; lb < task.n1 * task.n2; lb += params->smem_cab_length) {
-    const int ub = lb + params->smem_cab_length;
-    cab_store cab = {.data = smem_cab, .n1 = task.n1, .mask = {lb, ub}};
-    zero_cab(&cab);
-    block_to_cab<IS_FUNC_AB>(params, &task, &cab);
-    cab_to_cxyz(&task, smem_alpha, &cab, smem_cxyz);
+  // Allocate Cab from global memory if it does not fit into shared memory.
+  cab_store cab = {.data = NULL, .n1 = task.n1};
+  if (params->smem_cab_length < task.n1 * task.n2) {
+    cab.data = malloc_cab(&task);
+  } else {
+    cab.data = smem_cab;
   }
 
+  zero_cab(&cab, task.n1 * task.n2);
+  compute_alpha(&task, smem_alpha);
+
+  block_to_cab<IS_FUNC_AB>(params, &task, &cab);
+  cab_to_cxyz(&task, smem_alpha, &cab, smem_cxyz);
   cxyz_to_grid(params, &task, smem_cxyz, params->grid);
+
+  if (params->smem_cab_length < task.n1 * task.n2) {
+    free_cab(cab.data);
+  }
 }
 
 /*******************************************************************************
@@ -336,14 +342,13 @@ void grid_gpu_collocate_one_grid_level(
 
   init_constant_memory();
 
+  // Small Cab blocks are stored in shared mem, larger ones in global memory.
+  const int CAB_SMEM_LIMIT = ncoset(5) * ncoset(5); // = 56 * 56 = 3136
+
   // Compute required shared memory.
-  const size_t available_dynamic_smem = 48 * 1024 - sizeof(smem_task);
   const int alpha_len = 3 * (lb_max + 1) * (la_max + 1) * (lp_max + 1);
   const int cxyz_len = ncoset(lp_max);
-  const int leftover_smem_len =
-      (available_dynamic_smem / sizeof(double)) - alpha_len - cxyz_len;
-  const int cab_full_len = ncoset(lb_max) * ncoset(la_max);
-  const int cab_len = imin(cab_full_len, leftover_smem_len);
+  const int cab_len = imin(CAB_SMEM_LIMIT, ncoset(lb_max) * ncoset(la_max));
   const size_t smem_per_block =
       (alpha_len + cxyz_len + cab_len) * sizeof(double);
 
@@ -351,7 +356,7 @@ void grid_gpu_collocate_one_grid_level(
   kernel_params params;
   params.smem_cab_length = cab_len;
   params.smem_cab_offset = 0;
-  params.smem_alpha_offset = cab_len;
+  params.smem_alpha_offset = params.smem_cab_offset + cab_len;
   params.smem_cxyz_offset = params.smem_alpha_offset + alpha_len;
   params.first_task = first_task;
   params.func = func;

--- a/src/offload/offload_runtime.h
+++ b/src/offload/offload_runtime.h
@@ -328,6 +328,24 @@ static inline void offloadDeviceSynchronize(void) {
 #endif
 }
 
+/*******************************************************************************
+ * \brief Wrapper around cudaDeviceSetLimit(cudaLimitMallocHeapSize,...).
+ ******************************************************************************/
+static inline void offloadEnsureMallocHeapSize(const size_t required_size) {
+  size_t current_size;
+#if defined(__OFFLOAD_CUDA)
+  OFFLOAD_CHECK(cudaDeviceGetLimit(&current_size, cudaLimitMallocHeapSize));
+  if (current_size < required_size) {
+    OFFLOAD_CHECK(cudaDeviceSetLimit(cudaLimitMallocHeapSize, required_size));
+  }
+#elif defined(__OFFLOAD_HIP)
+  OFFLOAD_CHECK(hipDeviceGetLimit(&current_size, hipLimitMallocHeapSize));
+  if (current_size < required_size) {
+    OFFLOAD_CHECK(hipDeviceSetLimit(hipLimitMallocHeapSize, required_size));
+  }
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Follow up to #2787. Turns out using global memory is faster than doing multiple passes. See also #1785.