### PR TITLE
XAS_TDP| Fix bug leading to crashes when n_ranks >>> nex_atom

### DIFF
--- a/src/xas_tdp_types.F
+++ b/src/xas_tdp_types.F
@@ -1449,8 +1449,10 @@ CONTAINS
       ELSE
 
          !If nex_atom < nprocs, simply devide processors in nex_atom batches
+         !At most 128 ranks per atom, experiments have shown that if nprocs >>> nex_atom, crahes occur.
+         !The 128 upper limit is based on trial and error
          nbatch = nex_atom
-         batch_size = nprocs/nbatch
+         batch_size = MIN(nprocs/nbatch, 128)
 
       END IF
 


### PR DESCRIPTION
When doing XAS_TDP calculations, atomic grids are distributed over the MPI ranks. When the number of ranks is much larger than the number of excited atoms, the grids are over distributed and the code crashes. This PR introduces an upper limit to how many ranks work on a single atomic grid and fixes the issue.