### PR TITLE
Docs: Fix cross-referencing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,4 +20,4 @@ To build  a local version of the manual perform the following steps:
 
    `make html`
 
-1. Browse the HTML output in the `_build` directory.
+1. Browse the HTML output in the `_build/html` directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,14 +6,6 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-
-# Disable benign warning: https://github.com/sphinx-doc/sphinx/blob/d3c91f951255c6729a53e38c895ddc0af036b5b9/sphinx/domains/python.py#L1283
-import logging
-
-logging.getLogger("sphinx.sphinx.domains.python").setLevel(logging.ERROR)
-
-# add_module_names = False
-
 project = "CP2K"
 copyright = "2000-2023, CP2K Developers"
 author = "CP2K Developers"
@@ -26,7 +18,7 @@ extensions = ["myst_parser", "sphinx_rtd_theme"]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
 
-suppress_warnings = ["app", "ref", "index"]
+suppress_warnings = ["ref"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
@@ -35,7 +27,7 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 html_favicon = "_static/favicon.png"
 
-# add_module_names = False
+add_module_names = False
 
 # https://myst-parser.readthedocs.io/en/v0.16.1/syntax/optional.html#syntax-header-anchors
 


### PR DESCRIPTION
This change allows us to link to keywords from anywhere within our Sphinx docs and have them checked at build time.

Cross-references can be inserted like this: `[](MOTION.TMC.PRESSURE)` or like this: `[PRESSURE](MOTION.TMC.PRESSURE)`.

Thanks @mkrack for realizing that we can just use simple HTML anchors to preserve old links!