### PR TITLE
Do not use the default initializer if it has an allocatable component

### DIFF
--- a/src/cp_eri_mme_interface.F
+++ b/src/cp_eri_mme_interface.F
@@ -78,7 +78,8 @@ MODULE cp_eri_mme_interface
 
    TYPE cp_eri_mme_param
       TYPE(cp_logger_type), POINTER                      :: logger => NULL()
-      TYPE(eri_mme_param)                                :: par = eri_mme_param()
+      ! There is a bug with some older compilers preventing a default initialization of  derived types with allocatable components
+      TYPE(eri_mme_param)                                :: par != eri_mme_param()
       TYPE(section_vals_type), &
          POINTER                                         :: mme_section => NULL()
       INTEGER                                            :: G_count_2c = 0, R_count_2c = 0

--- a/src/tmc/tmc_analysis_types.F
+++ b/src/tmc/tmc_analysis_types.F
@@ -199,6 +199,8 @@ CONTAINS
 
       ALLOCATE (ana_dens%sum_density(nr_bins(1), nr_bins(2), nr_bins(3)))
       ALLOCATE (ana_dens%sum_dens2(nr_bins(1), nr_bins(2), nr_bins(3)))
+      ana_dens%sum_density = 0.0_dp
+      ana_dens%sum_dens2 = 0.0_dp
    END SUBROUTINE tmc_ana_density_create
 
 ! **************************************************************************************************
@@ -357,9 +359,13 @@ CONTAINS
       ALLOCATE (ana_dip_ana)
 
       ALLOCATE (ana_dip_ana%mu_psv(3))
+      ana_dip_ana%mu_psv = 0.0_dp
       ALLOCATE (ana_dip_ana%mu_pv(3))
+      ana_dip_ana%mu_pv = 0.0_dp
       ALLOCATE (ana_dip_ana%mu2_pv(3))
+      ana_dip_ana%mu2_pv = 0.0_dp
       ALLOCATE (ana_dip_ana%mu2_pv_mat(3, 3))
+      ana_dip_ana%mu2_pv_mat = 0.0_dp
    END SUBROUTINE tmc_ana_dipole_analysis_create
 
 ! **************************************************************************************************

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -87,6 +87,7 @@ cp_ddapc_types.F: Found type cp_ddapc_type without initializer https://cp2k.org/
 cp_ddapc_util.F: Found WRITE statement with hardcoded unit in "debug_charge" https://cp2k.org/conv#c012
 cp_ddapc_util.F: Found WRITE statement with hardcoded unit in "debug_der_a_matrix" https://cp2k.org/conv#c012
 cp_ddapc_util.F: Found WRITE statement with hardcoded unit in "debug_der_b_vector" https://cp2k.org/conv#c012
+cp_eri_mme_interface.F: Found type cp_eri_mme_param without initializer https://cp2k.org/conv#c016
 cp_error_handling.F: Found CALL mp_abort in procedure "cp_abort_handler" https://cp2k.org/conv#c103
 cp_files.F: Found CLOSE statement in procedure "close_file" https://cp2k.org/conv#c204
 cp_files.F: Found OPEN statement in procedure "open_file" https://cp2k.org/conv#c203


### PR DESCRIPTION
Follow up to #2833. This fixes testers with old compilers.