### PR TITLE
Fix tests failing because of use_ref_cell

### DIFF
--- a/src/cell_methods.F
+++ b/src/cell_methods.F
@@ -271,7 +271,7 @@ CONTAINS
                                   check_for_ref, para_env)
 
       TYPE(cell_type), POINTER                           :: cell, cell_ref
-      LOGICAL, INTENT(OUT), OPTIONAL                     :: use_ref_cell
+      LOGICAL, INTENT(INOUT), OPTIONAL                   :: use_ref_cell
       TYPE(section_vals_type), OPTIONAL, POINTER         :: cell_section
       LOGICAL, INTENT(IN), OPTIONAL                      :: check_for_ref
       TYPE(mp_para_env_type), POINTER                    :: para_env
@@ -374,15 +374,18 @@ CONTAINS
       ! Initialize cell
       CALL init_cell(cell)
 
-      IF (.NOT. my_check) RETURN
-      cell_ref_section => section_vals_get_subs_vals(cell_section, "CELL_REF")
-      IF (parsed_cp2k_input(cell_ref_section, check_this_section=.TRUE.)) THEN
-         IF (PRESENT(use_ref_cell)) use_ref_cell = .TRUE.
-         CALL read_cell(cell_ref, cell_ref, use_ref_cell, cell_section=cell_ref_section, &
-                        check_for_ref=.FALSE., para_env=para_env)
-      ELSE
-         CALL cell_clone(cell, cell_ref, tag="CELL_REF")
-         IF (PRESENT(use_ref_cell)) use_ref_cell = .FALSE.
+      IF (my_check) THEN
+         ! Recursive check for reference cell requested
+         cell_ref_section => section_vals_get_subs_vals(cell_section, "CELL_REF")
+         IF (parsed_cp2k_input(cell_ref_section, check_this_section=.TRUE.)) THEN
+            IF (PRESENT(use_ref_cell)) use_ref_cell = .TRUE.
+            CALL read_cell(cell_ref, cell_ref, use_ref_cell=use_ref_cell, &
+                           cell_section=cell_ref_section, check_for_ref=.FALSE., &
+                           para_env=para_env)
+         ELSE
+            CALL cell_clone(cell, cell_ref, tag="CELL_REF")
+            IF (PRESENT(use_ref_cell)) use_ref_cell = .FALSE.
+         END IF
       END IF
 
    END SUBROUTINE read_cell

--- a/src/qs_subsys_methods.F
+++ b/src/qs_subsys_methods.F
@@ -102,6 +102,7 @@ CONTAINS
 
       ! create cp_subsys%cell
       !TODO: moved to cp_subsys_create(), needs further disentanglement of cell_ref.
+      use_ref_cell = .FALSE.
       IF (PRESENT(cell)) THEN
          my_cell => cell
          IF (PRESENT(cell_ref)) THEN
@@ -110,7 +111,6 @@ CONTAINS
          ELSE
             CALL cell_create(my_cell_ref)
             CALL cell_clone(my_cell, my_cell_ref, tag="CELL_REF")
-            use_ref_cell = .FALSE.
          END IF
       ELSE
          cell_section => section_vals_get_subs_vals(subsys_section, "CELL")


### PR DESCRIPTION
4 tests failed with GCC 13.1.0 and OpenMPI 4.1.x, because use_ref_cell was not set correctly. For these tests, the consideration of the reference cell has a significant impact on the applied cutoff causing large deviations in the total energy.