### PR TITLE
Bump to Libxc 6.2.2

### DIFF
--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -6,8 +6,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-libxc_ver="6.2.0"
-libxc_sha256="b88dffdbaf5ff43aed6ae25a65dbbbb7a9f0e52b3430fb4d89b4b9b77d4b8716"
+libxc_ver="6.2.2"
+libxc_sha256="a0f6f1bba7ba5c0c85b2bfe65aca1591025f509a7f11471b4cd651a79491b045"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh


### PR DESCRIPTION
Can one of the admins add the [new tarball](http://www.tddft.org/programs/libxc/down.php?file=6.2.2/libxc-6.2.2.tar.gz)? Probably, the SHA256 will be off again.