### PR TITLE
Fixed minor sparse tensor force bug

### DIFF
--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -2631,7 +2631,6 @@ CONTAINS
 
          CALL timeset(routineN//"_3c", handle)
          !Start looping of the batches
-         CALL dbt_batched_contract_init(t_SVS)
          CALL dbt_batched_contract_init(t_R)
          DO i_mem = 1, n_mem
             ibounds(:, 1) = [batch_start(i_mem), batch_end(i_mem)]
@@ -2674,12 +2673,14 @@ CONTAINS
                   CALL dbt_copy(t_3c_sparse, t_3c_4, bounds=bounds_cpy)
 
                   !Contract with the 2-center product S^-1 * V * S^-1 while keeping sparsity of derivatives
+                  CALL dbt_batched_contract_init(t_SVS)
                   CALL dbt_contract(1.0_dp, t_SVS, t_3c_3, 0.0_dp, t_3c_4, &
                                     contract_1=[2], notcontract_1=[1], &
                                     contract_2=[1], notcontract_2=[2, 3], &
                                     map_1=[1], map_2=[2, 3], filter_eps=ri_data%filter_eps, &
                                     retain_sparsity=.TRUE., unit_nr=unit_nr_dbcsr, flop=nflop)
                   ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+                  CALL dbt_batched_contract_finalize(t_SVS)
 
                   CALL dbt_copy(t_3c_4, t_3c_5, summation=.TRUE., move_data=.TRUE.)
 
@@ -2748,7 +2749,6 @@ CONTAINS
             CALL dbt_clear(t_3c_help_1)
             CALL dbt_clear(t_3c_help_2)
          END DO !i_mem
-         CALL dbt_batched_contract_finalize(t_SVS)
          CALL dbt_batched_contract_finalize(t_R)
          CALL timestop(handle)
 

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -2051,7 +2051,6 @@ CONTAINS
 
       CALL dbt_batched_contract_init(t_R_occ)
       CALL dbt_batched_contract_init(t_R_virt)
-      CALL dbt_batched_contract_init(t_KBKT)
       DO i_mem = 1, cut_memory
          ibounds(:, 1) = [starts_array_mc(i_mem), ends_array_mc(i_mem)]
 
@@ -2138,12 +2137,14 @@ CONTAINS
 
                !Calculate the contraction of the above with K*B*K^T
                CALL timeset(routineN//"_3c_KBK", handle2)
+               CALL dbt_batched_contract_init(t_KBKT)
                CALL dbt_contract(1.0_dp, t_KBKT, t_3c_6, 0.0_dp, t_3c_7, &
                                  contract_1=[2], notcontract_1=[1], &
                                  contract_2=[1], notcontract_2=[2, 3], &
                                  map_1=[1], map_2=[2, 3], &
                                  retain_sparsity=.TRUE., flop=flop, unit_nr=unit_nr_dbcsr)
                dbcsr_nflop = dbcsr_nflop + flop
+               CALL dbt_batched_contract_finalize(t_KBKT)
                CALL timestop(handle2)
                CALL dbt_copy(t_3c_7, t_3c_8, summation=.TRUE.)
 
@@ -2184,7 +2185,6 @@ CONTAINS
 
          CALL dbt_clear(t_3c_help_2)
       END DO !i_mem
-      CALL dbt_batched_contract_finalize(t_KBKT)
       CALL dbt_batched_contract_finalize(t_R_occ)
       CALL dbt_batched_contract_finalize(t_R_virt)
 


### PR DESCRIPTION
In some very specific (and rare) combinations of number of MPI ranks, MEMORY_CUT value, and choice of system, the program would crash during forces calculation of sparse tensor based methods (RI-HFX, low-scaling post-HF). This PR fixes it.